### PR TITLE
feat(wallet): marketplace Phase 3 — public proxies for PostgREST

### DIFF
--- a/packages/data/sql/dbmate/init/01-auth-stub.sql
+++ b/packages/data/sql/dbmate/init/01-auth-stub.sql
@@ -16,13 +16,30 @@ CREATE TABLE IF NOT EXISTS auth.users (
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
--- Stub auth.uid() — returns NULL locally (proxy functions won't work,
--- but the migration DDL will succeed)
+-- Stub auth.uid() — reads request.jwt.claims (matches Supabase auth's
+-- behaviour closely enough for proxy-function tests that set the GUC
+-- via `SET LOCAL request.jwt.claims = '{"role":...,"sub":...}'`.
+-- Returns NULL when no claims are set (matches anon callers).
 CREATE OR REPLACE FUNCTION auth.uid()
 RETURNS UUID
 LANGUAGE sql
 STABLE
-AS $$ SELECT NULL::UUID; $$;
+SET search_path = ''
+AS $$
+    SELECT NULLIF(
+        COALESCE(
+            current_setting('request.jwt.claim.sub', true),
+            (NULLIF(current_setting('request.jwt.claims', true), '')::jsonb)->>'sub'
+        ),
+        ''
+    )::UUID;
+$$;
+
+-- Grant the auth helpers to the standard Supabase roles so SECURITY
+-- DEFINER functions owned by service_role (and called from
+-- authenticated/anon proxy paths) can resolve them.
+GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION auth.uid()  TO anon, authenticated, service_role;
 
 -- Stub auth.jwt() — returns empty JSON locally
 -- Used by vault functions and trigger bypass checks

--- a/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
@@ -7,18 +7,77 @@
 -- wallet.audit_log are append-only.
 
 -- SEED
+-- Ensure local auth stub is reachable by service_role + the auth.uid()
+-- function reads request.jwt.claims (matching Supabase prod). The
+-- production env already has these; this block is idempotent so it
+-- only patches the local dev container.
+GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION auth.uid() TO anon, authenticated, service_role;
+CREATE OR REPLACE FUNCTION auth.uid()
+RETURNS UUID
+LANGUAGE sql
+STABLE
+SET search_path = ''
+AS $$
+    SELECT NULLIF(
+        COALESCE(
+            current_setting('request.jwt.claim.sub', true),
+            (NULLIF(current_setting('request.jwt.claims', true), '')::jsonb)->>'sub'
+        ),
+        ''
+    )::UUID;
+$$;
+
 DROP TABLE IF EXISTS public.__market_proxies_fixture;
 CREATE TABLE public.__market_proxies_fixture (
     role    TEXT PRIMARY KEY,
     user_id UUID NOT NULL
 );
 INSERT INTO public.__market_proxies_fixture (role, user_id) VALUES
-    ('seller',  gen_random_uuid()),
-    ('bidder',  gen_random_uuid()),
-    ('outsider', gen_random_uuid());
+    ('seller',   gen_random_uuid()),
+    ('bidder',   gen_random_uuid()),
+    ('outsider', gen_random_uuid()),
+    -- 'orphan' has an auth.users row but no wallet.account (used for
+    -- the WLT01 missing-wallet test). We tear down the trigger-
+    -- provisioned account immediately below.
+    ('orphan',   gen_random_uuid());
 
 INSERT INTO auth.users (id)
 SELECT user_id FROM public.__market_proxies_fixture;
+
+-- Strip orphan's trigger-provisioned wallet rows so proxy calls raise WLT01.
+DO $$
+DECLARE
+    v_orphan_acc UUID;
+BEGIN
+    SELECT a.id INTO v_orphan_acc
+      FROM wallet.account a
+      JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'orphan';
+    IF v_orphan_acc IS NOT NULL THEN
+        DELETE FROM wallet.coupon WHERE account_id = v_orphan_acc;
+        DELETE FROM wallet.balance WHERE account_id = v_orphan_acc;
+        DELETE FROM wallet.account WHERE id = v_orphan_acc;
+    END IF;
+END;
+$$;
+
+-- Assert the auth.users trigger actually provisioned the other three
+-- fixture users' wallet accounts before we move on.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+          FROM public.__market_proxies_fixture f
+          LEFT JOIN wallet.account a
+            ON a.user_id = f.user_id AND a.kind = 'user'
+         WHERE f.role <> 'orphan'
+           AND a.id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'fail: fixture wallet accounts were not auto-provisioned';
+    END IF;
+END;
+$$;
 
 -- Fund the bidder + outsider so any debits succeed.
 DO $$
@@ -26,7 +85,10 @@ DECLARE
     v_account UUID;
     v_role    TEXT;
 BEGIN
-    FOR v_role IN SELECT role FROM public.__market_proxies_fixture WHERE role <> 'seller' LOOP
+    FOR v_role IN
+        SELECT role FROM public.__market_proxies_fixture
+         WHERE role IN ('bidder', 'outsider')
+    LOOP
         SELECT id INTO v_account
           FROM wallet.account a
           JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id
@@ -203,6 +265,10 @@ DECLARE
     v_seller_bal1  BIGINT;
     v_bidder_bal0  BIGINT;
     v_bidder_bal1  BIGINT;
+    v_buy_now_price BIGINT := 500;
+    v_expected_fee  BIGINT := v_buy_now_price / 100;  -- 1% rate
+    v_expected_net  BIGINT := v_buy_now_price - (v_buy_now_price / 100);
+    v_prior_bid     BIGINT := 200;
 BEGIN
     SELECT user_id INTO v_outsider_uid FROM public.__market_proxies_fixture WHERE role = 'outsider';
     SELECT user_id INTO v_seller_uid   FROM public.__market_proxies_fixture WHERE role = 'seller';
@@ -225,16 +291,40 @@ BEGIN
     );
     PERFORM public.proxy_market_buy_now(v_listing_id, gen_random_uuid());
 
-    -- seller receives buy_now - fee = 500 - 5 = 495
     SELECT khash INTO v_seller_bal1 FROM wallet.balance WHERE account_id = v_seller_acc;
-    IF v_seller_bal1 - v_seller_bal0 <> 495 THEN
-        RAISE EXCEPTION 'fail: seller net wrong after buy_now (% vs 495)', v_seller_bal1 - v_seller_bal0;
+    IF v_seller_bal1 - v_seller_bal0 <> v_expected_net THEN
+        RAISE EXCEPTION 'fail: seller net wrong after buy_now (% vs %)',
+            v_seller_bal1 - v_seller_bal0, v_expected_net;
     END IF;
 
-    -- prior bidder refunded their 200
     SELECT khash INTO v_bidder_bal1 FROM wallet.balance WHERE account_id = v_bidder_acc;
-    IF v_bidder_bal1 <> v_bidder_bal0 + 200 THEN
-        RAISE EXCEPTION 'fail: bidder not refunded (% vs %)', v_bidder_bal1, v_bidder_bal0 + 200;
+    IF v_bidder_bal1 <> v_bidder_bal0 + v_prior_bid THEN
+        RAISE EXCEPTION 'fail: bidder not refunded (% vs %)',
+            v_bidder_bal1, v_bidder_bal0 + v_prior_bid;
+    END IF;
+
+    -- Listing flips to sold with buyer + settled_at populated, live-bid
+    -- pointers cleared.
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.listing
+         WHERE id = v_listing_id
+           AND status = 'sold'
+           AND buyer_account = v_outsider_acc
+           AND settled_at IS NOT NULL
+           AND current_bid_id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'fail: listing not settled correctly after buy_now';
+    END IF;
+
+    -- Prior bid demoted to 'outbid' with refund_ledger_id set.
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.bid
+         WHERE listing_id = v_listing_id
+           AND bidder_account = v_bidder_acc
+           AND status = 'outbid'
+           AND refund_ledger_id IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'fail: prior bid not marked outbid with refund_ledger_id';
     END IF;
 END;
 $$;
@@ -249,10 +339,18 @@ DECLARE
     v_bidder_uid   UUID;
     v_outsider_uid UUID;
     v_listing_id   BIGINT;
+    v_bidder_acc   UUID;
+    v_bid_amount   BIGINT := 75;
+    v_bal0         BIGINT;
+    v_bal1         BIGINT;
 BEGIN
     SELECT user_id INTO v_seller_uid   FROM public.__market_proxies_fixture WHERE role = 'seller';
     SELECT user_id INTO v_bidder_uid   FROM public.__market_proxies_fixture WHERE role = 'bidder';
     SELECT user_id INTO v_outsider_uid FROM public.__market_proxies_fixture WHERE role = 'outsider';
+    SELECT id INTO v_bidder_acc
+      FROM wallet.account a
+      JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'bidder';
 
     PERFORM set_config(
         'request.jwt.claims',
@@ -275,7 +373,8 @@ BEGIN
         jsonb_build_object('role', 'authenticated', 'sub', v_bidder_uid::text)::text,
         true
     );
-    PERFORM public.proxy_market_place_bid(v_listing_id, 75, gen_random_uuid());
+    SELECT khash INTO v_bal0 FROM wallet.balance WHERE account_id = v_bidder_acc;
+    PERFORM public.proxy_market_place_bid(v_listing_id, v_bid_amount, gen_random_uuid());
 
     -- outsider cannot cancel.
     PERFORM set_config(
@@ -302,6 +401,289 @@ BEGIN
          WHERE id = v_listing_id AND status = 'cancelled'
     ) THEN
         RAISE EXCEPTION 'fail: listing not flipped to cancelled';
+    END IF;
+
+    -- Bidder balance restored.
+    SELECT khash INTO v_bal1 FROM wallet.balance WHERE account_id = v_bidder_acc;
+    IF v_bal1 <> v_bal0 THEN
+        RAISE EXCEPTION 'fail: bidder not refunded after cancel (% vs %)', v_bal1, v_bal0;
+    END IF;
+
+    -- Bid row marked 'refunded' with refund_ledger_id.
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.bid
+         WHERE listing_id = v_listing_id
+           AND bidder_account = v_bidder_acc
+           AND status = 'refunded'
+           AND refund_ledger_id IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'fail: cancelled bid not marked refunded with refund_ledger_id';
+    END IF;
+END;
+$$;
+COMMIT;
+
+-- 11. WLT01 missing-wallet path: orphan calls my_listings / my_bids /
+--     create_listing → all raise WLT01 (Rust client falls back to rw
+--     lazy-provision).
+BEGIN;
+DO $$
+DECLARE
+    v_orphan_uid UUID;
+BEGIN
+    SELECT user_id INTO v_orphan_uid FROM public.__market_proxies_fixture WHERE role = 'orphan';
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_orphan_uid::text)::text,
+        true
+    );
+
+    BEGIN
+        PERFORM * FROM public.proxy_market_my_listings_readonly();
+        RAISE EXCEPTION 'fail: orphan my_listings should have raised WLT01';
+    EXCEPTION WHEN sqlstate 'WLT01' THEN NULL;
+    END;
+
+    BEGIN
+        PERFORM * FROM public.proxy_market_my_bids_readonly();
+        RAISE EXCEPTION 'fail: orphan my_bids should have raised WLT01';
+    EXCEPTION WHEN sqlstate 'WLT01' THEN NULL;
+    END;
+
+    BEGIN
+        PERFORM public.proxy_market_create_listing(
+            jsonb_build_object('kind', 'mc_item', 'id', 'x', 'instance_id', 'orphan-' || v_orphan_uid::text),
+            100, NULL,
+            statement_timestamp() + interval '2 hours',
+            gen_random_uuid()
+        );
+        RAISE EXCEPTION 'fail: orphan create_listing should have raised WLT01';
+    EXCEPTION WHEN sqlstate 'WLT01' THEN NULL;
+    END;
+END;
+$$;
+COMMIT;
+
+-- 12. Cursor pair validation: mismatched cursor args raise 22023.
+BEGIN;
+DO $$
+BEGIN
+    BEGIN
+        PERFORM * FROM public.proxy_market_list_active_readonly(50, statement_timestamp(), NULL);
+        RAISE EXCEPTION 'fail: list_active half-cursor should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+    BEGIN
+        PERFORM * FROM public.proxy_market_list_active_readonly(50, NULL, 1::BIGINT);
+        RAISE EXCEPTION 'fail: list_active half-cursor (id only) should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+END;
+$$;
+COMMIT;
+
+-- 13. Limit clamping: huge limit clamps to 100; null / 0 / -1 land on
+--     valid defaults.
+BEGIN;
+DO $$
+DECLARE
+    v_count INT;
+BEGIN
+    SELECT count(*) INTO v_count FROM public.proxy_market_list_active_readonly(100000);
+    IF v_count > 100 THEN
+        RAISE EXCEPTION 'fail: list_active returned % rows, expected <= 100', v_count;
+    END IF;
+    -- Just exercise the boundary; returning >=0 with no error proves clamp.
+    PERFORM * FROM public.proxy_market_list_active_readonly(NULL);
+    PERFORM * FROM public.proxy_market_list_active_readonly(0);
+    PERFORM * FROM public.proxy_market_list_active_readonly(-1);
+END;
+$$;
+COMMIT;
+
+-- 14. Grants posture (drift catch): anon has EXECUTE on the public
+--     browse pair but NOT on personal or write proxies.
+DO $$
+BEGIN
+    IF NOT has_function_privilege(
+        'anon',
+        'public.proxy_market_list_active_readonly(integer,timestamp with time zone,bigint)',
+        'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION 'fail: anon missing EXECUTE on list_active_readonly';
+    END IF;
+    IF NOT has_function_privilege(
+        'anon',
+        'public.proxy_market_listing_detail_readonly(bigint)',
+        'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION 'fail: anon missing EXECUTE on listing_detail_readonly';
+    END IF;
+    IF has_function_privilege(
+        'anon',
+        'public.proxy_market_my_listings_readonly(integer,timestamp with time zone,bigint)',
+        'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION 'fail: anon should NOT have EXECUTE on my_listings_readonly';
+    END IF;
+    IF has_function_privilege(
+        'anon',
+        'public.proxy_market_create_listing(jsonb,bigint,bigint,timestamp with time zone,uuid)',
+        'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION 'fail: anon should NOT have EXECUTE on create_listing';
+    END IF;
+END;
+$$;
+
+-- 15. Seller cannot bid on or buy_now their own listing (P1005).
+BEGIN;
+DO $$
+DECLARE
+    v_seller_uid UUID;
+    v_listing_id BIGINT;
+BEGIN
+    SELECT user_id INTO v_seller_uid FROM public.__market_proxies_fixture WHERE role = 'seller';
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_seller_uid::text)::text,
+        true
+    );
+
+    v_listing_id := public.proxy_market_create_listing(
+        jsonb_build_object(
+            'kind', 'mc_item', 'id', 'self-bid-test',
+            'instance_id', 'proxies-test-self-' || v_seller_uid::text
+        ),
+        300, 50,
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+
+    BEGIN
+        PERFORM public.proxy_market_place_bid(v_listing_id, 100, gen_random_uuid());
+        RAISE EXCEPTION 'fail: seller self-bid should have raised P1005';
+    EXCEPTION WHEN sqlstate 'P1005' THEN NULL;
+    END;
+
+    BEGIN
+        PERFORM public.proxy_market_buy_now(v_listing_id, gen_random_uuid());
+        RAISE EXCEPTION 'fail: seller self-buy should have raised P1005';
+    EXCEPTION WHEN sqlstate 'P1005' THEN NULL;
+    END;
+END;
+$$;
+COMMIT;
+
+-- 16. Idempotency replay: same key returns the same row id.
+BEGIN;
+DO $$
+DECLARE
+    v_seller_uid UUID;
+    v_bidder_uid UUID;
+    v_outsider_uid UUID;
+    v_listing_id BIGINT;
+    v_create_key UUID := gen_random_uuid();
+    v_bid_key    UUID := gen_random_uuid();
+    v_buynow_key UUID := gen_random_uuid();
+    v_id1 BIGINT;
+    v_id2 BIGINT;
+    v_target_listing BIGINT;
+    v_target_listing_2 BIGINT;
+BEGIN
+    SELECT user_id INTO v_seller_uid   FROM public.__market_proxies_fixture WHERE role = 'seller';
+    SELECT user_id INTO v_bidder_uid   FROM public.__market_proxies_fixture WHERE role = 'bidder';
+    SELECT user_id INTO v_outsider_uid FROM public.__market_proxies_fixture WHERE role = 'outsider';
+
+    -- create_listing replay
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_seller_uid::text)::text,
+        true
+    );
+    v_id1 := public.proxy_market_create_listing(
+        jsonb_build_object('kind', 'mc_item', 'id', 'replay',
+            'instance_id', 'proxies-test-replay-' || v_seller_uid::text),
+        500, 100,
+        statement_timestamp() + interval '2 hours',
+        v_create_key
+    );
+    v_id2 := public.proxy_market_create_listing(
+        jsonb_build_object('kind', 'mc_item', 'id', 'replay-different',
+            'instance_id', 'proxies-test-replay-x-' || v_seller_uid::text),
+        999, 999,
+        statement_timestamp() + interval '5 hours',
+        v_create_key
+    );
+    IF v_id1 IS DISTINCT FROM v_id2 THEN
+        RAISE EXCEPTION 'fail: create_listing idempotency replay returned different ids (%, %)', v_id1, v_id2;
+    END IF;
+
+    -- place_bid replay (same listing, same key → same bid id)
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_bidder_uid::text)::text,
+        true
+    );
+    v_id1 := public.proxy_market_place_bid(v_id1, 120, v_bid_key);
+    v_id2 := public.proxy_market_place_bid(v_id1::BIGINT, 120, v_bid_key);
+    -- v_id1 was overwritten; assert by re-running
+    IF v_id1 IS DISTINCT FROM v_id2 THEN
+        RAISE EXCEPTION 'fail: place_bid idempotency replay returned different ids';
+    END IF;
+
+    -- buy_now replay on a SECOND fresh listing
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_seller_uid::text)::text,
+        true
+    );
+    v_target_listing := public.proxy_market_create_listing(
+        jsonb_build_object('kind', 'mc_item', 'id', 'buynow-replay',
+            'instance_id', 'proxies-test-buynow-replay-' || v_seller_uid::text),
+        400, NULL,
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_outsider_uid::text)::text,
+        true
+    );
+    v_id1 := public.proxy_market_buy_now(v_target_listing, v_buynow_key);
+    v_id2 := public.proxy_market_buy_now(v_target_listing, v_buynow_key);
+    IF v_id1 IS DISTINCT FROM v_id2 THEN
+        RAISE EXCEPTION 'fail: buy_now idempotency replay returned different bid ids';
+    END IF;
+END;
+$$;
+COMMIT;
+
+-- 17. Pagination actually moves forward: page-2 cursor excludes page-1.
+BEGIN;
+RESET request.jwt.claims;
+DO $$
+DECLARE
+    v_p1_last_id    BIGINT;
+    v_p1_last_at    TIMESTAMPTZ;
+    v_page2_overlap INT;
+BEGIN
+    SELECT listing_id, created_at INTO v_p1_last_id, v_p1_last_at
+      FROM public.proxy_market_list_active_readonly(2)
+     ORDER BY created_at ASC, listing_id ASC
+     LIMIT 1;
+
+    IF v_p1_last_id IS NULL THEN
+        -- Not enough listings to paginate; skip.
+        RETURN;
+    END IF;
+
+    SELECT COUNT(*) INTO v_page2_overlap
+      FROM public.proxy_market_list_active_readonly(2, v_p1_last_at, v_p1_last_id) p2
+      JOIN public.proxy_market_list_active_readonly(2) p1
+        ON p1.listing_id = p2.listing_id;
+    IF v_page2_overlap > 0 THEN
+        RAISE EXCEPTION 'fail: page-2 cursor returned % rows that overlap page-1', v_page2_overlap;
     END IF;
 END;
 $$;

