### PR TITLE
fix(mc-agones): take mc-map-rotation Job out of ArgoCD path

### DIFF
--- a/apps/kube/agones/mc/jobs/map-rotation-job.yaml
+++ b/apps/kube/agones/mc/jobs/map-rotation-job.yaml
@@ -1,0 +1,95 @@
+# MC Map Rotation — one-shot Job (manual ops, NOT ArgoCD-managed).
+#
+# Lives outside `manifests/` on purpose. ArgoCD's `agones-mc` application
+# tracks `path: apps/kube/agones/mc/manifests` only, so this file is
+# invisible to it and never auto-applied or auto-pruned. Apply this Job
+# by hand when (and only when) you actually want to rotate the world.
+#
+# Why it's not managed:
+#   - The Job is destructive (deletes region files outside the protected
+#     radius, optionally wipes nether/end/playerdata).
+#   - Earlier this Job lived under `manifests/` with
+#     `ttlSecondsAfterFinished: 86400`. Every 24h k8s GC'd the completed
+#     Job, ArgoCD saw it missing → auto-synced → fired the PreSync
+#     `mc-graceful-restart` hook → kicked every player with "Server is
+#     restarting for an update" even though nothing was actually being
+#     updated. Worse, ArgoCD then recreated the Job, which ran against
+#     the live PVC. See https://github.com/KBVE/kbve/issues/<...> for
+#     the post-mortem.
+#
+# Prereqs (both ConfigMaps below are ArgoCD-managed and always present):
+#   - mc-map-rotation-config   (tunables: CENTER_X, PROTECT_RADIUS, etc.)
+#   - mc-map-rotation-script   (the rotation bash script)
+#
+# Run procedure:
+#   1. Scale the fleet to 0 so no server is using the PVC:
+#        kubectl -n arc-runners scale fleet mc-fabric --replicas=0
+#   2. Wait for every GameServer pod to terminate:
+#        kubectl -n arc-runners get pods -l agones.dev/fleet=mc-fabric -w
+#   3. (Optional) Dry-run first to preview deletions:
+#        kubectl -n arc-runners create job mc-map-rotation-dry \
+#          --from=job/mc-map-rotation -- \
+#          /bin/bash -c "DRY_RUN=true /scripts/map-rotation.sh"
+#   4. Apply this manifest:
+#        kubectl apply -f apps/kube/agones/mc/jobs/map-rotation-job.yaml
+#   5. Watch logs:
+#        kubectl -n arc-runners logs -f job/mc-map-rotation
+#   6. After the Job reports "Map rotation complete":
+#        kubectl -n arc-runners delete job mc-map-rotation
+#   7. Scale fleet back up (or let FleetAutoscaler handle it):
+#        kubectl -n arc-runners scale fleet mc-fabric --replicas=1
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: mc-map-rotation
+    namespace: arc-runners
+    labels:
+        app.kubernetes.io/part-of: mc
+        app.kubernetes.io/component: map-rotation
+spec:
+    backoffLimit: 0
+    template:
+        metadata:
+            labels:
+                app: mc-map-rotation
+                app.kubernetes.io/part-of: mc
+        spec:
+            restartPolicy: Never
+            nodeSelector:
+                node.kbve.com/type: dedicated-server
+            containers:
+                - name: map-rotation
+                  image: ghcr.io/kbve/mc:1.0.13
+                  command:
+                      - /bin/bash
+                      - /scripts/map-rotation.sh
+                  envFrom:
+                      - configMapRef:
+                            name: mc-map-rotation-config
+                  env:
+                      - name: WORLD_DIR
+                        value: /data/world
+                      - name: BACKUP_DIR
+                        value: /data/backups
+                      - name: DRY_RUN
+                        value: 'false'
+                  volumeMounts:
+                      - name: mc-data
+                        mountPath: /data
+                      - name: rotation-script
+                        mountPath: /scripts
+                  resources:
+                      requests:
+                          cpu: 100m
+                          memory: 256Mi
+                      limits:
+                          cpu: 500m
+                          memory: 512Mi
+            volumes:
+                - name: mc-data
+                  persistentVolumeClaim:
+                      claimName: mc-world-data
+                - name: rotation-script
+                  configMap:
+                      name: mc-map-rotation-script
+                      defaultMode: 0755

