### PR TITLE
feat(discordsh): Discord <-> IRC relay channel via ergo-irc

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/bot.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/bot.rs
@@ -182,6 +182,8 @@ async fn event_handler(
             // Spawn GitHub board scheduler (posts notice/task boards on interval)
             super::scheduler::spawn_github_board_scheduler(data.app.clone());
 
+            super::relay::spawn_irc_forwarder(data.app.clone(), ctx.http.clone());
+
             // Record shard in tracker (best-effort)
             if let Some(ref tracker) = data.app.tracker {
                 let instance_id = std::env::var("HOSTNAME")
@@ -232,6 +234,10 @@ async fn event_handler(
             info!(id = %incomplete.id, "Left guild");
         }
 
+        serenity::FullEvent::Message { new_message } => {
+            super::relay::handle_discord_message(new_message, &data.app).await;
+        }
+
         _ => {}
     }
 
@@ -251,7 +257,8 @@ pub async fn start(app_state: Arc<AppState>) -> Result<()> {
         }
     };
 
-    let intents = serenity::GatewayIntents::non_privileged();
+    let intents =
+        serenity::GatewayIntents::non_privileged() | serenity::GatewayIntents::MESSAGE_CONTENT;
 
     let app_for_setup = Arc::clone(&app_state);
     let framework = poise::Framework::builder()

--- a/apps/discordsh/discordsh-bot/src/discord/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/mod.rs
@@ -8,4 +8,5 @@ pub mod game;
 pub mod github;
 pub mod github_cache;
 pub mod github_permissions;
+pub mod relay;
 pub mod scheduler;