--- a/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
@@ -464,18 +464,60 @@ END;
 $$;
 COMMIT;
 
--- 12. Cursor pair validation: mismatched cursor args raise 22023.
+-- 12. Cursor pair validation: mismatched cursor args raise 22023 for
+--     all three paged read proxies.
 BEGIN;
 DO $$
+DECLARE
+    v_seller_uid UUID;
+    v_bidder_uid UUID;
 BEGIN
+    SELECT user_id INTO v_seller_uid FROM public.__market_proxies_fixture WHERE role = 'seller';
+    SELECT user_id INTO v_bidder_uid FROM public.__market_proxies_fixture WHERE role = 'bidder';
+
+    -- list_active_readonly (anon)
     BEGIN
         PERFORM * FROM public.proxy_market_list_active_readonly(50, statement_timestamp(), NULL);
-        RAISE EXCEPTION 'fail: list_active half-cursor should have raised';
+        RAISE EXCEPTION 'fail: list_active half-cursor (no id) should have raised';
     EXCEPTION WHEN sqlstate '22023' THEN NULL;
     END;
     BEGIN
         PERFORM * FROM public.proxy_market_list_active_readonly(50, NULL, 1::BIGINT);
         RAISE EXCEPTION 'fail: list_active half-cursor (id only) should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+
+    -- my_listings_readonly (authenticated as seller)
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_seller_uid::text)::text,
+        true
+    );
+    BEGIN
+        PERFORM * FROM public.proxy_market_my_listings_readonly(50, statement_timestamp(), NULL);
+        RAISE EXCEPTION 'fail: my_listings half-cursor (no id) should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+    BEGIN
+        PERFORM * FROM public.proxy_market_my_listings_readonly(50, NULL, 1::BIGINT);
+        RAISE EXCEPTION 'fail: my_listings half-cursor (id only) should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+
+    -- my_bids_readonly (authenticated as bidder)
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_bidder_uid::text)::text,
+        true
+    );
+    BEGIN
+        PERFORM * FROM public.proxy_market_my_bids_readonly(50, statement_timestamp(), NULL);
+        RAISE EXCEPTION 'fail: my_bids half-cursor (no id) should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+    BEGIN
+        PERFORM * FROM public.proxy_market_my_bids_readonly(50, NULL, 1::BIGINT);
+        RAISE EXCEPTION 'fail: my_bids half-cursor (id only) should have raised';
     EXCEPTION WHEN sqlstate '22023' THEN NULL;
     END;
 END;
@@ -501,38 +543,49 @@ END;
 $$;
 COMMIT;
 
--- 14. Grants posture (drift catch): anon has EXECUTE on the public
---     browse pair but NOT on personal or write proxies.
+-- 14. Grants posture (drift catch). Locks down the full anon vs
+--     authenticated boundary across all 8 public proxies.
 DO $$
-BEGIN
-    IF NOT has_function_privilege(
-        'anon',
+DECLARE
+    v_anon_must_execute TEXT[] := ARRAY[
         'public.proxy_market_list_active_readonly(integer,timestamp with time zone,bigint)',
-        'EXECUTE'
-    ) THEN
-        RAISE EXCEPTION 'fail: anon missing EXECUTE on list_active_readonly';
-    END IF;
-    IF NOT has_function_privilege(
-        'anon',
-        'public.proxy_market_listing_detail_readonly(bigint)',
-        'EXECUTE'
-    ) THEN
-        RAISE EXCEPTION 'fail: anon missing EXECUTE on listing_detail_readonly';
-    END IF;
-    IF has_function_privilege(
-        'anon',
+        'public.proxy_market_listing_detail_readonly(bigint)'
+    ];
+    v_anon_must_NOT_execute TEXT[] := ARRAY[
         'public.proxy_market_my_listings_readonly(integer,timestamp with time zone,bigint)',
-        'EXECUTE'
-    ) THEN
-        RAISE EXCEPTION 'fail: anon should NOT have EXECUTE on my_listings_readonly';
-    END IF;
-    IF has_function_privilege(
-        'anon',
+        'public.proxy_market_my_bids_readonly(integer,timestamp with time zone,bigint)',
         'public.proxy_market_create_listing(jsonb,bigint,bigint,timestamp with time zone,uuid)',
-        'EXECUTE'
-    ) THEN
-        RAISE EXCEPTION 'fail: anon should NOT have EXECUTE on create_listing';
-    END IF;
+        'public.proxy_market_place_bid(bigint,bigint,uuid)',
+        'public.proxy_market_buy_now(bigint,uuid)',
+        'public.proxy_market_cancel_listing(bigint,text)'
+    ];
+    v_auth_must_execute TEXT[] := ARRAY[
+        'public.proxy_market_list_active_readonly(integer,timestamp with time zone,bigint)',
+        'public.proxy_market_listing_detail_readonly(bigint)',
+        'public.proxy_market_my_listings_readonly(integer,timestamp with time zone,bigint)',
+        'public.proxy_market_my_bids_readonly(integer,timestamp with time zone,bigint)',
+        'public.proxy_market_create_listing(jsonb,bigint,bigint,timestamp with time zone,uuid)',
+        'public.proxy_market_place_bid(bigint,bigint,uuid)',
+        'public.proxy_market_buy_now(bigint,uuid)',
+        'public.proxy_market_cancel_listing(bigint,text)'
+    ];
+    v_fn TEXT;
+BEGIN
+    FOREACH v_fn IN ARRAY v_anon_must_execute LOOP
+        IF NOT has_function_privilege('anon', v_fn, 'EXECUTE') THEN
+            RAISE EXCEPTION 'fail: anon missing EXECUTE on %', v_fn;
+        END IF;
+    END LOOP;
+    FOREACH v_fn IN ARRAY v_anon_must_NOT_execute LOOP
+        IF has_function_privilege('anon', v_fn, 'EXECUTE') THEN
+            RAISE EXCEPTION 'fail: anon should NOT have EXECUTE on %', v_fn;
+        END IF;
+    END LOOP;
+    FOREACH v_fn IN ARRAY v_auth_must_execute LOOP
+        IF NOT has_function_privilege('authenticated', v_fn, 'EXECUTE') THEN
+            RAISE EXCEPTION 'fail: authenticated missing EXECUTE on %', v_fn;
+        END IF;
+    END LOOP;
 END;
 $$;
 
