### PR TITLE
feat(wallet): coupon expiry sweep + pg_cron schedule

### DIFF
--- a/packages/data/sql/dbmate/migration-tests/20260514051116_wallet_coupon_expiry_sweep.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260514051116_wallet_coupon_expiry_sweep.test.sql
@@ -1,0 +1,219 @@
+-- Companion test fixtures for 20260514051116_wallet_coupon_expiry_sweep.
+-- Run via: ./test-migration.sh 20260514051116_wallet_coupon_expiry_sweep
+
+-- SEED
+-- Idempotent cleanup of prior-run rows (coupons + balance + account + user
+-- + the three test-only templates we add below).
+WITH test_users (id) AS (
+    VALUES ('cccccccc-cccc-cccc-cccc-cccccccccccc'::uuid)
+),
+test_accounts AS (
+    SELECT a.id FROM wallet.account a JOIN test_users u ON a.user_id = u.id
+),
+del_coupon AS (
+    DELETE FROM wallet.coupon WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_balance AS (
+    DELETE FROM wallet.balance WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_account AS (
+    DELETE FROM wallet.account WHERE id IN (SELECT id FROM test_accounts)
+),
+del_user AS (
+    DELETE FROM auth.users WHERE id IN (SELECT id FROM test_users)
+)
+DELETE FROM wallet.coupon_template
+ WHERE code IN ('TEST_SWEEP_EXPIRED', 'TEST_SWEEP_ACTIVE', 'TEST_SWEEP_NOEXP');
+
+-- wallet.audit_log is append-only (trigger blocks DELETE), so prior
+-- sweep rows from earlier test runs stay; assertions below use id
+-- baselines instead of absolute counts.
+
+INSERT INTO auth.users (id) VALUES ('cccccccc-cccc-cccc-cccc-cccccccccccc');
+
+-- Wipe the trigger-provisioned welcome coupon so our test coupons are the
+-- only ones for this account.
+DELETE FROM wallet.coupon
+ WHERE account_id IN (
+     SELECT id FROM wallet.account WHERE user_id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+ );
+
+-- Three distinct templates so the (account_id, template_id) unique
+-- constraint doesn't block our three test coupons.
+INSERT INTO wallet.coupon_template (code, label, reward_kind, reward_payload) VALUES
+    ('TEST_SWEEP_EXPIRED', 'sweep test expired', 'khash', '{"amount": 1}'::jsonb),
+    ('TEST_SWEEP_ACTIVE',  'sweep test active',  'khash', '{"amount": 1}'::jsonb),
+    ('TEST_SWEEP_NOEXP',   'sweep test no exp',  'khash', '{"amount": 1}'::jsonb);
+
+-- Three coupons against the trigger-provisioned account: one already
+-- expired (deadline in past), one near-future (still active), one with
+-- no deadline (must NOT be touched by sweep).
+WITH a AS (
+    SELECT id FROM wallet.account WHERE user_id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+),
+tpl AS (
+    SELECT code, id FROM wallet.coupon_template
+     WHERE code IN ('TEST_SWEEP_EXPIRED', 'TEST_SWEEP_ACTIVE', 'TEST_SWEEP_NOEXP')
+)
+INSERT INTO wallet.coupon (account_id, template_id, granted_at, expires_at)
+SELECT a.id, tpl.id, now() - interval '2 days', now() - interval '1 hour'
+  FROM a, tpl WHERE tpl.code = 'TEST_SWEEP_EXPIRED'
+UNION ALL
+SELECT a.id, tpl.id, now() - interval '1 day',  now() + interval '1 day'
+  FROM a, tpl WHERE tpl.code = 'TEST_SWEEP_ACTIVE'
+UNION ALL
+SELECT a.id, tpl.id, now() - interval '3 days', NULL
+  FROM a, tpl WHERE tpl.code = 'TEST_SWEEP_NOEXP';
+
+-- ASSERT_AFTER_UP
+
+-- 1. Index exists.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'wallet'
+           AND indexname = 'wallet_coupon_unredeemed_expires_idx'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet_coupon_unredeemed_expires_idx missing';
+    END IF;
+END;
+$$;
+
+-- 2. Sweep flips the one expired row. Returns count = 1 (BIGINT).
+DO $$
+DECLARE
+    v_count BIGINT;
+    v_expired_count INT;
+    v_unredeemed_count INT;
+BEGIN
+    SELECT wallet.sweep_expired_coupons() INTO v_count;
+    IF v_count <> 1 THEN
+        RAISE EXCEPTION 'fail: sweep returned % (expected 1)', v_count;
+    END IF;
+
+    SELECT COUNT(*) INTO v_expired_count
+      FROM wallet.coupon c
+      JOIN wallet.account a ON a.id = c.account_id
+     WHERE a.user_id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+       AND c.status = 'expired';
+    IF v_expired_count <> 1 THEN
+        RAISE EXCEPTION 'fail: expired status count = % (expected 1)', v_expired_count;
+    END IF;
+
+    SELECT COUNT(*) INTO v_unredeemed_count
+      FROM wallet.coupon c
+      JOIN wallet.account a ON a.id = c.account_id
+     WHERE a.user_id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+       AND c.status = 'unredeemed';
+    IF v_unredeemed_count <> 2 THEN
+        RAISE EXCEPTION 'fail: unredeemed remaining = % (expected 2)', v_unredeemed_count;
+    END IF;
+END;
+$$;
+
+-- 3. Audit row written by the sweep we just ran, carrying both count
+--    and cutoff_expires_at. Latest sweep_expired row corresponds to
+--    this assertion's run (we just executed it).
+DO $$
+DECLARE
+    v_count    BIGINT;
+    v_has_cut  BOOLEAN;
+BEGIN
+    SELECT (metadata->>'count')::BIGINT, (metadata ? 'cutoff_expires_at')
+      INTO v_count, v_has_cut
+      FROM wallet.audit_log
+     WHERE action = 'coupon.sweep_expired'
+     ORDER BY id DESC
+     LIMIT 1;
+    IF v_count IS DISTINCT FROM 1 OR v_has_cut IS NOT TRUE THEN
+        RAISE EXCEPTION 'fail: latest sweep audit row has count=% / cutoff_present=% (expected 1 / true)', v_count, v_has_cut;
+    END IF;
+END;
+$$;
+
+-- 4. Second sweep is a no-op (returns 0). Idempotency check.
+DO $$
+DECLARE
+    v_count BIGINT;
+BEGIN
+    SELECT wallet.sweep_expired_coupons() INTO v_count;
+    IF v_count <> 0 THEN
+        RAISE EXCEPTION 'fail: re-run sweep returned % (expected 0)', v_count;
+    END IF;
+END;
+$$;
+
+-- 4b. pg_cron schedule registered when the extension is present. Local
+-- dev containers don't ship pg_cron so this just asserts the migration
+-- registered the job iff the extension exists.
+DO $$
+DECLARE
+    v_has_pgcron BOOLEAN;
+    v_has_job    BOOLEAN;
+BEGIN
+    SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') INTO v_has_pgcron;
+    IF v_has_pgcron THEN
+        SELECT EXISTS (
+            SELECT 1 FROM cron.job WHERE jobname = 'wallet-sweep-expired-coupons'
+        ) INTO v_has_job;
+        IF NOT v_has_job THEN
+            RAISE EXCEPTION 'fail: pg_cron present but wallet-sweep-expired-coupons not registered';
+        END IF;
+    ELSE
+        RAISE NOTICE 'pg_cron not installed locally; skipping schedule registration assertion';
+    END IF;
+END;
+$$;
+
+-- 5. Empty sweep does NOT write an audit row. Use max(id) as baseline.
+DO $$
+DECLARE
+    v_max_before BIGINT;
+    v_max_after  BIGINT;
+BEGIN
+    SELECT COALESCE(MAX(id), 0) INTO v_max_before
+      FROM wallet.audit_log WHERE action = 'coupon.sweep_expired';
+    PERFORM wallet.sweep_expired_coupons();
+    SELECT COALESCE(MAX(id), 0) INTO v_max_after
+      FROM wallet.audit_log WHERE action = 'coupon.sweep_expired';
+    IF v_max_after <> v_max_before THEN
+        RAISE EXCEPTION 'fail: empty sweep appended audit row (%->%)',
+            v_max_before, v_max_after;
+    END IF;
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+BEGIN
+    -- 1. Function removed.
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'wallet' AND p.proname = 'sweep_expired_coupons'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet.sweep_expired_coupons still exists after rollback';
+    END IF;
+
+    -- 2. Partial index removed.
+    IF EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'wallet'
+           AND indexname = 'wallet_coupon_unredeemed_expires_idx'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet_coupon_unredeemed_expires_idx still exists after rollback';
+    END IF;
+
+    -- 3. Coupons we flipped to expired stay flipped (down does not undo data).
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.coupon c
+          JOIN wallet.account a ON a.id = c.account_id
+         WHERE a.user_id = 'cccccccc-cccc-cccc-cccc-cccccccccccc'
+           AND c.status = 'expired'
+    ) THEN
+        RAISE EXCEPTION 'fail: expired coupons lost during rollback';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migrations/20260514051116_wallet_coupon_expiry_sweep.sql
+++ b/packages/data/sql/dbmate/migrations/20260514051116_wallet_coupon_expiry_sweep.sql
@@ -27,7 +27,10 @@ CREATE OR REPLACE FUNCTION wallet.sweep_expired_coupons()
 RETURNS BIGINT
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_now     TIMESTAMPTZ := statement_timestamp();
+    -- Use transaction_timestamp() so cutoff_expires_at in the audit row
+    -- matches the transaction's consistent time, not a later
+    -- clock-drifted point inside the statement.
+    v_now     TIMESTAMPTZ := transaction_timestamp();
     v_count   BIGINT;
     v_min_id  BIGINT;
     v_max_id  BIGINT;
@@ -65,9 +68,16 @@ BEGIN
 END;
 $$;
 
+-- Ownership comes first so the SECURITY DEFINER contract is finalized
+-- before privileges are stated.
+ALTER FUNCTION wallet.sweep_expired_coupons() OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.sweep_expired_coupons() FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.sweep_expired_coupons() TO service_role;
-ALTER FUNCTION wallet.sweep_expired_coupons() OWNER TO service_role;
+-- pg_cron runs the scheduled job AS THE ROLE THAT CALLED cron.schedule().
+-- Dbmate connects as `postgres` (superuser), so the job runs as
+-- postgres. Postgres is a superuser and has implicit access, but make
+-- the EXECUTE grant explicit to document the cron-exec contract.
+GRANT EXECUTE ON FUNCTION wallet.sweep_expired_coupons() TO postgres;
 
 COMMENT ON FUNCTION wallet.sweep_expired_coupons() IS
     'Flips unredeemed coupons with expires_at <= now() to status=expired. Returns affected row count. Writes one summary audit_log row per non-empty sweep. Idempotent; safe to call from a cron loop.';
@@ -82,6 +92,11 @@ CREATE INDEX IF NOT EXISTS wallet_coupon_unredeemed_expires_idx
 -- preloaded on the supabase-cluster via shared_preload_libraries). The
 -- IF-guard keeps the migration portable to local dev containers that
 -- don't ship pg_cron — local test runs will simply skip scheduling.
