### PR TITLE
feat(arc-runner): v0.1.3 — bake protobuf-compiler + libprotobuf-dev

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.153",
+			"version": "1.0.155",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -17,7 +17,7 @@
 		{
 			"key": "arc_runner",
 			"app_name": "arc-runner",
-			"version": "0.1.2",
+			"version": "0.1.3",
 			"version_toml": "packages/docker/arc-runner/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx",
 			"source_path": "packages/docker/arc-runner",
@@ -245,7 +245,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.47",
+			"version": "1.0.48",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",

--- a/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
@@ -12,7 +12,7 @@ tags:
 key: arc_runner
 pipeline: docker
 app_name: arc-runner
-version: "0.1.2"
+version: "0.1.3"
 source_path: packages/docker/arc-runner
 version_toml: packages/docker/arc-runner/version.toml
 runner: ubuntu-latest
@@ -51,6 +51,13 @@ A baked image fixes the pattern in three ways:
 | `gh` | GitHub CLI for workflows that shell out to it |
 | `curl` | Inherited from upstream, kept explicit for downstream callers |
 | `ca-certificates` | TLS trust for HTTPS-fetched dependencies |
+| `rsync` | Cross-host file sync (Unity / UE asset shuffling) |
+| `build-essential` + `pkg-config` | Native-build deps for crates that compile C/C++ on the runner (`ci-uniti`, `ci-dashboard`) |
+| `protobuf-compiler` + `libprotobuf-dev` | `protoc` for crates that codegen from `.proto` (used six times across `ci-uniti`) |
+| `gettext-base` (`envsubst`) | k8s manifest rendering (`ci-dbmate-deploy`) |
+| `postgresql-client` (`psql`) | Seed/init step in `ci-dbmate-validate` |
+| `kubectl` | Pinned k8s client used by `ci-dbmate-deploy`; version controlled by `KUBECTL_VERSION` build arg |
+| `dbmate` | Pinned migrator. `ci-dbmate-validate` runs it directly; `ci-dbmate-deploy` invokes it via the in-cluster Job (image bake = parity); version controlled by `DBMATE_VERSION` build arg |
 
 The image runs as the upstream `runner` user by default. The pod spec sets `runAsUser: 0` and the entrypoint hands control to `/home/runner/run.sh`; a sudoers entry for `root` is baked in so a future cleanup can drop the inline `command:` override on `arc-runner-set`.
 
@@ -59,6 +66,8 @@ The image runs as the upstream `runner` user by default. The pod spec sets `runA
 | Arg | Default | Purpose |
 |-----|---------|---------|
 | `ACTIONS_RUNNER_VERSION` | `2.334.0` | Upstream `ghcr.io/actions/actions-runner` tag the image is layered onto. Bump to follow upstream minor releases. |
+| `KUBECTL_VERSION` | `1.31.0` | Pinned `kubectl` release. SHA verified against `dl.k8s.io/release/v<KUBECTL_VERSION>/bin/linux/amd64/kubectl.sha256` at build. |
+| `DBMATE_VERSION` | `2.28.0` | Pinned `dbmate` release. Tracks the in-cluster `ci-dbmate-deploy` Job image for parity. |
 
 ### Used by
 

--- a/packages/docker/arc-runner/Dockerfile
+++ b/packages/docker/arc-runner/Dockerfile
@@ -56,6 +56,8 @@ RUN set -eux; \
         rsync \
         build-essential \
         pkg-config \
+        protobuf-compiler \
+        libprotobuf-dev \
         gettext-base \
         postgresql-client; \
     install -m 0755 -d /etc/apt/keyrings; \
@@ -86,6 +88,7 @@ RUN set -eux; \
     kubectl version --client=true >/dev/null; \
     dbmate --version >/dev/null; \
     psql --version >/dev/null; \
-    envsubst --version >/dev/null
+    envsubst --version >/dev/null; \
+    protoc --version >/dev/null
 
 USER runner


### PR DESCRIPTION
## Summary

Phase-1 follow-up on [#10329](https://github.com/KBVE/kbve/issues/10329). The custom arc-runner image already bakes git-lfs, unzip, jq, xz-utils, gh, kubectl, dbmate, envsubst, postgresql-client, build-essential and pkg-config; this PR adds \`protobuf-compiler\` + \`libprotobuf-dev\` so that the last \`apt-get install\` line in \`ci-uniti.yml\` becomes a no-op the moment that workflow flips to \`runs-on: arc-runner-set-kbve\`.

## Why \`protobuf-compiler\` specifically

\`ci-uniti.yml\` runs the same install line six times per workflow run (one per matrix leg):

\`\`\`bash
sudo apt-get install -y --no-install-recommends build-essential pkg-config protobuf-compiler
\`\`\`

The first two are already in the image. \`protobuf-compiler\` was the lone holdout. libssl-dev (ci-dashboard) and brotli (ci-bevy) only show up once each — kept out of the bake to avoid bloat.

## Files

- \`packages/docker/arc-runner/Dockerfile\` — extends the apt-get install list with \`protobuf-compiler\` + \`libprotobuf-dev\`; smoke-test block now asserts \`protoc --version\` alongside the existing checks.
- \`apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx\` — version bumped \`0.1.2\` → \`0.1.3\`; Image layout table refreshed to list every binary baked since v0.1.0 (the table had drifted); Build args table gains \`KUBECTL_VERSION\` + \`DBMATE_VERSION\` rows.
- \`.github/ci-dispatch-manifest.json\` — regenerated via \`npx nx run astro-kbve:sync:ci-manifest\`. Per repo policy the whole manifest gets committed; the diff also picks up unrelated upstream version bumps (axum-kbve, mc) that landed on \`dev\` between this branch and the last manifest regeneration.
- \`packages/docker/arc-runner/version.toml\` — **deliberately untouched** at 0.1.2. CI's version-gate updates it on successful publish.

## Rollout state (for #10329)

| Phase | Status |
|-------|--------|
| Build custom image | done |
| Publish to ghcr.io/kbve/arc-runner | done (\`0.1.1\`, \`0.1.2\`; \`0.1.3\` after this PR merges + publishes) |
| Deploy canary scale-set (\`arc-runner-set-kbve\`) | done — currently pinned to \`0.1.1\`, idle |
| Migrate workflows to canary | not started |
| Strip apt-get install band-aids | not started |
| Flip main pool (\`arc-runner-set\`) to kbve image | not started |

Follow-up PRs already queued in scope:

1. Bump \`apps/kube/github/runners/manifests/values-kbve.yaml\` from \`arc-runner:0.1.1\` → \`:0.1.3\` after this image publishes.
2. Flip \`ci-dbmate-validate.yml\` + \`ci-dbmate-deploy.yml\` to \`runs-on: arc-runner-set-kbve\` and drop the corresponding \`sudo apt-get install\` lines. Low traffic, low risk — concrete proof the canary works under real load.
3. Flip \`ci-uniti.yml\` after step 2. Drop the six identical install lines.

## Test plan

- [ ] PR CI: \`docker-test-app.yml\` builds and pushes \`ghcr.io/kbve/arc-runner:0.1.3\`; the build's own smoke-test block confirms \`protoc --version\` works.
- [ ] After publish, \`docker run --rm ghcr.io/kbve/arc-runner:0.1.3 protoc --version\` returns a libprotoc version on a local check (visual confirm).
- [ ] Manifest sanity: \`jq '.projects[] | select(.key == "arc_runner")' .github/ci-dispatch-manifest.json\` shows \`version: "0.1.3"\`.