--- a/apps/kube/agones/mc/manifests/map-rotation-script.yaml
+++ b/apps/kube/agones/mc/manifests/map-rotation-script.yaml
@@ -1,79 +1,10 @@
-# One-shot Job for MC map rotation.
-#
-# PREREQUISITES — run these BEFORE creating the Job:
-#   1. Scale the fleet to 0 so no server is using the PVC:
-#        kubectl -n arc-runners scale fleet mc-fabric --replicas=0
-#   2. Wait for all GameServer pods to terminate:
-#        kubectl -n arc-runners get pods -l agones.dev/fleet=mc-fabric -w
-#
-# AFTER the Job completes:
-#   3. Scale the fleet back (or let the FleetAutoscaler handle it):
-#        kubectl -n arc-runners scale fleet mc-fabric --replicas=1
-#   4. Clean up the completed Job:
-#        kubectl -n arc-runners delete job mc-map-rotation
-#
-# DRY RUN — to preview what would be deleted without touching files:
-#   Add an env override: DRY_RUN=true
-#   kubectl -n arc-runners create job mc-map-rotation-dry \
-#     --from=job/mc-map-rotation -- /bin/bash -c "DRY_RUN=true /scripts/map-rotation.sh"
-apiVersion: batch/v1
-kind: Job
-metadata:
-    name: mc-map-rotation
-    namespace: arc-runners
-    labels:
-        app.kubernetes.io/part-of: mc
-spec:
-    backoffLimit: 0
-    ttlSecondsAfterFinished: 86400
-    template:
-        metadata:
-            labels:
-                app: mc-map-rotation
-                app.kubernetes.io/part-of: mc
-        spec:
-            restartPolicy: Never
-            nodeSelector:
-                node.kbve.com/type: dedicated-server
-            containers:
-                - name: map-rotation
-                  image: ghcr.io/kbve/mc:1.0.13
-                  command:
-                      - /bin/bash
-                      - /scripts/map-rotation.sh
-                  envFrom:
-                      - configMapRef:
-                            name: mc-map-rotation-config
-                  env:
-                      - name: WORLD_DIR
-                        value: /data/world
-                      - name: BACKUP_DIR
-                        value: /data/backups
-                      - name: DRY_RUN
-                        value: 'false'
-                  volumeMounts:
-                      - name: mc-data
-                        mountPath: /data
-                      - name: rotation-script
-                        mountPath: /scripts
-                  resources:
-                      requests:
-                          cpu: 100m
-                          memory: 256Mi
-                      limits:
-                          cpu: 500m
-                          memory: 512Mi
-            volumes:
-                - name: mc-data
-                  persistentVolumeClaim:
-                      claimName: mc-world-data
-                - name: rotation-script
-                  configMap:
-                      name: mc-map-rotation-script
-                      defaultMode: 0755
----
 # The rotation script packaged as a ConfigMap so the Job can mount it.
 # This avoids rebuilding the Docker image just to update rotation logic.
+#
+# The Job that consumes this ConfigMap lives at
+# `apps/kube/agones/mc/jobs/map-rotation-job.yaml` and is intentionally
+# NOT under this `manifests/` path — see that file for the run procedure
+# and the rationale for keeping it outside ArgoCD's auto-sync loop.
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
## Summary
Stops the daily phantom kicks ("Server is restarting for an update. Returning to lobby...") and the destructive auto-rerun of the map rotation against the live world PVC.

## Root cause
`mc-map-rotation` Job lived under [apps/kube/agones/mc/manifests/](apps/kube/agones/mc/manifests/) with `ttlSecondsAfterFinished: 86400`. Every 24h:
1. k8s GC'd the completed Job → ArgoCD saw the tracked resource missing.
2. `automated.prune: true` triggered a sync.
3. PreSync hook [graceful-restart-job.yaml](apps/kube/agones/mc/manifests/graceful-restart-job.yaml#L88) ran `rcon kick @a Server is restarting for an update. Returning to lobby...`.
4. ArgoCD recreated the Job, which **ran against the live PVC**: tarballed the world, scanned region files for deletion. Saved today only because every region fell inside the protected `r.[-1..1]` radius. A larger world would have lost non-protected regions silently every 24h.

Live evidence:
- ArgoCD `agones-mc` last sync: `2026-05-12T07:16:59Z` (rev `1f3d7b63`), `initiatedBy: automated`. Diff vs prior sync (`7b3aeb20`) on the mc/manifests path: zero files changed.
- Live Job state: `startTime=2026-05-12T07:16:59Z completionTime=2026-05-12T07:17:09Z ttl=86400`.
- Job log shows it ran the destructive script: `Creating backup: /data/backups/world-pre-rotation-20260512-071700.tar.gz`.

## Fix
- Move just the Job into new [apps/kube/agones/mc/jobs/](apps/kube/agones/mc/jobs/) path (outside ArgoCD's watched path).
- Keep `mc-map-rotation-config` and `mc-map-rotation-script` ConfigMaps under [manifests/](apps/kube/agones/mc/manifests/) — they're idempotent and operators want them always present.
- Rename `map-rotation-job.yaml` → `map-rotation-script.yaml` since it now only holds the script ConfigMap.
- Run procedure documented in the moved Job's header.

## Post-merge follow-up (do AFTER this PR lands on main)
The PR removes the Job from ArgoCD's desired state. With `automated.prune: true`, ArgoCD will prune the live (completed) Job on the next sync, and that sync will fire the PreSync hook → one final kick.

To avoid that final kick, before the prune sync runs:
```sh
kubectl -n arc-runners annotate job mc-map-rotation \
    argocd.argoproj.io/sync-options=Prune=false --overwrite
```
ArgoCD then leaves the live Job alone. After that, manually delete the old Job at leisure.

## Test plan
- [ ] PR merges, ArgoCD syncs (one expected kick if pre-annotate is skipped)
- [ ] 24h pass with no further phantom kicks
- [ ] Manual run procedure in moved Job header works on next image bump