### PR TITLE
perf(arcade): skip unchanged blackjack card draws

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('phaser', () => ({ default: {} }));
+
+import { CardPool } from './cardPool';
+
+class MockImage {
+	active = false;
+	visible = false;
+	textureKey = '';
+	x = 0;
+	y = 0;
+	readonly setTexture = vi.fn((textureKey: string) => {
+		this.textureKey = textureKey;
+		return this;
+	});
+	readonly setPosition = vi.fn((x: number, y: number) => {
+		this.x = x;
+		this.y = y;
+		return this;
+	});
+	readonly setVisible = vi.fn((visible: boolean) => {
+		this.visible = visible;
+		return this;
+	});
+	readonly setActive = vi.fn((active: boolean) => {
+		this.active = active;
+		return this;
+	});
+	readonly setOrigin = vi.fn(() => this);
+}
+
+describe('blackjack card pool', () => {
+	it('skips unchanged texture and position setters on reused views', () => {
+		const images: MockImage[] = [];
+		const scene = {
+			add: {
+				image: () => {
+					const image = new MockImage();
+					images.push(image);
+					return image;
+				},
+			},
+		};
+		const layer = { add: vi.fn() };
+		const pool = new CardPool(scene as never, layer as never, 'slot');
+
+		pool.begin();
+		pool.place('spades-A', 320, 420);
+		pool.hideUnused();
+		pool.begin();
+		pool.place('spades-A', 320, 420);
+
+		expect(images).toHaveLength(1);
+		expect(layer.add).toHaveBeenCalledTimes(1);
+		expect(images[0].setTexture).toHaveBeenCalledTimes(1);
+		expect(images[0].setPosition).toHaveBeenCalledTimes(1);
+	});
+
+	it('updates a reused view when its placement changes', () => {
+		const image = new MockImage();
+		const scene = {
+			add: {
+				image: () => image,
+			},
+		};
+		const pool = new CardPool(
+			scene as never,
+			{ add: vi.fn() } as never,
+			'slot',
+		);
+
+		pool.begin();
+		pool.place('spades-A', 320, 420);
+		pool.begin();
+		pool.place('hearts-K', 360, 420);
+
+		expect(image.setTexture).toHaveBeenCalledTimes(2);
+		expect(image.setPosition).toHaveBeenCalledTimes(2);
+	});
+});

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.ts
@@ -2,6 +2,9 @@ import Phaser from 'phaser';
 
 export class CardPool {
 	private readonly views: Phaser.GameObjects.Image[] = [];
+	private readonly textureKeys: string[] = [];
+	private readonly xPositions: number[] = [];
+	private readonly yPositions: number[] = [];
 	private activeViews = 0;
 
 	constructor(
@@ -15,11 +18,20 @@ export class CardPool {
 	}
 
 	place(textureKey: string, x: number, y: number) {
-		const view = this.getView();
-		view.setTexture(textureKey);
-		view.setPosition(x, y);
-		view.setVisible(true);
-		view.setActive(true);
+		const index = this.activeViews;
+		const view = this.getView(index);
+		if (this.textureKeys[index] !== textureKey) {
+			view.setTexture(textureKey);
+			this.textureKeys[index] = textureKey;
+		}
+		if (this.xPositions[index] !== x || this.yPositions[index] !== y) {
+			view.setPosition(x, y);
+			this.xPositions[index] = x;
+			this.yPositions[index] = y;
+		}
+		if (!view.visible) view.setVisible(true);
+		if (!view.active) view.setActive(true);
+		this.activeViews++;
 	}
 
 	hideUnused() {
@@ -29,17 +41,16 @@ export class CardPool {
 		}
 	}
 
-	private getView(): Phaser.GameObjects.Image {
+	private getView(index: number): Phaser.GameObjects.Image {
 		const view =
-			this.views[this.activeViews] ??
+			this.views[index] ??
 			this.scene.add.image(0, 0, this.fallbackTextureKey).setOrigin(0);
 
-		if (!this.views[this.activeViews]) {
+		if (!this.views[index]) {
 			this.views.push(view);
 			this.layer.add(view);
 		}
 
-		this.activeViews++;
 		return view;
 	}
 }


### PR DESCRIPTION
## Summary
- cache card pool texture and position state per pooled view
- skip repeated Phaser `setTexture` and `setPosition` calls when a card render slot is unchanged
- add unit coverage for unchanged and changed reused card views

## Validation
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.test.ts`
- `./kbve.sh -nx astro-kbve:test`
- `AXUM_PORT=4363 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`