### PR TITLE
chore(astro-kbve): wire orphaned cards.test.ts into nx test target

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.150",
+			"version": "1.0.152",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",

--- a/apps/kbve/astro-kbve/project.json
+++ b/apps/kbve/astro-kbve/project.json
@@ -74,6 +74,13 @@
 				"parallel": false
 			}
 		},
+		"test": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/kbve/astro-kbve",
+				"command": "vitest run --config vitest.config.ts"
+			}
+		},
 		"sync": {
 			"executor": "nx:run-commands",
 			"options": {

--- a/apps/kbve/astro-kbve/vitest.config.ts
+++ b/apps/kbve/astro-kbve/vitest.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+	},
+	resolve: {
+		alias: {
+			'@': path.resolve(__dirname, 'src'),
+			'@kbve/astro': path.resolve(
+				__dirname,
+				'../../../packages/npm/astro/src/index.ts',
+			),
+			'@kbve/devops': path.resolve(
+				__dirname,
+				'../../../packages/npm/devops/src/index.ts',
+			),
+			'@kbve/droid': path.resolve(
+				__dirname,
+				'../../../packages/npm/droid/src/index.ts',
+			),
+			'@kbve/laser': path.resolve(
+				__dirname,
+				'../../../packages/npm/laser/src/index.ts',
+			),
+		},
+	},
+});


### PR DESCRIPTION
## Summary
`src/arcade/blackjack/cards.test.ts` shipped with the blackjack arcade refactor but the project had no `vitest.config.ts` and no `test` target, so the file's 3 tests weren't running anywhere — local CLI, CI, or otherwise. astro-memes already uses this exact pattern; mirror it.

- Add `apps/kbve/astro-kbve/vitest.config.ts` with `@/*` + `@kbve/*` path aliases.
- Add `astro-kbve:test` nx target (`vitest run --config vitest.config.ts`).
- Regen `.github/ci-dispatch-manifest.json` to pick up the drifted `axum-kbve` version (1.0.150 → 1.0.152). The publish pipeline bumped Cargo.toml/version.toml after a release but never re-synced the manifest.

## Test plan
- [x] `./kbve.sh -nx astro-kbve:test` → 3 tests pass
- [x] `./kbve.sh -nx astro-kbve:check` → 0 errors / 0 warnings (still)
- [x] `./kbve.sh -nx astro-kbve:build` → clean