### PR TITLE
fix(kilobase): harden cnpg_pooler_pgbouncer bootstrap before first apply

### DIFF
--- a/packages/data/sql/dbmate/migrations/20260515064554_cnpg_pooler_pgbouncer_bootstrap.sql
+++ b/packages/data/sql/dbmate/migrations/20260515064554_cnpg_pooler_pgbouncer_bootstrap.sql
@@ -42,11 +42,18 @@ END
 $do$;
 
 -- PgBouncer connects to the application database to run auth_query, so
--- the auth role must have CONNECT on it. The kbve cluster routes all
--- pooled traffic through the `supabase` database (per the supabase
--- image's default DB name; verified via SELECT current_database() in
--- the live cluster). Re-running GRANT is idempotent.
-GRANT CONNECT ON DATABASE supabase TO cnpg_pooler_pgbouncer;
+-- the auth role must have CONNECT on it. Use current_database() via
+-- dynamic SQL instead of hardcoding the name, so the migration runs
+-- cleanly against prod (`supabase`), the local dev compose (`postgres`),
+-- and any future namespaced DB. Re-running GRANT is idempotent.
+DO $do$
+BEGIN
+    EXECUTE format(
+        'GRANT CONNECT ON DATABASE %I TO cnpg_pooler_pgbouncer',
+        current_database()
+    );
+END
+$do$;
 
 CREATE OR REPLACE FUNCTION public.user_search(uname TEXT)
     RETURNS TABLE (usename name, passwd text)

--- a/packages/data/sql/dbmate/migrations/20260515064554_cnpg_pooler_pgbouncer_bootstrap.sql
+++ b/packages/data/sql/dbmate/migrations/20260515064554_cnpg_pooler_pgbouncer_bootstrap.sql
@@ -20,20 +20,33 @@
 -- failure as `server_login_retry`, and every client through the pooler
 -- starts timing out at the edge (CF 408).
 --
--- This migration creates both pieces idempotently. Re-running is a no-op.
--- The function mirrors CNPG's stock implementation (SECURITY DEFINER,
--- search_path locked, read-only against pg_shadow).
+-- This migration creates the role, grants CONNECT on the application
+-- database, and (re)defines public.user_search owned by `postgres` so
+-- the SECURITY DEFINER body retains access to pg_shadow regardless of
+-- which role runs dbmate. Re-running is a no-op.
+--
+-- Reference: CloudNativePG "Connection Pooling" docs, "Connecting to
+-- the PgBouncer pooler" section — the same role/function/grant trio is
+-- what the operator creates on greenfield installs.
 
 DO $do$
 BEGIN
     IF NOT EXISTS (
-        SELECT 1 FROM pg_catalog.pg_roles
-        WHERE rolname = 'cnpg_pooler_pgbouncer'
+        SELECT 1
+          FROM pg_catalog.pg_roles
+         WHERE rolname = 'cnpg_pooler_pgbouncer'
     ) THEN
         CREATE ROLE cnpg_pooler_pgbouncer WITH LOGIN;
     END IF;
 END
 $do$;
+
+-- PgBouncer connects to the application database to run auth_query, so
+-- the auth role must have CONNECT on it. The kbve cluster routes all
+-- pooled traffic through the `supabase` database (per the supabase
+-- image's default DB name; verified via SELECT current_database() in
+-- the live cluster). Re-running GRANT is idempotent.
+GRANT CONNECT ON DATABASE supabase TO cnpg_pooler_pgbouncer;
 
 CREATE OR REPLACE FUNCTION public.user_search(uname TEXT)
     RETURNS TABLE (usename name, passwd text)
@@ -42,10 +55,19 @@ CREATE OR REPLACE FUNCTION public.user_search(uname TEXT)
     SECURITY DEFINER
     SET search_path = pg_catalog
     AS $fn$
-        SELECT usename, passwd FROM pg_shadow WHERE usename = $1;
+        SELECT usename, passwd
+          FROM pg_catalog.pg_shadow
+         WHERE usename = $1;
     $fn$;
 
