### PR TITLE
perf(ci): wire sccache → Valkey for axum-kbve docker builds

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -128,6 +128,13 @@ jobs:
               if: ${{ inputs.install_playwright }}
               run: pnpm exec playwright install --with-deps chromium
 
+            # VALKEY_PASSWORD is injected into the runner container's
+            # process env by the actions-runner-controller values.yaml
+            # (sourced from the valkey-sccache-credentials Secret synced
+            # by ExternalSecret). It auto-inherits into `run:` steps,
+            # so no explicit env entry needed — axum-kbve's container:ci
+            # command picks it up via `${VALKEY_PASSWORD:+--secret ...}`
+            # and only attaches the build secret when present.
             - name: Nx e2e ${{ inputs.project }}
               env:
                   BUILDKIT_PROGRESS: plain

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -130,7 +130,17 @@ COPY --from=planner /app/packages packages
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
-    cargo chef cook --release --recipe-path recipe.json -p axum-kbve
+    --mount=type=secret,id=valkey_password,env=SCCACHE_REDIS_PASSWORD,required=false \
+    if [ -n "${SCCACHE_REDIS_PASSWORD:-}" ]; then \
+        export SCCACHE_REDIS_ENDPOINT=tcp://valkey.valkey.svc.cluster.local:6379 \
+            SCCACHE_REDIS_USERNAME=default \
+            SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
+        echo "sccache: Redis backend enabled"; \
+    else \
+        echo "sccache: Redis password not provided, falling back to local disk cache"; \
+    fi && \
+    cargo chef cook --release --recipe-path recipe.json -p axum-kbve && \
+    (sccache --show-stats || true)
 
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
@@ -159,7 +169,14 @@ COPY packages/rust/bevy/bevy_tasker packages/rust/bevy/bevy_tasker
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
-    cargo build --release -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker
+    --mount=type=secret,id=valkey_password,env=SCCACHE_REDIS_PASSWORD,required=false \
+    if [ -n "${SCCACHE_REDIS_PASSWORD:-}" ]; then \
+        export SCCACHE_REDIS_ENDPOINT=tcp://valkey.valkey.svc.cluster.local:6379 \
+            SCCACHE_REDIS_USERNAME=default \
+            SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
+    fi && \
+    cargo build --release -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker && \
+    (sccache --show-stats || true)
 
 # ============================================================================
 # [STAGE F] - Build Application
@@ -192,7 +209,14 @@ RUN cp -a /app/apps/kbve/axum-kbve/templates/dist/askama/. /app/apps/kbve/axum-k
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    --mount=type=secret,id=valkey_password,env=SCCACHE_REDIS_PASSWORD,required=false \
+    if [ -n "${SCCACHE_REDIS_PASSWORD:-}" ]; then \
+        export SCCACHE_REDIS_ENDPOINT=tcp://valkey.valkey.svc.cluster.local:6379 \
+            SCCACHE_REDIS_USERNAME=default \
+            SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
+    fi && \
     cargo build --release -p axum-kbve --features jemalloc && \
+    (sccache --show-stats || true) && \
     strip target/release/axum-kbve
 
 # ============================================================================

--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -102,7 +102,7 @@
 				},
 				"ci": {
 					"commands": [
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile --cache-from=type=registry,ref=ghcr.io/kbve/kbve:buildcache --cache-to=type=registry,ref=ghcr.io/kbve/kbve:buildcache,mode=max,image-manifest=true,oci-mediatypes=true .",
+						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/kbve:latest --file apps/kbve/axum-kbve/Dockerfile --cache-from=type=registry,ref=ghcr.io/kbve/kbve:buildcache --cache-to=type=registry,ref=ghcr.io/kbve/kbve:buildcache,mode=max,image-manifest=true,oci-mediatypes=true ${VALKEY_PASSWORD:+--secret id=valkey_password,env=VALKEY_PASSWORD} .",
 						"VERSION=$(grep '^version' apps/kbve/axum-kbve/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve:latest kbve/kbve:$VERSION && echo \"Tagged kbve/kbve:$VERSION\""
 					]
 				}

--- a/apps/kube/github/runners/manifests/kustomization.yaml
+++ b/apps/kube/github/runners/manifests/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
     - ows-server-build-pvc.yaml
     - cache-cleanup-cronjob.yaml
     - registry-mirror.yaml
+    - valkey-sccache-externalsecret.yaml

--- a/apps/kube/github/runners/manifests/valkey-sccache-externalsecret.yaml
+++ b/apps/kube/github/runners/manifests/valkey-sccache-externalsecret.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: valkey-sccache-external-secrets
+    namespace: arc-runners
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: valkey-remote-store
+    namespace: arc-runners
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: valkey
+            auth:
+                serviceAccount:
+                    name: valkey-sccache-external-secrets
+                    namespace: arc-runners
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: valkey-sccache-credentials
+    namespace: arc-runners
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: valkey-remote-store
+        kind: SecretStore
+    target:
+        name: valkey-sccache-credentials
+        creationPolicy: Owner
+    data:
+        - secretKey: VALKEY_PASSWORD
+          remoteRef:
+              key: valkey-auth
+              property: valkey-password

--- a/apps/kube/github/runners/manifests/values-kbve.yaml
+++ b/apps/kube/github/runners/manifests/values-kbve.yaml
@@ -59,6 +59,15 @@ template:
                     value: tcp://localhost:2376
                   - name: RUNNER_ALLOW_RUNASROOT
                     value: '1'
+                  # See values.yaml for rationale; mirrored so the kbve
+                  # canary scale-set picks up the same sccache plumbing
+                  # once workflows migrate to runs-on: arc-runner-set-kbve.
+                  - name: VALKEY_PASSWORD
+                    valueFrom:
+                        secretKeyRef:
+                            name: valkey-sccache-credentials
+                            key: VALKEY_PASSWORD
+                            optional: true
               resources:
                   limits:
                       cpu: '12'

