### PR TITLE
feat(wallet): marketplace schema Phase 1 — listings, bids, treasury

### DIFF
--- a/packages/data/sql/dbmate/migration-tests/20260514113538_wallet_marketplace_schema.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260514113538_wallet_marketplace_schema.test.sql
@@ -2,31 +2,22 @@
 -- Run via: ./test-migration.sh 20260514113538_wallet_marketplace_schema
 
 -- SEED
--- Idempotent cleanup of prior-run rows. We use a single seller + bidder
--- pair to exercise the constraints. Treasury row is seeded by the
--- migration itself and is intentionally NOT cleaned up here.
-WITH test_users (id) AS (
-    VALUES
-        ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid),
-        ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid)
-),
-test_accounts AS (
-    SELECT a.id FROM wallet.account a JOIN test_users u ON a.user_id = u.id
-),
-del_balance AS (
-    DELETE FROM wallet.balance WHERE account_id IN (SELECT id FROM test_accounts)
-),
-del_coupon AS (
-    DELETE FROM wallet.coupon WHERE account_id IN (SELECT id FROM test_accounts)
-),
-del_account AS (
-    DELETE FROM wallet.account WHERE id IN (SELECT id FROM test_accounts)
-)
-DELETE FROM auth.users WHERE id IN (SELECT id FROM test_users);
+-- wallet.ledger and wallet.audit_log are append-only (triggers block DELETE),
+-- so cleanup-via-DELETE is not viable. Instead each test run generates
+-- fresh UUIDs and stashes them in a fixture table so the ASSERT_AFTER_UP
+-- and ASSERT_AFTER_DOWN sections (separate psql sessions) can look them up.
+DROP TABLE IF EXISTS public.__marketplace_test_fixture;
+CREATE TABLE public.__marketplace_test_fixture (
+    role    TEXT PRIMARY KEY,
+    user_id UUID NOT NULL
+);
 
-INSERT INTO auth.users (id) VALUES
-    ('dddddddd-dddd-dddd-dddd-dddddddddddd'),
-    ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee');
+INSERT INTO public.__marketplace_test_fixture (role, user_id) VALUES
+    ('seller', gen_random_uuid()),
+    ('bidder', gen_random_uuid());
+
+INSERT INTO auth.users (id)
+SELECT user_id FROM public.__marketplace_test_fixture;
 
 -- ASSERT_AFTER_UP
 
@@ -77,14 +68,23 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_active_expires_idx') THEN
         RAISE EXCEPTION 'fail: wallet_listing_active_expires_idx missing';
     END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_active_created_idx') THEN
+        RAISE EXCEPTION 'fail: wallet_listing_active_created_idx missing';
+    END IF;
     IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_seller_created_idx') THEN
         RAISE EXCEPTION 'fail: wallet_listing_seller_created_idx missing';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_idempotency_uq') THEN
+        RAISE EXCEPTION 'fail: wallet_listing_idempotency_uq missing';
     END IF;
     IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_bid_listing_placed_idx') THEN
         RAISE EXCEPTION 'fail: wallet_bid_listing_placed_idx missing';
     END IF;
-    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_bid_listing_bidder_active_uq') THEN
-        RAISE EXCEPTION 'fail: wallet_bid_listing_bidder_active_uq missing';
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_bid_listing_active_uq') THEN
+        RAISE EXCEPTION 'fail: wallet_bid_listing_active_uq missing';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_account_treasury_label_uq') THEN
+        RAISE EXCEPTION 'fail: wallet_account_treasury_label_uq missing';
     END IF;
 END;
 $$;
@@ -95,7 +95,7 @@ DECLARE
     v_seller UUID;
     v_listing_id BIGINT;
 BEGIN
-    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
     INSERT INTO wallet.listing (
         seller_account, item_ref, buy_now_price, expires_at
     ) VALUES (
@@ -115,7 +115,7 @@ DO $$
 DECLARE
     v_seller UUID;
 BEGIN
-    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
     INSERT INTO wallet.listing (
         seller_account, item_ref, min_bid, expires_at
     ) VALUES (
@@ -132,7 +132,7 @@ DO $$
 DECLARE
     v_seller UUID;
 BEGIN
-    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
     BEGIN
         INSERT INTO wallet.listing (seller_account, item_ref, expires_at)
         VALUES (v_seller, '{"item_id": "stick"}'::jsonb, statement_timestamp() + interval '2 hours');
@@ -147,7 +147,7 @@ DO $$
 DECLARE
     v_seller UUID;
 BEGIN
-    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
     BEGIN
         INSERT INTO wallet.listing (
             seller_account, item_ref, buy_now_price, min_bid, expires_at
@@ -166,7 +166,7 @@ DO $$
 DECLARE
     v_seller UUID;
 BEGIN
-    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
     BEGIN
         INSERT INTO wallet.listing (
             seller_account, item_ref, buy_now_price, expires_at
@@ -185,7 +185,7 @@ DO $$
 DECLARE
     v_seller UUID;
 BEGIN
-    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
     BEGIN
         INSERT INTO wallet.listing (
             seller_account, item_ref, buy_now_price, expires_at
@@ -204,7 +204,7 @@ DO $$
 DECLARE
     v_seller UUID;
 BEGIN
-    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
     BEGIN
         INSERT INTO wallet.listing (
             seller_account, item_ref, currency, buy_now_price, expires_at
@@ -223,7 +223,7 @@ DO $$
 DECLARE
     v_seller UUID;
 BEGIN
-    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
     BEGIN
         INSERT INTO wallet.listing (
             seller_account, item_ref, buy_now_price, expires_at
@@ -247,8 +247,8 @@ DECLARE
     v_listing_id   BIGINT;
     v_ledger_id    BIGINT;
 BEGIN
-    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
-    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
+    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='bidder');
 
     -- Fund the bidder so the escrow ledger ref is real.
     SELECT wallet.service_credit(
@@ -276,7 +276,7 @@ DECLARE
     v_listing_id BIGINT;
     v_ledger_id BIGINT;
 BEGIN
-    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='bidder');
     SELECT id INTO v_listing_id FROM wallet.listing ORDER BY id DESC LIMIT 1;
     SELECT id INTO v_ledger_id FROM wallet.ledger WHERE account_id = v_bidder ORDER BY id DESC LIMIT 1;
 
@@ -292,6 +292,108 @@ BEGIN
 END;
 $$;
 
+-- 13b. Listing reject: seller is current_bid_account (self-bid).
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, min_bid,
+            current_bid, current_bid_account, expires_at
+        ) VALUES (
+            v_seller, '{"item_id":"shield"}'::jsonb, 100, 50, 60, v_seller,
+            statement_timestamp() + interval '2 hours'
+        );
+        RAISE EXCEPTION 'fail: seller==current_bid_account should have failed listing_current_bid_not_seller_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 13c. Listing reject: status=sold with NULL buyer_account.
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, expires_at,
+            status, settled_at
+        ) VALUES (
+            v_seller, '{"item_id":"shield"}'::jsonb, 100,
+            statement_timestamp() + interval '2 hours',
+            'sold', statement_timestamp()
+        );
+        RAISE EXCEPTION 'fail: sold without buyer_account should have failed listing_buyer_state_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 13d. Listing reject: status=active but buyer_account set.
+DO $$
+DECLARE
+    v_seller UUID;
+    v_bidder UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
+    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='bidder');
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, expires_at,
+            status, buyer_account
+        ) VALUES (
+            v_seller, '{"item_id":"shield"}'::jsonb, 100,
+            statement_timestamp() + interval '2 hours',
+            'active', v_bidder
+        );
+        RAISE EXCEPTION 'fail: active+buyer_account should have failed listing_buyer_state_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 13e. Listing duplicate idempotency_key blocked.
+DO $$
+DECLARE
+    v_seller UUID;
+    v_key    UUID := gen_random_uuid();
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
+    INSERT INTO wallet.listing (
+        seller_account, item_ref, buy_now_price, expires_at, idempotency_key
+    ) VALUES (
+        v_seller, '{"item_id":"compass"}'::jsonb, 25,
+        statement_timestamp() + interval '2 hours', v_key
+    );
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, expires_at, idempotency_key
+        ) VALUES (
+            v_seller, '{"item_id":"clock"}'::jsonb, 30,
+            statement_timestamp() + interval '2 hours', v_key
+        );
+        RAISE EXCEPTION 'fail: duplicate idempotency_key should have failed wallet_listing_idempotency_uq';
+    EXCEPTION WHEN unique_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 13f. Treasury label is unique under kind='treasury' (concurrency-safe).
+DO $$
+BEGIN
+    BEGIN
+        INSERT INTO wallet.account (kind, user_id, guild_id, label)
+        VALUES ('treasury', NULL, NULL, 'kbve_treasury');
+        RAISE EXCEPTION 'fail: duplicate treasury label should have failed wallet_account_treasury_label_uq';
+    EXCEPTION WHEN unique_violation THEN NULL;
+    END;
+END;
+$$;
+
 -- 14. Bid lifecycle: cannot have status='active' with refund_ledger_id set.
 DO $$
 DECLARE
@@ -299,7 +401,7 @@ DECLARE
     v_listing_id BIGINT;
     v_ledger_id BIGINT;
 BEGIN
-    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='bidder');
     SELECT id INTO v_listing_id FROM wallet.listing ORDER BY id DESC LIMIT 1;
     SELECT id INTO v_ledger_id FROM wallet.ledger WHERE account_id = v_bidder ORDER BY id DESC LIMIT 1;
 
@@ -311,6 +413,35 @@ BEGIN
         );
         RAISE EXCEPTION 'fail: active+refund_ledger_id should have failed bid_lifecycle_chk';
     EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 15. Two active bids on the same listing rejected (one-active-per-listing).
