### PR TITLE
feat(firecracker): npm package cache for node rootfs

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-npm-cache-cronjob.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-npm-cache-cronjob.yaml
@@ -1,0 +1,100 @@
+# CronJob: refreshes the npm package cache (npm-cache.ext4) weekly.
+# Resolves the latest Fastify stack into a pre-built node_modules tree
+# and rebuilds the ext4 image. Mirrors the pip-cache pattern so node
+# VMs install offline at boot via `cp -r /mnt/packages/node_modules`.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+    name: firecracker-npm-cache-refresh
+    namespace: firecracker
+    labels:
+        app: firecracker-npm-cache
+spec:
+    schedule: '15 4 * * 0' # Weekly: Sunday 04:15 UTC (offset 15min from pip refresh)
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 3
+    jobTemplate:
+        spec:
+            backoffLimit: 2
+            ttlSecondsAfterFinished: 86400
+            template:
+                metadata:
+                    labels:
+                        # Reuse the rootfs-init label for network policy egress
+                        app: firecracker-rootfs-init
+                spec:
+                    restartPolicy: OnFailure
+                    containers:
+                        - name: npm-refresh
+                          image: alpine:3.21
+                          securityContext:
+                              runAsUser: 0
+                          command: ['/bin/sh', '-c']
+                          args:
+                              - |
+                                  set -eu
+                                  OUTPUT="/rootfs"
+                                  TARGET="${OUTPUT}/npm-cache.ext4"
+
+                                  echo "=== Npm cache refresh ==="
+
+                                  apk add --no-cache nodejs npm e2fsprogs
+
+                                  NPMCACHE=$(mktemp -d)
+                                  cd "${NPMCACHE}"
+
+                                  PACKAGES=$(grep -v '^\s*$' /npm-packages/packages.txt | tr '\n' ' ')
+                                  echo "Resolving: ${PACKAGES}"
+
+                                  # Bootstrap a throwaway project and install everything into it.
+                                  # The resulting node_modules tree is what gets shipped on the
+                                  # ext4 — at runtime the VM cp's it into /usr/lib/node_modules
+                                  # so `require('fastify')` resolves without a registry hop.
+                                  npm init -y > /dev/null
+                                  npm install --no-audit --no-fund --omit=dev --prefer-online ${PACKAGES} 2>&1 || \
+                                  npm install --no-audit --no-fund --omit=dev ${PACKAGES} 2>&1 || true
+
+                                  if [ ! -d "${NPMCACHE}/node_modules" ]; then
+                                      echo "WARNING: node_modules not produced, keeping existing cache"
+                                      rm -rf "${NPMCACHE}"
+                                      exit 0
+                                  fi
+
+                                  PKG_COUNT=$(ls -1 "${NPMCACHE}/node_modules" 2>/dev/null | wc -l)
+                                  echo "Resolved ${PKG_COUNT} top-level package entries"
+
+                                  # Stage just the node_modules dir into a clean parent so the
+                                  # ext4 layout is /node_modules at the root and nothing else.
+                                  STAGE=$(mktemp -d)
+                                  mv "${NPMCACHE}/node_modules" "${STAGE}/node_modules"
+
+                                  # Atomic-swap build: temp file, then mv.
+                                  TMPIMG=$(mktemp -p "${OUTPUT}" npm-cache.XXXXXX)
+                                  dd if=/dev/zero of="${TMPIMG}" bs=1M count=0 seek=384 2>/dev/null
+                                  mkfs.ext4 -F -d "${STAGE}" "${TMPIMG}"
+                                  mv "${TMPIMG}" "${TARGET}"
+
+                                  rm -rf "${NPMCACHE}" "${STAGE}"
+                                  echo "npm-cache.ext4 refreshed: $(du -h ${TARGET} | cut -f1) (${PKG_COUNT} packages)"
+                                  echo "=== Done ==="
+                          resources:
+                              requests:
+                                  cpu: 250m
+                                  memory: 512Mi
+                              limits:
+                                  cpu: 500m
+                                  memory: 1Gi
+                          volumeMounts:
+                              - name: rootfs
+                                mountPath: /rootfs
+                              - name: npm-packages
+                                mountPath: /npm-packages
+                                readOnly: true
+                    volumes:
+                        - name: rootfs
+                          persistentVolumeClaim:
+                              claimName: firecracker-rootfs
+                        - name: npm-packages
+                          configMap:
+                              name: firecracker-npm-packages

--- a/apps/kube/firecracker/manifests/firecracker-npm-packages.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-npm-packages.yaml
@@ -1,0 +1,35 @@
+# Package list for the firecracker npm cache.
+# Consumed by both the rootfs init job (first build) and the weekly
+# refresh CronJob. Updating this list + bumping the init job version
+# (v10 → v11) triggers a rebuild on next ArgoCD sync.
+#
+# Selection criteria:
+#   - Useful for a Node code playground (web servers, HTTP clients, CLIs)
+#   - Pure-JS or pre-built native binaries that work on musl/alpine
+#   - Stable, widely-used libraries
+#
+# Skipped (musl native build issues or too heavy):
+#   - sharp, canvas — large native deps, build-from-source on alpine
+#   - puppeteer — pulls Chromium, way too big
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: firecracker-npm-packages
+    namespace: firecracker
+    labels:
+        app: firecracker-ctl
+data:
+    packages.txt: |
+        fastify
+        @fastify/cors
+        @fastify/helmet
+        @fastify/static
+        undici
+        zod
+        pino
+        pino-pretty
+        dotenv
+        nanoid
+        date-fns
+        commander
+        chalk

