### PR TITLE
perf(arcade): reuse blackjack deal queue

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealQueue.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealQueue.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { collectNewDealPlacements } from './dealQueue';
+
+interface TestPlacement {
+	owner: 'dealer' | 'player';
+	index: number;
+}
+
+function placement(owner: TestPlacement['owner'], index: number) {
+	return { owner, index };
+}
+
+function labels(queue: readonly TestPlacement[]) {
+	return queue.map((card) => `${card.owner}:${card.index}`);
+}
+
+describe('blackjack deal queue', () => {
+	it('queues an opening deal in table order without sorting', () => {
+		const dealer = [placement('dealer', 0), placement('dealer', 1)];
+		const player = [placement('player', 0), placement('player', 1)];
+		const queue: TestPlacement[] = [];
+
+		const count = collectNewDealPlacements(queue, dealer, player, 0, 0);
+
+		expect(count).toBe(4);
+		expect(labels(queue)).toEqual([
+			'player:0',
+			'dealer:0',
+			'player:1',
+			'dealer:1',
+		]);
+	});
+
+	it('queues only newly drawn player cards', () => {
+		const dealer = [placement('dealer', 0), placement('dealer', 1)];
+		const player = [
+			placement('player', 0),
+			placement('player', 1),
+			placement('player', 2),
+		];
+		const queue = [placement('dealer', 99)];
+
+		const count = collectNewDealPlacements(queue, dealer, player, 2, 2);
+
+		expect(count).toBe(1);
+		expect(labels(queue)).toEqual(['player:2']);
+	});
+
+	it('queues dealer draw-down cards sequentially after stand', () => {
+		const dealer = [
+			placement('dealer', 0),
+			placement('dealer', 1),
+			placement('dealer', 2),
+			placement('dealer', 3),
+		];
+		const player = [placement('player', 0), placement('player', 1)];
+		const queue: TestPlacement[] = [];
+
+		const count = collectNewDealPlacements(queue, dealer, player, 2, 2);
+
+		expect(count).toBe(2);
+		expect(labels(queue)).toEqual(['dealer:2', 'dealer:3']);
+	});
+});

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealQueue.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealQueue.ts
@@ -1,0 +1,27 @@
+interface IndexedDealPlacement {
+	index: number;
+}
+
+export function collectNewDealPlacements<
+	TPlacement extends IndexedDealPlacement,
+>(
+	queue: TPlacement[],
+	dealerCards: readonly TPlacement[],
+	playerCards: readonly TPlacement[],
+	previousDealerCount: number,
+	previousPlayerCount: number,
+): number {
+	queue.length = 0;
+
+	const maxCards = Math.max(dealerCards.length, playerCards.length);
+	for (let index = 0; index < maxCards; index++) {
+		if (index >= previousPlayerCount && index < playerCards.length) {
+			queue.push(playerCards[index]);
+		}
+		if (index >= previousDealerCount && index < dealerCards.length) {
+			queue.push(dealerCards[index]);
+		}
+	}
+
+	return queue.length;
+}

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts
@@ -1,5 +1,7 @@
 import Phaser from 'phaser';
 
+import { collectNewDealPlacements } from './dealQueue';
+
 export type HandOwner = 'dealer' | 'player';
 
 export interface CardPlacement {
@@ -23,6 +25,8 @@ interface DealerAnimationOptions {
 
 export class DealerAnimation {
 	private readonly flyingCardViews: Phaser.GameObjects.Image[] = [];
+	private readonly dealQueue: CardPlacement[] = [];
+	private nextFlyingCardIndex = 0;
 	private previousDealerCardCount = 0;
 	private previousPlayerCardCount = 0;
 
@@ -43,22 +47,18 @@ export class DealerAnimation {
 
 		if (!this.options.enabled) return;
 
-		const newCards: CardPlacement[] = [];
-		if (dealerCards.length > previousDealerCount) {
-			newCards.push(...dealerCards.slice(previousDealerCount));
-		}
-		if (playerCards.length > previousPlayerCount) {
-			newCards.push(...playerCards.slice(previousPlayerCount));
-		}
-		if (newCards.length === 0) return;
+		const dealCount = collectNewDealPlacements(
+			this.dealQueue,
+			dealerCards,
+			playerCards,
+			previousDealerCount,
+			previousPlayerCount,
+		);
+		if (dealCount === 0) return;
 
-		newCards
-			.sort(
-				(a, b) => a.index - b.index || (a.owner === 'player' ? -1 : 1),
-			)
-			.forEach((placement, index) => {
-				this.animateCardFromShoe(placement, index);
-			});
+		for (let index = 0; index < dealCount; index++) {
+			this.animateCardFromShoe(this.dealQueue[index], index);
+		}
 	}
 
 	private animateCardFromShoe(placement: CardPlacement, order: number) {
@@ -93,8 +93,15 @@ export class DealerAnimation {
 	}
 
 	private getFlyingCardView(): Phaser.GameObjects.Image {
-		const inactiveView = this.flyingCardViews.find((view) => !view.active);
-		if (inactiveView) return inactiveView;
+		const viewCount = this.flyingCardViews.length;
+		for (let offset = 0; offset < viewCount; offset++) {
+			const index = (this.nextFlyingCardIndex + offset) % viewCount;
+			const view = this.flyingCardViews[index];
+			if (!view.active) {
+				this.nextFlyingCardIndex = (index + 1) % viewCount;
+				return view;
+			}
+		}
 
 		const view = this.scene.add
 			.image(0, 0, this.options.cardBackTextureKey)
@@ -102,6 +109,7 @@ export class DealerAnimation {
 			.setVisible(false)
 			.setActive(false);
 		this.flyingCardViews.push(view);
+		this.nextFlyingCardIndex = 0;
 		this.layer.add(view);
 		return view;
 	}


### PR DESCRIPTION
## Summary
- extract blackjack deal ordering into a pure queue helper
- reuse the dealer animation queue instead of slicing and sorting newly dealt cards each render
- rotate through pooled flying card views when available

## Validation
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealQueue.ts apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealQueue.test.ts apps/kbve/astro-kbve/src/arcade/blackjack/animation/dealerAnimation.ts`
- `./kbve.sh -nx astro-kbve:test`
- `AXUM_PORT=4361 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`