### PR TITLE
fix(firecracker-ctl-net): drop PREROUTING DNS REDIRECT, let VM DNS flow like KASM

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,7 +12,7 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.34"
+version: "0.1.35"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml

--- a/apps/vm/firecracker-ctl/src/tap.rs
+++ b/apps/vm/firecracker-ctl/src/tap.rs
@@ -294,33 +294,6 @@ pub fn build_input_accept_check(vm_subnet: &str) -> Vec<String> {
     ]
 }
 
-pub fn build_dns_dnat(proto: &str) -> Vec<String> {
-    vec![
-        "-t".into(),
-        "nat".into(),
-        "-I".into(),
-        "PREROUTING".into(),
-        "-i".into(),
-        "fctap+".into(),
-        "-p".into(),
-        proto.into(),
-        "--dport".into(),
-        "53".into(),
-        "-j".into(),
-        "REDIRECT".into(),
-        "--to-ports".into(),
-        "53".into(),
-    ]
-}
-
-pub fn build_dns_dnat_check(proto: &str) -> Vec<String> {
-    let mut v = build_dns_dnat(proto);
-    if let Some(a) = v.iter_mut().find(|s| s.as_str() == "-I") {
-        *a = "-C".into();
-    }
-    v
-}
-
 // ---------------------------------------------------------------------------
 // Execution wrappers (shell-out via tokio::process::Command)
 // ---------------------------------------------------------------------------
@@ -442,12 +415,6 @@ impl TapManager {
 
         if !iptables_rule_exists(&build_input_accept_check(&self.config.vm_subnet)).await? {
             run_iptables(&build_input_accept(&self.config.vm_subnet)).await?;
-        }
-
-        for proto in ["udp", "tcp"] {
-            if !iptables_rule_exists(&build_dns_dnat_check(proto)).await? {
-                run_iptables(&build_dns_dnat(proto)).await?;
-            }
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
KASM's Discord workspace resolves DNS over the same Proton WireGuard tunnel with \`DNS_ADDRESS=1.1.1.1\` and no iptables interception — plain UDP/53 to Cloudflare through \`tun0\` works. Our VM DNS was failing with \`EAI_AGAIN\` because \`tap.rs\` installed a PREROUTING \`REDIRECT\` that rewrote VM port-53 destinations to the per-VM \`fctap-N\` primary IP (172.18.0.x), where nothing listens.

The REDIRECT (from #10905) was added on the assumption that Proton blocked port 53. KASM's working setup proves that assumption was wrong.

This PR removes \`build_dns_dnat\` + \`build_dns_dnat_check\` and their \`init()\` call. VM DNS packets now flow through the existing MASQUERADE + FORWARD chain to \`tun0\`, exactly like KASM.

Bumps \`firecracker-ctl\` 0.1.34 → 0.1.35 via MDX so CI publishes a new image and post-publish sync rolls the \`firecracker-ctl-net\` deployment.

## Test plan
- [x] \`cargo build\` on \`apps/vm/firecracker-ctl\`
- [x] \`cargo test --bin firecracker-ctl tap::\` — 13 passed
- [ ] After publish + ArgoCD sync, rerun PoetryDB smoke test inside a network=true VM — expect a poem, not \`EAI_AGAIN\`.