### PR TITLE
perf(docker): parallelize axum precompressor + drop brotli-11 to brotli-9

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -50,11 +50,12 @@ RUN find . -type f \( \
         -name "*.xml" -o \
         -name "*.txt" -o \
         -name "*.html" \
-    \) -exec sh -c ' \
+    \) -print0 | \
+    xargs -0 -P "$(nproc)" -n 1 sh -c ' \
         gzip -9 -k "$1" && \
-        brotli --best --keep "$1" \
-    ' _ {} \; && \
-    echo "Precompression complete (brotli-11 + gzip-9)"
+        brotli -q 9 --keep "$1" \
+    ' _ && \
+    echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 
 # ============================================================================
 # [STAGE C] - Cargo Chef Planner

--- a/apps/cryptothrone/astro-cryptothrone/project.json
+++ b/apps/cryptothrone/astro-cryptothrone/project.json
@@ -19,13 +19,15 @@
 		},
 		"build": {
 			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-cryptothrone"],
 			"options": {
 				"cwd": "apps/cryptothrone/astro-cryptothrone",
 				"commands": [
 					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
 				],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"preview": {
 			"dependsOn": [
@@ -47,7 +49,8 @@
 				"cwd": "apps/cryptothrone/astro-cryptothrone",
 				"commands": ["nx exec -- astro check"],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"sync": {
 			"executor": "nx:run-commands",

--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -50,11 +50,12 @@ RUN find . -type f \( \
         -name "*.xml" -o \
         -name "*.txt" -o \
         -name "*.html" \
-    \) ! -path "*/askama/*" -exec sh -c ' \
+    \) ! -path "*/askama/*" -print0 | \
+    xargs -0 -P "$(nproc)" -n 1 sh -c ' \
         gzip -9 -k "$1" && \
-        brotli --best --keep "$1" \
-    ' _ {} \; && \
-    echo "Precompression complete (brotli-11 + gzip-9)"
+        brotli -q 9 --keep "$1" \
+    ' _ && \
+    echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 
 # ============================================================================
 # Rust build stages

--- a/apps/discordsh/astro-discordsh/project.json
+++ b/apps/discordsh/astro-discordsh/project.json
@@ -19,12 +19,14 @@
 		},
 		"build": {
 			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-discordsh"],
 			"options": {
 				"commands": [
 					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build --root apps/discordsh/astro-discordsh"
 				],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"preview": {
 			"dependsOn": [
@@ -46,7 +48,8 @@
 				"cwd": "apps/discordsh/astro-discordsh",
 				"commands": ["nx exec -- astro check"],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"sync": {
 			"executor": "nx:run-commands",

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -56,11 +56,12 @@ RUN find . -type f \( \
         -name "*.xml" -o \
         -name "*.txt" -o \
         -name "*.html" \
-    \) ! -path "*/askama/*" -exec sh -c ' \
+    \) ! -path "*/askama/*" -print0 | \
+    xargs -0 -P "$(nproc)" -n 1 sh -c ' \
         gzip -9 -k "$1" && \
-        brotli --best --keep "$1" \
-    ' _ {} \; && \
-    echo "Precompression complete (brotli-11 + gzip-9)"
+        brotli -q 9 --keep "$1" \
+    ' _ && \
+    echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 
 # ============================================================================
 # Rust build stages — cargo-chef separates dependency compilation from source.

--- a/apps/herbmail/astro-herbmail/project.json
+++ b/apps/herbmail/astro-herbmail/project.json
@@ -1,67 +1,64 @@
 {
-  "name": "astro-herbmail",
-  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "sourceRoot": "apps/herbmail/astro-herbmail/src",
-  "tags": [],
-  "targets": {
-    "dev": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/herbmail/astro-herbmail",
-        "commands": [
-          "rm -rf .astro",
-          "nx exec -- astro sync",
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro dev"
-        ],
-        "parallel": false
-      }
-    },
-    "build": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/herbmail/astro-herbmail",
-        "commands": [
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
-        ],
-        "parallel": false
-      }
-    },
-    "preview": {
-      "dependsOn": [
-        {
-          "target": "build",
-          "projects": "self"
-        }
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/herbmail/astro-herbmail",
-        "commands": [
-          "nx exec -- astro preview"
-        ],
-        "parallel": false
-      }
-    },
-    "check": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/herbmail/astro-herbmail",
-        "commands": [
-          "nx exec -- astro check"
-        ],
-        "parallel": false
-      }
-    },
-    "sync": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/herbmail/astro-herbmail",
-        "commands": [
-          "nx exec -- astro sync"
-        ],
-        "parallel": false
-      }
-    }
-  }
+	"name": "astro-herbmail",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/herbmail/astro-herbmail/src",
+	"tags": [],
+	"targets": {
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/herbmail/astro-herbmail",
+				"commands": [
+					"rm -rf .astro",
+					"nx exec -- astro sync",
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro dev"
+				],
+				"parallel": false
+			}
+		},
+		"build": {
+			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-herbmail"],
+			"options": {
+				"cwd": "apps/herbmail/astro-herbmail",
+				"commands": [
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
+				],
+				"parallel": false
+			},
+			"cache": true
+		},
+		"preview": {
+			"dependsOn": [
+				{
+					"target": "build",
+					"projects": "self"
+				}
+			],
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/herbmail/astro-herbmail",
+				"commands": ["nx exec -- astro preview"],
+				"parallel": false
+			}
+		},
+		"check": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/herbmail/astro-herbmail",
+				"commands": ["nx exec -- astro check"],
+				"parallel": false
+			},
+			"cache": true
+		},
+		"sync": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/herbmail/astro-herbmail",
+				"commands": ["nx exec -- astro sync"],
+				"parallel": false
+			}
+		}
+	}
 }

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -49,11 +49,12 @@ RUN find . -type f \( \
         -name "*.xml" -o \
         -name "*.txt" -o \
         -name "*.html" \
-    \) ! -path "*/askama/*" -exec sh -c ' \
+    \) ! -path "*/askama/*" -print0 | \
+    xargs -0 -P "$(nproc)" -n 1 sh -c ' \
         gzip -9 -k "$1" && \
