### PR TITLE
feat(wallet): split WalletClient into rw/ro pools + wire RO pooler env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "axum-chuckrpg"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "axum 0.8.9",

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     template:
         metadata:
             annotations:
-                rollout-restart: '2026-05-13T12:00:00Z'
+                rollout-restart: '2026-05-13T23:30:00Z'
             labels:
                 app: kbve
                 version: '1.0.22'
@@ -193,6 +193,17 @@ spec:
                             secretKeyRef:
                                 name: supabase-shared
                                 key: db-url
+                      # Optional RO pool — routes pure-read wallet handlers
+                      # (e.g. service/verify-balance) through the CNPG ro
+                      # pooler in session mode. Same `postgres` creds; only
+                      # the host differs. If unset, WalletClient falls back
+                      # to using the rw pool for reads, so deploys without
+                      # this key still work.
+                      - name: WALLET_DATABASE_URL_RO
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: db-url-ro
                   volumeMounts:
                       - name: argocd-ca
                         mountPath: /etc/ssl/argocd

--- a/apps/kube/kbve/manifest/kbve-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/kbve-externalsecret.yaml
@@ -1,68 +1,69 @@
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
-  name: kilobase-remote-secret-store
-  namespace: kbve
+    name: kilobase-remote-secret-store
+    namespace: kbve
 spec:
-  provider:
-    kubernetes:
-      remoteNamespace: kilobase
-      auth:
-        serviceAccount:
-          name: kbve-external-secrets
-          namespace: kbve
-      server:
-        url: https://kubernetes.default.svc
-        caProvider:
-          type: ConfigMap
-          name: kube-root-ca.crt
-          key: ca.crt
-          namespace: kube-system
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: kbve-external-secrets
+                    namespace: kbve
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: kbve-supabase-secrets
-  namespace: kbve
+    name: kbve-supabase-secrets
+    namespace: kbve
 spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: kilobase-remote-secret-store
-    kind: SecretStore
-  target:
-    name: supabase-shared
-    creationPolicy: Owner
-    template:
-      engineVersion: v2
-      data:
-        jwt-secret: "{{ .jwtsecret }}"
-        anon-key: "{{ .anonkey }}"
-        service-role-key: "{{ .servicekey }}"
-        db-url: "postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase"
-        twitch-client-id: "{{ .twitchclientid }}"
-        twitch-client-secret: "{{ .twitchclientsecret }}"
-  data:
-  - secretKey: jwtsecret
-    remoteRef:
-      key: supabase-jwt
-      property: secret
-  - secretKey: anonkey
-    remoteRef:
-      key: supabase-jwt
-      property: anon-key
-  - secretKey: servicekey
-    remoteRef:
-      key: supabase-jwt
-      property: service-key
-  - secretKey: dbpassword
-    remoteRef:
-      key: supabase-postgres
-      property: password
-  - secretKey: twitchclientid
-    remoteRef:
-      key: twitch-oauth-config
-      property: client-id
-  - secretKey: twitchclientsecret
-    remoteRef:
-      key: twitch-oauth-config
-      property: client-secret
+    refreshInterval: 1h
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: supabase-shared
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                jwt-secret: '{{ .jwtsecret }}'
+                anon-key: '{{ .anonkey }}'
+                service-role-key: '{{ .servicekey }}'
+                db-url: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
+                db-url-ro: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-pooler-ro.kilobase.svc.cluster.local:5432/supabase'
+                twitch-client-id: '{{ .twitchclientid }}'
+                twitch-client-secret: '{{ .twitchclientsecret }}'
+    data:
+        - secretKey: jwtsecret
+          remoteRef:
+              key: supabase-jwt
+              property: secret
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key
+        - secretKey: servicekey
+          remoteRef:
+              key: supabase-jwt
+              property: service-key
+        - secretKey: dbpassword
+          remoteRef:
+              key: supabase-postgres
+              property: password
+        - secretKey: twitchclientid
+          remoteRef:
+              key: twitch-oauth-config
+              property: client-id
+        - secretKey: twitchclientsecret
+          remoteRef:
+              key: twitch-oauth-config
+              property: client-secret

--- a/packages/rust/kbve/src/wallet/client.rs
+++ b/packages/rust/kbve/src/wallet/client.rs
@@ -14,17 +14,29 @@ use super::error::{Result, WalletError};
 pub type WalletPool = Pool<AsyncPgConnection>;
 pub type WalletConn<'a> = PooledConnection<'a, AsyncPgConnection>;
 
