### PR TITLE
perf(arcade): reduce blackjack control updates

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackControls.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackControls.ts
@@ -8,8 +8,17 @@ import {
 	stand,
 	startRound,
 	type BlackjackState,
+	type RoundPhase,
 } from '../state';
 import { ButtonBar, type ButtonKey, type ButtonSpec } from './buttonBar';
+
+const PHASE_STATE_BITS: Record<RoundPhase, number> = {
+	betting: 0,
+	'player-turn': 1,
+	'dealer-turn': 2,
+	'round-over': 3,
+	'table-closed': 4,
+} as const;
 
 interface BlackjackControlsOptions {
 	scene: Phaser.Scene;
@@ -22,7 +31,7 @@ interface BlackjackControlsOptions {
 
 export class BlackjackControls {
 	private readonly buttonBar: ButtonBar;
-	private lastButtonStateKey = '';
+	private lastButtonStateKey = -1;
 
 	constructor(private readonly options: BlackjackControlsOptions) {
 		this.buttonBar = new ButtonBar(
@@ -35,6 +44,7 @@ export class BlackjackControls {
 
 	create() {
 		this.buttonBar.create(this.createButtonSpecs());
+		this.lastButtonStateKey = this.buttonStateKey();
 		this.bindKeyboard();
 	}
 
@@ -45,9 +55,9 @@ export class BlackjackControls {
 		this.buttonBar.update();
 	}
 
-	private buttonStateKey(): string {
+	private buttonStateKey(): number {
 		const { phase, canDouble } = this.state;
-		return `${phase}:${canDouble ? 1 : 0}`;
+		return (PHASE_STATE_BITS[phase] << 1) | (canDouble ? 1 : 0);
 	}
 
 	private createButtonSpecs(): ButtonSpec[] {

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.test.ts
@@ -68,8 +68,8 @@ describe('blackjack button bar', () => {
 		bar.update();
 		bar.update();
 
-		expect(image.setTexture).toHaveBeenCalledTimes(1);
-		expect(text.setAlpha).toHaveBeenCalledTimes(1);
+		expect(image.setTexture).not.toHaveBeenCalled();
+		expect(text.setAlpha).not.toHaveBeenCalled();
 	});
 
 	it('updates alpha and texture when enabled state changes', () => {
@@ -89,8 +89,27 @@ describe('blackjack button bar', () => {
 		enabled = false;
 		bar.update();
 
-		expect(image.setTexture).toHaveBeenCalledTimes(2);
-		expect(text.setAlpha).toHaveBeenCalledTimes(2);
+		expect(image.setTexture).toHaveBeenCalledTimes(1);
+		expect(text.setAlpha).toHaveBeenCalledTimes(1);
+	});
+
+	it('seeds disabled alpha during creation', () => {
+		const spec: ButtonSpec = {
+			key: 'hit',
+			label: 'Hit',
+			x: 0,
+			y: 0,
+			w: 82,
+			enabled: () => false,
+			action: vi.fn(),
+		};
+		const { bar, image, text } = createHarness(spec);
+
+		bar.update();
+
+		expect(image.setTexture).not.toHaveBeenCalled();
+		expect(text.setAlpha).toHaveBeenCalledTimes(1);
+		expect(text.setAlpha).toHaveBeenCalledWith(0.42);
 	});
 
 	it('runs actions through the keyed view cache', () => {

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.ts
@@ -48,8 +48,10 @@ export class ButtonBar {
 
 	create(specs: readonly ButtonSpec[]) {
 		for (const spec of specs) {
+			const enabled = spec.enabled();
+			const textAlpha = enabled ? 1 : 0.42;
 			const box = this.scene.add
-				.image(spec.x, spec.y, this.textureKey(spec.enabled()))
+				.image(spec.x, spec.y, this.textureKey(enabled))
 				.setOrigin(0)
 				.setDisplaySize(spec.w, BUTTON_TEXTURE_SIZE.height);
 			const text = this.scene.add
@@ -59,6 +61,7 @@ export class ButtonBar {
 					color: '#ffffff',
 				})
 				.setOrigin(0.5);
+			if (textAlpha !== 1) text.setAlpha(textAlpha);
 
 			const hitArea = this.scene.add
 				.zone(spec.x, spec.y, spec.w, BUTTON_TEXTURE_SIZE.height)
@@ -75,8 +78,8 @@ export class ButtonBar {
 				spec,
 				box,
 				text,
-				lastEnabled: null,
-				lastTextAlpha: null,
+				lastEnabled: enabled,
+				lastTextAlpha: textAlpha,
 			};
 			this.views.push(view);
 			this.viewsByKey.set(spec.key, view);


### PR DESCRIPTION
## Summary
- seed blackjack button texture and alpha cache state during button creation
- skip first-render control refreshes when the visual enabled state is unchanged
- replace per-render control state string keys with a numeric bit key

## Validation
- `./kbve.sh -nx astro-kbve:test`
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.test.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackControls.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackControls.test.ts`
- `AXUM_PORT=4384 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`