### PR TITLE
feat(axum-kbve): /api/v1/wallet/me/* routes backed by kbve::wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,6 +1638,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "utoipa",
+ "uuid",
  "webpki-roots 0.26.11",
 ]
 

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -38,7 +38,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # OpenAPI spec generation. Emits /api/openapi.json which the astro side
 # renders via Scalar at /dashboard/api and consumes for /llms.txt.
-utoipa = { version = "5", features = ["axum_extras", "chrono"] }
+utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }
 
 # MCP server. Re-uses the utoipa OpenAPI spec to expose every annotated
 # handler as an MCP tool at /api/mcp. Token passthrough lets clients BYO
@@ -86,7 +86,8 @@ webpki-roots = "0.26"
 
 # Workspace path dependencies
 jedi = { path = "../../../packages/rust/jedi", features = ["clickhouse"] }
-kbve = { path = "../../../packages/rust/kbve" }
+kbve = { path = "../../../packages/rust/kbve", features = ["wallet"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }

--- a/apps/kbve/axum-kbve/src/db/mod.rs
+++ b/apps/kbve/axum-kbve/src/db/mod.rs
@@ -9,6 +9,7 @@ mod profile;
 mod rentearth;
 mod supabase;
 mod twitch;
+mod wallet;
 
 /// Parse a URL and require an `https` scheme before transmitting sensitive
 /// data. Returns a typed `reqwest::Url` so callers pass it straight to
@@ -39,3 +40,4 @@ pub use profile::{
 };
 pub use rentearth::{RentEarthProfile, get_rentearth_service, init_rentearth_service};
 pub use twitch::{get_twitch_client, init_twitch_client};
+pub use wallet::{get_wallet_client, init_wallet_client};

--- a/apps/kbve/axum-kbve/src/db/wallet.rs
+++ b/apps/kbve/axum-kbve/src/db/wallet.rs
@@ -1,0 +1,35 @@
+//! WalletClient registry — boots once at startup, returned to handlers via
+//! a `OnceLock`-backed getter (same pattern as the forum / mc / profile
+//! services in this crate). Heavy state stays out of `AppState`.
+
+use std::sync::OnceLock;
+
+use kbve::wallet::WalletClient;
+
+static WALLET_CLIENT: OnceLock<Option<WalletClient>> = OnceLock::new();
+
+/// Build the wallet client from env (`WALLET_DATABASE_URL` with
+/// `DATABASE_URL_PROD` fallback). Returns `true` if the client is live.
+///
+/// Idempotent — subsequent calls return the cached result.
+pub fn init_wallet_client() -> bool {
+    WALLET_CLIENT
+        .get_or_init(|| match WalletClient::from_env() {
+            Ok(client) => {
+                tracing::info!("WalletClient initialized");
+                Some(client)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "WalletClient disabled: failed to build pool"
+                );
+                None
+            }
+        })
+        .is_some()
+}
+
+pub fn get_wallet_client() -> Option<&'static WalletClient> {
+    WALLET_CLIENT.get().and_then(|c| c.as_ref())
+}

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -96,6 +96,12 @@ async fn main() -> anyhow::Result<()> {
         info!("Forum service not configured - /forum routes will 503");
     }
 
+    if db::init_wallet_client() {
+        info!("Wallet client initialized - /api/v1/wallet/me/* routes enabled");
+    } else {
+        warn!("Wallet client not configured - /api/v1/wallet routes will 503");
+    }
+
     let _osrs_cache = db::init_osrs_cache().await;
     info!("OSRS cache actor started");
 

--- a/apps/kbve/axum-kbve/src/openapi.rs
+++ b/apps/kbve/axum-kbve/src/openapi.rs
@@ -68,7 +68,8 @@ impl Modify for SecurityAddon {
         (name = "osrs", description = "Old School RuneScape item lookups."),
         (name = "mc", description = "Minecraft RCON-backed live data: player list, head textures."),
         (name = "telemetry", description = "Client-side error reporting from WASM/JS."),
-        (name = "dashboard", description = "Staff-only routes powering kbve.com/dashboard. Gated on DASHBOARD_VIEW.")
+        (name = "dashboard", description = "Staff-only routes powering kbve.com/dashboard. Gated on DASHBOARD_VIEW."),
+        (name = "wallet", description = "Authenticated wallet surface: balance, coupons, claim flows.")
     ),
     paths(
         // system
@@ -99,6 +100,10 @@ impl Modify for SecurityAddon {
         crate::transport::https::api_staff_edit_comment,
         // dashboard
         crate::transport::proxy::clickhouse_logs_proxy_handler,
+        // wallet
+        crate::transport::wallet::me_balance,
+        crate::transport::wallet::me_coupons,
+        crate::transport::wallet::me_redeem_coupon,
     ),
     components(
         schemas(
@@ -124,6 +129,11 @@ impl Modify for SecurityAddon {
             EditCommentBody,
             ClickHouseLogsRequest,
             ClickHouseLogsResponse,
+            // wallet
+            crate::transport::wallet::BalanceDto,
+            crate::transport::wallet::CouponDto,
+            crate::transport::wallet::RedeemCouponBody,
+            crate::transport::wallet::RedeemCouponDto,
         )
     ),
     modifiers(&SecurityAddon)

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -364,6 +364,15 @@ fn router(state: AppState) -> Router {
         .route("/api/v1/me/staff", get(api_me_staff))
         .route("/api/v1/forum/spaces", get(api_list_spaces))
         .route("/api/v1/forum/tags", get(api_list_tags))
+        // Wallet — authenticated user surface. Service routes
+        // (/api/v1/wallet/service/*) are deferred to a follow-up; the
+        // dashboard's Claim 1000 KHash button only needs the user proxy path.
+        .route("/api/v1/wallet/me/balance", get(super::wallet::me_balance))
+        .route("/api/v1/wallet/me/coupons", get(super::wallet::me_coupons))
+        .route(
+            "/api/v1/wallet/me/redeem-coupon",
+            post(super::wallet::me_redeem_coupon),
+        )
         // SEO-friendly 301: /forum/c/{slug} → /forum/s/{slug}. `c/` reads
         // as "category" but the canonical URL is `s/` (space). Crawlers
         // collapse the duplicate into the canonical via the redirect.
@@ -2893,7 +2902,7 @@ async fn forum_compose_handler(
 
 /// Helper: pull `Authorization: Bearer <token>` and verify via the JWT
 /// cache. Returns Ok(user_id) or an error response.
-async fn auth_user_id(headers: &HeaderMap) -> Result<String, Response> {
+pub(crate) async fn auth_user_id(headers: &HeaderMap) -> Result<String, Response> {
     let auth_header = headers
         .get(header::AUTHORIZATION)
         .and_then(|h| h.to_str().ok())

--- a/apps/kbve/axum-kbve/src/transport/mod.rs
+++ b/apps/kbve/axum-kbve/src/transport/mod.rs
@@ -1,3 +1,4 @@
 pub mod https;
 pub mod proxy;
 pub mod vnc_hub;
+pub mod wallet;

--- a/apps/kbve/axum-kbve/src/transport/wallet.rs
+++ b/apps/kbve/axum-kbve/src/transport/wallet.rs
@@ -1,0 +1,252 @@
+//! Wallet HTTP surface — user-facing `/api/v1/wallet/me/*` routes.
+//!
+//! Service routes (`/api/v1/wallet/service/*`) are deferred to a follow-up;
+//! the dashboard's Claim 1000 KHash button only needs the user proxy path.
+//!
+//! Each handler:
+//!   1. Extracts the Supabase user_id via the shared `auth_user_id` helper.
+//!   2. Looks up the global `WalletClient` (skip with 503 if disabled).
+//!   3. Calls the matching `WalletClient::user_*` op (sets request.jwt.claims
+//!      inside the txn so `auth.uid()` resolves correctly).
+//!   4. Maps `WalletError` to HTTP status + JSON error body.
+
+use axum::{
+    Json,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use kbve::wallet::WalletError;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::https::auth_user_id;
+use crate::db::get_wallet_client;
+
+// ---------------------------------------------------------------------------
+// DTOs
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct BalanceDto {
+    pub account_id: Uuid,
+    pub credits: i64,
+    pub khash: i64,
+    pub updated_at: String,
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct CouponDto {
+    pub coupon_id: i64,
+    pub template_code: String,
+    pub template_label: String,
+    pub reward_kind: String,
+    pub reward_payload: serde_json::Value,
+    pub status: String,
+    pub granted_at: String,
+    pub expires_at: Option<String>,
+    pub redeemed_at: Option<String>,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct RedeemCouponBody {
+    pub coupon_id: i64,
+    /// Caller-supplied UUID. Retries with the same key replay the same
+    /// redemption and return the original ledger_id.
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct RedeemCouponDto {
+    pub success: bool,
+    pub reward_kind: String,
+    pub reward_payload: serde_json::Value,
+    pub ledger_id: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `GET /api/v1/wallet/me/balance` — returns the caller's wallet balance.
+/// Lazily provisions the wallet account + welcome coupon on first call.
+#[utoipa::path(
+    get,
+    path = "/api/v1/wallet/me/balance",
+    tag = "wallet",
+    responses(
+        (status = 200, description = "Caller's balance", body = BalanceDto),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn me_balance(headers: HeaderMap) -> Response {
+    let user_id = match resolve_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+
+    match client.user_balance(user_id).await {
+        Ok(b) => Json(BalanceDto {
+            account_id: b.account_id,
+            credits: b.credits,
+            khash: b.khash,
+            updated_at: b.updated_at.to_rfc3339(),
+        })
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `GET /api/v1/wallet/me/coupons` — returns the caller's coupons
+/// (unredeemed + history).
+#[utoipa::path(
+    get,
+    path = "/api/v1/wallet/me/coupons",
+    tag = "wallet",
+    responses(
+        (status = 200, description = "Caller's coupons", body = [CouponDto]),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn me_coupons(headers: HeaderMap) -> Response {
+    let user_id = match resolve_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+
+    match client.user_coupons(user_id).await {
+        Ok(rows) => Json(
+            rows.into_iter()
+                .map(|c| CouponDto {
+                    coupon_id: c.coupon_id,
+                    template_code: c.template_code,
+                    template_label: c.template_label,
+                    reward_kind: c.reward_kind.as_pg().to_string(),
+                    reward_payload: c.reward_payload,
+                    status: c.status.as_pg().to_string(),
+                    granted_at: c.granted_at.to_rfc3339(),
+                    expires_at: c.expires_at.map(|t| t.to_rfc3339()),
+                    redeemed_at: c.redeemed_at.map(|t| t.to_rfc3339()),
+                })
+                .collect::<Vec<_>>(),
+        )
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `POST /api/v1/wallet/me/redeem-coupon` — redeem one of the caller's coupons.
+/// Ownership-checked + idempotent at the coupon layer.
+#[utoipa::path(
+    post,
+    path = "/api/v1/wallet/me/redeem-coupon",
+    tag = "wallet",
+    request_body = RedeemCouponBody,
+    responses(
+        (status = 200, description = "Redemption result", body = RedeemCouponDto),
+        (status = 400, description = "Invalid argument"),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 403, description = "Coupon not redeemable / expired / revoked"),
+        (status = 404, description = "Coupon not found / not owned by caller"),
+        (status = 409, description = "Idempotency replay mismatch"),
+        (status = 501, description = "Reward kind not yet implemented"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn me_redeem_coupon(
+    headers: HeaderMap,
+    Json(body): Json<RedeemCouponBody>,
+) -> Response {
+    let user_id = match resolve_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+
+    match client
+        .user_redeem_coupon(user_id, body.coupon_id, body.idempotency_key)
+        .await
+    {
+        Ok(r) => Json(RedeemCouponDto {
+            success: r.success,
+            reward_kind: r.reward_kind.as_pg().to_string(),
+            reward_payload: r.reward_payload,
+            ledger_id: r.ledger_id,
+        })
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn resolve_user(headers: &HeaderMap) -> Result<Uuid, Response> {
+    let s = auth_user_id(headers).await?;
+    Uuid::parse_str(&s).map_err(|_| {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "JWT sub is not a valid UUID"})),
+        )
+            .into_response()
+    })
+}
+
+fn service_unavailable() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({"error": "Wallet service unavailable"})),
+    )
+        .into_response()
+}
+
+fn wallet_error_response(err: WalletError) -> Response {
+    let (status, code) = match &err {
+        WalletError::InsufficientFunds => (StatusCode::PAYMENT_REQUIRED, "insufficient_funds"),
+        WalletError::ReplayMismatch => (StatusCode::CONFLICT, "replay_mismatch"),
+        WalletError::Overflow => (StatusCode::UNPROCESSABLE_ENTITY, "overflow"),
+        WalletError::NotAuthorized => (StatusCode::FORBIDDEN, "not_authorized"),
+        WalletError::NotAuthenticated => (StatusCode::UNAUTHORIZED, "not_authenticated"),
+        WalletError::NullArgument(_) => (StatusCode::UNPROCESSABLE_ENTITY, "null_argument"),
+        WalletError::InvalidArgument(_) => (StatusCode::BAD_REQUEST, "invalid_argument"),
+        WalletError::NotFound(_) => (StatusCode::NOT_FOUND, "not_found"),
+        WalletError::CouponNotRedeemable(_) => (StatusCode::FORBIDDEN, "coupon_not_redeemable"),
+        WalletError::CouponExpired => (StatusCode::FORBIDDEN, "coupon_expired"),
+        WalletError::Unimplemented(_) => (StatusCode::NOT_IMPLEMENTED, "unimplemented"),
+        WalletError::Pool(_) | WalletError::Join(_) | WalletError::Db(_) => {
+            // Log the raw error server-side, send a generic message to the client.
+            tracing::error!(error = %err, "wallet upstream failure");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal")
+        }
+    };
+
+    (
+        status,
+        Json(json!({
+            "error": code,
+            "message": err.to_string(),
+        })),
+    )
+        .into_response()
+}


### PR DESCRIPTION
## Summary

Wires the merged \`kbve::wallet\` Cargo feature (#10872) into axum-kbve. Adds the authenticated user surface for the wallet so the dashboard can render balances, list coupons, and run the **Claim 1000 KHash** flow over a typed HTTP API.

Service routes (\`/api/v1/wallet/service/*\`) are deferred to a follow-up — the dashboard claim button only needs the user proxy path. Daily-reward + market mutation flows will land alongside the service surface.

## Routes (authenticated, Supabase JWT)

| Path | Backed by |
|---|---|
| \`GET  /api/v1/wallet/me/balance\` | \`WalletClient::user_balance(uid)\` |
| \`GET  /api/v1/wallet/me/coupons\` | \`WalletClient::user_coupons(uid)\` |
| \`POST /api/v1/wallet/me/redeem-coupon\` | \`WalletClient::user_redeem_coupon(uid, coupon_id, idempotency_key)\` |

Each handler:
1. Extracts \`user_id\` via the existing \`auth_user_id\` helper (promoted to \`pub(crate)\` so siblings can reuse it).
2. Parses it into a \`Uuid\`.
3. Resolves the global \`WalletClient\` or 503s.
4. Calls the matching \`user_*\` op, mapping [\`WalletError\`](packages/rust/kbve/src/wallet/error.rs) → HTTP:

| WalletError | HTTP |
|---|---|
| \`InsufficientFunds\` | 402 |
| \`ReplayMismatch\` (40001) | 409 |
| \`NotAuthorized\` / \`CouponNotRedeemable\` / \`CouponExpired\` | 403 |
| \`NotAuthenticated\` | 401 |
| \`NotFound\` | 404 |
| \`NullArgument\` / \`InvalidArgument\` | 400 / 422 |
| \`Overflow\` | 422 |
| \`Unimplemented\` | 501 |
| \`Pool\` / \`Join\` / \`Db\` | 500 (logged server-side, generic body) |

## Wiring

- [\`Cargo.toml\`](apps/kbve/axum-kbve/Cargo.toml): enables \`kbve\` feature \`wallet\`, adds \`uuid\` + \`utoipa\` \`uuid\` feature for OpenAPI schema generation.
- [\`src/db/wallet.rs\`](apps/kbve/axum-kbve/src/db/wallet.rs): \`OnceLock\`-backed \`init_wallet_client\` / \`get_wallet_client\` matching the existing forum / mc / profile service pattern.
- [\`src/db/mod.rs\`](apps/kbve/axum-kbve/src/db/mod.rs): registers + re-exports.
- [\`src/transport/wallet.rs\`](apps/kbve/axum-kbve/src/transport/wallet.rs): DTOs (\`BalanceDto\`, \`CouponDto\`, \`RedeemCouponBody\`, \`RedeemCouponDto\`) + handlers + the \`WalletError\` → HTTP mapper.
- [\`src/transport/mod.rs\`](apps/kbve/axum-kbve/src/transport/mod.rs): \`pub mod wallet\`.
- [\`src/transport/https.rs\`](apps/kbve/axum-kbve/src/transport/https.rs): three \`.route()\` entries inside the existing \`public_router\` builder.
- [\`src/main.rs\`](apps/kbve/axum-kbve/src/main.rs): \`db::init_wallet_client()\` at boot, logged with the same \`info!\`/\`warn!\` shape as the other services.
- [\`src/openapi.rs\`](apps/kbve/axum-kbve/src/openapi.rs): registers the three paths + four DTOs + \"wallet\" tag so Scalar at \`kbve.com/dashboard/api\` picks them up.

## Env

\`\`\`
WALLET_DATABASE_URL=postgres://service_role:...@kilobase:5432/supabase
\`\`\`

Falls back to \`DATABASE_URL_PROD\` if unset (keeps dev working with one URL).

## Test plan

- [x] \`cargo build -p axum-kbve\` clean.
- [x] OpenAPI registered (\`/api/openapi.json\` will surface the three routes once deployed).
- [ ] End-to-end: dashboard fetches \`GET /api/v1/wallet/me/balance\` with a Supabase JWT → returns \`{credits:0, khash:0}\` for fresh users, welcome coupon present in \`/me/coupons\`, redeem → balance \`khash: 1000\`.

## Follow-ups

- Service routes: \`/api/v1/wallet/service/{credit,debit,transfer,revoke-coupon,verify-balance}\` for daily-reward + market mutation flows.
- Dashboard \"Claim 1000 KHash\" UI hitting \`POST /api/v1/wallet/me/redeem-coupon\`.
- MC mod calls the same gateway for daily-reward / market grants down the line.