### PR TITLE
perf(ci): registry buildx cache + mold linker; prep valkey for sccache

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -81,7 +81,10 @@ jobs:
             - name: Setup Docker Buildx
               uses: docker/setup-buildx-action@v4
               with:
-                  driver: docker
+                  driver: docker-container
+                  driver-opts: |
+                      image=moby/buildkit:v0.24.0
+                      network=host
 
             - name: Login to GHCR
               uses: docker/login-action@v4

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -120,6 +120,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
 # sccache is incompatible with incremental compilation
 ENV CARGO_INCREMENTAL=0
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
@@ -134,6 +135,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
 ENV CARGO_INCREMENTAL=0
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 
 COPY --from=builder-deps /app/target target
 COPY --from=builder-deps /usr/local/cargo /usr/local/cargo

--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -102,7 +102,7 @@
 				},
 				"ci": {
 					"commands": [
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile .",
+						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile --cache-from=type=registry,ref=ghcr.io/kbve/kbve:buildcache --cache-to=type=registry,ref=ghcr.io/kbve/kbve:buildcache,mode=max,image-manifest=true,oci-mediatypes=true .",
 						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION\""
 					]
 				}

--- a/apps/kube/github/runners/manifests/runner-networkpolicy.yaml
+++ b/apps/kube/github/runners/manifests/runner-networkpolicy.yaml
@@ -1,7 +1,7 @@
 # Egress restriction for self-hosted GitHub Actions runners
-# Allows only the ports needed for CI/CD (DNS, HTTPS, HTTP, SSH)
+# Allows only the ports needed for CI/CD (DNS, HTTPS, HTTP, SSH, sccache).
 # Blocks direct access to internal cluster services on non-standard ports
-# (e.g., PostgreSQL 5432, Redis 6379, RCON 25575)
+# (e.g., PostgreSQL 5432, Redis on non-sccache services, RCON 25575).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -29,4 +29,13 @@ spec:
         # SSH (git clone via SSH)
         - ports:
               - port: 22
+                protocol: TCP
+        # sccache → Valkey (port 6379, scoped to valkey ns only).
+        # Pairs with valkey-allow-arc-runners ingress policy in valkey ns.
+        - to:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: valkey
+          ports:
+              - port: 6379
                 protocol: TCP

--- a/apps/kube/valkey/manifests/kustomization.yaml
+++ b/apps/kube/valkey/manifests/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
     - valkey-auth-sealedsecret.yaml
+    - valkey-networkpolicy.yaml

--- a/apps/kube/valkey/manifests/valkey-networkpolicy.yaml
+++ b/apps/kube/valkey/manifests/valkey-networkpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: valkey-allow-arc-runners
+    namespace: valkey
+spec:
+    podSelector:
+        matchLabels:
+            app.kubernetes.io/name: valkey
+    policyTypes:
+        - Ingress
+    ingress:
+        - from:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: arc-runners
+          ports:
+              - port: 6379
+                protocol: TCP

--- a/apps/kube/valkey/manifests/values.yaml
+++ b/apps/kube/valkey/manifests/values.yaml
@@ -20,18 +20,27 @@ auth:
 
 dataStorage:
     enabled: true
-    requestedSize: 8Gi
+    # Sized for sccache Rust object cache (Bevy + axum-kbve workspace).
+    # Cold-build populates ~2-5GB of cache entries; 32Gi leaves headroom
+    # for additional projects + LRU churn.
+    requestedSize: 32Gi
     className: longhorn
     accessModes:
         - ReadWriteOnce
 
 resources:
     requests:
-        memory: '256Mi'
-        cpu: '100m'
+        memory: '1Gi'
+        cpu: '200m'
     limits:
-        memory: '512Mi'
-        cpu: '500m'
+        memory: '4Gi'
+        cpu: '1000m'
+
+# maxmemory caps in-memory working set under the pod limit so OOMKiller
+# doesn't fire; allkeys-lru evicts oldest sccache entries first.
+valkeyConfig: |-
+    maxmemory 3gb
+    maxmemory-policy allkeys-lru
 
 metrics:
     enabled: true


