### PR TITLE
feat(axum-kbve): /api/v1/fc/* alias for firecracker persistent endpoints

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -452,6 +452,14 @@ fn router(state: AppState) -> Router {
             "/dashboard/firecracker-net/proxy",
             any(super::proxy::firecracker_net_proxy_handler),
         )
+        // Stable public alias for the persistent endpoint surface.
+        // /api/v1/fc/<deploy|list|{name}|...> -> firecracker-ctl-net /fc/<rest>.
+        // Same staff gate as the firecracker-net proxy above; the underlying
+        // FIRECRACKER_NET singleton handles the upstream forward.
+        .route(
+            "/api/v1/fc/{*rest}",
+            any(super::proxy::firecracker_fc_alias_handler),
+        )
         // Public-facing persistent endpoint path — /fc/{name}/{*path}
         // routes to firecracker-ctl-net's /proxy/{name}/{*path} after a
         // staff-level auth gate. The {name} identifies the persistent VM.

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -1788,6 +1788,38 @@ pub async fn firecracker_net_proxy_handler(
     }
 }
 
+/// Public-shaped alias for the persistent endpoint surface of
+/// firecracker-ctl-net. Forwards `/api/v1/fc/<rest>` to
+/// `firecracker-ctl-net/fc/<rest>` after the same staff gate as
+/// [`firecracker_net_proxy_handler`].
+///
+/// Lets IDE clients, scripts, and the dashboard hit a stable
+/// `/api/v1/fc/deploy` (etc.) without leaking the internal
+/// `/dashboard/firecracker-net/proxy/...` path layout.
+pub async fn firecracker_fc_alias_handler(
+    Path(rest): Path<String>,
+    req: Request<Body>,
+) -> Response {
+    let headers = req.headers().clone();
+    if let Err(resp) = require_dashboard_manage(&headers, "Firecracker-FC").await {
+        return resp;
+    }
+
+    match FIRECRACKER_NET.get() {
+        Some(proxy) => {
+            let upstream_path = format!("fc/{rest}");
+            proxy
+                .handle_preauthorized(Some(Path(upstream_path)), req)
+                .await
+        }
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "Firecracker-Net proxy not configured"})),
+        )
+            .into_response(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // /fc/{name}/{*path} — public path prefix for persistent Firecracker endpoints
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Stable public-shaped path \`/api/v1/fc/{*rest}\` that forwards to firecracker-ctl-net's \`/fc/<rest>\` surface after the same \`DASHBOARD_MANAGE\` gate as the existing \`/dashboard/firecracker-net/proxy\` route. Keeps the internal proxy layout out of dashboard IDE clients, scripts, and the MCP server while preserving the upstream's expected \`/fc\` prefix.

## Changes
- New \`firecracker_fc_alias_handler\` in \`proxy.rs\` forwards \`/api/v1/fc/<rest>\` → firecracker-ctl-net \`/fc/<rest>\` via the \`FIRECRACKER_NET\` singleton (re-uses \`handle_preauthorized\` so the inner \`DASHBOARD_VIEW\` check is skipped after the outer \`DASHBOARD_MANAGE\` gate succeeds).
- Routes \`/api/v1/fc/{*rest}\` on the bypass router next to the existing \`/dashboard/firecracker-net/proxy\` entries.

## Now callable as
- \`POST /api/v1/fc/deploy\`
- \`GET  /api/v1/fc/list\`
- \`GET  /api/v1/fc/{name}\`
- \`DELETE /api/v1/fc/{name}\`

Used by the upcoming IDE Deploy panel and external automation.

## Test plan
- [ ] \`nx run axum-kbve:lint\` clean
- [ ] \`curl -i -X POST https://kbve.com/api/v1/fc/deploy\` with no auth returns 401/403
- [ ] Same with valid staff JWT forwards to firecracker-ctl-net and returns the same response shape as \`/dashboard/firecracker-net/proxy/fc/deploy\`
- [ ] \`GET /api/v1/fc/list\` (staff JWT) returns the persistent endpoint list