### PR TITLE
feat(wallet): auth.users trigger + JWT-free worker + migration test harness

### DIFF
--- a/packages/data/sql/dbmate/migration-tests/20260513114428_wallet_auth_user_trigger.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260513114428_wallet_auth_user_trigger.test.sql
@@ -1,0 +1,202 @@
+-- Companion test fixtures for 20260513114428_wallet_auth_user_trigger.
+-- Run via: ./test-migration.sh 20260513114428_wallet_auth_user_trigger
+--
+-- Sections (parsed by test-migration.sh):
+--   SEED              — runs BEFORE dbmate up
+--   ASSERT_AFTER_UP   — runs AFTER dbmate up; raises on failure
+--   ASSERT_AFTER_DOWN — runs AFTER dbmate rollback; raises on failure
+--
+-- Asserts are DO blocks that RAISE EXCEPTION when an invariant fails. psql
+-- runs with ON_ERROR_STOP=1, so the harness exit code reflects pass/fail.
+
+-- SEED
+-- Idempotent: clean any prior-run state first. wallet.account FK is ON
+-- DELETE NO ACTION, so we tear down child rows in order before purging
+-- auth.users. Local auth.users stub has only (id, created_at).
+WITH test_users (id) AS (
+    VALUES
+        ('11111111-1111-1111-1111-111111111111'::uuid),
+        ('22222222-2222-2222-2222-222222222222'::uuid),
+        ('44444444-4444-4444-4444-444444444444'::uuid)
+),
+test_accounts AS (
+    SELECT a.id FROM wallet.account a JOIN test_users u ON a.user_id = u.id
+),
+del_coupon AS (
+    DELETE FROM wallet.coupon WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_ledger AS (
+    DELETE FROM wallet.ledger WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_balance AS (
+    DELETE FROM wallet.balance WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_account AS (
+    DELETE FROM wallet.account WHERE id IN (SELECT id FROM test_accounts)
+)
+DELETE FROM auth.users WHERE id IN (SELECT id FROM test_users);
+
+INSERT INTO auth.users (id)
+VALUES
+    ('11111111-1111-1111-1111-111111111111'),
+    ('22222222-2222-2222-2222-222222222222');
+
+INSERT INTO wallet.account (id, kind, user_id, created_at)
+VALUES (
+    '33333333-3333-3333-3333-333333333333',
+    'user',
+    '11111111-1111-1111-1111-111111111111',
+    now()
+);
+INSERT INTO wallet.balance (account_id) VALUES ('33333333-3333-3333-3333-333333333333');
+
+-- ASSERT_AFTER_UP
+DO $$
+DECLARE
+    v_template_active BOOLEAN;
+BEGIN
+    -- 1. Backfill provisioned the second seeded user.
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.account
+         WHERE kind = 'user' AND user_id = '22222222-2222-2222-2222-222222222222'
+    ) THEN
+        RAISE EXCEPTION 'fail: backfill did not provision user 22222222';
+    END IF;
+
+    -- 2. Pre-existing wallet account preserved (not duplicated).
+    IF (
+        SELECT COUNT(*) FROM wallet.account
+         WHERE kind = 'user' AND user_id = '11111111-1111-1111-1111-111111111111'
+    ) <> 1 THEN
+        RAISE EXCEPTION 'fail: pre-existing user has wrong account count';
+    END IF;
+
+    -- 3. Backfilled user got balance row.
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.balance b
+          JOIN wallet.account a ON a.id = b.account_id
+         WHERE a.user_id = '22222222-2222-2222-2222-222222222222'
+    ) THEN
+        RAISE EXCEPTION 'fail: backfilled user missing balance row';
+    END IF;
+
+    -- 4. Backfilled user got WELCOME_KHASH coupon (if template is active).
+    SELECT EXISTS (
+        SELECT 1 FROM wallet.coupon_template
+         WHERE code = 'WELCOME_KHASH' AND is_active = TRUE
+    ) INTO v_template_active;
+
+    IF v_template_active AND NOT EXISTS (
+        SELECT 1 FROM wallet.coupon c
+          JOIN wallet.account a ON a.id = c.account_id
+          JOIN wallet.coupon_template t ON t.id = c.template_id
+         WHERE a.user_id = '22222222-2222-2222-2222-222222222222'
+           AND t.code = 'WELCOME_KHASH'
+    ) THEN
+        RAISE EXCEPTION 'fail: backfilled user missing welcome coupon';
+    END IF;
+
+    -- 5. Unique partial index in place.
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'wallet'
+           AND indexname = 'coupon_template_one_active_code_idx'
+    ) THEN
+        RAISE EXCEPTION 'fail: unique partial index missing';
+    END IF;
+END;
+$$;
+
+-- 5b. New auth.users insert fires the trigger. Separate block: this performs
+-- a write, not just an assert.
+INSERT INTO auth.users (id)
+VALUES ('44444444-4444-4444-4444-444444444444');
+
+DO $$
+BEGIN
+    -- 6. Trigger provisioned the new user.
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.account
+         WHERE kind = 'user' AND user_id = '44444444-4444-4444-4444-444444444444'
+    ) THEN
+        RAISE EXCEPTION 'fail: trigger did not fire on auth.users INSERT';
+    END IF;
+
+    -- 7. Trigger-provisioned user has balance row.
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.balance b
+          JOIN wallet.account a ON a.id = b.account_id
+         WHERE a.user_id = '44444444-4444-4444-4444-444444444444'
+    ) THEN
+        RAISE EXCEPTION 'fail: trigger-provisioned user missing balance row';
+    END IF;
+
+    -- 8. Worker is idempotent on re-call.
+    PERFORM wallet.ensure_user_account('44444444-4444-4444-4444-444444444444'::uuid);
+    IF (
+        SELECT COUNT(*) FROM wallet.account
+         WHERE kind = 'user' AND user_id = '44444444-4444-4444-4444-444444444444'
+    ) <> 1 THEN
+        RAISE EXCEPTION 'fail: ensure_user_account is not idempotent';
+    END IF;
+
+    -- 9. NULL user_id raises.
+    BEGIN
+        PERFORM wallet.ensure_user_account(NULL);
+        RAISE EXCEPTION 'fail: NULL user_id should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN
+        NULL;
+    END;
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+DO $$
+BEGIN
+    -- 1. Trigger no longer exists.
+    IF EXISTS (
+        SELECT 1 FROM pg_trigger
+         WHERE tgname = 'wallet_on_auth_user_created'
+           AND NOT tgisinternal
+    ) THEN
+        RAISE EXCEPTION 'fail: trigger still exists after rollback';
+    END IF;
+
+    -- 2. Worker function gone.
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'wallet'
+           AND p.proname = 'ensure_user_account'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet.ensure_user_account still exists after rollback';
+    END IF;
+
+    -- 3. Old proxy function restored.
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'wallet'
+           AND p.proname = 'proxy_ensure_user_account'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet.proxy_ensure_user_account missing after rollback';
+    END IF;
+
+    -- 4. Backfilled accounts preserved (rollback does NOT delete user data).
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.account
+         WHERE kind = 'user' AND user_id = '22222222-2222-2222-2222-222222222222'
+    ) THEN
+        RAISE EXCEPTION 'fail: backfilled user data lost during rollback';
+    END IF;
+
+    -- 5. Unique partial index removed.
+    IF EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'wallet'
+           AND indexname = 'coupon_template_one_active_code_idx'
+    ) THEN
+        RAISE EXCEPTION 'fail: unique partial index still present after rollback';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migrations/20260513114428_wallet_auth_user_trigger.sql
+++ b/packages/data/sql/dbmate/migrations/20260513114428_wallet_auth_user_trigger.sql
@@ -1,0 +1,247 @@
+-- migrate:up
+
+-- Split provisioning logic into a JWT-free worker so it can be called from
+-- triggers and admin scripts as well as from the JWT-aware proxy. The proxy
+-- (auth.uid()) becomes a thin wrapper, so production behavior of the
+-- /me/* RPC paths is preserved.
+
+-- Preflight: fail loudly on duplicate active rows so the unique-index create
+-- below cannot silently corrupt deploys. Operator must deactivate duplicates
+-- first.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+          FROM wallet.coupon_template
+         WHERE is_active = TRUE
+         GROUP BY code
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'duplicate active coupon_template.code rows exist; deactivate duplicates before creating unique index';
+    END IF;
+END;
+$$;
+
+-- Enforce one active template per code so wallet.ensure_user_account can
+-- look up WELCOME_KHASH unambiguously.
+CREATE UNIQUE INDEX IF NOT EXISTS coupon_template_one_active_code_idx
+    ON wallet.coupon_template (code)
+    WHERE is_active = TRUE;
+
+CREATE OR REPLACE FUNCTION wallet.ensure_user_account(p_user_id UUID)
+RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_account_id   UUID;
+    v_template_id  BIGINT;
+    v_default_exp  INTERVAL;
+    v_now          TIMESTAMPTZ := statement_timestamp();
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'p_user_id required' USING ERRCODE = '22023';
+    END IF;
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('wallet.ensure_user_account:' || p_user_id::TEXT, 0)
+    );
+
+    SELECT id INTO v_account_id
+      FROM wallet.account
+     WHERE kind = 'user' AND user_id = p_user_id;
+
+    IF v_account_id IS NOT NULL THEN
+        RETURN v_account_id;
+    END IF;
+
+    INSERT INTO wallet.account (kind, user_id, label, created_at)
+    VALUES ('user', p_user_id, NULL, v_now)
+    ON CONFLICT (user_id) WHERE kind = 'user' DO NOTHING
+    RETURNING id INTO v_account_id;
+
+    IF v_account_id IS NULL THEN
+        SELECT id INTO v_account_id
+          FROM wallet.account
+         WHERE kind = 'user' AND user_id = p_user_id;
+    END IF;
+
+    IF v_account_id IS NULL THEN
+        RAISE EXCEPTION 'failed to provision wallet account for user %', p_user_id
+            USING ERRCODE = '23514';
+    END IF;
+
+    INSERT INTO wallet.balance (account_id)
+    VALUES (v_account_id)
+    ON CONFLICT (account_id) DO NOTHING;
+
+    SELECT id, default_expires_in
+      INTO v_template_id, v_default_exp
+      FROM wallet.coupon_template
+     WHERE code = 'WELCOME_KHASH' AND is_active = TRUE;
+
+    IF v_template_id IS NOT NULL THEN
+        INSERT INTO wallet.coupon (account_id, template_id, expires_at)
+        VALUES (
+            v_account_id,
+            v_template_id,
+            CASE WHEN v_default_exp IS NOT NULL
+                 THEN v_now + v_default_exp
+                 ELSE NULL END
+        )
+        ON CONFLICT (account_id, template_id) DO NOTHING;
+    END IF;
+
+    RETURN v_account_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION wallet.ensure_user_account(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.ensure_user_account(UUID) TO service_role;
+ALTER FUNCTION wallet.ensure_user_account(UUID) OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.ensure_user_account(UUID) IS
+    'Idempotently provisions a wallet account, balance row, and optional welcome coupon for a given auth user. Intended for service_role, triggers, and admin repair jobs.';
+
+CREATE OR REPLACE FUNCTION wallet.proxy_ensure_user_account()
+RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_user_id UUID := auth.uid();
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+    END IF;
+    RETURN wallet.ensure_user_account(v_user_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION wallet.proxy_ensure_user_account() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION wallet.proxy_ensure_user_account() TO authenticated, service_role;
+ALTER FUNCTION wallet.proxy_ensure_user_account() OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.proxy_ensure_user_account() IS
+    'Authenticated RPC wrapper around wallet.ensure_user_account(auth.uid()).';
+
+-- Trigger function: fires after each auth.users INSERT and provisions the
+-- wallet account + welcome coupon. Wrapped in EXCEPTION so wallet failure
+-- never blocks user signup; the JWT-aware proxy remains as a fallback in
+-- /me/* paths to repair any user whose trigger run was lost.
+CREATE OR REPLACE FUNCTION wallet.handle_auth_user_created()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+    BEGIN
+        PERFORM wallet.ensure_user_account(NEW.id);
+    EXCEPTION WHEN OTHERS THEN
+        RAISE WARNING 'wallet.handle_auth_user_created failed for user %: %', NEW.id, SQLERRM;
+    END;
+    RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION wallet.handle_auth_user_created() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION wallet.handle_auth_user_created() OWNER TO service_role;
+
+DROP TRIGGER IF EXISTS wallet_on_auth_user_created ON auth.users;
+CREATE TRIGGER wallet_on_auth_user_created
+    AFTER INSERT ON auth.users
+    FOR EACH ROW EXECUTE FUNCTION wallet.handle_auth_user_created();
+
+-- Backfill existing users so /me/balance + /me/coupons can move toward
+-- pure reads. ensure_user_account is idempotent; logs a final count for
+-- ops visibility. If auth.users grows large enough that this becomes
+-- slow at deploy time, extract into a batched admin job.
+DO $$
+DECLARE
+    v_user      RECORD;
+    v_attempted INTEGER := 0;
+    v_failed    INTEGER := 0;
+BEGIN
+    FOR v_user IN SELECT id FROM auth.users LOOP
+        v_attempted := v_attempted + 1;
+        BEGIN
+            PERFORM wallet.ensure_user_account(v_user.id);
+        EXCEPTION WHEN OTHERS THEN
+            v_failed := v_failed + 1;
+            RAISE WARNING 'wallet backfill failed for user %: %', v_user.id, SQLERRM;
+        END;
+    END LOOP;
+    RAISE NOTICE 'wallet backfill: % attempted, % failed', v_attempted, v_failed;
+END;
+$$;
+
+-- migrate:down
+
+-- Intentionally does not delete backfilled wallet accounts, balances, or
+-- coupons. Rollback restores lazy-only provisioning; user-owned state
+-- created during the up migration is preserved.
+
+DROP TRIGGER IF EXISTS wallet_on_auth_user_created ON auth.users;
+DROP FUNCTION IF EXISTS wallet.handle_auth_user_created();
+DROP FUNCTION IF EXISTS wallet.ensure_user_account(UUID);
+DROP INDEX IF EXISTS wallet.coupon_template_one_active_code_idx;
+
+CREATE OR REPLACE FUNCTION wallet.proxy_ensure_user_account()
+RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_user_id      UUID := auth.uid();
+    v_account_id   UUID;
+    v_template_id  BIGINT;
+    v_default_exp  INTERVAL;
+    v_now          TIMESTAMPTZ := statement_timestamp();
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+    END IF;
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('wallet.proxy_ensure_user_account:' || v_user_id::TEXT, 0)
+    );
+
+    SELECT id INTO v_account_id
+      FROM wallet.account
+     WHERE kind = 'user' AND user_id = v_user_id;
+
+    IF v_account_id IS NOT NULL THEN
+        RETURN v_account_id;
+    END IF;
+
+    INSERT INTO wallet.account (kind, user_id, label, created_at)
+    VALUES ('user', v_user_id, NULL, v_now)
+    ON CONFLICT (user_id) WHERE kind = 'user' DO NOTHING
+    RETURNING id INTO v_account_id;
+
+    IF v_account_id IS NULL THEN
+        SELECT id INTO v_account_id
+          FROM wallet.account
+         WHERE kind = 'user' AND user_id = v_user_id;
+    END IF;
+
+    INSERT INTO wallet.balance (account_id)
+    VALUES (v_account_id)
+    ON CONFLICT (account_id) DO NOTHING;
+
+    SELECT id, default_expires_in
+      INTO v_template_id, v_default_exp
+      FROM wallet.coupon_template
+     WHERE code = 'WELCOME_KHASH' AND is_active = TRUE;
+
+    IF v_template_id IS NOT NULL THEN
+        INSERT INTO wallet.coupon (account_id, template_id, expires_at)
+        VALUES (
+            v_account_id,
+            v_template_id,
+            CASE WHEN v_default_exp IS NOT NULL
+                 THEN v_now + v_default_exp
+                 ELSE NULL END
+        )
+        ON CONFLICT (account_id, template_id) DO NOTHING;
+    END IF;
+
+    RETURN v_account_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION wallet.proxy_ensure_user_account() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION wallet.proxy_ensure_user_account() TO authenticated, service_role;
+ALTER FUNCTION wallet.proxy_ensure_user_account() OWNER TO service_role;

--- a/packages/data/sql/dbmate/test-migration.sh
+++ b/packages/data/sql/dbmate/test-migration.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# test-migration.sh — exercise a single dbmate migration against the local
+# dev-docker-compose postgres. Looks for a companion `.test.sql` next to the
+# migration with three sections:
+#
+#   -- SEED              fixtures, runs before dbmate up
+#   -- ASSERT_AFTER_UP   invariants after dbmate up
+#   -- ASSERT_AFTER_DOWN invariants after dbmate rollback
+#
+# Asserts should be `DO $$ ... RAISE EXCEPTION 'fail: ...' ... $$;` blocks.
+# psql runs with ON_ERROR_STOP=1, so a RAISE bubbles up as a non-zero exit
+# and fails the run. Backfilled user data is intentionally preserved across
+# rollback, so use the seeded UUIDs above to assert preservation.
+#
+# Usage:
+#   test-migration.sh <migration_basename_or_path>
+#
+# Examples:
+#   test-migration.sh 20260513114428_wallet_auth_user_trigger
+#   test-migration.sh migrations/20260513114428_wallet_auth_user_trigger.sql
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd "$SCRIPT_DIR"
+
+ARG="${1:-}"
+if [[ -z "$ARG" ]]; then
+    echo "usage: $0 <migration_basename_or_path>" >&2
+    exit 64
+fi
+
+BASENAME="$(basename "$ARG" .sql)"
+MIGRATION_FILE="migrations/${BASENAME}.sql"
+TEST_FILE="migration-tests/${BASENAME}.test.sql"
+
+if [[ ! -f "$MIGRATION_FILE" ]]; then
+    echo "migration not found: $MIGRATION_FILE" >&2
+    exit 66
+fi
+
+if [[ ! -f "$TEST_FILE" ]]; then
+    echo "companion test file not found: $TEST_FILE" >&2
+    echo "expected sections: -- SEED, -- ASSERT_AFTER_UP, -- ASSERT_AFTER_DOWN" >&2
+    exit 66
+fi
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+    DATABASE_URL="postgresql://postgres:postgres@localhost:54322/postgres?sslmode=disable&search_path=dbmate,public"
+fi
+export DATABASE_URL
+
+PSQL_URL="postgresql://postgres:postgres@localhost:54322/postgres?sslmode=disable"
+
+bring_up_compose() {
+    if docker compose -f dev-docker-compose.yml ps --status running --quiet postgres 2>/dev/null | grep -q .; then
+        return 0
+    fi
+    echo "→ starting dev-docker-compose postgres"
+    docker compose -f dev-docker-compose.yml up -d postgres >&2
+    for _ in $(seq 1 30); do
+        if docker compose -f dev-docker-compose.yml exec -T postgres pg_isready -U postgres >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "postgres failed to become ready" >&2
+    return 1
+}
+
+extract_section() {
+    local section="$1"
+    awk -v marker="-- $section" '
+        $0 ~ "^-- (SEED|ASSERT_AFTER_UP|ASSERT_AFTER_DOWN) *$" {
+            active = ($0 ~ "^"marker" *$") ? 1 : 0
+            next
+        }
+        active { print }
+    ' "$TEST_FILE"
+}
+
+run_psql() {
+    local label="$1"
+    local sql="$2"
+    if [[ -z "$(printf '%s' "$sql" | tr -d '[:space:]')" ]]; then
+        echo "  (no $label statements; skipping)"
+        return 0
+    fi
+    echo "→ $label"
+    printf '%s\n' "$sql" | psql "$PSQL_URL" -v ON_ERROR_STOP=1 -X -q
+}
+
+is_applied() {
+    psql "$PSQL_URL" -X -t -A -c \
+        "SELECT 1 FROM dbmate.schema_migrations WHERE version = '${BASENAME%%_*}'" \
+        2>/dev/null | grep -q '^1$'
+}
+
+bring_up_compose
+
+echo "→ ensure baseline migrations applied (everything before $BASENAME)"
+dbmate --no-dump-schema --migrations-dir migrations up >/dev/null
+
+if is_applied; then
+    echo "→ migration already applied; rolling back so we can re-test"
+    dbmate --no-dump-schema --migrations-dir migrations rollback >/dev/null
+fi
+
+SEED_SQL="$(extract_section SEED)"
+UP_ASSERT_SQL="$(extract_section ASSERT_AFTER_UP)"
+DOWN_ASSERT_SQL="$(extract_section ASSERT_AFTER_DOWN)"
+
+run_psql "seed" "$SEED_SQL"
+
+echo "→ dbmate up (apply $BASENAME)"
+dbmate --no-dump-schema --migrations-dir migrations up >/dev/null
+
+run_psql "assert_after_up" "$UP_ASSERT_SQL"
+
+echo "→ dbmate rollback (revert $BASENAME)"
+dbmate --no-dump-schema --migrations-dir migrations rollback >/dev/null
+
+run_psql "assert_after_down" "$DOWN_ASSERT_SQL"
+
+echo "→ re-apply $BASENAME (leave db in up state)"
+dbmate --no-dump-schema --migrations-dir migrations up >/dev/null
+
+echo "✓ migration test passed: $BASENAME"

--- a/packages/data/sql/project.json
+++ b/packages/data/sql/project.json
@@ -1,0 +1,51 @@
+{
+	"name": "data-sql",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/data/sql",
+	"tags": ["scope:data", "type:sql"],
+	"targets": {
+		"dev-up": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "docker compose -f dev-docker-compose.yml up -d postgres",
+				"cwd": "{projectRoot}/dbmate"
+			}
+		},
+		"dev-down": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "docker compose -f dev-docker-compose.yml down",
+				"cwd": "{projectRoot}/dbmate"
+			}
+		},
+		"dev-reset": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "docker compose -f dev-docker-compose.yml down -v && docker compose -f dev-docker-compose.yml up -d postgres",
+				"cwd": "{projectRoot}/dbmate"
+			}
+		},
+		"migrate-up": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "dbmate --no-dump-schema --migrations-dir migrations up",
+				"cwd": "{projectRoot}/dbmate"
+			}
+		},
+		"migrate-status": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "dbmate --no-dump-schema --migrations-dir migrations status",
+				"cwd": "{projectRoot}/dbmate"
+			}
+		},
+		"test-migration": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "./test-migration.sh",
+				"cwd": "{projectRoot}/dbmate"
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Splits wallet provisioning so future PRs can offload `/me/*` reads to the CNPG RO pooler. Lazy fallback in `/me/balance` + `/me/coupons` stays in place (Rust side) for this PR — the trigger + backfill are defense-in-depth that lets us remove lazy provisioning once monitoring lands.

## Schema changes (`20260513114428_wallet_auth_user_trigger`)

- `wallet.ensure_user_account(p_user_id UUID)` — JWT-free SECURITY DEFINER worker. Advisory-locked. Hard NULL guard. service_role only.
- `wallet.proxy_ensure_user_account()` — refactored into a thin `auth.uid()` wrapper around the worker. Existing RPC contract unchanged.
- `wallet.handle_auth_user_created()` — AFTER INSERT trigger on `auth.users`. Soft-fails so wallet errors never block signup.
- Partial unique index `coupon_template_one_active_code_idx` enforces one active row per code; preflight DO block fails the migration loudly if existing duplicates exist.
- Inline backfill loops existing `auth.users` → `ensure_user_account` with attempted/failed `RAISE NOTICE` for ops.
- Down migration restores the previous monolithic proxy and drops the trigger + index. Backfilled account/balance/coupon rows are intentionally preserved.

## Migration test harness

- `packages/data/sql/dbmate/test-migration.sh` parses companion `migration-tests/<basename>.test.sql` files split into `-- SEED`, `-- ASSERT_AFTER_UP`, `-- ASSERT_AFTER_DOWN` sections.
- Asserts are `DO` blocks that `RAISE EXCEPTION` on failure; psql `ON_ERROR_STOP=1` makes exit code reflect pass/fail.
- Idempotent flow: baseline up → rollback target if applied → seed → up → assert → rollback → assert → re-apply.
- Tests live in `migration-tests/` so dbmate's `*.sql` scanner ignores them.

`packages/data/sql/project.json` adds Nx targets: `test-migration`, `migrate-up`, `migrate-status`, `dev-up`, `dev-down`, `dev-reset`.

This migration's companion test covers backfill, pre-existing account preservation, balance + welcome coupon creation, trigger fire on new `auth.users` insert, worker idempotency, NULL rejection, unique index presence, and rollback preservation of user data.

## Test plan

- [x] Local `./kbve.sh -nx data-sql:test-migration 20260513114428_wallet_auth_user_trigger` green (up + down asserts)
- [ ] After merge: dispatch `ci-dbmate-deploy` against main
- [ ] Verify in prod: `SELECT proname FROM pg_proc WHERE proname IN ('ensure_user_account','handle_auth_user_created');`
- [ ] Spot-check: insert a fresh test user via Supabase, confirm wallet account auto-created
- [ ] Follow-up PR 2 will split `WalletClient` rw/ro pools + add `WALLET_DATABASE_URL_RO` env pointing at `supabase-cluster-pooler-ro`