--- a/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-rootfs-init.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: firecracker-rootfs-init-v10
+    name: firecracker-rootfs-init-v11
     namespace: firecracker
     labels:
         app: firecracker-rootfs-init
@@ -101,11 +101,11 @@ spec:
 
                           # --- pip package cache ---
                           # Reads package list from ConfigMap (firecracker-pip-packages).
-                          # Rebuild triggered when init job name is bumped (v9 → v10).
+                          # Rebuild triggered when init job name is bumped (v10 → v11).
                           # NOTE: firecracker-python-net.ext4 is staged by a
                           # dedicated Job (firecracker-net-rootfs-stage.yaml)
                           # that runs the published GHCR image directly.
-                          echo "[5/5] pip-cache..."
+                          echo "[5/6] pip-cache..."
                           # Bumping the init job name forces a pip-cache rebuild
                           # so that newly added entries in firecracker-pip-packages
                           # land without waiting for the weekly refresh CronJob.
@@ -137,6 +137,39 @@ spec:
                               echo "  pip-cache.ext4 already exists, skipping"
                           fi
 
+                          # --- npm package cache ---
+                          # Reads package list from ConfigMap (firecracker-npm-packages).
+                          # Builds a pre-resolved node_modules tree and ships it as the
+                          # ext4 root. VMs cp this into /usr/lib/node_modules at boot
+                          # so `require('fastify')` resolves without a registry hop.
+                          echo "[6/6] npm-cache..."
+                          rm -f "${OUTPUT}/npm-cache.ext4"
+                          if [ ! -f "${OUTPUT}/npm-cache.ext4" ]; then
+                              apk add --no-cache nodejs npm
+                              NPMCACHE=$(mktemp -d)
+                              cd "${NPMCACHE}"
+                              NPM_PACKAGES=$(grep -v '^\s*$' /npm-packages/packages.txt | tr '\n' ' ')
+                              echo "  Resolving: ${NPM_PACKAGES}"
+                              npm init -y > /dev/null
+                              npm install --no-audit --no-fund --omit=dev --prefer-online ${NPM_PACKAGES} 2>&1 || \
+                              npm install --no-audit --no-fund --omit=dev ${NPM_PACKAGES} 2>&1 || true
+                              if [ -d "${NPMCACHE}/node_modules" ]; then
+                                  STAGE=$(mktemp -d)
+                                  mv "${NPMCACHE}/node_modules" "${STAGE}/node_modules"
+                                  PKG_COUNT=$(ls -1 "${STAGE}/node_modules" 2>/dev/null | wc -l)
+                                  dd if=/dev/zero of="${OUTPUT}/npm-cache.ext4" bs=1M count=0 seek=384 2>/dev/null
+                                  mkfs.ext4 -F -d "${STAGE}" "${OUTPUT}/npm-cache.ext4"
+                                  echo "  npm-cache.ext4: $(du -h ${OUTPUT}/npm-cache.ext4 | cut -f1) (${PKG_COUNT} packages)"
+                                  rm -rf "${STAGE}"
+                              else
+                                  echo "  WARNING: node_modules not produced, skipping npm-cache"
+                              fi
+                              rm -rf "${NPMCACHE}"
+                              cd /
+                          else
+                              echo "  npm-cache.ext4 already exists, skipping"
+                          fi
+
                           echo "=== Done ==="
                           ls -lh "${OUTPUT}/"
                   resources:
@@ -155,6 +188,9 @@ spec:
                       - name: pip-packages
                         mountPath: /pip-packages
                         readOnly: true
+                      - name: npm-packages
+                        mountPath: /npm-packages
+                        readOnly: true
             volumes:
                 - name: rootfs
                   persistentVolumeClaim:
@@ -165,3 +201,6 @@ spec:
                 - name: pip-packages
                   configMap:
                       name: firecracker-pip-packages
+                - name: npm-packages
+                  configMap:
+                      name: firecracker-npm-packages

--- a/apps/kube/firecracker/manifests/firecracker-vm-init.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-vm-init.yaml
@@ -31,6 +31,13 @@ data:
           if [ -d /mnt/packages/pip ] && command -v pip3 >/dev/null 2>&1; then
             pip3 install --no-index --find-links /mnt/packages/pip \
               $(cat /tmp/packages.txt) 2>/tmp/pkg-install.log || true
