### PR TITLE
fix(firecracker-ctl-net): route VM DNS through Gluetun's DoT forwarder

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.149",
+			"version": "1.0.150",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -124,7 +124,7 @@
 		{
 			"key": "firecracker_ctl",
 			"app_name": "firecracker-ctl",
-			"version": "0.1.32",
+			"version": "0.1.33",
 			"version_toml": "apps/vm/firecracker-ctl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx",
 			"version_target": "apps/vm/firecracker-ctl/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,7 +12,7 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.32"
+version: "0.1.33"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml

--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -86,11 +86,16 @@ spec:
                         value: '9001,9999'
                       - name: FIREWALL_OUTBOUND_SUBNETS
                         value: '10.0.0.0/8,172.16.0.0/12'
-                      # DoT off — port 853 blocked through tunnel.
+                      # DoT on — Gluetun's local forwarder queries Cloudflare
+                      # over DNS-over-TLS (port 853) through the VPN tunnel.
+                      # DNS_ADDRESS=127.0.0.1 keeps the forwarder enabled so
+                      # both pod and VM DNS queries route via the tunnel
+                      # instead of leaking out eth0 (cluster CNI). VM traffic
+                      # is DNATed to 127.0.0.1:53 by tap.rs init.
                       - name: DOT
-                        value: 'off'
+                        value: 'on'
                       - name: DNS_ADDRESS
-                        value: '1.1.1.1'
+                        value: '127.0.0.1'
                       - name: HEALTH_VPN_DURATION_INITIAL
                         value: '30s'
                       - name: HEALTH_SERVER_ADDRESS

--- a/apps/vm/firecracker-ctl/src/tap.rs
+++ b/apps/vm/firecracker-ctl/src/tap.rs
@@ -294,6 +294,33 @@ pub fn build_input_accept_check(vm_subnet: &str) -> Vec<String> {
     ]
 }
 
+pub fn build_dns_dnat(proto: &str) -> Vec<String> {
+    vec![
+        "-t".into(),
+        "nat".into(),
+        "-I".into(),
+        "PREROUTING".into(),
+        "-i".into(),
+        "fctap+".into(),
+        "-p".into(),
+        proto.into(),
+        "--dport".into(),
+        "53".into(),
+        "-j".into(),
+        "DNAT".into(),
+        "--to-destination".into(),
+        "127.0.0.1:53".into(),
+    ]
+}
+
+pub fn build_dns_dnat_check(proto: &str) -> Vec<String> {
+    let mut v = build_dns_dnat(proto);
+    if let Some(a) = v.iter_mut().find(|s| s.as_str() == "-I") {
+        *a = "-C".into();
+    }
+    v
+}
+
 // ---------------------------------------------------------------------------
 // Execution wrappers (shell-out via tokio::process::Command)
 // ---------------------------------------------------------------------------
@@ -371,6 +398,14 @@ impl TapManager {
         // 1. IP forwarding
         run("sysctl", &["-w".into(), "net.ipv4.ip_forward=1".into()]).await?;
 
+        // route_localnet=1 allows DNAT to 127.0.0.1 for forwarded packets
+        // arriving on TAP interfaces. Required for the DNS redirect below.
+        run(
+            "sysctl",
+            &["-w".into(), "net.ipv4.conf.all.route_localnet=1".into()],
+        )
+        .await?;
+
         // 2. NAT MASQUERADE (add only if not already present)
         if !iptables_rule_exists(&build_nat_masquerade_check(
             &self.config.vm_subnet,
@@ -415,6 +450,12 @@ impl TapManager {
 
         if !iptables_rule_exists(&build_input_accept_check(&self.config.vm_subnet)).await? {
             run_iptables(&build_input_accept(&self.config.vm_subnet)).await?;
+        }
+
+        for proto in ["udp", "tcp"] {
+            if !iptables_rule_exists(&build_dns_dnat_check(proto)).await? {
+                run_iptables(&build_dns_dnat(proto)).await?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

PoetryDB smoke test still failed after PRs #10832 + #10884 with:

\`\`\`
[fail] connection: HTTPSConnectionPool(host='poetrydb.org', port=443): Max retries exceeded ... [Errno -3] Try again
\`\`\`

Diagnostic from inside the gluetun container:

\`\`\`
$ nslookup poetrydb.org           → 188.114.96.3  (works)
$ nslookup poetrydb.org 1.1.1.1   → connection timed out
\`\`\`

Pod's first query worked only because the pod's \`ip rule\` for source \`10.244.0.44\` (pod eth0) sends traffic into table 200 → out eth0, **bypassing the VPN**. That is a DNS leak. VM traffic with source \`172.18.0.2\` does not match that rule, falls into table 51820 → tun0, and Proton blocks third-party DNS over the tunnel to enforce leak prevention.

Gluetun log:

\`\`\`
DNS forwarder server enabled: no
WARN: DNS address is set to 1.1.1.1 so the local forwarding DNS server will not be used.
\`\`\`

\`DNS_ADDRESS=1.1.1.1\` disables Gluetun's internal DoT forwarder. The container was supposed to rely on the cluster-side leak. Not acceptable for a VPN-enforcing deployment, unworkable for VMs.

## Changes

### \`apps/kube/firecracker/manifests/firecracker-net-deployment.yaml\`

\`\`\`yaml
- name: DOT
  value: 'on'              # was 'off' — DoT (port 853) is not blocked
- name: DNS_ADDRESS
  value: '127.0.0.1'       # was '1.1.1.1' — enables Gluetun's local forwarder
\`\`\`

Gluetun's forwarder now queries Cloudflare via DoT through the tunnel. Pod's own DNS routes through the VPN (no leak).

### \`apps/vm/firecracker-ctl/src/tap.rs\`

- \`TapManager::init()\` now also sets \`net.ipv4.conf.all.route_localnet=1\` so packets DNATed to \`127.0.0.1\` from a forwarded path are routed.
- Two new idempotent iptables rules in \`nat PREROUTING\`:
  \`\`\`
  -i fctap+ -p udp --dport 53 -j DNAT --to-destination 127.0.0.1:53
  -i fctap+ -p tcp --dport 53 -j DNAT --to-destination 127.0.0.1:53
  \`\`\`
  VM DNS queries — to any upstream — get rewritten to Gluetun's local forwarder.

### \`apps/kbve/astro-kbve/.../firecracker-ctl.mdx\`

\`version: 0.1.32\` → \`0.1.33\` to trigger a fresh publish.

## Test plan

- [ ] Publish \`ghcr.io/kbve/firecracker-ctl:0.1.33\`.
- [ ] Post-publish atom PR bumps both fc-ctl deployment manifests.
- [ ] After ArgoCD reconciles, the new fc-ctl-net pod's iptables shows the two PREROUTING DNAT rules + \`net.ipv4.conf.all.route_localnet=1\`.
- [ ] Gluetun status \`/v1/dns/status\` reports the forwarder \`running\` instead of \`stopped\`.
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB → poem prints, exit 0.
- [ ] Bonus — pod's own \`nslookup poetrydb.org\` from gluetun container should still resolve, now through the tunnel.