### PR TITLE
feat(vector): join Java stack traces into a single ClickHouse row for mc

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -5,8 +5,8 @@ metadata:
     name: vector-config
     namespace: vector
     annotations:
-        kbve.sh/last-updated: '2026-05-12T00:00:00Z'
-        kbve.sh/config-version: 'v5-heartbeat-coverage'
+        kbve.sh/last-updated: '2026-05-15T00:00:00Z'
+        kbve.sh/config-version: 'v6-mc-multiline'
 data:
     vector.yml: |
         api:
@@ -24,10 +24,41 @@ data:
             data_dir: "/vector-data-dir"
 
         transforms:
+          # mc-fabric multiline aggregation. Java stack traces emit one line
+          # per frame; the default per-line ingest makes exception search
+          # useless. Route mc-fabric pods through a `reduce` that joins
+          # continuation lines onto the preceding `[HH:MM:SS]` header.
+          # Non-mc pods bypass the reduce via `pod_route._unmatched`.
+          pod_route:
+            type: route
+            inputs:
+              - kubernetes_logs
+            route:
+              mc_fabric: 'string!(.kubernetes.pod_namespace) == "arc-runners" && starts_with(string!(.kubernetes.pod_name), "mc-fabric")'
+
+          mc_fabric_multiline:
+            type: reduce
+            inputs:
+              - pod_route.mc_fabric
+            group_by:
+              - kubernetes.pod_name
+              - kubernetes.container_name
+            merge_strategies:
+              message: concat_newline
+            starts_when:
+              type: vrl
+              source: |-
+                msg = string(.message) ?? ""
+                match(msg, r'^\[\d{2}:\d{2}:\d{2}\]') ||
+                match(msg, r'^\d{4}-\d{2}-\d{2}T')
+            expire_after_ms: 2000
+            flush_period_ms: 500
+
           project_logs:
             type: remap
             inputs:
-              - kubernetes_logs
+              - mc_fabric_multiline
+              - pod_route._unmatched
             source: |-
               .event_message = del(.message)
               .appname = del(.kubernetes.container_name)


### PR DESCRIPTION
## Summary
Java exceptions from the `mc-fabric` pods currently land in `observability.logs_distributed` one row per frame. The PacketEvents NPE and `borealis_glint` codec exception we triaged earlier this week each spanned 10+ rows scattered across distinct timestamps, which made the ClickHouse query practically useless for diagnosis.

Routes mc-fabric pods through a Vector `reduce` transform upstream of `project_logs` so continuation lines (`at ...`, `Caused by:`, `... N more`, `Suppressed:`) merge onto the preceding `[HH:MM:SS] [thread/LEVEL]:` header. Everything else flows through unchanged.

## Changes
- New `pod_route` route transform: splits `kubernetes_logs` into `mc_fabric` (namespace `arc-runners`, pod name starts with `mc-fabric`) and `_unmatched`.
- New `mc_fabric_multiline` reduce transform: groups by `kubernetes.pod_name` + `kubernetes.container_name`, joins `message` with `concat_newline`, opens a new event when the line begins with `[HH:MM:SS]` or an ISO timestamp.
- `project_logs.inputs` now reads from `mc_fabric_multiline` + `pod_route._unmatched`.

## Settings
| Knob | Value | Reason |
|---|---|---|
| `expire_after_ms` | 2000 | Catches trailing `Caused by:` rows that arrive a tick or two after the header without holding events for so long that live diagnosis feels stale. |
| `flush_period_ms` | 500 | Idle flush cadence — for pods that go quiet between exceptions. |

## Validation
`docker run timberio/vector:latest-debian validate` on the rendered config loads clean (only error is the expected in-cluster kubeconfig probe).

## Test plan
- [ ] Vector DaemonSet rolls out without restart-looping (`kubectl -n vector logs ds/vector --follow` for the first 60s).
- [ ] Trigger a synthetic exception inside an mc-fabric pod (e.g. `/say` a known-bad command if available) and confirm in ClickHouse that the resulting row in `logs_distributed` carries the full stack trace in `message` (newline-separated), not one row per frame.
- [ ] Non-mc namespaces (axum-kbve, supabase, etc.) still ship at the same volume — `pod_route._unmatched` is the bypass.