### PR TITLE
feat(wallet): marketplace Phase 2 — service RPCs + pg_cron expire sweep

### DIFF
--- a/packages/data/sql/dbmate/migration-tests/20260515054304_wallet_marketplace_rpcs.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260515054304_wallet_marketplace_rpcs.test.sql
@@ -60,7 +60,7 @@ BEGIN
 
     v_id1 := wallet.service_create_listing(
         v_seller,
-        '{"item_id":"netherite_sword","instance_id":"rpcs-test-1"}'::jsonb,
+        jsonb_build_object('item_id', 'netherite_sword', 'instance_id', 'rpcs-test-1-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500,
         100,
@@ -74,7 +74,7 @@ BEGIN
     -- Replay returns the same id.
     v_id2 := wallet.service_create_listing(
         v_seller,
-        '{"item_id":"different","instance_id":"rpcs-test-replay"}'::jsonb,
+        jsonb_build_object('item_id', 'different', 'instance_id', 'rpcs-test-replay-' || v_seller::text),
         'khash'::wallet.currency_kind,
         999, 999,
         statement_timestamp() + interval '5 hours',
@@ -107,7 +107,7 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        '{"item_id":"axe","instance_id":"rpcs-test-bid"}'::jsonb,
+        jsonb_build_object('item_id', 'axe', 'instance_id', 'rpcs-test-bid-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500, 100,
         statement_timestamp() + interval '2 hours',
@@ -165,7 +165,7 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        '{"item_id":"shield","instance_id":"rpcs-test-reject"}'::jsonb,
+        jsonb_build_object('item_id', 'shield', 'instance_id', 'rpcs-test-reject-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500, 100,
         statement_timestamp() + interval '2 hours',
@@ -216,7 +216,7 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        '{"item_id":"crown","instance_id":"rpcs-test-shortcircuit"}'::jsonb,
+        jsonb_build_object('item_id', 'crown', 'instance_id', 'rpcs-test-shortcircuit-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500, 100,
         statement_timestamp() + interval '2 hours',
@@ -226,8 +226,9 @@ BEGIN
     SELECT khash INTO v_treasury_bal0 FROM wallet.balance WHERE account_id = v_treasury;
     SELECT khash INTO v_seller_bal0   FROM wallet.balance WHERE account_id = v_seller;
 
-    -- 600 >= buy_now 500 → short-circuit.
-    v_bid_id := wallet.service_place_bid(v_listing, v_bidderA, 600, gen_random_uuid());
+    -- 500 == buy_now 500 → short-circuit. Bids strictly above
+    -- buy_now_price are rejected (use buy_now instead).
+    v_bid_id := wallet.service_place_bid(v_listing, v_bidderA, 500, gen_random_uuid());
 
     SELECT * INTO v_lst_row FROM wallet.listing WHERE id = v_listing;
     IF v_lst_row.status <> 'sold' OR v_lst_row.buyer_account IS DISTINCT FROM v_bidderA THEN
@@ -243,13 +244,91 @@ BEGIN
 
     SELECT khash INTO v_treasury_bal1 FROM wallet.balance WHERE account_id = v_treasury;
     SELECT khash INTO v_seller_bal1   FROM wallet.balance WHERE account_id = v_seller;
-    -- fee = 600/100 = 6, seller gets 594.
-    IF v_treasury_bal1 - v_treasury_bal0 <> 6 THEN
-        RAISE EXCEPTION 'fail: treasury fee wrong: % expected 6', v_treasury_bal1 - v_treasury_bal0;
+    -- fee = 500/100 = 5, seller gets 495.
+    IF v_treasury_bal1 - v_treasury_bal0 <> 5 THEN
+        RAISE EXCEPTION 'fail: treasury fee wrong: % expected 5', v_treasury_bal1 - v_treasury_bal0;
     END IF;
-    IF v_seller_bal1 - v_seller_bal0 <> 594 THEN
-        RAISE EXCEPTION 'fail: seller net wrong: % expected 594', v_seller_bal1 - v_seller_bal0;
+    IF v_seller_bal1 - v_seller_bal0 <> 495 THEN
+        RAISE EXCEPTION 'fail: seller net wrong: % expected 495', v_seller_bal1 - v_seller_bal0;
     END IF;
+END;
+$$;
+
+-- 4b. Bid strictly above buy_now_price is rejected.
+DO $$
+DECLARE
+    v_seller   UUID;
+    v_bidderA  UUID;
+    v_listing  BIGINT;
+BEGIN
+    SELECT id INTO v_seller  FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'seller';
+    SELECT id INTO v_bidderA FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'bidderA';
+
+    v_listing := wallet.service_create_listing(
+        v_seller,
+        jsonb_build_object('item_id', 'lance', 'instance_id', 'rpcs-test-overpay-' || v_seller::text),
+        'khash'::wallet.currency_kind,
+        500, 100,
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+    BEGIN
+        PERFORM wallet.service_place_bid(v_listing, v_bidderA, 501, gen_random_uuid());
+        RAISE EXCEPTION 'fail: bid above buy_now_price should have raised';
+    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    END;
+END;
+$$;
+
+-- 4c. service_create_listing rejects invalid inputs.
+DO $$
+DECLARE
+    v_seller UUID;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'seller';
+    BEGIN
+        PERFORM wallet.service_create_listing(
+            v_seller,
+            jsonb_build_object('item_id', 'x', 'instance_id', 'rpcs-test-currency-' || v_seller::text),
+            'credits'::wallet.currency_kind, 100, NULL,
+            statement_timestamp() + interval '2 hours',
+            gen_random_uuid()
+        );
+        RAISE EXCEPTION 'fail: credits currency should have raised';
+    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    END;
+    BEGIN
+        PERFORM wallet.service_create_listing(
+            v_seller, '{}'::jsonb,
+            'khash'::wallet.currency_kind, 100, NULL,
+            statement_timestamp() + interval '2 hours',
+            gen_random_uuid()
+        );
+        RAISE EXCEPTION 'fail: empty item_ref should have raised';
+    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    END;
+    BEGIN
+        PERFORM wallet.service_create_listing(
+            v_seller,
+            jsonb_build_object('item_id', 'x', 'instance_id', 'rpcs-test-past-' || v_seller::text),
+            'khash'::wallet.currency_kind, 100, NULL,
+            statement_timestamp() - interval '1 hour',
+            gen_random_uuid()
+        );
+        RAISE EXCEPTION 'fail: past expires_at should have raised';
+    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    END;
+    BEGIN
+        PERFORM wallet.service_create_listing(
+            v_seller,
+            jsonb_build_object('item_id', 'x', 'instance_id', 'rpcs-test-noprice-' || v_seller::text),
+            'khash'::wallet.currency_kind, NULL, NULL,
+            statement_timestamp() + interval '2 hours',
+            gen_random_uuid()
+        );
+        RAISE EXCEPTION 'fail: no price should have raised';
+    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    END;
 END;
 $$;
 
@@ -277,7 +356,7 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        '{"item_id":"gem","instance_id":"rpcs-test-buynow"}'::jsonb,
+        jsonb_build_object('item_id', 'gem', 'instance_id', 'rpcs-test-buynow-' || v_seller::text),
         'khash'::wallet.currency_kind,
         400, 100,
         statement_timestamp() + interval '2 hours',
@@ -338,7 +417,7 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        '{"item_id":"helm","instance_id":"rpcs-test-cancel"}'::jsonb,
+        jsonb_build_object('item_id', 'helm', 'instance_id', 'rpcs-test-cancel-' || v_seller::text),
         'khash'::wallet.currency_kind,
         NULL, 50,  -- auction only
         statement_timestamp() + interval '2 hours',
@@ -401,7 +480,7 @@ BEGIN
         created_at, expires_at, idempotency_key
     ) VALUES (
         v_seller,
-        '{"item_id":"flute","instance_id":"rpcs-test-expire-no"}'::jsonb,
+        jsonb_build_object('item_id', 'flute', 'instance_id', 'rpcs-test-expire-no-' || v_seller::text),
         'khash'::wallet.currency_kind, 50,
         v_origin, v_past, gen_random_uuid()
     ) RETURNING id INTO v_listing_no;
@@ -411,7 +490,7 @@ BEGIN
     -- fresh listing window then backdate AFTER the bid lands.
     v_listing_yes := wallet.service_create_listing(
         v_seller,
-        '{"item_id":"horn","instance_id":"rpcs-test-expire-yes"}'::jsonb,
+        jsonb_build_object('item_id', 'horn', 'instance_id', 'rpcs-test-expire-yes-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500, 100,
         statement_timestamp() + interval '2 hours',

--- a/packages/data/sql/dbmate/migration-tests/20260515054304_wallet_marketplace_rpcs.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260515054304_wallet_marketplace_rpcs.test.sql
@@ -176,14 +176,14 @@ BEGIN
     BEGIN
         PERFORM wallet.service_place_bid(v_listing, v_seller, 200, gen_random_uuid());
         RAISE EXCEPTION 'fail: seller self-bid should have raised';
-    EXCEPTION WHEN sqlstate 'MK005' THEN NULL;
+    EXCEPTION WHEN sqlstate 'P1005' THEN NULL;
     END;
 
     -- Below min_bid blocked (MK004 bid_too_low).
     BEGIN
         PERFORM wallet.service_place_bid(v_listing, v_bidderA, 50, gen_random_uuid());
         RAISE EXCEPTION 'fail: bid below min_bid should have raised';
-    EXCEPTION WHEN sqlstate 'MK004' THEN NULL;
+    EXCEPTION WHEN sqlstate 'P1004' THEN NULL;
     END;
 
     -- Place a real bid then attempt a non-monotonic bid (MK004).
@@ -191,7 +191,7 @@ BEGIN
     BEGIN
         PERFORM wallet.service_place_bid(v_listing, v_bidderA, 140, gen_random_uuid());
         RAISE EXCEPTION 'fail: non-monotonic bid should have raised';
-    EXCEPTION WHEN sqlstate 'MK004' THEN NULL;
+    EXCEPTION WHEN sqlstate 'P1004' THEN NULL;
     END;
 END;
 $$;
@@ -275,7 +275,7 @@ BEGIN
     BEGIN
         PERFORM wallet.service_place_bid(v_listing, v_bidderA, 501, gen_random_uuid());
         RAISE EXCEPTION 'fail: bid above buy_now_price should have raised';
-    EXCEPTION WHEN sqlstate 'MK006' THEN NULL;
+    EXCEPTION WHEN sqlstate 'P1006' THEN NULL;
     END;
 END;
 $$;
@@ -504,9 +504,9 @@ BEGIN
 
     SELECT khash INTO v_treasury_bal0 FROM wallet.balance WHERE account_id = v_treasury;
 
-    v_swept := wallet.service_expire_listings();
+    SELECT total INTO v_swept FROM wallet.service_expire_listings();
     IF v_swept < 2 THEN
-        RAISE EXCEPTION 'fail: expire sweep returned % (expected >= 2)', v_swept;
+        RAISE EXCEPTION 'fail: expire sweep returned total=% (expected >= 2)', v_swept;
     END IF;
 
     SELECT * INTO v_lst_no  FROM wallet.listing WHERE id = v_listing_no;

--- a/packages/data/sql/dbmate/migration-tests/20260515054304_wallet_marketplace_rpcs.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260515054304_wallet_marketplace_rpcs.test.sql
@@ -295,7 +295,7 @@ BEGIN
             gen_random_uuid()
         );
         RAISE EXCEPTION 'fail: credits currency should have raised';
-    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    EXCEPTION WHEN sqlstate 'P1010' THEN NULL;
     END;
     BEGIN
         PERFORM wallet.service_create_listing(

--- a/packages/data/sql/dbmate/migration-tests/20260515054304_wallet_marketplace_rpcs.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260515054304_wallet_marketplace_rpcs.test.sql
@@ -1,0 +1,491 @@
+-- Companion test fixtures for 20260515054304_wallet_marketplace_rpcs.
+-- Run via: ./test-migration.sh 20260515054304_wallet_marketplace_rpcs
+--
+-- Covers the full create / bid / buy-now / cancel / settle / expire
+-- flow. Uses fresh UUIDs each run (stashed in a fixture table) because
+-- wallet.ledger and wallet.audit_log are append-only.
+
+-- SEED
+DROP TABLE IF EXISTS public.__marketplace_rpcs_fixture;
+CREATE TABLE public.__marketplace_rpcs_fixture (
+    role    TEXT PRIMARY KEY,
+    user_id UUID NOT NULL
+);
+INSERT INTO public.__marketplace_rpcs_fixture (role, user_id) VALUES
+    ('seller',  gen_random_uuid()),
+    ('bidderA', gen_random_uuid()),
+    ('bidderB', gen_random_uuid()),
+    ('buyer',   gen_random_uuid());
+
+INSERT INTO auth.users (id)
+SELECT user_id FROM public.__marketplace_rpcs_fixture;
+
+-- Fund the bidders + buyer with khash so debits succeed.
+DO $$
+DECLARE
+    v_account UUID;
+    v_role    TEXT;
+BEGIN
+    FOR v_role IN SELECT role FROM public.__marketplace_rpcs_fixture WHERE role <> 'seller' LOOP
+        SELECT id INTO v_account
+          FROM wallet.account a
+          JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id
+         WHERE f.role = v_role;
+        PERFORM wallet.service_credit(
+            v_account,
+            'khash'::wallet.currency_kind,
+            5000,
+            'reward'::wallet.source_kind,
+            'rpcs-test funding',
+            NULL, NULL,
+            gen_random_uuid()
+        );
+    END LOOP;
+END;
+$$;
+
+-- ASSERT_AFTER_UP
+
+-- 1. service_create_listing inserts + replays.
+DO $$
+DECLARE
+    v_seller UUID;
+    v_key    UUID := gen_random_uuid();
+    v_id1    BIGINT;
+    v_id2    BIGINT;
+BEGIN
+    SELECT id INTO v_seller FROM wallet.account a
+      JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'seller';
+
+    v_id1 := wallet.service_create_listing(
+        v_seller,
+        '{"item_id":"netherite_sword","instance_id":"rpcs-test-1"}'::jsonb,
+        'khash'::wallet.currency_kind,
+        500,
+        100,
+        statement_timestamp() + interval '2 hours',
+        v_key
+    );
+    IF v_id1 IS NULL THEN
+        RAISE EXCEPTION 'fail: service_create_listing returned NULL';
+    END IF;
+
+    -- Replay returns the same id.
+    v_id2 := wallet.service_create_listing(
+        v_seller,
+        '{"item_id":"different","instance_id":"rpcs-test-replay"}'::jsonb,
+        'khash'::wallet.currency_kind,
+        999, 999,
+        statement_timestamp() + interval '5 hours',
+        v_key
+    );
+    IF v_id2 <> v_id1 THEN
+        RAISE EXCEPTION 'fail: replay returned different id (%, %)', v_id1, v_id2;
+    END IF;
+END;
+$$;
+
+-- 2. service_place_bid happy path + outbid + refund.
+DO $$
+DECLARE
+    v_seller   UUID;
+    v_bidderA  UUID;
+    v_bidderB  UUID;
+    v_listing  BIGINT;
+    v_balA0    BIGINT;
+    v_balA1    BIGINT;
+    v_balA2    BIGINT;
+    v_balB1    BIGINT;
+    v_bidA_id  BIGINT;
+    v_bidB_id  BIGINT;
+    v_lst_row  wallet.listing%ROWTYPE;
+BEGIN
+    SELECT id INTO v_seller  FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'seller';
+    SELECT id INTO v_bidderA FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'bidderA';
+    SELECT id INTO v_bidderB FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'bidderB';
+
+    v_listing := wallet.service_create_listing(
+        v_seller,
+        '{"item_id":"axe","instance_id":"rpcs-test-bid"}'::jsonb,
+        'khash'::wallet.currency_kind,
+        500, 100,
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+
+    SELECT khash INTO v_balA0 FROM wallet.balance WHERE account_id = v_bidderA;
+
+    v_bidA_id := wallet.service_place_bid(v_listing, v_bidderA, 150, gen_random_uuid());
+    SELECT khash INTO v_balA1 FROM wallet.balance WHERE account_id = v_bidderA;
+    IF v_balA1 <> v_balA0 - 150 THEN
+        RAISE EXCEPTION 'fail: bidderA balance after first bid: % expected %', v_balA1, v_balA0 - 150;
+    END IF;
+
+    -- Listing current_bid* updated.
+    SELECT * INTO v_lst_row FROM wallet.listing WHERE id = v_listing;
+    IF v_lst_row.current_bid IS DISTINCT FROM 150
+       OR v_lst_row.current_bid_account IS DISTINCT FROM v_bidderA
+       OR v_lst_row.current_bid_id IS DISTINCT FROM v_bidA_id THEN
+        RAISE EXCEPTION 'fail: listing live-bid pointers wrong after first bid';
+    END IF;
+
+    -- bidderB outbids → bidderA refunded.
+    v_bidB_id := wallet.service_place_bid(v_listing, v_bidderB, 200, gen_random_uuid());
+    SELECT khash INTO v_balA2 FROM wallet.balance WHERE account_id = v_bidderA;
+    IF v_balA2 <> v_balA0 THEN
+        RAISE EXCEPTION 'fail: bidderA not fully refunded after outbid: % expected %', v_balA2, v_balA0;
+    END IF;
+    SELECT khash INTO v_balB1 FROM wallet.balance WHERE account_id = v_bidderB;
+    -- Confirm bidderB debited.
+    IF v_balB1 <> 5000 - 200 THEN
+        RAISE EXCEPTION 'fail: bidderB balance after bid: % expected %', v_balB1, 5000 - 200;
+    END IF;
+
+    -- Prior bid demoted to outbid with refund_ledger_id.
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.bid WHERE id = v_bidA_id
+           AND status = 'outbid' AND refund_ledger_id IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'fail: prior bid not transitioned to outbid';
+    END IF;
+END;
+$$;
+
+-- 3. service_place_bid rejects: seller bidding own listing, below min_bid,
+--    not exceeding current_bid, expired.
+DO $$
+DECLARE
+    v_seller   UUID;
+    v_bidderA  UUID;
+    v_listing  BIGINT;
+BEGIN
+    SELECT id INTO v_seller  FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'seller';
+    SELECT id INTO v_bidderA FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'bidderA';
+
+    v_listing := wallet.service_create_listing(
+        v_seller,
+        '{"item_id":"shield","instance_id":"rpcs-test-reject"}'::jsonb,
+        'khash'::wallet.currency_kind,
+        500, 100,
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+
+    -- Self-bid blocked.
+    BEGIN
+        PERFORM wallet.service_place_bid(v_listing, v_seller, 200, gen_random_uuid());
+        RAISE EXCEPTION 'fail: seller self-bid should have raised';
+    EXCEPTION WHEN insufficient_privilege THEN NULL;
+    END;
+
+    -- Below min_bid blocked.
+    BEGIN
+        PERFORM wallet.service_place_bid(v_listing, v_bidderA, 50, gen_random_uuid());
+        RAISE EXCEPTION 'fail: bid below min_bid should have raised';
+    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    END;
+
+    -- Place a real bid then attempt a non-monotonic bid.
+    PERFORM wallet.service_place_bid(v_listing, v_bidderA, 150, gen_random_uuid());
+    BEGIN
+        PERFORM wallet.service_place_bid(v_listing, v_bidderA, 140, gen_random_uuid());
+        RAISE EXCEPTION 'fail: non-monotonic bid should have raised';
+    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    END;
+END;
+$$;
+
+-- 4. service_place_bid short-circuits to settle when amount >= buy_now_price.
+DO $$
+DECLARE
+    v_seller         UUID;
+    v_bidderA        UUID;
+    v_listing        BIGINT;
+    v_treasury       UUID;
+    v_treasury_bal0  BIGINT;
+    v_treasury_bal1  BIGINT;
+    v_seller_bal0    BIGINT;
+    v_seller_bal1    BIGINT;
+    v_lst_row        wallet.listing%ROWTYPE;
+    v_bid_id         BIGINT;
+BEGIN
+    SELECT id INTO v_seller  FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'seller';
+    SELECT id INTO v_bidderA FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'bidderA';
+    SELECT wallet.treasury_account_id() INTO v_treasury;
+
+    v_listing := wallet.service_create_listing(
+        v_seller,
+        '{"item_id":"crown","instance_id":"rpcs-test-shortcircuit"}'::jsonb,
+        'khash'::wallet.currency_kind,
+        500, 100,
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+
+    SELECT khash INTO v_treasury_bal0 FROM wallet.balance WHERE account_id = v_treasury;
+    SELECT khash INTO v_seller_bal0   FROM wallet.balance WHERE account_id = v_seller;
+
+    -- 600 >= buy_now 500 → short-circuit.
+    v_bid_id := wallet.service_place_bid(v_listing, v_bidderA, 600, gen_random_uuid());
+
+    SELECT * INTO v_lst_row FROM wallet.listing WHERE id = v_listing;
+    IF v_lst_row.status <> 'sold' OR v_lst_row.buyer_account IS DISTINCT FROM v_bidderA THEN
+        RAISE EXCEPTION 'fail: short-circuit settle did not flip listing to sold';
+    END IF;
+    IF v_lst_row.current_bid_id IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: settled listing still carries current_bid_id';
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM wallet.bid WHERE id = v_bid_id AND status = 'won') THEN
+        RAISE EXCEPTION 'fail: winning bid not marked won';
+    END IF;
+
+    SELECT khash INTO v_treasury_bal1 FROM wallet.balance WHERE account_id = v_treasury;
+    SELECT khash INTO v_seller_bal1   FROM wallet.balance WHERE account_id = v_seller;
+    -- fee = 600/100 = 6, seller gets 594.
+    IF v_treasury_bal1 - v_treasury_bal0 <> 6 THEN
+        RAISE EXCEPTION 'fail: treasury fee wrong: % expected 6', v_treasury_bal1 - v_treasury_bal0;
+    END IF;
+    IF v_seller_bal1 - v_seller_bal0 <> 594 THEN
+        RAISE EXCEPTION 'fail: seller net wrong: % expected 594', v_seller_bal1 - v_seller_bal0;
+    END IF;
+END;
+$$;
+
+-- 5. service_buy_now: refunds active bid, settles immediately, fee flows.
+DO $$
+DECLARE
+    v_seller         UUID;
+    v_bidderA        UUID;
+    v_buyer          UUID;
+    v_listing        BIGINT;
+    v_balA0          BIGINT;
+    v_balA1          BIGINT;
+    v_balA2          BIGINT;
+    v_treasury       UUID;
+    v_treasury_bal0  BIGINT;
+    v_treasury_bal1  BIGINT;
+    v_seller_bal0    BIGINT;
+    v_seller_bal1    BIGINT;
+    v_lst_row        wallet.listing%ROWTYPE;
+BEGIN
+    SELECT id INTO v_seller  FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'seller';
+    SELECT id INTO v_bidderA FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'bidderA';
+    SELECT id INTO v_buyer   FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'buyer';
+    SELECT wallet.treasury_account_id() INTO v_treasury;
+
+    v_listing := wallet.service_create_listing(
+        v_seller,
+        '{"item_id":"gem","instance_id":"rpcs-test-buynow"}'::jsonb,
+        'khash'::wallet.currency_kind,
+        400, 100,
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+
+    SELECT khash INTO v_balA0 FROM wallet.balance WHERE account_id = v_bidderA;
+    PERFORM wallet.service_place_bid(v_listing, v_bidderA, 120, gen_random_uuid());
+    SELECT khash INTO v_balA1 FROM wallet.balance WHERE account_id = v_bidderA;
+    IF v_balA1 <> v_balA0 - 120 THEN
+        RAISE EXCEPTION 'fail: bidderA pre-buy-now balance wrong';
+    END IF;
+
+    SELECT khash INTO v_treasury_bal0 FROM wallet.balance WHERE account_id = v_treasury;
+    SELECT khash INTO v_seller_bal0   FROM wallet.balance WHERE account_id = v_seller;
+
+    PERFORM wallet.service_buy_now(v_listing, v_buyer, gen_random_uuid());
+
+    -- bidderA refunded.
+    SELECT khash INTO v_balA2 FROM wallet.balance WHERE account_id = v_bidderA;
+    IF v_balA2 <> v_balA0 THEN
+        RAISE EXCEPTION 'fail: bidderA not refunded by buy_now';
+    END IF;
+
+    -- treasury + seller increments.
+    SELECT khash INTO v_treasury_bal1 FROM wallet.balance WHERE account_id = v_treasury;
+    SELECT khash INTO v_seller_bal1   FROM wallet.balance WHERE account_id = v_seller;
+    -- fee = 400/100 = 4, net = 396.
+    IF v_treasury_bal1 - v_treasury_bal0 <> 4 THEN
+        RAISE EXCEPTION 'fail: treasury fee wrong on buy_now';
+    END IF;
+    IF v_seller_bal1 - v_seller_bal0 <> 396 THEN
+        RAISE EXCEPTION 'fail: seller net wrong on buy_now';
+    END IF;
+
+    SELECT * INTO v_lst_row FROM wallet.listing WHERE id = v_listing;
+    IF v_lst_row.status <> 'sold' OR v_lst_row.buyer_account IS DISTINCT FROM v_buyer THEN
+        RAISE EXCEPTION 'fail: buy_now did not flip listing to sold';
+    END IF;
+END;
+$$;
+
+-- 6. service_cancel_listing: refunds active bid, marks cancelled,
+--    rejects non-seller.
+DO $$
+DECLARE
+    v_seller   UUID;
+    v_bidderA  UUID;
+    v_buyer    UUID;
+    v_listing  BIGINT;
+    v_balA0    BIGINT;
+    v_balA1    BIGINT;
+    v_lst_row  wallet.listing%ROWTYPE;
+BEGIN
+    SELECT id INTO v_seller  FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'seller';
+    SELECT id INTO v_bidderA FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'bidderA';
+    SELECT id INTO v_buyer   FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'buyer';
+
+    v_listing := wallet.service_create_listing(
+        v_seller,
+        '{"item_id":"helm","instance_id":"rpcs-test-cancel"}'::jsonb,
+        'khash'::wallet.currency_kind,
+        NULL, 50,  -- auction only
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+
+    SELECT khash INTO v_balA0 FROM wallet.balance WHERE account_id = v_bidderA;
+    PERFORM wallet.service_place_bid(v_listing, v_bidderA, 75, gen_random_uuid());
+
+    -- Non-seller cancel rejected.
+    BEGIN
+        PERFORM wallet.service_cancel_listing(v_listing, v_buyer, 'malicious', gen_random_uuid());
+        RAISE EXCEPTION 'fail: non-seller cancel should have raised';
+    EXCEPTION WHEN insufficient_privilege THEN NULL;
+    END;
+
+    PERFORM wallet.service_cancel_listing(v_listing, v_seller, 'changed mind', gen_random_uuid());
+
+    SELECT * INTO v_lst_row FROM wallet.listing WHERE id = v_listing;
+    IF v_lst_row.status <> 'cancelled' OR v_lst_row.current_bid_id IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: cancel did not flip listing or clear live-bid pointers';
+    END IF;
+
+    SELECT khash INTO v_balA1 FROM wallet.balance WHERE account_id = v_bidderA;
+    IF v_balA1 <> v_balA0 THEN
+        RAISE EXCEPTION 'fail: bidderA not refunded on cancel: % vs %', v_balA1, v_balA0;
+    END IF;
+
+    -- Idempotent: re-cancel returns without error.
+    PERFORM wallet.service_cancel_listing(v_listing, v_seller, 'replay', gen_random_uuid());
+END;
+$$;
+
+-- 7. service_expire_listings — auction with no bids → 'expired',
+--    auction with bid → 'sold' via settle.
+DO $$
+DECLARE
+    v_seller        UUID;
+    v_bidderA       UUID;
+    v_treasury      UUID;
+    v_treasury_bal0 BIGINT;
+    v_treasury_bal1 BIGINT;
+    v_listing_no    BIGINT;
+    v_listing_yes   BIGINT;
+    v_swept         BIGINT;
+    v_lst_no        wallet.listing%ROWTYPE;
+    v_lst_yes       wallet.listing%ROWTYPE;
+    v_past          TIMESTAMPTZ := statement_timestamp() - interval '1 hour';
+    v_origin        TIMESTAMPTZ := statement_timestamp() - interval '3 hours';
+BEGIN
+    SELECT id INTO v_seller  FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'seller';
+    SELECT id INTO v_bidderA FROM wallet.account a JOIN public.__marketplace_rpcs_fixture f ON f.user_id = a.user_id WHERE f.role = 'bidderA';
+    SELECT wallet.treasury_account_id() INTO v_treasury;
+
+    -- Insert a listing directly with backdated created_at / expires_at
+    -- so the CHECK (expires_at >= created_at + 1h) still passes but the
+    -- deadline is already in the past.
+    INSERT INTO wallet.listing (
+        seller_account, item_ref, currency, min_bid,
+        created_at, expires_at, idempotency_key
+    ) VALUES (
+        v_seller,
+        '{"item_id":"flute","instance_id":"rpcs-test-expire-no"}'::jsonb,
+        'khash'::wallet.currency_kind, 50,
+        v_origin, v_past, gen_random_uuid()
+    ) RETURNING id INTO v_listing_no;
+
+    -- Same shape, but seed an active bid first via service_place_bid.
+    -- service_place_bid checks expires_at > now() so we must use a
+    -- fresh listing window then backdate AFTER the bid lands.
+    v_listing_yes := wallet.service_create_listing(
+        v_seller,
+        '{"item_id":"horn","instance_id":"rpcs-test-expire-yes"}'::jsonb,
+        'khash'::wallet.currency_kind,
+        500, 100,
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+    PERFORM wallet.service_place_bid(v_listing_yes, v_bidderA, 200, gen_random_uuid());
+    -- Now backdate the deadline.
+    UPDATE wallet.listing
+       SET created_at = v_origin, expires_at = v_past
+     WHERE id = v_listing_yes;
+
+    SELECT khash INTO v_treasury_bal0 FROM wallet.balance WHERE account_id = v_treasury;
+
+    v_swept := wallet.service_expire_listings();
+    IF v_swept < 2 THEN
+        RAISE EXCEPTION 'fail: expire sweep returned % (expected >= 2)', v_swept;
+    END IF;
+
+    SELECT * INTO v_lst_no  FROM wallet.listing WHERE id = v_listing_no;
+    SELECT * INTO v_lst_yes FROM wallet.listing WHERE id = v_listing_yes;
+
+    IF v_lst_no.status <> 'expired' THEN
+        RAISE EXCEPTION 'fail: no-bid listing should be expired, got %', v_lst_no.status;
+    END IF;
+    IF v_lst_yes.status <> 'sold' OR v_lst_yes.buyer_account IS DISTINCT FROM v_bidderA THEN
+        RAISE EXCEPTION 'fail: bid listing should be sold to bidderA, got %', v_lst_yes.status;
+    END IF;
+
+    -- Treasury fee from the auction-expire settle: 200/100 = 2.
+    SELECT khash INTO v_treasury_bal1 FROM wallet.balance WHERE account_id = v_treasury;
+    IF v_treasury_bal1 - v_treasury_bal0 < 2 THEN
+        RAISE EXCEPTION 'fail: treasury fee not collected on expire-settle: delta=%',
+            v_treasury_bal1 - v_treasury_bal0;
+    END IF;
+END;
+$$;
+
+-- 8. pg_cron schedule registered when extension is present.
+DO $$
+DECLARE
+    v_has_pgcron BOOLEAN;
+    v_has_job    BOOLEAN;
+BEGIN
+    SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') INTO v_has_pgcron;
+    IF v_has_pgcron THEN
+        SELECT EXISTS (
+            SELECT 1 FROM cron.job WHERE jobname = 'marketplace-expire-listings'
+        ) INTO v_has_job;
+        IF NOT v_has_job THEN
+            RAISE EXCEPTION 'fail: pg_cron present but marketplace-expire-listings not registered';
+        END IF;
+    ELSE
+        RAISE NOTICE 'pg_cron not installed locally; skipping schedule registration assertion';
+    END IF;
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+BEGIN
+    -- All RPCs dropped.
+    IF EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'wallet' AND p.proname IN (
+        'service_create_listing',
+        'service_place_bid',
+        'service_buy_now',
+        'service_cancel_listing',
+        'service_settle_listing',
+        'service_expire_listings',
+        'refund_active_bid',
+        'distribute_settlement',
+        'treasury_account_id'
+    )) THEN
+        RAISE EXCEPTION 'fail: marketplace RPC still present after rollback';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migration-tests/20260515054304_wallet_marketplace_rpcs.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260515054304_wallet_marketplace_rpcs.test.sql
@@ -60,7 +60,7 @@ BEGIN
 
     v_id1 := wallet.service_create_listing(
         v_seller,
-        jsonb_build_object('item_id', 'netherite_sword', 'instance_id', 'rpcs-test-1-' || v_seller::text),
+        jsonb_build_object('kind', 'mc_item', 'id', 'netherite_sword', 'instance_id', 'rpcs-test-1-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500,
         100,
@@ -74,7 +74,7 @@ BEGIN
     -- Replay returns the same id.
     v_id2 := wallet.service_create_listing(
         v_seller,
-        jsonb_build_object('item_id', 'different', 'instance_id', 'rpcs-test-replay-' || v_seller::text),
+        jsonb_build_object('kind', 'mc_item', 'id', 'different', 'instance_id', 'rpcs-test-replay-' || v_seller::text),
         'khash'::wallet.currency_kind,
         999, 999,
         statement_timestamp() + interval '5 hours',
@@ -107,7 +107,7 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        jsonb_build_object('item_id', 'axe', 'instance_id', 'rpcs-test-bid-' || v_seller::text),
+        jsonb_build_object('kind', 'mc_item', 'id', 'axe', 'instance_id', 'rpcs-test-bid-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500, 100,
         statement_timestamp() + interval '2 hours',
@@ -165,33 +165,33 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        jsonb_build_object('item_id', 'shield', 'instance_id', 'rpcs-test-reject-' || v_seller::text),
+        jsonb_build_object('kind', 'mc_item', 'id', 'shield', 'instance_id', 'rpcs-test-reject-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500, 100,
         statement_timestamp() + interval '2 hours',
         gen_random_uuid()
     );
 
-    -- Self-bid blocked.
+    -- Self-bid blocked (MK005 own_listing_forbidden).
     BEGIN
         PERFORM wallet.service_place_bid(v_listing, v_seller, 200, gen_random_uuid());
         RAISE EXCEPTION 'fail: seller self-bid should have raised';
-    EXCEPTION WHEN insufficient_privilege THEN NULL;
+    EXCEPTION WHEN sqlstate 'MK005' THEN NULL;
     END;
 
-    -- Below min_bid blocked.
+    -- Below min_bid blocked (MK004 bid_too_low).
     BEGIN
         PERFORM wallet.service_place_bid(v_listing, v_bidderA, 50, gen_random_uuid());
         RAISE EXCEPTION 'fail: bid below min_bid should have raised';
-    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    EXCEPTION WHEN sqlstate 'MK004' THEN NULL;
     END;
 
-    -- Place a real bid then attempt a non-monotonic bid.
+    -- Place a real bid then attempt a non-monotonic bid (MK004).
     PERFORM wallet.service_place_bid(v_listing, v_bidderA, 150, gen_random_uuid());
     BEGIN
         PERFORM wallet.service_place_bid(v_listing, v_bidderA, 140, gen_random_uuid());
         RAISE EXCEPTION 'fail: non-monotonic bid should have raised';
-    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    EXCEPTION WHEN sqlstate 'MK004' THEN NULL;
     END;
 END;
 $$;
@@ -216,7 +216,7 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        jsonb_build_object('item_id', 'crown', 'instance_id', 'rpcs-test-shortcircuit-' || v_seller::text),
+        jsonb_build_object('kind', 'mc_item', 'id', 'crown', 'instance_id', 'rpcs-test-shortcircuit-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500, 100,
         statement_timestamp() + interval '2 hours',
@@ -266,7 +266,7 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        jsonb_build_object('item_id', 'lance', 'instance_id', 'rpcs-test-overpay-' || v_seller::text),
+        jsonb_build_object('kind', 'mc_item', 'id', 'lance', 'instance_id', 'rpcs-test-overpay-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500, 100,
         statement_timestamp() + interval '2 hours',
@@ -275,7 +275,7 @@ BEGIN
     BEGIN
         PERFORM wallet.service_place_bid(v_listing, v_bidderA, 501, gen_random_uuid());
         RAISE EXCEPTION 'fail: bid above buy_now_price should have raised';
-    EXCEPTION WHEN invalid_parameter_value THEN NULL;
+    EXCEPTION WHEN sqlstate 'MK006' THEN NULL;
     END;
 END;
 $$;
@@ -289,7 +289,7 @@ BEGIN
     BEGIN
         PERFORM wallet.service_create_listing(
             v_seller,
-            jsonb_build_object('item_id', 'x', 'instance_id', 'rpcs-test-currency-' || v_seller::text),
+            jsonb_build_object('kind', 'mc_item', 'id', 'x', 'instance_id', 'rpcs-test-currency-' || v_seller::text),
             'credits'::wallet.currency_kind, 100, NULL,
             statement_timestamp() + interval '2 hours',
             gen_random_uuid()
@@ -310,7 +310,7 @@ BEGIN
     BEGIN
         PERFORM wallet.service_create_listing(
             v_seller,
-            jsonb_build_object('item_id', 'x', 'instance_id', 'rpcs-test-past-' || v_seller::text),
+            jsonb_build_object('kind', 'mc_item', 'id', 'x', 'instance_id', 'rpcs-test-past-' || v_seller::text),
             'khash'::wallet.currency_kind, 100, NULL,
             statement_timestamp() - interval '1 hour',
             gen_random_uuid()
@@ -321,7 +321,7 @@ BEGIN
     BEGIN
         PERFORM wallet.service_create_listing(
             v_seller,
-            jsonb_build_object('item_id', 'x', 'instance_id', 'rpcs-test-noprice-' || v_seller::text),
+            jsonb_build_object('kind', 'mc_item', 'id', 'x', 'instance_id', 'rpcs-test-noprice-' || v_seller::text),
             'khash'::wallet.currency_kind, NULL, NULL,
             statement_timestamp() + interval '2 hours',
             gen_random_uuid()
@@ -356,7 +356,7 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        jsonb_build_object('item_id', 'gem', 'instance_id', 'rpcs-test-buynow-' || v_seller::text),
+        jsonb_build_object('kind', 'mc_item', 'id', 'gem', 'instance_id', 'rpcs-test-buynow-' || v_seller::text),
         'khash'::wallet.currency_kind,
         400, 100,
         statement_timestamp() + interval '2 hours',
@@ -417,7 +417,7 @@ BEGIN
 
     v_listing := wallet.service_create_listing(
         v_seller,
-        jsonb_build_object('item_id', 'helm', 'instance_id', 'rpcs-test-cancel-' || v_seller::text),
+        jsonb_build_object('kind', 'mc_item', 'id', 'helm', 'instance_id', 'rpcs-test-cancel-' || v_seller::text),
         'khash'::wallet.currency_kind,
         NULL, 50,  -- auction only
         statement_timestamp() + interval '2 hours',
@@ -429,12 +429,12 @@ BEGIN
 
     -- Non-seller cancel rejected.
     BEGIN
-        PERFORM wallet.service_cancel_listing(v_listing, v_buyer, 'malicious', gen_random_uuid());
+        PERFORM wallet.service_cancel_listing(v_listing, v_buyer, 'malicious');
         RAISE EXCEPTION 'fail: non-seller cancel should have raised';
     EXCEPTION WHEN insufficient_privilege THEN NULL;
     END;
 
-    PERFORM wallet.service_cancel_listing(v_listing, v_seller, 'changed mind', gen_random_uuid());
+    PERFORM wallet.service_cancel_listing(v_listing, v_seller, 'changed mind');
 
     SELECT * INTO v_lst_row FROM wallet.listing WHERE id = v_listing;
     IF v_lst_row.status <> 'cancelled' OR v_lst_row.current_bid_id IS NOT NULL THEN
@@ -447,7 +447,7 @@ BEGIN
     END IF;
 
     -- Idempotent: re-cancel returns without error.
-    PERFORM wallet.service_cancel_listing(v_listing, v_seller, 'replay', gen_random_uuid());
+    PERFORM wallet.service_cancel_listing(v_listing, v_seller, 'replay');
 END;
 $$;
 
@@ -480,7 +480,7 @@ BEGIN
         created_at, expires_at, idempotency_key
     ) VALUES (
         v_seller,
-        jsonb_build_object('item_id', 'flute', 'instance_id', 'rpcs-test-expire-no-' || v_seller::text),
+        jsonb_build_object('kind', 'mc_item', 'id', 'flute', 'instance_id', 'rpcs-test-expire-no-' || v_seller::text),
         'khash'::wallet.currency_kind, 50,
         v_origin, v_past, gen_random_uuid()
     ) RETURNING id INTO v_listing_no;
@@ -490,7 +490,7 @@ BEGIN
     -- fresh listing window then backdate AFTER the bid lands.
     v_listing_yes := wallet.service_create_listing(
         v_seller,
-        jsonb_build_object('item_id', 'horn', 'instance_id', 'rpcs-test-expire-yes-' || v_seller::text),
+        jsonb_build_object('kind', 'mc_item', 'id', 'horn', 'instance_id', 'rpcs-test-expire-yes-' || v_seller::text),
         'khash'::wallet.currency_kind,
         500, 100,
         statement_timestamp() + interval '2 hours',
@@ -562,7 +562,9 @@ BEGIN
         'service_expire_listings',
         'refund_active_bid',
         'distribute_settlement',
-        'treasury_account_id'
+        'treasury_account_id',
+        'assert_user_account',
+        'marketplace_fee'
     )) THEN
         RAISE EXCEPTION 'fail: marketplace RPC still present after rollback';
     END IF;

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -47,7 +47,8 @@
 -- Idempotency:
 --   listing — (seller_account, idempotency_key) unique, looked up
 --             on replay; same key from same seller → same listing_id.
---   bid     — (bidder_account, listing_id, idempotency_key) unique,
+--   bid     — (bidder_account, listing_id, idempotency_key) unique
+--             (this order matches the actual index column order),
 --             looked up scoped by listing so the same key reused on
 --             a different listing creates a new bid.
 --   ledger writes inside an RPC use deterministic uuid_v5 keys
@@ -67,7 +68,7 @@
 --   wallet_listing_seller_idempotency_uq          (seller_account, idempotency_key)
 --   wallet_listing_active_item_instance_uq        partial: instance_id WHERE active
 --   wallet_bid_bidder_idempotency_uq              REPLACED below with
---                                                 (bidder_account, idempotency_key, listing_id)
+--                                                 (bidder_account, listing_id, idempotency_key)
 --   wallet_bid_listing_active_uq                  partial: listing_id WHERE active
 --   wallet_account_treasury_label_uq              partial: label WHERE kind='treasury'
 --   listing_current_bid_state_chk + listing_current_bid_id_fk → wallet.bid(id)
@@ -144,12 +145,11 @@ BEGIN
 END;
 $$;
 
--- Defensive double-drop: drop in wallet schema first (where the index
--- should live since the table is wallet.bid; PG creates indexes in the
--- table's schema), then try unqualified as a belt-and-suspenders against
--- any migration runner that placed it elsewhere.
+-- The old index lives in wallet schema (PG places indexes in the same
+-- schema as their table). Schema-qualified DROP is unambiguous; we
+-- intentionally do not run an unqualified fallback because that would
+-- depend on search_path and could surprise callers.
 DROP INDEX IF EXISTS wallet.wallet_bid_bidder_idempotency_uq;
-DROP INDEX IF EXISTS wallet_bid_bidder_idempotency_uq;
 
 -- New index is created in wallet schema because the target table is
 -- wallet.bid (PG indexes inherit their schema from the table).
@@ -361,10 +361,19 @@ COMMENT ON FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_k
 -- ============================================================================
 -- INTERNAL HELPER: refund the current active bid (if any)
 --
--- Locks the listing row and the active bid row, credits the prior bidder
--- their bid amount, marks the bid 'outbid' (status arg) or 'refunded'
--- (when called from cancel/expire). Returns the prior bid id (NULL if
--- there was none). Caller must already hold a lock on the listing.
+-- Self-locks the listing row via SELECT ... FOR UPDATE so direct
+-- service_role callers get the same isolation as the top-level RPCs.
+-- Inner callers that already hold the listing lock pay zero extra cost
+-- (re-locking inside the same transaction is a no-op).
+--
+-- Credits the prior bidder their bid amount via service_credit,
+-- transitions the bid to 'outbid' (place_bid path) or 'refunded'
+-- (cancel/expire path), and writes a marketplace audit row.
+--
+-- Returns the prior bid id, or NULL if the listing had no active bid.
+-- Raises P1001 if the listing itself doesn't exist; raises P1008 if
+-- the listing's current_bid pointer disagrees with the active bid row
+-- (drift).
 -- ============================================================================
 
 CREATE OR REPLACE FUNCTION wallet.refund_active_bid(
@@ -396,7 +405,10 @@ BEGIN
       FROM wallet.listing WHERE id = p_listing_id
      FOR UPDATE;
 
-    IF NOT COALESCE(v_listing_has_pointer, FALSE) THEN
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
+    END IF;
+    IF NOT v_listing_has_pointer THEN
         RETURN NULL;
     END IF;
 
@@ -459,8 +471,14 @@ $$;
 ALTER FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) TO service_role;
+-- Note: PG does NOT grant function EXECUTE implicitly to the owner;
+-- explicit service_role grant is required so the top-level RPCs
+-- (which run as service_role via SECURITY DEFINER) can chain in.
+-- Narrowing further (e.g., a dedicated wallet_internal role) is
+-- tracked as a follow-up — the current posture is service_role-only
+-- + self-locking helpers + audit trail.
 COMMENT ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) IS
-    'INTERNAL marketplace helper. Caller must already hold FOR UPDATE on the listing row. Do not wrap from public proxies.';
+    'INTERNAL marketplace helper. service_role-callable; self-locks the listing. Do not wrap from public proxies.';
 
 -- ============================================================================
 -- INTERNAL HELPER: distribute funds on settlement
@@ -550,7 +568,7 @@ ALTER FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) OWNER TO servi
 REVOKE ALL ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) TO service_role;
 COMMENT ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) IS
-    'INTERNAL marketplace helper. Splits a settled amount into (net, fee) via two service_credit calls. Do not wrap from public proxies.';
+    'INTERNAL marketplace helper. service_role-callable. Splits a settled amount into (net, fee) via two service_credit calls. Reached via service_settle_listing owner-chain. Narrower role posture (wallet_internal-only) tracked as a follow-up.';
 
 -- ============================================================================
 -- service_settle_listing
@@ -692,7 +710,7 @@ ALTER FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) OWNER TO serv
 REVOKE ALL ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) TO service_role;
 COMMENT ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) IS
-    'INTERNAL marketplace helper invoked by place_bid (buy-now short-circuit), buy_now, and expire_listings. Self-locks the listing row. Validates: listing status=active, no existing won bid, p_winning_bid_id matches listing.current_bid_id, winning bid status=active. Settlement reason recorded in audit metadata.';
+    'INTERNAL marketplace helper. service_role-callable. Invoked by place_bid (buy-now short-circuit), buy_now, and expire_listings via SECURITY DEFINER owner chain. Self-locks the listing row. Validates: listing status=active, currency=khash, no existing won bid, p_winning_bid_id matches listing.current_bid_id, winning bid status=active. Settlement reason recorded in audit metadata. Narrower role posture tracked as a follow-up.';
 
 -- ============================================================================
 -- service_place_bid
@@ -841,7 +859,7 @@ ALTER FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) OWNER TO ser
 REVOKE ALL ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) TO service_role;
 COMMENT ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) IS
-    'SERVICE marketplace RPC. Places a bid on behalf of kind=user bidder. Idempotent on (bidder_account, idempotency_key, listing_id). Escrows bidder funds, refunds prior active bid, short-circuits to settle when amount = buy_now_price.';
+    'SERVICE marketplace RPC. Places a bid on behalf of kind=user bidder. Idempotent on (bidder_account, listing_id, idempotency_key). Escrows bidder funds, refunds prior active bid, short-circuits to settle when amount = buy_now_price.';
 
 -- ============================================================================
 -- service_buy_now
@@ -1204,3 +1222,11 @@ DROP FUNCTION IF EXISTS wallet.marketplace_fee(BIGINT);
 DROP INDEX IF EXISTS wallet.wallet_bid_bidder_listing_idempotency_uq;
 CREATE UNIQUE INDEX IF NOT EXISTS wallet_bid_bidder_idempotency_uq
     ON wallet.bid (bidder_account, idempotency_key);
+
+DO $$
+BEGIN
+    IF to_regclass('wallet.wallet_bid_bidder_idempotency_uq') IS NULL THEN
+        RAISE EXCEPTION 'rollback expected wallet.wallet_bid_bidder_idempotency_uq but it is missing from wallet schema';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -183,6 +183,7 @@ $$;
 --   P1007 — auction_only / buy_now_only mismatch
 --   P1008 — settlement_drift (winning_bid_id != listing.current_bid_id)
 --   P1009 — account_not_user (actor is not kind='user')
+--   P1010 — unsupported_currency (listing currency is not 'khash' in v1)
 -- ============================================================================
 
 -- Fee rate is 1% on the gross amount. Kept as a single helper so the
@@ -261,6 +262,29 @@ COMMENT ON FUNCTION wallet.assert_user_account(UUID) IS
 
 -- ============================================================================
 -- service_create_listing
+--
+-- Item ownership / escrow:
+--   This RPC validates only the wallet-side invariants — currency,
+--   price, duration, item_ref shape, seller-is-user, and the
+--   wallet_listing_active_item_instance_uq partial unique (one active
+--   listing per instance_id). It does NOT prove the seller owns the
+--   underlying item or lock the item in the mc service while the
+--   listing is active.
+--
+--   Item custody is the responsibility of the mc service + the
+--   Phase 3 proxy_market_create_listing wrapper:
+--     1. Phase 3 proxy resolves auth.uid() → seller wallet account.
+--     2. Phase 3 proxy calls mc-side "reserve item for listing"
+--        (returns instance_id + signed claim).
+--     3. Phase 3 proxy invokes wallet.service_create_listing with
+--        item_ref populated from the reservation.
+--     4. mc holds the item locked until the wallet emits a
+--        marketplace.listing_settle / listing_cancel / expire_sweep
+--        audit row, which mc consumes to release/transfer.
+--   Until the Phase 3 proxy + mc reservation flow lands, the wallet
+--   layer trusts the caller and does NOT prevent double-listing
+--   beyond the active-instance_id unique. Do not expose v1 listings
+--   to real users until that loop is closed.
 -- ============================================================================
 
 CREATE OR REPLACE FUNCTION wallet.service_create_listing(
@@ -291,7 +315,7 @@ BEGIN
     -- raising at the RPC layer surfaces clean domain errors before the
     -- INSERT roundtrip.
     IF v_currency <> 'khash'::wallet.currency_kind THEN
-        RAISE EXCEPTION 'marketplace v1 only supports khash' USING ERRCODE = '22023';
+        RAISE EXCEPTION 'marketplace v1 only supports khash' USING ERRCODE = 'P1010';
     END IF;
     IF jsonb_typeof(p_item_ref) <> 'object' OR p_item_ref = '{}'::jsonb THEN
         RAISE EXCEPTION 'item_ref must be a non-empty JSON object' USING ERRCODE = '22023';
@@ -575,7 +599,7 @@ BEGIN
     END IF;
     IF v_listing_row.currency <> 'khash'::wallet.currency_kind THEN
         RAISE EXCEPTION 'listing % currency % is not khash',
-            p_listing_id, v_listing_row.currency USING ERRCODE = '22023';
+            p_listing_id, v_listing_row.currency USING ERRCODE = 'P1010';
     END IF;
     IF v_listing_row.seller_account <> p_seller THEN
         RAISE EXCEPTION 'seller mismatch for listing %: expected %, got %',
@@ -710,7 +734,7 @@ BEGIN
     END IF;
     IF v_listing_row.currency <> 'khash'::wallet.currency_kind THEN
         RAISE EXCEPTION 'listing % currency % is not khash; v1 unsupported',
-            p_listing_id, v_listing_row.currency USING ERRCODE = '22023';
+            p_listing_id, v_listing_row.currency USING ERRCODE = 'P1010';
     END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%); cannot settle',
@@ -803,7 +827,7 @@ ALTER FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) OWNER TO serv
 REVOKE ALL ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) TO service_role;
 COMMENT ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) IS
-    'INTERNAL marketplace helper. service_role-callable. Invoked by place_bid (buy-now short-circuit), buy_now, and expire_listings via SECURITY DEFINER owner chain. Self-locks the listing row. Validates: listing status=active, currency=khash, no existing won bid, p_winning_bid_id matches listing.current_bid_id, winning bid status=active. Settlement reason recorded in audit metadata. Narrower role posture tracked as a follow-up.';
+    'INTERNAL marketplace helper. service_role-callable. Invoked by place_bid (buy-now short-circuit), buy_now, and expire_listings. Self-locks the listing row. Validates listing status=active+currency=khash+no existing won bid+p_winning_bid_id matches listing.current_bid_id, then flips the winning bid active→won, then calls distribute_settlement (which re-verifies the bid is now status=won before crediting seller/treasury). Settlement reason recorded in audit metadata.';
 
 -- ============================================================================
 -- service_place_bid
@@ -856,7 +880,7 @@ BEGIN
     END IF;
     IF v_listing_row.currency <> 'khash'::wallet.currency_kind THEN
         RAISE EXCEPTION 'listing % currency % is not khash; v1 unsupported',
-            p_listing_id, v_listing_row.currency USING ERRCODE = '22023';
+            p_listing_id, v_listing_row.currency USING ERRCODE = 'P1010';
     END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%)',
@@ -997,7 +1021,7 @@ BEGIN
     END IF;
     IF v_listing_row.currency <> 'khash'::wallet.currency_kind THEN
         RAISE EXCEPTION 'listing % currency % is not khash; v1 unsupported',
-            p_listing_id, v_listing_row.currency USING ERRCODE = '22023';
+            p_listing_id, v_listing_row.currency USING ERRCODE = 'P1010';
     END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%)',

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -95,10 +95,38 @@ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
     v_existing_id BIGINT;
     v_listing_id  BIGINT;
+    v_currency    wallet.currency_kind := COALESCE(p_currency, 'khash'::wallet.currency_kind);
+    v_now         TIMESTAMPTZ := transaction_timestamp();
 BEGIN
     IF p_seller_account IS NULL OR p_idempotency_key IS NULL OR p_item_ref IS NULL THEN
         RAISE EXCEPTION 'seller_account, item_ref, idempotency_key are required'
             USING ERRCODE = '22004';
+    END IF;
+
+    -- Service-layer validation. Table CHECKs are belt-and-suspenders;
+    -- raising at the RPC layer surfaces clean domain errors before the
+    -- INSERT roundtrip.
+    IF v_currency <> 'khash'::wallet.currency_kind THEN
+        RAISE EXCEPTION 'marketplace v1 only supports khash' USING ERRCODE = '22023';
+    END IF;
+    IF jsonb_typeof(p_item_ref) <> 'object' OR p_item_ref = '{}'::jsonb THEN
+        RAISE EXCEPTION 'item_ref must be a non-empty JSON object' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NULL AND p_min_bid IS NULL THEN
+        RAISE EXCEPTION 'listing requires buy_now_price or min_bid' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NOT NULL AND p_buy_now_price <= 0 THEN
+        RAISE EXCEPTION 'buy_now_price must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_min_bid IS NOT NULL AND p_min_bid <= 0 THEN
+        RAISE EXCEPTION 'min_bid must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NOT NULL AND p_min_bid IS NOT NULL
+       AND p_min_bid > p_buy_now_price THEN
+        RAISE EXCEPTION 'min_bid cannot exceed buy_now_price' USING ERRCODE = '22023';
+    END IF;
+    IF p_expires_at IS NULL OR p_expires_at <= v_now THEN
+        RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
     END IF;
 
     -- Replay shortcut.
@@ -114,7 +142,7 @@ BEGIN
         seller_account, item_ref, currency,
         buy_now_price, min_bid, expires_at, idempotency_key
     ) VALUES (
-        p_seller_account, p_item_ref, COALESCE(p_currency, 'khash'),
+        p_seller_account, p_item_ref, v_currency,
         p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
     ) RETURNING id INTO v_listing_id;
 
@@ -157,17 +185,23 @@ DECLARE
     v_bidder           UUID;
     v_amount           BIGINT;
     v_refund_ledger_id BIGINT;
+    v_audit_action     TEXT;
+    v_now              TIMESTAMPTZ := transaction_timestamp();
 BEGIN
     IF p_next_status NOT IN ('outbid', 'refunded') THEN
         RAISE EXCEPTION 'refund_active_bid requires outbid or refunded'
             USING ERRCODE = '22023';
     END IF;
 
-    SELECT id, bidder_account, amount
+    -- Source-of-truth join: only refund the bid the listing actually
+    -- points at. Catches drift between listing.current_bid_id and the
+    -- active bid row.
+    SELECT b.id, b.bidder_account, b.amount
       INTO v_bid_id, v_bidder, v_amount
-      FROM wallet.bid
-     WHERE listing_id = p_listing_id AND status = 'active'
-     FOR UPDATE;
+      FROM wallet.listing l
+      JOIN wallet.bid b ON b.id = l.current_bid_id
+     WHERE l.id = p_listing_id AND b.status = 'active'
+     FOR UPDATE OF b;
 
     IF v_bid_id IS NULL THEN
         RETURN NULL;
@@ -186,9 +220,27 @@ BEGIN
 
     UPDATE wallet.bid
        SET status = p_next_status,
-           settled_at = statement_timestamp(),
+           settled_at = v_now,
            refund_ledger_id = v_refund_ledger_id
      WHERE id = v_bid_id;
+
+    v_audit_action := CASE p_next_status
+        WHEN 'outbid'   THEN 'marketplace.bid_outbid_refund'
+        WHEN 'refunded' THEN 'marketplace.bid_cancel_refund'
+    END;
+
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
+    VALUES (
+        v_audit_action, 'bid', v_bid_id::TEXT,
+        jsonb_build_object(
+            'listing_id', p_listing_id,
+            'bidder_account', v_bidder,
+            'amount', v_amount,
+            'refund_ledger_id', v_refund_ledger_id,
+            'refunded_at', v_now
+        ),
+        p_reason
+    );
 
     RETURN v_bid_id;
 END;
@@ -196,6 +248,8 @@ $$;
 ALTER FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) TO service_role;
+COMMENT ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) IS
+    'INTERNAL marketplace helper. Caller must already hold FOR UPDATE on the listing row. Do not wrap from public proxies.';
 
 -- ============================================================================
 -- INTERNAL HELPER: distribute funds on settlement
@@ -248,6 +302,8 @@ $$;
 ALTER FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) TO service_role;
+COMMENT ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) IS
+    'INTERNAL marketplace helper. Splits a settled amount into (net, fee) via two service_credit calls. Do not wrap from public proxies.';
 
 -- ============================================================================
 -- service_settle_listing
@@ -260,36 +316,56 @@ GRANT EXECUTE ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) TO 
 
 CREATE OR REPLACE FUNCTION wallet.service_settle_listing(
     p_listing_id     BIGINT,
-    p_winning_bid_id BIGINT  -- NULL = look up
+    p_winning_bid_id BIGINT  -- NULL = look up via listing.current_bid_id
 )
 RETURNS VOID
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_seller   UUID;
-    v_bid_id   BIGINT;
-    v_bidder   UUID;
-    v_amount   BIGINT;
-    v_now      TIMESTAMPTZ := statement_timestamp();
-    v_fee      BIGINT;
-    v_net      BIGINT;
+    v_listing_row wallet.listing%ROWTYPE;
+    v_seller      UUID;
+    v_bid_id      BIGINT;
+    v_bidder      UUID;
+    v_amount      BIGINT;
+    v_now         TIMESTAMPTZ := transaction_timestamp();
+    v_fee         BIGINT;
+    v_net         BIGINT;
 BEGIN
