### PR TITLE
feat(astro-kbve): compact wallet credit + khash display

### DIFF
--- a/apps/kbve/astro-kbve/src/components/providers/ReactProfileWallet.tsx
+++ b/apps/kbve/astro-kbve/src/components/providers/ReactProfileWallet.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { getAccessToken, useSession } from '@kbve/astro';
+import { formatCompact } from '../wallet/format';
 
 /**
  * Profile wallet island.
@@ -167,12 +168,6 @@ async function authedFetch(path: string, init: RequestInit = {}) {
 	return res.json();
 }
 
-function formatCredits(n: number) {
-	// 1 credit = $0.00001 (1 USD = 100,000 credits). For display use the
-	// thousands-separated integer; conversion to USD is a future affordance.
-	return n.toLocaleString();
-}
-
 export function ReactProfileWallet() {
 	const { ready, authenticated } = useSession();
 	const [profileUsername, setProfileUsername] = useState<string | null>(null);
@@ -277,14 +272,24 @@ export function ReactProfileWallet() {
 			<div style={styles.balances}>
 				<div style={styles.balanceCard}>
 					<div style={styles.balanceLabel}>Credits</div>
-					<div style={styles.balanceValue}>
-						{balance ? formatCredits(balance.credits) : '—'}
+					<div
+						style={styles.balanceValue}
+						title={
+							balance
+								? balance.credits.toLocaleString()
+								: undefined
+						}>
+						{balance ? formatCompact(balance.credits) : '—'}
 					</div>
 				</div>
 				<div style={styles.balanceCard}>
 					<div style={styles.balanceLabel}>KHash</div>
-					<div style={styles.balanceValue}>
-						{balance ? balance.khash.toLocaleString() : '—'}
+					<div
+						style={styles.balanceValue}
+						title={
+							balance ? balance.khash.toLocaleString() : undefined
+						}>
+						{balance ? formatCompact(balance.khash) : '—'}
 					</div>
 				</div>
 			</div>

--- a/apps/kbve/astro-kbve/src/components/wallet/ReactWalletBadge.tsx
+++ b/apps/kbve/astro-kbve/src/components/wallet/ReactWalletBadge.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { getAccessToken, useSession } from '@kbve/astro';
+import { formatCompact } from './format';
 
 /**
  * Compact wallet badge for the site navigation.
@@ -98,12 +99,12 @@ export function ReactWalletBadge() {
 			aria-label={`Wallet: ${balance.khash} KHash, ${balance.credits} Credits`}
 			title="Open wallet">
 			<span style={styles.chunk}>
-				<span>{balance.khash.toLocaleString()}</span>
+				<span>{formatCompact(balance.khash)}</span>
 				<span style={styles.label}>KH</span>
 			</span>
 			<span style={{ opacity: 0.35 }}>·</span>
 			<span style={styles.chunk}>
-				<span>{balance.credits.toLocaleString()}</span>
+				<span>{formatCompact(balance.credits)}</span>
 				<span style={styles.label}>C</span>
 			</span>
 		</a>

--- a/apps/kbve/astro-kbve/src/components/wallet/ReactWalletCard.tsx
+++ b/apps/kbve/astro-kbve/src/components/wallet/ReactWalletCard.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getAccessToken, useSession } from '@kbve/astro';
+import { formatCompact } from './format';
 
 type Balance = {
 	account_id: string;
@@ -90,9 +91,9 @@ export function ReactWalletCard() {
 			setShellText(
 				shell,
 				SLOT_CREDITS,
-				b ? b.credits.toLocaleString() : '—',
+				b ? formatCompact(b.credits) : '—',
 			);
-			setShellText(shell, SLOT_KHASH, b ? b.khash.toLocaleString() : '—');
+			setShellText(shell, SLOT_KHASH, b ? formatCompact(b.khash) : '—');
 			setShellText(
 				shell,
 				SLOT_UPDATED,

--- a/apps/kbve/astro-kbve/src/components/wallet/format.ts
+++ b/apps/kbve/astro-kbve/src/components/wallet/format.ts
@@ -1,0 +1,9 @@
+const compactFormatter = new Intl.NumberFormat('en', {
+	notation: 'compact',
+	maximumFractionDigits: 1,
+});
+
+export function formatCompact(n: number | null | undefined): string {
+	if (n == null || !Number.isFinite(n)) return '—';
+	return compactFormatter.format(n);
+}


### PR DESCRIPTION
## Summary
- Wallet renderers now show credits + KHash in compact form (\`1.2K\`, \`12K\`, \`1.2M\`) using \`Intl.NumberFormat({ notation: 'compact', maximumFractionDigits: 1 })\`. Long balances no longer push nav/card layouts.
- New shared helper \`apps/kbve/astro-kbve/src/components/wallet/format.ts\` (\`formatCompact\`) — single source for the rule.
- Profile balance card carries a \`title=\"...\"\` tooltip with the exact thousands-separated number, so power users can read the literal value on hover.

## Affected surfaces
- \`ReactWalletBadge\` (nav chip)
- \`ReactWalletCard\` (Astro shell slots: \`[data-kbve-wallet-credits]\`, \`[data-kbve-wallet-khash]\`)
- \`ReactProfileWallet\` (profile balance card)

## Examples
| Raw | Compact |
| --- | --- |
| 999 | 999 |
| 1,000 | 1K |
| 1,234 | 1.2K |
| 12,345 | 12K |
| 1,000,000 | 1M |
| 12,345,678 | 12M |

## Test plan
- [ ] \`npx nx run astro-kbve:build\` succeeds
- [ ] Signed-in nav badge shows compact balance
- [ ] \`/account\` wallet card shows compact balance, slot values update on redeem
- [ ] Own profile page card shows compact balance + tooltip with the raw integer on hover