### PR TITLE
feat(proto): kbve/vm.proto and kbve/firecracker.proto

### DIFF
--- a/packages/data/proto/kbve/firecracker.proto
+++ b/packages/data/proto/kbve/firecracker.proto
@@ -1,0 +1,179 @@
+syntax = "proto3";
+
+package kbve.firecracker;
+
+option csharp_namespace = "KBVE.Proto.Firecracker";
+
+import "kbve/common.proto";
+import "kbve/vm.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+// =============================================================================
+// Firecracker — Control plane verbs around kbve.vm shapes. RPC-friendly.
+// =============================================================================
+
+enum DeploymentTier {
+  DEPLOYMENT_TIER_UNSPECIFIED = 0;
+  DEPLOYMENT_TIER_SANDBOX = 1;
+  DEPLOYMENT_TIER_NET = 2;
+}
+
+enum EndpointStatus {
+  ENDPOINT_STATUS_UNSPECIFIED = 0;
+  ENDPOINT_STATUS_PENDING = 1;
+  ENDPOINT_STATUS_HEALTHY = 2;
+  ENDPOINT_STATUS_DEGRADED = 3;
+  ENDPOINT_STATUS_STOPPED = 4;
+}
+
+enum WorkflowStatus {
+  WORKFLOW_STATUS_UNSPECIFIED = 0;
+  WORKFLOW_STATUS_QUEUED = 1;
+  WORKFLOW_STATUS_RUNNING = 2;
+  WORKFLOW_STATUS_SUCCEEDED = 3;
+  WORKFLOW_STATUS_FAILED = 4;
+  WORKFLOW_STATUS_CANCELLED = 5;
+}
+
+// ---------- Quick mode (/vm/create) ----------
+
+message CreateVmRequest {
+  kbve.vm.VmSpec spec = 1;
+  kbve.common.UUID idempotency_key = 2;
+}
+
+message CreateVmResponse {
+  string vm_id = 1;
+  kbve.vm.VmStatus status = 2;
+}
+
+message DestroyVmRequest {
+  string vm_id = 1;
+}
+
+message DestroyVmResponse {
+  bool destroyed = 1;
+}
+
+message GetVmRequest {
+  string vm_id = 1;
+}
+
+message GetVmResponse {
+  kbve.vm.VmInfo info = 1;
+  kbve.vm.VmResult result = 2;
+}
+
+message ListVmsRequest {
+  uint32 limit = 1;
+  string page_token = 2;
+}
+
+message ListVmsResponse {
+  repeated kbve.vm.VmInfo items = 1;
+  string next_page_token = 2;
+}
+
+// ---------- Persistent endpoints (/fc/deploy) ----------
+
+message PersistentEndpoint {
+  string name = 1;
+  kbve.vm.VmSpec spec = 2;
+  uint32 http_port = 3;
+  string tap_ip = 4;
+  string vm_id = 5;
+  EndpointStatus status = 6;
+  google.protobuf.Timestamp created_at = 7;
+  string health_path = 8;
+}
+
+message DeployEndpointRequest {
+  string name = 1;
+  kbve.vm.VmSpec spec = 2;
+  uint32 http_port = 3;
+  string health_path = 4;
+}
+
+message DeployEndpointResponse {
+  PersistentEndpoint endpoint = 1;
+}
+
+message DeleteEndpointRequest {
+  string name = 1;
+}
+
+message DeleteEndpointResponse {
+  bool deleted = 1;
+}
+
+message ListEndpointsResponse {
+  repeated PersistentEndpoint items = 1;
+}
+
+// ---------- Agent workflows (future) ----------
+
+message WorkflowStep {
+  string id = 1;
+  kbve.vm.VmSpec spec = 2;
+  repeated string depends_on = 3;
+  string input_blob_ref = 4;
+}
+
+message AgentWorkflowDefinition {
+  string name = 1;
+  repeated WorkflowStep steps = 2;
+  google.protobuf.Duration max_duration = 3;
+}
+
+message WorkflowRun {
+  kbve.common.UUID id = 1;
+  string definition_name = 2;
+  WorkflowStatus status = 3;
+  map<string, kbve.vm.VmResult> step_results = 4;
+  google.protobuf.Timestamp started_at = 5;
+  google.protobuf.Timestamp ended_at = 6;
+}
+
+// ---------- Fleet / scheduler ----------
+
+message FleetStatus {
+  DeploymentTier tier = 1;
+  uint32 active_vms = 2;
+  uint32 max_concurrent_vms = 3;
+  uint32 ip_pool_used = 4;
+  uint32 ip_pool_capacity = 5;
+  uint32 endpoints_count = 6;
+}
+
+message SchedulerHint {
+  DeploymentTier tier = 1;
+  repeated string preferred_nodes = 2;
+}
+
+// ---------- Quota / billing surface ----------
+
+message Quota {
+  kbve.common.UUID account_id = 1;
+  uint32 max_concurrent_vms = 2;
+  uint64 daily_credits_budget = 3;
+  uint64 daily_credits_spent = 4;
+  uint32 daily_runs_limit = 5;
+  uint32 daily_runs_count = 6;
+  google.protobuf.Timestamp resets_at = 7;
+}
+
+message QuoteCostRequest {
+  kbve.vm.VmSpec spec = 1;
+  kbve.common.UUID account_id = 2;
+}
+
+message QuoteCostResponse {
+  kbve.vm.VmCostQuote quote = 1;
+}
+
+message RateCardUpdate {
+  kbve.vm.VmRateCard card = 1;
+  kbve.common.UUID actor_user_id = 2;
+  string reason = 3;
+}

