### PR TITLE
feat(firecracker-ctl): public endpoint visibility tier + access_token fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.150"
+version = "1.0.151"
 dependencies = [
  "anyhow",
  "askama 0.16.0",
@@ -6112,7 +6112,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "firecracker-ctl"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "axum 0.8.9",
  "dashmap 6.1.0",

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -506,6 +506,17 @@ fn router(state: AppState) -> Router {
             any(super::proxy::firecracker_fc_handler),
         )
         .route("/fc/{name}", any(super::proxy::firecracker_fc_handler))
+        // Anonymous public tier — no JWT gate at this layer; firecracker-ctl-net
+        // rejects with 403 when the endpoint was not deployed with
+        // `visibility: "public"`.
+        .route(
+            "/fc/public/{name}/{*path}",
+            any(super::proxy::firecracker_fc_public_handler),
+        )
+        .route(
+            "/fc/public/{name}",
+            any(super::proxy::firecracker_fc_public_handler),
+        )
         .route(
             "/dashboard/kasm/proxy/{*path}",
             any(super::proxy::kasm_proxy_handler),

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -353,11 +353,12 @@ async fn require_dashboard_view(headers: &HeaderMap, service_name: &str) -> Resu
 /// Gate for sensitive proxy routes that need a higher privilege level than
 /// plain DASHBOARD_VIEW (e.g. network-enabled firecracker). Requires the
 /// same JWT checks plus DASHBOARD_MANAGE permission.
-async fn require_dashboard_manage(headers: &HeaderMap, service_name: &str) -> Result<(), Response> {
-    // Reuse the DASHBOARD_VIEW gate for JWT validation, then check the
-    // higher permission on top. Duplicating the JWT fetch avoids mutating
-    // the existing helper and keeps the error paths identical.
-    let auth_token = match extract_auth_token(headers, None) {
+async fn require_dashboard_manage_with_query(
+    headers: &HeaderMap,
+    query: Option<&str>,
+    service_name: &str,
+) -> Result<(), Response> {
+    let auth_token = match extract_auth_token(headers, query) {
         Some(t) => t,
         None => {
             return Err((
@@ -1605,8 +1606,10 @@ pub async fn firecracker_net_proxy_handler(
     req: Request<Body>,
 ) -> Response {
     let headers = req.headers().clone();
-    // Higher privilege gate — network-enabled VMs are staff-only.
-    if let Err(resp) = require_dashboard_manage(&headers, "Firecracker-Net").await {
+    let query = req.uri().query().map(str::to_owned);
+    if let Err(resp) =
+        require_dashboard_manage_with_query(&headers, query.as_deref(), "Firecracker-Net").await
+    {
         return resp;
     }
 
@@ -1635,7 +1638,10 @@ pub async fn firecracker_fc_alias_handler(
     req: Request<Body>,
 ) -> Response {
     let headers = req.headers().clone();
-    if let Err(resp) = require_dashboard_manage(&headers, "Firecracker-FC").await {
+    let query = req.uri().query().map(str::to_owned);
+    if let Err(resp) =
+        require_dashboard_manage_with_query(&headers, query.as_deref(), "Firecracker-FC").await
+    {
         return resp;
     }
 
@@ -1666,7 +1672,10 @@ pub async fn firecracker_fc_handler(
     req: Request<Body>,
 ) -> Response {
     let headers = req.headers().clone();
-    if let Err(resp) = require_dashboard_manage(&headers, "Firecracker-FC").await {
+    let query = req.uri().query().map(str::to_owned);
+    if let Err(resp) =
+        require_dashboard_manage_with_query(&headers, query.as_deref(), "Firecracker-FC").await
+    {
         return resp;
     }
 
@@ -1699,6 +1708,60 @@ pub async fn firecracker_fc_handler(
         format!("proxy/{name}")
     } else {
         format!("proxy/{name}/{tail}")
+    };
+
+    match FIRECRACKER_NET.get() {
+        Some(proxy) => proxy.handle_preauthorized(Some(Path(rewritten)), req).await,
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "Firecracker-Net proxy not configured"})),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// /fc/public/{name}/{*path} — anonymous public endpoints
+// ---------------------------------------------------------------------------
+// Rewrites /fc/public/{name}/{*path} → firecracker-ctl-net /proxy/public/{name}/{*path}.
+// No JWT gate at this layer — ctl-net enforces that the endpoint was deployed
+// with `visibility: "public"`, returning 403 otherwise.
+//
+// Same name validation as the staff route. Future hardening (rate limit,
+// IP allowlist, request-size cap, header injection) can layer in here without
+// touching the staff path.
+
+pub async fn firecracker_fc_public_handler(
+    axum::extract::Path(params): axum::extract::Path<Vec<(String, String)>>,
+    req: Request<Body>,
+) -> Response {
+    let name = params
+        .iter()
+        .find(|(k, _)| k == "name")
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default();
+    let tail = params
+        .iter()
+        .find(|(k, _)| k == "path")
+        .map(|(_, v)| v.clone())
+        .unwrap_or_default();
+
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            axum::Json(json!({"error": "Invalid endpoint name"})),
+        )
+            .into_response();
+    }
+
+    let rewritten = if tail.is_empty() {
+        format!("proxy/public/{name}")
+    } else {
+        format!("proxy/public/{name}/{tail}")
     };
 
     match FIRECRACKER_NET.get() {

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -171,9 +171,18 @@ pub enum EndpointStatus {
     Stopping,
 }
 
+/// Whether an endpoint is reachable from the public `/fc/public/{name}/*`
+/// path (no JWT) or only via the staff-gated `/fc/{name}/*` path.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum EndpointVisibility {
+    #[default]
+    Staff,
+    Public,
+}
+
 /// Registered persistent endpoint. Owned by `PersistentState::endpoints`.
 struct PersistentEndpoint {
-    /// Public name — keys the DashMap and appears in /fc/{name} paths.
     name: String,
     rootfs: String,
     entrypoint: String,
@@ -181,13 +190,12 @@ struct PersistentEndpoint {
     health_path: String,
     vcpu_count: u8,
     mem_size_mib: u16,
-    /// Resources carried for lifetime of the endpoint; released on DELETE.
     allocation: persistent::IpAllocation,
     tap: tap::TapDevice,
-    /// Firecracker VMM pid once Phase 2e wires the launcher. None in 2c.
     pid: Option<u32>,
     status: EndpointStatus,
     created: Instant,
+    visibility: EndpointVisibility,
 }
 
 /// JSON-serialisable view of a PersistentEndpoint. Keeps the owning
@@ -208,6 +216,7 @@ pub struct PersistentEndpointInfo {
     pid: Option<u32>,
     status: EndpointStatus,
     uptime_secs: u64,
+    visibility: EndpointVisibility,
 }
 
 impl PersistentEndpointInfo {
@@ -226,6 +235,7 @@ impl PersistentEndpointInfo {
             pid: ep.pid,
             status: ep.status,
             uptime_secs: ep.created.elapsed().as_secs(),
+            visibility: ep.visibility,
         }
     }
 }
@@ -514,6 +524,12 @@ pub struct DeployFcRequest {
     pub env: serde_json::Map<String, serde_json::Value>,
     #[serde(default)]
     pub code: Option<String>,
+    /// Endpoint visibility. `staff` (default) requires a dashboard JWT with
+    /// `DASHBOARD_MANAGE`; `public` is reachable from `/fc/public/{name}/*`
+    /// with no auth. Hard-coded at deploy time — flipping visibility
+    /// requires redeploy.
+    #[serde(default)]
+    pub visibility: EndpointVisibility,
 }
 
 fn default_health_path() -> String {
@@ -549,7 +565,6 @@ async fn fc_deploy(
     State(state): State<AppState>,
     Json(req): Json<DeployFcRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    // --- Validate request shape ---
     if req.name.is_empty()
         || !req
             .name
@@ -559,6 +574,16 @@ async fn fc_deploy(
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": "invalid endpoint name"})),
+        );
+    }
+    if req.name == "public" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "reserved endpoint name",
+                "name": req.name,
+                "hint": "the name 'public' collides with the /fc/public/* tier",
+            })),
         );
     }
     if req.rootfs.is_empty() || req.entrypoint.is_empty() {
@@ -700,6 +725,7 @@ async fn fc_deploy(
         pid,
         status: EndpointStatus::Starting,
         created: Instant::now(),
+        visibility: req.visibility,
     };
     let info = PersistentEndpointInfo::from(&endpoint);
     persistent.endpoints.insert(req.name.clone(), endpoint);
@@ -885,6 +911,27 @@ async fn fc_proxy(
     Path(params): Path<Vec<(String, String)>>,
     req: Request<Body>,
 ) -> Response {
+    fc_proxy_inner(state, params, req, false).await
+}
+
+/// Public-tier sibling of [`fc_proxy`]. Forwards `/proxy/public/{name}/{*path}`
+/// into the guest VM only when the endpoint was registered with
+/// `visibility: "public"`. No auth required at this layer — the gate is the
+/// endpoint's visibility flag, which is fixed at deploy time.
+async fn fc_proxy_public(
+    State(state): State<AppState>,
+    Path(params): Path<Vec<(String, String)>>,
+    req: Request<Body>,
+) -> Response {
+    fc_proxy_inner(state, params, req, true).await
+}
+
+async fn fc_proxy_inner(
+    state: AppState,
+    params: Vec<(String, String)>,
+    req: Request<Body>,
+    require_public: bool,
+) -> Response {
     let persistent = match state.persistent.as_ref() {
         Some(p) => p,
         None => {
@@ -904,10 +951,19 @@ async fn fc_proxy(
         .map(|(_, v)| v.clone())
         .unwrap_or_default();
 
-    // --- Registry lookup ---
     let (guest_ip, http_port) = match persistent.endpoints.get(&name) {
         Some(entry) => {
             let ep = entry.value();
+            if require_public && ep.visibility != EndpointVisibility::Public {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(serde_json::json!({
+                        "error": "endpoint not public",
+                        "name": name,
+                    })),
+                )
+                    .into_response();
+            }
             (ep.allocation.guest_ip, ep.http_port)
         }
         None => {
@@ -2142,6 +2198,11 @@ async fn main() {
         .route("/fc/{name}", delete(fc_destroy))
         .route("/proxy/{name}", axum::routing::any(fc_proxy))
         .route("/proxy/{name}/{*path}", axum::routing::any(fc_proxy))
+        .route("/proxy/public/{name}", axum::routing::any(fc_proxy_public))
+        .route(
+            "/proxy/public/{name}/{*path}",
+            axum::routing::any(fc_proxy_public),
+        )
         .layer(TraceLayer::new_for_http())
         .with_state(state);
 


### PR DESCRIPTION
## Summary
- Adds `visibility: "staff" | "public"` field to `DeployFcRequest` so persistent endpoints can be marked anonymously reachable
- New `/fc/public/{name}/{*path}` (axum) → `/proxy/public/{name}/{*path}` (firecracker-ctl-net) tier — no JWT gate at the axum layer; ctl-net returns 403 unless endpoint was deployed `public`. Forward path already strips downstream `Authorization`/`Cookie`, so no auth leakage into guest VMs
- Bug fix: `require_dashboard_manage` ignored `?access_token=` query param. All three callers (`firecracker_net_proxy_handler`, `firecracker_fc_alias_handler`, `firecracker_fc_handler`) now thread `req.uri().query()` through

## Design
- `EndpointVisibility::Staff` is the default — existing deploy payloads keep prior behavior
- Reserved name `"public"` at deploy time to avoid `/fc/public/...` path collision with the new tier
- Staff path unchanged. Public tier is additive — future per-tier middleware (rate limit, CORS, header injection) plugs into `firecracker_fc_public_handler` without touching staff
- Shared `fc_proxy_inner(require_public: bool)` keeps both handlers on the same upstream / header / body code path

## Test plan
- [ ] Deploy a `visibility: "staff"` endpoint, hit `/fc/{name}/...` with a staff JWT — 200
- [ ] Same endpoint via `/fc/public/{name}/...` — 403 from ctl-net (endpoint not public)
- [ ] Deploy a `visibility: "public"` endpoint, hit `/fc/public/{name}/...` without auth — 200
- [ ] Hit `/dashboard/firecracker-net/proxy/proxy/test/?access_token=<jwt>` with a valid staff token — 200 (previously rejected as "Missing Authorization header")
- [ ] Attempt `POST /fc/deploy` with `name: "public"` — 400 reserved-name error