-    SELECT seller_account INTO v_seller
-      FROM wallet.listing WHERE id = p_listing_id;
-    IF v_seller IS NULL THEN
+    -- Self-locking: external callers may invoke this directly. Inner
+    -- callers (service_place_bid, service_buy_now, service_expire_listings)
+    -- have already taken FOR UPDATE on the listing — re-locking is a
+    -- no-op within the same transaction.
+    SELECT * INTO v_listing_row
+      FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
+    IF v_listing_row.id IS NULL THEN
         RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = '23503';
     END IF;
+    IF v_listing_row.status <> 'active' THEN
+        RAISE EXCEPTION 'listing % not active (status=%); cannot settle',
+            p_listing_id, v_listing_row.status USING ERRCODE = '22023';
+    END IF;
+    v_seller := v_listing_row.seller_account;
 
     IF p_winning_bid_id IS NULL THEN
+        -- Resolve via the denormalized pointer so settlement aligns
+        -- with the listing's current_bid_id source of truth.
+        IF v_listing_row.current_bid_id IS NULL THEN
+            RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
+                USING ERRCODE = '23503';
+        END IF;
         SELECT id, bidder_account, amount
           INTO v_bid_id, v_bidder, v_amount
           FROM wallet.bid
-         WHERE listing_id = p_listing_id AND status = 'active'
+         WHERE id = v_listing_row.current_bid_id
+           AND listing_id = p_listing_id
+           AND status = 'active'
          FOR UPDATE;
     ELSE
         SELECT id, bidder_account, amount
           INTO v_bid_id, v_bidder, v_amount
           FROM wallet.bid
