### PR TITLE
perf(arcade): cache blackjack button state updates

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('phaser', () => ({ default: {} }));
+
+import { ButtonBar, type ButtonSpec } from './buttonBar';
+
+class MockImage {
+	readonly setOrigin = vi.fn(() => this);
+	readonly setDisplaySize = vi.fn(() => this);
+	readonly setTexture = vi.fn(() => this);
+}
+
+class MockText {
+	readonly setOrigin = vi.fn(() => this);
+	readonly setAlpha = vi.fn(() => this);
+}
+
+class MockZone {
+	private pointerUp: (() => void) | undefined;
+	readonly setOrigin = vi.fn(() => this);
+	readonly setInteractive = vi.fn(() => this);
+	readonly on = vi.fn((_event: string, callback: () => void) => {
+		this.pointerUp = callback;
+		return this;
+	});
+
+	click() {
+		this.pointerUp?.();
+	}
+}
+
+function createHarness(spec: ButtonSpec) {
+	const image = new MockImage();
+	const text = new MockText();
+	const zone = new MockZone();
+	const scene = {
+		add: {
+			image: vi.fn(() => image),
+			text: vi.fn(() => text),
+			zone: vi.fn(() => zone),
+		},
+	};
+	const layer = { add: vi.fn() };
+	const bar = new ButtonBar(
+		scene as never,
+		layer as never,
+		(enabled) => (enabled ? 'button-on' : 'button-off'),
+		vi.fn(),
+	);
+
+	bar.create([spec]);
+	return { bar, image, text, zone };
+}
+
+describe('blackjack button bar', () => {
+	it('skips unchanged alpha and texture updates across renders', () => {
+		const spec: ButtonSpec = {
+			key: 'deal',
+			label: 'Deal',
+			x: 0,
+			y: 0,
+			w: 92,
+			enabled: () => true,
+			action: vi.fn(),
+		};
+		const { bar, image, text } = createHarness(spec);
+
+		bar.update();
+		bar.update();
+
+		expect(image.setTexture).toHaveBeenCalledTimes(1);
+		expect(text.setAlpha).toHaveBeenCalledTimes(1);
+	});
+
+	it('updates alpha and texture when enabled state changes', () => {
+		let enabled = true;
+		const spec: ButtonSpec = {
+			key: 'hit',
+			label: 'Hit',
+			x: 0,
+			y: 0,
+			w: 82,
+			enabled: () => enabled,
+			action: vi.fn(),
+		};
+		const { bar, image, text } = createHarness(spec);
+
+		bar.update();
+		enabled = false;
+		bar.update();
+
+		expect(image.setTexture).toHaveBeenCalledTimes(2);
+		expect(text.setAlpha).toHaveBeenCalledTimes(2);
+	});
+
+	it('runs actions through the keyed view cache', () => {
+		const action = vi.fn();
+		const spec: ButtonSpec = {
+			key: 'stand',
+			label: 'Stand',
+			x: 0,
+			y: 0,
+			w: 92,
+			enabled: () => true,
+			action,
+		};
+		const { bar } = createHarness(spec);
+
+		expect(bar.run('stand')).toBe(true);
+		expect(bar.run('deal')).toBe(false);
+		expect(action).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.ts
@@ -32,10 +32,12 @@ interface ButtonView {
 	box: Phaser.GameObjects.Image;
 	text: Phaser.GameObjects.Text;
 	lastEnabled: boolean | null;
+	lastTextAlpha: number | null;
 }
 
 export class ButtonBar {
 	private readonly views: ButtonView[] = [];
+	private readonly viewsByKey = new Map<ButtonKey, ButtonView>();
 
 	constructor(
 		private readonly scene: Phaser.Scene,
@@ -69,12 +71,20 @@ export class ButtonBar {
 			});
 
 			this.layer.add([box, text, hitArea]);
-			this.views.push({ spec, box, text, lastEnabled: null });
+			const view = {
+				spec,
+				box,
+				text,
+				lastEnabled: null,
+				lastTextAlpha: null,
+			};
+			this.views.push(view);
+			this.viewsByKey.set(spec.key, view);
 		}
 	}
 
 	run(key: ButtonKey): boolean {
-		const button = this.views.find((view) => view.spec.key === key);
+		const button = this.viewsByKey.get(key);
 		if (!button || !button.spec.enabled()) return false;
 		button.spec.action();
 		return true;
@@ -87,7 +97,11 @@ export class ButtonBar {
 				view.box.setTexture(this.textureKey(enabled));
 				view.lastEnabled = enabled;
 			}
-			view.text.setAlpha(enabled ? 1 : 0.42);
+			const textAlpha = enabled ? 1 : 0.42;
+			if (view.lastTextAlpha !== textAlpha) {
+				view.text.setAlpha(textAlpha);
+				view.lastTextAlpha = textAlpha;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- cache blackjack button views by key for keyboard/action dispatch
- dirty-check button text alpha updates so repeated renders skip unchanged `setAlpha` calls
- add unit coverage for unchanged button state, enabled-state flips, and keyed actions

## Validation
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.test.ts`
- `./kbve.sh -nx astro-kbve:test`
- `AXUM_PORT=4369 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`