### PR TITLE
feat(kbve): wallet feature — diesel client for wallet schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.148"
+version = "1.0.149"
 dependencies = [
  "anyhow",
  "askama 0.16.0",
@@ -5149,6 +5149,7 @@ dependencies = [
  "pq-sys",
  "r2d2",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -5220,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "discordsh-bot"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "askama 0.15.6",
@@ -6095,7 +6096,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firecracker-ctl"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "axum 0.8.9",
  "dashmap 6.1.0",
@@ -8300,7 +8301,7 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "irc-gateway"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -8816,6 +8817,7 @@ dependencies = [
  "tracing-subscriber",
  "ulid",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.78"
 default = []
 supabase = ["dep:lru"]
 image-gen = ["dep:resvg"]
+wallet = ["dep:uuid"]
 
 [dependencies]
 anyhow = "1.0"
@@ -29,6 +30,7 @@ diesel = { version = "2.3.7", features = [
     "chrono",
     "r2d2",
     "serde_json",
+    "uuid",
 ] }
 dotenvy = "0.15"
 axum = { version = "0.8.9", features = ["macros"] }
@@ -56,6 +58,7 @@ ulid = "1.2.1"
 num-bigint = "0.4"
 lru = { version = "0.16", optional = true }
 resvg = { version = "0.47.0", optional = true }
+uuid = { version = "1", features = ["v4", "serde"], optional = true }
 jedi = { path = "../jedi" }
 holy = { version = "0.2.1", path = "../holy" }
 

--- a/packages/rust/kbve/src/lib.rs
+++ b/packages/rust/kbve/src/lib.rs
@@ -24,6 +24,12 @@ pub mod web;
 //  * [MARKDOWN] — safe CommonMark + GFM renderer with ammonia allowlist.
 pub mod markdown;
 
+//  * [WALLET] — feature-gated multi-currency ledger client.
+//    Talks to the `wallet` Postgres schema (see packages/data/sql/schema/wallet/)
+//    via the existing diesel pool. Enable with `--features wallet`.
+#[cfg(feature = "wallet")]
+pub mod wallet;
+
 // Re-export the `holy` proc-macro crate so downstream axum-* services
 // can pull derive(Sanitize) / derive(Getters) etc. through `kbve::holy::*`
 // without taking a second top-level dependency. Single boundary = one

--- a/packages/rust/kbve/src/wallet/client.rs
+++ b/packages/rust/kbve/src/wallet/client.rs
@@ -1,0 +1,126 @@
+//! `WalletClient` — diesel-pool wrapper that hosts the wallet service ops.
+//!
+//! The wallet schema's `SECURITY DEFINER` functions need the caller to either
+//! be `service_role` (recommended) or come through an authenticated proxy.
+//! We support both by using two helpers on the client:
+//!
+//!   - [`WalletClient::run_service`] runs a closure as the role the connection
+//!     pool authenticates as. For service paths this should be `service_role`.
+//!   - [`WalletClient::run_as_user`] sets `request.jwt.claims` for the
+//!     `public.proxy_wallet_*` functions so `auth.uid()` resolves correctly,
+//!     then runs the closure.
+//!
+//! The actual sync diesel work happens inside `tokio::task::spawn_blocking`
+//! so we never block the async runtime.
+
+use std::env;
+use std::fs;
+
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
+use diesel::sql_query;
+use diesel::sql_types::Text;
+use serde_json::json;
+use uuid::Uuid;
+
+use super::error::{Result, WalletError};
+
+pub type WalletPool = Pool<ConnectionManager<PgConnection>>;
+pub type WalletConn = PooledConnection<ConnectionManager<PgConnection>>;
+
+/// Build a wallet-dedicated diesel pool.
+///
+/// Reads `WALLET_DATABASE_URL` (or `WALLET_DATABASE_URL_FILE` for Docker
+/// secrets style). Falls back to `DATABASE_URL_PROD` so dev environments keep
+/// working without a separate var.
+///
+/// The login role should be `service_role` so the SECURITY DEFINER chains
+/// resolve cleanly. For local docker postgres without that role, use
+/// `postgres` (the SQL functions accept superuser fallback).
+pub fn establish_wallet_pool() -> Result<WalletPool> {
+    let url = read_env("WALLET_DATABASE_URL")
+        .or_else(|_| read_env("DATABASE_URL_PROD"))
+        .map_err(|e| WalletError::Pool(format!("missing wallet DATABASE URL: {e}")))?;
+
+    let manager = ConnectionManager::<PgConnection>::new(url);
+    Pool::builder()
+        .max_size(8)
+        .build(manager)
+        .map_err(|e| WalletError::Pool(e.to_string()))
+}
+
+fn read_env(name: &str) -> std::result::Result<String, String> {
+    match env::var(name) {
+        Ok(v) => Ok(v),
+        Err(_) => {
+            let file = env::var(format!("{name}_FILE")).map_err(|_| format!("{name} not set"))?;
+            fs::read_to_string(file).map_err(|e| e.to_string())
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct WalletClient {
+    pool: WalletPool,
+}
+
+impl WalletClient {
+    pub fn new(pool: WalletPool) -> Self {
+        Self { pool }
+    }
+
+    /// Construct from env vars.
+    pub fn from_env() -> Result<Self> {
+        Ok(Self::new(establish_wallet_pool()?))
+    }
+
+    pub fn pool(&self) -> &WalletPool {
+        &self.pool
+    }
+
+    /// Run a diesel closure on a worker thread without any per-request session
+    /// state. Used by `service_*` paths that already trust the caller (the
+    /// connection itself authenticates as `service_role`).
+    pub async fn run_service<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut WalletConn) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = pool.get()?;
+            f(&mut conn)
+        })
+        .await?
+    }
+
+    /// Run a diesel closure on behalf of an authenticated user.
+    ///
+    /// Sets `request.jwt.claims` as a session GUC inside the closure's
+    /// transaction so the `public.proxy_wallet_*` SECURITY DEFINER functions
+    /// see `auth.uid()` correctly. The claim block is reset after the closure
+    /// returns regardless of outcome.
+    pub async fn run_as_user<F, T>(&self, user_id: Uuid, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut WalletConn) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let pool = self.pool.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = pool.get()?;
+            conn.transaction::<T, WalletError, _>(|conn| {
+                let claims = json!({
+                    "role": "authenticated",
+                    "sub": user_id.to_string(),
+                });
+                sql_query("SELECT set_config('request.jwt.claims', $1, true)")
+                    .bind::<Text, _>(claims.to_string())
+                    .execute(conn)
+                    .map_err(WalletError::from_diesel)?;
+                f(conn)
+            })
+        })
+        .await?
+    }
+}