-pub async fn establish_wallet_pool() -> Result<WalletPool> {
-    let url = read_env("WALLET_DATABASE_URL")
-        .or_else(|_| read_env("DATABASE_URL_PROD"))
-        .map_err(|e| WalletError::Pool(format!("missing wallet DATABASE URL: {e}")))?;
-
+async fn build_pool(url: String) -> Result<WalletPool> {
     let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
     Pool::builder()
         .max_size(8)
         .build(manager)
         .await
         .map_err(|e| WalletError::Pool(e.to_string()))
+}
+
+pub async fn establish_wallet_pool() -> Result<WalletPool> {
+    let url = read_env("WALLET_DATABASE_URL")
+        .or_else(|_| read_env("DATABASE_URL_PROD"))
+        .map_err(|e| WalletError::Pool(format!("missing wallet DATABASE URL: {e}")))?;
+    build_pool(url).await
+}
+
+async fn establish_readonly_pool() -> Result<Option<WalletPool>> {
+    let url = match read_env("WALLET_DATABASE_URL_RO").or_else(|_| read_env("DATABASE_URL_PROD_RO"))
+    {
+        Ok(u) => u,
+        Err(_) => return Ok(None),
+    };
+    build_pool(url).await.map(Some)
 }
 
 fn read_env(name: &str) -> std::result::Result<String, String> {
@@ -52,23 +64,39 @@ pub async fn set_user_claims(conn: &mut AsyncPgConnection, user_id: Uuid) -> Res
 
 #[derive(Clone)]
 pub struct WalletClient {
-    pool: WalletPool,
+    rw: WalletPool,
+    ro: WalletPool,
 }
 
 impl WalletClient {
-    pub fn new(pool: WalletPool) -> Self {
-        Self { pool }
+    pub fn new(rw: WalletPool, ro: Option<WalletPool>) -> Self {
+        let ro = ro.unwrap_or_else(|| rw.clone());
+        Self { rw, ro }
     }
 
     pub async fn from_env() -> Result<Self> {
-        Ok(Self::new(establish_wallet_pool().await?))
+        let rw = establish_wallet_pool().await?;
+        let ro = establish_readonly_pool().await?;
+        Ok(Self::new(rw, ro))
     }
 
-    pub fn pool(&self) -> &WalletPool {
-        &self.pool
+    pub fn rw_pool(&self) -> &WalletPool {
+        &self.rw
+    }
+
+    pub fn ro_pool(&self) -> &WalletPool {
+        &self.ro
+    }
+
+    pub async fn write(&self) -> Result<WalletConn<'_>> {
+        self.rw.get().await.map_err(WalletError::from)
+    }
+
+    pub async fn read(&self) -> Result<WalletConn<'_>> {
+        self.ro.get().await.map_err(WalletError::from)
     }
 
     pub async fn conn(&self) -> Result<WalletConn<'_>> {
-        self.pool.get().await.map_err(WalletError::from)
+        self.write().await
     }
 }

--- a/packages/rust/kbve/src/wallet/proxy.rs
+++ b/packages/rust/kbve/src/wallet/proxy.rs
@@ -57,7 +57,7 @@ struct RedeemRowDb {
 
 impl WalletClient {
     pub async fn user_balance(&self, user_id: Uuid) -> Result<BalanceRow> {
-        let mut conn = self.conn().await?;
+        let mut conn = self.write().await?;
         let inner: &mut AsyncPgConnection = &mut *conn;
         inner
             .transaction::<BalanceRow, WalletError, _>(async |conn| {
@@ -68,7 +68,7 @@ impl WalletClient {
     }
 
     pub async fn user_coupons(&self, user_id: Uuid) -> Result<Vec<CouponSummary>> {
-        let mut conn = self.conn().await?;
+        let mut conn = self.write().await?;
         let inner: &mut AsyncPgConnection = &mut *conn;
         inner
             .transaction::<Vec<CouponSummary>, WalletError, _>(async |conn| {
@@ -84,7 +84,7 @@ impl WalletClient {
         coupon_id: i64,
         idempotency_key: Uuid,
     ) -> Result<RedeemResult> {
-        let mut conn = self.conn().await?;
+        let mut conn = self.write().await?;
         let inner: &mut AsyncPgConnection = &mut *conn;
         inner
             .transaction::<RedeemResult, WalletError, _>(async |conn| {

--- a/packages/rust/kbve/src/wallet/service.rs
+++ b/packages/rust/kbve/src/wallet/service.rs
@@ -50,22 +50,22 @@ struct RevokedRow {
 
 impl WalletClient {
     pub async fn credit(&self, req: CreditRequest) -> Result<i64> {
-        let mut conn = self.conn().await?;
+        let mut conn = self.write().await?;
         credit_async(&mut conn, req).await
     }
 
     pub async fn debit(&self, req: DebitRequest) -> Result<i64> {
-        let mut conn = self.conn().await?;
+        let mut conn = self.write().await?;
         debit_async(&mut conn, req).await
     }
 
     pub async fn transfer(&self, req: TransferRequest) -> Result<()> {
-        let mut conn = self.conn().await?;
+        let mut conn = self.write().await?;
         transfer_async(&mut conn, req).await
     }
 
     pub async fn service_account_for_user(&self, user_id: Uuid) -> Result<Uuid> {
-        let mut conn = self.conn().await?;
+        let mut conn = self.write().await?;
         let inner: &mut AsyncPgConnection = &mut *conn;
         inner
             .transaction::<Uuid, WalletError, _>(async |conn| {
@@ -90,17 +90,17 @@ impl WalletClient {
         coupon_id: i64,
         idempotency_key: Uuid,
     ) -> Result<RedeemResult> {
-        let mut conn = self.conn().await?;
+        let mut conn = self.write().await?;
         redeem_async(&mut conn, coupon_id, idempotency_key).await
     }
 
     pub async fn revoke_coupon(&self, coupon_id: i64, reason: Option<String>) -> Result<bool> {
-        let mut conn = self.conn().await?;
+        let mut conn = self.write().await?;
         revoke_async(&mut conn, coupon_id, reason).await
     }
 
     pub async fn verify_balance(&self, account_id: Uuid) -> Result<VerifyBalanceRow> {
-        let mut conn = self.conn().await?;
+        let mut conn = self.read().await?;
         verify_async(&mut conn, account_id).await
     }
 }


### PR DESCRIPTION
## Summary

Adds a dedicated read pool so wallet handlers can offload pure-read traffic to the CNPG read-only pooler (session mode) without hammering the rw primary. Mutation paths and account-provisioning paths stay on rw unconditionally. Follow-up to #10920 (auth.users trigger + backfill).

## Rust changes

**`packages/rust/kbve/src/wallet/client.rs`**

- `WalletClient` now holds `(rw, ro)` pools. `ro` defaults to a clone of `rw` when `WALLET_DATABASE_URL_RO` / `DATABASE_URL_PROD_RO` is unset → backward-compatible.
- New accessors: `write()`, `read()`, `rw_pool()`, `ro_pool()`. `conn()` kept as alias for `write()` so existing call sites + tests compile unchanged.

**Routing in `service.rs` / `proxy.rs`:**

| Method | Pool | Why |
|---|---|---|
| `credit` / `debit` / `transfer` | `write()` | Txn |
| `redeem_coupon` / `revoke_coupon` | `write()` | Txn |
| `service_account_for_user` | `write()` | Calls `proxy_ensure_user_account` |
| `user_balance` / `user_coupons` / `user_redeem_coupon` | `write()` | Still call `proxy_ensure_user_account` internally; stays on rw until a RO-safe SQL variant lands |
| `verify_balance` | **`read()`** | Pure ledger sum vs stored balance; no writes |

## Manifest wiring

- `kbve-externalsecret.yaml`: template a new `db-url-ro` key pointing at `supabase-cluster-pooler-ro.kilobase.svc.cluster.local:5432`, same `postgres` creds.
- `kbve-deployment.yaml`: optional `WALLET_DATABASE_URL_RO` env from `supabase-shared.db-url-ro`. Bumps `rollout-restart` annotation so ArgoCD rolls the pod on next sync.

## Follow-up (out of scope)

- New SQL variants (e.g. `proxy_wallet_get_balance_readonly`) that skip `proxy_ensure_user_account` so `user_balance` / `user_coupons` can move to `read()` with a `write()` fallback on missing account. Requires PR #10920 fully deployed + monitoring on trigger soft-fails before lazy provisioning is removed.

## Test plan

- [x] `cargo check` clean for `kbve` (wallet feature) + `axum-kbve`
- [x] All 7 `wallet::tests::*` integration tests green against local docker postgres
- [ ] After merge + ArgoCD sync: verify `kubectl get secret supabase-shared -n kbve` has new `db-url-ro` key
- [ ] Verify `axum-kbve` pod logs show "WalletClient initialized" with no RO-pool warning
- [ ] Hit `GET /api/v1/wallet/service/verify-balance/<account>` and confirm RO pool is exercised (CNPG metrics)
- [ ] Confirm existing wallet routes (`/me/balance`, `/me/coupons`, `/me/redeem-coupon`, service `/credit*`, `/debit`, `/transfer`) keep returning 2xx