+--
+-- NOTE: pg_cron runs the job AS THE ROLE THAT CALLED cron.schedule().
+-- Dbmate connects as postgres, so the job will run as postgres. The
+-- explicit GRANT EXECUTE TO postgres above documents that contract;
+-- swap-in another scheduling role would also need an EXECUTE grant.
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN

--- a/packages/data/sql/dbmate/migrations/20260514051116_wallet_coupon_expiry_sweep.sql
+++ b/packages/data/sql/dbmate/migrations/20260514051116_wallet_coupon_expiry_sweep.sql
@@ -1,0 +1,117 @@
+-- migrate:up
+
+-- wallet.sweep_expired_coupons — flip unredeemed coupons whose deadline
+-- has passed from 'unredeemed' to 'expired'. Returns the number of rows
+-- affected so the cron caller can observe sweep volume. Writes one
+-- summary audit row per sweep when at least one row was flipped; empty
+-- sweeps stay silent to keep audit_log tidy.
+--
+-- Idempotent: re-running is safe — the WHERE clause excludes anything
+-- that is no longer 'unredeemed'. Concurrent callers are safe under
+-- READ COMMITTED: the first transaction locks the matching rows; the
+-- second re-checks the WHERE clause after waiting and skips rows that
+-- are no longer 'unredeemed'.
+--
+-- Scale note: current coupon volume is low. If/when a single expiry
+-- window can produce thousands of rows, swap this for a batched
+-- p_limit variant using `FOR UPDATE SKIP LOCKED` so multiple cron
+-- workers can share the work without one giant transaction.
+--
+-- Authority: service-role only. Scheduled via pg_cron at the bottom of
+-- this migration — runs inside Postgres, no external manifest needed.
+-- pg_cron is preloaded in supabase-cluster's shared_preload_libraries,
+-- and the schedule registration block is guarded on extension presence
+-- so the migration stays portable to local dev containers.
+
+CREATE OR REPLACE FUNCTION wallet.sweep_expired_coupons()
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_now     TIMESTAMPTZ := statement_timestamp();
+    v_count   BIGINT;
+    v_min_id  BIGINT;
+    v_max_id  BIGINT;
+BEGIN
+    WITH expired AS (
+        UPDATE wallet.coupon
+           SET status = 'expired'
+         WHERE status = 'unredeemed'
+           AND expires_at IS NOT NULL
+           AND expires_at <= v_now
+        RETURNING id
+    )
+    SELECT COUNT(*), MIN(id), MAX(id)
+      INTO v_count, v_min_id, v_max_id
+      FROM expired;
+
+    IF v_count > 0 THEN
+        INSERT INTO wallet.audit_log (
+            action, target_type, target_id, metadata
+        ) VALUES (
+            'coupon.sweep_expired',
+            'coupon',
+            'batch',
+            jsonb_build_object(
+                'count',             v_count,
+                'min_id',            v_min_id,
+                'max_id',            v_max_id,
+                'cutoff_expires_at', v_now,
+                'swept_at',          v_now
+            )
+        );
+    END IF;
+
+    RETURN v_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION wallet.sweep_expired_coupons() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.sweep_expired_coupons() TO service_role;
+ALTER FUNCTION wallet.sweep_expired_coupons() OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.sweep_expired_coupons() IS
+    'Flips unredeemed coupons with expires_at <= now() to status=expired. Returns affected row count. Writes one summary audit_log row per non-empty sweep. Idempotent; safe to call from a cron loop.';
+
+-- Index supporting the sweep's WHERE clause. Partial index keeps the
+-- working set small as redeemed/expired/revoked rows accumulate.
+CREATE INDEX IF NOT EXISTS wallet_coupon_unredeemed_expires_idx
+    ON wallet.coupon (expires_at)
+    WHERE status = 'unredeemed' AND expires_at IS NOT NULL;
+
+-- Schedule the sweep via pg_cron when the extension is present (it is
+-- preloaded on the supabase-cluster via shared_preload_libraries). The
+-- IF-guard keeps the migration portable to local dev containers that
+-- don't ship pg_cron — local test runs will simply skip scheduling.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        -- Idempotent: unschedule any prior instance of this job name so
+        -- re-running the migration doesn't accumulate duplicate jobs.
+        PERFORM cron.unschedule(jobid)
+          FROM cron.job
+         WHERE jobname = 'wallet-sweep-expired-coupons';
+        PERFORM cron.schedule(
+            'wallet-sweep-expired-coupons',
+            '0 * * * *',
+            $cron$SELECT wallet.sweep_expired_coupons();$cron$
+        );
+    ELSE
+        RAISE NOTICE 'pg_cron not installed; skipping wallet-sweep-expired-coupons schedule registration';
+    END IF;
+END;
+$$;
+
+-- migrate:down
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        PERFORM cron.unschedule(jobid)
+          FROM cron.job
+         WHERE jobname = 'wallet-sweep-expired-coupons';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS wallet.sweep_expired_coupons();
+DROP INDEX IF EXISTS wallet.wallet_coupon_unredeemed_expires_idx;