+DO $$
+DECLARE
+    v_seller     UUID;
+    v_bidder     UUID;
+    v_listing_id BIGINT;
+    v_ledger_id  BIGINT;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
+    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='bidder');
+    SELECT id INTO v_listing_id
+      FROM wallet.listing
+     WHERE seller_account = v_seller AND item_ref->>'item_id' = 'netherite_pickaxe'
+     ORDER BY id DESC LIMIT 1;
+    SELECT id INTO v_ledger_id
+      FROM wallet.ledger WHERE account_id = v_bidder ORDER BY id DESC LIMIT 1;
+
+    BEGIN
+        INSERT INTO wallet.bid (
+            listing_id, bidder_account, amount, escrow_ledger_id
+        ) VALUES (
+            v_listing_id, v_bidder, 75, v_ledger_id
+        );
+        RAISE EXCEPTION 'fail: two active bids on same listing should have failed wallet_bid_listing_active_uq';
+    EXCEPTION WHEN unique_violation THEN NULL;
     END;
 END;
 $$;

--- a/packages/data/sql/dbmate/migration-tests/20260514113538_wallet_marketplace_schema.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260514113538_wallet_marketplace_schema.test.sql
@@ -1,0 +1,341 @@
+-- Companion test fixtures for 20260514113538_wallet_marketplace_schema.
+-- Run via: ./test-migration.sh 20260514113538_wallet_marketplace_schema
+
+-- SEED
+-- Idempotent cleanup of prior-run rows. We use a single seller + bidder
+-- pair to exercise the constraints. Treasury row is seeded by the
+-- migration itself and is intentionally NOT cleaned up here.
+WITH test_users (id) AS (
+    VALUES
+        ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid),
+        ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'::uuid)
+),
+test_accounts AS (
+    SELECT a.id FROM wallet.account a JOIN test_users u ON a.user_id = u.id
+),
+del_balance AS (
+    DELETE FROM wallet.balance WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_coupon AS (
+    DELETE FROM wallet.coupon WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_account AS (
+    DELETE FROM wallet.account WHERE id IN (SELECT id FROM test_accounts)
+)
+DELETE FROM auth.users WHERE id IN (SELECT id FROM test_users);
+
+INSERT INTO auth.users (id) VALUES
+    ('dddddddd-dddd-dddd-dddd-dddddddddddd'),
+    ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee');
+
+-- ASSERT_AFTER_UP
+
+-- 1. Enums exist with the expected values.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type t
+          JOIN pg_namespace n ON n.oid = t.typnamespace
+         WHERE n.nspname = 'wallet'
+           AND t.typname = 'listing_status'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet.listing_status enum missing';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type t
+          JOIN pg_namespace n ON n.oid = t.typnamespace
+         WHERE n.nspname = 'wallet'
+           AND t.typname = 'bid_status'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet.bid_status enum missing';
+    END IF;
+END;
+$$;
+
+-- 2. Treasury account seeded with balance row.
+DO $$
+DECLARE
+    v_treasury_id UUID;
+BEGIN
+    SELECT id INTO v_treasury_id
+      FROM wallet.account
+     WHERE kind = 'treasury' AND label = 'kbve_treasury';
+    IF v_treasury_id IS NULL THEN
+        RAISE EXCEPTION 'fail: kbve_treasury account not seeded';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.balance WHERE account_id = v_treasury_id
+    ) THEN
+        RAISE EXCEPTION 'fail: kbve_treasury balance row missing';
+    END IF;
+END;
+$$;
+
+-- 3. Indexes present.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_active_expires_idx') THEN
+        RAISE EXCEPTION 'fail: wallet_listing_active_expires_idx missing';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_seller_created_idx') THEN
+        RAISE EXCEPTION 'fail: wallet_listing_seller_created_idx missing';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_bid_listing_placed_idx') THEN
+        RAISE EXCEPTION 'fail: wallet_bid_listing_placed_idx missing';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_bid_listing_bidder_active_uq') THEN
+        RAISE EXCEPTION 'fail: wallet_bid_listing_bidder_active_uq missing';
+    END IF;
+END;
+$$;
+
+-- 4. Listing insert succeeds with valid shape (buy_now only).
+DO $$
+DECLARE
+    v_seller UUID;
+    v_listing_id BIGINT;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    INSERT INTO wallet.listing (
+        seller_account, item_ref, buy_now_price, expires_at
+    ) VALUES (
+        v_seller,
+        '{"item_id": "diamond_sword", "qty": 1}'::jsonb,
+        100,
+        statement_timestamp() + interval '2 hours'
+    ) RETURNING id INTO v_listing_id;
+    IF v_listing_id IS NULL THEN
+        RAISE EXCEPTION 'fail: listing insert returned no id';
+    END IF;
+END;
+$$;
+
+-- 5. Listing insert succeeds with min_bid only (auction).
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    INSERT INTO wallet.listing (
+        seller_account, item_ref, min_bid, expires_at
+    ) VALUES (
+        v_seller,
+        '{"item_id": "netherite_pickaxe", "qty": 1}'::jsonb,
+        50,
+        statement_timestamp() + interval '12 hours'
+    );
+END;
+$$;
+
+-- 6. Listing reject: no price set (neither buy_now nor min_bid).
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    BEGIN
+        INSERT INTO wallet.listing (seller_account, item_ref, expires_at)
+        VALUES (v_seller, '{"item_id": "stick"}'::jsonb, statement_timestamp() + interval '2 hours');
+        RAISE EXCEPTION 'fail: insert with no price should have failed listing_has_price_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 7. Listing reject: buy_now < min_bid.
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, min_bid, expires_at
+        ) VALUES (
+            v_seller, '{"item_id": "stick"}'::jsonb, 10, 50,
+            statement_timestamp() + interval '2 hours'
+        );
+        RAISE EXCEPTION 'fail: buy_now < min_bid should have failed listing_buy_now_gte_min_bid_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 8. Listing reject: duration < 1h.
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, expires_at
+        ) VALUES (
+            v_seller, '{"item_id": "stick"}'::jsonb, 100,
+            statement_timestamp() + interval '30 minutes'
+        );
+        RAISE EXCEPTION 'fail: duration < 1h should have failed listing_min_duration_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 9. Listing reject: duration > 30d.
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, expires_at
+        ) VALUES (
+            v_seller, '{"item_id": "stick"}'::jsonb, 100,
+            statement_timestamp() + interval '31 days'
+        );
+        RAISE EXCEPTION 'fail: duration > 30d should have failed listing_max_duration_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 10. Listing reject: non-khash currency.
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, currency, buy_now_price, expires_at
+        ) VALUES (
+            v_seller, '{"item_id": "stick"}'::jsonb, 'credits', 100,
+            statement_timestamp() + interval '2 hours'
+        );
+        RAISE EXCEPTION 'fail: credits currency should have failed listing_khash_only_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 11. Listing reject: empty item_ref.
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, expires_at
+        ) VALUES (
+            v_seller, '{}'::jsonb, 100,
+            statement_timestamp() + interval '2 hours'
+        );
+        RAISE EXCEPTION 'fail: empty item_ref should have failed listing_item_ref_shape_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 12. Bid insert succeeds against an existing listing + bidder.
+--     Needs a real ledger row for escrow_ledger_id. We synthesize one by
+--     issuing a credit through the service_credit RPC so the FK is satisfied.
+DO $$
+DECLARE
+    v_seller       UUID;
+    v_bidder       UUID;
+    v_listing_id   BIGINT;
+    v_ledger_id    BIGINT;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+
+    -- Fund the bidder so the escrow ledger ref is real.
+    SELECT wallet.service_credit(
+        v_bidder, 'khash'::wallet.currency_kind, 200,
+        'reward'::wallet.source_kind, 'fixture', NULL, NULL, gen_random_uuid()
+    ) INTO v_ledger_id;
+
+    SELECT id INTO v_listing_id
+      FROM wallet.listing
+     WHERE seller_account = v_seller AND item_ref->>'item_id' = 'netherite_pickaxe'
+     ORDER BY id DESC LIMIT 1;
+
+    INSERT INTO wallet.bid (
+        listing_id, bidder_account, amount, escrow_ledger_id
+    ) VALUES (
+        v_listing_id, v_bidder, 50, v_ledger_id
+    );
+END;
+$$;
+
+-- 13. Bid reject: amount <= 0.
+DO $$
+DECLARE
+    v_bidder    UUID;
+    v_listing_id BIGINT;
+    v_ledger_id BIGINT;
+BEGIN
+    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    SELECT id INTO v_listing_id FROM wallet.listing ORDER BY id DESC LIMIT 1;
+    SELECT id INTO v_ledger_id FROM wallet.ledger WHERE account_id = v_bidder ORDER BY id DESC LIMIT 1;
+
+    BEGIN
+        INSERT INTO wallet.bid (
+            listing_id, bidder_account, amount, escrow_ledger_id
+        ) VALUES (
+            v_listing_id, v_bidder, 0, v_ledger_id
+        );
+        RAISE EXCEPTION 'fail: bid amount=0 should have failed bid_amount_pos_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 14. Bid lifecycle: cannot have status='active' with refund_ledger_id set.
+DO $$
+DECLARE
+    v_bidder    UUID;
+    v_listing_id BIGINT;
+    v_ledger_id BIGINT;
+BEGIN
+    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    SELECT id INTO v_listing_id FROM wallet.listing ORDER BY id DESC LIMIT 1;
+    SELECT id INTO v_ledger_id FROM wallet.ledger WHERE account_id = v_bidder ORDER BY id DESC LIMIT 1;
+
+    BEGIN
+        INSERT INTO wallet.bid (
+            listing_id, bidder_account, amount, escrow_ledger_id, refund_ledger_id, status
+        ) VALUES (
+            v_listing_id, v_bidder, 50, v_ledger_id, v_ledger_id, 'active'
+        );
+        RAISE EXCEPTION 'fail: active+refund_ledger_id should have failed bid_lifecycle_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+BEGIN
+    -- 1. Tables removed.
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='wallet' AND table_name='listing') THEN
+        RAISE EXCEPTION 'fail: wallet.listing still exists after rollback';
+    END IF;
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='wallet' AND table_name='bid') THEN
+        RAISE EXCEPTION 'fail: wallet.bid still exists after rollback';
+    END IF;
+    -- 2. Enums removed.
+    IF EXISTS (SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid=t.typnamespace WHERE n.nspname='wallet' AND t.typname='listing_status') THEN
+        RAISE EXCEPTION 'fail: wallet.listing_status enum still exists after rollback';
+    END IF;
+    IF EXISTS (SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid=t.typnamespace WHERE n.nspname='wallet' AND t.typname='bid_status') THEN
+        RAISE EXCEPTION 'fail: wallet.bid_status enum still exists after rollback';
+    END IF;
+    -- 3. Treasury account intentionally preserved across rollback.
+    IF NOT EXISTS (SELECT 1 FROM wallet.account WHERE kind='treasury' AND label='kbve_treasury') THEN
+        RAISE EXCEPTION 'fail: kbve_treasury account lost during rollback';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migration-tests/20260514113538_wallet_marketplace_schema.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260514113538_wallet_marketplace_schema.test.sql
@@ -74,14 +74,26 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_seller_created_idx') THEN
         RAISE EXCEPTION 'fail: wallet_listing_seller_created_idx missing';
     END IF;