-         WHERE id = p_winning_bid_id AND listing_id = p_listing_id
+         WHERE id = p_winning_bid_id
+           AND listing_id = p_listing_id
+           AND status = 'active'
          FOR UPDATE;
     END IF;
 
@@ -302,6 +378,10 @@ BEGIN
        SET status = 'won',
            settled_at = v_now
      WHERE id = v_bid_id;
+
+    -- Statement_timestamp keeps the rest of the wallet schema's
+    -- statement_timestamp(); we use transaction_timestamp() locally
+    -- so all marketplace writes in this txn share one logical time.
 
     SELECT d.fee, d.net INTO v_fee, v_net
       FROM wallet.distribute_settlement(p_listing_id, v_seller, v_amount) d;
@@ -332,6 +412,8 @@ $$;
 ALTER FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) TO service_role;
+COMMENT ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) IS
+    'INTERNAL marketplace helper invoked by place_bid (buy-now short-circuit), buy_now, and expire_listings. Self-locks the listing row and validates status=active + winning bid status=active.';
 
 -- ============================================================================
 -- service_place_bid
@@ -348,10 +430,9 @@ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
     v_existing_bid     BIGINT;
     v_listing_row      wallet.listing%ROWTYPE;
-    v_now              TIMESTAMPTZ := statement_timestamp();
+    v_now              TIMESTAMPTZ := transaction_timestamp();
     v_escrow_ledger_id BIGINT;
     v_new_bid_id       BIGINT;
-    v_short_circuit    BOOLEAN := FALSE;
 BEGIN
     IF p_listing_id IS NULL OR p_bidder_account IS NULL
        OR p_amount IS NULL OR p_idempotency_key IS NULL THEN
@@ -398,6 +479,14 @@ BEGIN
         RAISE EXCEPTION 'amount % must exceed current_bid %',
             p_amount, v_listing_row.current_bid USING ERRCODE = '22023';
     END IF;
+    -- Reject bids above buy_now_price; the buyer should use buy_now
+    -- instead so they don't overpay. Equality is allowed so this RPC
+    -- can still short-circuit to settle below.
+    IF v_listing_row.buy_now_price IS NOT NULL
+       AND p_amount > v_listing_row.buy_now_price THEN
+        RAISE EXCEPTION 'amount % exceeds buy_now_price %; use buy_now instead',
+            p_amount, v_listing_row.buy_now_price USING ERRCODE = '22023';
+    END IF;
 
     -- Escrow the bidder's funds.
     v_escrow_ledger_id := wallet.service_debit(
@@ -439,10 +528,10 @@ BEGIN
         )
     );
 
-    -- Short-circuit if this bid meets or exceeds buy_now_price.
+    -- Short-circuit if this bid equals buy_now_price (we rejected
+    -- amount > buy_now_price above).
     IF v_listing_row.buy_now_price IS NOT NULL AND p_amount >= v_listing_row.buy_now_price THEN
         PERFORM wallet.service_settle_listing(p_listing_id, v_new_bid_id);
-        v_short_circuit := TRUE;
     END IF;
 
     RETURN v_new_bid_id;
@@ -466,7 +555,7 @@ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
     v_existing_bid     BIGINT;
     v_listing_row      wallet.listing%ROWTYPE;
-    v_now              TIMESTAMPTZ := statement_timestamp();
+    v_now              TIMESTAMPTZ := transaction_timestamp();
     v_escrow_ledger_id BIGINT;
     v_new_bid_id       BIGINT;
 BEGIN
@@ -573,7 +662,7 @@ RETURNS VOID
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
     v_listing_row wallet.listing%ROWTYPE;
-    v_now         TIMESTAMPTZ := statement_timestamp();
+    v_now         TIMESTAMPTZ := transaction_timestamp();
     v_refund_id   BIGINT;
 BEGIN
     IF p_listing_id IS NULL OR p_seller_account IS NULL THEN
@@ -597,6 +686,13 @@ BEGIN
         END IF;
         RAISE EXCEPTION 'listing % not active (status=%)',
             p_listing_id, v_listing_row.status USING ERRCODE = '22023';
+    END IF;
+    -- Reject cancel once the deadline has passed. Even if cron has
+    -- not swept yet, the seller cannot undo an auction settlement by
+    -- racing the expire-sweep.
+    IF v_listing_row.expires_at <= v_now THEN
+        RAISE EXCEPTION 'listing % has expired and cannot be cancelled', p_listing_id
+            USING ERRCODE = '22023';
     END IF;
 
     v_refund_id := wallet.refund_active_bid(
@@ -643,25 +739,35 @@ CREATE OR REPLACE FUNCTION wallet.service_expire_listings()
 RETURNS BIGINT
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_now           TIMESTAMPTZ := transaction_timestamp();
-    v_listing_id    BIGINT;
-    v_has_bid       BOOLEAN;
-    v_total         BIGINT := 0;
-    v_settled       BIGINT := 0;
-    v_expired       BIGINT := 0;
+    v_now             TIMESTAMPTZ := transaction_timestamp();
+    v_listing_id      BIGINT;
+    v_current_bid_id  BIGINT;
+    v_total           BIGINT := 0;
+    v_settled         BIGINT := 0;
+    v_expired         BIGINT := 0;
 BEGIN
-    FOR v_listing_id IN
-        SELECT id FROM wallet.listing
+    -- Transaction-scoped advisory lock. Overlapping cron runs become a
+    -- no-op for the loser instead of racing on row locks + emitting
+    -- a redundant audit row. SKIP LOCKED below would also be safe, but
+    -- the advisory lock keeps audit traffic clean.
+    IF NOT pg_try_advisory_xact_lock(
+        hashtextextended('wallet.service_expire_listings', 0)
+    ) THEN
+        RETURN 0;
+    END IF;
+
+    FOR v_listing_id, v_current_bid_id IN
+        SELECT id, current_bid_id
+          FROM wallet.listing
          WHERE status = 'active' AND expires_at <= v_now
          ORDER BY expires_at, id
          LIMIT 100
          FOR UPDATE SKIP LOCKED
     LOOP
-        SELECT current_bid_id IS NOT NULL INTO v_has_bid
-          FROM wallet.listing WHERE id = v_listing_id;
-
-        IF v_has_bid THEN
-            PERFORM wallet.service_settle_listing(v_listing_id, NULL);
+        IF v_current_bid_id IS NOT NULL THEN
+            -- Settle deterministically against the listing's pointer
+            -- rather than relying on settle to look the active bid up.
+            PERFORM wallet.service_settle_listing(v_listing_id, v_current_bid_id);
             v_settled := v_settled + 1;
         ELSE
             UPDATE wallet.listing

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -60,12 +60,66 @@
 -- This migration depends on the schema shipped in PR #10976. Specifically:
 --   wallet_listing_seller_idempotency_uq          (seller_account, idempotency_key)
 --   wallet_listing_active_item_instance_uq        partial: instance_id WHERE active
---   wallet_bid_bidder_idempotency_uq              (bidder_account, idempotency_key)
+--   wallet_bid_bidder_idempotency_uq              REPLACED below with
+--                                                 (bidder_account, idempotency_key, listing_id)
 --   wallet_bid_listing_active_uq                  partial: listing_id WHERE active
 --   wallet_account_treasury_label_uq              partial: label WHERE kind='treasury'
 --   listing_current_bid_state_chk + listing_current_bid_id_fk → wallet.bid(id)
 --   listing_active_bid_fields_chk                  non-active rows clear current_bid*
 -- ============================================================================
+
+-- ============================================================================
+-- Enum preflight
+--
+-- The marketplace RPCs hardcode several enum labels (bid_status,
+-- listing_status, source_kind, currency_kind). Fail the migration
+-- early if any label is missing rather than discovering it at runtime.
+-- ============================================================================
+DO $$
+DECLARE
+    v_missing TEXT;
+BEGIN
+    FOR v_missing IN
+        SELECT label FROM (VALUES
+            ('wallet.bid_status:active'),
+            ('wallet.bid_status:outbid'),
+            ('wallet.bid_status:won'),
+            ('wallet.bid_status:refunded'),
+            ('wallet.listing_status:active'),
+            ('wallet.listing_status:sold'),
+            ('wallet.listing_status:cancelled'),
+            ('wallet.listing_status:expired'),
+            ('wallet.currency_kind:khash'),
+            ('wallet.source_kind:market_buy'),
+            ('wallet.source_kind:market_sell'),
+            ('wallet.source_kind:market_fee')
+        ) AS req(label)
+         WHERE NOT EXISTS (
+             SELECT 1 FROM pg_type t
+               JOIN pg_namespace n ON n.oid = t.typnamespace
+               JOIN pg_enum e ON e.enumtypid = t.oid
+              WHERE n.nspname = split_part(split_part(req.label, ':', 1), '.', 1)
+                AND t.typname = split_part(split_part(req.label, ':', 1), '.', 2)
+                AND e.enumlabel = split_part(req.label, ':', 2)
+         )
+    LOOP
+        RAISE EXCEPTION 'enum preflight: missing required label %', v_missing;
+    END LOOP;
+END;
+$$;
+
+-- ============================================================================
+-- Widen the bid idempotency unique to include listing_id.
+--
+-- Phase 1 shipped (bidder_account, idempotency_key) globally unique. That
+-- conflicts with the Phase 2 service_place_bid / service_buy_now replay
+-- semantics, which look up by (bidder, key, listing_id) and want clients
+-- to be able to reuse a key across different listings safely. Replace
+-- the Phase 1 partial unique with the wider shape.
+-- ============================================================================
+DROP INDEX IF EXISTS wallet.wallet_bid_bidder_idempotency_uq;
+CREATE UNIQUE INDEX IF NOT EXISTS wallet_bid_bidder_listing_idempotency_uq
+    ON wallet.bid (bidder_account, listing_id, idempotency_key);
 
 -- ============================================================================
 -- Marketplace domain errors (custom SQLSTATEs)
@@ -86,11 +140,19 @@
 -- ============================================================================
 
 -- Fee rate is 1% on the gross amount. Kept as a single helper so the
--- rate can move without hunting for magic /100 expressions.
+-- rate can move without hunting for magic /100 expressions. PL/pgSQL
+-- so we can RAISE on negative inputs — clamp-to-zero would hide
+-- misuse in a financial helper.
 CREATE OR REPLACE FUNCTION wallet.marketplace_fee(p_amount BIGINT)
 RETURNS BIGINT
-LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
-    SELECT GREATEST(0, p_amount) / 100;
+LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE AS $$
+BEGIN
+    IF p_amount IS NULL OR p_amount < 0 THEN
+        RAISE EXCEPTION 'marketplace_fee requires non-negative amount, got %', p_amount
+            USING ERRCODE = '22023';
+    END IF;
+    RETURN p_amount / 100;
+END;
 $$;
 REVOKE ALL ON FUNCTION wallet.marketplace_fee(BIGINT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.marketplace_fee(BIGINT) TO service_role;
@@ -282,10 +344,21 @@ BEGIN
             USING ERRCODE = '22023';
     END IF;
 
-    -- Source-of-truth join: only refund the bid the listing actually
-    -- points at. Asserts the denormalized listing pointers
-    -- (current_bid, current_bid_account, current_bid_id) agree with the
-    -- referenced bid row before we touch money.
+    -- If the listing has no current bid pointer, there's nothing to
+    -- refund. Otherwise the join must agree on all three denormalized
+    -- fields; drift means data corruption — surface P1008, don't no-op.
+    DECLARE
+        v_listing_has_pointer BOOLEAN;
+    BEGIN
+        SELECT current_bid_id IS NOT NULL
+          INTO v_listing_has_pointer
+          FROM wallet.listing WHERE id = p_listing_id;
+
+        IF NOT COALESCE(v_listing_has_pointer, FALSE) THEN
+            RETURN NULL;
+        END IF;
+    END;
+
     SELECT b.id, b.bidder_account, b.amount
       INTO v_bid_id, v_bidder, v_amount
       FROM wallet.listing l
@@ -297,7 +370,8 @@ BEGIN
      FOR UPDATE OF b;
 
     IF v_bid_id IS NULL THEN
-        RETURN NULL;
+        RAISE EXCEPTION 'listing % current_bid pointer disagrees with active bid; settlement drift',
+            p_listing_id USING ERRCODE = 'P1008';
     END IF;
 
     v_refund_ledger_id := wallet.service_credit(
@@ -520,17 +594,23 @@ BEGIN
     END IF;
 
     -- Conditional update: status must still be 'active' to flip. If
-    -- a concurrent path already won the bid, we want the conflict to
-    -- surface, not silently overwrite.
-    UPDATE wallet.bid
-       SET status = 'won',
-           settled_at = v_now
-     WHERE id = v_bid_id AND status = 'active'
-     RETURNING id INTO v_bid_id;
-    IF v_bid_id IS NULL THEN
-        RAISE EXCEPTION 'bid % no longer active; concurrent settle suspected', v_bid_id
-            USING ERRCODE = 'P1002';
-    END IF;
+    -- a concurrent path already won the bid, surface the conflict
+    -- instead of silently overwriting. Use a separate variable so a
+    -- NULL RETURNING doesn't wipe the original bid id from the error
+    -- message.
+    DECLARE
+        v_updated_bid_id BIGINT;
+    BEGIN
+        UPDATE wallet.bid
+           SET status = 'won',
+               settled_at = v_now
+         WHERE id = v_bid_id AND status = 'active'
+         RETURNING id INTO v_updated_bid_id;
+        IF v_updated_bid_id IS NULL THEN
+            RAISE EXCEPTION 'bid % no longer active; concurrent settle suspected', v_bid_id
+                USING ERRCODE = 'P1002';
+        END IF;
+    END;
 
     SELECT d.fee, d.net, d.seller_ledger_id, d.fee_ledger_id
       INTO v_fee, v_net, v_seller_ledger_id, v_fee_ledger_id
@@ -618,6 +698,10 @@ BEGIN
     IF v_listing_row.id IS NULL THEN
         RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
     END IF;
+    IF v_listing_row.currency <> 'khash'::wallet.currency_kind THEN
+        RAISE EXCEPTION 'listing % currency % is not khash; v1 unsupported',
+            p_listing_id, v_listing_row.currency USING ERRCODE = '22023';
+    END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%)',
             p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
@@ -660,7 +744,13 @@ BEGIN
         'marketplace bid escrow',
         'listing',
         p_listing_id,
-        extensions.uuid_generate_v5(p_idempotency_key, 'marketplace.bid.escrow')
+        extensions.uuid_generate_v5(
+            extensions.uuid_ns_url(),
+            'marketplace.bid.escrow:' ||
+            p_listing_id::TEXT || ':' ||
+            p_bidder_account::TEXT || ':' ||
+            p_idempotency_key::TEXT
+        )
     );
 
     -- Refund the prior active bid (if any).
@@ -749,6 +839,10 @@ BEGIN
     IF v_listing_row.id IS NULL THEN
         RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
     END IF;
+    IF v_listing_row.currency <> 'khash'::wallet.currency_kind THEN
+        RAISE EXCEPTION 'listing % currency % is not khash; v1 unsupported',
+            p_listing_id, v_listing_row.currency USING ERRCODE = '22023';
+    END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%)',
             p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
