### PR TITLE
feat(astro-kbve): move account page under /profile/, redirect /account

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -18,6 +18,10 @@ export default defineConfig({
 		domains: ['images.unsplash.com'],
 	},
 	prefetch: true,
+	redirects: {
+		'/account': '/profile/account/',
+		'/account/': '/profile/account/',
+	},
 	markdown: {
 		rehypePlugins: [rehypeLinkAttrs],
 	},

--- a/apps/kbve/astro-kbve/src/components/wallet/ReactWalletBadge.tsx
+++ b/apps/kbve/astro-kbve/src/components/wallet/ReactWalletBadge.tsx
@@ -94,7 +94,7 @@ export function ReactWalletBadge() {
 
 	return (
 		<a
-			href="/account"
+			href="/profile/account/"
 			style={{ ...styles.badge, textDecoration: 'none' }}
 			aria-label={`Wallet: ${balance.khash} KHash, ${balance.credits} Credits`}
 			title="Open wallet">

--- a/apps/kbve/astro-kbve/src/content/docs/profile/account.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/profile/account.mdx
@@ -1,0 +1,118 @@
+---
+title: Account
+description: |
+  Your KBVE account — wallet balance, credits, KHash, and coupon claims.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Account
+    order: 1
+tags:
+    - tools
+    - account
+    - wallet
+---
+
+import AstroWalletCard from '@/components/wallet/AstroWalletCard.astro';
+
+<div class="not-content account-page">
+	<header class="account-page__header">
+		<h1>Account</h1>
+		<p>
+			Your wallet balance, credits, and KHash. Claim coupons here when
+			they land.
+		</p>
+	</header>
+
+	<AstroWalletCard />
+
+	<aside class="account-page__signin" data-account-signin>
+		<h2>Sign in to view your wallet</h2>
+		<p>
+			You need a KBVE account to see balances or claim coupons.
+		</p>
+		<a class="account-page__signin-btn" href="/login/">Sign in</a>
+	</aside>
+</div>
+
+<script>
+	// Hide the sign-in fallback as soon as the wallet card becomes visible
+	// (its [hidden] attribute is cleared by ReactWalletCard once a balance
+	// loads). Until then, anon visitors still see a useful prompt.
+	const fallback = document.querySelector('[data-account-signin]');
+	const wallet = document.querySelector('[data-kbve-wallet-shell]');
+	if (fallback && wallet) {
+		const sync = () => {
+			if (!wallet.hasAttribute('hidden')) {
+				fallback.setAttribute('hidden', '');
+			}
+		};
+		sync();
+		new MutationObserver(sync).observe(wallet, {
+			attributes: true,
+			attributeFilter: ['hidden'],
+		});
+	}
+</script>
+
+<style>
+	.account-page {
+		max-width: 760px;
+		margin: 1.5rem auto 4rem;
+		padding: 0 1rem;
+	}
+	.account-page__header {
+		display: grid;
+		gap: 0.35rem;
+		margin-bottom: 1.25rem;
+	}
+	.account-page__header h1 {
+		font-size: clamp(1.75rem, 3.5vw, 2.25rem);
+		font-weight: 800;
+		letter-spacing: -0.01em;
+		margin: 0;
+	}
+	.account-page__header p {
+		margin: 0;
+		color: rgba(255, 255, 255, 0.6);
+		font-size: 0.95rem;
+		line-height: 1.5;
+	}
+	.account-page__signin {
+		margin-top: 1.25rem;
+		padding: 1.25rem;
+		border-radius: 16px;
+		background: rgba(15, 23, 42, 0.6);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		color: rgba(255, 255, 255, 0.85);
+		text-align: center;
+	}
+	.account-page__signin[hidden] {
+		display: none;
+	}
+	.account-page__signin h2 {
+		margin: 0 0 0.4rem;
+		font-size: 1.1rem;
+		font-weight: 700;
+	}
+	.account-page__signin p {
+		margin: 0 0 1rem;
+		font-size: 0.9rem;
+		color: rgba(255, 255, 255, 0.6);
+	}
+	.account-page__signin-btn {
+		display: inline-block;
+		padding: 0.55rem 1.1rem;
+		border-radius: 10px;
+		background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+		color: white;
+		font-weight: 600;
+		text-decoration: none;
+		transition: transform 0.12s ease, box-shadow 0.12s ease;
+	}
+	.account-page__signin-btn:hover {
+		transform: translateY(-1px);
+		box-shadow: 0 10px 24px rgba(99, 102, 241, 0.4);
+	}
+</style>


### PR DESCRIPTION
## Summary
- The wallet badge linked to \`/account\`, which 404'd. Reorganize so the account view lives **under** the profile route at \`/profile/account/\`.
- New \`/profile/account/\` page mounts \`AstroWalletCard\` with a sign-in fallback for anon visitors. A small inline \`MutationObserver\` hides the fallback the moment the wallet shell un-hides (i.e. React fills in a balance).
- Astro \`redirects\` map \`/account\` and \`/account/\` → \`/profile/account/\` so older links / bookmarks survive.
- \`ReactWalletBadge\` href updated to \`/profile/account/\`.

## Test plan
- [ ] \`npx nx run astro-kbve:build\` succeeds
- [ ] Visit \`/account\` → 301/redirect to \`/profile/account/\`
- [ ] Signed-in: \`/profile/account/\` shows the wallet card with compact balance + coupon claim affordance
- [ ] Anon: \`/profile/account/\` shows the sign-in CTA (wallet card hidden)
- [ ] Nav wallet badge click lands on \`/profile/account/\`