### PR TITLE
fix(astro-kbve): repair Discord invite link + center hero arrow

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/discord.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/discord.mdx
@@ -43,20 +43,20 @@ import Adsense from '@/components/astropad/adsense/Adsense.astro';
 			<div class="discord-hero__cta">
 				<a
 					class="discord-hero__btn discord-hero__btn--primary"
-					href="https://discord.com/invite/342732838598082562"
+					href="https://discord.com/invite/sSyHAxJY?utm_source=Discord%20Widget&utm_medium=Connect"
 					target="_blank"
 					rel="noopener noreferrer">
 					Join the server
 					<svg
-						viewBox="0 0 20 20"
+						viewBox="0 0 24 24"
 						fill="none"
 						stroke="currentColor"
 						aria-hidden="true">
 						<path
 							stroke-linecap="round"
 							stroke-linejoin="round"
-							stroke-width="1.8"
-							d="M5 10h10m0 0l-4-4m4 4l-4 4"
+							stroke-width="2"
+							d="M5 12h14M13 6l6 6-6 6"
 						/>
 					</svg>
 				</a>


### PR DESCRIPTION
## Summary
- Replace broken `/invite/342732838598082562` href on the Discord splash CTA with the working `sSyHAxJY` invite (Discord Widget UTM tagged).
- Normalize the hero button arrow SVG to a 24x24 viewBox with a centered path so the glyph sits true inside the pill instead of skewing left.

## Test plan
- [ ] `npx nx run astro-kbve:build` succeeds
- [ ] Visit `/discord/`; click **Join the server** → opens working Discord invite
- [ ] Arrow icon is visually centered inside the primary CTA