### PR TITLE
fix(kilobase): drop clientCASecret — cert-manager copy has no ca.key

### DIFF
--- a/apps/kube/kilobase/manifests/postgres-cluster.yaml
+++ b/apps/kube/kilobase/manifests/postgres-cluster.yaml
@@ -36,15 +36,23 @@ spec:
         size: 40Gi
         storageClass: longhorn
 
-    # TLS certificates issued by cert-manager via Crossplane provider-kubernetes
-    # cert-manager handles renewal (30 days before expiry); CNPG treats these as
-    # externally-managed and will use them without auto-generating its own certs.
+    # TLS certificates: server side uses cert-manager-issued cert via Crossplane
+    # provider-kubernetes (cert-manager handles renewal 30 days before expiry).
+    # Client side stays on CNPG's auto-managed default CA because the
+    # internal-ca-key-pair secret in this namespace is intentionally
+    # public-material-only (no ca.key) — Crossplane is configured to NOT
+    # copy the CA private key out of cert-manager. Without ca.key, CNPG
+    # cannot sign new client/replication certs against internal-ca, so it
+    # silently falls back to its default cluster CA. Pointing clientCASecret
+    # at internal-ca-key-pair then causes a CA mismatch: postgres pods would
+    # verify client mTLS against internal-ca while CNPG-issued client certs
+    # (pooler, replication user) were signed by the default cluster CA →
+    # "tlsv1 alert unknown ca" and pooler login retries cache forever.
     # Rollback: remove this certificates block to revert to CNPG auto-managed TLS.
     certificates:
         serverTLSSecret: supabase-server-tls
         serverCASecret: internal-ca-key-pair
         replicationTLSSecret: supabase-replication-tls
-        clientCASecret: internal-ca-key-pair
 
     monitoring:
         enablePodMonitor: true


### PR DESCRIPTION
## Why
\`/api/v1/wallet/*\` was returning 408. Investigation:

- Pooler-ro PgBouncer was hitting \`tls_sbufio_recv: read failed: error:0A000418:SSL routines::tlsv1 alert unknown ca\` on every server-side handshake; PgBouncer cached the failure (\`server_login_retry\`) and rejected client logins.
- The pooler's client cert (\`cnpg_pooler_pgbouncer\`) was signed by the CNPG default cluster CA \`OU=kilobase, CN=supabase-cluster\`, but Postgres pods were verifying client mTLS against \`internal-ca\` (per \`Cluster.spec.certificates.clientCASecret\`).
- Why the mismatch: \`internal-ca-key-pair\` in the \`kilobase\` namespace is **public-material-only** by design — Crossplane is configured to copy just \`ca.crt\` and \`tls.crt\` out of \`cert-manager\` (see \`apps/kube/crossplane/providers/cnpg-ca-secret.yaml\`), no private key. Without \`ca.key\`, CNPG cannot sign new client/replication certs with internal-ca, so it silently falls back to its default cluster CA. But \`clientCASecret\` told Postgres to **verify** against internal-ca → mismatch.

## What
- Remove \`clientCASecret: internal-ca-key-pair\` from \`Cluster.spec.certificates\`.
- Keep \`serverTLSSecret: supabase-server-tls\` + \`serverCASecret: internal-ca-key-pair\` so the **server-side** still uses the cert-manager-managed cert and external clients keep verifying against internal-ca.
- Also keep \`replicationTLSSecret\` (it's the cert itself, not the CA — fine).
- Document the why inline.

## What happens after merge
1. ArgoCD reconciles the Cluster — CNPG sees the spec change.
2. CNPG re-issues \`supabase-cluster-pooler\` (deleted during diagnosis) signed by the default cluster CA, which it has the private key for.
3. PgBouncer pods pick up the new cert and the server-side TLS handshake to Postgres succeeds.
4. \`/api/v1/wallet/*\` clears 408 once the pooler cache empties.

## Test plan
- [ ] PR merges to dev → main → ArgoCD syncs \`kilobase\`.
- [ ] \`kubectl -n kilobase get secret supabase-cluster-pooler\` returns a regenerated secret (TLS cert issuer = \`OU=kilobase, CN=supabase-cluster\`).
- [ ] \`kubectl -n kilobase logs deployment/supabase-cluster-pooler-ro --since=2m | grep -c 'unknown ca'\` is 0.
- [ ] \`psql\` through \`supabase-cluster-pooler-ro\` returns a row.
- [ ] \`/profile/account/\` wallet card loads compact balances.

## Follow-up (separate PR)
- Decide whether internal-ca should sign client certs at all. If yes, plumb a cert-manager \`CertificateRequest\`-based flow (or copy ca.key into the namespace with proper RBAC + SealedSecret rather than the current public-only Crossplane copy).