-REVOKE EXECUTE ON FUNCTION public.user_search(text) FROM PUBLIC;
+-- Pin ownership to `postgres` so SECURITY DEFINER runs as a superuser
+-- and the body can read pg_shadow regardless of which role applied
+-- the migration. Without this, a dbmate run as a restricted role would
+-- compile the function but it would fail at runtime with `permission
+-- denied for view pg_shadow`.
+ALTER FUNCTION public.user_search(text) OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION public.user_search(text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.user_search(text) TO cnpg_pooler_pgbouncer;
 
 COMMENT ON FUNCTION public.user_search(text) IS
@@ -60,6 +82,10 @@ COMMENT ON ROLE cnpg_pooler_pgbouncer IS
 
 -- migrate:down
 
-REVOKE EXECUTE ON FUNCTION public.user_search(text) FROM cnpg_pooler_pgbouncer;
-DROP FUNCTION IF EXISTS public.user_search(text);
-DROP ROLE IF EXISTS cnpg_pooler_pgbouncer;
+-- Intentionally a no-op. Dropping public.user_search or the
+-- cnpg_pooler_pgbouncer role at this point would instantly break every
+-- pooled client (wallet, MC, anything routing through pooler-ro /
+-- pooler-rw). The only safe time to run a cleanup is when both
+-- Pooler CRs have been deleted first; do that out-of-band, not via
+-- dbmate down.
+SELECT 1;


### PR DESCRIPTION
## Why
#11002 merged the initial pooler bootstrap migration but it has not been applied to production yet (we have not dispatched \`ci-dbmate-deploy\` against this SHA). Tighten the migration in dev before the first apply rather than ship a follow-up patch migration.

## What changes
1. **\`GRANT CONNECT ON DATABASE supabase TO cnpg_pooler_pgbouncer\`.** The original migration created the role and the auth function but never granted database connect. Without this, PgBouncer's auth_user can pass the TLS handshake but cannot actually open a connection to run \`auth_query\`. The kbve cluster routes all pooled traffic through the \`supabase\` database (verified via \`SELECT current_database()\` on the live cluster).
2. **\`ALTER FUNCTION public.user_search(text) OWNER TO postgres\`.** \`SECURITY DEFINER\` runs as the function owner. Without an explicit owner pin, the function inherits whatever role ran dbmate. If that role is restricted (no \`pg_read_all_settings\` / no superuser), the function compiles but fails at runtime with \`permission denied for view pg_shadow\`. Pinning to \`postgres\` guarantees the body keeps catalog access regardless of who applied the migration.
3. **Fully qualify \`pg_catalog.pg_shadow\` inside the function body.** Already safe under \`SET search_path = pg_catalog\`, but explicit qualification makes the intent unambiguous to future reviewers.
4. **Turn \`migrate:down\` into a no-op (\`SELECT 1\`).** Dropping \`public.user_search\` or the \`cnpg_pooler_pgbouncer\` role mid-flight would instantly break every pooled client (wallet, MC, anything routing through pooler-ro / pooler-rw). Cleanup, if ever, belongs out-of-band after the Pooler CRs are removed — not in a dbmate down step.

References: CloudNativePG "Connection Pooling" docs, manual integration section.

## Test plan
- [ ] PR merges to dev → main.
- [ ] \`gh workflow run ci-dbmate-deploy.yml --ref main -f confirm_sha=<HEAD>\` → approve \`kilobase-prod\` env gate.
- [ ] In Postgres:
  - \`SELECT rolname FROM pg_roles WHERE rolname='cnpg_pooler_pgbouncer'\` → one row.
  - \`SELECT has_database_privilege('cnpg_pooler_pgbouncer', 'supabase', 'CONNECT')\` → \`true\`.
  - \`SELECT pg_get_function_identity_arguments(oid), prosecdef FROM pg_proc WHERE proname='user_search'\` → \`text, t\`.
  - \`SELECT pg_get_userbyid(proowner) FROM pg_proc WHERE proname='user_search'\` → \`postgres\`.
- [ ] \`psql\` through \`supabase-cluster-pooler-ro\` returns a row.
- [ ] \`kubectl -n kilobase logs deployment/supabase-cluster-pooler-ro --since=2m | grep -c 'does not exist'\` is 0.
- [ ] \`/profile/account/\` wallet card loads compact balances.