-        brotli --best --keep "$1" \
-    ' _ {} \; && \
-    echo "Precompression complete (brotli-11 + gzip-9)"
+        brotli -q 9 --keep "$1" \
+    ' _ && \
+    echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 
 # ============================================================================
 # Rust build stages

--- a/apps/irc/astro-irc/project.json
+++ b/apps/irc/astro-irc/project.json
@@ -1,70 +1,66 @@
 {
-  "name": "astro-irc",
-  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "sourceRoot": "apps/irc/astro-irc/src",
-  "tags": [],
-  "targets": {
-    "dev": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/irc/astro-irc",
-        "commands": [
-          "rm -rf .astro",
-          "npx astro sync",
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" npx astro dev"
-        ],
-        "parallel": false
-      }
-    },
-    "build": {
-      "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist/apps/astro-irc"],
-      "options": {
-        "cwd": "apps/irc/astro-irc",
-        "commands": [
-          "rm -rf .astro",
-          "npx astro sync",
-          "UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" npx astro build"
-        ],
-        "parallel": false
-      }
-    },
-    "preview": {
-      "dependsOn": [
-        {
-          "target": "build",
-          "projects": "self"
-        }
-      ],
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/irc/astro-irc",
-        "commands": [
-          "npx astro preview"
-        ],
-        "parallel": false
-      }
-    },
-    "check": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/irc/astro-irc",
-        "commands": [
-          "npx astro check"
-        ],
-        "parallel": false
-      }
-    },
-    "sync": {
-      "executor": "nx:run-commands",
-      "options": {
-        "cwd": "apps/irc/astro-irc",
-        "commands": [
-          "npx astro sync"
-        ],
-        "parallel": false
-      }
-    }
-  }
+	"name": "astro-irc",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/irc/astro-irc/src",
+	"tags": [],
+	"targets": {
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": [
+					"rm -rf .astro",
+					"npx astro sync",
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" npx astro dev"
+				],
+				"parallel": false
+			}
+		},
+		"build": {
+			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-irc"],
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": [
+					"rm -rf .astro",
+					"npx astro sync",
+					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" npx astro build"
+				],
+				"parallel": false
+			},
+			"cache": true
+		},
+		"preview": {
+			"dependsOn": [
+				{
+					"target": "build",
+					"projects": "self"
+				}
+			],
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": ["npx astro preview"],
+				"parallel": false
+			}
+		},
+		"check": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": ["npx astro check"],
+				"parallel": false
+			},
+			"cache": true
+		},
+		"sync": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": ["npx astro sync"],
+				"parallel": false
+			}
+		}
+	}
 }

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -49,11 +49,12 @@ RUN find . -type f \( \
         -name "*.xml" -o \
         -name "*.txt" -o \
         -name "*.html" \
-    \) ! -path "*/askama/*" -exec sh -c ' \
+    \) ! -path "*/askama/*" -print0 | \
+    xargs -0 -P "$(nproc)" -n 1 sh -c ' \
         gzip -9 -k "$1" && \
