### PR TITLE
fix(axum-kbve): /fc/public/{name}/ trailing slash no longer 401s

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -476,12 +476,11 @@ fn router(state: AppState) -> Router {
         .route("/fc/{name}", any(super::proxy::firecracker_fc_handler))
         // No JWT gate here; firecracker-ctl-net rejects with 403 when
         // the endpoint was not deployed with `visibility: "public"`.
+        // Single catch-all (vs. {name} + {name}/{*path}) so the trailing-
+        // slash form `/fc/public/my-api/` still matches and does not fall
+        // through to the staff-gated `/fc/{name}/{*path}` route.
         .route(
-            "/fc/public/{name}/{*path}",
-            any(super::proxy::firecracker_fc_public_handler),
-        )
-        .route(
-            "/fc/public/{name}",
+            "/fc/public/{*rest}",
             any(super::proxy::firecracker_fc_public_handler),
         )
         .route(

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -1625,24 +1625,25 @@ pub async fn firecracker_fc_handler(
     }
 }
 
-/// Rewrites `/fc/public/{name}/{*path}` → firecracker-ctl-net
-/// `/proxy/public/{name}/{*path}`. No JWT gate here — ctl-net enforces
-/// that the endpoint was deployed with `visibility: "public"`, returning
-/// 403 otherwise.
+/// Rewrites `/fc/public/<rest>` → firecracker-ctl-net `/proxy/public/<rest>`.
+/// No JWT gate here — ctl-net enforces that the endpoint was deployed with
+/// `visibility: "public"`, returning 403 otherwise.
+///
+/// One catch-all so `/fc/public/my-api`, `/fc/public/my-api/`, and
+/// `/fc/public/my-api/sub/path` all match. Splitting into separate
+/// `{name}` + `{name}/{*path}` routes left `/fc/public/my-api/` (trailing
+/// slash, empty path) unmatched and falling through to the staff
+/// `/fc/{name}/{*path}` — visible as a spurious 401.
 pub async fn firecracker_fc_public_handler(
-    axum::extract::Path(params): axum::extract::Path<Vec<(String, String)>>,
+    rest: Option<Path<String>>,
     req: Request<Body>,
 ) -> Response {
-    let name = params
-        .iter()
-        .find(|(k, _)| k == "name")
-        .map(|(_, v)| v.clone())
-        .unwrap_or_default();
-    let tail = params
-        .iter()
-        .find(|(k, _)| k == "path")
-        .map(|(_, v)| v.clone())
-        .unwrap_or_default();
+    let rest_str = rest.map(|Path(p)| p).unwrap_or_default();
+    let trimmed = rest_str.trim_start_matches('/');
+    let (name, tail) = match trimmed.split_once('/') {
+        Some((n, t)) => (n, t),
+        None => (trimmed, ""),
+    };
 
     if name.is_empty()
         || !name


### PR DESCRIPTION
## Bug
`https://kbve.com/fc/public/my-api/` returns `401 Missing Authorization header` even though the endpoint was deployed with `visibility: "public"`.

## Root cause
matchit treats `/fc/public/{name}/{*path}` and `/fc/public/{name}` as distinct patterns. Neither matches `/fc/public/my-api/` (trailing slash, empty `*path`). The request falls through to the staff-gated `/fc/{name}/{*path}` route (with `name="public"`, `path="my-api/"`) and hits the DASHBOARD_MANAGE auth gate.

## Fix
Collapse the two public routes into one catch-all `/fc/public/{*rest}` and parse `name` + tail inside the handler. Covers the bare, trailing-slash, and sub-path forms uniformly:

- `/fc/public/my-api` → name="my-api", tail=""
- `/fc/public/my-api/` → name="my-api", tail=""
- `/fc/public/my-api/sub/path` → name="my-api", tail="sub/path"

Staff routes (`/fc/{name}/{*path}` + `/fc/{name}`) are unchanged.

## Test plan
- [ ] Deploy public endpoint, hit `/fc/public/my-api` — 200
- [ ] Hit `/fc/public/my-api/` — 200 (previously 401)
- [ ] Hit `/fc/public/my-api/sub/path` — 200, sub/path reaches guest
- [ ] Hit `/fc/public/unknown-name` — 404 from ctl-net (not 401)
- [ ] Deploy staff endpoint, hit `/fc/public/staff-name/` — 403 (not_public) from ctl-net