### PR TITLE
revert(ci): drop release-ci cargo profile from axum-kbve docker build

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.workspace.toml
+++ b/apps/kbve/axum-kbve/Cargo.workspace.toml
@@ -15,9 +15,3 @@ lto = true
 strip = true
 codegen-units = 1
 panic = "abort"
-
-[profile.release-ci]
-inherits = "release"
-opt-level = 2
-lto = "off"
-codegen-units = 16

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -139,7 +139,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     else \
         echo "sccache: Redis password not provided, falling back to local disk cache"; \
     fi && \
-    cargo chef cook --profile release-ci --recipe-path recipe.json -p axum-kbve && \
+    cargo chef cook --release --recipe-path recipe.json -p axum-kbve && \
     (sccache --show-stats || true)
 
 # [STAGE E] - Foundation Layer (Compile kbve + jedi from real source)
@@ -175,7 +175,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
             SCCACHE_REDIS_USERNAME=default \
             SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
     fi && \
-    cargo build --profile release-ci -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker && \
+    cargo build --release -p kbve -p jedi -p holy -p bevy_kbve_net -p bevy_npc -p bevy_tasker && \
     (sccache --show-stats || true)
 
 # ============================================================================
@@ -215,16 +215,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
             SCCACHE_REDIS_USERNAME=default \
             SCCACHE_REDIS_KEY_PREFIX=axum-kbve; \
     fi && \
-    cargo build --profile release-ci -p axum-kbve --features jemalloc && \
+    cargo build --release -p axum-kbve --features jemalloc && \
     (sccache --show-stats || true) && \
-    strip target/release-ci/axum-kbve
+    strip target/release/axum-kbve
 
 # ============================================================================
 # [STAGE Z] - Runtime Image (shared chisel base)
 # ============================================================================
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
-COPY --from=builder --chown=10001:10001 /app/target/release-ci/axum-kbve /app/axum-kbve
+COPY --from=builder --chown=10001:10001 /app/target/release/axum-kbve /app/axum-kbve
 
 # Ship Cargo.toml alongside the binary so `/health` reports the version
 # that was current when *this image* was built. CI's pre-build sync step


### PR DESCRIPTION
## Summary

Reverts the \`[profile.release-ci]\` + \`--profile release-ci\` changes that landed via #10936. Astro double-build removal from #10936 stays untouched.

## Why revert

The axum-kbve CI image flows directly to production via \`ci-publish.yml\` — that workflow only re-tags \`ci-<sha>\` to \`latest\` and pushes; there is no separate prod rebuild with a different profile. So \`lto=off\` + \`codegen-units=16\` + \`opt-level=2\` ship to kube and degrade steady-state runtime perf (estimated 2-10% for axum-kbve's HTTP/JSON/static workload).

This was a scoping mistake. The PR was merged before the revert commit made it on the branch.

## Diff

- \`apps/kbve/axum-kbve/Cargo.workspace.toml\` — drop the \`[profile.release-ci]\` block.
- \`apps/kbve/axum-kbve/Dockerfile\` — 3 \`--profile release-ci\` → \`--release\`; \`target/release-ci/\` → \`target/release/\` in the strip step and the runtime \`COPY --from=builder\`.

## Compile-time savings now come from

- Registry buildx cache (already landed in #10907)
- sccache → Valkey Redis (already landed in #10910, populated on the run that followed it)
- Astro double-build removal (landed via the unreverted part of #10936)

## Test plan

- [ ] PR CI: \`docker-test-app.yml\` succeeds end-to-end on \`--release\`.
- [ ] Confirm the built binary lives at \`/app/axum-kbve\` and serves traffic via the existing vitest e2e suite.
- [ ] After merge, the next axum-kbve docker test job should still benefit from registry-cache + sccache hits even though release profile is back to full opts.