### PR TITLE
feat(astro-kbve): private wallet card on own /@username profile

### DIFF
--- a/apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro
+++ b/apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro
@@ -1,5 +1,6 @@
 ---
 import Adsense from '@/components/astropad/adsense/Adsense.astro';
+import { ReactProfileWallet } from './ReactProfileWallet';
 // AskamaProfileProvider - Mirrors the Askama profile.html template
 // This component renders the user profile page that Axum serves for /@username routes
 // Askama variables: {{ username }}, {{ username_first_char }}, {{ unsplash_banner_id }}, {{ bio }}, {{ status }}, {{ primary_avatar_url }}, {{ discord_username }}, {{ discord_avatar }}, {{ discord_is_guild_member }}, {{ discord_id }}, {{ discord_guild_nickname }}, {{ discord_joined_at }}, {{ discord_is_boosting }}, {{ discord_role_count }}, {{ discord_role_names }}, {{ github_username }}, {{ github_avatar }}, {{ twitch_username }}, {{ twitch_avatar }}, {{ twitch_is_live }}, {{ rentearth_characters }}, {{ rentearth_total_playtime_hours }}, {{ rentearth_last_activity }}
@@ -847,6 +848,15 @@ const forumProfileSection = `{% if forum_present %}
 				</aside>
 			</div>
 		</main>
+
+		<!-- Private wallet card. Askama injects `{{ username }}` into the meta
+		     tag below; the React island reads it on mount, compares against
+		     the caller's own /api/v1/me username, and renders the wallet
+		     UI only on their own profile. Returns null otherwise. -->
+		<meta name="kbve-profile-username" content={`{{ username }}`} />
+		<div class="profile-wallet-container">
+			<ReactProfileWallet client:only="react" />
+		</div>
 
 		<!-- Adsense -->
 		<div class="adsense-container">

--- a/apps/kbve/astro-kbve/src/components/providers/ReactProfileWallet.tsx
+++ b/apps/kbve/astro-kbve/src/components/providers/ReactProfileWallet.tsx
@@ -1,0 +1,318 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getAccessToken, useSession } from '@kbve/astro';
+
+/**
+ * Profile wallet island.
+ *
+ * Mounted from `AskamaProfileProvider.astro`. Renders the caller's wallet
+ * balance + claim-coupon affordance ONLY on their own profile page; on
+ * other users' profiles the card stays hidden.
+ *
+ * Ownership check:
+ *   1. Read `data-profile-username` from the host element (set by the SSR
+ *      Askama template).
+ *   2. Pull session via `useSession`; if anon → render nothing.
+ *   3. Call `/api/v1/me` once to resolve the caller's own username.
+ *   4. If `me.username === profileUsername` → fetch wallet + render.
+ *
+ * Everything else is conventional fetch + state: balance, coupon list,
+ * claim with idempotency key.
+ */
+
+type Balance = {
+	account_id: string;
+	credits: number;
+	khash: number;
+	updated_at: string;
+};
+
+type Coupon = {
+	coupon_id: number;
+	template_code: string;
+	template_label: string;
+	reward_kind: string;
+	reward_payload: Record<string, unknown>;
+	status: 'unredeemed' | 'redeemed' | 'expired' | 'revoked';
+	granted_at: string;
+	expires_at: string | null;
+	redeemed_at: string | null;
+};
+
+type RedeemResult = {
+	success: boolean;
+	reward_kind: string;
+	reward_payload: Record<string, unknown>;
+	ledger_id: number;
+};
+
+/**
+ * The Askama-emitted username is injected into the page via a hidden
+ * `<meta name="kbve-profile-username" content="{{ username }}">` tag (see
+ * `AskamaProfileProvider.astro`). Reading from the DOM keeps the Astro
+ * island free of prop-marshaling across the Askama → Astro boundary.
+ */
+function readProfileUsername(): string | null {
+	if (typeof document === 'undefined') return null;
+	const meta = document.querySelector(
+		'meta[name="kbve-profile-username"]',
+	) as HTMLMetaElement | null;
+	return meta?.content?.trim() || null;
+}
+
+const styles = {
+	container: {
+		marginTop: '1rem',
+		padding: '1.25rem',
+		borderRadius: '16px',
+		background:
+			'linear-gradient(145deg, rgba(30,41,59,0.9) 0%, rgba(15,23,42,0.95) 100%)',
+		border: '1px solid rgba(255,255,255,0.08)',
+		color: 'rgba(255,255,255,0.9)',
+		boxShadow: '0 25px 50px -12px rgba(0,0,0,0.5)',
+	} as React.CSSProperties,
+	header: {
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		marginBottom: '0.85rem',
+	} as React.CSSProperties,
+	title: {
+		fontSize: '0.85rem',
+		fontWeight: 700,
+		letterSpacing: '2px',
+		textTransform: 'uppercase',
+	} as React.CSSProperties,
+	balances: {
+		display: 'grid',
+		gridTemplateColumns: '1fr 1fr',
+		gap: '0.75rem',
+	} as React.CSSProperties,
+	balanceCard: {
+		padding: '0.85rem 1rem',
+		borderRadius: '12px',
+		background: 'rgba(255,255,255,0.04)',
+		border: '1px solid rgba(255,255,255,0.06)',
+	} as React.CSSProperties,
+	balanceLabel: {
+		fontSize: '0.7rem',
+		fontWeight: 600,
+		letterSpacing: '1.5px',
+		textTransform: 'uppercase',
+		color: 'rgba(255,255,255,0.55)',
+	} as React.CSSProperties,
+	balanceValue: {
+		marginTop: '0.25rem',
+		fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+		fontSize: '1.5rem',
+		fontWeight: 700,
+	} as React.CSSProperties,
+	coupons: {
+		marginTop: '1rem',
+		display: 'flex',
+		flexDirection: 'column',
+		gap: '0.5rem',
+	} as React.CSSProperties,
+	coupon: {
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		gap: '0.75rem',
+		padding: '0.6rem 0.85rem',
+		borderRadius: '10px',
+		background: 'rgba(16,185,129,0.08)',
+		border: '1px solid rgba(16,185,129,0.25)',
+	} as React.CSSProperties,
+	couponLabel: {
+		fontSize: '0.9rem',
+		fontWeight: 600,
+	} as React.CSSProperties,
+	claimBtn: {
+		padding: '0.4rem 0.9rem',
+		borderRadius: '8px',
+		border: '1px solid rgba(16,185,129,0.5)',
+		background: 'linear-gradient(135deg,#10b981 0%,#059669 100%)',
+		color: 'white',
+		fontWeight: 700,
+		cursor: 'pointer',
+	} as React.CSSProperties,
+	muted: {
+		marginTop: '0.5rem',
+		fontSize: '0.8rem',
+		color: 'rgba(255,255,255,0.5)',
+	} as React.CSSProperties,
+	error: {
+		marginTop: '0.5rem',
+		fontSize: '0.8rem',
+		color: 'rgb(248,113,113)',
+	} as React.CSSProperties,
+};
+
+async function authedFetch(path: string, init: RequestInit = {}) {
+	const token = await getAccessToken();
+	if (!token) throw new Error('not authenticated');
+	const headers = new Headers(init.headers);
+	headers.set('Authorization', `Bearer ${token}`);
+	if (init.body && !headers.has('Content-Type')) {
+		headers.set('Content-Type', 'application/json');
+	}
+	const res = await fetch(path, { ...init, headers });
+	if (!res.ok) {
+		let detail = await res.text().catch(() => '');
+		try {
+			const parsed = JSON.parse(detail);
+			detail = parsed.error || parsed.message || detail;
+		} catch {}
+		throw new Error(`${res.status}: ${detail || res.statusText}`);
+	}
+	return res.json();
+}
+
+function formatCredits(n: number) {
+	// 1 credit = $0.00001 (1 USD = 100,000 credits). For display use the
+	// thousands-separated integer; conversion to USD is a future affordance.
+	return n.toLocaleString();
+}
+
+export function ReactProfileWallet() {
+	const { ready, authenticated } = useSession();
+	const [profileUsername, setProfileUsername] = useState<string | null>(null);
+	const [own, setOwn] = useState<boolean | null>(null);
+
+	// Read the SSR-injected profile username once on mount.
+	useEffect(() => {
+		setProfileUsername(readProfileUsername());
+	}, []);
+	const [balance, setBalance] = useState<Balance | null>(null);
+	const [coupons, setCoupons] = useState<Coupon[]>([]);
+	const [error, setError] = useState<string | null>(null);
+	const [claiming, setClaiming] = useState<number | null>(null);
+
+	// 1. Resolve ownership (only authenticated callers).
+	useEffect(() => {
+		if (!ready) return;
+		if (!authenticated || !profileUsername) {
+			setOwn(false);
+			return;
+		}
+		(async () => {
+			try {
+				const me = await authedFetch('/api/v1/me');
+				const myUsername: string | undefined = me?.username;
+				setOwn(
+					!!myUsername &&
+						myUsername.toLowerCase() ===
+							profileUsername.toLowerCase(),
+				);
+			} catch (err) {
+				setError(
+					err instanceof Error ? err.message : 'me lookup failed',
+				);
+				setOwn(false);
+			}
+		})();
+	}, [ready, authenticated, profileUsername]);
+
+	// 2. Once confirmed owner, load balance + coupons.
+	const refresh = useCallback(async () => {
+		try {
+			const [bal, cps] = await Promise.all([
+				authedFetch('/api/v1/wallet/me/balance'),
+				authedFetch('/api/v1/wallet/me/coupons'),
+			]);
+			setBalance(bal);
+			setCoupons(cps);
+			setError(null);
+		} catch (err) {
+			setError(
+				err instanceof Error ? err.message : 'wallet fetch failed',
+			);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (own === true) void refresh();
+	}, [own, refresh]);
+
+	const claim = useCallback(
+		async (couponId: number) => {
+			setClaiming(couponId);
+			try {
+				const body = JSON.stringify({
+					coupon_id: couponId,
+					idempotency_key: crypto.randomUUID(),
+				});
+				const result: RedeemResult = await authedFetch(
+					'/api/v1/wallet/me/redeem-coupon',
+					{ method: 'POST', body },
+				);
+				if (!result.success) {
+					setError('claim failed');
+					return;
+				}
+				await refresh();
+			} catch (err) {
+				setError(err instanceof Error ? err.message : 'claim failed');
+			} finally {
+				setClaiming(null);
+			}
+		},
+		[refresh],
+	);
+
+	if (own !== true) return null;
+
+	const claimable = coupons.filter((c) => c.status === 'unredeemed');
+
+	return (
+		<div style={styles.container} aria-label="Your wallet">
+			<div style={styles.header}>
+				<span style={styles.title}>Wallet</span>
+				<span style={styles.muted}>
+					{balance
+						? `updated ${new Date(balance.updated_at).toLocaleString()}`
+						: '…'}
+				</span>
+			</div>
+
+			<div style={styles.balances}>
+				<div style={styles.balanceCard}>
+					<div style={styles.balanceLabel}>Credits</div>
+					<div style={styles.balanceValue}>
+						{balance ? formatCredits(balance.credits) : '—'}
+					</div>
+				</div>
+				<div style={styles.balanceCard}>
+					<div style={styles.balanceLabel}>KHash</div>
+					<div style={styles.balanceValue}>
+						{balance ? balance.khash.toLocaleString() : '—'}
+					</div>
+				</div>
+			</div>
+
+			{claimable.length > 0 && (
+				<div style={styles.coupons}>
+					{claimable.map((c) => (
+						<div key={c.coupon_id} style={styles.coupon}>
+							<span style={styles.couponLabel}>
+								{c.template_label}
+							</span>
+							<button
+								type="button"
+								onClick={() => void claim(c.coupon_id)}
+								disabled={claiming === c.coupon_id}
+								style={styles.claimBtn}>
+								{claiming === c.coupon_id
+									? 'Claiming…'
+									: 'Claim'}
+							</button>
+						</div>
+					))}
+				</div>
+			)}
+
+			{error && <div style={styles.error}>{error}</div>}
+		</div>
+	);
+}
+
+export default ReactProfileWallet;


### PR DESCRIPTION
## Summary

Adds a Credits + KHash balance card with a claim affordance to the profile page, rendered **only on the viewer's own profile**. On someone else's \`/@username\` the card stays hidden. Completes the user-facing slice of the wallet stack — the WELCOME_KHASH coupon already seeded on signup can finally be claimed end-to-end through the UI.

## How

- [\`AskamaProfileProvider.astro\`](apps/kbve/astro-kbve/src/components/providers/AskamaProfileProvider.astro) emits a hidden \`<meta name="kbve-profile-username" content="{{ username }}">\` tag right next to the React island mount point. axum-kbve's Askama renderer substitutes the literal username at serve time.
- [\`ReactProfileWallet\`](apps/kbve/astro-kbve/src/components/providers/ReactProfileWallet.tsx) (\`client:only="react"\`):
  1. Reads the meta on mount.
  2. Pulls the Supabase JWT via \`@kbve/astro\`'s \`useSession\` + \`getAccessToken\`.
  3. Calls \`/api/v1/me\` once for the caller's own username; compares case-insensitively to the profile's username.
  4. If owner → fetches \`/api/v1/wallet/me/balance\` + \`/me/coupons\` and renders.
  5. Unredeemed coupons (e.g. \`WELCOME_KHASH\`) get a **Claim** button that POSTs \`/api/v1/wallet/me/redeem-coupon\` with a fresh \`crypto.randomUUID()\` idempotency key; on success the card refetches both endpoints.

Returns \`null\` when:
- meta is missing (older deployments without the embed),
- viewer is anon,
- \`/api/v1/me\` lookup fails,
- usernames don't match.

## Security note

Ownership comparison is **client-side**. That's fine because the server only ever returns the caller's own wallet — \`/api/v1/wallet/me/*\` is gated by Supabase JWT and tied to \`auth.uid()\`. There is no path that leaks foreign balances; the meta-tag compare is purely a UI gate.

## Wire-up

| API hit | Backed by |
|---|---|
| \`GET /api/v1/me\` | existing forum/profile probe |
| \`GET /api/v1/wallet/me/balance\` | #10876 |
| \`GET /api/v1/wallet/me/coupons\` | #10876 |
| \`POST /api/v1/wallet/me/redeem-coupon\` | #10876 |

Welcome coupon machinery already in prod from [\`wallet_schema_init\`](packages/data/sql/dbmate/migrations/20260511104220_wallet_schema_init.sql).

## Test plan

- [x] \`nx run astro-kbve:check\` — no new errors related to the wallet code; pre-existing errors unchanged.
- [ ] Live: sign in, visit own \`/@username\` → card shows balance + WELCOME_KHASH claim button.
- [ ] Click Claim → balance flips to \`khash: 1,000\` after redeem.
- [ ] Click Claim again with same idempotency key → no error (server replays). Different key → server raises \`409 replay_mismatch\`. (Tested via PR #10876.)
- [ ] Visit another user's \`/@username\` → no wallet card.
- [ ] Logged out → no wallet card.

## Follow-ups

- Daily-login cron hits \`/api/v1/wallet/service/credit\` with \`source_kind=reward\` (#10878 routes are live).
- MC mod uses the same gateway for daily-login khash / market grants.
- Marketplace UI on \`/mc/\` pricing items in khash / credits.