### PR TITLE
fix(firecracker): wire python-web and node-web into publish pipeline

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -96,7 +96,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.13",
+			"version": "0.1.14",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
@@ -140,7 +140,7 @@
 		{
 			"key": "firecracker_node_web",
 			"app_name": "firecracker-node-web",
-			"version": "0.0.1",
+			"version": "0.1.0",
 			"version_toml": "packages/docker/firecracker/node/web/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-web.mdx",
 			"source_path": "packages/docker/firecracker/node/web",
@@ -168,7 +168,7 @@
 		{
 			"key": "firecracker_python_web",
 			"app_name": "firecracker-python-web",
-			"version": "0.0.1",
+			"version": "0.1.0",
 			"version_toml": "packages/docker/firecracker/python/web/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-web.mdx",
 			"source_path": "packages/docker/firecracker/python/web",

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -162,6 +162,12 @@ on:
             firecracker_python_net:
                 description: 'Firecracker Python Net rootfs changed'
                 value: ${{ jobs.alter.outputs.firecracker_python_net }}
+            firecracker_python_web:
+                description: 'Firecracker Python Web rootfs changed'
+                value: ${{ jobs.alter.outputs.firecracker_python_web }}
+            firecracker_node_web:
+                description: 'Firecracker Node Web rootfs changed'
+                value: ${{ jobs.alter.outputs.firecracker_node_web }}
 
 jobs:
     alter:
@@ -218,6 +224,8 @@ jobs:
             ue_kbvezstd: ${{ steps.delta.outputs.ue_kbvezstd_any_changed }}
             ue_kbvesqlite: ${{ steps.delta.outputs.ue_kbvesqlite_any_changed }}
             firecracker_python_net: ${{ steps.delta.outputs.firecracker_python_net_any_changed }}
+            firecracker_python_web: ${{ steps.delta.outputs.firecracker_python_web_any_changed }}
+            firecracker_node_web: ${{ steps.delta.outputs.firecracker_node_web_any_changed }}
 
         steps:
             - name: Checkout the repository
@@ -381,3 +389,9 @@ jobs:
                       firecracker_python_net:
                           - 'packages/docker/firecracker/python/net/**'
                           - 'apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-net.mdx'
+                      firecracker_python_web:
+                          - 'packages/docker/firecracker/python/web/**'
+                          - 'apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-web.mdx'
+                      firecracker_node_web:
+                          - 'packages/docker/firecracker/node/web/**'
+                          - 'apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-web.mdx'

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-node-web.mdx
@@ -14,7 +14,7 @@ tags:
 key: firecracker_node_web
 pipeline: docker
 app_name: firecracker-node-web
-version: "0.0.1"
+version: "0.1.0"
 version_toml: packages/docker/firecracker/node/web/version.toml
 source_path: packages/docker/firecracker/node/web
 runner: ubuntu-latest

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-web.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-python-web.mdx
@@ -14,7 +14,7 @@ tags:
 key: firecracker_python_web
 pipeline: docker
 app_name: firecracker-python-web
-version: "0.0.1"
+version: "0.1.0"
 version_toml: packages/docker/firecracker/python/web/version.toml
 source_path: packages/docker/firecracker/python/web
 runner: ubuntu-latest


### PR DESCRIPTION
## Summary

\`firecracker-python-web\` and \`firecracker-node-web\` packages were scaffolded (Dockerfiles + MDX + stage Job manifests) but **never published**. Both stage Jobs sit in \`ImagePullBackOff\` against \`ghcr.io/kbve/firecracker-{python,node}-web:0.0.1\` (\`skopeo list-tags\` returns HTTP 403 — packages don't exist on GHCR).

Side effect: ArgoCD's \`firecracker-ctl\` Application is stuck on \`waiting for completion of hook batch/Job/firecracker-web-rootfs-stage and 1 more hooks\`. That blocks the \`fc-ctl-net\` Deployment from rolling forward to \`:0.1.32\` — the build that carries the INPUT-chain ACCEPT fix for VM egress (PR #10832). Smoke test keeps failing on DNS.

## Cause

| Layer | State |
|------|-------|
| MDX \`version\` | \`0.0.1\` |
| \`version.toml\` | \`0.0.1\` |
| Version gate | \"matches version.toml — publish skipped\" (equality short-circuit) |
| \`is_altered(<key>)\` | always \`false\` because \`utils-file-alterations.yml\` has no entries for the two new keys |

Same pattern that bit \`firecracker_python_net\` initially.

## Fix

- \`.github/workflows/utils-file-alterations.yml\` — add outputs declaration + \`jobs.alter\` outputs map + filter patterns for \`firecracker_python_web\` and \`firecracker_node_web\` (mirrors the existing \`firecracker_python_net\` entries).
- \`apps/kbve/astro-kbve/.../firecracker-python-web.mdx\` — \`version: \"0.0.1\"\` → \`\"0.1.0\"\`.
- \`apps/kbve/astro-kbve/.../firecracker-node-web.mdx\` — same.
- \`.github/ci-dispatch-manifest.json\` — regenerated.

\`version.toml\` stays at \`0.0.1\` until the post-publish hook bumps it after the first successful publish.

## Test plan

- [ ] After merge, the next CI - Docker run for both apps fires (version gate sees \`0.1.0 > 0.0.1\`) and publishes \`ghcr.io/kbve/firecracker-python-web:0.1.0\` and \`ghcr.io/kbve/firecracker-node-web:0.1.0\`.
- [ ] Post-publish atom PRs bump each stage Job manifest to \`:0.1.0\`.
- [ ] ArgoCD reconciles \`firecracker-ctl\` Application — both stage Jobs go \`Complete\`, releasing the hook block.
- [ ] \`fc-ctl-net\` Deployment finally rolls to \`:0.1.32\`.
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB → poem prints.