### PR TITLE
chore(axum-kbve): sweep chatty comments across transport/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.151"
+version = "1.0.152"
 dependencies = [
  "anyhow",
  "askama 0.16.0",

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -48,14 +48,9 @@ const PERMANENT_REDIRECTS: &[(&str, &str)] = &[
     ("/application/argo/", "/application/kubernetes/#argo"),
     ("/application/bevy", "/application/rust/#bevy"),
     ("/application/bevy/", "/application/rust/#bevy"),
-    // /health is the canonical (no trailing slash) — match how the
-    // ingress + uptime probes hit it.
     ("/health/", "/health"),
-    // GET API endpoints under /api/v1/* are canonical without a
-    // trailing slash. axum doesn't normalize trailing slashes by
-    // default and our route table only registers the no-slash
-    // form. Mirror them here so curl + bookmarks + the astro-kbve
-    // build-time fetch still resolve.
+    // axum doesn't normalize trailing slashes; route table only
+    // registers the no-slash form for /api/v1/* GET endpoints.
     ("/api/v1/forum/tags/", "/api/v1/forum/tags"),
     ("/api/v1/forum/spaces/", "/api/v1/forum/spaces"),
     ("/api/v1/me/", "/api/v1/me"),
@@ -72,18 +67,13 @@ const PERMANENT_REDIRECTS: &[(&str, &str)] = &[
         "/osrs/bracelet-of-ethereum/",
         "/osrs/bracelet-of-ethereum-uncharged/",
     ),
-    // Tag listing — short alias for users.
     ("/tags", "/forum/tags"),
     ("/tags/", "/forum/tags"),
     ("/t", "/forum/tags"),
     ("/t/", "/forum/tags"),
-    // Askama SSG source pages — every .mdx under
-    // src/content/docs/askama/* still ships an HTML file in dist/
-    // because Starlight builds the whole content collection. None of
-    // them are meant to resolve as public URLs; the live versions
-    // are handled by axum routes that interpolate the askama
-    // placeholders. Funnel each to its canonical target so search
-    // engines + bookmarks land on the dynamic version.
+    // Askama SSG source pages ship HTML in dist/ but are not public
+    // URLs — live versions are served by axum routes that interpolate
+    // placeholders. Funnel to canonical so crawlers don't index them.
     ("/askama/forum/feed", "/forum/"),
     ("/askama/forum/feed/", "/forum/"),
     ("/askama/forum/thread", "/forum/"),
@@ -183,7 +173,6 @@ pub async fn serve(state: AppState) -> Result<()> {
     let key_path = std::env::var("HTTP_KEY").ok();
 
     if let (Some(cert), Some(key)) = (cert_path, key_path) {
-        // TLS mode — mkcert or production certs
         let tls_config = axum_server::tls_rustls::RustlsConfig::from_pem_file(&cert, &key)
             .await
             .map_err(|e| anyhow::anyhow!("failed to load TLS certs ({cert}, {key}): {e}"))?;
@@ -194,7 +183,6 @@ pub async fn serve(state: AppState) -> Result<()> {
             .serve(app.into_make_service())
             .await?;
     } else {
-        // Plain HTTP (production behind reverse proxy, or legacy dev)
         let listener = tuned_listener(addr)?;
         info!("HTTP listening on http://{addr}");
 
@@ -218,7 +206,6 @@ fn router(state: AppState) -> Router {
             ),
         )
         .layer(tower_http::cors::CorsLayer::permissive())
-        // Security headers
         .layer(SetResponseHeaderLayer::overriding(
             header::X_CONTENT_TYPE_OPTIONS,
             HeaderValue::from_static("nosniff"),
@@ -298,9 +285,6 @@ fn router(state: AppState) -> Router {
         .route("/@{username}", get(profile_handler))
         .route("/osrs/{item}", get(osrs_item_handler))
         .route("/osrs/{item}/", get(osrs_item_handler_trailing))
-        // Bare /forum (no trailing slash) → /forum/. Crawlers + typed
-        // URLs land on the canonical with a permanent redirect. Same
-        // for shorthand aliases /community + /c.
         .route("/forum", get(|| async { Redirect::permanent("/forum/") }))
         .route(
             "/community",
@@ -349,9 +333,6 @@ fn router(state: AppState) -> Router {
             "/api/v1/forum/t/{slug_or_id}/comments",
             post(api_create_comment),
         )
-        // PATCH = author edit-own. DELETE = staff remove. The mod-edit
-        // path lives at a sibling /moderate route to keep the verb/url
-        // matrix readable.
         .route(
             "/api/v1/forum/c/{comment_id}",
             axum::routing::patch(api_edit_comment).delete(api_remove_comment),
@@ -364,16 +345,13 @@ fn router(state: AppState) -> Router {
         .route("/api/v1/me/staff", get(api_me_staff))
         .route("/api/v1/forum/spaces", get(api_list_spaces))
         .route("/api/v1/forum/tags", get(api_list_tags))
-        // Wallet — authenticated user surface (Supabase JWT).
         .route("/api/v1/wallet/me/balance", get(super::wallet::me_balance))
         .route("/api/v1/wallet/me/coupons", get(super::wallet::me_coupons))
         .route(
             "/api/v1/wallet/me/redeem-coupon",
             post(super::wallet::me_redeem_coupon),
         )
-        // Wallet — service surface (service_role JWT required). Backend
-        // callers: daily-reward cron, market mutations, MC mod, admin
-        // tooling. Anon / authenticated JWTs are rejected with 403.
+        // service_role JWT required; anon / authenticated JWTs are rejected with 403.
         .route(
             "/api/v1/wallet/service/credit",
             post(super::wallet::service_credit),
@@ -402,9 +380,6 @@ fn router(state: AppState) -> Router {
             "/api/v1/wallet/service/verify-balance/{account_id}",
             get(super::wallet::service_verify_balance),
         )
-        // SEO-friendly 301: /forum/c/{slug} → /forum/s/{slug}. `c/` reads
-        // as "category" but the canonical URL is `s/` (space). Crawlers
-        // collapse the duplicate into the canonical via the redirect.
         .route("/forum/c/", get(forum_c_root_redirect))
         .route("/forum/c/{slug}", get(forum_c_redirect))
         .route("/forum/c/{slug}/", get(forum_c_redirect));
@@ -414,7 +389,7 @@ fn router(state: AppState) -> Router {
 
     let main_app = static_router.merge(public_router).layer(middleware);
 
-    // Proxy + WebSocket routes bypass global middleware (no 10s timeout, no 1MB body limit)
+    // Proxy + WebSocket routes bypass global middleware (no 10s timeout, no 1MB body limit).
     let mut bypass_router = Router::new();
     if let Some(mcp_svc) = crate::mcp::build_service() {
         bypass_router = bypass_router
@@ -490,25 +465,17 @@ fn router(state: AppState) -> Router {
             "/dashboard/firecracker-net/proxy",
             any(super::proxy::firecracker_net_proxy_handler),
         )
-        // Stable public alias for the persistent endpoint surface.
-        // /api/v1/fc/<deploy|list|{name}|...> -> firecracker-ctl-net /fc/<rest>.
-        // Same staff gate as the firecracker-net proxy above; the underlying
-        // FIRECRACKER_NET singleton handles the upstream forward.
         .route(
             "/api/v1/fc/{*rest}",
             any(super::proxy::firecracker_fc_alias_handler),
         )
-        // Public-facing persistent endpoint path — /fc/{name}/{*path}
-        // routes to firecracker-ctl-net's /proxy/{name}/{*path} after a
-        // staff-level auth gate. The {name} identifies the persistent VM.
         .route(
             "/fc/{name}/{*path}",
             any(super::proxy::firecracker_fc_handler),
         )
         .route("/fc/{name}", any(super::proxy::firecracker_fc_handler))
-        // Anonymous public tier — no JWT gate at this layer; firecracker-ctl-net
-        // rejects with 403 when the endpoint was not deployed with
-        // `visibility: "public"`.
+        // No JWT gate here; firecracker-ctl-net rejects with 403 when
+        // the endpoint was not deployed with `visibility: "public"`.
         .route(
             "/fc/public/{name}/{*path}",
             any(super::proxy::firecracker_fc_public_handler),
@@ -570,15 +537,8 @@ fn router(state: AppState) -> Router {
             any(super::proxy::chuckrpg_proxy_handler),
         );
 
-    // Game server WebSocket is now handled by lightyear on a separate port
-    // (GAME_WS_ADDR, default :5000). No Axum route needed.
-
     bypass_router.merge(main_app)
 }
-
-// ---------------------------------------------------------------------------
-// Health / status handlers (monorepo versions)
-// ---------------------------------------------------------------------------
 
 #[utoipa::path(
     get,
@@ -621,14 +581,8 @@ pub(crate) async fn api_status(State(state): State<AppState>) -> impl IntoRespon
     })
 }
 
-// ---------------------------------------------------------------------------
-// Profile page handler
-// ---------------------------------------------------------------------------
-
-/// Profile page handler - displays user profile by username.
-/// Uses cache-first strategy with Discord enrichment.
+/// Profile page handler — cache-first with Discord enrichment.
 async fn profile_handler(Path(username): Path<String>) -> impl IntoResponse {
-    // Step 1: Validate username format (prevents unnecessary DB/cache calls)
     let validated_username = match validate_username(&username) {
         Ok(u) => u,
         Err(e) => {
@@ -643,7 +597,7 @@ async fn profile_handler(Path(username): Path<String>) -> impl IntoResponse {
         }
     };
 
-    // Step 2: Try cache first; concurrent misses collapse to one enrichment.
+    // Concurrent misses collapse to one enrichment via get_or_load.
     let profile = if let Some(cache) = get_profile_cache() {
         cache
             .get_or_load(&validated_username, |u| async move {
@@ -655,15 +609,13 @@ async fn profile_handler(Path(username): Path<String>) -> impl IntoResponse {
         fetch_profile_from_db(&validated_username).await
     };
 
-    // Step 3: Render response with appropriate cache headers
     match profile {
         Some(profile) => {
-            // Forum block is fetched fresh (not cached with the rest of the
-            // profile) so post counts and recent activity stay current.
+            // Forum block bypasses the profile cache so post counts and
+            // recent activity stay current.
             let forum_block = fetch_forum_profile_block(&profile.user_id).await;
             let response =
                 render_profile_template(&validated_username, &profile, forum_block.as_ref());
-            // Cache for 5 minutes, allow stale content while revalidating
             (
                 [
                     (
@@ -678,7 +630,6 @@ async fn profile_handler(Path(username): Path<String>) -> impl IntoResponse {
         }
         None => {
             tracing::info!("Profile not found for username: {}", validated_username);
-            // Don't cache 404s as long - user might register soon
             (
                 StatusCode::NOT_FOUND,
                 [(header::CACHE_CONTROL, "public, max-age=60")],
@@ -690,10 +641,6 @@ async fn profile_handler(Path(username): Path<String>) -> impl IntoResponse {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// Profile enrichment pipeline
-// ---------------------------------------------------------------------------
 
 /// Fetch profile from database and run the enrichment pipeline.
 /// Caching is the caller's responsibility (typically via `ProfileCache::get_or_load`).
@@ -723,7 +670,6 @@ async fn fetch_profile_from_db(username: &str) -> Option<UserProfile> {
 
 /// Enrich profile with Discord API data (guild member info)
 async fn enrich_with_discord(mut profile: UserProfile) -> UserProfile {
-    // Only enrich if we have Discord info and a Discord client
     let discord_id = match &profile.discord {
         Some(d) => d.id.clone(),
         None => return profile,
@@ -734,23 +680,16 @@ async fn enrich_with_discord(mut profile: UserProfile) -> UserProfile {
         None => return profile,
     };
 
-    // Fetch guild member data
     match client.get_guild_member(&discord_id).await {
         Ok(Some(member)) => {
-            // Update Discord info with guild-specific data
             if let Some(ref mut discord) = profile.discord {
-                // Mark as guild member
                 discord.is_guild_member = Some(true);
-
-                // Store guild nickname
                 discord.guild_nickname = member.nick.clone();
 
-                // Use guild nickname for display if available
                 if member.nick.is_some() {
                     discord.username = member.nick.clone();
                 }
 
-                // Use guild avatar if available, otherwise use user avatar
                 if let Some(avatar_hash) = member.avatar {
                     discord.avatar_url = Some(DiscordClient::guild_avatar_url(
                         client.guild_id(),
@@ -763,28 +702,21 @@ async fn enrich_with_discord(mut profile: UserProfile) -> UserProfile {
                     }
                 }
 
-                // Use global_name if we still don't have a username
                 if discord.username.is_none() {
                     if let Some(ref user) = member.user {
                         discord.username = user.global_name.clone().or(Some(user.username.clone()));
                     }
                 }
 
-                // Store join date
                 discord.joined_at = member.joined_at.clone();
-
-                // Store role IDs and resolve role names from cached guild roles
                 discord.role_ids = member.roles.clone();
                 discord.role_names = get_role_names(&member.roles);
-
-                // Check if user is boosting
                 discord.is_boosting = Some(member.premium_since.is_some());
             }
 
             tracing::debug!("Enriched Discord profile for user {}", discord_id);
         }
         Ok(None) => {
-            // User is NOT in the KBVE Discord guild
             if let Some(ref mut discord) = profile.discord {
                 discord.is_guild_member = Some(false);
             }
@@ -800,7 +732,6 @@ async fn enrich_with_discord(mut profile: UserProfile) -> UserProfile {
 
 /// Enrich profile with Twitch API data (live status, updated avatar)
 async fn enrich_with_twitch(mut profile: UserProfile) -> UserProfile {
-    // Only enrich if we have Twitch info and a Twitch client
     let twitch_username = match &profile.twitch {
         Some(t) => match &t.username {
             Some(u) => u.clone(),
@@ -814,7 +745,6 @@ async fn enrich_with_twitch(mut profile: UserProfile) -> UserProfile {
         None => return profile,
     };
 
-    // Check if user is currently live
     match client.is_user_live(&twitch_username).await {
         Ok(is_live) => {
             if let Some(ref mut twitch) = profile.twitch {
@@ -833,11 +763,9 @@ async fn enrich_with_twitch(mut profile: UserProfile) -> UserProfile {
         }
     }
 
-    // Optionally fetch fresh user data for updated avatar
     match client.get_user_by_login(&twitch_username).await {
         Ok(Some(user)) => {
             if let Some(ref mut twitch) = profile.twitch {
-                // Update avatar URL from Twitch API (more reliable/up-to-date)
                 twitch.avatar_url = Some(user.profile_image_url);
             }
             tracing::debug!("Enriched Twitch profile for user {}", twitch_username);
@@ -855,13 +783,11 @@ async fn enrich_with_twitch(mut profile: UserProfile) -> UserProfile {
 
 /// Enrich profile with RentEarth character data
 async fn enrich_with_rentearth(mut profile: UserProfile) -> UserProfile {
-    // Only enrich if we have a RentEarth service
     let service = match get_rentearth_service() {
         Some(s) => s,
         None => return profile,
     };
 
-    // Fetch RentEarth profile for this user
     match service
         .get_profile(&profile.user_id, &profile.username)
         .await
@@ -890,13 +816,8 @@ async fn enrich_with_rentearth(mut profile: UserProfile) -> UserProfile {
     profile
 }
 
-// ---------------------------------------------------------------------------
-// Profile template rendering
-// ---------------------------------------------------------------------------
-
 /// Convert archetype flags to human-readable class name
 fn archetype_flags_to_name(flags: i64) -> String {
-    // Primary archetypes based on flag values from the schema
     match flags {
         1 => "Warrior".to_string(),
         2 => "Mage".to_string(),
@@ -923,7 +844,6 @@ fn render_profile_template(
     profile: &UserProfile,
     forum: Option<&ForumProfileBlock>,
 ) -> TemplateResponse<ProfileTemplate> {
-    // Extract Discord info
     let (
         discord_username,
         discord_avatar,
@@ -952,21 +872,18 @@ fn render_profile_template(
         })
         .unwrap_or((None, None, None, None, None, None, None, 0, Vec::new()));
 
-    // Extract GitHub info
     let (github_username, github_avatar) = profile
         .github
         .as_ref()
         .map(|g| (g.username.clone(), g.avatar_url.clone()))
         .unwrap_or((None, None));
 
-    // Extract Twitch info
     let (twitch_username, twitch_avatar, twitch_is_live) = profile
         .twitch
         .as_ref()
         .map(|t| (t.username.clone(), t.avatar_url.clone(), t.is_live))
         .unwrap_or((None, None, None));
 
-    // Extract RentEarth info
     let (rentearth_characters, rentearth_total_playtime_hours, rentearth_last_activity) = profile
         .rentearth
         .as_ref()
@@ -975,11 +892,8 @@ fn render_profile_template(
                 .characters
                 .iter()
                 .map(|c| {
-                    // Convert archetype_flags to human-readable name
                     let archetype_name = archetype_flags_to_name(c.archetype_flags);
-                    // Convert playtime seconds to hours
                     let total_playtime_hours = c.total_playtime_seconds.unwrap_or(0) / 3600;
-                    // Compute health percentage (0-100), avoiding division by zero
                     let health_percent = if c.health_max > 0 {
                         ((c.health_current as i64 * 100) / c.health_max as i64).clamp(0, 100) as i32
                     } else {
@@ -1011,14 +925,12 @@ fn render_profile_template(
         })
         .unwrap_or((Vec::new(), None, None));
 
-    // Get first character of username for avatar placeholder
     let username_first_char = username
         .chars()
         .next()
         .map(|c| c.to_uppercase().to_string())
         .unwrap_or_else(|| "?".to_string());
 
-    // Pre-compute profile description for SEO (avoids template conditionals)
     let profile_description = match (&discord_username, &github_username, &twitch_username) {
         (Some(_), Some(_), _) => {
             format!(
@@ -1038,7 +950,6 @@ fn render_profile_template(
         _ => format!("{}'s member profile on KBVE", username),
     };
 
-    // Debug log all template values to diagnose visibility issues
     tracing::info!(
         "Profile {} - discord_username: {:?}, discord_is_guild_member: {:?}, twitch_username: {:?}, twitch_is_live: {:?}, github_username: {:?}",
         username,
@@ -1049,7 +960,6 @@ fn render_profile_template(
         github_username
     );
 
-    // Determine primary avatar URL (prefer Discord > GitHub > Twitch)
     let primary_avatar_url = discord_avatar
         .clone()
         .or_else(|| github_avatar.clone())
@@ -1059,12 +969,10 @@ fn render_profile_template(
         username: username.to_string(),
         username_first_char,
         profile_description,
-        // Banner/Hero fields (static placeholders for now)
         unsplash_banner_id: "1594671581654-cc7ed83167bb".to_string(),
         bio: None,
         status: None,
         primary_avatar_url,
-        // Discord fields
         discord_username,
         discord_avatar,
         discord_is_guild_member,
@@ -1074,20 +982,16 @@ fn render_profile_template(
         discord_is_boosting,
         discord_role_count,
         discord_role_names,
-        // GitHub fields
         github_username,
         github_avatar,
-        // Twitch fields
         twitch_username,
         twitch_avatar,
         twitch_is_live,
-        // RentEarth fields
         rentearth_characters,
         rentearth_total_playtime_hours,
         rentearth_last_activity,
-        // Forum block — empty defaults when forum lookup found no row
-        // (user has never posted) so the template can still render and
-        // hide the section via `forum_present == false`.
+        // Empty defaults when forum lookup found no row (user has never
+        // posted) so the template hides the section via forum_present.
         forum_present: forum.is_some(),
         forum_karma: forum.map(|f| f.karma).unwrap_or(0),
         forum_post_count: forum.map(|f| f.post_count).unwrap_or(0),
@@ -1113,7 +1017,6 @@ fn build_profile_json(profile: &UserProfile) -> serde_json::Value {
         "user_id": profile.user_id,
     });
 
-    // Add Discord data if present
     if let Some(ref discord) = profile.discord {
         response["discord"] = json!({
             "id": discord.id,
@@ -1128,7 +1031,6 @@ fn build_profile_json(profile: &UserProfile) -> serde_json::Value {
         });
     }
 
-    // Add GitHub data if present
     if let Some(ref github) = profile.github {
         response["github"] = json!({
             "id": github.id,
@@ -1137,7 +1039,6 @@ fn build_profile_json(profile: &UserProfile) -> serde_json::Value {
         });
     }
 
-    // Add Twitch data if present
     if let Some(ref twitch) = profile.twitch {
         response["twitch"] = json!({
             "id": twitch.id,
@@ -1147,12 +1048,10 @@ fn build_profile_json(profile: &UserProfile) -> serde_json::Value {
         });
     }
 
-    // Add RentEarth data if present
     if let Some(ref rentearth) = profile.rentearth {
         response["rentearth"] = json!(rentearth);
     }
 
-    // Add connected providers list
     let mut connected_providers = Vec::new();
     if profile.discord.is_some() {
         connected_providers.push("discord");
@@ -1168,15 +1067,10 @@ fn build_profile_json(profile: &UserProfile) -> serde_json::Value {
     }
     response["connected_providers"] = json!(connected_providers);
 
-    // Add provider count
     response["provider_count"] = json!(connected_providers.len());
 
     response
 }
-
-// ---------------------------------------------------------------------------
-// OSRS handlers
-// ---------------------------------------------------------------------------
 
 /// Convert item name or query to URL slug format.
 /// "Dragon hunter crossbow" -> "dragon-hunter-crossbow"
@@ -1192,13 +1086,12 @@ fn item_to_slug(name: &str) -> String {
         .join("-")
 }
 
-/// OSRS item page handler - redirects to static Astro pages.
-/// Supports both item names (Dragon_hunter_crossbow) and numeric IDs (21012).
+/// OSRS item page handler — redirects to static Astro pages.
+/// Supports both item names and numeric IDs.
 async fn osrs_item_handler(Path(item): Path<String>) -> impl IntoResponse {
     let cache = match get_osrs_cache() {
         Some(c) => c,
         None => {
-            // Fallback: redirect to the item slug directly, let Astro handle 404
             let slug = item_to_slug(&item);
             return (
                 StatusCode::TEMPORARY_REDIRECT,
@@ -1208,7 +1101,6 @@ async fn osrs_item_handler(Path(item): Path<String>) -> impl IntoResponse {
         }
     };
 
-    // Try to parse as numeric ID first, otherwise treat as item name
     let result = if let Ok(id) = item.parse::<u32>() {
         cache.get_by_id(id).await
     } else {
@@ -1217,10 +1109,7 @@ async fn osrs_item_handler(Path(item): Path<String>) -> impl IntoResponse {
 
     match result {
         Some(item_with_price) => {
-            // Convert item name to Astro slug format (lowercase, hyphens)
             let slug = item_to_slug(&item_with_price.item.name);
-
-            // 301 redirect to Astro static page
             (
                 StatusCode::MOVED_PERMANENTLY,
                 [(header::LOCATION, format!("/osrs/{}/", slug))],
@@ -1228,7 +1117,6 @@ async fn osrs_item_handler(Path(item): Path<String>) -> impl IntoResponse {
                 .into_response()
         }
         None => {
-            // Item not found in cache - redirect to slug anyway, let Astro handle 404
             let slug = item_to_slug(&item);
             (
                 StatusCode::TEMPORARY_REDIRECT,
@@ -1239,10 +1127,9 @@ async fn osrs_item_handler(Path(item): Path<String>) -> impl IntoResponse {
     }
 }
 
-/// OSRS item handler for trailing slash URLs (e.g., /osrs/willow-Logs/, /osrs/385/).
+/// OSRS item handler for trailing slash URLs.
 /// Supports both item names and numeric IDs, normalizes to canonical lowercase slug.
 async fn osrs_item_handler_trailing(Path(item): Path<String>) -> Response<Body> {
-    // Check if this is a numeric ID - if so, look it up and redirect to the canonical slug
     if let Ok(id) = item.parse::<u32>() {
         if let Some(cache) = get_osrs_cache() {
             if let Some(item_with_price) = cache.get_by_id(id).await {
@@ -1254,14 +1141,11 @@ async fn osrs_item_handler_trailing(Path(item): Path<String>) -> Response<Body> 
                     .unwrap();
             }
         }
-        // Numeric ID not found - fall through to 404
     }
 
     let slug = item_to_slug(&item);
 
-    // Only redirect if the URL needs normalization (case differs)
     if slug != item {
-        // Redirect to canonical lowercase slug
         return Response::builder()
             .status(StatusCode::MOVED_PERMANENTLY)
             .header(header::LOCATION, format!("/osrs/{}/", slug))
@@ -1269,10 +1153,7 @@ async fn osrs_item_handler_trailing(Path(item): Path<String>) -> Response<Body> 
             .unwrap();
     }
 
-    // Already canonical - serve the static file
-    // We need to read and serve the file ourselves since we matched the route
     let static_dir = std::env::var("STATIC_DIR").unwrap_or_else(|_| {
-        // Try to find the dist directory
         for candidate in ["templates/dist", "../astro/dist", "astro/dist"] {
             let path = std::path::Path::new(candidate);
             if path.exists() {
@@ -1285,7 +1166,6 @@ async fn osrs_item_handler_trailing(Path(item): Path<String>) -> Response<Body> 
     let file_path = format!("{}/osrs/{}/index.html", static_dir, slug);
     let gz_path = format!("{}.gz", file_path);
 
-    // Try gzipped version first
     if let Ok(content) = tokio::fs::read(&gz_path).await {
         return Response::builder()
             .status(StatusCode::OK)
@@ -1296,7 +1176,6 @@ async fn osrs_item_handler_trailing(Path(item): Path<String>) -> Response<Body> 
             .unwrap();
     }
 
-    // Try uncompressed version
     if let Ok(content) = tokio::fs::read(&file_path).await {
         return Response::builder()
             .status(StatusCode::OK)
@@ -1306,7 +1185,6 @@ async fn osrs_item_handler_trailing(Path(item): Path<String>) -> Response<Body> 
             .unwrap();
     }
 
-    // File not found - serve 404
     let not_found_path = format!("{}/404.html", static_dir);
     let not_found_gz = format!("{}.gz", not_found_path);
 
@@ -1396,11 +1274,8 @@ async fn serve_astro_error_page(status: StatusCode) -> Response {
         .unwrap_or_else(|_| Response::new(Body::empty()))
 }
 
-/// OSRS API endpoint - returns item price data as JSON.
-/// GET /api/v1/osrs/{item_id}
-///
-/// Supports both numeric IDs (21012) and item names (dragon_hunter_crossbow).
-/// Returns current GE prices from the cache (refreshed every 60s).
+/// OSRS API endpoint — returns item price data as JSON.
+/// Supports both numeric IDs and item names. Cache refreshes every 60s.
 #[utoipa::path(
     get,
     path = "/api/v1/osrs/{item_id}",
@@ -1428,7 +1303,6 @@ pub(crate) async fn osrs_api_handler(Path(item_id): Path<String>) -> impl IntoRe
         }
     };
 
-    // Try to parse as numeric ID first, otherwise treat as item name
     let result = if let Ok(id) = item_id.parse::<u32>() {
         cache.get_by_id(id).await
     } else {
@@ -1440,7 +1314,6 @@ pub(crate) async fn osrs_api_handler(Path(item_id): Path<String>) -> impl IntoRe
             let item = &item_with_price.item;
             let price = &item_with_price.price;
 
-            // Calculate average price
             let avg = match (price.high, price.low) {
                 (Some(h), Some(l)) => Some((h + l) / 2),
                 (Some(h), None) => Some(h),
@@ -1477,17 +1350,7 @@ pub(crate) async fn osrs_api_handler(Path(item_id): Path<String>) -> impl IntoRe
     }
 }
 
-// ---------------------------------------------------------------------------
-// Profile API handlers
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// MC API handlers
-// ---------------------------------------------------------------------------
-
-/// MC players API endpoint - returns online player list with UUIDs and skin URLs.
-/// GET /api/v1/mc/players
-///
+/// MC players API endpoint — returns online player list with UUIDs and skin URLs.
 /// Data is cached and refreshed every 15s via RCON background task.
 #[utoipa::path(
     get,
@@ -1525,9 +1388,7 @@ pub(crate) async fn mc_players_handler() -> impl IntoResponse {
         .into_response()
 }
 
-/// MC texture proxy - fetches skin PNGs from textures.minecraft.net.
-/// GET /api/v1/mc/textures/{hash}
-///
+/// MC texture proxy — fetches skin PNGs from textures.minecraft.net.
 /// Hash must be 60-64 hex characters. Responses are immutably cached (24h).
 #[utoipa::path(
     get,
@@ -1544,7 +1405,6 @@ pub(crate) async fn mc_players_handler() -> impl IntoResponse {
     ),
 )]
 pub(crate) async fn mc_texture_handler(Path(hash): Path<String>) -> impl IntoResponse {
-    // Validate hash: 60-64 hex chars only
     if hash.len() < 60 || hash.len() > 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
         return StatusCode::BAD_REQUEST.into_response();
     }
@@ -1568,15 +1428,8 @@ pub(crate) async fn mc_texture_handler(Path(hash): Path<String>) -> impl IntoRes
     }
 }
 
-// ---------------------------------------------------------------------------
-// Profile API handlers
-// ---------------------------------------------------------------------------
-
-/// Profile API endpoint - returns user profile data as JSON.
-/// GET /api/v1/profile/{username}
-///
-/// Returns the user's profile data including connected accounts (Discord, GitHub, Twitch)
-/// and enriched data from external APIs when available.
+/// Profile API endpoint — returns user profile data as JSON, enriched
+/// from Discord / GitHub / Twitch / RentEarth when available.
 #[utoipa::path(
     get,
     path = "/api/v1/profile/{username}",
@@ -1591,7 +1444,6 @@ pub(crate) async fn mc_texture_handler(Path(hash): Path<String>) -> impl IntoRes
     ),
 )]
 pub(crate) async fn profile_api_handler(Path(username): Path<String>) -> impl IntoResponse {
-    // Validate username format
     let validated_username = match validate_username(&username) {
         Ok(u) => u,
         Err(e) => {
@@ -1607,7 +1459,7 @@ pub(crate) async fn profile_api_handler(Path(username): Path<String>) -> impl In
         }
     };
 
-    // Try cache first; concurrent misses collapse to one enrichment.
+    // Concurrent misses collapse to one enrichment via get_or_load.
     let profile = if let Some(cache) = get_profile_cache() {
         cache
             .get_or_load(&validated_username, |u| async move {
@@ -1621,7 +1473,6 @@ pub(crate) async fn profile_api_handler(Path(username): Path<String>) -> impl In
 
     match profile {
         Some(profile) => {
-            // Build JSON response with all profile data
             let response = build_profile_json(&profile);
 
             (
@@ -1652,9 +1503,7 @@ pub(crate) async fn profile_api_handler(Path(username): Path<String>) -> impl In
     }
 }
 
-/// Authenticated profile endpoint - returns the current user's profile.
-/// GET /api/v1/profile/me
-///
+/// Authenticated profile endpoint — returns the caller's profile.
 /// Requires Bearer token in Authorization header.
 #[utoipa::path(
     get,
@@ -1668,7 +1517,6 @@ pub(crate) async fn profile_api_handler(Path(username): Path<String>) -> impl In
     security(("bearerAuth" = [])),
 )]
 pub(crate) async fn profile_me_handler(headers: HeaderMap) -> impl IntoResponse {
-    // Extract Authorization header
     let auth_header = match headers.get(header::AUTHORIZATION) {
         Some(h) => match h.to_str() {
             Ok(s) => s,
@@ -1694,7 +1542,6 @@ pub(crate) async fn profile_me_handler(headers: HeaderMap) -> impl IntoResponse 
         }
     };
 
-    // Extract bearer token
     let token = match extract_bearer_token(auth_header) {
         Some(t) => t,
         None => {
@@ -1709,7 +1556,6 @@ pub(crate) async fn profile_me_handler(headers: HeaderMap) -> impl IntoResponse 
         }
     };
 
-    // Get JWT cache
     let jwt_cache = match get_jwt_cache() {
         Some(cache) => cache,
         None => {
@@ -1724,7 +1570,6 @@ pub(crate) async fn profile_me_handler(headers: HeaderMap) -> impl IntoResponse 
         }
     };
 
-    // Verify token with Supabase (cached)
     let token_info = match jwt_cache.verify_and_cache(token).await {
         Ok(info) => info,
         Err(e) => {
@@ -1753,7 +1598,6 @@ pub(crate) async fn profile_me_handler(headers: HeaderMap) -> impl IntoResponse 
         }
     };
 
-    // Now fetch the user's profile by their user_id
     let profile_service = match get_profile_service() {
         Some(s) => s,
         None => {
@@ -1767,14 +1611,12 @@ pub(crate) async fn profile_me_handler(headers: HeaderMap) -> impl IntoResponse 
         }
     };
 
-    // Get profile by user_id
     let profile = match profile_service
         .get_profile_by_user_id(&token_info.user_id)
         .await
     {
         Ok(Some(p)) => p,
         Ok(None) => {
-            // User authenticated but no profile yet - return basic info
             return (
                 StatusCode::OK,
                 Json(json!({
@@ -1799,7 +1641,6 @@ pub(crate) async fn profile_me_handler(headers: HeaderMap) -> impl IntoResponse 
         }
     };
 
-    // Build and return profile JSON
     let mut response = build_profile_json(&profile);
     response["email"] = json!(token_info.email);
     response["role"] = json!(token_info.role);
@@ -1816,16 +1657,8 @@ pub(crate) async fn profile_me_handler(headers: HeaderMap) -> impl IntoResponse 
         .into_response()
 }
 
-/// Set username endpoint - creates username for authenticated user.
-/// POST /api/v1/profile/username
-///
-/// Requires Bearer token in Authorization header.
-/// Body: { "username": "desired_username" }
-///
-/// Validates username at multiple levels:
-/// 1. Client-side validation (Handy app)
-/// 2. Axum-level validation (this endpoint)
-/// 3. Database-level validation (proxy_add_username RPC)
+/// Set username endpoint — creates username for authenticated user.
+/// Validates at axum level, then defers to the proxy_add_username RPC.
 #[utoipa::path(
     post,
     path = "/api/v1/profile/username",
@@ -1844,7 +1677,6 @@ pub(crate) async fn set_username_handler(
     headers: HeaderMap,
     Json(body): Json<SetUsernameRequest>,
 ) -> impl IntoResponse {
-    // Step 1: Extract and verify bearer token
     let auth_header = match headers.get(header::AUTHORIZATION) {
         Some(h) => match h.to_str() {
             Ok(s) => s,
@@ -1884,7 +1716,6 @@ pub(crate) async fn set_username_handler(
         }
     };
 
-    // Step 2: Verify JWT with Supabase
     let jwt_cache = match get_jwt_cache() {
         Some(cache) => cache,
         None => {
@@ -1927,7 +1758,6 @@ pub(crate) async fn set_username_handler(
         }
     };
 
-    // Step 3: Validate username format at Axum level
     let validated_username = match validate_username(&body.username) {
         Ok(u) => u,
         Err(e) => {
@@ -1948,7 +1778,6 @@ pub(crate) async fn set_username_handler(
         }
     };
 
-    // Step 4: Get profile service and set username
     let profile_service = match get_profile_service() {
         Some(s) => s,
         None => {
@@ -1962,7 +1791,6 @@ pub(crate) async fn set_username_handler(
         }
     };
 
-    // Call the set_username method with verified user_id
     match profile_service
         .set_username(&token_info.user_id, &validated_username)
         .await
@@ -1991,7 +1819,6 @@ pub(crate) async fn set_username_handler(
                 "Failed to set username"
             );
 
-            // Determine appropriate status code based on error
             let status = if e.contains("already taken") || e.contains("already have") {
                 StatusCode::CONFLICT
             } else if e.contains("Invalid") {
@@ -2011,10 +1838,6 @@ pub(crate) async fn set_username_handler(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Utility helpers
-// ---------------------------------------------------------------------------
-
 #[allow(dead_code)]
 fn format_duration(d: Duration) -> String {
     let secs = d.as_secs();
@@ -2031,23 +1854,17 @@ fn format_duration(d: Duration) -> String {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Middleware
-// ---------------------------------------------------------------------------
-
 /// Set Cache-Control based on request path.
 async fn cache_headers(request: Request, next: Next) -> Response {
     let path = request.uri().path().to_owned();
     let mut response = next.run(request).await;
 
     let cache_value = if path.starts_with("/_astro/") {
-        // Content-hashed Vite bundles — cache forever
+        // Content-hashed Vite bundles — cache forever.
         "public, max-age=31536000, immutable"
     } else if path.starts_with("/pagefind/") || path.starts_with("/images/") {
-        // Build-time generated, static until next deploy
         "public, max-age=86400"
     } else if path.ends_with(".html") || path == "/" || !path.contains('.') {
-        // Static HTML pages — immutable until next container deploy
         "public, max-age=86400"
     } else {
         "public, max-age=86400"
@@ -2107,10 +1924,6 @@ async fn shutdown_signal() {
     let _ = tokio::signal::ctrl_c().await;
 }
 
-// ---------------------------------------------------------------------------
-// Forum profile block (renders the "Forum activity" section on /@username)
-// ---------------------------------------------------------------------------
-
 /// Subset of forum data shown on the profile page. Built by
 /// `fetch_forum_profile_block`; consumed by `render_profile_template`.
 struct ForumProfileBlock {
@@ -2143,7 +1956,6 @@ async fn fetch_forum_profile_block(user_id: &str) -> Option<ForumProfileBlock> {
         }
     };
 
-    // Fetch recent threads + spaces map for slug resolution.
     let threads = svc
         .list_threads_by_author(user_id, FORUM_PROFILE_RECENT_LIMIT)
         .await
@@ -2184,9 +1996,8 @@ async fn fetch_forum_profile_block(user_id: &str) -> Option<ForumProfileBlock> {
     let mut recent_comments_html = String::with_capacity(comments.len() * 256);
     let ctx = forum_render_ctx();
     for c in &comments {
-        // Render comment markdown then strip to plain text excerpt for
-        // the profile preview row. Avoid leaking nested HTML into the
-        // anchor that wraps the row.
+        // Strip rendered markdown to plain text — the anchor wrapping
+        // the row would otherwise nest HTML.
         let rendered = kbve::markdown::render(&c.body, &ctx);
         let excerpt = plain_excerpt(&rendered.html, FORUM_PROFILE_COMMENT_EXCERPT);
         let partial = ProfileForumCommentRowPartial {
@@ -2213,12 +2024,8 @@ async fn fetch_forum_profile_block(user_id: &str) -> Option<ForumProfileBlock> {
     })
 }
 
-// ---------------------------------------------------------------------------
-// Forum SSR handlers
-// ---------------------------------------------------------------------------
-
 /// Image-host allowlist for thread + comment markdown rendering. Empty
-/// by default; populate once we wire avatars / Supabase storage.
+/// by default; populate once avatars / Supabase storage are wired.
 const FORUM_IMG_HOSTS: &[&str] = &[];
 
 const FEED_BODY_EXCERPT_CHARS: usize = 280;
@@ -2232,12 +2039,10 @@ fn forum_render_ctx() -> kbve::markdown::RenderCtx<'static> {
     }
 }
 
-/// Percent-encode a string for safe inclusion as an `application/x-www-form-urlencoded`
-/// query-component value. RFC 3986 unreserved chars pass through; everything
-/// else (including `+`, `|`, `:`, space, etc.) gets `%HH` encoded. We need
-/// this for cursor pagination because the feed cursor format
-/// `<timestamp+offset>|<id>` carries `+` and `|`, both of which the browser
-/// + axum::extract::Query mangle if dumped raw into an `<a href>`.
+/// Percent-encode for `application/x-www-form-urlencoded` query-component
+/// values (RFC 3986). Needed for cursor pagination: the cursor format
+/// `<timestamp+offset>|<id>` carries `+` and `|` which the browser +
+/// axum::extract::Query mangle if dumped raw into an `<a href>`.
 fn url_encode_component(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for byte in s.bytes() {
@@ -2254,9 +2059,9 @@ fn url_encode_component(s: &str) -> String {
     out
 }
 
-/// Crude HTML-escape for plain text strings going into pre-rendered HTML
-/// fragments. Askama templates use the default `e` filter for direct
-/// interpolation; this helper is for the few spots we hand-roll HTML.
+/// HTML-escape for plain text going into hand-rolled HTML fragments.
+/// Askama templates auto-escape via the `e` filter; this helper covers
+/// the few spots we build HTML strings directly.
 fn html_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for ch in s.chars() {
@@ -2283,9 +2088,8 @@ fn resolve_username(map: &std::collections::HashMap<String, String>, uuid: &str)
         .unwrap_or_else(|| FORUM_DELETED_USER.to_string())
 }
 
-/// Truncate the rendered markdown to a feed excerpt. Naive char-count
-/// truncation is fine here because ammonia already balanced the tags.
-/// We append an ellipsis if the body was cut.
+/// Truncate rendered markdown to a feed excerpt. Char-count truncation
+/// is safe here because ammonia already balanced the tags.
 fn excerpt_html(rendered: &str, limit: usize) -> String {
     if rendered.chars().count() <= limit {
         return rendered.to_string();
@@ -2333,8 +2137,6 @@ fn render_partial<T: Template>(tpl: &T, name: &str) -> String {
 }
 
 fn humanize_ts(ts: &str) -> String {
-    // Trim to date+time prefix (YYYY-MM-DDTHH:MM:SS). Good enough until a
-    // real relative-time formatter lands.
     ts.split('.')
         .next()
         .unwrap_or(ts)
@@ -2425,11 +2227,8 @@ fn build_pagination_html(rows: &[FeedRow], sort: &str, space_path: &str) -> Stri
         _ => return String::new(), // hot cursor needs hot_rank — skip
     };
     let cursor = format!("{}|{}", key, last.id);
-    // `+`, `|`, `:` in the cursor must be percent-encoded — otherwise
-    // the browser reads them as form-urlencoded and `+` becomes a space,
-    // which axum::extract::Query then deserializes as a malformed
-    // timestamp. html_escape only handles `&<>"'`, so we run the cursor
-    // (and the space_path / sort, defensively) through url_encode_component.
+    // `+`, `|`, `:` must be percent-encoded — html_escape only covers
+    // `&<>"'`, and unescaped `+` is decoded as space by axum::extract::Query.
     format!(
         r#"<a class="forum-pagination__next" href="{base}?sort={sort}&amp;cursor={cursor}">Older →</a>"#,
         base = html_escape(space_path),
@@ -2520,7 +2319,6 @@ async fn forum_tag_handler(
     render_feed_page(None, Some(slug), &q).await
 }
 
-/// GET /forum/tags — popularity-sorted tag listing.
 /// GET /api/v1/forum/tags — JSON list of popularity-sorted tags.
 /// Drives the astro-kbve build-time top-tags fetch.
 #[utoipa::path(
@@ -2725,9 +2523,6 @@ async fn render_feed_page(
         }
     };
 
-    // Build (space_id → SpaceRow). When filtered to a single space we
-    // already have the row; otherwise batch-fetch every space referenced
-    // by the feed rows so the chip renders the slug instead of a UUID.
     let mut spaces_by_id = std::collections::HashMap::new();
     if let Some(s) = space.as_ref() {
         spaces_by_id.insert(s.id.clone(), s.clone());
@@ -2739,9 +2534,6 @@ async fn render_feed_page(
         });
     }
 
-    // Batch-resolve every author UUID to a username. One round-trip via
-    // PostgREST `?user_id=in.(…)`. Missing rows fall back to a sentinel
-    // through resolve_username().
     let usernames_by_id = match get_profile_service() {
         Some(profile_svc) => {
             let ids: Vec<String> = rows.iter().map(|r| r.author_id.clone()).collect();
@@ -2925,10 +2717,6 @@ fn build_tag_chips_html(rows: &[crate::db::TagRow]) -> String {
     out
 }
 
-// ---------------------------------------------------------------------------
-// Forum compose page + write APIs
-// ---------------------------------------------------------------------------
-
 #[derive(serde::Deserialize, Default)]
 struct ComposeQuery {
     space: Option<String>,
@@ -2996,12 +2784,11 @@ pub(crate) async fn auth_user_id(headers: &HeaderMap) -> Result<String, Response
 pub(crate) struct CreateThreadBody {
     #[holy(sanitize = "trim, lowercase, slug, truncate(50)")]
     pub space_slug: String,
-    // No `escape_html` here — askama auto-escapes on render. Storing
-    // pre-escaped HTML would double-escape `&amp;` etc.
+    // No escape_html — askama auto-escapes on render; pre-escaping would
+    // double-encode &amp; etc.
     #[holy(sanitize = "trim, control_strip, truncate(180)")]
     pub title: String,
-    // body is markdown; only nul_strip + length cap. control_strip
-    // would eat \n / \t.
+    // body is markdown — control_strip would eat \n / \t.
     #[holy(sanitize = "nul_strip, truncate(50000)")]
     pub body: String,
     #[serde(default = "default_thread_type")]
@@ -3104,8 +2891,8 @@ pub(crate) async fn api_create_thread(
         }
         Err(e) => {
             tracing::warn!("forum.service_create_thread error: {}", e);
-            // Surface RPC error message so the client can show "username
-            // required" / "thread title length" / etc directly.
+            // Surface RPC message so the client can render "username
+            // required" / "title length" / etc directly.
             (StatusCode::BAD_REQUEST, Json(json!({"error": e}))).into_response()
         }
     }
@@ -3115,8 +2902,7 @@ pub(crate) async fn api_create_thread(
 pub(crate) struct CreateCommentBody {
     #[holy(sanitize = "nul_strip, truncate(50000)")]
     pub body: String,
-    // parent_comment_id is a UUID — RPC will reject malformed values,
-    // no sanitize needed.
+    // UUID — RPC rejects malformed values, no sanitize needed.
     #[serde(default)]
     pub parent_comment_id: Option<String>,
 }
@@ -3305,7 +3091,7 @@ pub(crate) async fn api_remove_comment(
         }
     };
 
-    // First belt: deny non-staff at the axum layer.
+    // Belt-and-suspenders: deny non-staff at the axum layer; SQL re-checks.
     match svc.is_staff(&user_id).await {
         Ok(true) => {}
         Ok(false) => {
@@ -3508,8 +3294,8 @@ mod tests {
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
-    /// Build a minimal router with just the health endpoint + middleware
-    /// (no static file serving, which requires a real directory).
+    /// Minimal router with health endpoint + middleware (no static file
+    /// serving, which requires a real directory).
     fn test_router() -> Router {
         let middleware = tower::ServiceBuilder::new()
             .layer(SetResponseHeaderLayer::overriding(
@@ -3682,9 +3468,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Profile handler now returns 404 for not-found (with cache), or BAD_REQUEST for invalid.
-        // Without DB/cache services initialized, fetch_profile_from_db returns None,
-        // so we get NOT_FOUND with the ProfileNotFoundTemplate.
         let status = response.status();
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let html = String::from_utf8(body.to_vec()).unwrap();
@@ -3704,7 +3487,6 @@ mod tests {
             .route("/script.js", get(|| async { "code" }))
             .layer(axum::middleware::from_fn(fix_ts_mime));
 
-        // .ts file should get JS content-type
         let response = app
             .clone()
             .oneshot(
@@ -3720,7 +3502,6 @@ mod tests {
             "application/javascript; charset=utf-8"
         );
 
-        // .js file should NOT be rewritten
         let response = app
             .oneshot(
                 Request::builder()

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -13,10 +13,6 @@ use tracing::{debug, warn};
 
 use crate::auth::{extract_bearer_token, get_jwt_cache, jwt_cache::staff_perm};
 
-// ---------------------------------------------------------------------------
-// ServiceProxy — generic reverse proxy with optional upstream auth
-// ---------------------------------------------------------------------------
-
 struct ServiceProxy {
     name: &'static str,
     client: Client,
@@ -39,16 +35,11 @@ impl ServiceProxy {
     /// Authenticate the incoming request (JWT + DASHBOARD_VIEW) then forward
     /// to the upstream service.
     async fn handle(&self, path: Option<Path<String>>, req: Request<Body>) -> Response {
-        // Extract headers before the async auth gate — `&Request<Body>` is not
-        // `Send` (Body is !Sync), so we must not hold a reference to `req`
-        // across an .await boundary.
+        // `&Request<Body>` is not `Send` (Body is !Sync) — clone headers/query
+        // before crossing the .await boundary.
         let req_headers = req.headers().clone();
-        // Capture the query string up front so the auth gate can fall back to
-        // an `access_token=` param when no Authorization header is present
-        // (e.g. iframe loads where headers cannot be set client-side).
         let raw_query = req.uri().query().map(|q| q.to_string());
 
-        // --- JWT + staff gate ---
         if let Err(resp) =
             require_dashboard_view_with_query(&req_headers, raw_query.as_deref(), self.name).await
         {
@@ -58,9 +49,8 @@ impl ServiceProxy {
         self.forward_request(path, req, None).await
     }
 
-    /// Forward the request to the upstream service without running the
-    /// DASHBOARD_VIEW gate. Callers must have already authenticated the
-    /// request (e.g. with a higher-privilege permission check).
+    /// Forward the request without running the DASHBOARD_VIEW gate. Callers
+    /// must have already authenticated.
     async fn handle_preauthorized(
         &self,
         path: Option<Path<String>>,
@@ -70,10 +60,8 @@ impl ServiceProxy {
     }
 
     /// Like `handle_preauthorized` but injects an upstream `Authorization`
-    /// header value (e.g. `Basic <b64(user:pw)>`) instead of the proxy's
-    /// configured upstream_token. Used for KASM where the upstream password
-    /// rotates per pod start and the JWT-validated launch flow knows the
-    /// freshly fetched value.
+    /// header value instead of the configured upstream_token. Used for KASM
+    /// where the upstream password rotates per pod start.
     async fn handle_with_auth(
         &self,
         path: Option<Path<String>>,
@@ -101,10 +89,9 @@ impl ServiceProxy {
         let method = req.method().clone();
         let mut headers = req_headers;
 
-        // Strip hop-by-hop and content-negotiation headers before forwarding
-        // upstream. These must not cross proxy boundaries per RFC 7230 §6.1.
-        // accept-encoding is removed so upstream never compresses — we buffer
-        // the full body and re-serve it, so we need the raw bytes.
+        // RFC 7230 §6.1: hop-by-hop headers must not cross proxy boundaries.
+        // accept-encoding is also removed so upstream never compresses — we
+        // buffer the body and re-serve raw bytes.
         headers.remove(header::HOST);
         headers.remove(header::AUTHORIZATION);
         headers.remove(header::ACCEPT_ENCODING);
@@ -189,8 +176,7 @@ impl ServiceProxy {
         let status =
             StatusCode::from_u16(upstream_status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
-        // Collect headers before consuming the body.
-        // Use `append` to preserve multi-value headers (e.g. Set-Cookie, Vary).
+        // `append` preserves multi-value headers (Set-Cookie, Vary).
         let mut resp_headers = HeaderMap::new();
         for (k, v) in upstream_resp.headers() {
             if let Ok(name) = axum::http::HeaderName::from_bytes(k.as_str().as_bytes()) {
@@ -200,15 +186,12 @@ impl ServiceProxy {
             }
         }
 
-        // Strip hop-by-hop headers from the upstream response — they must not
-        // be forwarded to the downstream client (RFC 7230 §6.1). In particular:
-        //   transfer-encoding — body is already fully buffered; axum sets the
-        //                        correct content-length automatically.
-        //   connection        — forwarding "close" would make hyper close the
-        //                        nginx keep-alive connection prematurely, which
-        //                        nginx logs as "upstream prematurely closed".
-        //   content-encoding  — reqwest may have decoded the body; forwarding
-        //                        the original encoding header would mismatch.
+        // RFC 7230 §6.1: strip hop-by-hop headers from the upstream response.
+        // transfer-encoding — body is buffered; axum will set content-length.
+        // connection — forwarding "close" makes hyper close the nginx
+        //              keep-alive prematurely ("upstream prematurely closed").
+        // content-encoding — reqwest may have decoded the body, so the
+        //                    original encoding header would mismatch.
         const HOP_BY_HOP: &[&str] = &[
             "transfer-encoding",
             "connection",
@@ -223,19 +206,17 @@ impl ServiceProxy {
             resp_headers.remove(*h);
         }
 
-        // For services rendered in an iframe (e.g. KASM workspace viewer),
-        // strip framing-restriction headers so the upstream UI can embed.
-        // We're already gating access via JWT + DASHBOARD_VIEW so the
-        // clickjacking protection these headers provide is redundant here.
+        // JWT + DASHBOARD_VIEW already gates access, so clickjacking
+        // protection is redundant here — strip framing headers so the
+        // upstream UI can embed in an iframe.
         if self.iframe_safe {
             resp_headers.remove("x-frame-options");
             resp_headers.remove("content-security-policy");
             resp_headers.remove("content-security-policy-report-only");
         }
 
-        // Stream successful responses; buffer error responses so 4xx/5xx
-        // bodies (login pages, JSON errors, redirect targets) propagate
-        // intact even when upstream omits Content-Length / Transfer-Encoding.
+        // Buffer error responses so 4xx/5xx bodies propagate intact even
+        // when upstream omits Content-Length / Transfer-Encoding.
         if self.streaming && upstream_status < 400 {
             let body = Body::from_stream(upstream_resp.bytes_stream());
             let mut response = Response::builder().status(status);
@@ -253,7 +234,6 @@ impl ServiceProxy {
                 .into_response();
         }
 
-        // --- Buffered mode (default) ---
         let resp_body = match upstream_resp.bytes().await {
             Ok(b) => b,
             Err(e) => {
@@ -266,9 +246,8 @@ impl ServiceProxy {
             }
         };
 
-        // When upstream returns a server error (5xx), wrap in our standard
-        // format so the frontend always gets a parseable {"reason", "detail"}
-        // response instead of raw upstream HTML/text.
+        // Wrap 5xx upstream responses so the frontend always gets a parseable
+        // {"reason", "detail"} JSON instead of raw upstream HTML/text.
         if upstream_status >= 500 {
             let body_preview =
                 String::from_utf8_lossy(&resp_body[..resp_body.len().min(512)]).to_string();
@@ -304,10 +283,6 @@ impl ServiceProxy {
             .into_response()
     }
 }
-
-// ---------------------------------------------------------------------------
-// Shared JWT + staff permission gate
-// ---------------------------------------------------------------------------
 
 /// Extract Bearer token from Authorization header, `?access_token=` query,
 /// or `kasm_session` / `dashboard_session` cookie.
@@ -477,10 +452,6 @@ async fn require_dashboard_view_with_query(
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Grafana proxy singleton
-// ---------------------------------------------------------------------------
-
 static GRAFANA: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_grafana_proxy() -> bool {
@@ -518,10 +489,6 @@ pub async fn grafana_proxy_handler(path: Option<Path<String>>, req: Request<Body
             .into_response(),
     }
 }
-
-// ---------------------------------------------------------------------------
-// ArgoCD proxy singleton
-// ---------------------------------------------------------------------------
 
 static ARGO: OnceLock<ServiceProxy> = OnceLock::new();
 
@@ -585,24 +552,6 @@ pub async fn argo_proxy_handler(path: Option<Path<String>>, req: Request<Body>) 
             .into_response(),
     }
 }
-
-// ---------------------------------------------------------------------------
-// ClickHouse logs proxy singleton
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// ClickHouse Logs — direct path
-//
-// Replaces the previous /functions/v1/logs supabase edge function fronting.
-// axum-kbve now talks straight to the ClickHouse cluster via jedi's
-// ClickHouseConfig, so a CDN outage on esm.sh (which 500'd the edge fn boot
-// graph and produced the "0 / 0 / 0 logs" outage on 2026-05-08) cannot kill
-// the dashboard logs view again.
-//
-// Auth: same DASHBOARD_VIEW gate every other dashboard proxy uses. Query
-// surface is locked down inside jedi (clamped minutes/limit/search, escaped
-// label values).
-// ---------------------------------------------------------------------------
 
 use jedi::entity::pipe_clickhouse::logs as ch_logs;
 use jedi::state::sidecar::ClickHouseConfig;
@@ -769,10 +718,6 @@ pub async fn clickhouse_logs_proxy_handler(headers: HeaderMap, body: Bytes) -> R
     }
 }
 
-// ---------------------------------------------------------------------------
-// Forgejo proxy singleton
-// ---------------------------------------------------------------------------
-
 static FORGEJO: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_forgejo_proxy() -> bool {
@@ -816,10 +761,6 @@ pub async fn forgejo_proxy_handler(path: Option<Path<String>>, req: Request<Body
     }
 }
 
-// ---------------------------------------------------------------------------
-// KubeVirt proxy singleton (Kubernetes API for VM control)
-// ---------------------------------------------------------------------------
-
 static KUBEVIRT: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_kubevirt_proxy() -> bool {
@@ -831,7 +772,6 @@ pub fn init_kubevirt_proxy() -> bool {
     let auth_token = match std::env::var("KUBEVIRT_TOKEN") {
         Ok(t) => t,
         Err(_) => {
-            // Fall back to in-cluster service account token
             match std::fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/token") {
                 Ok(t) => t.trim().to_string(),
                 Err(_) => return false,
@@ -844,7 +784,6 @@ pub fn init_kubevirt_proxy() -> bool {
         .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(30));
 
-    // Load CA cert for K8s API TLS verification
     if let Ok(ca_path) = std::env::var("KUBEVIRT_CA_CERT_PATH") {
         match std::fs::read(&ca_path) {
             Ok(pem) => match reqwest::Certificate::from_pem(&pem) {
@@ -863,7 +802,6 @@ pub fn init_kubevirt_proxy() -> bool {
             }
         }
     } else {
-        // Fall back to in-cluster CA
         let ca_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
         if let Ok(pem) = std::fs::read(ca_path) {
             if let Ok(cert) = reqwest::Certificate::from_pem(&pem) {
@@ -900,13 +838,8 @@ pub async fn kubevirt_proxy_handler(path: Option<Path<String>>, req: Request<Bod
     }
 }
 
-// ---------------------------------------------------------------------------
-// KubeVirt VNC WebSocket bridge
-// ---------------------------------------------------------------------------
-// Upgrades the browser connection to WebSocket and opens an upstream WebSocket
-// to the KubeVirt VNC subresource, then relays frames bidirectionally.
-// This enables interactive noVNC sessions from the dashboard.
-
+/// Bridges a browser WebSocket to the KubeVirt VNC subresource so the
+/// dashboard can run interactive noVNC sessions.
 pub async fn kubevirt_vnc_handler(
     Path(vm_name): Path<String>,
     ws: axum::extract::ws::WebSocketUpgrade,
@@ -915,8 +848,8 @@ pub async fn kubevirt_vnc_handler(
     let headers = req.headers().clone();
     let query = req.uri().query().map(|q| q.to_string());
 
-    // Auth gate — accepts Bearer header or ?access_token= query param
-    // (browser WebSocket API cannot set custom headers)
+    // Browser WebSocket API cannot set custom headers, so the auth gate
+    // also accepts ?access_token= as a fallback.
     if let Err(resp) =
         require_dashboard_view_with_query(&headers, query.as_deref(), "KubeVirt-VNC").await
     {
@@ -934,7 +867,6 @@ pub async fn kubevirt_vnc_handler(
         }
     };
 
-    // Sanitize VM name — alphanumeric + hyphens only
     if !vm_name
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '-')
@@ -951,12 +883,11 @@ pub async fn kubevirt_vnc_handler(
         kubevirt.upstream, VM_NAMESPACE, vm_name
     );
     let upstream_token = kubevirt.upstream_token.clone();
-    // Session key: namespace + name. KASM/other VM namespaces will want
-    // this parameterised later, but for now we only serve angelscript.
+    // VM_NAMESPACE is hardcoded to angelscript; parameterise once another
+    // VM namespace lands.
     let vm_key = format!("{VM_NAMESPACE}/{vm_name}");
 
-    // Accept the WebSocket upgrade and hand the browser connection off to
-    // the VNC hub, which shares a single upstream across every viewer.
+    // vnc_hub shares a single upstream connection across every viewer.
     ws.protocols(["binary.k8s.io", "base64.binary.k8s.io"])
         .on_upgrade(move |browser_ws| async move {
             if let Err(e) =
@@ -969,10 +900,6 @@ pub async fn kubevirt_vnc_handler(
 
 const VM_NAMESPACE: &str = "angelscript";
 const KASM_NAMESPACE: &str = "kasm";
-
-// ---------------------------------------------------------------------------
-// VNC session info endpoints — viewer count + primary status
-// ---------------------------------------------------------------------------
 
 /// GET /dashboard/vm/vnc-info/{name} — returns viewer count for a specific VM
 pub async fn kubevirt_vnc_info_handler(
@@ -1011,10 +938,6 @@ pub async fn kubevirt_vnc_sessions_handler(req: Request<Body>) -> Response {
     axum::Json(json!({"sessions": sessions})).into_response()
 }
 
-// ---------------------------------------------------------------------------
-// KASM workspace proxy singleton (reverse proxy to KASM web UI)
-// ---------------------------------------------------------------------------
-
 static KASM: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_kasm_proxy() -> bool {
@@ -1025,13 +948,12 @@ pub fn init_kasm_proxy() -> bool {
         .redirect(reqwest::redirect::Policy::none())
         .connect_timeout(Duration::from_secs(10))
         // No overall timeout — KASM streams VNC data that can last hours.
-        // The Cilium gateway already caps the outer request at 3600s.
-        .danger_accept_invalid_certs(true) // KASM uses self-signed certs internally
-        // Force HTTP/1.1 — websockify (KASM's built-in server) doesn't
-        // support h2 and ALPN negotiation can cause spurious resets.
+        // The Cilium gateway caps the outer request at 3600s.
+        .danger_accept_invalid_certs(true)
+        // websockify (KASM's built-in server) doesn't support h2; ALPN
+        // negotiation can also cause spurious resets.
         .http1_only();
 
-    // Load in-cluster CA if available
     let ca_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
     if let Ok(pem) = std::fs::read(ca_path) {
         if let Ok(cert) = reqwest::Certificate::from_pem(&pem) {
@@ -1047,10 +969,10 @@ pub fn init_kasm_proxy() -> bool {
         name: "KASM",
         client,
         upstream: upstream.trim_end_matches('/').to_string(),
-        upstream_token: None, // KASM uses its own VNC_PW auth
-        iframe_safe: true,    // strip X-Frame-Options for iframe embedding
-        streaming: true,      // stream response body — websockify sends
-                              // chunked responses that fail when buffered
+        upstream_token: None,
+        iframe_safe: true,
+        // websockify chunked responses fail when buffered.
+        streaming: true,
     })
     .is_ok()
 }
@@ -1321,7 +1243,6 @@ pub async fn kasm_workspaces_handler(req: Request<Body>) -> Response {
         }
     };
 
-    // Query K8s API for deployments in the kasm namespace
     let url = format!(
         "{}/apis/apps/v1/namespaces/{}/deployments",
         kubevirt.upstream, KASM_NAMESPACE
@@ -1372,7 +1293,6 @@ pub async fn kasm_scale_handler(Path(name): Path<String>, req: Request<Body>) ->
         return resp;
     }
 
-    // Validate name
     if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
         return (
             StatusCode::BAD_REQUEST,
@@ -1392,7 +1312,6 @@ pub async fn kasm_scale_handler(Path(name): Path<String>, req: Request<Body>) ->
         }
     };
 
-    // Parse desired replicas from request body
     let body_bytes = match axum::body::to_bytes(req.into_body(), 1024).await {
         Ok(b) => b,
         Err(_) => {
@@ -1506,10 +1425,6 @@ pub async fn kasm_launch_handler(req: Request<Body>) -> Response {
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }
 
-// ---------------------------------------------------------------------------
-// Firecracker proxy singleton (reverse proxy to firecracker-ctl REST API)
-// ---------------------------------------------------------------------------
-
 static FIRECRACKER: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_firecracker_proxy() -> bool {
@@ -1572,10 +1487,6 @@ pub async fn firecracker_openapi_handler(req: Request<Body>) -> Response {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Firecracker-Net proxy singleton (network-enabled, DASHBOARD_MANAGE gated)
-// ---------------------------------------------------------------------------
-
 static FIRECRACKER_NET: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_firecracker_net_proxy() -> bool {
@@ -1614,8 +1525,8 @@ pub async fn firecracker_net_proxy_handler(
     }
 
     match FIRECRACKER_NET.get() {
-        // Already authenticated with DASHBOARD_MANAGE — skip the inner
-        // DASHBOARD_VIEW check to avoid double auth fetch.
+        // DASHBOARD_MANAGE already authenticated above — skip the inner
+        // DASHBOARD_VIEW check to avoid a double JWT fetch.
         Some(proxy) => proxy.handle_preauthorized(path, req).await,
         None => (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -1660,13 +1571,9 @@ pub async fn firecracker_fc_alias_handler(
     }
 }
 
-// ---------------------------------------------------------------------------
-// /fc/{name}/{*path} — public path prefix for persistent Firecracker endpoints
-// ---------------------------------------------------------------------------
-// Rewrites /fc/{name}/{*path} → firecracker-ctl-net /proxy/{name}/{*path}.
-// Staff-gated (same level as /dashboard/firecracker-net/*) because the
-// networked ecosystem has outbound internet via the VPN tunnel.
-
+/// Rewrites `/fc/{name}/{*path}` → firecracker-ctl-net `/proxy/{name}/{*path}`.
+/// Staff-gated (same level as `/dashboard/firecracker-net/*`) because the
+/// networked ecosystem has outbound internet via the VPN tunnel.
 pub async fn firecracker_fc_handler(
     axum::extract::Path(params): axum::extract::Path<Vec<(String, String)>>,
     req: Request<Body>,
@@ -1679,8 +1586,6 @@ pub async fn firecracker_fc_handler(
         return resp;
     }
 
-    // Params come in as [("name", ...), ("path", ...)] for /fc/{name}/{*path}
-    // or just [("name", ...)] for the /fc/{name} bare-name route.
     let name = params
         .iter()
         .find(|(k, _)| k == "name")
@@ -1720,17 +1625,10 @@ pub async fn firecracker_fc_handler(
     }
 }
 
-// ---------------------------------------------------------------------------
-// /fc/public/{name}/{*path} — anonymous public endpoints
-// ---------------------------------------------------------------------------
-// Rewrites /fc/public/{name}/{*path} → firecracker-ctl-net /proxy/public/{name}/{*path}.
-// No JWT gate at this layer — ctl-net enforces that the endpoint was deployed
-// with `visibility: "public"`, returning 403 otherwise.
-//
-// Same name validation as the staff route. Future hardening (rate limit,
-// IP allowlist, request-size cap, header injection) can layer in here without
-// touching the staff path.
-
+/// Rewrites `/fc/public/{name}/{*path}` → firecracker-ctl-net
+/// `/proxy/public/{name}/{*path}`. No JWT gate here — ctl-net enforces
+/// that the endpoint was deployed with `visibility: "public"`, returning
+/// 403 otherwise.
 pub async fn firecracker_fc_public_handler(
     axum::extract::Path(params): axum::extract::Path<Vec<(String, String)>>,
     req: Request<Body>,
@@ -1774,14 +1672,6 @@ pub async fn firecracker_fc_public_handler(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Guacamole proxy singleton (reverse proxy to Apache Guacamole web app)
-// ---------------------------------------------------------------------------
-// guacamole-common-js connects via HTTP tunnel or WebSocket to:
-//   {base}/guacamole/tunnel (HTTP polling)
-//   {base}/guacamole/websocket-tunnel (WebSocket)
-// We proxy /dashboard/guac/proxy/* → guacamole.angelscript.svc.cluster.local:8080
-
 static GUACAMOLE: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_guacamole_proxy() -> bool {
@@ -1800,7 +1690,7 @@ pub fn init_guacamole_proxy() -> bool {
             name: "Guacamole",
             client,
             upstream: upstream.trim_end_matches('/').to_string(),
-            upstream_token: None, // Guacamole uses its own session auth
+            upstream_token: None,
             iframe_safe: false,
             streaming: false,
         })
@@ -1818,15 +1708,10 @@ pub async fn guacamole_proxy_handler(path: Option<Path<String>>, req: Request<Bo
     }
 }
 
-// ---------------------------------------------------------------------------
-// Guacamole WebSocket tunnel bridge
-// ---------------------------------------------------------------------------
-// guacamole-common-js opens a WebSocket to /guacamole/websocket-tunnel.
-// The generic ServiceProxy cannot handle WebSocket upgrades (reqwest is
-// HTTP-only and the Upgrade header is stripped). This handler upgrades the
-// browser connection, opens an upstream WebSocket to the Guacamole servlet,
-// and relays frames bidirectionally — same pattern as `kubevirt_vnc_handler`.
-
+/// Bridges the browser WebSocket to `/guacamole/websocket-tunnel`. The
+/// generic ServiceProxy can't do this — reqwest is HTTP-only and strips
+/// the Upgrade header — so we relay frames directly here (same pattern as
+/// `kubevirt_vnc_handler`).
 pub async fn guacamole_ws_handler(
     ws: axum::extract::ws::WebSocketUpgrade,
     req: Request<Body>,
@@ -1834,7 +1719,6 @@ pub async fn guacamole_ws_handler(
     let headers = req.headers().clone();
     let query = req.uri().query().map(|q| q.to_string());
 
-    // Auth gate — accepts Bearer header or ?access_token= query param
     if let Err(resp) =
         require_dashboard_view_with_query(&headers, query.as_deref(), "Guacamole-WS").await
     {
@@ -1852,7 +1736,7 @@ pub async fn guacamole_ws_handler(
         }
     };
 
-    // Preserve the query string (token, GUAC_WIDTH, GUAC_HEIGHT, GUAC_DPI, etc.)
+    // Guacamole needs the query string forwarded — token, GUAC_WIDTH, etc.
     let query = req
         .uri()
         .query()
@@ -1877,7 +1761,6 @@ async fn guacamole_ws_bridge(
     use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::{Message as TungMsg, client::IntoClientRequest};
 
-    // Build upstream WebSocket URL
     let ws_url = upstream_url
         .replace("https://", "wss://")
         .replace("http://", "ws://");
@@ -1890,7 +1773,6 @@ async fn guacamole_ws_bridge(
     let (mut browser_tx, mut browser_rx) = browser_ws.split();
     let (mut upstream_tx, mut upstream_rx) = upstream_ws.split();
 
-    // Browser → Guacamole
     let browser_to_upstream = async {
         while let Some(msg) = browser_rx.next().await {
             match msg {
@@ -1912,7 +1794,6 @@ async fn guacamole_ws_bridge(
         let _ = upstream_tx.close().await;
     };
 
-    // Guacamole → Browser
     let upstream_to_browser = async {
         while let Some(msg) = upstream_rx.next().await {
             match msg {
@@ -1942,10 +1823,6 @@ async fn guacamole_ws_bridge(
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Edge Functions proxy singleton (Supabase → internal Kong)
-// ---------------------------------------------------------------------------
-
 static EDGE: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_edge_proxy() -> bool {
@@ -1953,7 +1830,6 @@ pub fn init_edge_proxy() -> bool {
         Ok(u) => u.trim_end_matches('/').to_string(),
         Err(_) => return false,
     };
-    // Proxy to the Supabase functions base — callers append /health, /meme, etc.
     let upstream = format!("{supabase_url}/functions/v1");
 
     let service_role_key = match std::env::var("SUPABASE_SERVICE_ROLE_KEY") {
@@ -1989,10 +1865,6 @@ pub async fn edge_proxy_handler(path: Option<Path<String>>, req: Request<Body>) 
             .into_response(),
     }
 }
-
-// ---------------------------------------------------------------------------
-// ChuckRPG (ROWS Swagger) proxy singleton
-// ---------------------------------------------------------------------------
 
 static CHUCKRPG: OnceLock<ServiceProxy> = OnceLock::new();
 
@@ -2032,16 +1904,12 @@ pub async fn chuckrpg_proxy_handler(path: Option<Path<String>>, req: Request<Bod
     }
 }
 
-// ---------------------------------------------------------------------------
-// Convert axum HeaderMap to reqwest HeaderMap
-// ---------------------------------------------------------------------------
-
 fn reqwest_headers(headers: &HeaderMap) -> reqwest::header::HeaderMap {
     let mut out = reqwest::header::HeaderMap::new();
     for (k, v) in headers {
         if let Ok(name) = reqwest::header::HeaderName::from_bytes(k.as_str().as_bytes()) {
             if let Ok(val) = reqwest::header::HeaderValue::from_bytes(v.as_bytes()) {
-                // Use append to preserve multi-value headers (Accept, Cookie, etc.)
+                // `append` preserves multi-value headers (Accept, Cookie, ...).
                 out.append(name, val);
             }
         }

--- a/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
+++ b/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
@@ -59,24 +59,16 @@ type UpstreamWs =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 type UpstreamSink = futures_util::stream::SplitSink<UpstreamWs, TungMsg>;
 
-/// Per-VM shared VNC session. Lives for as long as at least one viewer is
-/// connected; torn down when the last viewer leaves.
+/// Per-VM shared VNC session. Torn down when the last viewer leaves.
 pub struct VncSession {
     vm_key: String,
-    /// All upstream-side bytes received since session start, bounded by
-    /// `MAX_CACHE_BYTES`. Replayed verbatim to each new viewer before they
-    /// subscribe to the live broadcast.
+    /// Replay buffer bounded by `MAX_CACHE_BYTES`; new viewers replay this
+    /// before subscribing to the live broadcast.
     cache: Mutex<Vec<u8>>,
-    /// Live upstream bytes broadcast to every connected viewer.
     broadcast: broadcast::Sender<Bytes>,
-    /// Write side of the upstream WebSocket. Wrapped so client tasks can
-    /// forward input under a mutex. Set to `None` once the upstream closes.
     upstream_sink: Mutex<Option<UpstreamSink>>,
-    /// Number of connected viewers. When it drops to zero, the session is
-    /// removed from `SESSIONS` and the upstream is torn down.
     clients: AtomicUsize,
-    /// Client id of the current input holder (primary). `0` = no primary;
-    /// the next client to send input CASes itself in.
+    /// `0` = no primary; the next client to send input CASes itself in.
     primary_id: AtomicUsize,
 }
 
@@ -170,9 +162,6 @@ pub async fn join_session_with_config(
     let client_id = NEXT_CLIENT_ID.fetch_add(1, Ordering::Relaxed);
     let registry = sessions();
 
-    // Either grab the existing session for this VM or create a new one.
-    // We hold a short-lived `entry` borrow to avoid two simultaneous
-    // first-client requests both opening an upstream.
     let session = {
         if let Some(existing) = registry.get(&vm_key) {
             existing.clone()
@@ -191,8 +180,6 @@ pub async fn join_session_with_config(
     };
 
     let prior = session.clients.fetch_add(1, Ordering::Relaxed);
-    // First-ever viewer becomes the primary. Subsequent joiners start as
-    // observers; they can be promoted later if the primary drops.
     if prior == 0 {
         session.primary_id.store(client_id, Ordering::Relaxed);
         info!(
@@ -210,8 +197,6 @@ pub async fn join_session_with_config(
 
     let result = run_client(session.clone(), client_id, browser_ws).await;
 
-    // Cleanup. If we were the primary, clear the primary_id so the next
-    // input from an observer can opportunistically take over.
     if session.primary_id.load(Ordering::Relaxed) == client_id {
         session.primary_id.store(0, Ordering::Relaxed);
     }
@@ -327,10 +312,8 @@ async fn run_client(
     };
 
     if !cache_snapshot.is_empty() {
-        // K8s VNC uses the `binary.k8s.io` subprotocol, so bytes flow as
-        // WebSocket Binary frames. Sending the whole cache in one frame is
-        // fine — noVNC buffers until it has enough for the next RFB
-        // message.
+        // K8s VNC uses the binary.k8s.io subprotocol; one Binary frame is
+        // fine because noVNC re-frames internally on RFB boundaries.
         if browser_tx
             .send(AxumMsg::Binary(Bytes::from(cache_snapshot)))
             .await
@@ -340,7 +323,6 @@ async fn run_client(
         }
     }
 
-    // browser → upstream (primary only; observers are dropped on the floor)
     let session_input = session.clone();
     let input_task = tokio::spawn(async move {
         while let Some(msg) = browser_rx.next().await {
@@ -351,8 +333,7 @@ async fn run_client(
                 _ => continue,
             };
 
-            // Opportunistic primary promotion: if there is no current
-            // primary, take the slot. Otherwise only the primary may send.
+            // Opportunistic primary CAS — observers fall through to drop.
             let primary = session_input.primary_id.load(Ordering::Relaxed);
             let may_write = if primary == client_id {
                 true
@@ -381,7 +362,6 @@ async fn run_client(
         }
     });
 
-    // upstream → browser (live byte broadcast)
     let output_task = tokio::spawn(async move {
         loop {
             match live_rx.recv().await {
@@ -390,9 +370,8 @@ async fn run_client(
                         break;
                     }
                 }
-                // Lagged: the broadcast queue filled up. Keep going — we
-                // can't recover the lost bytes, but continuing is better
-                // than killing this viewer.
+                // Continuing on lag beats killing the viewer; lost bytes
+                // are unrecoverable but the next full refresh resyncs.
                 Err(broadcast::error::RecvError::Lagged(skipped)) => {
                     warn!(
                         "VNC hub: client {} lagged, skipped {} frames",

--- a/apps/kbve/axum-kbve/src/transport/wallet.rs
+++ b/apps/kbve/axum-kbve/src/transport/wallet.rs
@@ -1,14 +1,9 @@
-//! Wallet HTTP surface — user-facing `/api/v1/wallet/me/*` routes.
+//! Wallet HTTP surface.
 //!
-//! Service routes (`/api/v1/wallet/service/*`) are deferred to a follow-up;
-//! the dashboard's Claim 1000 KHash button only needs the user proxy path.
-//!
-//! Each handler:
-//!   1. Extracts the Supabase user_id via the shared `auth_user_id` helper.
-//!   2. Looks up the global `WalletClient` (skip with 503 if disabled).
-//!   3. Calls the matching `WalletClient::user_*` op (sets request.jwt.claims
-//!      inside the txn so `auth.uid()` resolves correctly).
-//!   4. Maps `WalletError` to HTTP status + JSON error body.
+//! User routes (`/api/v1/wallet/me/*`) resolve the caller via `auth_user_id`;
+//! service routes require a `service_role` JWT. Each handler delegates to
+//! `WalletClient`, which sets `request.jwt.claims` inside the txn so
+//! `auth.uid()` resolves on the SQL side.
 
 use axum::{
     Json,
@@ -27,10 +22,6 @@ use uuid::Uuid;
 use super::https::auth_user_id;
 use crate::auth::{extract_bearer_token, get_jwt_cache};
 use crate::db::get_wallet_client;
-
-// ---------------------------------------------------------------------------
-// DTOs
-// ---------------------------------------------------------------------------
 
 #[derive(Serialize, ToSchema)]
 pub(crate) struct BalanceDto {
@@ -68,10 +59,6 @@ pub(crate) struct RedeemCouponDto {
     pub reward_payload: serde_json::Value,
     pub ledger_id: i64,
 }
-
-// ---------------------------------------------------------------------------
-// Service-layer DTOs
-// ---------------------------------------------------------------------------
 
 #[derive(Deserialize, ToSchema)]
 pub(crate) struct ServiceCreditBody {
@@ -157,10 +144,6 @@ pub(crate) struct ServiceVerifyBalanceDto {
     pub ledger_khash: i64,
     pub ok: bool,
 }
-
-// ---------------------------------------------------------------------------
-// Handlers
-// ---------------------------------------------------------------------------
 
 /// `GET /api/v1/wallet/me/balance` — returns the caller's wallet balance.
 /// Lazily provisions the wallet account + welcome coupon on first call.
@@ -291,10 +274,6 @@ pub(crate) async fn me_redeem_coupon(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 async fn resolve_user(headers: &HeaderMap) -> Result<Uuid, Response> {
     let s = auth_user_id(headers).await?;
     Uuid::parse_str(&s).map_err(|_| {
@@ -398,7 +377,6 @@ fn wallet_error_response(err: WalletError) -> Response {
         WalletError::CouponExpired => (StatusCode::FORBIDDEN, "coupon_expired"),
         WalletError::Unimplemented(_) => (StatusCode::NOT_IMPLEMENTED, "unimplemented"),
         WalletError::Pool(_) | WalletError::Db(_) => {
-            // Log the raw error server-side, send a generic message to the client.
             tracing::error!(error = %err, "wallet upstream failure");
             (StatusCode::INTERNAL_SERVER_ERROR, "internal")
         }
@@ -413,10 +391,6 @@ fn wallet_error_response(err: WalletError) -> Response {
     )
         .into_response()
 }
-
-// ---------------------------------------------------------------------------
-// Service handlers (service_role JWT required)
-// ---------------------------------------------------------------------------
 
 /// `POST /api/v1/wallet/service/credit` — credit a positive delta to any
 /// account. Returns the resulting ledger id. Idempotent: replays with the


### PR DESCRIPTION
## Summary
Drops section banners, step-by-step narration, and block comments that just restate what the code says. Keeps every `///` outer doc, all `#[utoipa::path]` annotations, RFC + lock-ordering + auth rationale, and the non-obvious WHY comments (askama auto-escape, hop-by-hop strip rationale, Cilium 3600s KASM cap, cursor percent-encoding, etc).

## Diff
- `https.rs`: -219 lines
- `proxy.rs`: -132 lines
- `vnc_hub.rs`: -27 lines
- `wallet.rs`: -22 lines
- **Net: -398 lines, zero behavior change**

## Test plan
- [x] `cargo check` clean
- [x] `cargo clippy --no-deps` — no new warnings; pre-existing ones (too_many_arguments, result_large_err) unchanged
- [ ] CI green