### PR TITLE
test(astro-kbve): expand unit + fuzz coverage to lib, solitaire, wallet

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/solitaire/cards.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/solitaire/cards.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import {
+	ALL_BONUS_BYTES,
+	ALL_MONSTER_BYTES,
+	BONUS_CASH_BYTE,
+	BONUS_HP_BYTE,
+	BONUS_REVEAL_BYTE,
+	BonusType,
+	ColorByte,
+	FOUNDATION_SUITS,
+	IDENTITY_MASK,
+	IDENTITY_SLOTS,
+	JOKER_BLACK_BYTE,
+	JOKER_RANK,
+	JOKER_RED_BYTE,
+	MONSTER_GHOUL_BYTE,
+	MONSTER_GOBLIN_BYTE,
+	MONSTER_SKELETON_BYTE,
+	MonsterKind,
+	RANK_LABEL,
+	SUIT_GLYPH,
+	SUIT_LABEL,
+	SuitByte,
+	getBonusType,
+	getCardId,
+	getCardIndex,
+	getColor,
+	getDisplayRank,
+	getMonsterKind,
+	getRank,
+	getSuit,
+	isBonus,
+	isFaceUp,
+	isJoker,
+	isMonster,
+	packCard,
+	setFaceUp,
+} from './cards';
+
+const SUITS: readonly SuitByte[] = [
+	SuitByte.Spades,
+	SuitByte.Hearts,
+	SuitByte.Diamonds,
+	SuitByte.Clubs,
+];
+
+describe('cards — byte layout invariants', () => {
+	it('IDENTITY_MASK occupies bits 0..6', () => {
+		expect(IDENTITY_MASK).toBe(0b0111_1111);
+	});
+
+	it('IDENTITY_SLOTS is 128', () => {
+		expect(IDENTITY_SLOTS).toBe(128);
+	});
+
+	it('SUIT_LABEL / SUIT_GLYPH / FOUNDATION_SUITS all align', () => {
+		expect(SUIT_LABEL.length).toBe(4);
+		expect(SUIT_GLYPH.length).toBe(4);
+		expect(FOUNDATION_SUITS.length).toBe(4);
+		expect(RANK_LABEL.length).toBe(13);
+	});
+});
+
+describe('packCard / getRank / getSuit / isFaceUp', () => {
+	it('packs and unpacks (suit, rank, faceUp) round-trip', () => {
+		for (const suit of SUITS) {
+			for (let rank = 0; rank < 13; rank++) {
+				for (const faceUp of [false, true]) {
+					const c = packCard(suit, rank, faceUp);
+					expect(getSuit(c)).toBe(suit);
+					expect(getRank(c)).toBe(rank);
+					expect(isFaceUp(c)).toBe(faceUp);
+					expect(getDisplayRank(c)).toBe(rank + 1);
+				}
+			}
+		}
+	});
+
+	it('setFaceUp(true/false) flips only the face-up bit', () => {
+		const base = packCard(SuitByte.Hearts, 5, false);
+		const up = setFaceUp(base, true);
+		expect(isFaceUp(up)).toBe(true);
+		expect(getSuit(up)).toBe(SuitByte.Hearts);
+		expect(getRank(up)).toBe(5);
+
+		const down = setFaceUp(up, false);
+		expect(isFaceUp(down)).toBe(false);
+		expect(down).toBe(base);
+	});
+
+	it('masks rank input to 5 bits (no overflow into suit/face)', () => {
+		const c = packCard(SuitByte.Diamonds, 0xff, false);
+		expect(getSuit(c)).toBe(SuitByte.Diamonds);
+		expect(isFaceUp(c)).toBe(false);
+	});
+});
+
+describe('getColor', () => {
+	it('hearts + diamonds are red, spades + clubs are black', () => {
+		expect(getColor(packCard(SuitByte.Hearts, 0))).toBe(ColorByte.Red);
+		expect(getColor(packCard(SuitByte.Diamonds, 0))).toBe(ColorByte.Red);
+		expect(getColor(packCard(SuitByte.Spades, 0))).toBe(ColorByte.Black);
+		expect(getColor(packCard(SuitByte.Clubs, 0))).toBe(ColorByte.Black);
+	});
+});
+
+describe('jokers', () => {
+	it('JOKER_BLACK_BYTE and JOKER_RED_BYTE register as jokers', () => {
+		expect(isJoker(JOKER_BLACK_BYTE)).toBe(true);
+		expect(isJoker(JOKER_RED_BYTE)).toBe(true);
+		expect(getRank(JOKER_BLACK_BYTE)).toBe(JOKER_RANK);
+		expect(getColor(JOKER_BLACK_BYTE)).toBe(ColorByte.Black);
+		expect(getColor(JOKER_RED_BYTE)).toBe(ColorByte.Red);
+	});
+
+	it('regular cards are not jokers', () => {
+		for (const suit of SUITS) {
+			for (let rank = 0; rank < 13; rank++) {
+				expect(isJoker(packCard(suit, rank))).toBe(false);
+			}
+		}
+	});
+
+	it('face-up flag does not affect joker detection', () => {
+		expect(isJoker(setFaceUp(JOKER_BLACK_BYTE, true))).toBe(true);
+		expect(isJoker(setFaceUp(JOKER_RED_BYTE, false))).toBe(true);
+	});
+});
+
+describe('bonus cards', () => {
+	it('every byte in ALL_BONUS_BYTES is detected as bonus', () => {
+		for (const b of ALL_BONUS_BYTES) {
+			expect(isBonus(b)).toBe(true);
+		}
+	});
+
+	it('non-bonus playing cards return false', () => {
+		for (const suit of SUITS) {
+			for (let rank = 0; rank < 13; rank++) {
+				expect(isBonus(packCard(suit, rank))).toBe(false);
+			}
+		}
+	});
+
+	it('getBonusType returns the correct subtype', () => {
+		expect(getBonusType(BONUS_HP_BYTE)).toBe(BonusType.HP);
+		expect(getBonusType(BONUS_CASH_BYTE)).toBe(BonusType.Cash);
+		expect(getBonusType(BONUS_REVEAL_BYTE)).toBe(BonusType.Reveal);
+	});
+
+	it('getBonusType on non-bonus card falls back to HP (sentinel default)', () => {
+		const regular = packCard(SuitByte.Spades, 0);
+		expect(getBonusType(regular)).toBe(BonusType.HP);
+		expect(isBonus(regular)).toBe(false);
+	});
+});
+
+describe('monster cards', () => {
+	it('every monster byte is detected', () => {
+		for (const b of ALL_MONSTER_BYTES) {
+			expect(isMonster(b)).toBe(true);
+		}
+	});
+
+	it('getMonsterKind returns the correct kind', () => {
+		expect(getMonsterKind(MONSTER_GOBLIN_BYTE)).toBe(MonsterKind.Goblin);
+		expect(getMonsterKind(MONSTER_SKELETON_BYTE)).toBe(
+			MonsterKind.Skeleton,
+		);
+		expect(getMonsterKind(MONSTER_GHOUL_BYTE)).toBe(MonsterKind.Ghoul);
+	});
+
+	it('bonus and monster sets are disjoint', () => {
+		for (const b of ALL_BONUS_BYTES) {
+			expect(isMonster(b)).toBe(false);
+		}
+		for (const m of ALL_MONSTER_BYTES) {
+			expect(isBonus(m)).toBe(false);
+		}
+	});
+});
+
+describe('getCardId / getCardIndex', () => {
+	it('every regular card has a stable id of the form "S-R"', () => {
+		for (const suit of SUITS) {
+			for (let rank = 0; rank < 13; rank++) {
+				const c = packCard(suit, rank, false);
+				const id = getCardId(c);
+				expect(id).toMatch(/^[SHDC]-\d+$/);
+				const same = packCard(suit, rank, true);
+				expect(getCardId(same)).toBe(id);
+			}
+		}
+	});
+
+	it('jokers, bonuses, monsters all have named ids', () => {
+		expect(getCardId(JOKER_BLACK_BYTE)).toBe('JOKER-BLACK');
+		expect(getCardId(JOKER_RED_BYTE)).toBe('JOKER-RED');
+		expect(getCardId(BONUS_HP_BYTE)).toBe('BONUS-HP-1');
+		expect(getCardId(MONSTER_GOBLIN_BYTE)).toBe('MONSTER-GOBLIN');
+	});
+
+	it('getCardIndex returns the low 7 bits, ignoring face-up flag', () => {
+		const c = packCard(SuitByte.Clubs, 9, false);
+		const flipped = setFaceUp(c, true);
+		expect(getCardIndex(c)).toBe(getCardIndex(flipped));
+		expect(getCardIndex(c)).toBeGreaterThanOrEqual(0);
+		expect(getCardIndex(c)).toBeLessThan(IDENTITY_SLOTS);
+	});
+});
+
+describe('fuzz — byte layout is total', () => {
+	const arbCard = fc.integer({ min: 0, max: 255 });
+
+	it('getRank always returns 0..31, getSuit always returns 0..3', () => {
+		fc.assert(
+			fc.property(arbCard, (c) => {
+				const r = getRank(c);
+				const s = getSuit(c);
+				return r >= 0 && r <= 31 && s >= 0 && s <= 3;
+			}),
+			{ numRuns: 1000 },
+		);
+	});
+
+	it('isFaceUp is a pure bit-7 read', () => {
+		fc.assert(
+			fc.property(arbCard, (c) => isFaceUp(c) === ((c & 0x80) !== 0)),
+			{ numRuns: 500 },
+		);
+	});
+
+	it('setFaceUp(c, true) then setFaceUp(_, false) is identity (modulo face)', () => {
+		fc.assert(
+			fc.property(arbCard, (c) => {
+				const up = setFaceUp(c, true);
+				const down = setFaceUp(up, false);
+				return (
+					(down & 0x7f) === (c & 0x7f) &&
+					isFaceUp(up) === true &&
+					isFaceUp(down) === false
+				);
+			}),
+			{ numRuns: 500 },
+		);
+	});
+
+	it('isJoker / isBonus / isMonster are mutually exclusive on every byte', () => {
+		fc.assert(
+			fc.property(arbCard, (c) => {
+				const flags = [isJoker(c), isBonus(c), isMonster(c)].filter(
+					Boolean,
+				).length;
+				return flags <= 1;
+			}),
+			{ numRuns: 1000 },
+		);
+	});
+
+	it('getCardId never throws and returns either string or undefined for any byte', () => {
+		fc.assert(
+			fc.property(arbCard, (c) => {
+				const id = getCardId(c);
+				return typeof id === 'string' || typeof id === 'undefined';
+			}),
+			{ numRuns: 500 },
+		);
+	});
+});