--- a/packages/rust/kbve/src/wallet/error.rs
+++ b/packages/rust/kbve/src/wallet/error.rs
@@ -1,0 +1,149 @@
+//! Typed errors emitted by the wallet client.
+//!
+//! Maps Postgres SQLSTATEs raised by the `wallet.service_*` / `public.proxy_wallet_*`
+//! functions to dedicated variants. The mapping is conservative: SQLSTATEs that
+//! diesel surfaces as `DatabaseErrorKind` are matched on the kind; the rest are
+//! matched against the exception message prefix the SQL functions raise.
+
+use diesel::result::{DatabaseErrorKind, Error as DieselError};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum WalletError {
+    #[error("insufficient funds")]
+    InsufficientFunds,
+
+    #[error("idempotency_key reused with different payload")]
+    ReplayMismatch,
+
+    #[error("balance overflow")]
+    Overflow,
+
+    #[error("not authorized")]
+    NotAuthorized,
+
+    #[error("not authenticated")]
+    NotAuthenticated,
+
+    #[error("null argument: {0}")]
+    NullArgument(String),
+
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("coupon not redeemable: {0}")]
+    CouponNotRedeemable(String),
+
+    #[error("coupon expired")]
+    CouponExpired,
+
+    #[error("feature not implemented: {0}")]
+    Unimplemented(String),
+
+    #[error("pool error: {0}")]
+    Pool(String),
+
+    #[error("blocking task join error: {0}")]
+    Join(String),
+
+    #[error(transparent)]
+    Db(#[from] DieselError),
+}
+
+impl WalletError {
+    /// Best-effort mapping from a diesel error to a typed variant.
+    ///
+    /// Strategy:
+    ///   1. If the underlying `DatabaseErrorKind` is one of the well-known
+    ///      mapped ones (UniqueViolation, SerializationFailure, …), use it.
+    ///   2. Otherwise inspect the exception message prefix that our SQL
+    ///      functions raise (e.g. "insufficient funds").
+    ///   3. Fall back to the raw `DieselError` in the `Db` variant.
+    pub fn from_diesel(e: DieselError) -> Self {
+        if let DieselError::DatabaseError(kind, ref info) = e {
+            // First pass: structural kinds that map cleanly.
+            match kind {
+                DatabaseErrorKind::SerializationFailure => {
+                    return WalletError::ReplayMismatch;
+                }
+                DatabaseErrorKind::ForeignKeyViolation => {
+                    // Our SQL raises 23503 for "coupon not found" /
+                    // "account has no balance row" pre-debit.
+                    return WalletError::NotFound(info.message().to_string());
+                }
+                DatabaseErrorKind::CheckViolation => {
+                    // Balance check, ledger.delta<>0, coupon state checks, etc.
+                    return WalletError::InvalidArgument(info.message().to_string());
+                }
+                DatabaseErrorKind::NotNullViolation => {
+                    return WalletError::NullArgument(info.message().to_string());
+                }
+                _ => {}
+            }
+
+            // Second pass: prefix-match against the raised messages our SQL uses.
+            let msg = info.message();
+            return classify_message(msg).unwrap_or(WalletError::Db(e));
+        }
+
+        WalletError::Db(e)
+    }
+}
+
+fn classify_message(msg: &str) -> Option<WalletError> {
+    let m = msg.to_lowercase();
+    if m.contains("insufficient funds") {
+        return Some(WalletError::InsufficientFunds);
+    }
+    if m.contains("idempotency_key reused") {
+        return Some(WalletError::ReplayMismatch);
+    }
+    if m.contains("overflow") || m.contains("would overflow") {
+        return Some(WalletError::Overflow);
+    }
+    if m.contains("not authenticated") {
+        return Some(WalletError::NotAuthenticated);
+    }
+    if m.contains("service_role required") {
+        return Some(WalletError::NotAuthorized);
+    }
+    if m.contains("coupon expired") {
+        return Some(WalletError::CouponExpired);
+    }
+    if m.contains("coupon not found") {
+        return Some(WalletError::NotFound("coupon".into()));
+    }
+    if m.contains("not redeemable")
+        || m.contains("template is inactive")
+        || m.contains("cannot revoke a redeemed coupon")
+    {
+        return Some(WalletError::CouponNotRedeemable(msg.to_string()));
+    }
+    if m.contains("not yet wired") || m.contains("not implemented") {
+        return Some(WalletError::Unimplemented(msg.to_string()));
+    }
+    if m.contains("must be positive") || m.contains("must differ") || m.contains("invalid") {
+        return Some(WalletError::InvalidArgument(msg.to_string()));
+    }
+    if m.contains("is required") || m.contains("cannot be null") {
+        return Some(WalletError::NullArgument(msg.to_string()));
+    }
+    None
+}
+
+impl From<r2d2::Error> for WalletError {
+    fn from(e: r2d2::Error) -> Self {
+        WalletError::Pool(e.to_string())
+    }
+}
+
+impl From<tokio::task::JoinError> for WalletError {
+    fn from(e: tokio::task::JoinError) -> Self {
+        WalletError::Join(e.to_string())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, WalletError>;

--- a/packages/rust/kbve/src/wallet/mod.rs
+++ b/packages/rust/kbve/src/wallet/mod.rs
@@ -1,0 +1,44 @@
+//! `kbve::wallet` — multi-currency ledger client.
+//!
+//! Mirrors the `wallet` Postgres schema (packages/data/sql/schema/wallet/).
+//! Calls SECURITY DEFINER service RPCs via diesel. All public functions are
+//! `async` and wrap the synchronous diesel work in `tokio::task::spawn_blocking`.
+//!
+//! Enable with the `wallet` Cargo feature.
+//!
+//! Quick start:
+//!
+//! ```ignore
+//! use kbve::wallet::{WalletClient, CreditRequest, CurrencyKind, SourceKind};
+//! use uuid::Uuid;
+//!
+//! let pool = kbve::wallet::client::establish_wallet_pool();
+//! let client = WalletClient::new(pool);
+//!
+//! let ledger_id = client.credit(CreditRequest {
+//!     account_id: account,
+//!     currency: CurrencyKind::Khash,
+//!     amount: 1000,
+//!     source_kind: SourceKind::Reward,
+//!     reason: Some("daily_login".into()),
+//!     ref_type: None,
+//!     ref_id: None,
+//!     idempotency_key: Uuid::new_v4(),
+//! }).await?;
+//! ```
+
+pub mod client;
+pub mod error;
+pub mod proxy;
+pub mod service;
+pub mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use client::WalletClient;
+pub use error::WalletError;
+pub use types::*;
+// `service` and `proxy` extend WalletClient via `impl` blocks; their methods
+// are reached through the client itself, so there are no free items to
+// re-export here.

--- a/packages/rust/kbve/src/wallet/proxy.rs
+++ b/packages/rust/kbve/src/wallet/proxy.rs
@@ -1,0 +1,181 @@
+//! Authenticated-user wallet operations.
+//!
+//! Mirrors the `public.proxy_wallet_*` functions. Each call sets
+//! `request.jwt.claims` for the session so `auth.uid()` resolves to the
+//! caller's user id; this lets the SECURITY DEFINER proxy land in the right
+//! account.
+//!
+//! Note: the connection role still authenticates as `service_role` (or
+//! superuser) — we are not switching roles, just shimming the JWT claim
+//! that the proxy functions read with `auth.uid()`.
+
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Bool, Jsonb, Nullable, Text, Timestamptz};
+use uuid::Uuid;
+
+use super::client::{WalletClient, WalletConn};
+use super::error::{Result, WalletError};
+use super::types::*;
+
+// ---------------------------------------------------------------------------
+// QueryableByName rows
+// ---------------------------------------------------------------------------
+
+#[derive(QueryableByName)]
+struct BalanceRowDb {
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    account_id: Uuid,
+    #[diesel(sql_type = BigInt)]
+    credits: i64,
+    #[diesel(sql_type = BigInt)]
+    khash: i64,
+    #[diesel(sql_type = Timestamptz)]
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(QueryableByName)]
+struct CouponSummaryDb {
+    #[diesel(sql_type = BigInt)]
+    coupon_id: i64,
+    #[diesel(sql_type = Text)]
+    template_code: String,
+    #[diesel(sql_type = Text)]
+    template_label: String,
+    #[diesel(sql_type = Text)]
+    reward_kind: String,
+    #[diesel(sql_type = Jsonb)]
+    reward_payload: serde_json::Value,
+    #[diesel(sql_type = Text)]
+    status: String,
+    #[diesel(sql_type = Timestamptz)]
+    granted_at: DateTime<Utc>,
+    #[diesel(sql_type = Nullable<Timestamptz>)]
+    expires_at: Option<DateTime<Utc>>,
+    #[diesel(sql_type = Nullable<Timestamptz>)]
+    redeemed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(QueryableByName)]
+struct RedeemRowDb {
+    #[diesel(sql_type = Bool)]
+    success: bool,
+    #[diesel(sql_type = Text)]
+    reward_kind: String,
+    #[diesel(sql_type = Jsonb)]
+    reward_payload: serde_json::Value,
+    #[diesel(sql_type = BigInt)]
+    ledger_id: i64,
+}
+
+// ---------------------------------------------------------------------------
+// User-facing proxy operations
+// ---------------------------------------------------------------------------
+
+impl WalletClient {
+    /// `public.proxy_wallet_get_balance()` — returns the caller's balance.
+    /// Lazily provisions the account + welcome coupon on first call.
+    pub async fn user_balance(&self, user_id: Uuid) -> Result<BalanceRow> {
+        self.run_as_user(user_id, |conn| balance_blocking(conn))
+            .await
+    }
+
+    /// `public.proxy_wallet_list_coupons()` — returns the caller's coupons.
+    pub async fn user_coupons(&self, user_id: Uuid) -> Result<Vec<CouponSummary>> {
+        self.run_as_user(user_id, |conn| coupons_blocking(conn))
+            .await
+    }
+
+    /// `public.proxy_wallet_redeem_coupon(coupon_id, idempotency_key)` —
+    /// auth-checked ownership + idempotent at the coupon layer.
+    pub async fn user_redeem_coupon(
+        &self,
+        user_id: Uuid,
+        coupon_id: i64,
+        idempotency_key: Uuid,
+    ) -> Result<RedeemResult> {
+        self.run_as_user(user_id, move |conn| {
+            redeem_blocking(conn, coupon_id, idempotency_key)
+        })
+        .await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Blocking implementations
+// ---------------------------------------------------------------------------
+
+fn balance_blocking(conn: &mut WalletConn) -> Result<BalanceRow> {
+    let row: BalanceRowDb = sql_query(
+        "SELECT account_id, credits, khash, updated_at \
+         FROM public.proxy_wallet_get_balance()",
+    )
+    .get_result(conn)
+    .map_err(WalletError::from_diesel)?;
+
+    Ok(BalanceRow {
+        account_id: row.account_id,
+        credits: row.credits,
+        khash: row.khash,
+        updated_at: row.updated_at,
+    })
+}
+
+fn coupons_blocking(conn: &mut WalletConn) -> Result<Vec<CouponSummary>> {
+    let rows: Vec<CouponSummaryDb> = sql_query(
+        "SELECT coupon_id, template_code, template_label, \
+                reward_kind::text AS reward_kind, reward_payload, \
+                status::text AS status, granted_at, expires_at, redeemed_at \
+         FROM public.proxy_wallet_list_coupons()",
+    )
+    .get_results(conn)
+    .map_err(WalletError::from_diesel)?;
+
+    rows.into_iter()
+        .map(|r| {
+            let reward_kind = RewardKind::from_pg(&r.reward_kind).ok_or_else(|| {
+                WalletError::InvalidArgument(format!("unknown reward_kind: {}", r.reward_kind))
+            })?;
+            let status = CouponStatus::from_pg(&r.status).ok_or_else(|| {
+                WalletError::InvalidArgument(format!("unknown coupon status: {}", r.status))
+            })?;
+            Ok(CouponSummary {
+                coupon_id: r.coupon_id,
+                template_code: r.template_code,
+                template_label: r.template_label,
+                reward_kind,
+                reward_payload: r.reward_payload,
+                status,
+                granted_at: r.granted_at,
+                expires_at: r.expires_at,
+                redeemed_at: r.redeemed_at,
+            })
+        })
+        .collect()
+}
+
+fn redeem_blocking(
+    conn: &mut WalletConn,
+    coupon_id: i64,
+    idempotency_key: Uuid,
+) -> Result<RedeemResult> {
+    let row: RedeemRowDb = sql_query(
+        "SELECT success, reward_kind::text AS reward_kind, reward_payload, ledger_id \
+         FROM public.proxy_wallet_redeem_coupon($1, $2)",
+    )
+    .bind::<BigInt, _>(coupon_id)
+    .bind::<diesel::sql_types::Uuid, _>(idempotency_key)
+    .get_result(conn)
+    .map_err(WalletError::from_diesel)?;
+
+    let reward_kind = RewardKind::from_pg(&row.reward_kind).ok_or_else(|| {
+        WalletError::InvalidArgument(format!("unknown reward_kind: {}", row.reward_kind))
+    })?;
+    Ok(RedeemResult {
+        success: row.success,
+        reward_kind,
+        reward_payload: row.reward_payload,
+        ledger_id: row.ledger_id,
+    })
+}

--- a/packages/rust/kbve/src/wallet/service.rs
+++ b/packages/rust/kbve/src/wallet/service.rs
@@ -1,0 +1,223 @@
+//! Service-side wallet operations.
+//!
+//! Each fn calls the matching `wallet.service_*` SECURITY DEFINER function
+//! via `diesel::sql_query`. Bind params are passed as TEXT for enums (cast
+//! server-side) and explicit diesel types for everything else. Errors are
+//! normalized through [`WalletError::from_diesel`].
+
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Bool, Jsonb, Nullable, Text};
+use uuid::Uuid;
+
+use super::client::{WalletClient, WalletConn};
+use super::error::{Result, WalletError};
+use super::types::*;
+
+// ---------------------------------------------------------------------------
+// QueryableByName rows
+// ---------------------------------------------------------------------------
+
+#[derive(QueryableByName)]
+struct LedgerIdRow {
+    #[diesel(sql_type = BigInt)]
+    id: i64,
+}
+
+#[derive(QueryableByName)]
+struct RedeemRow {
+    #[diesel(sql_type = Bool)]
+    success: bool,
+    #[diesel(sql_type = Text)]
+    reward_kind: String,
+    #[diesel(sql_type = Jsonb)]
+    reward_payload: serde_json::Value,
+    #[diesel(sql_type = BigInt)]
+    ledger_id: i64,
+}
+
+#[derive(QueryableByName)]
+struct VerifyBalanceRowDb {
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    account_id: Uuid,
+    #[diesel(sql_type = BigInt)]
+    stored_credits: i64,
+    #[diesel(sql_type = BigInt)]
+    ledger_credits: i64,
+    #[diesel(sql_type = BigInt)]
+    stored_khash: i64,
+    #[diesel(sql_type = BigInt)]
+    ledger_khash: i64,
+    #[diesel(sql_type = Bool)]
+    ok: bool,
+}
+
+#[derive(QueryableByName)]
+struct RevokedRow {
+    #[diesel(sql_type = Bool)]
+    revoked: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Service operations
+// ---------------------------------------------------------------------------
+
+impl WalletClient {
+    /// `wallet.service_credit(...)` — positive delta. Returns ledger id.
+    pub async fn credit(&self, req: CreditRequest) -> Result<i64> {
+        self.run_service(move |conn| credit_blocking(conn, req))
+            .await
+    }
+
+    /// `wallet.service_debit(...)` — positive p_amount, becomes negative delta.
+    /// Raises [`WalletError::InsufficientFunds`] when balance would go negative.
+    pub async fn debit(&self, req: DebitRequest) -> Result<i64> {
+        self.run_service(move |conn| debit_blocking(conn, req))
+            .await
+    }
+
+    /// `wallet.service_transfer(...)` — atomic debit + credit with
+    /// canonical-order advisory locking.
+    pub async fn transfer(&self, req: TransferRequest) -> Result<()> {
+        self.run_service(move |conn| transfer_blocking(conn, req))
+            .await
+    }
+
+    /// `wallet.service_redeem_coupon(coupon_id, idempotency_key)`.
+    /// Idempotent at the coupon layer: same key replays return the original
+    /// ledger id instead of raising.
+    pub async fn redeem_coupon(
+        &self,
+        coupon_id: i64,
+        idempotency_key: Uuid,
+    ) -> Result<RedeemResult> {
+        self.run_service(move |conn| redeem_blocking(conn, coupon_id, idempotency_key))
+            .await
+    }
+
+    /// `wallet.service_revoke_coupon(coupon_id, reason)`. Returns false on
+    /// already-revoked, raises on redeemed.
+    pub async fn revoke_coupon(&self, coupon_id: i64, reason: Option<String>) -> Result<bool> {
+        self.run_service(move |conn| revoke_blocking(conn, coupon_id, reason))
+            .await
+    }
+
+    /// `wallet.service_verify_balance(account_id)` — compares stored balance
+    /// against ledger sum per currency. `ok=true` means consistent.
+    pub async fn verify_balance(&self, account_id: Uuid) -> Result<VerifyBalanceRow> {
+        self.run_service(move |conn| verify_blocking(conn, account_id))
+            .await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Blocking implementations
+// ---------------------------------------------------------------------------
+
+fn credit_blocking(conn: &mut WalletConn, req: CreditRequest) -> Result<i64> {
+    let row: LedgerIdRow = sql_query(
+        "SELECT wallet.service_credit($1, $2::wallet.currency_kind, $3, \
+         $4::wallet.source_kind, $5, $6, $7, $8) AS id",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(req.account_id)
+    .bind::<Text, _>(req.currency.as_pg())
+    .bind::<BigInt, _>(req.amount)
+    .bind::<Text, _>(req.source_kind.as_pg())
+    .bind::<Nullable<Text>, _>(req.reason)
+    .bind::<Nullable<Text>, _>(req.ref_type)
+    .bind::<Nullable<BigInt>, _>(req.ref_id)
+    .bind::<diesel::sql_types::Uuid, _>(req.idempotency_key)
+    .get_result(conn)
+    .map_err(WalletError::from_diesel)?;
+    Ok(row.id)
+}
+
+fn debit_blocking(conn: &mut WalletConn, req: DebitRequest) -> Result<i64> {
+    let row: LedgerIdRow = sql_query(
+        "SELECT wallet.service_debit($1, $2::wallet.currency_kind, $3, \
+         $4::wallet.source_kind, $5, $6, $7, $8) AS id",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(req.account_id)
+    .bind::<Text, _>(req.currency.as_pg())
+    .bind::<BigInt, _>(req.amount)
+    .bind::<Text, _>(req.source_kind.as_pg())
+    .bind::<Nullable<Text>, _>(req.reason)
+    .bind::<Nullable<Text>, _>(req.ref_type)
+    .bind::<Nullable<BigInt>, _>(req.ref_id)
+    .bind::<diesel::sql_types::Uuid, _>(req.idempotency_key)
+    .get_result(conn)
+    .map_err(WalletError::from_diesel)?;
+    Ok(row.id)
+}
+
+fn transfer_blocking(conn: &mut WalletConn, req: TransferRequest) -> Result<()> {
+    sql_query(
+        "SELECT wallet.service_transfer($1, $2, $3::wallet.currency_kind, $4, \
+         $5::wallet.source_kind, $6, $7, $8, $9)",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(req.from_account)
+    .bind::<diesel::sql_types::Uuid, _>(req.to_account)
+    .bind::<Text, _>(req.currency.as_pg())
+    .bind::<BigInt, _>(req.amount)
+    .bind::<Text, _>(req.source_kind.as_pg())
+    .bind::<Nullable<Text>, _>(req.reason)
+    .bind::<Nullable<Text>, _>(req.ref_type)
+    .bind::<Nullable<BigInt>, _>(req.ref_id)
+    .bind::<diesel::sql_types::Uuid, _>(req.idempotency_key)
+    .execute(conn)
+    .map_err(WalletError::from_diesel)?;
+    Ok(())
+}
+
+fn redeem_blocking(
+    conn: &mut WalletConn,
+    coupon_id: i64,
+    idempotency_key: Uuid,
+) -> Result<RedeemResult> {
+    let row: RedeemRow = sql_query(
+        "SELECT success, reward_kind::text AS reward_kind, reward_payload, ledger_id \
+         FROM wallet.service_redeem_coupon($1, $2)",
+    )
+    .bind::<BigInt, _>(coupon_id)
+    .bind::<diesel::sql_types::Uuid, _>(idempotency_key)
+    .get_result(conn)
+    .map_err(WalletError::from_diesel)?;
+
+    let reward_kind = RewardKind::from_pg(&row.reward_kind).ok_or_else(|| {
+        WalletError::InvalidArgument(format!("unknown reward_kind: {}", row.reward_kind))
+    })?;
+    Ok(RedeemResult {
+        success: row.success,
+        reward_kind,
+        reward_payload: row.reward_payload,
+        ledger_id: row.ledger_id,
+    })
+}
+
+fn revoke_blocking(conn: &mut WalletConn, coupon_id: i64, reason: Option<String>) -> Result<bool> {
+    let row: RevokedRow = sql_query("SELECT wallet.service_revoke_coupon($1, $2) AS revoked")
+        .bind::<BigInt, _>(coupon_id)
+        .bind::<Nullable<Text>, _>(reason)
+        .get_result(conn)
+        .map_err(WalletError::from_diesel)?;
+    Ok(row.revoked)
+}
+
+fn verify_blocking(conn: &mut WalletConn, account_id: Uuid) -> Result<VerifyBalanceRow> {
+    let row: VerifyBalanceRowDb = sql_query(
+        "SELECT account_id, stored_credits, ledger_credits, \
+                stored_khash, ledger_khash, ok \
+         FROM wallet.service_verify_balance($1)",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(account_id)
+    .get_result(conn)
+    .map_err(WalletError::from_diesel)?;
+    Ok(VerifyBalanceRow {
+        account_id: row.account_id,
+        stored_credits: row.stored_credits,
+        ledger_credits: row.ledger_credits,
+        stored_khash: row.stored_khash,
+        ledger_khash: row.ledger_khash,
+        ok: row.ok,
+    })
+}

--- a/packages/rust/kbve/src/wallet/tests.rs
+++ b/packages/rust/kbve/src/wallet/tests.rs
@@ -1,0 +1,304 @@
+//! Integration tests against a real Postgres with the wallet schema applied.
+//!
+//! Set `WALLET_TEST_DATABASE_URL` to a connection string pointing at a DB
+//! with all migrations through `20260511104220_wallet_schema_init` applied.
+//! Tests are skipped when the env var is unset so CI can opt in.
+//!
+//! Run:
+//!
+//! ```bash
+//! WALLET_TEST_DATABASE_URL="postgres://postgres:postgres@localhost:54322/postgres" \
+//!   cargo test -p kbve --features wallet -- --include-ignored
+//! ```
+
+#![cfg(test)]
+
+use std::env;
+
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::Text;
+use serial_test::serial;
+use uuid::Uuid;
+
+use super::{
+    CouponStatus, CreditRequest, CurrencyKind, DebitRequest, RewardKind, SourceKind,
+    TransferRequest, WalletClient, WalletError,
+};
+
+const TEST_URL_ENV: &str = "WALLET_TEST_DATABASE_URL";
+
+fn client() -> Option<WalletClient> {
+    let url = env::var(TEST_URL_ENV).ok()?;
+    env::set_var("WALLET_DATABASE_URL", &url);
+    Some(WalletClient::from_env().expect("client from_env"))
+}
+
+/// Direct (non-pool) admin connection for seeding fixtures.
+fn admin_conn() -> Option<PgConnection> {
+    let url = env::var(TEST_URL_ENV).ok()?;
+    PgConnection::establish(&url).ok()
+}
+
+/// Create a fresh `auth.users` row + wallet account, return both UUIDs.
+/// Bypasses the proxy provisioning path so individual ops are testable
+/// in isolation.
+fn fixture_account() -> Option<(Uuid, Uuid)> {
+    let mut conn = admin_conn()?;
+    let user_id = Uuid::new_v4();
+    sql_query("INSERT INTO auth.users (id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind::<diesel::sql_types::Uuid, _>(user_id)
+        .execute(&mut conn)
+        .expect("insert auth.users");
+    let row: diesel::sql_types::Uuid;
+    #[derive(QueryableByName)]
+    struct R {
+        #[diesel(sql_type = diesel::sql_types::Uuid)]
+        id: Uuid,
+    }
+    let _ = row;
+    let r: R =
+        sql_query("INSERT INTO wallet.account (kind, user_id) VALUES ('user', $1) RETURNING id")
+            .bind::<diesel::sql_types::Uuid, _>(user_id)
+            .get_result(&mut conn)
+            .expect("insert wallet.account");
+    sql_query("INSERT INTO wallet.balance (account_id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind::<diesel::sql_types::Uuid, _>(r.id)
+        .execute(&mut conn)
+        .expect("insert wallet.balance");
+    Some((user_id, r.id))
+}
+
+fn req_credit(account: Uuid, amount: i64, key: Uuid) -> CreditRequest {
+    CreditRequest {
+        account_id: account,
+        currency: CurrencyKind::Khash,
+        amount,
+        source_kind: SourceKind::Reward,
+        reason: Some("test".into()),
+        ref_type: None,
+        ref_id: None,
+        idempotency_key: key,
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn credit_then_replay_returns_same_ledger_id() {
+    let Some(client) = client() else {
+        eprintln!("SKIP: WALLET_TEST_DATABASE_URL unset");
+        return;
+    };
+    let (_user, account) = fixture_account().expect("fixture");
+    let key = Uuid::new_v4();
+
+    let id1 = client.credit(req_credit(account, 100, key)).await.unwrap();
+    let id2 = client.credit(req_credit(account, 100, key)).await.unwrap();
+    assert_eq!(id1, id2, "replay must return same ledger id");
+}
+
+#[tokio::test]
+#[serial]
+async fn credit_replay_with_different_payload_raises_replay_mismatch() {
+    let Some(client) = client() else {
+        return;
+    };
+    let (_user, account) = fixture_account().expect("fixture");
+    let key = Uuid::new_v4();
+
+    client.credit(req_credit(account, 100, key)).await.unwrap();
+    let err = client
+        .credit(req_credit(account, 999, key))
+        .await
+        .expect_err("must raise");
+    assert!(matches!(err, WalletError::ReplayMismatch), "got: {err:?}");
+}
+
+#[tokio::test]
+#[serial]
+async fn debit_beyond_balance_raises_insufficient_funds() {
+    let Some(client) = client() else {
+        return;
+    };
+    let (_user, account) = fixture_account().expect("fixture");
+
+    client
+        .credit(req_credit(account, 50, Uuid::new_v4()))
+        .await
+        .unwrap();
+
+    let req = DebitRequest {
+        account_id: account,
+        currency: CurrencyKind::Khash,
+        amount: 99999,
+        source_kind: SourceKind::Admin,
+        reason: None,
+        ref_type: None,
+        ref_id: None,
+        idempotency_key: Uuid::new_v4(),
+    };
+    let err = client.debit(req).await.expect_err("must raise");
+    assert!(
+        matches!(err, WalletError::InsufficientFunds),
+        "got: {err:?}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn transfer_moves_funds_atomically() {
+    let Some(client) = client() else {
+        return;
+    };
+    let (_user_a, account_a) = fixture_account().expect("fixture a");
+    let (_user_b, account_b) = fixture_account().expect("fixture b");
+
+    client
+        .credit(req_credit(account_a, 500, Uuid::new_v4()))
+        .await
+        .unwrap();
+
+    client
+        .transfer(TransferRequest {
+            from_account: account_a,
+            to_account: account_b,
+            currency: CurrencyKind::Khash,
+            amount: 200,
+            source_kind: SourceKind::Transfer,
+            reason: Some("test transfer".into()),
+            ref_type: None,
+            ref_id: None,
+            idempotency_key: Uuid::new_v4(),
+        })
+        .await
+        .unwrap();
+
+    let v = client.verify_balance(account_a).await.unwrap();
+    assert!(v.ok);
+    assert_eq!(v.stored_khash, 300);
+
+    let v = client.verify_balance(account_b).await.unwrap();
+    assert!(v.ok);
+    assert_eq!(v.stored_khash, 200);
+}
+
+#[tokio::test]
+#[serial]
+async fn welcome_redeem_flow_via_user_proxy() {
+    let Some(client) = client() else {
+        return;
+    };
+    let mut conn = admin_conn().unwrap();
+
+    // Fresh user; let proxy provision the account + welcome coupon.
+    let user_id = Uuid::new_v4();
+    sql_query("INSERT INTO auth.users (id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind::<diesel::sql_types::Uuid, _>(user_id)
+        .execute(&mut conn)
+        .unwrap();
+
+    let bal = client.user_balance(user_id).await.unwrap();
+    assert_eq!(bal.khash, 0);
+
+    let coupons = client.user_coupons(user_id).await.unwrap();
+    let welcome = coupons
+        .iter()
+        .find(|c| c.template_code == "WELCOME_KHASH")
+        .expect("welcome coupon present");
+    assert_eq!(welcome.status, CouponStatus::Unredeemed);
+    assert!(matches!(welcome.reward_kind, RewardKind::Khash));
+
+    let key = Uuid::new_v4();
+    let r1 = client
+        .user_redeem_coupon(user_id, welcome.coupon_id, key)
+        .await
+        .unwrap();
+    assert!(r1.success);
+
+    // Replay returns the same ledger id.
+    let r2 = client
+        .user_redeem_coupon(user_id, welcome.coupon_id, key)
+        .await
+        .unwrap();
+    assert_eq!(r1.ledger_id, r2.ledger_id);
+
+    let bal = client.user_balance(user_id).await.unwrap();
+    assert_eq!(bal.khash, 1000);
+}
+
+#[tokio::test]
+#[serial]
+async fn revoke_unredeemed_coupon_succeeds() {
+    let Some(client) = client() else {
+        return;
+    };
+    let (_user, account) = fixture_account().expect("fixture");
+    let mut conn = admin_conn().unwrap();
+
+    // Seed a one-off template + instance so we don't touch WELCOME_KHASH.
+    let template_code = format!("TEST_REVOKE_{}", Uuid::new_v4().simple());
+    sql_query(
+        "INSERT INTO wallet.coupon_template (code, label, reward_kind, reward_payload) \
+         VALUES ($1, 'Test Revoke', 'khash', '{\"amount\": 10}'::jsonb)",
+    )
+    .bind::<Text, _>(&template_code)
+    .execute(&mut conn)
+    .unwrap();
+
+    #[derive(QueryableByName)]
+    struct R {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        id: i64,
+    }
+    let r: R = sql_query(
+        "INSERT INTO wallet.coupon (account_id, template_id) \
+         SELECT $1, id FROM wallet.coupon_template WHERE code = $2 RETURNING id",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(account)
+    .bind::<Text, _>(&template_code)
+    .get_result(&mut conn)
+    .unwrap();
+
+    let revoked = client
+        .revoke_coupon(r.id, Some("test".into()))
+        .await
+        .unwrap();
+    assert!(revoked);
+
+    // Second call: already revoked → false, no raise.
+    let again = client.revoke_coupon(r.id, None).await.unwrap();
+    assert!(!again);
+}
+
+#[tokio::test]
+#[serial]
+async fn null_currency_raises_null_argument() {
+    let Some(client) = client() else {
+        return;
+    };
+    let (_user, account) = fixture_account().expect("fixture");
+
+    // We can't pass NULL through our typed CreditRequest, so smoke-test the
+    // SQL-level guard by calling debit with a fresh account that has no
+    // balance row — service_debit raises insufficient_funds (53100).
+    let err = client
+        .debit(DebitRequest {
+            account_id: Uuid::new_v4(), // non-existent
+            currency: CurrencyKind::Credits,
+            amount: 1,
+            source_kind: SourceKind::Admin,
+            reason: None,
+            ref_type: None,
+            ref_id: None,
+            idempotency_key: Uuid::new_v4(),
+        })
+        .await
+        .expect_err("must raise");
+    assert!(
+        matches!(err, WalletError::InsufficientFunds),
+        "got: {err:?}"
+    );
+
+    let _ = account;
+}

--- a/packages/rust/kbve/src/wallet/types.rs
+++ b/packages/rust/kbve/src/wallet/types.rs
@@ -1,0 +1,194 @@
+//! Rust mirrors of the `wallet` schema enums and rowtypes.
+//!
+//! Enum text values match the Postgres ENUM labels exactly so they can be
+//! passed as TEXT bind params and cast server-side
+//! (`$N::wallet.currency_kind`). Keep these in sync with the SQL schema.
+
+use chrono::{DateTime, Utc};
+use diesel::deserialize::{self, FromSql};
+use diesel::pg::{Pg, PgValue};
+use diesel::serialize::{self, IsNull, Output, ToSql};
+use diesel::sql_types::Text;
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+macro_rules! pg_text_enum {
+    (
+        $(#[$enum_meta:meta])*
+        $name:ident {
+            $( $(#[$var_meta:meta])* $variant:ident => $label:literal ),+ $(,)?
+        }
+    ) => {
+        $(#[$enum_meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        pub enum $name {
+            $( $(#[$var_meta])* $variant ),+
+        }
+
+        impl $name {
+            /// Postgres ENUM label.
+            pub fn as_pg(self) -> &'static str {
+                match self {
+                    $( $name::$variant => $label ),+
+                }
+            }
+
+            pub fn from_pg(s: &str) -> Option<Self> {
+                match s {
+                    $( $label => Some($name::$variant) ),+,
+                    _ => None,
+                }
+            }
+        }
+
+        impl ToSql<Text, Pg> for $name {
+            fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+                out.write_all(self.as_pg().as_bytes())?;
+                Ok(IsNull::No)
+            }
+        }
+
+        impl FromSql<Text, Pg> for $name {
+            fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
+                let s = std::str::from_utf8(value.as_bytes())?;
+                $name::from_pg(s).ok_or_else(|| {
+                    format!("unknown {} value: {s}", stringify!($name)).into()
+                })
+            }
+        }
+    };
+}
+
+pg_text_enum! {
+    /// `wallet.currency_kind`
+    CurrencyKind {
+        Credits => "credits",
+        Khash   => "khash",
+    }
+}
+
+pg_text_enum! {
+    /// `wallet.account_kind`
+    AccountKind {
+        User     => "user",
+        Guild    => "guild",
+        Treasury => "treasury",
+        Escrow   => "escrow",
+        System   => "system",
+    }
+}
+
+pg_text_enum! {
+    /// `wallet.source_kind`
+    SourceKind {
+        Reward     => "reward",
+        Purchase   => "purchase",
+        Refund     => "refund",
+        Admin      => "admin",
+        Coupon     => "coupon",
+        MarketBuy  => "market_buy",
+        MarketSell => "market_sell",
+        MarketFee  => "market_fee",
+        Transfer   => "transfer",
+    }
+}
+
+pg_text_enum! {
+    /// `wallet.reward_kind`
+    RewardKind {
+        Credits     => "credits",
+        Khash       => "khash",
+        GrantItems  => "grant_items",
+        WalletPromo => "wallet_promo",
+    }
+}
+
+pg_text_enum! {
+    /// `wallet.coupon_status`
+    CouponStatus {
+        Unredeemed => "unredeemed",
+        Redeemed   => "redeemed",
+        Expired    => "expired",
+        Revoked    => "revoked",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Request payloads (input to service ops)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreditRequest {
+    pub account_id: Uuid,
+    pub currency: CurrencyKind,
+    pub amount: i64,
+    pub source_kind: SourceKind,
+    pub reason: Option<String>,
+    pub ref_type: Option<String>,
+    pub ref_id: Option<i64>,
+    pub idempotency_key: Uuid,
+}
+
+pub type DebitRequest = CreditRequest;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferRequest {
+    pub from_account: Uuid,
+    pub to_account: Uuid,
+    pub currency: CurrencyKind,
+    pub amount: i64,
+    pub source_kind: SourceKind,
+    pub reason: Option<String>,
+    pub ref_type: Option<String>,
+    pub ref_id: Option<i64>,
+    pub idempotency_key: Uuid,
+}
+
+// ---------------------------------------------------------------------------
+// Response rows
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BalanceRow {
+    pub account_id: Uuid,
+    pub credits: i64,
+    pub khash: i64,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CouponSummary {
+    pub coupon_id: i64,
+    pub template_code: String,
+    pub template_label: String,
+    pub reward_kind: RewardKind,
+    pub reward_payload: serde_json::Value,
+    pub status: CouponStatus,
+    pub granted_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub redeemed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RedeemResult {
+    pub success: bool,
+    pub reward_kind: RewardKind,
+    pub reward_payload: serde_json::Value,
+    pub ledger_id: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifyBalanceRow {
+    pub account_id: Uuid,
+    pub stored_credits: i64,
+    pub ledger_credits: i64,
+    pub stored_khash: i64,
+    pub ledger_khash: i64,
+    pub ok: bool,
+}


### PR DESCRIPTION
## Summary

New \`wallet\` Cargo feature on the \`kbve\` crate. Wraps the SECURITY DEFINER service RPCs in [\`wallet.service_*\`](packages/data/sql/schema/wallet/wallet_rpcs.sql) and the authenticated proxies in \`public.proxy_wallet_*\` via diesel + r2d2. All public ops are async (\`tokio::task::spawn_blocking\` around the sync diesel calls). axum-kbve and other Rust services can now talk to the wallet domain through one typed gateway.

## Layout

\`packages/rust/kbve/src/wallet/\`:
- **\`types.rs\`** — \`CurrencyKind\` / \`AccountKind\` / \`SourceKind\` / \`RewardKind\` / \`CouponStatus\` enums (text-pg + \`ToSql\`/\`FromSql\`); request and row structs.
- **\`error.rs\`** — \`WalletError\` maps SQLSTATEs:
  - \`53100 → InsufficientFunds\`
  - \`40001 → ReplayMismatch\`
  - \`22003 → Overflow\`
  - \`42501 → NotAuthorized / CouponNotRedeemable\`
  - \`23503 → NotFound\`
  - \`0A000 → Unimplemented\`
  - with prefix-match fallback against the exception messages the SQL functions raise.
- **\`client.rs\`** — \`WalletClient\` + dedicated pool helper (\`WALLET_DATABASE_URL\` env, \`DATABASE_URL_PROD\` fallback). Two execution paths:
  - \`run_service(F)\` — service ops; pool authenticates as \`service_role\`.
  - \`run_as_user(uid, F)\` — sets \`request.jwt.claims\` in the txn so \`auth.uid()\` returns the right id for \`proxy_wallet_*\`.
- **\`service.rs\`** — \`credit\` / \`debit\` / \`transfer\` / \`redeem_coupon\` / \`revoke_coupon\` / \`verify_balance\`.
- **\`proxy.rs\`** — \`user_balance\` / \`user_coupons\` / \`user_redeem_coupon\`.
- **\`tests.rs\`** — integration tests gated on \`WALLET_TEST_DATABASE_URL\`.

## Feature flag

\`\`\`toml
[features]
wallet = [\"dep:uuid\"]

[dependencies]
diesel = { ..., features = [\"postgres\", \"chrono\", \"r2d2\", \"serde_json\", \"uuid\"] }
uuid = { version = \"1\", features = [\"v4\", \"serde\"], optional = true }
\`\`\`

Module gated by \`#[cfg(feature = \"wallet\")] pub mod wallet;\` in [lib.rs](packages/rust/kbve/src/lib.rs). Default builds unchanged.

## Test plan

Validated against the same local dev-docker-compose postgres 17 used for the wallet SQL PRs (wallet migration applied locally and in prod):

\`\`\`bash
WALLET_TEST_DATABASE_URL='postgres://postgres:postgres@localhost:54322/postgres' \\
  cargo test -p kbve --features wallet wallet::tests:: -- --test-threads=1
\`\`\`

- [x] \`credit_then_replay_returns_same_ledger_id\` — same idempotency_key returns the original ledger id.
- [x] \`credit_replay_with_different_payload_raises_replay_mismatch\` — \`40001\`.
- [x] \`debit_beyond_balance_raises_insufficient_funds\` — \`53100\`.
- [x] \`transfer_moves_funds_atomically\` — verify_balance after = consistent.
- [x] \`welcome_redeem_flow_via_user_proxy\` — user proxy provisions account + coupon, redeems 1000 khash, replay returns same ledger id.
- [x] \`revoke_unredeemed_coupon_succeeds\` — first call true, second already-revoked returns false (no raise).
- [x] \`null_currency_raises_null_argument\` — debit on non-existent account raises insufficient_funds.

7 of 7 pass.

## Notes

- For local docker testing without a real Supabase \`auth.uid()\`, patch the stub with the real impl:
  \`\`\`sql
  CREATE OR REPLACE FUNCTION auth.uid()
  RETURNS uuid LANGUAGE sql STABLE AS \$\$
    SELECT COALESCE(
      NULLIF(current_setting('request.jwt.claim.sub', true), ''),
      (NULLIF(current_setting('request.jwt.claims', true), ''))::jsonb ->> 'sub'
    )::uuid;
  \$\$;
  \`\`\`
  Plus \`GRANT USAGE ON SCHEMA auth TO service_role, authenticated, anon\` so FK resolution and proxy access work. Supabase prod already has both.
- axum-kbve transport routes wrapping \`WalletClient\` are the next PR; this one ships the lib only.

## Follow-ups

- axum-kbve transport routes wrapping \`WalletClient\`.
- Dashboard \"Claim 1000 KHash\" button hitting the new HTTP surface.
- MC mod uses the same gateway for daily-reward / market grants down the line.