@@ -901,14 +954,11 @@ BEGIN
         IF EXISTS (
             SELECT 1 FROM jsonb_array_elements(v_bid_json) elem
              WHERE elem ? 'bidder_account'
+                OR elem ? 'settled_at'
+                OR elem ? 'escrow_ledger_id'
+                OR elem ? 'refund_ledger_id'
         ) THEN
-            RAISE EXCEPTION 'fail: public bids array leaks bidder_account';
-        END IF;
-        IF EXISTS (
-            SELECT 1 FROM jsonb_array_elements(v_bid_json) elem
-             WHERE elem ? 'settled_at'
-        ) THEN
-            RAISE EXCEPTION 'fail: public bids array leaks settled_at';
+            RAISE EXCEPTION 'fail: public bids array leaks a redacted field';
         END IF;
     END IF;
 END;

--- a/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
@@ -689,6 +689,158 @@ END;
 $$;
 COMMIT;
 
+-- 18. Proxy-level write validation rejects invalid inputs cleanly
+--     (before the service layer sees them).
+BEGIN;
+DO $$
+DECLARE
+    v_seller_uid UUID;
+BEGIN
+    SELECT user_id INTO v_seller_uid FROM public.__market_proxies_fixture WHERE role = 'seller';
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_seller_uid::text)::text,
+        true
+    );
+
+    -- create_listing: null item_ref
+    BEGIN
+        PERFORM public.proxy_market_create_listing(
+            NULL, 100, NULL,
+            statement_timestamp() + interval '2 hours',
+            gen_random_uuid()
+        );
+        RAISE EXCEPTION 'fail: null item_ref should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+
+    -- create_listing: empty pricing
+    BEGIN
+        PERFORM public.proxy_market_create_listing(
+            jsonb_build_object('kind','mc_item','id','x','instance_id','val-' || v_seller_uid::text),
+            NULL, NULL,
+            statement_timestamp() + interval '2 hours',
+            gen_random_uuid()
+        );
+        RAISE EXCEPTION 'fail: missing price should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+
+    -- create_listing: negative buy_now_price
+    BEGIN
+        PERFORM public.proxy_market_create_listing(
+            jsonb_build_object('kind','mc_item','id','x','instance_id','val2-' || v_seller_uid::text),
+            -1, NULL,
+            statement_timestamp() + interval '2 hours',
+            gen_random_uuid()
+        );
+        RAISE EXCEPTION 'fail: negative buy_now_price should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+
+    -- create_listing: past expires_at
+    BEGIN
+        PERFORM public.proxy_market_create_listing(
+            jsonb_build_object('kind','mc_item','id','x','instance_id','val3-' || v_seller_uid::text),
+            100, NULL,
+            statement_timestamp() - interval '1 hour',
+            gen_random_uuid()
+        );
+        RAISE EXCEPTION 'fail: past expires_at should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+
+    -- create_listing: null idempotency_key
+    BEGIN
+        PERFORM public.proxy_market_create_listing(
+            jsonb_build_object('kind','mc_item','id','x','instance_id','val4-' || v_seller_uid::text),
+            100, NULL,
+            statement_timestamp() + interval '2 hours',
+            NULL
+        );
+        RAISE EXCEPTION 'fail: null idempotency_key should have raised';
+    EXCEPTION WHEN sqlstate '22004' THEN NULL;
+    END;
+
+    -- place_bid: amount <= 0
+    BEGIN
+        PERFORM public.proxy_market_place_bid(1::BIGINT, 0::BIGINT, gen_random_uuid());
+        RAISE EXCEPTION 'fail: amount=0 should have raised';
+    EXCEPTION WHEN sqlstate '22023' THEN NULL;
+    END;
+
+    -- buy_now: null listing_id
+    BEGIN
+        PERFORM public.proxy_market_buy_now(NULL, gen_random_uuid());
+        RAISE EXCEPTION 'fail: null listing_id should have raised';
+    EXCEPTION WHEN sqlstate '22004' THEN NULL;
+    END;
+
+    -- cancel_listing: null listing_id
+    BEGIN
+        PERFORM public.proxy_market_cancel_listing(NULL, 'oops');
+        RAISE EXCEPTION 'fail: null listing_id should have raised';
+    EXCEPTION WHEN sqlstate '22004' THEN NULL;
+    END;
+
+    -- cancel_listing: reason > 500 chars
+    BEGIN
+        PERFORM public.proxy_market_cancel_listing(1::BIGINT, repeat('x', 501));
+        RAISE EXCEPTION 'fail: overlong reason should have raised';
+    EXCEPTION WHEN sqlstate '22001' THEN NULL;
+    END;
+END;
+$$;
+COMMIT;
+
+-- 19. Expired-but-not-yet-swept active listings are hidden from public
+--     browse. Backdate created_at + expires_at so the duration CHECK
+--     still passes while the deadline is already in the past.
+BEGIN;
+DO $$
+DECLARE
+    v_seller_acc UUID;
+    v_listing_id BIGINT;
+    v_origin     TIMESTAMPTZ := statement_timestamp() - interval '3 hours';
+    v_past       TIMESTAMPTZ := statement_timestamp() - interval '1 minute';
+BEGIN
+    SELECT id INTO v_seller_acc
+      FROM wallet.account a
+      JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'seller';
+
+    INSERT INTO wallet.listing (
+        seller_account, item_ref, currency, buy_now_price,
+        created_at, expires_at, idempotency_key
+    ) VALUES (
+        v_seller_acc,
+        jsonb_build_object(
+            'kind','mc_item','id','expired',
+            'instance_id','proxies-test-expired-' || v_seller_acc::text
+        ),
+        'khash'::wallet.currency_kind, 100,
+        v_origin, v_past, gen_random_uuid()
+    ) RETURNING id INTO v_listing_id;
+
+    -- Direct row check confirms it landed as 'active'.
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.listing
+         WHERE id = v_listing_id AND status = 'active'
+    ) THEN
+        RAISE EXCEPTION 'fail: backdated listing did not land active';
+    END IF;
+
+    -- Browse proxy must hide it because expires_at <= now().
+    IF EXISTS (
+        SELECT 1 FROM public.proxy_market_list_active_readonly(100)
+         WHERE listing_id = v_listing_id
+    ) THEN
+        RAISE EXCEPTION 'fail: expired-but-active listing leaked into public browse';
+    END IF;
+END;
+$$;
+COMMIT;
+
 -- ASSERT_AFTER_DOWN
 
 DO $$

--- a/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
@@ -1,0 +1,321 @@
+-- Companion test fixtures for 20260516015242_wallet_marketplace_proxies.
+-- Run via: ./test-migration.sh 20260516015242_wallet_marketplace_proxies
+--
+-- Exercises the auth-mediated public.proxy_market_* surface using
+-- SET LOCAL request.jwt.claims to impersonate authenticated callers.
+-- Fresh UUIDs per run via the fixture table since wallet.ledger and
+-- wallet.audit_log are append-only.
+
+-- SEED
+DROP TABLE IF EXISTS public.__market_proxies_fixture;
+CREATE TABLE public.__market_proxies_fixture (
+    role    TEXT PRIMARY KEY,
+    user_id UUID NOT NULL
+);
+INSERT INTO public.__market_proxies_fixture (role, user_id) VALUES
+    ('seller',  gen_random_uuid()),
+    ('bidder',  gen_random_uuid()),
+    ('outsider', gen_random_uuid());
+
+INSERT INTO auth.users (id)
+SELECT user_id FROM public.__market_proxies_fixture;
+
+-- Fund the bidder + outsider so any debits succeed.
+DO $$
+DECLARE
+    v_account UUID;
+    v_role    TEXT;
+BEGIN
+    FOR v_role IN SELECT role FROM public.__market_proxies_fixture WHERE role <> 'seller' LOOP
+        SELECT id INTO v_account
+          FROM wallet.account a
+          JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id
+         WHERE f.role = v_role;
+        PERFORM wallet.service_credit(
+            v_account,
+            'khash'::wallet.currency_kind,
+            5000,
+            'reward'::wallet.source_kind,
+            'proxies-test funding',
+            NULL, NULL,
+            gen_random_uuid()
+        );
+    END LOOP;
+END;
+$$;
+
+-- ASSERT_AFTER_UP
+
+-- 1. Anon-callable: list_active_readonly works without claims.
+BEGIN;
+RESET request.jwt.claims;
+DO $$
+BEGIN
+    PERFORM * FROM public.proxy_market_list_active_readonly();
+END;
+$$;
+COMMIT;
+
+-- 2. listing_detail_readonly raises P1001 on missing listing.
+BEGIN;
+RESET request.jwt.claims;
+DO $$
+BEGIN
+    BEGIN
+        PERFORM * FROM public.proxy_market_listing_detail_readonly(999999999::BIGINT);
+        RAISE EXCEPTION 'fail: missing listing should have raised P1001';
+    EXCEPTION WHEN sqlstate 'P1001' THEN NULL;
+    END;
+END;
+$$;
+COMMIT;
+
+-- 3. my_listings_readonly raises 28000 for anon.
+BEGIN;
+RESET request.jwt.claims;
+DO $$
+BEGIN
+    BEGIN
+        PERFORM * FROM public.proxy_market_my_listings_readonly();
+        RAISE EXCEPTION 'fail: anon my_listings should have raised 28000';
+    EXCEPTION WHEN sqlstate '28000' THEN NULL;
+    END;
+END;
+$$;
+COMMIT;
+
+-- 4. create_listing via authenticated seller proxies through to service.
+BEGIN;
+DO $$
+DECLARE
+    v_seller_uid UUID;
+    v_listing_id BIGINT;
+BEGIN
+    SELECT user_id INTO v_seller_uid
+      FROM public.__market_proxies_fixture WHERE role = 'seller';
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_seller_uid::text)::text,
+        true
+    );
+
+    v_listing_id := public.proxy_market_create_listing(
+        jsonb_build_object(
+            'kind', 'mc_item',
+            'id', 'diamond_axe',
+            'instance_id', 'proxies-test-create-' || v_seller_uid::text
+        ),
+        500,
+        100,
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+    IF v_listing_id IS NULL THEN
+        RAISE EXCEPTION 'fail: proxy_market_create_listing returned NULL';
+    END IF;
+
+    -- 5. seller appears in my_listings_readonly.
+    IF NOT EXISTS (
+        SELECT 1 FROM public.proxy_market_my_listings_readonly()
+         WHERE listing_id = v_listing_id
+    ) THEN
+        RAISE EXCEPTION 'fail: created listing not visible in my_listings';
+    END IF;
+END;
+$$;
+COMMIT;
+
+-- 6. place_bid as bidder JWT, balance + listing pointers update.
+BEGIN;
+DO $$
+DECLARE
+    v_seller_uid UUID;
+    v_bidder_uid UUID;
+    v_bidder_acc UUID;
+    v_listing_id BIGINT;
+    v_bid_id     BIGINT;
+    v_bal0       BIGINT;
+    v_bal1       BIGINT;
+BEGIN
+    SELECT user_id INTO v_seller_uid FROM public.__market_proxies_fixture WHERE role = 'seller';
+    SELECT user_id INTO v_bidder_uid FROM public.__market_proxies_fixture WHERE role = 'bidder';
+    SELECT id INTO v_bidder_acc
+      FROM wallet.account a
+      JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'bidder';
+
+    SELECT id INTO v_listing_id
+      FROM wallet.listing
+     WHERE seller_account = (
+         SELECT id FROM wallet.account a
+           JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id
+          WHERE f.role = 'seller'
+     )
+       AND item_ref->>'instance_id' = 'proxies-test-create-' || v_seller_uid::text;
+
+    SELECT khash INTO v_bal0 FROM wallet.balance WHERE account_id = v_bidder_acc;
+
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_bidder_uid::text)::text,
+        true
+    );
+    v_bid_id := public.proxy_market_place_bid(v_listing_id, 200, gen_random_uuid());
+
+    SELECT khash INTO v_bal1 FROM wallet.balance WHERE account_id = v_bidder_acc;
+    IF v_bal1 <> v_bal0 - 200 THEN
+        RAISE EXCEPTION 'fail: bidder balance wrong after place_bid (% vs %)', v_bal1, v_bal0 - 200;
+    END IF;
+
+    -- 7. bidder appears in my_bids_readonly.
+    IF NOT EXISTS (
+        SELECT 1 FROM public.proxy_market_my_bids_readonly()
+         WHERE bid_id = v_bid_id
+    ) THEN
+        RAISE EXCEPTION 'fail: placed bid not visible in my_bids';
+    END IF;
+
+    -- 8. listing_detail_readonly carries the bid in the bids array.
+    IF NOT EXISTS (
+        SELECT 1
+          FROM jsonb_array_elements(
+              (SELECT bids FROM public.proxy_market_listing_detail_readonly(v_listing_id))
+          ) elem
+         WHERE (elem->>'bid_id')::BIGINT = v_bid_id
+    ) THEN
+        RAISE EXCEPTION 'fail: bid not in listing_detail bids array';
+    END IF;
+END;
+$$;
+COMMIT;
+
+-- 9. buy_now via outsider JWT settles + bidder is refunded.
+BEGIN;
+DO $$
+DECLARE
+    v_outsider_uid UUID;
+    v_outsider_acc UUID;
+    v_bidder_acc   UUID;
+    v_seller_uid   UUID;
+    v_seller_acc   UUID;
+    v_listing_id   BIGINT;
+    v_seller_bal0  BIGINT;
+    v_seller_bal1  BIGINT;
+    v_bidder_bal0  BIGINT;
+    v_bidder_bal1  BIGINT;
+BEGIN
+    SELECT user_id INTO v_outsider_uid FROM public.__market_proxies_fixture WHERE role = 'outsider';
+    SELECT user_id INTO v_seller_uid   FROM public.__market_proxies_fixture WHERE role = 'seller';
+    SELECT id INTO v_outsider_acc FROM wallet.account a JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id WHERE f.role = 'outsider';
+    SELECT id INTO v_bidder_acc   FROM wallet.account a JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id WHERE f.role = 'bidder';
+    SELECT id INTO v_seller_acc   FROM wallet.account a JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id WHERE f.role = 'seller';
+
+    SELECT id INTO v_listing_id
+      FROM wallet.listing
+     WHERE seller_account = v_seller_acc
+       AND item_ref->>'instance_id' = 'proxies-test-create-' || v_seller_uid::text;
+
+    SELECT khash INTO v_seller_bal0 FROM wallet.balance WHERE account_id = v_seller_acc;
+    SELECT khash INTO v_bidder_bal0 FROM wallet.balance WHERE account_id = v_bidder_acc;
+
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_outsider_uid::text)::text,
+        true
+    );
+    PERFORM public.proxy_market_buy_now(v_listing_id, gen_random_uuid());
+
+    -- seller receives buy_now - fee = 500 - 5 = 495
+    SELECT khash INTO v_seller_bal1 FROM wallet.balance WHERE account_id = v_seller_acc;
+    IF v_seller_bal1 - v_seller_bal0 <> 495 THEN
+        RAISE EXCEPTION 'fail: seller net wrong after buy_now (% vs 495)', v_seller_bal1 - v_seller_bal0;
+    END IF;
+
+    -- prior bidder refunded their 200
+    SELECT khash INTO v_bidder_bal1 FROM wallet.balance WHERE account_id = v_bidder_acc;
+    IF v_bidder_bal1 <> v_bidder_bal0 + 200 THEN
+        RAISE EXCEPTION 'fail: bidder not refunded (% vs %)', v_bidder_bal1, v_bidder_bal0 + 200;
+    END IF;
+END;
+$$;
+COMMIT;
+
+-- 10. cancel_listing on a new auction-only listing refunds the active bidder
+--     and rejects non-seller cancel.
+BEGIN;
+DO $$
+DECLARE
+    v_seller_uid   UUID;
+    v_bidder_uid   UUID;
+    v_outsider_uid UUID;
+    v_listing_id   BIGINT;
+BEGIN
+    SELECT user_id INTO v_seller_uid   FROM public.__market_proxies_fixture WHERE role = 'seller';
+    SELECT user_id INTO v_bidder_uid   FROM public.__market_proxies_fixture WHERE role = 'bidder';
+    SELECT user_id INTO v_outsider_uid FROM public.__market_proxies_fixture WHERE role = 'outsider';
+
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_seller_uid::text)::text,
+        true
+    );
+    v_listing_id := public.proxy_market_create_listing(
+        jsonb_build_object(
+            'kind', 'mc_item',
+            'id', 'shovel',
+            'instance_id', 'proxies-test-cancel-' || v_seller_uid::text
+        ),
+        NULL, 50,
+        statement_timestamp() + interval '2 hours',
+        gen_random_uuid()
+    );
+
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_bidder_uid::text)::text,
+        true
+    );
+    PERFORM public.proxy_market_place_bid(v_listing_id, 75, gen_random_uuid());
+
+    -- outsider cannot cancel.
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_outsider_uid::text)::text,
+        true
+    );
+    BEGIN
+        PERFORM public.proxy_market_cancel_listing(v_listing_id, 'malicious');
+        RAISE EXCEPTION 'fail: non-seller cancel should have raised';
+    EXCEPTION WHEN insufficient_privilege THEN NULL;
+    END;
+
+    -- seller cancels.
+    PERFORM set_config(
+        'request.jwt.claims',
+        jsonb_build_object('role', 'authenticated', 'sub', v_seller_uid::text)::text,
+        true
+    );
+    PERFORM public.proxy_market_cancel_listing(v_listing_id, 'changed mind');
+
+    IF NOT EXISTS (
+        SELECT 1 FROM wallet.listing
+         WHERE id = v_listing_id AND status = 'cancelled'
+    ) THEN
+        RAISE EXCEPTION 'fail: listing not flipped to cancelled';
+    END IF;
+END;
+$$;
+COMMIT;
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public' AND p.proname LIKE 'proxy_market_%'
+    ) THEN
+        RAISE EXCEPTION 'fail: proxy_market_* still present after rollback';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
@@ -916,7 +916,9 @@ $$;
 COMMIT;
 
 -- 21. private.proxy_market_caller_account is not reachable through