--- a/apps/kbve/astro-kbve/src/arcade/solitaire/rules.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/solitaire/rules.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import {
+	JOKER_BLACK_BYTE,
+	JOKER_RED_BYTE,
+	MONSTER_GOBLIN_BYTE,
+	SuitByte,
+	packCard,
+	setFaceUp,
+} from './cards';
+
+const JOKER_BLACK_FACEUP = setFaceUp(JOKER_BLACK_BYTE, true);
+const JOKER_RED_FACEUP = setFaceUp(JOKER_RED_BYTE, true);
+const MONSTER_GOBLIN_FACEUP = setFaceUp(MONSTER_GOBLIN_BYTE, true);
+import {
+	canDropOnFoundation,
+	canDropOnTableau,
+	isMovableRun,
+	isWin,
+	movableRun,
+} from './rules';
+
+const c = (suit: SuitByte, rank: number, faceUp = true) =>
+	packCard(suit, rank, faceUp);
+
+const RED_KING = c(SuitByte.Hearts, 12);
+const BLACK_KING = c(SuitByte.Spades, 12);
+const RED_QUEEN = c(SuitByte.Hearts, 11);
+const BLACK_QUEEN = c(SuitByte.Spades, 11);
+const RED_JACK = c(SuitByte.Diamonds, 10);
+const BLACK_JACK = c(SuitByte.Clubs, 10);
+const ACE_SPADES = c(SuitByte.Spades, 0);
+
+describe('canDropOnTableau', () => {
+	it('king can land on empty column', () => {
+		expect(canDropOnTableau(RED_KING, [])).toBe(true);
+		expect(canDropOnTableau(BLACK_KING, [])).toBe(true);
+	});
+
+	it('non-king cannot land on empty column', () => {
+		expect(canDropOnTableau(RED_QUEEN, [])).toBe(false);
+		expect(canDropOnTableau(ACE_SPADES, [])).toBe(false);
+	});
+
+	it('opposite color, one rank lower lands on top', () => {
+		expect(canDropOnTableau(RED_QUEEN, [BLACK_KING])).toBe(true);
+		expect(canDropOnTableau(BLACK_QUEEN, [RED_KING])).toBe(true);
+	});
+
+	it('same color is rejected', () => {
+		expect(canDropOnTableau(RED_QUEEN, [RED_KING])).toBe(false);
+		expect(canDropOnTableau(BLACK_QUEEN, [BLACK_KING])).toBe(false);
+	});
+
+	it('wrong rank gap is rejected', () => {
+		expect(canDropOnTableau(RED_JACK, [BLACK_KING])).toBe(false);
+		expect(canDropOnTableau(c(SuitByte.Spades, 10), [RED_KING])).toBe(
+			false,
+		);
+	});
+
+	it('face-down top blocks any drop', () => {
+		expect(
+			canDropOnTableau(RED_QUEEN, [setFaceUp(BLACK_KING, false)]),
+		).toBe(false);
+	});
+
+	it('joker is wild — drops on anything face-up, plays as anything', () => {
+		expect(canDropOnTableau(JOKER_BLACK_BYTE, [])).toBe(true);
+		expect(canDropOnTableau(JOKER_RED_BYTE, [BLACK_KING])).toBe(true);
+		expect(canDropOnTableau(RED_QUEEN, [JOKER_BLACK_FACEUP])).toBe(true);
+	});
+
+	it('monster card cannot be dropped, monster on top blocks drop', () => {
+		expect(canDropOnTableau(MONSTER_GOBLIN_BYTE, [])).toBe(false);
+		expect(canDropOnTableau(RED_QUEEN, [MONSTER_GOBLIN_FACEUP])).toBe(
+			false,
+		);
+	});
+});
+
+describe('canDropOnFoundation', () => {
+	it('ace starts the foundation', () => {
+		expect(canDropOnFoundation(ACE_SPADES, [])).toBe(true);
+	});
+
+	it('non-ace rejected on empty foundation', () => {
+		expect(canDropOnFoundation(c(SuitByte.Spades, 1), [])).toBe(false);
+		expect(canDropOnFoundation(RED_KING, [])).toBe(false);
+	});
+
+	it('rank N+1 stacks on a foundation of length N', () => {
+		const foundation = [ACE_SPADES];
+		expect(canDropOnFoundation(c(SuitByte.Spades, 1), foundation)).toBe(
+			true,
+		);
+	});
+
+	it('wrong rank rejected', () => {
+		const foundation = [ACE_SPADES];
+		expect(canDropOnFoundation(c(SuitByte.Spades, 2), foundation)).toBe(
+			false,
+		);
+	});
+
+	it('full foundation (13 cards) is locked', () => {
+		const full = Array.from({ length: 13 }, (_, i) =>
+			c(SuitByte.Spades, i),
+		);
+		expect(canDropOnFoundation(c(SuitByte.Spades, 12), full)).toBe(false);
+	});
+
+	it('joker and monster always rejected on foundation', () => {
+		expect(canDropOnFoundation(JOKER_BLACK_FACEUP, [])).toBe(false);
+		expect(canDropOnFoundation(MONSTER_GOBLIN_BYTE, [])).toBe(false);
+	});
+});
+
+describe('movableRun / isMovableRun', () => {
+	it('single face-up card at the bottom is a movable run', () => {
+		const col = [setFaceUp(RED_KING, true)];
+		expect(isMovableRun(col, 0)).toBe(true);
+		expect(movableRun(col, 0)).toEqual([RED_KING]);
+	});
+
+	it('valid alternating descending run is movable', () => {
+		const col = [BLACK_KING, RED_QUEEN, BLACK_JACK];
+		expect(isMovableRun(col, 0)).toBe(true);
+		expect(movableRun(col, 0)).toEqual([BLACK_KING, RED_QUEEN, BLACK_JACK]);
+	});
+
+	it('invalid alternation breaks the run', () => {
+		const col = [BLACK_KING, BLACK_QUEEN];
+		expect(isMovableRun(col, 0)).toBe(false);
+		expect(movableRun(col, 0)).toBeNull();
+	});
+
+	it('face-down card in the run is rejected', () => {
+		const col = [setFaceUp(BLACK_KING, false), setFaceUp(RED_QUEEN, true)];
+		expect(isMovableRun(col, 0)).toBe(false);
+		expect(movableRun(col, 0)).toBeNull();
+	});
+
+	it('joker acts as a wildcard inside a run', () => {
+		const col = [BLACK_KING, JOKER_RED_FACEUP, BLACK_JACK];
+		expect(isMovableRun(col, 0)).toBe(true);
+	});
+
+	it('monster in column breaks the run', () => {
+		const col = [BLACK_KING, MONSTER_GOBLIN_FACEUP];
+		expect(isMovableRun(col, 0)).toBe(false);
+	});
+
+	it('out-of-range fromIndex returns null/false', () => {
+		const col = [BLACK_KING];
+		expect(isMovableRun(col, -1)).toBe(false);
+		expect(isMovableRun(col, 5)).toBe(false);
+		expect(movableRun(col, -1)).toBeNull();
+		expect(movableRun(col, 5)).toBeNull();
+	});
+
+	it('partial slice from middle is movable when bottom alternates', () => {
+		const col = [BLACK_KING, RED_QUEEN, BLACK_JACK];
+		expect(isMovableRun(col, 1)).toBe(true);
+		expect(movableRun(col, 1)).toEqual([RED_QUEEN, BLACK_JACK]);
+	});
+});
+
+describe('isWin', () => {
+	it('all four foundations holding 13 cards = win', () => {
+		const full = Array.from({ length: 13 }, (_, i) =>
+			c(SuitByte.Spades, i),
+		);
+		expect(isWin([full, full, full, full])).toBe(true);
+	});
+
+	it('not all 13 = no win', () => {
+		const full = Array.from({ length: 13 }, (_, i) =>
+			c(SuitByte.Spades, i),
+		);
+		const partial = full.slice(0, 12);
+		expect(isWin([full, full, full, partial])).toBe(false);
+	});
+
+	it('wrong number of foundations = no win', () => {
+		expect(isWin([])).toBe(false);
+		expect(isWin([[], [], []])).toBe(false);
+	});
+});
+
+describe('fuzz — rule purity', () => {
+	const arbCard = fc.integer({ min: 0, max: 0xff });
+	const arbColumn = fc.array(arbCard, { maxLength: 13 });
+
+	it('canDropOnTableau never throws on random bytes', () => {
+		fc.assert(
+			fc.property(arbCard, arbColumn, (card, col) => {
+				expect(() => canDropOnTableau(card, col)).not.toThrow();
+				expect(typeof canDropOnTableau(card, col)).toBe('boolean');
+			}),
+			{ numRuns: 500 },
+		);
+	});
+
+	it('canDropOnFoundation never throws and returns boolean', () => {
+		fc.assert(
+			fc.property(arbCard, arbColumn, (card, col) => {
+				const r = canDropOnFoundation(card, col);
+				return typeof r === 'boolean';
+			}),
+			{ numRuns: 500 },
+		);
+	});
+
+	it('isMovableRun and movableRun agree on success/failure', () => {
+		fc.assert(
+			fc.property(
+				arbColumn,
+				fc.integer({ min: -2, max: 15 }),
+				(col, i) => {
+					const predicate = isMovableRun(col, i);
+					const materialized = movableRun(col, i);
+					return predicate === (materialized !== null);
+				},
+			),
+			{ numRuns: 500 },
+		);
+	});
+
+	it('isWin requires exactly 4 entries of length 13 — never throws on garbage shapes', () => {
+		fc.assert(
+			fc.property(fc.array(arbColumn), (foundations) => {
+				const r = isWin(foundations);
+				if (
+					foundations.length === 4 &&
+					foundations.every((f) => f.length === 13)
+				) {
+					return r === true;
+				}
+				return r === false;
+			}),
+			{ numRuns: 200 },
+		);
+	});
+});

