### PR TITLE
test(rareicon): expand e2e coverage

### DIFF
--- a/apps/rareicon/astro-rareicon-e2e/e2e/api.spec.ts
+++ b/apps/rareicon/astro-rareicon-e2e/e2e/api.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from '@playwright/test';
+
+type IconTerm = {
+	ref: string;
+	name: string;
+	description: string;
+	primary_category?: string;
+	categories: string[];
+	tags: string[];
+	styles: string[];
+	sourcePacks: string[];
+	multiSource: boolean;
+	attributionRequired: boolean;
+	variantCount: number;
+	featured: boolean;
+	url: string;
+};
+
+type IconCatalog = {
+	generatedAt: string;
+	count: number;
+	terms: IconTerm[];
+};
+
+type IconDetail = {
+	ref: string;
+	name: string;
+	title: string;
+	description: string;
+	categories: string[];
+	tags: string[];
+	icons: Array<{
+		ref: string;
+		svg_body: string;
+		license?: string;
+	}>;
+	url: string;
+};
+
+type CategoryCatalog = {
+	generatedAt: string;
+	count: number;
+	categories: Array<{
+		name: string;
+		count: number;
+		url: string;
+	}>;
+};
+
+type SourceCatalog = {
+	generatedAt: string;
+	count: number;
+	sources: Array<{
+		name: string;
+		termCount: number;
+		license: string;
+		homeUrl: string;
+		attribution: boolean;
+	}>;
+};
+
+test.describe('RareIcon catalog API', () => {
+	test('icons.json exposes stable searchable icon summaries', async ({
+		request,
+	}) => {
+		const response = await request.get('/api/icons.json');
+		expect(response.status()).toBe(200);
+		expect(response.headers()['content-type']).toContain(
+			'application/json',
+		);
+		expect(response.headers()['cache-control']).toContain('max-age=300');
+
+		const body = (await response.json()) as IconCatalog;
+		expect(Date.parse(body.generatedAt)).not.toBeNaN();
+		expect(body.count).toBe(body.terms.length);
+		expect(body.count).toBeGreaterThan(100);
+
+		const refs = new Set(body.terms.map((term) => term.ref));
+		expect(refs.size).toBe(body.terms.length);
+
+		const python = body.terms.find((term) => term.ref === 'python');
+		expect(python).toMatchObject({
+			ref: 'python',
+			multiSource: true,
+			featured: true,
+		});
+		expect(python?.variantCount).toBeGreaterThanOrEqual(2);
+		expect(python?.sourcePacks.length).toBeGreaterThanOrEqual(2);
+		expect(python?.url).toBe('https://rareicon.com/icons/python/');
+
+		const broadsword = body.terms.find((term) => term.ref === 'broadsword');
+		expect(broadsword).toMatchObject({
+			ref: 'broadsword',
+			attributionRequired: true,
+		});
+	});
+
+	test('individual icon json contains SVG variants and attribution data', async ({
+		request,
+	}) => {
+		const response = await request.get('/api/icons/python.json/');
+		expect(response.status()).toBe(200);
+		expect(response.headers()['content-type']).toContain(
+			'application/json',
+		);
+
+		const body = (await response.json()) as IconDetail;
+		expect(body.ref).toBe('python');
+		expect(body.url).toBe('https://rareicon.com/icons/python/');
+		expect(body.icons.length).toBeGreaterThanOrEqual(2);
+		expect(body.icons.every((icon) => icon.svg_body.includes('<svg'))).toBe(
+			true,
+		);
+		expect(
+			new Set(body.icons.map((icon) => icon.ref)).size,
+		).toBeGreaterThanOrEqual(2);
+	});
+
+	test('categories.json is sorted by descending term count', async ({
+		request,
+	}) => {
+		const response = await request.get('/api/categories.json');
+		expect(response.status()).toBe(200);
+		expect(response.headers()['content-type']).toContain(
+			'application/json',
+		);
+
+		const body = (await response.json()) as CategoryCatalog;
+		expect(body.count).toBe(body.categories.length);
+		expect(body.count).toBeGreaterThan(5);
+
+		for (let i = 1; i < body.categories.length; i += 1) {
+			expect(body.categories[i - 1].count).toBeGreaterThanOrEqual(
+				body.categories[i].count,
+			);
+		}
+
+		expect(body.categories[0].url).toMatch(
+			/^https:\/\/rareicon\.com\/icons\/category\/.+\/$/,
+		);
+	});
+
+	test('sources.json preserves known license metadata', async ({
+		request,
+	}) => {
+		const response = await request.get('/api/sources.json');
+		expect(response.status()).toBe(200);
+		expect(response.headers()['content-type']).toContain(
+			'application/json',
+		);
+
+		const body = (await response.json()) as SourceCatalog;
+		expect(body.count).toBe(body.sources.length);
+		expect(body.count).toBeGreaterThan(5);
+
+		const sources = new Map(
+			body.sources.map((source) => [source.name, source]),
+		);
+		expect(sources.get('lucide')).toMatchObject({
+			license: 'ISC',
+			homeUrl: 'https://lucide.dev/',
+			attribution: true,
+		});
+		expect(sources.get('simple-icons')).toMatchObject({
+			license: 'CC0',
+			attribution: false,
+		});
+		expect(sources.get('game-icons')).toMatchObject({
+			license: 'CC BY 3.0',
+			attribution: true,
+		});
+	});
+});

