### PR TITLE
fix(cryptothrone): harden make-install fallback against nodesource IPv6 outage

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -124,9 +124,15 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ============================================================================
 FROM foundation AS builder
 
-# Ensure make is available for tikv-jemalloc-sys compilation (build from source)
-RUN dpkg -s make >/dev/null 2>&1 || \
-    (apt-get update && apt-get install -y --no-install-recommends make && rm -rf /var/lib/apt/lists/*)
+# Ensure make is available for tikv-jemalloc-sys compilation (build from source).
+# Drop nodesource sources + force IPv4 so the fallback survives transient
+# nodesource.com IPv6 outages — make only needs debian main.
+RUN dpkg -s make >/dev/null 2>&1 || ( \
+        rm -f /etc/apt/sources.list.d/nodesource.list && \
+        apt-get update -o Acquire::ForceIPv4=true && \
+        apt-get install -y --no-install-recommends make && \
+        rm -rf /var/lib/apt/lists/* \
+    )
 
 COPY --from=astro-precompressor /static /app/apps/cryptothrone/axum-cryptothrone/templates/dist
 


### PR DESCRIPTION
## Summary
- `axum-cryptothrone` Dockerfile's `make` fallback ran `apt-get update` against the base image's `nodesource.list`, which dies when `deb.nodesource.com` IPv6 is unreachable.
- CI run [#25810064823](https://github.com/KBVE/kbve/actions/runs/25810064823) failed with `Cannot initiate the connection to deb.nodesource.com:443 (2606:4700:10::6814:2dbe). - connect (101: Network is unreachable)` → `exit code: 100`.
- Drop `nodesource.list` before `apt-get update` and force IPv4 — `make` only needs debian main.

## Test plan
- [ ] CI - Docker / cryptothrone passes
- [ ] Verify base image still ships `make` (fallback should not even fire on green path)

Closes #10923