### PR TITLE
fix(astro): nest autogenerate inside items for Starlight v0.39+

### DIFF
--- a/apps/chuckrpg/astro-chuckrpg/astro.config.mjs
+++ b/apps/chuckrpg/astro-chuckrpg/astro.config.mjs
@@ -75,15 +75,15 @@ export default defineConfig({
 			sidebar: [
 				{
 					label: 'Getting Started',
-					autogenerate: { directory: 'guides' },
+					items: [{ autogenerate: { directory: 'guides' } }],
 				},
 				{
 					label: 'Game',
-					autogenerate: { directory: 'game' },
+					items: [{ autogenerate: { directory: 'game' } }],
 				},
 				{
 					label: 'Account',
-					autogenerate: { directory: 'auth' },
+					items: [{ autogenerate: { directory: 'auth' } }],
 				},
 			],
 		}),

--- a/apps/cryptothrone/astro-cryptothrone/astro.config.mjs
+++ b/apps/cryptothrone/astro-cryptothrone/astro.config.mjs
@@ -27,7 +27,7 @@ export default defineConfig({
 				},
 				{
 					label: 'Guides',
-					autogenerate: { directory: 'guides' },
+					items: [{ autogenerate: { directory: 'guides' } }],
 				},
 			],
 		}),

--- a/apps/discordsh/astro-discordsh/astro.config.mjs
+++ b/apps/discordsh/astro-discordsh/astro.config.mjs
@@ -34,11 +34,11 @@ export default defineConfig({
       sidebar: [
         {
           label: 'Servers',
-          autogenerate: { directory: 'servers' },
+          items: [{ autogenerate: { directory: 'servers' } }],
         },
         {
           label: 'Guides',
-          autogenerate: { directory: 'guides' },
+          items: [{ autogenerate: { directory: 'guides' } }],
         },
       ],
     }),

--- a/apps/herbmail/astro-herbmail/astro.config.mjs
+++ b/apps/herbmail/astro-herbmail/astro.config.mjs
@@ -20,7 +20,7 @@ export default defineConfig({
       sidebar: [
         {
           label: 'Guides',
-          autogenerate: { directory: 'guides' },
+          items: [{ autogenerate: { directory: 'guides' } }],
         },
       ],
     }),

--- a/apps/memes/astro-memes/astro.config.mjs
+++ b/apps/memes/astro-memes/astro.config.mjs
@@ -26,7 +26,7 @@ export default defineConfig({
       sidebar: [
         {
           label: 'Guides',
-          autogenerate: { directory: 'guides' },
+          items: [{ autogenerate: { directory: 'guides' } }],
         },
       ],
     }),


### PR DESCRIPTION
## Summary
Starlight v0.39 removed \`label\` on top-level \`autogenerate\` sidebar entries. The old shape now hard-errors at \`astro sync\`:
\`\`\`
[AstroUserError] Invalid config passed to starlight integration
Found an \`autogenerate\` object with a \`label\`. Support for
autogenerated sidebar groups was removed in Starlight v0.39.0.
\`\`\`
This was the root cause behind #10837 (irc-gateway docker e2e failure on main) — the e2e target runs \`astro-irc:build\` as a webServer warmup, and an older snapshot of \`astro-irc\` still had the flat shape. \`astro-irc\` itself has since been migrated on main, but five other sites still carry the legacy form and would break on the next Starlight bump.

Migrate them now so we don't get blindsided again.

## Migration

Old:
\`\`\`js
{ label: 'Guides', autogenerate: { directory: 'guides' } }
\`\`\`
New:
\`\`\`js
{ label: 'Guides', items: [{ autogenerate: { directory: 'guides' } }] }
\`\`\`

## Sites touched
- \`apps/cryptothrone/astro-cryptothrone\` — 1 entry
- \`apps/discordsh/astro-discordsh\` — 2 entries (Servers, Guides)
- \`apps/herbmail/astro-herbmail\` — 1 entry
- \`apps/chuckrpg/astro-chuckrpg\` — 3 entries (Getting Started, Game, Account)
- \`apps/memes/astro-memes\` — 1 entry

\`apps/kbve/astro-kbve\`, \`apps/irc/astro-irc\`, \`apps/rareicon/astro-rareicon\` were already on the supported shape — no change.

## Test plan
- [x] \`npx astro sync\` per site (cryptothrone, discordsh, chuckrpg, memes, herbmail) — all sync clean
- [ ] Re-run CI - Docker / irc-gateway after merge; expect the AstroUserError that originally tripped #10837 to stay gone
- [ ] CI builds for the five touched Astro sites pass

Closes #10837