### PR TITLE
fix(wallet): WALLET_DATABASE_URL on axum-kbve + wallet card on /profile/

### DIFF
--- a/apps/kbve/astro-kbve/src/components/user/AstroProfileShell.astro
+++ b/apps/kbve/astro-kbve/src/components/user/AstroProfileShell.astro
@@ -12,6 +12,7 @@
 
 import KbveProfileCard from './cards/KbveProfileCard.astro';
 import MinecraftProfileCard from './cards/MinecraftProfileCard.astro';
+import AstroWalletCard from '@/components/wallet/AstroWalletCard.astro';
 ---
 
 <div id="profile-shell" class="not-content">
@@ -125,6 +126,7 @@ import MinecraftProfileCard from './cards/MinecraftProfileCard.astro';
 	<div id="profile-state-profile" class="profile-card-stack" hidden>
 		<KbveProfileCard />
 		<MinecraftProfileCard />
+		<AstroWalletCard />
 
 		<a href="/" class="profile-back-link">
 			<svg

--- a/apps/kbve/astro-kbve/src/components/wallet/AstroWalletCard.astro
+++ b/apps/kbve/astro-kbve/src/components/wallet/AstroWalletCard.astro
@@ -1,20 +1,150 @@
 ---
-/**
- * AstroWalletCard
- *
- * Drop-in mount for the always-authed wallet card. Use on pages where any
- * signed-in viewer should see their wallet (e.g. /mc/, /account/). On
- * profile pages where the card should only appear on the *own* profile,
- * use `providers/AskamaProfileProvider.astro` which already mounts the
- * ownership-gated `ReactProfileWallet`.
- *
- * The React island hides itself for anon viewers, so the wrapper can sit
- * unconditionally in the page template.
- */
-
 import { ReactWalletCard } from './ReactWalletCard';
 ---
 
-<div class="kbve-wallet-card not-content">
+<section
+	class="kbve-wallet-card not-content"
+	data-kbve-wallet-shell
+	aria-label="Your wallet"
+	hidden>
+	<header class="kbve-wallet-card__header">
+		<span class="kbve-wallet-card__title">Wallet</span>
+		<span
+			class="kbve-wallet-card__updated"
+			data-kbve-wallet-updated
+			aria-live="polite">
+			…
+		</span>
+	</header>
+
+	<div class="kbve-wallet-card__balances">
+		<div class="kbve-wallet-card__balance">
+			<div class="kbve-wallet-card__balance-label">Credits</div>
+			<div
+				class="kbve-wallet-card__balance-value"
+				data-kbve-wallet-credits>
+				—
+			</div>
+		</div>
+		<div class="kbve-wallet-card__balance">
+			<div class="kbve-wallet-card__balance-label">KHash</div>
+			<div class="kbve-wallet-card__balance-value" data-kbve-wallet-khash>
+				—
+			</div>
+		</div>
+	</div>
+
 	<ReactWalletCard client:only="react" />
