### PR TITLE
feat(astro-kbve): IDE Deploy panel for persistent firecracker endpoints

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroIDEDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroIDEDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import ReactVMAuth from './ReactVMAuth';
 import ReactCodeIDE from './ReactCodeIDE';
+import ReactDeployPanel from './ReactDeployPanel';
 ---
 
 <section
@@ -11,6 +12,7 @@ import ReactCodeIDE from './ReactCodeIDE';
 		<ReactVMAuth client:only="react">
 			<div class="not-content ide-dashboard">
 				<ReactCodeIDE client:only="react" />
+				<ReactDeployPanel client:only="react" />
 			</div>
 		</ReactVMAuth>
 	</div>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactDeployPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactDeployPanel.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	deployService,
+	TEMPLATES,
+	type DeployedEndpoint,
+} from './deployService';
+import { vmService } from './vmService';
+import {
+	Rocket,
+	Square,
+	RefreshCw,
+	ExternalLink,
+	Copy,
+	CheckCircle2,
+} from 'lucide-react';
+import { EditorView, basicSetup } from 'codemirror';
+import { keymap } from '@codemirror/view';
+import { EditorState, Compartment } from '@codemirror/state';
+import { python } from '@codemirror/lang-python';
+import { javascript } from '@codemirror/lang-javascript';
+import { oneDark } from '@codemirror/theme-one-dark';
+import type { Extension } from '@codemirror/state';
+
+function langExtension(language: string): Extension {
+	switch (language) {
+		case 'python':
+			return python();
+		case 'javascript':
+			return javascript();
+		default:
+			return [];
+	}
+}
+
+interface CopyButtonProps {
+	value: string;
+}
+
+function CopyButton({ value }: CopyButtonProps) {
+	const [copied, setCopied] = useState(false);
+	return (
+		<button
+			type="button"
+			onClick={() => {
+				void navigator.clipboard
+					.writeText(value)
+					.then(() => {
+						setCopied(true);
+						setTimeout(() => setCopied(false), 1200);
+					})
+					.catch(() => {});
+			}}
+			className="deploy-copy"
+			aria-label="Copy">
+			{copied ? <CheckCircle2 size={14} /> : <Copy size={14} />}
+		</button>
+	);
+}
+
+interface EndpointRowProps {
+	endpoint: DeployedEndpoint;
+	onStop: (name: string) => void;
+	stopping: boolean;
+}
+
+function EndpointRow({ endpoint, onStop, stopping }: EndpointRowProps) {
+	const url = deployService.urlFor(endpoint.name);
+	const absolute =
+		typeof window !== 'undefined'
+			? new URL(url, window.location.origin).toString()
+			: url;
+	return (
+		<tr>
+			<td>
+				<code>{endpoint.name}</code>
+			</td>
+			<td>
+				<code>{endpoint.rootfs}</code>
+			</td>
+			<td>
+				<code>
+					{endpoint.ip}:{endpoint.http_port}
+				</code>
+			</td>
+			<td>
+				<a
+					href={url}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="deploy-link">
+					{url} <ExternalLink size={12} />
+				</a>{' '}
+				<CopyButton value={absolute} />
+			</td>
+			<td>
+				<button
+					type="button"
+					onClick={() => onStop(endpoint.name)}
+					disabled={stopping}
+					className="deploy-stop"
+					aria-label={`Stop ${endpoint.name}`}>
+					<Square size={12} />
+					Stop
+				</button>
+			</td>
+		</tr>
+	);
+}
+
+export default function ReactDeployPanel() {
+	const phase = useStore(deployService.$phase);
+	const error = useStore(deployService.$error);
+	const template = useStore(deployService.$template);
+	const name = useStore(deployService.$name);
+	const code = useStore(deployService.$code);
+	const port = useStore(deployService.$port);
+	const endpoints = useStore(deployService.$endpoints);
+	const lastDeployed = useStore(deployService.$lastDeployedName);
+	const token = useStore(vmService.$accessToken);
+
+	const editorRef = useRef<HTMLDivElement | null>(null);
+	const viewRef = useRef<EditorView | null>(null);
+	const langCompartment = useRef(new Compartment());
+
+	const [stoppingName, setStoppingName] = useState<string | null>(null);
+
+	// Mount editor once.
+	useEffect(() => {
+		if (!editorRef.current || viewRef.current) return;
+		const state = EditorState.create({
+			doc: deployService.$code.get(),
+			extensions: [
+				basicSetup,
+				keymap.of([]),
+				oneDark,
+				langCompartment.current.of(langExtension(template.language)),
+				EditorView.updateListener.of((v) => {
+					if (v.docChanged) {
+						deployService.$code.set(v.state.doc.toString());
+					}
+				}),
+				EditorView.theme({
+					'&': { height: '320px', fontSize: '13px' },
+					'.cm-content': {
+						fontFamily:
+							'ui-monospace, SFMono-Regular, Menlo, monospace',
+					},
+				}),
+			],
+		});
+		viewRef.current = new EditorView({ state, parent: editorRef.current });
+		return () => {
+			viewRef.current?.destroy();
+			viewRef.current = null;
+		};
+	}, []);
+
+	// Swap language extension when template changes.
+	useEffect(() => {
+		if (!viewRef.current) return;
+		viewRef.current.dispatch({
+			effects: langCompartment.current.reconfigure(
+				langExtension(template.language),
+			),
+		});
+	}, [template.language]);
+
+	// Sync editor when code resets via template switch.
+	useEffect(() => {
+		if (!viewRef.current) return;
+		if (viewRef.current.state.doc.toString() !== code) {
+			viewRef.current.dispatch({
+				changes: {
+					from: 0,
+					to: viewRef.current.state.doc.length,
+					insert: code,
+				},
+			});
+		}
+	}, [code]);
+
+	// Pull endpoint list on mount + every 15s.
+	useEffect(() => {
+		if (!token) return;
+		void deployService.refresh(token);
+		const id = window.setInterval(() => {
+			if (token) void deployService.refresh(token);
+		}, 15000);
+		return () => window.clearInterval(id);
+	}, [token]);
+
+	const handleDeploy = useCallback(() => {
+		if (!token) return;
+		void deployService.deploy(token);
+	}, [token]);
+
+	const handleStop = useCallback(
+		(target: string) => {
+			if (!token) return;
+			setStoppingName(target);
+			void deployService
+				.stop(token, target)
+				.finally(() => setStoppingName(null));
+		},
+		[token],
+	);
+
+	const submitting = phase === 'submitting';
+
+	return (
+		<section className="deploy-panel not-content">
+			<header className="deploy-head">
+				<h2 className="deploy-title">
+					<Rocket size={16} /> Deploy
+				</h2>
+				<p className="deploy-sub">
+					Boot a persistent firecracker-ctl-net microVM serving your
+					code on an HTTP endpoint. Staff-gated. Endpoint stays up
+					until you stop it.
+				</p>
+			</header>
+
+			<div className="deploy-form">
+				<label className="deploy-field">
+					<span>Template</span>
+					<select
+						value={template.id}
+						onChange={(e) =>
+							deployService.selectTemplate(e.target.value)
+						}>
+						{TEMPLATES.map((t) => (
+							<option key={t.id} value={t.id}>
+								{t.label}
+							</option>
+						))}
+					</select>
+				</label>
+
+				<label className="deploy-field">
+					<span>Name</span>
+					<input
+						type="text"
+						value={name}
+						onChange={(e) =>
+							deployService.$name.set(e.target.value)
+						}
+						placeholder="my-api"
+						maxLength={39}
+					/>
+				</label>
+
+				<label className="deploy-field">
+					<span>Port</span>
+					<input
+						type="number"
+						min={1024}
+						max={65535}
+						value={port}
+						onChange={(e) =>
+							deployService.$port.set(Number(e.target.value) || 0)
+						}
+					/>
+				</label>
+
+				<label className="deploy-field deploy-field--meta">
+					<span>Entrypoint</span>
+					<code>{template.entrypoint}</code>
+				</label>
+
+				<label className="deploy-field deploy-field--meta">
+					<span>Rootfs</span>
+					<code>{template.rootfs}</code>
+				</label>
+			</div>
+
+			<div ref={editorRef} className="deploy-editor" />
+
+			<div className="deploy-actions">
+				<button
+					type="button"
+					onClick={handleDeploy}
+					disabled={submitting || !token}
+					className="deploy-submit">
+					<Rocket size={14} /> {submitting ? 'Deploying…' : 'Deploy'}
+				</button>
+				<button
+					type="button"
+					onClick={() => token && void deployService.refresh(token)}
+					disabled={!token}
+					className="deploy-refresh"
+					aria-label="Refresh endpoint list">
+					<RefreshCw size={14} />
+				</button>
+			</div>
+
+			{error && <div className="deploy-error">{error}</div>}
+
+			{phase === 'ready' && lastDeployed && (
+				<div className="deploy-ready">
+					Deployed{' '}
+					<a
+						href={deployService.urlFor(lastDeployed)}
+						target="_blank"
+						rel="noopener noreferrer">
+						{deployService.urlFor(lastDeployed)}
+					</a>
+				</div>
+			)}
+
+			<div className="deploy-list">
+				<h3>Running endpoints ({endpoints.length})</h3>
+				{endpoints.length === 0 ? (
+					<p className="deploy-empty">No persistent endpoints yet.</p>
+				) : (
+					<table className="deploy-table">
+						<thead>
+							<tr>
+								<th>Name</th>
+								<th>Rootfs</th>
+								<th>IP:Port</th>
+								<th>URL</th>
+								<th></th>
+							</tr>
+						</thead>
+						<tbody>
+							{endpoints.map((ep) => (
+								<EndpointRow
+									key={ep.name}
+									endpoint={ep}
+									onStop={handleStop}
+									stopping={stoppingName === ep.name}
+								/>
+							))}
+						</tbody>
+					</table>
+				)}
+			</div>
+
+			<style>{`
+				.deploy-panel { display: flex; flex-direction: column; gap: 1rem; padding: 1rem; border: 1px solid rgba(255,255,255,0.08); border-radius: 0.5rem; background: rgba(255,255,255,0.02); }
+				.deploy-head { display: flex; flex-direction: column; gap: 0.25rem; }
+				.deploy-title { display: inline-flex; align-items: center; gap: 0.5rem; margin: 0; font-size: 1rem; }
+				.deploy-sub { margin: 0; opacity: 0.7; font-size: 0.85rem; }
+				.deploy-form { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
+				.deploy-field { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.8rem; }
+				.deploy-field span { opacity: 0.7; }
+				.deploy-field input, .deploy-field select { padding: 0.4rem 0.5rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.1); border-radius: 0.25rem; color: inherit; font: inherit; }
+				.deploy-field--meta code { padding: 0.4rem 0.5rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.06); border-radius: 0.25rem; font-size: 0.78rem; }
+				.deploy-editor { border: 1px solid rgba(255,255,255,0.08); border-radius: 0.25rem; overflow: hidden; }
+				.deploy-actions { display: flex; gap: 0.5rem; align-items: center; }
+				.deploy-submit, .deploy-refresh, .deploy-stop, .deploy-copy { display: inline-flex; align-items: center; gap: 0.4rem; padding: 0.4rem 0.7rem; border: 1px solid rgba(255,255,255,0.12); border-radius: 0.25rem; background: rgba(255,255,255,0.04); color: inherit; cursor: pointer; font: inherit; }
+				.deploy-submit { background: rgba(34,197,94,0.18); border-color: rgba(34,197,94,0.45); }
+				.deploy-submit:disabled { opacity: 0.5; cursor: not-allowed; }
+				.deploy-copy { padding: 0.2rem 0.35rem; }
+				.deploy-stop { background: rgba(239,68,68,0.15); border-color: rgba(239,68,68,0.45); }
+				.deploy-error { padding: 0.5rem 0.7rem; background: rgba(239,68,68,0.12); border: 1px solid rgba(239,68,68,0.4); border-radius: 0.25rem; font-size: 0.85rem; }
+				.deploy-ready { padding: 0.5rem 0.7rem; background: rgba(34,197,94,0.1); border: 1px solid rgba(34,197,94,0.4); border-radius: 0.25rem; font-size: 0.85rem; }
+				.deploy-list h3 { margin: 0 0 0.5rem 0; font-size: 0.9rem; }
+				.deploy-empty { margin: 0; opacity: 0.6; font-size: 0.85rem; }
+				.deploy-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
+				.deploy-table th, .deploy-table td { text-align: left; padding: 0.4rem 0.5rem; border-bottom: 1px solid rgba(255,255,255,0.06); }
+				.deploy-table th { font-weight: 500; opacity: 0.7; }
+				.deploy-link { display: inline-flex; align-items: center; gap: 0.25rem; }
+			`}</style>
+		</section>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/deployService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/deployService.ts
@@ -1,0 +1,277 @@
+import { atom } from 'nanostores';
+
+// ---------------------------------------------------------------------------
+// Types — mirror firecracker-ctl's DeployFcRequest + PersistentEndpointInfo
+// ---------------------------------------------------------------------------
+
+export interface DeployRequest {
+	name: string;
+	rootfs: string;
+	http_port: number;
+	entrypoint: string;
+	vcpu_count?: number;
+	mem_size_mib?: number;
+	health_path?: string;
+	env?: Record<string, unknown>;
+	code?: string;
+}
+
+export interface DeployedEndpoint {
+	name: string;
+	vm_id: string;
+	rootfs: string;
+	ip: string;
+	http_port: number;
+	entrypoint: string;
+	status?: string;
+	created_at?: string;
+}
+
+export interface DeployTemplate {
+	id: string;
+	label: string;
+	rootfs: string;
+	language: 'python' | 'javascript';
+	http_port: number;
+	entrypoint: string;
+	vcpu_count: number;
+	mem_size_mib: number;
+	default_code: string;
+}
+
+export type DeployPhase = 'idle' | 'submitting' | 'ready' | 'failed';
+
+// ---------------------------------------------------------------------------
+// Template inventory
+// ---------------------------------------------------------------------------
+
+const PYTHON_FASTAPI_CODE = `from fastapi import FastAPI
+import uvicorn
+
+app = FastAPI()
+
+@app.get("/")
+def root():
+    return {"hello": "world"}
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8080)
+`;
+
+const NODE_FASTIFY_CODE = `const Fastify = require('fastify');
+const app = Fastify({ logger: true });
+
+app.get('/', async () => ({ hello: 'world' }));
+app.get('/health', async () => ({ ok: true }));
+
+app
+  .listen({ host: '0.0.0.0', port: 8080 })
+  .then((addr) => app.log.info(\`listening on \${addr}\`))
+  .catch((err) => { app.log.error(err); process.exit(1); });
+`;
+
+export const TEMPLATES: DeployTemplate[] = [
+	{
+		id: 'python-web-baked',
+		label: 'Python · FastAPI (baked)',
+		rootfs: 'firecracker-python-web',
+		language: 'python',
+		http_port: 8080,
+		entrypoint: 'python3 /tmp/code',
+		vcpu_count: 1,
+		mem_size_mib: 256,
+		default_code: PYTHON_FASTAPI_CODE,
+	},
+	{
+		id: 'python-fastapi-cache',
+		label: 'Python · FastAPI (cache)',
+		rootfs: 'alpine-python',
+		language: 'python',
+		http_port: 8080,
+		entrypoint: 'python3 /tmp/code',
+		vcpu_count: 1,
+		mem_size_mib: 256,
+		default_code: PYTHON_FASTAPI_CODE,
+	},
+	{
+		id: 'node-web-baked',
+		label: 'Node · Fastify (baked)',
+		rootfs: 'firecracker-node-web',
+		language: 'javascript',
+		http_port: 8080,
+		entrypoint: 'node /tmp/code',
+		vcpu_count: 1,
+		mem_size_mib: 256,
+		default_code: NODE_FASTIFY_CODE,
+	},
+	{
+		id: 'node-fastify-cache',
+		label: 'Node · Fastify (cache)',
+		rootfs: 'alpine-node',
+		language: 'javascript',
+		http_port: 8080,
+		entrypoint: 'node /tmp/code',
+		vcpu_count: 1,
+		mem_size_mib: 256,
+		default_code: NODE_FASTIFY_CODE,
+	},
+];
+
+// Cache-tier templates need explicit packages so the init script knows
+// what to install from the pip/npm cache drive.
+export const TEMPLATE_PACKAGES: Record<string, string[]> = {
+	'python-fastapi-cache': ['fastapi', 'uvicorn'],
+	'node-fastify-cache': ['fastify'],
+};
+
+// ---------------------------------------------------------------------------
+// API
+// ---------------------------------------------------------------------------
+
+const FC_BASE = '/api/v1/fc';
+
+async function fcFetch<T>(
+	token: string,
+	path: string,
+	method = 'GET',
+	body?: unknown,
+): Promise<T> {
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${token}`,
+	};
+	const opts: RequestInit = {
+		method,
+		headers,
+		signal: AbortSignal.timeout(20000),
+	};
+	if (body !== undefined) {
+		headers['Content-Type'] = 'application/json';
+		opts.body = JSON.stringify(body);
+	}
+	const resp = await fetch(`${FC_BASE}${path}`, opts);
+	if (!resp.ok) {
+		const text = await resp.text().catch(() => '');
+		throw new Error(`fc ${resp.status}: ${text.slice(0, 300)}`);
+	}
+	const text = await resp.text();
+	if (!text.trim()) return {} as T;
+	return JSON.parse(text) as T;
+}
+
+function endpointUrl(name: string): string {
+	return `/dashboard/firecracker-net/proxy/proxy/${name}/`;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+class DeployService {
+	public readonly $phase = atom<DeployPhase>('idle');
+	public readonly $error = atom<string | null>(null);
+	public readonly $template = atom<DeployTemplate>(TEMPLATES[0]);
+	public readonly $name = atom<string>('');
+	public readonly $code = atom<string>(TEMPLATES[0].default_code);
+	public readonly $port = atom<number>(TEMPLATES[0].http_port);
+	public readonly $endpoints = atom<DeployedEndpoint[]>([]);
+	public readonly $lastDeployedName = atom<string | null>(null);
+
+	public selectTemplate(id: string): void {
+		const tpl = TEMPLATES.find((t) => t.id === id);
+		if (!tpl) return;
+		this.$template.set(tpl);
+		this.$port.set(tpl.http_port);
+		const current = this.$code.get();
+		const wasDefault = TEMPLATES.some(
+			(t) => t.default_code.trim() === current.trim(),
+		);
+		if (wasDefault) {
+			this.$code.set(tpl.default_code);
+		}
+	}
+
+	public urlFor(name: string): string {
+		return endpointUrl(name);
+	}
+
+	public async deploy(token: string): Promise<void> {
+		const tpl = this.$template.get();
+		const name = this.$name.get().trim().toLowerCase();
+		const code = this.$code.get();
+		const port = this.$port.get();
+
+		if (!name || !/^[a-z0-9][a-z0-9-_]{1,38}$/.test(name)) {
+			this.$error.set(
+				'Name must be 2–39 chars, lowercase alphanumeric / hyphen / underscore.',
+			);
+			return;
+		}
+		if (!code.trim()) {
+			this.$error.set('No code to deploy.');
+			return;
+		}
+		if (!port || port < 1024 || port > 65535) {
+			this.$error.set('Port must be between 1024 and 65535.');
+			return;
+		}
+
+		this.$phase.set('submitting');
+		this.$error.set(null);
+
+		const req: DeployRequest = {
+			name,
+			rootfs: tpl.rootfs,
+			http_port: port,
+			entrypoint: tpl.entrypoint,
+			vcpu_count: tpl.vcpu_count,
+			mem_size_mib: tpl.mem_size_mib,
+			code,
+			env: {},
+		};
+		const packages = TEMPLATE_PACKAGES[tpl.id];
+		if (packages && packages.length > 0) {
+			(req as unknown as Record<string, unknown>).packages = packages;
+		}
+
+		try {
+			await fcFetch<DeployedEndpoint>(token, '/deploy', 'POST', req);
+			this.$phase.set('ready');
+			this.$lastDeployedName.set(name);
+			void this.refresh(token);
+		} catch (err) {
+			this.$phase.set('failed');
+			this.$error.set(err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	public async refresh(token: string): Promise<void> {
+		try {
+			const list = await fcFetch<
+				{ endpoints?: DeployedEndpoint[] } | DeployedEndpoint[]
+			>(token, '/list');
+			const arr = Array.isArray(list)
+				? list
+				: Array.isArray(list?.endpoints)
+					? list.endpoints
+					: [];
+			this.$endpoints.set(arr);
+		} catch (err) {
+			this.$error.set(err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	public async stop(token: string, name: string): Promise<void> {
+		try {
+			await fcFetch(token, `/${encodeURIComponent(name)}`, 'DELETE');
+			void this.refresh(token);
+		} catch (err) {
+			this.$error.set(err instanceof Error ? err.message : String(err));
+		}
+	}
+}
+
+export const deployService = new DeployService();


### PR DESCRIPTION
## Summary
Adds a Deploy panel under \`/dashboard/ide/\` that lets staff users boot a persistent firecracker-ctl-net microVM with their own FastAPI or Fastify code, get an HTTPS endpoint URL, and stop the VM from the same view. Sits beside the existing Quick Run editor — separate flows since they target different lifecycle paths.

## Changes
- New \`deployService\` nanostore wraps \`/api/v1/fc/*\` (deploy / list / {name}) with a four-template picker:
  - **Python · FastAPI (baked)** — \`firecracker-python-web\` rootfs
  - **Python · FastAPI (cache)** — \`alpine-python\` + pip-cache install at boot
  - **Node · Fastify (baked)** — \`firecracker-node-web\` rootfs
  - **Node · Fastify (cache)** — \`alpine-node\` + npm-cache install at boot
  Defaults to the baked rootfs so cold start is instant.
- New \`ReactDeployPanel\` renders a CodeMirror editor pre-filled with a minimal FastAPI / Fastify hello-world skeleton, a name/port form, Deploy button, "Running endpoints" table, and per-row Stop button. Auto-refreshes the list every 15s.
- Wires the panel into \`AstroIDEDashboard\` alongside \`ReactCodeIDE\`; both sit inside the existing \`ReactVMAuth\` gate so the staff JWT carries through unchanged.

Pairs with #10877 (the \`/api/v1/fc/*\` alias route in axum-kbve).

## Test plan
- [ ] \`nx run astro-kbve:build\` clean
- [ ] \`/dashboard/ide/\` renders the new Deploy panel below the Quick Run editor
- [ ] Selecting each template loads the matching hello-world skeleton in the editor
- [ ] Deploy → name validation, port validation, error feedback
- [ ] Successful deploy shows the endpoint URL and refreshes the Running endpoints table
- [ ] Stop button removes the entry on next refresh
- [ ] Unauth user is gated by \`ReactVMAuth\`