--- a/packages/data/proto/kbve/vm.proto
+++ b/packages/data/proto/kbve/vm.proto
@@ -1,0 +1,114 @@
+syntax = "proto3";
+
+package kbve.vm;
+
+option csharp_namespace = "KBVE.Proto.Vm";
+
+import "kbve/common.proto";
+import "google/protobuf/timestamp.proto";
+
+// =============================================================================
+// VM — Runtime entity shapes shared by every orchestrator (firecracker today,
+// cloud-hypervisor / Kata / etc. tomorrow). Pure data — no transport.
+// =============================================================================
+
+enum VmStatus {
+  VM_STATUS_UNSPECIFIED = 0;
+  VM_STATUS_CREATING = 1;
+  VM_STATUS_RUNNING = 2;
+  VM_STATUS_COMPLETED = 3;
+  VM_STATUS_FAILED = 4;
+  VM_STATUS_TIMEOUT = 5;
+  VM_STATUS_DESTROYED = 6;
+}
+
+enum VmExitReason {
+  VM_EXIT_REASON_UNSPECIFIED = 0;
+  VM_EXIT_REASON_COMPLETED = 1;
+  VM_EXIT_REASON_FAILED = 2;
+  VM_EXIT_REASON_TIMEOUT = 3;
+  VM_EXIT_REASON_KILLED = 4;
+}
+
+enum ChargeOutcome {
+  CHARGE_OUTCOME_UNSPECIFIED = 0;
+  CHARGE_OUTCOME_BILLED = 1;
+  CHARGE_OUTCOME_FREE_TIER = 2;
+  CHARGE_OUTCOME_INSUFFICIENT_FUNDS = 3;
+  CHARGE_OUTCOME_WAIVED = 4;
+}
+
+message VmSpec {
+  string rootfs = 1;
+  uint32 vcpu_count = 2;
+  uint32 mem_size_mib = 3;
+  uint64 timeout_ms = 4;
+  string entrypoint = 5;
+  map<string, string> env = 6;
+  string boot_args = 7;
+  repeated string packages = 8;
+  bool network = 9;
+}
+
+message VmInfo {
+  string vm_id = 1;
+  VmStatus status = 2;
+  VmSpec spec = 3;
+  google.protobuf.Timestamp created_at = 4;
+}
+
+message VmResult {
+  string vm_id = 1;
+  VmStatus status = 2;
+  int32 exit_code = 3;
+  string stdout = 4;
+  string stderr = 5;
+  uint64 duration_ms = 6;
+}
+
+// Emitted once per VM run when the lifecycle ends. Source of truth for billing.
+message VmUsageEvent {
+  string vm_id = 1;
+  kbve.common.UUID user_id = 2;
+  kbve.common.UUID account_id = 3;
+  VmSpec spec = 4;
+  uint64 duration_ms = 5;
+  uint64 net_tx_bytes = 6;
+  uint64 net_rx_bytes = 7;
+  int32 exit_code = 8;
+  VmExitReason exit_reason = 9;
+  google.protobuf.Timestamp started_at = 10;
+  google.protobuf.Timestamp ended_at = 11;
+  kbve.common.UUID idempotency_key = 12;
+}
+
+// SKU-keyed pricing. One row per rootfs (or rootfs class). Lets rates flex
+// without code changes.
+message VmRateCard {
+  string sku = 1;
+  uint64 startup_credits = 2;
+  uint64 credits_per_vcpu_second = 3;
+  uint64 credits_per_mib_second = 4;
+  uint64 credits_per_egress_byte = 5;
+  uint64 khash_reward_per_second = 6;
+  bool network_allowed = 7;
+}
+
+// Derived from VmUsageEvent × VmRateCard. Stays linked to ledger via ledger_id.
+message VmCharge {
+  kbve.common.UUID idempotency_key = 1;
+  kbve.common.UUID account_id = 2;
+  string sku = 3;
+  uint64 credits_debited = 4;
+  uint64 khash_credited = 5;
+  int64 ledger_id = 6;
+  ChargeOutcome outcome = 7;
+}
+
+// Pre-flight quote — "what would this cost". Caller can reject before commit.
+message VmCostQuote {
+  VmSpec spec = 1;
+  uint64 max_credits = 2;
+  uint64 account_balance_credits = 3;
+  bool affordable = 4;
+}


