### PR TITLE
perf(arcade): reduce blackjack render allocations

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
@@ -77,7 +77,10 @@ interface ButtonView {
 }
 
 interface PlacementCacheEntry {
-	signature: string;
+	cards: Card[];
+	centerX: number;
+	y: number;
+	hideHole: boolean;
 	placements: CardPlacement[];
 }
 
@@ -388,9 +391,10 @@ export class BlackjackScene extends Phaser.Scene {
 		hideHole: boolean,
 		owner: HandOwner,
 	): CardPlacement[] {
-		const signature = `${centerX}:${y}:${hideHole}:${cards.join(',')}`;
 		const cached = this.placementCache.get(owner);
-		if (cached?.signature === signature) return cached.placements;
+		if (this.matchesPlacementCache(cached, cards, centerX, y, hideHole)) {
+			return cached.placements;
+		}
 
 		const totalWidth =
 			cards.length * CARD_SIZE.width + Math.max(0, cards.length - 1) * 18;
@@ -410,8 +414,37 @@ export class BlackjackScene extends Phaser.Scene {
 			});
 			x += CARD_SIZE.width + 18;
 		});
-		this.placementCache.set(owner, { signature, placements });
+		this.placementCache.set(owner, {
+			cards: cards.slice(),
+			centerX,
+			y,
+			hideHole,
+			placements,
+		});
 		return placements;
+	}
+
+	private matchesPlacementCache(
+		cached: PlacementCacheEntry | undefined,
+		cards: readonly Card[],
+		centerX: number,
+		y: number,
+		hideHole: boolean,
+	): cached is PlacementCacheEntry {
+		if (
+			!cached ||
+			cached.centerX !== centerX ||
+			cached.y !== y ||
+			cached.hideHole !== hideHole ||
+			cached.cards.length !== cards.length
+		) {
+			return false;
+		}
+
+		for (let i = 0; i < cards.length; i++) {
+			if (cached.cards[i] !== cards[i]) return false;
+		}
+		return true;
 	}
 
 	private drawHand(

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts
@@ -41,6 +41,8 @@ export class DealerAnimation {
 		this.previousDealerCardCount = dealerCards.length;
 		this.previousPlayerCardCount = playerCards.length;
 
+		if (!this.options.enabled) return;
+
 		const newCards: CardPlacement[] = [];
 		if (dealerCards.length > previousDealerCount) {
 			newCards.push(...dealerCards.slice(previousDealerCount));
@@ -48,7 +50,7 @@ export class DealerAnimation {
 		if (playerCards.length > previousPlayerCount) {
 			newCards.push(...playerCards.slice(previousPlayerCount));
 		}
-		if (!this.options.enabled || newCards.length === 0) return;
+		if (newCards.length === 0) return;
 
 		newCards
 			.sort(


### PR DESCRIPTION
## Summary
- Replace per-render hand placement string signatures with a value-based placement cache.
- Snapshot card ids only when a hand placement changes, avoiding `cards.join(',')` allocation on every render.
- Skip fly-card array/sort work entirely when dealer animations are disabled by reduced-motion settings.

## Validation
- `pnpm exec prettier --write apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts`
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts` (passes with existing Nx ProjectGraph warning)
- `pnpm exec vitest run apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts`
- `AXUM_PORT=4334 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`