### PR TITLE
perf(nx): wire cache + outputs across all 7 astro sites

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/project.json
+++ b/apps/cryptothrone/astro-cryptothrone/project.json
@@ -19,13 +19,15 @@
 		},
 		"build": {
 			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-cryptothrone"],
 			"options": {
 				"cwd": "apps/cryptothrone/astro-cryptothrone",
 				"commands": [
 					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
 				],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"preview": {
 			"dependsOn": [
@@ -47,7 +49,8 @@
 				"cwd": "apps/cryptothrone/astro-cryptothrone",
 				"commands": ["nx exec -- astro check"],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"sync": {
 			"executor": "nx:run-commands",

--- a/apps/discordsh/astro-discordsh/project.json
+++ b/apps/discordsh/astro-discordsh/project.json
@@ -19,12 +19,14 @@
 		},
 		"build": {
 			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-discordsh"],
 			"options": {
 				"commands": [
 					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build --root apps/discordsh/astro-discordsh"
 				],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"preview": {
 			"dependsOn": [
@@ -46,7 +48,8 @@
 				"cwd": "apps/discordsh/astro-discordsh",
 				"commands": ["nx exec -- astro check"],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"sync": {
 			"executor": "nx:run-commands",

--- a/apps/herbmail/astro-herbmail/project.json
+++ b/apps/herbmail/astro-herbmail/project.json
@@ -1,67 +1,64 @@
 {
-  "name": "astro-herbmail",
-  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "sourceRoot": "apps/herbmail/astro-herbmail/src",
-  "tags": [],
-  "targets": {
-    "dev": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/herbmail/astro-herbmail",
-        "commands": [
-          "rm -rf .astro",
-          "nx exec -- astro sync",
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro dev"
-        ],
-        "parallel": false
-      }
-    },
-    "build": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/herbmail/astro-herbmail",
-        "commands": [
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
-        ],
-        "parallel": false
-      }
-    },
-    "preview": {
-      "dependsOn": [
-        {
-          "target": "build",
-          "projects": "self"
-        }
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/herbmail/astro-herbmail",
-        "commands": [
-          "nx exec -- astro preview"
-        ],
-        "parallel": false
-      }
-    },
-    "check": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/herbmail/astro-herbmail",
-        "commands": [
-          "nx exec -- astro check"
-        ],
-        "parallel": false
-      }
-    },
-    "sync": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/herbmail/astro-herbmail",
-        "commands": [
-          "nx exec -- astro sync"
-        ],
-        "parallel": false
-      }
-    }
-  }
+	"name": "astro-herbmail",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/herbmail/astro-herbmail/src",
+	"tags": [],
+	"targets": {
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/herbmail/astro-herbmail",
+				"commands": [
+					"rm -rf .astro",
+					"nx exec -- astro sync",
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro dev"
+				],
+				"parallel": false
+			}
+		},
+		"build": {
+			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-herbmail"],
+			"options": {
+				"cwd": "apps/herbmail/astro-herbmail",
+				"commands": [
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
+				],
+				"parallel": false
+			},
+			"cache": true
+		},
+		"preview": {
+			"dependsOn": [
+				{
+					"target": "build",
+					"projects": "self"
+				}
+			],
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/herbmail/astro-herbmail",
+				"commands": ["nx exec -- astro preview"],
+				"parallel": false
+			}
+		},
+		"check": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/herbmail/astro-herbmail",
+				"commands": ["nx exec -- astro check"],
+				"parallel": false
+			},
+			"cache": true
+		},
+		"sync": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/herbmail/astro-herbmail",
+				"commands": ["nx exec -- astro sync"],
+				"parallel": false
+			}
+		}
+	}
 }

