### PR TITLE
perf(arcade): pool blackjack card views

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
@@ -57,6 +57,8 @@ interface ButtonView {
 export class BlackjackScene extends Phaser.Scene {
 	private state: BlackjackState = createBlackjackState();
 	private cardLayer!: Phaser.GameObjects.Container;
+	private cardViews: Phaser.GameObjects.Image[] = [];
+	private activeCardViews = 0;
 	private hudLayer!: Phaser.GameObjects.Container;
 	private buttons: ButtonView[] = [];
 	private statusText!: Phaser.GameObjects.Text;
@@ -465,7 +467,7 @@ export class BlackjackScene extends Phaser.Scene {
 	}
 
 	private render() {
-		this.cardLayer.removeAll(true);
+		this.activeCardViews = 0;
 		this.drawHand(
 			this.state.dealer,
 			BASE_WIDTH / 2,
@@ -473,6 +475,7 @@ export class BlackjackScene extends Phaser.Scene {
 			this.hideDealerHole(),
 		);
 		this.drawHand(this.state.player, BASE_WIDTH / 2, 420, false);
+		this.hideUnusedCardViews();
 		this.updateText();
 		this.updateButtons();
 	}
@@ -510,21 +513,44 @@ export class BlackjackScene extends Phaser.Scene {
 	}
 
 	private drawCardSlot(x: number, y: number) {
-		this.cardLayer.add(
-			this.add.image(x, y, this.cardTextureKey('slot')).setOrigin(0),
-		);
+		this.placeCardTexture(this.cardTextureKey('slot'), x, y);
 	}
 
 	private drawCardBack(x: number, y: number) {
-		this.cardLayer.add(
-			this.add.image(x, y, this.cardTextureKey('back')).setOrigin(0),
-		);
+		this.placeCardTexture(this.cardTextureKey('back'), x, y);
 	}
 
 	private drawCardFace(card: Card, x: number, y: number) {
-		this.cardLayer.add(
-			this.add.image(x, y, this.cardTextureKey(card)).setOrigin(0),
-		);
+		this.placeCardTexture(this.cardTextureKey(card), x, y);
+	}
+
+	private placeCardTexture(textureKey: string, x: number, y: number) {
+		const view = this.getCardView();
+		view.setTexture(textureKey);
+		view.setPosition(x, y);
+		view.setVisible(true);
+		view.setActive(true);
+	}
+
+	private getCardView(): Phaser.GameObjects.Image {
+		const view =
+			this.cardViews[this.activeCardViews] ??
+			this.add.image(0, 0, this.cardTextureKey('slot')).setOrigin(0);
+
+		if (!this.cardViews[this.activeCardViews]) {
+			this.cardViews.push(view);
+			this.cardLayer.add(view);
+		}
+
+		this.activeCardViews++;
+		return view;
+	}
+
+	private hideUnusedCardViews() {
+		for (let i = this.activeCardViews; i < this.cardViews.length; i++) {
+			this.cardViews[i].setVisible(false);
+			this.cardViews[i].setActive(false);
+		}
 	}
 
 	private createCardTextures() {


### PR DESCRIPTION
## Summary
- reuse blackjack card image objects across renders instead of recreating them
- hide inactive pooled card views when hands shrink or reset
- build on the cached card texture path to reduce Phaser object churn during deal/hit/stand/next flows

## Validation
- pnpm exec prettier --write apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
- pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts apps/kbve/astro-kbve/src/arcade/blackjack/ReactBlackjackApp.tsx apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts apps/kbve/astro-kbve/src/arcade/blackjack/state.ts
- pnpm exec vitest run apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts
- Playwright smoke loaded /arcade/blackjack/ and exercised deal -> hit -> stand/next -> deal again with no page/console errors

Note: eslint reports the existing Nx ProjectGraph warning for @nx/enforce-module-boundaries, but exits successfully.