--- a/apps/discordsh/discordsh-bot/src/discord/relay.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/relay.rs
@@ -1,0 +1,176 @@
+use std::sync::Arc;
+
+use bevy_chat::{ChatMessage, MessageKind};
+use poise::serenity_prelude as serenity;
+use tracing::{debug, error, info, warn};
+
+use crate::state::AppState;
+
+const MAX_RELAY_LEN: usize = 350;
+const PLATFORM_DISCORD: &str = "discord";
+
+pub async fn handle_discord_message(message: &serenity::Message, app: &Arc<AppState>) {
+    let Some(relay) = app.relay.as_ref() else {
+        return;
+    };
+    let Some(irc) = app.irc.as_ref() else {
+        return;
+    };
+    if message.author.bot {
+        return;
+    }
+    if message.guild_id != Some(relay.guild_id) || message.channel_id != relay.channel_id {
+        return;
+    }
+
+    let content = sanitize(&message.content);
+    if content.is_empty() {
+        return;
+    }
+    let sender = message
+        .author
+        .global_name
+        .clone()
+        .unwrap_or_else(|| message.author.name.clone());
+
+    let chat = ChatMessage::chat(&sender, PLATFORM_DISCORD, &relay.irc_channel, &content);
+    if let Err(e) = irc.send(&chat).await {
+        warn!(error = %e, "Failed to relay Discord -> IRC");
+    } else {
+        debug!(sender = %sender, "Relayed Discord -> IRC");
+    }
+}
+
+pub fn spawn_irc_forwarder(app: Arc<AppState>, http: Arc<serenity::Http>) {
+    let Some(relay) = app.relay.clone() else {
+        return;
+    };
+    let Some(irc) = app.irc.as_ref() else {
+        return;
+    };
+    let mut rx = irc.subscribe();
+    info!(
+        irc_channel = %relay.irc_channel,
+        discord_channel = %relay.channel_id,
+        "Spawning IRC -> Discord forwarder"
+    );
+
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(msg) => {
+                    if !should_forward_irc(&msg, &relay.irc_channel) {
+                        continue;
+                    }
+                    let body = format_irc_for_discord(&msg);
+                    if let Err(e) = relay.channel_id.say(&http, body).await {
+                        warn!(error = %e, "Failed to relay IRC -> Discord");
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(skipped, "IRC -> Discord forwarder lagged, dropped messages");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    error!("IRC -> Discord forwarder channel closed; exiting task");
+                    break;
+                }
+            }
+        }
+    });
+}
+
+fn should_forward_irc(msg: &ChatMessage, target_channel: &str) -> bool {
+    if msg.channel != target_channel {
+        return false;
+    }
+    if msg.platform == PLATFORM_DISCORD {
+        return false;
+    }
+    matches!(msg.kind, MessageKind::Chat)
+}
+
+fn format_irc_for_discord(msg: &ChatMessage) -> String {
+    let sender = sanitize(&msg.sender);
+    let content = sanitize(&msg.content);
+    let head = if sender.is_empty() {
+        "**IRC**".to_owned()
+    } else {
+        format!("**IRC \u{2022} {sender}**")
+    };
+    if content.is_empty() {
+        head
+    } else {
+        format!("{head}: {content}")
+    }
+}
+
+fn sanitize(input: &str) -> String {
+    let stripped = input.trim();
+    if stripped.is_empty() {
+        return String::new();
+    }
+    let neutralised: String = stripped
+        .chars()
+        .map(|c| match c {
+            '\r' | '\n' => ' ',
+            '`' => '\'',
+            '@' => '＠',
+            other => other,
+        })
+        .collect();
+    if neutralised.chars().count() > MAX_RELAY_LEN {
+        neutralised.chars().take(MAX_RELAY_LEN).collect::<String>() + "…"
+    } else {
+        neutralised
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forwarder_skips_non_chat() {
+        let msg = ChatMessage::event(
+            MessageKind::Kill,
+            "Bob",
+            "isometric",
+            "#kbve",
+            "killed something",
+            None,
+        );
+        assert!(!should_forward_irc(&msg, "#kbve"));
+    }
+
+    #[test]
+    fn forwarder_skips_other_channels() {
+        let msg = ChatMessage::chat("Bob", "irc", "#other", "hi");
+        assert!(!should_forward_irc(&msg, "#kbve"));
+    }
+
+    #[test]
+    fn forwarder_skips_discord_platform() {
+        let msg = ChatMessage::chat("Alice", PLATFORM_DISCORD, "#kbve", "hi");
+        assert!(!should_forward_irc(&msg, "#kbve"));
+    }
+
+    #[test]
+    fn forwarder_passes_chat_from_irc() {
+        let msg = ChatMessage::chat("Bob", "irc", "#kbve", "hello there");
+        assert!(should_forward_irc(&msg, "#kbve"));
+    }
+
+    #[test]
+    fn sanitize_strips_at_signs_and_backticks() {
+        let out = sanitize("hey @everyone `pwn`");
+        assert!(!out.contains('@'));
+        assert!(!out.contains('`'));
+    }
+
+    #[test]
+    fn sanitize_caps_length() {
+        let long = "a".repeat(500);
+        let out = sanitize(&long);
+        assert!(out.chars().count() <= MAX_RELAY_LEN + 1);
+    }
+}

--- a/apps/discordsh/discordsh-bot/src/state.rs
+++ b/apps/discordsh/discordsh-bot/src/state.rs
@@ -11,6 +11,32 @@ use kbve::{FontDb, MemberCache};
 
 use bevy_chat::ChatClient;
 
+#[derive(Debug, Clone)]
+pub struct RelayConfig {
+    pub guild_id: serenity::GuildId,
+    pub channel_id: serenity::ChannelId,
+    pub irc_channel: String,
+}
+
+impl RelayConfig {
+    pub fn from_env() -> Option<Self> {
+        let guild = std::env::var("RELAY_GUILD_ID").ok()?.parse::<u64>().ok()?;
+        let channel = std::env::var("RELAY_CHANNEL_ID")
+            .ok()?
+            .parse::<u64>()
+            .ok()?;
+        let irc_channel = std::env::var("RELAY_IRC_CHANNEL").ok()?;
+        if guild == 0 || channel == 0 || irc_channel.trim().is_empty() {
+            return None;
+        }
+        Some(Self {
+            guild_id: serenity::GuildId::new(guild),
+            channel_id: serenity::ChannelId::new(channel),
+            irc_channel,
+        })
+    }
+}
+
 use crate::discord::game::{ProfileStore, SessionStore};
 use crate::discord::github_cache::GitHubCache;
 use crate::discord::github_permissions::GitHubCommandGuard;
@@ -73,6 +99,8 @@ pub struct AppState {
     /// Optional IRC client for cross-platform chat and world events.
     /// `None` if IRC is unavailable or not configured.
     pub irc: Option<ChatClient>,
+
+    pub relay: Option<RelayConfig>,
 
     /// Optional persistent KV store (redb). Opened from `DB_PATH` env var
     /// at startup. `None` when the variable is unset or the file fails to
@@ -173,6 +201,20 @@ impl AppState {
         let local_db = open_local_db();
         let profiles = Arc::new(ProfileStore::from_env_with_local(local_db.clone()));
 
+        let relay = RelayConfig::from_env();
+        if let Some(ref r) = relay {
+            tracing::info!(
+                guild = %r.guild_id,
+                channel = %r.channel_id,
+                irc_channel = %r.irc_channel,
+                "Discord ↔ IRC relay configured"
+            );
+        } else {
+            tracing::info!(
+                "Relay not configured (set RELAY_GUILD_ID, RELAY_CHANNEL_ID, RELAY_IRC_CHANNEL to enable)"
+            );
+        }
+
         Self {
             health_monitor,
             tracker,
@@ -190,6 +232,7 @@ impl AppState {
             github_guard: GitHubCommandGuard::from_env(),
             github_cache: GitHubCache::new(),
             irc,
+            relay,
             local_db,
         }
     }

--- a/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
+++ b/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
@@ -85,6 +85,20 @@ spec:
                       # profiles stay warm during Supabase outages.
                       - name: DB_PATH
                         value: '/data/discordsh.redb'
+                      - name: IRC_HOST
+                        value: 'ergo-irc-service.irc.svc.cluster.local'
+                      - name: IRC_PORT
+                        value: '6667'
+                      - name: IRC_NICK
+                        value: 'discordsh-bot'
+                      - name: IRC_CHANNELS
+                        value: '#kbve'
+                      - name: RELAY_GUILD_ID
+                        value: '342732838598082562'
+                      - name: RELAY_CHANNEL_ID
+                        value: '935690630657638422'
+                      - name: RELAY_IRC_CHANNEL
+                        value: '#kbve'
                   resources:
                       requests:
                           memory: '256Mi'

--- a/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
+++ b/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
@@ -92,13 +92,13 @@ spec:
                       - name: IRC_NICK
                         value: 'discordsh-bot'
                       - name: IRC_CHANNELS
-                        value: '#kbve'
+                        value: '#general'
                       - name: RELAY_GUILD_ID
                         value: '342732838598082562'
                       - name: RELAY_CHANNEL_ID
                         value: '935690630657638422'
                       - name: RELAY_IRC_CHANNEL
-                        value: '#kbve'
+                        value: '#general'
                   resources:
                       requests:
                           memory: '256Mi'


### PR DESCRIPTION
Wires the bot to relay messages between **one Discord channel** and a **single IRC channel** on the cluster Ergo server. Out of the box the relay is off — it activates only when all three \`RELAY_*\` env vars are set, so no behaviour change for any other deployment.

## Behavior

**Discord → IRC**: every \`MessageCreate\` event in the configured guild + channel is rewritten as a \`ChatMessage::chat\` and sent on the \`ChatClient\` to \`RELAY_IRC_CHANNEL\`. Author is \`global_name\` falling back to \`name\`. Messages from bot accounts (including this bot's own posts) are dropped so an IRC→Discord forward can't loop back.

**IRC → Discord**: on \`Ready\`, the bot spawns a tokio task that subscribes to the \`ChatClient\` broadcast. Messages with \`kind == Chat\`, \`channel == RELAY_IRC_CHANNEL\`, and \`platform != "discord"\` are forwarded to the Discord channel as \`**IRC • sender**: content\`. Skipping \`platform == "discord"\` prevents echoing our own Discord→IRC posts back, since those carry \`platform = "discord"\` on the wire.

**Echo prevention**:
- Discord side ignores any bot account → drops self-posted IRC→Discord forwards
- IRC side ignores \`platform == "discord"\` → drops self-posted Discord→IRC forwards

**Sanitiser** strips \`\\r\\n\`, replaces \`@\` with the full-width variant to disarm group mentions, swaps backticks to apostrophes, and caps payloads at 350 chars with a \`…\` suffix.

## Code
- New \`discord::relay\` module owns the bridge. \`handle_discord_message\` + \`spawn_irc_forwarder\`, plus pure unit tests for the forwarding predicate and the sanitiser.
- New \`state::RelayConfig\` reads \`RELAY_GUILD_ID\`, \`RELAY_CHANNEL_ID\`, \`RELAY_IRC_CHANNEL\`. Missing or zero values → \`None\`, bridge stays disabled.
- \`bot.rs\` adds the \`FullEvent::Message\` arm, spawns the IRC forwarder during the \`Ready\` event, and ORs \`GatewayIntents::MESSAGE_CONTENT\` onto the non-privileged base so Discord actually delivers message bodies.

> **Action required on Discord side**: \`MESSAGE_CONTENT\` is a privileged intent. It must be enabled in the Discord developer portal for this bot application before the gateway will deliver message bodies. Bot also needs the standard \`View Channel\` + \`Send Messages\` perms on the relay channel.

## K8s manifest (\`discordsh-bot-deployment.yaml\`)
\`\`\`yaml
- name: IRC_HOST
  value: 'ergo-irc-service.irc.svc.cluster.local'
- name: IRC_PORT
  value: '6667'
- name: IRC_NICK
  value: 'discordsh-bot'
- name: IRC_CHANNELS
  value: '#kbve'
- name: RELAY_GUILD_ID
  value: '342732838598082562'
- name: RELAY_CHANNEL_ID
  value: '935690630657638422'
- name: RELAY_IRC_CHANNEL
  value: '#kbve'
\`\`\`

## Test plan
- [x] \`cargo check\` clean
- [x] \`cargo clippy --no-deps\` clean on edited regions
- [x] \`cargo test --bin discordsh-bot\` — 720/720 (711 baseline + 6 new relay tests + earlier merges)
- [ ] Enable \`MESSAGE_CONTENT\` intent in Discord developer portal
- [ ] Smoke in staging:
  - User posts in \`#935690630657638422\` → appears in \`#kbve\` on Ergo as \`<user>: text\`
  - IRC user posts in \`#kbve\` → appears in Discord channel as \`**IRC • nick**: text\`
  - Bot's own forwards do NOT echo back (no infinite loop)
  - \`@everyone\` in either direction does not ping (full-width replacement)