---     PostgREST: anon + authenticated have no USAGE on schema private.
+--     PostgREST: anon + authenticated have no USAGE on schema private,
+--     and the helper itself rejects EXECUTE from both roles even if
+--     the schema USAGE were ever granted accidentally.
 DO $$
 BEGIN
     IF has_schema_privilege('anon', 'private', 'USAGE') THEN
@@ -927,6 +929,27 @@ BEGIN
     END IF;
     IF NOT has_schema_privilege('service_role', 'private', 'USAGE') THEN
         RAISE EXCEPTION 'fail: service_role missing USAGE on schema private';
+    END IF;
+    IF has_function_privilege(
+        'anon',
+        'private.proxy_market_caller_account()',
+        'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION 'fail: anon has EXECUTE on private.proxy_market_caller_account';
+    END IF;
+    IF has_function_privilege(
+        'authenticated',
+        'private.proxy_market_caller_account()',
+        'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION 'fail: authenticated has EXECUTE on private.proxy_market_caller_account';
+    END IF;
+    IF NOT has_function_privilege(
+        'service_role',
+        'private.proxy_market_caller_account()',
+        'EXECUTE'
+    ) THEN
+        RAISE EXCEPTION 'fail: service_role missing EXECUTE on private.proxy_market_caller_account';
     END IF;
 END;
 $$;

--- a/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516015242_wallet_marketplace_proxies.test.sql
@@ -619,17 +619,19 @@ BEGIN
         RAISE EXCEPTION 'fail: create_listing idempotency replay returned different ids (%, %)', v_id1, v_id2;
     END IF;
 
-    -- place_bid replay (same listing, same key → same bid id)
+    -- place_bid replay (same listing, same key → same bid id).
+    -- Capture the listing id separately so the second call still uses
+    -- the listing, not the just-returned bid_id.
+    v_target_listing_2 := v_id1;
     PERFORM set_config(
         'request.jwt.claims',
         jsonb_build_object('role', 'authenticated', 'sub', v_bidder_uid::text)::text,
         true
     );
-    v_id1 := public.proxy_market_place_bid(v_id1, 120, v_bid_key);
-    v_id2 := public.proxy_market_place_bid(v_id1::BIGINT, 120, v_bid_key);
-    -- v_id1 was overwritten; assert by re-running
+    v_id1 := public.proxy_market_place_bid(v_target_listing_2, 120, v_bid_key);
+    v_id2 := public.proxy_market_place_bid(v_target_listing_2, 120, v_bid_key);
     IF v_id1 IS DISTINCT FROM v_id2 THEN
-        RAISE EXCEPTION 'fail: place_bid idempotency replay returned different ids';
+        RAISE EXCEPTION 'fail: place_bid idempotency replay returned different ids (%, %)', v_id1, v_id2;
     END IF;
 
     -- buy_now replay on a SECOND fresh listing
@@ -841,13 +843,101 @@ END;
 $$;
 COMMIT;
 
+-- 20. Anon-callable proxies do not leak wallet account UUIDs we
+--     intentionally redacted. Public bid history must also not carry
+--     bidder_account or settled_at.
+BEGIN;
+RESET request.jwt.claims;
+DO $$
+DECLARE
+    v_seller_acc UUID;
+    v_listing_id BIGINT;
+    v_detail_cols TEXT[];
+    v_bid_json    JSONB;
+BEGIN
+    SELECT id INTO v_seller_acc
+      FROM wallet.account a
+      JOIN public.__market_proxies_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'seller';
+
+    -- Pick an active listing the seller owns (any one will do).
+    SELECT id INTO v_listing_id
+      FROM wallet.listing
+     WHERE seller_account = v_seller_acc AND status = 'active'
+     ORDER BY id DESC LIMIT 1;
+    IF v_listing_id IS NULL THEN RETURN; END IF;
+
+    -- Browse return columns: current_bid_account must not be present.
+    SELECT array_agg(p.parameter_name::text) INTO v_detail_cols
+      FROM information_schema.routines r
+      JOIN information_schema.parameters p
+        ON r.specific_name = p.specific_name
+     WHERE r.routine_schema = 'public'
+       AND r.routine_name = 'proxy_market_list_active_readonly'
+       AND p.parameter_mode = 'OUT';
+    IF 'current_bid_account' = ANY (v_detail_cols) THEN
+        RAISE EXCEPTION 'fail: list_active leaks current_bid_account';
+    END IF;
+
+    -- Detail return columns: buyer_account + current_bid_account redacted.
+    SELECT array_agg(p.parameter_name::text) INTO v_detail_cols
+      FROM information_schema.routines r
+      JOIN information_schema.parameters p
+        ON r.specific_name = p.specific_name
+     WHERE r.routine_schema = 'public'
+       AND r.routine_name = 'proxy_market_listing_detail_readonly'
+       AND p.parameter_mode = 'OUT';
+    IF 'current_bid_account' = ANY (v_detail_cols) THEN
+        RAISE EXCEPTION 'fail: listing_detail leaks current_bid_account';
+    END IF;
+    IF 'buyer_account' = ANY (v_detail_cols) THEN
+        RAISE EXCEPTION 'fail: listing_detail leaks buyer_account';
+    END IF;
+
+    -- Public bid JSON shape: no bidder_account, no settled_at.
+    SELECT bids INTO v_bid_json
+      FROM public.proxy_market_listing_detail_readonly(v_listing_id);
+    IF v_bid_json IS NOT NULL AND jsonb_array_length(v_bid_json) > 0 THEN
+        IF EXISTS (
+            SELECT 1 FROM jsonb_array_elements(v_bid_json) elem
+             WHERE elem ? 'bidder_account'
+        ) THEN
+            RAISE EXCEPTION 'fail: public bids array leaks bidder_account';
+        END IF;
+        IF EXISTS (
+            SELECT 1 FROM jsonb_array_elements(v_bid_json) elem
+             WHERE elem ? 'settled_at'
+        ) THEN
+            RAISE EXCEPTION 'fail: public bids array leaks settled_at';
+        END IF;
+    END IF;
+END;
+$$;
+COMMIT;
+
+-- 21. private.proxy_market_caller_account is not reachable through
+--     PostgREST: anon + authenticated have no USAGE on schema private.
+DO $$
+BEGIN
+    IF has_schema_privilege('anon', 'private', 'USAGE') THEN
+        RAISE EXCEPTION 'fail: anon should NOT have USAGE on schema private';
+    END IF;
+    IF has_schema_privilege('authenticated', 'private', 'USAGE') THEN
+        RAISE EXCEPTION 'fail: authenticated should NOT have USAGE on schema private';
+    END IF;
+    IF NOT has_schema_privilege('service_role', 'private', 'USAGE') THEN
+        RAISE EXCEPTION 'fail: service_role missing USAGE on schema private';
+    END IF;
+END;
+$$;
+
 -- ASSERT_AFTER_DOWN
 
 DO $$
 BEGIN
     IF EXISTS (
         SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
-         WHERE n.nspname = 'public' AND p.proname LIKE 'proxy_market_%'
+         WHERE n.nspname IN ('public', 'private') AND p.proname LIKE 'proxy_market_%'
     ) THEN
         RAISE EXCEPTION 'fail: proxy_market_* still present after rollback';
     END IF;

--- a/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
@@ -153,11 +153,11 @@ BEGIN
 END;
 $$;
 ALTER FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) OWNER TO service_role;
-ALTER FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) ROWS 50;
+ALTER FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) COST 100 ROWS 50;
 REVOKE ALL ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO anon, authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
