### PR TITLE
feat(mc/behavior_statetree): exclude AI hostiles from the spawn cube

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
@@ -55,6 +55,19 @@ public class AiCreatureManager {
      */
     private static final String AI_MARKER_TAG = "kbve_ai_creature";
 
+    /**
+     * Spawn protection cuboid. Hostile mobs (owner == null) refuse to spawn
+     * if the picked surface lands inside this box. Pets are allowed because
+     * they follow their owner anywhere, including the hub. Must stay in
+     * lockstep with {@code WorldSpawnProtection} on the Rust side.
+     */
+    private static final int SPAWN_PROTECT_MIN_X = -200;
+    private static final int SPAWN_PROTECT_MIN_Y = -200;
+    private static final int SPAWN_PROTECT_MIN_Z = -200;
+    private static final int SPAWN_PROTECT_MAX_X = 200;
+    private static final int SPAWN_PROTECT_MAX_Y = 200;
+    private static final int SPAWN_PROTECT_MAX_Z = 200;
+
     /** Tracked creatures keyed by Minecraft entity ID. */
     private final ConcurrentHashMap<Integer, CreatureSlot> creatures = new ConcurrentHashMap<>();
 
@@ -300,6 +313,12 @@ public class AiCreatureManager {
                 BlockPos.ofFloored(x, 0, z)
         );
 
+        // Reject hostile spawns inside the protected spawn cube. Pet spawns
+        // (owner != null) pass through because they follow the player.
+        if (owner == null && isInsideSpawnProtection(surface)) {
+            return false;
+        }
+
         // Reject underwater spawn positions — skeletons should not appear
         // in rivers, oceans, or any waterlogged surface.
         BlockState surfaceState = world.getBlockState(surface);
@@ -331,6 +350,18 @@ public class AiCreatureManager {
                 mob.getId(),
                 ownerEntityId != 0 ? " owner=" + ownerEntityId : "");
         return true;
+    }
+
+    private static boolean isInsideSpawnProtection(BlockPos pos) {
+        int x = pos.getX();
+        int y = pos.getY();
+        int z = pos.getZ();
+        return x >= SPAWN_PROTECT_MIN_X
+                && x <= SPAWN_PROTECT_MAX_X
+                && y >= SPAWN_PROTECT_MIN_Y
+                && y <= SPAWN_PROTECT_MAX_Y
+                && z >= SPAWN_PROTECT_MIN_Z
+                && z <= SPAWN_PROTECT_MAX_Z;
     }
 
     private boolean hasCreatureOwnedBy(CreatureKind kind, int ownerEntityId) {

--- a/apps/mc/behavior_statetree/src/ecs/components.rs
+++ b/apps/mc/behavior_statetree/src/ecs/components.rs
@@ -252,6 +252,44 @@ impl CooldownState for GlobalCallCooldown {
 }
 
 // ---------------------------------------------------------------------------
+// World spawn protection — server-defined cuboid (block coords) inside which
+// no AI hostile entity should be spawned or allowed to persist. Pets are
+// exempt because they follow their owner anywhere, including the hub.
+// ---------------------------------------------------------------------------
+
+#[derive(Resource, Debug, Clone)]
+pub struct WorldSpawnProtection {
+    pub min: [i32; 3],
+    pub max: [i32; 3],
+}
+
+impl WorldSpawnProtection {
+    /// Cheap inside-cube test against a floating-point world position. Mirrors
+    /// the Java safety net so both sides agree on the same boundary.
+    #[inline]
+    pub fn contains_pos(&self, pos: [f64; 3]) -> bool {
+        let x = pos[0].floor() as i32;
+        let y = pos[1].floor() as i32;
+        let z = pos[2].floor() as i32;
+        x >= self.min[0]
+            && x <= self.max[0]
+            && y >= self.min[1]
+            && y <= self.max[1]
+            && z >= self.min[2]
+            && z <= self.max[2]
+    }
+}
+
+impl Default for WorldSpawnProtection {
+    fn default() -> Self {
+        Self {
+            min: [-200, -200, -200],
+            max: [200, 200, 200],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Skeleton population config — single source of truth for the spawn/despawn
 // policy. Lives in Rust so Java has zero say in "how many skeletons exist".
 // ---------------------------------------------------------------------------

--- a/apps/mc/behavior_statetree/src/ecs/mod.rs
+++ b/apps/mc/behavior_statetree/src/ecs/mod.rs
@@ -17,7 +17,7 @@ use components::{
     CurrentBlockGrid, DetectedFlowGates, FleeFlowField, FlowFieldRebuildInterval,
     FlowFieldRebuildTick, GlobalCallCooldown, LastPetDogManagedTick, LastPetParrotManagedTick,
     LastPopulationManagedTick, PetDogPopulationConfig, PetParrotPopulationConfig, PlayerFlowFields,
-    ServerTick, SkeletonPopulationConfig,
+    ServerTick, SkeletonPopulationConfig, WorldSpawnProtection,
 };
 use events::{
     IntentBuffer, MapDataBuffer, ObservationBuffer, PlayerObservationBuffer, WorldIntentBuffer,
@@ -47,6 +47,7 @@ impl Plugin for AiBehaviorPlugin {
             .init_resource::<DetectedFlowGates>()
             .init_resource::<FlowFieldRebuildTick>()
             .init_resource::<FlowFieldRebuildInterval>()
+            .init_resource::<WorldSpawnProtection>()
             .init_resource::<SkeletonPopulationConfig>()
             .init_resource::<LastPopulationManagedTick>()
             .init_resource::<PetDogPopulationConfig>()

--- a/apps/mc/behavior_statetree/src/ecs/systems.rs
+++ b/apps/mc/behavior_statetree/src/ecs/systems.rs
@@ -289,6 +289,7 @@ pub fn manage_skeleton_population(
     skeletons: Query<(&McEntityId, &McPosition), With<AiSkeleton>>,
     players: Query<(&OnlinePlayer, &McPosition)>,
     config: Res<SkeletonPopulationConfig>,
+    protection: Res<WorldSpawnProtection>,
     server_tick: Res<ServerTick>,
     mut last_managed: ResMut<LastPopulationManagedTick>,
     mut world_intents: ResMut<WorldIntentBuffer>,
@@ -304,24 +305,25 @@ pub fn manage_skeleton_population(
         .map(|(p, pos)| (p.entity_id, [pos.x, pos.y, pos.z]))
         .collect();
 
-    // ---- Despawn pass ------------------------------------------------------
-    // For each skeleton, find the closest player. If beyond despawn range
-    // (or no players online), emit a Despawn intent.
     let despawn_sq = config.despawn_range * config.despawn_range;
     let mut despawn_count: usize = 0;
     let mut total_skeletons: usize = 0;
     for (mc_id, sk_pos) in &skeletons {
         total_skeletons += 1;
+        let sk_xyz = [sk_pos.x, sk_pos.y, sk_pos.z];
         let too_far = if player_positions.is_empty() {
             true
         } else {
             player_positions
                 .iter()
-                .map(|(_, p)| dist_sq([sk_pos.x, sk_pos.y, sk_pos.z], *p))
+                .map(|(_, p)| dist_sq(sk_xyz, *p))
                 .fold(f64::INFINITY, f64::min)
                 > despawn_sq
         };
-        if too_far {
+        // Skeletons that wander into the protected hub also despawn so the
+        // spawn city stays clean even if pathing carries them past the edge.
+        let inside_spawn = protection.contains_pos(sk_xyz);
+        if too_far || inside_spawn {
             world_intents.ready.push(IntentReady {
                 entity_id: 0,
                 epoch: 0,
@@ -333,13 +335,8 @@ pub fn manage_skeleton_population(
         }
     }
 
-    // Effective alive count (subtract any we just queued for despawn so we
-    // don't over-spawn while the despawns are still in flight).
     let alive = total_skeletons.saturating_sub(despawn_count);
 
-    // ---- Spawn pass --------------------------------------------------------
-    // Spawn a mix of archetypes: cycle through melee, mage, archer.
-    // This gives each spawn wave a balanced composition.
     if alive >= config.max_skeletons || player_positions.is_empty() {
         return;
     }
@@ -350,11 +347,19 @@ pub fn manage_skeleton_population(
         SkeletonArchetype::Melee,
         SkeletonArchetype::Mage,
     ];
-    for (i, (player_id, _)) in player_positions.iter().enumerate() {
-        if i >= needed {
+    // Skip players standing inside the spawn protection cube so the city
+    // never becomes a spawn anchor for hostile reinforcements. Java has a
+    // belt-and-suspenders surface check too, but filtering here saves a
+    // JNI hop on every doomed attempt.
+    let mut anchor_idx: usize = 0;
+    for (player_id, player_pos) in player_positions.iter() {
+        if anchor_idx >= needed {
             break;
         }
-        let archetype = archetype_cycle[i % archetype_cycle.len()];
+        if protection.contains_pos(*player_pos) {
+            continue;
+        }
+        let archetype = archetype_cycle[anchor_idx % archetype_cycle.len()];
         let cmd = match archetype {
             SkeletonArchetype::Melee => NpcCommand::SpawnSkeletonMelee {
                 near_player: *player_id,
@@ -374,6 +379,7 @@ pub fn manage_skeleton_population(
             epoch: 0,
             commands: vec![cmd],
         });
+        anchor_idx += 1;
     }
 }
 


### PR DESCRIPTION
## Summary
Stops AI-managed hostile mobs (skeleton archetypes) from spawning inside the spawn city cuboid `-200..200` on every axis around `(0, 67, 0)`. Pets are unaffected — they follow their owner anywhere, including the hub.

## Changes
- **Rust** — new [`WorldSpawnProtection`](apps/mc/behavior_statetree/src/ecs/components.rs) resource (default `-200..200` cube) registered in the `AiBehaviorPlugin` and consumed by `manage_skeleton_population`:
  - **Spawn pass**: skip players inside the cube as spawn anchors so the city never becomes a reinforcement origin.
  - **Despawn pass**: skeletons inside the cube despawn even if a player is nearby, so wanderers don't accumulate in the hub.
- **Java** — belt-and-suspenders check in [`AiCreatureManager.spawnNear`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java): if `owner == null` (hostile spawn) and the picked surface lands inside the cube, the spawn is refused before the entity is even created. Catches the edge case where a player at the edge of the cube has the random offset land back inside.

## Why two checks
The Rust filter saves a doomed JNI hop on every player anchor in the cube. The Java filter catches the rare case where a player outside the cube still has the random spawn offset land inside. Both share the same `-200..200` bounds, hardcoded to keep this PR small.

## Not bumping the mc version
v1.0.50 is currently stuck behind the GrimAC ↔ ViaBackwards ABI break being fixed in #11005. Once #11005 lands and 1.0.50 ships clean, the next mc bump will pick this up.

## Follow-up (separate PR)
Read the cuboid from OPAC's `ClaimsManager` so any admin claim is treated the same way without a code change. Lets the cuboid grow/shrink/move at runtime from in-game commands.

## Test plan
- [ ] `cargo check` on `apps/mc/behavior_statetree` clean (verified locally).
- [ ] `gradle compileJava` on the fabric mod clean (verified locally).
- [ ] After deploy: standing inside spawn, no `[AI] Spawned skeleton_...` log lines appear over a 5-minute window.
- [ ] After deploy: walking a skeleton from outside the cube into the cube triggers a despawn within `manage_interval_ticks` (~20s).
- [ ] After deploy: pets (dog/parrot) still spawn next to the owner inside spawn.