### PR TITLE
fix(ci): sync Cargo.lock in post-publish to prevent drift

### DIFF
--- a/.github/workflows/utils-post-publish.yml
+++ b/.github/workflows/utils-post-publish.yml
@@ -172,6 +172,44 @@ jobs:
                   esac
                   echo "Synced $TARGET to $VERSION"
 
+            # Bump the matching [[package]] block in the workspace
+            # Cargo.lock so the lockfile no longer drifts when CI bumps a
+            # Cargo.toml. Without this step, every fresh checkout regenerates
+            # Cargo.lock as soon as `cargo` runs, leaving the working tree
+            # dirty (e.g., axum-kbve 1.0.151 in lock vs 1.0.152 in Cargo.toml
+            # after a post-publish).
+            - name: Sync Cargo.lock
+              if: inputs.version_target_path != '' && endsWith(inputs.version_target_path, 'Cargo.toml')
+              run: |
+                  TARGET="${{ inputs.version_target_path }}"
+                  VERSION="${{ steps.validate.outputs.version }}"
+
+                  if [ ! -f Cargo.lock ]; then
+                    echo "::notice::Cargo.lock not present at workspace root — skipping."
+                    exit 0
+                  fi
+
+                  PKG_NAME=$(grep -m 1 '^name = "' "$TARGET" | sed 's/name = "\(.*\)"/\1/')
+                  if [ -z "$PKG_NAME" ]; then
+                    echo "::warning::Could not parse package name from '$TARGET' — skipping Cargo.lock sync."
+                    exit 0
+                  fi
+
+                  awk -v pkg="$PKG_NAME" -v new="$VERSION" '
+                    /^\[\[package\]\]$/ { in_pkg=1; matched=0 }
+                    in_pkg && /^name = "/ {
+                      n=$0; sub(/^name = "/, "", n); sub(/"$/, "", n);
+                      if (n == pkg) matched=1
+                    }
+                    in_pkg && matched && /^version = "/ {
+                      sub(/version = "[^"]+"/, "version = \"" new "\"")
+                      matched=0
+                    }
+                    /^$/ { in_pkg=0; matched=0 }
+                    { print }
+                  ' Cargo.lock > Cargo.lock.tmp && mv Cargo.lock.tmp Cargo.lock
+                  echo "Synced Cargo.lock entry for $PKG_NAME to $VERSION"
+
             - name: Update kube deployment manifests
               if: (inputs.deployment_yaml != '' || inputs.deployment_yamls != '') && inputs.image_name != ''
               env:
@@ -218,6 +256,11 @@ jobs:
                   EXPECTED_FILES="${{ inputs.version_toml_path }}"
                   if [ -n "${{ inputs.version_target_path }}" ]; then
                     EXPECTED_FILES="$EXPECTED_FILES ${{ inputs.version_target_path }}"
+                    case "${{ inputs.version_target_path }}" in
+                      *Cargo.toml)
+                        [ -f Cargo.lock ] && EXPECTED_FILES="$EXPECTED_FILES Cargo.lock"
+                        ;;
+                    esac
                   fi
                   if [ -n "${{ inputs.deployment_yaml }}" ]; then
                     EXPECTED_FILES="$EXPECTED_FILES ${{ inputs.deployment_yaml }}"
@@ -267,6 +310,11 @@ jobs:
                   git add "${{ inputs.version_toml_path }}"
                   if [ -n "${{ inputs.version_target_path }}" ] && [ -f "${{ inputs.version_target_path }}" ]; then
                     git add "${{ inputs.version_target_path }}"
+                    case "${{ inputs.version_target_path }}" in
+                      *Cargo.toml)
+                        [ -f Cargo.lock ] && git add Cargo.lock
+                        ;;
+                    esac
                   fi
 
                   DEPLOYMENT_FILES=""

--- a/.github/workflows/utils-post-publish.yml
+++ b/.github/workflows/utils-post-publish.yml
@@ -40,6 +40,17 @@ on:
                 description: 'PAT for pushing atom branches'
                 required: true
 
+# Serialize post-publish runs. Multiple crate releases firing in
+# parallel would each rebase Cargo.lock from the same pre-publish dev
+# HEAD, and even though each touches a different `[[package]]` block
+# the 3-way merge can fail when transitive deps shift adjacent lines.
+# Queuing keeps each atom branch based on dev that already contains
+# the prior post-publish, eliminating the race for Cargo.lock and
+# version.toml history.
+concurrency:
+    group: post-publish
+    cancel-in-progress: false
+
 jobs:
     update:
         name: Post-publish v${{ inputs.version }}


### PR DESCRIPTION
## Summary
The post-publish workflow (`utils-post-publish.yml`) was bumping `Cargo.toml` + `version.toml` for crate releases but never touching `Cargo.lock`. The lockfile's `[[package]]` block stayed at the pre-publish version, so every fresh checkout regenerated the lock on the first `cargo` invocation, leaving the working tree dirty (most recently: lock had `axum-kbve 1.0.151` while Cargo.toml had `1.0.152` after #10924).

This PR adds two protections — the missing Cargo.lock sync, plus serialization so parallel releases can't race.

## Changes
1. **`Sync Cargo.lock` step** — runs after the version target sync when `version_target_path` ends with `Cargo.toml`. Parses the package name out of the target Cargo.toml and rewrites the matching `[[package]]` block in `Cargo.lock` via `awk` — no rust toolchain on the runner. Output is byte-identical to what `cargo check` writes on a stale lock (verified locally).
2. **`Verify changed files` + atom-branch `git add`** — extended to allow `Cargo.lock`, both gated on `*Cargo.toml` suffix.
3. **`concurrency: post-publish` group** — serializes all post-publish runs. Without this, two crates releasing in parallel each base their atom branch on the same dev HEAD; even though their Cargo.lock diffs touch different `[[package]]` blocks, transitive deps shifting adjacent lines can break the 3-way merge when the second auto-merges. Queuing keeps each atom branch based on dev that already contains the prior post-publish.

## Why Cargo.lock is NOT in this PR
The existing axum-kbve drift (`1.0.151` → `1.0.152`) is deliberately left out. Cargo.lock is high-churn and bundling the reconciliation would force this workflow patch to rebase against every parallel Rust merge. The next post-publish run (v1.0.153 prep is already on dev) will pick up the drift automatically once this lands.

## Test plan
- [x] awk patch produces byte-identical Cargo.lock to `cargo check` on the current stale state
- [x] `actionlint` clean on the touched lines
- [ ] Next post-publish run — atom PR should now include `Cargo.lock` alongside `Cargo.toml` + `version.toml`
- [ ] Two near-simultaneous releases — second one waits in the `post-publish` concurrency queue rather than racing on Cargo.lock