--- a/apps/irc/astro-irc/project.json
+++ b/apps/irc/astro-irc/project.json
@@ -1,70 +1,66 @@
 {
-  "name": "astro-irc",
-  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "sourceRoot": "apps/irc/astro-irc/src",
-  "tags": [],
-  "targets": {
-    "dev": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/irc/astro-irc",
-        "commands": [
-          "rm -rf .astro",
-          "npx astro sync",
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" npx astro dev"
-        ],
-        "parallel": false
-      }
-    },
-    "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist/apps/astro-irc"],
-      "options": {
-        "cwd": "apps/irc/astro-irc",
-        "commands": [
-          "rm -rf .astro",
-          "npx astro sync",
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" npx astro build"
-        ],
-        "parallel": false
-      }
-    },
-    "preview": {
-      "dependsOn": [
-        {
-          "target": "build",
-          "projects": "self"
-        }
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/irc/astro-irc",
-        "commands": [
-          "npx astro preview"
-        ],
-        "parallel": false
-      }
-    },
-    "check": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/irc/astro-irc",
-        "commands": [
-          "npx astro check"
-        ],
-        "parallel": false
-      }
-    },
-    "sync": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/irc/astro-irc",
-        "commands": [
-          "npx astro sync"
-        ],
-        "parallel": false
-      }
-    }
-  }
+	"name": "astro-irc",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/irc/astro-irc/src",
+	"tags": [],
+	"targets": {
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": [
+					"rm -rf .astro",
+					"npx astro sync",
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" npx astro dev"
+				],
+				"parallel": false
+			}
+		},
+		"build": {
+			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-irc"],
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": [
+					"rm -rf .astro",
+					"npx astro sync",
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" npx astro build"
+				],
+				"parallel": false
+			},
+			"cache": true
+		},
+		"preview": {
+			"dependsOn": [
+				{
+					"target": "build",
+					"projects": "self"
+				}
+			],
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": ["npx astro preview"],
+				"parallel": false
+			}
+		},
+		"check": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": ["npx astro check"],
+				"parallel": false
+			},
+			"cache": true
+		},
+		"sync": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": ["npx astro sync"],
+				"parallel": false
+			}
+		}
+	}
 }

--- a/apps/kbve/astro-kbve/project.json
+++ b/apps/kbve/astro-kbve/project.json
@@ -30,13 +30,15 @@
 		"build": {
 			"dependsOn": ["proto"],
 			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-kbve"],
 			"options": {
 				"cwd": "apps/kbve/astro-kbve",
 				"commands": [
 					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=8192\" nx exec -- astro build"
 				],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"build:osrs": {
 			"dependsOn": ["proto"],
@@ -72,14 +74,16 @@
 				"cwd": "apps/kbve/astro-kbve",
 				"commands": ["nx exec -- astro check"],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"test": {
 			"executor": "nx:run-commands",
 			"options": {
 				"cwd": "apps/kbve/astro-kbve",
 				"command": "vitest run --config vitest.config.ts"
-			}
+			},
+			"cache": true
 		},
 		"sync": {
 			"executor": "nx:run-commands",

--- a/apps/memes/astro-memes/project.json
+++ b/apps/memes/astro-memes/project.json
@@ -33,13 +33,15 @@
 		"build": {
 			"dependsOn": ["proto"],
 			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-memes"],
 			"options": {
 				"cwd": "apps/memes/astro-memes",
 				"commands": [
 					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
 				],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"preview": {
 			"dependsOn": [
@@ -62,7 +64,8 @@
 				"cwd": "apps/memes/astro-memes",
 				"commands": ["nx exec -- astro check"],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"sync": {
 			"executor": "nx:run-commands",
@@ -77,7 +80,8 @@
 			"options": {
 				"cwd": "apps/memes/astro-memes",
 				"command": "vitest run --config vitest.config.ts"
-			}
+			},
+			"cache": true
 		}
 	}
 }

--- a/apps/rareicon/astro-rareicon/project.json
+++ b/apps/rareicon/astro-rareicon/project.json
@@ -63,7 +63,8 @@
 				"cwd": "apps/rareicon/astro-rareicon",
 				"commands": ["nx exec -- astro check"],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"sync": {
 			"executor": "nx:run-commands",


### PR DESCRIPTION
## Summary
Before this PR only \`astro-rareicon:build\` had \`cache: true\` + \`outputs\` declared explicitly. The other 6 sites' \`build\` / \`check\` / \`test\` targets either inherited a partial config from \`nx.json\`'s \`targetDefaults\` or fell off the cache entirely — \`nx:run-commands\` needs \`outputs\` declared per project for the cache replay to restore dist artifacts.

## Changes per astro-* site
- **build**: declare \`outputs: ["{workspaceRoot}/dist/apps/astro-<name>"]\` and \`cache: true\`. Caches the static-build dist and replays it on the next run instead of re-running a 100–166 s \`astro build\`.
- **check**: add \`cache: true\`. Pure type check over source — re-runs with no input changes are free. Verified locally: `./kbve.sh -nx astro-discordsh:check` flips from "Successfully ran" to \`Nx read the output from the cache instead of running the command for 1 out of 1 tasks\` on the second invocation.
- **test** (\`astro-kbve\`, \`astro-memes\`): same, make \`cache: true\` explicit.

\`sync\` deliberately left uncached — it's cheap and mutates \`.astro/\` which we don't want to pin to a hash.

## Test plan
- [x] \`./kbve.sh -nx astro-discordsh:check\` × 2 → second run hits cache
- [ ] CI: first dev run after merge primes caches; subsequent dev runs without source changes should hit cache on \`build\` + \`check\` + \`test\`