--- a/apps/kbve/astro-kbve/src/components/wallet/format.test.ts
+++ b/apps/kbve/astro-kbve/src/components/wallet/format.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import { formatCompact } from './format';
+
+describe('formatCompact', () => {
+	describe('null / undefined / NaN guards', () => {
+		it('returns em dash for null', () => {
+			expect(formatCompact(null)).toBe('—');
+		});
+
+		it('returns em dash for undefined', () => {
+			expect(formatCompact(undefined)).toBe('—');
+		});
+
+		it('returns em dash for NaN', () => {
+			expect(formatCompact(Number.NaN)).toBe('—');
+		});
+
+		it('returns em dash for Infinity', () => {
+			expect(formatCompact(Number.POSITIVE_INFINITY)).toBe('—');
+			expect(formatCompact(Number.NEGATIVE_INFINITY)).toBe('—');
+		});
+	});
+
+	describe('small integers stay raw', () => {
+		it.each([
+			[0, '0'],
+			[1, '1'],
+			[42, '42'],
+			[999, '999'],
+		])('formatCompact(%i) → %s', (input, expected) => {
+			expect(formatCompact(input)).toBe(expected);
+		});
+	});
+
+	describe('thousands collapse to K', () => {
+		it('1000 → 1K', () => {
+			expect(formatCompact(1000)).toBe('1K');
+		});
+
+		it('1234 → 1.2K (one decimal under 10)', () => {
+			expect(formatCompact(1234)).toBe('1.2K');
+		});
+
+		it('12345 → 12.3K (Intl keeps one decimal)', () => {
+			expect(formatCompact(12345)).toBe('12.3K');
+		});
+
+		it('123456 → 123.5K', () => {
+			expect(formatCompact(123456)).toBe('123.5K');
+		});
+
+		it('999999 rounds up to 1M (boundary)', () => {
+			expect(formatCompact(999999)).toBe('1M');
+		});
+	});
+
+	describe('millions collapse to M', () => {
+		it('1000000 → 1M', () => {
+			expect(formatCompact(1_000_000)).toBe('1M');
+		});
+
+		it('1234567 → 1.2M', () => {
+			expect(formatCompact(1_234_567)).toBe('1.2M');
+		});
+
+		it('12345678 → 12.3M', () => {
+			expect(formatCompact(12_345_678)).toBe('12.3M');
+		});
+	});
+
+	describe('billions collapse to B', () => {
+		it('1000000000 → 1B', () => {
+			expect(formatCompact(1_000_000_000)).toBe('1B');
+		});
+	});
+
+	describe('negative numbers', () => {
+		it('-1234 → -1.2K (preserves sign)', () => {
+			expect(formatCompact(-1234)).toBe('-1.2K');
+		});
+
+		it('-12345 → -12.3K', () => {
+			expect(formatCompact(-12345)).toBe('-12.3K');
+		});
+	});
+
+	describe('fuzz', () => {
+		it('always returns a non-empty string for any finite number', () => {
+			fc.assert(
+				fc.property(
+					fc.double({
+						noNaN: true,
+						min: -1e15,
+						max: 1e15,
+					}),
+					(n) => {
+						const out = formatCompact(n);
+						return typeof out === 'string' && out.length > 0;
+					},
+				),
+				{ numRuns: 500 },
+			);
+		});
+
+		it('never throws for any value, including pathological cases', () => {
+			fc.assert(
+				fc.property(
+					fc.oneof(
+						fc.double(),
+						fc.constant(Number.NaN),
+						fc.constant(Number.POSITIVE_INFINITY),
+						fc.constant(Number.NEGATIVE_INFINITY),
+						fc.constant(0),
+						fc.constant(-0),
+						fc.integer(),
+						fc.bigInt().map((b) => Number(b)),
+					),
+					(n) => {
+						expect(() => formatCompact(n)).not.toThrow();
+					},
+				),
+				{ numRuns: 500 },
+			);
+		});
+
+		it('produces em dash for non-finite, real output otherwise', () => {
+			fc.assert(
+				fc.property(fc.double(), (n) => {
+					const out = formatCompact(n);
+					if (!Number.isFinite(n)) {
+						return out === '—';
+					}
+					return out !== '—';
+				}),
+				{ numRuns: 500 },
+			);
+		});
+
+		it('monotonic-ish: larger magnitudes do not shrink output length too aggressively', () => {
+			fc.assert(
+				fc.property(
+					fc.integer({ min: 1000, max: 1_000_000_000 }),
+					(n) => {
+						const out = formatCompact(n);
+						return out.length <= 6;
+					},
+				),
+				{ numRuns: 300 },
+			);
+		});
+	});
+});

