### PR TITLE
perf(arcade): cache blackjack HUD labels

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts
@@ -1,6 +1,6 @@
 import Phaser from 'phaser';
 import { createBlackjackState, type BlackjackState } from './state';
-import { BASE_WIDTH, CARD_SIZE, COLORS } from './config';
+import { BASE_WIDTH, CARD_SIZE } from './config';
 import {
 	DealerAnimation,
 	type CardPlacement,
@@ -8,8 +8,7 @@ import {
 import { CardPool } from './objects/cardPool';
 import { HandLayout } from './objects/handLayout';
 import { BlackjackHud } from './objects/blackjackHud';
-import { StrategyAdvisor } from './objects/strategyAdvisor';
-import { HandValueFormatter } from './objects/handValueFormatter';
+import { BlackjackHudPresenter } from './objects/blackjackHudPresenter';
 import {
 	BlackjackTextures,
 	CHIP_TEXTURE_KEY,
@@ -29,13 +28,12 @@ export class BlackjackScene extends Phaser.Scene {
 	private cardLayer!: Phaser.GameObjects.Container;
 	private cardPool!: CardPool;
 	private handLayout!: HandLayout;
-	private strategyAdvisor = new StrategyAdvisor();
 	private dealLayer!: Phaser.GameObjects.Container;
 	private dealerAnimation!: DealerAnimation;
 	private hudLayer!: Phaser.GameObjects.Container;
 	private hud!: BlackjackHud;
 	private controls!: BlackjackControls;
-	private readonly handValueFormatter = new HandValueFormatter();
+	private readonly hudPresenter = new BlackjackHudPresenter();
 
 	constructor() {
 		super('blackjack');
@@ -150,47 +148,8 @@ export class BlackjackScene extends Phaser.Scene {
 	}
 
 	private updateHud() {
-		const hideHole = this.hideDealerHole();
-		const dealerValue = this.handValueFormatter.label(
-			'dealer',
-			'Dealer',
-			this.state.dealer,
-			hideHole ? 1 : this.state.dealer.length,
+		this.hud.update(
+			this.hudPresenter.values(this.state, this.hideDealerHole()),
 		);
-		const playerValue = this.handValueFormatter.label(
-			'player',
-			'Player',
-			this.state.player,
-		);
-		const delta =
-			this.state.lastDelta === 0
-				? ''
-				: this.state.lastDelta > 0
-					? `  (+$${this.state.lastDelta})`
-					: `  (-$${Math.abs(this.state.lastDelta)})`;
-
-		this.hud.update({
-			bankroll: `Bankroll $${this.state.bankroll}\nBet $${this.state.bet}${delta}`,
-			status: this.state.message,
-			statusColor: this.getStatusColor(),
-			strategy: this.strategyAdvisor.getHint(this.state),
-			betChip: `$${this.state.bet}`,
-			dealerValue,
-			playerValue,
-			shoe: `Shoe ${this.state.shoe.length} cards\nRound ${this.state.rounds}`,
-			stats: `Session  W ${this.state.stats.wins}  L ${this.state.stats.losses}  P ${this.state.stats.pushes}\nBJ ${this.state.stats.blackjacks}  Best $${this.state.stats.bestBankroll}`,
-		});
-	}
-
-	private getStatusColor(): string {
-		if (this.state.outcome === 'loss') return COLORS.danger;
-		if (this.state.outcome === 'push') return COLORS.muted;
-		if (
-			this.state.outcome === 'win' ||
-			this.state.outcome === 'blackjack'
-		) {
-			return COLORS.gold;
-		}
-		return '#ffffff';
 	}
 }

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackHudPresenter.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackHudPresenter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { encodeCard } from '../cards';
+import { COLORS } from '../config';
+import { createBlackjackState } from '../state';
+import { BlackjackHudPresenter } from './blackjackHudPresenter';
+
+describe('blackjack HUD presenter', () => {
+	it('formats stable HUD labels from state', () => {
+		const state = createBlackjackState();
+		state.bankroll = 975;
+		state.bet = 25;
+		state.lastDelta = -25;
+		state.rounds = 3;
+		state.shoe = [encodeCard('spades', 'A'), encodeCard('clubs', 'K')];
+		state.stats.wins = 2;
+		state.stats.losses = 1;
+		state.stats.pushes = 1;
+		state.stats.blackjacks = 1;
+		state.stats.bestBankroll = 1050;
+
+		const values = new BlackjackHudPresenter().values(state, false);
+
+		expect(values.bankroll).toBe('Bankroll $975\nBet $25  (-$25)');
+		expect(values.shoe).toBe('Shoe 2 cards\nRound 3');
+		expect(values.stats).toBe('Session  W 2  L 1  P 1\nBJ 1  Best $1050');
+	});
+
+	it('reuses cached scalar labels until their inputs change', () => {
+		const presenter = new BlackjackHudPresenter();
+		const state = createBlackjackState();
+
+		const first = presenter.values(state, false);
+		const second = presenter.values(state, false);
+
+		expect(second.bankroll).toBe(first.bankroll);
+		expect(second.shoe).toBe(first.shoe);
+		expect(second.stats).toBe(first.stats);
+
+		state.bet += 25;
+		const third = presenter.values(state, false);
+
+		expect(third.bankroll).not.toBe(first.bankroll);
+		expect(third.shoe).toBe(first.shoe);
+		expect(third.stats).toBe(first.stats);
+	});
+
+	it('formats hand labels and status colors for visible state', () => {
+		const presenter = new BlackjackHudPresenter();
+		const state = createBlackjackState();
+		state.phase = 'player-turn';
+		state.player = [encodeCard('spades', 'A'), encodeCard('clubs', 'K')];
+		state.dealer = [encodeCard('hearts', '9'), encodeCard('clubs', 'K')];
+		state.outcome = 'win';
+
+		const hidden = presenter.values(state, true);
+		const visible = presenter.values(state, false);
+
+		expect(hidden.dealerValue).toBe('Dealer  9');
+		expect(visible.dealerValue).toBe('Dealer  19');
+		expect(visible.playerValue).toBe('Player  21 soft blackjack');
+		expect(visible.statusColor).toBe(COLORS.gold);
+	});
+});

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackHudPresenter.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackHudPresenter.ts
@@ -1,0 +1,156 @@
+import { COLORS } from '../config';
+import type { BlackjackState, RoundOutcome } from '../state';
+import type { BlackjackHudValues } from './blackjackHud';
+import { HandValueFormatter } from './handValueFormatter';
+import { StrategyAdvisor } from './strategyAdvisor';
+
+interface BankrollLabelCache {
+	bankroll: number;
+	bet: number;
+	lastDelta: number;
+	label: string;
+}
+
+interface ShoeLabelCache {
+	cards: number;
+	rounds: number;
+	label: string;
+}
+
+interface StatsLabelCache {
+	wins: number;
+	losses: number;
+	pushes: number;
+	blackjacks: number;
+	bestBankroll: number;
+	label: string;
+}
+
+interface StatusColorCache {
+	outcome: RoundOutcome;
+	color: string;
+}
+
+export class BlackjackHudPresenter {
+	private readonly handValueFormatter = new HandValueFormatter();
+	private readonly strategyAdvisor = new StrategyAdvisor();
+	private bankrollLabelCache: BankrollLabelCache | null = null;
+	private shoeLabelCache: ShoeLabelCache | null = null;
+	private statsLabelCache: StatsLabelCache | null = null;
+	private statusColorCache: StatusColorCache | null = null;
+
+	values(state: BlackjackState, hideDealerHole: boolean): BlackjackHudValues {
+		return {
+			bankroll: this.bankrollLabel(state),
+			status: state.message,
+			statusColor: this.statusColor(state.outcome),
+			strategy: this.strategyAdvisor.getHint(state),
+			betChip: `$${state.bet}`,
+			dealerValue: this.handValueFormatter.label(
+				'dealer',
+				'Dealer',
+				state.dealer,
+				hideDealerHole ? 1 : state.dealer.length,
+			),
+			playerValue: this.handValueFormatter.label(
+				'player',
+				'Player',
+				state.player,
+			),
+			shoe: this.shoeLabel(state),
+			stats: this.statsLabel(state),
+		};
+	}
+
+	private bankrollLabel(state: BlackjackState): string {
+		const cached = this.bankrollLabelCache;
+		if (
+			cached &&
+			cached.bankroll === state.bankroll &&
+			cached.bet === state.bet &&
+			cached.lastDelta === state.lastDelta
+		) {
+			return cached.label;
+		}
+
+		const delta =
+			state.lastDelta === 0
+				? ''
+				: state.lastDelta > 0
+					? `  (+$${state.lastDelta})`
+					: `  (-$${Math.abs(state.lastDelta)})`;
+		const label = `Bankroll $${state.bankroll}\nBet $${state.bet}${delta}`;
+		this.bankrollLabelCache = {
+			bankroll: state.bankroll,
+			bet: state.bet,
+			lastDelta: state.lastDelta,
+			label,
+		};
+		return label;
+	}
+
+	private shoeLabel(state: BlackjackState): string {
+		const cards = state.shoe.length;
+		const cached = this.shoeLabelCache;
+		if (
+			cached &&
+			cached.cards === cards &&
+			cached.rounds === state.rounds
+		) {
+			return cached.label;
+		}
+
+		const label = `Shoe ${cards} cards\nRound ${state.rounds}`;
+		this.shoeLabelCache = {
+			cards,
+			rounds: state.rounds,
+			label,
+		};
+		return label;
+	}
+
+	private statsLabel(state: BlackjackState): string {
+		const { wins, losses, pushes, blackjacks, bestBankroll } = state.stats;
+		const cached = this.statsLabelCache;
+		if (
+			cached &&
+			cached.wins === wins &&
+			cached.losses === losses &&
+			cached.pushes === pushes &&
+			cached.blackjacks === blackjacks &&
+			cached.bestBankroll === bestBankroll
+		) {
+			return cached.label;
+		}
+
+		const label = `Session  W ${wins}  L ${losses}  P ${pushes}\nBJ ${blackjacks}  Best $${bestBankroll}`;
+		this.statsLabelCache = {
+			wins,
+			losses,
+			pushes,
+			blackjacks,
+			bestBankroll,
+			label,
+		};
+		return label;
+	}
+
+	private statusColor(outcome: RoundOutcome): string {
+		const cached = this.statusColorCache;
+		if (cached && cached.outcome === outcome) return cached.color;
+
+		const color = this.resolveStatusColor(outcome);
+		this.statusColorCache = {
+			outcome,
+			color,
+		};
+		return color;
+	}
+
+	private resolveStatusColor(outcome: RoundOutcome): string {
+		if (outcome === 'loss') return COLORS.danger;
+		if (outcome === 'push') return COLORS.muted;
+		if (outcome === 'win' || outcome === 'blackjack') return COLORS.gold;
+		return '#ffffff';
+	}
+}


### PR DESCRIPTION
## Summary
- move blackjack HUD value assembly out of `BlackjackScene` into a cached presenter
- cache bankroll, shoe, stats, and status color labels by their scalar inputs
- keep hand value and strategy caches composed behind the presenter while simplifying scene render code

## Validation
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/BlackjackScene.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackHudPresenter.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackHudPresenter.test.ts`
- `./kbve.sh -nx astro-kbve:test`
- `AXUM_PORT=4373 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`