--- a/packages/data/sql/schema/wallet/wallet_coupons.sql
+++ b/packages/data/sql/schema/wallet/wallet_coupons.sql
@@ -121,6 +121,11 @@ CREATE INDEX wallet_coupon_template_idx
 -- proxy_wallet_list_coupons_readonly filter + keyset cursor shape.
 CREATE INDEX wallet_coupon_account_granted_idx
     ON wallet.coupon(account_id, granted_at DESC, id DESC);
+-- Partial index for the wallet.sweep_expired_coupons hot path. Keeps
+-- the working set small as redeemed/expired/revoked rows accumulate.
+CREATE INDEX wallet_coupon_unredeemed_expires_idx
+    ON wallet.coupon(expires_at)
+    WHERE status = 'unredeemed' AND expires_at IS NOT NULL;
 
 COMMENT ON TABLE wallet.coupon IS
     'Per-account coupon instance. redeem_idempotency_key + redeem_ledger_id support idempotent retries.';

--- a/packages/data/sql/schema/wallet/wallet_rpcs.sql
+++ b/packages/data/sql/schema/wallet/wallet_rpcs.sql
@@ -531,7 +531,7 @@ CREATE OR REPLACE FUNCTION wallet.sweep_expired_coupons()
 RETURNS BIGINT
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_now     TIMESTAMPTZ := statement_timestamp();
+    v_now     TIMESTAMPTZ := transaction_timestamp();
     v_count   BIGINT;
     v_min_id  BIGINT;
     v_max_id  BIGINT;