### PR DESCRIPTION
## Summary

Cuts the axum-kbve docker-test job (currently ~60min, 48min of which is release-mode cargo builds inside a fresh BuildKit container on an ephemeral ARC runner pod). Targets three independent wins this PR and stages the infra for sccache → Valkey in a follow-up.

- **Registry buildx cache** — `setup-buildx-action` driver flipped from \`docker\` → \`docker-container\` (the in-tree \`docker\` driver cannot export registry cache). The Nx \`axum-kbve:container:ci\` target now passes \`cache-from\`/\`cache-to=type=registry,ref=ghcr.io/kbve/kbve:buildcache\` (\`mode=max\`, OCI manifest + media types). Dependency and foundation stages survive runner recycles instead of cold-rebuilding every job.
- **mold linker** — \`RUSTFLAGS=-C link-arg=-fuse-ld=mold\` set on \`builder-deps\` and \`foundation\` stages of \`apps/kbve/axum-kbve/Dockerfile\`. mold is already in the shared \`chisel-ubuntu-axum:24.04-builder\` base image, so no base-image rebuild required. \`builder\` (stage F) inherits via \`FROM foundation\`.
- **Valkey resource bump + maxmemory cap** — \`apps/kube/valkey/manifests/values.yaml\` pod limits 512Mi → 4Gi, requests 256Mi → 1Gi, PVC 8Gi → 32Gi. Adds \`valkeyConfig: maxmemory 3gb / allkeys-lru\` so the working set stays under the pod limit. Sized for a cold Bevy + axum-kbve sccache cache (~2–5GB), with LRU churn headroom.
- **NetworkPolicy plumbing** — new \`valkey-allow-arc-runners\` ingress in the \`valkey\` namespace; \`arc-runner-egress\` gets a scoped egress rule to the \`valkey\` namespace on 6379. Pre-staged so the sccache Dockerfile wiring lands cleanly in the follow-up PR without re-opening the runner egress baseline.

## What is intentionally not in this PR

- **sccache → Valkey Dockerfile wiring.** Decided in scoping that we'd land infra first (Valkey resources + reachability) so the rollout can be verified independently of build-image changes. Follow-up PR will add \`SCCACHE_REDIS\` / build-secret password / \`RUSTC_WRAPPER\` to the axum-kbve Dockerfile builder stages.

## Why this should be safe

- Registry cache is additive: if \`ghcr.io/kbve/kbve:buildcache\` does not exist yet, buildx \`cache-from\` is a miss and the build proceeds normally — the first run on this branch seeds the cache, subsequent runs hit it.
- mold is a drop-in linker; rustc keeps using its default \`cc\` toolchain and just passes \`-fuse-ld=mold\` through. Same final binary contents.
- Valkey bump goes via ArgoCD self-heal as a chart \`values.yaml\` change; rollout is a single pod recycle. The new NetworkPolicy on the valkey side defaults closed for unrelated traffic only when no other Ingress policy exists in the namespace — there is none today, so it acts as additive ingress for arc-runners. The arc-runner-egress addition is scoped to namespaceSelector \`kubernetes.io/metadata.name: valkey\`.

## Test plan

- [ ] PR CI: confirm \`docker-test-app.yml\` succeeds end-to-end with the new buildx driver + registry cache flags (first run = cache miss, expect roughly previous-baseline runtime).
- [ ] Re-run the job a second time on the same branch and compare the \`Nx e2e axum-kbve-e2e\` step duration — expect a notable drop on the cargo stages (\`cargo chef cook\` + \`foundation\` + \`builder\`).
- [ ] Verify \`ghcr.io/kbve/kbve:buildcache\` appears in GHCR after the first successful run.
- [ ] Confirm Valkey pod restarts cleanly via ArgoCD with new resource limits / PVC resize (Longhorn online expand should handle 8Gi → 32Gi without remount).
- [ ] Confirm arc-runner pods can still resolve and reach external HTTPS / GHCR after the egress policy edit (no DNS or 443 regression).