### PR TITLE
feat(mc): add Open Parties and Claims for spawn lockdown + player claims

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -245,7 +245,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.49",
+			"version": "1.0.50",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",

--- a/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/mc.mdx
@@ -12,7 +12,7 @@ tags:
 key: mc
 pipeline: docker
 app_name: mc
-version: "1.0.49"
+version: "1.0.50"
 source_path: apps/mc
 version_toml: apps/mc/version.toml
 runner: ubuntu-latest

--- a/apps/mc/Dockerfile.mods
+++ b/apps/mc/Dockerfile.mods
@@ -191,6 +191,12 @@ declare -A MODS=(
   # Macaw's Paintings 1.1.0 — adds 40+ new painting variants in
   # multiple sizes. Client + server.
   ["mcw-paintings-1.1.0-mc1.21.11fabric.jar"]="580ba60f2811796b7906ebc7edea053849a0d1fd https://cdn.modrinth.com/data/okE6QVAY/versions/VPvufXfe/mcw-paintings-1.1.0-mc1.21.11fabric.jar"
+  # ── Land claims + parties ──────────────────────────────────────────
+  # Open Parties and Claims 0.26.2 — chunk-based claim system with
+  # built-in party (guild) support and an admin claim type used to
+  # lock the spawn city. Configured in-game via /opac admin-mode +
+  # /opac claim on first deploy.
+  ["open-parties-and-claims-fabric-1.21.11-0.26.2.jar"]="af76f66591622b945ef37fbf20bee7ae36d82329 https://cdn.modrinth.com/data/gF3BGWvG/versions/JkiXvTq4/open-parties-and-claims-fabric-1.21.11-0.26.2.jar"
 )
 
 for name in "${!MODS[@]}"; do

--- a/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
+++ b/apps/mc/behavior_statetree/mrpack/build-mrpack.sh
@@ -396,6 +396,42 @@ cat > "$WORK_DIR/modrinth.index.json" << MANIFEST
       ],
       "fileSize": 611547,
       "env": { "client": "required", "server": "unsupported" }
+    },
+    {
+      "path": "mods/open-parties-and-claims-fabric-1.21.11-0.26.2.jar",
+      "hashes": {
+        "sha1": "af76f66591622b945ef37fbf20bee7ae36d82329",
+        "sha512": "56552c8d772ff5a01baeb897b646bd3c3ec715e46d16457aed8d1208e5662abe831eeae1b45fa0837f93a9775b28c3af14fad9d5acf3da474a1e9bd975bde1a2"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/gF3BGWvG/versions/JkiXvTq4/open-parties-and-claims-fabric-1.21.11-0.26.2.jar"
+      ],
+      "fileSize": 1649817,
+      "env": { "client": "required", "server": "required" }
+    },
+    {
+      "path": "mods/xaeroworldmap-fabric-1.21.11-1.40.16.jar",
+      "hashes": {
+        "sha1": "7e8f4cf756a5ea8d9ab0583aa7ea69723ace8ab6",
+        "sha512": "70bb88a05f8b36dfa39ef971d3e757beeb6845e674d2cfa337fa0a48f003bdc7fe4f6af1f0fa0dfd0ab17593df4f4348528d7952781abeb6a46cff00d693520b"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/NcUtCpym/versions/vOQ76ooY/xaeroworldmap-fabric-1.21.11-1.40.16.jar"
+      ],
+      "fileSize": 1435689,
+      "env": { "client": "required", "server": "unsupported" }
+    },
+    {
+      "path": "mods/xaerominimap-fabric-1.21.11-25.3.12.jar",
+      "hashes": {
+        "sha1": "c17e50a44669f04e5e051ed87db4c05f0eb5923f",
+        "sha512": "5072fe7d02471956d227b834ee1fa5b1a752f7546cf880c99e32790f09b3b13143c5c16c99b3ba39e0de8a8e6d46f37f1bb3a88ff0fa41207ccce5deae45681b"
+      },
+      "downloads": [
+        "https://cdn.modrinth.com/data/1bokaNcj/versions/q5DQinHS/xaerominimap-fabric-1.21.11-25.3.12.jar"
+      ],
+      "fileSize": 2152212,
+      "env": { "client": "required", "server": "unsupported" }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Bump mc to **1.0.50** to ship a server mod addition.
- Add **Open Parties and Claims (OPAC) 0.26.2** for fabric 1.21.11. Chunk-based claim system with built-in party (guild) support, sub-claims, per-action perms, and an admin claim type.

## Plan for the spawn city
- After deploy, op runs:
  ```
  /opac admin-mode
  /opac claim
  ```
  while standing inside the cube `-200..200` X/Z around spawn `(0, 67, 0)`. That marks the surrounding chunks as **server admin** claim, locking the city to ops only.
- Outside the admin claim: players form parties and claim chunks via OPAC's in-game UI to defend their own builds.

## Why OPAC (not FTB Chunks)
FTB Chunks / FTB Teams would have been the obvious pick, but neither has a fabric 1.21.11 release — the FTB suite caps at fabric 1.21.1. OPAC is the active 1.21.11 fabric alternative (latest 0.26.2 published 2026-04-26) and ships parties + claims in a single mod.

## Future phase (separate PR)
`behavior_statetree` NPC AI to query OPAC's `ClaimsManager` API during pathing so NPCs respect player ownership.

## Test plan
- [ ] `ci-docker mc` rebuilds image at v1.0.50 cleanly.
- [ ] OPAC mod loads on server startup, generates `serverconfig/openpartiesandclaims-server.toml` on the world PVC.
- [ ] Op can claim chunks via `/opac admin-mode` + `/opac claim` and a non-op player cannot break blocks inside the admin claim.
- [ ] Non-op player can form a party via OPAC commands outside the admin claim and claim chunks.
- [ ] `external_publish` ships mrpack v1.0.50 to Modpack project `GktWTywL`.