### PR TITLE
chore(playwright): scope postinstall browser fetch to chromium only

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
 		"includedScripts": []
 	},
 	"scripts": {
-		"postinstall": "pnpm exec playwright install",
+		"postinstall": "pnpm exec playwright install chromium",
 		"prepare": "husky"
 	},
 	"pnpm": {


### PR DESCRIPTION
## Summary
\`pnpm exec playwright install\` with no browser arg downloads chromium, firefox, and webkit on every install. Every e2e config in this repo is pinned to \`devices['Desktop Chrome']\` (irc-e2e, memes-e2e, etc.), so firefox + webkit are dead weight — they add ~half a gig of disk and fire Playwright's Linux host-dependency validator. On GitHub Actions the validator complains about \`libgtk-4.so.1\` / \`libgraphene-1.0.so.0\` / \`libevent-2.1.so.7\` / \`libopus.so.0\` etc. (full webkit dep list) and the warning is now part of the noise tracked in the irc docker e2e failure.

Scope the root postinstall to chromium only:

\`\`\`json
\"postinstall\": \"pnpm exec playwright install chromium\"
\`\`\`

The CI Docker workflow already runs \`pnpm exec playwright install --with-deps chromium\` as a dedicated host-deps step (see \`docker-test-app.yml\` line 125), so the workflow still gets the apt packages it needs. This change just stops the extra firefox/webkit fetch + validation during \`pnpm install\` postinstall.

## Why now
Stacks with #10857 (Starlight sidebar fix). Once both land, the irc-gateway docker e2e job should finally green out.

## Test plan
- [ ] Fresh \`pnpm install\` locally — only chromium downloads
- [ ] CI: irc-gateway docker e2e run shows no \"Host system is missing dependencies\" warning during \`pnpm install\` step
- [ ] CI \`pnpm exec playwright install --with-deps chromium\` step still passes