### PR TITLE
fix(firecracker-ctl-net): bind Gluetun DNS forwarder to 0.0.0.0

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -83,14 +83,17 @@ spec:
                       - name: TZ
                         value: 'UTC'
                       - name: FIREWALL_INPUT_PORTS
-                        value: '9001,9999'
+                        value: '9001,9999,53'
                       - name: FIREWALL_OUTBOUND_SUBNETS
                         value: '10.0.0.0/8,172.16.0.0/12'
                       # DoH over 443 — Proton blocks 53 and 853 over tunnel.
                       - name: DOT
                         value: 'off'
+                      # Bind DNS forwarder to all interfaces — iptables REDIRECT
+                      # rewrites VM DNS dest to the fctap-N host IP (172.18.0.x),
+                      # not 127.0.0.1, so a loopback-only bind drops the packet.
                       - name: DNS_ADDRESS
-                        value: '127.0.0.1'
+                        value: '0.0.0.0'
                       - name: DNS_UPSTREAM_RESOLVER_TYPE
                         value: 'DoH'
                       - name: DNS_UPSTREAM_RESOLVERS


### PR DESCRIPTION
## Summary
- VM DNS still fails with \`EAI_AGAIN\` after #10938 (DoH switch). Root cause: iptables \`REDIRECT\` from #10905 rewrites the VM's port-53 destination to the **primary address of the inbound interface** (the per-VM TAP host IP, 172.18.0.x), not 127.0.0.1. Gluetun's resolver was bound to 127.0.0.1 only, so the rewritten packet had no socket to land on and the kernel dropped it.
- Switch \`DNS_ADDRESS\` from \`127.0.0.1\` → \`0.0.0.0\` so the forwarder accepts on every local IP including the fctap-N host IPs.
- Append \`53\` to \`FIREWALL_INPUT_PORTS\` so Gluetun's own INPUT firewall (which gets re-applied on VPN reconnect) doesn't shadow the fc-ctl-installed \`-I INPUT -s 172.18.0.0/16 -j ACCEPT\` from #10832.

NetworkPolicy still gates external pod access; no Service exposes 53.

## Test plan
- [ ] After ArgoCD sync, rerun the PoetryDB smoke test from the dashboard with network=true — expect a poem instead of \`EAI_AGAIN\`.
- [ ] \`kubectl exec\` into Gluetun, \`netstat -tlnp | grep :53\` should bind to \`0.0.0.0:53\`.
- [ ] Confirm Gluetun health probe still green (no regression on VPN tunnel).