### PR TITLE
fix(ci): free disk space in utils-ci-lint-test before nx affected

### DIFF
--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -27,6 +27,17 @@ jobs:
         permissions:
             contents: read
         steps:
+            - name: Free disk space
+              uses: jlumbroso/free-disk-space@main
+              with:
+                  tool-cache: false
+                  android: true
+                  dotnet: true
+                  haskell: true
+                  large-packages: false
+                  swap-storage: false
+                  docker-images: true
+
             - name: Checkout
               uses: actions/checkout@v6
               with:


### PR DESCRIPTION
## Summary

\`pnpm nx affected --target=test\` runs cargo test for every affected Rust project, each writing into its own \`dist/target/<project>/\` directory. With Bevy + axum-kbve in the workspace, each target dir balloons to multi-GB. \`ubuntu-latest\` starts with ~14GB free; the dev → main release validation run [25855336044](https://github.com/KBVE/kbve/actions/runs/25855336044/job/75971641879) failed with \`No space left on device (os error 28)\` mid-\`axum-kbve:test\` after the first affected test pass had already succeeded.

## Fix

Add \`jlumbroso/free-disk-space@main\` as the first step in the \`lint-and-test\` job, matching the configuration used by [utils-publish-docker-image.yml](.github/workflows/utils-publish-docker-image.yml#L51-L60) (the docker-test workflow). Reclaims ~30GB by deleting Android SDK, .NET runtime, Haskell toolchains, and the preinstalled docker images. \`tool-cache\` and \`large-packages\` stay off — Node, Rust, and apt deps installed later by the same job still need them.

## Test plan

- [ ] PR CI: the affected lint + test pass now completes (Rust projects: axum-kbve, axum-rareicon, etc).
- [ ] Re-run the dev → main validation workflow after merge; expect no \`os error 28\`.