@@ -775,7 +869,13 @@ BEGIN
         'marketplace buy-now',
         'listing',
         p_listing_id,
-        extensions.uuid_generate_v5(p_idempotency_key, 'marketplace.buy_now.escrow')
+        extensions.uuid_generate_v5(
+            extensions.uuid_ns_url(),
+            'marketplace.buy_now.escrow:' ||
+            p_listing_id::TEXT || ':' ||
+            p_buyer_account::TEXT || ':' ||
+            p_idempotency_key::TEXT
+        )
     );
 
     PERFORM wallet.refund_active_bid(p_listing_id, 'outbid', 'outbid by buy-now');
@@ -890,7 +990,7 @@ BEGIN
             'seller_account', p_seller_account,
             'refunded_bid_id', v_refund_id
         ),
-        p_reason
+        COALESCE(p_reason, 'seller cancelled listing')
     );
 END;
 $$;
@@ -938,10 +1038,12 @@ BEGIN
     PERFORM set_config('lock_timeout', '2s', true);
     PERFORM set_config('statement_timeout', '30s', true);
 
-    -- Transaction-scoped advisory lock. Overlapping cron runs become a
-    -- no-op for the loser instead of racing on row locks + emitting
-    -- a redundant audit row. SKIP LOCKED below would also be safe, but
-    -- the advisory lock keeps audit traffic clean.
+    -- Transaction-scoped advisory lock SERIALIZES sweep workers — the
+    -- loser returns a (0, 0, 0) row immediately. SKIP LOCKED below is
+    -- therefore redundant against parallel cron runs (the advisory
+    -- lock has already excluded them) but it still protects against
+    -- contention from any non-cron caller of service_settle_listing
+    -- holding a listing lock.
     IF NOT pg_try_advisory_xact_lock(
         hashtextextended('wallet.service_expire_listings', 0)
     ) THEN
@@ -1017,7 +1119,7 @@ BEGIN
         PERFORM cron.schedule(
             'marketplace-expire-listings',
             '*/15 * * * *',
-            $cron$SELECT wallet.service_expire_listings();$cron$
+            $cron$SELECT * FROM wallet.service_expire_listings(100);$cron$
         );
     ELSE
         RAISE NOTICE 'pg_cron not installed; skipping marketplace-expire-listings schedule registration';
@@ -1047,3 +1149,11 @@ DROP FUNCTION IF EXISTS wallet.service_create_listing(UUID, JSONB, wallet.curren
 DROP FUNCTION IF EXISTS wallet.assert_user_account(UUID);
 DROP FUNCTION IF EXISTS wallet.treasury_account_id();
 DROP FUNCTION IF EXISTS wallet.marketplace_fee(BIGINT);
+
+-- Restore the Phase 1 shape of the bid idempotency unique. Rollback
+-- intentionally narrows; pre-existing rows may violate the narrower
+-- unique, in which case rollback fails — that's the right signal that
+-- the DB is past the point of free reversal.
+DROP INDEX IF EXISTS wallet.wallet_bid_bidder_listing_idempotency_uq;
+CREATE UNIQUE INDEX IF NOT EXISTS wallet_bid_bidder_idempotency_uq
+    ON wallet.bid (bidder_account, idempotency_key);

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -1,0 +1,742 @@
+-- migrate:up
+
+-- Phase 2 of the marketplace bootstrap: service-layer RPCs for the
+-- create / bid / buy-now / cancel / settle / expire lifecycle, plus a
+-- pg_cron schedule that drives the periodic expire sweep.
+--
+-- All functions are SECURITY DEFINER, service_role only, owned by
+-- service_role, with search_path = ''. They are the authorization
+-- boundary for the marketplace; Phase 3 public proxies wrap these
+-- after applying auth.uid()-based ownership checks.
+--
+-- Money flow (khash-only in v1):
+--
+--   place_bid(listing, bidder, amount):
+--     service_debit(bidder, khash, amount, 'market_buy')
+--       → escrow_ledger_id stored on the new wallet.bid row
+--     if prior active bid exists:
+--       service_credit(prior_bidder, khash, prior_amount, 'market_buy')
+--         → refund_ledger_id stored on the prior bid row; status='outbid'
+--     if amount >= buy_now_price:
+--       service_settle_listing(listing, the new bid) — short-circuit win
+--
+--   buy_now(listing, buyer):
+--     refund the current active bid (if any) just like place_bid
+--     service_debit(buyer, khash, buy_now_price, 'market_buy')
+--     settle:
+--       service_credit(seller, khash, price - fee, 'market_sell')
+--       service_credit(treasury, khash, fee, 'market_fee')
+--
+--   cancel_listing(listing, seller):
+--     refund the current active bid (if any) — service_credit('market_buy')
+--     status='cancelled', settled_at = now()
+--
+--   settle_listing(listing, winning_bid):
+--     mark bid 'won' (no refund_ledger_id; funds go to seller)
+--     service_credit(seller, khash, winning_amount - fee, 'market_sell')
+--     service_credit(treasury, khash, fee, 'market_fee')
+--     mark listing 'sold', buyer_account = winning_bid.bidder_account
+--
+--   expire_listings():  -- pg_cron @ */15 * * * *
+--     for each active listing with expires_at <= now():
+--       if current_bid_id IS NOT NULL: settle_listing
+--       else:                          mark 'expired'
+--
+-- Fee = floor(amount / 100) = 1%. Rounding favours the seller; for
+-- small amounts the fee is 0 (acceptable).
+--
+-- Idempotency:
+--   Each top-level RPC accepts a client-supplied idempotency_key. We
+--   look up the existing row by (actor_account, idempotency_key) and
+--   return its id if found. Intermediate ledger writes use freshly-
+--   generated keys because they live inside the outer transaction:
+--   if the outer call is a replay we never reach them; if not, the
+--   wallet_bid_listing_active_uq / wallet_listing_seller_idempotency_uq
+--   indexes still protect against double-spending.
+
+-- ============================================================================
+-- HELPER: treasury account id (cached at session level)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.treasury_account_id()
+RETURNS UUID
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_id UUID;
+BEGIN
+    SELECT id INTO v_id
+      FROM wallet.account
+     WHERE kind = 'treasury' AND label = 'kbve_treasury';
+    IF v_id IS NULL THEN
+        RAISE EXCEPTION 'kbve_treasury account missing' USING ERRCODE = '23503';
+    END IF;
+    RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION wallet.treasury_account_id() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.treasury_account_id() TO service_role;
+ALTER FUNCTION wallet.treasury_account_id() OWNER TO service_role;
+
+-- ============================================================================
+-- service_create_listing
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.service_create_listing(
+    p_seller_account  UUID,
+    p_item_ref        JSONB,
+    p_currency        wallet.currency_kind,
+    p_buy_now_price   BIGINT,
+    p_min_bid         BIGINT,
+    p_expires_at      TIMESTAMPTZ,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT  -- listing.id
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_existing_id BIGINT;
+    v_listing_id  BIGINT;
+BEGIN
+    IF p_seller_account IS NULL OR p_idempotency_key IS NULL OR p_item_ref IS NULL THEN
+        RAISE EXCEPTION 'seller_account, item_ref, idempotency_key are required'
+            USING ERRCODE = '22004';
+    END IF;
+
+    -- Replay shortcut.
+    SELECT id INTO v_existing_id
+      FROM wallet.listing
+     WHERE seller_account = p_seller_account
+       AND idempotency_key = p_idempotency_key;
+    IF v_existing_id IS NOT NULL THEN
+        RETURN v_existing_id;
+    END IF;
+
+    INSERT INTO wallet.listing (
+        seller_account, item_ref, currency,
+        buy_now_price, min_bid, expires_at, idempotency_key
+    ) VALUES (
+        p_seller_account, p_item_ref, COALESCE(p_currency, 'khash'),
+        p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
+    ) RETURNING id INTO v_listing_id;
+
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+    VALUES (
+        'marketplace.listing_create', 'listing', v_listing_id::TEXT,
+        jsonb_build_object(
+            'seller_account', p_seller_account,
+            'buy_now_price', p_buy_now_price,
+            'min_bid', p_min_bid,
+            'expires_at', p_expires_at
+        )
+    );
+
+    RETURN v_listing_id;
+END;
+$$;
+ALTER FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO service_role;
+
+-- ============================================================================
+-- INTERNAL HELPER: refund the current active bid (if any)
+--
+-- Locks the listing row and the active bid row, credits the prior bidder
+-- their bid amount, marks the bid 'outbid' (status arg) or 'refunded'
+-- (when called from cancel/expire). Returns the prior bid id (NULL if
+-- there was none). Caller must already hold a lock on the listing.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.refund_active_bid(
+    p_listing_id BIGINT,
+    p_next_status wallet.bid_status,  -- 'outbid' | 'refunded'
+    p_reason     TEXT
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_bid_id           BIGINT;
+    v_bidder           UUID;
+    v_amount           BIGINT;
+    v_refund_ledger_id BIGINT;
+BEGIN
+    IF p_next_status NOT IN ('outbid', 'refunded') THEN
+        RAISE EXCEPTION 'refund_active_bid requires outbid or refunded'
+            USING ERRCODE = '22023';
+    END IF;
+
+    SELECT id, bidder_account, amount
+      INTO v_bid_id, v_bidder, v_amount
+      FROM wallet.bid
+     WHERE listing_id = p_listing_id AND status = 'active'
+     FOR UPDATE;
+
+    IF v_bid_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    v_refund_ledger_id := wallet.service_credit(
+        v_bidder,
+        'khash'::wallet.currency_kind,
+        v_amount,
+        'market_buy'::wallet.source_kind,
+        p_reason,
+        'bid',
+        v_bid_id,
+        extensions.gen_random_uuid()
+    );
+
+    UPDATE wallet.bid
+       SET status = p_next_status,
+           settled_at = statement_timestamp(),
+           refund_ledger_id = v_refund_ledger_id
+     WHERE id = v_bid_id;
+
+    RETURN v_bid_id;
+END;
+$$;
+ALTER FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) TO service_role;
+
+-- ============================================================================
+-- INTERNAL HELPER: distribute funds on settlement
+--
+-- Credits seller (price - fee) and treasury (fee). Returns (fee, net).
+-- Caller must already hold the FOR UPDATE lock on the listing.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.distribute_settlement(
+    p_listing_id BIGINT,
+    p_seller     UUID,
+    p_amount     BIGINT
+)
+RETURNS TABLE (fee BIGINT, net BIGINT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_fee      BIGINT := p_amount / 100;
+    v_net      BIGINT := p_amount - (p_amount / 100);
+    v_treasury UUID   := wallet.treasury_account_id();
+BEGIN
+    PERFORM wallet.service_credit(
+        p_seller,
+        'khash'::wallet.currency_kind,
+        v_net,
+        'market_sell'::wallet.source_kind,
+        'marketplace settlement (seller)',
+        'listing',
+        p_listing_id,
+        extensions.gen_random_uuid()
+    );
+
+    IF v_fee > 0 THEN
+        PERFORM wallet.service_credit(
+            v_treasury,
+            'khash'::wallet.currency_kind,
+            v_fee,
+            'market_fee'::wallet.source_kind,
+            'marketplace fee (1%)',
+            'listing',
+            p_listing_id,
+            extensions.gen_random_uuid()
+        );
+    END IF;
+
+    fee := v_fee;
+    net := v_net;
+    RETURN NEXT;
+END;
+$$;
+ALTER FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) TO service_role;
+
+-- ============================================================================
+-- service_settle_listing
+--
+-- Marks the winning bid 'won', distributes funds, marks listing 'sold'
+-- with buyer_account = winning_bid.bidder. Caller MUST hold FOR UPDATE
+-- on the listing row already. p_winning_bid_id allows the caller to
+-- assert the expected bid; pass NULL to look up the active bid.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.service_settle_listing(
+    p_listing_id     BIGINT,
+    p_winning_bid_id BIGINT  -- NULL = look up
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_seller   UUID;
+    v_bid_id   BIGINT;
+    v_bidder   UUID;
+    v_amount   BIGINT;
+    v_now      TIMESTAMPTZ := statement_timestamp();
+    v_fee      BIGINT;
+    v_net      BIGINT;
+BEGIN
+    SELECT seller_account INTO v_seller
+      FROM wallet.listing WHERE id = p_listing_id;
+    IF v_seller IS NULL THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = '23503';
+    END IF;
+
+    IF p_winning_bid_id IS NULL THEN
+        SELECT id, bidder_account, amount
+          INTO v_bid_id, v_bidder, v_amount
+          FROM wallet.bid
+         WHERE listing_id = p_listing_id AND status = 'active'
+         FOR UPDATE;
+    ELSE
+        SELECT id, bidder_account, amount
+          INTO v_bid_id, v_bidder, v_amount
+          FROM wallet.bid
+         WHERE id = p_winning_bid_id AND listing_id = p_listing_id
+         FOR UPDATE;
+    END IF;
+
+    IF v_bid_id IS NULL THEN
+        RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
+            USING ERRCODE = '23503';
+    END IF;
+
+    UPDATE wallet.bid
+       SET status = 'won',
+           settled_at = v_now
+     WHERE id = v_bid_id;
+
+    SELECT d.fee, d.net INTO v_fee, v_net
+      FROM wallet.distribute_settlement(p_listing_id, v_seller, v_amount) d;
+
+    UPDATE wallet.listing
+       SET status = 'sold',
+           settled_at = v_now,
+           buyer_account = v_bidder,
+           current_bid = NULL,
+           current_bid_account = NULL,
+           current_bid_id = NULL
+     WHERE id = p_listing_id;
+
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+    VALUES (
+        'marketplace.listing_settle', 'listing', p_listing_id::TEXT,
+        jsonb_build_object(
+            'winning_bid_id', v_bid_id,
+            'buyer_account', v_bidder,
+            'amount', v_amount,
+            'fee', v_fee,
+            'seller_net', v_net,
+            'settled_at', v_now
+        )
+    );
+END;
+$$;
+ALTER FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) TO service_role;
+
+-- ============================================================================
+-- service_place_bid
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.service_place_bid(
+    p_listing_id      BIGINT,
+    p_bidder_account  UUID,
+    p_amount          BIGINT,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT  -- bid.id
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_existing_bid     BIGINT;
+    v_listing_row      wallet.listing%ROWTYPE;
+    v_now              TIMESTAMPTZ := statement_timestamp();
+    v_escrow_ledger_id BIGINT;
+    v_new_bid_id       BIGINT;
+    v_short_circuit    BOOLEAN := FALSE;
+BEGIN
+    IF p_listing_id IS NULL OR p_bidder_account IS NULL
+       OR p_amount IS NULL OR p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'listing_id, bidder_account, amount, idempotency_key are required'
+            USING ERRCODE = '22004';
+    END IF;
+    IF p_amount <= 0 THEN
+        RAISE EXCEPTION 'amount must be positive' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT id INTO v_existing_bid
+      FROM wallet.bid
+     WHERE bidder_account = p_bidder_account
+       AND idempotency_key = p_idempotency_key;
+    IF v_existing_bid IS NOT NULL THEN
+        RETURN v_existing_bid;
+    END IF;
+
+    -- Lock the listing for the lifetime of this transaction.
+    SELECT * INTO v_listing_row
+      FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
+
+    IF v_listing_row.id IS NULL THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = '23503';
+    END IF;
+    IF v_listing_row.status <> 'active' THEN
+        RAISE EXCEPTION 'listing % not active (status=%)',
+            p_listing_id, v_listing_row.status USING ERRCODE = '22023';
+    END IF;
+    IF v_listing_row.expires_at <= v_now THEN
+        RAISE EXCEPTION 'listing % has expired', p_listing_id USING ERRCODE = '22023';
+    END IF;
+    IF v_listing_row.seller_account = p_bidder_account THEN
+        RAISE EXCEPTION 'seller cannot bid on own listing' USING ERRCODE = '42501';
+    END IF;
+    IF v_listing_row.min_bid IS NULL THEN
+        RAISE EXCEPTION 'listing % is buy-now only', p_listing_id USING ERRCODE = '22023';
+    END IF;
+    IF p_amount < v_listing_row.min_bid THEN
+        RAISE EXCEPTION 'amount % below min_bid %', p_amount, v_listing_row.min_bid
+            USING ERRCODE = '22023';
+    END IF;
+    IF v_listing_row.current_bid IS NOT NULL AND p_amount <= v_listing_row.current_bid THEN
+        RAISE EXCEPTION 'amount % must exceed current_bid %',
+            p_amount, v_listing_row.current_bid USING ERRCODE = '22023';
+    END IF;
+
+    -- Escrow the bidder's funds.
+    v_escrow_ledger_id := wallet.service_debit(
+        p_bidder_account,
+        'khash'::wallet.currency_kind,
+        p_amount,
+        'market_buy'::wallet.source_kind,
+        'marketplace bid escrow',
+        'listing',
+        p_listing_id,
+        extensions.gen_random_uuid()
+    );
+
+    -- Refund the prior active bid (if any).
+    PERFORM wallet.refund_active_bid(p_listing_id, 'outbid', 'outbid by higher bid');
+
+    -- Insert the new active bid.
+    INSERT INTO wallet.bid (
+        listing_id, bidder_account, amount, escrow_ledger_id, idempotency_key
+    ) VALUES (
+        p_listing_id, p_bidder_account, p_amount, v_escrow_ledger_id, p_idempotency_key
+    ) RETURNING id INTO v_new_bid_id;
+
+    -- Update the listing with the new live-bid pointers.
+    UPDATE wallet.listing
+       SET current_bid = p_amount,
+           current_bid_account = p_bidder_account,
+           current_bid_id = v_new_bid_id
+     WHERE id = p_listing_id;
+
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+    VALUES (
+        'marketplace.bid_place', 'bid', v_new_bid_id::TEXT,
+        jsonb_build_object(
+            'listing_id', p_listing_id,
+            'bidder_account', p_bidder_account,
+            'amount', p_amount,
+            'escrow_ledger_id', v_escrow_ledger_id
+        )
+    );
+
+    -- Short-circuit if this bid meets or exceeds buy_now_price.
+    IF v_listing_row.buy_now_price IS NOT NULL AND p_amount >= v_listing_row.buy_now_price THEN
+        PERFORM wallet.service_settle_listing(p_listing_id, v_new_bid_id);
+        v_short_circuit := TRUE;
+    END IF;
+
+    RETURN v_new_bid_id;
+END;
+$$;
+ALTER FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) TO service_role;
+
+-- ============================================================================
+-- service_buy_now
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.service_buy_now(
+    p_listing_id      BIGINT,
+    p_buyer_account   UUID,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT  -- bid.id (the buyer's winning bid row)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_existing_bid     BIGINT;
+    v_listing_row      wallet.listing%ROWTYPE;
+    v_now              TIMESTAMPTZ := statement_timestamp();
+    v_escrow_ledger_id BIGINT;
+    v_new_bid_id       BIGINT;
+BEGIN
+    IF p_listing_id IS NULL OR p_buyer_account IS NULL OR p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'listing_id, buyer_account, idempotency_key are required'
+            USING ERRCODE = '22004';
+    END IF;
+
+    SELECT id INTO v_existing_bid
+      FROM wallet.bid
+     WHERE bidder_account = p_buyer_account
+       AND idempotency_key = p_idempotency_key;
+    IF v_existing_bid IS NOT NULL THEN
+        RETURN v_existing_bid;
+    END IF;
+
+    SELECT * INTO v_listing_row
+      FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
+
+    IF v_listing_row.id IS NULL THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = '23503';
+    END IF;
+    IF v_listing_row.status <> 'active' THEN
+        RAISE EXCEPTION 'listing % not active (status=%)',
+            p_listing_id, v_listing_row.status USING ERRCODE = '22023';
+    END IF;
+    IF v_listing_row.expires_at <= v_now THEN
+        RAISE EXCEPTION 'listing % has expired', p_listing_id USING ERRCODE = '22023';
+    END IF;
+    IF v_listing_row.seller_account = p_buyer_account THEN
+        RAISE EXCEPTION 'seller cannot buy own listing' USING ERRCODE = '42501';
+    END IF;
+    IF v_listing_row.buy_now_price IS NULL THEN
+        RAISE EXCEPTION 'listing % is auction-only', p_listing_id USING ERRCODE = '22023';
+    END IF;
+
+    -- Refund any existing active bid; the buy-now buyer wins immediately.
+    PERFORM wallet.refund_active_bid(p_listing_id, 'outbid', 'outbid by buy-now');
+
+    v_escrow_ledger_id := wallet.service_debit(
+        p_buyer_account,
+        'khash'::wallet.currency_kind,
+        v_listing_row.buy_now_price,
+        'market_buy'::wallet.source_kind,
+        'marketplace buy-now',
+        'listing',
+        p_listing_id,
+        extensions.gen_random_uuid()
+    );
+
+    INSERT INTO wallet.bid (
+        listing_id, bidder_account, amount, escrow_ledger_id, idempotency_key
+    ) VALUES (
+        p_listing_id, p_buyer_account, v_listing_row.buy_now_price,
+        v_escrow_ledger_id, p_idempotency_key
+    ) RETURNING id INTO v_new_bid_id;
+
+    -- Settle immediately. service_settle_listing will UPDATE the
+    -- listing → 'sold' and clear the live-bid pointers (we don't need
+    -- to set them since we're settling in the same transaction).
+    UPDATE wallet.listing
+       SET current_bid = v_listing_row.buy_now_price,
+           current_bid_account = p_buyer_account,
+           current_bid_id = v_new_bid_id
+     WHERE id = p_listing_id;
+
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+    VALUES (
+        'marketplace.buy_now', 'bid', v_new_bid_id::TEXT,
+        jsonb_build_object(
+            'listing_id', p_listing_id,
+            'buyer_account', p_buyer_account,
+            'amount', v_listing_row.buy_now_price,
+            'escrow_ledger_id', v_escrow_ledger_id
+        )
+    );
+
+    PERFORM wallet.service_settle_listing(p_listing_id, v_new_bid_id);
+
+    RETURN v_new_bid_id;
+END;
+$$;
+ALTER FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) TO service_role;
+
+-- ============================================================================
+-- service_cancel_listing
+--
+-- Seller-driven cancel. Refunds any active bid back to its bidder
+-- (status='refunded'), marks the listing 'cancelled'. The auth.uid
+-- check happens in the Phase 3 public proxy; here we just enforce
+-- that the supplied seller_account actually owns the listing so an
+-- mis-routed service call cannot cancel arbitrary listings.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.service_cancel_listing(
+    p_listing_id      BIGINT,
+    p_seller_account  UUID,
+    p_reason          TEXT,
+    p_idempotency_key UUID  -- accepted for symmetry; not yet used for replay
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_listing_row wallet.listing%ROWTYPE;
+    v_now         TIMESTAMPTZ := statement_timestamp();
+    v_refund_id   BIGINT;
+BEGIN
+    IF p_listing_id IS NULL OR p_seller_account IS NULL THEN
+        RAISE EXCEPTION 'listing_id, seller_account are required' USING ERRCODE = '22004';
+    END IF;
+
+    SELECT * INTO v_listing_row
+      FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
+
+    IF v_listing_row.id IS NULL THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = '23503';
+    END IF;
+    IF v_listing_row.seller_account <> p_seller_account THEN
+        RAISE EXCEPTION 'seller_account does not own listing %', p_listing_id
+            USING ERRCODE = '42501';
+    END IF;
+    IF v_listing_row.status <> 'active' THEN
+        -- Idempotent: re-cancel of a cancelled listing is a no-op.
+        IF v_listing_row.status = 'cancelled' THEN
+            RETURN;
+        END IF;
+        RAISE EXCEPTION 'listing % not active (status=%)',
+            p_listing_id, v_listing_row.status USING ERRCODE = '22023';
+    END IF;
+
+    v_refund_id := wallet.refund_active_bid(
+        p_listing_id, 'refunded', COALESCE(p_reason, 'seller cancelled listing')
+    );
+
+    UPDATE wallet.listing
+       SET status = 'cancelled',
+           settled_at = v_now,
+           current_bid = NULL,
+           current_bid_account = NULL,
+           current_bid_id = NULL
+     WHERE id = p_listing_id;
+
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
+    VALUES (
+        'marketplace.listing_cancel', 'listing', p_listing_id::TEXT,
+        jsonb_build_object(
+            'seller_account', p_seller_account,
+            'refunded_bid_id', v_refund_id
+        ),
+        p_reason
+    );
+END;
+$$;
+ALTER FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID) TO service_role;
+
+-- ============================================================================
+-- service_expire_listings — pg_cron-driven sweep
+--
+-- Walks active listings whose deadline has passed and either settles
+-- the winning bid (if any) or marks the listing 'expired' (no bids).
+-- One summary audit row per non-empty sweep. Returns the number of
+-- listings touched.
+--
+-- Uses FOR UPDATE SKIP LOCKED so multiple cron runs can share work
+-- safely. Bounded to 100 listings per call to keep the transaction
+-- small; the cron schedule runs every 15min so backlog clears quickly.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.service_expire_listings()
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_now           TIMESTAMPTZ := transaction_timestamp();
+    v_listing_id    BIGINT;
+    v_has_bid       BOOLEAN;
+    v_total         BIGINT := 0;
+    v_settled       BIGINT := 0;
+    v_expired       BIGINT := 0;
+BEGIN
+    FOR v_listing_id IN
+        SELECT id FROM wallet.listing
+         WHERE status = 'active' AND expires_at <= v_now
+         ORDER BY expires_at, id
+         LIMIT 100
+         FOR UPDATE SKIP LOCKED
+    LOOP
+        SELECT current_bid_id IS NOT NULL INTO v_has_bid
+          FROM wallet.listing WHERE id = v_listing_id;
+
+        IF v_has_bid THEN
+            PERFORM wallet.service_settle_listing(v_listing_id, NULL);
+            v_settled := v_settled + 1;
+        ELSE
+            UPDATE wallet.listing
+               SET status = 'expired',
+                   settled_at = v_now,
+                   current_bid = NULL,
+                   current_bid_account = NULL,
+                   current_bid_id = NULL
+             WHERE id = v_listing_id;
+            v_expired := v_expired + 1;
+        END IF;
+        v_total := v_total + 1;
+    END LOOP;
+
+    IF v_total > 0 THEN
+        INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+        VALUES (
+            'marketplace.expire_sweep', 'listing', 'batch',
+            jsonb_build_object(
+                'total', v_total,
+                'settled', v_settled,
+                'expired', v_expired,
+                'cutoff_at', v_now,
+                'swept_at', v_now
+            )
+        );
+    END IF;
+
+    RETURN v_total;
+END;
+$$;
+ALTER FUNCTION wallet.service_expire_listings() OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_expire_listings() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_expire_listings() TO service_role;
+-- pg_cron runs jobs as the scheduling role (postgres). Document the
+-- exec contract with an explicit grant.
+GRANT EXECUTE ON FUNCTION wallet.service_expire_listings() TO postgres;
+
+COMMENT ON FUNCTION wallet.service_expire_listings() IS
+    'Sweeps active listings whose expires_at has passed. Settles winning bid if any, otherwise marks expired. Bounded to 100 rows/call. Writes one summary audit row per non-empty sweep.';
+
+-- pg_cron schedule — guarded by extension presence so local dev passes.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        PERFORM cron.unschedule(jobid)
+          FROM cron.job WHERE jobname = 'marketplace-expire-listings';
+        PERFORM cron.schedule(
+            'marketplace-expire-listings',
+            '*/15 * * * *',
+            $cron$SELECT wallet.service_expire_listings();$cron$
+        );
+    ELSE
+        RAISE NOTICE 'pg_cron not installed; skipping marketplace-expire-listings schedule registration';
+    END IF;
+END;
+$$;
+
+-- migrate:down
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+        PERFORM cron.unschedule(jobid)
+          FROM cron.job WHERE jobname = 'marketplace-expire-listings';
+    END IF;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS wallet.service_expire_listings();
+DROP FUNCTION IF EXISTS wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID);
+DROP FUNCTION IF EXISTS wallet.service_buy_now(BIGINT, UUID, UUID);
+DROP FUNCTION IF EXISTS wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID);
+DROP FUNCTION IF EXISTS wallet.service_settle_listing(BIGINT, BIGINT);
+DROP FUNCTION IF EXISTS wallet.distribute_settlement(BIGINT, UUID, BIGINT);
+DROP FUNCTION IF EXISTS wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT);
+DROP FUNCTION IF EXISTS wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID);
+DROP FUNCTION IF EXISTS wallet.treasury_account_id();

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -21,11 +21,10 @@
 --       service_settle_listing(listing, the new bid) — short-circuit win
 --
 --   buy_now(listing, buyer):
