### PR TITLE
feat(mc-daily-reward): daily-login khash on MC server join

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10051,14 +10051,17 @@ version = "0.1.0"
 dependencies = [
  "agones",
  "bevy_supa",
+ "chrono",
  "crossbeam-channel",
  "jni 0.21.1",
  "jsonwebtoken 9.3.1",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -14638,6 +14641,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17485,6 +17494,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/apps/kbve/axum-kbve/src/openapi.rs
+++ b/apps/kbve/axum-kbve/src/openapi.rs
@@ -106,6 +106,7 @@ impl Modify for SecurityAddon {
         crate::transport::wallet::me_redeem_coupon,
         // wallet — service surface (service_role JWT)
         crate::transport::wallet::service_credit,
+        crate::transport::wallet::service_credit_user,
         crate::transport::wallet::service_debit,
         crate::transport::wallet::service_transfer,
         crate::transport::wallet::service_redeem_coupon,
@@ -143,6 +144,8 @@ impl Modify for SecurityAddon {
             crate::transport::wallet::RedeemCouponDto,
             // wallet — service surface
             crate::transport::wallet::ServiceCreditBody,
+            crate::transport::wallet::ServiceCreditUserBody,
+            crate::transport::wallet::ServiceCreditUserDto,
             crate::transport::wallet::ServiceLedgerDto,
             crate::transport::wallet::ServiceTransferBody,
             crate::transport::wallet::ServiceRedeemCouponBody,

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -379,6 +379,10 @@ fn router(state: AppState) -> Router {
             post(super::wallet::service_credit),
         )
         .route(
+            "/api/v1/wallet/service/credit-user",
+            post(super::wallet::service_credit_user),
+        )
+        .route(
             "/api/v1/wallet/service/debit",
             post(super::wallet::service_debit),
         )

--- a/apps/kbve/axum-kbve/src/transport/wallet.rs
+++ b/apps/kbve/axum-kbve/src/transport/wallet.rs
@@ -95,6 +95,29 @@ pub(crate) struct ServiceLedgerDto {
     pub ledger_id: i64,
 }
 
+/// Variant of [`ServiceCreditBody`] keyed on Supabase `user_id` instead of
+/// the wallet `account_id`. Used by service callers (MC mod daily reward,
+/// edge functions) that know the user but not their wallet account UUID.
+/// The handler resolves the account on first call (creating it + welcome
+/// coupon if missing) before delegating to the regular credit path.
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct ServiceCreditUserBody {
+    pub user_id: Uuid,
+    pub currency: String,
+    pub amount: i64,
+    pub source_kind: String,
+    pub reason: Option<String>,
+    pub ref_type: Option<String>,
+    pub ref_id: Option<i64>,
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct ServiceCreditUserDto {
+    pub account_id: Uuid,
+    pub ledger_id: i64,
+}
+
 #[derive(Deserialize, ToSchema)]
 pub(crate) struct ServiceTransferBody {
     pub from_account: Uuid,
@@ -674,6 +697,74 @@ pub(crate) async fn service_verify_balance(
             stored_khash: v.stored_khash,
             ledger_khash: v.ledger_khash,
             ok: v.ok,
+        })
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `POST /api/v1/wallet/service/credit-user` — credit keyed on Supabase
+/// user_id rather than wallet account_id. Resolves (or creates) the
+/// account first via `wallet.proxy_ensure_user_account`, then runs the
+/// regular service_credit path. Idempotent with the same key.
+///
+/// Designed for the MC mod daily-login flow + edge-function callers that
+/// only know a user_id.
+#[utoipa::path(
+    post,
+    path = "/api/v1/wallet/service/credit-user",
+    tag = "wallet",
+    request_body = ServiceCreditUserBody,
+    responses(
+        (status = 200, description = "Account resolved + ledger row created", body = ServiceCreditUserDto),
+        (status = 400, description = "Invalid currency / source_kind / payload"),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 403, description = "service_role required"),
+        (status = 409, description = "Idempotency replay mismatch"),
+        (status = 422, description = "Overflow / null argument"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn service_credit_user(
+    headers: HeaderMap,
+    Json(body): Json<ServiceCreditUserBody>,
+) -> Response {
+    if let Err(resp) = require_service_role(&headers).await {
+        return resp;
+    }
+    let currency = match parse_currency(&body.currency) {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    let source_kind = match parse_source_kind(&body.source_kind) {
+        Ok(s) => s,
+        Err(r) => return r,
+    };
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+
+    let account_id = match client.service_account_for_user(body.user_id).await {
+        Ok(id) => id,
+        Err(e) => return wallet_error_response(e),
+    };
+
+    let req = CreditRequest {
+        account_id,
+        currency,
+        amount: body.amount,
+        source_kind,
+        reason: body.reason,
+        ref_type: body.ref_type,
+        ref_id: body.ref_id,
+        idempotency_key: body.idempotency_key,
+    };
+    match client.credit(req).await {
+        Ok(ledger_id) => Json(ServiceCreditUserDto {
+            account_id,
+            ledger_id,
         })
         .into_response(),
         Err(e) => wallet_error_response(e),

--- a/apps/mc/mc_auth/Cargo.toml
+++ b/apps/mc/mc_auth/Cargo.toml
@@ -28,6 +28,14 @@ serde_json = "1"
 # Logging
 tracing = "0.1"
 
+# Wallet integration — deterministic daily-credit idempotency keys are
+# UUIDv5(namespace, user_id || UTC date), so we need a UTC clock + a
+# UUID crate that can compute v5. thiserror is the error type for the
+# wallet HTTP shim.
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+uuid = { version = "1", features = ["v5"] }
+thiserror = "2"
+
 # Shared Supabase (PostgREST) client — lives in bevy_supa so future Bevy
 # games (isometric, etc.) can import the same plugin + SupaClient shape
 # without re-rolling the reqwest wrapper. mc_auth is JNI, not Bevy, so we

--- a/apps/mc/mc_auth/src/lib.rs
+++ b/apps/mc/mc_auth/src/lib.rs
@@ -22,6 +22,7 @@ pub mod chat_jwt;
 pub mod runtime;
 pub mod supabase;
 pub mod types;
+pub mod wallet;
 
 use std::sync::OnceLock;
 

--- a/apps/mc/mc_auth/src/runtime.rs
+++ b/apps/mc/mc_auth/src/runtime.rs
@@ -19,6 +19,7 @@ use tracing::{debug, warn};
 use crate::agones;
 use crate::supabase::{LookupOutcome, SupabaseClient, VerifyOutcome};
 use crate::types::{AuthJob, AuthResponse, PlayerEvent};
+use crate::wallet::WalletClient;
 
 const REQUEST_CHANNEL_SIZE: usize = 256;
 const EVENT_CHANNEL_SIZE: usize = 256;
@@ -105,6 +106,14 @@ async fn worker_loop(request_rx: Receiver<AuthJob>, event_tx: Sender<PlayerEvent
     if !supabase.is_enabled() {
         warn!("mc_auth worker: supabase client disabled — all lookups will be treated as Unlinked");
     }
+    // Optional — null when AXUM_KBVE_URL / WALLET_SERVICE_JWT are unset.
+    // The mod still functions without it; daily-reward calls are skipped.
+    let wallet = WalletClient::from_env().map(Arc::new);
+    if wallet.is_none() {
+        warn!(
+            "mc_auth worker: wallet client disabled (AXUM_KBVE_URL or WALLET_SERVICE_JWT unset) — daily khash reward will not fire"
+        );
+    }
 
     loop {
         // crossbeam's `recv` is blocking — yield to Tokio via spawn_blocking
@@ -129,14 +138,20 @@ async fn worker_loop(request_rx: Receiver<AuthJob>, event_tx: Sender<PlayerEvent
         // Handle each job in its own spawned task so slow calls don't
         // head-of-line block the worker queue.
         let supabase = Arc::clone(&supabase);
+        let wallet = wallet.clone();
         let tx = event_tx.clone();
         tokio::spawn(async move {
-            handle_job(job, supabase.as_ref(), &tx).await;
+            handle_job(job, supabase.as_ref(), wallet.as_deref(), &tx).await;
         });
     }
 }
 
-async fn handle_job(job: AuthJob, supabase: &SupabaseClient, event_tx: &Sender<PlayerEvent>) {
+async fn handle_job(
+    job: AuthJob,
+    supabase: &SupabaseClient,
+    wallet: Option<&WalletClient>,
+    event_tx: &Sender<PlayerEvent>,
+) {
     let event = match job {
         AuthJob::Authenticate {
             player_uuid,
@@ -195,6 +210,40 @@ async fn handle_job(job: AuthJob, supabase: &SupabaseClient, event_tx: &Sender<P
             }
         }
     };
+
+    // Fire daily-khash credit for any newly-confirmed linked player. The
+    // server's idempotency key (UUIDv5 over user_id + UTC date) dedups
+    // multiple joins on the same day, so we can call this on every link
+    // confirmation without tracking per-player state on the mod side.
+    // Errors are logged and swallowed — they must not block the player.
+    if let Some(client) = wallet {
+        let user_id = match &event {
+            PlayerEvent::AlreadyLinked {
+                supabase_user_id, ..
+            } => Some(supabase_user_id.clone()),
+            PlayerEvent::LinkVerified {
+                supabase_user_id, ..
+            } => Some(supabase_user_id.clone()),
+            _ => None,
+        };
+        if let Some(uid) = user_id {
+            let client = client.clone();
+            tokio::spawn(async move {
+                match client.daily_credit_khash(&uid).await {
+                    Ok(resp) => {
+                        debug!(
+                            user_id = %uid,
+                            ledger_id = resp.ledger_id,
+                            "mc_auth: daily khash credit ok (or replay)"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(user_id = %uid, error = %e, "mc_auth: daily khash credit failed");
+                    }
+                }
+            });
+        }
+    }
 
     if event_tx.try_send(event).is_err() {
         warn!("mc_auth: event channel full dropping primary event");

--- a/apps/mc/mc_auth/src/wallet.rs
+++ b/apps/mc/mc_auth/src/wallet.rs
@@ -1,0 +1,191 @@
+//! Wallet integration — calls axum-kbve `/api/v1/wallet/service/credit-user`
+//! to grant daily-login khash to linked players.
+//!
+//! The MC mod knows a Supabase `user_id` (returned by `lookup_player_link`
+//! / `verify_link`) but not a wallet `account_id`. The new
+//! `service_credit_user` route on axum-kbve does the resolution + credit
+//! atomically, so this module is a thin reqwest wrapper.
+//!
+//! Daily semantics:
+//!   - idempotency_key derived via UUIDv5 from (user_id, "YYYY-MM-DD" in UTC).
+//!   - same user joining twice on the same UTC day → same key → server
+//!     replays the original ledger row instead of crediting again.
+//!   - server returns the original ledger_id on replay; mod treats both
+//!     "first credit today" and "already credited" as success and logs both
+//!     uniformly. No client-side state needed.
+//!
+//! Env:
+//!   - `AXUM_KBVE_URL` — base URL (e.g. `http://axum-kbve.kbve:4321` in cluster).
+//!     Wallet integration is disabled if unset.
+//!   - `WALLET_SERVICE_JWT` — Supabase service_role JWT. Wallet integration
+//!     is disabled if unset.
+//!   - `MC_DAILY_KHASH_AMOUNT` — optional, defaults to 100.
+
+use std::env;
+use std::time::Duration;
+
+use chrono::Utc;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+const DEFAULT_DAILY_AMOUNT: i64 = 100;
+const REQUEST_TIMEOUT_SECS: u64 = 10;
+
+/// Namespace UUID used to derive the daily idempotency key. Stable; do not
+/// change without also accepting that historical replays will start to look
+/// like new credits.
+///
+/// Generated as `uuidv5(NIL, "kbve.mc.daily_khash.v1")`; the literal value
+/// is pinned so the binary doesn't need to compute it at startup.
+const DAILY_NAMESPACE: uuid::Uuid =
+    uuid::Uuid::from_u128(0x2cba_9eb2_bd9b_5d9b_8b32_ad28_71fa_85d2);
+
+#[derive(Clone)]
+pub struct WalletClient {
+    http: Client,
+    base_url: String,
+    service_jwt: String,
+    daily_amount: i64,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WalletCallError {
+    #[error("wallet integration disabled (missing env)")]
+    Disabled,
+    #[error("invalid user_id: {0}")]
+    InvalidUserId(String),
+    #[error("http error: {0}")]
+    Http(String),
+    #[error("upstream {status}: {body}")]
+    Upstream { status: u16, body: String },
+}
+
+#[derive(Serialize)]
+struct CreditUserReq<'a> {
+    user_id: &'a str,
+    currency: &'a str,
+    amount: i64,
+    source_kind: &'a str,
+    reason: &'a str,
+    ref_type: &'a str,
+    ref_id: Option<i64>,
+    idempotency_key: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct CreditUserResp {
+    pub account_id: String,
+    pub ledger_id: i64,
+}
+
+impl WalletClient {
+    /// Read env and build a client. Returns `None` if the integration is
+    /// disabled (missing URL or JWT) — caller should log and skip wallet
+    /// ops, not fail.
+    pub fn from_env() -> Option<Self> {
+        let base_url = match env::var("AXUM_KBVE_URL") {
+            Ok(v) if !v.is_empty() => v.trim_end_matches('/').to_string(),
+            _ => {
+                debug!("mc_auth wallet: AXUM_KBVE_URL not set, integration disabled");
+                return None;
+            }
+        };
+        let service_jwt = match env::var("WALLET_SERVICE_JWT") {
+            Ok(v) if !v.is_empty() => v,
+            _ => {
+                debug!("mc_auth wallet: WALLET_SERVICE_JWT not set, integration disabled");
+                return None;
+            }
+        };
+        let daily_amount = env::var("MC_DAILY_KHASH_AMOUNT")
+            .ok()
+            .and_then(|s| s.parse::<i64>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(DEFAULT_DAILY_AMOUNT);
+
+        let http = Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .ok()?;
+
+        info!(
+            base_url = %base_url,
+            daily_amount,
+            "mc_auth wallet: integration enabled"
+        );
+
+        Some(Self {
+            http,
+            base_url,
+            service_jwt,
+            daily_amount,
+        })
+    }
+
+    /// Credit daily khash for the given Supabase user. Idempotent across
+    /// repeated calls within the same UTC day.
+    pub async fn daily_credit_khash(
+        &self,
+        user_id: &str,
+    ) -> Result<CreditUserResp, WalletCallError> {
+        // Validate the user_id is a real UUID before crossing the wire.
+        let user_uuid = uuid::Uuid::parse_str(user_id)
+            .map_err(|e| WalletCallError::InvalidUserId(format!("{user_id}: {e}")))?;
+
+        // Deterministic key: namespace ⊕ (user_id, UTC date).
+        let date = Utc::now().format("%Y-%m-%d").to_string();
+        let key_input = format!("{user_uuid}:{date}");
+        let idem = uuid::Uuid::new_v5(&DAILY_NAMESPACE, key_input.as_bytes());
+
+        let body = CreditUserReq {
+            user_id,
+            currency: "khash",
+            amount: self.daily_amount,
+            source_kind: "reward",
+            reason: "mc_daily_login",
+            ref_type: "mc_daily",
+            ref_id: None,
+            idempotency_key: idem.to_string(),
+        };
+
+        let resp = self
+            .http
+            .post(format!(
+                "{}/api/v1/wallet/service/credit-user",
+                self.base_url
+            ))
+            .bearer_auth(&self.service_jwt)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| WalletCallError::Http(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(WalletCallError::Upstream {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        resp.json::<CreditUserResp>()
+            .await
+            .map_err(|e| WalletCallError::Http(e.to_string()))
+    }
+
+    pub fn daily_amount(&self) -> i64 {
+        self.daily_amount
+    }
+}
+
+/// Convenience: optional client constructor + logger. Use this in the
+/// runtime boot path so a misconfigured deploy doesn't crash the mod.
+pub fn maybe_init() -> Option<WalletClient> {
+    let c = WalletClient::from_env();
+    if c.is_none() {
+        warn!("mc_auth wallet: daily-khash integration disabled (env not set)");
+    }
+    c
+}

--- a/packages/rust/kbve/src/wallet/service.rs
+++ b/packages/rust/kbve/src/wallet/service.rs
@@ -83,6 +83,31 @@ impl WalletClient {
             .await
     }
 
+    /// Resolve a Supabase user_id to its `wallet.account.id`.
+    ///
+    /// Calls `wallet.proxy_ensure_user_account()` via `run_as_user`, which
+    /// sets `request.jwt.claims.sub` for the SECURITY DEFINER function to
+    /// see the right `auth.uid()`. Creates the account + welcome coupon on
+    /// first call. Idempotent across repeated calls.
+    ///
+    /// Intended for service callers (MC mod daily reward, edge functions)
+    /// that know a user_id but not an account_id.
+    pub async fn service_account_for_user(&self, user_id: Uuid) -> Result<Uuid> {
+        self.run_as_user(user_id, |conn| {
+            #[derive(QueryableByName)]
+            struct AccountRow {
+                #[diesel(sql_type = diesel::sql_types::Uuid)]
+                account_id: Uuid,
+            }
+            let r: AccountRow =
+                sql_query("SELECT wallet.proxy_ensure_user_account() AS account_id")
+                    .get_result(conn)
+                    .map_err(WalletError::from_diesel)?;
+            Ok(r.account_id)
+        })
+        .await
+    }
+
     /// `wallet.service_redeem_coupon(coupon_id, idempotency_key)`.
     /// Idempotent at the coupon layer: same key replays return the original
     /// ledger id instead of raising.


### PR DESCRIPTION
## Summary

End-to-end daily-login khash reward for linked Minecraft players. Player joins → if linked → mc_auth fires a server-side credit through axum-kbve → wallet ledger row → balance bumped → user sees it on /mc/ and in the nav badge from #10885.

Default reward: **100 khash/day**, configurable via env. No new SQL migration — uses the existing wallet schema + the new \`credit-user\` route added here.

## Idempotency

Per-day idempotency key = \`UUIDv5(namespace, "user_id:UTC_date")\`. Mod calls the credit-user route on every join; server replays duplicate calls within the same UTC day to the original ledger row, so no client-side state tracking is needed. Multiple joins same day = same ledger id, balance never doubles.

## Pieces

### kbve crate — [\`packages/rust/kbve/src/wallet/service.rs\`](packages/rust/kbve/src/wallet/service.rs)

- New \`WalletClient::service_account_for_user(user_id) -> Result<Uuid>\`. Wraps \`run_as_user\` + \`wallet.proxy_ensure_user_account()\`. Creates the account + welcome coupon on first call. Service callers can now credit by user_id without needing the wallet account UUID.

### axum-kbve — [\`transport/wallet.rs\`](apps/kbve/axum-kbve/src/transport/wallet.rs)

- \`POST /api/v1/wallet/service/credit-user\` (service_role JWT only).
  - Body: \`{user_id, currency, amount, source_kind, reason, ref_type, ref_id, idempotency_key}\`.
  - Handler resolves the account via \`service_account_for_user\`, then delegates to the regular \`service_credit\` path.
  - Returns \`{account_id, ledger_id}\`.
  - Wired into \`https.rs\` + registered in \`openapi.rs\` alongside the other service routes.

### mc_auth — [\`apps/mc/mc_auth/src/wallet.rs\`](apps/mc/mc_auth/src/wallet.rs)

- New module owning the reqwest client to axum-kbve. Reads \`AXUM_KBVE_URL\` + \`WALLET_SERVICE_JWT\` from env; integration **disabled (with warn!) if either is unset**, so a misconfigured deploy can't kick players.
- Optional \`MC_DAILY_KHASH_AMOUNT\` env override; defaults to **100**.
- \`WalletClient::daily_credit_khash(user_id)\` — computes the daily idempotency key, POSTs to credit-user, returns the ledger row id or a typed \`WalletCallError\`.

### runtime hook — [\`runtime.rs\`](apps/mc/mc_auth/src/runtime.rs)

- \`worker_loop\` constructs an optional \`WalletClient\` at boot and passes it through to \`handle_job\`.
- After emitting an \`AlreadyLinked\` or \`LinkVerified\` event, the handler spawns a fire-and-forget task calling \`daily_credit_khash\`.
- Errors are logged and **swallowed** — daily-reward failures must never block a player join.

## Env (new for the MC server pod)

\`\`\`
AXUM_KBVE_URL=http://axum-kbve.kbve:4321
WALLET_SERVICE_JWT=<Supabase service_role JWT>
MC_DAILY_KHASH_AMOUNT=100  # optional
\`\`\`

## Test plan

- [x] \`cargo build -p mc_auth\` clean (mod side)
- [x] \`cargo build -p axum-kbve\` clean (server side)
- [ ] Deploy v1.0.150+ axum-kbve + new mc image. Player joins with linked account → \`/api/v1/wallet/me/balance\` (and the nav badge) reflects +100 khash.
- [ ] Player joins twice in same UTC day → second join returns the same \`ledger_id\` (server replay), balance does not double.
- [ ] AXUM_KBVE_URL or WALLET_SERVICE_JWT unset → mod logs the warn, player join still works, no daily credit fires.

## Deploy order

1. **Merge + release axum-kbve v1.0.150+** so \`/service/credit-user\` is live.
2. **Set env on the mc gameserver pod** (\`AXUM_KBVE_URL\`, \`WALLET_SERVICE_JWT\`).
3. **Bake + roll the new mc image** with the updated mc_auth binary.

Until #1 + #3 align, the route + the mod side both no-op cleanly (warn-and-skip).

## Future

- Streak tracking (consecutive days bumped khash) needs schema (\`wallet.daily_streak\` or similar) — deferred.
- In-game \`/balance\` chat command surfacing the wallet from the mod side.