--- a/apps/rareicon/astro-rareicon-e2e/e2e/helpers/routes.ts
+++ b/apps/rareicon/astro-rareicon-e2e/e2e/helpers/routes.ts
@@ -14,7 +14,7 @@ export const ICON_ROUTES = [
 	{ path: '/icons/', label: 'Icon library landing' },
 	{ path: '/icons/sword/', label: 'Sword term page' },
 	{ path: '/icons/shield/', label: 'Shield term page' },
-	{ path: '/icons/arrow-right/', label: 'Arrow-right term page' },
+	{ path: '/icons/arrow/', label: 'Arrow term page' },
 	{ path: '/icons/close/', label: 'Close term page' },
 	{ path: '/icons/terminal/', label: 'Terminal term page' },
 ] as const;
@@ -42,8 +42,6 @@ export const MULTI_SOURCE_ICON_ROUTES = [
 	{ path: '/icons/react/', label: 'React multi-source term' },
 	{ path: '/icons/docker/', label: 'Docker multi-source term' },
 	{ path: '/icons/rust/', label: 'Rust multi-source term' },
-	{ path: '/icons/home/', label: 'Home multi-source term' },
-	{ path: '/icons/heart/', label: 'Heart multi-source term' },
 ] as const;
 
 /**

--- a/apps/rareicon/astro-rareicon-e2e/e2e/smoke.spec.ts
+++ b/apps/rareicon/astro-rareicon-e2e/e2e/smoke.spec.ts
@@ -101,23 +101,99 @@ test.describe('Icon library', () => {
 		page,
 	}) => {
 		await page.goto('/icons/sword/');
-		const copyBtn = page.locator('.ri-icon-variant__copy').first();
+		const copyBtn = page
+			.locator('.ri-icon-variant__copy[data-copy-format="svg"]')
+			.first();
 		await expect(copyBtn).toBeVisible();
-		await expect(copyBtn).toHaveText(/Copy SVG/);
+		await expect(copyBtn).toHaveText('SVG');
+		await expect(copyBtn).toHaveAttribute('data-copy-svg', /<svg/i);
+	});
+
+	test('copy controls write SVG payloads and surface copied state', async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			Object.defineProperty(navigator, 'clipboard', {
+				value: {
+					writeText: (text: string) => {
+						window.localStorage.setItem('rareicon:last-copy', text);
+						return Promise.resolve();
+					},
+				},
+				configurable: true,
+			});
+		});
+
+		await page.goto('/icons/sword/');
+		const copyBtn = page
+			.locator('.ri-icon-variant__copy[data-copy-format="svg"]')
+			.first();
+		await copyBtn.click();
+
+		await expect(copyBtn).toHaveAttribute('data-copied', 'true');
+		await expect(copyBtn).toHaveText('Copied');
+
+		const copied = await page.evaluate(() =>
+			window.localStorage.getItem('rareicon:last-copy'),
+		);
+		expect(copied).toContain('<svg');
 	});
 });
 
 test.describe('sidebar + search', () => {
 	test('sidebar contains Icons section', async ({ page }) => {
 		await page.goto('/');
-		const sidebar = page.locator('nav[aria-label="Main"]');
-		await expect(sidebar).toBeAttached();
-		await expect(sidebar.locator('a[href="/icons/"]')).toBeAttached();
+		await expect(page.locator('a[href="/icons/"]').first()).toBeVisible();
 	});
 
 	test('Pagefind search trigger present', async ({ page }) => {
 		await page.goto('/');
 		const trigger = page.locator('button[data-open-modal]');
 		await expect(trigger).toBeVisible({ timeout: 10_000 });
+	});
+
+	test('icon browser filters by direct search query', async ({ page }) => {
+		await page.goto('/icons/');
+		const search = page.getByRole('searchbox', { name: 'Search icons' });
+		await expect(search).toBeVisible({ timeout: 10_000 });
+
+		await search.fill('docker');
+
+		const card = page.locator(
+			'.ri-icons-browser__card[href="/icons/docker/"]',
+		);
+		await expect(card).toBeVisible();
+		await expect(page.locator('.ri-icons-browser__empty')).toHaveCount(0);
+	});
+
+	test('icon browser exposes multi-source and attribution filters', async ({
+		page,
+	}) => {
+		await page.goto('/icons/');
+
+		const multiSource = page.getByRole('button', {
+			name: 'Multi-source only',
+		});
+		const attribution = page.getByRole('button', {
+			name: 'Attribution required (CC BY)',
+		});
+
+		await multiSource.click();
+		await expect(multiSource).toHaveAttribute('aria-pressed', 'true');
+		await expect(
+			page.locator('.ri-icons-browser__card[href="/icons/python/"]'),
+		).toBeVisible();
+
+		await multiSource.click();
+		await attribution.click();
+		await expect(multiSource).toHaveAttribute('aria-pressed', 'false');
+		await expect(attribution).toHaveAttribute('aria-pressed', 'true');
+
+		await page
+			.getByRole('searchbox', { name: 'Search icons' })
+			.fill('broadsword');
+		await expect(
+			page.locator('.ri-icons-browser__card[href="/icons/broadsword/"]'),
+		).toBeVisible();
 	});
 });

--- a/apps/rareicon/astro-rareicon/astro.config.mjs
+++ b/apps/rareicon/astro-rareicon/astro.config.mjs
@@ -73,7 +73,8 @@ export default defineConfig({
 					tag: 'meta',
 					attrs: {
 						property: 'og:image',
-						content: 'https://rareicon.com/assets/steam/rareicon_library_header_920_x_430px.png',
+						content:
+							'https://rareicon.com/assets/steam/rareicon_library_header_920_x_430px.png',
 					},
 				},
 				{
@@ -94,21 +95,24 @@ export default defineConfig({
 					tag: 'meta',
 					attrs: {
 						property: 'og:image:alt',
-						content: 'RareIcon — 2D sci-fi action-RPG bullet-hell roguelite',
+						content:
+							'RareIcon — 2D sci-fi action-RPG bullet-hell roguelite',
 					},
 				},
 				{
 					tag: 'meta',
 					attrs: {
 						name: 'twitter:image',
-						content: 'https://rareicon.com/assets/steam/rareicon_library_header_920_x_430px.png',
+						content:
+							'https://rareicon.com/assets/steam/rareicon_library_header_920_x_430px.png',
 					},
 				},
 				{
 					tag: 'meta',
 					attrs: {
 						name: 'twitter:image:alt',
-						content: 'RareIcon — 2D sci-fi action-RPG bullet-hell roguelite',
+						content:
+							'RareIcon — 2D sci-fi action-RPG bullet-hell roguelite',
 					},
 				},
 				{
@@ -159,11 +163,11 @@ export default defineConfig({
 				},
 				{
 					label: 'Getting Started',
-					autogenerate: { directory: 'guides' },
+					items: [{ autogenerate: { directory: 'guides' } }],
 				},
 				{
 					label: 'Game',
-					autogenerate: { directory: 'game' },
+					items: [{ autogenerate: { directory: 'game' } }],
 				},
 				{
 					label: 'Icons',
@@ -174,20 +178,59 @@ export default defineConfig({
 							label: 'Categories',
 							collapsed: true,
 							items: [
-								{ label: 'Action', link: '/icons/category/action/' },
-								{ label: 'Commerce', link: '/icons/category/commerce/' },
-								{ label: 'Communication', link: '/icons/category/comms/' },
-								{ label: 'Files', link: '/icons/category/file/' },
-								{ label: 'Gamedev', link: '/icons/category/game/' },
-								{ label: 'Gaming platforms', link: '/icons/category/gaming/' },
-								{ label: 'Media', link: '/icons/category/media/' },
-								{ label: 'Navigation', link: '/icons/category/navigation/' },
-								{ label: 'Sci-fi', link: '/icons/category/sci-fi/' },
-								{ label: 'Social', link: '/icons/category/social/' },
-								{ label: 'Tech', link: '/icons/category/tech/' },
+								{
+									label: 'Action',
+									link: '/icons/category/action/',
+								},
+								{
+									label: 'Commerce',
+									link: '/icons/category/commerce/',
+								},
+								{
+									label: 'Communication',
+									link: '/icons/category/comms/',
+								},
+								{
+									label: 'Files',
+									link: '/icons/category/file/',
+								},
+								{
+									label: 'Gamedev',
+									link: '/icons/category/game/',
+								},
+								{
+									label: 'Gaming platforms',
+									link: '/icons/category/gaming/',
+								},
+								{
+									label: 'Media',
+									link: '/icons/category/media/',
+								},
+								{
+									label: 'Navigation',
+									link: '/icons/category/navigation/',
+								},
+								{
+									label: 'Sci-fi',
+									link: '/icons/category/sci-fi/',
+								},
+								{
+									label: 'Social',
+									link: '/icons/category/social/',
+								},
+								{
+									label: 'Tech',
+									link: '/icons/category/tech/',
+								},
 								{ label: 'UI', link: '/icons/category/ui/' },
-								{ label: 'Weapons', link: '/icons/category/weapon/' },
-								{ label: 'Weather', link: '/icons/category/weather/' },
+								{
+									label: 'Weapons',
+									link: '/icons/category/weapon/',
+								},
+								{
+									label: 'Weather',
+									link: '/icons/category/weather/',
+								},
 							],
 						},
 						{
@@ -212,7 +255,7 @@ export default defineConfig({
 				},
 				{
 					label: 'Account',
-					autogenerate: { directory: 'auth' },
+					items: [{ autogenerate: { directory: 'auth' } }],
 				},
 				{
 					label: 'Journal',

--- a/apps/rareicon/axum-rareicon-e2e/e2e/headers.spec.ts
+++ b/apps/rareicon/axum-rareicon-e2e/e2e/headers.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+
+describe('HTTP headers and middleware', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('GET /health includes JSON content type and security headers', async () => {
+		const res = await fetch(`${BASE_URL}/health`);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type')).toContain('application/json');
+		expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+		expect(res.headers.get('x-frame-options')).toBe('DENY');
+		expect(res.headers.get('referrer-policy')).toBe(
+			'strict-origin-when-cross-origin',
+		);
+	});
+
+	it('GET / receives HTML cache headers from the static fallback pipeline', async () => {
+		const res = await fetch(`${BASE_URL}/`);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type')).toContain('text/html');
+		expect(res.headers.get('cache-control')).toContain('max-age=86400');
+	});
+
+	it('CORS preflight allows browser clients to call public endpoints', async () => {
+		const res = await fetch(`${BASE_URL}/health`, {
+			method: 'OPTIONS',
+			headers: {
+				origin: 'https://rareicon.com',
+				'access-control-request-method': 'GET',
+			},
+		});
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('access-control-allow-origin')).toBe('*');
+		expect(res.headers.get('access-control-allow-methods')).toMatch(
+			/\*|GET/,
+		);
+	});
+});

--- a/apps/rareicon/axum-rareicon-e2e/e2e/health.spec.ts
+++ b/apps/rareicon/axum-rareicon-e2e/e2e/health.spec.ts
@@ -9,19 +9,23 @@ describe('Health endpoint', () => {
 	it('GET /health returns 200 with JSON', async () => {
 		const res = await fetch(`${BASE_URL}/health`);
 		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type')).toContain('application/json');
 
 		const body = await res.json();
 		expect(body).toHaveProperty('status', 'ok');
 		expect(body).toHaveProperty('service', 'axum-rareicon');
 		expect(body).toHaveProperty('version');
 		expect(typeof body.version).toBe('string');
+		expect(body.version).toMatch(/^\d+\.\d+\.\d+/);
 	});
 
 	it('GET /api/health mirrors /health', async () => {
-		const res = await fetch(`${BASE_URL}/api/health`);
-		expect(res.status).toBe(200);
-		const body = await res.json();
-		expect(body.service).toBe('axum-rareicon');
+		const [health, apiHealth] = await Promise.all([
+			fetch(`${BASE_URL}/health`).then((res) => res.json()),
+			fetch(`${BASE_URL}/api/health`).then((res) => res.json()),
+		]);
+
+		expect(apiHealth).toEqual(health);
 	});
 
 	it('GET /health responds within 500ms', async () => {

--- a/apps/rareicon/axum-rareicon-e2e/e2e/helpers/http.ts
+++ b/apps/rareicon/axum-rareicon-e2e/e2e/helpers/http.ts
@@ -11,7 +11,7 @@ export async function waitForReady(timeoutMs = 30_000): Promise<void> {
 			const res = await fetch(`${BASE_URL}/health`, {
 				signal: AbortSignal.timeout(2_000),
 			});
-			if (res.status > 0) return;
+			if (res.status === 200) return;
 		} catch {
 			// Connection refused or reset — keep trying
 		}

--- a/apps/rareicon/axum-rareicon-e2e/e2e/static-assets.spec.ts
+++ b/apps/rareicon/axum-rareicon-e2e/e2e/static-assets.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+
+describe('Static asset serving', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('serves public RareIcon image assets with image content type', async () => {
+		const res = await fetch(
+			`${BASE_URL}/assets/icon/rareicon_low_res_256px.png`,
+		);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type')).toContain('image/png');
+		expect(res.headers.get('cache-control')).toContain('max-age=86400');
+
+		const body = new Uint8Array(await res.arrayBuffer());
+		expect(body.length).toBeGreaterThan(1024);
+		expect(Array.from(body.slice(0, 8))).toEqual([
+			0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		]);
+	});
+
+	it('keeps generated API JSON available from the static dist', async () => {
+		const res = await fetch(`${BASE_URL}/api/icons/python.json/`);
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type')).toContain('application/json');
+
+		const body = (await res.json()) as {
+			ref: string;
+			icons: Array<{ source: string; svg_body: string }>;
+		};
+		expect(body.ref).toBe('python');
+		expect(body.icons.length).toBeGreaterThanOrEqual(2);
+		expect(body.icons.every((icon) => icon.svg_body.includes('<svg'))).toBe(
+			true,
+		);
+	});
+
+	it('serves Astro 404 HTML for missing pages', async () => {
+		const res = await fetch(`${BASE_URL}/missing-rareicon-page`);
+		const body = await res.text();
+
+		expect(res.status).toBe(404);
+		expect(res.headers.get('content-type')).toContain('text/html');
+		expect(body).toContain('RareIcon');
+	});
+});

--- a/apps/rareicon/axum-rareicon/Dockerfile
+++ b/apps/rareicon/axum-rareicon/Dockerfile
@@ -21,6 +21,7 @@ COPY packages/npm/laser/ packages/npm/laser/
 
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 
+COPY apps/rareicon/icons-codegen/ apps/rareicon/icons-codegen/
 COPY apps/rareicon/astro-rareicon/ apps/rareicon/astro-rareicon/
 
 WORKDIR /app/apps/rareicon/astro-rareicon


### PR DESCRIPTION
## Summary
- add Astro RareIcon e2e coverage for catalog API contracts, icon browser filters, and copy controls
- add Axum RareIcon e2e coverage for health/header/static asset behavior
- update RareIcon Starlight sidebar config and Docker build inputs so the test targets boot cleanly

## Validation
- pnpm exec tsc -p apps/rareicon/astro-rareicon-e2e/tsconfig.json --noEmit
- pnpm exec tsc -p apps/rareicon/axum-rareicon-e2e/tsconfig.json --noEmit
- ./kbve.sh -nx astro-rareicon-e2e:e2e
- ./kbve.sh -nx axum-rareicon-e2e:e2e