### PR TITLE
fix(firecracker-ctl-net): switch Gluetun DNS forwarder DoT → DoH

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -86,16 +86,15 @@ spec:
                         value: '9001,9999'
                       - name: FIREWALL_OUTBOUND_SUBNETS
                         value: '10.0.0.0/8,172.16.0.0/12'
-                      # DoT on — Gluetun's local forwarder queries Cloudflare
-                      # over DNS-over-TLS (port 853) through the VPN tunnel.
-                      # DNS_ADDRESS=127.0.0.1 keeps the forwarder enabled so
-                      # both pod and VM DNS queries route via the tunnel
-                      # instead of leaking out eth0 (cluster CNI). VM traffic
-                      # is DNATed to 127.0.0.1:53 by tap.rs init.
+                      # DoH over 443 — Proton blocks 53 and 853 over tunnel.
                       - name: DOT
-                        value: 'on'
+                        value: 'off'
                       - name: DNS_ADDRESS
                         value: '127.0.0.1'
+                      - name: DNS_UPSTREAM_RESOLVER_TYPE
+                        value: 'DoH'
+                      - name: DNS_UPSTREAM_RESOLVERS
+                        value: 'cloudflare'
                       - name: HEALTH_VPN_DURATION_INITIAL
                         value: '30s'
                       - name: HEALTH_SERVER_ADDRESS


### PR DESCRIPTION
## Summary

VM DNS queries reach Gluetun's local forwarder via the REDIRECT rule (16 packets matched INPUT ACCEPT for \`172.18.0.0/16\`), but the forwarder itself can't resolve:

\`\`\`
WARN [dns] exchanging over tls connection (0ms) for request IN A cloudflare.com.:
    write tcp 10.2.0.2:53202->1.1.1.1:853: write: connection timed out
\`\`\`

Proton VPN blocks DoT (port 853) over the tunnel in addition to plain DNS (port 53). Only DoH (port 443) passes — HTTPS isn't filtered.

Earlier pod \`nslookup\` successes were Gluetun cache hits (\`DNS_CACHING=on\`). Fresh queries fail.

## Changes

\`apps/kube/firecracker/manifests/firecracker-net-deployment.yaml\`:

| Env | Before | After |
|---|---|---|
| \`DOT\` | \`on\` | \`off\` (disables unbound DoT path) |
| \`DNS_ADDRESS\` | unchanged | \`127.0.0.1\` |
| \`DNS_UPSTREAM_RESOLVER_TYPE\` | (default DoT) | \`DoH\` |
| \`DNS_UPSTREAM_RESOLVERS\` | (implicit) | \`cloudflare\` (pinned) |

YAML-only. No code change, no MDX bump.

## Test plan

- [ ] After merge + ArgoCD reconcile, Gluetun logs show \`[dns] DNS server listening on [::]:53\` plus DoH queries succeeding (no more \`write: connection timed out\` to port 853).
- [ ] Dashboard IDE: Python Quick + Network (VPN) + 🌐 PoetryDB → poem prints, exit 0.