### PR TITLE
fix(firecracker): stage Jobs PostSync + HookFailed unwedges rollouts

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-rootfs-stage.yaml
@@ -13,8 +13,10 @@
 # net.mdx wires this manifest into the dispatch manifest via
 # `deployment_yamls`.
 #
-# Sync hook: hook-delete-policy `BeforeHookCreation` removes the previous
-# Job before each ArgoCD sync so a new image tag re-runs cleanly.
+# PostSync hook: runs after the Deployment has applied so an absent or
+# failing image does not block the rollout. HookFailed in the delete
+# policy auto-cleans failed Jobs instead of accumulating ImagePullBackOff
+# pods that wedge subsequent reconciles.
 # ---------------------------------------------------------------------------
 apiVersion: batch/v1
 kind: Job
@@ -24,8 +26,8 @@ metadata:
     labels:
         app: firecracker-rootfs-init
     annotations:
-        argocd.argoproj.io/hook: Sync
-        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookFailed
 spec:
     backoffLimit: 3
     ttlSecondsAfterFinished: 3600

--- a/apps/kube/firecracker/manifests/firecracker-node-web-rootfs-stage.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-node-web-rootfs-stage.yaml
@@ -13,8 +13,10 @@
 # web.mdx wires this manifest into the dispatch manifest via
 # `deployment_yamls`.
 #
-# Sync hook: hook-delete-policy `BeforeHookCreation` removes the previous
-# Job before each ArgoCD sync so a new image tag re-runs cleanly.
+# PostSync hook: runs after the Deployment has applied so an absent or
+# failing image does not block the rollout. HookFailed in the delete
+# policy auto-cleans failed Jobs instead of accumulating ImagePullBackOff
+# pods that wedge subsequent reconciles.
 # ---------------------------------------------------------------------------
 apiVersion: batch/v1
 kind: Job
@@ -24,8 +26,8 @@ metadata:
     labels:
         app: firecracker-rootfs-init
     annotations:
-        argocd.argoproj.io/hook: Sync
-        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookFailed
 spec:
     backoffLimit: 3
     ttlSecondsAfterFinished: 3600

--- a/apps/kube/firecracker/manifests/firecracker-web-rootfs-stage.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-web-rootfs-stage.yaml
@@ -13,8 +13,10 @@
 # web.mdx wires this manifest into the dispatch manifest via
 # `deployment_yamls`.
 #
-# Sync hook: hook-delete-policy `BeforeHookCreation` removes the previous
-# Job before each ArgoCD sync so a new image tag re-runs cleanly.
+# PostSync hook: runs after the Deployment has applied so an absent or
+# failing image does not block the rollout. HookFailed in the delete
+# policy auto-cleans failed Jobs instead of accumulating ImagePullBackOff
+# pods that wedge subsequent reconciles.
 # ---------------------------------------------------------------------------
 apiVersion: batch/v1
 kind: Job
@@ -24,8 +26,8 @@ metadata:
     labels:
         app: firecracker-rootfs-init
     annotations:
-        argocd.argoproj.io/hook: Sync
-        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookFailed
 spec:
     backoffLimit: 3
     ttlSecondsAfterFinished: 3600


### PR DESCRIPTION
## Summary

All three rootfs staging Jobs (\`firecracker-net-rootfs-stage\`, \`firecracker-web-rootfs-stage\`, \`firecracker-node-web-rootfs-stage\`) used \`argocd.argoproj.io/hook: Sync\`. With \`Sync\`, ArgoCD runs the hook **before** applying the rest of the wave, so when a stage image is missing (e.g. \`firecracker-python-web:0.1.0\` not yet on GHCR) the Job sits in \`ImagePullBackOff\` forever and the \`firecracker-ctl-net\` Deployment never rolls.

Hit twice now: in-flight rootfs work on python-web/node-web wedged unrelated \`fc-ctl\` updates (including PR #10832's INPUT-chain fix) for hours, requiring manual finalizer strips and kubectl patches to break the deadlock.

## Fix

Two annotation flips per Job:

\`\`\`
argocd.argoproj.io/hook: Sync          → PostSync
argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
                                       → BeforeHookCreation,HookFailed
\`\`\`

**\`PostSync\`** runs staging after the Deployment has rolled, so a failing stage Job no longer gates Deployment apply. The Application still reports \`Degraded\` while the hook fails, but the binary update lands.

**\`HookFailed\`** auto-deletes failed hook Jobs so they do not pile up as stuck \`ImagePullBackOff\` pods. No more manual finalizer strips when an in-flight image hasn't published yet.

## Safety

The staging Jobs are idempotent — their image's \`ENTRYPOINT\` is \`cp /rootfs.ext4 /dest/...\`. Re-running on subsequent syncs is safe. The rootfs PVC carries state across pod restarts, so a brand-new deploy without a successful stage just means the corresponding rootfs name returns 400 from \`/vm/create\` until the stage Job lands. Acceptable for staff-side endpoints.

## Test plan

- [ ] After merge, ArgoCD reconciles → the existing wedged stage Jobs get cleaned (HookFailed) → Deployment applies → \`fc-ctl-net\` rolls to \`:0.1.32\`.
- [ ] \`iptables -L INPUT -n -v\` inside the new fc-ctl-net pod shows the ACCEPT rule for \`172.18.0.0/16\` from PR #10832.
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB → poem prints, exit 0.
- [ ] Future stage-Job-without-image incidents no longer block unrelated app updates.