-    'PUBLIC marketplace proxy. Paged active-listing browse, anon-callable. Keyset cursor on (created_at DESC, id DESC), limit clamped [1, 100], default 50.';
+    'PUBLIC marketplace proxy. Paged active-listing browse, anon-callable. Keyset cursor on (created_at DESC, id DESC), limit clamped [1, 100], default 50. WARNING: returns wallet.account UUIDs (seller_account, current_bid_account); replace with profile handles once profile schema is wired up. Hides deadline-passed-but-not-yet-swept rows via expires_at > now().';
 
 -- ============================================================================
 -- public.proxy_market_listing_detail_readonly
@@ -237,10 +237,11 @@ BEGIN
 END;
 $$;
 ALTER FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) OWNER TO service_role;
+ALTER FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) COST 100 ROWS 1;
 REVOKE ALL ON FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) TO anon, authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) IS
-    'PUBLIC marketplace proxy. Single listing + 50 most recent bids. Anon-callable. Raises P1001 on missing listing.';
+    'PUBLIC marketplace proxy. Anon-callable single-listing read + 50 most recent bids. WARNING: returns stable wallet.account UUIDs (seller_account, current_bid_account, buyer_account, bidder_account inside the bids array) — replace with profile handles + narrow bid history once the profile schema is wired up. Raises P1001 on missing listing, 22004 on null id.';
 
 -- ============================================================================
 -- public.proxy_market_my_listings_readonly
@@ -294,7 +295,7 @@ BEGIN
 END;
 $$;
 ALTER FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) OWNER TO service_role;
-ALTER FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) ROWS 50;
+ALTER FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) COST 100 ROWS 50;
 REVOKE ALL ON FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
@@ -344,7 +345,7 @@ BEGIN
 END;
 $$;
 ALTER FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) OWNER TO service_role;
-ALTER FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) ROWS 50;
+ALTER FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) COST 100 ROWS 50;
 REVOKE ALL ON FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
@@ -375,6 +376,18 @@ BEGIN
     IF p_item_ref IS NULL OR jsonb_typeof(p_item_ref) <> 'object' THEN
         RAISE EXCEPTION 'item_ref must be a JSON object' USING ERRCODE = '22023';
     END IF;
