### PR TITLE
chore(security): scope composite actions to KBVE/kbve only

### DIFF
--- a/.github/actions/gql-project-migration/action.yml
+++ b/.github/actions/gql-project-migration/action.yml
@@ -26,6 +26,14 @@ inputs:
 runs:
     using: 'composite'
     steps:
+        - name: Repository scope guard
+          shell: bash
+          run: |
+              if [ "$GITHUB_REPOSITORY" != "KBVE/kbve" ]; then
+                  echo "::error::This composite action is scoped to KBVE/kbve only (got: $GITHUB_REPOSITORY)"
+                  exit 1
+              fi
+
         - name: GQL Query Organization
           shell: bash
           env:

--- a/.github/actions/kbve-shell/action.yml
+++ b/.github/actions/kbve-shell/action.yml
@@ -26,6 +26,14 @@ inputs:
 runs:
     using: 'composite'
     steps:
+        - name: Repository scope guard
+          shell: bash
+          run: |
+              if [ "$GITHUB_REPOSITORY" != "KBVE/kbve" ]; then
+                  echo "::error::This composite action is scoped to KBVE/kbve only (got: $GITHUB_REPOSITORY)"
+                  exit 1
+              fi
+
         - name: Run kbve.sh with flag
           shell: bash
           env:

--- a/.github/actions/portainer-deployment/action.yml
+++ b/.github/actions/portainer-deployment/action.yml
@@ -1,48 +1,54 @@
 name: '[WIP] Portainer Depolyment'
 description: 'An action to help manage the Portainer deployment'
 inputs:
-  token:
-    description: 'Your Github Organization Token'
-  portainer-api-key:
-    description: 'Your Portainer API Key'
-    required: true
-  portainer-url:
-    description: 'Your Portainer URL'
-    default: '2'
-  portainer-swarm-id:
-    description: 'Your Portainer Swarm ID'
-  portainer-stack-name:
-    description: 'Your Portainer Stack Name'
-  portainer-stack-definition:
-    description: 'Your Stack Definitions'
-  portainer-template-variables:
-    description: 'Your Template Variables'
-  portainer-image:
-    description: 'Your Image'
-  portainer-prune-stack:
-    description: 'Do you want to Prune Stack?'
-    required: false
-    default: 'false'
-  org:
-    description: 'Your Github Organization Name'
-    default: 'KBVE'
-
+    token:
+        description: 'Your Github Organization Token'
+    portainer-api-key:
+        description: 'Your Portainer API Key'
+        required: true
+    portainer-url:
+        description: 'Your Portainer URL'
+        default: '2'
+    portainer-swarm-id:
+        description: 'Your Portainer Swarm ID'
+    portainer-stack-name:
+        description: 'Your Portainer Stack Name'
+    portainer-stack-definition:
+        description: 'Your Stack Definitions'
+    portainer-template-variables:
+        description: 'Your Template Variables'
+    portainer-image:
+        description: 'Your Image'
+    portainer-prune-stack:
+        description: 'Do you want to Prune Stack?'
+        required: false
+        default: 'false'
+    org:
+        description: 'Your Github Organization Name'
+        default: 'KBVE'
 
 runs:
-  using: 'composite'
-  steps:
-    - name: Portainer Init
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-        PORTAINER_URL: ${{ inputs.portainer-url}}
-        PORTAINER_API_KEY: ${{ inputs.portainer-api-key}}
-      run: |
+    using: 'composite'
+    steps:
+        - name: Repository scope guard
+          shell: bash
+          run: |
+              if [ "$GITHUB_REPOSITORY" != "KBVE/kbve" ]; then
+                echo "::error::This composite action is scoped to KBVE/kbve only (got: $GITHUB_REPOSITORY)"
+                exit 1
+              fi
 
-      curl -s -X POST "$PORTAINER_URL/api/endpoints/$ENDPOINT_ID/docker/stacks" \
-        -H "Authorization: Bearer $PORTAINER_API_KEY" \
-        -H "Content-Type: multipart/form-data" \
-        -F "file=@$DOCKER_COMPOSE_FILE" \
-        -F "Name=name-of-your-stack" \
-        -F "SwarmID=target-swarm-id" \
-        -F "Env=ENV_VAR1=value1,ENV_VAR2=value2"
+        - name: Portainer Init
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.token }}
+              PORTAINER_URL: ${{ inputs.portainer-url}}
+              PORTAINER_API_KEY: ${{ inputs.portainer-api-key}}
+          run: |
+              curl -s -X POST "$PORTAINER_URL/api/endpoints/$ENDPOINT_ID/docker/stacks" \
+                -H "Authorization: Bearer $PORTAINER_API_KEY" \
+                -H "Content-Type: multipart/form-data" \
+                -F "file=@$DOCKER_COMPOSE_FILE" \
+                -F "Name=name-of-your-stack" \
+                -F "SwarmID=target-swarm-id" \
+                -F "Env=ENV_VAR1=value1,ENV_VAR2=value2"

--- a/.github/actions/proxmox-deployment/action.yml
+++ b/.github/actions/proxmox-deployment/action.yml
@@ -3,19 +3,27 @@ description: 'An action to manage the Proxmox Deployment'
 # Helper Scripts from https://tteck.github.io/Proxmox/
 # Packer https://github.com/hashicorp/packer-plugin-proxmox/tree/main/docs
 inputs:
-  token:
-    description: 'Your Github Organization Token'
-  org:
-    description: 'Your Github Organization Name'
-    default: 'KBVE'
-  ssh-key:
-    description: 'Your Github SSH Key'
+    token:
+        description: 'Your Github Organization Token'
+    org:
+        description: 'Your Github Organization Name'
+        default: 'KBVE'
+    ssh-key:
+        description: 'Your Github SSH Key'
 
 runs:
-  using: 'composite'
-  steps:
-    - name: Proxmox Init.
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-      run: |
+    using: 'composite'
+    steps:
+        - name: Repository scope guard
+          shell: bash
+          run: |
+              if [ "$GITHUB_REPOSITORY" != "KBVE/kbve" ]; then
+                echo "::error::This composite action is scoped to KBVE/kbve only (got: $GITHUB_REPOSITORY)"
+                exit 1
+              fi
+
+        - name: Proxmox Init.
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.token }}
+          run: |

--- a/.github/actions/shieldwall-command-center/action.yml
+++ b/.github/actions/shieldwall-command-center/action.yml
@@ -1,33 +1,41 @@
 name: '[WIP] - SWCC'
 description: 'An action to send commands towards the shield wall'
 inputs:
-  token:
-    description: 'Your Github Organization Token'
-  org:
-    description: 'Your Github Organization Name'
-    default: 'KBVE'
-  command:
-    description: 'Your Action / Command for the Wall'
-    required: true
-  kbve-shield-token:
-    description: 'Your Shield Token for Auth'
-    required: true
+    token:
+        description: 'Your Github Organization Token'
+    org:
+        description: 'Your Github Organization Name'
+        default: 'KBVE'
+    command:
+        description: 'Your Action / Command for the Wall'
+        required: true
+    kbve-shield-token:
+        description: 'Your Shield Token for Auth'
+        required: true
 
 runs:
-  using: 'composite'
-  steps:
-    - name: Command Center For The Wall.
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.token }}
-        COMMAND_CENTER: ${{ inputs.command }}
-        KBVE_SHIELD_TOKEN: ${{ inputs.kbve-shield-token }}
-      run: |
-          response=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "kbve-shieldwall: $KBVE_SHIELD_TOKEN" \
-            "https://rust.kbve.com/api/v1/shieldwall/$COMMAND_CENTER")
-          echo "Response Code: $response"
-          if [ "$response" != "200" ]; then
-            echo "Error: Request failed with status $response"
-            exit 1
-          fi
+    using: 'composite'
+    steps:
+        - name: Repository scope guard
+          shell: bash
+          run: |
+              if [ "$GITHUB_REPOSITORY" != "KBVE/kbve" ]; then
+                echo "::error::This composite action is scoped to KBVE/kbve only (got: $GITHUB_REPOSITORY)"
+                exit 1
+              fi
+
+        - name: Command Center For The Wall.
+          shell: bash
+          env:
+              GITHUB_TOKEN: ${{ inputs.token }}
+              COMMAND_CENTER: ${{ inputs.command }}
+              KBVE_SHIELD_TOKEN: ${{ inputs.kbve-shield-token }}
+          run: |
+              response=$(curl -s -o /dev/null -w "%{http_code}" \
+                -H "kbve-shieldwall: $KBVE_SHIELD_TOKEN" \
+                "https://rust.kbve.com/api/v1/shieldwall/$COMMAND_CENTER")
+              echo "Response Code: $response"
+              if [ "$response" != "200" ]; then
+                echo "Error: Request failed with status $response"
+                exit 1
+              fi

--- a/.github/actions/virustotal-scan/action.yml
+++ b/.github/actions/virustotal-scan/action.yml
@@ -34,6 +34,14 @@ outputs:
 runs:
     using: 'composite'
     steps:
+        - name: Repository scope guard
+          shell: bash
+          run: |
+              if [ "$GITHUB_REPOSITORY" != "KBVE/kbve" ]; then
+                  echo "::error::This composite action is scoped to KBVE/kbve only (got: $GITHUB_REPOSITORY)"
+                  exit 1
+              fi
+
         - id: scan
           shell: bash
           env:


### PR DESCRIPTION
## Summary
Adds a **Repository scope guard** as the first step of every composite action under \`.github/actions/\`. The guard checks \`\$GITHUB_REPOSITORY\` against the exact-match allowlist \`KBVE/kbve\` and fails the action otherwise.

Forks and external repos that reference these actions get a clear error instead of executing KBVE-specific deployment, GraphQL, or shieldwall control flows.

This is upstream of workflow-level supply-chain hardening (cache key isolation, \`persist-credentials: false\`, action SHA pinning, etc.). Even if a downstream workflow is misconfigured, the action itself refuses to run outside the canonical repository.

## Motivation
Inspired by the [TanStack supply-chain postmortem (2026-05-11)](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem). Scoping internal automation tightly is the simplest defense-in-depth layer before tackling cache, OIDC, and \`pull_request_target\` boundary issues.

## Actions covered
| Action | Why it must be repo-scoped |
|---|---|
| \`gql-project-migration\` | Org GraphQL against KBVE Project #5 |
| \`kbve-shell\` | Executes \`./kbve.sh\` from the monorepo |
| \`portainer-deployment\` | KBVE Portainer endpoint |
| \`proxmox-deployment\` | KBVE Proxmox hosts |
| \`shieldwall-command-center\` | \`rust.kbve.com\` shieldwall API |
| \`virustotal-scan\` | KBVE CI binary scanning |

## Side-quest
Also fixes a pre-existing YAML break in \`portainer-deployment/action.yml\` where the curl invocation lived outside the \`run: |\` block (wrong indent, stray blank line). The action is still WIP but now parses as valid YAML and survives the prettier pre-commit hook.

## Test plan
- [x] All 6 \`action.yml\` files parse as YAML (\`prettier\` pre-commit hook passes)
- [x] First step is the scope guard in every action
- [ ] CI green
- [ ] Existing workflows that invoke these actions (e.g. \`utils-nx-kbve-shell.yml\`) still succeed on dev