### PR TITLE
refactor(kbve): migrate wallet to diesel-async, drop libpq/libssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5137,9 +5137,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.7"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ae09a41a4b89f94ec1e053623da8340d996bc32c6517d325a9daad9b239358"
+checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
 dependencies = [
  "bitflags 2.11.0",
  "byteorder",
@@ -5151,6 +5151,21 @@ dependencies = [
  "r2d2",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "diesel-async"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c20ddcc6737cecdaef3dfecb2796bdfe3002456521189d30be8e4c5a1bc821d"
+dependencies = [
+ "bb8",
+ "diesel",
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -6097,7 +6112,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firecracker-ctl"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "axum 0.8.9",
  "dashmap 6.1.0",
@@ -8775,10 +8790,13 @@ dependencies = [
  "async-trait",
  "axum 0.8.9",
  "axum-extra",
+ "bb8",
  "chrono",
  "dashmap 6.1.0",
  "diesel",
+ "diesel-async",
  "dotenvy",
+ "futures-util",
  "holy",
  "jedi",
  "jsonwebtoken 10.3.0",

--- a/apps/kbve/axum-kbve/src/db/wallet.rs
+++ b/apps/kbve/axum-kbve/src/db/wallet.rs
@@ -1,32 +1,27 @@
-//! WalletClient registry — boots once at startup, returned to handlers via
-//! a `OnceLock`-backed getter (same pattern as the forum / mc / profile
-//! services in this crate). Heavy state stays out of `AppState`.
-
-use std::sync::OnceLock;
+use tokio::sync::OnceCell;
 
 use kbve::wallet::WalletClient;
 
-static WALLET_CLIENT: OnceLock<Option<WalletClient>> = OnceLock::new();
+static WALLET_CLIENT: OnceCell<Option<WalletClient>> = OnceCell::const_new();
 
-/// Build the wallet client from env (`WALLET_DATABASE_URL` with
-/// `DATABASE_URL_PROD` fallback). Returns `true` if the client is live.
-///
-/// Idempotent — subsequent calls return the cached result.
-pub fn init_wallet_client() -> bool {
+pub async fn init_wallet_client() -> bool {
     WALLET_CLIENT
-        .get_or_init(|| match WalletClient::from_env() {
-            Ok(client) => {
-                tracing::info!("WalletClient initialized");
-                Some(client)
-            }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "WalletClient disabled: failed to build pool"
-                );
-                None
+        .get_or_init(|| async {
+            match WalletClient::from_env().await {
+                Ok(client) => {
+                    tracing::info!("WalletClient initialized");
+                    Some(client)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "WalletClient disabled: failed to build pool"
+                    );
+                    None
+                }
             }
         })
+        .await
         .is_some()
 }
 

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -96,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
         info!("Forum service not configured - /forum routes will 503");
     }
 
-    if db::init_wallet_client() {
+    if db::init_wallet_client().await {
         info!("Wallet client initialized - /api/v1/wallet/me/* routes enabled");
     } else {
         warn!("Wallet client not configured - /api/v1/wallet routes will 503");

--- a/apps/kbve/axum-kbve/src/transport/wallet.rs
+++ b/apps/kbve/axum-kbve/src/transport/wallet.rs
@@ -397,7 +397,7 @@ fn wallet_error_response(err: WalletError) -> Response {
         WalletError::CouponNotRedeemable(_) => (StatusCode::FORBIDDEN, "coupon_not_redeemable"),
         WalletError::CouponExpired => (StatusCode::FORBIDDEN, "coupon_expired"),
         WalletError::Unimplemented(_) => (StatusCode::NOT_IMPLEMENTED, "unimplemented"),
-        WalletError::Pool(_) | WalletError::Join(_) | WalletError::Db(_) => {
+        WalletError::Pool(_) | WalletError::Db(_) => {
             // Log the raw error server-side, send a generic message to the client.
             tracing::error!(error = %err, "wallet upstream failure");
             (StatusCode::INTERNAL_SERVER_ERROR, "internal")

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -15,6 +15,7 @@ default = []
 supabase = ["dep:lru"]
 image-gen = ["dep:resvg"]
 wallet = ["dep:uuid"]
+legacy-sync-db = ["diesel/postgres", "diesel/r2d2", "dep:r2d2"]
 
 [dependencies]
 anyhow = "1.0"
@@ -25,13 +26,14 @@ url = "2.5"
 askama = "0.15.6"
 async-trait = "0.1.74"
 chrono = { version = "0.4.44", features = ["serde"] }
-diesel = { version = "2.3.7", features = [
-    "postgres",
+diesel = { version = "2.3.7", default-features = false, features = [
     "chrono",
-    "r2d2",
     "serde_json",
     "uuid",
 ] }
+diesel-async = { version = "0.9", features = ["postgres", "bb8"] }
+bb8 = "0.9"
+futures-util = "0.3"
 dotenvy = "0.15"
 axum = { version = "0.8.9", features = ["macros"] }
 axum-extra = { version = "0.12.6", features = ["cookie"] }
@@ -51,7 +53,7 @@ tower = { version = "0.5.3", features = ["timeout", "util"] }
 tower-http = { version = "0.6.8", features = ["cors", "fs"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-r2d2 = "0.8.9"
+r2d2 = { version = "0.8.9", optional = true }
 regex = "1.10.2"
 once_cell = "1"
 ulid = "1.2.1"

--- a/packages/rust/kbve/src/db.rs
+++ b/packages/rust/kbve/src/db.rs
@@ -1,11 +1,13 @@
-use diesel::pg::PgConnection;
-use diesel::prelude::*;
-use diesel::r2d2::{self, ConnectionManager};
 use std::env;
 use std::fs;
 use std::result::Result;
 
-pub type Pool = r2d2::Pool<ConnectionManager<PgConnection>>;
+use diesel_async::AsyncPgConnection;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::bb8::{Pool as Bb8Pool, PooledConnection as Bb8Conn};
+
+pub type Pool = Bb8Pool<AsyncPgConnection>;
+pub type PooledConn<'a> = Bb8Conn<'a, AsyncPgConnection>;
 
 fn get_env_var(name: &str) -> Result<String, String> {
     match env::var(name) {
@@ -21,26 +23,27 @@ fn get_env_var(name: &str) -> Result<String, String> {
     }
 }
 
-pub fn establish_connection_dev() -> Result<PgConnection, String> {
-    establish_connection_generic("DATABASE_URL_DEV")
-}
-pub fn establish_connection_prod() -> Result<PgConnection, String> {
-    establish_connection_generic("DATABASE_URL_PROD")
+pub async fn establish_connection_dev() -> Result<AsyncPgConnection, String> {
+    establish_connection_generic("DATABASE_URL_DEV").await
 }
 
-fn establish_connection_generic(env_var: &str) -> Result<PgConnection, String> {
+pub async fn establish_connection_prod() -> Result<AsyncPgConnection, String> {
+    establish_connection_generic("DATABASE_URL_PROD").await
+}
+
+async fn establish_connection_generic(env_var: &str) -> Result<AsyncPgConnection, String> {
+    use diesel_async::AsyncConnection;
     let database_url = get_env_var(env_var)?;
-    PgConnection::establish(&database_url)
+    AsyncPgConnection::establish(&database_url)
+        .await
         .map_err(|err| format!("Error connecting to {}: {}", database_url, err))
 }
 
-pub fn establish_connection_pool() -> Pool {
-    let database_url =
-        get_env_var("DATABASE_URL_PROD").expect("DATABASE_URL_PROD must be set for production");
-
-    let manager = ConnectionManager::<PgConnection>::new(database_url);
-
-    r2d2::Pool::builder()
+pub async fn establish_connection_pool() -> Result<Pool, String> {
+    let database_url = get_env_var("DATABASE_URL_PROD")?;
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    Bb8Pool::builder()
         .build(manager)
-        .expect("Failed to create the database connection pool")
+        .await
+        .map_err(|e| format!("Failed to create the database connection pool: {e}"))
 }

--- a/packages/rust/kbve/src/lib.rs
+++ b/packages/rust/kbve/src/lib.rs
@@ -1,50 +1,53 @@
 #![allow(dead_code)]
 
-//  * Planned : [Code Splitting]
-
-//  * [MODS]
+#[cfg(feature = "legacy-sync-db")]
 pub mod authentication;
 pub mod db;
+#[cfg(feature = "legacy-sync-db")]
 pub mod guild;
+#[cfg(feature = "legacy-sync-db")]
 pub mod models;
+#[cfg(feature = "legacy-sync-db")]
 pub mod runes;
+#[cfg(feature = "legacy-sync-db")]
 pub mod schema;
 pub mod social;
+#[cfg(feature = "legacy-sync-db")]
 pub mod spellbook;
+#[cfg(feature = "legacy-sync-db")]
 pub mod utility;
 
-//  * [REFACTOR]
+#[cfg(feature = "legacy-sync-db")]
 pub mod entity;
+#[cfg(feature = "legacy-sync-db")]
 pub mod sys;
 pub mod utils;
 
-//  * [WEB] — shared HTTP/web building blocks for axum-* services.
 pub mod web;
 
-//  * [MARKDOWN] — safe CommonMark + GFM renderer with ammonia allowlist.
 pub mod markdown;
 
-//  * [WALLET] — feature-gated multi-currency ledger client.
-//    Talks to the `wallet` Postgres schema (see packages/data/sql/schema/wallet/)
-//    via the existing diesel pool. Enable with `--features wallet`.
 #[cfg(feature = "wallet")]
 pub mod wallet;
 
-// Re-export the `holy` proc-macro crate so downstream axum-* services
-// can pull derive(Sanitize) / derive(Getters) etc. through `kbve::holy::*`
-// without taking a second top-level dependency. Single boundary = one
-// place to bump.
 pub use holy;
 
+#[cfg(feature = "legacy-sync-db")]
 pub use authentication::*;
 pub use db::*;
+#[cfg(feature = "legacy-sync-db")]
 pub use guild::*;
+#[cfg(feature = "legacy-sync-db")]
 pub use models::*;
+#[cfg(feature = "legacy-sync-db")]
 pub use runes::*;
+#[cfg(feature = "legacy-sync-db")]
 pub use schema::*;
+#[cfg(feature = "legacy-sync-db")]
 pub use utility::*;
 
-//  * [REFACTOR]
+#[cfg(feature = "legacy-sync-db")]
 pub use entity::*;
+#[cfg(feature = "legacy-sync-db")]
 pub use sys::*;
 pub use utils::*;

--- a/packages/rust/kbve/src/utils/mod.rs
+++ b/packages/rust/kbve/src/utils/mod.rs
@@ -1,5 +1,7 @@
+#[cfg(feature = "legacy-sync-db")]
 pub mod captcha;
 pub mod sanitization;
 
+#[cfg(feature = "legacy-sync-db")]
 pub use captcha::*;
 pub use sanitization::*;

--- a/packages/rust/kbve/src/wallet/client.rs
+++ b/packages/rust/kbve/src/wallet/client.rs
@@ -1,52 +1,29 @@
-//! `WalletClient` — diesel-pool wrapper that hosts the wallet service ops.
-//!
-//! The wallet schema's `SECURITY DEFINER` functions need the caller to either
-//! be `service_role` (recommended) or come through an authenticated proxy.
-//! We support both by using two helpers on the client:
-//!
-//!   - [`WalletClient::run_service`] runs a closure as the role the connection
-//!     pool authenticates as. For service paths this should be `service_role`.
-//!   - [`WalletClient::run_as_user`] sets `request.jwt.claims` for the
-//!     `public.proxy_wallet_*` functions so `auth.uid()` resolves correctly,
-//!     then runs the closure.
-//!
-//! The actual sync diesel work happens inside `tokio::task::spawn_blocking`
-//! so we never block the async runtime.
-
 use std::env;
 use std::fs;
 
-use diesel::pg::PgConnection;
-use diesel::prelude::*;
-use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel::sql_query;
 use diesel::sql_types::Text;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::bb8::{Pool, PooledConnection};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde_json::json;
 use uuid::Uuid;
 
 use super::error::{Result, WalletError};
 
-pub type WalletPool = Pool<ConnectionManager<PgConnection>>;
-pub type WalletConn = PooledConnection<ConnectionManager<PgConnection>>;
+pub type WalletPool = Pool<AsyncPgConnection>;
+pub type WalletConn<'a> = PooledConnection<'a, AsyncPgConnection>;
 
-/// Build a wallet-dedicated diesel pool.
-///
-/// Reads `WALLET_DATABASE_URL` (or `WALLET_DATABASE_URL_FILE` for Docker
-/// secrets style). Falls back to `DATABASE_URL_PROD` so dev environments keep
-/// working without a separate var.
-///
-/// The login role should be `service_role` so the SECURITY DEFINER chains
-/// resolve cleanly. For local docker postgres without that role, use
-/// `postgres` (the SQL functions accept superuser fallback).
-pub fn establish_wallet_pool() -> Result<WalletPool> {
+pub async fn establish_wallet_pool() -> Result<WalletPool> {
     let url = read_env("WALLET_DATABASE_URL")
         .or_else(|_| read_env("DATABASE_URL_PROD"))
         .map_err(|e| WalletError::Pool(format!("missing wallet DATABASE URL: {e}")))?;
 
-    let manager = ConnectionManager::<PgConnection>::new(url);
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
     Pool::builder()
         .max_size(8)
         .build(manager)
+        .await
         .map_err(|e| WalletError::Pool(e.to_string()))
 }
 
@@ -60,6 +37,19 @@ fn read_env(name: &str) -> std::result::Result<String, String> {
     }
 }
 
+pub async fn set_user_claims(conn: &mut AsyncPgConnection, user_id: Uuid) -> Result<()> {
+    let claims = json!({
+        "role": "authenticated",
+        "sub": user_id.to_string(),
+    });
+    sql_query("SELECT set_config('request.jwt.claims', $1, true)")
+        .bind::<Text, _>(claims.to_string())
+        .execute(conn)
+        .await
+        .map_err(WalletError::from_diesel)?;
+    Ok(())
+}
+
 #[derive(Clone)]
 pub struct WalletClient {
     pool: WalletPool,
@@ -70,57 +60,15 @@ impl WalletClient {
         Self { pool }
     }
 
-    /// Construct from env vars.
-    pub fn from_env() -> Result<Self> {
-        Ok(Self::new(establish_wallet_pool()?))
+    pub async fn from_env() -> Result<Self> {
+        Ok(Self::new(establish_wallet_pool().await?))
     }
 
     pub fn pool(&self) -> &WalletPool {
         &self.pool
     }
 
-    /// Run a diesel closure on a worker thread without any per-request session
-    /// state. Used by `service_*` paths that already trust the caller (the
-    /// connection itself authenticates as `service_role`).
-    pub async fn run_service<F, T>(&self, f: F) -> Result<T>
-    where
-        F: FnOnce(&mut WalletConn) -> Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let pool = self.pool.clone();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get()?;
-            f(&mut conn)
-        })
-        .await?
-    }
-
-    /// Run a diesel closure on behalf of an authenticated user.
-    ///
-    /// Sets `request.jwt.claims` as a session GUC inside the closure's
-    /// transaction so the `public.proxy_wallet_*` SECURITY DEFINER functions
-    /// see `auth.uid()` correctly. The claim block is reset after the closure
-    /// returns regardless of outcome.
-    pub async fn run_as_user<F, T>(&self, user_id: Uuid, f: F) -> Result<T>
-    where
-        F: FnOnce(&mut WalletConn) -> Result<T> + Send + 'static,
-        T: Send + 'static,
-    {
-        let pool = self.pool.clone();
-        tokio::task::spawn_blocking(move || {
-            let mut conn = pool.get()?;
-            conn.transaction::<T, WalletError, _>(|conn| {
-                let claims = json!({
-                    "role": "authenticated",
-                    "sub": user_id.to_string(),
-                });
-                sql_query("SELECT set_config('request.jwt.claims', $1, true)")
-                    .bind::<Text, _>(claims.to_string())
-                    .execute(conn)
-                    .map_err(WalletError::from_diesel)?;
-                f(conn)
-            })
-        })
-        .await?
+    pub async fn conn(&self) -> Result<WalletConn<'_>> {
+        self.pool.get().await.map_err(WalletError::from)
     }
 }

--- a/packages/rust/kbve/src/wallet/error.rs
+++ b/packages/rust/kbve/src/wallet/error.rs
@@ -46,9 +46,6 @@ pub enum WalletError {
     #[error("pool error: {0}")]
     Pool(String),
 
-    #[error("blocking task join error: {0}")]
-    Join(String),
-
     #[error(transparent)]
     Db(#[from] DieselError),
 }
@@ -134,15 +131,15 @@ fn classify_message(msg: &str) -> Option<WalletError> {
     None
 }
 
-impl From<r2d2::Error> for WalletError {
-    fn from(e: r2d2::Error) -> Self {
+impl From<bb8::RunError<diesel_async::pooled_connection::PoolError>> for WalletError {
+    fn from(e: bb8::RunError<diesel_async::pooled_connection::PoolError>) -> Self {
         WalletError::Pool(e.to_string())
     }
 }
 
-impl From<tokio::task::JoinError> for WalletError {
-    fn from(e: tokio::task::JoinError) -> Self {
-        WalletError::Join(e.to_string())
+impl From<diesel_async::pooled_connection::PoolError> for WalletError {
+    fn from(e: diesel_async::pooled_connection::PoolError) -> Self {
+        WalletError::Pool(e.to_string())
     }
 }
 

--- a/packages/rust/kbve/src/wallet/proxy.rs
+++ b/packages/rust/kbve/src/wallet/proxy.rs
@@ -1,27 +1,13 @@
-//! Authenticated-user wallet operations.
-//!
-//! Mirrors the `public.proxy_wallet_*` functions. Each call sets
-//! `request.jwt.claims` for the session so `auth.uid()` resolves to the
-//! caller's user id; this lets the SECURITY DEFINER proxy land in the right
-//! account.
-//!
-//! Note: the connection role still authenticates as `service_role` (or
-//! superuser) — we are not switching roles, just shimming the JWT claim
-//! that the proxy functions read with `auth.uid()`.
-
 use chrono::{DateTime, Utc};
-use diesel::prelude::*;
+use diesel::QueryableByName;
 use diesel::sql_query;
 use diesel::sql_types::{BigInt, Bool, Jsonb, Nullable, Text, Timestamptz};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
-use super::client::{WalletClient, WalletConn};
+use super::client::{WalletClient, set_user_claims};
 use super::error::{Result, WalletError};
 use super::types::*;
-
-// ---------------------------------------------------------------------------
-// QueryableByName rows
-// ---------------------------------------------------------------------------
 
 #[derive(QueryableByName)]
 struct BalanceRowDb {
@@ -69,49 +55,53 @@ struct RedeemRowDb {
     ledger_id: i64,
 }
 
-// ---------------------------------------------------------------------------
-// User-facing proxy operations
-// ---------------------------------------------------------------------------
-
 impl WalletClient {
-    /// `public.proxy_wallet_get_balance()` — returns the caller's balance.
-    /// Lazily provisions the account + welcome coupon on first call.
     pub async fn user_balance(&self, user_id: Uuid) -> Result<BalanceRow> {
-        self.run_as_user(user_id, |conn| balance_blocking(conn))
+        let mut conn = self.conn().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<BalanceRow, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                balance_async(conn).await
+            })
             .await
     }
 
-    /// `public.proxy_wallet_list_coupons()` — returns the caller's coupons.
     pub async fn user_coupons(&self, user_id: Uuid) -> Result<Vec<CouponSummary>> {
-        self.run_as_user(user_id, |conn| coupons_blocking(conn))
+        let mut conn = self.conn().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Vec<CouponSummary>, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                coupons_async(conn).await
+            })
             .await
     }
 
-    /// `public.proxy_wallet_redeem_coupon(coupon_id, idempotency_key)` —
-    /// auth-checked ownership + idempotent at the coupon layer.
     pub async fn user_redeem_coupon(
         &self,
         user_id: Uuid,
         coupon_id: i64,
         idempotency_key: Uuid,
     ) -> Result<RedeemResult> {
-        self.run_as_user(user_id, move |conn| {
-            redeem_blocking(conn, coupon_id, idempotency_key)
-        })
-        .await
+        let mut conn = self.conn().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<RedeemResult, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                redeem_async(conn, coupon_id, idempotency_key).await
+            })
+            .await
     }
 }
 
-// ---------------------------------------------------------------------------
-// Blocking implementations
-// ---------------------------------------------------------------------------
-
-fn balance_blocking(conn: &mut WalletConn) -> Result<BalanceRow> {
+async fn balance_async(conn: &mut AsyncPgConnection) -> Result<BalanceRow> {
     let row: BalanceRowDb = sql_query(
         "SELECT account_id, credits, khash, updated_at \
          FROM public.proxy_wallet_get_balance()",
     )
     .get_result(conn)
+    .await
     .map_err(WalletError::from_diesel)?;
 
     Ok(BalanceRow {
@@ -122,7 +112,7 @@ fn balance_blocking(conn: &mut WalletConn) -> Result<BalanceRow> {
     })
 }
 
-fn coupons_blocking(conn: &mut WalletConn) -> Result<Vec<CouponSummary>> {
+async fn coupons_async(conn: &mut AsyncPgConnection) -> Result<Vec<CouponSummary>> {
     let rows: Vec<CouponSummaryDb> = sql_query(
         "SELECT coupon_id, template_code, template_label, \
                 reward_kind::text AS reward_kind, reward_payload, \
@@ -130,6 +120,7 @@ fn coupons_blocking(conn: &mut WalletConn) -> Result<Vec<CouponSummary>> {
          FROM public.proxy_wallet_list_coupons()",
     )
     .get_results(conn)
+    .await
     .map_err(WalletError::from_diesel)?;
 
     rows.into_iter()
@@ -155,8 +146,8 @@ fn coupons_blocking(conn: &mut WalletConn) -> Result<Vec<CouponSummary>> {
         .collect()
 }
 
-fn redeem_blocking(
-    conn: &mut WalletConn,
+async fn redeem_async(
+    conn: &mut AsyncPgConnection,
     coupon_id: i64,
     idempotency_key: Uuid,
 ) -> Result<RedeemResult> {
@@ -167,6 +158,7 @@ fn redeem_blocking(
     .bind::<BigInt, _>(coupon_id)
     .bind::<diesel::sql_types::Uuid, _>(idempotency_key)
     .get_result(conn)
+    .await
     .map_err(WalletError::from_diesel)?;
 
     let reward_kind = RewardKind::from_pg(&row.reward_kind).ok_or_else(|| {

--- a/packages/rust/kbve/src/wallet/service.rs
+++ b/packages/rust/kbve/src/wallet/service.rs
@@ -1,22 +1,12 @@
-//! Service-side wallet operations.
-//!
-//! Each fn calls the matching `wallet.service_*` SECURITY DEFINER function
-//! via `diesel::sql_query`. Bind params are passed as TEXT for enums (cast
-//! server-side) and explicit diesel types for everything else. Errors are
-//! normalized through [`WalletError::from_diesel`].
-
-use diesel::prelude::*;
+use diesel::QueryableByName;
 use diesel::sql_query;
 use diesel::sql_types::{BigInt, Bool, Jsonb, Nullable, Text};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
-use super::client::{WalletClient, WalletConn};
+use super::client::{WalletClient, set_user_claims};
 use super::error::{Result, WalletError};
 use super::types::*;
-
-// ---------------------------------------------------------------------------
-// QueryableByName rows
-// ---------------------------------------------------------------------------
 
 #[derive(QueryableByName)]
 struct LedgerIdRow {
@@ -58,88 +48,64 @@ struct RevokedRow {
     revoked: bool,
 }
 
-// ---------------------------------------------------------------------------
-// Service operations
-// ---------------------------------------------------------------------------
-
 impl WalletClient {
-    /// `wallet.service_credit(...)` — positive delta. Returns ledger id.
     pub async fn credit(&self, req: CreditRequest) -> Result<i64> {
-        self.run_service(move |conn| credit_blocking(conn, req))
-            .await
+        let mut conn = self.conn().await?;
+        credit_async(&mut conn, req).await
     }
 
-    /// `wallet.service_debit(...)` — positive p_amount, becomes negative delta.
-    /// Raises [`WalletError::InsufficientFunds`] when balance would go negative.
     pub async fn debit(&self, req: DebitRequest) -> Result<i64> {
-        self.run_service(move |conn| debit_blocking(conn, req))
-            .await
+        let mut conn = self.conn().await?;
+        debit_async(&mut conn, req).await
     }
 
-    /// `wallet.service_transfer(...)` — atomic debit + credit with
-    /// canonical-order advisory locking.
     pub async fn transfer(&self, req: TransferRequest) -> Result<()> {
-        self.run_service(move |conn| transfer_blocking(conn, req))
+        let mut conn = self.conn().await?;
+        transfer_async(&mut conn, req).await
+    }
+
+    pub async fn service_account_for_user(&self, user_id: Uuid) -> Result<Uuid> {
+        let mut conn = self.conn().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Uuid, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                #[derive(QueryableByName)]
+                struct AccountRow {
+                    #[diesel(sql_type = diesel::sql_types::Uuid)]
+                    account_id: Uuid,
+                }
+                let r: AccountRow =
+                    sql_query("SELECT wallet.proxy_ensure_user_account() AS account_id")
+                        .get_result(conn)
+                        .await
+                        .map_err(WalletError::from_diesel)?;
+                Ok(r.account_id)
+            })
             .await
     }
 
-    /// Resolve a Supabase user_id to its `wallet.account.id`.
-    ///
-    /// Calls `wallet.proxy_ensure_user_account()` via `run_as_user`, which
-    /// sets `request.jwt.claims.sub` for the SECURITY DEFINER function to
-    /// see the right `auth.uid()`. Creates the account + welcome coupon on
-    /// first call. Idempotent across repeated calls.
-    ///
-    /// Intended for service callers (MC mod daily reward, edge functions)
-    /// that know a user_id but not an account_id.
-    pub async fn service_account_for_user(&self, user_id: Uuid) -> Result<Uuid> {
-        self.run_as_user(user_id, |conn| {
-            #[derive(QueryableByName)]
-            struct AccountRow {
-                #[diesel(sql_type = diesel::sql_types::Uuid)]
-                account_id: Uuid,
-            }
-            let r: AccountRow =
-                sql_query("SELECT wallet.proxy_ensure_user_account() AS account_id")
-                    .get_result(conn)
-                    .map_err(WalletError::from_diesel)?;
-            Ok(r.account_id)
-        })
-        .await
-    }
-
-    /// `wallet.service_redeem_coupon(coupon_id, idempotency_key)`.
-    /// Idempotent at the coupon layer: same key replays return the original
-    /// ledger id instead of raising.
     pub async fn redeem_coupon(
         &self,
         coupon_id: i64,
         idempotency_key: Uuid,
     ) -> Result<RedeemResult> {
-        self.run_service(move |conn| redeem_blocking(conn, coupon_id, idempotency_key))
-            .await
+        let mut conn = self.conn().await?;
+        redeem_async(&mut conn, coupon_id, idempotency_key).await
     }
 
-    /// `wallet.service_revoke_coupon(coupon_id, reason)`. Returns false on
-    /// already-revoked, raises on redeemed.
     pub async fn revoke_coupon(&self, coupon_id: i64, reason: Option<String>) -> Result<bool> {
-        self.run_service(move |conn| revoke_blocking(conn, coupon_id, reason))
-            .await
+        let mut conn = self.conn().await?;
+        revoke_async(&mut conn, coupon_id, reason).await
     }
 
-    /// `wallet.service_verify_balance(account_id)` — compares stored balance
-    /// against ledger sum per currency. `ok=true` means consistent.
     pub async fn verify_balance(&self, account_id: Uuid) -> Result<VerifyBalanceRow> {
-        self.run_service(move |conn| verify_blocking(conn, account_id))
-            .await
+        let mut conn = self.conn().await?;
+        verify_async(&mut conn, account_id).await
     }
 }
 
-// ---------------------------------------------------------------------------
-// Blocking implementations
-// ---------------------------------------------------------------------------
-
-fn credit_blocking(conn: &mut WalletConn, req: CreditRequest) -> Result<i64> {
+async fn credit_async(conn: &mut AsyncPgConnection, req: CreditRequest) -> Result<i64> {
     let row: LedgerIdRow = sql_query(
         "SELECT wallet.service_credit($1, $2::wallet.currency_kind, $3, \
          $4::wallet.source_kind, $5, $6, $7, $8) AS id",
@@ -153,11 +119,12 @@ fn credit_blocking(conn: &mut WalletConn, req: CreditRequest) -> Result<i64> {
     .bind::<Nullable<BigInt>, _>(req.ref_id)
     .bind::<diesel::sql_types::Uuid, _>(req.idempotency_key)
     .get_result(conn)
+    .await
     .map_err(WalletError::from_diesel)?;
     Ok(row.id)
 }
 
-fn debit_blocking(conn: &mut WalletConn, req: DebitRequest) -> Result<i64> {
+async fn debit_async(conn: &mut AsyncPgConnection, req: DebitRequest) -> Result<i64> {
     let row: LedgerIdRow = sql_query(
         "SELECT wallet.service_debit($1, $2::wallet.currency_kind, $3, \
          $4::wallet.source_kind, $5, $6, $7, $8) AS id",
@@ -171,11 +138,12 @@ fn debit_blocking(conn: &mut WalletConn, req: DebitRequest) -> Result<i64> {
     .bind::<Nullable<BigInt>, _>(req.ref_id)
     .bind::<diesel::sql_types::Uuid, _>(req.idempotency_key)
     .get_result(conn)
+    .await
     .map_err(WalletError::from_diesel)?;
     Ok(row.id)
 }
 
-fn transfer_blocking(conn: &mut WalletConn, req: TransferRequest) -> Result<()> {
+async fn transfer_async(conn: &mut AsyncPgConnection, req: TransferRequest) -> Result<()> {
     sql_query(
         "SELECT wallet.service_transfer($1, $2, $3::wallet.currency_kind, $4, \
          $5::wallet.source_kind, $6, $7, $8, $9)",
@@ -190,12 +158,13 @@ fn transfer_blocking(conn: &mut WalletConn, req: TransferRequest) -> Result<()> 
     .bind::<Nullable<BigInt>, _>(req.ref_id)
     .bind::<diesel::sql_types::Uuid, _>(req.idempotency_key)
     .execute(conn)
+    .await
     .map_err(WalletError::from_diesel)?;
     Ok(())
 }
 
-fn redeem_blocking(
-    conn: &mut WalletConn,
+async fn redeem_async(
+    conn: &mut AsyncPgConnection,
     coupon_id: i64,
     idempotency_key: Uuid,
 ) -> Result<RedeemResult> {
@@ -206,6 +175,7 @@ fn redeem_blocking(
     .bind::<BigInt, _>(coupon_id)
     .bind::<diesel::sql_types::Uuid, _>(idempotency_key)
     .get_result(conn)
+    .await
     .map_err(WalletError::from_diesel)?;
 
     let reward_kind = RewardKind::from_pg(&row.reward_kind).ok_or_else(|| {
@@ -219,16 +189,21 @@ fn redeem_blocking(
     })
 }
 
-fn revoke_blocking(conn: &mut WalletConn, coupon_id: i64, reason: Option<String>) -> Result<bool> {
+async fn revoke_async(
+    conn: &mut AsyncPgConnection,
+    coupon_id: i64,
+    reason: Option<String>,
+) -> Result<bool> {
     let row: RevokedRow = sql_query("SELECT wallet.service_revoke_coupon($1, $2) AS revoked")
         .bind::<BigInt, _>(coupon_id)
         .bind::<Nullable<Text>, _>(reason)
         .get_result(conn)
+        .await
         .map_err(WalletError::from_diesel)?;
     Ok(row.revoked)
 }
 
-fn verify_blocking(conn: &mut WalletConn, account_id: Uuid) -> Result<VerifyBalanceRow> {
+async fn verify_async(conn: &mut AsyncPgConnection, account_id: Uuid) -> Result<VerifyBalanceRow> {
     let row: VerifyBalanceRowDb = sql_query(
         "SELECT account_id, stored_credits, ledger_credits, \
                 stored_khash, ledger_khash, ok \
@@ -236,6 +211,7 @@ fn verify_blocking(conn: &mut WalletConn, account_id: Uuid) -> Result<VerifyBala
     )
     .bind::<diesel::sql_types::Uuid, _>(account_id)
     .get_result(conn)
+    .await
     .map_err(WalletError::from_diesel)?;
     Ok(VerifyBalanceRow {
         account_id: row.account_id,

--- a/packages/rust/kbve/src/wallet/tests.rs
+++ b/packages/rust/kbve/src/wallet/tests.rs
@@ -1,24 +1,11 @@
-//! Integration tests against a real Postgres with the wallet schema applied.
-//!
-//! Set `WALLET_TEST_DATABASE_URL` to a connection string pointing at a DB
-//! with all migrations through `20260511104220_wallet_schema_init` applied.
-//! Tests are skipped when the env var is unset so CI can opt in.
-//!
-//! Run:
-//!
-//! ```bash
-//! WALLET_TEST_DATABASE_URL="postgres://postgres:postgres@localhost:54322/postgres" \
-//!   cargo test -p kbve --features wallet -- --include-ignored
-//! ```
-
 #![cfg(test)]
 
 use std::env;
 
-use diesel::pg::PgConnection;
-use diesel::prelude::*;
+use diesel::QueryableByName;
 use diesel::sql_query;
 use diesel::sql_types::Text;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use serial_test::serial;
 use uuid::Uuid;
 
@@ -29,43 +16,40 @@ use super::{
 
 const TEST_URL_ENV: &str = "WALLET_TEST_DATABASE_URL";
 
-fn client() -> Option<WalletClient> {
+async fn client() -> Option<WalletClient> {
     let url = env::var(TEST_URL_ENV).ok()?;
     env::set_var("WALLET_DATABASE_URL", &url);
-    Some(WalletClient::from_env().expect("client from_env"))
+    Some(WalletClient::from_env().await.expect("client from_env"))
 }
 
-/// Direct (non-pool) admin connection for seeding fixtures.
-fn admin_conn() -> Option<PgConnection> {
+async fn admin_conn() -> Option<AsyncPgConnection> {
     let url = env::var(TEST_URL_ENV).ok()?;
-    PgConnection::establish(&url).ok()
+    AsyncPgConnection::establish(&url).await.ok()
 }
 
-/// Create a fresh `auth.users` row + wallet account, return both UUIDs.
-/// Bypasses the proxy provisioning path so individual ops are testable
-/// in isolation.
-fn fixture_account() -> Option<(Uuid, Uuid)> {
-    let mut conn = admin_conn()?;
+async fn fixture_account() -> Option<(Uuid, Uuid)> {
+    let mut conn = admin_conn().await?;
     let user_id = Uuid::new_v4();
     sql_query("INSERT INTO auth.users (id) VALUES ($1) ON CONFLICT DO NOTHING")
         .bind::<diesel::sql_types::Uuid, _>(user_id)
         .execute(&mut conn)
+        .await
         .expect("insert auth.users");
-    let row: diesel::sql_types::Uuid;
     #[derive(QueryableByName)]
     struct R {
         #[diesel(sql_type = diesel::sql_types::Uuid)]
         id: Uuid,
     }
-    let _ = row;
     let r: R =
         sql_query("INSERT INTO wallet.account (kind, user_id) VALUES ('user', $1) RETURNING id")
             .bind::<diesel::sql_types::Uuid, _>(user_id)
             .get_result(&mut conn)
+            .await
             .expect("insert wallet.account");
     sql_query("INSERT INTO wallet.balance (account_id) VALUES ($1) ON CONFLICT DO NOTHING")
         .bind::<diesel::sql_types::Uuid, _>(r.id)
         .execute(&mut conn)
+        .await
         .expect("insert wallet.balance");
     Some((user_id, r.id))
 }
@@ -86,11 +70,11 @@ fn req_credit(account: Uuid, amount: i64, key: Uuid) -> CreditRequest {
 #[tokio::test]
 #[serial]
 async fn credit_then_replay_returns_same_ledger_id() {
-    let Some(client) = client() else {
+    let Some(client) = client().await else {
         eprintln!("SKIP: WALLET_TEST_DATABASE_URL unset");
         return;
     };
-    let (_user, account) = fixture_account().expect("fixture");
+    let (_user, account) = fixture_account().await.expect("fixture");
     let key = Uuid::new_v4();
 
     let id1 = client.credit(req_credit(account, 100, key)).await.unwrap();
@@ -101,10 +85,10 @@ async fn credit_then_replay_returns_same_ledger_id() {
 #[tokio::test]
 #[serial]
 async fn credit_replay_with_different_payload_raises_replay_mismatch() {
-    let Some(client) = client() else {
+    let Some(client) = client().await else {
         return;
     };
-    let (_user, account) = fixture_account().expect("fixture");
+    let (_user, account) = fixture_account().await.expect("fixture");
     let key = Uuid::new_v4();
 
     client.credit(req_credit(account, 100, key)).await.unwrap();
@@ -118,10 +102,10 @@ async fn credit_replay_with_different_payload_raises_replay_mismatch() {
 #[tokio::test]
 #[serial]
 async fn debit_beyond_balance_raises_insufficient_funds() {
-    let Some(client) = client() else {
+    let Some(client) = client().await else {
         return;
     };
-    let (_user, account) = fixture_account().expect("fixture");
+    let (_user, account) = fixture_account().await.expect("fixture");
 
     client
         .credit(req_credit(account, 50, Uuid::new_v4()))
@@ -148,11 +132,11 @@ async fn debit_beyond_balance_raises_insufficient_funds() {
 #[tokio::test]
 #[serial]
 async fn transfer_moves_funds_atomically() {
-    let Some(client) = client() else {
+    let Some(client) = client().await else {
         return;
     };
-    let (_user_a, account_a) = fixture_account().expect("fixture a");
-    let (_user_b, account_b) = fixture_account().expect("fixture b");
+    let (_user_a, account_a) = fixture_account().await.expect("fixture a");
+    let (_user_b, account_b) = fixture_account().await.expect("fixture b");
 
     client
         .credit(req_credit(account_a, 500, Uuid::new_v4()))
@@ -186,16 +170,16 @@ async fn transfer_moves_funds_atomically() {
 #[tokio::test]
 #[serial]
 async fn welcome_redeem_flow_via_user_proxy() {
-    let Some(client) = client() else {
+    let Some(client) = client().await else {
         return;
     };
-    let mut conn = admin_conn().unwrap();
+    let mut conn = admin_conn().await.unwrap();
 
-    // Fresh user; let proxy provision the account + welcome coupon.
     let user_id = Uuid::new_v4();
     sql_query("INSERT INTO auth.users (id) VALUES ($1) ON CONFLICT DO NOTHING")
         .bind::<diesel::sql_types::Uuid, _>(user_id)
         .execute(&mut conn)
+        .await
         .unwrap();
 
     let bal = client.user_balance(user_id).await.unwrap();
@@ -216,7 +200,6 @@ async fn welcome_redeem_flow_via_user_proxy() {
         .unwrap();
     assert!(r1.success);
 
-    // Replay returns the same ledger id.
     let r2 = client
         .user_redeem_coupon(user_id, welcome.coupon_id, key)
         .await
@@ -230,13 +213,12 @@ async fn welcome_redeem_flow_via_user_proxy() {
 #[tokio::test]
 #[serial]
 async fn revoke_unredeemed_coupon_succeeds() {
-    let Some(client) = client() else {
+    let Some(client) = client().await else {
         return;
     };
-    let (_user, account) = fixture_account().expect("fixture");
-    let mut conn = admin_conn().unwrap();
+    let (_user, account) = fixture_account().await.expect("fixture");
+    let mut conn = admin_conn().await.unwrap();
 
-    // Seed a one-off template + instance so we don't touch WELCOME_KHASH.
     let template_code = format!("TEST_REVOKE_{}", Uuid::new_v4().simple());
     sql_query(
         "INSERT INTO wallet.coupon_template (code, label, reward_kind, reward_payload) \
@@ -244,6 +226,7 @@ async fn revoke_unredeemed_coupon_succeeds() {
     )
     .bind::<Text, _>(&template_code)
     .execute(&mut conn)
+    .await
     .unwrap();
 
     #[derive(QueryableByName)]
@@ -258,6 +241,7 @@ async fn revoke_unredeemed_coupon_succeeds() {
     .bind::<diesel::sql_types::Uuid, _>(account)
     .bind::<Text, _>(&template_code)
     .get_result(&mut conn)
+    .await
     .unwrap();
 
     let revoked = client
@@ -266,7 +250,6 @@ async fn revoke_unredeemed_coupon_succeeds() {
         .unwrap();
     assert!(revoked);
 
-    // Second call: already revoked → false, no raise.
     let again = client.revoke_coupon(r.id, None).await.unwrap();
     assert!(!again);
 }
@@ -274,17 +257,14 @@ async fn revoke_unredeemed_coupon_succeeds() {
 #[tokio::test]
 #[serial]
 async fn null_currency_raises_null_argument() {
-    let Some(client) = client() else {
+    let Some(client) = client().await else {
         return;
     };
-    let (_user, account) = fixture_account().expect("fixture");
+    let (_user, account) = fixture_account().await.expect("fixture");
 
-    // We can't pass NULL through our typed CreditRequest, so smoke-test the
-    // SQL-level guard by calling debit with a fresh account that has no
-    // balance row — service_debit raises insufficient_funds (53100).
     let err = client
         .debit(DebitRequest {
-            account_id: Uuid::new_v4(), // non-existent
+            account_id: Uuid::new_v4(),
             currency: CurrencyKind::Credits,
             amount: 1,
             source_kind: SourceKind::Admin,


### PR DESCRIPTION
## Summary
- Migrates `axum-kbve` from sync `diesel` (libpq dynamic link) to `diesel-async 0.9` + `tokio-postgres` backend. Binary is now pure-Rust on the Postgres side — no `pq-sys`, no `libpq.so.5`, no `libssl.so.3` runtime dep.
- All sync-diesel modules (`authentication`, `guild`, `models`, `runes`, `schema`, `spellbook`, `utility`, `entity`, `sys`, `utils::captcha`) move behind a new `legacy-sync-db` Cargo feature. `axum-kbve` only enables `wallet`, so it pulls none of them.
- Wallet client + service ops + proxy ops rewritten to async. User-scoped JWT-claims helper extracted to `wallet::client::set_user_claims` and called inline before each `proxy_wallet_*` call inside a single `AsyncConnection::transaction(async |conn| ...)`.

## Why
- Chiseled runtime image (`chisel-ubuntu-axum`) ships no `libssl.so.3` / `libcrypto.so.3` by design. axum-kbve's libpq dynamic-link chain demanded both → loader failed at startup with `libssl.so.3: cannot open shared object file`.
- Pulling libssl + the entire libpq closure (krb5, ldap, sasl, gnutls, …) into the runtime image was rejected as bloat — the only consumer was the wallet path, and tokio-postgres + rustls covers it natively.

## Verification
```bash
cargo tree -p axum-kbve | grep -E 'pq-sys|libpq|native-tls|openssl-sys'   # → empty
otool -L target/debug/axum-kbve | grep -iE 'libpq|libssl|libcrypto'        # → empty
```
Compiled artifacts include `tokio_postgres` + `diesel_async`. `pq_sys`, `openssl_sys`, `native_tls` not built.

## Test plan
- [ ] CI green on Lint and Test
- [ ] axum-kbve-e2e: container becomes ready, no `libssl.so.3` loader error
- [ ] Wallet endpoints (`/api/v1/wallet/*`) return expected results against a Postgres with the wallet schema applied
- [ ] `WALLET_TEST_DATABASE_URL=... cargo test -p kbve --features wallet -- --include-ignored` passes (integration tests in `wallet/tests.rs`)