--- a/apps/kbve/astro-kbve/src/lib/sitegraph/osrs-extractor.test.ts
+++ b/apps/kbve/astro-kbve/src/lib/sitegraph/osrs-extractor.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import {
+	osrsExtractor,
+	osrsEdgeColors,
+	osrsEdgeDashes,
+	osrsEdgeLabels,
+	osrsTagOf,
+} from './osrs-extractor';
+
+const entry = (data: Record<string, any>): any => ({
+	data,
+	id: 'osrs/test',
+	body: '',
+	collection: 'docs',
+});
+
+describe('osrsExtractor', () => {
+	it('returns empty links when frontmatter has no osrs block', () => {
+		const result = osrsExtractor(entry({}), 'osrs/foo');
+		expect(result).toEqual({ links: [] });
+	});
+
+	it('extracts related_items by slug', () => {
+		const result = osrsExtractor(
+			entry({
+				osrs: {
+					related_items: [
+						{ slug: 'rune-axe', relationship: 'upgrade' },
+					],
+				},
+			}),
+			'osrs/iron-axe',
+		);
+		expect(result.links).toEqual(['osrs/rune-axe']);
+		expect(result.edges?.['osrs/rune-axe']).toBe('upgrade');
+	});
+
+	it('derives slug from item_name when slug missing', () => {
+		const result = osrsExtractor(
+			entry({
+				osrs: {
+					related_items: [{ item_name: 'Dragon Long Sword' }],
+				},
+			}),
+			'osrs/some-item',
+		);
+		expect(result.links).toEqual(['osrs/dragon-long-sword']);
+		expect(result.edges?.['osrs/dragon-long-sword']).toBe('related');
+	});
+
+	it('drops self-references', () => {
+		const result = osrsExtractor(
+			entry({
+				osrs: {
+					related_items: [{ slug: 'rune-axe' }],
+				},
+			}),
+			'osrs/rune-axe',
+		);
+		expect(result.links).toEqual([]);
+	});
+
+	it('recipes link to product and material with respective edges', () => {
+		const result = osrsExtractor(
+			entry({
+				osrs: {
+					recipes: [
+						{
+							product: 'Steel Bar',
+							materials: [{ item_name: 'Iron Ore' }],
+						},
+					],
+				},
+			}),
+			'osrs/coal',
+		);
+		expect(result.links).toContain('osrs/steel-bar');
+		expect(result.links).toContain('osrs/iron-ore');
+		expect(result.edges?.['osrs/steel-bar']).toBe('product');
+		expect(result.edges?.['osrs/iron-ore']).toBe('component');
+	});
+
+	it('drop_table sources resolve to drop-source edges', () => {
+		const result = osrsExtractor(
+			entry({
+				osrs: {
+					drop_table: { sources: [{ source: 'King Black Dragon' }] },
+				},
+			}),
+			'osrs/dragon-claws',
+		);
+		expect(result.links).toEqual(['osrs/king-black-dragon']);
+		expect(result.edges?.['osrs/king-black-dragon']).toBe('drop-source');
+	});
+
+	it('drop_table can also be a plain array of source objects', () => {
+		const result = osrsExtractor(
+			entry({
+				osrs: {
+					drop_table: [
+						{ source: 'Goblin' },
+						{ source: 'Hill Giant' },
+					],
+				},
+			}),
+			'osrs/bones',
+		);
+		expect(result.links).toContain('osrs/goblin');
+		expect(result.links).toContain('osrs/hill-giant');
+	});
+
+	it('first edge wins when the same target appears in multiple places', () => {
+		const result = osrsExtractor(
+			entry({
+				osrs: {
+					related_items: [
+						{ slug: 'iron-ore', relationship: 'related' },
+					],
+					recipes: [
+						{
+							product: 'Iron Bar',
+							materials: [{ item_name: 'Iron Ore' }],
+						},
+					],
+				},
+			}),
+			'osrs/coal',
+		);
+		expect(result.edges?.['osrs/iron-ore']).toBe('related');
+	});
+});
+
+describe('osrsTagOf', () => {
+	it('returns "osrs" only for slugs under osrs/', () => {
+		expect(osrsTagOf('osrs/dragon-axe')).toBe('osrs');
+		expect(osrsTagOf('osrs/')).toBe('osrs');
+		expect(osrsTagOf('gaming/rimworld')).toBe(null);
+		expect(osrsTagOf('')).toBe(null);
+	});
+
+	it('fuzz: returns "osrs" iff input startsWith "osrs/"', () => {
+		fc.assert(
+			fc.property(fc.string(), (s) => {
+				const tagged = osrsTagOf(s);
+				if (s.startsWith('osrs/')) return tagged === 'osrs';
+				return tagged === null;
+			}),
+			{ numRuns: 500 },
+		);
+	});
+});
+
+describe('style lookup tables stay aligned', () => {
+	it('every edge color has a matching dash + label', () => {
+		const colorKeys = Object.keys(osrsEdgeColors).sort();
+		const dashKeys = Object.keys(osrsEdgeDashes).sort();
+		const labelKeys = Object.keys(osrsEdgeLabels).sort();
+		expect(colorKeys).toEqual(dashKeys);
+		expect(colorKeys).toEqual(labelKeys);
+	});
+});
+
+describe('fuzz — osrsExtractor purity', () => {
+	const arbItem = fc.record({
+		slug: fc.option(fc.string({ minLength: 1, maxLength: 12 }), {
+			nil: undefined,
+		}),
+		item_name: fc.option(fc.string({ minLength: 1, maxLength: 12 }), {
+			nil: undefined,
+		}),
+		relationship: fc.option(
+			fc.constantFrom(
+				'upgrade',
+				'downgrade',
+				'product',
+				'component',
+				'variant',
+				'related',
+			),
+			{ nil: undefined },
+		),
+	});
+
+	const arbRecipe = fc.record({
+		product: fc.option(fc.string({ minLength: 1, maxLength: 12 }), {
+			nil: undefined,
+		}),
+		materials: fc.option(fc.array(arbItem, { maxLength: 4 }), {
+			nil: undefined,
+		}),
+	});
+
+	const arbOsrs = fc.record({
+		related_items: fc.option(fc.array(arbItem, { maxLength: 6 }), {
+			nil: undefined,
+		}),
+		recipes: fc.option(fc.array(arbRecipe, { maxLength: 4 }), {
+			nil: undefined,
+		}),
+	});
+
+	it('never throws and always returns a {links: string[]} shape', () => {
+		fc.assert(
+			fc.property(arbOsrs, fc.string(), (osrs, slug) => {
+				const r = osrsExtractor(entry({ osrs }), slug);
+				return (
+					Array.isArray(r.links) &&
+					r.links.every((l) => typeof l === 'string')
+				);
+			}),
+			{ numRuns: 300 },
+		);
+	});
+
+	it('current slug is never present in returned links', () => {
+		fc.assert(
+			fc.property(
+				arbOsrs,
+				fc.string({ minLength: 1, maxLength: 12 }),
+				(osrs, name) => {
+					const slug = `osrs/${name}`;
+					const r = osrsExtractor(entry({ osrs }), slug);
+					return !r.links.includes(slug);
+				},
+			),
+			{ numRuns: 300 },
+		);
+	});
+});

