### PR TITLE
feat(vector): track all namespaces via heartbeat throttle + keep noise_filter

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -5,8 +5,8 @@ metadata:
     name: vector-config
     namespace: vector
     annotations:
-        kbve.sh/last-updated: '2026-05-11T00:00:00Z'
-        kbve.sh/config-version: 'v4-track-all-namespaces'
+        kbve.sh/last-updated: '2026-05-12T00:00:00Z'
+        kbve.sh/config-version: 'v5-heartbeat-coverage'
 data:
     vector.yml: |
         api:
@@ -59,13 +59,43 @@ data:
                   if exists(parsed.msg) { .event_message = string(parsed.msg) ?? .event_message }
                   .metadata = parsed
               }
-          # Firehose: every namespace except vector (self-loop) and kube-system
-          # (security; apiserver/kubelet/etcd may carry tokens/secret refs) flows
-          # to ClickHouse unfiltered. 8-day TTL on logs_raw caps disk.
+          # Drop info/debug from noisy infra namespaces; keep warn+/error+ from
+          # them and everything from app namespaces. Cost discipline — these
+          # 13 namespaces emit massive low-signal chatter.
+          noise_filter:
+            type: filter
+            inputs:
+              - project_logs
+            condition:
+              type: vrl
+              source: |-
+                noisy = ["argocd", "clickhouse", "arc-systems", "arc-runners", "monitoring",
+                         "kube-system", "kube-node-lease", "kube-public",
+                         "longhorn-system", "metallb-system", "cnpg-system",
+                         "cert-manager", "external-secrets-system"]
+                ns = string(.pod_namespace) ?? ""
+                if !includes(noisy, ns) {
+                    true
+                } else {
+                    msg = string(.event_message) ?? ""
+                    match(msg, r'(?i)(warn|error|fatal|panic|crit|exception|fail)')
+                }
+          # Heartbeat: emit at most 1 row per namespace per 5min straight from
+          # project_logs (pre-filter), so quiet namespaces with no warn+/error+
+          # in window still show up on the dashboard's namespace count.
+          # ~600 rows/hour cluster-wide. Bypasses the appname router and lands
+          # directly in ch_normalize.
+          namespace_heartbeat:
+            type: throttle
+            inputs:
+              - project_logs
+            threshold: 1
+            window_secs: 300
+            key_field: "{{ pod_namespace }}"
           router:
             type: route
             inputs:
-              - project_logs
+              - noise_filter
             route:
               kong: '.appname == "supabase-kong" || .appname == "kong-kong" || .appname == "proxy"'
               auth: '.appname == "supabase-auth" || .appname == "gotrue"'
@@ -235,6 +265,7 @@ data:
               - router.functions
               - router.firecracker
               - router._unmatched
+              - namespace_heartbeat
             source: |-
               # Extract level from metadata fields first
               .level = string(.severity) ??

--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -5,8 +5,8 @@ metadata:
     name: vector-config
     namespace: vector
     annotations:
-        kbve.sh/last-updated: '2026-04-09T04:50:00Z'
-        kbve.sh/config-version: 'v3-fix-vrl-warnings'
+        kbve.sh/last-updated: '2026-05-11T00:00:00Z'
+        kbve.sh/config-version: 'v4-track-all-namespaces'
 data:
     vector.yml: |
         api:
@@ -20,8 +20,6 @@ data:
             exclude_paths_glob_patterns:
               - "**/vector_*/**"
               - "**/kube-system_*/**"
-              - "**/kube-node-lease_*/**"
-              - "**/kube-public_*/**"
             auto_partial_merge: true
             data_dir: "/vector-data-dir"
 
@@ -61,29 +59,13 @@ data:
                   if exists(parsed.msg) { .event_message = string(parsed.msg) ?? .event_message }
                   .metadata = parsed
               }
-          # Drop info/debug from noisy infra namespaces, keep all for app namespaces
-          noise_filter:
-            type: filter
-            inputs:
-              - project_logs
-            condition:
-              type: vrl
-              source: |-
-                noisy = ["argocd", "clickhouse", "arc-systems", "arc-runners", "monitoring",
-                         "kube-system", "kube-node-lease", "kube-public",
-                         "longhorn-system", "metallb-system", "cnpg-system",
-                         "cert-manager", "external-secrets-system"]
-                ns = string(.pod_namespace) ?? ""
-                if !includes(noisy, ns) {
-                    true
-                } else {
-                    msg = string(.event_message) ?? ""
-                    match(msg, r'(?i)(warn|error|fatal|panic|crit|exception|fail)')
-                }
+          # Firehose: every namespace except vector (self-loop) and kube-system
+          # (security; apiserver/kubelet/etcd may carry tokens/secret refs) flows
+          # to ClickHouse unfiltered. 8-day TTL on logs_raw caps disk.
           router:
             type: route
             inputs:
-              - noise_filter
+              - project_logs
             route:
               kong: '.appname == "supabase-kong" || .appname == "kong-kong" || .appname == "proxy"'
               auth: '.appname == "supabase-auth" || .appname == "gotrue"'


### PR DESCRIPTION
## Summary
Dashboard at `/dashboard/clickhouse/` was missing ~13 namespaces. Cluster has 53; pipeline was surfacing 36 across the 7d window. Two layers of suppression in [vector-config.yaml](apps/kube/vector/manifests/vector-config.yaml):

1. `exclude_paths_glob_patterns` dropped 4 namespaces at the source
2. `noise_filter` transform dropped info/debug from 13 chatty infra namespaces — quiet namespaces with no warn+/error+ in window silently vanished

## Approach
Goal: accurate namespace coverage, **not** an unfiltered firehose. The first commit on this branch ripped out `noise_filter` entirely (3-10× volume jump). Walked it back in the second commit. Final state:

- **`noise_filter` restored** — info/debug from the 13 chatty infra namespaces stays suppressed. Cost discipline preserved.
- **`namespace_heartbeat` throttle added** — emits at most 1 row per `pod_namespace` per 5min straight from `project_logs` into `ch_normalize`. Quiet namespaces (cilium-secrets, reloader, kyverno, etc.) now appear on the dashboard count regardless of log level.
- **Path-glob trim** — kube-node-lease + kube-public unblocked (low-risk infra). `kube-system` stays excluded for security (apiserver/kubelet/etcd may carry tokens/secret refs).

## Volume Impact
~53 ns × 12 rows/hour = **~600 extra rows/hour** cluster-wide from heartbeat. Trivial. 8-day TTL from #10848 caps disk regardless.

## Why kube-system stays excluded
apiserver / kubelet / etcd error output may carry bearer tokens, secret refs, audit payloads. Tracking it needs a redaction transform (strip `Authorization`, `Bearer`, `Secret`, ServiceAccountToken fields) first. Follow-up PR.

## Test plan
- [ ] Merge #10848 (TTL 8d) first
- [ ] ArgoCD picks up the new ConfigMap; Vector DaemonSet rolls
- [ ] Dashboard at `/dashboard/clickhouse/` shows ~51 namespaces across 24h window (53 cluster − 2 path-excluded)
- [ ] Watch ClickHouse PVC trend for 48h after merge — should plateau within the 8-day TTL ceiling
- [ ] Verify info/debug from noisy 13 stays suppressed (no flood from longhorn/argocd)