### PR TITLE
feat(firecracker): firecracker-node-web rootfs for Fastify deploys

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.148",
+			"version": "1.0.149",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -138,6 +138,20 @@
 			"has_test": false
 		},
 		{
+			"key": "firecracker_node_web",
+			"app_name": "firecracker-node-web",
+			"version": "0.0.1",
+			"version_toml": "packages/docker/firecracker/node/web/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-web.mdx",
+			"source_path": "packages/docker/firecracker/node/web",
+			"runner": "ubuntu-latest",
+			"image": "kbve/firecracker-node-web",
+			"deployment_yamls": [
+				"apps/kube/firecracker/manifests/firecracker-node-web-rootfs-stage.yaml"
+			],
+			"has_test": false
+		},
+		{
 			"key": "firecracker_python_net",
 			"app_name": "firecracker-python-net",
 			"version": "0.1.3",
@@ -194,7 +208,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.15",
+			"version": "0.1.16",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",
@@ -681,7 +695,7 @@
 	"unreal_game": [],
 	"bevy_game": [],
 	"summary": {
-		"docker": 24,
+		"docker": 25,
 		"npm": 4,
 		"crates": 24,
 		"python": 2,
@@ -691,6 +705,6 @@
 		"godot": 0,
 		"unreal_game": 0,
 		"bevy_game": 0,
-		"total": 63
+		"total": 64
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-web.mdx
@@ -1,0 +1,69 @@
+---
+title: Firecracker Node Web
+description: |
+    Fastify-ready Alpine + Node 22 rootfs for long-lived persistent endpoints deployed through the dashboard IDE. Bakes fastify, undici, zod, pino, and the @fastify ecosystem so VMs boot with the server libraries already on disk.
+sidebar:
+    label: FC Node Web
+    order: 57
+tags:
+    - docker
+    - firecracker
+    - node
+    - fastify
+    - base-image
+key: firecracker_node_web
+pipeline: docker
+app_name: firecracker-node-web
+version: "0.0.1"
+version_toml: packages/docker/firecracker/node/web/version.toml
+source_path: packages/docker/firecracker/node/web
+runner: ubuntu-latest
+image: kbve/firecracker-node-web
+deployment_yamls:
+    - apps/kube/firecracker/manifests/firecracker-node-web-rootfs-stage.yaml
+has_test: false
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+Fastify-ready Node rootfs used by the **staff-side** Firecracker deployment (`firecracker-ctl-net`). Built as a multi-stage Docker image whose final layer (alpine 3.21 + `/rootfs.ext4`) ships a `cp` entrypoint so the in-cluster stage Job can run the image directly and copy `/rootfs.ext4` onto the firecracker rootfs PVC.
+
+This is the **long-lived deploy** rootfs for Node endpoints submitted through the dashboard IDE — week-to-month TTL VMs where paying a build-time `npm install` is the right tradeoff for instant boot. Quick one-shot Node VMs keep the smaller `alpine-node` rootfs plus the shared `npm-cache.ext4` drive.
+
+## What's baked in
+
+- Alpine 3.21 + Node.js 22 LTS + npm
+- `fastify`, `@fastify/cors`, `@fastify/helmet`, `@fastify/static`, `undici`, `zod`, `pino`, `pino-pretty`, `dotenv`, `nanoid`, `date-fns`, `commander`, `chalk` resolved into `/usr/lib/node_modules`
+- `ca-certificates-bundle`, `ca-certificates`, `iproute2`
+- `/etc/resolv.conf` with `1.1.1.1` and `8.8.8.8`
+- `/init` mounts `/proc`, `/sys`, `/dev`, brings up `lo` + `eth0`, exports `NODE_PATH=/usr/lib/node_modules`, then `exec /entrypoint`
+
+## Ecosystem
+
+| Image | Runtime | Deployment | Network | Server lib baked |
+|-------|---------|-----------|---------|------------------|
+| `alpine-python` | Python | `firecracker-ctl` (public quick) | none | no |
+| `alpine-node` | Node | `firecracker-ctl` (public quick) | none | no |
+| `firecracker-python-net` | Python | `firecracker-ctl-net` (staff, short-lived) | TAP via Gluetun/WireGuard | requests/httpx |
+| `firecracker-python-web` | Python | `firecracker-ctl-net` (staff, long-lived) | TAP via Gluetun/WireGuard | FastAPI |
+| `firecracker-node-web` (this) | Node | `firecracker-ctl-net` (staff, long-lived) | TAP via Gluetun/WireGuard | Fastify |
+
+## Build
+
+```bash
+npx nx run firecracker-node-web:container
+npx nx run firecracker-node-web:extract
+```
+
+Output: `packages/docker/firecracker/node/web/dist/node-web.ext4`.
+
+## Publish
+
+```bash
+npx nx run firecracker-node-web:container:production
+```
+
+Pushes `ghcr.io/kbve/firecracker-node-web:latest` and `:<version>`.

--- a/apps/kube/firecracker/manifests/firecracker-node-web-rootfs-stage.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-node-web-rootfs-stage.yaml
@@ -1,0 +1,60 @@
+# ---------------------------------------------------------------------------
+# firecracker-node-web-rootfs-stage
+#
+# Stages /var/lib/firecracker/rootfs/firecracker-node-web.ext4 onto the
+# shared `firecracker-rootfs` PVC by running the published
+# ghcr.io/kbve/firecracker-node-web image directly. The image's ENTRYPOINT
+# is `cp` and CMD is the args below — copies /rootfs.ext4 from the image's
+# own filesystem to /dest on the PVC.
+#
+# The image: line below is bumped automatically by utils-post-publish.yml
+# whenever a new version of firecracker-node-web is published. The MDX
+# entry at apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-
+# web.mdx wires this manifest into the dispatch manifest via
+# `deployment_yamls`.
+#
+# Sync hook: hook-delete-policy `BeforeHookCreation` removes the previous
+# Job before each ArgoCD sync so a new image tag re-runs cleanly.
+# ---------------------------------------------------------------------------
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: firecracker-node-web-rootfs-stage
+    namespace: firecracker
+    labels:
+        app: firecracker-rootfs-init
+    annotations:
+        argocd.argoproj.io/hook: Sync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+    backoffLimit: 3
+    ttlSecondsAfterFinished: 3600
+    template:
+        metadata:
+            labels:
+                app: firecracker-rootfs-init
+        spec:
+            restartPolicy: OnFailure
+            containers:
+                - name: stage
+                  image: ghcr.io/kbve/firecracker-node-web:0.0.1
+                  imagePullPolicy: IfNotPresent
+                  args:
+                      - /rootfs.ext4
+                      - /dest/firecracker-node-web.ext4
+                  resources:
+                      requests:
+                          cpu: 100m
+                          memory: 128Mi
+                      limits:
+                          cpu: 500m
+                          memory: 512Mi
+                  volumeMounts:
+                      - name: rootfs
+                        mountPath: /dest
+                  securityContext:
+                      runAsUser: 0
+            volumes:
+                - name: rootfs
+                  persistentVolumeClaim:
+                      claimName: firecracker-rootfs

--- a/apps/kube/firecracker/manifests/kustomization.yaml
+++ b/apps/kube/firecracker/manifests/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
     - firecracker-rootfs-init.yaml
     - firecracker-net-rootfs-stage.yaml
     - firecracker-web-rootfs-stage.yaml
+    - firecracker-node-web-rootfs-stage.yaml
     - firecracker-pip-cache-cronjob.yaml
     - firecracker-npm-cache-cronjob.yaml
     - firecracker-deployment.yaml

--- a/packages/docker/firecracker/node/web/Dockerfile
+++ b/packages/docker/firecracker/node/web/Dockerfile
@@ -1,0 +1,79 @@
+# ============================================================================
+# firecracker-node-web — Fastify-ready Node rootfs for Firecracker
+#
+# Alpine 3.21 + Node.js 22 LTS + npm-installed Fastify stack baked into
+# /usr/lib/node_modules so `require('fastify')` resolves at boot without
+# the runtime needing to mount the npm-cache drive.
+#
+# Bakes:
+#   - nodejs, npm (apk)
+#   - fastify, @fastify/cors, @fastify/helmet, @fastify/static, undici,
+#     zod, pino, pino-pretty, dotenv, nanoid, date-fns, commander, chalk
+#   - ca-certificates-bundle, ca-certificates, iproute2
+#   - /etc/resolv.conf with 1.1.1.1 + 8.8.8.8
+#   - init that mounts proc/sys/dev, brings up lo + eth0, exec /entrypoint
+#
+# Pairs with: firecracker-ctl-net (FC_PERSISTENT_ENDPOINTS_ENABLED=true).
+# Use this image for long-lived Fastify deploys submitted through the
+# dashboard IDE. Short-lived Node VMs keep the smaller alpine-node rootfs
+# and pull from the shared npm-cache.ext4 at boot.
+#
+# Final image is a tiny alpine layer with /rootfs.ext4 + a `cp` entrypoint so
+# the in-cluster stage Job (apps/kube/firecracker/manifests/firecracker-
+# node-web-rootfs-stage.yaml) can run the image directly:
+#   image: ghcr.io/kbve/firecracker-node-web:<version>
+#   args:  ["/rootfs.ext4", "/dest/firecracker-node-web.ext4"]
+# ============================================================================
+
+FROM --platform=linux/amd64 alpine:3.21 AS rootfs-builder
+
+RUN apk add --no-cache e2fsprogs e2fsprogs-extra nodejs npm
+
+COPY init.sh /tmp/init.sh
+
+# Stage apk-managed system layer into /rootfs.
+RUN mkdir -p /rootfs/etc/apk && \
+    cp /etc/apk/repositories /rootfs/etc/apk/repositories && \
+    cp -a /etc/apk/keys /rootfs/etc/apk/ && \
+    apk add --root /rootfs --initdb --no-cache \
+        alpine-baselayout \
+        busybox \
+        musl \
+        ca-certificates-bundle \
+        ca-certificates \
+        iproute2 \
+        nodejs \
+        npm && \
+    mkdir -p /rootfs/{dev,proc,sys,tmp,run,var/log,etc,mnt,app,usr/lib/node_modules}
+
+# Resolve the Fastify stack into /usr/lib/node_modules so `require()`
+# inside the guest works without any /mnt/packages mount step.
+RUN cd /tmp && npm init -y > /dev/null && \
+    npm install --no-audit --no-fund --omit=dev --prefer-online \
+        fastify \
+        @fastify/cors \
+        @fastify/helmet \
+        @fastify/static \
+        undici \
+        zod \
+        pino \
+        pino-pretty \
+        dotenv \
+        nanoid \
+        date-fns \
+        commander \
+        chalk && \
+    cp -a /tmp/node_modules/. /rootfs/usr/lib/node_modules/ && \
+    rm -rf /tmp/node_modules /tmp/package.json /tmp/package-lock.json
+
+RUN printf 'nameserver 1.1.1.1\nnameserver 8.8.8.8\n' > /rootfs/etc/resolv.conf && \
+    cp /tmp/init.sh /rootfs/init && \
+    chmod +x /rootfs/init && \
+    dd if=/dev/zero of=/rootfs.ext4 bs=1M count=0 seek=384 && \
+    mkfs.ext4 -F -d /rootfs /rootfs.ext4 && \
+    resize2fs -M /rootfs.ext4
+
+FROM --platform=linux/amd64 alpine:3.21
+COPY --from=rootfs-builder /rootfs.ext4 /rootfs.ext4
+ENTRYPOINT ["/bin/cp"]
+CMD ["/rootfs.ext4", "/dest/firecracker-node-web.ext4"]

--- a/packages/docker/firecracker/node/web/README.md
+++ b/packages/docker/firecracker/node/web/README.md
@@ -1,0 +1,37 @@
+# firecracker-node-web
+
+Fastify-ready Node rootfs for Firecracker microVMs.
+
+## What's baked
+
+- Alpine 3.21 + Node.js 22 LTS + npm
+- `fastify`, `@fastify/cors`, `@fastify/helmet`, `@fastify/static`, `undici`, `zod`, `pino`, `pino-pretty`, `dotenv`, `nanoid`, `date-fns`, `commander`, `chalk` resolved into `/usr/lib/node_modules`
+- `ca-certificates-bundle`, `ca-certificates`, `iproute2`
+- `/etc/resolv.conf` with `1.1.1.1` and `8.8.8.8`
+- `/init` mounts `/proc`, `/sys`, `/dev`, brings up `lo` + `eth0`, exports `NODE_PATH=/usr/lib/node_modules`, then `exec /entrypoint`
+
+## When to use
+
+This image pairs with the **net deployment** (`firecracker-ctl-net`, `FC_PERSISTENT_ENDPOINTS_ENABLED=true`). It is the **long-lived deploy** rootfs for Node endpoints submitted through the dashboard IDE — week-to-month TTL VMs where paying a build-time `npm install` is the right tradeoff for instant boot.
+
+For short-lived runs the cheaper path is the existing `alpine-node` rootfs plus the shared `npm-cache.ext4` drive (which carries the same Fastify stack via the `firecracker-npm-packages` ConfigMap).
+
+## Output
+
+- Container image: `ghcr.io/kbve/firecracker-node-web:<version>` (alpine layer carrying `/rootfs.ext4` with a `cp` entrypoint)
+- Extracted ext4 (via `nx run firecracker-node-web:extract`): `dist/node-web.ext4`
+
+## Build
+
+```bash
+npx nx run firecracker-node-web:container
+npx nx run firecracker-node-web:extract
+```
+
+## Publish
+
+```bash
+npx nx run firecracker-node-web:container:production
+```
+
+Pushes `ghcr.io/kbve/firecracker-node-web:latest` and `:<version>`.

--- a/packages/docker/firecracker/node/web/init.sh
+++ b/packages/docker/firecracker/node/web/init.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+mount -t proc proc /proc 2>/dev/null
+mount -t sysfs sys /sys 2>/dev/null
+mount -t devtmpfs dev /dev 2>/dev/null
+mount -t tmpfs tmpfs /tmp 2>/dev/null
+
+ip link set lo up 2>/dev/null
+ip link set eth0 up 2>/dev/null
+
+# Baked node_modules live in /usr/lib/node_modules; expose them to
+# `require()` so user code can `require('fastify')` without any extra
+# mount or copy step.
+export NODE_PATH=/usr/lib/node_modules
+
+ENTRYPOINT="/bin/sh"
+for param in $(cat /proc/cmdline); do
+  case "$param" in
+    fc_entrypoint=*) ENTRYPOINT="${param#fc_entrypoint=}" ;;
+  esac
+done
+
+if [ -b /dev/vdc ] && [ -b /dev/vdd ]; then
+  dd if=/dev/vdc of=/tmp/packages.raw bs=4096 2>/dev/null
+  tr -d '\0' < /tmp/packages.raw > /tmp/packages.txt
+
+  mkdir -p /mnt/packages
+  mount -o ro /dev/vdd /mnt/packages 2>/dev/null
+
+  if [ -d /mnt/packages/pip ] && command -v pip3 >/dev/null 2>&1; then
+    pip3 install --no-index --find-links /mnt/packages/pip \
+      $(cat /tmp/packages.txt) 2>/tmp/pkg-install.log || true
+  elif [ -d /mnt/packages/node_modules ] && command -v node >/dev/null 2>&1; then
+    cp -r /mnt/packages/node_modules/. /usr/lib/node_modules/ 2>/tmp/pkg-install.log || true
+  fi
+
+  umount /mnt/packages 2>/dev/null
+fi
+
+if [ -b /dev/vdb ]; then
+  dd if=/dev/vdb of=/tmp/code.raw bs=4096 2>/dev/null
+  tr -d '\0' < /tmp/code.raw > /tmp/code
+  echo "---FC_OUTPUT_START---"
+  "$ENTRYPOINT" /tmp/code
+  EC=$?
+  echo "---FC_OUTPUT_END---"
+  exit $EC
+fi
+exec /bin/sh

--- a/packages/docker/firecracker/node/web/project.json
+++ b/packages/docker/firecracker/node/web/project.json
@@ -1,0 +1,80 @@
+{
+	"name": "firecracker-node-web",
+	"$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/docker/firecracker/node/web",
+	"targets": {
+		"container": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"npx nx run firecracker-node-web:containerx",
+					"VERSION=$(grep -m1 'version' packages/docker/firecracker/node/web/version.toml | sed 's/.*\"\\(.*\\)\\\"/\\1/') && docker tag ghcr.io/kbve/firecracker-node-web:latest ghcr.io/kbve/firecracker-node-web:${VERSION} && echo \"Tagged ghcr.io/kbve/firecracker-node-web:${VERSION}\""
+				],
+				"parallel": false
+			},
+			"configurations": {
+				"local": {},
+				"production": {
+					"commands": [
+						"npx nx run firecracker-node-web:containerx:production",
+						"VERSION=$(sed -n 's/^version: *\"\\([^\"]*\\)\".*/\\1/p' apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-web.mdx | head -1) && docker tag ghcr.io/kbve/firecracker-node-web:latest ghcr.io/kbve/firecracker-node-web:${VERSION} && docker tag ghcr.io/kbve/firecracker-node-web:latest kbve/firecracker-node-web:${VERSION} && docker tag ghcr.io/kbve/firecracker-node-web:latest kbve/firecracker-node-web:latest && echo \"Daemon tagged :${VERSION} + :latest for both registries\""
+					]
+				}
+			}
+		},
+		"containerx": {
+			"executor": "@nx-tools/nx-container:build",
+			"options": {
+				"engine": "docker",
+				"context": "packages/docker/firecracker/node/web",
+				"file": "packages/docker/firecracker/node/web/Dockerfile",
+				"platforms": ["linux/amd64"],
+				"load": true,
+				"push": false,
+				"tags": ["ghcr.io/kbve/firecracker-node-web:latest"]
+			},
+			"configurations": {
+				"local": {
+					"tags": ["ghcr.io/kbve/firecracker-node-web:latest"]
+				},
+				"production": {
+					"tags": ["ghcr.io/kbve/firecracker-node-web:latest"],
+					"load": true,
+					"push": false,
+					"provenance": "false",
+					"sbom": false
+				}
+			}
+		},
+		"extract": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["container"],
+			"options": {
+				"commands": [
+					"mkdir -p packages/docker/firecracker/node/web/dist",
+					"docker create --name fc-node-web-extract ghcr.io/kbve/firecracker-node-web:latest true > /dev/null 2>&1 || true",
+					"docker cp fc-node-web-extract:/rootfs.ext4 packages/docker/firecracker/node/web/dist/node-web.ext4",
+					"docker rm fc-node-web-extract > /dev/null 2>&1 || true",
+					"echo 'Extracted: packages/docker/firecracker/node/web/dist/node-web.ext4'"
+				],
+				"parallel": false
+			}
+		},
+		"test": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["container"],
+			"options": {
+				"commands": [
+					"echo '=== firecracker-node-web rootfs tests ==='",
+					"docker create --name fc-node-web-test ghcr.io/kbve/firecracker-node-web:latest true > /dev/null 2>&1",
+					"docker export fc-node-web-test | tar -t | grep -q '^rootfs.ext4$' && echo 'PASS: rootfs.ext4 present'",
+					"docker rm fc-node-web-test > /dev/null 2>&1",
+					"echo '=== All firecracker-node-web tests passed ==='"
+				],
+				"parallel": false
+			}
+		}
+	},
+	"tags": ["docker", "base-image", "firecracker", "node", "web"]
+}