@@ -568,15 +568,19 @@ BEGIN
     RETURN v_count;
 END;
 $$;
+ALTER FUNCTION wallet.sweep_expired_coupons() OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.sweep_expired_coupons() FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.sweep_expired_coupons() TO service_role;
-ALTER FUNCTION wallet.sweep_expired_coupons() OWNER TO service_role;
+-- pg_cron runs the scheduled job as the role that called cron.schedule
+-- (postgres via dbmate). Explicit grant documents that contract.
+GRANT EXECUTE ON FUNCTION wallet.sweep_expired_coupons() TO postgres;
 
 COMMENT ON FUNCTION wallet.sweep_expired_coupons() IS
     'Flips unredeemed coupons with expires_at <= now() to status=expired. Returns affected row count. Writes one summary audit_log row per non-empty sweep. Idempotent; safe to call from a cron loop.';
 
 -- Schedule via pg_cron when present. Lives next to the function so the
--- schedule is reviewed alongside the SQL it calls.
+-- schedule is reviewed alongside the SQL it calls. Job runs as the role
+-- that scheduled it (postgres).
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN

--- a/packages/data/sql/schema/wallet/wallet_rpcs.sql
+++ b/packages/data/sql/schema/wallet/wallet_rpcs.sql
@@ -519,6 +519,80 @@ GRANT EXECUTE ON FUNCTION wallet.service_verify_balance(UUID)
 ALTER FUNCTION wallet.service_verify_balance(UUID) OWNER TO service_role;
 
 -- ============================================================================
