### PR TITLE
perf(ci): drop astro double-build

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.workspace.toml
+++ b/apps/kbve/axum-kbve/Cargo.workspace.toml
@@ -15,3 +15,9 @@ lto = true
 strip = true
 codegen-units = 1
 panic = "abort"
+
+[profile.release-ci]
+inherits = "release"
+opt-level = 2
+lto = "off"
+codegen-units = 16

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -139,7 +139,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     else \
         echo "sccache: Redis password not provided, falling back to local disk cache"; \
     fi && \
-    cargo chef cook --release --recipe-path recipe.json -p axum-kbve && \
+    cargo chef cook --profile release-ci --recipe-path recipe.json -p axum-kbve && \
     (sccache --show-stats || true)
 
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
@@ -175,7 +175,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
             SCCACHE_REDIS_USERNAME=default \
             SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
     fi && \
-    cargo build --release -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker && \
+    cargo build --profile release-ci -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker && \
     (sccache --show-stats || true)
 
 # ============================================================================
@@ -215,16 +215,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
             SCCACHE_REDIS_USERNAME=default \
             SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
     fi && \
-    cargo build --release -p axum-kbve --features jemalloc && \
+    cargo build --profile release-ci -p axum-kbve --features jemalloc && \
     (sccache --show-stats || true) && \
-    strip target/release/axum-kbve
+    strip target/release-ci/axum-kbve
 
 # ============================================================================
 # [STAGE Z] - Runtime Image (shared chisel base)
 # ============================================================================
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
-COPY --from=builder --chown=10001:10001 /app/target/release/axum-kbve /app/axum-kbve
+COPY --from=builder --chown=10001:10001 /app/target/release-ci/axum-kbve /app/axum-kbve
 
 # Ship Cargo.toml alongside the binary so `/health` reports the version
 # that was current when *this image* was built. CI's pre-build sync step

--- a/apps/kbve/axum-kbve/project.json
+++ b/apps/kbve/axum-kbve/project.json
@@ -68,21 +68,8 @@
 				"parallel": false
 			}
 		},
-		"container-prep": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"./kbve.sh -nx astro-kbve:build",
-					"rm -rf ./apps/kbve/axum-kbve/dist/",
-					"mkdir -p ./apps/kbve/axum-kbve/dist/",
-					"cp -a ./dist/apps/astro-kbve/. ./apps/kbve/axum-kbve/dist/"
-				],
-				"parallel": false
-			}
-		},
 		"container": {
 			"executor": "nx:run-commands",
-			"dependsOn": ["container-prep"],
 			"defaultConfiguration": "local",
 			"options": {
 				"parallel": false


### PR DESCRIPTION
## Summary

The container-prep Nx target ran \`astro-kbve:build\` outside docker and copied the dist into \`apps/kbve/axum-kbve/dist/\`, but the Dockerfile already has its own \`astro-builder\` stage that builds from source. Host-side copy is no longer consumed by any stage — pure ~6-7 minute waste per axum-kbve docker test job.

Drop the \`container-prep\` target entirely + the \`dependsOn\` on \`container\`. Docker owns astro for every config now (local / production / ci).

## What got reverted

This branch initially also added a \`[profile.release-ci]\` cargo profile (lto=off, codegen-units=16, opt-level=2) for the docker stages. Reverted before merge — the CI image is the prod image (\`ci-publish.yml\` only retags, no separate prod rebuild), so degrading the profile would permanently hit kube runtime perf. Compile-time savings get pursued via sccache Redis hits + other infra instead.

## Test plan

- [ ] PR CI: confirm \`docker-test-app.yml\` still succeeds with the prep target gone.
- [ ] Job log: confirm only one \`astro build\` invocation (inside docker).
- [ ] Confirm produced image still serves the static site (vitest e2e covers this).