### PR TITLE
feat(firecracker): firecracker-python-web rootfs for FastAPI deploys

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -152,6 +152,20 @@
 			"has_test": false
 		},
 		{
+			"key": "firecracker_python_web",
+			"app_name": "firecracker-python-web",
+			"version": "0.0.1",
+			"version_toml": "packages/docker/firecracker/python/web/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-web.mdx",
+			"source_path": "packages/docker/firecracker/python/web",
+			"runner": "ubuntu-latest",
+			"image": "kbve/firecracker-python-web",
+			"deployment_yamls": [
+				"apps/kube/firecracker/manifests/firecracker-web-rootfs-stage.yaml"
+			],
+			"has_test": false
+		},
+		{
 			"key": "herbmail",
 			"app_name": "herbmail",
 			"version": "0.1.1",
@@ -667,7 +681,7 @@
 	"unreal_game": [],
 	"bevy_game": [],
 	"summary": {
-		"docker": 23,
+		"docker": 24,
 		"npm": 4,
 		"crates": 24,
 		"python": 2,
@@ -677,6 +691,6 @@
 		"godot": 0,
 		"unreal_game": 0,
 		"bevy_game": 0,
-		"total": 62
+		"total": 63
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-web.mdx
@@ -1,0 +1,68 @@
+---
+title: Firecracker Python Web
+description: |
+    FastAPI-ready Alpine + Python rootfs for long-lived persistent endpoints deployed through the dashboard IDE. Bakes fastapi, uvicorn, starlette, websockets, and the existing requests/httpx stack so VMs boot with the server libraries already on disk.
+sidebar:
+    label: FC Python Web
+    order: 56
+tags:
+    - docker
+    - firecracker
+    - python
+    - fastapi
+    - base-image
+key: firecracker_python_web
+pipeline: docker
+app_name: firecracker-python-web
+version: "0.0.1"
+version_toml: packages/docker/firecracker/python/web/version.toml
+source_path: packages/docker/firecracker/python/web
+runner: ubuntu-latest
+image: kbve/firecracker-python-web
+deployment_yamls:
+    - apps/kube/firecracker/manifests/firecracker-web-rootfs-stage.yaml
+has_test: false
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+FastAPI-ready Python rootfs used by the **staff-side** Firecracker deployment (`firecracker-ctl-net`). Built as a multi-stage Docker image whose final layer (alpine 3.21 + `/rootfs.ext4`) ships a `cp` entrypoint so the in-cluster stage Job can run the image directly and copy `/rootfs.ext4` onto the firecracker rootfs PVC.
+
+This is the **long-lived deploy** rootfs for endpoints submitted through the dashboard IDE — week-to-month TTL VMs where paying a build-time pip install is the right tradeoff for instant boot. Quick one-shot VMs keep the smaller `alpine-python` rootfs plus the shared pip-cache.
+
+## What's baked in
+
+- Alpine 3.21 + Python 3.12
+- `py3-pip`, `py3-requests`, `py3-httpx`, `py3-urllib3`, `py3-certifi` (apk)
+- `fastapi`, `uvicorn`, `starlette`, `python-multipart`, `email-validator`, `websockets`, `anyio`, `sniffio`, `h11`, `click` (pip, musllinux wheels)
+- `ca-certificates-bundle`, `ca-certificates`, `iproute2`
+- `/etc/resolv.conf` with `1.1.1.1` and `8.8.8.8`
+- `/init` mounts `/proc`, `/sys`, `/dev`, brings up `lo` + `eth0`, then `exec /entrypoint`
+
+## Three ecosystems
+
+| Image | Deployment | Network | DNS | requests baked | FastAPI baked |
+|-------|-----------|---------|-----|----------------|---------------|
+| `alpine-python` | `firecracker-ctl` (public quick) | none | no | no | no |
+| `firecracker-python-net` | `firecracker-ctl-net` (staff, short-lived) | TAP via Gluetun/WireGuard | yes | yes | no |
+| `firecracker-python-web` (this) | `firecracker-ctl-net` (staff, long-lived) | TAP via Gluetun/WireGuard | yes | yes | yes |
+
+## Build
+
+```bash
+npx nx run firecracker-python-web:container
+npx nx run firecracker-python-web:extract
+```
+
+Output: `packages/docker/firecracker/python/web/dist/python-web.ext4`.
+
+## Publish
+
+```bash
+npx nx run firecracker-python-web:container:production
+```
+
+Pushes `ghcr.io/kbve/firecracker-python-web:latest` and `:<version>`.

--- a/apps/kube/firecracker/manifests/firecracker-web-rootfs-stage.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-web-rootfs-stage.yaml
@@ -1,0 +1,60 @@
+# ---------------------------------------------------------------------------
+# firecracker-web-rootfs-stage
+#
+# Stages /var/lib/firecracker/rootfs/firecracker-python-web.ext4 onto the
+# shared `firecracker-rootfs` PVC by running the published
+# ghcr.io/kbve/firecracker-python-web image directly. The image's ENTRYPOINT
+# is `cp` and CMD is the args below — copies /rootfs.ext4 from the image's
+# own filesystem to /dest on the PVC.
+#
+# The image: line below is bumped automatically by utils-post-publish.yml
+# whenever a new version of firecracker-python-web is published. The MDX
+# entry at apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-
+# web.mdx wires this manifest into the dispatch manifest via
+# `deployment_yamls`.
+#
+# Sync hook: hook-delete-policy `BeforeHookCreation` removes the previous
+# Job before each ArgoCD sync so a new image tag re-runs cleanly.
+# ---------------------------------------------------------------------------
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: firecracker-web-rootfs-stage
+    namespace: firecracker
+    labels:
+        app: firecracker-rootfs-init
+    annotations:
+        argocd.argoproj.io/hook: Sync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+    backoffLimit: 3
+    ttlSecondsAfterFinished: 3600
+    template:
+        metadata:
+            labels:
+                app: firecracker-rootfs-init
+        spec:
+            restartPolicy: OnFailure
+            containers:
+                - name: stage
+                  image: ghcr.io/kbve/firecracker-python-web:0.0.1
+                  imagePullPolicy: IfNotPresent
+                  args:
+                      - /rootfs.ext4
+                      - /dest/firecracker-python-web.ext4
+                  resources:
+                      requests:
+                          cpu: 100m
+                          memory: 128Mi
+                      limits:
+                          cpu: 500m
+                          memory: 512Mi
+                  volumeMounts:
+                      - name: rootfs
+                        mountPath: /dest
+                  securityContext:
+                      runAsUser: 0
+            volumes:
+                - name: rootfs
+                  persistentVolumeClaim:
+                      claimName: firecracker-rootfs

--- a/apps/kube/firecracker/manifests/kustomization.yaml
+++ b/apps/kube/firecracker/manifests/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
     - firecracker-vm-init.yaml
     - firecracker-rootfs-init.yaml
     - firecracker-net-rootfs-stage.yaml
+    - firecracker-web-rootfs-stage.yaml
     - firecracker-pip-cache-cronjob.yaml
     - firecracker-deployment.yaml
     - firecracker-service.yaml

--- a/packages/docker/firecracker/python/web/Dockerfile
+++ b/packages/docker/firecracker/python/web/Dockerfile
@@ -1,0 +1,84 @@
+# ============================================================================
+# firecracker-python-web — FastAPI-ready Python rootfs for Firecracker
+#
+# Alpine 3.21 + Python 3.12 + pip-installed FastAPI + uvicorn + Starlette.
+# Output: /rootfs.ext4 (~120 MB) for the firecracker-ctl-net deployment.
+#
+# Bakes on top of the net image's stack:
+#   - python3, py3-pip
+#   - py3-requests, py3-httpx, py3-urllib3, py3-certifi (apk)
+#   - fastapi, uvicorn, starlette, python-multipart, email-validator,
+#     websockets, anyio, sniffio, h11, click (pip, musllinux wheels)
+#   - ca-certificates-bundle, ca-certificates, iproute2
+#   - /etc/resolv.conf with 1.1.1.1 + 8.8.8.8
+#   - init that mounts proc/sys/dev, brings up lo + eth0, exec /entrypoint
+#
+# Pairs with: firecracker-ctl-net (FC_PERSISTENT_ENDPOINTS_ENABLED=true).
+# Use this image for long-lived FastAPI deploys submitted through the
+# dashboard IDE. Quick one-shot VMs keep the smaller alpine-python or
+# pip-cache-driven flow.
+#
+# Final image is a tiny alpine layer with /rootfs.ext4 + a `cp` entrypoint so
+# the in-cluster stage Job (apps/kube/firecracker/manifests/firecracker-
+# web-rootfs-stage.yaml) can run the image directly:
+#   image: ghcr.io/kbve/firecracker-python-web:<version>
+#   args:  ["/rootfs.ext4", "/dest/firecracker-python-web.ext4"]
+# ============================================================================
+
+FROM --platform=linux/amd64 alpine:3.21 AS rootfs-builder
+
+RUN apk add --no-cache e2fsprogs e2fsprogs-extra python3 py3-pip
+
+COPY init.sh /tmp/init.sh
+
+# Stage apk-managed system layer into /rootfs.
+RUN mkdir -p /rootfs/etc/apk && \
+    cp /etc/apk/repositories /rootfs/etc/apk/repositories && \
+    cp -a /etc/apk/keys /rootfs/etc/apk/ && \
+    apk add --root /rootfs --initdb --no-cache \
+        alpine-baselayout \
+        busybox \
+        musl \
+        ca-certificates-bundle \
+        ca-certificates \
+        iproute2 \
+        python3 \
+        py3-pip \
+        py3-requests \
+        py3-httpx \
+        py3-urllib3 \
+        py3-certifi && \
+    mkdir -p /rootfs/{dev,proc,sys,tmp,run,var/log,etc,mnt,app}
+
+# Layer FastAPI stack on top via pip (--target so we don't depend on the
+# guest having writable site-packages or pip at runtime).
+RUN pip3 install --no-cache-dir \
+        --target /rootfs/usr/lib/python3.12/site-packages \
+        --platform musllinux_1_2_x86_64 \
+        --platform musllinux_1_1_x86_64 \
+        --platform any \
+        --python-version 3.12 \
+        --only-binary=:all: \
+        --upgrade \
+        fastapi \
+        uvicorn \
+        starlette \
+        python-multipart \
+        email-validator \
+        websockets \
+        anyio \
+        sniffio \
+        h11 \
+        click
+
+RUN printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /rootfs/etc/resolv.conf && \
+    cp /tmp/init.sh /rootfs/init && \
+    chmod +x /rootfs/init && \
+    dd if=/dev/zero of=/rootfs.ext4 bs=1M count=0 seek=256 && \
+    mkfs.ext4 -F -d /rootfs /rootfs.ext4 && \
+    resize2fs -M /rootfs.ext4
+
+FROM --platform=linux/amd64 alpine:3.21
+COPY --from=rootfs-builder /rootfs.ext4 /rootfs.ext4
+ENTRYPOINT ["/bin/cp"]
+CMD ["/rootfs.ext4", "/dest/firecracker-python-web.ext4"]

--- a/packages/docker/firecracker/python/web/README.md
+++ b/packages/docker/firecracker/python/web/README.md
@@ -1,0 +1,38 @@
+# firecracker-python-web
+
+FastAPI-ready Python rootfs for Firecracker microVMs.
+
+## What's baked
+
+- Alpine 3.21 + Python 3.12
+- `py3-pip`, `py3-requests`, `py3-httpx`, `py3-urllib3`, `py3-certifi` (apk)
+- `fastapi`, `uvicorn`, `starlette`, `python-multipart`, `email-validator`, `websockets`, `anyio`, `sniffio`, `h11`, `click` (pip, musllinux wheels)
+- `ca-certificates-bundle`, `ca-certificates`, `iproute2`
+- `/etc/resolv.conf` with `1.1.1.1` and `8.8.8.8`
+- `/init` that mounts `/proc`, `/sys`, `/dev`, brings up `lo` + `eth0`, then `exec /entrypoint`
+
+## When to use
+
+This image pairs with the **net deployment** (`firecracker-ctl-net`, `FC_PERSISTENT_ENDPOINTS_ENABLED=true`). It is intended for **long-lived FastAPI deploys** submitted through the dashboard IDE — week-to-month TTL endpoints that need the server libraries available immediately at boot, without a per-deploy `pip install` hop.
+
+For short-lived runs or arbitrary dependency sets, the cheaper path is the existing `alpine-python` rootfs plus the shared pip-cache (which now carries `fastapi` + `uvicorn` thanks to #10828). For sandbox quick-mode VMs with no network, keep using the no-network `alpine-python` rootfs.
+
+## Output
+
+- Container image: `ghcr.io/kbve/firecracker-python-web:<version>` (alpine layer carrying `/rootfs.ext4` with a `cp` entrypoint)
+- Extracted ext4 (via `nx run firecracker-python-web:extract`): `dist/python-web.ext4`
+
+## Build
+
+```bash
+npx nx run firecracker-python-web:container
+npx nx run firecracker-python-web:extract
+```
+
+## Publish
+
+```bash
+npx nx run firecracker-python-web:container:production
+```
+
+Pushes `ghcr.io/kbve/firecracker-python-web:latest` and `:<version>`.

--- a/packages/docker/firecracker/python/web/init.sh
+++ b/packages/docker/firecracker/python/web/init.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+mount -t proc proc /proc 2>/dev/null
+mount -t sysfs sys /sys 2>/dev/null
+mount -t devtmpfs dev /dev 2>/dev/null
+mount -t tmpfs tmpfs /tmp 2>/dev/null
+
+ip link set lo up 2>/dev/null
+ip link set eth0 up 2>/dev/null
+
+ENTRYPOINT="/bin/sh"
+for param in $(cat /proc/cmdline); do
+  case "$param" in
+    fc_entrypoint=*) ENTRYPOINT="${param#fc_entrypoint=}" ;;
+  esac
+done
+
+if [ -b /dev/vdc ] && [ -b /dev/vdd ]; then
+  dd if=/dev/vdc of=/tmp/packages.raw bs=4096 2>/dev/null
+  tr -d '\0' < /tmp/packages.raw > /tmp/packages.txt
+
+  mkdir -p /mnt/packages
+  mount -o ro /dev/vdd /mnt/packages 2>/dev/null
+
+  if [ -d /mnt/packages/pip ] && command -v pip3 >/dev/null 2>&1; then
+    pip3 install --no-index --find-links /mnt/packages/pip \
+      $(cat /tmp/packages.txt) 2>/tmp/pkg-install.log || true
+  fi
+
+  umount /mnt/packages 2>/dev/null
+fi
+
+if [ -b /dev/vdb ]; then
+  dd if=/dev/vdb of=/tmp/code.raw bs=4096 2>/dev/null
+  tr -d '\0' < /tmp/code.raw > /tmp/code
+  echo "---FC_OUTPUT_START---"
+  "$ENTRYPOINT" /tmp/code
+  EC=$?
+  echo "---FC_OUTPUT_END---"
+  exit $EC
+fi
+exec /bin/sh

--- a/packages/docker/firecracker/python/web/project.json
+++ b/packages/docker/firecracker/python/web/project.json
@@ -1,0 +1,80 @@
+{
+	"name": "firecracker-python-web",
+	"$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/docker/firecracker/python/web",
+	"targets": {
+		"container": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"npx nx run firecracker-python-web:containerx",
+					"VERSION=$(grep -m1 'version' packages/docker/firecracker/python/web/version.toml | sed 's/.*\"\\(.*\\)\\\"/\\1/') && docker tag ghcr.io/kbve/firecracker-python-web:latest ghcr.io/kbve/firecracker-python-web:${VERSION} && echo \"Tagged ghcr.io/kbve/firecracker-python-web:${VERSION}\""
+				],
+				"parallel": false
+			},
+			"configurations": {
+				"local": {},
+				"production": {
+					"commands": [
+						"npx nx run firecracker-python-web:containerx:production",
+						"VERSION=$(sed -n 's/^version: *\"\\([^\"]*\\)\".*/\\1/p' apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-web.mdx | head -1) && docker tag ghcr.io/kbve/firecracker-python-web:latest ghcr.io/kbve/firecracker-python-web:${VERSION} && docker tag ghcr.io/kbve/firecracker-python-web:latest kbve/firecracker-python-web:${VERSION} && docker tag ghcr.io/kbve/firecracker-python-web:latest kbve/firecracker-python-web:latest && echo \"Daemon tagged :${VERSION} + :latest for both registries\""
+					]
+				}
+			}
+		},
+		"containerx": {
+			"executor": "@nx-tools/nx-container:build",
+			"options": {
+				"engine": "docker",
+				"context": "packages/docker/firecracker/python/web",
+				"file": "packages/docker/firecracker/python/web/Dockerfile",
+				"platforms": ["linux/amd64"],
+				"load": true,
+				"push": false,
+				"tags": ["ghcr.io/kbve/firecracker-python-web:latest"]
+			},
+			"configurations": {
+				"local": {
+					"tags": ["ghcr.io/kbve/firecracker-python-web:latest"]
+				},
+				"production": {
+					"tags": ["ghcr.io/kbve/firecracker-python-web:latest"],
+					"load": true,
+					"push": false,
+					"provenance": "false",
+					"sbom": false
+				}
+			}
+		},
+		"extract": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["container"],
+			"options": {
+				"commands": [
+					"mkdir -p packages/docker/firecracker/python/web/dist",
+					"docker create --name fc-python-web-extract ghcr.io/kbve/firecracker-python-web:latest true > /dev/null 2>&1 || true",
+					"docker cp fc-python-web-extract:/rootfs.ext4 packages/docker/firecracker/python/web/dist/python-web.ext4",
+					"docker rm fc-python-web-extract > /dev/null 2>&1 || true",
+					"echo 'Extracted: packages/docker/firecracker/python/web/dist/python-web.ext4'"
+				],
+				"parallel": false
+			}
+		},
+		"test": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["container"],
+			"options": {
+				"commands": [
+					"echo '=== firecracker-python-web rootfs tests ==='",
+					"docker create --name fc-python-web-test ghcr.io/kbve/firecracker-python-web:latest true > /dev/null 2>&1",
+					"docker export fc-python-web-test | tar -t | grep -q '^rootfs.ext4$' && echo 'PASS: rootfs.ext4 present'",
+					"docker rm fc-python-web-test > /dev/null 2>&1",
+					"echo '=== All firecracker-python-web tests passed ==='"
+				],
+				"parallel": false
+			}
+		}
+	},
+	"tags": ["docker", "base-image", "firecracker", "python", "web"]
+}

