### PR TITLE
perf(arcade): cache blackjack strategy hints

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/strategyAdvisor.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/strategyAdvisor.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { encodeCard } from '../cards';
+import { createBlackjackState } from '../state';
+import { StrategyAdvisor } from './strategyAdvisor';
+
+describe('blackjack strategy advisor', () => {
+	it('returns no hint outside the player turn', () => {
+		const state = createBlackjackState();
+		state.phase = 'betting';
+		state.player = [encodeCard('spades', '10'), encodeCard('clubs', '6')];
+		state.dealer = [encodeCard('hearts', '6')];
+
+		expect(new StrategyAdvisor().getHint(state)).toBe('');
+	});
+
+	it('reuses cached hard hand hints until the hand changes', () => {
+		const advisor = new StrategyAdvisor();
+		const state = createBlackjackState();
+		state.phase = 'player-turn';
+		state.canDouble = true;
+		state.player = [encodeCard('spades', '5'), encodeCard('clubs', '5')];
+		state.dealer = [encodeCard('hearts', '9')];
+
+		expect(advisor.getHint(state)).toBe('Hint: Double');
+		expect(advisor.getHint(state)).toBe('Hint: Double');
+
+		state.player = [
+			encodeCard('spades', '5'),
+			encodeCard('clubs', '5'),
+			encodeCard('diamonds', '8'),
+		];
+		state.canDouble = false;
+
+		expect(advisor.getHint(state)).toBe('Hint: Stand');
+	});
+
+	it('refreshes cached hints when the dealer up card changes', () => {
+		const advisor = new StrategyAdvisor();
+		const state = createBlackjackState();
+		state.phase = 'player-turn';
+		state.canDouble = false;
+		state.player = [encodeCard('spades', '10'), encodeCard('clubs', '2')];
+		state.dealer = [encodeCard('hearts', '6')];
+
+		expect(advisor.getHint(state)).toBe('Hint: Stand');
+
+		state.dealer = [encodeCard('hearts', '10')];
+
+		expect(advisor.getHint(state)).toBe('Hint: Hit');
+	});
+
+	it('refreshes cached soft hand hints when doubling becomes unavailable', () => {
+		const advisor = new StrategyAdvisor();
+		const state = createBlackjackState();
+		state.phase = 'player-turn';
+		state.canDouble = true;
+		state.player = [encodeCard('spades', 'A'), encodeCard('clubs', '7')];
+		state.dealer = [encodeCard('hearts', '3')];
+
+		expect(advisor.getHint(state)).toBe('Hint: Double');
+
+		state.canDouble = false;
+
+		expect(advisor.getHint(state)).toBe('Hint: Hit');
+	});
+});

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/strategyAdvisor.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/strategyAdvisor.ts
@@ -1,20 +1,53 @@
-import { cardPoints, cardRank, valueHand, type Card } from '../cards';
+import {
+	cardPoints,
+	cardRank,
+	handFingerprint,
+	valueHand,
+	type Card,
+} from '../cards';
 import type { BlackjackState } from '../state';
 
+interface StrategyHintCache {
+	playerFingerprint: number;
+	dealerUp: Card;
+	canDouble: boolean;
+	hint: string;
+}
+
 export class StrategyAdvisor {
+	private lastHint: StrategyHintCache | null = null;
+
 	getHint(state: BlackjackState): string {
 		if (state.phase !== 'player-turn' || state.dealer.length === 0) {
+			this.lastHint = null;
 			return '';
 		}
 
-		const playerValue = valueHand(state.player);
-		const dealerUp = this.dealerUpValue(state.dealer[0]);
+		const playerFingerprint = handFingerprint(state.player);
+		const dealerUpCard = state.dealer[0];
 		const canDouble = state.canDouble && state.player.length === 2;
-
-		if (playerValue.soft) {
-			return `Hint: ${this.softStrategy(playerValue.total, dealerUp, canDouble)}`;
+		if (
+			this.lastHint &&
+			this.lastHint.playerFingerprint === playerFingerprint &&
+			this.lastHint.dealerUp === dealerUpCard &&
+			this.lastHint.canDouble === canDouble
+		) {
+			return this.lastHint.hint;
 		}
-		return `Hint: ${this.hardStrategy(playerValue.total, dealerUp, canDouble)}`;
+
+		const playerValue = valueHand(state.player);
+		const dealerUp = this.dealerUpValue(dealerUpCard);
+
+		const hint = playerValue.soft
+			? `Hint: ${this.softStrategy(playerValue.total, dealerUp, canDouble)}`
+			: `Hint: ${this.hardStrategy(playerValue.total, dealerUp, canDouble)}`;
+		this.lastHint = {
+			playerFingerprint,
+			dealerUp: dealerUpCard,
+			canDouble,
+			hint,
+		};
+		return hint;
 	}
 
 	private hardStrategy(


### PR DESCRIPTION
## Summary
- cache blackjack strategy hints using the player hand fingerprint, dealer up card, and double availability
- clear cached hints when leaving player-turn state
- add unit coverage for cached hints and refresh cases when the hand, dealer card, or double state changes

## Validation
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/objects/strategyAdvisor.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/strategyAdvisor.test.ts`
- `./kbve.sh -nx astro-kbve:test`
- `AXUM_PORT=4371 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`