+    IF p_buy_now_price IS NULL AND p_min_bid IS NULL THEN
+        RAISE EXCEPTION 'listing requires buy_now_price or min_bid' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NOT NULL AND p_buy_now_price <= 0 THEN
+        RAISE EXCEPTION 'buy_now_price must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_min_bid IS NOT NULL AND p_min_bid <= 0 THEN
+        RAISE EXCEPTION 'min_bid must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_expires_at IS NULL OR p_expires_at <= statement_timestamp() THEN
+        RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
+    END IF;
     RETURN wallet.service_create_listing(
         v_seller, p_item_ref, 'khash'::wallet.currency_kind,
         p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
@@ -403,6 +416,9 @@ DECLARE
 BEGIN
     IF p_listing_id IS NULL OR p_idempotency_key IS NULL THEN
         RAISE EXCEPTION 'listing_id and idempotency_key are required' USING ERRCODE = '22004';
+    END IF;
+    IF p_amount IS NULL OR p_amount <= 0 THEN
+        RAISE EXCEPTION 'amount must be positive' USING ERRCODE = '22023';
     END IF;
     RETURN wallet.service_place_bid(p_listing_id, v_bidder, p_amount, p_idempotency_key);
 END;

--- a/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
@@ -1,0 +1,400 @@
+-- migrate:up
+
+-- Phase 3 of the marketplace bootstrap: PostgREST-exposed public proxy
+-- functions that wrap the Phase 2 service-layer RPCs after applying
+-- auth.uid()-based ownership checks. These are the only marketplace
+-- functions callable by `authenticated` JWTs.
+--
+-- Read-side functions are STABLE and avoid any writes, so they are
+-- safe on the supabase-cluster-pooler-ro replica via the wallet
+-- client's read() path. On missing wallet account for the caller
+-- they raise SQLSTATE 'WLT01' so the Rust client can fall back to
+-- the rw pool's lazy-provisioning proxy (same contract as
+-- public.proxy_wallet_get_balance_readonly).
+--
+-- Auth model:
+--   - list_active_readonly + listing_detail_readonly: callable by
+--     anon + authenticated. Browse is public.
+--   - my_listings_readonly + my_bids_readonly: authenticated only,
+--     uses auth.uid() to scope.
+--   - create_listing / place_bid / buy_now / cancel_listing: write
+--     proxies, authenticated only. Each resolves auth.uid() →
+--     wallet account (raises WLT01 on missing) before calling the
+--     Phase 2 service RPC. Phase 2 already locks tables + verifies
+--     state, so the proxy is a thin auth layer.
+--
+-- Owner / grants:
+--   All functions OWNER service_role + SECURITY DEFINER + search_path
+--   = ''. Read-side proxies STABLE. Grants per-function vary
+--   (anon allowed for the public browse pair).
+
+-- ============================================================================
+-- INTERNAL HELPER: resolve auth.uid() → wallet.account.id
+--
+-- Raises 28000 if unauthenticated, WLT01 if the caller has no wallet
+-- account (Rust client falls back to the rw lazy-provision path).
+-- Used by every authenticated proxy below.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.proxy_market_caller_account()
+RETURNS UUID
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_user_id    UUID := auth.uid();
+    v_account_id UUID;
+BEGIN
+    IF v_user_id IS NULL THEN
+        RAISE EXCEPTION 'not_authenticated' USING ERRCODE = '28000';
+    END IF;
+    SELECT id INTO v_account_id
+      FROM wallet.account
+     WHERE kind = 'user' AND user_id = v_user_id;
+    IF v_account_id IS NULL THEN
+        RAISE EXCEPTION 'wallet_account_missing' USING ERRCODE = 'WLT01';
+    END IF;
+    RETURN v_account_id;
+END;
+$$;
+ALTER FUNCTION public.proxy_market_caller_account() OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_caller_account() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_market_caller_account() TO service_role;
+COMMENT ON FUNCTION public.proxy_market_caller_account() IS
+    'INTERNAL marketplace proxy helper. Resolves auth.uid() → wallet.account.id. Raises 28000 on anon, WLT01 on missing wallet account.';
+
+-- ============================================================================
+-- public.proxy_market_list_active_readonly
+--
+-- Public browse. Keyset cursor on (created_at DESC, id DESC) matches
+-- wallet_listing_active_created_idx. No auth required.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.proxy_market_list_active_readonly(
+    p_limit             INTEGER     DEFAULT 50,
+    p_before_created_at TIMESTAMPTZ DEFAULT NULL,
+    p_before_id         BIGINT      DEFAULT NULL
+)
+RETURNS TABLE (
+    listing_id          BIGINT,
+    seller_account      UUID,
+    item_ref            JSONB,
+    currency            wallet.currency_kind,
+    buy_now_price       BIGINT,
+    min_bid             BIGINT,
+    current_bid         BIGINT,
+    current_bid_account UUID,
+    expires_at          TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = '' AS $$
+DECLARE
+    v_limit INTEGER := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 100);
+BEGIN
+    RETURN QUERY
+    SELECT
+        l.id, l.seller_account, l.item_ref, l.currency,
+        l.buy_now_price, l.min_bid, l.current_bid, l.current_bid_account,
+        l.expires_at, l.created_at
+      FROM wallet.listing l
+     WHERE l.status = 'active'
+       AND (
+           p_before_created_at IS NULL
+           OR l.created_at < p_before_created_at
+           OR (l.created_at = p_before_created_at AND l.id < p_before_id)
+       )
+     ORDER BY l.created_at DESC, l.id DESC
+     LIMIT v_limit;
+END;
+$$;
+ALTER FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO anon, authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
+    'PUBLIC marketplace proxy. Paged active-listing browse, anon-callable. Keyset cursor on (created_at DESC, id DESC), limit clamped [1, 100], default 50.';
+
+-- ============================================================================
+-- public.proxy_market_listing_detail_readonly
+--
+-- Single listing + bid history (most recent 50 bids). Anon-callable.
+-- Raises P1001 on missing listing so the client surfaces a clean 404.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.proxy_market_listing_detail_readonly(
+    p_listing_id BIGINT
+)
+RETURNS TABLE (
+    listing_id          BIGINT,
+    seller_account      UUID,
+    item_ref            JSONB,
+    currency            wallet.currency_kind,
+    buy_now_price       BIGINT,
+    min_bid             BIGINT,
+    current_bid         BIGINT,
+    current_bid_account UUID,
+    current_bid_id      BIGINT,
+    buyer_account       UUID,
+    listing_status      wallet.listing_status,
+    expires_at          TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ,
+    updated_at          TIMESTAMPTZ,
+    settled_at          TIMESTAMPTZ,
+    bids                JSONB
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = '' AS $$
+DECLARE
+    v_listing wallet.listing%ROWTYPE;
+    v_bids    JSONB;
+BEGIN
+    SELECT * INTO v_listing FROM wallet.listing WHERE id = p_listing_id;
+    IF v_listing.id IS NULL THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
+    END IF;
+
+    SELECT COALESCE(jsonb_agg(sub.row ORDER BY sub.placed_at DESC, sub.id DESC), '[]'::jsonb)
+      INTO v_bids
+      FROM (
+          SELECT jsonb_build_object(
+              'bid_id', b.id,
+              'bidder_account', b.bidder_account,
+              'amount', b.amount,
+              'status', b.status,
+              'placed_at', b.placed_at,
+              'settled_at', b.settled_at
+          ) AS row, b.placed_at, b.id
+            FROM wallet.bid b
+           WHERE b.listing_id = p_listing_id
+           ORDER BY b.placed_at DESC, b.id DESC
+           LIMIT 50
+      ) sub;
+
+    listing_id          := v_listing.id;
+    seller_account      := v_listing.seller_account;
+    item_ref            := v_listing.item_ref;
+    currency            := v_listing.currency;
+    buy_now_price       := v_listing.buy_now_price;
+    min_bid             := v_listing.min_bid;
+    current_bid         := v_listing.current_bid;
+    current_bid_account := v_listing.current_bid_account;
+    current_bid_id      := v_listing.current_bid_id;
+    buyer_account       := v_listing.buyer_account;
+    listing_status      := v_listing.status;
+    expires_at          := v_listing.expires_at;
+    created_at          := v_listing.created_at;
+    updated_at          := v_listing.updated_at;
+    settled_at          := v_listing.settled_at;
+    bids                := v_bids;
+    RETURN NEXT;
+END;
+$$;
+ALTER FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) TO anon, authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) IS
+    'PUBLIC marketplace proxy. Single listing + 50 most recent bids. Anon-callable. Raises P1001 on missing listing.';
+
+-- ============================================================================
+-- public.proxy_market_my_listings_readonly
+--
+-- Caller's own listings, paged. Auth required. Raises WLT01 on missing
+-- wallet account (client falls back to rw provisioning).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.proxy_market_my_listings_readonly(
+    p_limit             INTEGER     DEFAULT 50,
+    p_before_created_at TIMESTAMPTZ DEFAULT NULL,
+    p_before_id         BIGINT      DEFAULT NULL
+)
+RETURNS TABLE (
+    listing_id          BIGINT,
+    item_ref            JSONB,
+    currency            wallet.currency_kind,
+    buy_now_price       BIGINT,
+    min_bid             BIGINT,
+    current_bid         BIGINT,
+    current_bid_account UUID,
+    buyer_account       UUID,
+    listing_status      wallet.listing_status,
+    expires_at          TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ,
+    settled_at          TIMESTAMPTZ
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = '' AS $$
+DECLARE
+    v_seller UUID := public.proxy_market_caller_account();
+    v_limit  INTEGER := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 100);
+BEGIN
+    RETURN QUERY
+    SELECT
+        l.id, l.item_ref, l.currency,
+        l.buy_now_price, l.min_bid, l.current_bid, l.current_bid_account,
+        l.buyer_account, l.status AS listing_status, l.expires_at, l.created_at, l.settled_at
+      FROM wallet.listing l
+     WHERE l.seller_account = v_seller
+       AND (
+           p_before_created_at IS NULL
+           OR l.created_at < p_before_created_at
+           OR (l.created_at = p_before_created_at AND l.id < p_before_id)
+       )
+     ORDER BY l.created_at DESC, l.id DESC
+     LIMIT v_limit;
+END;
+$$;
+ALTER FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
+    'PUBLIC marketplace proxy. Caller-scoped (auth.uid()) listing history, paged. Raises WLT01 when the caller has no wallet account.';
+
+-- ============================================================================
+-- public.proxy_market_my_bids_readonly
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.proxy_market_my_bids_readonly(
+    p_limit            INTEGER     DEFAULT 50,
+    p_before_placed_at TIMESTAMPTZ DEFAULT NULL,
+    p_before_id        BIGINT      DEFAULT NULL
+)
+RETURNS TABLE (
+    bid_id           BIGINT,
+    listing_id       BIGINT,
+    amount           BIGINT,
+    bid_status       wallet.bid_status,
+    placed_at        TIMESTAMPTZ,
+    settled_at       TIMESTAMPTZ,
+    escrow_ledger_id BIGINT,
+    refund_ledger_id BIGINT
+)
+LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = '' AS $$
+DECLARE
+    v_bidder UUID := public.proxy_market_caller_account();
+    v_limit  INTEGER := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 100);
+BEGIN
+    RETURN QUERY
+    SELECT
+        b.id, b.listing_id, b.amount, b.status AS bid_status, b.placed_at,
+        b.settled_at, b.escrow_ledger_id, b.refund_ledger_id
+      FROM wallet.bid b
+     WHERE b.bidder_account = v_bidder
+       AND (
+           p_before_placed_at IS NULL
+           OR b.placed_at < p_before_placed_at
+           OR (b.placed_at = p_before_placed_at AND b.id < p_before_id)
+       )
+     ORDER BY b.placed_at DESC, b.id DESC
+     LIMIT v_limit;
+END;
+$$;
+ALTER FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
+    'PUBLIC marketplace proxy. Caller-scoped (auth.uid()) bid history, paged. Raises WLT01 when the caller has no wallet account.';
+
+-- ============================================================================
+-- public.proxy_market_create_listing — write proxy
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.proxy_market_create_listing(
+    p_item_ref        JSONB,
+    p_buy_now_price   BIGINT,
+    p_min_bid         BIGINT,
+    p_expires_at      TIMESTAMPTZ,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_seller UUID := public.proxy_market_caller_account();
+BEGIN
+    RETURN wallet.service_create_listing(
+        v_seller, p_item_ref, 'khash'::wallet.currency_kind,
+        p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
+    );
+END;
+$$;
+ALTER FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
+    'PUBLIC marketplace proxy. Authenticated create-listing wrapper. Resolves auth.uid() → seller wallet account, then calls wallet.service_create_listing with currency=khash.';
+
+-- ============================================================================
+-- public.proxy_market_place_bid — write proxy
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.proxy_market_place_bid(
+    p_listing_id      BIGINT,
+    p_amount          BIGINT,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_bidder UUID := public.proxy_market_caller_account();
+BEGIN
+    RETURN wallet.service_place_bid(p_listing_id, v_bidder, p_amount, p_idempotency_key);
+END;
+$$;
+ALTER FUNCTION public.proxy_market_place_bid(BIGINT, BIGINT, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_place_bid(BIGINT, BIGINT, UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_market_place_bid(BIGINT, BIGINT, UUID) TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_market_place_bid(BIGINT, BIGINT, UUID) IS
+    'PUBLIC marketplace proxy. Authenticated place-bid wrapper. Resolves auth.uid() → bidder wallet account, then calls wallet.service_place_bid.';
+
+-- ============================================================================
+-- public.proxy_market_buy_now — write proxy
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.proxy_market_buy_now(
+    p_listing_id      BIGINT,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_buyer UUID := public.proxy_market_caller_account();
+BEGIN
+    RETURN wallet.service_buy_now(p_listing_id, v_buyer, p_idempotency_key);
+END;
+$$;
+ALTER FUNCTION public.proxy_market_buy_now(BIGINT, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_buy_now(BIGINT, UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_market_buy_now(BIGINT, UUID) TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_market_buy_now(BIGINT, UUID) IS
+    'PUBLIC marketplace proxy. Authenticated buy-now wrapper. Resolves auth.uid() → buyer wallet account, then calls wallet.service_buy_now.';
+
+-- ============================================================================
+-- public.proxy_market_cancel_listing — write proxy
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.proxy_market_cancel_listing(
+    p_listing_id BIGINT,
+    p_reason     TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_seller UUID := public.proxy_market_caller_account();
+BEGIN
+    PERFORM wallet.service_cancel_listing(p_listing_id, v_seller, p_reason);
+END;
+$$;
+ALTER FUNCTION public.proxy_market_cancel_listing(BIGINT, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_cancel_listing(BIGINT, TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_market_cancel_listing(BIGINT, TEXT) TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_market_cancel_listing(BIGINT, TEXT) IS
+    'PUBLIC marketplace proxy. Authenticated seller-cancel wrapper. Resolves auth.uid() → seller wallet account, then calls wallet.service_cancel_listing.';
+
+-- PostgREST schema cache refresh after the new public.* surface lands.
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS public.proxy_market_cancel_listing(BIGINT, TEXT);
+DROP FUNCTION IF EXISTS public.proxy_market_buy_now(BIGINT, UUID);
+DROP FUNCTION IF EXISTS public.proxy_market_place_bid(BIGINT, BIGINT, UUID);
+DROP FUNCTION IF EXISTS public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID);
+DROP FUNCTION IF EXISTS public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT);
+DROP FUNCTION IF EXISTS public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT);
+DROP FUNCTION IF EXISTS public.proxy_market_listing_detail_readonly(BIGINT);
+DROP FUNCTION IF EXISTS public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT);
+DROP FUNCTION IF EXISTS public.proxy_market_caller_account();

--- a/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
@@ -72,8 +72,20 @@ BEGIN
            AND array_length(i.indkey, 1) = 1
            AND a.attname = 'user_id'
            AND i.indpred IS NOT NULL
-           AND pg_get_expr(i.indpred, i.indrelid) LIKE '%kind%'
-           AND pg_get_expr(i.indpred, i.indrelid) LIKE '%user%'
+           -- Normalize whitespace + match the rendered predicate
+           -- against the known shapes. Postgres can emit any of:
+           --   (kind = 'user'::wallet.account_kind)
+           --   ((kind)::text = 'user'::text)
+           --   (kind = 'user'::text)
+           -- depending on cast direction; accept all three.
+           AND regexp_replace(
+                   pg_get_expr(i.indpred, i.indrelid),
+                   '\s+', ' ', 'g'
+               ) IN (
+                   '(kind = ''user''::wallet.account_kind)',
+                   '((kind)::text = ''user''::text)',
+                   '(kind = ''user''::text)'
+               )
     ) THEN
         RAISE EXCEPTION 'dependency missing: wallet.account partial unique on (user_id) WHERE kind=user';
     END IF;
@@ -107,13 +119,22 @@ $$;
 
 CREATE SCHEMA IF NOT EXISTS private;
 REVOKE ALL ON SCHEMA private FROM PUBLIC;
+-- Belt-and-suspenders: REVOKE from PUBLIC covers the named-role
+-- defaults too, but a prior migration may have explicitly granted
+-- USAGE to anon/authenticated. These explicit revokes audit-proof
+-- that path closed.
+REVOKE ALL ON SCHEMA private FROM anon;
+REVOKE ALL ON SCHEMA private FROM authenticated;
 GRANT USAGE ON SCHEMA private TO service_role;
 
 -- Defaults for future objects: any function created in `private` by
 -- service_role automatically has EXECUTE revoked from PUBLIC, so a
 -- future helper can't accidentally inherit anon/authenticated reach
--- if a future maintainer forgets the explicit REVOKE.
-ALTER DEFAULT PRIVILEGES IN SCHEMA private
+-- if a future maintainer forgets the explicit REVOKE. Scoped to
+-- service_role since SECURITY DEFINER functions will be owned by
+-- service_role; postgres-owned objects won't pick up this default
+-- (those don't need protection — they aren't reachable via PostgREST).
+ALTER DEFAULT PRIVILEGES FOR ROLE service_role IN SCHEMA private
     REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
 
 CREATE OR REPLACE FUNCTION private.proxy_market_caller_account()

--- a/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
@@ -50,19 +50,31 @@ BEGIN
             RAISE EXCEPTION 'dependency missing: % — apply Phase 2 first', v_proc;
         END IF;
     END LOOP;
+    IF to_regclass('wallet.account') IS NULL THEN
+        RAISE EXCEPTION 'dependency missing: wallet.account';
+    END IF;
+    -- proxy_market_caller_account relies on this partial unique to
+    -- safely SELECT INTO without STRICT.
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'wallet'
+           AND tablename = 'account'
+           AND indexname = 'wallet_account_user_uq'
+    ) THEN
+        RAISE EXCEPTION 'dependency missing: wallet_account_user_uq partial unique index';
+    END IF;
 END;
 $$;
 
 -- Public-exposure note:
 -- proxy_market_list_active_readonly + proxy_market_listing_detail_readonly
--- are anon-callable. Both return wallet.account UUIDs (seller_account,
--- current_bid_account, buyer_account, bidder_account inside the bids
--- array). These UUIDs are random and not directly PII, but they are
--- stable per-user identifiers that can be cross-referenced across
--- listings. A future profile-join refactor should replace them with
--- profile.username + profile.id when the profile schema is wired up;
--- bid-history visibility for anon callers can also be revisited then
--- (e.g. show only current high bid).
+-- are anon-callable. Both expose seller_account as a stable wallet
+-- UUID — acceptable since the seller is the public storefront, and
+-- a future profile-join will replace it with a public handle. All
+-- other wallet account UUIDs (current_bid_account, buyer_account,
+-- bidder_account inside bids) are redacted from the anon surface.
+-- Authenticated my_listings + my_bids proxies return the caller's
+-- own context only, so no extra exposure there.
 
 -- ============================================================================
 -- INTERNAL HELPER: resolve auth.uid() → wallet.account.id
@@ -117,7 +129,6 @@ RETURNS TABLE (
     buy_now_price       BIGINT,
     min_bid             BIGINT,
     current_bid         BIGINT,
-    current_bid_account UUID,
     expires_at          TIMESTAMPTZ,
     created_at          TIMESTAMPTZ
 )
@@ -132,10 +143,13 @@ BEGIN
             USING ERRCODE = '22023';
     END IF;
 
+    -- current_bid_account redacted from anon output; bidder identity
+    -- is exposed only via authenticated my_bids_readonly. seller_account
+    -- stays since a marketplace listing's seller is the storefront.
     RETURN QUERY
     SELECT
         l.id, l.seller_account, l.item_ref, l.currency,
-        l.buy_now_price, l.min_bid, l.current_bid, l.current_bid_account,
+        l.buy_now_price, l.min_bid, l.current_bid,
         l.expires_at, l.created_at
       FROM wallet.listing l
      WHERE l.status = 'active'
@@ -157,7 +171,7 @@ ALTER FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BI
 REVOKE ALL ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO anon, authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
-    'PUBLIC marketplace proxy. Paged active-listing browse, anon-callable. Keyset cursor on (created_at DESC, id DESC), limit clamped [1, 100], default 50. WARNING: returns wallet.account UUIDs (seller_account, current_bid_account); replace with profile handles once profile schema is wired up. Hides deadline-passed-but-not-yet-swept rows via expires_at > now().';
+    'PUBLIC marketplace proxy. Paged active-listing browse, anon-callable. Keyset cursor on (created_at DESC, id DESC), limit clamped [1, 100], default 50. seller_account stays exposed (storefront identity); current_bid_account redacted. Hides deadline-passed-but-not-yet-swept rows via expires_at > now().';
 
 -- ============================================================================
 -- public.proxy_market_listing_detail_readonly
@@ -177,9 +191,7 @@ RETURNS TABLE (
     buy_now_price       BIGINT,
     min_bid             BIGINT,
     current_bid         BIGINT,
-    current_bid_account UUID,
     current_bid_id      BIGINT,
-    buyer_account       UUID,
     listing_status      wallet.listing_status,
     expires_at          TIMESTAMPTZ,
     created_at          TIMESTAMPTZ,
@@ -200,12 +212,15 @@ BEGIN
         RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
     END IF;
 
+    -- Anon-visible bid history: bidder_account intentionally redacted.
+    -- A future profile-join refactor will expose a stable public
+    -- handle here; for now the bid amount + timing + status is enough
+    -- for browse UX without leaking the wallet account graph.
     SELECT COALESCE(jsonb_agg(sub.row ORDER BY sub.placed_at DESC, sub.id DESC), '[]'::jsonb)
       INTO v_bids
       FROM (
           SELECT jsonb_build_object(
               'bid_id', b.id,
-              'bidder_account', b.bidder_account,
               'amount', b.amount,
               'status', b.status,
               'placed_at', b.placed_at,
@@ -224,9 +239,7 @@ BEGIN
     buy_now_price       := v_listing.buy_now_price;
     min_bid             := v_listing.min_bid;
     current_bid         := v_listing.current_bid;
-    current_bid_account := v_listing.current_bid_account;
     current_bid_id      := v_listing.current_bid_id;
-    buyer_account       := v_listing.buyer_account;
     listing_status      := v_listing.status;
     expires_at          := v_listing.expires_at;
     created_at          := v_listing.created_at;
@@ -241,7 +254,7 @@ ALTER FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) COST 100 ROWS
 REVOKE ALL ON FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) TO anon, authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_market_listing_detail_readonly(BIGINT) IS
-    'PUBLIC marketplace proxy. Anon-callable single-listing read + 50 most recent bids. WARNING: returns stable wallet.account UUIDs (seller_account, current_bid_account, buyer_account, bidder_account inside the bids array) — replace with profile handles + narrow bid history once the profile schema is wired up. Raises P1001 on missing listing, 22004 on null id.';
+    'PUBLIC marketplace proxy. Anon-callable single-listing read + 50 most recent bids. seller_account stays exposed (the listing storefront); current_bid_account, buyer_account, and bidder_account inside bids are redacted to avoid leaking the wallet-account graph. Once a profile schema lands, replace seller_account with a profile handle too. Raises P1001 on missing listing, 22004 on null id.';
 
 -- ============================================================================
 -- public.proxy_market_my_listings_readonly

--- a/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
@@ -55,7 +55,9 @@ BEGIN
     END IF;
     -- proxy_market_caller_account relies on a partial-unique invariant
     -- (one user-wallet per auth.uid) so SELECT INTO is safe without
-    -- STRICT. Verify the actual shape, not just an index by name.
+    -- STRICT. Verify the actual shape AND the predicate restricts to
+    -- kind='user' (the column is the wallet.account_kind enum so the
+    -- rendered predicate may show as `(kind = 'user'::...)`).
     IF NOT EXISTS (
         SELECT 1
           FROM pg_index i
@@ -70,6 +72,8 @@ BEGIN
            AND array_length(i.indkey, 1) = 1
            AND a.attname = 'user_id'
            AND i.indpred IS NOT NULL
+           AND pg_get_expr(i.indpred, i.indrelid) LIKE '%kind%'
+           AND pg_get_expr(i.indpred, i.indrelid) LIKE '%user%'
     ) THEN
         RAISE EXCEPTION 'dependency missing: wallet.account partial unique on (user_id) WHERE kind=user';
     END IF;
@@ -104,6 +108,13 @@ $$;
 CREATE SCHEMA IF NOT EXISTS private;
 REVOKE ALL ON SCHEMA private FROM PUBLIC;
 GRANT USAGE ON SCHEMA private TO service_role;
+
+-- Defaults for future objects: any function created in `private` by
+-- service_role automatically has EXECUTE revoked from PUBLIC, so a
+-- future helper can't accidentally inherit anon/authenticated reach
+-- if a future maintainer forgets the explicit REVOKE.
+ALTER DEFAULT PRIVILEGES IN SCHEMA private
+    REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
 
 CREATE OR REPLACE FUNCTION private.proxy_market_caller_account()
 RETURNS UUID
@@ -418,6 +429,11 @@ BEGIN
     IF p_min_bid IS NOT NULL AND p_min_bid <= 0 THEN
         RAISE EXCEPTION 'min_bid must be positive' USING ERRCODE = '22023';
     END IF;
+    -- v1 intentionally requires an expiry deadline on every listing.
+    -- Non-expiring buy-now listings ARE NOT supported: the
+    -- proxy_market_list_active_readonly browse explicitly filters
+    -- `expires_at > now()`, so a NULL or past expires_at would result
+    -- in a listing that never appears in browse.
     IF p_expires_at IS NULL OR p_expires_at <= statement_timestamp() THEN
         RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
     END IF;

--- a/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
@@ -53,15 +53,25 @@ BEGIN
     IF to_regclass('wallet.account') IS NULL THEN
         RAISE EXCEPTION 'dependency missing: wallet.account';
     END IF;
-    -- proxy_market_caller_account relies on this partial unique to
-    -- safely SELECT INTO without STRICT.
+    -- proxy_market_caller_account relies on a partial-unique invariant
+    -- (one user-wallet per auth.uid) so SELECT INTO is safe without
+    -- STRICT. Verify the actual shape, not just an index by name.
     IF NOT EXISTS (
-        SELECT 1 FROM pg_indexes
-         WHERE schemaname = 'wallet'
-           AND tablename = 'account'
-           AND indexname = 'wallet_account_user_uq'
+        SELECT 1
+          FROM pg_index i
+          JOIN pg_class c   ON c.oid = i.indrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          JOIN pg_attribute a
+            ON a.attrelid = i.indrelid
+           AND a.attnum = i.indkey[0]
+         WHERE n.nspname = 'wallet'
+           AND c.relname = 'account'
+           AND i.indisunique
+           AND array_length(i.indkey, 1) = 1
+           AND a.attname = 'user_id'
+           AND i.indpred IS NOT NULL
     ) THEN
-        RAISE EXCEPTION 'dependency missing: wallet_account_user_uq partial unique index';
+        RAISE EXCEPTION 'dependency missing: wallet.account partial unique on (user_id) WHERE kind=user';
     END IF;
 END;
 $$;
@@ -79,12 +89,23 @@ $$;
 -- ============================================================================
 -- INTERNAL HELPER: resolve auth.uid() → wallet.account.id
 --
+-- Lives in the `private` schema so it's never reachable through
+-- PostgREST: anon + authenticated have no USAGE on `private`, so the
+-- function is effectively invisible to JWT callers. service_role
+-- still needs an explicit EXECUTE grant — verified empirically in
+-- Phase 2 round-7 that REVOKE EXECUTE FROM owner_role does strip
+-- owner's execute privilege.
+--
 -- Raises 28000 if unauthenticated, WLT01 if the caller has no wallet
 -- account (Rust client falls back to the rw lazy-provision path).
 -- Used by every authenticated proxy below.
 -- ============================================================================
 
-CREATE OR REPLACE FUNCTION public.proxy_market_caller_account()
+CREATE SCHEMA IF NOT EXISTS private;
+REVOKE ALL ON SCHEMA private FROM PUBLIC;
+GRANT USAGE ON SCHEMA private TO service_role;
+
+CREATE OR REPLACE FUNCTION private.proxy_market_caller_account()
 RETURNS UUID
 LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
@@ -103,11 +124,11 @@ BEGIN
     RETURN v_account_id;
 END;
 $$;
-ALTER FUNCTION public.proxy_market_caller_account() OWNER TO service_role;
-REVOKE ALL ON FUNCTION public.proxy_market_caller_account() FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.proxy_market_caller_account() TO service_role;
-COMMENT ON FUNCTION public.proxy_market_caller_account() IS
-    'INTERNAL marketplace proxy helper. Resolves auth.uid() → wallet.account.id. Raises 28000 on anon, WLT01 on missing wallet account.';
+ALTER FUNCTION private.proxy_market_caller_account() OWNER TO service_role;
+REVOKE ALL ON FUNCTION private.proxy_market_caller_account() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION private.proxy_market_caller_account() TO service_role;
+COMMENT ON FUNCTION private.proxy_market_caller_account() IS
+    'INTERNAL marketplace proxy helper. Resolves auth.uid() → wallet.account.id. Raises 28000 on anon, WLT01 on missing wallet account. Lives in the private schema so PostgREST never exposes it.';
 
 -- ============================================================================
 -- public.proxy_market_list_active_readonly
@@ -213,9 +234,9 @@ BEGIN
     END IF;
 
     -- Anon-visible bid history: bidder_account intentionally redacted.
-    -- A future profile-join refactor will expose a stable public
-    -- handle here; for now the bid amount + timing + status is enough
-    -- for browse UX without leaking the wallet account graph.
+    -- settled_at also dropped so refund/cancel timing isn't leaked
+    -- for outbid/refunded transitions. Browse UX only needs the bid
+    -- amount + placement + current status.
     SELECT COALESCE(jsonb_agg(sub.row ORDER BY sub.placed_at DESC, sub.id DESC), '[]'::jsonb)
       INTO v_bids
       FROM (
@@ -223,8 +244,7 @@ BEGIN
               'bid_id', b.id,
               'amount', b.amount,
               'status', b.status,
-              'placed_at', b.placed_at,
-              'settled_at', b.settled_at
+              'placed_at', b.placed_at
           ) AS row, b.placed_at, b.id
             FROM wallet.bid b
            WHERE b.listing_id = p_listing_id
@@ -284,7 +304,7 @@ RETURNS TABLE (
 )
 LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = '' AS $$
 DECLARE
-    v_seller UUID := public.proxy_market_caller_account();
+    v_seller UUID := private.proxy_market_caller_account();
     v_limit  INTEGER := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 100);
 BEGIN
     IF (p_before_created_at IS NULL) <> (p_before_id IS NULL) THEN
@@ -335,7 +355,7 @@ RETURNS TABLE (
 )
 LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = '' AS $$
 DECLARE
-    v_bidder UUID := public.proxy_market_caller_account();
+    v_bidder UUID := private.proxy_market_caller_account();
     v_limit  INTEGER := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 100);
 BEGIN
     IF (p_before_placed_at IS NULL) <> (p_before_id IS NULL) THEN
@@ -378,7 +398,7 @@ CREATE OR REPLACE FUNCTION public.proxy_market_create_listing(
 RETURNS BIGINT
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_seller UUID := public.proxy_market_caller_account();
+    v_seller UUID := private.proxy_market_caller_account();
 BEGIN
     -- Reject obviously bad inputs early; Phase 2 service does deeper
     -- validation but a clean proxy boundary avoids surfacing the
@@ -425,7 +445,7 @@ CREATE OR REPLACE FUNCTION public.proxy_market_place_bid(
 RETURNS BIGINT
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_bidder UUID := public.proxy_market_caller_account();
+    v_bidder UUID := private.proxy_market_caller_account();
 BEGIN
     IF p_listing_id IS NULL OR p_idempotency_key IS NULL THEN
         RAISE EXCEPTION 'listing_id and idempotency_key are required' USING ERRCODE = '22004';
@@ -453,7 +473,7 @@ CREATE OR REPLACE FUNCTION public.proxy_market_buy_now(
 RETURNS BIGINT
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_buyer UUID := public.proxy_market_caller_account();
+    v_buyer UUID := private.proxy_market_caller_account();
 BEGIN
     IF p_listing_id IS NULL OR p_idempotency_key IS NULL THEN
         RAISE EXCEPTION 'listing_id and idempotency_key are required' USING ERRCODE = '22004';
@@ -478,7 +498,7 @@ CREATE OR REPLACE FUNCTION public.proxy_market_cancel_listing(
 RETURNS VOID
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
-    v_seller UUID := public.proxy_market_caller_account();
+    v_seller UUID := private.proxy_market_caller_account();
     v_reason TEXT;
 BEGIN
     IF p_listing_id IS NULL THEN
@@ -510,6 +530,12 @@ DROP FUNCTION IF EXISTS public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPT
 DROP FUNCTION IF EXISTS public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT);
 DROP FUNCTION IF EXISTS public.proxy_market_listing_detail_readonly(BIGINT);
 DROP FUNCTION IF EXISTS public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT);
+-- Defensive: earlier draft of this migration shipped the helper in
+-- public. Drop both signatures so rollback is clean across DB states.
 DROP FUNCTION IF EXISTS public.proxy_market_caller_account();
+DROP FUNCTION IF EXISTS private.proxy_market_caller_account();
+-- Intentionally do NOT DROP SCHEMA private — other migrations may
+-- place objects there too. CREATE SCHEMA IF NOT EXISTS on up is
+-- idempotent regardless.
 
 NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
@@ -101,6 +101,14 @@ $$;
 -- bidder_account inside bids) are redacted from the anon surface.
 -- Authenticated my_listings + my_bids proxies return the caller's
 -- own context only, so no extra exposure there.
+--
+-- SQLSTATE namespace (follow-up):
+-- Marketplace domain errors use P1001-P1010 (set in Phase 2). The
+-- P-class is generic; a dedicated MKTxx rename is tracked as a
+-- Phase 2.5 unified-rename migration so the wire contract changes
+-- in one shot across Phase 2 + Phase 3 instead of fragmenting per
+-- migration. Until then, this proxy raises the same P1xxx codes
+-- the service RPCs emit so client error-matching stays single-keyed.
 
 -- ============================================================================
 -- INTERNAL HELPER: resolve auth.uid() → wallet.account.id

--- a/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
+++ b/packages/data/sql/dbmate/migrations/20260516015242_wallet_marketplace_proxies.sql
@@ -29,6 +29,42 @@
 --   (anon allowed for the public browse pair).
 
 -- ============================================================================
+-- Dependency preflight
+--
+-- Phase 3 proxies require the Phase 2 service RPCs to exist. Fail the
+-- migration with a clear message if a prior phase is missing rather
+-- than letting CREATE FUNCTION compile against a phantom signature.
+-- ============================================================================
+DO $$
+DECLARE
+    v_required TEXT[] := ARRAY[
+        'wallet.service_create_listing(uuid,jsonb,wallet.currency_kind,bigint,bigint,timestamptz,uuid)',
+        'wallet.service_place_bid(bigint,uuid,bigint,uuid)',
+        'wallet.service_buy_now(bigint,uuid,uuid)',
+        'wallet.service_cancel_listing(bigint,uuid,text)'
+    ];
+    v_proc TEXT;
+BEGIN
+    FOREACH v_proc IN ARRAY v_required LOOP
+        IF to_regprocedure(v_proc) IS NULL THEN
+            RAISE EXCEPTION 'dependency missing: % — apply Phase 2 first', v_proc;
+        END IF;
+    END LOOP;
+END;
+$$;
+
+-- Public-exposure note:
+-- proxy_market_list_active_readonly + proxy_market_listing_detail_readonly
+-- are anon-callable. Both return wallet.account UUIDs (seller_account,
+-- current_bid_account, buyer_account, bidder_account inside the bids
+-- array). These UUIDs are random and not directly PII, but they are
+-- stable per-user identifiers that can be cross-referenced across
+-- listings. A future profile-join refactor should replace them with
+-- profile.username + profile.id when the profile schema is wired up;
+-- bid-history visibility for anon callers can also be revisited then
+-- (e.g. show only current high bid).
+
+-- ============================================================================
 -- INTERNAL HELPER: resolve auth.uid() → wallet.account.id
 --
 -- Raises 28000 if unauthenticated, WLT01 if the caller has no wallet
@@ -89,6 +125,13 @@ LANGUAGE plpgsql SECURITY DEFINER STABLE SET search_path = '' AS $$
 DECLARE
     v_limit INTEGER := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 100);
 BEGIN
+    -- Cursor pair must be all-or-nothing; otherwise the keyset
+    -- tie-breaker `id < NULL` silently turns the cursor into a no-op.
+    IF (p_before_created_at IS NULL) <> (p_before_id IS NULL) THEN
+        RAISE EXCEPTION 'cursor requires both before_created_at and before_id'
+            USING ERRCODE = '22023';
+    END IF;
+
     RETURN QUERY
     SELECT
         l.id, l.seller_account, l.item_ref, l.currency,
@@ -96,6 +139,10 @@ BEGIN
         l.expires_at, l.created_at
       FROM wallet.listing l
      WHERE l.status = 'active'
+       -- Hide listings whose deadline has passed but the cron sweep
+       -- has not yet flipped status. Keeps browse output consistent
+       -- with what users can actually act on.
+       AND l.expires_at > statement_timestamp()
        AND (
            p_before_created_at IS NULL
            OR l.created_at < p_before_created_at
@@ -106,6 +153,7 @@ BEGIN
 END;
 $$;
 ALTER FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) OWNER TO service_role;
+ALTER FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) ROWS 50;
 REVOKE ALL ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO anon, authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
@@ -144,6 +192,9 @@ DECLARE
     v_listing wallet.listing%ROWTYPE;
     v_bids    JSONB;
 BEGIN
+    IF p_listing_id IS NULL THEN
+        RAISE EXCEPTION 'listing_id is required' USING ERRCODE = '22004';
+    END IF;
     SELECT * INTO v_listing FROM wallet.listing WHERE id = p_listing_id;
     IF v_listing.id IS NULL THEN
         RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
@@ -222,6 +273,10 @@ DECLARE
     v_seller UUID := public.proxy_market_caller_account();
     v_limit  INTEGER := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 100);
 BEGIN
+    IF (p_before_created_at IS NULL) <> (p_before_id IS NULL) THEN
+        RAISE EXCEPTION 'cursor requires both before_created_at and before_id'
+            USING ERRCODE = '22023';
+    END IF;
     RETURN QUERY
     SELECT
         l.id, l.item_ref, l.currency,
@@ -239,6 +294,7 @@ BEGIN
 END;
 $$;
 ALTER FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) OWNER TO service_role;
