### PR TITLE
fix(kilobase): bootstrap cnpg_pooler_pgbouncer role + user_search function

### DIFF
--- a/packages/data/sql/dbmate/migrations/20260515064554_cnpg_pooler_pgbouncer_bootstrap.sql
+++ b/packages/data/sql/dbmate/migrations/20260515064554_cnpg_pooler_pgbouncer_bootstrap.sql
@@ -1,0 +1,65 @@
+-- migrate:up
+
+-- CNPG Pooler bootstrap — provision the role + auth-query function that
+-- PgBouncer needs to authenticate clients.
+--
+-- Background. The supabase Postgres cluster predates the CNPG Pooler
+-- resources in this repo (Pooler was added 2026-03-05; supabase image
+-- was already running for ~9 months prior). When CNPG sees an existing
+-- database that already has its own pgbouncer/auth setup, it does NOT
+-- run its standard pooler bootstrap that creates the cnpg_pooler_pgbouncer
+-- role + public.user_search function.
+--
+-- The Pooler controller still writes pgbouncer.ini with
+--   auth_user  = cnpg_pooler_pgbouncer
+--   auth_query = SELECT usename, passwd FROM public.user_search($1)
+-- and configures the mTLS client cert with CN=cnpg_pooler_pgbouncer.
+--
+-- Without the role + function, every server-side handshake fails with
+-- `role "cnpg_pooler_pgbouncer" does not exist`, PgBouncer caches the
+-- failure as `server_login_retry`, and every client through the pooler
+-- starts timing out at the edge (CF 408).
+--
+-- This migration creates both pieces idempotently. Re-running is a no-op.
+-- The function mirrors CNPG's stock implementation (SECURITY DEFINER,
+-- search_path locked, read-only against pg_shadow).
+
+DO $do$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_roles
+        WHERE rolname = 'cnpg_pooler_pgbouncer'
+    ) THEN
+        CREATE ROLE cnpg_pooler_pgbouncer WITH LOGIN;
+    END IF;
+END
+$do$;
+
+CREATE OR REPLACE FUNCTION public.user_search(uname TEXT)
+    RETURNS TABLE (usename name, passwd text)
+    LANGUAGE sql
+    STABLE
+    SECURITY DEFINER
+    SET search_path = pg_catalog
+    AS $fn$
+        SELECT usename, passwd FROM pg_shadow WHERE usename = $1;
+    $fn$;
+
+REVOKE EXECUTE ON FUNCTION public.user_search(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.user_search(text) TO cnpg_pooler_pgbouncer;
+
+COMMENT ON FUNCTION public.user_search(text) IS
+    'CNPG Pooler auth-query target. Used by PgBouncer as auth_user '
+    'cnpg_pooler_pgbouncer to look up SCRAM credentials for the user '
+    'a client is attempting to log in as. Mirrors CNPG''s stock function.';
+
+COMMENT ON ROLE cnpg_pooler_pgbouncer IS
+    'PgBouncer auth_user. CNPG signs an mTLS client cert with CN matching '
+    'this role; the pooler then runs public.user_search to authenticate '
+    'every downstream client. Required by every Pooler in this cluster.';
+
+-- migrate:down
+
+REVOKE EXECUTE ON FUNCTION public.user_search(text) FROM cnpg_pooler_pgbouncer;
+DROP FUNCTION IF EXISTS public.user_search(text);
+DROP ROLE IF EXISTS cnpg_pooler_pgbouncer;


### PR DESCRIPTION
## Why
After the CA-chain fix (#10987 + #10997), the pooler's TLS handshake to Postgres now succeeds — but the login itself fails:

\`\`\`
psql: error: connection to server at \"supabase-cluster-pooler-ro\" ... failed:
FATAL:  server login has been failing, cached error:
role \"cnpg_pooler_pgbouncer\" does not exist (server_login_retry)
\`\`\`

CNPG writes \`pgbouncer.ini\` with \`auth_user = cnpg_pooler_pgbouncer\` and issues an mTLS client cert whose CN matches that role. Normally CNPG's Pooler controller also creates the role + \`public.user_search\` function during bootstrap, but **our supabase cluster predates the Pooler resources** in this repo (the DB has been running for ~9 months; the Pooler CRs were added 2026-03-05). When CNPG inherits an existing database with its own pgbouncer setup, that bootstrap is a no-op — so the role + function never got created.

We confirmed they're missing:

\`\`\`
SELECT rolname FROM pg_roles WHERE rolname='cnpg_pooler_pgbouncer';
-- (0 rows)

SELECT proname FROM pg_proc WHERE proname='user_search';
-- (0 rows)
\`\`\`

## What
A dbmate migration that idempotently:

- creates the \`cnpg_pooler_pgbouncer\` LOGIN role
- (re)defines \`public.user_search(text)\` as a \`SECURITY DEFINER STABLE\` function with \`search_path\` locked to \`pg_catalog\`, mirroring CNPG's stock implementation
- revokes \`EXECUTE\` from \`PUBLIC\`, grants only to \`cnpg_pooler_pgbouncer\`

Re-running is a no-op (existence guard on the role; \`CREATE OR REPLACE\` on the function; revoke/grant idempotent).

## What happens after merge
1. Trigger \`ci-dbmate-deploy.yml\` (manual dispatch from \`main\`, approve the \`kilobase-prod\` env gate).
2. Migration applies once → role + function exist.
3. PgBouncer's cached \`server_login_retry\` clears within a few seconds.
4. \`/api/v1/wallet/*\` recovers.

## Test plan
- [ ] PR merges to dev → main → \`gh workflow run ci-dbmate-deploy.yml --ref main -f confirm_sha=<HEAD>\` → approve.
- [ ] After apply, \`SELECT rolname FROM pg_roles WHERE rolname='cnpg_pooler_pgbouncer'\` returns one row.
- [ ] \`SELECT proname FROM pg_proc WHERE proname='user_search'\` returns one row.
- [ ] \`psql\` through \`supabase-cluster-pooler-ro\` returns a row (e.g. \`SELECT 1\`).
- [ ] \`kubectl -n kilobase logs deployment/supabase-cluster-pooler-ro --since=2m | grep -c 'does not exist'\` is 0.
- [ ] \`/profile/account/\` wallet card loads compact balances.