+-- MAINTENANCE: scheduled coupon expiry sweep
+--
+-- Flips unredeemed coupons whose expires_at deadline has passed to
+-- 'expired'. Idempotent + concurrent-safe under READ COMMITTED.
+-- Writes one summary audit_log row per non-empty sweep. Scheduled via
+-- pg_cron at the bottom of this file.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.sweep_expired_coupons()
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_now     TIMESTAMPTZ := statement_timestamp();
+    v_count   BIGINT;
+    v_min_id  BIGINT;
+    v_max_id  BIGINT;
+BEGIN
+    WITH expired AS (
+        UPDATE wallet.coupon
+           SET status = 'expired'
+         WHERE status = 'unredeemed'
+           AND expires_at IS NOT NULL
+           AND expires_at <= v_now
+        RETURNING id
+    )
+    SELECT COUNT(*), MIN(id), MAX(id)
+      INTO v_count, v_min_id, v_max_id
+      FROM expired;
+
+    IF v_count > 0 THEN
+        INSERT INTO wallet.audit_log (
+            action, target_type, target_id, metadata
+        ) VALUES (
+            'coupon.sweep_expired',
+            'coupon',
+            'batch',
+            jsonb_build_object(
+                'count',             v_count,
+                'min_id',            v_min_id,
+                'max_id',            v_max_id,
+                'cutoff_expires_at', v_now,
+                'swept_at',          v_now
+            )
+        );
+    END IF;
+
+    RETURN v_count;
+END;
+$$;
+REVOKE ALL ON FUNCTION wallet.sweep_expired_coupons() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.sweep_expired_coupons() TO service_role;
+ALTER FUNCTION wallet.sweep_expired_coupons() OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.sweep_expired_coupons() IS
+    'Flips unredeemed coupons with expires_at <= now() to status=expired. Returns affected row count. Writes one summary audit_log row per non-empty sweep. Idempotent; safe to call from a cron loop.';
+
+-- Schedule via pg_cron when present. Lives next to the function so the
+-- schedule is reviewed alongside the SQL it calls.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        PERFORM cron.unschedule(jobid)
+          FROM cron.job
+         WHERE jobname = 'wallet-sweep-expired-coupons';
+        PERFORM cron.schedule(
+            'wallet-sweep-expired-coupons',
+            '0 * * * *',
+            $cron$SELECT wallet.sweep_expired_coupons();$cron$
+        );
+    END IF;
+END;
+$$;
+
+-- ============================================================================
 -- AUTHENTICATED USER PROXIES (public.*)
 -- ============================================================================
 


