### PR TITLE
chore(security): override handlebars to >=4.7.9 (GHSA-2w6w-674q-4c4q)

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
 		"overrides": {
 			"@novnc/novnc": "1.5.0",
 			"fast-xml-parser": ">=5.5.8",
+			"handlebars@<4.7.9": ">=4.7.9",
 			"minimatch@<3.1.4": "3.1.4",
 			"minimatch@>=5.0.0 <5.1.8": "5.1.8",
 			"minimatch@>=7.0.0 <7.4.8": "7.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@novnc/novnc': 1.5.0
   fast-xml-parser: '>=5.5.8'
+  handlebars@<4.7.9: '>=4.7.9'
   minimatch@<3.1.4: 3.1.4
   minimatch@>=5.0.0 <5.1.8: 5.1.8
   minimatch@>=7.0.0 <7.4.8: 7.4.8
@@ -10038,16 +10039,6 @@ packages:
 
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
-
-  handlebars@4.7.7:
-    resolution: {integrity: sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
-
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
-    engines: {node: '>=0.4.7'}
-    hasBin: true
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -21202,7 +21193,7 @@ snapshots:
       '@nx/devkit': 22.7.0(nx@22.7.0(@swc-node/register@1.11.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18)))
       '@renovatebot/pep440': 4.2.1
       csv-parse: 5.6.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       moment-timezone: 0.5.48
       semver: 7.7.4
       tslib: 2.8.1
@@ -21225,7 +21216,7 @@ snapshots:
       '@nx/js': 22.7.0(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18))(nx@22.7.0(@swc-node/register@1.11.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18)))(verdaccio@6.5.1(encoding@0.1.13)(typanion@3.14.0))
       csv-parse: 5.6.0
       dotenv: 16.4.7
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       nx: 22.7.0(@swc-node/register@1.11.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(@swc/core@1.15.21(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.21(@swc/helpers@0.5.18))
       semver: 7.7.4
       tmp: 0.2.5
@@ -29527,7 +29518,7 @@ snapshots:
   grpc_tools_node_protoc_ts@5.3.3:
     dependencies:
       google-protobuf: 3.15.8
-      handlebars: 4.7.7
+      handlebars: 4.7.9
 
   gsap@3.13.0: {}
 
@@ -29559,24 +29550,6 @@ snapshots:
   hachure-fill@0.5.2: {}
 
   handle-thing@2.0.1: {}
-
-  handlebars@4.7.7:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
-
-  handlebars@4.7.8:
-    dependencies:
-      minimist: 1.2.8
-      neo-async: 2.6.2
-      source-map: 0.6.1
-      wordwrap: 1.0.0
-    optionalDependencies:
-      uglify-js: 3.19.3
 
   handlebars@4.7.9:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `handlebars@<4.7.9` -> `>=4.7.9` to `pnpm.overrides` so every transitive copy of Handlebars collapses to the patched `4.7.9`.
- Closes the critical CVE-2026-33937 / GHSA-2w6w-674q-4c4q (CVSS 9.8) AST-driven code injection, plus the related high-severity AST/decorator/CLI advisories.

## Where the bad copies came from
- `4.7.8` via `@nx-tools/nx-container@7.2.1` + `@nx-tools/container-metadata@7.2.1`
- `4.7.7` via `grpc_tools_node_protoc_ts@5.3.3`
- (Verdaccio peer already used `4.7.9`, untouched.)

All consumers are dev-only tooling, but `Handlebars.compile()` still runs in CI when these tools render templates, so the gadget is reachable from a poisoned template input.

## Audit delta
- `pnpm audit` critical: **2 -> 0**
- `pnpm audit` high: **42 -> 34** (handlebars high advisories also cleared)

## Test plan
- [x] `pnpm install` succeeds in worktree.
- [x] `grep handlebars pnpm-lock.yaml` shows only `4.7.9`.
- [x] `pnpm audit` reports zero handlebars advisories.
- [ ] CI green on container build + protoc codegen jobs.