### PR TITLE
perf(arcade): animate blackjack deals from shoe

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
@@ -34,6 +34,15 @@ const BUTTON_TEXTURE_SIZE = {
 	radius: 8,
 } as const;
 const CHIP_TEXTURE_KEY = 'blackjack-chip';
+const SHOE_TEXTURE_KEY = 'blackjack-shoe-stack';
+const SHOE_POSITION = {
+	x: 1030,
+	y: 198,
+} as const;
+const DEAL_ANIMATION = {
+	duration: 220,
+	stagger: 70,
+} as const;
 
 type ButtonKey =
 	| 'deal'
@@ -62,11 +71,25 @@ interface ButtonView {
 	lastEnabled: boolean | null;
 }
 
+type HandOwner = 'dealer' | 'player';
+
+interface CardPlacement {
+	textureKey: string;
+	x: number;
+	y: number;
+	owner: HandOwner;
+	index: number;
+}
+
 export class BlackjackScene extends Phaser.Scene {
 	private state: BlackjackState = createBlackjackState();
 	private cardLayer!: Phaser.GameObjects.Container;
 	private cardViews: Phaser.GameObjects.Image[] = [];
 	private activeCardViews = 0;
+	private dealLayer!: Phaser.GameObjects.Container;
+	private flyingCardViews: Phaser.GameObjects.Image[] = [];
+	private previousDealerCardCount = 0;
+	private previousPlayerCardCount = 0;
 	private hudLayer!: Phaser.GameObjects.Container;
 	private buttons: ButtonView[] = [];
 	private statusText!: Phaser.GameObjects.Text;
@@ -88,6 +111,7 @@ export class BlackjackScene extends Phaser.Scene {
 		this.createHudTextures();
 		this.drawTable();
 		this.cardLayer = this.add.container(0, 0).setDepth(10);
+		this.dealLayer = this.add.container(0, 0).setDepth(15);
 		this.hudLayer = this.add.container(0, 0).setDepth(20);
 		this.createHud();
 		this.createButtons();
@@ -136,6 +160,9 @@ export class BlackjackScene extends Phaser.Scene {
 
 		this.drawHandBand(154, 'DEALER');
 		this.drawHandBand(408, 'PLAYER');
+		this.add
+			.image(SHOE_POSITION.x, SHOE_POSITION.y, SHOE_TEXTURE_KEY)
+			.setOrigin(0);
 
 		this.add
 			.text(BASE_WIDTH / 2, 86, 'KBVE BLACKJACK', {
@@ -482,14 +509,26 @@ export class BlackjackScene extends Phaser.Scene {
 
 	private render() {
 		this.activeCardViews = 0;
-		this.drawHand(
+		const hideHole = this.hideDealerHole();
+		const dealerCards = this.cardPlacements(
 			this.state.dealer,
 			BASE_WIDTH / 2,
 			166,
-			this.hideDealerHole(),
+			hideHole,
+			'dealer',
 		);
-		this.drawHand(this.state.player, BASE_WIDTH / 2, 420, false);
+		const playerCards = this.cardPlacements(
+			this.state.player,
+			BASE_WIDTH / 2,
+			420,
+			false,
+			'player',
+		);
+
+		this.drawHand(dealerCards, BASE_WIDTH / 2, 166);
+		this.drawHand(playerCards, BASE_WIDTH / 2, 420);
 		this.hideUnusedCardViews();
+		this.animateNewCards(dealerCards, playerCards);
 		this.updateText();
 		this.updateButtons();
 	}
@@ -500,42 +539,56 @@ export class BlackjackScene extends Phaser.Scene {
 		);
 	}
 
-	private drawHand(
+	private cardPlacements(
 		cards: readonly Card[],
 		centerX: number,
 		y: number,
 		hideHole: boolean,
-	) {
+		owner: HandOwner,
+	): CardPlacement[] {
 		const totalWidth =
 			cards.length * CARD_SIZE.width + Math.max(0, cards.length - 1) * 18;
 		let x = centerX - totalWidth / 2;
+		const placements: CardPlacement[] = [];
 
-		if (cards.length === 0) {
+		cards.forEach((card, index) => {
+			placements.push({
+				textureKey:
+					hideHole && index === 1
+						? this.cardTextureKey('back')
+						: this.cardTextureKey(card),
+				x,
+				y,
+				owner,
+				index,
+			});
+			x += CARD_SIZE.width + 18;
+		});
+		return placements;
+	}
+
+	private drawHand(
+		placements: readonly CardPlacement[],
+		centerX: number,
+		y: number,
+	) {
+		if (placements.length === 0) {
 			this.drawCardSlot(centerX - CARD_SIZE.width - 10, y);
 			this.drawCardSlot(centerX + 10, y);
 			return;
 		}
 
-		cards.forEach((card, index) => {
-			if (hideHole && index === 1) {
-				this.drawCardBack(x, y);
-			} else {
-				this.drawCardFace(card, x, y);
-			}
-			x += CARD_SIZE.width + 18;
-		});
+		for (const placement of placements) {
+			this.placeCardTexture(
+				placement.textureKey,
+				placement.x,
+				placement.y,
+			);
+		}
 	}
 
 	private drawCardSlot(x: number, y: number) {
 		this.placeCardTexture(this.cardTextureKey('slot'), x, y);
-	}
-
-	private drawCardBack(x: number, y: number) {
-		this.placeCardTexture(this.cardTextureKey('back'), x, y);
-	}
-
-	private drawCardFace(card: Card, x: number, y: number) {
-		this.placeCardTexture(this.cardTextureKey(card), x, y);
 	}
 
 	private placeCardTexture(textureKey: string, x: number, y: number) {
@@ -567,11 +620,83 @@ export class BlackjackScene extends Phaser.Scene {
 		}
 	}
 
+	private animateNewCards(
+		dealerCards: readonly CardPlacement[],
+		playerCards: readonly CardPlacement[],
+	) {
+		const previousDealerCount = this.previousDealerCardCount;
+		const previousPlayerCount = this.previousPlayerCardCount;
+		this.previousDealerCardCount = dealerCards.length;
+		this.previousPlayerCardCount = playerCards.length;
+
+		const newCards: CardPlacement[] = [];
+		if (dealerCards.length > previousDealerCount) {
+			newCards.push(...dealerCards.slice(previousDealerCount));
+		}
+		if (playerCards.length > previousPlayerCount) {
+			newCards.push(...playerCards.slice(previousPlayerCount));
+		}
+		if (newCards.length === 0) return;
+
+		newCards
+			.sort(
+				(a, b) => a.index - b.index || (a.owner === 'player' ? -1 : 1),
+			)
+			.forEach((placement, index) => {
+				this.animateCardFromShoe(placement, index);
+			});
+	}
+
+	private animateCardFromShoe(placement: CardPlacement, order: number) {
+		const view = this.getFlyingCardView();
+		const startX = SHOE_POSITION.x + 18;
+		const startY = SHOE_POSITION.y + 16;
+		view.setTexture(placement.textureKey)
+			.setPosition(startX, startY)
+			.setScale(0.78)
+			.setAlpha(0.92)
+			.setAngle(-8)
+			.setVisible(true)
+			.setActive(true);
+
+		this.tweens.killTweensOf(view);
+		this.tweens.add({
+			targets: view,
+			x: placement.x,
+			y: placement.y,
+			scale: 1,
+			alpha: 0,
+			angle: 0,
+			duration: DEAL_ANIMATION.duration,
+			delay: order * DEAL_ANIMATION.stagger,
+			ease: 'Sine.easeOut',
+			onComplete: () => {
+				view.setVisible(false);
+				view.setActive(false);
+			},
+		});
+	}
+
+	private getFlyingCardView(): Phaser.GameObjects.Image {
+		const inactiveView = this.flyingCardViews.find((view) => !view.active);
+		if (inactiveView) return inactiveView;
+
+		const view = this.add
+			.image(0, 0, this.cardTextureKey('back'))
+			.setOrigin(0)
+			.setVisible(false)
+			.setActive(false);
+		this.flyingCardViews.push(view);
+		this.dealLayer.add(view);
+		return view;
+	}
+
 	private createCardTextures() {
 		if (this.textures.exists(this.cardTextureKey('back'))) return;
 
 		this.createSlotTexture();
 		this.createBackTexture();
+		this.createShoeTexture();
 
 		for (const suit of ['spades', 'hearts', 'diamonds', 'clubs'] as const) {
 			for (const rank of [
@@ -661,6 +786,67 @@ export class BlackjackScene extends Phaser.Scene {
 		ctx.globalAlpha = 1;
 
 		this.textures.addCanvas(CHIP_TEXTURE_KEY, canvas);
+	}
+
+	private createShoeTexture() {
+		if (this.textures.exists(SHOE_TEXTURE_KEY)) return;
+
+		const stackOffset = 9;
+		const canvas = document.createElement('canvas');
+		canvas.width =
+			CARD_SIZE.width + CARD_TEXTURE_MARGIN.x + stackOffset * 3;
+		canvas.height =
+			CARD_SIZE.height + CARD_TEXTURE_MARGIN.y + stackOffset * 3;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) throw new Error('Canvas 2D context is unavailable.');
+
+		for (let i = 3; i >= 0; i--) {
+			const x = i * stackOffset;
+			const y = i * stackOffset;
+			this.drawCardShadowAt(ctx, x + 5, y + 7);
+			ctx.fillStyle = this.hexColor(COLORS.cardBack);
+			this.roundRect(
+				ctx,
+				x,
+				y,
+				CARD_SIZE.width,
+				CARD_SIZE.height,
+				CARD_SIZE.radius,
+			);
+			ctx.fill();
+			ctx.strokeStyle = this.hexColor(COLORS.cardBorder);
+			ctx.globalAlpha = 0.9;
+			ctx.lineWidth = 2;
+			ctx.stroke();
+			ctx.globalAlpha = 1;
+
+			ctx.strokeStyle = this.hexColor(COLORS.cardBackAccent);
+			ctx.globalAlpha = 0.55;
+			ctx.lineWidth = 2;
+			this.strokeRoundRect(
+				ctx,
+				x + 10,
+				y + 10,
+				CARD_SIZE.width - 20,
+				CARD_SIZE.height - 20,
+				8,
+			);
+			ctx.globalAlpha = 1;
+		}
+
+		ctx.font = `18px ${FONT.serif}`;
+		ctx.fillStyle = COLORS.gold;
+		ctx.textAlign = 'center';
+		ctx.textBaseline = 'middle';
+		ctx.globalAlpha = 0.9;
+		ctx.fillText(
+			'KBVE',
+			(CARD_SIZE.width + stackOffset * 3) / 2,
+			(CARD_SIZE.height + stackOffset * 3) / 2,
+		);
+		ctx.globalAlpha = 1;
+
+		this.textures.addCanvas(SHOE_TEXTURE_KEY, canvas);
 	}
 
 	private createSlotTexture() {
@@ -781,10 +967,18 @@ export class BlackjackScene extends Phaser.Scene {
 
 	private drawCardShadow(ctx: CanvasRenderingContext2D) {
 		ctx.fillStyle = 'rgba(0, 0, 0, 0.22)';
+		this.drawCardShadowAt(ctx, 5, 7);
+	}
+
+	private drawCardShadowAt(
+		ctx: CanvasRenderingContext2D,
+		x: number,
+		y: number,
+	) {
 		this.roundRect(
 			ctx,
-			5,
-			7,
+			x,
+			y,
 			CARD_SIZE.width,
 			CARD_SIZE.height,
 			CARD_SIZE.radius,


### PR DESCRIPTION
## Summary
- Add a cached shoe stack texture to the blackjack table so cards have a visible source.
- Compute card placements once per render and reuse them for both static card rendering and deal animation targets.
- Add a small pooled fly-card overlay that animates newly added cards from the shoe to their mat positions, with inactive sprites reused to avoid permanent extra draw calls.

## Validation
- `pnpm exec prettier --write apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts`
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts apps/kbve/astro-kbve/src/arcade/blackjack/ReactBlackjackApp.tsx apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts apps/kbve/astro-kbve/src/arcade/blackjack/state.ts` (passes with existing Nx ProjectGraph warning)
- `pnpm exec vitest run apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts`
- Playwright smoke on `http://127.0.0.1:4329/arcade/blackjack/`: deal -> hit -> stand -> next -> deal again, no page/app console errors