### PR TITLE
refactor(arcade): pack blackjack cards

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
@@ -11,6 +11,8 @@ import {
 } from './state';
 import {
 	cardPoints,
+	cardRank,
+	cardSuit,
 	type Card,
 	isBlackjack,
 	isRedSuit,
@@ -573,6 +575,9 @@ export class BlackjackScene extends Phaser.Scene {
 	}
 
 	private drawCardFace(card: Card, x: number, y: number) {
+		const suitName = cardSuit(card);
+		const rankName = cardRank(card);
+		const suitGlyph = SUIT_GLYPH[suitName];
 		const g = this.add.graphics();
 		g.fillStyle(0x000000, 0.22);
 		g.fillRoundedRect(
@@ -599,13 +604,13 @@ export class BlackjackScene extends Phaser.Scene {
 			CARD_SIZE.radius,
 		);
 
-		const color = isRedSuit(card.suit) ? COLORS.red : COLORS.black;
-		const rank = this.add.text(x + 12, y + 10, card.rank, {
+		const color = isRedSuit(suitName) ? COLORS.red : COLORS.black;
+		const rank = this.add.text(x + 12, y + 10, rankName, {
 			fontFamily: FONT.serif,
 			fontSize: '30px',
 			color,
 		});
-		const suit = this.add.text(x + 13, y + 43, SUIT_GLYPH[card.suit], {
+		const suit = this.add.text(x + 13, y + 43, suitGlyph, {
 			fontFamily: FONT.serif,
 			fontSize: '27px',
 			color,
@@ -614,7 +619,7 @@ export class BlackjackScene extends Phaser.Scene {
 			.text(
 				x + CARD_SIZE.width / 2,
 				y + CARD_SIZE.height / 2 + 4,
-				SUIT_GLYPH[card.suit],
+				suitGlyph,
 				{
 					fontFamily: FONT.serif,
 					fontSize: '58px',
@@ -626,7 +631,7 @@ export class BlackjackScene extends Phaser.Scene {
 			.text(
 				x + CARD_SIZE.width - 12,
 				y + CARD_SIZE.height - 10,
-				card.rank,
+				rankName,
 				{
 					fontFamily: FONT.serif,
 					fontSize: '30px',
@@ -790,7 +795,7 @@ export class BlackjackScene extends Phaser.Scene {
 	}
 
 	private dealerUpValue(card: Card): number {
-		if (card.rank === 'A') return 11;
+		if (cardRank(card) === 'A') return 11;
 		return Math.min(cardPoints(card), 10);
 	}
 }

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildShoe,
+	cardId,
+	cardPoints,
+	cardRank,
+	cardSuit,
+	encodeCard,
+	isBlackjack,
+	valueHand,
+} from './cards';
+
+describe('blackjack card encoding', () => {
+	it('packs and decodes suit and rank into a card byte', () => {
+		const card = encodeCard('diamonds', '9');
+
+		expect(card).toBeTypeOf('number');
+		expect(card).toBeLessThanOrEqual(0xff);
+		expect(cardId(card)).toBe('diamonds-9');
+		expect(cardSuit(card)).toBe('diamonds');
+		expect(cardRank(card)).toBe('9');
+		expect(cardPoints(card)).toBe(9);
+	});
+
+	it('builds multi-deck shoes without object card allocation', () => {
+		const shoe = buildShoe(6);
+
+		expect(shoe).toHaveLength(312);
+		expect(shoe.every((card) => typeof card === 'number')).toBe(true);
+		expect(new Set(shoe.map(cardId))).toHaveLength(52);
+	});
+
+	it('keeps blackjack hand valuation semantics', () => {
+		const ace = encodeCard('spades', 'A');
+		const king = encodeCard('hearts', 'K');
+		const nine = encodeCard('clubs', '9');
+
+		expect(isBlackjack([ace, king])).toBe(true);
+		expect(valueHand([ace, nine, king])).toEqual({
+			total: 20,
+			soft: false,
+		});
+	});
+});

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts
@@ -14,19 +14,16 @@ export type Rank =
 	| 'Q'
 	| 'K';
 
-export interface Card {
-	id: string;
-	suit: Suit;
-	rank: Rank;
-}
+export type CardByte = number;
+export type Card = CardByte;
 
 export interface HandValue {
 	total: number;
 	soft: boolean;
 }
 
-const SUITS: readonly Suit[] = ['spades', 'hearts', 'diamonds', 'clubs'];
-const RANKS: readonly Rank[] = [
+const SUITS = ['spades', 'hearts', 'diamonds', 'clubs'] as const;
+const RANKS = [
 	'A',
 	'2',
 	'3',
@@ -40,7 +37,12 @@ const RANKS: readonly Rank[] = [
 	'J',
 	'Q',
 	'K',
-];
+] as const;
+
+const RANK_MASK = 0b1111;
+const SUIT_MASK = 0b11;
+const SUIT_SHIFT = 4;
+const RANK_POINTS = [11, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10] as const;
 
 export const SUIT_GLYPH: Record<Suit, string> = {
 	spades: '♠',
@@ -53,16 +55,31 @@ export function isRedSuit(suit: Suit): boolean {
 	return suit === 'hearts' || suit === 'diamonds';
 }
 
+export function encodeCard(suit: Suit, rank: Rank): Card {
+	const suitIndex = SUITS.indexOf(suit);
+	const rankIndex = RANKS.indexOf(rank);
+
+	return (suitIndex << SUIT_SHIFT) | rankIndex;
+}
+
+export function cardSuit(card: Card): Suit {
+	return SUITS[(card >> SUIT_SHIFT) & SUIT_MASK];
+}
+
+export function cardRank(card: Card): Rank {
+	return RANKS[card & RANK_MASK];
+}
+
+export function cardId(card: Card): string {
+	return `${cardSuit(card)}-${cardRank(card)}`;
+}
+
 export function buildShoe(decks: number): Card[] {
 	const shoe: Card[] = [];
 	for (let deck = 0; deck < decks; deck++) {
 		for (const suit of SUITS) {
 			for (const rank of RANKS) {
-				shoe.push({
-					id: `${deck}-${suit}-${rank}`,
-					suit,
-					rank,
-				});
+				shoe.push(encodeCard(suit, rank));
 			}
 		}
 	}
@@ -79,9 +96,7 @@ export function shuffleCards(cards: readonly Card[]): Card[] {
 }
 
 export function cardPoints(card: Card): number {
-	if (card.rank === 'A') return 11;
-	if (card.rank === 'K' || card.rank === 'Q' || card.rank === 'J') return 10;
-	return Number(card.rank);
+	return RANK_POINTS[card & RANK_MASK];
 }
 
 export function valueHand(cards: readonly Card[]): HandValue {
@@ -90,7 +105,7 @@ export function valueHand(cards: readonly Card[]): HandValue {
 
 	for (const card of cards) {
 		total += cardPoints(card);
-		if (card.rank === 'A') aces++;
+		if ((card & RANK_MASK) === 0) aces++;
 	}
 
 	while (total > 21 && aces > 0) {

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/index.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/index.ts
@@ -1,13 +1,18 @@
 export { BlackjackScene } from './BlackjackScene';
 export {
 	buildShoe,
+	cardId,
 	cardPoints,
+	cardRank,
+	cardSuit,
+	encodeCard,
 	isBlackjack,
 	isRedSuit,
 	shuffleCards,
 	valueHand,
 	SUIT_GLYPH,
 	type Card,
+	type CardByte,
 	type HandValue,
 	type Rank,
 	type Suit,


### PR DESCRIPTION
## Summary
- replace blackjack card objects with packed numeric card bytes
- add rank/suit encode and decode helpers for render and game logic
- add focused Vitest coverage for card encoding, shoe sizing, and hand valuation

## Validation
- pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts apps/kbve/astro-kbve/src/arcade/blackjack/index.ts apps/kbve/astro-kbve/src/arcade/blackjack/state.ts
- pnpm exec vitest run apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts
- Playwright smoke loaded /arcade/blackjack/, dealt a hand, and confirmed no page/console errors

Note: eslint reports the existing Nx ProjectGraph warning for @nx/enforce-module-boundaries, but exits successfully. astro-kbve:check still fails on existing unrelated repo-wide Astro/type issues outside this blackjack change.