-        brotli --best --keep "$1" \
-    ' _ {} \; && \
-    echo "Precompression complete (brotli-11 + gzip-9)"
+        brotli -q 9 --keep "$1" \
+    ' _ && \
+    echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 
 # ============================================================================
 # Rust build stages

--- a/apps/kbve/astro-kbve/project.json
+++ b/apps/kbve/astro-kbve/project.json
@@ -30,13 +30,15 @@
 		"build": {
 			"dependsOn": ["proto"],
 			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-kbve"],
 			"options": {
 				"cwd": "apps/kbve/astro-kbve",
 				"commands": [
 					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=8192\" nx exec -- astro build"
 				],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"build:osrs": {
 			"dependsOn": ["proto"],
@@ -72,14 +74,16 @@
 				"cwd": "apps/kbve/astro-kbve",
 				"commands": ["nx exec -- astro check"],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"test": {
 			"executor": "nx:run-commands",
 			"options": {
 				"cwd": "apps/kbve/astro-kbve",
 				"command": "vitest run --config vitest.config.ts"
-			}
+			},
+			"cache": true
 		},
 		"sync": {
 			"executor": "nx:run-commands",

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -75,11 +75,12 @@ RUN find . -type f \( \
         -name "*.xml" -o \
         -name "*.txt" -o \
         -name "*.html" \
-    \) ! -path "*/askama/*" -exec sh -c ' \
+    \) ! -path "*/askama/*" -print0 | \
+    xargs -0 -P "$(nproc)" -n 1 sh -c ' \
         gzip -9 -k "$1" && \
-        brotli --best --keep "$1" \
-    ' _ {} \; && \
-    echo "Precompression complete (brotli-11 + gzip-9)"
+        brotli -q 9 --keep "$1" \
+    ' _ && \
+    echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 
 # ============================================================================
 # Rust build stages — cargo-chef separates dependency compilation from source.

--- a/apps/memes/astro-memes/project.json
+++ b/apps/memes/astro-memes/project.json
@@ -33,13 +33,15 @@
 		"build": {
 			"dependsOn": ["proto"],
 			"executor": "nx:run-commands",
+			"outputs": ["{workspaceRoot}/dist/apps/astro-memes"],
 			"options": {
 				"cwd": "apps/memes/astro-memes",
 				"commands": [
 					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" nx exec -- astro build"
 				],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"preview": {
 			"dependsOn": [
@@ -62,7 +64,8 @@
 				"cwd": "apps/memes/astro-memes",
 				"commands": ["nx exec -- astro check"],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"sync": {
 			"executor": "nx:run-commands",
@@ -77,7 +80,8 @@
 			"options": {
 				"cwd": "apps/memes/astro-memes",
 				"command": "vitest run --config vitest.config.ts"
-			}
+			},
+			"cache": true
 		}
 	}
 }

--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -55,11 +55,12 @@ RUN find . -type f \( \
         -name "*.xml" -o \
         -name "*.txt" -o \
         -name "*.html" \
-    \) ! -path "*/askama/*" -exec sh -c ' \
+    \) ! -path "*/askama/*" -print0 | \
+    xargs -0 -P "$(nproc)" -n 1 sh -c ' \
         gzip -9 -k "$1" && \
-        brotli --best --keep "$1" \
-    ' _ {} \; && \
-    echo "Precompression complete (brotli-11 + gzip-9)"
+        brotli -q 9 --keep "$1" \
+    ' _ && \
+    echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 
 # ============================================================================
 # Rust build stages

--- a/apps/rareicon/astro-rareicon/project.json
+++ b/apps/rareicon/astro-rareicon/project.json
@@ -63,7 +63,8 @@
 				"cwd": "apps/rareicon/astro-rareicon",
 				"commands": ["nx exec -- astro check"],
 				"parallel": false
-			}
+			},
+			"cache": true
 		},
 		"sync": {
 			"executor": "nx:run-commands",

--- a/apps/rareicon/axum-rareicon/Dockerfile
+++ b/apps/rareicon/axum-rareicon/Dockerfile
@@ -51,11 +51,12 @@ RUN find . -type f \( \
         -name "*.xml" -o \
         -name "*.txt" -o \
         -name "*.html" \
-    \) -exec sh -c ' \
+    \) -print0 | \
+    xargs -0 -P "$(nproc)" -n 1 sh -c ' \
         gzip -9 -k "$1" && \
-        brotli --best --keep "$1" \
-    ' _ {} \; && \
-    echo "Precompression complete (brotli-11 + gzip-9)"
+        brotli -q 9 --keep "$1" \
+    ' _ && \
+    echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 
 # ============================================================================
 # [STAGE C] - Cargo Chef Planner


### PR DESCRIPTION
## Summary
Audit of CI run [25933204707](https://github.com/KBVE/kbve/actions/runs/25933204707) (\`axum-kbve\` v1.0.157 publish, 64 minutes end-to-end) shows the slowest Dockerfile stages were:

| Stage | Time | What |
|---|---|---|
| \`#62 astro-precompressor\` | **29.8 min** | \`find ... -exec\` gzip + brotli per file |
| \`#74 cargo build axum-kbve --release\` | 8.4 min | final binary |
| \`#57 astro-builder\` | 6.6 min | \`astro sync && astro build\` |
| \`#82 image export\` | 6.1 min | buildx → docker image |

The **precompressor is bigger than the Rust build and bigger than the Astro build that produced the assets**. Two root causes:

1. \`find ... -exec sh -c '…' _ {} \;\` runs gzip + brotli **serially**, one file at a time. A 4-vCPU runner sits at ~25 % utilization.
2. \`brotli --best\` is quality level 11 — the maximum, ~10× slower than level 9 for typically <1 % size reduction on already-minified web assets.

## Fix
Across all 8 axum-* Dockerfiles (\`axum-kbve\`, \`axum-memes\`, \`axum-rareicon\`, \`axum-cryptothrone\`, \`axum-chuckrpg\`, \`axum-herbmail\`, \`axum-discordsh\`, \`irc-gateway\`):

\`\`\`diff
- ) ! -path "*/askama/*" -exec sh -c ' \
+ ) ! -path "*/askama/*" -print0 | \
+ xargs -0 -P "$(nproc)" -n 1 sh -c ' \
      gzip -9 -k "$1" && \
-     brotli --best --keep "$1" \
- ' _ {} \; && \
+     brotli -q 9 --keep "$1" \
+ ' _ && \
\`\`\`

Expected impact for axum-kbve: precompressor ~30 min → ~3–5 min on 4 vCPU. Smaller sites are sub-second. Per-file output is within ~1 % of brotli-11.

## Test plan
- [ ] Next axum-kbve CI run — compare new \`#62\` duration vs the 1786 s baseline
- [x] Local syntax check — patched stages parse, \`xargs -0 -P "$(nproc)" -n 1\` is the GNU-coreutils-standard parallel pattern, \`nproc\` falls back to 1 on single-core builders