---     refund the current active bid (if any) just like place_bid
---     service_debit(buyer, khash, buy_now_price, 'market_buy')
---     settle:
---       service_credit(seller, khash, price - fee, 'market_sell')
---       service_credit(treasury, khash, fee, 'market_fee')
+--     service_debit(buyer, khash, buy_now_price, 'market_buy')   -- buyer pays first
+--     refund the current active bid (if any) — service_credit('market_buy')
+--     insert winning bid + flip listing pointers
+--     service_settle_listing(...) — credits seller (price - fee) + treasury (fee)
 --
 --   cancel_listing(listing, seller):
 --     refund the current active bid (if any) — service_credit('market_buy')
@@ -46,13 +45,20 @@
 -- small amounts the fee is 0 (acceptable).
 --
 -- Idempotency:
---   Each top-level RPC accepts a client-supplied idempotency_key. We
---   look up the existing row by (actor_account, idempotency_key) and
---   return its id if found. Intermediate ledger writes use freshly-
---   generated keys because they live inside the outer transaction:
---   if the outer call is a replay we never reach them; if not, the
---   wallet_bid_listing_active_uq / wallet_listing_seller_idempotency_uq
---   indexes still protect against double-spending.
+--   listing — (seller_account, idempotency_key) unique, looked up
+--             on replay; same key from same seller → same listing_id.
+--   bid     — (bidder_account, listing_id, idempotency_key) unique,
+--             looked up scoped by listing so the same key reused on
+--             a different listing creates a new bid.
+--   ledger writes inside an RPC use deterministic uuid_v5 keys
+--             derived from (uuid_ns_url(), descriptive name) so
+--             retries collide cleanly at the wallet.ledger unique.
+--
+-- Deployment note:
+--   This migration widens wallet.bid's bidder idempotency unique. Once
+--   any client reuses a key across different listings, the migration
+--   down-path (which would narrow it back) WILL fail. Treat as
+--   forward-only after the first production run.
 
 -- ============================================================================
 -- Required Phase 1 invariants
@@ -113,13 +119,50 @@ $$;
 --
 -- Phase 1 shipped (bidder_account, idempotency_key) globally unique. That
 -- conflicts with the Phase 2 service_place_bid / service_buy_now replay
--- semantics, which look up by (bidder, key, listing_id) and want clients
--- to be able to reuse a key across different listings safely. Replace
--- the Phase 1 partial unique with the wider shape.
+-- semantics, which look up by (bidder, listing, key) and want clients
+-- to be able to reuse a key across different listings safely.
+--
+-- Preflight: refuse to widen if existing rows would violate the new
+-- shape. The old narrower constraint should already prevent this, but
+-- a dirty INSERT bypassing the index (none should exist) would surface
+-- here rather than at index creation time.
 -- ============================================================================
+
+DO $$
+DECLARE
+    v_dupes BIGINT;
+BEGIN
+    SELECT COUNT(*) INTO v_dupes FROM (
+        SELECT 1 FROM wallet.bid
+         GROUP BY bidder_account, listing_id, idempotency_key
+        HAVING COUNT(*) > 1
+    ) d;
+    IF v_dupes > 0 THEN
+        RAISE EXCEPTION 'widen bid idempotency: % duplicate (bidder, listing, key) groups exist; resolve before applying',
+            v_dupes USING ERRCODE = '23505';
+    END IF;
+END;
+$$;
+
+-- Defensive double-drop: drop in wallet schema first (where the index
+-- should live since the table is wallet.bid; PG creates indexes in the
+-- table's schema), then try unqualified as a belt-and-suspenders against
+-- any migration runner that placed it elsewhere.
 DROP INDEX IF EXISTS wallet.wallet_bid_bidder_idempotency_uq;
+DROP INDEX IF EXISTS wallet_bid_bidder_idempotency_uq;
+
+-- New index is created in wallet schema because the target table is
+-- wallet.bid (PG indexes inherit their schema from the table).
 CREATE UNIQUE INDEX IF NOT EXISTS wallet_bid_bidder_listing_idempotency_uq
     ON wallet.bid (bidder_account, listing_id, idempotency_key);
+
+DO $$
+BEGIN
+    IF to_regclass('wallet.wallet_bid_bidder_listing_idempotency_uq') IS NULL THEN
+        RAISE EXCEPTION 'expected wallet.wallet_bid_bidder_listing_idempotency_uq but it is missing from wallet schema';
+    END IF;
+END;
+$$;
 
 -- ============================================================================
 -- Marketplace domain errors (custom SQLSTATEs)
@@ -332,32 +375,30 @@ CREATE OR REPLACE FUNCTION wallet.refund_active_bid(
 RETURNS BIGINT
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_bid_id           BIGINT;
-    v_bidder           UUID;
-    v_amount           BIGINT;
-    v_refund_ledger_id BIGINT;
-    v_audit_action     TEXT;
-    v_now              TIMESTAMPTZ := transaction_timestamp();
+    v_bid_id              BIGINT;
+    v_bidder              UUID;
+    v_amount              BIGINT;
+    v_refund_ledger_id    BIGINT;
+    v_audit_action        TEXT;
+    v_listing_has_pointer BOOLEAN;
+    v_now                 TIMESTAMPTZ := transaction_timestamp();
 BEGIN
     IF p_next_status NOT IN ('outbid', 'refunded') THEN
         RAISE EXCEPTION 'refund_active_bid requires outbid or refunded'
             USING ERRCODE = '22023';
     END IF;
 
-    -- If the listing has no current bid pointer, there's nothing to
-    -- refund. Otherwise the join must agree on all three denormalized
-    -- fields; drift means data corruption — surface P1008, don't no-op.
-    DECLARE
-        v_listing_has_pointer BOOLEAN;
-    BEGIN
-        SELECT current_bid_id IS NOT NULL
-          INTO v_listing_has_pointer
-          FROM wallet.listing WHERE id = p_listing_id;
+    -- Self-lock the listing row so direct service_role callers get the
+    -- same isolation that the top-level RPCs already have. Re-locking
+    -- inside an enclosing transaction is a no-op.
+    SELECT current_bid_id IS NOT NULL
+      INTO v_listing_has_pointer
+      FROM wallet.listing WHERE id = p_listing_id
+     FOR UPDATE;
 
-        IF NOT COALESCE(v_listing_has_pointer, FALSE) THEN
-            RETURN NULL;
-        END IF;
-    END;
+    IF NOT COALESCE(v_listing_has_pointer, FALSE) THEN
+        RETURN NULL;
+    END IF;
 
     SELECT b.id, b.bidder_account, b.amount
       INTO v_bid_id, v_bidder, v_amount
@@ -555,6 +596,10 @@ BEGIN
       FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
     IF v_listing_row.id IS NULL THEN
         RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
+    END IF;
+    IF v_listing_row.currency <> 'khash'::wallet.currency_kind THEN
+        RAISE EXCEPTION 'listing % currency % is not khash; v1 unsupported',
+            p_listing_id, v_listing_row.currency USING ERRCODE = '22023';
     END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%); cannot settle',
@@ -1055,7 +1100,9 @@ BEGIN
     FOR v_listing_id, v_current_bid_id IN
         SELECT id, current_bid_id
           FROM wallet.listing
-         WHERE status = 'active' AND expires_at <= v_now
+         WHERE status = 'active'
+           AND currency = 'khash'::wallet.currency_kind  -- v1: skip foreign currency
+           AND expires_at <= v_now
          ORDER BY expires_at, id
          LIMIT v_limit
          FOR UPDATE SKIP LOCKED

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -55,20 +55,34 @@
 --   indexes still protect against double-spending.
 
 -- ============================================================================
+-- Required Phase 1 invariants
+--
+-- This migration depends on the schema shipped in PR #10976. Specifically:
+--   wallet_listing_seller_idempotency_uq          (seller_account, idempotency_key)
+--   wallet_listing_active_item_instance_uq        partial: instance_id WHERE active
+--   wallet_bid_bidder_idempotency_uq              (bidder_account, idempotency_key)
+--   wallet_bid_listing_active_uq                  partial: listing_id WHERE active
+--   wallet_account_treasury_label_uq              partial: label WHERE kind='treasury'
+--   listing_current_bid_state_chk + listing_current_bid_id_fk → wallet.bid(id)
+--   listing_active_bid_fields_chk                  non-active rows clear current_bid*
+-- ============================================================================
+
+-- ============================================================================
 -- Marketplace domain errors (custom SQLSTATEs)
 --
 -- Phase 3+ clients can map these to typed errors without parsing
--- message strings.
+-- message strings. We use class P1xxx — P-class is PostgreSQL's
+-- user-defined SQLSTATE namespace, kept distinct from built-in classes.
 --
---   MK001 — listing_not_found
---   MK002 — listing_not_active
---   MK003 — listing_expired
---   MK004 — bid_too_low
---   MK005 — own_listing_forbidden
---   MK006 — buy_now_required (bid amount above buy_now_price)
---   MK007 — auction_only / buy_now_only mismatch
---   MK008 — settlement_drift (winning_bid_id != listing.current_bid_id)
---   MK009 — account_not_user (actor account is not kind='user')
+--   P1001 — listing_not_found
+--   P1002 — listing_not_active
+--   P1003 — listing_expired
+--   P1004 — bid_too_low
+--   P1005 — own_listing_forbidden
+--   P1006 — bid_exceeds_buy_now_price (use service_buy_now instead)
+--   P1007 — auction_only / buy_now_only mismatch
+--   P1008 — settlement_drift (winning_bid_id != listing.current_bid_id)
+--   P1009 — account_not_user (actor is not kind='user')
 -- ============================================================================
 
 -- Fee rate is 1% on the gross amount. Kept as a single helper so the
@@ -127,7 +141,7 @@ BEGIN
          WHERE id = p_account AND kind = 'user'
     ) THEN
         RAISE EXCEPTION 'account % is not a user account', p_account
-            USING ERRCODE = 'MK009';
+            USING ERRCODE = 'P1009';
     END IF;
 END;
 $$;
@@ -135,7 +149,7 @@ REVOKE ALL ON FUNCTION wallet.assert_user_account(UUID) FROM PUBLIC, anon, authe
 GRANT EXECUTE ON FUNCTION wallet.assert_user_account(UUID) TO service_role;
 ALTER FUNCTION wallet.assert_user_account(UUID) OWNER TO service_role;
 COMMENT ON FUNCTION wallet.assert_user_account(UUID) IS
-    'INTERNAL marketplace helper. Raises MK009 if the supplied account is not kind=user.';
+    'INTERNAL marketplace helper. Raises P1009 if the supplied account is not kind=user.';
 
 -- ============================================================================
 -- service_create_listing
@@ -237,7 +251,7 @@ ALTER FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, 
 REVOKE ALL ON FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO service_role;
 COMMENT ON FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
-    'PUBLIC marketplace RPC. Creates a listing for kind=user seller. Idempotent on (seller_account, idempotency_key). Validates currency=khash, item_ref shape, price invariants, future expires_at.';
+    'SERVICE marketplace RPC. Creates a listing for kind=user seller. Idempotent on (seller_account, idempotency_key). Validates currency=khash, item_ref shape, price invariants, future expires_at.';
 
 -- ============================================================================
 -- INTERNAL HELPER: refund the current active bid (if any)
@@ -269,13 +283,17 @@ BEGIN
     END IF;
 
     -- Source-of-truth join: only refund the bid the listing actually
-    -- points at. Catches drift between listing.current_bid_id and the
-    -- active bid row.
+    -- points at. Asserts the denormalized listing pointers
+    -- (current_bid, current_bid_account, current_bid_id) agree with the
+    -- referenced bid row before we touch money.
     SELECT b.id, b.bidder_account, b.amount
       INTO v_bid_id, v_bidder, v_amount
       FROM wallet.listing l
       JOIN wallet.bid b ON b.id = l.current_bid_id
-     WHERE l.id = p_listing_id AND b.status = 'active'
+     WHERE l.id = p_listing_id
+       AND b.status = 'active'
+       AND b.amount = l.current_bid
+       AND b.bidder_account = l.current_bid_account
      FOR UPDATE OF b;
 
     IF v_bid_id IS NULL THEN
@@ -290,7 +308,10 @@ BEGIN
         p_reason,
         'bid',
         v_bid_id,
-        extensions.gen_random_uuid()
+        extensions.uuid_generate_v5(
+            extensions.uuid_ns_url(),
+            'marketplace.bid.refund:' || v_bid_id::TEXT
+        )
     );
 
     UPDATE wallet.bid
@@ -350,12 +371,29 @@ RETURNS TABLE (
 )
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_fee              BIGINT := wallet.marketplace_fee(p_amount);
-    v_net              BIGINT := p_amount - wallet.marketplace_fee(p_amount);
-    v_treasury         UUID   := wallet.treasury_account_id();
+    v_fee              BIGINT;
+    v_net              BIGINT;
+    v_treasury         UUID;
     v_seller_ledger_id BIGINT;
     v_fee_ledger_id    BIGINT := NULL;
 BEGIN
+    -- Defensive: callers already guard this, but distribute_settlement is
+    -- service_role-callable directly. Block bad inputs at the boundary.
+    IF p_amount IS NULL OR p_amount <= 0 THEN
+        RAISE EXCEPTION 'settlement amount must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_seller IS NULL THEN
+        RAISE EXCEPTION 'p_seller is required' USING ERRCODE = '22004';
+    END IF;
+    PERFORM wallet.assert_user_account(p_seller);
+
+    v_fee := wallet.marketplace_fee(p_amount);
+    v_net := p_amount - v_fee;
+    v_treasury := wallet.treasury_account_id();
+
+    -- Deterministic ledger idempotency keys for internal writes —
+    -- listing+bid+action identifies the operation uniquely. Replay/debug
+    -- correlation is easier than gen_random_uuid().
     v_seller_ledger_id := wallet.service_credit(
         p_seller,
         'khash'::wallet.currency_kind,
@@ -364,7 +402,10 @@ BEGIN
         'marketplace settlement (seller)',
         'listing',
         p_listing_id,
-        extensions.gen_random_uuid()
+        extensions.uuid_generate_v5(
+            extensions.uuid_ns_url(),
+            'marketplace.settlement.seller:' || p_listing_id::TEXT
+        )
     );
 
     IF v_fee > 0 THEN
