### PR TITLE
chore(supply-chain): set pnpm.minimumReleaseAge to 720m (12h)

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
 		"prepare": "husky"
 	},
 	"pnpm": {
+		"minimumReleaseAge": 720,
 		"overrides": {
 			"@novnc/novnc": "1.5.0",
 			"@xmldom/xmldom@<0.8.13": ">=0.8.13",


### PR DESCRIPTION
## Summary

Adds the pnpm 10.16+ supply-chain gate. New publishes to the public npm registry are invisible to pnpm's resolver until 12 hours after their first publish — catches the fastest-burning malicious publishes (typosquats + credential-exfil payloads, usually discovered + delisted within hours per Phylum / Socket reports) without holding back legitimate dependency updates for multiple days.

## Scope of effect

- \`pnpm install --frozen-lockfile\` (CI default) skips resolution entirely, so existing fresh-pinned deps in \`pnpm-lock.yaml\` continue to install. No CI breakage on currently-pinned deps younger than 12 h (verified via local install — exit 0).
- \`pnpm update <pkg>\` and \`pnpm add <pkg>@latest\` pick the most recent version that satisfies the semver range **and** is ≥ 12 h old. Just-released versions get held back until they pass the gate.

## Why 12 h instead of 3–7 d

Tradeoff discussed in chat: aggressive thresholds (3 d / 7 d) catch a wider attack window but block all same-day dependency bumps. 12 h is the minimum useful window that still catches the typical "publish-and-pull" credential-exfil pattern (most malicious publishes get yanked by npm Trust & Safety inside the first 12 h once Socket / GitGuardian / Phylum auto-detectors fire). We can ratchet upward later if the team is comfortable with the friction.

## Pairs with existing hardening already in package.json

The repo already runs the second-most-impactful hardening lever:

\`\`\`json
"onlyBuiltDependencies": [
    "@parcel/watcher", "@swc/core", "core-js", "core-js-pure",
    "esbuild", "grpc-tools", "nx", "sharp", "styled-components"
]
\`\`\`

That allow-list blocks postinstall scripts on every other package — the dominant payload vector for npm supply-chain attacks. Local \`pnpm install\` currently reports 3 blocked builds (\`@bufbuild/buf\`, \`unrs-resolver\`, \`vue-demi\`); none break the build, and adding them to the list would be a separate audit-driven PR.

## Known noise

VS Code shows a JSON-schema warning on \`minimumReleaseAge\` because schemastore has not yet picked up the pnpm 10.16 field. pnpm itself reads and honours the field. Will resolve when the schema upstream updates.

## Test plan

- [ ] PR CI: \`pnpm install --frozen-lockfile\` in every workflow still completes successfully (gate doesn't fire because lockfile is authoritative).
- [ ] After merge, run \`pnpm update --latest\` on a side branch and confirm pnpm picks slightly-older-than-latest versions for any package whose newest publish is < 12 h old. If pnpm errors out cleanly with no satisfying version, that's the gate working as intended.