+ALTER FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) ROWS 50;
 REVOKE ALL ON FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
@@ -268,6 +324,10 @@ DECLARE
     v_bidder UUID := public.proxy_market_caller_account();
     v_limit  INTEGER := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 100);
 BEGIN
+    IF (p_before_placed_at IS NULL) <> (p_before_id IS NULL) THEN
+        RAISE EXCEPTION 'cursor requires both before_placed_at and before_id'
+            USING ERRCODE = '22023';
+    END IF;
     RETURN QUERY
     SELECT
         b.id, b.listing_id, b.amount, b.status AS bid_status, b.placed_at,
@@ -284,6 +344,7 @@ BEGIN
 END;
 $$;
 ALTER FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) OWNER TO service_role;
+ALTER FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) ROWS 50;
 REVOKE ALL ON FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) TO authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
@@ -305,6 +366,15 @@ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
     v_seller UUID := public.proxy_market_caller_account();
 BEGIN
+    -- Reject obviously bad inputs early; Phase 2 service does deeper
+    -- validation but a clean proxy boundary avoids surfacing the
+    -- service-layer NULL errors via the HTTP path.
+    IF p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'idempotency_key is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_item_ref IS NULL OR jsonb_typeof(p_item_ref) <> 'object' THEN
+        RAISE EXCEPTION 'item_ref must be a JSON object' USING ERRCODE = '22023';
+    END IF;
     RETURN wallet.service_create_listing(
         v_seller, p_item_ref, 'khash'::wallet.currency_kind,
         p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
@@ -331,6 +401,9 @@ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
     v_bidder UUID := public.proxy_market_caller_account();
 BEGIN
+    IF p_listing_id IS NULL OR p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'listing_id and idempotency_key are required' USING ERRCODE = '22004';
+    END IF;
     RETURN wallet.service_place_bid(p_listing_id, v_bidder, p_amount, p_idempotency_key);
 END;
 $$;
@@ -353,6 +426,9 @@ LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
     v_buyer UUID := public.proxy_market_caller_account();
 BEGIN
+    IF p_listing_id IS NULL OR p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'listing_id and idempotency_key are required' USING ERRCODE = '22004';
+    END IF;
     RETURN wallet.service_buy_now(p_listing_id, v_buyer, p_idempotency_key);
 END;
 $$;
@@ -374,8 +450,16 @@ RETURNS VOID
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
     v_seller UUID := public.proxy_market_caller_account();
+    v_reason TEXT;
 BEGIN
-    PERFORM wallet.service_cancel_listing(p_listing_id, v_seller, p_reason);
+    IF p_listing_id IS NULL THEN
+        RAISE EXCEPTION 'listing_id is required' USING ERRCODE = '22004';
+    END IF;
+    v_reason := NULLIF(btrim(p_reason), '');
+    IF v_reason IS NOT NULL AND length(v_reason) > 500 THEN
+        RAISE EXCEPTION 'reason exceeds 500 chars' USING ERRCODE = '22001';
+    END IF;
+    PERFORM wallet.service_cancel_listing(p_listing_id, v_seller, v_reason);
 END;
 $$;
 ALTER FUNCTION public.proxy_market_cancel_listing(BIGINT, TEXT) OWNER TO service_role;
@@ -398,3 +482,5 @@ DROP FUNCTION IF EXISTS public.proxy_market_my_listings_readonly(INTEGER, TIMEST
 DROP FUNCTION IF EXISTS public.proxy_market_listing_detail_readonly(BIGINT);
 DROP FUNCTION IF EXISTS public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT);
 DROP FUNCTION IF EXISTS public.proxy_market_caller_account();
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/schema/wallet/wallet_marketplace.sql
+++ b/packages/data/sql/schema/wallet/wallet_marketplace.sql
@@ -312,3 +312,40 @@ GRANT EXECUTE ON FUNCTION wallet.treasury_account_id() TO service_role;
 --   jobname:  marketplace-expire-listings
 --   schedule: '*/15 * * * *'
 --   command:  SELECT wallet.service_expire_listings();
+
+-- ============================================================================
+-- MARKETPLACE PUBLIC PROXIES (Phase 3)
+--
+-- PostgREST-exposed wrappers that apply auth.uid()-based ownership
+-- checks before delegating to the Phase 2 SECURITY DEFINER service
+-- RPCs. These are the only marketplace functions callable by
+-- `authenticated` JWTs. Read-side proxies + browse are anon-callable.
+--
+-- All bodies live in migration 20260516015242_wallet_marketplace_proxies.
+-- This mirror documents signatures + grants for the review surface.
+--
+-- Signatures:
+--   public.proxy_market_caller_account()
+--       → UUID (INTERNAL helper, service_role only)
+--
+--   public.proxy_market_list_active_readonly(INTEGER, TIMESTAMPTZ, BIGINT)
+--       → TABLE(...)  anon + authenticated + service_role
+--   public.proxy_market_listing_detail_readonly(BIGINT)
+--       → TABLE(...)  anon + authenticated + service_role
+--   public.proxy_market_my_listings_readonly(INTEGER, TIMESTAMPTZ, BIGINT)
+--       → TABLE(...)  authenticated + service_role
+--   public.proxy_market_my_bids_readonly(INTEGER, TIMESTAMPTZ, BIGINT)
+--       → TABLE(...)  authenticated + service_role
+--
+--   public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID)
+--       → BIGINT     authenticated + service_role
+--   public.proxy_market_place_bid(BIGINT, BIGINT, UUID)
+--       → BIGINT     authenticated + service_role
+--   public.proxy_market_buy_now(BIGINT, UUID)
+--       → BIGINT     authenticated + service_role
+--   public.proxy_market_cancel_listing(BIGINT, TEXT)
+--       → VOID       authenticated + service_role
+--
+-- All proxies are SECURITY DEFINER, OWNER service_role, search_path
+-- '. Reads STABLE. The migration ends with NOTIFY pgrst, 'reload
+-- schema' so PostgREST picks the new functions up immediately.