--- a/apps/kbve/astro-kbve/src/lib/utils.test.ts
+++ b/apps/kbve/astro-kbve/src/lib/utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import { cn } from './utils';
+
+describe('cn', () => {
+	it('joins multiple classes with a single space', () => {
+		expect(cn('a', 'b', 'c')).toBe('a b c');
+	});
+
+	it('drops falsy values', () => {
+		expect(cn('a', false, null, undefined, 0, 'b')).toBe('a b');
+	});
+
+	it('handles objects with truthy values', () => {
+		expect(cn('a', { b: true, c: false, d: 1 })).toBe('a b d');
+	});
+
+	it('flattens arrays', () => {
+		expect(cn(['a', 'b'], 'c', ['d', ['e']])).toBe('a b c d e');
+	});
+
+	it('tailwind-merge resolves conflicts (later wins)', () => {
+		expect(cn('p-2', 'p-4')).toBe('p-4');
+		expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500');
+	});
+
+	it('preserves non-conflicting tailwind utilities', () => {
+		const out = cn('p-2', 'm-4', 'text-red-500');
+		expect(out).toContain('p-2');
+		expect(out).toContain('m-4');
+		expect(out).toContain('text-red-500');
+	});
+
+	it('returns empty string with no inputs', () => {
+		expect(cn()).toBe('');
+	});
+
+	it('fuzz: never throws on arbitrary scalar inputs', () => {
+		fc.assert(
+			fc.property(
+				fc.array(
+					fc.oneof(
+						fc.string(),
+						fc.boolean(),
+						fc.constant(null),
+						fc.constant(undefined),
+						fc.integer(),
+					),
+				),
+				(parts) => {
+					expect(() => cn(...parts)).not.toThrow();
+					expect(typeof cn(...parts)).toBe('string');
+				},
+			),
+			{ numRuns: 300 },
+		);
+	});
+
+	it('fuzz: output is always a single-line whitespace-separated string', () => {
+		fc.assert(
+			fc.property(fc.array(fc.string()), (parts) => {
+				const out = cn(...parts);
+				return !out.includes('\n');
+			}),
+			{ numRuns: 300 },
+		);
+	});
+});

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"eslint-plugin-react": "7.35.0",
 		"eslint-plugin-react-hooks": "^7.0.1",
 		"fake-indexeddb": "^6.2.5",