-    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_idempotency_uq') THEN
-        RAISE EXCEPTION 'fail: wallet_listing_idempotency_uq missing';
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_seller_idempotency_uq') THEN
+        RAISE EXCEPTION 'fail: wallet_listing_seller_idempotency_uq missing';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_seller_status_created_idx') THEN
+        RAISE EXCEPTION 'fail: wallet_listing_seller_status_created_idx missing';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_buyer_created_idx') THEN
+        RAISE EXCEPTION 'fail: wallet_listing_buyer_created_idx missing';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_listing_active_item_instance_uq') THEN
+        RAISE EXCEPTION 'fail: wallet_listing_active_item_instance_uq missing';
     END IF;
     IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_bid_listing_placed_idx') THEN
         RAISE EXCEPTION 'fail: wallet_bid_listing_placed_idx missing';
     END IF;
     IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_bid_listing_active_uq') THEN
         RAISE EXCEPTION 'fail: wallet_bid_listing_active_uq missing';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_bid_bidder_idempotency_uq') THEN
+        RAISE EXCEPTION 'fail: wallet_bid_bidder_idempotency_uq missing';
     END IF;
     IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname='wallet' AND indexname='wallet_account_treasury_label_uq') THEN
         RAISE EXCEPTION 'fail: wallet_account_treasury_label_uq missing';
@@ -414,6 +426,99 @@ BEGIN
         RAISE EXCEPTION 'fail: active+refund_ledger_id should have failed bid_lifecycle_chk';
     EXCEPTION WHEN check_violation THEN NULL;
     END;
+END;
+$$;
+
+-- 14a. listing_active_bid_fields_chk: non-active row may not carry
+--      live-bid pointers.
+DO $$
+DECLARE
+    v_seller UUID;
+    v_bidder UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
+    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='bidder');
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, expires_at,
+            status, settled_at, current_bid, current_bid_account, buyer_account
+        ) VALUES (
+            v_seller, '{"item_id":"flint"}'::jsonb, 100,
+            statement_timestamp() + interval '2 hours',
+            'sold', statement_timestamp(), 60, v_bidder, v_bidder
+        );
+        RAISE EXCEPTION 'fail: sold+current_bid should have failed listing_active_bid_fields_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 14b. listing_current_bid_state_chk: current_bid_id must move with
+--      current_bid + current_bid_account.
+DO $$
+DECLARE
+    v_seller UUID;
+    v_bidder UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
+    SELECT id INTO v_bidder FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='bidder');
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, expires_at,
+            current_bid, current_bid_account
+        ) VALUES (
+            v_seller, '{"item_id":"feather"}'::jsonb, 100,
+            statement_timestamp() + interval '2 hours',
+            60, v_bidder
+        );
+        RAISE EXCEPTION 'fail: current_bid_id NULL with other fields set should have failed listing_current_bid_state_chk';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 14c. Same physical item cannot be listed twice while active
+--      (item_instance_id partial unique).
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account WHERE user_id = (SELECT user_id FROM public.__marketplace_test_fixture WHERE role='seller');
+    INSERT INTO wallet.listing (
+        seller_account, item_ref, buy_now_price, expires_at
+    ) VALUES (
+        v_seller,
+        '{"item_id": "elytra", "qty": 1, "instance_id": "abc-123"}'::jsonb,
+        500,
+        statement_timestamp() + interval '2 hours'
+    );
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, buy_now_price, expires_at
+        ) VALUES (
+            v_seller,
+            '{"item_id": "elytra", "qty": 1, "instance_id": "abc-123"}'::jsonb,
+            600,
+            statement_timestamp() + interval '2 hours'
+        );
+        RAISE EXCEPTION 'fail: duplicate active item_instance_id should have failed wallet_listing_active_item_instance_uq';
+    EXCEPTION WHEN unique_violation THEN NULL;
+    END;
+END;
+$$;
+
+-- 14d. updated_at trigger exists on wallet.listing. We don't assert
+--      a timestamp bump because everything in a DO block shares one
+--      statement_timestamp(); the trigger is verified structurally.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+         WHERE tgname = 'trg_wallet_listing_touch_updated_at'
+           AND NOT tgisinternal
+    ) THEN
+        RAISE EXCEPTION 'fail: trg_wallet_listing_touch_updated_at missing';
+    END IF;
 END;
 $$;
 

