### PR TITLE
chore(codegen): move barrel-check.ts under packages/data/codegen

### DIFF
--- a/packages/data/codegen/barrel-check.ts
+++ b/packages/data/codegen/barrel-check.ts
@@ -1,0 +1,31 @@
+import {
+	VmSpecSchema,
+	VmStatuses,
+	UUIDSchema,
+	VmRateCardSchema,
+	CreateVmRequestSchema,
+	CreateVmResponseSchema,
+	PersistentEndpointSchema,
+	DeploymentTiers,
+	EndpointStatuses,
+	WorkflowStatuses,
+	QuoteCostRequestSchema,
+	RateCardUpdateSchema,
+	CiProjectSchema,
+} from './generated/index.js';
+
+export const _smoke = {
+	VmSpecSchema,
+	VmStatuses,
+	UUIDSchema,
+	VmRateCardSchema,
+	CreateVmRequestSchema,
+	CreateVmResponseSchema,
+	PersistentEndpointSchema,
+	DeploymentTiers,
+	EndpointStatuses,
+	WorkflowStatuses,
+	QuoteCostRequestSchema,
+	RateCardUpdateSchema,
+	CiProjectSchema,
+};


### PR DESCRIPTION
## Summary
`.barrel-check.ts` was sitting at the repo root as an untracked scratch file. It's a smoke test that imports a specific spread of named exports from `packages/data/codegen/generated/index.ts` so that if codegen drops a symbol from the public barrel a tsc pass catches it. The file belongs next to the thing it's checking.

- Move to `packages/data/codegen/barrel-check.ts`.
- Switch the import path from the workspace-rooted `./packages/data/codegen/generated/index` to the relative `./generated/index.js`.

No behavior change beyond location. The file is still off the nx graph — adding a target to wire it into CI is a separate concern.

## Note (out of scope)
Running `tsc` against `packages/data/codegen/generated/index.ts` surfaces unrelated `TS2308` duplicate-export ambiguity errors (e.g. `ReportReasonSchema` re-exported by both `forum-schema` and a sibling, same for `Item` / `ItemSchema` / `Elements` / a few others). The codegen barrel needs a deduplication pass — separate PR.