--- a/apps/kube/github/runners/manifests/values.yaml
+++ b/apps/kube/github/runners/manifests/values.yaml
@@ -63,6 +63,17 @@ template:
                     value: tcp://localhost:2376
                   - name: RUNNER_ALLOW_RUNASROOT
                     value: '1'
+                  # Surfaced for sccache → Valkey wiring in axum-kbve
+                  # Dockerfile (passed to docker buildx as a build secret,
+                  # never written into image layers or registry cache).
+                  # ExternalSecret valkey-sccache-credentials syncs the
+                  # password from valkey-auth in the valkey namespace.
+                  - name: VALKEY_PASSWORD
+                    valueFrom:
+                        secretKeyRef:
+                            name: valkey-sccache-credentials
+                            key: VALKEY_PASSWORD
+                            optional: true
               resources:
                   limits:
                       cpu: '12'

--- a/apps/kube/valkey/manifests/kustomization.yaml
+++ b/apps/kube/valkey/manifests/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
     - valkey-auth-sealedsecret.yaml
     - valkey-networkpolicy.yaml
+    - valkey-sccache-rbac.yaml

--- a/apps/kube/valkey/manifests/valkey-sccache-rbac.yaml
+++ b/apps/kube/valkey/manifests/valkey-sccache-rbac.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: valkey-auth-reader
+    namespace: valkey
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['valkey-auth']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: arc-runners-read-valkey-auth
+    namespace: valkey
+subjects:
+    - kind: ServiceAccount
+      name: valkey-sccache-external-secrets
+      namespace: arc-runners
+roleRef:
+    kind: Role
+    name: valkey-auth-reader
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary

Follow-up to #10907. Wires the sccache Redis backend on top of the registry buildx cache + mold linker landed previously, so cargo's per-crate object cache survives across ARC runner pod recycles instead of repopulating on every CI run.

## How the secret flows

\`valkey-auth.valkey-password\` (valkey ns, sealed)
  → ExternalSecret (arc-runners ns) → \`valkey-sccache-credentials\` Secret
  → \`VALKEY_PASSWORD\` env on the runner container (k8s pod env, via Helm values)
  → process-env inheritance into the \`pnpm nx e2e\` shell
  → \`\${VALKEY_PASSWORD:+--secret id=valkey_password,env=VALKEY_PASSWORD}\` in the Nx \`container:ci\` command
  → \`--mount=type=secret,id=valkey_password,env=SCCACHE_REDIS_PASSWORD,required=false\` on each cargo \`RUN\` in [apps/kbve/axum-kbve/Dockerfile](apps/kbve/axum-kbve/Dockerfile)
  → sccache opens a Redis connection to \`valkey.valkey.svc.cluster.local:6379\` for the duration of that single RUN.

Password never lands in:
- Image layers (BuildKit \`type=secret\` mount is tmpfs, not committed)
- The registry-cache export at \`ghcr.io/kbve/kbve:buildcache\` (built with \`mode=max\` but type=secret content is explicitly excluded)
- Process env outside the cargo RUN (each \`RUN\` is its own ephemeral container)
- CI logs (only the inline \`echo\` and \`sccache --show-stats\` are emitted)

## What's not in this PR (deliberate)

- **\`runner-networkpolicy.yaml\` is still not in the arc-runners kustomization.** Activating it now would gate \`ci-ue-{mac,win}-setup.yml\` egress to \`file-server.angelscript.svc:8080\` and break the UE pipeline. The netpol stays as latent file content in the repo; runner egress remains unrestricted today, which is what's letting sccache hit valkey:6379. A separate PR can activate the netpol after auditing the full egress matrix.
- **arc-runner-set-kbve canary** picks up the same wiring via \`values-kbve.yaml\` so it works the moment workflows flip to \`runs-on: arc-runner-set-kbve\`. No additional change needed there.

## Why \`required=false\` and the \`\${VALKEY_PASSWORD:+…}\` guard

Local dev (\`./kbve.sh -nx axum-kbve:containerx\`) and the \`production\` Nx configuration never pass a build secret to buildx. Without the conditional, the Dockerfile would fail there. With \`required=false\` plus the inline shell guard, the same Dockerfile + same Nx target works:
- in CI with sccache → Valkey,
- on a developer laptop with no Valkey reachable,
- on the \`arc-runner-set-kbve\` canary once it's swapped in,

with the same image hash byte-for-byte (sccache wrapping rustc is a no-op when no remote backend is configured — it just falls back to the existing \`/usr/local/sccache\` BuildKit cache mount).

## Test plan

- [ ] PR CI: confirm \`docker-test-app.yml\` succeeds end-to-end on the new wiring; cold run is the cache seed.
- [ ] Inspect the \`Nx e2e axum-kbve-e2e\` step log for \`sccache: Redis backend enabled\` followed by non-zero \`Cache hits\` on the second consecutive run (the first run populates Redis, the second should hit).
- [ ] Confirm \`valkey-sccache-credentials\` Secret exists in arc-runners after ArgoCD syncs the ExternalSecret.
- [ ] Confirm new runner pods come up with \`VALKEY_PASSWORD\` env set (\`kubectl exec\` into one runner pod, \`printenv VALKEY_PASSWORD | head -c 8\`).
- [ ] Confirm \`ghcr.io/kbve/kbve:buildcache\` tag still does not contain the password (\`docker manifest inspect\` + spot check of layers via \`crane export\`).
- [ ] Spot-check Valkey memory after a couple of full builds — should stabilise well under the 3GB \`maxmemory\` cap.