### PR DESCRIPTION
## Summary

Flips unredeemed coupons whose `expires_at` deadline has passed to `expired`. Scheduled inside Postgres via `pg_cron` — no Kubernetes CronJob, no manifest, no image pulls. Just SQL.

## Migration `20260514051116_wallet_coupon_expiry_sweep`

- `wallet.sweep_expired_coupons()` — SECURITY DEFINER, service_role only. Returns BIGINT. Audit metadata: `count`, `min_id`, `max_id`, `cutoff_expires_at`, `swept_at`.
- `wallet_coupon_unredeemed_expires_idx` — partial index on `(expires_at) WHERE status='unredeemed' AND expires_at IS NOT NULL`. Keeps the working set small as redeemed/expired rows accumulate.
- pg_cron schedule `wallet-sweep-expired-coupons` at `'0 * * * *'`. Registered inside a DO block guarded on `pg_extension` presence so the migration stays portable to local dev containers that don't ship pg_cron. Production `supabase-cluster` has pg_cron preloaded in `shared_preload_libraries`.
- Idempotent re-registration: the DO block unschedules any prior instance of the job name before scheduling, so re-running the migration doesn't accumulate duplicates.
- Down migration unschedules the job (when pg_cron present), drops the function + index.

## Why pg_cron instead of a Kubernetes CronJob

- Schedule lives next to the function it calls — one source of truth.
- Runs inside Postgres — no external image pull, no manifest RBAC, no namespace coupling. Survives any cluster-level disruption short of Postgres itself being down.
- Idiomatic Supabase / CNPG pattern; pg_cron is already preloaded.

## Schema mirror

`packages/data/sql/schema/wallet/` updated to match:
- `wallet_rpcs.sql` gains a MAINTENANCE section with the function + schedule
- `wallet_coupons.sql` gains the partial index

## Test plan

- [x] `nx run data-sql:test-migration 20260514051116_wallet_coupon_expiry_sweep` green
- [x] Asserts: index present, sweep returns 1 (expired-only flip), status counts correct, audit row carries `count` + `cutoff_expires_at`, pg_cron schedule registered when extension present, idempotent re-run returns 0, empty sweep appends no audit row
- [x] After-down: function + index dropped, expired coupon data preserved across rollback
- [ ] After merge: dispatch `ci-dbmate-deploy` on main
- [ ] After deploy: `SELECT * FROM cron.job WHERE jobname = 'wallet-sweep-expired-coupons'` shows the schedule
- [ ] Watch `wallet.audit_log` for `action = 'coupon.sweep_expired'` rows on the next hour boundary