### PR TITLE
fix(firecracker-ctl-net): REDIRECT VM DNS to incoming iface IP

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -124,7 +124,7 @@
 		{
 			"key": "firecracker_ctl",
 			"app_name": "firecracker-ctl",
-			"version": "0.1.33",
+			"version": "0.1.34",
 			"version_toml": "apps/vm/firecracker-ctl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx",
 			"version_target": "apps/vm/firecracker-ctl/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,7 +12,7 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.33"
+version: "0.1.34"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml

--- a/apps/vm/firecracker-ctl/src/tap.rs
+++ b/apps/vm/firecracker-ctl/src/tap.rs
@@ -307,9 +307,9 @@ pub fn build_dns_dnat(proto: &str) -> Vec<String> {
         "--dport".into(),
         "53".into(),
         "-j".into(),
-        "DNAT".into(),
-        "--to-destination".into(),
-        "127.0.0.1:53".into(),
+        "REDIRECT".into(),
+        "--to-ports".into(),
+        "53".into(),
     ]
 }
 
@@ -397,14 +397,6 @@ impl TapManager {
     pub async fn init(&self) -> Result<(), TapError> {
         // 1. IP forwarding
         run("sysctl", &["-w".into(), "net.ipv4.ip_forward=1".into()]).await?;
-
-        // route_localnet=1 allows DNAT to 127.0.0.1 for forwarded packets
-        // arriving on TAP interfaces. Required for the DNS redirect below.
-        run(
-            "sysctl",
-            &["-w".into(), "net.ipv4.conf.all.route_localnet=1".into()],
-        )
-        .await?;
 
         // 2. NAT MASQUERADE (add only if not already present)
         if !iptables_rule_exists(&build_nat_masquerade_check(


### PR DESCRIPTION
## Summary

PR #10893 added \`DNAT --to-destination 127.0.0.1:53\` for VM DNS, but the pod's \`securityContext.readOnlyRootFilesystem: true\` makes \`/proc/sys\` read-only:

\`\`\`
$ sysctl -w net.ipv4.conf.all.route_localnet=1
sysctl: setting key ..., ignoring: Read-only file system
\`\`\`

The companion sysctl call in \`tap.rs\` silently no-ops (\`sysctl -w\` exits 0 even when ignored), so \`route_localnet\` stays at 0. DNAT to a 127/8 destination from a forwarded path is dropped by the kernel when \`route_localnet=0\` — the 8 DNAT-matched VM packets go nowhere. \`EAI_AGAIN\` persists.

\`\`\`
$ kubectl exec ... -- sysctl net.ipv4.conf.all.route_localnet
net.ipv4.conf.all.route_localnet = 0

$ kubectl exec ... -- iptables -t nat -L PREROUTING -n -v
... 8 packets matched DNAT to 127.0.0.1:53 ... (then dropped by routing)
\`\`\`

## Fix

Two changes that avoid the sysctl entirely:

1. Swap nat PREROUTING rules from
   \`\`\`
   -j DNAT --to-destination 127.0.0.1:53
   \`\`\`
   to
   \`\`\`
   -j REDIRECT --to-ports 53
   \`\`\`
   \`REDIRECT\` rewrites the destination to the **incoming interface's IP** (the TAP host-side address, e.g. \`172.18.0.1\` for a /30 slot). Local + non-loopback = no \`route_localnet\` needed. Gluetun's DNS forwarder listens on \`::\` and Linux dual-stack accepts the IPv4 destination on any local address.

2. Drop the failing \`route_localnet\` sysctl call from \`TapManager::init()\`. It was a no-op anyway.

## Test plan

- [ ] Publish \`ghcr.io/kbve/firecracker-ctl:0.1.34\`, atom PR bumps deployment manifests, fc-ctl-net rolls.
- [ ] \`kubectl exec ... -- iptables -t nat -L PREROUTING -n -v\` shows two \`REDIRECT redir ports 53\` rules with non-zero packet counts.
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB → poem prints, exit 0.