### PR TITLE
fix(astro-kbve): extract account sign-in fallback to .astro component

### DIFF
--- a/apps/kbve/astro-kbve/src/components/wallet/AccountPage.astro
+++ b/apps/kbve/astro-kbve/src/components/wallet/AccountPage.astro
@@ -1,0 +1,42 @@
+---
+import AstroWalletCard from '@/components/wallet/AstroWalletCard.astro';
+import AccountSignInFallback from '@/components/wallet/AccountSignInFallback.astro';
+---
+
+<div class="not-content account-page">
+	<header class="account-page__header">
+		<h1>Account</h1>
+		<p>
+			Your wallet balance, credits, and KHash. Claim coupons here when
+			they land.
+		</p>
+	</header>
+
+	<AstroWalletCard />
+	<AccountSignInFallback />
+</div>
+
+<style>
+	.account-page {
+		max-width: 760px;
+		margin: 1.5rem auto 4rem;
+		padding: 0 1rem;
+	}
+	.account-page__header {
+		display: grid;
+		gap: 0.35rem;
+		margin-bottom: 1.25rem;
+	}
+	.account-page__header h1 {
+		font-size: clamp(1.75rem, 3.5vw, 2.25rem);
+		font-weight: 800;
+		letter-spacing: -0.01em;
+		margin: 0;
+	}
+	.account-page__header p {
+		margin: 0;
+		color: rgba(255, 255, 255, 0.6);
+		font-size: 0.95rem;
+		line-height: 1.5;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/wallet/AccountSignInFallback.astro
+++ b/apps/kbve/astro-kbve/src/components/wallet/AccountSignInFallback.astro
@@ -1,0 +1,67 @@
+---
+
+---
+
+<aside class="account-signin" data-account-signin>
+	<h2>Sign in to view your wallet</h2>
+	<p>You need a KBVE account to see balances or claim coupons.</p>
+	<a class="account-signin__btn" href="/login/">Sign in</a>
+</aside>
+
+<script>
+	const fallback = document.querySelector('[data-account-signin]');
+	const wallet = document.querySelector('[data-kbve-wallet-shell]');
+	if (fallback && wallet) {
+		const sync = () => {
+			if (!wallet.hasAttribute('hidden')) {
+				fallback.setAttribute('hidden', '');
+			}
+		};
+		sync();
+		new MutationObserver(sync).observe(wallet, {
+			attributes: true,
+			attributeFilter: ['hidden'],
+		});
+	}
+</script>
+
+<style>
+	.account-signin {
+		margin-top: 1.25rem;
+		padding: 1.25rem;
+		border-radius: 16px;
+		background: rgba(15, 23, 42, 0.6);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		color: rgba(255, 255, 255, 0.85);
+		text-align: center;
+	}
+	.account-signin[hidden] {
+		display: none;
+	}
+	.account-signin h2 {
+		margin: 0 0 0.4rem;
+		font-size: 1.1rem;
+		font-weight: 700;
+	}
+	.account-signin p {
+		margin: 0 0 1rem;
+		font-size: 0.9rem;
+		color: rgba(255, 255, 255, 0.6);
+	}
+	.account-signin__btn {
+		display: inline-block;
+		padding: 0.55rem 1.1rem;
+		border-radius: 10px;
+		background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+		color: white;
+		font-weight: 600;
+		text-decoration: none;
+		transition:
+			transform 0.12s ease,
+			box-shadow 0.12s ease;
+	}
+	.account-signin__btn:hover {
+		transform: translateY(-1px);
+		box-shadow: 0 10px 24px rgba(99, 102, 241, 0.4);
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/content/docs/profile/account.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/profile/account.mdx
@@ -15,6 +15,7 @@ tags:
 ---
 
 import AstroWalletCard from '@/components/wallet/AstroWalletCard.astro';
+import AccountSignInFallback from '@/components/wallet/AccountSignInFallback.astro';
 
 <div class="not-content account-page">
 	<header class="account-page__header">
@@ -26,35 +27,8 @@ import AstroWalletCard from '@/components/wallet/AstroWalletCard.astro';
 	</header>
 
 	<AstroWalletCard />
-
-	<aside class="account-page__signin" data-account-signin>
-		<h2>Sign in to view your wallet</h2>
-		<p>
-			You need a KBVE account to see balances or claim coupons.
-		</p>
-		<a class="account-page__signin-btn" href="/login/">Sign in</a>
-	</aside>
+	<AccountSignInFallback />
 </div>
-
-<script>
-	// Hide the sign-in fallback as soon as the wallet card becomes visible
-	// (its [hidden] attribute is cleared by ReactWalletCard once a balance
-	// loads). Until then, anon visitors still see a useful prompt.
-	const fallback = document.querySelector('[data-account-signin]');
-	const wallet = document.querySelector('[data-kbve-wallet-shell]');
-	if (fallback && wallet) {
-		const sync = () => {
-			if (!wallet.hasAttribute('hidden')) {
-				fallback.setAttribute('hidden', '');
-			}
-		};
-		sync();
-		new MutationObserver(sync).observe(wallet, {
-			attributes: true,
-			attributeFilter: ['hidden'],
-		});
-	}
-</script>
 
 <style>
 	.account-page {
@@ -78,41 +52,5 @@ import AstroWalletCard from '@/components/wallet/AstroWalletCard.astro';
 		color: rgba(255, 255, 255, 0.6);
 		font-size: 0.95rem;
 		line-height: 1.5;
-	}
-	.account-page__signin {
-		margin-top: 1.25rem;
-		padding: 1.25rem;
-		border-radius: 16px;
-		background: rgba(15, 23, 42, 0.6);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		color: rgba(255, 255, 255, 0.85);
-		text-align: center;
-	}
-	.account-page__signin[hidden] {
-		display: none;
-	}
-	.account-page__signin h2 {
-		margin: 0 0 0.4rem;
-		font-size: 1.1rem;
-		font-weight: 700;
-	}
-	.account-page__signin p {
-		margin: 0 0 1rem;
-		font-size: 0.9rem;
-		color: rgba(255, 255, 255, 0.6);
-	}
-	.account-page__signin-btn {
-		display: inline-block;
-		padding: 0.55rem 1.1rem;
-		border-radius: 10px;
-		background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
-		color: white;
-		font-weight: 600;
-		text-decoration: none;
-		transition: transform 0.12s ease, box-shadow 0.12s ease;
-	}
-	.account-page__signin-btn:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 10px 24px rgba(99, 102, 241, 0.4);
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/content/docs/profile/account.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/profile/account.mdx
@@ -14,43 +14,6 @@ tags:
     - wallet
 ---
 
-import AstroWalletCard from '@/components/wallet/AstroWalletCard.astro';
-import AccountSignInFallback from '@/components/wallet/AccountSignInFallback.astro';
+import AccountPage from '@/components/wallet/AccountPage.astro';
 
-<div class="not-content account-page">
-	<header class="account-page__header">
-		<h1>Account</h1>
-		<p>
-			Your wallet balance, credits, and KHash. Claim coupons here when
-			they land.
-		</p>
-	</header>
-
-	<AstroWalletCard />
-	<AccountSignInFallback />
-</div>
-
-<style>
-	.account-page {
-		max-width: 760px;
-		margin: 1.5rem auto 4rem;
-		padding: 0 1rem;
-	}
-	.account-page__header {
-		display: grid;
-		gap: 0.35rem;
-		margin-bottom: 1.25rem;
-	}
-	.account-page__header h1 {
-		font-size: clamp(1.75rem, 3.5vw, 2.25rem);
-		font-weight: 800;
-		letter-spacing: -0.01em;
-		margin: 0;
-	}
-	.account-page__header p {
-		margin: 0;
-		color: rgba(255, 255, 255, 0.6);
-		font-size: 0.95rem;
-		line-height: 1.5;
-	}
-</style>
+<AccountPage />


### PR DESCRIPTION
## Summary

MDX 3 parser interprets \`<script>\` body in [apps/kbve/astro-kbve/src/content/docs/profile/account.mdx](apps/kbve/astro-kbve/src/content/docs/profile/account.mdx) as JSX text and trips on the \`{\` of arrow-function bodies (\`() => {\`). Build fails with:

\`\`\`
[@mdx-js/rollup] Could not parse expression with acorn
file: /app/apps/kbve/astro-kbve/src/content/docs/profile/account.mdx:46:3
Caused by: Unexpected token
\`\`\`

This broke the latest main-release docker run ([25840350698](https://github.com/KBVE/kbve/actions/runs/25840350698/job/75924188229)) — astro build aborts after 39s, the astro-precompressor stage then 404s on its \`COPY --from=astro-builder /app/dist/apps/astro-kbve /static\` step.

## Fix

Move the sign-in fallback \`<aside>\`, the MutationObserver \`<script>\`, and the related styles out of the MDX into a new \`AccountSignInFallback.astro\` component. The MDX file now only contains content + page-level layout styles, so MDX never has to parse JS curly braces.

Introduced by #10957. Behaviour is identical — same selectors, same MutationObserver logic, same CSS modulo class names.

## Verified

- \`npx astro sync\` from \`apps/kbve/astro-kbve/\` completes cleanly, no MDX/acorn errors.
- The pre-existing \`[router] /account vs /account/\` warning is unchanged (unrelated, from the redirect config in #10957).

## Test plan

- [ ] PR CI: \`docker-test-app.yml\` succeeds (astro-builder produces \`/app/dist/apps/astro-kbve\`).
- [ ] Manually navigate to \`/profile/account/\` after deploy — anon user sees the sign-in fallback; signed-in user sees the wallet card and the fallback is hidden by the MutationObserver.