### PR TITLE
perf(arcade): compact blackjack hand snapshots

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts
@@ -7,6 +7,7 @@ import {
 	cardRank,
 	cardSuit,
 	encodeCard,
+	handFingerprint,
 	isBlackjack,
 	valueHand,
 } from './cards';
@@ -41,5 +42,25 @@ describe('blackjack card encoding', () => {
 			total: 20,
 			soft: false,
 		});
+	});
+
+	it('builds stable bit-packed hand fingerprints', () => {
+		const hand = [
+			encodeCard('spades', 'A'),
+			encodeCard('hearts', '9'),
+			encodeCard('clubs', 'J'),
+		];
+		const reordered = [hand[1], hand[0], hand[2]];
+		const longHand = [
+			...hand,
+			encodeCard('diamonds', '2'),
+			encodeCard('spades', '3'),
+			encodeCard('hearts', '4'),
+		];
+
+		expect(handFingerprint(hand)).toBe(handFingerprint([...hand]));
+		expect(handFingerprint(hand)).not.toBe(handFingerprint(reordered));
+		expect(handFingerprint(longHand)).toBe(handFingerprint([...longHand]));
+		expect(handFingerprint(longHand)).not.toBe(handFingerprint(hand));
 	});
 });

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts
@@ -42,6 +42,8 @@ const RANKS = [
 const RANK_MASK = 0b1111;
 const SUIT_MASK = 0b11;
 const SUIT_SHIFT = 4;
+const CARD_BYTE_MASK = 0b111111;
+const CARDS_PER_DECK = SUITS.length * RANKS.length;
 const RANK_POINTS = [11, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10] as const;
 
 export const SUIT_GLYPH: Record<Suit, string> = {
@@ -75,11 +77,13 @@ export function cardId(card: Card): string {
 }
 
 export function buildShoe(decks: number): Card[] {
-	const shoe: Card[] = [];
+	const shoe = new Array<Card>(decks * CARDS_PER_DECK);
+	let index = 0;
 	for (let deck = 0; deck < decks; deck++) {
-		for (const suit of SUITS) {
-			for (const rank of RANKS) {
-				shoe.push(encodeCard(suit, rank));
+		for (let suitIndex = 0; suitIndex < SUITS.length; suitIndex++) {
+			for (let rankIndex = 0; rankIndex < RANKS.length; rankIndex++) {
+				shoe[index] = (suitIndex << SUIT_SHIFT) | rankIndex;
+				index++;
 			}
 		}
 	}
@@ -103,7 +107,8 @@ export function valueHand(cards: readonly Card[]): HandValue {
 	let total = 0;
 	let aces = 0;
 
-	for (const card of cards) {
+	for (let i = 0; i < cards.length; i++) {
+		const card = cards[i];
 		total += cardPoints(card);
 		if ((card & RANK_MASK) === 0) aces++;
 	}
@@ -121,4 +126,22 @@ export function valueHand(cards: readonly Card[]): HandValue {
 
 export function isBlackjack(cards: readonly Card[]): boolean {
 	return cards.length === 2 && valueHand(cards).total === 21;
+}
+
+export function handFingerprint(cards: readonly Card[]): number {
+	let fingerprint = cards.length & 0xff;
+	const packedCards = Math.min(cards.length, 4);
+
+	for (let i = 0; i < packedCards; i++) {
+		fingerprint |= (cards[i] & CARD_BYTE_MASK) << (8 + i * 6);
+	}
+
+	for (let i = packedCards; i < cards.length; i++) {
+		fingerprint = Math.imul(
+			fingerprint ^ (cards[i] & CARD_BYTE_MASK),
+			16777619,
+		);
+	}
+
+	return fingerprint >>> 0;
 }

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/handLayout.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/handLayout.ts
@@ -1,9 +1,10 @@
 import { CARD_SIZE } from '../config';
-import type { Card } from '../cards';
+import { handFingerprint, type Card } from '../cards';
 import type { CardPlacement, HandOwner } from '../animation/dealerAnimation';
 
 interface PlacementCacheEntry {
-	cards: Card[];
+	cards: Uint8Array;
+	fingerprint: number;
 	centerX: number;
 	y: number;
 	hideHole: boolean;
@@ -23,7 +24,17 @@ export class HandLayout {
 		owner: HandOwner,
 	): CardPlacement[] {
 		const cached = this.placementCache.get(owner);
-		if (this.matchesPlacementCache(cached, cards, centerX, y, hideHole)) {
+		const fingerprint = handFingerprint(cards);
+		if (
+			this.matchesPlacementCache(
+				cached,
+				cards,
+				fingerprint,
+				centerX,
+				y,
+				hideHole,
+			)
+		) {
 			return cached.placements;
 		}
 
@@ -46,7 +57,8 @@ export class HandLayout {
 			x += CARD_SIZE.width + 18;
 		});
 		this.placementCache.set(owner, {
-			cards: cards.slice(),
+			cards: Uint8Array.from(cards),
+			fingerprint,
 			centerX,
 			y,
 			hideHole,
@@ -58,6 +70,7 @@ export class HandLayout {
 	private matchesPlacementCache(
 		cached: PlacementCacheEntry | undefined,
 		cards: readonly Card[],
+		fingerprint: number,
 		centerX: number,
 		y: number,
 		hideHole: boolean,
@@ -67,6 +80,7 @@ export class HandLayout {
 			cached.centerX !== centerX ||
 			cached.y !== y ||
 			cached.hideHole !== hideHole ||
+			cached.fingerprint !== fingerprint ||
 			cached.cards.length !== cards.length
 		) {
 			return false;


### PR DESCRIPTION
## Summary
- preallocate blackjack shoe construction while keeping byte-encoded cards
- add a bit-packed hand fingerprint helper for cache checks
- store hand layout cache snapshots in `Uint8Array` and validate with the fingerprint before comparing bytes

## Validation
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/handLayout.ts`
- `./kbve.sh -nx astro-kbve:test`
- `AXUM_PORT=4357 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`