### PR TITLE
perf(arcade): tighten blackjack card helpers

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
 	buildShoe,
@@ -9,10 +9,16 @@ import {
 	encodeCard,
 	handFingerprint,
 	isBlackjack,
+	shuffleCards,
+	shuffleCardsInPlace,
 	valueHand,
 } from './cards';
 
 describe('blackjack card encoding', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('packs and decodes suit and rank into a card byte', () => {
 		const card = encodeCard('diamonds', '9');
 
@@ -35,13 +41,42 @@ describe('blackjack card encoding', () => {
 	it('keeps blackjack hand valuation semantics', () => {
 		const ace = encodeCard('spades', 'A');
 		const king = encodeCard('hearts', 'K');
+		const queen = encodeCard('diamonds', 'Q');
 		const nine = encodeCard('clubs', '9');
 
 		expect(isBlackjack([ace, king])).toBe(true);
+		expect(isBlackjack([queen, king])).toBe(false);
+		expect(isBlackjack([ace, nine, king])).toBe(false);
 		expect(valueHand([ace, nine, king])).toEqual({
 			total: 20,
 			soft: false,
 		});
+	});
+
+	it('supports immutable and in-place card shuffles', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0);
+		const cards = [
+			encodeCard('spades', 'A'),
+			encodeCard('hearts', 'K'),
+			encodeCard('clubs', '9'),
+		];
+
+		const shuffled = shuffleCards(cards);
+		const mutable = [...cards];
+		const inPlace = shuffleCardsInPlace(mutable);
+
+		expect(shuffled).toEqual([
+			encodeCard('hearts', 'K'),
+			encodeCard('clubs', '9'),
+			encodeCard('spades', 'A'),
+		]);
+		expect(cards).toEqual([
+			encodeCard('spades', 'A'),
+			encodeCard('hearts', 'K'),
+			encodeCard('clubs', '9'),
+		]);
+		expect(inPlace).toBe(mutable);
+		expect(mutable).toEqual(shuffled);
 	});
 
 	it('builds stable bit-packed hand fingerprints', () => {

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts
@@ -92,9 +92,16 @@ export function buildShoe(decks: number): Card[] {
 
 export function shuffleCards(cards: readonly Card[]): Card[] {
 	const out = cards.slice();
+	return shuffleCardsInPlace(out);
+}
+
+export function shuffleCardsInPlace(cards: Card[]): Card[] {
+	const out = cards;
 	for (let i = out.length - 1; i > 0; i--) {
 		const j = Math.floor(Math.random() * (i + 1));
-		[out[i], out[j]] = [out[j], out[i]];
+		const card = out[i];
+		out[i] = out[j];
+		out[j] = card;
 	}
 	return out;
 }
@@ -125,7 +132,9 @@ export function valueHand(cards: readonly Card[]): HandValue {
 }
 
 export function isBlackjack(cards: readonly Card[]): boolean {
-	return cards.length === 2 && valueHand(cards).total === 21;
+	return (
+		cards.length === 2 && cardPoints(cards[0]) + cardPoints(cards[1]) === 21
+	);
 }
 
 export function handFingerprint(cards: readonly Card[]): number {

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/state.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/state.ts
@@ -2,7 +2,7 @@ import {
 	buildShoe,
 	type Card,
 	isBlackjack,
-	shuffleCards,
+	shuffleCardsInPlace,
 	valueHand,
 } from './cards';
 import { GAME } from './config';
@@ -65,7 +65,7 @@ export function createBlackjackState(): BlackjackState {
 }
 
 export function freshShoe(): Card[] {
-	return shuffleCards(buildShoe(GAME.decks));
+	return shuffleCardsInPlace(buildShoe(GAME.decks));
 }
 
 export function clampBet(value: number, bankroll: number): number {


### PR DESCRIPTION
## Summary
- replace blackjack shuffle destructuring swaps with a temp-variable swap
- add an in-place shuffle path for newly built shoes to avoid cloning during shoe refresh
- avoid full hand valuation allocation when checking two-card blackjack naturals
- add card semantics coverage for non-natural 20, three-card 20, and shuffle behavior

## Validation
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/cards.ts apps/kbve/astro-kbve/src/arcade/blackjack/cards.test.ts apps/kbve/astro-kbve/src/arcade/blackjack/state.ts`
- `./kbve.sh -nx astro-kbve:test`
- `AXUM_PORT=4381 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`