### PR TITLE
fix(jedi): switch twitch-irc to pure rustls, revert chisel libssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,7 +4444,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -4457,7 +4457,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-graphics-types 0.2.0",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -6274,21 +6274,12 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -6301,12 +6292,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -10117,7 +10102,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block",
  "core-graphics-types 0.2.0",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -10401,23 +10386,6 @@ name = "nanoserde-derive"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a846cbc04412cf509efcd8f3694b114fc700a035fb5a37f21517f9fb019f1ebc"
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "ndk"
@@ -11225,48 +11193,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -16244,16 +16174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17013,10 +16933,11 @@ dependencies = [
  "smallvec",
  "thiserror 1.0.69",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.24.1",
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]

--- a/packages/docker/chisel-ubuntu-axum/Dockerfile
+++ b/packages/docker/chisel-ubuntu-axum/Dockerfile
@@ -108,7 +108,7 @@ RUN chisel cut --release ubuntu-24.04 --root /rootfs \
 FROM --platform=linux/amd64 ubuntu:24.04 AS libs-stage
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libjemalloc-dev libpq5 libssl3t64 && \
+    apt-get install -y --no-install-recommends libjemalloc-dev libpq5 && \
     rm -rf /var/lib/apt/lists/*
 
 # ── Assemble runtime image ──────────────────────────────────────────
@@ -117,8 +117,6 @@ FROM --platform=linux/amd64 scratch AS runtime
 COPY --from=chisel-stage /rootfs /
 COPY --from=libs-stage /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 COPY --from=libs-stage /usr/lib/x86_64-linux-gnu/libpq.so.5* /usr/lib/x86_64-linux-gnu/
-COPY --from=libs-stage /usr/lib/x86_64-linux-gnu/libssl.so.3 /usr/lib/x86_64-linux-gnu/libssl.so.3
-COPY --from=libs-stage /usr/lib/x86_64-linux-gnu/libcrypto.so.3 /usr/lib/x86_64-linux-gnu/libcrypto.so.3
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENV MALLOC_CONF="background_thread:true,dirty_decay_ms:10000,muzzy_decay_ms:10000,lg_tcache_max:32,oversize_threshold:4194304"

--- a/packages/docker/chisel-ubuntu-axum/project.json
+++ b/packages/docker/chisel-ubuntu-axum/project.json
@@ -107,7 +107,6 @@
 					"docker create --name chisel-runtime-test ghcr.io/kbve/chisel-ubuntu-axum:24.04 true > /dev/null 2>&1 && docker export chisel-runtime-test > /tmp/chisel-runtime.tar && docker rm chisel-runtime-test > /dev/null 2>&1",
 					"tar -tf /tmp/chisel-runtime.tar | grep -q 'usr/lib/x86_64-linux-gnu/libjemalloc.so.2' && echo 'PASS: libjemalloc.so.2 present'",
 					"tar -tf /tmp/chisel-runtime.tar | grep -q 'usr/lib/x86_64-linux-gnu/libpq.so.5' && echo 'PASS: libpq.so.5 present'",
-					"tar -tf /tmp/chisel-runtime.tar | grep -q 'usr/lib/x86_64-linux-gnu/libssl.so' && echo 'PASS: libssl present (TLS)'",
 					"tar -tf /tmp/chisel-runtime.tar | grep -q 'etc/ssl/certs/ca-certificates.crt' && echo 'PASS: CA bundle present'",
 					"tar -tf /tmp/chisel-runtime.tar | grep -q 'lib/x86_64-linux-gnu/libc.so' && echo 'PASS: libc present'",
 					"! tar -tf /tmp/chisel-runtime.tar | grep -qE '^bin/(sh|bash|dash)$' && echo 'PASS: no shell in runtime (chiseled)'",
@@ -135,7 +134,7 @@
 					"docker inspect ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^RUSTC_WRAPPER=/usr/local/cargo/bin/sccache$' && echo 'PASS: RUSTC_WRAPPER=sccache'",
 					"docker inspect ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1$' && echo 'PASS: Playwright browser download disabled'",
 					"echo '=== All chisel base image tests passed ==='",
-					"echo 'Runtime: user, workdir, jemalloc, libpq, libssl, CA bundle, no-shell, size<40MiB'",
+					"echo 'Runtime: user, workdir, jemalloc, libpq, CA bundle, no-shell, size<40MiB'",
 					"echo 'Builder: rustc 1.94, cargo-chef, sccache, mold, protoc, brotli, gzip, libpq-dev, libssl-dev, node 24, pnpm, real-TLS, env hygiene'"
 				],
 				"parallel": false

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -74,7 +74,7 @@ hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1"] }
 rustc-hash = "2.1.1"
 flexbuffers = "25.2.10"
 # Twitch
-twitch-irc = { version = "5.0.1", features = ["with-serde", "refreshing-token-rustls-webpki-roots", "transport-ws", "transport-ws-rustls-webpki-roots"] }
+twitch-irc = { version = "5.0.1", default-features = false, features = ["with-serde", "refreshing-token-rustls-webpki-roots", "transport-tcp", "transport-tcp-rustls-webpki-roots", "transport-ws", "transport-ws-rustls-webpki-roots"] }
 # Replaceable
 crossbeam = "0.8.4"
 regex = "1.10.3"


### PR DESCRIPTION
## Summary
- **Root cause of `libssl.so.3: cannot open shared object file`** in `axum-kbve-e2e:e2e:ci`: `twitch-irc 5.0.1` default features include `transport-tcp-native-tls` + `refreshing-token-native-tls`, which transitively pulls `openssl-sys` → dynamic link against `libssl.so.3` / `libcrypto.so.3`. The chiseled runtime image has neither.
- **Fix**: in [packages/rust/jedi/Cargo.toml](packages/rust/jedi/Cargo.toml), set `twitch-irc { default-features = false, … }` and explicitly enable `transport-tcp` + `transport-tcp-rustls-webpki-roots` alongside the existing `transport-ws*` + `refreshing-token-rustls-webpki-roots` features. Binary now links rustls/ring statically — no OpenSSL.
- **Revert** the libssl/libcrypto copy added in `0fe860399` to [packages/docker/chisel-ubuntu-axum/Dockerfile](packages/docker/chisel-ubuntu-axum/Dockerfile). Verified via `cargo tree -i openssl-sys --target all` that no other axum service in the repo pulls `openssl-sys` (cryptothrone, herbmail, discordsh, axum-discordsh, chuckrpg, rareicon, memes, rows, irc-gateway all clean). Runtime image stays minimal.

## Test plan
- [x] `cargo tree --manifest-path apps/kbve/axum-kbve/Cargo.toml -i openssl-sys --target all` → `package ID specification openssl-sys did not match any packages`
- [x] `cargo check --manifest-path apps/kbve/axum-kbve/Cargo.toml` → clean
- [ ] `nx run chisel-ubuntu-axum:test` after CI publishes new chisel image
- [ ] `nx run axum-kbve-e2e:e2e:ci` → container becomes ready (no `libssl.so.3` error)