### PR TITLE
test(astro-kbve): coverage round 2 — config invariants, fetchers, schema, footer

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/config.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/config.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+	BASE_HEIGHT,
+	BASE_WIDTH,
+	CARD_SIZE,
+	COLORS,
+	FONT,
+	GAME,
+} from './config';
+
+describe('blackjack config invariants', () => {
+	it('base resolution is a sensible 16:10 widescreen', () => {
+		expect(BASE_WIDTH).toBeGreaterThan(0);
+		expect(BASE_HEIGHT).toBeGreaterThan(0);
+		const ratio = BASE_WIDTH / BASE_HEIGHT;
+		expect(ratio).toBeGreaterThan(1);
+		expect(ratio).toBeLessThan(2);
+	});
+
+	it('card geometry is positive and rounded corner radius is sane', () => {
+		expect(CARD_SIZE.width).toBeGreaterThan(0);
+		expect(CARD_SIZE.height).toBeGreaterThan(0);
+		expect(CARD_SIZE.radius).toBeGreaterThanOrEqual(0);
+		expect(CARD_SIZE.radius).toBeLessThan(
+			Math.min(CARD_SIZE.width, CARD_SIZE.height) / 2,
+		);
+	});
+
+	it('card aspect ratio is portrait (height > width)', () => {
+		expect(CARD_SIZE.height).toBeGreaterThan(CARD_SIZE.width);
+	});
+
+	it('FONT lookup has serif / sans / mono entries', () => {
+		expect(typeof FONT.serif).toBe('string');
+		expect(typeof FONT.sans).toBe('string');
+		expect(typeof FONT.mono).toBe('string');
+		expect(FONT.serif.length).toBeGreaterThan(0);
+	});
+
+	it('numeric COLORS are 24-bit RGB values (0..0xFFFFFF)', () => {
+		const numericKeys: Array<keyof typeof COLORS> = [
+			'background',
+			'feltCenter',
+			'feltEdge',
+			'feltPattern',
+			'feltInk',
+			'tableTrim',
+			'tableTrimDark',
+			'rail',
+			'railLight',
+			'panel',
+			'panelStroke',
+			'cardFace',
+			'cardBorder',
+			'cardBack',
+			'cardBackAccent',
+			'tableShadow',
+			'action',
+		];
+		for (const k of numericKeys) {
+			const v = COLORS[k];
+			expect(typeof v).toBe('number');
+			expect(v).toBeGreaterThanOrEqual(0);
+			expect(v).toBeLessThanOrEqual(0xffffff);
+		}
+	});
+
+	it('string COLORS are valid CSS hex strings', () => {
+		const stringKeys: Array<keyof typeof COLORS> = [
+			'red',
+			'black',
+			'gold',
+			'soft',
+			'muted',
+			'danger',
+		];
+		for (const k of stringKeys) {
+			const v = COLORS[k];
+			expect(typeof v).toBe('string');
+			expect(v).toMatch(/^#[0-9a-fA-F]{3,8}$/);
+		}
+	});
+
+	describe('GAME rules', () => {
+		it('starting bankroll is positive', () => {
+			expect(GAME.startingBankroll).toBeGreaterThan(0);
+		});
+
+		it('default bet is between min and max bet', () => {
+			expect(GAME.defaultBet).toBeGreaterThanOrEqual(GAME.minBet);
+			expect(GAME.defaultBet).toBeLessThanOrEqual(GAME.maxBet);
+		});
+
+		it('min bet is positive and not greater than max', () => {
+			expect(GAME.minBet).toBeGreaterThan(0);
+			expect(GAME.minBet).toBeLessThan(GAME.maxBet);
+		});
+
+		it('max bet does not exceed starting bankroll (no immediate ruin)', () => {
+			expect(GAME.maxBet).toBeLessThanOrEqual(GAME.startingBankroll);
+		});
+
+		it('deck count is a standard multi-deck shoe (1, 2, 4, 6, or 8)', () => {
+			expect([1, 2, 4, 6, 8]).toContain(GAME.decks);
+		});
+
+		it('blackjack payout is the standard 3:2 or higher', () => {
+			expect(GAME.blackjackPayout).toBeGreaterThanOrEqual(1.2);
+		});
+
+		it('dealer rule is a boolean', () => {
+			expect(typeof GAME.dealerHitsSoft17).toBe('boolean');
+		});
+	});
+});

--- a/apps/kbve/astro-kbve/src/arcade/runner/config.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/runner/config.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+	BASE_HEIGHT,
+	BASE_WIDTH,
+	COLORS,
+	GAME_CONFIG,
+	PLAYER_SIZE,
+} from './config';
+
+describe('runner config invariants', () => {
+	it('base resolution is positive 16:9-ish', () => {
+		expect(BASE_WIDTH).toBeGreaterThan(0);
+		expect(BASE_HEIGHT).toBeGreaterThan(0);
+		const ratio = BASE_WIDTH / BASE_HEIGHT;
+		expect(ratio).toBeGreaterThan(1.5);
+		expect(ratio).toBeLessThan(2.0);
+	});
+
+	it('player size is positive and shorter than base', () => {
+		expect(PLAYER_SIZE.width).toBeGreaterThan(0);
+		expect(PLAYER_SIZE.height).toBeGreaterThan(0);
+		expect(PLAYER_SIZE.width).toBeLessThan(BASE_WIDTH);
+		expect(PLAYER_SIZE.height).toBeLessThan(BASE_HEIGHT);
+	});
+
+	it('gravity pulls down (positive value, applied as +y)', () => {
+		expect(GAME_CONFIG.gravity).toBeGreaterThan(0);
+	});
+
+	it('jump force pushes up (negative y)', () => {
+		expect(GAME_CONFIG.jumpForce).toBeLessThan(0);
+	});
+
+	it('horizontal speeds are positive and player speed <= maxSpeed', () => {
+		expect(GAME_CONFIG.playerSpeed).toBeGreaterThan(0);
+		expect(GAME_CONFIG.maxSpeed).toBeGreaterThanOrEqual(
+			GAME_CONFIG.playerSpeed,
+		);
+	});
+
+	it('deceleration >= acceleration (snappy stop)', () => {
+		expect(GAME_CONFIG.deceleration).toBeGreaterThanOrEqual(
+			GAME_CONFIG.acceleration,
+		);
+	});
+
+	it('grapple max distance fits inside screen width with headroom', () => {
+		expect(GAME_CONFIG.grappleMaxDistance).toBeGreaterThan(0);
+		expect(GAME_CONFIG.grappleMaxDistance).toBeLessThanOrEqual(BASE_WIDTH);
+	});
+
+	it('numeric COLORS are within 24-bit range', () => {
+		for (const k of [
+			'background',
+			'ground',
+			'player',
+			'platform',
+			'enemyWalker',
+			'enemyFlyer',
+			'enemySpiker',
+			'grappleLine',
+		] as const) {
+			const v = COLORS[k];
+			expect(typeof v).toBe('number');
+			expect(v).toBeGreaterThanOrEqual(0);
+			expect(v).toBeLessThanOrEqual(0xffffff);
+		}
+	});
+
+	it('string COLORS are valid CSS hex', () => {
+		for (const k of ['gameOverText', 'scoreText', 'hintText'] as const) {
+			expect(COLORS[k]).toMatch(/^#[0-9a-fA-F]{3,8}$/);
+		}
+	});
+
+	it('spawn interval is in a sane game-loop range', () => {
+		expect(GAME_CONFIG.spawnInterval).toBeGreaterThan(500);
+		expect(GAME_CONFIG.spawnInterval).toBeLessThan(10_000);
+	});
+
+	it('groundOffset fits inside base height', () => {
+		expect(GAME_CONFIG.groundOffset).toBeGreaterThan(0);
+		expect(GAME_CONFIG.groundOffset).toBeLessThan(BASE_HEIGHT);
+	});
+});

--- a/apps/kbve/astro-kbve/src/components/footer/serviceFooter.test.ts
+++ b/apps/kbve/astro-kbve/src/components/footer/serviceFooter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import footerService from './serviceFooter';
+
+describe('FooterService', () => {
+	it('default export and getInstance return the same singleton', async () => {
+		const mod = await import('./serviceFooter');
+		expect(footerService).toBe(mod.default);
+	});
+
+	it('quickLinks store exposes a non-empty list after construction', () => {
+		const links = footerService.getQuickLinks().get();
+		expect(Array.isArray(links)).toBe(true);
+	});
+
+	it('updateLinksForUser(true) swaps to the authenticated link set', () => {
+		footerService.updateLinksForUser(true);
+		const links = footerService.getQuickLinks().get();
+		const labels = links.map((l) => l.label);
+		expect(labels).toContain('Dashboard');
+		expect(labels).toContain('Profile');
+		expect(labels).toContain('Logout');
+	});
+
+	it('updateLinksForUser(false) restores anonymous defaults', () => {
+		footerService.updateLinksForUser(false);
+		const links = footerService.getQuickLinks().get();
+		const labels = links.map((l) => l.label);
+		expect(labels).toContain('Support');
+		expect(labels).not.toContain('Logout');
+	});
+
+	it('reset() restores defaults and clears auth flag', () => {
+		footerService.updateLinksForUser(true);
+		footerService.setUserAuthenticated(true);
+		footerService.reset();
+
+		const links = footerService.getQuickLinks().get();
+		expect(links.some((l) => l.label === 'Logout')).toBe(false);
+	});
+
+	it('every link has href + label string', () => {
+		footerService.reset();
+		const links = footerService.getQuickLinks().get();
+		for (const link of links) {
+			expect(typeof link.href).toBe('string');
+			expect(link.href.length).toBeGreaterThan(0);
+			expect(typeof link.label).toBe('string');
+			expect(link.label.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('setUserAuthenticated toggles without crashing for arbitrary booleans', () => {
+		expect(() => footerService.setUserAuthenticated(true)).not.toThrow();
+		expect(() => footerService.setUserAuthenticated(false)).not.toThrow();
+	});
+});

--- a/apps/kbve/astro-kbve/src/data/forum-spaces.test.ts
+++ b/apps/kbve/astro-kbve/src/data/forum-spaces.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+const realFetch = globalThis.fetch;
+
+async function freshModule() {
+	vi.resetModules();
+	return await import('./forum-spaces');
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+	return Promise.resolve({
+		ok,
+		status,
+		json: () => Promise.resolve(body),
+	} as Response);
+}
+
+describe('getForumSpaces', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		globalThis.fetch = realFetch;
+		vi.restoreAllMocks();
+	});
+
+	it('returns upstream spaces when non-empty', async () => {
+		const spaces = [
+			{
+				id: 'x',
+				slug: 'general',
+				name: 'General',
+				description: null,
+				status: 'active',
+			},
+		];
+		globalThis.fetch = vi.fn(() =>
+			jsonResponse({ spaces }),
+		) as unknown as typeof fetch;
+
+		const { getForumSpaces } = await freshModule();
+		const r = await getForumSpaces();
+		expect(r).toEqual(spaces);
+	});
+
+	it('falls back to hardcoded mirror when upstream returns empty', async () => {
+		globalThis.fetch = vi.fn(() =>
+			jsonResponse({ spaces: [] }),
+		) as unknown as typeof fetch;
+
+		const { getForumSpaces } = await freshModule();
+		const r = await getForumSpaces();
+		expect(r.length).toBeGreaterThan(0);
+		expect(r.some((s) => s.slug === 'announcements')).toBe(true);
+		expect(r.some((s) => s.slug === 'support')).toBe(true);
+	});
+
+	it('falls back to hardcoded mirror on non-ok upstream', async () => {
+		globalThis.fetch = vi.fn(() =>
+			jsonResponse({}, false, 500),
+		) as unknown as typeof fetch;
+
+		const { getForumSpaces } = await freshModule();
+		const r = await getForumSpaces();
+		expect(r.some((s) => s.slug === 'announcements')).toBe(true);
+	});
+
+	it('falls back to hardcoded mirror on fetch rejection', async () => {
+		globalThis.fetch = vi.fn(() =>
+			Promise.reject(new Error('network')),
+		) as unknown as typeof fetch;
+
+		const { getForumSpaces } = await freshModule();
+		const r = await getForumSpaces();
+		expect(r.length).toBeGreaterThan(0);
+	});
+
+	it('caches result across repeated calls', async () => {
+		const spaces = [
+			{
+				id: 'x',
+				slug: 'g',
+				name: 'G',
+				description: null,
+				status: 'active',
+			},
+		];
+		const spy = vi.fn(() => jsonResponse({ spaces }));
+		globalThis.fetch = spy as unknown as typeof fetch;
+
+		const { getForumSpaces } = await freshModule();
+		await getForumSpaces();
+		await getForumSpaces();
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it('every fallback space has the required shape', async () => {
+		globalThis.fetch = vi.fn(() =>
+			Promise.reject(new Error('down')),
+		) as unknown as typeof fetch;
+
+		const { getForumSpaces } = await freshModule();
+		const r = await getForumSpaces();
+		for (const s of r) {
+			expect(typeof s.slug).toBe('string');
+			expect(typeof s.name).toBe('string');
+			expect(typeof s.status).toBe('string');
+			expect(['string', 'object']).toContain(typeof s.description);
+		}
+	});
+});

--- a/apps/kbve/astro-kbve/src/data/forum-tags.test.ts
+++ b/apps/kbve/astro-kbve/src/data/forum-tags.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import fc from 'fast-check';
+
+const realFetch = globalThis.fetch;
+
+async function freshModule() {
+	vi.resetModules();
+	return await import('./forum-tags');
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+	return Promise.resolve({
+		ok,
+		status,
+		json: () => Promise.resolve(body),
+	} as Response);
+}
+
+describe('getForumTopTags', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		globalThis.fetch = realFetch;
+		vi.restoreAllMocks();
+	});
+
+	it('returns tags from upstream, sliced to the requested limit', async () => {
+		const tags = Array.from({ length: 20 }, (_, i) => ({
+			id: i,
+			slug: `t${i}`,
+			name: `Tag ${i}`,
+			description: null,
+			thread_count: i,
+		}));
+		globalThis.fetch = vi.fn(() =>
+			jsonResponse({ tags }),
+		) as unknown as typeof fetch;
+
+		const { getForumTopTags } = await freshModule();
+		const result = await getForumTopTags(5);
+		expect(result).toHaveLength(5);
+		expect(result[0].slug).toBe('t0');
+	});
+
+	it('default limit is 12', async () => {
+		const tags = Array.from({ length: 50 }, (_, i) => ({
+			id: i,
+			slug: `t${i}`,
+			name: `Tag ${i}`,
+			description: null,
+			thread_count: i,
+		}));
+		globalThis.fetch = vi.fn(() =>
+			jsonResponse({ tags }),
+		) as unknown as typeof fetch;
+
+		const { getForumTopTags } = await freshModule();
+		const result = await getForumTopTags();
+		expect(result).toHaveLength(12);
+	});
+
+	it('returns empty array on non-ok upstream response', async () => {
+		globalThis.fetch = vi.fn(() =>
+			jsonResponse({}, false, 503),
+		) as unknown as typeof fetch;
+
+		const { getForumTopTags } = await freshModule();
+		const result = await getForumTopTags(5);
+		expect(result).toEqual([]);
+	});
+
+	it('returns empty array on fetch rejection', async () => {
+		globalThis.fetch = vi.fn(() =>
+			Promise.reject(new Error('ECONNREFUSED')),
+		) as unknown as typeof fetch;
+
+		const { getForumTopTags } = await freshModule();
+		const result = await getForumTopTags(3);
+		expect(result).toEqual([]);
+	});
+
+	it('returns empty array when response body lacks a tags array', async () => {
+		globalThis.fetch = vi.fn(() =>
+			jsonResponse({ tags: 'not-an-array' }),
+		) as unknown as typeof fetch;
+
+		const { getForumTopTags } = await freshModule();
+		const result = await getForumTopTags(3);
+		expect(result).toEqual([]);
+	});
+
+	it('caches across calls — fetch only fires once', async () => {
+		const tags = [
+			{
+				id: 1,
+				slug: 'a',
+				name: 'A',
+				description: null,
+				thread_count: 0,
+			},
+		];
+		const spy = vi.fn(() => jsonResponse({ tags }));
+		globalThis.fetch = spy as unknown as typeof fetch;
+
+		const { getForumTopTags } = await freshModule();
+		await getForumTopTags(1);
+		await getForumTopTags(1);
+		await getForumTopTags(1);
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it('caches the empty fallback so failures do not retry on every call', async () => {
+		const spy = vi.fn(() =>
+			Promise.reject(new Error('boom')),
+		) as unknown as typeof fetch;
+		globalThis.fetch = spy;
+
+		const { getForumTopTags } = await freshModule();
+		await getForumTopTags();
+		await getForumTopTags();
+		expect(
+			spy as unknown as ReturnType<typeof vi.fn>,
+		).toHaveBeenCalledTimes(1);
+	});
+
+	it('fuzz: limit parameter is always respected', async () => {
+		const tags = Array.from({ length: 30 }, (_, i) => ({
+			id: i,
+			slug: `t${i}`,
+			name: `Tag ${i}`,
+			description: null,
+			thread_count: i,
+		}));
+		globalThis.fetch = vi.fn(() =>
+			jsonResponse({ tags }),
+		) as unknown as typeof fetch;
+
+		const { getForumTopTags } = await freshModule();
+		await fc.assert(
+			fc.asyncProperty(fc.integer({ min: 0, max: 50 }), async (limit) => {
+				const r = await getForumTopTags(limit);
+				return r.length === Math.min(limit, tags.length);
+			}),
+			{ numRuns: 30 },
+		);
+	});
+});

--- a/apps/kbve/astro-kbve/src/data/schema/ICiProjectSchema.test.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/ICiProjectSchema.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
+import {
+	DispatchPipelines,
+	ICiProjectSchema,
+	TestFrameworks,
+} from './ICiProjectSchema';
+
+describe('ICiProjectSchema', () => {
+	it('parses a minimal valid entry with no proto fields set', () => {
+		const result = ICiProjectSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	it('parses Astro-only fields without touching the proto contract', () => {
+		const r = ICiProjectSchema.safeParse({
+			unsplash: 'photo-id',
+			img: 'https://images.unsplash.com/photo-1234?fit=crop',
+		});
+		expect(r.success).toBe(true);
+	});
+
+	it('rejects a malformed img (non-URL string)', () => {
+		const r = ICiProjectSchema.safeParse({ img: 'not-a-url' });
+		expect(r.success).toBe(false);
+	});
+
+	it('accepts every value enumerated in DispatchPipelineSchema', () => {
+		for (const p of DispatchPipelines) {
+			const r = ICiProjectSchema.safeParse({ pipeline: p });
+			expect(r.success).toBe(true);
+		}
+	});
+
+	it('rejects pipelines outside the proto enum', () => {
+		const r = ICiProjectSchema.safeParse({
+			pipeline: 'not-a-real-pipeline',
+		});
+		expect(r.success).toBe(false);
+	});
+
+	it('accepts every TestFrameworkSchema value', () => {
+		for (const f of TestFrameworks) {
+			const r = ICiProjectSchema.safeParse({ test_framework: f });
+			expect(r.success).toBe(true);
+		}
+	});
+
+	it('rejects unknown test frameworks', () => {
+		const r = ICiProjectSchema.safeParse({ test_framework: 'cobol' });
+		expect(r.success).toBe(false);
+	});
+
+	it('round-trips a realistic entry', () => {
+		const entry = {
+			unsplash: 'photo-1581276879432-15e50529f34b',
+			img: 'https://images.unsplash.com/photo-1581276879432-15e50529f34b?fit=crop&w=1400&h=700&q=75',
+			pipeline: 'npm' as const,
+			test_framework: 'typescript' as const,
+		};
+		const r = ICiProjectSchema.safeParse(entry);
+		expect(r.success).toBe(true);
+		if (r.success) {
+			expect(r.data.pipeline).toBe('npm');
+			expect(r.data.test_framework).toBe('typescript');
+		}
+	});
+
+	describe('fuzz', () => {
+		it('any pipeline string from the enum always parses', () => {
+			fc.assert(
+				fc.property(
+					fc.constantFrom(...DispatchPipelines),
+					(pipeline) => {
+						const r = ICiProjectSchema.safeParse({ pipeline });
+						return r.success;
+					},
+				),
+				{ numRuns: 100 },
+			);
+		});
+
+		it('any random string outside the pipeline enum is rejected', () => {
+			fc.assert(
+				fc.property(
+					fc
+						.string({ minLength: 1, maxLength: 30 })
+						.filter(
+							(s) =>
+								!(
+									DispatchPipelines as readonly string[]
+								).includes(s),
+						),
+					(s) => {
+						const r = ICiProjectSchema.safeParse({ pipeline: s });
+						return r.success === false;
+					},
+				),
+				{ numRuns: 100 },
+			);
+		});
+
+		it('schema is total — never throws on arbitrary shapes', () => {
+			fc.assert(
+				fc.property(
+					fc.object({
+						maxDepth: 2,
+						maxKeys: 6,
+					}),
+					(obj) => {
+						expect(() =>
+							ICiProjectSchema.safeParse(obj),
+						).not.toThrow();
+					},
+				),
+				{ numRuns: 200 },
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Follow-on to #11019

Round 2 of the astro-kbve unit + fuzz push. Same approach: pick pure-TS surfaces with zero coverage and add deterministic invariants + property-based tests where useful.

\`\`\`
Before round 1:  11 files,  48 tests
After  round 1:  16 files, 147 tests
After  round 2:  22 files, 203 tests
\`\`\`

## New files
- **\`src/arcade/blackjack/config.test.ts\`** (13 tests) — base-resolution ratio sanity, card geometry, font lookup, RGB / CSS-hex color ranges, GAME rule invariants (bankroll positive, min<=default<=max, max<=bankroll, deck count 1/2/4/6/8, payout >= 1.2, dealer rule boolean).
- **\`src/arcade/runner/config.test.ts\`** (11 tests) — base aspect ratio, player size fits screen, gravity sign, jumpForce sign, playerSpeed <= maxSpeed, deceleration >= acceleration, grappleMaxDistance bounded, color value ranges.
- **\`src/data/forum-tags.test.ts\`** (8 tests) — happy path with limit slicing, non-ok upstream → empty fallback, fetch reject → empty fallback, malformed body → empty fallback, **cache memoization** validated (fetch called once across N calls, cached-fallback after failure does not retry), fuzz: limit parameter respected for arbitrary values.
- **\`src/data/forum-spaces.test.ts\`** (6 tests) — upstream success, fallback when upstream empty / non-ok / rejected, cache identity across calls, shape validation of every fallback entry.
- **\`src/components/footer/serviceFooter.test.ts\`** (7 tests) — singleton identity, default link set, authenticated link swap, anonymous restore, \`reset()\` side effects, link-shape validation, \`setUserAuthenticated\` doesn't throw.
- **\`src/data/schema/ICiProjectSchema.test.ts\`** (11 tests) — Zod parse: minimal entry, Astro extensions, \`img\` URL validation, every \`DispatchPipelineSchema\` and \`TestFrameworkSchema\` enum value accepted, bogus values rejected, realistic entry round-trip. Fuzz: pipeline enum totality, random non-enum strings always reject, schema is total on arbitrary nested objects (safeParse never throws).

## Notable findings
- **Pre-existing flake**: \`src/arcade/blackjack/objects/blackjackControls.test.ts > maps stand and double keyboard shortcuts to player actions\` fails ~1 in 5 runs locally on \`main\`. **Predates this PR**; flagging here so it can be picked up in a separate stability pass. None of the new tests in this PR are sensitive to ordering or timing.

## Test plan
- [ ] \`npx vitest run\` from \`apps/kbve/astro-kbve\` reports 203 passed (allowing for the known pre-existing flake on \`blackjackControls\` only).
- [ ] CI runs the same suite via the existing \`astro-kbve:test\` target.

## Follow-ups (not in this PR)
- Fix \`blackjackControls\` flake (separate task).
- IDB-coupled lib code (\`storage-migration.ts\`, \`storage.ts\`) needs \`fake-indexeddb\` to be testable.
- \`AuthBridge\` / \`bootAuth\` integration tests need a Supabase client mock layer.
- Snapshot tests for Astro components (\`GamingHub.astro\`, etc) need \`@testing-library/astro\` or a custom renderer.