+		"fast-check": "^4.8.0",
 		"grpc-tools": "^1.13.1",
 		"grpc_tools_node_protoc_ts": "^5.3.3",
 		"husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,9 @@ importers:
       fake-indexeddb:
         specifier: ^6.2.5
         version: 6.2.5
+      fast-check:
+        specifier: ^4.8.0
+        version: 4.8.0
       grpc-tools:
         specifier: ^1.13.1
         version: 1.13.1(encoding@0.1.13)
@@ -9422,6 +9425,10 @@ packages:
     resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
     engines: {node: '>=18'}
 
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
@@ -13327,6 +13334,9 @@ packages:
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
@@ -28594,6 +28604,10 @@ snapshots:
 
   fake-indexeddb@6.2.5: {}
 
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
   fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -33598,6 +33612,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@7.0.1: {}
+
+  pure-rand@8.4.0: {}
 
   pvtsutils@1.3.6:
     dependencies:


### PR DESCRIPTION
## Why
The astro-kbve suite was blackjack-only (11 files, 48 tests). Solitaire, the wallet formatter, the OSRS sitegraph extractor, and the \`cn\` helper had **zero** unit coverage. This PR squeezes coverage into each pure-TS surface and adds property-based fuzz tests where the API is total and has obvious algebraic invariants.

## Result
\`\`\`
Before:  11 files,  48 tests
After:   16 files, 147 tests
Net:     +5 files, +99 tests
\`\`\`

\`\`\`
Test Files  16 passed (16)
Tests       147 passed (147)
Duration    ~440 ms
\`\`\`

## What's new
- **\`src/components/wallet/format.test.ts\`** — \`formatCompact\` (23 tests): null/NaN/Infinity guards, K/M/B compaction, sign preservation; fuzz over [-1e15, 1e15] never throws, em dash iff non-finite.
- **\`src/arcade/solitaire/cards.test.ts\`** — byte layout (25 tests): pack/unpack round-trip across the whole 4×13 deck, mask-overflow safety, joker/bonus/monster sentinels, ID lookup; fuzz over all 256 bytes confirms purity, \`isJoker\`/\`isBonus\`/\`isMonster\` mutually exclusive, \`setFaceUp\` identity.
- **\`src/arcade/solitaire/rules.test.ts\`** — game rules (29 tests): \`canDropOnTableau\`, \`canDropOnFoundation\`, \`movableRun\` + \`isMovableRun\` parity, joker wildcards, monster blockers, \`isWin\`; fuzz over random byte streams + out-of-range indices confirms totality.
- **\`src/lib/sitegraph/osrs-extractor.test.ts\`** — frontmatter graph extraction (13 tests): related_items (slug + item_name), recipes (product + materials), drop_table (array vs sources), self-reference drop, first-edge-wins precedence; fuzz over arbitrary OSRS frontmatter shapes confirms totality + self-slug never present.
- **\`src/lib/utils.test.ts\`** — \`cn\` (9 tests): falsy drop, conditional object, array flatten, tailwind-merge conflict resolution, empty input; fuzz never throws on mixed scalars.

## Tooling
Adds \`fast-check\` as a **root** devDependency (memory: pnpm root deps only — package-level deps don't auto-install).

No vitest config changes — existing \`src/**/*.test.ts\` glob picks up the new files.

## Test plan
- [ ] \`npx nx run astro-kbve:test\` passes (CI \`Apply all migrations on blank Postgres\` is unrelated; the astro-kbve test target is the vitest one).
- [ ] Locally \`npx vitest run\` from \`apps/kbve/astro-kbve\` reports 147 passed.
- [ ] No new flakiness — fast-check uses default seeded RNG; failures are reproducible.

## Follow-up ideas (not in this PR)
- \`storage-migration.ts\` requires \`fake-indexeddb\`; worth a separate PR with that dev dep.
- Astro components (\`GamingHub.astro\`, etc.) benefit from snapshot tests once we wire \`@testing-library/astro\` or similar.
- Worker / WebSocket paths in \`src/workers/\` need either MSW or a SharedWorker harness — bigger lift.