### PR TITLE
fix(ci): allow Cargo.lock in auto-merge bot validator for crate atom PRs

### DIFF
--- a/.github/workflows/ci-auto-merge-bot-prs.yml
+++ b/.github/workflows/ci-auto-merge-bot-prs.yml
@@ -217,6 +217,17 @@ jobs:
                         }
                         core.info(`Found '${appName}' in manifest (pipeline: ${entry.pipeline})`);
 
+                        // utils-post-publish.yml + utils-update-version-toml.yml
+                        // both bump Cargo.lock alongside Cargo.toml for crate
+                        // releases so fresh checkouts don't regenerate the
+                        // lock on the first `cargo` run. Allow it here when
+                        // the app's version_target is a Cargo.toml — without
+                        // this gate, post-publish atom PRs for any axum/bevy
+                        // crate fail validation on the lockfile.
+                        const versionTargetIsCargo =
+                          typeof entry.version_target === 'string' &&
+                          entry.version_target.endsWith('Cargo.toml');
+
                         const allowedFiles = new Set(
                           [
                             entry.version_toml,
@@ -224,6 +235,7 @@ jobs:
                             entry.deployment_yaml,
                             ...(Array.isArray(entry.deployment_yamls) ? entry.deployment_yamls : []),
                             '.github/ci-dispatch-manifest.json',
+                            ...(versionTargetIsCargo ? ['Cargo.lock'] : []),
                           ]
                             .filter(Boolean)
                             .map(sanitize)


### PR DESCRIPTION
## Summary
Direct fix for the blocker on #10966.

`utils-post-publish.yml` (#10930) and `utils-update-version-toml.yml` (#10947) both started adding `Cargo.lock` to post-publish atom PRs so fresh checkouts no longer regenerate the lockfile on the first `cargo` invocation. The first such atom PR — **#10966** (\`atom-post-publish-axum-kbve-v1.0.154\`) — was rejected by \`ci-auto-merge-bot-prs.yml\` with:

> \`PR modifies files not in manifest for 'axum-kbve': Cargo.lock\`

Because the validator's per-app allowlist was derived only from \`version_toml\`, \`version_target\`, \`deployment_yaml(s)\`, and \`.github/ci-dispatch-manifest.json\`. \`Cargo.lock\` wasn't on the list.

## Change
Allow \`Cargo.lock\` when the manifest entry's \`version_target\` ends with \`Cargo.toml\` — the same gate the publish workflows use to decide whether to bump the lock at all. Validator and bumpers now stay in sync.

## After this lands
- **#10966** (axum-kbve v1.0.154) just needs an auto-merge bot re-run:
  \`\`\`
  gh workflow run ci-auto-merge-bot-prs.yml --field pr_number=10966
  \`\`\`
- Future post-publish atom PRs with a Cargo.lock bump auto-merge as designed.