### PR TITLE
fix(astro-kbve): resolve astro check type errors across schemas and consumers

### DIFF
--- a/apps/kbve/astro-kbve/project.json
+++ b/apps/kbve/astro-kbve/project.json
@@ -66,6 +66,7 @@
 			}
 		},
 		"check": {
+			"dependsOn": ["proto"],
 			"executor": "nx:run-commands",
 			"options": {
 				"cwd": "apps/kbve/astro-kbve",

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -36,6 +36,7 @@ export interface ForgejoRepo {
 	language: string;
 	languages_url: string;
 	owner: {
+		id: number;
 		login: string;
 		avatar_url: string;
 	};

--- a/apps/kbve/astro-kbve/src/components/dashboard/rowsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/rowsService.ts
@@ -110,9 +110,7 @@ const PROXY_BASE = '/dashboard/chuckrpg/proxy';
 async function getAuthHeaders(): Promise<Record<string, string>> {
 	const supa = getSupa() ?? initSupa();
 	if (!supa) return {};
-	const {
-		data: { session },
-	} = await supa.auth.getSession();
+	const { session } = await supa.getSession();
 	if (!session?.access_token) return {};
 	return {
 		Authorization: `Bearer ${session.access_token}`,

--- a/apps/kbve/astro-kbve/src/components/gameserver/useGS.ts
+++ b/apps/kbve/astro-kbve/src/components/gameserver/useGS.ts
@@ -96,24 +96,17 @@ export function useGS() {
 				});
 
 				// Listen for WebSocket messages
-				const unsubMessage = supa.onWebSocketMessage(
-					(message: WSMessage) => {
-						if (!mounted) return;
+				const unsubMessage = supa.onWebSocketMessage((raw: unknown) => {
+					const message = raw as WSMessage;
+					if (!mounted) return;
 
-						// Don't log heartbeat messages (too noisy)
-						if (
-							message.type === 'ping' ||
-							message.type === 'pong'
-						) {
-							return;
-						}
+					// Don't log heartbeat messages (too noisy)
+					if (message.type === 'ping' || message.type === 'pong') {
+						return;
+					}
 
-						addLog(
-							`� Received: ${JSON.stringify(message)}`,
-							'success',
-						);
-					},
-				);
+					addLog(`� Received: ${JSON.stringify(message)}`, 'success');
+				});
 
 				unsubscribeRefs.current = [unsubStatus, unsubMessage];
 

--- a/apps/kbve/astro-kbve/src/components/npcdb/NPCDBPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/npcdb/NPCDBPanel.astro
@@ -162,7 +162,7 @@ function formatAction(action: string): string {
 										{npc.stats.speed}
 									</span>
 								</div>
-								{npc.stats.armor !== undefined &&
+								{npc.stats.armor != null &&
 									npc.stats.armor > 0 && (
 										<div class="flex justify-between px-3 py-1.5 rounded-lg bg-white/5">
 											<span class="text-zinc-400">
@@ -218,14 +218,14 @@ function formatAction(action: string): string {
 								{npc.flavor_text.map(
 									(ft: {
 										action: string;
-										messages: string[];
+										messages?: string[];
 									}) => (
 										<div>
 											<span class="text-xs font-medium uppercase text-purple-400">
 												{formatAction(ft.action)}
 											</span>
 											<ul class="mt-1 space-y-1 ml-3">
-												{ft.messages.map(
+												{(ft.messages ?? []).map(
 													(msg: string) => (
 														<li class="text-zinc-400 text-xs italic">
 															"{msg}"

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSItemJsonLd.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSItemJsonLd.astro
@@ -179,7 +179,7 @@ interface HowToInput {
 
 function recipeToHowTo(r: OSRSRecipe, idx: number): HowToInput | null {
 	const productName = r.product ?? item.name;
-	const skill = r.skill;
+	const skill = r.skill ?? undefined;
 	const level = r.level ?? null;
 	const xp = r.xp ?? null;
 	const supplies =

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSRecipes.astro
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSRecipes.astro
@@ -75,7 +75,7 @@ function getSkillColor(skill: string | null | undefined): string {
 							<span class="osrs-recipe__label">Creates:</span>
 							<span class="osrs-recipe__product-item">
 								{recipe.product_quantity &&
-									recipe.product_quantity > 1 && (
+									Number(recipe.product_quantity) > 1 && (
 										<span class="osrs-recipe__qty">
 											{recipe.product_quantity}x
 										</span>
@@ -103,7 +103,7 @@ function getSkillColor(skill: string | null | undefined): string {
 							<div class="osrs-recipe__items">
 								{recipe.materials.map((mat, i) => (
 									<span class="osrs-recipe__item">
-										{mat.quantity > 1 && (
+										{Number(mat.quantity) > 1 && (
 											<span class="osrs-recipe__qty">
 												{mat.quantity}x
 											</span>

--- a/apps/kbve/astro-kbve/src/components/providers/SupaProvider.tsx
+++ b/apps/kbve/astro-kbve/src/components/providers/SupaProvider.tsx
@@ -45,8 +45,10 @@ export function SupaProvider({ children }: { children: ReactNode }) {
 			}
 
 			// live updates broadcast from the worker
-			off = supa.on('auth', async (msg) => {
-				const newSession = msg.session ?? null;
+			off = supa.on('auth', async (msg: unknown) => {
+				const newSession =
+					(msg as { session?: Session | null } | null)?.session ??
+					null;
 				setSession(newSession);
 
 				// Connect WebSocket when user authenticates

--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -1,4 +1,5 @@
-import { z, defineCollection } from 'astro:content';
+import { defineCollection } from 'astro:content';
+import { z } from 'astro/zod';
 import { docsSchema } from '@astrojs/starlight/schema';
 import { docsLoader } from '@astrojs/starlight/loaders';
 // TODO: Re-enable once starlight-site-graph supports Zod 4 / Astro 6
@@ -16,9 +17,7 @@ import {
 
 const OSRSFrontmatterSchema = OSRSExtendedSchema;
 
-export function validateItemUniqueness(
-	items: (typeof IObjectSchema)['_type'][],
-) {
+export function validateItemUniqueness(items: z.infer<typeof IObjectSchema>[]) {
 	const seenIds = new Set<string>();
 	const seenKeys = new Set<number>();
 	const seenRefs = new Set<string>();
@@ -54,6 +53,15 @@ const gdd = defineCollection({
 });
 
 const ProjectSchemaWithEngine = ICiProjectSchema.extend({
+	title: z.string().optional(),
+	sidebar: z
+		.object({
+			label: z.string().optional(),
+			order: z.number().optional(),
+			hidden: z.boolean().optional(),
+			badge: z.unknown().optional(),
+		})
+		.optional(),
 	engine: z
 		.object({
 			version: z.string().min(1).max(64),

--- a/apps/kbve/astro-kbve/src/data/osrs-used-in-index.ts
+++ b/apps/kbve/astro-kbve/src/data/osrs-used-in-index.ts
@@ -115,7 +115,7 @@ async function build(): Promise<UsedInIndex> {
 					product: product.name,
 					product_id: product.id,
 					slug: product.slug,
-					skill: recipe.skill,
+					skill: recipe.skill ?? undefined,
 					level: recipe.level ?? null,
 					xp: recipe.xp ?? null,
 					quantity: mat.quantity ?? 1,

--- a/apps/kbve/astro-kbve/src/data/schema/ICiProjectSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/ICiProjectSchema.ts
@@ -5,7 +5,7 @@
  * (packages/data/codegen/generated/ci_registry-schema.ts).
  * Astro/Starlight-specific fields are layered on top.
  */
-import { z } from 'astro:content';
+import { z } from 'astro/zod';
 import {
 	CiProjectSchema,
 	DispatchPipelineSchema,

--- a/apps/kbve/astro-kbve/src/data/schema/IMapSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/IMapSchema.ts
@@ -5,7 +5,7 @@
  * (packages/data/codegen/generated/mapdb-schema.ts).
  * Astro-specific rendering fields are layered on top.
  */
-import { z } from 'astro:content';
+import { z } from 'astro/zod';
 import {
 	WorldObjectDefSchema,
 	WorldObjectTypeSchema,

--- a/apps/kbve/astro-kbve/src/data/schema/INpcSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/INpcSchema.ts
@@ -4,7 +4,7 @@
  * Game-logic fields come from the proto-generated NpcSchema
  * (packages/data/codegen/generated/npcdb-schema.ts).
  */
-import { z } from 'astro:content';
+import { z } from 'astro/zod';
 import {
 	NpcSchema,
 	NpcTypeFlagSchema,

--- a/apps/kbve/astro-kbve/src/data/schema/IObjectSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/IObjectSchema.ts
@@ -5,7 +5,7 @@
  * (packages/data/codegen/generated/itemdb-schema.ts).
  * Astro-specific fields are layered on top.
  */
-import { z } from 'astro:content';
+import { z } from 'astro/zod';
 import {
 	ItemSchema,
 	ItemBonusesSchema,

--- a/apps/kbve/astro-kbve/src/data/schema/IQuestSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/IQuestSchema.ts
@@ -4,7 +4,7 @@
  * Game-logic fields come from the proto-generated QuestSchema
  * (packages/data/codegen/generated/questdb-schema.ts).
  */
-import { z } from 'astro:content';
+import { z } from 'astro/zod';
 import {
 	QuestSchema,
 	QuestCategorySchema,

--- a/apps/kbve/astro-kbve/src/data/schema/osrs/generated.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/osrs/generated.ts
@@ -67,7 +67,7 @@
  *   this file can be fully generated with a thin refinement layer.
  */
 
-import { z } from 'astro:content';
+import { z } from 'astro/zod';
 
 // ============================================================================
 // Shared — proto: OSRSSkill enum
@@ -1253,7 +1253,7 @@ export function getGathering(
 	item: OSRSExtended,
 ): (OSRSGathering & { skill: string }) | undefined {
 	if (item.gathering)
-		return { skill: item.gathering.skill ?? 'unknown', ...item.gathering };
+		return { ...item.gathering, skill: item.gathering.skill ?? 'unknown' };
 	if (item.woodcutting) return { ...item.woodcutting, skill: 'woodcutting' };
 	if (item.mining) return { ...item.mining, skill: 'mining' };
 	if (item.fishing) return { ...item.fishing, skill: 'fishing' };

--- a/apps/kbve/astro-kbve/src/data/types/SteamAchievementTypes.ts
+++ b/apps/kbve/astro-kbve/src/data/types/SteamAchievementTypes.ts
@@ -1,4 +1,4 @@
-import { z } from 'astro:content';
+import { z } from 'astro/zod';
 
 export const AchievementSetByValues = ['Client', 'GS', 'OfficialGS'] as const;
 export type AchievementSetBy = (typeof AchievementSetByValues)[number];

--- a/apps/kbve/astro-kbve/src/data/types/UtilityTypes.ts
+++ b/apps/kbve/astro-kbve/src/data/types/UtilityTypes.ts
@@ -1,4 +1,4 @@
-import { z } from 'astro:content';
+import { z } from 'astro/zod';
 
 export const ULID = z
 	.string()

--- a/apps/kbve/astro-kbve/src/pages/api/npcdb.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/npcdb.json.ts
@@ -83,7 +83,10 @@ export const GET = async () => {
 		const { id, ref, name } = entry.data;
 		if (!id || !ref || !name) continue;
 
-		const npc = { ...NPC_DEFAULTS, ...convertEnums(entry.data) } as INpc;
+		const npc = {
+			...NPC_DEFAULTS,
+			...(convertEnums(entry.data) as Record<string, unknown>),
+		} as INpc;
 
 		const idx = npcs.length;
 		npcs.push(npc);

--- a/apps/kbve/astro-kbve/src/pages/api/osrs.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/osrs.json.ts
@@ -1,5 +1,6 @@
 import { getCollection } from 'astro:content';
 import type { OSRSExtended } from '@/data/schema';
+import { hasDropSources } from '@/data/schema/osrs/generated';
 
 interface OSRSIndexEntry {
 	id: number;
@@ -32,7 +33,7 @@ function buildTags(o: OSRSExtended): string[] {
 	if (o.potion) tags.push(TAG_POTION);
 	if (o.equipment) tags.push(TAG_EQUIPMENT);
 	if (o.quest_data) tags.push(TAG_QUEST);
-	if (o.drop_table?.sources?.length) tags.push(TAG_DROP);
+	if (hasDropSources(o)) tags.push(TAG_DROP);
 	if (o.farming) tags.push(TAG_FARM);
 	if (o.gathering || o.woodcutting || o.mining || o.fishing)
 		tags.push(TAG_GATHER);
@@ -60,8 +61,8 @@ export const GET = async () => {
 			highalch: o.highalch ?? null,
 			limit: o.limit ?? null,
 			members: !!o.members,
-			slot: o.equipment?.slot,
-			weapon: o.equipment?.weapon_type,
+			slot: o.equipment?.slot ?? undefined,
+			weapon: o.equipment?.weapon_type ?? undefined,
 			tags: buildTags(o),
 		});
 	}

--- a/apps/kbve/astro-kbve/src/pages/api/projects.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/projects.json.ts
@@ -2,7 +2,7 @@ import { getCollection } from 'astro:content';
 
 export const GET = async () => {
 	const projectEntries = (await getCollection('project')).filter(
-		(entry: { id: string; data: { title: string } }) =>
+		(entry: { id: string; data: { title?: string } }) =>
 			!entry.id.endsWith('index.mdx') && entry.data.title !== '',
 	);
 

--- a/apps/kbve/astro-kbve/src/vendor-shims.d.ts
+++ b/apps/kbve/astro-kbve/src/vendor-shims.d.ts
@@ -1,0 +1,10 @@
+declare module 'd3-sankey' {
+	export function sankey<N = unknown, L = unknown>(): any;
+	export function sankeyLinkHorizontal(): any;
+	export const sankeyLeft: any;
+	export const sankeyRight: any;
+	export const sankeyCenter: any;
+	export const sankeyJustify: any;
+}
+declare module 'guacamole-common-js';
+declare module '@novnc/novnc/lib/rfb';


### PR DESCRIPTION
## Summary
- Migrate schema files + `content.config.ts` from `astro:content`'s value-only `z` re-export to `astro/zod` (preserves zod namespace required for `z.infer<T>`; Astro 7 will remove `astro:content` z export).
- Add `src/vendor-shims.d.ts` declaring `d3-sankey`, `guacamole-common-js`, `@novnc/novnc/lib/rfb` so dashboard vendor imports stop tripping `astro check`.
- Patch schema drift in `ProjectSchemaWithEngine` (title + sidebar fields), `ForgejoRepo.owner.id`, `rowsService` SupabaseGateway call shape, `osrs.json.ts` DropTable union handling, plus the null|undefined and `string|number` cleanup in OSRS consumers and panel astro files.

Result: `astro-kbve:check` goes from **75 errors → 0** (444 → 445 files, after generating proto).

## Test plan
- [x] `./kbve.sh -nx astro-kbve:proto` (regenerate proto/kbve/common.js etc.)
- [x] `./kbve.sh -nx astro-kbve:check` → 0 errors, 0 warnings
- [ ] CI: `astro-kbve:build` (verify production build still completes)
- [ ] Spot-check `/dashboard/*`, OSRS pages, npcdb panel render without runtime regressions