### PR TITLE
feat(firecracker-ctl): public-tier follow-ups — rate limit, metrics, idle TTL, deploy UI

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactDeployPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactDeployPanel.tsx
@@ -117,6 +117,13 @@ export default function ReactDeployPanel() {
 	const port = useStore(deployService.$port);
 	const endpoints = useStore(deployService.$endpoints);
 	const lastDeployed = useStore(deployService.$lastDeployedName);
+	const visibility = useStore(deployService.$visibility);
+	const corsOrigins = useStore(deployService.$corsOriginsRaw);
+	const rateRps = useStore(deployService.$rateRps);
+	const rateBurst = useStore(deployService.$rateBurst);
+	const idleTtl = useStore(deployService.$idleTtlSecs);
+	const injectHeaders = useStore(deployService.$injectHeadersRaw);
+	const [showAdvanced, setShowAdvanced] = useState(false);
 	const token = useStore(vmService.$accessToken);
 
 	const editorRef = useRef<HTMLDivElement | null>(null);
@@ -272,7 +279,111 @@ export default function ReactDeployPanel() {
 					<span>Rootfs</span>
 					<code>{template.rootfs}</code>
 				</label>
+
+				<label className="deploy-field">
+					<span>Visibility</span>
+					<select
+						value={visibility}
+						onChange={(e) =>
+							deployService.$visibility.set(
+								e.target.value === 'public'
+									? 'public'
+									: 'staff',
+							)
+						}>
+						<option value="staff">staff (JWT required)</option>
+						<option value="public">
+							public (anonymous /fc/public/*)
+						</option>
+					</select>
+				</label>
 			</div>
+
+			<details
+				className="deploy-advanced"
+				open={showAdvanced}
+				onToggle={(e) =>
+					setShowAdvanced((e.target as HTMLDetailsElement).open)
+				}>
+				<summary>Advanced HTTP config</summary>
+				<div className="deploy-form">
+					<label className="deploy-field deploy-field--wide">
+						<span>
+							CORS allowed origins
+							<small>(comma or newline; `*` for any)</small>
+						</span>
+						<textarea
+							rows={2}
+							value={corsOrigins}
+							placeholder="https://kbve.com, https://*.kbve.com"
+							onChange={(e) =>
+								deployService.$corsOriginsRaw.set(
+									e.target.value,
+								)
+							}
+						/>
+					</label>
+					<label className="deploy-field deploy-field--wide">
+						<span>
+							Inject request headers
+							<small>(one per line: `Name: value`)</small>
+						</span>
+						<textarea
+							rows={3}
+							value={injectHeaders}
+							placeholder={
+								'X-Endpoint-Name: my-api\nX-Tenant-Id: alpha'
+							}
+							onChange={(e) =>
+								deployService.$injectHeadersRaw.set(
+									e.target.value,
+								)
+							}
+						/>
+					</label>
+					<label className="deploy-field">
+						<span>Rate limit RPS</span>
+						<input
+							type="number"
+							min={0}
+							max={10000}
+							value={rateRps}
+							onChange={(e) =>
+								deployService.$rateRps.set(
+									Number(e.target.value) || 0,
+								)
+							}
+						/>
+					</label>
+					<label className="deploy-field">
+						<span>Rate burst</span>
+						<input
+							type="number"
+							min={0}
+							max={100000}
+							value={rateBurst}
+							onChange={(e) =>
+								deployService.$rateBurst.set(
+									Number(e.target.value) || 0,
+								)
+							}
+						/>
+					</label>
+					<label className="deploy-field">
+						<span>Idle TTL secs (0 = off)</span>
+						<input
+							type="number"
+							min={0}
+							value={idleTtl}
+							onChange={(e) =>
+								deployService.$idleTtlSecs.set(
+									Number(e.target.value) || 0,
+								)
+							}
+						/>
+					</label>
+				</div>
+			</details>
 
 			<div ref={editorRef} className="deploy-editor" />
 
@@ -305,6 +416,17 @@ export default function ReactDeployPanel() {
 						rel="noopener noreferrer">
 						{deployService.urlFor(lastDeployed)}
 					</a>
+					{visibility === 'public' && (
+						<>
+							{' · public: '}
+							<a
+								href={deployService.publicUrlFor(lastDeployed)}
+								target="_blank"
+								rel="noopener noreferrer">
+								{deployService.publicUrlFor(lastDeployed)}
+							</a>
+						</>
+					)}
 				</div>
 			)}
 
@@ -345,7 +467,12 @@ export default function ReactDeployPanel() {
 				.deploy-form { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
 				.deploy-field { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.8rem; }
 				.deploy-field span { opacity: 0.7; }
-				.deploy-field input, .deploy-field select { padding: 0.4rem 0.5rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.1); border-radius: 0.25rem; color: inherit; font: inherit; }
+				.deploy-field input, .deploy-field select, .deploy-field textarea { padding: 0.4rem 0.5rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.1); border-radius: 0.25rem; color: inherit; font: inherit; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+					.deploy-field--wide { grid-column: 1 / -1; }
+					.deploy-field small { opacity: 0.55; margin-left: 0.4rem; font-size: 0.7rem; }
+					.deploy-advanced { border: 1px solid rgba(255,255,255,0.08); border-radius: 0.25rem; padding: 0.5rem 0.75rem; background: rgba(255,255,255,0.015); }
+					.deploy-advanced summary { cursor: pointer; font-size: 0.85rem; opacity: 0.85; padding: 0.15rem 0; }
+					.deploy-advanced[open] summary { margin-bottom: 0.6rem; }
 				.deploy-field--meta code { padding: 0.4rem 0.5rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.06); border-radius: 0.25rem; font-size: 0.78rem; }
 				.deploy-editor { border: 1px solid rgba(255,255,255,0.08); border-radius: 0.25rem; overflow: hidden; }
 				.deploy-actions { display: flex; gap: 0.5rem; align-items: center; }

--- a/apps/kbve/astro-kbve/src/components/dashboard/deployService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/deployService.ts
@@ -4,6 +4,23 @@ import { atom } from 'nanostores';
 // Types — mirror firecracker-ctl's DeployFcRequest + PersistentEndpointInfo
 // ---------------------------------------------------------------------------
 
+export type EndpointVisibility = 'staff' | 'public';
+
+export interface RateLimitConfig {
+	requests_per_sec?: number;
+	burst?: number;
+}
+
+export interface EndpointHttpConfig {
+	cors_allow_origins?: string[];
+	cors_allow_methods?: string[];
+	cors_allow_headers?: string[];
+	cors_max_age_secs?: number;
+	cors_allow_credentials?: boolean;
+	inject_request_headers?: Record<string, string>;
+	rate_limit?: RateLimitConfig;
+}
+
 export interface DeployRequest {
 	name: string;
 	rootfs: string;
@@ -14,6 +31,9 @@ export interface DeployRequest {
 	health_path?: string;
 	env?: Record<string, unknown>;
 	code?: string;
+	visibility?: EndpointVisibility;
+	idle_ttl_secs?: number;
+	http_config?: EndpointHttpConfig;
 }
 
 export interface DeployedEndpoint {
@@ -25,6 +45,9 @@ export interface DeployedEndpoint {
 	entrypoint: string;
 	status?: string;
 	created_at?: string;
+	visibility?: EndpointVisibility;
+	idle_ttl_secs?: number;
+	http_config?: EndpointHttpConfig;
 }
 
 export interface DeployTemplate {
@@ -179,6 +202,12 @@ class DeployService {
 	public readonly $port = atom<number>(TEMPLATES[0].http_port);
 	public readonly $endpoints = atom<DeployedEndpoint[]>([]);
 	public readonly $lastDeployedName = atom<string | null>(null);
+	public readonly $visibility = atom<EndpointVisibility>('staff');
+	public readonly $corsOriginsRaw = atom<string>('');
+	public readonly $rateRps = atom<number>(0);
+	public readonly $rateBurst = atom<number>(0);
+	public readonly $idleTtlSecs = atom<number>(0);
+	public readonly $injectHeadersRaw = atom<string>('');
 
 	public selectTemplate(id: string): void {
 		const tpl = TEMPLATES.find((t) => t.id === id);
@@ -196,6 +225,69 @@ class DeployService {
 
 	public urlFor(name: string): string {
 		return endpointUrl(name);
+	}
+
+	public publicUrlFor(name: string): string {
+		return `/fc/public/${name}/`;
+	}
+
+	private parseInjectHeaders(
+		raw: string,
+	): Record<string, string> | undefined {
+		const out: Record<string, string> = {};
+		let count = 0;
+		for (const line of raw.split('\n')) {
+			const trimmed = line.trim();
+			if (!trimmed) continue;
+			const idx = trimmed.indexOf(':');
+			if (idx <= 0) {
+				throw new Error(
+					`Invalid header line (expected "Name: value"): ${trimmed}`,
+				);
+			}
+			const key = trimmed.slice(0, idx).trim();
+			const value = trimmed.slice(idx + 1).trim();
+			if (!key || !value) {
+				throw new Error(`Invalid header line: ${trimmed}`);
+			}
+			out[key] = value;
+			count += 1;
+			if (count > 16) {
+				throw new Error('Inject headers limit (16) exceeded.');
+			}
+		}
+		return Object.keys(out).length > 0 ? out : undefined;
+	}
+
+	private buildHttpConfig(): EndpointHttpConfig | undefined {
+		const originsRaw = this.$corsOriginsRaw.get().trim();
+		const corsOrigins = originsRaw
+			? originsRaw
+					.split(/[\s,]+/)
+					.map((s) => s.trim())
+					.filter(Boolean)
+			: [];
+		const injectHeaders = this.parseInjectHeaders(
+			this.$injectHeadersRaw.get(),
+		);
+		const rps = Math.max(0, Math.floor(this.$rateRps.get() ?? 0));
+		const burst = Math.max(0, Math.floor(this.$rateBurst.get() ?? 0));
+
+		const cfg: EndpointHttpConfig = {};
+		let any = false;
+		if (corsOrigins.length > 0) {
+			cfg.cors_allow_origins = corsOrigins;
+			any = true;
+		}
+		if (injectHeaders) {
+			cfg.inject_request_headers = injectHeaders;
+			any = true;
+		}
+		if (rps > 0 || burst > 0) {
+			cfg.rate_limit = { requests_per_sec: rps, burst };
+			any = true;
+		}
+		return any ? cfg : undefined;
 	}
 
 	public async deploy(token: string): Promise<void> {
@@ -222,6 +314,18 @@ class DeployService {
 		this.$phase.set('submitting');
 		this.$error.set(null);
 
+		let httpConfig: EndpointHttpConfig | undefined;
+		try {
+			httpConfig = this.buildHttpConfig();
+		} catch (e) {
+			this.$phase.set('idle');
+			this.$error.set(e instanceof Error ? e.message : String(e));
+			return;
+		}
+
+		const visibility = this.$visibility.get();
+		const idleTtl = Math.max(0, Math.floor(this.$idleTtlSecs.get() ?? 0));
+
 		const req: DeployRequest = {
 			name,
 			rootfs: tpl.rootfs,
@@ -231,7 +335,11 @@ class DeployService {
 			mem_size_mib: tpl.mem_size_mib,
 			code,
 			env: {},
+			visibility,
 		};
+		if (idleTtl > 0) req.idle_ttl_secs = idleTtl;
+		if (httpConfig) req.http_config = httpConfig;
+
 		const packages = TEMPLATE_PACKAGES[tpl.id];
 		if (packages && packages.length > 0) {
 			(req as unknown as Record<string, unknown>).packages = packages;

--- a/apps/vm/firecracker-ctl-e2e/e2e/fc-public.spec.ts
+++ b/apps/vm/firecracker-ctl-e2e/e2e/fc-public.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+
+const DEPLOY_BASE = {
+	rootfs: 'alpine-python',
+	entrypoint: '/usr/bin/python3',
+	http_port: 8080,
+};
+
+describe('Persistent endpoints — /fc/* + /fc/public/*', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('rejects deploy with reserved name "public"', async () => {
+		const res = await fetch(`${BASE_URL}/fc/deploy`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ ...DEPLOY_BASE, name: 'public' }),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('reserved');
+	});
+
+	it('rejects CORS wildcard with credentials', async () => {
+		const res = await fetch(`${BASE_URL}/fc/deploy`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				...DEPLOY_BASE,
+				name: 'fc-test-wildcard-creds',
+				http_config: {
+					cors_allow_origins: ['*'],
+					cors_allow_credentials: true,
+				},
+			}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects reserved inject header name', async () => {
+		const res = await fetch(`${BASE_URL}/fc/deploy`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				...DEPLOY_BASE,
+				name: 'fc-test-reserved-header',
+				http_config: {
+					inject_request_headers: { Authorization: 'Bearer x' },
+				},
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('reserved');
+	});
+
+	it('rejects CORS origin without scheme', async () => {
+		const res = await fetch(`${BASE_URL}/fc/deploy`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				...DEPLOY_BASE,
+				name: 'fc-test-bad-origin',
+				http_config: { cors_allow_origins: ['kbve.com'] },
+			}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('rejects rate_limit.requests_per_sec over cap', async () => {
+		const res = await fetch(`${BASE_URL}/fc/deploy`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				...DEPLOY_BASE,
+				name: 'fc-test-rate-cap',
+				http_config: { rate_limit: { requests_per_sec: 1_000_000 } },
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('requests_per_sec');
+	});
+
+	it('rejects idle_ttl_secs over 30 days', async () => {
+		const res = await fetch(`${BASE_URL}/fc/deploy`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				...DEPLOY_BASE,
+				name: 'fc-test-ttl-cap',
+				idle_ttl_secs: 365 * 24 * 60 * 60,
+			}),
+		});
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.error).toContain('idle_ttl_secs');
+	});
+
+	it('rejects inject header value with CR/LF (response-splitting guard)', async () => {
+		const res = await fetch(`${BASE_URL}/fc/deploy`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				...DEPLOY_BASE,
+				name: 'fc-test-crlf',
+				http_config: {
+					inject_request_headers: {
+						'X-Evil': 'a\r\nSet-Cookie: pwned=1',
+					},
+				},
+			}),
+		});
+		expect(res.status).toBe(400);
+	});
+
+	it('/proxy/public/{name} returns 503 when persistent endpoints disabled', async () => {
+		const res = await fetch(`${BASE_URL}/proxy/public/anything-here`);
+		expect(res.status).toBe(503);
+	});
+});

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -12,7 +12,7 @@ use std::{
     net::SocketAddr,
     sync::{
         Arc, OnceLock,
-        atomic::{AtomicI64, Ordering},
+        atomic::{AtomicI64, AtomicU64, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -240,6 +240,32 @@ struct PersistentEndpoint {
     visibility: EndpointVisibility,
     http_config: EndpointHttpConfig,
     rate_limiter: TokenBucket,
+    metrics: Arc<EndpointMetrics>,
+    /// Idle TTL in seconds. 0 disables auto-teardown.
+    idle_ttl_secs: u32,
+}
+
+#[derive(Default)]
+struct EndpointMetrics {
+    requests_total: AtomicU64,
+    requests_throttled: AtomicU64,
+    requests_forbidden: AtomicU64,
+    upstream_errors: AtomicU64,
+    bytes_in: AtomicU64,
+    bytes_out: AtomicU64,
+    /// 0 = never seen traffic. Otherwise micros since start.
+    last_request_micros: AtomicI64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, ToSchema)]
+pub struct EndpointMetricsSnapshot {
+    pub requests_total: u64,
+    pub requests_throttled: u64,
+    pub requests_forbidden: u64,
+    pub upstream_errors: u64,
+    pub bytes_in: u64,
+    pub bytes_out: u64,
+    pub last_request_age_secs: Option<u64>,
 }
 
 /// Lock-free token bucket. Stores milli-tokens so sub-1 RPS rates round
@@ -331,6 +357,8 @@ pub struct PersistentEndpointInfo {
     uptime_secs: u64,
     visibility: EndpointVisibility,
     http_config: EndpointHttpConfig,
+    idle_ttl_secs: u32,
+    metrics: EndpointMetricsSnapshot,
 }
 
 impl PersistentEndpointInfo {
@@ -351,6 +379,28 @@ impl PersistentEndpointInfo {
             uptime_secs: ep.created.elapsed().as_secs(),
             visibility: ep.visibility,
             http_config: ep.http_config.clone(),
+            idle_ttl_secs: ep.idle_ttl_secs,
+            metrics: ep.metrics.snapshot(),
+        }
+    }
+}
+
+impl EndpointMetrics {
+    fn snapshot(&self) -> EndpointMetricsSnapshot {
+        let last = self.last_request_micros.load(Ordering::Relaxed);
+        let last_request_age_secs = if last == 0 {
+            None
+        } else {
+            Some(((now_micros() - last).max(0) / 1_000_000) as u64)
+        };
+        EndpointMetricsSnapshot {
+            requests_total: self.requests_total.load(Ordering::Relaxed),
+            requests_throttled: self.requests_throttled.load(Ordering::Relaxed),
+            requests_forbidden: self.requests_forbidden.load(Ordering::Relaxed),
+            upstream_errors: self.upstream_errors.load(Ordering::Relaxed),
+            bytes_in: self.bytes_in.load(Ordering::Relaxed),
+            bytes_out: self.bytes_out.load(Ordering::Relaxed),
+            last_request_age_secs,
         }
     }
 }
@@ -384,6 +434,7 @@ const MAX_HEADER_VALUE_LEN: usize = 256;
 const MAX_CORS_MAX_AGE_SECS: u32 = 86_400;
 const MAX_RATE_REQUESTS_PER_SEC: u32 = 10_000;
 const MAX_RATE_BURST: u32 = 100_000;
+const MAX_IDLE_TTL_SECS: u32 = 30 * 24 * 60 * 60;
 
 /// Header names that callers must never override on the upstream request.
 /// Hop-by-hop framing, plus Host/Authorization which we set ourselves.
@@ -774,6 +825,11 @@ pub struct DeployFcRequest {
     /// requires redeploy.
     #[serde(default)]
     pub visibility: EndpointVisibility,
+    /// Idle teardown TTL in seconds. After this many seconds with zero
+    /// traffic, the background sweeper releases the TAP + IP and drops
+    /// the registry entry. `0` (default) disables auto-teardown.
+    #[serde(default)]
+    pub idle_ttl_secs: u32,
     /// CORS + header-injection policy. CORS fields apply only to the public
     /// tier; `inject_request_headers` applies on every forward. Defaults
     /// disable both, preserving Phase 2c behavior.
@@ -851,6 +907,17 @@ async fn fc_deploy(
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": msg})),
+        );
+    }
+    if req.idle_ttl_secs > MAX_IDLE_TTL_SECS {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!(
+                    "idle_ttl_secs {} exceeds cap of {MAX_IDLE_TTL_SECS}",
+                    req.idle_ttl_secs
+                ),
+            })),
         );
     }
 
@@ -983,6 +1050,8 @@ async fn fc_deploy(
         visibility: req.visibility,
         rate_limiter: TokenBucket::from_config(req.http_config.rate_limit),
         http_config: req.http_config.clone(),
+        metrics: Arc::new(EndpointMetrics::default()),
+        idle_ttl_secs: req.idle_ttl_secs,
     };
     let info = PersistentEndpointInfo::from(&endpoint);
     persistent.endpoints.insert(req.name.clone(), endpoint);
@@ -1127,6 +1196,56 @@ async fn fc_destroy(
     (StatusCode::OK, Json(serde_json::json!({"removed": name})))
 }
 
+/// Scan the registry every `interval`, remove endpoints whose
+/// `idle_ttl_secs` expired (no traffic seen in that window). Endpoints
+/// with `idle_ttl_secs == 0` are skipped. Endpoints that have never been
+/// hit are measured from `created`, not `last_request_micros`.
+async fn idle_sweeper_task(persistent: Arc<PersistentState>, interval: Duration) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        ticker.tick().await;
+        let now = now_micros();
+        let mut to_kill: Vec<String> = Vec::new();
+        for entry in persistent.endpoints.iter() {
+            let ep = entry.value();
+            if ep.idle_ttl_secs == 0 {
+                continue;
+            }
+            let ttl_us = (ep.idle_ttl_secs as i64) * 1_000_000;
+            let last = ep.metrics.last_request_micros.load(Ordering::Relaxed);
+            let reference = if last == 0 {
+                ep.created.elapsed().as_micros() as i64
+            } else {
+                now - last
+            };
+            if reference > ttl_us {
+                to_kill.push(ep.name.clone());
+            }
+        }
+        for name in to_kill {
+            let Some((_, endpoint)) = persistent.endpoints.remove(&name) else {
+                continue;
+            };
+            if let Some(pid) = endpoint.pid {
+                unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+            if let Err(e) = persistent.tap_manager.destroy_tap(&endpoint.tap).await {
+                tracing::warn!(
+                    "idle_sweeper: TAP teardown failed for {name} ({}): {e}",
+                    endpoint.tap.name
+                );
+            }
+            persistent.pool.release(&endpoint.allocation);
+            tracing::info!(
+                "idle_sweeper: tore down idle endpoint {name} (ttl={}s)",
+                endpoint.idle_ttl_secs
+            );
+        }
+    }
+}
+
 /// Hop-by-hop headers that must not cross proxy boundaries per RFC 7230 §6.1.
 /// `accept-encoding` is stripped on the request side so upstream never
 /// compresses — reqwest would transparently decode and the content-length
@@ -1210,10 +1329,13 @@ async fn fc_proxy_inner(
 
     let is_preflight = require_public && req.method() == axum::http::Method::OPTIONS;
 
-    let (guest_ip, http_port, http_config) = match persistent.endpoints.get(&name) {
+    let (guest_ip, http_port, http_config, metrics) = match persistent.endpoints.get(&name) {
         Some(entry) => {
             let ep = entry.value();
             if require_public && ep.visibility != EndpointVisibility::Public {
+                ep.metrics
+                    .requests_forbidden
+                    .fetch_add(1, Ordering::Relaxed);
                 return (
                     StatusCode::FORBIDDEN,
                     Json(serde_json::json!({
@@ -1226,6 +1348,9 @@ async fn fc_proxy_inner(
             // Preflights bypass the bucket so a flood of CORS probes cannot
             // starve real traffic; budget is for the actual workload.
             if require_public && !is_preflight && !ep.rate_limiter.try_acquire() {
+                ep.metrics
+                    .requests_throttled
+                    .fetch_add(1, Ordering::Relaxed);
                 return (
                     StatusCode::TOO_MANY_REQUESTS,
                     Json(serde_json::json!({
@@ -1235,7 +1360,16 @@ async fn fc_proxy_inner(
                 )
                     .into_response();
             }
-            (ep.allocation.guest_ip, ep.http_port, ep.http_config.clone())
+            ep.metrics.requests_total.fetch_add(1, Ordering::Relaxed);
+            ep.metrics
+                .last_request_micros
+                .store(now_micros(), Ordering::Relaxed);
+            (
+                ep.allocation.guest_ip,
+                ep.http_port,
+                ep.http_config.clone(),
+                ep.metrics.clone(),
+            )
         }
         None => {
             return (
@@ -1308,6 +1442,9 @@ async fn fc_proxy_inner(
                 .into_response();
         }
     };
+    metrics
+        .bytes_in
+        .fetch_add(body_bytes.len() as u64, Ordering::Relaxed);
 
     // --- Issue the upstream request ---
     let reqwest_method = match reqwest::Method::from_bytes(method.as_str().as_bytes()) {
@@ -1333,6 +1470,7 @@ async fn fc_proxy_inner(
     {
         Ok(r) => r,
         Err(e) => {
+            metrics.upstream_errors.fetch_add(1, Ordering::Relaxed);
             let (status, reason) = classify_reqwest_error(&e);
             tracing::warn!("fc_proxy: upstream error for {name} ({upstream_url}): {e}");
             return (
@@ -1365,7 +1503,15 @@ async fn fc_proxy_inner(
         attach_cors_response_headers(&mut resp_headers, request_origin.as_deref(), &http_config);
     }
 
-    let body_stream = upstream_resp.bytes_stream();
+    let metrics_for_stream = metrics.clone();
+    let body_stream = tokio_stream::StreamExt::map(upstream_resp.bytes_stream(), move |r| {
+        if let Ok(ref b) = r {
+            metrics_for_stream
+                .bytes_out
+                .fetch_add(b.len() as u64, Ordering::Relaxed);
+        }
+        r
+    });
     let body = Body::from_stream(body_stream);
 
     let mut response = Response::builder().status(upstream_status);
@@ -2572,8 +2718,12 @@ async fn main() {
         rootfs_dir,
         max_concurrent_vms,
         jailer,
-        persistent,
+        persistent: persistent.clone(),
     };
+
+    if let Some(p) = persistent.clone() {
+        tokio::spawn(idle_sweeper_task(p, Duration::from_secs(60)));
+    }
 
     tracing::info!(
         "FC_MAX_CONCURRENT_VMS={}, FC_VM_TTL_SECS={}",

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -10,7 +10,10 @@ use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
-    sync::Arc,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicI64, Ordering},
+    },
     time::{Duration, Instant},
 };
 use tokio::sync::Notify;
@@ -204,6 +207,20 @@ pub struct EndpointHttpConfig {
     /// hop-by-hop / framing headers are rejected at deploy time.
     #[serde(default)]
     pub inject_request_headers: std::collections::BTreeMap<String, String>,
+    /// Per-endpoint global token bucket. Applies only to the public tier.
+    /// `requests_per_sec = 0` (default) disables rate limiting.
+    #[serde(default)]
+    pub rate_limit: RateLimitConfig,
+}
+
+/// Per-endpoint global token bucket. Burst defaults to one second of capacity
+/// when omitted. Validated by [`validate_http_config`].
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct RateLimitConfig {
+    #[serde(default)]
+    pub requests_per_sec: u32,
+    #[serde(default)]
+    pub burst: u32,
 }
 
 /// Registered persistent endpoint. Owned by `PersistentState::endpoints`.
@@ -222,7 +239,77 @@ struct PersistentEndpoint {
     created: Instant,
     visibility: EndpointVisibility,
     http_config: EndpointHttpConfig,
+    rate_limiter: TokenBucket,
 }
+
+/// Lock-free token bucket. Stores milli-tokens so sub-1 RPS rates round
+/// cleanly.
+struct TokenBucket {
+    tokens_x1000: AtomicI64,
+    last_refill_micros: AtomicI64,
+    capacity_x1000: i64,
+    refill_per_sec_x1000: i64,
+}
+
+impl TokenBucket {
+    fn disabled() -> Self {
+        Self {
+            tokens_x1000: AtomicI64::new(0),
+            last_refill_micros: AtomicI64::new(0),
+            capacity_x1000: 0,
+            refill_per_sec_x1000: 0,
+        }
+    }
+
+    fn from_config(cfg: RateLimitConfig) -> Self {
+        if cfg.requests_per_sec == 0 {
+            return Self::disabled();
+        }
+        let capacity = cfg.burst.max(cfg.requests_per_sec).max(1) as i64 * 1000;
+        Self {
+            tokens_x1000: AtomicI64::new(capacity),
+            last_refill_micros: AtomicI64::new(now_micros()),
+            capacity_x1000: capacity,
+            refill_per_sec_x1000: cfg.requests_per_sec as i64 * 1000,
+        }
+    }
+
+    fn try_acquire(&self) -> bool {
+        if self.capacity_x1000 == 0 {
+            return true;
+        }
+        let now = now_micros();
+        let last = self.last_refill_micros.swap(now, Ordering::Relaxed);
+        let elapsed_us = (now - last).max(0);
+        let added = (elapsed_us * self.refill_per_sec_x1000) / 1_000_000;
+        let mut current = self.tokens_x1000.load(Ordering::Relaxed);
+        loop {
+            let refilled = (current + added).min(self.capacity_x1000);
+            if refilled < 1000 {
+                self.tokens_x1000.store(refilled, Ordering::Relaxed);
+                return false;
+            }
+            match self.tokens_x1000.compare_exchange_weak(
+                current,
+                refilled - 1000,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
+fn now_micros() -> i64 {
+    START_INSTANT
+        .get_or_init(Instant::now)
+        .elapsed()
+        .as_micros() as i64
+}
+
+static START_INSTANT: OnceLock<Instant> = OnceLock::new();
 
 /// JSON-serialisable view of a PersistentEndpoint. Keeps the owning
 /// struct free of serde plumbing so internal fields can change without
@@ -295,6 +382,8 @@ const MAX_INJECT_HEADERS: usize = 16;
 const MAX_HEADER_NAME_LEN: usize = 64;
 const MAX_HEADER_VALUE_LEN: usize = 256;
 const MAX_CORS_MAX_AGE_SECS: u32 = 86_400;
+const MAX_RATE_REQUESTS_PER_SEC: u32 = 10_000;
+const MAX_RATE_BURST: u32 = 100_000;
 
 /// Header names that callers must never override on the upstream request.
 /// Hop-by-hop framing, plus Host/Authorization which we set ourselves.
@@ -401,6 +490,18 @@ fn validate_http_config(cfg: &EndpointHttpConfig) -> Result<(), String> {
         if RESERVED_INJECT_HEADER_NAMES.contains(&lower.as_str()) {
             return Err(format!("reserved inject header name: {k:?}"));
         }
+    }
+    if cfg.rate_limit.requests_per_sec > MAX_RATE_REQUESTS_PER_SEC {
+        return Err(format!(
+            "rate_limit.requests_per_sec {} exceeds cap of {MAX_RATE_REQUESTS_PER_SEC}",
+            cfg.rate_limit.requests_per_sec
+        ));
+    }
+    if cfg.rate_limit.burst > MAX_RATE_BURST {
+        return Err(format!(
+            "rate_limit.burst {} exceeds cap of {MAX_RATE_BURST}",
+            cfg.rate_limit.burst
+        ));
     }
     Ok(())
 }
@@ -880,6 +981,7 @@ async fn fc_deploy(
         status: EndpointStatus::Starting,
         created: Instant::now(),
         visibility: req.visibility,
+        rate_limiter: TokenBucket::from_config(req.http_config.rate_limit),
         http_config: req.http_config.clone(),
     };
     let info = PersistentEndpointInfo::from(&endpoint);
@@ -1106,6 +1208,8 @@ async fn fc_proxy_inner(
         .map(|(_, v)| v.clone())
         .unwrap_or_default();
 
+    let is_preflight = require_public && req.method() == axum::http::Method::OPTIONS;
+
     let (guest_ip, http_port, http_config) = match persistent.endpoints.get(&name) {
         Some(entry) => {
             let ep = entry.value();
@@ -1114,6 +1218,18 @@ async fn fc_proxy_inner(
                     StatusCode::FORBIDDEN,
                     Json(serde_json::json!({
                         "error": "endpoint not public",
+                        "name": name,
+                    })),
+                )
+                    .into_response();
+            }
+            // Preflights bypass the bucket so a flood of CORS probes cannot
+            // starve real traffic; budget is for the actual workload.
+            if require_public && !is_preflight && !ep.rate_limiter.try_acquire() {
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    Json(serde_json::json!({
+                        "error": "rate limit exceeded",
                         "name": name,
                     })),
                 )
@@ -1130,11 +1246,7 @@ async fn fc_proxy_inner(
         }
     };
 
-    // --- CORS preflight short-circuit (public tier only) ---
-    if require_public
-        && req.method() == axum::http::Method::OPTIONS
-        && !http_config.cors_allow_origins.is_empty()
-    {
+    if is_preflight && !http_config.cors_allow_origins.is_empty() {
         return build_cors_preflight_response(req.headers(), &http_config);
     }
 


### PR DESCRIPTION
## Summary
Four conventional commits stacking the public-tier hardening promised in #10918 / #10926:

1. **`feat(firecracker-ctl): per-endpoint global rate limit on /fc/public/*`** — `rate_limit.{requests_per_sec,burst}` on `EndpointHttpConfig`. Lock-free milli-token bucket on every public-tier request. CORS preflights bypass the bucket. Defaults disabled; capped at 10k RPS / 100k burst.
2. **`feat(firecracker-ctl): per-endpoint metrics + idle shutdown sweeper`** — atomic counters (requests_total / throttled / forbidden, upstream_errors, bytes_in, bytes_out, last_request_micros) surfaced on `PersistentEndpointInfo`. Response bytes counted via stream wrapper so SSE / long-poll still streams. `idle_ttl_secs` on `DeployFcRequest` (capped at 30 days, 0 disables). 60s background sweeper tears down endpoints whose last_request_micros fell behind ttl_secs.
3. **`test(firecracker-ctl-e2e): validation coverage for /fc/public surface`** — reserved-name, CORS wildcard+credentials, reserved inject-header names, malformed CORS origins, rate + idle caps, CR/LF response-splitting guard, plus a 503 sanity on the mock container. Proxy-forward path tests still need a NET_ADMIN container (fake-TAP test mode is a follow-up).
4. **`feat(astro-kbve): deploy UI for visibility + http_config`** — visibility select + collapsible "Advanced HTTP config" panel (CORS origins, inject headers, rate RPS/burst, idle TTL). Client-side header parse + 16-header cap mirrors the server. Post-deploy banner shows both staff + public URLs when visibility=public.

## Test plan
- [ ] `cargo check` + `cargo clippy` on `firecracker-ctl` — clean
- [ ] `cargo test --bin firecracker-ctl` — 26 tests pass
- [ ] Deploy in dashboard with visibility=public + CORS `https://kbve.com` + RPS=5
  - [ ] OPTIONS preflight from kbve.com returns CORS headers
  - [ ] 11 requests in 1s — 11th returns 429
  - [ ] `GET /fc/{name}` shows incrementing `metrics.requests_total` + `metrics.requests_throttled`
- [ ] Deploy with idle_ttl_secs=60, leave alone for 90s — endpoint removed from `/fc/list`
- [ ] CI green