### PR TITLE
revert(firecracker-ctl-net): DNS_ADDRESS=0.0.0.0 disables Gluetun forwarder

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -83,17 +83,14 @@ spec:
                       - name: TZ
                         value: 'UTC'
                       - name: FIREWALL_INPUT_PORTS
-                        value: '9001,9999,53'
+                        value: '9001,9999'
                       - name: FIREWALL_OUTBOUND_SUBNETS
                         value: '10.0.0.0/8,172.16.0.0/12'
                       # DoH over 443 — Proton blocks 53 and 853 over tunnel.
                       - name: DOT
                         value: 'off'
-                      # Bind DNS forwarder to all interfaces — iptables REDIRECT
-                      # rewrites VM DNS dest to the fctap-N host IP (172.18.0.x),
-                      # not 127.0.0.1, so a loopback-only bind drops the packet.
                       - name: DNS_ADDRESS
-                        value: '0.0.0.0'
+                        value: '127.0.0.1'
                       - name: DNS_UPSTREAM_RESOLVER_TYPE
                         value: 'DoH'
                       - name: DNS_UPSTREAM_RESOLVERS


### PR DESCRIPTION
## Summary
Reverts the env-var changes from #10977. Gluetun's own logs reveal that `DNS_ADDRESS=0.0.0.0` is a documented sentinel that **disables** the internal forwarding DNS server:

\`\`\`
WARN DNS address is set to 0.0.0.0 so the local forwarding DNS server will not be used.
DNS forwarder server enabled: no
\`\`\`

Gluetun's startup healthcheck then fails with `connection refused on 127.0.0.1:53`, VPN never reaches healthy, liveness probe goes red, ingress returns 502 on `/fc/deploy`. Restoring `DNS_ADDRESS=127.0.0.1` (and dropping the `,53` from `FIREWALL_INPUT_PORTS`) brings the pod back so persistent endpoints work.

## Known follow-up
VM DNS resolution inside the microVM remains broken — the original problem #10977 tried to address. The proper fix needs DNAT (not REDIRECT) targeting `127.0.0.1:53` plus `net.ipv4.conf.all.route_localnet=1` set via pod `securityContext.sysctls` (since `/proc/sys` is read-only inside the fc-ctl container). Tracking as a separate change.

## Test plan
- [ ] After ArgoCD sync, `kubectl get pods -n firecracker -l app=firecracker-ctl-net` reports 2/2 Ready.
- [ ] `kubectl logs ... -c gluetun` shows successful WG handshake + DNS forwarder enabled.
- [ ] Dashboard "Deploy" against `firecracker-python-web` returns 200, not CF 502.