### PR TITLE
fix(firecracker-ctl): drain VM stdio so guest doesn't hang mid-boot

### DIFF
--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -2463,10 +2463,15 @@ async fn spawn_persistent(
         .await
         .map_err(|e| format!("config write failed: {e}"))?;
 
+    // Inherit stdio. Earlier `piped()` setup was never drained, so the
+    // kernel serial console filled the 64 KiB pipe buffer mid-boot and
+    // the guest hung on the next write — health prober then never saw a
+    // 2xx. With `inherit()` the VM's stdout/stderr flow to
+    // firecracker-ctl's own stdout, which k8s drains via the pod log.
     let child = tokio::process::Command::new("firecracker")
         .args(["--api-sock", &socket_path, "--config-file", &config_path])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
         .spawn()
         .map_err(|e| format!("firecracker spawn failed: {e}"))?;
 


### PR DESCRIPTION
## Bug
Public-tier endpoints stayed in \`Starting\` forever after deploy. The readiness gate kept returning \`503 endpoint starting\` because the health prober never observed a 2xx from the guest.

## Root cause
\`spawn_persistent\` set firecracker's stdout/stderr to \`Stdio::piped()\` but no task ever reads from those pipes. The Linux kernel serial console (\`console=ttyS0\`) writes the boot log into the pipe; once the 64 KiB buffer fills, the next write blocks. The VM hangs mid-boot, never starts the user app, port 8080 never opens.

Confirmed on a running pod: \`dd if=/proc/<vmm-pid>/fd/1\` dumped the buffered boot log and resumed the VM momentarily, but no consumer exists to keep draining.

## Fix
Switch to \`Stdio::inherit()\`. The VM's serial console flows into firecracker-ctl's own stdout, which the pod log already drains. Side benefit: VM boot lines + \`/init\` script output + app stdout now show up in the \`firecracker-ctl-net\` pod log — a useful diagnostic surface for future debugging.

## Test plan
- [ ] Pod gets the new image, deploy a public python-web endpoint
- [ ] \`kubectl logs -n firecracker firecracker-ctl-net-<pod>\` shows kernel boot + uvicorn startup
- [ ] Status flips \`Starting\` → \`Healthy\` within ~10s (prober interval 2s, FastAPI cold start ~3-6s)
- [ ] \`/fc/public/<name>/\` returns 200
- [ ] No "blank screen / 502" regression

## Follow-up (separate PR)
Per-endpoint ring buffer + \`/fc/{name}/logs\` endpoint so the dashboard can surface VM stdout without scraping pod logs.