### PR TITLE
feat(wallet): RO-safe public proxies + read-then-write fallback in client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "axum-kbve"
-version = "1.0.152"
+version = "1.0.153"
 dependencies = [
  "anyhow",
  "askama 0.16.0",

--- a/apps/kbve/axum-kbve/src/transport/wallet.rs
+++ b/apps/kbve/axum-kbve/src/transport/wallet.rs
@@ -370,6 +370,7 @@ fn wallet_error_response(err: WalletError) -> Response {
         WalletError::Overflow => (StatusCode::UNPROCESSABLE_ENTITY, "overflow"),
         WalletError::NotAuthorized => (StatusCode::FORBIDDEN, "not_authorized"),
         WalletError::NotAuthenticated => (StatusCode::UNAUTHORIZED, "not_authenticated"),
+        WalletError::AccountMissing => (StatusCode::NOT_FOUND, "account_missing"),
         WalletError::NullArgument(_) => (StatusCode::UNPROCESSABLE_ENTITY, "null_argument"),
         WalletError::InvalidArgument(_) => (StatusCode::BAD_REQUEST, "invalid_argument"),
         WalletError::NotFound(_) => (StatusCode::NOT_FOUND, "not_found"),

--- a/packages/data/sql/dbmate/migration-tests/20260514011143_wallet_ro_proxies.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260514011143_wallet_ro_proxies.test.sql
@@ -116,6 +116,19 @@ END;
 $$;
 COMMIT;
 
+-- 4b. Composite index on wallet.coupon present.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'wallet'
+           AND indexname = 'wallet_coupon_account_granted_idx'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet_coupon_account_granted_idx missing';
+    END IF;
+END;
+$$;
+
 -- 5. Write-path provisions user B, then 6. readonly returns a row for them.
 BEGIN;
 SET LOCAL request.jwt.claims = '{"role":"authenticated","sub":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}';
@@ -168,6 +181,15 @@ BEGIN
            AND p.proname = 'proxy_wallet_get_balance'
     ) THEN
         RAISE EXCEPTION 'fail: write-path proxy_wallet_get_balance lost during rollback';
+    END IF;
+
+    -- 3. Composite coupon index removed by down.
+    IF EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'wallet'
+           AND indexname = 'wallet_coupon_account_granted_idx'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet_coupon_account_granted_idx still present after rollback';
     END IF;
 END;
 $$;

--- a/packages/data/sql/dbmate/migration-tests/20260514011143_wallet_ro_proxies.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260514011143_wallet_ro_proxies.test.sql
@@ -1,0 +1,173 @@
+-- Companion test fixtures for 20260514011143_wallet_ro_proxies.
+-- Run via: ./test-migration.sh 20260514011143_wallet_ro_proxies
+
+-- SEED
+-- Idempotent cleanup of test rows so re-runs pass on the same DB.
+WITH test_users (id) AS (
+    VALUES
+        ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid),
+        ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid)
+),
+test_accounts AS (
+    SELECT a.id FROM wallet.account a JOIN test_users u ON a.user_id = u.id
+),
+del_coupon AS (
+    DELETE FROM wallet.coupon WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_ledger AS (
+    DELETE FROM wallet.ledger WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_balance AS (
+    DELETE FROM wallet.balance WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_account AS (
+    DELETE FROM wallet.account WHERE id IN (SELECT id FROM test_accounts)
+)
+DELETE FROM auth.users WHERE id IN (SELECT id FROM test_users);
+
+-- User A has a wallet account (insert triggers wallet.handle_auth_user_created
+-- after PR #10920 lands; we rely on that). User B has none (we delete the
+-- account immediately to simulate the missing-account case).
+INSERT INTO auth.users (id)
+VALUES
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+
+-- Force a clean slate for user B: trigger may have provisioned it. We tear
+-- down so the missing-account path is exercised.
+DELETE FROM wallet.coupon WHERE account_id IN (
+    SELECT id FROM wallet.account WHERE user_id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+);
+DELETE FROM wallet.balance WHERE account_id IN (
+    SELECT id FROM wallet.account WHERE user_id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+);
+DELETE FROM wallet.account WHERE user_id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+-- ASSERT_AFTER_UP
+
+-- 1. user A: balance_readonly returns the row provisioned by the trigger.
+-- 2. user A: list_coupons_readonly returns the welcome coupon.
+-- Each test runs in its own transaction so SET LOCAL is in scope.
+BEGIN;
+SET LOCAL request.jwt.claims = '{"role":"authenticated","sub":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}';
+
+DO $$
+DECLARE
+    v_row RECORD;
+    v_count INT;
+BEGIN
+    SELECT * INTO v_row FROM public.proxy_wallet_get_balance_readonly();
+    IF v_row IS NULL THEN
+        RAISE EXCEPTION 'fail: balance_readonly returned no row for user A';
+    END IF;
+    IF v_row.credits IS NULL OR v_row.khash IS NULL THEN
+        RAISE EXCEPTION 'fail: balance_readonly returned NULL credits/khash for user A';
+    END IF;
+
+    SELECT COUNT(*) INTO v_count FROM public.proxy_wallet_list_coupons_readonly();
+    IF v_count < 1 THEN
+        RAISE EXCEPTION 'fail: list_coupons_readonly returned 0 rows for user A (expected welcome coupon)';
+    END IF;
+END;
+$$;
+COMMIT;
+
+-- 3. user B (no account): both RO functions raise SQLSTATE WLT01.
+BEGIN;
+SET LOCAL request.jwt.claims = '{"role":"authenticated","sub":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}';
+
+DO $$
+BEGIN
+    BEGIN
+        PERFORM * FROM public.proxy_wallet_get_balance_readonly();
+        RAISE EXCEPTION 'fail: balance_readonly should have raised WLT01 for user B';
+    EXCEPTION WHEN sqlstate 'WLT01' THEN
+        NULL;
+    END;
+
+    BEGIN
+        PERFORM * FROM public.proxy_wallet_list_coupons_readonly();
+        RAISE EXCEPTION 'fail: list_coupons_readonly should have raised WLT01 for user B';
+    EXCEPTION WHEN sqlstate 'WLT01' THEN
+        NULL;
+    END;
+END;
+$$;
+COMMIT;
+
+-- 4. Unauthenticated raises SQLSTATE 28000.
+BEGIN;
+DO $$
+BEGIN
+    BEGIN
+        PERFORM * FROM public.proxy_wallet_get_balance_readonly();
+        RAISE EXCEPTION 'fail: balance_readonly should have raised 28000 for anon';
+    EXCEPTION WHEN sqlstate '28000' THEN
+        NULL;
+    END;
+
+    BEGIN
+        PERFORM * FROM public.proxy_wallet_list_coupons_readonly();
+        RAISE EXCEPTION 'fail: list_coupons_readonly should have raised 28000 for anon';
+    EXCEPTION WHEN sqlstate '28000' THEN
+        NULL;
+    END;
+END;
+$$;
+COMMIT;
+
+-- 5. Write-path provisions user B, then 6. readonly returns a row for them.
+BEGIN;
+SET LOCAL request.jwt.claims = '{"role":"authenticated","sub":"bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"}';
+
+DO $$
+DECLARE
+    v_row RECORD;
+BEGIN
+    SELECT * INTO v_row FROM public.proxy_wallet_get_balance();
+    IF v_row IS NULL THEN
+        RAISE EXCEPTION 'fail: write-path proxy_wallet_get_balance did not provision user B';
+    END IF;
+
+    SELECT * INTO v_row FROM public.proxy_wallet_get_balance_readonly();
+    IF v_row IS NULL THEN
+        RAISE EXCEPTION 'fail: balance_readonly missing user B after write-path provisioning';
+    END IF;
+END;
+$$;
+COMMIT;
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+BEGIN
+    -- 1. RO functions removed.
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public'
+           AND p.proname = 'proxy_wallet_get_balance_readonly'
+    ) THEN
+        RAISE EXCEPTION 'fail: proxy_wallet_get_balance_readonly still exists after rollback';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public'
+           AND p.proname = 'proxy_wallet_list_coupons_readonly'
+    ) THEN
+        RAISE EXCEPTION 'fail: proxy_wallet_list_coupons_readonly still exists after rollback';
+    END IF;
+
+    -- 2. Existing write-path proxies preserved (unchanged by this migration).
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public'
+           AND p.proname = 'proxy_wallet_get_balance'
+    ) THEN
+        RAISE EXCEPTION 'fail: write-path proxy_wallet_get_balance lost during rollback';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migrations/20260514011143_wallet_ro_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260514011143_wallet_ro_proxies.sql
@@ -1,0 +1,105 @@
+-- migrate:up
+
+-- Read-only proxy variants of public.proxy_wallet_get_balance and
+-- public.proxy_wallet_list_coupons. These DO NOT call
+-- wallet.proxy_ensure_user_account, so they can be executed on the
+-- supabase-cluster-pooler-ro replica without write conflicts.
+--
+-- Contract on missing account: raise SQLSTATE 'WLT01' (custom). The Rust
+-- WalletClient catches that one sqlstate and falls back to the rw pool's
+-- provisioning proxy, then retries the read. Account provisioning still
+-- runs through wallet.proxy_ensure_user_account, just as a repair lane.
+--
+-- Why a custom sqlstate (not P0002 / NO_DATA_FOUND): P0002 is raised by
+-- plpgsql for a number of generic "no row" scenarios, so matching on it
+-- would be fragile. WLT01 is reserved for this wallet RO contract.
+
+CREATE OR REPLACE FUNCTION public.proxy_wallet_get_balance_readonly()
+RETURNS TABLE (
+    account_id  UUID,
+    credits     BIGINT,
+    khash       BIGINT,
+    updated_at  TIMESTAMPTZ
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = '' AS $$
+DECLARE
+    v_user_id    UUID := auth.uid();
+    v_account_id UUID;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+    END IF;
+
+    SELECT a.id INTO v_account_id
+      FROM wallet.account a
+     WHERE a.kind = 'user' AND a.user_id = v_user_id;
+
+    IF v_account_id IS NULL THEN
+        RAISE EXCEPTION 'wallet_account_missing' USING ERRCODE = 'WLT01';
+    END IF;
+
+    RETURN QUERY
+    SELECT b.account_id, b.credits, b.khash, b.updated_at
+      FROM wallet.balance b
+     WHERE b.account_id = v_account_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.proxy_wallet_get_balance_readonly() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_wallet_get_balance_readonly() TO authenticated, service_role;
+ALTER FUNCTION public.proxy_wallet_get_balance_readonly() OWNER TO service_role;
+
+COMMENT ON FUNCTION public.proxy_wallet_get_balance_readonly() IS
+    'Read-only balance fetch. Raises SQLSTATE WLT01 when the caller has no wallet account; the client falls back to the rw pool to provision and retry.';
+
+CREATE OR REPLACE FUNCTION public.proxy_wallet_list_coupons_readonly()
+RETURNS TABLE (
+    coupon_id      BIGINT,
+    template_code  TEXT,
+    template_label TEXT,
+    reward_kind    wallet.reward_kind,
+    reward_payload JSONB,
+    status         wallet.coupon_status,
+    granted_at     TIMESTAMPTZ,
+    expires_at     TIMESTAMPTZ,
+    redeemed_at    TIMESTAMPTZ
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = '' AS $$
+DECLARE
+    v_user_id    UUID := auth.uid();
+    v_account_id UUID;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+    END IF;
+
+    SELECT a.id INTO v_account_id
+      FROM wallet.account a
+     WHERE a.kind = 'user' AND a.user_id = v_user_id;
+
+    IF v_account_id IS NULL THEN
+        RAISE EXCEPTION 'wallet_account_missing' USING ERRCODE = 'WLT01';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        c.id, t.code, t.label, t.reward_kind, t.reward_payload,
+        c.status, c.granted_at, c.expires_at, c.redeemed_at
+      FROM wallet.coupon c
+      JOIN wallet.coupon_template t ON t.id = c.template_id
+     WHERE c.account_id = v_account_id
+     ORDER BY c.granted_at DESC;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.proxy_wallet_list_coupons_readonly() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_wallet_list_coupons_readonly() TO authenticated, service_role;
+ALTER FUNCTION public.proxy_wallet_list_coupons_readonly() OWNER TO service_role;
+
+COMMENT ON FUNCTION public.proxy_wallet_list_coupons_readonly() IS
+    'Read-only coupon list. Raises SQLSTATE WLT01 when the caller has no wallet account; the client falls back to the rw pool to provision and retry.';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS public.proxy_wallet_get_balance_readonly();
+DROP FUNCTION IF EXISTS public.proxy_wallet_list_coupons_readonly();

--- a/packages/data/sql/dbmate/migrations/20260514011143_wallet_ro_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260514011143_wallet_ro_proxies.sql
@@ -5,27 +5,30 @@
 -- wallet.proxy_ensure_user_account, so they can be executed on the
 -- supabase-cluster-pooler-ro replica without write conflicts.
 --
--- Contract on missing account / missing balance: raise SQLSTATE 'WLT01'
--- (custom). The Rust WalletClient catches that one sqlstate and falls
--- back to the rw pool's provisioning proxy, then retries the read.
--- Account provisioning still runs through wallet.proxy_ensure_user_account
--- as a repair lane.
+-- Error contract (Rust WalletClient maps these):
+--   WLT01 'wallet_account_missing'   — caller has no wallet account row
+--   WLT01 'wallet_balance_missing'   — account exists, balance row missing
+--   WLT02 'wallet_account_duplicate' — invariant violation: more than one
+--                                      user-wallet account; data corruption,
+--                                      not a normal repair condition
 --
--- Why a custom sqlstate (not P0002 / NO_DATA_FOUND): P0002 is raised by
--- plpgsql for a number of generic "no row" scenarios, so matching on it
--- would be fragile. WLT01 is reserved for this wallet RO contract.
+-- WLT01 (both messages) triggers fallback to the rw pool's provisioning
+-- proxy; WLT02 surfaces as a 500 because it indicates a broken
+-- wallet_account_user_uq invariant that needs manual intervention.
 --
--- Schema invariants relied on:
---   wallet_account_user_uq (partial unique on user_id WHERE kind='user')
---     guarantees at most one user-wallet per auth user, so SELECT INTO
---     cannot pick an arbitrary row.
---   wallet.balance.account_id is PRIMARY KEY of wallet.balance, so one
---     balance row per account_id is structural. The defensive IF NOT
---     FOUND below covers older rows that were inserted before the
---     trigger/backfill provisioned the balance row.
+-- Why custom sqlstates (not P0002 / NO_DATA_FOUND): P0002 is raised by
+-- plpgsql for many generic "no row" scenarios, so matching on it would
+-- be fragile.
+--
+-- SECURITY DEFINER intentionally scopes access by auth.uid(); table RLS
+-- is not the authorization boundary for these proxy functions. The
+-- function owner (service_role) holds the SELECT privileges; the JWT
+-- claim is the only thing distinguishing one authenticated caller from
+-- another.
 
 -- Composite index matching the list_coupons_readonly query: filter on
--- account_id, order by granted_at DESC + id DESC for stable pagination.
+-- account_id, order by granted_at DESC + id DESC. Supports the keyset
+-- pagination shape (cursor on (granted_at, id)).
 CREATE INDEX IF NOT EXISTS wallet_coupon_account_granted_idx
     ON wallet.coupon (account_id, granted_at DESC, id DESC);
 
@@ -42,16 +45,19 @@ DECLARE
     v_account_id UUID;
 BEGIN
     IF v_user_id IS NULL THEN
-        RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+        RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
     END IF;
 
-    SELECT a.id INTO v_account_id
-      FROM wallet.account a
-     WHERE a.kind = 'user' AND a.user_id = v_user_id;
-
-    IF v_account_id IS NULL THEN
-        RAISE EXCEPTION 'wallet_account_missing' USING ERRCODE = 'WLT01';
-    END IF;
+    BEGIN
+        SELECT a.id INTO STRICT v_account_id
+          FROM wallet.account a
+         WHERE a.kind = 'user' AND a.user_id = v_user_id;
+    EXCEPTION
+        WHEN no_data_found THEN
+            RAISE EXCEPTION 'wallet_account_missing' USING ERRCODE = 'WLT01';
+        WHEN too_many_rows THEN
+            RAISE EXCEPTION 'wallet_account_duplicate' USING ERRCODE = 'WLT02';
+    END;
 
     RETURN QUERY
     SELECT b.account_id, b.credits, b.khash, b.updated_at
@@ -59,7 +65,7 @@ BEGIN
      WHERE b.account_id = v_account_id;
 
     IF NOT FOUND THEN
-        RAISE EXCEPTION 'wallet_account_missing' USING ERRCODE = 'WLT01';
+        RAISE EXCEPTION 'wallet_balance_missing' USING ERRCODE = 'WLT01';
     END IF;
 END;
 $$;
@@ -69,9 +75,26 @@ GRANT EXECUTE ON FUNCTION public.proxy_wallet_get_balance_readonly() TO authenti
 ALTER FUNCTION public.proxy_wallet_get_balance_readonly() OWNER TO service_role;
 
 COMMENT ON FUNCTION public.proxy_wallet_get_balance_readonly() IS
-    'Read-only balance fetch. Raises SQLSTATE WLT01 when the caller has no wallet account or balance row; the client falls back to the rw pool to provision and retry.';
+    'Read-only balance fetch. Raises SQLSTATE WLT01 (wallet_account_missing or wallet_balance_missing) when repair is needed; WLT02 (wallet_account_duplicate) on a broken uniqueness invariant.';
 
-CREATE OR REPLACE FUNCTION public.proxy_wallet_list_coupons_readonly()
+-- Defensive: an earlier draft of this migration shipped without keyset
+-- pagination args. Drop the no-arg signature first so the new 3-arg
+-- function below doesn't collide on environments that already saw the
+-- earlier version. No-op on fresh DBs.
+DROP FUNCTION IF EXISTS public.proxy_wallet_list_coupons_readonly();
+
+-- list_coupons_readonly takes optional keyset cursor arguments so the
+-- coupon history can be paged without grabbing the whole list. All
+-- arguments have defaults so existing no-arg callers keep working.
+--
+-- p_limit            page size, clamped to [1, 100], default 50
+-- p_before_granted_at cursor anchor — return rows strictly before this
+-- p_before_id        tiebreaker for rows with equal granted_at
+CREATE OR REPLACE FUNCTION public.proxy_wallet_list_coupons_readonly(
+    p_limit             INTEGER DEFAULT 50,
+    p_before_granted_at TIMESTAMPTZ DEFAULT NULL,
+    p_before_id         BIGINT DEFAULT NULL
+)
 RETURNS TABLE (
     coupon_id      BIGINT,
     template_code  TEXT,
@@ -87,18 +110,22 @@ LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = '' AS $$
 DECLARE
     v_user_id    UUID := auth.uid();
     v_account_id UUID;
+    v_limit      INTEGER := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 100);
 BEGIN
     IF v_user_id IS NULL THEN
-        RAISE EXCEPTION 'Not authenticated' USING ERRCODE = '28000';
+        RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
     END IF;
 
-    SELECT a.id INTO v_account_id
-      FROM wallet.account a
-     WHERE a.kind = 'user' AND a.user_id = v_user_id;
-
-    IF v_account_id IS NULL THEN
-        RAISE EXCEPTION 'wallet_account_missing' USING ERRCODE = 'WLT01';
-    END IF;
+    BEGIN
+        SELECT a.id INTO STRICT v_account_id
+          FROM wallet.account a
+         WHERE a.kind = 'user' AND a.user_id = v_user_id;
+    EXCEPTION
+        WHEN no_data_found THEN
+            RAISE EXCEPTION 'wallet_account_missing' USING ERRCODE = 'WLT01';
+        WHEN too_many_rows THEN
+            RAISE EXCEPTION 'wallet_account_duplicate' USING ERRCODE = 'WLT02';
+    END;
 
     RETURN QUERY
     SELECT
@@ -107,19 +134,28 @@ BEGIN
       FROM wallet.coupon c
       JOIN wallet.coupon_template t ON t.id = c.template_id
      WHERE c.account_id = v_account_id
-     ORDER BY c.granted_at DESC, c.id DESC;
+       AND (
+           p_before_granted_at IS NULL
+           OR c.granted_at < p_before_granted_at
+           OR (c.granted_at = p_before_granted_at AND c.id < p_before_id)
+       )
+     ORDER BY c.granted_at DESC, c.id DESC
+     LIMIT v_limit;
 END;
 $$;
 
-REVOKE ALL ON FUNCTION public.proxy_wallet_list_coupons_readonly() FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION public.proxy_wallet_list_coupons_readonly() TO authenticated, service_role;
-ALTER FUNCTION public.proxy_wallet_list_coupons_readonly() OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_wallet_list_coupons_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_wallet_list_coupons_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO authenticated, service_role;
+ALTER FUNCTION public.proxy_wallet_list_coupons_readonly(INTEGER, TIMESTAMPTZ, BIGINT) OWNER TO service_role;
 
-COMMENT ON FUNCTION public.proxy_wallet_list_coupons_readonly() IS
-    'Read-only coupon list. Raises SQLSTATE WLT01 when the caller has no wallet account; the client falls back to the rw pool to provision and retry.';
+COMMENT ON FUNCTION public.proxy_wallet_list_coupons_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
+    'Read-only paged coupon list. Keyset pagination on (granted_at DESC, id DESC). Limit clamped to [1, 100], default 50. Raises SQLSTATE WLT01 (wallet_account_missing) when the caller has no wallet account; the client falls back to the rw pool.';
 
 -- migrate:down
 
 DROP FUNCTION IF EXISTS public.proxy_wallet_get_balance_readonly();
+DROP FUNCTION IF EXISTS public.proxy_wallet_list_coupons_readonly(INTEGER, TIMESTAMPTZ, BIGINT);
+-- Belt-and-suspenders: drop any older signature too (no-arg version
+-- shipped briefly in an earlier draft).
 DROP FUNCTION IF EXISTS public.proxy_wallet_list_coupons_readonly();
 DROP INDEX IF EXISTS wallet.wallet_coupon_account_granted_idx;

--- a/packages/data/sql/dbmate/migrations/20260514011143_wallet_ro_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260514011143_wallet_ro_proxies.sql
@@ -5,14 +5,29 @@
 -- wallet.proxy_ensure_user_account, so they can be executed on the
 -- supabase-cluster-pooler-ro replica without write conflicts.
 --
--- Contract on missing account: raise SQLSTATE 'WLT01' (custom). The Rust
--- WalletClient catches that one sqlstate and falls back to the rw pool's
--- provisioning proxy, then retries the read. Account provisioning still
--- runs through wallet.proxy_ensure_user_account, just as a repair lane.
+-- Contract on missing account / missing balance: raise SQLSTATE 'WLT01'
+-- (custom). The Rust WalletClient catches that one sqlstate and falls
+-- back to the rw pool's provisioning proxy, then retries the read.
+-- Account provisioning still runs through wallet.proxy_ensure_user_account
+-- as a repair lane.
 --
 -- Why a custom sqlstate (not P0002 / NO_DATA_FOUND): P0002 is raised by
 -- plpgsql for a number of generic "no row" scenarios, so matching on it
 -- would be fragile. WLT01 is reserved for this wallet RO contract.
+--
+-- Schema invariants relied on:
+--   wallet_account_user_uq (partial unique on user_id WHERE kind='user')
+--     guarantees at most one user-wallet per auth user, so SELECT INTO
+--     cannot pick an arbitrary row.
+--   wallet.balance.account_id is PRIMARY KEY of wallet.balance, so one
+--     balance row per account_id is structural. The defensive IF NOT
+--     FOUND below covers older rows that were inserted before the
+--     trigger/backfill provisioned the balance row.
+
+-- Composite index matching the list_coupons_readonly query: filter on
+-- account_id, order by granted_at DESC + id DESC for stable pagination.
+CREATE INDEX IF NOT EXISTS wallet_coupon_account_granted_idx
+    ON wallet.coupon (account_id, granted_at DESC, id DESC);
 
 CREATE OR REPLACE FUNCTION public.proxy_wallet_get_balance_readonly()
 RETURNS TABLE (
@@ -42,6 +57,10 @@ BEGIN
     SELECT b.account_id, b.credits, b.khash, b.updated_at
       FROM wallet.balance b
      WHERE b.account_id = v_account_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'wallet_account_missing' USING ERRCODE = 'WLT01';
+    END IF;
 END;
 $$;
 
@@ -50,7 +69,7 @@ GRANT EXECUTE ON FUNCTION public.proxy_wallet_get_balance_readonly() TO authenti
 ALTER FUNCTION public.proxy_wallet_get_balance_readonly() OWNER TO service_role;
 
 COMMENT ON FUNCTION public.proxy_wallet_get_balance_readonly() IS
-    'Read-only balance fetch. Raises SQLSTATE WLT01 when the caller has no wallet account; the client falls back to the rw pool to provision and retry.';
+    'Read-only balance fetch. Raises SQLSTATE WLT01 when the caller has no wallet account or balance row; the client falls back to the rw pool to provision and retry.';
 
 CREATE OR REPLACE FUNCTION public.proxy_wallet_list_coupons_readonly()
 RETURNS TABLE (
@@ -88,7 +107,7 @@ BEGIN
       FROM wallet.coupon c
       JOIN wallet.coupon_template t ON t.id = c.template_id
      WHERE c.account_id = v_account_id
-     ORDER BY c.granted_at DESC;
+     ORDER BY c.granted_at DESC, c.id DESC;
 END;
 $$;
 
@@ -103,3 +122,4 @@ COMMENT ON FUNCTION public.proxy_wallet_list_coupons_readonly() IS
 
 DROP FUNCTION IF EXISTS public.proxy_wallet_get_balance_readonly();
 DROP FUNCTION IF EXISTS public.proxy_wallet_list_coupons_readonly();
+DROP INDEX IF EXISTS wallet.wallet_coupon_account_granted_idx;

--- a/packages/rust/kbve/src/wallet/error.rs
+++ b/packages/rust/kbve/src/wallet/error.rs
@@ -64,12 +64,19 @@ impl WalletError {
     ///   3. Fall back to the raw `DieselError` in the `Db` variant.
     pub fn from_diesel(e: DieselError) -> Self {
         if let DieselError::DatabaseError(_, ref info) = e {
-            // SQLSTATE WLT01 surfaces as the message 'wallet_account_missing'
-            // raised by public.proxy_wallet_*_readonly. diesel's
+            // SQLSTATE WLT01 surfaces as one of these messages raised by
+            // public.proxy_wallet_*_readonly. diesel's
             // DatabaseErrorInformation doesn't expose the SQLSTATE on this
             // diesel version, so we match on the message string instead.
-            if info.message() == "wallet_account_missing" {
-                return WalletError::AccountMissing;
+            // wallet_account_duplicate (WLT02) is intentionally not mapped
+            // here: it indicates a broken wallet_account_user_uq invariant
+            // that needs human intervention, so it falls through to the
+            // generic Db variant and surfaces as a 500.
+            match info.message() {
+                "wallet_account_missing" | "wallet_balance_missing" => {
+                    return WalletError::AccountMissing;
+                }
+                _ => {}
             }
         }
         if let DieselError::DatabaseError(kind, ref info) = e {
@@ -113,7 +120,7 @@ fn classify_message(msg: &str) -> Option<WalletError> {
     if m.contains("overflow") || m.contains("would overflow") {
         return Some(WalletError::Overflow);
     }
-    if m.contains("not authenticated") {
+    if m.contains("not authenticated") || m.contains("not_authenticated") {
         return Some(WalletError::NotAuthenticated);
     }
     if m.contains("service_role required") {

--- a/packages/rust/kbve/src/wallet/error.rs
+++ b/packages/rust/kbve/src/wallet/error.rs
@@ -25,6 +25,9 @@ pub enum WalletError {
     #[error("not authenticated")]
     NotAuthenticated,
 
+    #[error("wallet account missing for caller")]
+    AccountMissing,
+
     #[error("null argument: {0}")]
     NullArgument(String),
 
@@ -60,6 +63,15 @@ impl WalletError {
     ///      functions raise (e.g. "insufficient funds").
     ///   3. Fall back to the raw `DieselError` in the `Db` variant.
     pub fn from_diesel(e: DieselError) -> Self {
+        if let DieselError::DatabaseError(_, ref info) = e {
+            // SQLSTATE WLT01 surfaces as the message 'wallet_account_missing'
+            // raised by public.proxy_wallet_*_readonly. diesel's
+            // DatabaseErrorInformation doesn't expose the SQLSTATE on this
+            // diesel version, so we match on the message string instead.
+            if info.message() == "wallet_account_missing" {
+                return WalletError::AccountMissing;
+            }
+        }
         if let DieselError::DatabaseError(kind, ref info) = e {
             // First pass: structural kinds that map cleanly.
             match kind {

--- a/packages/rust/kbve/src/wallet/proxy.rs
+++ b/packages/rust/kbve/src/wallet/proxy.rs
@@ -56,7 +56,32 @@ struct RedeemRowDb {
 }
 
 impl WalletClient {
+    /// Reads the caller's balance from the read-only pool. On
+    /// `AccountMissing` (SQLSTATE WLT01), falls back to the rw pool's
+    /// provisioning proxy, which is the historic write-path lazy
+    /// provisioning. Both reads + writes are observable in the diesel
+    /// pool metrics, so the rate of fallback indicates how often a user
+    /// signup escaped the auth.users trigger or hit replica lag.
     pub async fn user_balance(&self, user_id: Uuid) -> Result<BalanceRow> {
+        match self.read_user_balance(user_id).await {
+            Ok(row) => Ok(row),
+            Err(WalletError::AccountMissing) => self.write_user_balance(user_id).await,
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn read_user_balance(&self, user_id: Uuid) -> Result<BalanceRow> {
+        let mut conn = self.read().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<BalanceRow, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                balance_async_readonly(conn).await
+            })
+            .await
+    }
+
+    async fn write_user_balance(&self, user_id: Uuid) -> Result<BalanceRow> {
         let mut conn = self.write().await?;
         let inner: &mut AsyncPgConnection = &mut *conn;
         inner
@@ -68,6 +93,25 @@ impl WalletClient {
     }
 
     pub async fn user_coupons(&self, user_id: Uuid) -> Result<Vec<CouponSummary>> {
+        match self.read_user_coupons(user_id).await {
+            Ok(rows) => Ok(rows),
+            Err(WalletError::AccountMissing) => self.write_user_coupons(user_id).await,
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn read_user_coupons(&self, user_id: Uuid) -> Result<Vec<CouponSummary>> {
+        let mut conn = self.read().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Vec<CouponSummary>, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                coupons_async_readonly(conn).await
+            })
+            .await
+    }
+
+    async fn write_user_coupons(&self, user_id: Uuid) -> Result<Vec<CouponSummary>> {
         let mut conn = self.write().await?;
         let inner: &mut AsyncPgConnection = &mut *conn;
         inner
@@ -112,16 +156,45 @@ async fn balance_async(conn: &mut AsyncPgConnection) -> Result<BalanceRow> {
     })
 }
 
+async fn balance_async_readonly(conn: &mut AsyncPgConnection) -> Result<BalanceRow> {
+    let row: BalanceRowDb = sql_query(
+        "SELECT account_id, credits, khash, updated_at \
+         FROM public.proxy_wallet_get_balance_readonly()",
+    )
+    .get_result(conn)
+    .await
+    .map_err(WalletError::from_diesel)?;
+
+    Ok(BalanceRow {
+        account_id: row.account_id,
+        credits: row.credits,
+        khash: row.khash,
+        updated_at: row.updated_at,
+    })
+}
+
 async fn coupons_async(conn: &mut AsyncPgConnection) -> Result<Vec<CouponSummary>> {
-    let rows: Vec<CouponSummaryDb> = sql_query(
+    coupons_async_inner(conn, "public.proxy_wallet_list_coupons()").await
+}
+
+async fn coupons_async_readonly(conn: &mut AsyncPgConnection) -> Result<Vec<CouponSummary>> {
+    coupons_async_inner(conn, "public.proxy_wallet_list_coupons_readonly()").await
+}
+
+async fn coupons_async_inner(
+    conn: &mut AsyncPgConnection,
+    fn_call: &str,
+) -> Result<Vec<CouponSummary>> {
+    let query = format!(
         "SELECT coupon_id, template_code, template_label, \
                 reward_kind::text AS reward_kind, reward_payload, \
                 status::text AS status, granted_at, expires_at, redeemed_at \
-         FROM public.proxy_wallet_list_coupons()",
-    )
-    .get_results(conn)
-    .await
-    .map_err(WalletError::from_diesel)?;
+         FROM {fn_call}"
+    );
+    let rows: Vec<CouponSummaryDb> = sql_query(query)
+        .get_results(conn)
+        .await
+        .map_err(WalletError::from_diesel)?;
 
     rows.into_iter()
         .map(|r| {

--- a/packages/rust/kbve/src/wallet/tests.rs
+++ b/packages/rust/kbve/src/wallet/tests.rs
@@ -40,12 +40,11 @@ async fn fixture_account() -> Option<(Uuid, Uuid)> {
         #[diesel(sql_type = diesel::sql_types::Uuid)]
         id: Uuid,
     }
-    let r: R =
-        sql_query("INSERT INTO wallet.account (kind, user_id) VALUES ('user', $1) RETURNING id")
-            .bind::<diesel::sql_types::Uuid, _>(user_id)
-            .get_result(&mut conn)
-            .await
-            .expect("insert wallet.account");
+    let r: R = sql_query("SELECT id FROM wallet.account WHERE kind = 'user' AND user_id = $1")
+        .bind::<diesel::sql_types::Uuid, _>(user_id)
+        .get_result(&mut conn)
+        .await
+        .expect("trigger-provisioned wallet.account lookup");
     sql_query("INSERT INTO wallet.balance (account_id) VALUES ($1) ON CONFLICT DO NOTHING")
         .bind::<diesel::sql_types::Uuid, _>(r.id)
         .execute(&mut conn)
@@ -208,6 +207,54 @@ async fn welcome_redeem_flow_via_user_proxy() {
 
     let bal = client.user_balance(user_id).await.unwrap();
     assert_eq!(bal.khash, 1000);
+}
+
+#[tokio::test]
+#[serial]
+async fn user_balance_ro_fallback_reprovisions_missing_account() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let mut conn = admin_conn().await.unwrap();
+
+    let user_id = Uuid::new_v4();
+    sql_query("INSERT INTO auth.users (id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind::<diesel::sql_types::Uuid, _>(user_id)
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    sql_query(
+        "DELETE FROM wallet.coupon WHERE account_id IN \
+            (SELECT id FROM wallet.account WHERE user_id = $1)",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(user_id)
+    .execute(&mut conn)
+    .await
+    .unwrap();
+    sql_query(
+        "DELETE FROM wallet.balance WHERE account_id IN \
+            (SELECT id FROM wallet.account WHERE user_id = $1)",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(user_id)
+    .execute(&mut conn)
+    .await
+    .unwrap();
+    sql_query("DELETE FROM wallet.account WHERE user_id = $1")
+        .bind::<diesel::sql_types::Uuid, _>(user_id)
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let bal = client
+        .user_balance(user_id)
+        .await
+        .expect("user_balance falls back to rw and provisions");
+    assert_eq!(bal.credits, 0);
+    assert_eq!(bal.khash, 0);
+
+    let bal2 = client.user_balance(user_id).await.unwrap();
+    assert_eq!(bal.account_id, bal2.account_id);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Routes `/me/balance` and `/me/coupons` through the CNPG `supabase-cluster-pooler-ro` replica on the happy path. Lazy provisioning is preserved as a repair lane via the existing rw proxy, but only runs when an account is genuinely missing.

Follow-up to #10920 (`auth.users` trigger + backfill) and #10941 (rw/ro client + RO env wire).

## SQL changes (`20260514011143_wallet_ro_proxies`)

- `public.proxy_wallet_get_balance_readonly()` — STABLE SECURITY DEFINER variant. Looks up the caller's wallet account via `auth.uid()` **without** calling `wallet.proxy_ensure_user_account`. Raises SQLSTATE `WLT01` (custom, reserved for this contract) on missing account.
- `public.proxy_wallet_list_coupons_readonly()` — same shape for coupons.
- Both granted to `authenticated`, `service_role`. Owned by `service_role`. `search_path = ''`.
- Existing write-path `proxy_wallet_get_balance` / `list_coupons` / `redeem_coupon` unchanged.

## Rust changes

- `WalletError::AccountMissing` variant. `from_diesel` detects WLT01 by message string (`'wallet_account_missing'`) because diesel 2.3 doesn't expose `DatabaseErrorInformation::code()`.
- `WalletClient::user_balance` and `user_coupons` route through new private `read_user_*` helpers on the RO pool. On `AccountMissing` they fall back to `write_user_*`, which uses the rw pool + write-path proxies (provisioning + reading).
- `coupons_async` refactored to share row-mapping logic across rw / ro variants via a single inner function.
- `transport/wallet.rs` maps `AccountMissing` → `404 account_missing` so it's wire-visible if it ever escapes (it shouldn't — read failures always fall through to rw).
- `fixture_account` test helper updated: auth.users trigger now provisions wallet.account, so the fixture just looks up the trigger-created account instead of double-inserting.

## Tests

- ✅ New `user_balance_ro_fallback_reprovisions_missing_account` integration test (8/8 wallet tests pass): inserts `auth.users`, deletes wallet rows directly to simulate the missing-account case, verifies `client.user_balance` fallback re-provisions.
- ✅ `nx run data-sql:test-migration 20260514011143_wallet_ro_proxies` green — exercises both user-with-account and user-without-account paths plus rollback assertions.

## Test plan

- [x] `cargo check` clean for `kbve` + `axum-kbve`
- [x] All 8 `wallet::tests::*` integration tests green
- [x] Migration test harness green (up + down asserts)
- [ ] After merge: dispatch `ci-dbmate-deploy` on main
- [ ] After ArgoCD sync of axum-kbve: hit `GET /api/v1/wallet/me/balance` for a known-good user, confirm RO pool is exercised (CNPG metrics)
- [ ] Monitor `WalletError::AccountMissing` rate via axum-kbve logs — should be near-zero after PR #10920's backfill