### PR TITLE
feat(axum-kbve): /api/v1/wallet/service/* surface

### DIFF
--- a/apps/kbve/axum-kbve/src/openapi.rs
+++ b/apps/kbve/axum-kbve/src/openapi.rs
@@ -100,10 +100,17 @@ impl Modify for SecurityAddon {
         crate::transport::https::api_staff_edit_comment,
         // dashboard
         crate::transport::proxy::clickhouse_logs_proxy_handler,
-        // wallet
+        // wallet — authenticated user surface
         crate::transport::wallet::me_balance,
         crate::transport::wallet::me_coupons,
         crate::transport::wallet::me_redeem_coupon,
+        // wallet — service surface (service_role JWT)
+        crate::transport::wallet::service_credit,
+        crate::transport::wallet::service_debit,
+        crate::transport::wallet::service_transfer,
+        crate::transport::wallet::service_redeem_coupon,
+        crate::transport::wallet::service_revoke_coupon,
+        crate::transport::wallet::service_verify_balance,
     ),
     components(
         schemas(
@@ -129,11 +136,19 @@ impl Modify for SecurityAddon {
             EditCommentBody,
             ClickHouseLogsRequest,
             ClickHouseLogsResponse,
-            // wallet
+            // wallet — user surface
             crate::transport::wallet::BalanceDto,
             crate::transport::wallet::CouponDto,
             crate::transport::wallet::RedeemCouponBody,
             crate::transport::wallet::RedeemCouponDto,
+            // wallet — service surface
+            crate::transport::wallet::ServiceCreditBody,
+            crate::transport::wallet::ServiceLedgerDto,
+            crate::transport::wallet::ServiceTransferBody,
+            crate::transport::wallet::ServiceRedeemCouponBody,
+            crate::transport::wallet::ServiceRevokeCouponBody,
+            crate::transport::wallet::ServiceRevokeDto,
+            crate::transport::wallet::ServiceVerifyBalanceDto,
         )
     ),
     modifiers(&SecurityAddon)

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -364,14 +364,39 @@ fn router(state: AppState) -> Router {
         .route("/api/v1/me/staff", get(api_me_staff))
         .route("/api/v1/forum/spaces", get(api_list_spaces))
         .route("/api/v1/forum/tags", get(api_list_tags))
-        // Wallet — authenticated user surface. Service routes
-        // (/api/v1/wallet/service/*) are deferred to a follow-up; the
-        // dashboard's Claim 1000 KHash button only needs the user proxy path.
+        // Wallet — authenticated user surface (Supabase JWT).
         .route("/api/v1/wallet/me/balance", get(super::wallet::me_balance))
         .route("/api/v1/wallet/me/coupons", get(super::wallet::me_coupons))
         .route(
             "/api/v1/wallet/me/redeem-coupon",
             post(super::wallet::me_redeem_coupon),
+        )
+        // Wallet — service surface (service_role JWT required). Backend
+        // callers: daily-reward cron, market mutations, MC mod, admin
+        // tooling. Anon / authenticated JWTs are rejected with 403.
+        .route(
+            "/api/v1/wallet/service/credit",
+            post(super::wallet::service_credit),
+        )
+        .route(
+            "/api/v1/wallet/service/debit",
+            post(super::wallet::service_debit),
+        )
+        .route(
+            "/api/v1/wallet/service/transfer",
+            post(super::wallet::service_transfer),
+        )
+        .route(
+            "/api/v1/wallet/service/redeem-coupon",
+            post(super::wallet::service_redeem_coupon),
+        )
+        .route(
+            "/api/v1/wallet/service/revoke-coupon",
+            post(super::wallet::service_revoke_coupon),
+        )
+        .route(
+            "/api/v1/wallet/service/verify-balance/{account_id}",
+            get(super::wallet::service_verify_balance),
         )
         // SEO-friendly 301: /forum/c/{slug} → /forum/s/{slug}. `c/` reads
         // as "category" but the canonical URL is `s/` (space). Crawlers

--- a/apps/kbve/axum-kbve/src/transport/wallet.rs
+++ b/apps/kbve/axum-kbve/src/transport/wallet.rs
@@ -12,16 +12,20 @@
 
 use axum::{
     Json,
-    http::{HeaderMap, StatusCode},
+    extract::Path,
+    http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
-use kbve::wallet::WalletError;
+use kbve::wallet::{
+    CreditRequest, CurrencyKind, DebitRequest, SourceKind, TransferRequest, WalletError,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::https::auth_user_id;
+use crate::auth::{extract_bearer_token, get_jwt_cache};
 use crate::db::get_wallet_client;
 
 // ---------------------------------------------------------------------------
@@ -63,6 +67,72 @@ pub(crate) struct RedeemCouponDto {
     pub reward_kind: String,
     pub reward_payload: serde_json::Value,
     pub ledger_id: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Service-layer DTOs
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct ServiceCreditBody {
+    pub account_id: Uuid,
+    /// `credits` or `khash`. Non-convertible currencies.
+    pub currency: String,
+    /// Positive amount in smallest unit (1 credit / 1 khash).
+    pub amount: i64,
+    /// One of: reward, purchase, refund, admin, coupon, market_buy,
+    /// market_sell, market_fee, transfer.
+    pub source_kind: String,
+    pub reason: Option<String>,
+    pub ref_type: Option<String>,
+    pub ref_id: Option<i64>,
+    /// Caller-supplied. Replay-safe with payload-mismatch detection.
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct ServiceLedgerDto {
+    pub ledger_id: i64,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct ServiceTransferBody {
+    pub from_account: Uuid,
+    pub to_account: Uuid,
+    pub currency: String,
+    pub amount: i64,
+    pub source_kind: String,
+    pub reason: Option<String>,
+    pub ref_type: Option<String>,
+    pub ref_id: Option<i64>,
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct ServiceRedeemCouponBody {
+    pub coupon_id: i64,
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct ServiceRevokeCouponBody {
+    pub coupon_id: i64,
+    pub reason: Option<String>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct ServiceRevokeDto {
+    pub revoked: bool,
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct ServiceVerifyBalanceDto {
+    pub account_id: Uuid,
+    pub stored_credits: i64,
+    pub ledger_credits: i64,
+    pub stored_khash: i64,
+    pub ledger_khash: i64,
+    pub ok: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -221,6 +291,76 @@ fn service_unavailable() -> Response {
         .into_response()
 }
 
+/// Gate service routes: requires a Supabase JWT whose `role` claim is
+/// `service_role`. Used by backend callers (MC mod, cron jobs, internal
+/// scripts). Anon/authenticated JWTs are rejected.
+async fn require_service_role(headers: &HeaderMap) -> Result<(), Response> {
+    let auth_header = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        .ok_or_else(|| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(json!({"error": "Missing Authorization header"})),
+            )
+                .into_response()
+        })?;
+
+    let token = extract_bearer_token(auth_header).ok_or_else(|| {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "Invalid bearer token"})),
+        )
+            .into_response()
+    })?;
+
+    let cache = get_jwt_cache().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "Auth service unavailable"})),
+        )
+            .into_response()
+    })?;
+
+    let info = cache.verify_and_cache(token).await.map_err(|e| {
+        tracing::warn!(error = %e, "JWT verify failed on service route");
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "Invalid or expired token"})),
+        )
+            .into_response()
+    })?;
+
+    if info.role != "service_role" {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(json!({"error": "service_role required"})),
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
+fn parse_currency(s: &str) -> Result<CurrencyKind, Response> {
+    CurrencyKind::from_pg(s).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "invalid currency", "message": format!("unknown currency: {s}")})),
+        )
+            .into_response()
+    })
+}
+
+fn parse_source_kind(s: &str) -> Result<SourceKind, Response> {
+    SourceKind::from_pg(s).ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "invalid source_kind", "message": format!("unknown source_kind: {s}")})),
+        )
+            .into_response()
+    })
+}
+
 fn wallet_error_response(err: WalletError) -> Response {
     let (status, code) = match &err {
         WalletError::InsufficientFunds => (StatusCode::PAYMENT_REQUIRED, "insufficient_funds"),
@@ -249,4 +389,293 @@ fn wallet_error_response(err: WalletError) -> Response {
         })),
     )
         .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Service handlers (service_role JWT required)
+// ---------------------------------------------------------------------------
+
+/// `POST /api/v1/wallet/service/credit` — credit a positive delta to any
+/// account. Returns the resulting ledger id. Idempotent: replays with the
+/// same `idempotency_key` return the original id; mismatched payloads on
+/// the same key raise `409 replay_mismatch`.
+#[utoipa::path(
+    post,
+    path = "/api/v1/wallet/service/credit",
+    tag = "wallet",
+    request_body = ServiceCreditBody,
+    responses(
+        (status = 200, description = "Ledger row created", body = ServiceLedgerDto),
+        (status = 400, description = "Invalid currency / source_kind / payload"),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 403, description = "service_role required"),
+        (status = 409, description = "Idempotency replay mismatch"),
+        (status = 422, description = "Overflow / null argument"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn service_credit(
+    headers: HeaderMap,
+    Json(body): Json<ServiceCreditBody>,
+) -> Response {
+    if let Err(resp) = require_service_role(&headers).await {
+        return resp;
+    }
+    let currency = match parse_currency(&body.currency) {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    let source_kind = match parse_source_kind(&body.source_kind) {
+        Ok(s) => s,
+        Err(r) => return r,
+    };
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    let req = CreditRequest {
+        account_id: body.account_id,
+        currency,
+        amount: body.amount,
+        source_kind,
+        reason: body.reason,
+        ref_type: body.ref_type,
+        ref_id: body.ref_id,
+        idempotency_key: body.idempotency_key,
+    };
+    match client.credit(req).await {
+        Ok(ledger_id) => Json(ServiceLedgerDto { ledger_id }).into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `POST /api/v1/wallet/service/debit` — deduct from an account. Raises
+/// `402 insufficient_funds` if the balance would go negative.
+#[utoipa::path(
+    post,
+    path = "/api/v1/wallet/service/debit",
+    tag = "wallet",
+    request_body = ServiceCreditBody,
+    responses(
+        (status = 200, description = "Ledger row created", body = ServiceLedgerDto),
+        (status = 400, description = "Invalid currency / source_kind / payload"),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 402, description = "Insufficient funds"),
+        (status = 403, description = "service_role required"),
+        (status = 409, description = "Idempotency replay mismatch"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn service_debit(
+    headers: HeaderMap,
+    Json(body): Json<ServiceCreditBody>,
+) -> Response {
+    if let Err(resp) = require_service_role(&headers).await {
+        return resp;
+    }
+    let currency = match parse_currency(&body.currency) {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    let source_kind = match parse_source_kind(&body.source_kind) {
+        Ok(s) => s,
+        Err(r) => return r,
+    };
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    let req = DebitRequest {
+        account_id: body.account_id,
+        currency,
+        amount: body.amount,
+        source_kind,
+        reason: body.reason,
+        ref_type: body.ref_type,
+        ref_id: body.ref_id,
+        idempotency_key: body.idempotency_key,
+    };
+    match client.debit(req).await {
+        Ok(ledger_id) => Json(ServiceLedgerDto { ledger_id }).into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `POST /api/v1/wallet/service/transfer` — atomic debit + credit. Locks
+/// both accounts in canonical UUID order to eliminate the A↔B deadlock vector.
+#[utoipa::path(
+    post,
+    path = "/api/v1/wallet/service/transfer",
+    tag = "wallet",
+    request_body = ServiceTransferBody,
+    responses(
+        (status = 204, description = "Transfer committed"),
+        (status = 400, description = "Invalid currency / source_kind / payload"),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 402, description = "Insufficient funds on source"),
+        (status = 403, description = "service_role required"),
+        (status = 409, description = "Idempotency replay mismatch"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn service_transfer(
+    headers: HeaderMap,
+    Json(body): Json<ServiceTransferBody>,
+) -> Response {
+    if let Err(resp) = require_service_role(&headers).await {
+        return resp;
+    }
+    let currency = match parse_currency(&body.currency) {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    let source_kind = match parse_source_kind(&body.source_kind) {
+        Ok(s) => s,
+        Err(r) => return r,
+    };
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    let req = TransferRequest {
+        from_account: body.from_account,
+        to_account: body.to_account,
+        currency,
+        amount: body.amount,
+        source_kind,
+        reason: body.reason,
+        ref_type: body.ref_type,
+        ref_id: body.ref_id,
+        idempotency_key: body.idempotency_key,
+    };
+    match client.transfer(req).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `POST /api/v1/wallet/service/redeem-coupon` — redeem a coupon on behalf
+/// of any account. Service-side variant of the user proxy; useful for
+/// admin grants or backend-initiated redemptions.
+#[utoipa::path(
+    post,
+    path = "/api/v1/wallet/service/redeem-coupon",
+    tag = "wallet",
+    request_body = ServiceRedeemCouponBody,
+    responses(
+        (status = 200, description = "Redemption result", body = RedeemCouponDto),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 403, description = "service_role required / coupon not redeemable"),
+        (status = 404, description = "Coupon not found"),
+        (status = 409, description = "Idempotency replay mismatch"),
+        (status = 501, description = "Reward kind not yet implemented"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn service_redeem_coupon(
+    headers: HeaderMap,
+    Json(body): Json<ServiceRedeemCouponBody>,
+) -> Response {
+    if let Err(resp) = require_service_role(&headers).await {
+        return resp;
+    }
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    match client
+        .redeem_coupon(body.coupon_id, body.idempotency_key)
+        .await
+    {
+        Ok(r) => Json(RedeemCouponDto {
+            success: r.success,
+            reward_kind: r.reward_kind.as_pg().to_string(),
+            reward_payload: r.reward_payload,
+            ledger_id: r.ledger_id,
+        })
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `POST /api/v1/wallet/service/revoke-coupon` — admin clawback. Cannot
+/// revoke a redeemed coupon (funds already out). Idempotent: revoking an
+/// already-revoked coupon returns `{revoked: false}` without raising.
+#[utoipa::path(
+    post,
+    path = "/api/v1/wallet/service/revoke-coupon",
+    tag = "wallet",
+    request_body = ServiceRevokeCouponBody,
+    responses(
+        (status = 200, description = "Revoke result", body = ServiceRevokeDto),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 403, description = "service_role required / coupon already redeemed"),
+        (status = 404, description = "Coupon not found"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn service_revoke_coupon(
+    headers: HeaderMap,
+    Json(body): Json<ServiceRevokeCouponBody>,
+) -> Response {
+    if let Err(resp) = require_service_role(&headers).await {
+        return resp;
+    }
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    match client.revoke_coupon(body.coupon_id, body.reason).await {
+        Ok(revoked) => Json(ServiceRevokeDto { revoked }).into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `GET /api/v1/wallet/service/verify-balance/:account_id` — compare stored
+/// balance vs ledger sum per currency. Run periodically or after suspected
+/// corruption. `ok=true` means consistent.
+#[utoipa::path(
+    get,
+    path = "/api/v1/wallet/service/verify-balance/{account_id}",
+    tag = "wallet",
+    params(
+        ("account_id" = String, Path, description = "Wallet account UUID")
+    ),
+    responses(
+        (status = 200, description = "Balance vs ledger comparison", body = ServiceVerifyBalanceDto),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 403, description = "service_role required"),
+        (status = 404, description = "Account not found"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn service_verify_balance(
+    headers: HeaderMap,
+    Path(account_id): Path<Uuid>,
+) -> Response {
+    if let Err(resp) = require_service_role(&headers).await {
+        return resp;
+    }
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    match client.verify_balance(account_id).await {
+        Ok(v) => Json(ServiceVerifyBalanceDto {
+            account_id: v.account_id,
+            stored_credits: v.stored_credits,
+            ledger_credits: v.ledger_credits,
+            stored_khash: v.stored_khash,
+            ledger_khash: v.ledger_khash,
+            ok: v.ok,
+        })
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
 }


### PR DESCRIPTION
## Summary

Adds the service-role-gated wallet HTTP surface so backend callers (the upcoming daily-reward cron, market mutation flows, MC mod, admin tooling) can move funds through axum-kbve instead of touching the DB directly. Builds on #10876 which shipped the \`/me/*\` user proxy surface.

## Routes (Supabase \`service_role\` JWT required)

| Method | Path | Backed by |
|---|---|---|
| POST | \`/api/v1/wallet/service/credit\` | \`WalletClient::credit\` |
| POST | \`/api/v1/wallet/service/debit\` | \`WalletClient::debit\` |
| POST | \`/api/v1/wallet/service/transfer\` | \`WalletClient::transfer\` |
| POST | \`/api/v1/wallet/service/redeem-coupon\` | \`WalletClient::redeem_coupon\` |
| POST | \`/api/v1/wallet/service/revoke-coupon\` | \`WalletClient::revoke_coupon\` |
| GET | \`/api/v1/wallet/service/verify-balance/{account_id}\` | \`WalletClient::verify_balance\` |

## Auth

\`require_service_role\` guard parses the bearer JWT through the existing [\`jwt_cache\`](apps/kbve/axum-kbve/src/auth/jwt_cache.rs), then asserts the role claim is \`service_role\`. Anon and authenticated tokens get **403**. No new secret to rotate — the existing Supabase \`service_role\` JWT is the credential.

## Request shape

- \`currency\` / \`source_kind\` passed as TEXT; parsed against [\`CurrencyKind\` / \`SourceKind\`](packages/rust/kbve/src/wallet/types.rs) enums; invalid values 400 early.
- \`idempotency_key\` UUID supplied by the caller. The replay safety from [\`wallet.replay_fingerprint\`](packages/data/sql/schema/wallet/wallet_core.sql) carries through unchanged: same key + same payload = same ledger id; same key + different payload = **409 replay_mismatch**.

## Error mapping (consistent with \`/me/*\` routes)

| WalletError | HTTP |
|---|---|
| \`InsufficientFunds\` | 402 |
| \`ReplayMismatch\` (40001) | 409 |
| \`NotAuthorized\` / \`CouponNotRedeemable\` / \`CouponExpired\` | 403 |
| \`NotFound\` | 404 |
| \`NullArgument\` / \`InvalidArgument\` | 400 / 422 |
| \`Overflow\` | 422 |
| \`Unimplemented\` | 501 |
| \`Pool\` / \`Join\` / \`Db\` | 500 (logged server-side) |

## Wiring

- [\`transport/wallet.rs\`](apps/kbve/axum-kbve/src/transport/wallet.rs): 6 new handlers + \`require_service_role\` guard + \`parse_currency\` / \`parse_source_kind\` helpers + 7 service DTOs.
- [\`transport/https.rs\`](apps/kbve/axum-kbve/src/transport/https.rs): 6 \`.route()\` entries appended after the \`/me/*\` block in \`public_router\`.
- [\`openapi.rs\`](apps/kbve/axum-kbve/src/openapi.rs): 6 paths + 7 DTOs registered so Scalar at \`kbve.com/dashboard/api\` picks them up alongside the user routes.

## Test plan

- [x] \`cargo build -p axum-kbve\` clean.
- [ ] After deploy: smoke a credit via curl with a service_role JWT to \`/api/v1/wallet/service/credit\` against the treasury account, verify via \`/api/v1/wallet/service/verify-balance/{treasury}\` returns \`ok: true\`.
- [ ] Anon / authenticated JWT to \`/api/v1/wallet/service/credit\` → 403.

## Next

- Astro Askama profile template wires a balance row using \`/api/v1/wallet/me/balance\` server-side (private profile only).
- Dashboard "Claim 1000 KHash" island POSTs \`/api/v1/wallet/me/redeem-coupon\`.
- Daily-login cron hits \`/api/v1/wallet/service/credit\` with \`source_kind=reward\`.