### PR TITLE
fix(observability): align logs_raw TTL at 8 days + ALTER existing table

### DIFF
--- a/apps/kube/vector/manifests/observability-ch-setup-job.yaml
+++ b/apps/kube/vector/manifests/observability-ch-setup-job.yaml
@@ -45,12 +45,21 @@ data:
         ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/observability/logs_raw', '{replica}')
         ORDER BY (service, timestamp)
         PARTITION BY toYYYYMMDD(timestamp)
-        TTL toDateTime(timestamp) + INTERVAL 7 DAY
+        TTL toDateTime(timestamp) + INTERVAL 8 DAY
         " || {
           echo "ERROR: Failed to create logs_raw table"
           exit 1
         }
         echo "Table 'observability.logs_raw' ready."
+
+        echo "Enforcing 8-day TTL on existing logs_raw (no-op on fresh table)..."
+        curl -sf --max-time 30 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "ALTER TABLE observability.logs_raw ON CLUSTER 'cluster' MODIFY TTL toDateTime(timestamp) + INTERVAL 8 DAY" || {
+          echo "ERROR: Failed to apply TTL to logs_raw"
+          exit 1
+        }
+        echo "TTL on 'observability.logs_raw' enforced at 8 days."
 
         echo "Creating logs_distributed table (Distributed)..."
         curl -sf --max-time 30 \
@@ -78,7 +87,7 @@ metadata:
         app: observability-ch-setup
         component: vector
     annotations:
-        kbve.sh/last-updated: '2026-04-05'
+        kbve.sh/last-updated: '2026-05-11'
         argocd.argoproj.io/hook: PostSync
 spec:
     ttlSecondsAfterFinished: 86400

--- a/packages/data/ch/README.md
+++ b/packages/data/ch/README.md
@@ -7,15 +7,15 @@ ClickHouse DDL for the KBVE observability stack. Two flavors live side by side:
 
 ## Files
 
-| File                     | Purpose                                                                                                                            |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `database.sql`           | Creates the `logflare` database. Run before any `logflare.*` template.                                                             |
-| `logs.sql`               | Logflare OTEL log templates (JSON attribute columns + map-typed variants).                                                         |
-| `metrics.sql`            | Logflare OTEL metric templates.                                                                                                    |
-| `traces.sql`             | Logflare OTEL trace templates.                                                                                                     |
-| `observability.sql`      | `observability.logs_raw` (replicated) + `logs_distributed` — direct Vector → ClickHouse log pipeline. Day-partitioned, 45-day TTL. |
-| `firecracker.sql`        | `firecracker.vm_events` — microVM lifecycle telemetry from `firecracker-ctl`. 90-day TTL for capacity planning.                    |
-| `dev-docker-compose.yml` | Single-node ClickHouse for local DDL validation (no Logflare, no Postgres). Mounted on `tmpfs` for cheap teardown.                 |
+| File                     | Purpose                                                                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `database.sql`           | Creates the `logflare` database. Run before any `logflare.*` template.                                                            |
+| `logs.sql`               | Logflare OTEL log templates (JSON attribute columns + map-typed variants).                                                        |
+| `metrics.sql`            | Logflare OTEL metric templates.                                                                                                   |
+| `traces.sql`             | Logflare OTEL trace templates.                                                                                                    |
+| `observability.sql`      | `observability.logs_raw` (replicated) + `logs_distributed` — direct Vector → ClickHouse log pipeline. Day-partitioned, 8-day TTL. |
+| `firecracker.sql`        | `firecracker.vm_events` — microVM lifecycle telemetry from `firecracker-ctl`. 90-day TTL for capacity planning.                   |
+| `dev-docker-compose.yml` | Single-node ClickHouse for local DDL validation (no Logflare, no Postgres). Mounted on `tmpfs` for cheap teardown.                |
 
 ## Engines and retention
 
@@ -24,7 +24,7 @@ ClickHouse DDL for the KBVE observability stack. Two flavors live side by side:
 | `logflare.otel_logs_template`    | MergeTree (templated) | daily          | 45 days |
 | `logflare.otel_metrics_template` | MergeTree (templated) | daily          | 45 days |
 | `logflare.otel_traces_template`  | MergeTree (templated) | daily          | 45 days |
-| `observability.logs_raw`         | ReplicatedMergeTree   | `toYYYYMMDD`   | 45 days |
+| `observability.logs_raw`         | ReplicatedMergeTree   | `toYYYYMMDD`   | 8 days  |
 | `observability.logs_distributed` | Distributed           | (fan-out only) | n/a     |
 | `firecracker.vm_events`          | MergeTree             | `toYYYYMMDD`   | 90 days |
 

--- a/packages/data/ch/schemas/observability.sql
+++ b/packages/data/ch/schemas/observability.sql
@@ -1,6 +1,6 @@
 -- observability.logs_raw — replicated local table for Vector → ClickHouse direct pipeline
 -- All services (kong, auth, rest, realtime, storage, functions, db, analytics, meta, studio)
--- land in one table, partitioned by day, 45-day TTL.
+-- land in one table, partitioned by day, 8-day TTL.
 --
 -- Cluster topology: 2 shards × 2 replicas.
 -- Vector writes to logs_raw (local); queries go through logs_distributed.
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS observability.logs_raw ON CLUSTER 'cluster'
 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/observability/logs_raw', '{replica}')
 ORDER BY (service, timestamp)
 PARTITION BY toYYYYMMDD(timestamp)
-TTL toDateTime(timestamp) + INTERVAL 45 DAY;
+TTL toDateTime(timestamp) + INTERVAL 8 DAY;
 
 -- Distributed table — fans out reads/writes across all shards.
 -- Queries should use this table; Vector writes to logs_raw (local) directly.


### PR DESCRIPTION
## Summary
- Two sources of truth for `observability.logs_raw` disagreed on TTL:
  - `packages/data/ch/schemas/observability.sql` declared **45 day** TTL
  - `apps/kube/vector/manifests/observability-ch-setup-job.yaml` (the actual ArgoCD provisioner) declared **7 day** TTL
- Aligned both at **8 days** — one day of buffer beyond the dashboard's 7-day UI window.
- Added an unconditional `ALTER TABLE ... ON CLUSTER 'cluster' MODIFY TTL ...` step in the setup job. `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables, so a TTL change in the script alone never reached the live table.

## Why
- Caps ClickHouse disk growth at a known short window so the planned Vector firehose change (removing noise filter to track all namespaces) doesn't blow up storage.
- Aligning repo state with prod state stops the next reader from being misled.

## Test plan
- [ ] After merge, ArgoCD re-runs the PostSync job and the ALTER step applies the 8-day TTL to the live `logs_raw` table
- [ ] Verify with `SHOW CREATE TABLE observability.logs_raw` from `clickhouse-client` (expect `TTL toDateTime(timestamp) + INTERVAL 8 DAY`)
- [ ] Watch ClickHouse PVC usage trend down over the following days as data older than 8d is dropped on merge