### PR TITLE
fix(droid): readonly registrations to match newer lib.dom

### DIFF
--- a/packages/npm/droid/src/lib/sw-recovery.ts
+++ b/packages/npm/droid/src/lib/sw-recovery.ts
@@ -69,7 +69,7 @@ export async function swRecovery(
 
 	result.supported = true;
 
-	let registrations: ServiceWorkerRegistration[] = [];
+	let registrations: readonly ServiceWorkerRegistration[] = [];
 	try {
 		registrations = await navigator.serviceWorker.getRegistrations();
 	} catch (err) {


### PR DESCRIPTION
Closes #10851.

## What broke
\`CI - Docker / discordsh\` e2e failed via the chain:
\`discordsh:e2e → axum-discordsh:container-prep → astro-discordsh:build → droid:build\`

Real error (TS4104):
\`\`\`
packages/npm/droid/src/lib/sw-recovery.ts:74:3 - error TS4104:
The type 'readonly ServiceWorkerRegistration[]' is 'readonly' and
cannot be assigned to the mutable type 'ServiceWorkerRegistration[]'.

let registrations: ServiceWorkerRegistration[] = [];
try {
    registrations = await navigator.serviceWorker.getRegistrations();
\`\`\`

\`navigator.serviceWorker.getRegistrations()\` is typed as \`Promise<readonly ServiceWorkerRegistration[]>\` in newer \`lib.dom.d.ts\` revisions. The local binding was declared mutable, so the assignment was rejected.

## Fix
Widen the local binding to \`readonly ServiceWorkerRegistration[]\`. The variable is only iterated below, never mutated in place — readonly is sufficient.

\`\`\`diff
-let registrations: ServiceWorkerRegistration[] = [];
+let registrations: readonly ServiceWorkerRegistration[] = [];
\`\`\`

## Test plan
- [x] \`npx tsc --noEmit -p packages/npm/droid/tsconfig.lib.json\` from within the worktree — exit 0 (Nx's executor misresolves tsconfig paths across git worktrees per project memory, so direct tsc is the source of truth)
- [ ] CI green on the \`discordsh\` Docker e2e job