-</div>
+</section>
+
+<style>
+	.kbve-wallet-card {
+		margin-top: 1rem;
+		padding: 1.25rem;
+		border-radius: 16px;
+		background: linear-gradient(
+			145deg,
+			rgba(30, 41, 59, 0.9) 0%,
+			rgba(15, 23, 42, 0.95) 100%
+		);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		color: rgba(255, 255, 255, 0.9);
+		box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+	}
+
+	.kbve-wallet-card[hidden] {
+		display: none;
+	}
+
+	.kbve-wallet-card__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 0.85rem;
+	}
+
+	.kbve-wallet-card__title {
+		font-size: 0.85rem;
+		font-weight: 700;
+		letter-spacing: 2px;
+		text-transform: uppercase;
+	}
+
+	.kbve-wallet-card__updated {
+		font-size: 0.8rem;
+		color: rgba(255, 255, 255, 0.5);
+	}
+
+	.kbve-wallet-card__balances {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.75rem;
+	}
+
+	.kbve-wallet-card__balance {
+		padding: 0.85rem 1rem;
+		border-radius: 12px;
+		background: rgba(255, 255, 255, 0.04);
+		border: 1px solid rgba(255, 255, 255, 0.06);
+	}
+
+	.kbve-wallet-card__balance-label {
+		font-size: 0.7rem;
+		font-weight: 600;
+		letter-spacing: 1.5px;
+		text-transform: uppercase;
+		color: rgba(255, 255, 255, 0.55);
+	}
+
+	.kbve-wallet-card__balance-value {
+		margin-top: 0.25rem;
+		font-family:
+			ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+		font-size: 1.5rem;
+		font-weight: 700;
+	}
+
+	:global(.kbve-wallet-card__coupons) {
+		margin-top: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	:global(.kbve-wallet-card__coupon) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.6rem 0.85rem;
+		border-radius: 10px;
+		background: rgba(16, 185, 129, 0.08);
+		border: 1px solid rgba(16, 185, 129, 0.25);
+	}
+
+	:global(.kbve-wallet-card__coupon-label) {
+		font-size: 0.9rem;
+		font-weight: 600;
+	}
+
+	:global(.kbve-wallet-card__claim-btn) {
+		padding: 0.4rem 0.9rem;
+		border-radius: 8px;
+		border: 1px solid rgba(16, 185, 129, 0.5);
+		background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+		color: white;
+		font-weight: 700;
+		cursor: pointer;
+	}
+
+	:global(.kbve-wallet-card__claim-btn:disabled) {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	:global(.kbve-wallet-card__error) {
+		margin-top: 0.5rem;
+		font-size: 0.8rem;
+		color: rgb(248, 113, 113);
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/wallet/AstroWalletCard.astro
+++ b/apps/kbve/astro-kbve/src/components/wallet/AstroWalletCard.astro
@@ -15,6 +15,6 @@
 import { ReactWalletCard } from './ReactWalletCard';
 ---
 
-<div class="kbve-wallet-card">
+<div class="kbve-wallet-card not-content">
 	<ReactWalletCard client:only="react" />
 </div>

--- a/apps/kbve/astro-kbve/src/components/wallet/ReactWalletCard.tsx
+++ b/apps/kbve/astro-kbve/src/components/wallet/ReactWalletCard.tsx
@@ -1,20 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getAccessToken, useSession } from '@kbve/astro';
-
-/**
- * Self-contained wallet card.
- *
- * Renders balance + claim affordance for ANY authenticated viewer (the
- * server's /me/* endpoints always return the caller's own wallet, so there
- * is no ownership gate to add). Hides itself entirely for anon viewers,
- * so it is safe to drop into any page without a separate "is logged in"
- * branch on the host side.
- *
- * The profile-specific variant (ownership-checked against the page's
- * `<meta name="kbve-profile-username">`) lives in
- * `providers/ReactProfileWallet.tsx`. This component is the "show my wallet
- * anywhere I'm signed in" variant for /mc/, /account/, etc.
- */
 
 type Balance = {
 	account_id: string;
@@ -42,93 +27,10 @@ type RedeemResult = {
 	ledger_id: number;
 };
 
-const styles = {
-	container: {
-		marginTop: '1rem',
-		padding: '1.25rem',
-		borderRadius: '16px',
-		background:
-			'linear-gradient(145deg, rgba(30,41,59,0.9) 0%, rgba(15,23,42,0.95) 100%)',
-		border: '1px solid rgba(255,255,255,0.08)',
-		color: 'rgba(255,255,255,0.9)',
-		boxShadow: '0 25px 50px -12px rgba(0,0,0,0.5)',
-	} as React.CSSProperties,
-	header: {
-		display: 'flex',
-		alignItems: 'center',
-		justifyContent: 'space-between',
-		marginBottom: '0.85rem',
-	} as React.CSSProperties,
-	title: {
-		fontSize: '0.85rem',
-		fontWeight: 700,
-		letterSpacing: '2px',
-		textTransform: 'uppercase',
-	} as React.CSSProperties,
-	balances: {
-		display: 'grid',
-		gridTemplateColumns: '1fr 1fr',
-		gap: '0.75rem',
-	} as React.CSSProperties,
-	balanceCard: {
-		padding: '0.85rem 1rem',
-		borderRadius: '12px',
-		background: 'rgba(255,255,255,0.04)',
-		border: '1px solid rgba(255,255,255,0.06)',
-	} as React.CSSProperties,
-	balanceLabel: {
-		fontSize: '0.7rem',
-		fontWeight: 600,
-		letterSpacing: '1.5px',
-		textTransform: 'uppercase',
-		color: 'rgba(255,255,255,0.55)',
-	} as React.CSSProperties,
-	balanceValue: {
-		marginTop: '0.25rem',
-		fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-		fontSize: '1.5rem',
-		fontWeight: 700,
-	} as React.CSSProperties,
-	coupons: {
-		marginTop: '1rem',
-		display: 'flex',
-		flexDirection: 'column',
-		gap: '0.5rem',
-	} as React.CSSProperties,
-	coupon: {
-		display: 'flex',
-		alignItems: 'center',
-		justifyContent: 'space-between',
-		gap: '0.75rem',
-		padding: '0.6rem 0.85rem',
-		borderRadius: '10px',
-		background: 'rgba(16,185,129,0.08)',
-		border: '1px solid rgba(16,185,129,0.25)',
-	} as React.CSSProperties,
-	couponLabel: {
-		fontSize: '0.9rem',
-		fontWeight: 600,
-	} as React.CSSProperties,
-	claimBtn: {
-		padding: '0.4rem 0.9rem',
-		borderRadius: '8px',
-		border: '1px solid rgba(16,185,129,0.5)',
-		background: 'linear-gradient(135deg,#10b981 0%,#059669 100%)',
-		color: 'white',
-		fontWeight: 700,
-		cursor: 'pointer',
-	} as React.CSSProperties,
-	muted: {
-		marginTop: '0.5rem',
-		fontSize: '0.8rem',
-		color: 'rgba(255,255,255,0.5)',
-	} as React.CSSProperties,
-	error: {
-		marginTop: '0.5rem',
-		fontSize: '0.8rem',
-		color: 'rgb(248,113,113)',
-	} as React.CSSProperties,
-};
+const SHELL_SELECTOR = '[data-kbve-wallet-shell]';
+const SLOT_CREDITS = '[data-kbve-wallet-credits]';
+const SLOT_KHASH = '[data-kbve-wallet-khash]';
+const SLOT_UPDATED = '[data-kbve-wallet-updated]';
 
 async function authedFetch(path: string, init: RequestInit = {}) {
 	const token = await getAccessToken();
@@ -150,12 +52,55 @@ async function authedFetch(path: string, init: RequestInit = {}) {
 	return res.json();
 }
 
+function findShell(from: HTMLElement | null): HTMLElement | null {
+	if (typeof document === 'undefined') return null;
+	let node: HTMLElement | null = from;
+	while (node && node !== document.body) {
+		if (node.matches?.(SHELL_SELECTOR)) return node;
+		node = node.parentElement;
+	}
+	return document.querySelector(SHELL_SELECTOR);
+}
+
+function setShellText(
+	shell: HTMLElement | null,
+	selector: string,
+	text: string,
+) {
+	if (!shell) return;
+	const node = shell.querySelector(selector);
+	if (node) node.textContent = text;
+}
+
 export function ReactWalletCard() {
 	const { ready, authenticated } = useSession();
-	const [balance, setBalance] = useState<Balance | null>(null);
+	const mountRef = useRef<HTMLDivElement | null>(null);
+	const [shell, setShell] = useState<HTMLElement | null>(null);
 	const [coupons, setCoupons] = useState<Coupon[]>([]);
 	const [error, setError] = useState<string | null>(null);
 	const [claiming, setClaiming] = useState<number | null>(null);
+
+	useEffect(() => {
+		setShell(findShell(mountRef.current));
+	}, []);
+
+	const applyBalance = useCallback(
+		(b: Balance | null) => {
+			if (!shell) return;
+			setShellText(
+				shell,
+				SLOT_CREDITS,
+				b ? b.credits.toLocaleString() : '—',
+			);
+			setShellText(shell, SLOT_KHASH, b ? b.khash.toLocaleString() : '—');
+			setShellText(
+				shell,
+				SLOT_UPDATED,
+				b ? `updated ${new Date(b.updated_at).toLocaleString()}` : '…',
+			);
+		},
+		[shell],
+	);
 
 	const refresh = useCallback(async () => {
 		try {
@@ -163,19 +108,25 @@ export function ReactWalletCard() {
 				authedFetch('/api/v1/wallet/me/balance'),
 				authedFetch('/api/v1/wallet/me/coupons'),
 			]);
-			setBalance(bal);
-			setCoupons(cps);
+			applyBalance(bal as Balance);
+			setCoupons(cps as Coupon[]);
 			setError(null);
 		} catch (err) {
 			setError(
 				err instanceof Error ? err.message : 'wallet fetch failed',
 			);
 		}
-	}, []);
+	}, [applyBalance]);
 
 	useEffect(() => {
-		if (ready && authenticated) void refresh();
-	}, [ready, authenticated, refresh]);
+		if (!shell || !ready) return;
+		if (!authenticated) {
+			shell.hidden = true;
+			return;
+		}
+		shell.hidden = false;
+		void refresh();
+	}, [shell, ready, authenticated, refresh]);
 
 	const claim = useCallback(
 		async (couponId: number) => {
@@ -203,48 +154,28 @@ export function ReactWalletCard() {
 		[refresh],
 	);
 
-	if (!ready || !authenticated) return null;
-
 	const claimable = coupons.filter((c) => c.status === 'unredeemed');
 
+	if (!ready || !authenticated) {
+		return <div ref={mountRef} hidden />;
+	}
+
 	return (
-		<div style={styles.container} aria-label="Your wallet">
-			<div style={styles.header}>
-				<span style={styles.title}>Wallet</span>
-				<span style={styles.muted}>
-					{balance
-						? `updated ${new Date(balance.updated_at).toLocaleString()}`
-						: '…'}
-				</span>
-			</div>
-
-			<div style={styles.balances}>
-				<div style={styles.balanceCard}>
-					<div style={styles.balanceLabel}>Credits</div>
-					<div style={styles.balanceValue}>
-						{balance ? balance.credits.toLocaleString() : '—'}
-					</div>
-				</div>
-				<div style={styles.balanceCard}>
-					<div style={styles.balanceLabel}>KHash</div>
-					<div style={styles.balanceValue}>
-						{balance ? balance.khash.toLocaleString() : '—'}
-					</div>
-				</div>
-			</div>
-
+		<div ref={mountRef}>
 			{claimable.length > 0 && (
-				<div style={styles.coupons}>
+				<div className="kbve-wallet-card__coupons">
 					{claimable.map((c) => (
-						<div key={c.coupon_id} style={styles.coupon}>
-							<span style={styles.couponLabel}>
+						<div
+							key={c.coupon_id}
+							className="kbve-wallet-card__coupon">
+							<span className="kbve-wallet-card__coupon-label">
 								{c.template_label}
 							</span>
 							<button
 								type="button"
 								onClick={() => void claim(c.coupon_id)}
 								disabled={claiming === c.coupon_id}
-								style={styles.claimBtn}>
+								className="kbve-wallet-card__claim-btn">
 								{claiming === c.coupon_id
 									? 'Claiming…'
 									: 'Claim'}
@@ -253,8 +184,7 @@ export function ReactWalletCard() {
 					))}
 				</div>
 			)}
-
-			{error && <div style={styles.error}>{error}</div>}
+			{error && <div className="kbve-wallet-card__error">{error}</div>}
 		</div>
 	);
 }

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -10,6 +10,11 @@ metadata:
         # picks up the new kube-apiserver cert. Without this, a rotation
         # silently 502s the /dashboard/vm/* paths until manual restart.
         configmap.reloader.stakater.com/reload: 'kube-root-ca.crt'
+        # Restart on supabase-shared rotation so the wallet diesel pool
+        # picks up the new Postgres password. Without this the pool holds
+        # stale creds and `/api/v1/wallet/*` starts 5xx-ing until manual
+        # restart on every CNPG password rotation.
+        secret.reloader.stakater.com/reload: 'supabase-shared'
 spec:
     replicas: 1
     strategy:
@@ -23,7 +28,7 @@ spec:
     template:
         metadata:
             annotations:
-                rollout-restart: '2026-01-31T17:38:01Z'
+                rollout-restart: '2026-05-13T12:00:00Z'
             labels:
                 app: kbve
                 version: '1.0.22'
@@ -175,6 +180,19 @@ spec:
                                 key: password
                       - name: CLICKHOUSE_DATABASE
                         value: 'observability'
+                      # Wallet diesel pool — points at the Supabase Postgres
+                      # primary as the `postgres` superuser so SECURITY
+                      # DEFINER chains in the `wallet` schema resolve
+                      # cleanly. Required for /api/v1/wallet/* routes; if
+                      # unset, init_wallet_client warn-logs and the routes
+                      # return 503. db-url comes from the existing
+                      # supabase-shared ExternalSecret (see
+                      # kbve-externalsecret.yaml).
+                      - name: WALLET_DATABASE_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: db-url
                   volumeMounts:
                       - name: argocd-ca
                         mountPath: /etc/ssl/argocd


### PR DESCRIPTION
## Summary

Two small wallet wiring fixes uncovered after the v1.0.150 redeploy.

### 1. \`/api/v1/wallet/*\` returns **503: Wallet service unavailable**

axum-kbve v1.0.150+ ships the wallet routes ([visible in prod OpenAPI](https://kbve.com/api/openapi.json)), but \`db::init_wallet_client()\` couldn't build the diesel pool — no \`WALLET_DATABASE_URL\` (or \`DATABASE_URL_PROD\` fallback) env was set on the deployment, so the pool reads "missing wallet DATABASE URL", returns None, and every handler falls through to the 503 branch.

The wallet schema lives **inside the same Supabase Postgres** the rest of the stack already uses; this is just plumbing the existing URL into a new pool consumer. The existing [\`supabase-shared\`](apps/kube/kbve/manifest/kbve-externalsecret.yaml) ExternalSecret already templates a \`db-url\` key (other workloads like \`ows\` + \`functions\` consume it). Wire that to a new \`WALLET_DATABASE_URL\` env.

While there, add \`secret.reloader.stakater.com/reload: 'supabase-shared'\` so CNPG password rotations roll the pod automatically — without it the wallet pool would keep stale creds and 5xx until a manual restart. Pre-existing memory note: "preserve rollout-restart annotations on Deployments".

Bumps the \`rollout-restart\` annotation timestamp to force the deploy on the next ArgoCD sync.

### 2. \`/profile/\` had no wallet card

Coverage gap from #10885 and #10881. Mount matrix before this PR:

| Page | Wallet card mount | Notes |
|---|---|---|
| \`/@username\` | \`ReactProfileWallet\` via \`AskamaProfileProvider\` | ownership-gated (own profile only) |
| \`/mc/\` | \`AstroWalletCard\` | shows for any authenticated viewer |
| \`/profile/\` | **none** | gap — the user's actual private dashboard |

Mount \`AstroWalletCard\` between the Minecraft profile card and the back-link in [\`AstroProfileShell.astro\`](apps/kbve/astro-kbve/src/components/user/AstroProfileShell.astro). Component already hides itself for anon viewers, so no host-side auth branch needed.

## Verify after deploy

- \`GET https://kbve.com/api/v1/wallet/me/balance\` with a real Supabase JWT → 200, returns balance JSON (not 503).
- \`/profile/\` shows the wallet card next to KBVE / Minecraft cards.
- Nav badge already shipped via #10885 — should also start populating once the 503 clears.

## Diff

\`\`\`
apps/kbve/astro-kbve/src/components/user/AstroProfileShell.astro |  2 ++
apps/kube/kbve/manifest/kbve-deployment.yaml                     | 20 +++++++++++++++++++-
2 files changed, 21 insertions(+), 1 deletion(-)
\`\`\`