--- a/packages/docker/firecracker/python/web/version.toml
+++ b/packages/docker/firecracker/python/web/version.toml
@@ -1,0 +1,2 @@
+[package]
+version = "0.0.1"


### PR DESCRIPTION
## Summary
Dedicated rootfs image (\`firecracker-python-web\`) for long-lived FastAPI endpoints submitted through the dashboard IDE. Sits alongside \`firecracker-python-net\` and bakes the FastAPI stack into the ext4 image so VMs boot with the server libs already on disk — no per-deploy \`pip install\` hop.

## Changes
- New \`packages/docker/firecracker/python/web/\` scaffolds (Dockerfile, init.sh, project.json, version.toml @ 0.0.1, README) following the existing \`net\` shape.
- Dockerfile layers \`fastapi\`, \`uvicorn\`, \`starlette\`, \`python-multipart\`, \`email-validator\`, \`websockets\`, \`anyio\`, \`sniffio\`, \`h11\`, \`click\` into \`/usr/lib/python3.12/site-packages\` via \`pip --target\` with musllinux wheels so the rootfs stays self-contained.
- New \`firecracker-web-rootfs-stage.yaml\` Job mirrors the net stage Job, pinned at \`:0.0.1\` (auto-bumped by \`utils-post-publish\` on each release).
- Wires the manifest into \`kustomization.yaml\` and regenerates \`.github/ci-dispatch-manifest.json\`.

## Ecosystem context
| Image | Deployment | Network | FastAPI baked |
|-------|-----------|---------|---------------|
| \`alpine-python\` | \`firecracker-ctl\` (public quick) | none | no |
| \`firecracker-python-net\` | \`firecracker-ctl-net\` (staff, short-lived) | TAP via Gluetun/WireGuard | no |
| \`firecracker-python-web\` (this) | \`firecracker-ctl-net\` (staff, long-lived) | TAP via Gluetun/WireGuard | yes |

Part 2 of 3 for the dashboard-IDE-driven Firecracker deploy story. PR 1 (#10828) widened the pip-cache. PR 3 mirrors the ecosystem for Node + Fastify.

## Test plan
- [ ] \`nx run firecracker-python-web:container\` builds locally
- [ ] \`nx run firecracker-python-web:test\` passes
- [ ] CI publish workflow tags + pushes \`ghcr.io/kbve/firecracker-python-web:0.0.1\`
- [ ] ArgoCD sync runs \`firecracker-web-rootfs-stage\` and \`firecracker-python-web.ext4\` appears on the \`firecracker-rootfs\` PVC
- [ ] \`POST /fc/deploy\` with \`rootfs: \"firecracker-python-web\"\` and a FastAPI single-file entrypoint boots a VM that serves on the configured port immediately, no pip install delay