### PR TITLE
test(arcade): expand blackjack smoke coverage

### DIFF
--- a/apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { chromium, type Browser, type Page } from 'playwright';
+import { BASE_URL, waitForReady } from './helpers/http';
+
+const BLACKJACK_PATH = '/arcade/blackjack/';
+
+describe('Blackjack arcade smoke', () => {
+	let browser: Browser;
+
+	beforeAll(async () => {
+		await waitForReady();
+		browser = await chromium.launch({ headless: true });
+	});
+
+	afterAll(async () => {
+		await browser?.close();
+	});
+
+	it('serves the blackjack arcade route', async () => {
+		const res = await fetch(`${BASE_URL}${BLACKJACK_PATH}`);
+		expect(res.status).toBe(200);
+		const body = await res.text();
+		expect(body).toContain('data-blackjack-stage');
+		expect(body).toContain('Theater');
+		expect(body).toContain('Fullscreen');
+	});
+
+	it('renders the Phaser canvas and toolbar controls', async () => {
+		const { page, errors } = await openBlackjackPage(browser);
+		try {
+			const canvasBox = await page.locator('canvas').boundingBox();
+			expect(canvasBox).toBeTruthy();
+			expect(canvasBox?.width).toBeGreaterThan(300);
+			expect(canvasBox?.height).toBeGreaterThan(180);
+			expect(
+				await page
+					.locator('[data-blackjack-theater]')
+					.getAttribute('aria-pressed'),
+			).toBe('false');
+			expect(
+				await page
+					.locator('[data-blackjack-fullscreen]')
+					.getAttribute('aria-pressed'),
+			).toBe('false');
+			expect(errors).toEqual([]);
+		} finally {
+			await page.close();
+		}
+	});
+
+	it('accepts a keyboard gameplay flow without page errors', async () => {
+		const { page, errors } = await openBlackjackPage(browser);
+		try {
+			await page.locator('.blackjack-frame').click();
+			for (const key of ['Enter', 'H', 'S', 'Enter', 'Enter']) {
+				await page.keyboard.press(key);
+				await page.waitForTimeout(300);
+			}
+
+			const canvasCount = await page.locator('canvas').count();
+			expect(canvasCount).toBe(1);
+			expect(errors).toEqual([]);
+		} finally {
+			await page.close();
+		}
+	});
+
+	it('toggles theater mode and exits with Escape', async () => {
+		const { page, errors } = await openBlackjackPage(browser);
+		try {
+			const stage = page.locator('[data-blackjack-stage]');
+			const theater = page.locator('[data-blackjack-theater]');
+			await theater.click();
+			await expectClass(stage, 'is-theater', true);
+			expect(await theater.getAttribute('aria-pressed')).toBe('true');
+
+			await page.keyboard.press('Escape');
+			await expectClass(stage, 'is-theater', false);
+			expect(await theater.getAttribute('aria-pressed')).toBe('false');
+			expect(errors).toEqual([]);
+		} finally {
+			await page.close();
+		}
+	});
+
+	it('runs the deal flow with reduced motion enabled', async () => {
+		const page = await browser.newPage({
+			viewport: { width: 1280, height: 900 },
+			deviceScaleFactor: 1,
+		});
+		const errors = attachPageErrorCapture(page);
+		try {
+			await page.emulateMedia({ reducedMotion: 'reduce' });
+			await gotoBlackjack(page);
+			await page.locator('.blackjack-frame').click();
+			await page.keyboard.press('Enter');
+			await page.waitForTimeout(300);
+
+			const canvasBox = await page.locator('canvas').boundingBox();
+			expect(canvasBox).toBeTruthy();
+			expect(errors).toEqual([]);
+		} finally {
+			await page.close();
+		}
+	});
+});
+
+async function openBlackjackPage(browser: Browser) {
+	const page = await browser.newPage({
+		viewport: { width: 1280, height: 900 },
+		deviceScaleFactor: 1,
+	});
+	const errors = attachPageErrorCapture(page);
+	await gotoBlackjack(page);
+	return { page, errors };
+}
+
+async function gotoBlackjack(page: Page) {
+	await page.goto(`${BASE_URL}${BLACKJACK_PATH}`, {
+		waitUntil: 'domcontentloaded',
+		timeout: 30_000,
+	});
+	await page.waitForSelector('canvas', { timeout: 30_000 });
+	await page.waitForTimeout(750);
+}
+
+function attachPageErrorCapture(page: Page): string[] {
+	const errors: string[] = [];
+	page.on('console', (msg) => {
+		const text = msg.text();
+		if (text.includes('GPU stall due to ReadPixels')) return;
+		if (msg.type() === 'error' || msg.type() === 'warning') {
+			errors.push(`${msg.type()}: ${text}`);
+		}
+	});
+	page.on('pageerror', (error) => {
+		errors.push(`pageerror: ${error.message}`);
+	});
+	return errors;
+}
+
+async function expectClass(
+	locator: ReturnType<Page['locator']>,
+	className: string,
+	expected: boolean,
+) {
+	const classes = (await locator.getAttribute('class')) ?? '';
+	expect(classes.split(/\s+/).includes(className)).toBe(expected);
+}

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
@@ -119,6 +119,7 @@ export class BlackjackScene extends Phaser.Scene {
 			shoePosition: SHOE_POSITION,
 			duration: DEAL_ANIMATION.duration,
 			stagger: DEAL_ANIMATION.stagger,
+			enabled: !this.prefersReducedMotion(),
 		});
 		this.hudLayer = this.add.container(0, 0).setDepth(20);
 		this.createHud();
@@ -339,6 +340,13 @@ export class BlackjackScene extends Phaser.Scene {
 	private changeBet(delta: number) {
 		this.state.bet = clampBet(this.state.bet + delta, this.state.bankroll);
 		this.state.message = `Bet set to $${this.state.bet}.`;
+	}
+
+	private prefersReducedMotion(): boolean {
+		return (
+			window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ??
+			false
+		);
 	}
 
 	private render() {

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts
@@ -18,6 +18,7 @@ interface DealerAnimationOptions {
 	};
 	duration: number;
 	stagger: number;
+	enabled: boolean;
 }
 
 export class DealerAnimation {
@@ -47,7 +48,7 @@ export class DealerAnimation {
 		if (playerCards.length > previousPlayerCount) {
 			newCards.push(...playerCards.slice(previousPlayerCount));
 		}
-		if (newCards.length === 0) return;
+		if (!this.options.enabled || newCards.length === 0) return;
 
 		newCards
 			.sort(


### PR DESCRIPTION
## Summary
- Add a Vitest/Chromium blackjack smoke suite under `astro-kbve-e2e`.
- Cover blackjack route HTML, Phaser canvas boot, keyboard gameplay flow, theater mode toggle, and reduced-motion deal flow.
- Add a reduced-motion gate to dealer fly-card animations so users/devices requesting reduced motion skip tween work while state still advances normally.

## Validation
- `pnpm exec prettier --write apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts`
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts` (passes with existing Nx ProjectGraph warning)
- `pnpm exec vitest run apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts`
- `AXUM_PORT=4333 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`