### PR TITLE
test(arcade): expand blackjack control coverage

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackControls.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackControls.test.ts
@@ -26,6 +26,8 @@ function createHarness() {
 	let state: BlackjackState = createBlackjackState();
 	const images: MockImage[] = [];
 	const texts: MockText[] = [];
+	const keyHandlers = new Map<string, () => void>();
+	const onAction = vi.fn();
 	const scene = {
 		add: {
 			image: vi.fn(() => {
@@ -42,7 +44,9 @@ function createHarness() {
 		},
 		input: {
 			keyboard: {
-				on: vi.fn(),
+				on: vi.fn((event: string, callback: () => void) => {
+					keyHandlers.set(event, callback);
+				}),
 			},
 		},
 	};
@@ -54,11 +58,18 @@ function createHarness() {
 		setState: (next) => {
 			state = next;
 		},
-		onAction: vi.fn(),
+		onAction,
 	});
 
 	controls.create();
-	return { controls, images, texts, state };
+	return {
+		controls,
+		images,
+		texts,
+		keyHandlers,
+		onAction,
+		getState: () => state,
+	};
 }
 
 function countImageTextures(images: readonly MockImage[]): number {
@@ -77,7 +88,8 @@ function countTextAlphas(texts: readonly MockText[]): number {
 
 describe('blackjack controls', () => {
 	it('skips button updates while the visual enabled state is unchanged', () => {
-		const { controls, images, texts, state } = createHarness();
+		const { controls, images, texts, getState } = createHarness();
+		const state = getState();
 
 		controls.update();
 		const firstTextureUpdates = countImageTextures(images);
@@ -91,7 +103,8 @@ describe('blackjack controls', () => {
 	});
 
 	it('refreshes buttons when phase or double availability changes', () => {
-		const { controls, images, texts, state } = createHarness();
+		const { controls, images, texts, getState } = createHarness();
+		const state = getState();
 
 		controls.update();
 		const firstTextureUpdates = countImageTextures(images);
@@ -102,5 +115,82 @@ describe('blackjack controls', () => {
 
 		expect(countImageTextures(images)).toBeGreaterThan(firstTextureUpdates);
 		expect(countTextAlphas(texts)).toBeGreaterThan(firstAlphaUpdates);
+	});
+
+	it('runs keyboard actions only when the matching button is enabled', () => {
+		const { keyHandlers, onAction, getState } = createHarness();
+		const state = getState();
+
+		keyHandlers.get('keydown-H')?.();
+		expect(onAction).not.toHaveBeenCalled();
+
+		state.phase = 'player-turn';
+		state.player = [];
+		state.dealer = [1, 2];
+		state.shoe = [
+			3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+			22,
+		];
+		keyHandlers.get('keydown-H')?.();
+
+		expect(onAction).toHaveBeenCalledTimes(1);
+		expect(state.player).toHaveLength(1);
+	});
+
+	it('maps keyboard shortcuts to betting and reset actions', () => {
+		const { keyHandlers, onAction, getState } = createHarness();
+		let state = getState();
+
+		keyHandlers.get('keydown-UP')?.();
+		expect(state.bet).toBe(50);
+		expect(state.message).toBe('Bet set to $50.');
+
+		keyHandlers.get('keydown-DOWN')?.();
+		expect(state.bet).toBe(25);
+
+		keyHandlers.get('keydown-ENTER')?.();
+		expect(state.phase).not.toBe('betting');
+
+		state.phase = 'round-over';
+		state.player = [1];
+		state.dealer = [2];
+		keyHandlers.get('keydown-ENTER')?.();
+		expect(state.phase).toBe('betting');
+		expect(state.player).toEqual([]);
+
+		keyHandlers.get('keydown-N')?.();
+		state = getState();
+		expect(state.phase).toBe('betting');
+		expect(state.bankroll).toBe(1000);
+		expect(onAction).toHaveBeenCalled();
+	});
+
+	it('maps stand and double keyboard shortcuts to player actions', () => {
+		const { keyHandlers, onAction, getState } = createHarness();
+		const state = getState();
+
+		state.phase = 'player-turn';
+		state.player = [9, 10];
+		state.dealer = [22, 7];
+		keyHandlers.get('keydown-S')?.();
+
+		expect(state.phase).toBe('round-over');
+		expect(state.outcome).toBe('win');
+
+		state.phase = 'player-turn';
+		state.player = [4, 5];
+		state.dealer = [22, 7];
+		state.shoe = [
+			3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+			22,
+		];
+		state.canDouble = true;
+		state.bankroll = 1000;
+		state.bet = 25;
+		keyHandlers.get('keydown-D')?.();
+
+		expect(state.bet).toBe(50);
+		expect(state.phase).toBe('round-over');
+		expect(onAction).toHaveBeenCalledTimes(2);
 	});
 });

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.test.ts
@@ -129,4 +129,25 @@ describe('blackjack button bar', () => {
 		expect(bar.run('deal')).toBe(false);
 		expect(action).toHaveBeenCalledTimes(1);
 	});
+
+	it('runs enabled pointer actions and ignores disabled pointer actions', () => {
+		let enabled = true;
+		const action = vi.fn();
+		const spec: ButtonSpec = {
+			key: 'deal',
+			label: 'Deal',
+			x: 0,
+			y: 0,
+			w: 92,
+			enabled: () => enabled,
+			action,
+		};
+		const { zone } = createHarness(spec);
+
+		zone.click();
+		enabled = false;
+		zone.click();
+
+		expect(action).toHaveBeenCalledTimes(1);
+	});
 });

--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/strategyAdvisor.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/strategyAdvisor.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
-import { encodeCard } from '../cards';
-import { createBlackjackState } from '../state';
+import { encodeCard, type Card } from '../cards';
+import { createBlackjackState, type BlackjackState } from '../state';
 import { StrategyAdvisor } from './strategyAdvisor';
+
+function playerTurnState(
+	player: readonly Card[],
+	dealerUp: Card,
+	canDouble: boolean,
+): BlackjackState {
+	const state = createBlackjackState();
+	state.phase = 'player-turn';
+	state.canDouble = canDouble;
+	state.player = [...player];
+	state.dealer = [dealerUp];
+	return state;
+}
 
 describe('blackjack strategy advisor', () => {
 	it('returns no hint outside the player turn', () => {
@@ -63,5 +76,101 @@ describe('blackjack strategy advisor', () => {
 		state.canDouble = false;
 
 		expect(advisor.getHint(state)).toBe('Hint: Hit');
+	});
+
+	it('covers hard total stand and hit boundaries', () => {
+		const advisor = new StrategyAdvisor();
+
+		expect(
+			advisor.getHint(
+				playerTurnState(
+					[encodeCard('spades', '10'), encodeCard('clubs', '7')],
+					encodeCard('hearts', 'A'),
+					false,
+				),
+			),
+		).toBe('Hint: Stand');
+		expect(
+			advisor.getHint(
+				playerTurnState(
+					[encodeCard('spades', '7'), encodeCard('clubs', '5')],
+					encodeCard('hearts', '4'),
+					false,
+				),
+			),
+		).toBe('Hint: Stand');
+		expect(
+			advisor.getHint(
+				playerTurnState(
+					[encodeCard('spades', '7'), encodeCard('clubs', '5')],
+					encodeCard('hearts', '3'),
+					false,
+				),
+			),
+		).toBe('Hint: Hit');
+	});
+
+	it('covers hard double down boundaries', () => {
+		const advisor = new StrategyAdvisor();
+
+		expect(
+			advisor.getHint(
+				playerTurnState(
+					[encodeCard('spades', '5'), encodeCard('clubs', '4')],
+					encodeCard('hearts', '3'),
+					true,
+				),
+			),
+		).toBe('Hint: Double');
+		expect(
+			advisor.getHint(
+				playerTurnState(
+					[encodeCard('spades', '5'), encodeCard('clubs', '4')],
+					encodeCard('hearts', '2'),
+					true,
+				),
+			),
+		).toBe('Hint: Hit');
+	});
+
+	it('covers soft total stand, hit, and double boundaries', () => {
+		const advisor = new StrategyAdvisor();
+
+		expect(
+			advisor.getHint(
+				playerTurnState(
+					[encodeCard('spades', 'A'), encodeCard('clubs', '8')],
+					encodeCard('hearts', '10'),
+					false,
+				),
+			),
+		).toBe('Hint: Stand');
+		expect(
+			advisor.getHint(
+				playerTurnState(
+					[encodeCard('spades', 'A'), encodeCard('clubs', '7')],
+					encodeCard('hearts', '7'),
+					false,
+				),
+			),
+		).toBe('Hint: Stand');
+		expect(
+			advisor.getHint(
+				playerTurnState(
+					[encodeCard('spades', 'A'), encodeCard('clubs', '4')],
+					encodeCard('hearts', '4'),
+					true,
+				),
+			),
+		).toBe('Hint: Double');
+		expect(
+			advisor.getHint(
+				playerTurnState(
+					[encodeCard('spades', 'A'), encodeCard('clubs', '2')],
+					encodeCard('hearts', '5'),
+					true,
+				),
+			),
+		).toBe('Hint: Double');
 	});
 });


### PR DESCRIPTION
## Summary
- add button bar pointer interaction coverage for enabled and disabled states
- expand blackjack controls keyboard coverage for hit, stand, double, bet, next, and new-game actions
- add strategy advisor branch coverage for hard and soft total boundaries

## Validation
- `./kbve.sh -nx astro-kbve:test`
- `pnpm exec eslint --no-ignore apps/kbve/astro-kbve/src/arcade/blackjack/objects/buttonBar.test.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackControls.test.ts apps/kbve/astro-kbve/src/arcade/blackjack/objects/strategyAdvisor.test.ts`
- `../../../node_modules/.bin/vitest run --config ./vitest.config.ts --coverage --coverage.include='src/arcade/blackjack/**/*.ts' --coverage.exclude='src/arcade/blackjack/**/*.test.ts' --coverage.reporter=text`
- `AXUM_PORT=4385 pnpm exec vitest run apps/kbve/astro-kbve-e2e/e2e/blackjack.spec.ts`

## Coverage
- `buttonBar.ts`: 100% statements, branches, functions, and lines
- `blackjackControls.ts`: 100% statements/functions/lines, 90% branches
- blackjack-focused report: 56.67% statements overall, with remaining gaps concentrated in Phaser scene/texture/animation modules