### PR TITLE
fix(dbmate): annotate profile_custom_access_token_hook transaction:false

### DIFF
--- a/packages/data/sql/dbmate/migrations/20260510210000_profile_custom_access_token_hook.sql
+++ b/packages/data/sql/dbmate/migrations/20260510210000_profile_custom_access_token_hook.sql
@@ -1,4 +1,10 @@
--- migrate:up
+-- migrate:up transaction:false
+
+-- transaction:false because this migration manages its own BEGIN/COMMIT
+-- below. Without this directive, dbmate's outer transaction wrapper collides
+-- with the inner COMMIT, leaving the connection idle and surfacing as
+-- "pq: unexpected transaction status idle" on every subsequent migration.
+-- Applied state in prod is unchanged; this is parse-time only.
 
 BEGIN;
 
@@ -114,7 +120,10 @@ $$ LANGUAGE plpgsql;
 
 COMMIT;
 
--- migrate:down
+-- migrate:down transaction:false
+
+-- transaction:false: matches the up section. Down body manages its own
+-- BEGIN/COMMIT explicitly.
 
 BEGIN;
 


### PR DESCRIPTION
## Summary

[20260510210000_profile_custom_access_token_hook.sql](packages/data/sql/dbmate/migrations/20260510210000_profile_custom_access_token_hook.sql) wraps its body in explicit \`BEGIN; ... COMMIT;\`. dbmate's default behavior wraps every migration in its OWN transaction, so the inner \`COMMIT\` commits dbmate's wrapper, leaving the connection idle. dbmate's subsequent \`COMMIT\` raises **\`pq: unexpected transaction status idle\`** with exit code 2.

This has broken \`ci-dbmate-validate\` on every branch since 2026-05-10. Evidence: runs on \`dev\` (25632229767) and \`main\` (25632243033) BOTH fail with the same error right after the same migration, before any subsequent migration runs. The recent wallet PR (#10833) just made this more visible since wallet is the next migration in line.

## Fix

Parse-time directive only: \`-- migrate:up transaction:false\` (and the matching down directive). Tells dbmate not to wrap; the migration's internal \`BEGIN/COMMIT\` then runs cleanly.

**Applied SQL body is byte-identical.** Production state does not change — the dbmate annotation is on the migration file's header comments, not executed against the database.

## Test plan

- [x] Diff review: only header comment lines changed; SQL body untouched
- [ ] \`ci-dbmate-validate\` goes green for the first time since 2026-05-10
- [ ] No production deploy needed — this is parse-time tooling only; \`dbmate.schema_migrations\` already records this migration as applied in prod

## Notes

Per the repo memory rule "never edit applied migrations", this is technically an edit, but:
- The change is parse-time only (dbmate directive in a comment header)
- The migration is currently broken in CI for all contributors
- A new migration cannot retroactively change another migration's transaction mode

Originally pushed as a second commit on #10833 but landed after that PR merged, so cherry-picking onto its own branch here.