### PR TITLE
perf(arcade): trim blackjack card pool hides

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.test.ts
@@ -78,4 +78,43 @@ describe('blackjack card pool', () => {
 		expect(image.setTexture).toHaveBeenCalledTimes(2);
 		expect(image.setPosition).toHaveBeenCalledTimes(2);
 	});
+
+	it('only hides views when the active card count shrinks', () => {
+		const images: MockImage[] = [];
+		const scene = {
+			add: {
+				image: () => {
+					const image = new MockImage();
+					images.push(image);
+					return image;
+				},
+			},
+		};
+		const pool = new CardPool(
+			scene as never,
+			{ add: vi.fn() } as never,
+			'slot',
+		);
+
+		pool.begin();
+		pool.place('spades-A', 320, 420);
+		pool.place('hearts-K', 440, 420);
+		pool.hideUnused();
+
+		pool.begin();
+		pool.place('spades-A', 320, 420);
+		pool.place('hearts-K', 440, 420);
+		pool.hideUnused();
+
+		expect(images[0].setVisible).toHaveBeenCalledTimes(1);
+		expect(images[1].setVisible).toHaveBeenCalledTimes(1);
+
+		pool.begin();
+		pool.place('spades-A', 320, 420);
+		pool.hideUnused();
+
+		expect(images[0].setVisible).toHaveBeenCalledTimes(1);
+		expect(images[1].setVisible).toHaveBeenCalledTimes(2);
+		expect(images[1].visible).toBe(false);
+	});
 });

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.ts
@@ -6,6 +6,7 @@ export class CardPool {
 	private readonly xPositions: number[] = [];
 	private readonly yPositions: number[] = [];
 	private activeViews = 0;
+	private visibleViews = 0;
 
 	constructor(
 		private readonly scene: Phaser.Scene,
@@ -35,10 +36,11 @@ export class CardPool {
 	}
 
 	hideUnused() {
-		for (let i = this.activeViews; i < this.views.length; i++) {
+		for (let i = this.activeViews; i < this.visibleViews; i++) {
 			this.views[i].setVisible(false);
 			this.views[i].setActive(false);
 		}
+		this.visibleViews = this.activeViews;
 	}
 
 	private getView(index: number): Phaser.GameObjects.Image {


### PR DESCRIPTION
## Summary
- track the previous visible card pool count so unchanged renders skip unused-view hide loops
- only hide pooled card views when the active card count shrinks
- add unit coverage for repeated same-count renders and shrink behavior

## Validation
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/cardPool.test.ts`
- `./kbve.sh -nx astro-kbve:test`
- `AXUM_PORT=4376 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`