### PR TITLE
fix(astro-irc): wrap autogenerate in items for Starlight 0.39+

### DIFF
--- a/apps/irc/astro-irc/astro.config.mjs
+++ b/apps/irc/astro-irc/astro.config.mjs
@@ -29,7 +29,7 @@ export default defineConfig({
       sidebar: [
         {
           label: 'Guides',
-          autogenerate: { directory: 'guides' },
+          items: [{ autogenerate: { directory: 'guides' } }],
         },
       ],
     }),


### PR DESCRIPTION
## Summary

Starlight 0.39 removed support for autogenerated sidebar groups declared inline on a label entry. The CI Playwright run for \`astro-irc\` died at \`astro sync\`:

\`\`\`
[AstroUserError] Invalid config passed to starlight integration
  Hint:
    Found an \`autogenerate\` object with a \`label\`. Support for
    autogenerated sidebar groups was removed in Starlight v0.39.0.
    You should instead create a group with the desired \`label\` and an
    \`items\` array containing the autogenerate config:

    {
      label: 'Guides',
      items: [{ autogenerate: { \"directory\": \"guides\" } }]
    }
\`\`\`

## Fix

\`\`\`diff
 sidebar: [
   {
     label: 'Guides',
-    autogenerate: { directory: 'guides' },
+    items: [{ autogenerate: { directory: 'guides' } }],
   },
 ],
\`\`\`

## Test plan

- [ ] After merge, \`./kbve.sh -nx astro-irc:build\` succeeds.
- [ ] Playwright \`astro-irc-e2e\` job's webServer step starts cleanly.