### PR TITLE
perf(arcade): cache blackjack hand value labels

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
@@ -1,6 +1,5 @@
 import Phaser from 'phaser';
 import { createBlackjackState, type BlackjackState } from './state';
-import { type Card, isBlackjack, valueHand } from './cards';
 import { BASE_WIDTH, CARD_SIZE, COLORS } from './config';
 import {
 	DealerAnimation,
@@ -10,6 +9,7 @@ import { CardPool } from './objects/cardPool';
 import { HandLayout } from './objects/handLayout';
 import { BlackjackHud } from './objects/blackjackHud';
 import { StrategyAdvisor } from './objects/strategyAdvisor';
+import { HandValueFormatter } from './objects/handValueFormatter';
 import {
 	BlackjackTextures,
 	CHIP_TEXTURE_KEY,
@@ -35,6 +35,7 @@ export class BlackjackScene extends Phaser.Scene {
 	private hudLayer!: Phaser.GameObjects.Container;
 	private hud!: BlackjackHud;
 	private controls!: BlackjackControls;
+	private readonly handValueFormatter = new HandValueFormatter();
 
 	constructor() {
 		super('blackjack');
@@ -149,17 +150,18 @@ export class BlackjackScene extends Phaser.Scene {
 	}
 
 	private updateHud() {
-		const dealerVisible = this.hideDealerHole()
-			? [this.state.dealer[0]].filter(Boolean)
-			: this.state.dealer;
-		const dealerValue =
-			dealerVisible.length > 0
-				? `Dealer  ${this.formatValue(dealerVisible)}`
-				: 'Dealer: -';
-		const playerValue =
-			this.state.player.length > 0
-				? `Player  ${this.formatValue(this.state.player)}`
-				: 'Player: -';
+		const hideHole = this.hideDealerHole();
+		const dealerValue = this.handValueFormatter.label(
+			'dealer',
+			'Dealer',
+			this.state.dealer,
+			hideHole ? 1 : this.state.dealer.length,
+		);
+		const playerValue = this.handValueFormatter.label(
+			'player',
+			'Player',
+			this.state.player,
+		);
 		const delta =
 			this.state.lastDelta === 0
 				? ''
@@ -178,12 +180,6 @@ export class BlackjackScene extends Phaser.Scene {
 			shoe: `Shoe ${this.state.shoe.length} cards\nRound ${this.state.rounds}`,
 			stats: `Session  W ${this.state.stats.wins}  L ${this.state.stats.losses}  P ${this.state.stats.pushes}\nBJ ${this.state.stats.blackjacks}  Best $${this.state.stats.bestBankroll}`,
 		});
-	}
-
-	private formatValue(cards: readonly Card[]): string {
-		const value = valueHand(cards);
-		const natural = isBlackjack(cards) ? ' blackjack' : '';
-		return `${value.total}${value.soft ? ' soft' : ''}${natural}`;
 	}
 
 	private getStatusColor(): string {

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/handValueFormatter.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/handValueFormatter.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { encodeCard } from '../cards';
+import { HandValueFormatter } from './handValueFormatter';
+
+describe('blackjack hand value formatter', () => {
+	it('formats empty, soft, and natural hand labels', () => {
+		const formatter = new HandValueFormatter();
+		const ace = encodeCard('spades', 'A');
+		const king = encodeCard('hearts', 'K');
+
+		expect(formatter.label('dealer', 'Dealer', [])).toBe('Dealer: -');
+		expect(formatter.label('dealer', 'Dealer', [ace])).toBe(
+			'Dealer  11 soft',
+		);
+		expect(formatter.label('player', 'Player', [ace, king])).toBe(
+			'Player  21 soft blackjack',
+		);
+	});
+
+	it('formats only visible cards when the dealer hole card is hidden', () => {
+		const formatter = new HandValueFormatter();
+		const dealer = [encodeCard('spades', '9'), encodeCard('hearts', 'K')];
+
+		expect(formatter.label('dealer', 'Dealer', dealer, 1)).toBe(
+			'Dealer  9',
+		);
+		expect(formatter.label('dealer', 'Dealer', dealer)).toBe('Dealer  19');
+	});
+
+	it('refreshes cached labels when cards change behind the same key', () => {
+		const formatter = new HandValueFormatter();
+
+		expect(
+			formatter.label('player', 'Player', [
+				encodeCard('clubs', '8'),
+				encodeCard('diamonds', '2'),
+			]),
+		).toBe('Player  10');
+		expect(
+			formatter.label('player', 'Player', [
+				encodeCard('clubs', '8'),
+				encodeCard('diamonds', '3'),
+			]),
+		).toBe('Player  11');
+	});
+});

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/handValueFormatter.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/handValueFormatter.ts
@@ -1,0 +1,120 @@
+import {
+	cardPoints,
+	handFingerprint,
+	type Card,
+	type HandValue,
+} from '../cards';
+
+interface HandValueCacheEntry {
+	fingerprint: number;
+	visibleCount: number;
+	cards: Uint8Array;
+	label: string;
+}
+
+const CARD_BYTE_MASK = 0b111111;
+const RANK_MASK = 0b1111;
+
+export class HandValueFormatter {
+	private readonly labelCache = new Map<string, HandValueCacheEntry>();
+
+	label(
+		cacheKey: string,
+		prefix: string,
+		cards: readonly Card[],
+		visibleCount = cards.length,
+	): string {
+		const cappedVisibleCount = Math.min(visibleCount, cards.length);
+		if (cappedVisibleCount === 0) return `${prefix}: -`;
+
+		const cached = this.labelCache.get(cacheKey);
+		const fingerprint = this.visibleFingerprint(cards, cappedVisibleCount);
+		if (this.matchesCache(cached, cards, cappedVisibleCount, fingerprint)) {
+			return cached.label;
+		}
+
+		const value = this.valueVisible(cards, cappedVisibleCount);
+		const natural =
+			cappedVisibleCount === 2 && value.total === 21 ? ' blackjack' : '';
+		const label = `${prefix}  ${value.total}${value.soft ? ' soft' : ''}${natural}`;
+		this.labelCache.set(cacheKey, {
+			fingerprint,
+			visibleCount: cappedVisibleCount,
+			cards: this.snapshot(cards, cappedVisibleCount),
+			label,
+		});
+		return label;
+	}
+
+	private visibleFingerprint(
+		cards: readonly Card[],
+		visibleCount: number,
+	): number {
+		if (visibleCount === cards.length) return handFingerprint(cards);
+
+		let fingerprint = visibleCount & 0xff;
+		const packedCards = Math.min(visibleCount, 4);
+		for (let i = 0; i < packedCards; i++) {
+			fingerprint |= (cards[i] & CARD_BYTE_MASK) << (8 + i * 6);
+		}
+		for (let i = packedCards; i < visibleCount; i++) {
+			fingerprint = Math.imul(
+				fingerprint ^ (cards[i] & CARD_BYTE_MASK),
+				16777619,
+			);
+		}
+		return fingerprint >>> 0;
+	}
+
+	private valueVisible(
+		cards: readonly Card[],
+		visibleCount: number,
+	): HandValue {
+		let total = 0;
+		let aces = 0;
+		for (let i = 0; i < visibleCount; i++) {
+			const card = cards[i];
+			total += cardPoints(card);
+			if ((card & RANK_MASK) === 0) aces++;
+		}
+
+		while (total > 21 && aces > 0) {
+			total -= 10;
+			aces--;
+		}
+
+		return {
+			total,
+			soft: aces > 0,
+		};
+	}
+
+	private matchesCache(
+		cached: HandValueCacheEntry | undefined,
+		cards: readonly Card[],
+		visibleCount: number,
+		fingerprint: number,
+	): cached is HandValueCacheEntry {
+		if (
+			!cached ||
+			cached.visibleCount !== visibleCount ||
+			cached.fingerprint !== fingerprint ||
+			cached.cards.length !== visibleCount
+		) {
+			return false;
+		}
+
+		for (let i = 0; i < visibleCount; i++) {
+			if (cached.cards[i] !== cards[i]) return false;
+		}
+		return true;
+	}
+
+	private snapshot(cards: readonly Card[], visibleCount: number): Uint8Array {
+		const snapshot = new Uint8Array(visibleCount);
+		for (let i = 0; i < visibleCount; i++) {
+			snapshot[i] = cards[i];
+		}
+		return snapshot;
+	}
+}


### PR DESCRIPTION
## Summary
- move dealer/player hand label formatting out of `BlackjackScene`
- cache formatted hand value labels with byte-card fingerprints and exact `Uint8Array` snapshots
- avoid allocating a temporary dealer-visible array when the hole card is hidden

## Validation
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/handValueFormatter.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/handValueFormatter.test.ts`
- `./kbve.sh -nx astro-kbve:test`
- `AXUM_PORT=4367 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`