@@ -376,7 +417,10 @@ BEGIN
             'marketplace fee (1%)',
             'listing',
             p_listing_id,
-            extensions.gen_random_uuid()
+            extensions.uuid_generate_v5(
+                extensions.uuid_ns_url(),
+                'marketplace.settlement.fee:' || p_listing_id::TEXT
+            )
         );
     END IF;
 
@@ -436,18 +480,18 @@ BEGIN
     SELECT * INTO v_listing_row
       FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
     IF v_listing_row.id IS NULL THEN
-        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'MK001';
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
     END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%); cannot settle',
-            p_listing_id, v_listing_row.status USING ERRCODE = 'MK002';
+            p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
     END IF;
     IF EXISTS (
         SELECT 1 FROM wallet.bid
          WHERE listing_id = p_listing_id AND status = 'won'
     ) THEN
         RAISE EXCEPTION 'listing % already has a winning bid', p_listing_id
-            USING ERRCODE = 'MK002';
+            USING ERRCODE = 'P1002';
     END IF;
     v_seller := v_listing_row.seller_account;
 
@@ -459,7 +503,7 @@ BEGIN
        AND p_winning_bid_id <> v_listing_row.current_bid_id THEN
         RAISE EXCEPTION 'winning bid % is not current bid % for listing %',
             p_winning_bid_id, v_listing_row.current_bid_id, p_listing_id
-            USING ERRCODE = 'MK008';
+            USING ERRCODE = 'P1008';
     END IF;
 
     SELECT id, bidder_account, amount
@@ -475,10 +519,18 @@ BEGIN
             USING ERRCODE = '23503';
     END IF;
 
+    -- Conditional update: status must still be 'active' to flip. If
+    -- a concurrent path already won the bid, we want the conflict to
+    -- surface, not silently overwrite.
     UPDATE wallet.bid
        SET status = 'won',
            settled_at = v_now
-     WHERE id = v_bid_id;
+     WHERE id = v_bid_id AND status = 'active'
+     RETURNING id INTO v_bid_id;
+    IF v_bid_id IS NULL THEN
+        RAISE EXCEPTION 'bid % no longer active; concurrent settle suspected', v_bid_id
+            USING ERRCODE = 'P1002';
+    END IF;
 
     SELECT d.fee, d.net, d.seller_ledger_id, d.fee_ledger_id
       INTO v_fee, v_net, v_seller_ledger_id, v_fee_ledger_id
@@ -564,28 +616,28 @@ BEGIN
       FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
 
     IF v_listing_row.id IS NULL THEN
-        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'MK001';
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
     END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%)',
-            p_listing_id, v_listing_row.status USING ERRCODE = 'MK002';
+            p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
     END IF;
     IF v_listing_row.expires_at <= v_now THEN
-        RAISE EXCEPTION 'listing % has expired', p_listing_id USING ERRCODE = 'MK003';
+        RAISE EXCEPTION 'listing % has expired', p_listing_id USING ERRCODE = 'P1003';
     END IF;
     IF v_listing_row.seller_account = p_bidder_account THEN
-        RAISE EXCEPTION 'seller cannot bid on own listing' USING ERRCODE = 'MK005';
+        RAISE EXCEPTION 'seller cannot bid on own listing' USING ERRCODE = 'P1005';
     END IF;
     IF v_listing_row.min_bid IS NULL THEN
-        RAISE EXCEPTION 'listing % is buy-now only', p_listing_id USING ERRCODE = 'MK007';
+        RAISE EXCEPTION 'listing % is buy-now only', p_listing_id USING ERRCODE = 'P1007';
     END IF;
     IF p_amount < v_listing_row.min_bid THEN
         RAISE EXCEPTION 'amount % below min_bid %', p_amount, v_listing_row.min_bid
-            USING ERRCODE = 'MK004';
+            USING ERRCODE = 'P1004';
     END IF;
     IF v_listing_row.current_bid IS NOT NULL AND p_amount <= v_listing_row.current_bid THEN
         RAISE EXCEPTION 'amount % must exceed current_bid %',
-            p_amount, v_listing_row.current_bid USING ERRCODE = 'MK004';
+            p_amount, v_listing_row.current_bid USING ERRCODE = 'P1004';
     END IF;
     -- Reject bids above buy_now_price; the buyer should use buy_now
     -- instead so they don't overpay. Equality is allowed so this RPC
@@ -593,10 +645,13 @@ BEGIN
     IF v_listing_row.buy_now_price IS NOT NULL
        AND p_amount > v_listing_row.buy_now_price THEN
         RAISE EXCEPTION 'amount % exceeds buy_now_price %; use buy_now instead',
-            p_amount, v_listing_row.buy_now_price USING ERRCODE = 'MK006';
+            p_amount, v_listing_row.buy_now_price USING ERRCODE = 'P1006';
     END IF;
 
-    -- Escrow the bidder's funds.
+    -- Escrow the bidder's funds. Deterministic key derived from the
+    -- caller-supplied idempotency_key so a retry of the outer RPC
+    -- without first reaching the bid-row replay shortcut still
+    -- collides cleanly at the ledger layer.
     v_escrow_ledger_id := wallet.service_debit(
         p_bidder_account,
         'khash'::wallet.currency_kind,
@@ -605,7 +660,7 @@ BEGIN
         'marketplace bid escrow',
         'listing',
         p_listing_id,
-        extensions.gen_random_uuid()
+        extensions.uuid_generate_v5(p_idempotency_key, 'marketplace.bid.escrow')
     );
 
     -- Refund the prior active bid (if any).
@@ -651,7 +706,7 @@ ALTER FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) OWNER TO ser
 REVOKE ALL ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) TO service_role;
 COMMENT ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) IS
-    'PUBLIC marketplace RPC. Places a bid on behalf of kind=user bidder. Idempotent on (bidder_account, idempotency_key, listing_id). Escrows bidder funds, refunds prior active bid, short-circuits to settle when amount = buy_now_price.';
+    'SERVICE marketplace RPC. Places a bid on behalf of kind=user bidder. Idempotent on (bidder_account, idempotency_key, listing_id). Escrows bidder funds, refunds prior active bid, short-circuits to settle when amount = buy_now_price.';
 
 -- ============================================================================
 -- service_buy_now
@@ -692,20 +747,20 @@ BEGIN
       FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
 
     IF v_listing_row.id IS NULL THEN
-        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'MK001';
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
     END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%)',
-            p_listing_id, v_listing_row.status USING ERRCODE = 'MK002';
+            p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
     END IF;
     IF v_listing_row.expires_at <= v_now THEN
-        RAISE EXCEPTION 'listing % has expired', p_listing_id USING ERRCODE = 'MK003';
+        RAISE EXCEPTION 'listing % has expired', p_listing_id USING ERRCODE = 'P1003';
     END IF;
     IF v_listing_row.seller_account = p_buyer_account THEN
-        RAISE EXCEPTION 'seller cannot buy own listing' USING ERRCODE = 'MK005';
+        RAISE EXCEPTION 'seller cannot buy own listing' USING ERRCODE = 'P1005';
     END IF;
     IF v_listing_row.buy_now_price IS NULL THEN
-        RAISE EXCEPTION 'listing % is auction-only', p_listing_id USING ERRCODE = 'MK007';
+        RAISE EXCEPTION 'listing % is auction-only', p_listing_id USING ERRCODE = 'P1007';
     END IF;
 
     -- Debit buyer FIRST, then refund the prior active bid. Reordering
@@ -720,7 +775,7 @@ BEGIN
         'marketplace buy-now',
         'listing',
         p_listing_id,
-        extensions.gen_random_uuid()
+        extensions.uuid_generate_v5(p_idempotency_key, 'marketplace.buy_now.escrow')
     );
 
     PERFORM wallet.refund_active_bid(p_listing_id, 'outbid', 'outbid by buy-now');
@@ -760,7 +815,7 @@ ALTER FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) TO service_role;
 COMMENT ON FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) IS
-    'PUBLIC marketplace RPC. Buy-now purchase for kind=user buyer. Idempotent on (buyer_account, idempotency_key, listing_id). Debits buyer first, then refunds the prior active bid, then settles. Settlement reason = "buy_now".';
+    'SERVICE marketplace RPC. Buy-now purchase for kind=user buyer. Idempotent on (buyer_account, idempotency_key, listing_id). Debits buyer first, then refunds the prior active bid, then settles. Settlement reason = "buy_now".';
 
 -- ============================================================================
 -- service_cancel_listing
@@ -797,7 +852,7 @@ BEGIN
       FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
 
     IF v_listing_row.id IS NULL THEN
-        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'MK001';
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
     END IF;
     IF v_listing_row.seller_account <> p_seller_account THEN
         RAISE EXCEPTION 'seller_account does not own listing %', p_listing_id
@@ -809,11 +864,11 @@ BEGIN
             RETURN;
         END IF;
         RAISE EXCEPTION 'listing % not active (status=%)',
-            p_listing_id, v_listing_row.status USING ERRCODE = 'MK002';
+            p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
     END IF;
     IF v_listing_row.expires_at <= v_now THEN
         RAISE EXCEPTION 'listing % has expired and cannot be cancelled', p_listing_id
-            USING ERRCODE = 'MK003';
+            USING ERRCODE = 'P1003';
     END IF;
 
     v_refund_id := wallet.refund_active_bid(
@@ -843,7 +898,7 @@ ALTER FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) OWNER TO servic
 REVOKE ALL ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) TO service_role;
 COMMENT ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) IS
-    'PUBLIC marketplace RPC. Seller-driven cancel for an active listing. Refunds the active bid (if any) and flips status to cancelled. Idempotent on already-cancelled. Rejects after expires_at to prevent racing the expire-sweep.';
+    'SERVICE marketplace RPC. Seller-driven cancel for an active listing. Refunds the active bid (if any) and flips status to cancelled. Idempotent on already-cancelled. Rejects after expires_at to prevent racing the expire-sweep.';
 
 -- ============================================================================
 -- service_expire_listings — pg_cron-driven sweep
@@ -858,15 +913,16 @@ COMMENT ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) IS
 -- small; the cron schedule runs every 15min so backlog clears quickly.
 -- ============================================================================
 
--- Defensive: earlier drafts shipped without p_limit. Drop the no-arg
--- signature first so re-runs of this migration don't end up with two
--- overload variants.
+-- Defensive: earlier drafts shipped without p_limit and with
+-- RETURNS BIGINT. Drop both so the new RETURNS TABLE shape can land
+-- cleanly on a dirty DB.
 DROP FUNCTION IF EXISTS wallet.service_expire_listings();
+DROP FUNCTION IF EXISTS wallet.service_expire_listings(INTEGER);
 
 CREATE OR REPLACE FUNCTION wallet.service_expire_listings(
     p_limit INTEGER DEFAULT 100
 )
-RETURNS BIGINT
+RETURNS TABLE (total BIGINT, settled BIGINT, expired BIGINT)
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
     v_now             TIMESTAMPTZ := transaction_timestamp();
@@ -877,6 +933,11 @@ DECLARE
     v_expired         BIGINT := 0;
     v_limit           INTEGER := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 1000);
 BEGIN
+    -- Cron-job hygiene: time out fast instead of stalling under a
+    -- pathological lock. Both settings are transaction-local.
+    PERFORM set_config('lock_timeout', '2s', true);
+    PERFORM set_config('statement_timeout', '30s', true);
+
     -- Transaction-scoped advisory lock. Overlapping cron runs become a
     -- no-op for the loser instead of racing on row locks + emitting
     -- a redundant audit row. SKIP LOCKED below would also be safe, but
@@ -884,7 +945,9 @@ BEGIN
     IF NOT pg_try_advisory_xact_lock(
         hashtextextended('wallet.service_expire_listings', 0)
     ) THEN
-        RETURN 0;
+        total := 0; settled := 0; expired := 0;
+        RETURN NEXT;
+        RETURN;
     END IF;
 
     FOR v_listing_id, v_current_bid_id IN
@@ -929,7 +992,10 @@ BEGIN
         );
     END IF;
 
-    RETURN v_total;
+    total := v_total;
+    settled := v_settled;
+    expired := v_expired;
+    RETURN NEXT;
 END;
 $$;
 ALTER FUNCTION wallet.service_expire_listings(INTEGER) OWNER TO service_role;
@@ -940,7 +1006,7 @@ GRANT EXECUTE ON FUNCTION wallet.service_expire_listings(INTEGER) TO service_rol
 GRANT EXECUTE ON FUNCTION wallet.service_expire_listings(INTEGER) TO postgres;
 
 COMMENT ON FUNCTION wallet.service_expire_listings(INTEGER) IS
-    'PUBLIC marketplace RPC. Sweeps active listings whose expires_at has passed. Settles winning bid if any (settlement_reason=expired_with_bid), otherwise marks expired. Bounded to p_limit rows (default 100, clamped [1, 1000]). Writes one summary audit row per non-empty sweep. Wraps in pg_try_advisory_xact_lock so overlapping cron runs no-op for the loser.';
+    'SERVICE marketplace RPC. Sweeps active listings whose expires_at has passed. Settles winning bid if any (settlement_reason=expired_with_bid), otherwise marks expired. Bounded to p_limit rows (default 100, clamped [1, 1000]). Returns (total, settled, expired) row. Writes one summary audit row per non-empty sweep. pg_try_advisory_xact_lock makes overlapping cron runs no-op for the loser. lock_timeout=2s + statement_timeout=30s applied transaction-locally.';
 
 -- pg_cron schedule — guarded by extension presence so local dev passes.
 DO $$

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -37,9 +37,12 @@
 --     mark listing 'sold', buyer_account = winning_bid.bidder_account
 --
 --   expire_listings():  -- pg_cron @ */15 * * * *
---     for each active listing with expires_at <= now():
+--     for each active KHASH listing with expires_at <= now():
 --       if current_bid_id IS NOT NULL: settle_listing
 --       else:                          mark 'expired'
+--     non-khash legacy/dirty active rows are skipped by the cursor;
+--     they stay 'active' until a cross-currency migration ships, at
+--     which point a backfill can pick them up.
 --
 -- Fee = floor(amount / 100) = 1%. Rounding favours the seller; for
 -- small amounts the fee is 0 (acceptable).
@@ -188,7 +191,7 @@ $$;
 -- misuse in a financial helper.
 CREATE OR REPLACE FUNCTION wallet.marketplace_fee(p_amount BIGINT)
 RETURNS BIGINT
-LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE AS $$
+LANGUAGE plpgsql IMMUTABLE AS $$
 BEGIN
     IF p_amount IS NULL OR p_amount < 0 THEN
         RAISE EXCEPTION 'marketplace_fee requires non-negative amount, got %', p_amount
@@ -471,12 +474,18 @@ $$;
 ALTER FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) TO service_role;
--- Note: PG does NOT grant function EXECUTE implicitly to the owner;
--- explicit service_role grant is required so the top-level RPCs
--- (which run as service_role via SECURITY DEFINER) can chain in.
--- Narrowing further (e.g., a dedicated wallet_internal role) is
--- tracked as a follow-up — the current posture is service_role-only
--- + self-locking helpers + audit trail.
+-- Note: REVOKE EXECUTE FROM owner_role DOES strip owner's execute
+-- privilege in PostgreSQL — verified empirically. The conventional
+-- "owners have implicit privileges" rule applies to GRANT OPTION
+-- (an owner can always re-grant), not to bypassing an explicit
+-- REVOKE against themselves. Therefore the top-level RPCs (which
+-- run AS service_role via SECURITY DEFINER) need an explicit
+-- GRANT EXECUTE TO service_role on the helper to chain in.
+--
+-- Narrowing further would require a dedicated wallet_internal role
+-- owning the helpers + a service_role-callable top-level wrapper.
+-- That's a Phase 1 schema change tracked as a follow-up; current
+-- posture is service_role-only + self-locking helpers + audit trail.
 COMMENT ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) IS
     'INTERNAL marketplace helper. service_role-callable; self-locks the listing. Do not wrap from public proxies.';
 

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -55,7 +55,40 @@
 --   indexes still protect against double-spending.
 
 -- ============================================================================
--- HELPER: treasury account id (cached at session level)
+-- Marketplace domain errors (custom SQLSTATEs)
+--
+-- Phase 3+ clients can map these to typed errors without parsing
+-- message strings.
+--
+--   MK001 — listing_not_found
+--   MK002 — listing_not_active
+--   MK003 — listing_expired
+--   MK004 — bid_too_low
+--   MK005 — own_listing_forbidden
+--   MK006 — buy_now_required (bid amount above buy_now_price)
+--   MK007 — auction_only / buy_now_only mismatch
+--   MK008 — settlement_drift (winning_bid_id != listing.current_bid_id)
+--   MK009 — account_not_user (actor account is not kind='user')
+-- ============================================================================
+
+-- Fee rate is 1% on the gross amount. Kept as a single helper so the
+-- rate can move without hunting for magic /100 expressions.
+CREATE OR REPLACE FUNCTION wallet.marketplace_fee(p_amount BIGINT)
+RETURNS BIGINT
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+    SELECT GREATEST(0, p_amount) / 100;
+$$;
+REVOKE ALL ON FUNCTION wallet.marketplace_fee(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.marketplace_fee(BIGINT) TO service_role;
+ALTER FUNCTION wallet.marketplace_fee(BIGINT) OWNER TO service_role;
+COMMENT ON FUNCTION wallet.marketplace_fee(BIGINT) IS
+    'Returns the treasury fee for a settled marketplace amount. Currently 1% (floor). Change here to move the rate.';
+
+-- ============================================================================
+-- HELPER: treasury account lookup
+--
+-- STABLE only because the row never moves; Postgres may avoid repeated
+-- execution within a single statement, but this is not a session cache.
 -- ============================================================================
 
 CREATE OR REPLACE FUNCTION wallet.treasury_account_id()
@@ -76,6 +109,33 @@ $$;
 REVOKE ALL ON FUNCTION wallet.treasury_account_id() FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.treasury_account_id() TO service_role;
 ALTER FUNCTION wallet.treasury_account_id() OWNER TO service_role;
+
+-- ============================================================================
+-- HELPER: assert_user_account
+--
+-- Marketplace actors must be wallet.account kind='user'. Treasury,
+-- system, escrow, and guild accounts cannot create listings or place
+-- bids — that path is reserved for service-internal flows.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.assert_user_account(p_account UUID)
+RETURNS VOID
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.account
+         WHERE id = p_account AND kind = 'user'
+    ) THEN
+        RAISE EXCEPTION 'account % is not a user account', p_account
+            USING ERRCODE = 'MK009';
+    END IF;
+END;
+$$;
+REVOKE ALL ON FUNCTION wallet.assert_user_account(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.assert_user_account(UUID) TO service_role;
+ALTER FUNCTION wallet.assert_user_account(UUID) OWNER TO service_role;
+COMMENT ON FUNCTION wallet.assert_user_account(UUID) IS
+    'INTERNAL marketplace helper. Raises MK009 if the supplied account is not kind=user.';
 
 -- ============================================================================
 -- service_create_listing
@@ -103,6 +163,8 @@ BEGIN
             USING ERRCODE = '22004';
     END IF;
 
+    PERFORM wallet.assert_user_account(p_seller_account);
+
     -- Service-layer validation. Table CHECKs are belt-and-suspenders;
     -- raising at the RPC layer surfaces clean domain errors before the
     -- INSERT roundtrip.
@@ -111,6 +173,17 @@ BEGIN
     END IF;
     IF jsonb_typeof(p_item_ref) <> 'object' OR p_item_ref = '{}'::jsonb THEN
         RAISE EXCEPTION 'item_ref must be a non-empty JSON object' USING ERRCODE = '22023';
+    END IF;
+    -- Required item_ref shape: kind + id. Phase 1 schema also stores
+    -- item_ref->>'instance_id' as a generated column for the active-
+    -- listing uniqueness index; that's expected, not required.
+    IF NOT (
+        p_item_ref ? 'kind'
+        AND p_item_ref ? 'id'
+        AND jsonb_typeof(p_item_ref->'kind') = 'string'
+        AND jsonb_typeof(p_item_ref->'id')   IN ('string', 'number')
+    ) THEN
+        RAISE EXCEPTION 'item_ref requires string kind and string|number id' USING ERRCODE = '22023';
     END IF;
     IF p_buy_now_price IS NULL AND p_min_bid IS NULL THEN
         RAISE EXCEPTION 'listing requires buy_now_price or min_bid' USING ERRCODE = '22023';
@@ -163,6 +236,8 @@ $$;
 ALTER FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO service_role;
+COMMENT ON FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
+    'PUBLIC marketplace RPC. Creates a listing for kind=user seller. Idempotent on (seller_account, idempotency_key). Validates currency=khash, item_ref shape, price invariants, future expires_at.';
 
 -- ============================================================================
 -- INTERNAL HELPER: refund the current active bid (if any)
@@ -258,19 +333,30 @@ COMMENT ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) IS
 -- Caller must already hold the FOR UPDATE lock on the listing.
 -- ============================================================================
 
+-- Defensive: earlier draft returned only (fee, net). Drop so CREATE OR
+-- REPLACE doesn't error on changed RETURNS TABLE shape.
+DROP FUNCTION IF EXISTS wallet.distribute_settlement(BIGINT, UUID, BIGINT);
+
 CREATE OR REPLACE FUNCTION wallet.distribute_settlement(
     p_listing_id BIGINT,
     p_seller     UUID,
     p_amount     BIGINT
 )
-RETURNS TABLE (fee BIGINT, net BIGINT)
+RETURNS TABLE (
+    fee              BIGINT,
+    net              BIGINT,
+    seller_ledger_id BIGINT,
+    fee_ledger_id    BIGINT
+)
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_fee      BIGINT := p_amount / 100;
-    v_net      BIGINT := p_amount - (p_amount / 100);
-    v_treasury UUID   := wallet.treasury_account_id();
+    v_fee              BIGINT := wallet.marketplace_fee(p_amount);
+    v_net              BIGINT := p_amount - wallet.marketplace_fee(p_amount);
+    v_treasury         UUID   := wallet.treasury_account_id();
+    v_seller_ledger_id BIGINT;
+    v_fee_ledger_id    BIGINT := NULL;
 BEGIN
-    PERFORM wallet.service_credit(
+    v_seller_ledger_id := wallet.service_credit(
         p_seller,
         'khash'::wallet.currency_kind,
         v_net,
@@ -282,7 +368,7 @@ BEGIN
     );
 
     IF v_fee > 0 THEN
-        PERFORM wallet.service_credit(
+        v_fee_ledger_id := wallet.service_credit(
             v_treasury,
             'khash'::wallet.currency_kind,
             v_fee,
@@ -296,6 +382,8 @@ BEGIN
 
     fee := v_fee;
     net := v_net;
+    seller_ledger_id := v_seller_ledger_id;
+    fee_ledger_id := v_fee_ledger_id;
     RETURN NEXT;
 END;
 $$;
@@ -314,22 +402,33 @@ COMMENT ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) IS
 -- assert the expected bid; pass NULL to look up the active bid.
 -- ============================================================================
 
+-- Defensive: earlier draft shipped as 2-arg (no reason).
+DROP FUNCTION IF EXISTS wallet.service_settle_listing(BIGINT, BIGINT);
+
 CREATE OR REPLACE FUNCTION wallet.service_settle_listing(
     p_listing_id     BIGINT,
-    p_winning_bid_id BIGINT  -- NULL = look up via listing.current_bid_id
+    p_winning_bid_id BIGINT,        -- NULL = look up via listing.current_bid_id
+    p_reason         TEXT DEFAULT NULL  -- 'bid_reached_buy_now' | 'buy_now' | 'expired_with_bid'
 )
 RETURNS VOID
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_listing_row wallet.listing%ROWTYPE;
-    v_seller      UUID;
-    v_bid_id      BIGINT;
-    v_bidder      UUID;
-    v_amount      BIGINT;
-    v_now         TIMESTAMPTZ := transaction_timestamp();
-    v_fee         BIGINT;
-    v_net         BIGINT;
+    v_listing_row      wallet.listing%ROWTYPE;
+    v_seller           UUID;
+    v_bid_id           BIGINT;
+    v_bidder           UUID;
+    v_amount           BIGINT;
+    v_now              TIMESTAMPTZ := transaction_timestamp();
+    v_fee              BIGINT;
+    v_net              BIGINT;
+    v_seller_ledger_id BIGINT;
+    v_fee_ledger_id    BIGINT;
 BEGIN
+    -- All ledger writes (bid 'won', seller credit, treasury credit) and
+    -- the listing status flip occur in one DB transaction. Any
+    -- exception rolls back escrow, refunds, settlement credits, status
+    -- changes, and audit rows together.
+
     -- Self-locking: external callers may invoke this directly. Inner
     -- callers (service_place_bid, service_buy_now, service_expire_listings)
     -- have already taken FOR UPDATE on the listing — re-locking is a
@@ -337,37 +436,39 @@ BEGIN
     SELECT * INTO v_listing_row
       FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
     IF v_listing_row.id IS NULL THEN
-        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = '23503';
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'MK001';
     END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%); cannot settle',
-            p_listing_id, v_listing_row.status USING ERRCODE = '22023';
+            p_listing_id, v_listing_row.status USING ERRCODE = 'MK002';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM wallet.bid
+         WHERE listing_id = p_listing_id AND status = 'won'
+    ) THEN
+        RAISE EXCEPTION 'listing % already has a winning bid', p_listing_id
+            USING ERRCODE = 'MK002';
     END IF;
     v_seller := v_listing_row.seller_account;
 