### PR DESCRIPTION
## Summary

Split the firecracker / VM domain into two proto files along the noun/verb seam discussed in the design pass:

| File | Scope |
|---|---|
| \`kbve/vm.proto\` (\`kbve.vm\`) | Runtime entity shapes — \`VmSpec\`, \`VmStatus\`, \`VmResult\`, \`VmUsageEvent\`, \`VmRateCard\`, \`VmCharge\`, \`VmCostQuote\`. Pure data, no transport. Stays stable across orchestrator swaps. |
| \`kbve/firecracker.proto\` (\`kbve.firecracker\`) | Control plane around \`vm\` shapes — \`CreateVm\`, \`DestroyVm\`, \`GetVm\`, \`ListVms\`, \`PersistentEndpoint\`, \`DeployEndpoint\`, \`AgentWorkflowDefinition\`, \`WorkflowRun\`, \`FleetStatus\`, \`Quota\`, \`QuoteCost\`, \`RateCardUpdate\`. |

Both compile clean under
\`\`\`
protoc --proto_path=packages/data/proto packages/data/proto/kbve/vm.proto packages/data/proto/kbve/firecracker.proto -o /tmp/check.binpb
\`\`\`

## What's intentionally not here

- \`packages/data/codegen/gen-all.mjs\` registry entries
- Zod config JSONs (\`vm-zod-config.json\`, \`firecracker-zod-config.json\`)
- \`@kbve/devops\` and Astro barrel TS exports
- Cost values on the rate card (all zeros — we agreed to land shape first, fill values once the dispatch / wallet integration plan is firm)

These follow in a separate PR once we agree on the public surface.

## Why the split helps

- Astro dashboard / wallet ledger imports \`vm.proto\` only — small bundle, no orchestration cruft.
- A future Rust gRPC service can hang an \`rpc Create(CreateVmRequest) returns (CreateVmResponse)\` block off \`firecracker.proto\` without churning \`vm.proto\`.
- Replacing firecracker with cloud-hypervisor / Kata in the future swaps \`firecracker.proto\` only; \`vm.proto\` survives.

## Test plan

- [x] \`protoc\` compiles both files.
- [ ] Land follow-up PR wiring \`vm\` and \`firecracker\` into the codegen registry.
- [ ] Land follow-up PR migrating \`apps/vm/firecracker-ctl\` Rust types to use generated bindings.