### PR TITLE
feat(droid,astro-irc): swRecovery() + drop dead /dashboard nav

### DIFF
--- a/apps/irc/astro-irc/src/components/navigation/NavBar.astro
+++ b/apps/irc/astro-irc/src/components/navigation/NavBar.astro
@@ -77,35 +77,6 @@ const currentPath = Astro.url.pathname;
 				</path>
 			</svg>
 		</a>
-		<a
-			href="/dashboard"
-			class:list={[
-				'nav-link',
-				{ active: currentPath.startsWith('/dashboard') },
-			]}
-			data-astro-prefetch
-			title="Dashboard">
-			<svg
-				class="nav-icon"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round">
-				<rect x="3" y="3" width="7" height="7"></rect><rect
-					x="14"
-					y="3"
-					width="7"
-					height="7">
-				</rect><rect x="14" y="14" width="7" height="7"></rect><rect
-					x="3"
-					y="14"
-					width="7"
-					height="7">
-				</rect>
-			</svg>
-		</a>
 	</div>
 
 	{/* Desktop auth container — skeleton until React hydrates */}

--- a/apps/irc/astro-irc/src/components/navigation/ReactNavBar.tsx
+++ b/apps/irc/astro-irc/src/components/navigation/ReactNavBar.tsx
@@ -22,14 +22,11 @@ import { authBridge, initSupa } from '../../lib/supa';
 import {
 	Home,
 	BookOpen,
-	LayoutDashboard,
 	MessageSquare,
 	LogIn,
 	LogOut,
 	X,
 	User,
-	Settings,
-	UserCircle,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
@@ -46,14 +43,9 @@ const NAV_ITEMS: NavItem[] = [
 	{ label: 'Home', href: '/', icon: Home },
 	{ label: 'Chat', href: '/chat', icon: MessageSquare },
 	{ label: 'Docs', href: '/guides/getting-started', icon: BookOpen },
-	{ label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
 ];
 
-const USER_MENU_ITEMS: NavItem[] = [
-	{ label: 'Profile', href: '/profile', icon: UserCircle },
-	{ label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
-	{ label: 'Settings', href: '/settings', icon: Settings },
-];
+const USER_MENU_ITEMS: NavItem[] = [];
 
 function isActive(href: string, path: string): boolean {
 	if (href === '/') return path === '/' || path === '';

--- a/apps/irc/astro-irc/src/lib/boot.ts
+++ b/apps/irc/astro-irc/src/lib/boot.ts
@@ -3,7 +3,7 @@
 // Call once early (e.g. in a layout or top-level component).
 // After this resolves, window.kbve.ws is available for WebSocket chat.
 
-import { droid } from '@kbve/droid';
+import { droid, swRecovery } from '@kbve/droid';
 import { workerURLs } from './workers';
 import { initSupa } from './supa';
 
@@ -42,7 +42,8 @@ export function bootChat(): Promise<void> {
 	attachDiagnostics();
 
 	_bootPromise = (async () => {
-		// Boot droid (workers) and auth in parallel
+		await swRecovery({ allowedScripts: [], reloadOnCleanup: true });
+
 		const [droidResult] = await Promise.all([
 			droid({ workerURLs, initTimeout: 15_000 }),
 			initSupa(),

--- a/packages/npm/droid/src/index.ts
+++ b/packages/npm/droid/src/index.ts
@@ -5,6 +5,7 @@ export * from './lib/types/bento';
 export * from './lib/types/event-types';
 export * from './lib/types/panel-types';
 export * from './lib/types/ui-event-types';
+export * from './lib/sw-recovery';
 export * from './lib/workers/events';
 export * from './lib/mod/mod-urls';
 export * from './lib/gateway';

--- a/packages/npm/droid/src/lib/sw-recovery.spec.ts
+++ b/packages/npm/droid/src/lib/sw-recovery.spec.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { swRecovery } from './sw-recovery';
+
+type Reg = {
+	scriptURL: string;
+	unregister: ReturnType<typeof vi.fn>;
+};
+
+function makeReg(scriptURL: string, unregisterReturn = true): Reg {
+	return {
+		scriptURL,
+		unregister: vi.fn().mockResolvedValue(unregisterReturn),
+	};
+}
+
+function installNavigator(regs: Reg[]) {
+	const registrations = regs.map((r) => ({
+		active: { scriptURL: r.scriptURL },
+		installing: null,
+		waiting: null,
+		unregister: r.unregister,
+	})) as unknown as ServiceWorkerRegistration[];
+
+	Object.defineProperty(globalThis, 'navigator', {
+		value: {
+			serviceWorker: {
+				getRegistrations: vi.fn().mockResolvedValue(registrations),
+			},
+		},
+		configurable: true,
+		writable: true,
+	});
+}
+
+function installCaches(keys: string[]) {
+	const cacheStore: Record<string, boolean> = Object.fromEntries(
+		keys.map((k) => [k, true]),
+	);
+	(globalThis as unknown as { caches: CacheStorage }).caches = {
+		keys: vi.fn().mockResolvedValue([...keys]),
+		delete: vi.fn(async (key: string) => {
+			const had = !!cacheStore[key];
+			delete cacheStore[key];
+			return had;
+		}),
+		match: vi.fn(),
+		has: vi.fn(),
+		open: vi.fn(),
+	} as unknown as CacheStorage;
+}
+
+function clearGlobals() {
+	delete (globalThis as unknown as { navigator?: unknown }).navigator;
+	delete (globalThis as unknown as { caches?: unknown }).caches;
+}
+
+beforeEach(() => {
+	clearGlobals();
+	vi.spyOn(console, 'info').mockImplementation(vi.fn());
+	vi.spyOn(console, 'warn').mockImplementation(vi.fn());
+});
+
+afterEach(() => {
+	clearGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('swRecovery', () => {
+	it('returns unsupported when navigator has no serviceWorker', async () => {
+		Object.defineProperty(globalThis, 'navigator', {
+			value: {},
+			configurable: true,
+			writable: true,
+		});
+		const result = await swRecovery();
+		expect(result.supported).toBe(false);
+		expect(result.unregistered).toEqual([]);
+	});
+
+	it('unregisters all SWs when allowedScripts is empty', async () => {
+		const stale = makeReg('https://chat.kbve.com/sw.js');
+		const other = makeReg('https://chat.kbve.com/old-sw.js');
+		installNavigator([stale, other]);
+		installCaches(['a', 'b']);
+
+		const result = await swRecovery();
+		expect(result.supported).toBe(true);
+		expect(result.unregistered).toEqual([
+			'https://chat.kbve.com/sw.js',
+			'https://chat.kbve.com/old-sw.js',
+		]);
+		expect(result.keptScripts).toEqual([]);
+		expect(result.cachesCleared).toEqual(['a', 'b']);
+		expect(stale.unregister).toHaveBeenCalledTimes(1);
+		expect(other.unregister).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps SWs whose absolute scriptURL is in allowedScripts', async () => {
+		const keep = makeReg('https://chat.kbve.com/sw.js');
+		const drop = makeReg('https://chat.kbve.com/legacy.js');
+		installNavigator([keep, drop]);
+		installCaches([]);
+
+		const result = await swRecovery({
+			allowedScripts: ['https://chat.kbve.com/sw.js'],
+		});
+		expect(result.keptScripts).toEqual(['https://chat.kbve.com/sw.js']);
+		expect(result.unregistered).toEqual([
+			'https://chat.kbve.com/legacy.js',
+		]);
+		expect(keep.unregister).not.toHaveBeenCalled();
+		expect(drop.unregister).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps SWs whose pathname matches an allowed pathname rule', async () => {
+		const keep = makeReg('https://chat.kbve.com/sw.js');
+		installNavigator([keep]);
+		installCaches([]);
+
+		const result = await swRecovery({
+			allowedScripts: ['/sw.js'],
+		});
+		expect(result.keptScripts).toEqual(['https://chat.kbve.com/sw.js']);
+		expect(keep.unregister).not.toHaveBeenCalled();
+	});
+
+	it('skips cache clearing when clearCaches is false', async () => {
+		installNavigator([makeReg('https://chat.kbve.com/old.js')]);
+		installCaches(['x']);
+
+		const result = await swRecovery({ clearCaches: false });
+		expect(result.cachesCleared).toEqual([]);
+	});
+
+	it('does not reload when nothing was removed', async () => {
+		installNavigator([]);
+		installCaches([]);
+
+		const reload = vi.fn();
+		Object.defineProperty(globalThis, 'window', {
+			value: { location: { reload } },
+			configurable: true,
+			writable: true,
+		});
+
+		const result = await swRecovery({ reloadOnCleanup: true });
+		expect(result.reloaded).toBe(false);
+		expect(reload).not.toHaveBeenCalled();
+	});
+
+	it('continues when an individual unregister rejects', async () => {
+		const ok = makeReg('https://chat.kbve.com/a.js');
+		const bad: Reg = {
+			scriptURL: 'https://chat.kbve.com/b.js',
+			unregister: vi.fn().mockRejectedValue(new Error('boom')),
+		};
+		installNavigator([ok, bad]);
+		installCaches([]);
+
+		const result = await swRecovery();
+		expect(result.unregistered).toEqual(['https://chat.kbve.com/a.js']);
+		expect(ok.unregister).toHaveBeenCalled();
+		expect(bad.unregister).toHaveBeenCalled();
+	});
+});

--- a/packages/npm/droid/src/lib/sw-recovery.ts
+++ b/packages/npm/droid/src/lib/sw-recovery.ts
@@ -1,0 +1,141 @@
+export interface SwRecoveryOptions {
+	allowedScripts?: readonly string[];
+	clearCaches?: boolean;
+	reloadOnCleanup?: boolean;
+	logPrefix?: string;
+}
+
+export interface SwRecoveryResult {
+	supported: boolean;
+	unregistered: string[];
+	keptScripts: string[];
+	cachesCleared: string[];
+	reloaded: boolean;
+}
+
+const DEFAULT_OPTS: Required<Omit<SwRecoveryOptions, 'allowedScripts'>> & {
+	allowedScripts: readonly string[];
+} = {
+	allowedScripts: [],
+	clearCaches: true,
+	reloadOnCleanup: false,
+	logPrefix: '[sw-recovery]',
+};
+
+function getScriptURL(reg: ServiceWorkerRegistration): string | null {
+	return (
+		reg.active?.scriptURL ??
+		reg.installing?.scriptURL ??
+		reg.waiting?.scriptURL ??
+		null
+	);
+}
+
+function scriptIsAllowed(
+	scriptURL: string | null,
+	allowed: readonly string[],
+): boolean {
+	if (!scriptURL) return false;
+	if (allowed.length === 0) return false;
+	return allowed.some((rule) => {
+		if (rule === scriptURL) return true;
+		try {
+			return new URL(scriptURL).pathname === rule;
+		} catch {
+			return false;
+		}
+	});
+}
+
+export async function swRecovery(
+	opts: SwRecoveryOptions = {},
+): Promise<SwRecoveryResult> {
+	const cfg = { ...DEFAULT_OPTS, ...opts };
+	const result: SwRecoveryResult = {
+		supported: false,
+		unregistered: [],
+		keptScripts: [],
+		cachesCleared: [],
+		reloaded: false,
+	};
+
+	if (
+		typeof navigator === 'undefined' ||
+		!('serviceWorker' in navigator) ||
+		typeof navigator.serviceWorker?.getRegistrations !== 'function'
+	) {
+		return result;
+	}
+
+	result.supported = true;
+
+	let registrations: ServiceWorkerRegistration[] = [];
+	try {
+		registrations = await navigator.serviceWorker.getRegistrations();
+	} catch (err) {
+		console.warn(`${cfg.logPrefix} getRegistrations failed:`, err);
+		return result;
+	}
+
+	for (const reg of registrations) {
+		const scriptURL = getScriptURL(reg);
+		if (scriptIsAllowed(scriptURL, cfg.allowedScripts)) {
+			result.keptScripts.push(scriptURL as string);
+			continue;
+		}
+
+		try {
+			const ok = await reg.unregister();
+			if (ok) {
+				result.unregistered.push(scriptURL ?? '<unknown>');
+			}
+		} catch (err) {
+			console.warn(
+				`${cfg.logPrefix} unregister failed for ${scriptURL}:`,
+				err,
+			);
+		}
+	}
+
+	if (cfg.clearCaches && typeof caches !== 'undefined') {
+		try {
+			const keys = await caches.keys();
+			for (const key of keys) {
+				try {
+					const ok = await caches.delete(key);
+					if (ok) result.cachesCleared.push(key);
+				} catch (err) {
+					console.warn(
+						`${cfg.logPrefix} cache delete failed for ${key}:`,
+						err,
+					);
+				}
+			}
+		} catch (err) {
+			console.warn(`${cfg.logPrefix} caches.keys failed:`, err);
+		}
+	}
+
+	const removedAnything =
+		result.unregistered.length > 0 || result.cachesCleared.length > 0;
+
+	if (removedAnything) {
+		console.info(`${cfg.logPrefix} cleaned`, {
+			unregistered: result.unregistered,
+			kept: result.keptScripts,
+			caches: result.cachesCleared,
+		});
+	}
+
+	if (
+		cfg.reloadOnCleanup &&
+		removedAnything &&
+		typeof window !== 'undefined' &&
+		typeof window.location?.reload === 'function'
+	) {
+		result.reloaded = true;
+		window.location.reload();
+	}
+
+	return result;
+}


### PR DESCRIPTION
## Summary
- New shared helper \`swRecovery()\` on \`@kbve/droid\` so any KBVE Astro site can unregister stale/broken service workers (and clear their caches) on boot, instead of every site re-implementing the same defensive snippet.
- Wire it into chat.kbve.com's boot to heal browsers that still carry a service worker from an older deploy.
- Drop the dead \`/dashboard\`, \`/profile\`, \`/settings\` nav entries on chat.kbve.com — those routes don't exist, but \`prefetch: true\` was firing requests for them on every visit and hitting whichever stale SW happened to be alive (the recent \`FetchEvent.respondWith received an error: request-not-in-cache\` log).

## Why ecosystem-wide?
A stale SW from a previous deploy isn't a chat-only problem; any site that ever shipped a SW and stopped shipping one risks the same ghost. Putting recovery in the droid package means kbve.com, herbmail, memes, discordsh etc. can just call it from their boot too.

## API
\`\`\`ts
import { swRecovery } from '@kbve/droid';

await swRecovery({
  allowedScripts: [],      // empty = wipe everything; pass URLs/pathnames to keep
  clearCaches: true,       // default
  reloadOnCleanup: true,   // reload only if something was actually removed
  logPrefix: '[sw-recovery]',
});
\`\`\`

Returns \`{ supported, unregistered[], keptScripts[], cachesCleared[], reloaded }\`. Safe to call repeatedly; safe in SSR (\`supported: false\` when no navigator/serviceWorker). Each step is wrapped in try/catch with \`console.warn\` so a partial failure can't break boot.

## Tests
- \`packages/npm/droid/src/lib/sw-recovery.spec.ts\` — 7 vitest cases:
  - unsupported env (no navigator.serviceWorker)
  - full wipe when allowedScripts is empty
  - absolute scriptURL allowlist match
  - pathname-only allowlist match
  - clearCaches=false skips caches.delete
  - reloadOnCleanup is a no-op when nothing was removed
  - one unregister rejection doesn't abort the others
- \`npx vitest run --config packages/npm/droid/vite.config.ts\` → 13 files, 118 tests pass

## Chat-site changes
- \`apps/irc/astro-irc/src/lib/boot.ts\` — \`await swRecovery({ allowedScripts: [], reloadOnCleanup: true })\` ahead of droid + auth.
- \`apps/irc/astro-irc/src/components/navigation/NavBar.astro\` — remove dead Dashboard link.
- \`apps/irc/astro-irc/src/components/navigation/ReactNavBar.tsx\` — remove Dashboard / Profile / Settings entries and unused lucide imports.

## Test plan
- [ ] In a browser that previously hit chat.kbve.com with the stale SW, load /chat once after deploy; expect a single recovery reload, no \`request-not-in-cache\` rejection on next load.
- [ ] Fresh browser: no console noise, no extra reload.
- [ ] Network panel on /chat: no requests for /dashboard, /profile, /settings.
- [ ] When a real PWA SW ships in the future, pass its scriptURL in \`allowedScripts\` to whitelist it.