--- a/packages/data/sql/dbmate/migrations/20260514113538_wallet_marketplace_schema.sql
+++ b/packages/data/sql/dbmate/migrations/20260514113538_wallet_marketplace_schema.sql
@@ -59,9 +59,14 @@ CREATE TABLE wallet.listing (
     min_bid             BIGINT,
     current_bid         BIGINT,
     current_bid_account UUID REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    -- buyer_account is set on settlement (sold). Decoupled from
+    -- current_bid_account so buy-now purchasers can be recorded
+    -- without faking a bid row.
+    buyer_account       UUID REFERENCES wallet.account(id) ON DELETE NO ACTION,
     status              wallet.listing_status NOT NULL DEFAULT 'active',
     expires_at          TIMESTAMPTZ NOT NULL,
     created_at          TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
     settled_at          TIMESTAMPTZ,
     idempotency_key     UUID NOT NULL DEFAULT extensions.gen_random_uuid(),
 
@@ -106,6 +111,20 @@ CREATE TABLE wallet.listing (
      OR (status <> 'active' AND settled_at IS NOT NULL)
     ),
 
+    -- Seller never bids on or buys their own listing.
+    CONSTRAINT listing_current_bid_not_seller_chk CHECK (
+        current_bid_account IS NULL OR current_bid_account <> seller_account
+    ),
+    CONSTRAINT listing_buyer_not_seller_chk CHECK (
+        buyer_account IS NULL OR buyer_account <> seller_account
+    ),
+
+    -- buyer_account set iff sold.
+    CONSTRAINT listing_buyer_state_chk CHECK (
+        (status =  'sold' AND buyer_account IS NOT NULL)
+     OR (status <> 'sold' AND buyer_account IS NULL)
+    ),
+
     -- Duration window. expires_at is caller-supplied; we enforce
     -- 1h <= duration <= 30d at insert time.
     CONSTRAINT listing_min_duration_chk CHECK (
@@ -119,8 +138,16 @@ CREATE TABLE wallet.listing (
 COMMENT ON TABLE wallet.listing IS
     'Marketplace listing. Combines fixed-price (buy_now_price) and auction (min_bid) in one row; either or both can be set. Settlement is materialized in wallet.ledger via Phase 2 RPCs.';
 
+CREATE UNIQUE INDEX wallet_listing_idempotency_uq
+    ON wallet.listing (idempotency_key);
+
 CREATE INDEX wallet_listing_active_expires_idx
     ON wallet.listing (expires_at)
+    WHERE status = 'active';
+
+-- Browse index: active listings sorted newest-first for /mc/market home.
+CREATE INDEX wallet_listing_active_created_idx
+    ON wallet.listing (created_at DESC, id DESC)
     WHERE status = 'active';
 
 CREATE INDEX wallet_listing_seller_created_idx
@@ -182,11 +209,14 @@ CREATE INDEX wallet_bid_listing_placed_idx
 CREATE INDEX wallet_bid_bidder_placed_idx
     ON wallet.bid (bidder_account, placed_at DESC, id DESC);
 
--- One ACTIVE bid per (listing, bidder). Bidders increase their bid by
--- placing a new bid; the prior bid for that bidder transitions to
--- 'outbid' as part of the same RPC.
-CREATE UNIQUE INDEX wallet_bid_listing_bidder_active_uq
-    ON wallet.bid (listing_id, bidder_account)
+-- Exactly one ACTIVE bid per listing. Listing.current_bid_account is
+-- single-valued, so the bid table mirrors that invariant: any new bid
+-- demotes the prior 'active' row to 'outbid' (with refund_ledger_id)
+-- in the same RPC transaction. Combined with the lifecycle CHECK on
+-- wallet.bid, this prevents two active high bids from existing for a
+-- single listing even under concurrent place_bid calls.
+CREATE UNIQUE INDEX wallet_bid_listing_active_uq
+    ON wallet.bid (listing_id)
     WHERE status = 'active';
 
 -- ============================================================================
@@ -218,17 +248,22 @@ GRANT USAGE ON SEQUENCE wallet.bid_id_seq TO service_role;
 -- Seed a known treasury account so Phase 2's settle_listing RPC can
 -- transfer the 1% marketplace fee deterministically. Lookup is by
 -- label='kbve_treasury' so we don't have to encode a UUID constant.
--- Idempotent: ON CONFLICT on the partial uniqueness shape.
+--
+-- Concurrency: a partial unique index on (label) WHERE kind='treasury'
+-- backs an ON CONFLICT DO NOTHING insert so the seed is safe under
+-- concurrent migration retries and against future "create treasury for
+-- X" callers that might race on the same label.
 -- ============================================================================
 
-INSERT INTO wallet.account (kind, user_id, guild_id, label, created_at)
-SELECT 'treasury', NULL, NULL, 'kbve_treasury', statement_timestamp()
-WHERE NOT EXISTS (
-    SELECT 1 FROM wallet.account
-     WHERE kind = 'treasury' AND label = 'kbve_treasury'
-);
+CREATE UNIQUE INDEX IF NOT EXISTS wallet_account_treasury_label_uq
+    ON wallet.account (label)
+    WHERE kind = 'treasury';
 
--- Make sure the treasury balance row exists.
+INSERT INTO wallet.account (kind, user_id, guild_id, label, created_at)
+VALUES ('treasury', NULL, NULL, 'kbve_treasury', statement_timestamp())
+ON CONFLICT (label) WHERE kind = 'treasury' DO NOTHING;
+
+-- Treasury balance row.
 INSERT INTO wallet.balance (account_id)
 SELECT id FROM wallet.account
  WHERE kind = 'treasury' AND label = 'kbve_treasury'
@@ -240,7 +275,8 @@ DROP TABLE IF EXISTS wallet.bid;
 DROP TABLE IF EXISTS wallet.listing;
 DROP TYPE  IF EXISTS wallet.bid_status;
 DROP TYPE  IF EXISTS wallet.listing_status;
+DROP INDEX IF EXISTS wallet.wallet_account_treasury_label_uq;
 
 -- Intentionally does NOT delete the seeded kbve_treasury wallet.account
--- row, since rolling back this migration must not erase funds. Phase 2
--- migrations will create real balance rows under that account.
+-- or its balance row, since rolling back this migration must not erase
+-- funds. Phase 2 migrations will rely on those rows already existing.

--- a/packages/data/sql/dbmate/migrations/20260514113538_wallet_marketplace_schema.sql
+++ b/packages/data/sql/dbmate/migrations/20260514113538_wallet_marketplace_schema.sql
@@ -1,0 +1,246 @@
+-- migrate:up
+
+-- Phase 1 of the marketplace bootstrap: tables, enums, indexes, RLS, and
+-- a seeded KBVE Treasury account. Service-layer RPCs (create_listing,
+-- place_bid, settle, expire-sweep cron) land in a follow-up migration.
+--
+-- Currency:
+--   Marketplace transactions are KHASH-ONLY for v1. The currency column
+--   exists with a CHECK constraint so a future migration can drop the
+--   CHECK to allow credits without re-shaping the table.
+--
+-- Pricing:
+--   A listing can have a buy_now_price, a min_bid (auction floor), or
+--   both. At least one of the two is required. When both are present,
+--   buy_now_price must be >= min_bid.
+--
+-- Duration:
+--   Listings live 1h–30d. Caller passes expires_at; CHECK constraints
+--   enforce the window. settle/expire sweeps in Phase 2 flip status and
+--   settled_at when the deadline lapses or a buy-now / auction win
+--   resolves.
+--
+-- Item representation:
+--   item_ref is JSONB; the shape is owned by the mc service (game item
+--   id, qty, instance hash, etc.). The wallet trusts that exactly one
+--   real-world item is escrowed per active listing; mc locks the item
+--   in its own inventory schema. Decoupling on JSONB lets the mc shape
+--   evolve without breaking wallet migrations.
+
+-- ============================================================================
+-- ENUMS
+-- ============================================================================
+
+CREATE TYPE wallet.listing_status AS ENUM (
+    'active',     -- listing live, accepting bids / buy-now
+    'sold',       -- buy-now or auction win settled to buyer
+    'cancelled',  -- seller cancelled before settlement
+    'expired'     -- deadline passed with no buyer / no bids
+);
+
+CREATE TYPE wallet.bid_status AS ENUM (
+    'active',     -- bid is current high bid; funds escrowed
+    'outbid',     -- a higher bid arrived; funds refunded
+    'won',        -- listing settled; bidder is winner
+    'refunded',   -- listing cancelled or expired with this as high bid
+    'cancelled'   -- bidder withdrew (not used in v1; reserved for future)
+);
+
+-- ============================================================================
+-- TABLE: wallet.listing
+-- ============================================================================
+
+CREATE TABLE wallet.listing (
+    id                  BIGSERIAL PRIMARY KEY,
+    seller_account      UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    item_ref            JSONB NOT NULL,
+    currency            wallet.currency_kind NOT NULL DEFAULT 'khash',
+    buy_now_price       BIGINT,
+    min_bid             BIGINT,
+    current_bid         BIGINT,
+    current_bid_account UUID REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    status              wallet.listing_status NOT NULL DEFAULT 'active',
+    expires_at          TIMESTAMPTZ NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    settled_at          TIMESTAMPTZ,
+    idempotency_key     UUID NOT NULL DEFAULT extensions.gen_random_uuid(),
+
+    -- v1 is khash-only. Drop this CHECK in a future migration to allow
+    -- credits.
+    CONSTRAINT listing_khash_only_chk CHECK (currency = 'khash'),
+
+    -- item_ref must be a non-empty JSON object.
+    CONSTRAINT listing_item_ref_shape_chk CHECK (
+        jsonb_typeof(item_ref) = 'object' AND item_ref <> '{}'::jsonb
+    ),
+
+    -- Pricing invariants.
+    CONSTRAINT listing_has_price_chk CHECK (
+        buy_now_price IS NOT NULL OR min_bid IS NOT NULL
+    ),
+    CONSTRAINT listing_buy_now_pos_chk CHECK (
+        buy_now_price IS NULL OR buy_now_price > 0
+    ),
+    CONSTRAINT listing_min_bid_pos_chk CHECK (
+        min_bid IS NULL OR min_bid > 0
+    ),
+    CONSTRAINT listing_buy_now_gte_min_bid_chk CHECK (
+        buy_now_price IS NULL OR min_bid IS NULL OR buy_now_price >= min_bid
+    ),
+
+    -- current_bid + current_bid_account move together.
+    CONSTRAINT listing_current_bid_state_chk CHECK (
+        (current_bid IS NULL     AND current_bid_account IS NULL)
+     OR (current_bid IS NOT NULL AND current_bid_account IS NOT NULL)
+    ),
+    CONSTRAINT listing_current_bid_pos_chk CHECK (
+        current_bid IS NULL OR current_bid > 0
+    ),
+    CONSTRAINT listing_current_bid_gte_min_chk CHECK (
+        current_bid IS NULL OR min_bid IS NULL OR current_bid >= min_bid
+    ),
+
+    -- Status / settled_at invariants.
+    CONSTRAINT listing_settled_at_chk CHECK (
+        (status =  'active' AND settled_at IS NULL)
+     OR (status <> 'active' AND settled_at IS NOT NULL)
+    ),
+
+    -- Duration window. expires_at is caller-supplied; we enforce
+    -- 1h <= duration <= 30d at insert time.
+    CONSTRAINT listing_min_duration_chk CHECK (
+        expires_at >= created_at + interval '1 hour'
+    ),
+    CONSTRAINT listing_max_duration_chk CHECK (
+        expires_at <= created_at + interval '30 days'
+    )
+);
+
+COMMENT ON TABLE wallet.listing IS
+    'Marketplace listing. Combines fixed-price (buy_now_price) and auction (min_bid) in one row; either or both can be set. Settlement is materialized in wallet.ledger via Phase 2 RPCs.';
+
+CREATE INDEX wallet_listing_active_expires_idx
+    ON wallet.listing (expires_at)
+    WHERE status = 'active';
+
+CREATE INDEX wallet_listing_seller_created_idx
+    ON wallet.listing (seller_account, created_at DESC, id DESC);
+
+CREATE INDEX wallet_listing_current_bidder_idx
+    ON wallet.listing (current_bid_account, status)
+    WHERE current_bid_account IS NOT NULL;
+
+CREATE INDEX wallet_listing_status_created_idx
+    ON wallet.listing (status, created_at DESC, id DESC);
+
+-- ============================================================================
+-- TABLE: wallet.bid — per-listing bid history
+-- ============================================================================
+
+CREATE TABLE wallet.bid (
+    id                BIGSERIAL PRIMARY KEY,
+    listing_id        BIGINT NOT NULL REFERENCES wallet.listing(id) ON DELETE NO ACTION,
+    bidder_account    UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    amount            BIGINT NOT NULL,
+    placed_at         TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    status            wallet.bid_status NOT NULL DEFAULT 'active',
+    settled_at        TIMESTAMPTZ,
+    -- Ledger entry that debited the bidder's account into escrow.
+    escrow_ledger_id  BIGINT NOT NULL REFERENCES wallet.ledger(id) ON DELETE NO ACTION,
+    -- Ledger entry that returned funds to the bidder (set when status
+    -- transitions to outbid / refunded / cancelled). NULL while active
+    -- and after a 'won' transition (funds went to seller, not refunded).
+    refund_ledger_id  BIGINT REFERENCES wallet.ledger(id) ON DELETE NO ACTION,
+    idempotency_key   UUID NOT NULL DEFAULT extensions.gen_random_uuid(),
+
+    CONSTRAINT bid_amount_pos_chk CHECK (amount > 0),
+
+    -- Lifecycle invariants. Active bids have no settled_at and no
+    -- refund_ledger_id. Outbid/refunded/cancelled have both. Won has
+    -- settled_at but no refund (the escrow goes to the seller, not back).
+    CONSTRAINT bid_lifecycle_chk CHECK (
+        (status =  'active'
+            AND settled_at      IS NULL
+            AND refund_ledger_id IS NULL)
+     OR (status IN ('outbid', 'refunded', 'cancelled')
+            AND settled_at      IS NOT NULL
+            AND refund_ledger_id IS NOT NULL)
+     OR (status =  'won'
+            AND settled_at      IS NOT NULL
+            AND refund_ledger_id IS NULL)
+    )
+);
+
+COMMENT ON TABLE wallet.bid IS
+    'Per-listing bid history. escrow_ledger_id is mandatory: every bid must reference the debit that escrowed the funds. refund_ledger_id is set on outbid/refunded/cancelled transitions.';
+
+CREATE UNIQUE INDEX wallet_bid_idempotency_uq ON wallet.bid(idempotency_key);
+
+CREATE INDEX wallet_bid_listing_placed_idx
+    ON wallet.bid (listing_id, placed_at DESC, id DESC);
+
+CREATE INDEX wallet_bid_bidder_placed_idx
+    ON wallet.bid (bidder_account, placed_at DESC, id DESC);
+
+-- One ACTIVE bid per (listing, bidder). Bidders increase their bid by
+-- placing a new bid; the prior bid for that bidder transitions to
+-- 'outbid' as part of the same RPC.
+CREATE UNIQUE INDEX wallet_bid_listing_bidder_active_uq
+    ON wallet.bid (listing_id, bidder_account)
+    WHERE status = 'active';
+
+-- ============================================================================
+-- RLS
+-- ============================================================================
+
+ALTER TABLE wallet.listing ENABLE ROW LEVEL SECURITY;
+ALTER TABLE wallet.bid     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE wallet.listing FORCE  ROW LEVEL SECURITY;
+ALTER TABLE wallet.bid     FORCE  ROW LEVEL SECURITY;
+
+CREATE POLICY "service_role_full_access" ON wallet.listing
+    FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+CREATE POLICY "service_role_full_access" ON wallet.bid
+    FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+-- No direct authenticated access. All reads/writes flow through the
+-- public.proxy_market_* SECURITY DEFINER functions added in Phase 3.
+
+GRANT SELECT, INSERT, UPDATE ON wallet.listing TO service_role;
+GRANT USAGE ON SEQUENCE wallet.listing_id_seq TO service_role;
+GRANT SELECT, INSERT, UPDATE ON wallet.bid TO service_role;
+GRANT USAGE ON SEQUENCE wallet.bid_id_seq TO service_role;
+
+-- ============================================================================
+-- KBVE Treasury account
+--
+-- Seed a known treasury account so Phase 2's settle_listing RPC can
+-- transfer the 1% marketplace fee deterministically. Lookup is by
+-- label='kbve_treasury' so we don't have to encode a UUID constant.
+-- Idempotent: ON CONFLICT on the partial uniqueness shape.
+-- ============================================================================
+
+INSERT INTO wallet.account (kind, user_id, guild_id, label, created_at)
+SELECT 'treasury', NULL, NULL, 'kbve_treasury', statement_timestamp()
+WHERE NOT EXISTS (
+    SELECT 1 FROM wallet.account
+     WHERE kind = 'treasury' AND label = 'kbve_treasury'
+);
+
+-- Make sure the treasury balance row exists.
+INSERT INTO wallet.balance (account_id)
+SELECT id FROM wallet.account
+ WHERE kind = 'treasury' AND label = 'kbve_treasury'
+ON CONFLICT (account_id) DO NOTHING;
+
+-- migrate:down
+
+DROP TABLE IF EXISTS wallet.bid;
+DROP TABLE IF EXISTS wallet.listing;
+DROP TYPE  IF EXISTS wallet.bid_status;
+DROP TYPE  IF EXISTS wallet.listing_status;
+
+-- Intentionally does NOT delete the seeded kbve_treasury wallet.account
+-- row, since rolling back this migration must not erase funds. Phase 2
+-- migrations will create real balance rows under that account.

--- a/packages/data/sql/dbmate/migrations/20260514113538_wallet_marketplace_schema.sql
+++ b/packages/data/sql/dbmate/migrations/20260514113538_wallet_marketplace_schema.sql
@@ -54,11 +54,20 @@ CREATE TABLE wallet.listing (
     id                  BIGSERIAL PRIMARY KEY,
     seller_account      UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
     item_ref            JSONB NOT NULL,
+    -- Stable per-item instance id extracted from item_ref. NULL if the
+    -- mc service omits it (e.g. legacy listings); the partial unique
+    -- index below skips those rows. Prevents the same physical item
+    -- from appearing in two active listings.
+    item_instance_id    TEXT GENERATED ALWAYS AS (item_ref->>'instance_id') STORED,
     currency            wallet.currency_kind NOT NULL DEFAULT 'khash',
     buy_now_price       BIGINT,
     min_bid             BIGINT,
     current_bid         BIGINT,
     current_bid_account UUID REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    -- current_bid_id ties the denormalized current_bid + current_bid_account
+    -- to the real wallet.bid row. Phase 2 place_bid keeps the three in
+    -- lockstep; the CHECK below enforces all-or-none.
+    current_bid_id      BIGINT,
     -- buyer_account is set on settlement (sold). Decoupled from
     -- current_bid_account so buy-now purchasers can be recorded
     -- without faking a bid row.
@@ -93,10 +102,19 @@ CREATE TABLE wallet.listing (
         buy_now_price IS NULL OR min_bid IS NULL OR buy_now_price >= min_bid
     ),
 
-    -- current_bid + current_bid_account move together.
+    -- current_bid + current_bid_account + current_bid_id move together.
     CONSTRAINT listing_current_bid_state_chk CHECK (
-        (current_bid IS NULL     AND current_bid_account IS NULL)
-     OR (current_bid IS NOT NULL AND current_bid_account IS NOT NULL)
+        (current_bid IS NULL     AND current_bid_account IS NULL     AND current_bid_id IS NULL)
+     OR (current_bid IS NOT NULL AND current_bid_account IS NOT NULL AND current_bid_id IS NOT NULL)
+    ),
+
+    -- Non-active listings must not retain live-bid pointers. wallet.bid
+    -- is the historical source of truth. Final states (sold/cancelled/
+    -- expired) keep buyer_account but clear current_bid* so state is
+    -- unambiguous.
+    CONSTRAINT listing_active_bid_fields_chk CHECK (
+        status =  'active'
+     OR (current_bid IS NULL AND current_bid_account IS NULL AND current_bid_id IS NULL)
     ),
     CONSTRAINT listing_current_bid_pos_chk CHECK (
         current_bid IS NULL OR current_bid > 0
@@ -138,8 +156,11 @@ CREATE TABLE wallet.listing (
 COMMENT ON TABLE wallet.listing IS
     'Marketplace listing. Combines fixed-price (buy_now_price) and auction (min_bid) in one row; either or both can be set. Settlement is materialized in wallet.ledger via Phase 2 RPCs.';
 
-CREATE UNIQUE INDEX wallet_listing_idempotency_uq
-    ON wallet.listing (idempotency_key);
+-- Idempotency is scoped per actor so a key reused across users does
+-- not cause spurious 409s. Server-generated UUIDs would not need this,
+-- but client-provided keys (likely in Phase 4) get safer semantics.
+CREATE UNIQUE INDEX wallet_listing_seller_idempotency_uq
+    ON wallet.listing (seller_account, idempotency_key);
 
 CREATE INDEX wallet_listing_active_expires_idx
     ON wallet.listing (expires_at)
@@ -153,6 +174,15 @@ CREATE INDEX wallet_listing_active_created_idx
 CREATE INDEX wallet_listing_seller_created_idx
     ON wallet.listing (seller_account, created_at DESC, id DESC);
 
+-- Seller dashboards filtered by status.
+CREATE INDEX wallet_listing_seller_status_created_idx
+    ON wallet.listing (seller_account, status, created_at DESC, id DESC);
+
+-- Buyer dashboards / "my purchases".
+CREATE INDEX wallet_listing_buyer_created_idx
+    ON wallet.listing (buyer_account, created_at DESC, id DESC)
+    WHERE buyer_account IS NOT NULL;
+
 CREATE INDEX wallet_listing_current_bidder_idx
     ON wallet.listing (current_bid_account, status)
     WHERE current_bid_account IS NOT NULL;
@@ -160,8 +190,24 @@ CREATE INDEX wallet_listing_current_bidder_idx
 CREATE INDEX wallet_listing_status_created_idx
     ON wallet.listing (status, created_at DESC, id DESC);
 
+-- Prevents the same physical item from being in two active listings.
+-- Skips rows where the mc service omits instance_id.
+CREATE UNIQUE INDEX wallet_listing_active_item_instance_uq
+    ON wallet.listing (item_instance_id)
+    WHERE status = 'active' AND item_instance_id IS NOT NULL;
+
 -- ============================================================================
 -- TABLE: wallet.bid — per-listing bid history
+--
+-- Phase 2 contract for place_bid:
+--   - SELECT ... FOR UPDATE on the listing row first
+--   - Reject if bidder_account = listing.seller_account (no self-bid;
+--     CHECK can't reference another table)
+--   - Reject if listing status != 'active' or expires_at has passed
+--   - Reject if amount < min_bid or amount <= current_bid
+--   - Demote any prior active bid to 'outbid' (refund_ledger_id set)
+--   - Insert the new bid in 'active'; set listing.current_bid*
+--   - If amount >= buy_now_price, short-circuit to settle (status='sold')
 -- ============================================================================
 
 CREATE TABLE wallet.bid (
@@ -201,7 +247,9 @@ CREATE TABLE wallet.bid (
 COMMENT ON TABLE wallet.bid IS
     'Per-listing bid history. escrow_ledger_id is mandatory: every bid must reference the debit that escrowed the funds. refund_ledger_id is set on outbid/refunded/cancelled transitions.';
 
-CREATE UNIQUE INDEX wallet_bid_idempotency_uq ON wallet.bid(idempotency_key);
+-- Actor-scoped idempotency (same rationale as the listing variant).
+CREATE UNIQUE INDEX wallet_bid_bidder_idempotency_uq
+    ON wallet.bid (bidder_account, idempotency_key);
 
 CREATE INDEX wallet_bid_listing_placed_idx
     ON wallet.bid (listing_id, placed_at DESC, id DESC);
@@ -220,7 +268,45 @@ CREATE UNIQUE INDEX wallet_bid_listing_active_uq
     WHERE status = 'active';
 
 -- ============================================================================
+-- FK back-link: listing.current_bid_id → wallet.bid(id)
+--
+-- Added after both tables exist (wallet.bid references wallet.listing,
+-- so the FK on listing.current_bid_id must be declared post-create).
+-- ON DELETE NO ACTION mirrors the rest of the wallet schema; bid rows
+-- are never deleted, only state-transitioned.
+-- ============================================================================
+
+ALTER TABLE wallet.listing
+    ADD CONSTRAINT listing_current_bid_id_fk
+    FOREIGN KEY (current_bid_id) REFERENCES wallet.bid(id) ON DELETE NO ACTION;
+
+-- ============================================================================
+-- TRIGGER: updated_at touch
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.trg_listing_touch_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql SET search_path = '' AS $$
+BEGIN
+    NEW.updated_at := statement_timestamp();
+    RETURN NEW;
+END;
+$$;
+REVOKE ALL ON FUNCTION wallet.trg_listing_touch_updated_at() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION wallet.trg_listing_touch_updated_at() OWNER TO service_role;
+
+CREATE TRIGGER trg_wallet_listing_touch_updated_at
+    BEFORE UPDATE ON wallet.listing
+    FOR EACH ROW EXECUTE FUNCTION wallet.trg_listing_touch_updated_at();
+
+-- ============================================================================
 -- RLS
+--
+-- FORCE ROW LEVEL SECURITY means every caller (including table owner)
+-- must pass a policy. The market RPCs in Phase 2 are SECURITY DEFINER
+-- and MUST be owned by service_role so they inherit the
+-- service_role_full_access policy below. A function owned by anyone
+-- else (or by a role without an explicit policy / BYPASSRLS) will
+-- silently get zero rows back from these tables.
 -- ============================================================================
 
 ALTER TABLE wallet.listing ENABLE ROW LEVEL SECURITY;
@@ -236,6 +322,11 @@ CREATE POLICY "service_role_full_access" ON wallet.bid
 
 -- No direct authenticated access. All reads/writes flow through the
 -- public.proxy_market_* SECURITY DEFINER functions added in Phase 3.
+
+REVOKE ALL ON TABLE wallet.listing FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE wallet.bid     FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON SEQUENCE wallet.listing_id_seq FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON SEQUENCE wallet.bid_id_seq     FROM PUBLIC, anon, authenticated;
 
 GRANT SELECT, INSERT, UPDATE ON wallet.listing TO service_role;
 GRANT USAGE ON SEQUENCE wallet.listing_id_seq TO service_role;
@@ -271,6 +362,13 @@ ON CONFLICT (account_id) DO NOTHING;
 
 -- migrate:down
 
+-- Drop the cross-table FK first so DROP TABLE on wallet.bid succeeds
+-- (wallet.listing.current_bid_id references wallet.bid(id)).
+ALTER TABLE IF EXISTS wallet.listing
+    DROP CONSTRAINT IF EXISTS listing_current_bid_id_fk;
+
+DROP TRIGGER IF EXISTS trg_wallet_listing_touch_updated_at ON wallet.listing;
+DROP FUNCTION IF EXISTS wallet.trg_listing_touch_updated_at();
 DROP TABLE IF EXISTS wallet.bid;
 DROP TABLE IF EXISTS wallet.listing;
 DROP TYPE  IF EXISTS wallet.bid_status;

--- a/packages/data/sql/schema/README.md
+++ b/packages/data/sql/schema/README.md
@@ -18,7 +18,7 @@ Hand-authored reference DDL grouped by Postgres schema. This tree is the **revie
 | [`staff/`](./staff/)         | `staff`         | Bitwise staff permission / access-control tables.                                   |
 | [`tracker/`](./tracker/)     | `tracker`       | Activity / metrics tracking.                                                        |
 | [`vault/`](./vault/)         | `vault`         | Encrypted secret storage helpers.                                                   |
-| [`wallet/`](./wallet/)       | `wallet`        | Multi-currency ledger + coupon system (credits, khash, treasury, escrow).           |
+| [`wallet/`](./wallet/)       | `wallet`        | Multi-currency ledger + coupons + khash marketplace (listings, bids, treasury fee). |
 
 ## File layout convention
 

--- a/packages/data/sql/schema/wallet/wallet_marketplace.sql
+++ b/packages/data/sql/schema/wallet/wallet_marketplace.sql
@@ -1,0 +1,183 @@
+-- ============================================================================
+-- WALLET MARKETPLACE — listings + bids
+--
+-- Reference mirror. Depends on wallet_core.sql (account, balance, ledger,
+-- currency_kind enum) and wallet_audit.sql.
+--
+-- v1 design notes:
+--   - khash-only (CHECK constraint; drop later to allow credits).
+--   - A listing can be buy-now, auction, or both. At least one price set.
+--   - Listings live 1h–30d.
+--   - item_ref is JSONB owned by the mc service; the wallet trusts that
+--     exactly one real item is escrowed per active listing.
+--   - settlement RPCs (create / bid / cancel / settle / expire-sweep)
+--     land in wallet_rpcs.sql + a pg_cron schedule.
+-- ============================================================================
+
+-- ============================================================================
+-- ENUMS
+-- ============================================================================
+
+CREATE TYPE wallet.listing_status AS ENUM (
+    'active',
+    'sold',
+    'cancelled',
+    'expired'
+);
+
+CREATE TYPE wallet.bid_status AS ENUM (
+    'active',
+    'outbid',
+    'won',
+    'refunded',
+    'cancelled'
+);
+
+-- ============================================================================
+-- TABLE: wallet.listing
+-- ============================================================================
+
+CREATE TABLE wallet.listing (
+    id                  BIGSERIAL PRIMARY KEY,
+    seller_account      UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    item_ref            JSONB NOT NULL,
+    currency            wallet.currency_kind NOT NULL DEFAULT 'khash',
+    buy_now_price       BIGINT,
+    min_bid             BIGINT,
+    current_bid         BIGINT,
+    current_bid_account UUID REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    status              wallet.listing_status NOT NULL DEFAULT 'active',
+    expires_at          TIMESTAMPTZ NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    settled_at          TIMESTAMPTZ,
+    idempotency_key     UUID NOT NULL DEFAULT extensions.gen_random_uuid(),
+
+    CONSTRAINT listing_khash_only_chk CHECK (currency = 'khash'),
+    CONSTRAINT listing_item_ref_shape_chk CHECK (
+        jsonb_typeof(item_ref) = 'object' AND item_ref <> '{}'::jsonb
+    ),
+    CONSTRAINT listing_has_price_chk CHECK (
+        buy_now_price IS NOT NULL OR min_bid IS NOT NULL
+    ),
+    CONSTRAINT listing_buy_now_pos_chk CHECK (
+        buy_now_price IS NULL OR buy_now_price > 0
+    ),
+    CONSTRAINT listing_min_bid_pos_chk CHECK (
+        min_bid IS NULL OR min_bid > 0
+    ),
+    CONSTRAINT listing_buy_now_gte_min_bid_chk CHECK (
+        buy_now_price IS NULL OR min_bid IS NULL OR buy_now_price >= min_bid
+    ),
+    CONSTRAINT listing_current_bid_state_chk CHECK (
+        (current_bid IS NULL     AND current_bid_account IS NULL)
+     OR (current_bid IS NOT NULL AND current_bid_account IS NOT NULL)
+    ),
+    CONSTRAINT listing_current_bid_pos_chk CHECK (
+        current_bid IS NULL OR current_bid > 0
+    ),
+    CONSTRAINT listing_current_bid_gte_min_chk CHECK (
+        current_bid IS NULL OR min_bid IS NULL OR current_bid >= min_bid
+    ),
+    CONSTRAINT listing_settled_at_chk CHECK (
+        (status =  'active' AND settled_at IS NULL)
+     OR (status <> 'active' AND settled_at IS NOT NULL)
+    ),
+    CONSTRAINT listing_min_duration_chk CHECK (
+        expires_at >= created_at + interval '1 hour'
+    ),
+    CONSTRAINT listing_max_duration_chk CHECK (
+        expires_at <= created_at + interval '30 days'
+    )
+);
+
+COMMENT ON TABLE wallet.listing IS
+    'Marketplace listing. Combines fixed-price (buy_now_price) and auction (min_bid) in one row; either or both can be set. Settlement is materialized in wallet.ledger via Phase 2 RPCs.';
+
+CREATE INDEX wallet_listing_active_expires_idx
+    ON wallet.listing (expires_at)
+    WHERE status = 'active';
+CREATE INDEX wallet_listing_seller_created_idx
+    ON wallet.listing (seller_account, created_at DESC, id DESC);
+CREATE INDEX wallet_listing_current_bidder_idx
+    ON wallet.listing (current_bid_account, status)
+    WHERE current_bid_account IS NOT NULL;
+CREATE INDEX wallet_listing_status_created_idx
+    ON wallet.listing (status, created_at DESC, id DESC);
+
+-- ============================================================================
+-- TABLE: wallet.bid
+-- ============================================================================
+
+CREATE TABLE wallet.bid (
+    id                BIGSERIAL PRIMARY KEY,
+    listing_id        BIGINT NOT NULL REFERENCES wallet.listing(id) ON DELETE NO ACTION,
+    bidder_account    UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    amount            BIGINT NOT NULL,
+    placed_at         TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    status            wallet.bid_status NOT NULL DEFAULT 'active',
+    settled_at        TIMESTAMPTZ,
+    escrow_ledger_id  BIGINT NOT NULL REFERENCES wallet.ledger(id) ON DELETE NO ACTION,
+    refund_ledger_id  BIGINT REFERENCES wallet.ledger(id) ON DELETE NO ACTION,
+    idempotency_key   UUID NOT NULL DEFAULT extensions.gen_random_uuid(),
+
+    CONSTRAINT bid_amount_pos_chk CHECK (amount > 0),
+    CONSTRAINT bid_lifecycle_chk CHECK (
+        (status =  'active'
+            AND settled_at      IS NULL
+            AND refund_ledger_id IS NULL)
+     OR (status IN ('outbid', 'refunded', 'cancelled')
+            AND settled_at      IS NOT NULL
+            AND refund_ledger_id IS NOT NULL)
+     OR (status =  'won'
+            AND settled_at      IS NOT NULL
+            AND refund_ledger_id IS NULL)
+    )
+);
+
+COMMENT ON TABLE wallet.bid IS
+    'Per-listing bid history. escrow_ledger_id is mandatory: every bid must reference the debit that escrowed the funds. refund_ledger_id is set on outbid/refunded/cancelled transitions.';
+
+CREATE UNIQUE INDEX wallet_bid_idempotency_uq ON wallet.bid(idempotency_key);
+CREATE INDEX wallet_bid_listing_placed_idx
+    ON wallet.bid (listing_id, placed_at DESC, id DESC);
+CREATE INDEX wallet_bid_bidder_placed_idx
+    ON wallet.bid (bidder_account, placed_at DESC, id DESC);
+CREATE UNIQUE INDEX wallet_bid_listing_bidder_active_uq
+    ON wallet.bid (listing_id, bidder_account)
+    WHERE status = 'active';
+
+-- ============================================================================
+-- RLS
+-- ============================================================================
+
+ALTER TABLE wallet.listing ENABLE ROW LEVEL SECURITY;
+ALTER TABLE wallet.bid     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE wallet.listing FORCE  ROW LEVEL SECURITY;
+ALTER TABLE wallet.bid     FORCE  ROW LEVEL SECURITY;
+
+CREATE POLICY "service_role_full_access" ON wallet.listing
+    FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+CREATE POLICY "service_role_full_access" ON wallet.bid
+    FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+GRANT SELECT, INSERT, UPDATE ON wallet.listing TO service_role;
+GRANT USAGE ON SEQUENCE wallet.listing_id_seq TO service_role;
+GRANT SELECT, INSERT, UPDATE ON wallet.bid TO service_role;
+GRANT USAGE ON SEQUENCE wallet.bid_id_seq TO service_role;
+
+-- ============================================================================
+-- KBVE Treasury seed (idempotent)
+-- ============================================================================
+
+INSERT INTO wallet.account (kind, user_id, guild_id, label, created_at)
+SELECT 'treasury', NULL, NULL, 'kbve_treasury', statement_timestamp()
+WHERE NOT EXISTS (
+    SELECT 1 FROM wallet.account
+     WHERE kind = 'treasury' AND label = 'kbve_treasury'
+);
+
+INSERT INTO wallet.balance (account_id)
+SELECT id FROM wallet.account
+ WHERE kind = 'treasury' AND label = 'kbve_treasury'
+ON CONFLICT (account_id) DO NOTHING;

--- a/packages/data/sql/schema/wallet/wallet_marketplace.sql
+++ b/packages/data/sql/schema/wallet/wallet_marketplace.sql
@@ -41,11 +41,13 @@ CREATE TABLE wallet.listing (
     id                  BIGSERIAL PRIMARY KEY,
     seller_account      UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
     item_ref            JSONB NOT NULL,
+    item_instance_id    TEXT GENERATED ALWAYS AS (item_ref->>'instance_id') STORED,
     currency            wallet.currency_kind NOT NULL DEFAULT 'khash',
     buy_now_price       BIGINT,
     min_bid             BIGINT,
     current_bid         BIGINT,
     current_bid_account UUID REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    current_bid_id      BIGINT,
     buyer_account       UUID REFERENCES wallet.account(id) ON DELETE NO ACTION,
     status              wallet.listing_status NOT NULL DEFAULT 'active',
     expires_at          TIMESTAMPTZ NOT NULL,
@@ -71,8 +73,12 @@ CREATE TABLE wallet.listing (
         buy_now_price IS NULL OR min_bid IS NULL OR buy_now_price >= min_bid
     ),
     CONSTRAINT listing_current_bid_state_chk CHECK (
-        (current_bid IS NULL     AND current_bid_account IS NULL)
-     OR (current_bid IS NOT NULL AND current_bid_account IS NOT NULL)
+        (current_bid IS NULL     AND current_bid_account IS NULL     AND current_bid_id IS NULL)
+     OR (current_bid IS NOT NULL AND current_bid_account IS NOT NULL AND current_bid_id IS NOT NULL)
+    ),
+    CONSTRAINT listing_active_bid_fields_chk CHECK (
+        status =  'active'
+     OR (current_bid IS NULL AND current_bid_account IS NULL AND current_bid_id IS NULL)
     ),
     CONSTRAINT listing_current_bid_pos_chk CHECK (
         current_bid IS NULL OR current_bid > 0
@@ -105,8 +111,8 @@ CREATE TABLE wallet.listing (
 COMMENT ON TABLE wallet.listing IS
     'Marketplace listing. Combines fixed-price (buy_now_price) and auction (min_bid) in one row; either or both can be set. Settlement is materialized in wallet.ledger via Phase 2 RPCs.';
 
-CREATE UNIQUE INDEX wallet_listing_idempotency_uq
-    ON wallet.listing (idempotency_key);
+CREATE UNIQUE INDEX wallet_listing_seller_idempotency_uq
+    ON wallet.listing (seller_account, idempotency_key);
 CREATE INDEX wallet_listing_active_expires_idx
     ON wallet.listing (expires_at)
     WHERE status = 'active';
@@ -115,11 +121,19 @@ CREATE INDEX wallet_listing_active_created_idx
     WHERE status = 'active';
 CREATE INDEX wallet_listing_seller_created_idx
     ON wallet.listing (seller_account, created_at DESC, id DESC);
+CREATE INDEX wallet_listing_seller_status_created_idx
+    ON wallet.listing (seller_account, status, created_at DESC, id DESC);
+CREATE INDEX wallet_listing_buyer_created_idx
+    ON wallet.listing (buyer_account, created_at DESC, id DESC)
+    WHERE buyer_account IS NOT NULL;
 CREATE INDEX wallet_listing_current_bidder_idx
     ON wallet.listing (current_bid_account, status)
     WHERE current_bid_account IS NOT NULL;
 CREATE INDEX wallet_listing_status_created_idx
     ON wallet.listing (status, created_at DESC, id DESC);
+CREATE UNIQUE INDEX wallet_listing_active_item_instance_uq
+    ON wallet.listing (item_instance_id)
+    WHERE status = 'active' AND item_instance_id IS NOT NULL;
 
 -- ============================================================================
 -- TABLE: wallet.bid
@@ -154,7 +168,8 @@ CREATE TABLE wallet.bid (
 COMMENT ON TABLE wallet.bid IS
     'Per-listing bid history. escrow_ledger_id is mandatory: every bid must reference the debit that escrowed the funds. refund_ledger_id is set on outbid/refunded/cancelled transitions.';
 
-CREATE UNIQUE INDEX wallet_bid_idempotency_uq ON wallet.bid(idempotency_key);
+CREATE UNIQUE INDEX wallet_bid_bidder_idempotency_uq
+    ON wallet.bid (bidder_account, idempotency_key);
 CREATE INDEX wallet_bid_listing_placed_idx
     ON wallet.bid (listing_id, placed_at DESC, id DESC);
 CREATE INDEX wallet_bid_bidder_placed_idx
@@ -163,6 +178,32 @@ CREATE INDEX wallet_bid_bidder_placed_idx
 CREATE UNIQUE INDEX wallet_bid_listing_active_uq
     ON wallet.bid (listing_id)
     WHERE status = 'active';
+
+-- ============================================================================
+-- Cross-table FK: listing.current_bid_id → wallet.bid(id)
+-- ============================================================================
+
+ALTER TABLE wallet.listing
+    ADD CONSTRAINT listing_current_bid_id_fk
+    FOREIGN KEY (current_bid_id) REFERENCES wallet.bid(id) ON DELETE NO ACTION;
+
+-- ============================================================================
+-- updated_at trigger
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.trg_listing_touch_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql SET search_path = '' AS $$
+BEGIN
+    NEW.updated_at := statement_timestamp();
+    RETURN NEW;
+END;
+$$;
+REVOKE ALL ON FUNCTION wallet.trg_listing_touch_updated_at() FROM PUBLIC, anon, authenticated;
+ALTER FUNCTION wallet.trg_listing_touch_updated_at() OWNER TO service_role;
+
+CREATE TRIGGER trg_wallet_listing_touch_updated_at
+    BEFORE UPDATE ON wallet.listing
+    FOR EACH ROW EXECUTE FUNCTION wallet.trg_listing_touch_updated_at();
 
 -- ============================================================================
 -- RLS
@@ -178,6 +219,11 @@ CREATE POLICY "service_role_full_access" ON wallet.listing
 
 CREATE POLICY "service_role_full_access" ON wallet.bid
     FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+REVOKE ALL ON TABLE wallet.listing FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE wallet.bid     FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON SEQUENCE wallet.listing_id_seq FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON SEQUENCE wallet.bid_id_seq     FROM PUBLIC, anon, authenticated;
 
 GRANT SELECT, INSERT, UPDATE ON wallet.listing TO service_role;
 GRANT USAGE ON SEQUENCE wallet.listing_id_seq TO service_role;

--- a/packages/data/sql/schema/wallet/wallet_marketplace.sql
+++ b/packages/data/sql/schema/wallet/wallet_marketplace.sql
@@ -46,9 +46,11 @@ CREATE TABLE wallet.listing (
     min_bid             BIGINT,
     current_bid         BIGINT,
     current_bid_account UUID REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    buyer_account       UUID REFERENCES wallet.account(id) ON DELETE NO ACTION,
     status              wallet.listing_status NOT NULL DEFAULT 'active',
     expires_at          TIMESTAMPTZ NOT NULL,
     created_at          TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
     settled_at          TIMESTAMPTZ,
     idempotency_key     UUID NOT NULL DEFAULT extensions.gen_random_uuid(),
 
@@ -82,6 +84,16 @@ CREATE TABLE wallet.listing (
         (status =  'active' AND settled_at IS NULL)
      OR (status <> 'active' AND settled_at IS NOT NULL)
     ),
+    CONSTRAINT listing_current_bid_not_seller_chk CHECK (
+        current_bid_account IS NULL OR current_bid_account <> seller_account
+    ),
+    CONSTRAINT listing_buyer_not_seller_chk CHECK (
+        buyer_account IS NULL OR buyer_account <> seller_account
+    ),
+    CONSTRAINT listing_buyer_state_chk CHECK (
+        (status =  'sold' AND buyer_account IS NOT NULL)
+     OR (status <> 'sold' AND buyer_account IS NULL)
+    ),
     CONSTRAINT listing_min_duration_chk CHECK (
         expires_at >= created_at + interval '1 hour'
     ),
@@ -93,8 +105,13 @@ CREATE TABLE wallet.listing (
 COMMENT ON TABLE wallet.listing IS
     'Marketplace listing. Combines fixed-price (buy_now_price) and auction (min_bid) in one row; either or both can be set. Settlement is materialized in wallet.ledger via Phase 2 RPCs.';
 
+CREATE UNIQUE INDEX wallet_listing_idempotency_uq
+    ON wallet.listing (idempotency_key);
 CREATE INDEX wallet_listing_active_expires_idx
     ON wallet.listing (expires_at)
+    WHERE status = 'active';
+CREATE INDEX wallet_listing_active_created_idx
+    ON wallet.listing (created_at DESC, id DESC)
     WHERE status = 'active';
 CREATE INDEX wallet_listing_seller_created_idx
     ON wallet.listing (seller_account, created_at DESC, id DESC);
@@ -142,8 +159,9 @@ CREATE INDEX wallet_bid_listing_placed_idx
     ON wallet.bid (listing_id, placed_at DESC, id DESC);
 CREATE INDEX wallet_bid_bidder_placed_idx
     ON wallet.bid (bidder_account, placed_at DESC, id DESC);
-CREATE UNIQUE INDEX wallet_bid_listing_bidder_active_uq
-    ON wallet.bid (listing_id, bidder_account)
+-- Exactly one active high bid per listing.
+CREATE UNIQUE INDEX wallet_bid_listing_active_uq
+    ON wallet.bid (listing_id)
     WHERE status = 'active';
 
 -- ============================================================================
@@ -167,15 +185,16 @@ GRANT SELECT, INSERT, UPDATE ON wallet.bid TO service_role;
 GRANT USAGE ON SEQUENCE wallet.bid_id_seq TO service_role;
 
 -- ============================================================================
--- KBVE Treasury seed (idempotent)
+-- KBVE Treasury seed (idempotent + concurrency-safe)
 -- ============================================================================
 
+CREATE UNIQUE INDEX IF NOT EXISTS wallet_account_treasury_label_uq
+    ON wallet.account (label)
+    WHERE kind = 'treasury';
+
 INSERT INTO wallet.account (kind, user_id, guild_id, label, created_at)
-SELECT 'treasury', NULL, NULL, 'kbve_treasury', statement_timestamp()
-WHERE NOT EXISTS (
-    SELECT 1 FROM wallet.account
-     WHERE kind = 'treasury' AND label = 'kbve_treasury'
-);
+VALUES ('treasury', NULL, NULL, 'kbve_treasury', statement_timestamp())
+ON CONFLICT (label) WHERE kind = 'treasury' DO NOTHING;
 
 INSERT INTO wallet.balance (account_id)
 SELECT id FROM wallet.account


### PR DESCRIPTION
## Summary

First slice of the khash marketplace bootstrap. Tables + enums + indexes + RLS + seeded treasury account. Service-layer RPCs land in Phase 2; PostgREST public proxies in Phase 3; axum-kbve transport in Phase 4; Astro UI in Phase 5.

## Schema

**Tables**
- `wallet.listing` — seller, `item_ref` JSONB (shape owned by mc service), `currency` (CHECK = 'khash' for v1), `buy_now_price` + `min_bid` (either or both required), `current_bid` + `current_bid_account`, status, expires_at. Listings live 1h–30d via CHECK on `expires_at` vs `created_at`.
- `wallet.bid` — `listing_id`, `bidder_account`, `amount`, `escrow_ledger_id` (mandatory FK to the debit that escrowed funds), `refund_ledger_id` (set on outbid/refunded/cancelled), lifecycle CHECK keeping status + settled_at + refund_ledger_id consistent.

**Enums**
- `wallet.listing_status` (active, sold, cancelled, expired)
- `wallet.bid_status` (active, outbid, won, refunded, cancelled)

**Indexes**
| Name | Shape | Purpose |
|---|---|---|
| `wallet_listing_active_expires_idx` | partial on `expires_at WHERE status='active'` | Phase 2 expire-sweep hot path |
| `wallet_listing_seller_created_idx` | `(seller, created_at DESC, id DESC)` | my-listings keyset |
| `wallet_listing_current_bidder_idx` | partial on `(current_bid_account, status)` | my-bids reads |
| `wallet_listing_status_created_idx` | `(status, created_at DESC, id DESC)` | public list-active keyset |
| `wallet_bid_idempotency_uq` | unique on `idempotency_key` | replay safety |
| `wallet_bid_listing_placed_idx` | `(listing_id, placed_at DESC, id DESC)` | bid history per listing |
| `wallet_bid_bidder_placed_idx` | `(bidder_account, placed_at DESC, id DESC)` | my-bids history |
| `wallet_bid_listing_bidder_active_uq` | partial unique `(listing_id, bidder_account)` WHERE active | one active bid per (listing, bidder); raising replaces by transitioning prior to 'outbid' in same RPC |

**RLS** — FORCE on both tables. service_role full access. No authenticated grants; all access flows through `public.proxy_market_*` SECURITY DEFINER functions in Phase 3.

**Treasury seed** — Idempotent INSERT of `wallet.account` row with `kind='treasury'`, `label='kbve_treasury'`. Phase 2 `settle_listing` routes the 1% marketplace fee here.

## Test plan

- [x] `nx run data-sql:test-migration 20260514113538_wallet_marketplace_schema` green
- [x] 14 assertions covering: enums + indexes present, treasury seeded with balance row, valid listing inserts succeed (buy_now only, auction only), listing rejects no-price / `buy_now<min_bid` / duration out of `[1h, 30d]` / non-khash currency / empty `item_ref`, bid insert succeeds with real escrow_ledger_id, bid rejects amount=0, lifecycle CHECK prevents active+refund_ledger_id
- [x] After-down: tables + enums dropped, treasury account preserved
- [ ] After merge: dispatch `ci-dbmate-deploy` on main; treasury row + tables ready for Phase 2

## Phase roadmap

1. **Schema** (this PR)
2. Service-layer RPCs + pg_cron expire-sweep
3. Public proxies (RW + RO)
4. Rust axum-kbve transport routes
5. Astro UI `/mc/market` + `/profile/market`

## Design decisions baked in

- khash-only (currency CHECK; drop later if credits become eligible)
- One row per listing combines buy-now + auction; either or both optional
- 1h ≤ duration ≤ 30d
- `item_ref` JSONB — wallet trusts mc to escrow the real item
- Treasury looked up by label (`kbve_treasury`), not UUID constant