### PR TITLE
chore(npm): clean up @kbve/astro and @kbve/droid bundler warnings

### DIFF
--- a/packages/npm/astro/src/index.ts
+++ b/packages/npm/astro/src/index.ts
@@ -141,7 +141,5 @@ export {
 	getSiteGraphWorkerPort,
 	fetchViaWorker,
 	SITE_GRAPH_WORKER_SOURCE,
-	SiteGraph,
-	Backlinks,
 	SiteGraphLoader,
 } from './sitegraph';

--- a/packages/npm/astro/src/sitegraph/index.ts
+++ b/packages/npm/astro/src/sitegraph/index.ts
@@ -31,9 +31,7 @@ export {
 	fetchViaWorker,
 } from './react/worker-client';
 export { SITE_GRAPH_WORKER_SOURCE } from './react/worker-source';
-export { SiteGraph } from './react/SiteGraph';
 export type { SiteGraphProps } from './react/SiteGraph';
-export { Backlinks } from './react/Backlinks';
 export type { BacklinksProps } from './react/Backlinks';
 export { SiteGraphLoader } from './react/SiteGraphLoader';
 export type { SiteGraphLoaderProps } from './react/SiteGraphLoader';

--- a/packages/npm/droid/vite.config.ts
+++ b/packages/npm/droid/vite.config.ts
@@ -5,100 +5,122 @@ import dts from 'vite-plugin-dts';
 import path from 'path';
 
 export default defineConfig(() => ({
-  root: __dirname,
-  cacheDir: '../../../node_modules/.vite/npm/droid',
-  plugins: [
-    nxViteTsPaths(),
-    nxCopyAssetsPlugin(['*.md']),
-    dts({
-      entryRoot: 'src',
-      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
-      outDir: '../../../dist/packages/npm/droid',
-    }),
-  ],
+	root: __dirname,
+	cacheDir: '../../../node_modules/.vite/npm/droid',
+	plugins: [
+		nxViteTsPaths(),
+		nxCopyAssetsPlugin(['*.md']),
+		dts({
+			entryRoot: 'src',
+			tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+			outDir: '../../../dist/packages/npm/droid',
+		}),
+	],
 
-  resolve: {
-    alias: {
-      '/workers/canvas-worker': path.resolve(__dirname, 'src/lib/workers/canvas-worker.ts'),
-      '/workers/db-worker': path.resolve(__dirname, 'src/lib/workers/db-worker.ts'),
-      '/workers/ws-worker': path.resolve(__dirname, 'src/lib/workers/ws-worker.ts'),
-      '/workers/supabase-shared-worker': path.resolve(__dirname, 'src/lib/workers/supabase-shared-worker.ts'),
-      '/workers/supabase-db-worker': path.resolve(__dirname, 'src/lib/workers/supabase-db-worker.ts'),
-    },
-  },
+	resolve: {
+		alias: {
+			'/workers/canvas-worker': path.resolve(
+				__dirname,
+				'src/lib/workers/canvas-worker.ts',
+			),
+			'/workers/db-worker': path.resolve(
+				__dirname,
+				'src/lib/workers/db-worker.ts',
+			),
+			'/workers/ws-worker': path.resolve(
+				__dirname,
+				'src/lib/workers/ws-worker.ts',
+			),
+			'/workers/supabase-shared-worker': path.resolve(
+				__dirname,
+				'src/lib/workers/supabase-shared-worker.ts',
+			),
+			'/workers/supabase-db-worker': path.resolve(
+				__dirname,
+				'src/lib/workers/supabase-db-worker.ts',
+			),
+		},
+	},
 
-  build: {
-    lib: {
-      entry: path.resolve(__dirname, 'src/index.ts'),
-      name: 'droid',
-      fileName: (format) => `droid.${format}.js`,
-      formats: ['es'] as const,
-    },
-    outDir: '../../../dist/packages/npm/droid',
-    target: 'esnext',
-	assetsInlineLimit: 0,
-    rollupOptions: {
-      input: {
-        droid: path.resolve(__dirname, 'src/index.ts'),
-        'workers/main': path.resolve(__dirname, 'src/lib/workers/main.ts'),
-        'workers/canvas-worker': path.resolve(__dirname, 'src/lib/workers/canvas-worker.ts'),
-        'workers/db-worker': path.resolve(__dirname, 'src/lib/workers/db-worker.ts'),
-        'workers/ws-worker': path.resolve(__dirname, 'src/lib/workers/ws-worker.ts'),
-        'workers/supabase-shared-worker': path.resolve(__dirname, 'src/lib/workers/supabase-shared-worker.ts'),
-        'workers/supabase-db-worker': path.resolve(__dirname, 'src/lib/workers/supabase-db-worker.ts'),
-      },
-    output: {
-		manualChunks: undefined,
-        entryFileNames: (chunkInfo) => {
-          if (chunkInfo.facadeModuleId?.includes('canvas-worker.ts')) return 'lib/workers/canvas-worker.js';
-          if (chunkInfo.facadeModuleId?.includes('db-worker.ts') && !chunkInfo.facadeModuleId?.includes('supabase')) return 'lib/workers/db-worker.js';
-          if (chunkInfo.facadeModuleId?.includes('ws-worker.ts')) return 'lib/workers/ws-worker.js';
-          if (chunkInfo.facadeModuleId?.includes('supabase-shared-worker.ts')) return 'lib/workers/supabase-shared-worker.js';
-          if (chunkInfo.facadeModuleId?.includes('supabase-db-worker.ts')) return 'lib/workers/supabase-db-worker.js';
-          if (chunkInfo.facadeModuleId?.includes('main.ts')) return 'workers/main.js';
-		  if (chunkInfo.facadeModuleId?.includes('index.ts')) return 'droid.mjs';
-        return '[name].js';
-      },
-	chunkFileNames: '[name].js',
-  	assetFileNames: '[name].[ext]',
-    },
-		  external: [] as string[], // optionally add external deps here
-    },
-  },
+	build: {
+		lib: {
+			entry: path.resolve(__dirname, 'src/index.ts'),
+			name: 'droid',
+			fileName: (format) => `droid.${format}.js`,
+			formats: ['es'] as const,
+		},
+		outDir: '../../../dist/packages/npm/droid',
+		target: 'esnext',
+		assetsInlineLimit: 0,
+		rollupOptions: {
+			input: {
+				droid: path.resolve(__dirname, 'src/index.ts'),
+				'workers/main': path.resolve(
+					__dirname,
+					'src/lib/workers/main.ts',
+				),
+			},
+			output: {
+				manualChunks: undefined,
+				entryFileNames: (chunkInfo) =>
+					chunkInfo.facadeModuleId?.includes('index.ts')
+						? 'droid.mjs'
+						: '[name].js',
+				chunkFileNames: '[name].js',
+				assetFileNames: '[name].[ext]',
+			},
+			external: [] as string[],
+		},
+	},
 
-  worker: {
-    plugins: () => [nxViteTsPaths()],
-	  format: 'es',
-    rollupOptions: {
-      input: {
-        'canvas-worker': path.resolve(__dirname, 'src/lib/workers/canvas-worker.ts'),
-        'db-worker': path.resolve(__dirname, 'src/lib/workers/db-worker.ts'),
-        'ws-worker': path.resolve(__dirname, 'src/lib/workers/ws-worker.ts'),
-        'supabase-shared-worker': path.resolve(__dirname, 'src/lib/workers/supabase-shared-worker.ts'),
-        'supabase-db-worker': path.resolve(__dirname, 'src/lib/workers/supabase-db-worker.ts'),
-      },
-      output: {
-        entryFileNames: 'lib/workers/[name].js',
-        chunkFileNames: 'lib/workers/[name].js',
-        assetFileNames: 'assets/[name].[ext]',
-        manualChunks: undefined,
-        inlineDynamicImports: false,
-      },
-    },
-    inline: false,
-  },
+	worker: {
+		plugins: () => [nxViteTsPaths()],
+		format: 'es',
+		rollupOptions: {
+			input: {
+				'canvas-worker': path.resolve(
+					__dirname,
+					'src/lib/workers/canvas-worker.ts',
+				),
+				'db-worker': path.resolve(
+					__dirname,
+					'src/lib/workers/db-worker.ts',
+				),
+				'ws-worker': path.resolve(
+					__dirname,
+					'src/lib/workers/ws-worker.ts',
+				),
+				'supabase-shared-worker': path.resolve(
+					__dirname,
+					'src/lib/workers/supabase-shared-worker.ts',
+				),
+				'supabase-db-worker': path.resolve(
+					__dirname,
+					'src/lib/workers/supabase-db-worker.ts',
+				),
+			},
+			output: {
+				entryFileNames: 'lib/workers/[name].js',
+				chunkFileNames: 'lib/workers/[name].js',
+				assetFileNames: 'assets/[name].[ext]',
+				manualChunks: undefined,
+				inlineDynamicImports: false,
+			},
+		},
+		inline: false,
+	},
 
-  test: {
-    setupFiles: ['src/setup-vitest.ts'],
-    watch: false,
-    globals: true,
-    threads: false,
-    environment: 'jsdom',
-    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    reporters: ['default'],
-    coverage: {
-      reportsDirectory: '../../../coverage/npm/droid',
-      provider: 'v8' as const,
-    },
-  },
+	test: {
+		setupFiles: ['src/setup-vitest.ts'],
+		watch: false,
+		globals: true,
+		threads: false,
+		environment: 'jsdom',
+		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+		reporters: ['default'],
+		coverage: {
+			reportsDirectory: '../../../coverage/npm/droid',
+			provider: 'v8' as const,
+		},
+	},
 }));