--- a/packages/docker/firecracker/node/web/version.toml
+++ b/packages/docker/firecracker/node/web/version.toml
@@ -1,0 +1,2 @@
+[package]
+version = "0.0.1"


### PR DESCRIPTION
## Summary
Dedicated rootfs image (\`firecracker-node-web\`) for long-lived Fastify endpoints submitted through the dashboard IDE. Sits alongside \`firecracker-python-web\` and bakes the Fastify stack into the ext4 image so VMs boot with the server libs already on disk — no per-deploy \`npm install\` hop.

## Changes
- New \`packages/docker/firecracker/node/web/\` scaffolds (Dockerfile, init.sh, project.json, version.toml @ 0.0.1, README) following the python-web shape.
- Dockerfile installs \`fastify\`, \`@fastify/cors\`, \`@fastify/helmet\`, \`@fastify/static\`, \`undici\`, \`zod\`, \`pino\`, \`pino-pretty\`, \`dotenv\`, \`nanoid\`, \`date-fns\`, \`commander\`, \`chalk\` into \`/usr/lib/node_modules\` so \`require('fastify')\` resolves at boot.
- init.sh exports \`NODE_PATH=/usr/lib/node_modules\` before exec'ing the entrypoint and also accepts an optional \`/mnt/packages/node_modules\` overlay for ad-hoc dep additions.
- New \`firecracker-node-web-rootfs-stage.yaml\` Job mirrors the python-web stage Job, pinned at \`:0.0.1\` (auto-bumped by \`utils-post-publish\` on each release).
- Wires the manifest into \`kustomization.yaml\` and regenerates \`.github/ci-dispatch-manifest.json\`.

## Ecosystem completion
| Image | Runtime | Server lib baked |
|-------|---------|------------------|
| \`alpine-python\` | Python | no |
| \`alpine-node\` | Node | no |
| \`firecracker-python-net\` | Python | requests/httpx |
| \`firecracker-python-web\` | Python | FastAPI (#10842) |
| \`firecracker-node-web\` (this) | Node | Fastify |

PR 3b of 3 — completes the dashboard-IDE-driven Firecracker deploy story:
- PR 1 (#10828): pip-cache widened with fastapi/uvicorn ✅
- PR 2 (#10842): \`firecracker-python-web\` ✅
- PR 3a (#10844): npm-cache infra ✅
- PR 3b (this): \`firecracker-node-web\`

## Test plan
- [ ] \`nx run firecracker-node-web:container\` builds locally
- [ ] \`nx run firecracker-node-web:test\` passes
- [ ] CI publish workflow tags + pushes \`ghcr.io/kbve/firecracker-node-web:0.0.1\`
- [ ] ArgoCD sync runs \`firecracker-node-web-rootfs-stage\` and \`firecracker-node-web.ext4\` appears on the \`firecracker-rootfs\` PVC
- [ ] \`POST /fc/deploy\` with \`rootfs: \"firecracker-node-web\"\` and a Fastify single-file entrypoint boots a VM that serves on the configured port immediately