### PR TITLE
feat(mc): publish mrpack to Modpack project GktWTywL

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.152",
+			"version": "1.0.153",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -54,7 +54,7 @@
 		{
 			"key": "chuckrpg",
 			"app_name": "axum-chuckrpg",
-			"version": "0.1.7",
+			"version": "0.1.8",
 			"version_toml": "apps/chuckrpg/axum-chuckrpg/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/chuckrpg.mdx",
 			"version_target": "apps/chuckrpg/axum-chuckrpg/Cargo.toml",
@@ -245,7 +245,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.46",
+			"version": "1.0.47",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",
@@ -256,11 +256,10 @@
 			"has_test": true,
 			"external_publish": {
 				"modrinth_mod_id": "QoFCg0tO",
-				"modrinth_pack_id": "86Wqkiak",
+				"modrinth_pack_id": "GktWTywL",
 				"modrinth_version_type": "release",
 				"modrinth_game_versions": "[\"1.21.11\"]",
-				"modrinth_loaders": "[\"fabric\"]",
-				"modrinth_server_address": "mc.kbve.com"
+				"modrinth_loaders": "[\"fabric\"]"
 			}
 		},
 		{

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -22,11 +22,10 @@ has_test: true
 e2e_name: mc
 external_publish:
     modrinth_mod_id: QoFCg0tO
-    modrinth_pack_id: 86Wqkiak
+    modrinth_pack_id: GktWTywL
     modrinth_version_type: release
     modrinth_loaders: '["fabric"]'
     modrinth_game_versions: '["1.21.11"]'
-    modrinth_server_address: mc.kbve.com
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary
- Swap `modrinth_pack_id` from Server project `86Wqkiak` → Modpack project `GktWTywL` in [mc.mdx](apps/kbve/astro-kbve/src/content/docs/project/mc.mdx).
- Drop `modrinth_server_address` so the v3 `minecraft_java_server` listing PATCH (which needs an `mra_` session token and was returning HTTP 401) no longer runs.
- Regenerate `.github/ci-dispatch-manifest.json` (full sync — also picks up post-publish bumps for astro_kbve 1.0.153 and chuckrpg 0.1.8 that landed since the manifest was last regen'd).

Fixes the failing ci-docker mc job (#10934).

## Why this shape
- Server project `86Wqkiak` is `minecraft_java_server` type; updating its listing pointer requires a `mra_` session token in addition to the PAT (per `project_modrinth_server_listing.md`). Session tokens expire → recurring CI break.
- Modpack project `GktWTywL` accepts mrpack uploads via PAT alone. No session token, no v3 PATCH.
- Server listing on `86Wqkiak` can be repointed manually once `GktWTywL` is out of Draft (or dropped entirely).

## Follow-up
- [ ] First publish lands on `GktWTywL` (Draft is fine for version uploads).
- [ ] Submit `GktWTywL` for review on Modrinth dashboard (manual).
- [ ] Decide fate of Server project `86Wqkiak` (repoint listing to GktWTywL or remove).

## Test plan
- [ ] Next mc dispatch (1.0.48 or rerun) uploads mrpack to `GktWTywL` without `MODRINTH_SESSION`.
- [ ] `modrinth_verify` step passes for `GktWTywL`.
- [ ] v3 server-listing step skipped (no `server_address` set).