### PR DESCRIPTION
## Summary
Two latent bundler warnings in published npm packages had been firing on every build. Both are now resolved.

### `@kbve/astro`
`SiteGraph` and `Backlinks` were re-exported statically from the package root **and** lazy-imported inside `SiteGraphLoader.tsx` via `lazy(() => import('./SiteGraph'))`. Vite/Rollup warned on every build:

> `src/sitegraph/react/SiteGraph.tsx` is dynamically imported by `SiteGraphLoader.tsx` but also statically imported by `src/sitegraph/index.ts`, dynamic import will not move module into another chunk.

Every consumer (including `astro-kbve`) was pulling SiteGraph + Backlinks into the main bundle eagerly, defeating the lazy boundary. The only consumer of these modules anywhere in the monorepo is `SiteGraphLoader` itself; dropping the static re-exports lets the dynamic import actually emit a separate chunk. Prop type aliases stay exported.

### `@kbve/droid`
`build.rollupOptions.input` and `worker.rollupOptions.input` both listed all five Web Worker entrypoints, so Vite was emitting each worker twice to the same path:

```
The emitted file "lib/workers/canvas-worker.js" overwrites a previously emitted file of the same name.
... (4 more)
```

All worker consumers (`SupabaseGateway`, droid's `index.ts`) use `?worker&url` imports, so the `worker:` config is authoritative; the duplicate `build.rollupOptions.input` entries are what to drop. Also collapsed the now-unnecessary `entryFileNames` chained conditional into a single ternary.

## Test plan
- [x] `./kbve.sh -nx astro:build` → 0 warnings
- [x] `./kbve.sh -nx droid:build` → 0 worker-overwrite warnings; `dist/packages/npm/droid/lib/workers/*.js` still emit
- [x] `./kbve.sh -nx droid:test` → green
- [x] `./kbve.sh -nx astro-kbve:check` → still 0 errors / 0 warnings
- [x] `./kbve.sh -nx astro-kbve:build` → still builds (no behavior change at the consumer)