### PR TITLE
ci(version-sync): mirror Cargo.lock + concurrency fix to update-version-toml

### DIFF
--- a/.github/workflows/utils-post-publish.yml
+++ b/.github/workflows/utils-post-publish.yml
@@ -40,15 +40,13 @@ on:
                 description: 'PAT for pushing atom branches'
                 required: true
 
-# Serialize post-publish runs. Multiple crate releases firing in
-# parallel would each rebase Cargo.lock from the same pre-publish dev
-# HEAD, and even though each touches a different `[[package]]` block
-# the 3-way merge can fail when transitive deps shift adjacent lines.
-# Queuing keeps each atom branch based on dev that already contains
-# the prior post-publish, eliminating the race for Cargo.lock and
-# version.toml history.
+# Shared with utils-update-version-toml.yml. Both workflows commit to
+# version.toml / Cargo.toml / Cargo.lock from per-release atom branches
+# based on the same dev HEAD; without one shared group two crate
+# releases firing across both workflows can race on Cargo.lock when
+# their atom PRs auto-merge.
 concurrency:
-    group: post-publish
+    group: version-sync
     cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/utils-update-version-toml.yml
+++ b/.github/workflows/utils-update-version-toml.yml
@@ -25,6 +25,14 @@ on:
                 type: string
                 default: ''
 
+# Shared with utils-post-publish.yml. Both workflows commit to
+# version.toml / Cargo.toml / Cargo.lock from per-release atom branches
+# based on the same dev HEAD; without this group two crate releases
+# firing in parallel race on Cargo.lock when their atom PRs auto-merge.
+concurrency:
+    group: version-sync
+    cancel-in-progress: false
+
 jobs:
     update:
         name: PR version.toml → ${{ inputs.version }}
@@ -82,6 +90,41 @@ jobs:
                   echo "Synced $TARGET to $VERSION:"
                   grep -m1 'version' "$TARGET"
 
+            # Mirror utils-post-publish.yml: keep Cargo.lock in sync with
+            # the matching Cargo.toml bump so fresh checkouts don't
+            # regenerate the lock on the first `cargo` invocation.
+            - name: Sync Cargo.lock
+              if: inputs.version_target_path != '' && endsWith(inputs.version_target_path, 'Cargo.toml')
+              run: |
+                  TARGET="${{ inputs.version_target_path }}"
+                  VERSION="${{ inputs.version }}"
+
+                  if [ ! -f Cargo.lock ]; then
+                    echo "::notice::Cargo.lock not present at workspace root — skipping."
+                    exit 0
+                  fi
+
+                  PKG_NAME=$(grep -m 1 '^name = "' "$TARGET" | sed 's/name = "\(.*\)"/\1/')
+                  if [ -z "$PKG_NAME" ]; then
+                    echo "::warning::Could not parse package name from '$TARGET' — skipping Cargo.lock sync."
+                    exit 0
+                  fi
+
+                  awk -v pkg="$PKG_NAME" -v new="$VERSION" '
+                    /^\[\[package\]\]$/ { in_pkg=1; matched=0 }
+                    in_pkg && /^name = "/ {
+                      n=$0; sub(/^name = "/, "", n); sub(/"$/, "", n);
+                      if (n == pkg) matched=1
+                    }
+                    in_pkg && matched && /^version = "/ {
+                      sub(/version = "[^"]+"/, "version = \"" new "\"")
+                      matched=0
+                    }
+                    /^$/ { in_pkg=0; matched=0 }
+                    { print }
+                  ' Cargo.lock > Cargo.lock.tmp && mv Cargo.lock.tmp Cargo.lock
+                  echo "Synced Cargo.lock entry for $PKG_NAME to $VERSION"
+
             - uses: actions/setup-node@v6
               with:
                   node-version: 24
@@ -123,6 +166,11 @@ jobs:
                   git add "${{ inputs.version_toml_path }}"
                   if [ -n "${{ inputs.version_target_path }}" ] && [ -f "${{ inputs.version_target_path }}" ]; then
                     git add "${{ inputs.version_target_path }}"
+                    case "${{ inputs.version_target_path }}" in
+                      *Cargo.toml)
+                        [ -f Cargo.lock ] && git add Cargo.lock
+                        ;;
+                    esac
                   fi
                   git add .github/ci-dispatch-manifest.json
                   if git diff --cached --quiet; then


### PR DESCRIPTION
## Summary
Sister workflow to #10930. `utils-post-publish.yml` was patched there; the *other* publish-time workflow — `utils-update-version-toml.yml`, called from `ci-publish.yml` for npm / crates / python releases — had the same two gaps:

1. **No Cargo.lock sync.** Crates published via `ci-publish.yml` (e.g. `bevy_*`, `kbve`) bumped `Cargo.toml` + `version.toml` but never `Cargo.lock`, leading to the same drift #10930 just fixed on the docker / unity / godot path.
2. **No concurrency group.** Two crates publishing in parallel would each base their atom branch on the same dev HEAD and race on `Cargo.lock` when auto-merge fires.

## Changes
- Add the same awk-based `Sync Cargo.lock` step (gated on `*Cargo.toml` target).
- Extend the atom-branch `git add` to include `Cargo.lock` for the same case.
- Add `concurrency: version-sync` and switch `utils-post-publish.yml`'s group from `post-publish` → `version-sync` so **both** workflows queue against each other across the whole release pipeline. A bevy crate release on `ci-publish` no longer races a docker app post-publish.

`cancel-in-progress: false` — never abort an in-flight version sync (would orphan a published artifact's git state).

## Test plan
- [x] `actionlint` clean on both touched workflows
- [ ] Next crate publish through `ci-publish.yml` — atom PR should include `Cargo.lock` alongside `Cargo.toml` + `version.toml`
- [ ] Two crate releases firing within seconds of each other — second one waits in the `version-sync` queue rather than racing