### PR TITLE
fix(firecracker-ctl): /fc/public 404 — move upstream prefix to /public-proxy/

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -1625,7 +1625,7 @@ pub async fn firecracker_fc_handler(
     }
 }
 
-/// Rewrites `/fc/public/<rest>` → firecracker-ctl-net `/proxy/public/<rest>`.
+/// Rewrites `/fc/public/<rest>` → firecracker-ctl-net `/public-proxy/<rest>`.
 /// No JWT gate here — ctl-net enforces that the endpoint was deployed with
 /// `visibility: "public"`, returning 403 otherwise.
 ///
@@ -1634,6 +1634,10 @@ pub async fn firecracker_fc_handler(
 /// `{name}` + `{name}/{*path}` routes left `/fc/public/my-api/` (trailing
 /// slash, empty path) unmatched and falling through to the staff
 /// `/fc/{name}/{*path}` — visible as a spurious 401.
+///
+/// Upstream prefix is `/public-proxy/`, not `/proxy/public/`, because the
+/// nested form overlapped with the staff `/proxy/{name}/{*path}` route on
+/// ctl-net (matchit picked the catch-all → name="public" → 404).
 pub async fn firecracker_fc_public_handler(
     rest: Option<Path<String>>,
     req: Request<Body>,
@@ -1658,9 +1662,9 @@ pub async fn firecracker_fc_public_handler(
     }
 
     let rewritten = if tail.is_empty() {
-        format!("proxy/public/{name}")
+        format!("public-proxy/{name}")
     } else {
-        format!("proxy/public/{name}/{tail}")
+        format!("public-proxy/{name}/{tail}")
     };
 
     match FIRECRACKER_NET.get() {

--- a/apps/vm/firecracker-ctl-e2e/e2e/fc-public.spec.ts
+++ b/apps/vm/firecracker-ctl-e2e/e2e/fc-public.spec.ts
@@ -116,8 +116,8 @@ describe('Persistent endpoints — /fc/* + /fc/public/*', () => {
 		expect(res.status).toBe(400);
 	});
 
-	it('/proxy/public/{name} returns 503 when persistent endpoints disabled', async () => {
-		const res = await fetch(`${BASE_URL}/proxy/public/anything-here`);
+	it('/public-proxy/{name} returns 503 when persistent endpoints disabled', async () => {
+		const res = await fetch(`${BASE_URL}/public-proxy/anything-here`);
 		expect(res.status).toBe(503);
 	});
 });

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -1290,7 +1290,7 @@ async fn fc_proxy(
     fc_proxy_inner(state, params, req, false).await
 }
 
-/// Public-tier sibling of [`fc_proxy`]. Forwards `/proxy/public/{name}/{*path}`
+/// Public-tier sibling of [`fc_proxy`]. Forwards `/public-proxy/{name}/{*path}`
 /// into the guest VM only when the endpoint was registered with
 /// `visibility: "public"`. No auth required at this layer — the gate is the
 /// endpoint's visibility flag, which is fixed at deploy time.
@@ -2746,9 +2746,13 @@ async fn main() {
         .route("/fc/{name}", delete(fc_destroy))
         .route("/proxy/{name}", axum::routing::any(fc_proxy))
         .route("/proxy/{name}/{*path}", axum::routing::any(fc_proxy))
-        .route("/proxy/public/{name}", axum::routing::any(fc_proxy_public))
+        // Sibling prefix (not nested under /proxy/) so matchit can't pick
+        // the staff `/proxy/{name}/{*path}` over the public route. Earlier
+        // shape `/proxy/public/{name}` overlapped at depth 2 and the
+        // catch-all swallowed requests as name="public".
+        .route("/public-proxy/{name}", axum::routing::any(fc_proxy_public))
         .route(
-            "/proxy/public/{name}/{*path}",
+            "/public-proxy/{name}/{*path}",
             axum::routing::any(fc_proxy_public),
         )
         .layer(TraceLayer::new_for_http())


### PR DESCRIPTION
## Bug
Public-tier requests landed on the staff handler and 404'd with the wrong name:
\`\`\`
GET https://kbve.com/fc/public/my-api-public
→ {"error":"endpoint not found","name":"public"}
\`\`\`

## Root cause
ctl-net registered both:
- \`/proxy/{name}/{*path}\` (staff)
- \`/proxy/public/{name}\` + \`/proxy/public/{name}/{*path}\` (public)

For \`/proxy/public/my-api-public\`, matchit picked the staff catch-all (name=\"public\", path=\"my-api-public\") instead of the literal-\"public\" sub-prefix. matchit's "static beats dynamic" guarantee did not hold here — the overlap between depth-2 \`{name}\` and depth-3 \`public/{name}\` is exactly the case where it picks the catch-all.

## Fix
Move the public upstream surface to a sibling prefix that doesn't overlap with the staff route:
- \`/proxy/public/{name}[/{*path}]\` → \`/public-proxy/{name}[/{*path}]\`
- Axum side rewrites \`/fc/public/<rest>\` → \`/public-proxy/<rest>\` to match
- E2E sanity probe bumped to hit the new prefix

External \`/fc/public/<name>\` URLs are unchanged. Only the internal forward path moves.

## Test plan
- [ ] Hit \`/fc/public/my-api-public\` — 200 (was 404)
- [ ] Hit \`/fc/public/my-api-public/\` — 200
- [ ] Hit \`/fc/public/my-api-public/health\` — 200, reaches guest
- [ ] Hit \`/fc/public/unknown-name\` — 404 with name="unknown-name" (not "public")
- [ ] Deploy staff endpoint, hit \`/fc/public/staff-name\` — 403 (not_public) from ctl-net
- [ ] Staff routes \`/fc/{name}\` + \`/dashboard/firecracker-net/proxy/proxy/{name}/...\` unchanged