### PR DESCRIPTION
## Summary

Phase 3 of the marketplace bootstrap (#10979). Authenticated PostgREST surface that wraps the Phase 2 service RPCs with `auth.uid()`-based ownership checks. Read proxies are STABLE + RO-pool-safe.

Builds on:
- Phase 1 schema (#10976) — tables + treasury
- Phase 2 service RPCs (#10983) — create / bid / buy_now / cancel / settle / expire

## Functions

**INTERNAL helper**
- `proxy_market_caller_account() → UUID` — resolves `auth.uid()` → wallet account. Raises `28000` (anon) / `WLT01` (missing wallet account, triggers rw fallback).

**Read proxies (STABLE)**
| Function | Auth | Notes |
|---|---|---|
| `proxy_market_list_active_readonly(limit, before_created_at, before_id)` | **anon** + auth | Public browse, keyset cursor |
| `proxy_market_listing_detail_readonly(listing_id)` | **anon** + auth | Single listing + 50 most recent bids as JSONB; P1001 on missing |
| `proxy_market_my_listings_readonly(limit, ...)` | auth | Seller-scoped via auth.uid() |
| `proxy_market_my_bids_readonly(limit, ...)` | auth | Bidder-scoped via auth.uid() |

**Write proxies**
| Function | Auth | Wraps |
|---|---|---|
| `proxy_market_create_listing(item_ref, buy_now, min_bid, expires_at, key)` | auth | `service_create_listing` (currency hardcoded to khash) |
| `proxy_market_place_bid(listing_id, amount, key)` | auth | `service_place_bid` |
| `proxy_market_buy_now(listing_id, key)` | auth | `service_buy_now` |
| `proxy_market_cancel_listing(listing_id, reason)` | auth | `service_cancel_listing` |

All proxies `OWNER service_role + SECURITY DEFINER + search_path = ''`. Migration ends with `NOTIFY pgrst, 'reload schema'`.

## Test plan

- [x] `nx run data-sql:test-migration 20260516015242_wallet_marketplace_proxies` green
- [x] 10 assertions covering: anon browse, P1001 on missing listing, 28000 on anon my_listings, authenticated create_listing roundtrip + visible in my_listings, place_bid debit + my_bids + listing_detail bids JSONB, buy_now refund + fee/net, non-seller cancel blocked + seller cancel flips status.
- [x] After-down: all `proxy_market_*` functions removed.

## Local-env note

`init/01-auth-stub.sql` upgraded so `auth.uid()` reads `request.jwt.claim.sub` / `request.jwt.claims` GUC like Supabase prod. Standard `anon/authenticated/service_role` grants added on the auth schema + function.

## Roadmap

- [x] Phase 1 — Schema (#10976)
- [x] Phase 2 — Service RPCs + pg_cron (#10983)
- [x] **Phase 3 — Public proxies** (this PR)
- [ ] Phase 4 — Rust axum-kbve transport routes
- [ ] Phase 5 — Astro UI `/mc/market` + `/profile/market`