-    IF p_winning_bid_id IS NULL THEN
-        -- Resolve via the denormalized pointer so settlement aligns
-        -- with the listing's current_bid_id source of truth.
-        IF v_listing_row.current_bid_id IS NULL THEN
-            RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
-                USING ERRCODE = '23503';
-        END IF;
-        SELECT id, bidder_account, amount
-          INTO v_bid_id, v_bidder, v_amount
-          FROM wallet.bid
-         WHERE id = v_listing_row.current_bid_id
-           AND listing_id = p_listing_id
-           AND status = 'active'
-         FOR UPDATE;
-    ELSE
-        SELECT id, bidder_account, amount
-          INTO v_bid_id, v_bidder, v_amount
-          FROM wallet.bid
-         WHERE id = p_winning_bid_id
-           AND listing_id = p_listing_id
-           AND status = 'active'
-         FOR UPDATE;
+    IF v_listing_row.current_bid_id IS NULL THEN
+        RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
+            USING ERRCODE = '23503';
     END IF;
+    IF p_winning_bid_id IS NOT NULL
+       AND p_winning_bid_id <> v_listing_row.current_bid_id THEN
+        RAISE EXCEPTION 'winning bid % is not current bid % for listing %',
+            p_winning_bid_id, v_listing_row.current_bid_id, p_listing_id
+            USING ERRCODE = 'MK008';
+    END IF;
+
+    SELECT id, bidder_account, amount
+      INTO v_bid_id, v_bidder, v_amount
+      FROM wallet.bid
+     WHERE id = v_listing_row.current_bid_id
+       AND listing_id = p_listing_id
+       AND status = 'active'
+     FOR UPDATE;
 
     IF v_bid_id IS NULL THEN
         RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
@@ -379,11 +480,8 @@ BEGIN
            settled_at = v_now
      WHERE id = v_bid_id;
 
-    -- Statement_timestamp keeps the rest of the wallet schema's
-    -- statement_timestamp(); we use transaction_timestamp() locally
-    -- so all marketplace writes in this txn share one logical time.
-
-    SELECT d.fee, d.net INTO v_fee, v_net
+    SELECT d.fee, d.net, d.seller_ledger_id, d.fee_ledger_id
+      INTO v_fee, v_net, v_seller_ledger_id, v_fee_ledger_id
       FROM wallet.distribute_settlement(p_listing_id, v_seller, v_amount) d;
 
     UPDATE wallet.listing
@@ -395,7 +493,7 @@ BEGIN
            current_bid_id = NULL
      WHERE id = p_listing_id;
 
-    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
     VALUES (
         'marketplace.listing_settle', 'listing', p_listing_id::TEXT,
         jsonb_build_object(
@@ -404,16 +502,20 @@ BEGIN
             'amount', v_amount,
             'fee', v_fee,
             'seller_net', v_net,
+            'seller_ledger_id', v_seller_ledger_id,
+            'fee_ledger_id', v_fee_ledger_id,
+            'settlement_reason', COALESCE(p_reason, 'unspecified'),
             'settled_at', v_now
-        )
+        ),
+        p_reason
     );
 END;
 $$;
-ALTER FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) OWNER TO service_role;
-REVOKE ALL ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) TO service_role;
-COMMENT ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT) IS
-    'INTERNAL marketplace helper invoked by place_bid (buy-now short-circuit), buy_now, and expire_listings. Self-locks the listing row and validates status=active + winning bid status=active.';
+ALTER FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) TO service_role;
+COMMENT ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) IS
+    'INTERNAL marketplace helper invoked by place_bid (buy-now short-circuit), buy_now, and expire_listings. Self-locks the listing row. Validates: listing status=active, no existing won bid, p_winning_bid_id matches listing.current_bid_id, winning bid status=active. Settlement reason recorded in audit metadata.';
 
 -- ============================================================================
 -- service_place_bid
@@ -443,10 +545,16 @@ BEGIN
         RAISE EXCEPTION 'amount must be positive' USING ERRCODE = '22023';
     END IF;
 
+    PERFORM wallet.assert_user_account(p_bidder_account);
+
+    -- Replay lookup scoped by listing too: the same bidder reusing the
+    -- same idempotency_key across different listings would otherwise
+    -- return an unrelated old bid id.
     SELECT id INTO v_existing_bid
       FROM wallet.bid
      WHERE bidder_account = p_bidder_account
-       AND idempotency_key = p_idempotency_key;
+       AND idempotency_key = p_idempotency_key
+       AND listing_id = p_listing_id;
     IF v_existing_bid IS NOT NULL THEN
         RETURN v_existing_bid;
     END IF;
@@ -456,28 +564,28 @@ BEGIN
       FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
 
     IF v_listing_row.id IS NULL THEN
-        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = '23503';
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'MK001';
     END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%)',
-            p_listing_id, v_listing_row.status USING ERRCODE = '22023';
+            p_listing_id, v_listing_row.status USING ERRCODE = 'MK002';
     END IF;
     IF v_listing_row.expires_at <= v_now THEN
-        RAISE EXCEPTION 'listing % has expired', p_listing_id USING ERRCODE = '22023';
+        RAISE EXCEPTION 'listing % has expired', p_listing_id USING ERRCODE = 'MK003';
     END IF;
     IF v_listing_row.seller_account = p_bidder_account THEN
-        RAISE EXCEPTION 'seller cannot bid on own listing' USING ERRCODE = '42501';
+        RAISE EXCEPTION 'seller cannot bid on own listing' USING ERRCODE = 'MK005';
     END IF;
     IF v_listing_row.min_bid IS NULL THEN
-        RAISE EXCEPTION 'listing % is buy-now only', p_listing_id USING ERRCODE = '22023';
+        RAISE EXCEPTION 'listing % is buy-now only', p_listing_id USING ERRCODE = 'MK007';
     END IF;
     IF p_amount < v_listing_row.min_bid THEN
         RAISE EXCEPTION 'amount % below min_bid %', p_amount, v_listing_row.min_bid
-            USING ERRCODE = '22023';
+            USING ERRCODE = 'MK004';
     END IF;
     IF v_listing_row.current_bid IS NOT NULL AND p_amount <= v_listing_row.current_bid THEN
         RAISE EXCEPTION 'amount % must exceed current_bid %',
-            p_amount, v_listing_row.current_bid USING ERRCODE = '22023';
+            p_amount, v_listing_row.current_bid USING ERRCODE = 'MK004';
     END IF;
     -- Reject bids above buy_now_price; the buyer should use buy_now
     -- instead so they don't overpay. Equality is allowed so this RPC
@@ -485,7 +593,7 @@ BEGIN
     IF v_listing_row.buy_now_price IS NOT NULL
        AND p_amount > v_listing_row.buy_now_price THEN
         RAISE EXCEPTION 'amount % exceeds buy_now_price %; use buy_now instead',
-            p_amount, v_listing_row.buy_now_price USING ERRCODE = '22023';
+            p_amount, v_listing_row.buy_now_price USING ERRCODE = 'MK006';
     END IF;
 
     -- Escrow the bidder's funds.
@@ -531,7 +639,9 @@ BEGIN
     -- Short-circuit if this bid equals buy_now_price (we rejected
     -- amount > buy_now_price above).
     IF v_listing_row.buy_now_price IS NOT NULL AND p_amount >= v_listing_row.buy_now_price THEN
-        PERFORM wallet.service_settle_listing(p_listing_id, v_new_bid_id);
+        PERFORM wallet.service_settle_listing(
+            p_listing_id, v_new_bid_id, 'bid_reached_buy_now'
+        );
     END IF;
 
     RETURN v_new_bid_id;
@@ -540,6 +650,8 @@ $$;
 ALTER FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) TO service_role;
+COMMENT ON FUNCTION wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID) IS
+    'PUBLIC marketplace RPC. Places a bid on behalf of kind=user bidder. Idempotent on (bidder_account, idempotency_key, listing_id). Escrows bidder funds, refunds prior active bid, short-circuits to settle when amount = buy_now_price.';
 
 -- ============================================================================
 -- service_buy_now
@@ -564,10 +676,14 @@ BEGIN
             USING ERRCODE = '22004';
     END IF;
 
+    PERFORM wallet.assert_user_account(p_buyer_account);
+
+    -- Replay lookup scoped by listing too.
     SELECT id INTO v_existing_bid
       FROM wallet.bid
      WHERE bidder_account = p_buyer_account
-       AND idempotency_key = p_idempotency_key;
+       AND idempotency_key = p_idempotency_key
+       AND listing_id = p_listing_id;
     IF v_existing_bid IS NOT NULL THEN
         RETURN v_existing_bid;
     END IF;
@@ -576,25 +692,26 @@ BEGIN
       FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
 
     IF v_listing_row.id IS NULL THEN
-        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = '23503';
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'MK001';
     END IF;
     IF v_listing_row.status <> 'active' THEN
         RAISE EXCEPTION 'listing % not active (status=%)',
-            p_listing_id, v_listing_row.status USING ERRCODE = '22023';
+            p_listing_id, v_listing_row.status USING ERRCODE = 'MK002';
     END IF;
     IF v_listing_row.expires_at <= v_now THEN
-        RAISE EXCEPTION 'listing % has expired', p_listing_id USING ERRCODE = '22023';
+        RAISE EXCEPTION 'listing % has expired', p_listing_id USING ERRCODE = 'MK003';
     END IF;
     IF v_listing_row.seller_account = p_buyer_account THEN
-        RAISE EXCEPTION 'seller cannot buy own listing' USING ERRCODE = '42501';
+        RAISE EXCEPTION 'seller cannot buy own listing' USING ERRCODE = 'MK005';
     END IF;
     IF v_listing_row.buy_now_price IS NULL THEN
-        RAISE EXCEPTION 'listing % is auction-only', p_listing_id USING ERRCODE = '22023';
+        RAISE EXCEPTION 'listing % is auction-only', p_listing_id USING ERRCODE = 'MK007';
     END IF;
 
-    -- Refund any existing active bid; the buy-now buyer wins immediately.
-    PERFORM wallet.refund_active_bid(p_listing_id, 'outbid', 'outbid by buy-now');
-
+    -- Debit buyer FIRST, then refund the prior active bid. Reordering
+    -- (was refund→debit) keeps the audit trail "buyer paid, prior
+    -- bidder refunded" in causal order and surfaces a debit failure
+    -- before we touch the prior bidder's balance.
     v_escrow_ledger_id := wallet.service_debit(
         p_buyer_account,
         'khash'::wallet.currency_kind,
@@ -606,6 +723,8 @@ BEGIN
         extensions.gen_random_uuid()
     );
 
+    PERFORM wallet.refund_active_bid(p_listing_id, 'outbid', 'outbid by buy-now');
+
     INSERT INTO wallet.bid (
         listing_id, bidder_account, amount, escrow_ledger_id, idempotency_key
     ) VALUES (
@@ -613,9 +732,8 @@ BEGIN
         v_escrow_ledger_id, p_idempotency_key
     ) RETURNING id INTO v_new_bid_id;
 
-    -- Settle immediately. service_settle_listing will UPDATE the
-    -- listing → 'sold' and clear the live-bid pointers (we don't need
-    -- to set them since we're settling in the same transaction).
+    -- Set the listing's live-bid pointers so service_settle_listing's
+    -- p_winning_bid_id assertion lines up with current_bid_id.
     UPDATE wallet.listing
        SET current_bid = v_listing_row.buy_now_price,
            current_bid_account = p_buyer_account,
@@ -633,7 +751,7 @@ BEGIN
         )
     );
 
-    PERFORM wallet.service_settle_listing(p_listing_id, v_new_bid_id);
+    PERFORM wallet.service_settle_listing(p_listing_id, v_new_bid_id, 'buy_now');
 
     RETURN v_new_bid_id;
 END;
@@ -641,6 +759,8 @@ $$;
 ALTER FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) TO service_role;
+COMMENT ON FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) IS
+    'PUBLIC marketplace RPC. Buy-now purchase for kind=user buyer. Idempotent on (buyer_account, idempotency_key, listing_id). Debits buyer first, then refunds the prior active bid, then settles. Settlement reason = "buy_now".';
 
 -- ============================================================================
 -- service_cancel_listing
@@ -652,11 +772,13 @@ GRANT EXECUTE ON FUNCTION wallet.service_buy_now(BIGINT, UUID, UUID) TO service_
 -- mis-routed service call cannot cancel arbitrary listings.
 -- ============================================================================
 
+-- Defensive: earlier draft shipped with a p_idempotency_key UUID arg.
+DROP FUNCTION IF EXISTS wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID);
+
 CREATE OR REPLACE FUNCTION wallet.service_cancel_listing(
     p_listing_id      BIGINT,
     p_seller_account  UUID,
-    p_reason          TEXT,
-    p_idempotency_key UUID  -- accepted for symmetry; not yet used for replay
+    p_reason          TEXT
 )
 RETURNS VOID
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
@@ -669,11 +791,13 @@ BEGIN
         RAISE EXCEPTION 'listing_id, seller_account are required' USING ERRCODE = '22004';
     END IF;
 
+    PERFORM wallet.assert_user_account(p_seller_account);
+
     SELECT * INTO v_listing_row
       FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
 
     IF v_listing_row.id IS NULL THEN
-        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = '23503';
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'MK001';
     END IF;
     IF v_listing_row.seller_account <> p_seller_account THEN
         RAISE EXCEPTION 'seller_account does not own listing %', p_listing_id
@@ -685,14 +809,11 @@ BEGIN
             RETURN;
         END IF;
         RAISE EXCEPTION 'listing % not active (status=%)',
-            p_listing_id, v_listing_row.status USING ERRCODE = '22023';
+            p_listing_id, v_listing_row.status USING ERRCODE = 'MK002';
     END IF;
-    -- Reject cancel once the deadline has passed. Even if cron has
-    -- not swept yet, the seller cannot undo an auction settlement by
-    -- racing the expire-sweep.
     IF v_listing_row.expires_at <= v_now THEN
         RAISE EXCEPTION 'listing % has expired and cannot be cancelled', p_listing_id
-            USING ERRCODE = '22023';
+            USING ERRCODE = 'MK003';
     END IF;
 
     v_refund_id := wallet.refund_active_bid(
@@ -718,9 +839,11 @@ BEGIN
     );
 END;
 $$;
-ALTER FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID) OWNER TO service_role;
-REVOKE ALL ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID) TO service_role;
+ALTER FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) TO service_role;
+COMMENT ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) IS
+    'PUBLIC marketplace RPC. Seller-driven cancel for an active listing. Refunds the active bid (if any) and flips status to cancelled. Idempotent on already-cancelled. Rejects after expires_at to prevent racing the expire-sweep.';
 
 -- ============================================================================
 -- service_expire_listings — pg_cron-driven sweep
@@ -735,7 +858,14 @@ GRANT EXECUTE ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID
 -- small; the cron schedule runs every 15min so backlog clears quickly.
 -- ============================================================================
 
-CREATE OR REPLACE FUNCTION wallet.service_expire_listings()
+-- Defensive: earlier drafts shipped without p_limit. Drop the no-arg
+-- signature first so re-runs of this migration don't end up with two
+-- overload variants.
+DROP FUNCTION IF EXISTS wallet.service_expire_listings();
+
+CREATE OR REPLACE FUNCTION wallet.service_expire_listings(
+    p_limit INTEGER DEFAULT 100
+)
 RETURNS BIGINT
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
@@ -745,6 +875,7 @@ DECLARE
     v_total           BIGINT := 0;
     v_settled         BIGINT := 0;
     v_expired         BIGINT := 0;
+    v_limit           INTEGER := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 1000);
 BEGIN
     -- Transaction-scoped advisory lock. Overlapping cron runs become a
     -- no-op for the loser instead of racing on row locks + emitting
@@ -761,13 +892,15 @@ BEGIN
           FROM wallet.listing
          WHERE status = 'active' AND expires_at <= v_now
          ORDER BY expires_at, id
-         LIMIT 100
+         LIMIT v_limit
          FOR UPDATE SKIP LOCKED
     LOOP
         IF v_current_bid_id IS NOT NULL THEN
             -- Settle deterministically against the listing's pointer
             -- rather than relying on settle to look the active bid up.
-            PERFORM wallet.service_settle_listing(v_listing_id, v_current_bid_id);
+            PERFORM wallet.service_settle_listing(
+                v_listing_id, v_current_bid_id, 'expired_with_bid'
+            );
             v_settled := v_settled + 1;
         ELSE
             UPDATE wallet.listing
@@ -799,15 +932,15 @@ BEGIN
     RETURN v_total;
 END;
 $$;
-ALTER FUNCTION wallet.service_expire_listings() OWNER TO service_role;
-REVOKE ALL ON FUNCTION wallet.service_expire_listings() FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION wallet.service_expire_listings() TO service_role;
+ALTER FUNCTION wallet.service_expire_listings(INTEGER) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_expire_listings(INTEGER) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_expire_listings(INTEGER) TO service_role;
 -- pg_cron runs jobs as the scheduling role (postgres). Document the
 -- exec contract with an explicit grant.
-GRANT EXECUTE ON FUNCTION wallet.service_expire_listings() TO postgres;
+GRANT EXECUTE ON FUNCTION wallet.service_expire_listings(INTEGER) TO postgres;
 
-COMMENT ON FUNCTION wallet.service_expire_listings() IS
-    'Sweeps active listings whose expires_at has passed. Settles winning bid if any, otherwise marks expired. Bounded to 100 rows/call. Writes one summary audit row per non-empty sweep.';
+COMMENT ON FUNCTION wallet.service_expire_listings(INTEGER) IS
+    'PUBLIC marketplace RPC. Sweeps active listings whose expires_at has passed. Settles winning bid if any (settlement_reason=expired_with_bid), otherwise marks expired. Bounded to p_limit rows (default 100, clamped [1, 1000]). Writes one summary audit row per non-empty sweep. Wraps in pg_try_advisory_xact_lock so overlapping cron runs no-op for the loser.';
 
 -- pg_cron schedule — guarded by extension presence so local dev passes.
 DO $$
@@ -837,12 +970,14 @@ BEGIN
 END;
 $$;
 
-DROP FUNCTION IF EXISTS wallet.service_expire_listings();
-DROP FUNCTION IF EXISTS wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID);
+DROP FUNCTION IF EXISTS wallet.service_expire_listings(INTEGER);
+DROP FUNCTION IF EXISTS wallet.service_cancel_listing(BIGINT, UUID, TEXT);
 DROP FUNCTION IF EXISTS wallet.service_buy_now(BIGINT, UUID, UUID);
 DROP FUNCTION IF EXISTS wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID);
-DROP FUNCTION IF EXISTS wallet.service_settle_listing(BIGINT, BIGINT);
+DROP FUNCTION IF EXISTS wallet.service_settle_listing(BIGINT, BIGINT, TEXT);
 DROP FUNCTION IF EXISTS wallet.distribute_settlement(BIGINT, UUID, BIGINT);
 DROP FUNCTION IF EXISTS wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT);
 DROP FUNCTION IF EXISTS wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID);
+DROP FUNCTION IF EXISTS wallet.assert_user_account(UUID);
 DROP FUNCTION IF EXISTS wallet.treasury_account_id();
+DROP FUNCTION IF EXISTS wallet.marketplace_fee(BIGINT);

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -362,6 +362,34 @@ COMMENT ON FUNCTION wallet.service_create_listing(UUID, JSONB, wallet.currency_k
     'SERVICE marketplace RPC. Creates a listing for kind=user seller. Idempotent on (seller_account, idempotency_key). Validates currency=khash, item_ref shape, price invariants, future expires_at.';
 
 -- ============================================================================
+-- Helper privilege posture (applies to all wallet.* helpers below)
+--
+-- Every helper is OWNER service_role, REVOKE FROM PUBLIC/anon/
+-- authenticated, GRANT EXECUTE TO service_role. The explicit grant is
+-- required because REVOKE EXECUTE FROM owner_role DOES strip owner's
+-- execute privilege in PostgreSQL 17 — verified empirically with:
+--
+--   CREATE FUNCTION helper SECURITY DEFINER OWNER service_role;
+--   REVOKE EXECUTE ON helper FROM service_role;
+--   CREATE FUNCTION caller SECURITY DEFINER OWNER service_role
+--     -> calls helper;
+--   SET ROLE service_role; SELECT caller();
+--   -- ERROR: permission denied for function helper
+--
+-- The "owners have implicit privileges" rule applies to GRANT OPTION
+-- (an owner can always re-grant), not to bypassing an explicit REVOKE
+-- against themselves. Therefore the top-level RPCs (which run AS
+-- service_role via SECURITY DEFINER) need an explicit GRANT EXECUTE
+-- TO service_role on each helper to chain in.
+--
+-- Tighter posture (a dedicated wallet_internal role owning helpers
+-- + top-level wrappers granted to service_role) is tracked as a
+-- Phase 1 schema-refactor follow-up. Current posture is:
+-- service_role-only + self-locking helpers + per-helper invariant
+-- checks (e.g. distribute_settlement verifies listing+bid state).
+-- ============================================================================
+
+-- ============================================================================
 -- INTERNAL HELPER: refund the current active bid (if any)
 --
 -- Self-locks the listing row via SELECT ... FOR UPDATE so direct
@@ -474,34 +502,25 @@ $$;
 ALTER FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) TO service_role;
--- Note: REVOKE EXECUTE FROM owner_role DOES strip owner's execute
--- privilege in PostgreSQL 17 — verified empirically with:
---
---   CREATE FUNCTION helper SECURITY DEFINER OWNER service_role;
---   REVOKE EXECUTE ON helper FROM service_role;
---   CREATE FUNCTION caller SECURITY DEFINER OWNER service_role
---     -> calls helper;
---   SET ROLE service_role; SELECT caller();
---   -- ERROR: permission denied for function helper
---
--- The conventional "owners have implicit privileges" rule applies
--- to GRANT OPTION (an owner can always re-grant), not to bypassing
--- an explicit REVOKE against themselves. Therefore the top-level
--- RPCs (which run AS service_role via SECURITY DEFINER) need an
--- explicit GRANT EXECUTE TO service_role on the helper to chain in.
---
--- Narrowing further would require a dedicated wallet_internal role
--- owning the helpers + a service_role-callable top-level wrapper.
--- That's a Phase 1 schema change tracked as a follow-up; current
--- posture is service_role-only + self-locking helpers + audit trail.
+-- (Privilege posture explained in the "Helper privilege posture"
+-- comment block above.)
 COMMENT ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) IS
     'INTERNAL marketplace helper. service_role-callable; self-locks the listing. Do not wrap from public proxies.';
 
 -- ============================================================================
 -- INTERNAL HELPER: distribute funds on settlement
 --
