### PR TITLE
feat(astro-kbve): Jagex trademark disclaimer on OSRS index + item pages

### DIFF
--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSDisclaimer.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSDisclaimer.astro
@@ -1,0 +1,51 @@
+---
+
+---
+
+<aside class="osrs-disclaimer not-content" role="note">
+	<p>
+		<strong>"RuneScape"</strong> and <strong>"OSRS"</strong> are registered trademarks
+		of <a
+			href="https://www.jagex.com/"
+			target="_blank"
+			rel="noopener noreferrer">
+			Jagex Limited
+		</a>. This website is in no way affiliated with, authorised, maintained,
+		sponsored or endorsed by Jagex Limited or any of its affiliates or
+		subsidiaries. All game content and assets are copyright of Jagex
+		Limited.
+	</p>
+</aside>
+
+<style>
+	.osrs-disclaimer {
+		margin-top: 1.5rem;
+		padding: 0.75rem 1rem;
+		border-radius: 0.5rem;
+		border: 1px solid var(--sl-color-gray-5);
+		background: var(--sl-color-gray-7, var(--sl-color-bg));
+		font-size: 0.6875rem;
+		line-height: 1.5;
+		color: var(--sl-color-gray-3);
+	}
+
+	.osrs-disclaimer p {
+		margin: 0;
+	}
+
+	.osrs-disclaimer strong {
+		color: var(--sl-color-gray-2);
+		font-weight: 600;
+	}
+
+	.osrs-disclaimer a {
+		color: var(--sl-color-gray-2);
+		text-decoration: underline;
+		text-decoration-style: dotted;
+		text-underline-offset: 2px;
+	}
+
+	.osrs-disclaimer a:hover {
+		color: var(--sl-color-accent-high);
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSItemPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSItemPanel.astro
@@ -19,6 +19,7 @@ import OSRSShops from './OSRSShops.astro';
 import OSRSUsedIn from './OSRSUsedIn.astro';
 import OSRSHistory from './OSRSHistory.astro';
 import OSRSItemJsonLd from './OSRSItemJsonLd.astro';
+import OSRSDisclaimer from './OSRSDisclaimer.astro';
 import { getUsedInIndex } from '@/data/osrs-used-in-index';
 import type {
 	OSRSExtended,
@@ -379,6 +380,8 @@ const showUsedIn = (usedInEntries?.length ?? 0) > 0;
 
 		<!-- Global tooltip for OSRS item link hovers -->
 		<OSRSLinkTooltip client:idle />
+
+		<OSRSDisclaimer />
 	</div>
 </section>
 

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/index.mdx
@@ -12,6 +12,7 @@ tags:
 ---
 
 import OSRSItemBrowser from '@/components/osrs/OSRSItemBrowser.tsx';
+import OSRSDisclaimer from '@/components/osrs/OSRSDisclaimer.astro';
 
 The KBVE OSRS database tracks every tradeable Old School RuneScape item with
 live Grand Exchange pricing, equipment stats, drop sources, recipes, and more.
@@ -26,3 +27,5 @@ Use the browser below to find an item, then click through to its full page.
 - Filter by **Equipment**, **Food**, **Potions**, **Quest**, **Drops**, **Farming**,
   **Gathering**, **Teleport**, **Ammunition**, or **Prayer**.
 - The browser shows item id, GE limit, high alch, and base value at a glance.
+
+<OSRSDisclaimer />


### PR DESCRIPTION
## Summary
Adds a fixed disclaimer noting that "RuneScape" and "OSRS" are registered trademarks of Jagex Limited and that KBVE is not affiliated with, authorised, maintained, sponsored or endorsed by Jagex.

- New shared component: `src/components/osrs/OSRSDisclaimer.astro`
- Wired into `OSRSItemPanel.astro` — covers all 4524 item pages
- Wired into `src/content/docs/osrs/index.mdx` — covers `/osrs/` index

## Test plan
- [x] Dev server: `/osrs/` renders disclaimer
- [x] Dev server: `/osrs/thread/` renders disclaimer
- [ ] CI build passes