### PR TITLE
fix(astro-kbve/blackjack): make stand-keyboard test deterministic

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackControls.test.ts
+++ b/apps/kbve/astro-kbve/src/arcade/blackjack/objects/blackjackControls.test.ts
@@ -172,6 +172,10 @@ describe('blackjack controls', () => {
 		state.phase = 'player-turn';
 		state.player = [9, 10];
 		state.dealer = [22, 7];
+		state.shoe = [
+			3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+			22,
+		];
 		keyHandlers.get('keydown-S')?.();
 
 		expect(state.phase).toBe('round-over');


### PR DESCRIPTION
## Summary
\`maps stand and double keyboard shortcuts to player actions\` was flaky. It set the player + dealer hands but left \`state.shoe\` as the \`createBlackjackState()\` default — a freshly **shuffled** deck. Pressing S drives the dealer's hit loop from 15, and the next card it draws is \`state.shoe.pop()\` (random). Most runs the dealer ends at 17–19 or busts and the assertion passes; today CI got dealt a card that landed the dealer on 20/21 and the test failed:

\`\`\`
AssertionError: expected 'loss' to be 'win'
  src/arcade/blackjack/objects/blackjackControls.test.ts:178:25
\`\`\`

## Fix
Set \`state.shoe\` to the same fixed 20-card sequence the **double-down** half of this same test already uses. \`shoe.pop()\` returns \`22\` (rank index 6 = '7' = 8 points), so the dealer goes 15 → 23 and busts every time. Player 20 wins deterministically.

## Test plan
- [x] \`./kbve.sh -nx astro-kbve:test\` × 5 back-to-back — 203/203 pass each run, no flakes