--- Credits seller (price - fee) and treasury (fee). Returns (fee, net).
--- Caller must already hold the FOR UPDATE lock on the listing.
+-- Credits seller (amount - fee) and treasury (fee). Returns
+-- (fee, net, seller_ledger_id, fee_ledger_id) so the caller can
+-- include both ledger ids in audit metadata.
+--
+-- Self-locks the listing row + the winning bid row. Direct
+-- service_role callers cannot mint settlement credits unless the
+-- listing is active+khash, the bid id matches listing.current_bid_id,
+-- the amount agrees, the seller matches, and the bid has already
+-- been flipped to status='won' by the caller. The 'won' precondition
+-- means this helper assumes service_settle_listing has already
+-- recorded the bid transition; it is not a standalone settler.
 -- ============================================================================
 
 -- Defensive: earlier drafts shipped a 3-arg signature and a different
@@ -572,6 +591,23 @@ BEGIN
             p_amount, v_listing_row.current_bid, p_listing_id USING ERRCODE = 'P1008';
     END IF;
 
+    -- Lock + verify the winning bid row directly. service_settle_listing
+    -- has already flipped the bid to status='won' before calling us, so
+    -- the precondition is 'won', not 'active'. Direct callers that
+    -- skip the won-transition cannot reach this code path.
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.bid b
+         WHERE b.id = p_winning_bid_id
+           AND b.listing_id = p_listing_id
+           AND b.bidder_account = v_listing_row.current_bid_account
+           AND b.amount = p_amount
+           AND b.status = 'won'
+         FOR UPDATE
+    ) THEN
+        RAISE EXCEPTION 'winning bid % for listing % not in expected won/matching state',
+            p_winning_bid_id, p_listing_id USING ERRCODE = 'P1008';
+    END IF;
+
     v_fee := wallet.marketplace_fee(p_amount);
     v_net := p_amount - v_fee;
     v_treasury := wallet.treasury_account_id();
@@ -623,15 +659,17 @@ ALTER FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT) OWNER 
 REVOKE ALL ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT) TO service_role;
 COMMENT ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT) IS
-    'INTERNAL marketplace helper. service_role-callable. Splits a settled amount into (net, fee) via two service_credit calls. Reached via service_settle_listing owner-chain. Narrower role posture (wallet_internal-only) tracked as a follow-up.';
+    'INTERNAL marketplace helper. service_role-callable. Self-locks listing + winning bid; requires listing active+khash, bid status=won + matching id/amount/seller. Splits a settled amount into (net, fee) via two service_credit calls. Reached via service_settle_listing. Narrower role posture (wallet_internal-only) tracked as a follow-up.';
 
 -- ============================================================================
 -- service_settle_listing
 --
 -- Marks the winning bid 'won', distributes funds, marks listing 'sold'
--- with buyer_account = winning_bid.bidder. Caller MUST hold FOR UPDATE
--- on the listing row already. p_winning_bid_id allows the caller to
--- assert the expected bid; pass NULL to look up the active bid.
+-- with buyer_account = winning_bid.bidder. Self-locks the listing row
+-- (inner callers that already hold the lock pay zero cost; re-locking
+-- inside one transaction is a no-op). p_winning_bid_id allows the
+-- caller to assert the expected bid; pass NULL to resolve via
+-- listing.current_bid_id.
 -- ============================================================================
 
 -- Defensive: earlier draft shipped as 2-arg (no reason).

--- a/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
+++ b/packages/data/sql/dbmate/migrations/20260515054304_wallet_marketplace_rpcs.sql
@@ -475,12 +475,20 @@ ALTER FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) OWNER T
 REVOKE ALL ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) TO service_role;
 -- Note: REVOKE EXECUTE FROM owner_role DOES strip owner's execute
--- privilege in PostgreSQL — verified empirically. The conventional
--- "owners have implicit privileges" rule applies to GRANT OPTION
--- (an owner can always re-grant), not to bypassing an explicit
--- REVOKE against themselves. Therefore the top-level RPCs (which
--- run AS service_role via SECURITY DEFINER) need an explicit
--- GRANT EXECUTE TO service_role on the helper to chain in.
+-- privilege in PostgreSQL 17 — verified empirically with:
+--
+--   CREATE FUNCTION helper SECURITY DEFINER OWNER service_role;
+--   REVOKE EXECUTE ON helper FROM service_role;
+--   CREATE FUNCTION caller SECURITY DEFINER OWNER service_role
+--     -> calls helper;
+--   SET ROLE service_role; SELECT caller();
+--   -- ERROR: permission denied for function helper
+--
+-- The conventional "owners have implicit privileges" rule applies
+-- to GRANT OPTION (an owner can always re-grant), not to bypassing
+-- an explicit REVOKE against themselves. Therefore the top-level
+-- RPCs (which run AS service_role via SECURITY DEFINER) need an
+-- explicit GRANT EXECUTE TO service_role on the helper to chain in.
 --
 -- Narrowing further would require a dedicated wallet_internal role
 -- owning the helpers + a service_role-callable top-level wrapper.
@@ -496,14 +504,17 @@ COMMENT ON FUNCTION wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT) IS
 -- Caller must already hold the FOR UPDATE lock on the listing.
 -- ============================================================================
 
--- Defensive: earlier draft returned only (fee, net). Drop so CREATE OR
--- REPLACE doesn't error on changed RETURNS TABLE shape.
+-- Defensive: earlier drafts shipped a 3-arg signature and a different
+-- RETURNS TABLE shape. Drop both old and new so CREATE OR REPLACE
+-- doesn't error on changed argument list / return-type.
 DROP FUNCTION IF EXISTS wallet.distribute_settlement(BIGINT, UUID, BIGINT);
+DROP FUNCTION IF EXISTS wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT);
 
 CREATE OR REPLACE FUNCTION wallet.distribute_settlement(
-    p_listing_id BIGINT,
-    p_seller     UUID,
-    p_amount     BIGINT
+    p_listing_id     BIGINT,
+    p_seller         UUID,
+    p_amount         BIGINT,
+    p_winning_bid_id BIGINT
 )
 RETURNS TABLE (
     fee              BIGINT,
@@ -518,24 +529,57 @@ DECLARE
     v_treasury         UUID;
     v_seller_ledger_id BIGINT;
     v_fee_ledger_id    BIGINT := NULL;
+    v_listing_row      wallet.listing%ROWTYPE;
 BEGIN
-    -- Defensive: callers already guard this, but distribute_settlement is
-    -- service_role-callable directly. Block bad inputs at the boundary.
+    -- Defensive: callers already guard this, but distribute_settlement
+    -- is service_role-callable directly. Block bad inputs at the
+    -- boundary AND re-verify the listing/bid state inside.
     IF p_amount IS NULL OR p_amount <= 0 THEN
         RAISE EXCEPTION 'settlement amount must be positive' USING ERRCODE = '22023';
     END IF;
-    IF p_seller IS NULL THEN
-        RAISE EXCEPTION 'p_seller is required' USING ERRCODE = '22004';
+    IF p_seller IS NULL OR p_winning_bid_id IS NULL THEN
+        RAISE EXCEPTION 'p_seller and p_winning_bid_id are required' USING ERRCODE = '22004';
     END IF;
     PERFORM wallet.assert_user_account(p_seller);
+
+    -- Lock the listing and verify it's still settle-able. A direct
+    -- caller cannot mint settlement credits for a cancelled, sold,
+    -- expired, or wrong-seller listing.
+    SELECT * INTO v_listing_row
+      FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
+    IF v_listing_row.id IS NULL THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
+    END IF;
+    IF v_listing_row.status <> 'active' THEN
+        RAISE EXCEPTION 'listing % not active (status=%); cannot distribute',
+            p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
+    END IF;
+    IF v_listing_row.currency <> 'khash'::wallet.currency_kind THEN
+        RAISE EXCEPTION 'listing % currency % is not khash',
+            p_listing_id, v_listing_row.currency USING ERRCODE = '22023';
+    END IF;
+    IF v_listing_row.seller_account <> p_seller THEN
+        RAISE EXCEPTION 'seller mismatch for listing %: expected %, got %',
+            p_listing_id, v_listing_row.seller_account, p_seller USING ERRCODE = 'P1008';
+    END IF;
+    IF v_listing_row.current_bid_id IS DISTINCT FROM p_winning_bid_id THEN
+        RAISE EXCEPTION 'winning bid % is not current bid % for listing %',
+            p_winning_bid_id, v_listing_row.current_bid_id, p_listing_id
+            USING ERRCODE = 'P1008';
+    END IF;
+    IF v_listing_row.current_bid IS DISTINCT FROM p_amount THEN
+        RAISE EXCEPTION 'amount % disagrees with listing.current_bid % for listing %',
+            p_amount, v_listing_row.current_bid, p_listing_id USING ERRCODE = 'P1008';
+    END IF;
 
     v_fee := wallet.marketplace_fee(p_amount);
     v_net := p_amount - v_fee;
     v_treasury := wallet.treasury_account_id();
 
     -- Deterministic ledger idempotency keys for internal writes —
-    -- listing+bid+action identifies the operation uniquely. Replay/debug
-    -- correlation is easier than gen_random_uuid().
+    -- listing+bid+action identifies the operation uniquely so replay
+    -- correlation lines up with the winning bid even if the listing
+    -- id is reused in some future schema migration.
     v_seller_ledger_id := wallet.service_credit(
         p_seller,
         'khash'::wallet.currency_kind,
@@ -546,7 +590,8 @@ BEGIN
         p_listing_id,
         extensions.uuid_generate_v5(
             extensions.uuid_ns_url(),
-            'marketplace.settlement.seller:' || p_listing_id::TEXT
+            'marketplace.settlement.seller:' ||
+            p_listing_id::TEXT || ':' || p_winning_bid_id::TEXT
         )
     );
 
@@ -561,7 +606,8 @@ BEGIN
             p_listing_id,
             extensions.uuid_generate_v5(
                 extensions.uuid_ns_url(),
-                'marketplace.settlement.fee:' || p_listing_id::TEXT
+                'marketplace.settlement.fee:' ||
+                p_listing_id::TEXT || ':' || p_winning_bid_id::TEXT
             )
         );
     END IF;
@@ -573,10 +619,10 @@ BEGIN
     RETURN NEXT;
 END;
 $$;
-ALTER FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) OWNER TO service_role;
-REVOKE ALL ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) TO service_role;
-COMMENT ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT) IS
+ALTER FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT) TO service_role;
+COMMENT ON FUNCTION wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT) IS
     'INTERNAL marketplace helper. service_role-callable. Splits a settled amount into (net, fee) via two service_credit calls. Reached via service_settle_listing owner-chain. Narrower role posture (wallet_internal-only) tracked as a follow-up.';
 
 -- ============================================================================
@@ -686,7 +732,7 @@ BEGIN
 
     SELECT d.fee, d.net, d.seller_ledger_id, d.fee_ledger_id
       INTO v_fee, v_net, v_seller_ledger_id, v_fee_ledger_id
-      FROM wallet.distribute_settlement(p_listing_id, v_seller, v_amount) d;
+      FROM wallet.distribute_settlement(p_listing_id, v_seller, v_amount, v_bid_id) d;
 
     UPDATE wallet.listing
        SET status = 'sold',
@@ -1075,14 +1121,23 @@ COMMENT ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) IS
 -- ============================================================================
 -- service_expire_listings — pg_cron-driven sweep
 --
--- Walks active listings whose deadline has passed and either settles
--- the winning bid (if any) or marks the listing 'expired' (no bids).
--- One summary audit row per non-empty sweep. Returns the number of
--- listings touched.
+-- Walks active KHASH listings whose deadline has passed and either
+-- settles the winning bid (if any) or marks the listing 'expired'
+-- (no bids). Non-khash legacy active rows are filtered out of the
+-- cursor; a separate audit row records the skipped count so a future
+-- cross-currency migration can backfill them.
 --
--- Uses FOR UPDATE SKIP LOCKED so multiple cron runs can share work
--- safely. Bounded to 100 listings per call to keep the transaction
--- small; the cron schedule runs every 15min so backlog clears quickly.
+-- Concurrency:
+--   pg_try_advisory_xact_lock SERIALIZES sweep workers — the loser
+--   immediately returns (0, 0, 0). FOR UPDATE SKIP LOCKED in the
+--   cursor still protects against row contention from any non-cron
+--   caller of service_settle_listing that holds a listing lock.
+--
+-- Bounded to p_limit listings per call (default 100, clamped to
+-- [1, 1000]) so the transaction stays small. lock_timeout=2s +
+-- statement_timeout=30s are set transaction-locally so a pathological
+-- lock can't stall the sweep. One summary audit row per non-empty
+-- sweep; a separate audit row whenever non-khash actives are skipped.
 -- ============================================================================
 
 -- Defensive: earlier drafts shipped without p_limit and with
@@ -1154,6 +1209,31 @@ BEGIN
         v_total := v_total + 1;
     END LOOP;
 
+    -- Observability for non-khash legacy active rows that the cursor
+    -- filtered out. Non-zero count means a future cross-currency
+    -- backfill has work to do.
+    DECLARE
+        v_skipped_non_khash BIGINT;
+    BEGIN
+        SELECT COUNT(*) INTO v_skipped_non_khash
+          FROM wallet.listing
+         WHERE status = 'active'
+           AND currency <> 'khash'::wallet.currency_kind
+           AND expires_at <= v_now;
+
+        IF v_skipped_non_khash > 0 THEN
+            INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+            VALUES (
+                'marketplace.expire_sweep_unsupported_currency',
+                'listing', 'batch',
+                jsonb_build_object(
+                    'skipped_non_khash', v_skipped_non_khash,
+                    'cutoff_at', v_now
+                )
+            );
+        END IF;
+    END;
+
     IF v_total > 0 THEN
         INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
         VALUES (
@@ -1182,7 +1262,7 @@ GRANT EXECUTE ON FUNCTION wallet.service_expire_listings(INTEGER) TO service_rol
 GRANT EXECUTE ON FUNCTION wallet.service_expire_listings(INTEGER) TO postgres;
 
 COMMENT ON FUNCTION wallet.service_expire_listings(INTEGER) IS
-    'SERVICE marketplace RPC. Sweeps active listings whose expires_at has passed. Settles winning bid if any (settlement_reason=expired_with_bid), otherwise marks expired. Bounded to p_limit rows (default 100, clamped [1, 1000]). Returns (total, settled, expired) row. Writes one summary audit row per non-empty sweep. pg_try_advisory_xact_lock makes overlapping cron runs no-op for the loser. lock_timeout=2s + statement_timeout=30s applied transaction-locally.';
+    'SERVICE marketplace RPC. Sweeps active KHASH listings whose expires_at has passed. Settles winning bid if any (settlement_reason=expired_with_bid), otherwise marks expired. Non-khash legacy actives are filtered out of the cursor; a separate marketplace.expire_sweep_unsupported_currency audit row records the skipped count. Bounded to p_limit rows (default 100, clamped [1, 1000]). Returns (total, settled, expired) row. pg_try_advisory_xact_lock SERIALIZES sweep workers; SKIP LOCKED protects against non-cron contention. lock_timeout=2s + statement_timeout=30s applied transaction-locally.';
 
 -- pg_cron schedule — guarded by extension presence so local dev passes.
 DO $$
@@ -1217,7 +1297,7 @@ DROP FUNCTION IF EXISTS wallet.service_cancel_listing(BIGINT, UUID, TEXT);
 DROP FUNCTION IF EXISTS wallet.service_buy_now(BIGINT, UUID, UUID);
 DROP FUNCTION IF EXISTS wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID);
 DROP FUNCTION IF EXISTS wallet.service_settle_listing(BIGINT, BIGINT, TEXT);
-DROP FUNCTION IF EXISTS wallet.distribute_settlement(BIGINT, UUID, BIGINT);
+DROP FUNCTION IF EXISTS wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT);
 DROP FUNCTION IF EXISTS wallet.refund_active_bid(BIGINT, wallet.bid_status, TEXT);
 DROP FUNCTION IF EXISTS wallet.service_create_listing(UUID, JSONB, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID);
 DROP FUNCTION IF EXISTS wallet.assert_user_account(UUID);

--- a/packages/data/sql/schema/wallet/wallet_marketplace.sql
+++ b/packages/data/sql/schema/wallet/wallet_marketplace.sql
@@ -246,3 +246,69 @@ INSERT INTO wallet.balance (account_id)
 SELECT id FROM wallet.account
  WHERE kind = 'treasury' AND label = 'kbve_treasury'
 ON CONFLICT (account_id) DO NOTHING;
+
+-- ============================================================================
+-- MARKETPLACE RPCs (Phase 2)
+--
+-- Service-layer mutators for the create / bid / buy-now / cancel /
+-- settle / expire lifecycle. All SECURITY DEFINER, service_role only,
+-- owned by service_role. Phase 3 public proxies wrap these after
+-- applying auth.uid() ownership checks.
+--
+-- Money flow (khash-only in v1):
+--   place_bid:  service_debit(bidder, amount) → escrow; on outbid the
+--               prior bidder is refunded via service_credit.
+--   buy_now:    same debit, then immediate service_settle_listing.
+--   cancel:     refund active bid (status='refunded'), mark listing
+--               'cancelled'.
+--   settle:     mark winning bid 'won' (no refund); service_credit
+--               seller with (amount - fee) and treasury with fee.
+--   expire:     pg_cron-driven sweep. For each active listing with
+--               expires_at <= now(): settle if a current_bid exists,
+--               otherwise mark 'expired'.
+-- Fee = floor(amount / 100) = 1%.
+--
+-- Idempotency is enforced via the per-actor (seller/bidder) unique
+-- index on idempotency_key. Replays return the existing row id.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.treasury_account_id()
+RETURNS UUID
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_id UUID;
+BEGIN
+    SELECT id INTO v_id
+      FROM wallet.account
+     WHERE kind = 'treasury' AND label = 'kbve_treasury';
+    IF v_id IS NULL THEN
+        RAISE EXCEPTION 'kbve_treasury account missing' USING ERRCODE = '23503';
+    END IF;
+    RETURN v_id;
+END;
+$$;
+ALTER FUNCTION wallet.treasury_account_id() OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.treasury_account_id() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.treasury_account_id() TO service_role;
+
+-- The full bodies of service_create_listing / service_place_bid /
+-- service_buy_now / service_cancel_listing / service_settle_listing /
+-- service_expire_listings / refund_active_bid / distribute_settlement
+-- live in the dbmate migration 20260515054304_wallet_marketplace_rpcs.
+-- This mirror documents only signatures + grants for review surface.
+
+-- Signatures (see migration for bodies):
+--   wallet.service_create_listing(UUID, JSONB, currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID)
+--                                                            → BIGINT (listing.id)
+--   wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID)      → BIGINT (bid.id)
+--   wallet.service_buy_now(BIGINT, UUID, UUID)                → BIGINT (bid.id)
+--   wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID)   → VOID
+--   wallet.service_settle_listing(BIGINT, BIGINT)             → VOID
+--   wallet.service_expire_listings()                          → BIGINT (rows touched)
+--   wallet.refund_active_bid(BIGINT, bid_status, TEXT)        → BIGINT (refunded bid id or NULL)
+--   wallet.distribute_settlement(BIGINT, UUID, BIGINT)        → (BIGINT fee, BIGINT net)
+
+-- pg_cron schedule (registered when extension is present):
+--   jobname:  marketplace-expire-listings
+--   schedule: '*/15 * * * *'
+--   command:  SELECT wallet.service_expire_listings();


### PR DESCRIPTION
## Summary

Phase 2 of the marketplace bootstrap (#10979). Service-layer mutators for the full lifecycle — create / bid / buy-now / cancel / settle / expire — plus a pg_cron schedule driving the expire sweep. All SECURITY DEFINER, service_role only, owned by service_role. Phase 3 public proxies will wrap these after applying `auth.uid()` ownership checks.

Builds on:
- Phase 1 schema (#10976) — `wallet.listing`, `wallet.bid`, treasury account, indexes, RLS
- Existing wallet ledger primitives (`service_credit` / `service_debit`)

## RPCs

| Function | Returns | Behavior |
|---|---|---|
| `wallet.service_create_listing(seller, item_ref, currency, buy_now, min_bid, expires_at, key)` | `BIGINT` listing_id | Idempotent via `(seller, key)`. Audit `marketplace.listing_create`. |
| `wallet.service_place_bid(listing_id, bidder, amount, key)` | `BIGINT` bid_id | FOR UPDATE on listing. Rejects self-bid / below-min / non-monotonic / inactive / expired / buy-now-only. Debits bidder, refunds prior, updates `current_bid_id`. Short-circuits to settle if `amount >= buy_now_price`. |
| `wallet.service_buy_now(listing_id, buyer, key)` | `BIGINT` bid_id | Refunds active bid, debits buyer, settles in same txn. |
| `wallet.service_cancel_listing(listing_id, seller, reason, key)` | `VOID` | Seller-owned. Refunds active bid (status `refunded`). Idempotent on already-cancelled. |
| `wallet.service_settle_listing(listing_id, winning_bid_id NULL)` | `VOID` | Marks bid `won`, credits seller `(amount - fee)`, credits treasury `fee = floor(amount/100)`. |
| `wallet.service_expire_listings()` | `BIGINT` | pg_cron sweep. FOR UPDATE SKIP LOCKED. Bounded 100/call. Settle if `current_bid_id` set, else mark `expired`. One summary audit row per non-empty sweep. |

**Helpers:** `wallet.treasury_account_id()`, `wallet.refund_active_bid(listing_id, next_status, reason)`, `wallet.distribute_settlement(listing_id, seller, amount) → (fee, net)`.

## pg_cron

- `marketplace-expire-listings` at `'*/15 * * * *'`
- Guarded on `pg_extension` presence → local dev without pg_cron still applies cleanly
- Idempotent re-registration (unschedules prior job by name first)
- Explicit `GRANT EXECUTE TO postgres` on the sweep RPC documents the cron-exec contract

## Privilege posture

- All functions `OWNER service_role` (inherits the `service_role_full_access` RLS policy from Phase 1)
- `REVOKE ALL FROM PUBLIC, anon, authenticated` on every function
- `GRANT EXECUTE TO service_role` only (plus explicit `postgres` grant on the cron-target)

## Test plan

- [x] `nx run data-sql:test-migration 20260515054304_wallet_marketplace_rpcs` green
- [x] 8 assertions covering full lifecycle:
  1. create_listing happy path + idempotent replay
  2. place_bid happy path + outbid refunds prior + live-bid pointers updated
  3. place_bid rejects (self-bid, below min, non-monotonic)
  4. place_bid short-circuits at buy_now_price → settle (fee=6, net=594 on 600)
  5. buy_now refunds active bid, settles (fee=4, net=396 on 400)
  6. cancel_listing refunds + idempotent + rejects non-seller
  7. expire_listings no-bid → `expired`, bid → `sold` with treasury fee
  8. pg_cron schedule registered when extension present
- [x] After-down: all 9 marketplace functions dropped
- [ ] After merge: dispatch `ci-dbmate-deploy` on main
- [ ] After deploy: `SELECT * FROM cron.job WHERE jobname='marketplace-expire-listings'` shows the schedule
- [ ] Watch `wallet.audit_log` for `marketplace.*` rows on next 15-min boundary

## Roadmap

- [x] Phase 1 — Schema (#10976, merged)
- [x] **Phase 2 — Service-layer RPCs + pg_cron** (this PR)
- [ ] Phase 3 — Public proxies (RW + RO)
- [ ] Phase 4 — Rust axum-kbve transport routes
- [ ] Phase 5 — Astro UI `/mc/market` + `/profile/market`