+          elif [ -d /mnt/packages/node_modules ] && command -v node >/dev/null 2>&1; then
+            # Node path: copy the prebuilt node_modules tree into the guest's
+            # global module path so `require('fastify')` resolves without a
+            # registry hop. /tmp is tmpfs; /usr/lib persists for the VM lifetime.
+            mkdir -p /usr/lib/node_modules
+            cp -r /mnt/packages/node_modules/. /usr/lib/node_modules/ 2>/tmp/pkg-install.log || true
+            export NODE_PATH=/usr/lib/node_modules
           fi
 
           umount /mnt/packages 2>/dev/null

--- a/apps/kube/firecracker/manifests/kustomization.yaml
+++ b/apps/kube/firecracker/manifests/kustomization.yaml
@@ -15,10 +15,12 @@ resources:
     - firecracker-networkpolicy.yaml
     - firecracker-seccomp.yaml
     - firecracker-pip-packages.yaml
+    - firecracker-npm-packages.yaml
     - firecracker-vm-init.yaml
     - firecracker-rootfs-init.yaml
     - firecracker-net-rootfs-stage.yaml
     - firecracker-pip-cache-cronjob.yaml
+    - firecracker-npm-cache-cronjob.yaml
     - firecracker-deployment.yaml
     - firecracker-service.yaml
     - firecracker-keda.yaml

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -1147,15 +1147,26 @@ async fn run_vm_lifecycle(
         Some(buf)
     };
 
-    // Resolve the pip package cache ext4 image path.
-    // Only python rootfs images get the pip cache attached.
-    let pkg_cache_path = if pkg_buf.is_some() && req.rootfs.contains("python") {
-        let path = format!("{}/pip-cache.ext4", rootfs_dir);
-        if tokio::fs::try_exists(&path).await.unwrap_or(false) {
-            Some(path)
+    // Resolve the package cache ext4 image path based on rootfs flavour.
+    // Python rootfs → pip-cache.ext4; node rootfs → npm-cache.ext4.
+    let pkg_cache_path = if pkg_buf.is_some() {
+        let (label, filename) = if req.rootfs.contains("python") {
+            ("pip", "pip-cache.ext4")
+        } else if req.rootfs.contains("node") {
+            ("npm", "npm-cache.ext4")
         } else {
-            tracing::warn!("pip-cache.ext4 not found, skipping package install");
+            ("", "")
+        };
+        if filename.is_empty() {
             None
+        } else {
+            let path = format!("{}/{}", rootfs_dir, filename);
+            if tokio::fs::try_exists(&path).await.unwrap_or(false) {
+                Some(path)
+            } else {
+                tracing::warn!("{filename} not found, skipping {label} package install");
+                None
+            }
         }
     } else {
         None


### PR DESCRIPTION
## Summary
Mirrors the pip-cache flow for Node so VMs booted from the \`alpine-node\` rootfs can install \`fastify\` / \`undici\` / \`zod\` / etc. offline at first boot via the prebuilt \`npm-cache.ext4\` drive attached automatically by firecracker-ctl.

## Changes
- **\`firecracker-npm-packages\` ConfigMap** with the Fastify stack and a handful of commonly-useful libraries (zod, pino, dotenv, undici, date-fns, etc.).
- **\`firecracker-npm-cache-refresh\` CronJob**, Sunday 04:15 UTC, builds a fresh \`node_modules\` tree and atomic-swaps \`npm-cache.ext4\`.
- **\`firecracker-rootfs-init\`** bumps v10 → v11 and grows a sixth step that resolves the npm package set and builds the cache image alongside the existing pip-cache step. ConfigMap mounted under \`/npm-packages\`.
- **\`firecracker-vm-init\` init.sh** now picks the package manager from the mounted \`/mnt/packages\` tree: pip flow when \`/mnt/packages/pip\` exists and \`pip3\` is on PATH, node flow when \`/mnt/packages/node_modules\` is present and \`node\` is on PATH (\`cp -r\` into \`/usr/lib/node_modules\`, exports \`NODE_PATH\` so \`require()\` resolves).
- **firecracker-ctl** \`pkg_cache_path\` branch now attaches \`pip-cache.ext4\` for python rootfs and \`npm-cache.ext4\` for node rootfs, with the same missing-file warning shape for either flavour.

## PR plan recap
- #10828 — PR 1: extend pip-cache (fastapi/uvicorn) ✅
- #10842 — PR 2: \`firecracker-python-web\` image (FastAPI baked) ✅
- This — PR 3a: npm-cache infra
- Pending — PR 3b: \`firecracker-node-web\` image (Fastify baked)

## Test plan
- [ ] ArgoCD sync runs \`firecracker-rootfs-init-v11\` and the npm-cache log shows fastify + friends resolved
- [ ] \`ls -lh /var/lib/firecracker/rootfs/\` on the controller shows \`npm-cache.ext4\` next to \`pip-cache.ext4\`
- [ ] \`POST /fc/deploy\` with \`rootfs: \"alpine-node\"\` and \`packages: [\"fastify\"]\` boots a VM that exposes a Fastify HTTP server on the requested port
- [ ] Weekly \`firecracker-npm-cache-refresh\` CronJob picks up new packages on the next Sunday run