### PR TITLE
fix(firecracker-ctl-net): VM return traffic hijacked by Gluetun's RFC1918 policy route

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,7 +12,7 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.35"
+version: "0.1.36"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml

--- a/apps/vm/firecracker-ctl/src/tap.rs
+++ b/apps/vm/firecracker-ctl/src/tap.rs
@@ -33,6 +33,10 @@ use std::net::Ipv4Addr;
 /// the pool caps at 16384 = 5 digits so we're well under).
 pub const TAP_PREFIX: &str = "fctap-";
 
+/// Routing-rule priority for the VM-subnet → main-table override. Must
+/// be < Gluetun's own pref 99 (which routes 172.16.0.0/12 via eth0).
+pub const VM_RETURN_RULE_PREF: u32 = 50;
+
 /// Errors surfacing from TAP / iptables plumbing.
 #[derive(Debug)]
 pub enum TapError {
@@ -294,6 +298,36 @@ pub fn build_input_accept_check(vm_subnet: &str) -> Vec<String> {
     ]
 }
 
+// Gluetun installs `from all to 172.16.0.0/12 lookup 199` at pref 99 and
+// table 199 routes 172.16.0.0/12 via eth0. That swallows VM-bound return
+// traffic (the VM subnet is inside 172.16/12), so DNS replies from
+// upstream egress the pod through cluster CNI instead of reaching
+// fctap-N. Inserting a higher-priority rule that sends VM-subnet
+// destinations to the main table lets the per-/30 fctap routes win.
+pub fn build_return_rule_add(vm_subnet: &str, pref: u32) -> Vec<String> {
+    vec![
+        "rule".into(),
+        "add".into(),
+        "to".into(),
+        vm_subnet.into(),
+        "lookup".into(),
+        "main".into(),
+        "pref".into(),
+        pref.to_string(),
+    ]
+}
+
+pub fn build_return_rule_show(vm_subnet: &str, pref: u32) -> Vec<String> {
+    vec![
+        "rule".into(),
+        "show".into(),
+        "to".into(),
+        vm_subnet.into(),
+        "pref".into(),
+        pref.to_string(),
+    ]
+}
+
 // ---------------------------------------------------------------------------
 // Execution wrappers (shell-out via tokio::process::Command)
 // ---------------------------------------------------------------------------
@@ -415,6 +449,23 @@ impl TapManager {
 
         if !iptables_rule_exists(&build_input_accept_check(&self.config.vm_subnet)).await? {
             run_iptables(&build_input_accept(&self.config.vm_subnet)).await?;
+        }
+
+        // ip rule that beats Gluetun's `from all to 172.16/12 lookup 199`
+        // (pref 99) so reply traffic to the VM subnet ends up in the main
+        // table where the per-/30 fctap routes live.
+        let show = run_ip(&build_return_rule_show(
+            &self.config.vm_subnet,
+            VM_RETURN_RULE_PREF,
+        ))
+        .await
+        .unwrap_or_default();
+        if show.trim().is_empty() {
+            run_ip(&build_return_rule_add(
+                &self.config.vm_subnet,
+                VM_RETURN_RULE_PREF,
+            ))
+            .await?;
         }
 
         Ok(())
@@ -610,5 +661,33 @@ mod tests {
         let b = pool.allocate().unwrap();
         assert_eq!(tap_name(a.slot_index()).unwrap(), "fctap-0");
         assert_eq!(tap_name(b.slot_index()).unwrap(), "fctap-1");
+    }
+
+    #[test]
+    fn return_rule_add_targets_main_with_higher_priority_than_gluetun() {
+        let args = build_return_rule_add("172.18.0.0/16", VM_RETURN_RULE_PREF);
+        assert_eq!(
+            args,
+            vec![
+                "rule",
+                "add",
+                "to",
+                "172.18.0.0/16",
+                "lookup",
+                "main",
+                "pref",
+                "50"
+            ]
+        );
+        assert!(VM_RETURN_RULE_PREF < 99, "must beat Gluetun's pref 99");
+    }
+
+    #[test]
+    fn return_rule_show_uses_same_selector() {
+        let args = build_return_rule_show("172.18.0.0/16", VM_RETURN_RULE_PREF);
+        assert_eq!(
+            args,
+            vec!["rule", "show", "to", "172.18.0.0/16", "pref", "50"]
+        );
     }
 }


### PR DESCRIPTION
## Summary
Live diagnosis from inside the pod netns pinpointed why VM DNS / TCP to public IPs times out from a \`network=true\` Firecracker microVM. The pod's egress + iptables are correct, but Gluetun's policy routing rule

\`\`\`
rule 99: from all to 172.16.0.0/12 lookup 199
table 199: 172.16.0.0/12 via 10.244.0.123 dev eth0
\`\`\`

hijacks the reply path. The VM subnet \`172.18.0.0/16\` is inside \`172.16.0.0/12\`, so when DNS / TCP replies return through \`tun0\` and conntrack reverses NAT to \`172.18.0.6\`, the kernel consults rule 99 → table 199 → sends the reply out **eth0** (cluster CNI), not the \`fctap-N\` interface where the VM actually lives.

Counters confirm the leak:
- POSTROUTING MASQUERADE: 34 packets (VM → tun0 → masqueraded fine)
- FORWARD tun0→VM-subnet: 46 packets (replies arrived and got forwarded)
- VM application: silence — replies left the pod via eth0

\`ip route get 172.18.0.6 from 1.1.1.1 iif tun0\` returned:
\`\`\`
172.18.0.6 from 1.1.1.1 via 10.244.0.123 dev eth0 table 199
\`\`\`

## Fix
Add \`ip rule add to 172.18.0.0/16 lookup main pref 50\` in \`TapManager::init()\`. Priority 50 beats Gluetun's pref 99, so VM-bound destinations consult the main table — which has the per-/30 \`fctap-N proto kernel scope link\` routes — and return traffic lands on the right TAP.

Idempotent: \`ip rule show to <subnet> pref 50\` is checked first; install is skipped when the rule already exists.

Bumps \`firecracker-ctl\` 0.1.35 → 0.1.36 via MDX.

## Test plan
- [x] \`cargo test tap::\` — 15 passed, including new \`return_rule_add_*\` builder tests
- [ ] After publish + ArgoCD sync, rerun PoetryDB smoke test inside a \`network=true\` VM — expect a poem.