### PR TITLE
perf(arcade): tighten blackjack hand layout

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/handLayout.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/handLayout.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { encodeCard } from '../cards';
+import { CARD_SIZE } from '../config';
+import { HandLayout } from './handLayout';
+
+describe('blackjack hand layout', () => {
+	it('precomputes centered card placements with stable spacing', () => {
+		const layout = new HandLayout((card) => `card-${card}`);
+		const cards = [
+			encodeCard('spades', 'A'),
+			encodeCard('clubs', 'K'),
+			encodeCard('diamonds', '3'),
+		];
+		const cardGap = 18;
+		const cardStride = CARD_SIZE.width + cardGap;
+		const firstX = 640 - (CARD_SIZE.width * cards.length + cardGap * 2) / 2;
+
+		const placements = layout.cardPlacements(
+			cards,
+			640,
+			420,
+			false,
+			'player',
+		);
+
+		expect(placements).toHaveLength(3);
+		expect(placements.map((placement) => placement.x)).toEqual([
+			firstX,
+			firstX + cardStride,
+			firstX + cardStride * 2,
+		]);
+		expect(placements.map((placement) => placement.y)).toEqual([
+			420, 420, 420,
+		]);
+	});
+
+	it('reuses cached placements when the hand layout inputs are unchanged', () => {
+		const layout = new HandLayout((card) => `card-${card}`);
+		const cards = [encodeCard('hearts', '9'), encodeCard('clubs', 'K')];
+
+		const first = layout.cardPlacements(cards, 640, 166, false, 'dealer');
+		const second = layout.cardPlacements(
+			[...cards],
+			640,
+			166,
+			false,
+			'dealer',
+		);
+
+		expect(second).toBe(first);
+	});
+
+	it('refreshes cached placements when hole card visibility changes', () => {
+		const layout = new HandLayout((card) =>
+			card === 'back' ? 'card-back' : `card-${card}`,
+		);
+		const cards = [encodeCard('hearts', '9'), encodeCard('clubs', 'K')];
+
+		const hidden = layout.cardPlacements(cards, 640, 166, true, 'dealer');
+		const visible = layout.cardPlacements(cards, 640, 166, false, 'dealer');
+
+		expect(hidden).not.toBe(visible);
+		expect(hidden[1].textureKey).toBe('card-back');
+		expect(visible[1].textureKey).toBe(`card-${cards[1]}`);
+	});
+});

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/handLayout.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/handLayout.ts
@@ -11,6 +11,8 @@ interface PlacementCacheEntry {
 	placements: CardPlacement[];
 }
 
+const CARD_GAP = 18;
+
 export class HandLayout {
 	private readonly placementCache = new Map<HandOwner, PlacementCacheEntry>();
 
@@ -39,12 +41,14 @@ export class HandLayout {
 		}
 
 		const totalWidth =
-			cards.length * CARD_SIZE.width + Math.max(0, cards.length - 1) * 18;
+			cards.length * CARD_SIZE.width +
+			Math.max(0, cards.length - 1) * CARD_GAP;
 		let x = centerX - totalWidth / 2;
-		const placements: CardPlacement[] = [];
+		const placements = new Array<CardPlacement>(cards.length);
 
-		cards.forEach((card, index) => {
-			placements.push({
+		for (let index = 0; index < cards.length; index++) {
+			const card = cards[index];
+			placements[index] = {
 				textureKey:
 					hideHole && index === 1
 						? this.textureKey('back')
@@ -53,11 +57,11 @@ export class HandLayout {
 				y,
 				owner,
 				index,
-			});
-			x += CARD_SIZE.width + 18;
-		});
+			};
+			x += CARD_SIZE.width + CARD_GAP;
+		}
 		this.placementCache.set(owner, {
-			cards: Uint8Array.from(cards),
+			cards: this.snapshot(cards),
 			fingerprint,
 			centerX,
 			y,
@@ -90,5 +94,13 @@ export class HandLayout {
 			if (cached.cards[i] !== cards[i]) return false;
 		}
 		return true;
+	}
+
+	private snapshot(cards: readonly Card[]): Uint8Array {
+		const snapshot = new Uint8Array(cards.length);
+		for (let i = 0; i < cards.length; i++) {
+			snapshot[i] = cards[i];
+		}
+		return snapshot;
 	}
 }


### PR DESCRIPTION
## Summary
- pre-size blackjack hand placement arrays and use indexed loops
- replace repeated card gap literals with a shared layout constant
- snapshot cached hand cards with an indexed Uint8Array fill
- add unit coverage for placement spacing and cache refresh behavior

## Validation
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/objects/handLayout.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/handLayout.test.ts`
- `./kbve.sh -nx astro-kbve:test`
- `AXUM_PORT=4375 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`