### PR TITLE
feat(referral): schema + record_click RPC (Phase 1)

### DIFF
--- a/packages/data/proto/README.md
+++ b/packages/data/proto/README.md
@@ -4,13 +4,15 @@ This directory contains **protobuf definition files** (`.proto`) that serve as t
 
 ## Structure
 
-| Directory | Purpose |
-|-----------|---------|
-| `kbve/` | Core KBVE protos (OSRS items, discordsh, common types) |
-| `npc/` | NPC database proto (`npcdb.proto`) — universal NPC definitions |
-| `google/` | Google well-known proto imports |
-| `jedi/` | Jedi-specific protos |
-| `meme/` | Meme schema protos |
+| Directory   | Purpose                                                                      |
+| ----------- | ---------------------------------------------------------------------------- |
+| `kbve/`     | Core KBVE protos (OSRS items, discordsh, common types)                       |
+| `npc/`      | NPC database proto (`npcdb.proto`) — universal NPC definitions               |
+| `google/`   | Google well-known proto imports                                              |
+| `jedi/`     | Jedi-specific protos                                                         |
+| `meme/`     | Meme schema protos                                                           |
+| `referral/` | Referral system schema (per-user redirect links + click log + reward policy) |
+| `wallet/`   | Wallet schema (ledger + coupons + marketplace + treasury)                    |
 
 ## Rules
 

--- a/packages/data/proto/referral/referral.proto
+++ b/packages/data/proto/referral/referral.proto
@@ -1,0 +1,103 @@
+syntax = "proto3";
+
+package referral;
+
+// =============================================================================
+// KBVE Referral — per-user referral links + click log + reward credit
+//
+// Mirrors the `referral` Postgres schema
+// (packages/data/sql/schema/referral/). Phase 1 ships the DB rails only;
+// Phase 2 wires this proto into the axum-kbve handler that hashes the
+// visitor IP and calls referral.record_click().
+//
+// URL surface
+//   /referral/@<handle>/             → user's default target
+//   /referral/@<handle>/<target>/    → specific target from the catalog
+//
+// Privacy note: this proto carries hashed IP material only (raw IPs are
+// never crossed over a wire or written to disk). The handler hashes
+// before constructing the request.
+// =============================================================================
+
+// ---------------------------------------------------------------------------
+// Core entities
+// ---------------------------------------------------------------------------
+
+// Admin-curated redirect destination.
+message Target {
+  string slug         = 1;  // [a-z0-9-]{1,63}
+  string title        = 2;
+  string url          = 3;
+  string description  = 4;
+  bool   active       = 5;
+  string created_at   = 6;  // RFC3339 timestamp
+}
+
+// User opt-in row + default-target slot.
+message UserTarget {
+  string user_id      = 1;  // UUID
+  string target_slug  = 2;
+  bool   is_default   = 3;
+  string enabled_at   = 4;  // RFC3339 timestamp
+}
+
+// Single-row reward economics.
+message RewardPolicy {
+  int64  credits_per_click  = 1;
+  int32  dedup_window_days  = 2;
+  string updated_at         = 3;  // RFC3339 timestamp
+}
+
+// One row in referral.click. Stored after every HTTP hit.
+message Click {
+  int64  id            = 1;
+  string referrer_id   = 2;  // UUID
+  string target_slug   = 3;
+  bytes  ip_hash       = 4;  // HMAC-SHA256(server_secret, ip)
+  bytes  subnet_hash   = 5;  // HMAC-SHA256(server_secret, /24 or /48 prefix)
+  string user_agent    = 6;  // truncated to 256 chars
+  string referer       = 7;  // truncated to 512 chars
+  string accept_lang   = 8;  // truncated to 64 chars
+  bool   qualified     = 9;  // triggered a credit
+  bool   credited      = 10;
+  int64  ledger_id     = 11; // wallet.ledger.id when credited, else 0
+  string created_at    = 12; // RFC3339 timestamp
+}
+
+// ---------------------------------------------------------------------------
+// RPC envelopes
+// ---------------------------------------------------------------------------
+
+// record_click input. axum-kbve handler builds this, calls the SECURITY
+// DEFINER referral.record_click(...) function in Postgres, and forwards
+// the visitor with a 302 to the returned target_url.
+message RecordClickRequest {
+  string referrer_id   = 1;  // UUID — resolved from @handle by the handler
+  string target_slug   = 2;  // from URL or user default
+  bytes  ip_hash       = 3;
+  bytes  subnet_hash   = 4;
+  string user_agent    = 5;
+  string referer       = 6;
+  string accept_lang   = 7;
+}
+
+message RecordClickResponse {
+  int64  click_id    = 1;
+  bool   qualified   = 2;
+  bool   credited    = 3;
+  int64  ledger_id   = 4;  // 0 when not credited
+  string target_url  = 5;  // 302 destination
+}
+
+// resolve_user_target input.
+message ResolveUserTargetRequest {
+  string user_id      = 1;  // UUID
+  string target_slug  = 2;  // empty → return user's default
+}
+
+message ResolveUserTargetResponse {
+  string slug    = 1;
+  string title   = 2;
+  string url     = 3;
+  bool   found   = 4;
+}

--- a/packages/data/proto/referral/referral.proto
+++ b/packages/data/proto/referral/referral.proto
@@ -38,7 +38,9 @@ message UserTarget {
   string user_id      = 1;  // UUID
   string target_slug  = 2;
   bool   is_default   = 3;
-  string enabled_at   = 4;  // RFC3339 timestamp
+  bool   active       = 4;  // flipping to false disables without losing history
+  string enabled_at   = 5;  // RFC3339 timestamp
+  string disabled_at  = 6;  // RFC3339 timestamp; empty when active = true
 }
 
 // Single-row reward economics.
@@ -82,11 +84,12 @@ message RecordClickRequest {
 }
 
 message RecordClickResponse {
-  int64  click_id    = 1;
-  bool   qualified   = 2;
-  bool   credited    = 3;
-  int64  ledger_id   = 4;  // 0 when not credited
-  string target_url  = 5;  // 302 destination
+  int64  click_id     = 1;
+  string target_slug  = 2;  // resolved slug for log correlation
+  string target_url   = 3;  // 302 destination
+  bool   qualified    = 4;  // first inside dedup window for this tuple
+  bool   credited     = 5;  // wallet.service_credit ran
+  int64  ledger_id    = 6;  // 0 when credited = false
 }
 
 // resolve_user_target input.

--- a/packages/data/proto/wallet/wallet.proto
+++ b/packages/data/proto/wallet/wallet.proto
@@ -49,6 +49,7 @@ enum SourceKind {
   SOURCE_KIND_MARKET_SELL = 7;  // marketplace sale (seller credit)
   SOURCE_KIND_MARKET_FEE  = 8;  // treasury skim on a market trade
   SOURCE_KIND_TRANSFER    = 9;  // generic peer-to-peer transfer
+  SOURCE_KIND_REFERRAL    = 10; // referral.record_click reward (qualified click)
 }
 
 // Coupon template payout dispatcher.

--- a/packages/data/sql/dbmate/migration-tests/20260515221756_referral_schema_init.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260515221756_referral_schema_init.test.sql
@@ -35,7 +35,8 @@ INSERT INTO auth.users (id) VALUES ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1');
 
 -- ASSERT_AFTER_UP
 
--- Catalog seed exists with both shipped targets.
+-- Catalog seed exists with both shipped targets, AND the seed is
+-- DO UPDATE so a re-run reflects URL/title edits (not just DO NOTHING).
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM referral.target WHERE slug = 'rareicon' AND active) THEN
@@ -62,7 +63,7 @@ BEGIN
     END IF;
 END $$;
 
--- target slug check rejects bad values.
+-- target CHECKs reject malformed values.
 DO $$
 BEGIN
     BEGIN
@@ -80,9 +81,19 @@ BEGIN
     EXCEPTION WHEN check_violation THEN
         -- expected
     END;
+
+    -- New: whitespace + control chars now rejected by the tighter url regex.
+    BEGIN
+        INSERT INTO referral.target (slug, title, url)
+        VALUES ('bad-space', 'x', 'https://example.com/has space');
+        RAISE EXCEPTION 'fail: target.url check should have rejected whitespace';
+    EXCEPTION WHEN check_violation THEN
+        -- expected
+    END;
 END $$;
 
--- partial unique index allows multiple non-default rows, blocks two defaults.
+-- Partial unique index allows multiple non-default rows, blocks two
+-- defaults among ACTIVE rows.
 DO $$
 DECLARE u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
 BEGIN
@@ -94,17 +105,17 @@ BEGIN
 
     BEGIN
         INSERT INTO referral.user_target (user_id, target_slug, is_default)
-        VALUES (u, 'mc', TRUE);  -- conflict with the partial unique
+        VALUES (u, 'mc', TRUE);
         RAISE EXCEPTION 'fail: partial unique index should have blocked second default';
     EXCEPTION WHEN unique_violation THEN
         -- expected
     END;
 
-    -- clean up so the rest of the assertions start fresh on user_target
     DELETE FROM referral.user_target WHERE user_id = u;
 END $$;
 
--- resolve_user_target returns the configured default when slug is NULL.
+-- resolve_user_target returns the configured default when slug is NULL,
+-- AND skips inactive user_target rows.
 DO $$
 DECLARE
     u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
@@ -120,13 +131,26 @@ BEGIN
         RAISE EXCEPTION 'fail: default resolution expected rareicon, got %', r.slug;
     END IF;
 
-    -- Explicit slug overrides default.
     SELECT * INTO r FROM referral.resolve_user_target(u, 'mc');
     IF r.slug IS DISTINCT FROM 'mc' THEN
         RAISE EXCEPTION 'fail: explicit slug should have returned mc, got %', r.slug;
     END IF;
 
-    -- Slug user does not have enabled returns no row.
+    -- Disable the rareicon row → resolve_user_target(NULL) returns nothing.
+    UPDATE referral.user_target
+       SET active = FALSE, disabled_at = now()
+     WHERE user_id = u AND target_slug = 'rareicon';
+
+    PERFORM 1 FROM referral.resolve_user_target(u, NULL);
+    IF FOUND THEN
+        RAISE EXCEPTION 'fail: disabled default should not resolve';
+    END IF;
+
+    -- Re-enable and clean up.
+    UPDATE referral.user_target
+       SET active = TRUE, disabled_at = NULL
+     WHERE user_id = u AND target_slug = 'rareicon';
+
     PERFORM 1 FROM referral.resolve_user_target(u, 'nonexistent');
     IF FOUND THEN
         RAISE EXCEPTION 'fail: unknown slug should not resolve';
@@ -135,8 +159,25 @@ BEGIN
     DELETE FROM referral.user_target WHERE user_id = u;
 END $$;
 
--- record_click: first call credits 10, returns qualified=true; second call
--- with same (referrer, target, ip_hash) inside the dedup window does not.
+-- record_click: enforces user_target enablement.
+DO $$
+DECLARE
+    u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+    ip BYTEA := decode('aabbccddeeff00112233445566778899', 'hex');
+    sn BYTEA := decode('1122334455667788', 'hex');
+BEGIN
+    BEGIN
+        PERFORM * FROM referral.record_click(u, 'rareicon', ip, sn);
+        RAISE EXCEPTION 'fail: record_click should reject targets the user has not enabled';
+    EXCEPTION WHEN SQLSTATE 'RFU01' THEN
+        -- expected: custom SQLSTATE for "user has target unset/disabled"
+    END;
+END $$;
+
+-- record_click: first call credits 10, returns qualified=true, credited=true,
+-- target_slug + target_url populated, ledger_id non-null. Second call with
+-- same (referrer, target, ip_hash) inside the dedup window logs without
+-- crediting.
 DO $$
 DECLARE
     u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
@@ -146,6 +187,12 @@ DECLARE
     r2 RECORD;
     bal BIGINT;
 BEGIN
+    -- Enable the targets for this user.
+    INSERT INTO referral.user_target (user_id, target_slug, is_default)
+    VALUES (u, 'rareicon', TRUE);
+    INSERT INTO referral.user_target (user_id, target_slug, is_default)
+    VALUES (u, 'mc', FALSE);
+
     SELECT * INTO r1
       FROM referral.record_click(u, 'rareicon', ip, sn, 'UA/1.0', 'https://t.co/x', 'en');
     IF NOT r1.qualified THEN
@@ -157,6 +204,9 @@ BEGIN
     IF r1.ledger_id IS NULL THEN
         RAISE EXCEPTION 'fail: first click ledger_id should be set';
     END IF;
+    IF r1.target_slug IS DISTINCT FROM 'rareicon' THEN
+        RAISE EXCEPTION 'fail: target_slug mismatch: %', r1.target_slug;
+    END IF;
     IF r1.target_url IS DISTINCT FROM 'https://store.steampowered.com/app/2238370/RareIcon/' THEN
         RAISE EXCEPTION 'fail: target_url mismatch: %', r1.target_url;
     END IF;
@@ -167,6 +217,14 @@ BEGIN
      WHERE a.user_id = u AND a.kind = 'user';
     IF bal <> 10 THEN
         RAISE EXCEPTION 'fail: expected 10 credits after first click, got %', bal;
+    END IF;
+
+    -- Click row should have credited + ledger_id populated.
+    PERFORM 1
+       FROM referral.click
+      WHERE id = r1.click_id AND credited AND ledger_id IS NOT NULL;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'fail: click row should be credited with ledger_id';
     END IF;
 
     SELECT * INTO r2
@@ -193,75 +251,68 @@ BEGIN
     END IF;
 END $$;
 
--- A different ip_hash on the same target credits independently.
+-- credits_per_click = 0 path: click qualifies but does NOT credit.
 DO $$
 DECLARE
     u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
-    ip BYTEA := decode('cafebabedeadbeef00112233445566ff', 'hex');
-    sn BYTEA := decode('aaaaaaaaaaaaaaaa', 'hex');
+    ip BYTEA := decode('00112233445566778899aabbccddeeff', 'hex');
+    sn BYTEA := decode('aabbccdd00112233', 'hex');
     r RECORD;
-    bal BIGINT;
+    bal_before BIGINT;
+    bal_after  BIGINT;
 BEGIN
-    SELECT * INTO r
-      FROM referral.record_click(u, 'rareicon', ip, sn, 'UA/2.0', NULL, NULL);
-    IF NOT r.qualified THEN
-        RAISE EXCEPTION 'fail: new IP should qualify';
-    END IF;
-
-    SELECT b.credits INTO bal
+    SELECT b.credits INTO bal_before
       FROM wallet.balance b
       JOIN wallet.account a ON a.id = b.account_id
-     WHERE a.user_id = u;
-    IF bal <> 20 THEN
-        RAISE EXCEPTION 'fail: expected 20 credits after two distinct IPs, got %', bal;
-    END IF;
+     WHERE a.user_id = u AND a.kind = 'user';
+
+    UPDATE referral.reward_policy SET credits_per_click = 0 WHERE id = 1;
+    BEGIN
+        SELECT * INTO r
+          FROM referral.record_click(u, 'mc', ip, sn, NULL, NULL, NULL);
+        IF NOT r.qualified THEN
+            RAISE EXCEPTION 'fail: zero-credit click should still qualify';
+        END IF;
+        IF r.credited THEN
+            RAISE EXCEPTION 'fail: zero-credit click should NOT credit';
+        END IF;
+        IF r.ledger_id IS NOT NULL THEN
+            RAISE EXCEPTION 'fail: zero-credit click ledger_id should be NULL';
+        END IF;
+
+        SELECT b.credits INTO bal_after
+          FROM wallet.balance b
+          JOIN wallet.account a ON a.id = b.account_id
+         WHERE a.user_id = u AND a.kind = 'user';
+        IF bal_after IS DISTINCT FROM bal_before THEN
+            RAISE EXCEPTION 'fail: balance moved with credits_per_click=0';
+        END IF;
+    END;
+    UPDATE referral.reward_policy SET credits_per_click = 10 WHERE id = 1;
 END $$;
 
--- A different target on the same IP credits independently.
+-- Custom SQLSTATEs surface on unknown target.
 DO $$
 DECLARE
     u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
-    ip BYTEA := decode('aabbccddeeff00112233445566778899', 'hex');
-    sn BYTEA := decode('1122334455667788', 'hex');
-    r RECORD;
-    bal BIGINT;
 BEGIN
-    SELECT * INTO r
-      FROM referral.record_click(u, 'mc', ip, sn, NULL, NULL, NULL);
-    IF NOT r.qualified THEN
-        RAISE EXCEPTION 'fail: different target should qualify for same IP';
-    END IF;
-    IF r.target_url IS DISTINCT FROM 'https://kbve.com/mc/' THEN
-        RAISE EXCEPTION 'fail: mc target_url mismatch: %', r.target_url;
-    END IF;
-
-    SELECT b.credits INTO bal
-      FROM wallet.balance b
-      JOIN wallet.account a ON a.id = b.account_id
-     WHERE a.user_id = u;
-    IF bal <> 30 THEN
-        RAISE EXCEPTION 'fail: expected 30 credits after mc click, got %', bal;
-    END IF;
+    BEGIN
+        PERFORM * FROM referral.record_click(
+            u, 'nope-not-a-target', '\x01'::bytea, '\x01'::bytea
+        );
+        RAISE EXCEPTION 'fail: unknown target should have raised';
+    EXCEPTION WHEN SQLSTATE 'RFT01' THEN
+        -- expected
+    END;
 END $$;
 
 -- Missing required args raise.
 DO $$
 BEGIN
     BEGIN
-        PERFORM * FROM referral.record_click(NULL, 'rareicon', '\x01', '\x01');
+        PERFORM * FROM referral.record_click(NULL, 'rareicon', '\x01'::bytea, '\x01'::bytea);
         RAISE EXCEPTION 'fail: NULL referrer should have raised';
-    EXCEPTION WHEN OTHERS THEN
-        -- expected
-    END;
-
-    BEGIN
-        PERFORM * FROM referral.record_click(
-            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1'::UUID,
-            'nope-not-a-target',
-            '\x01', '\x01'
-        );
-        RAISE EXCEPTION 'fail: unknown target should have raised';
-    EXCEPTION WHEN OTHERS THEN
+    EXCEPTION WHEN SQLSTATE '22023' THEN
         -- expected
     END;
 END $$;
@@ -269,8 +320,7 @@ END $$;
 -- ASSERT_AFTER_DOWN
 
 -- migrate:down is intentionally a no-op so production cannot accidentally
--- truncate referral data. Verify the schema is still present after a
--- rollback and the seeded targets persist.
+-- truncate referral data. Schema + seeds survive a rollback.
 DO $$
 BEGIN
     IF NOT EXISTS (

--- a/packages/data/sql/dbmate/migration-tests/20260515221756_referral_schema_init.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260515221756_referral_schema_init.test.sql
@@ -1,0 +1,286 @@
+-- Companion test fixtures for 20260515221756_referral_schema_init.
+-- Run via: ./test-migration.sh 20260515221756_referral_schema_init
+
+-- SEED
+-- Idempotent cleanup of prior-run rows.
+WITH test_users (id) AS (
+    VALUES ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1'::uuid)
+),
+test_accounts AS (
+    SELECT a.id FROM wallet.account a JOIN test_users u ON a.user_id = u.id
+),
+del_user_target AS (
+    DELETE FROM referral.user_target
+     WHERE user_id IN (SELECT id FROM test_users)
+),
+del_click AS (
+    DELETE FROM referral.click
+     WHERE referrer_id IN (SELECT id FROM test_users)
+),
+del_balance AS (
+    DELETE FROM wallet.balance
+     WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_coupon AS (
+    DELETE FROM wallet.coupon
+     WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_account AS (
+    DELETE FROM wallet.account
+     WHERE id IN (SELECT id FROM test_accounts)
+)
+DELETE FROM auth.users WHERE id IN (SELECT id FROM test_users);
+
+INSERT INTO auth.users (id) VALUES ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1');
+
+-- ASSERT_AFTER_UP
+
+-- Catalog seed exists with both shipped targets.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM referral.target WHERE slug = 'rareicon' AND active) THEN
+        RAISE EXCEPTION 'fail: rareicon target missing';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM referral.target WHERE slug = 'mc' AND active) THEN
+        RAISE EXCEPTION 'fail: mc target missing';
+    END IF;
+END $$;
+
+-- Reward policy exists with the documented defaults.
+DO $$
+DECLARE p referral.reward_policy%ROWTYPE;
+BEGIN
+    SELECT * INTO p FROM referral.reward_policy WHERE id = 1;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'fail: reward_policy row 1 missing';
+    END IF;
+    IF p.credits_per_click <> 10 THEN
+        RAISE EXCEPTION 'fail: expected 10 credits per click, got %', p.credits_per_click;
+    END IF;
+    IF p.dedup_window_days <> 30 THEN
+        RAISE EXCEPTION 'fail: expected 30-day dedup window, got %', p.dedup_window_days;
+    END IF;
+END $$;
+
+-- target slug check rejects bad values.
+DO $$
+BEGIN
+    BEGIN
+        INSERT INTO referral.target (slug, title, url)
+        VALUES ('NOT-SLUG', 'x', 'https://example.com');
+        RAISE EXCEPTION 'fail: target.slug check should have rejected uppercase';
+    EXCEPTION WHEN check_violation THEN
+        -- expected
+    END;
+
+    BEGIN
+        INSERT INTO referral.target (slug, title, url)
+        VALUES ('ftp-not-http', 'x', 'ftp://example.com');
+        RAISE EXCEPTION 'fail: target.url check should have rejected ftp';
+    EXCEPTION WHEN check_violation THEN
+        -- expected
+    END;
+END $$;
+
+-- partial unique index allows multiple non-default rows, blocks two defaults.
+DO $$
+DECLARE u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+BEGIN
+    INSERT INTO referral.user_target (user_id, target_slug, is_default)
+    VALUES (u, 'rareicon', TRUE);
+
+    INSERT INTO referral.user_target (user_id, target_slug, is_default)
+    VALUES (u, 'mc', FALSE);
+
+    BEGIN
+        INSERT INTO referral.user_target (user_id, target_slug, is_default)
+        VALUES (u, 'mc', TRUE);  -- conflict with the partial unique
+        RAISE EXCEPTION 'fail: partial unique index should have blocked second default';
+    EXCEPTION WHEN unique_violation THEN
+        -- expected
+    END;
+
+    -- clean up so the rest of the assertions start fresh on user_target
+    DELETE FROM referral.user_target WHERE user_id = u;
+END $$;
+
+-- resolve_user_target returns the configured default when slug is NULL.
+DO $$
+DECLARE
+    u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+    r referral.target%ROWTYPE;
+BEGIN
+    INSERT INTO referral.user_target (user_id, target_slug, is_default)
+    VALUES (u, 'rareicon', TRUE);
+    INSERT INTO referral.user_target (user_id, target_slug, is_default)
+    VALUES (u, 'mc', FALSE);
+
+    SELECT * INTO r FROM referral.resolve_user_target(u, NULL);
+    IF r.slug IS DISTINCT FROM 'rareicon' THEN
+        RAISE EXCEPTION 'fail: default resolution expected rareicon, got %', r.slug;
+    END IF;
+
+    -- Explicit slug overrides default.
+    SELECT * INTO r FROM referral.resolve_user_target(u, 'mc');
+    IF r.slug IS DISTINCT FROM 'mc' THEN
+        RAISE EXCEPTION 'fail: explicit slug should have returned mc, got %', r.slug;
+    END IF;
+
+    -- Slug user does not have enabled returns no row.
+    PERFORM 1 FROM referral.resolve_user_target(u, 'nonexistent');
+    IF FOUND THEN
+        RAISE EXCEPTION 'fail: unknown slug should not resolve';
+    END IF;
+
+    DELETE FROM referral.user_target WHERE user_id = u;
+END $$;
+
+-- record_click: first call credits 10, returns qualified=true; second call
+-- with same (referrer, target, ip_hash) inside the dedup window does not.
+DO $$
+DECLARE
+    u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+    ip BYTEA := decode('aabbccddeeff00112233445566778899', 'hex');
+    sn BYTEA := decode('1122334455667788', 'hex');
+    r1 RECORD;
+    r2 RECORD;
+    bal BIGINT;
+BEGIN
+    SELECT * INTO r1
+      FROM referral.record_click(u, 'rareicon', ip, sn, 'UA/1.0', 'https://t.co/x', 'en');
+    IF NOT r1.qualified THEN
+        RAISE EXCEPTION 'fail: first click should qualify';
+    END IF;
+    IF NOT r1.credited THEN
+        RAISE EXCEPTION 'fail: first click should credit';
+    END IF;
+    IF r1.ledger_id IS NULL THEN
+        RAISE EXCEPTION 'fail: first click ledger_id should be set';
+    END IF;
+    IF r1.target_url IS DISTINCT FROM 'https://store.steampowered.com/app/2238370/RareIcon/' THEN
+        RAISE EXCEPTION 'fail: target_url mismatch: %', r1.target_url;
+    END IF;
+
+    SELECT b.credits INTO bal
+      FROM wallet.balance b
+      JOIN wallet.account a ON a.id = b.account_id
+     WHERE a.user_id = u AND a.kind = 'user';
+    IF bal <> 10 THEN
+        RAISE EXCEPTION 'fail: expected 10 credits after first click, got %', bal;
+    END IF;
+
+    SELECT * INTO r2
+      FROM referral.record_click(u, 'rareicon', ip, sn, 'UA/1.0', NULL, 'en');
+    IF r2.qualified THEN
+        RAISE EXCEPTION 'fail: second click should NOT qualify (dedup window)';
+    END IF;
+    IF r2.credited THEN
+        RAISE EXCEPTION 'fail: second click should NOT credit';
+    END IF;
+    IF r2.ledger_id IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: second click ledger_id should be NULL';
+    END IF;
+    IF r2.target_url IS DISTINCT FROM r1.target_url THEN
+        RAISE EXCEPTION 'fail: target_url should still resolve on dup';
+    END IF;
+
+    SELECT b.credits INTO bal
+      FROM wallet.balance b
+      JOIN wallet.account a ON a.id = b.account_id
+     WHERE a.user_id = u AND a.kind = 'user';
+    IF bal <> 10 THEN
+        RAISE EXCEPTION 'fail: credits should remain 10 after duplicate click, got %', bal;
+    END IF;
+END $$;
+
+-- A different ip_hash on the same target credits independently.
+DO $$
+DECLARE
+    u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+    ip BYTEA := decode('cafebabedeadbeef00112233445566ff', 'hex');
+    sn BYTEA := decode('aaaaaaaaaaaaaaaa', 'hex');
+    r RECORD;
+    bal BIGINT;
+BEGIN
+    SELECT * INTO r
+      FROM referral.record_click(u, 'rareicon', ip, sn, 'UA/2.0', NULL, NULL);
+    IF NOT r.qualified THEN
+        RAISE EXCEPTION 'fail: new IP should qualify';
+    END IF;
+
+    SELECT b.credits INTO bal
+      FROM wallet.balance b
+      JOIN wallet.account a ON a.id = b.account_id
+     WHERE a.user_id = u;
+    IF bal <> 20 THEN
+        RAISE EXCEPTION 'fail: expected 20 credits after two distinct IPs, got %', bal;
+    END IF;
+END $$;
+
+-- A different target on the same IP credits independently.
+DO $$
+DECLARE
+    u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+    ip BYTEA := decode('aabbccddeeff00112233445566778899', 'hex');
+    sn BYTEA := decode('1122334455667788', 'hex');
+    r RECORD;
+    bal BIGINT;
+BEGIN
+    SELECT * INTO r
+      FROM referral.record_click(u, 'mc', ip, sn, NULL, NULL, NULL);
+    IF NOT r.qualified THEN
+        RAISE EXCEPTION 'fail: different target should qualify for same IP';
+    END IF;
+    IF r.target_url IS DISTINCT FROM 'https://kbve.com/mc/' THEN
+        RAISE EXCEPTION 'fail: mc target_url mismatch: %', r.target_url;
+    END IF;
+
+    SELECT b.credits INTO bal
+      FROM wallet.balance b
+      JOIN wallet.account a ON a.id = b.account_id
+     WHERE a.user_id = u;
+    IF bal <> 30 THEN
+        RAISE EXCEPTION 'fail: expected 30 credits after mc click, got %', bal;
+    END IF;
+END $$;
+
+-- Missing required args raise.
+DO $$
+BEGIN
+    BEGIN
+        PERFORM * FROM referral.record_click(NULL, 'rareicon', '\x01', '\x01');
+        RAISE EXCEPTION 'fail: NULL referrer should have raised';
+    EXCEPTION WHEN OTHERS THEN
+        -- expected
+    END;
+
+    BEGIN
+        PERFORM * FROM referral.record_click(
+            'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1'::UUID,
+            'nope-not-a-target',
+            '\x01', '\x01'
+        );
+        RAISE EXCEPTION 'fail: unknown target should have raised';
+    EXCEPTION WHEN OTHERS THEN
+        -- expected
+    END;
+END $$;
+
+-- ASSERT_AFTER_DOWN
+
+-- migrate:down is intentionally a no-op so production cannot accidentally
+-- truncate referral data. Verify the schema is still present after a
+-- rollback and the seeded targets persist.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_namespace WHERE nspname = 'referral'
+    ) THEN
+        RAISE EXCEPTION 'fail: referral schema should survive no-op down';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM referral.target WHERE slug = 'rareicon'
+    ) THEN
+        RAISE EXCEPTION 'fail: rareicon target should survive no-op down';
+    END IF;
+END $$;

--- a/packages/data/sql/dbmate/migration-tests/20260515221756_referral_schema_init.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260515221756_referral_schema_init.test.sql
@@ -163,8 +163,9 @@ END $$;
 DO $$
 DECLARE
     u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
-    ip BYTEA := decode('aabbccddeeff00112233445566778899', 'hex');
-    sn BYTEA := decode('1122334455667788', 'hex');
+    -- 32-byte HMAC-SHA256-shaped fixtures (record_click rejects other sizes).
+    ip BYTEA := decode('aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899', 'hex');
+    sn BYTEA := decode('1122334455667788112233445566778811223344556677881122334455667788', 'hex');
 BEGIN
     BEGIN
         PERFORM * FROM referral.record_click(u, 'rareicon', ip, sn);
@@ -181,8 +182,9 @@ END $$;
 DO $$
 DECLARE
     u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
-    ip BYTEA := decode('aabbccddeeff00112233445566778899', 'hex');
-    sn BYTEA := decode('1122334455667788', 'hex');
+    -- 32-byte HMAC-SHA256-shaped fixtures (record_click rejects other sizes).
+    ip BYTEA := decode('aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899', 'hex');
+    sn BYTEA := decode('1122334455667788112233445566778811223344556677881122334455667788', 'hex');
     r1 RECORD;
     r2 RECORD;
     bal BIGINT;
@@ -255,8 +257,8 @@ END $$;
 DO $$
 DECLARE
     u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
-    ip BYTEA := decode('00112233445566778899aabbccddeeff', 'hex');
-    sn BYTEA := decode('aabbccdd00112233', 'hex');
+    ip BYTEA := decode('00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff', 'hex');
+    sn BYTEA := decode('aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233', 'hex');
     r RECORD;
     bal_before BIGINT;
     bal_after  BIGINT;
@@ -295,26 +297,118 @@ END $$;
 DO $$
 DECLARE
     u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+    ip BYTEA := decode(repeat('cc', 32), 'hex');
+    sn BYTEA := decode(repeat('dd', 32), 'hex');
 BEGIN
     BEGIN
-        PERFORM * FROM referral.record_click(
-            u, 'nope-not-a-target', '\x01'::bytea, '\x01'::bytea
-        );
+        PERFORM * FROM referral.record_click(u, 'nope-not-a-target', ip, sn);
         RAISE EXCEPTION 'fail: unknown target should have raised';
     EXCEPTION WHEN SQLSTATE 'RFT01' THEN
         -- expected
     END;
 END $$;
 
--- Missing required args raise.
+-- NULL referrer raises 22023.
 DO $$
+DECLARE
+    ip BYTEA := decode(repeat('cc', 32), 'hex');
+    sn BYTEA := decode(repeat('dd', 32), 'hex');
 BEGIN
     BEGIN
-        PERFORM * FROM referral.record_click(NULL, 'rareicon', '\x01'::bytea, '\x01'::bytea);
+        PERFORM * FROM referral.record_click(NULL, 'rareicon', ip, sn);
         RAISE EXCEPTION 'fail: NULL referrer should have raised';
     EXCEPTION WHEN SQLSTATE '22023' THEN
         -- expected
     END;
+END $$;
+
+-- Hash-length validation: anything other than 32 bytes raises 22023.
+DO $$
+DECLARE
+    u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+    ip32 BYTEA := decode(repeat('ee', 32), 'hex');
+BEGIN
+    BEGIN
+        PERFORM * FROM referral.record_click(
+            u, 'rareicon', '\x01020304'::bytea, ip32
+        );
+        RAISE EXCEPTION 'fail: 4-byte ip_hash should have raised';
+    EXCEPTION WHEN SQLSTATE '22023' THEN
+        -- expected
+    END;
+
+    BEGIN
+        PERFORM * FROM referral.record_click(
+            u, 'rareicon', ip32, '\x0102'::bytea
+        );
+        RAISE EXCEPTION 'fail: 2-byte subnet_hash should have raised';
+    EXCEPTION WHEN SQLSTATE '22023' THEN
+        -- expected
+    END;
+END $$;
+
+-- Slug normalization: whitespace + uppercase resolved before lookup.
+DO $$
+DECLARE
+    u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+    ip BYTEA := decode(repeat('ff', 32), 'hex');
+    sn BYTEA := decode(repeat('11', 32), 'hex');
+    r RECORD;
+BEGIN
+    SELECT * INTO r
+      FROM referral.record_click(u, '  RAREICON  ', ip, sn, NULL, NULL, NULL);
+    IF r.target_slug IS DISTINCT FROM 'rareicon' THEN
+        RAISE EXCEPTION 'fail: slug normalization missed: %', r.target_slug;
+    END IF;
+END $$;
+
+-- active/disabled_at invariant: cannot insert active=FALSE without
+-- a disabled_at timestamp.
+DO $$
+DECLARE u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+BEGIN
+    BEGIN
+        INSERT INTO referral.user_target (user_id, target_slug, is_default, active)
+        VALUES (u, 'rareicon', FALSE, FALSE);
+        RAISE EXCEPTION 'fail: active=FALSE without disabled_at should have raised';
+    EXCEPTION WHEN check_violation THEN
+        -- expected
+    END;
+END $$;
+
+-- credited/ledger_id invariant: cannot manually insert a click row
+-- where credited and ledger_id disagree.
+DO $$
+DECLARE
+    u UUID := 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbb1';
+    ip BYTEA := decode(repeat('22', 32), 'hex');
+    sn BYTEA := decode(repeat('33', 32), 'hex');
+BEGIN
+    BEGIN
+        INSERT INTO referral.click (
+            referrer_id, target_slug, ip_hash, subnet_hash,
+            qualified, credited, ledger_id
+        ) VALUES (u, 'rareicon', ip, sn, TRUE, TRUE, NULL);
+        RAISE EXCEPTION 'fail: credited=TRUE + ledger_id=NULL should have raised';
+    EXCEPTION WHEN check_violation THEN
+        -- expected
+    END;
+END $$;
+
+-- reward_policy.updated_at auto-bumps on UPDATE via trigger.
+DO $$
+DECLARE
+    ts_before TIMESTAMPTZ;
+    ts_after  TIMESTAMPTZ;
+BEGIN
+    SELECT updated_at INTO ts_before FROM referral.reward_policy WHERE id = 1;
+    PERFORM pg_sleep(0.05);
+    UPDATE referral.reward_policy SET credits_per_click = 11 WHERE id = 1;
+    SELECT updated_at INTO ts_after  FROM referral.reward_policy WHERE id = 1;
+    IF ts_after <= ts_before THEN
+        RAISE EXCEPTION 'fail: reward_policy trigger did not bump updated_at';
+    END IF;
+    UPDATE referral.reward_policy SET credits_per_click = 10 WHERE id = 1;
 END $$;
 
 -- ASSERT_AFTER_DOWN

--- a/packages/data/sql/dbmate/migrations/20260515220000_wallet_source_kind_referral.sql
+++ b/packages/data/sql/dbmate/migrations/20260515220000_wallet_source_kind_referral.sql
@@ -1,0 +1,21 @@
+-- migrate:up
+
+-- Add 'referral' to wallet.source_kind so the referral schema migration
+-- (20260515221756_referral_schema_init.sql) can immediately cast values to
+-- it inside its function bodies.
+--
+-- ALTER TYPE ... ADD VALUE is allowed inside a transaction on Postgres 12+
+-- BUT the new value cannot be used in the same transaction it was added
+-- in. dbmate wraps each migration file in one transaction, so the enum
+-- add and its first cast site must live in separate migration files.
+-- This migration handles the enum add; the next one consumes it.
+ALTER TYPE wallet.source_kind ADD VALUE IF NOT EXISTS 'referral';
+
+-- migrate:down
+
+-- Intentionally a no-op. Postgres has no DROP VALUE for enum types, and
+-- removing the value would orphan any ledger rows already tagged
+-- 'referral'. Stripping a referral entry requires rewriting the ledger
+-- row's source_kind out-of-band; do that with a dedicated script if it
+-- is ever actually needed.
+SELECT 1;

--- a/packages/data/sql/dbmate/migrations/20260515221756_referral_schema_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260515221756_referral_schema_init.sql
@@ -7,10 +7,12 @@
 --   wallet.source_kind = 'referral' (20260515220000_wallet_source_kind_referral)
 --   pgcrypto for gen_random_uuid()
 --
--- Custom SQLSTATEs raised by record_click for the Phase 2 axum handler:
---   RFP01 = referral.reward_policy row missing
---   RFT01 = referral target not found / inactive
---   RFU01 = referrer does not have target enabled in user_target
+-- Custom SQLSTATEs raised by this migration's functions for the Phase 2
+-- axum handler:
+--   RFP01  = referral.reward_policy row missing
+--   RFT01  = referral target not found / inactive
+--   RFU01  = referrer does not have target enabled in user_target
+--   RFWA1  = ensure_referrer_account failed to provision a wallet account
 --
 -- Surface (consumed in Phase 2 by axum-kbve):
 --   /referral/@<handle>/             → user's default target
@@ -117,13 +119,25 @@ CREATE TABLE IF NOT EXISTS referral.click (
     -- invariant. wallet.ledger is append-only in practice, so RESTRICT
     -- is the safe default.
     ledger_id     BIGINT REFERENCES wallet.ledger(id) ON DELETE RESTRICT,
-    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- Hard invariant: credited iff ledger_id is set. record_click writes
+    -- both together; this CHECK keeps any future writer honest.
+    CONSTRAINT click_credit_ledger_chk
+        CHECK (
+            (credited AND ledger_id IS NOT NULL)
+         OR (NOT credited AND ledger_id IS NULL)
+        )
 );
 CREATE INDEX IF NOT EXISTS click_created_at ON referral.click (created_at);
 -- Hot lookup path for the dedup check inside record_click().
 CREATE INDEX IF NOT EXISTS click_dedup_idx
     ON referral.click (referrer_id, target_slug, ip_hash, created_at DESC)
     WHERE qualified;
+-- One click maps to at most one ledger row. Enforces the
+-- "ledger_id is the wallet credit for THIS click" invariant.
+CREATE UNIQUE INDEX IF NOT EXISTS click_ledger_id_uq
+    ON referral.click (ledger_id)
+    WHERE ledger_id IS NOT NULL;
 COMMENT ON COLUMN referral.click.ip_hash IS
     'HMAC-SHA256(server_secret, ip) — never store raw IP.';
 COMMENT ON COLUMN referral.click.subnet_hash IS
@@ -160,7 +174,9 @@ RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $fn$
 BEGIN
-    NEW.updated_at := now();
+    -- statement_timestamp() matches the RPC-side audit semantics
+    -- (record_click also captures statement_timestamp into v_now).
+    NEW.updated_at := statement_timestamp();
     RETURN NEW;
 END;
 $fn$;
@@ -184,8 +200,12 @@ ALTER TABLE referral.user_target     ENABLE ROW LEVEL SECURITY;
 ALTER TABLE referral.click           ENABLE ROW LEVEL SECURITY;
 ALTER TABLE referral.reward_policy   ENABLE ROW LEVEL SECURITY;
 
-REVOKE ALL ON ALL TABLES    IN SCHEMA referral FROM PUBLIC, anon, authenticated;
-REVOKE ALL ON ALL SEQUENCES IN SCHEMA referral FROM PUBLIC, anon, authenticated;
+-- Revoke from every role we know about, including service_role. Direct
+-- table SELECT/INSERT/etc must NOT be possible — the only callable surface
+-- is the SECURITY DEFINER functions (which are owned by postgres, not
+-- service_role, so REVOKE here does not affect them).
+REVOKE ALL ON ALL TABLES    IN SCHEMA referral FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA referral FROM PUBLIC, anon, authenticated, service_role;
 
 -- ---------------------------------------------------------------------------
 -- ensure_referrer_account — lazy wallet account provisioning for a brand
@@ -218,6 +238,8 @@ BEGIN
         RETURN v_account_id;
     END IF;
 
+    -- The ON CONFLICT target depends on the partial unique index on
+    -- wallet.account (user_id) WHERE kind = 'user' — a wallet invariant.
     INSERT INTO wallet.account (kind, user_id, created_at)
     VALUES ('user', p_user_id, now())
     ON CONFLICT (user_id) WHERE kind = 'user' DO NOTHING
@@ -227,6 +249,17 @@ BEGIN
         SELECT id INTO v_account_id
           FROM wallet.account
          WHERE kind = 'user' AND user_id = p_user_id;
+    END IF;
+
+    -- Hard safety net: if both insert paths failed (advisory lock + ON
+    -- CONFLICT + fallback SELECT) and we still have no account, refuse
+    -- to insert a balance row keyed on NULL. Custom SQLSTATE so the
+    -- handler can distinguish provisioning failures from generic data
+    -- errors.
+    IF v_account_id IS NULL THEN
+        RAISE EXCEPTION 'failed to provision wallet account for user %',
+                        p_user_id
+            USING ERRCODE = 'RFWA1';
     END IF;
 
     INSERT INTO wallet.balance (account_id)
@@ -289,6 +322,7 @@ SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
+    v_now          TIMESTAMPTZ := statement_timestamp();
     v_policy       referral.reward_policy%ROWTYPE;
     v_target       referral.target%ROWTYPE;
     v_existing_id  BIGINT;
@@ -305,11 +339,23 @@ BEGIN
     IF p_target_slug IS NULL THEN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
-    IF p_ip_hash IS NULL OR octet_length(p_ip_hash) = 0 THEN
-        RAISE EXCEPTION 'ip_hash is required' USING ERRCODE = '22023';
+    -- Normalize slug before it influences the advisory lock key or the
+    -- catalog lookup. Slug-shape constraint on referral.target accepts
+    -- only lowercase + dashes; reject obviously bad input here too.
+    p_target_slug := lower(btrim(p_target_slug));
+    IF p_target_slug = '' THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
-    IF p_subnet_hash IS NULL OR octet_length(p_subnet_hash) = 0 THEN
-        RAISE EXCEPTION 'subnet_hash is required' USING ERRCODE = '22023';
+
+    -- HMAC-SHA256 digests are exactly 32 bytes. Reject anything else so
+    -- malformed (or empty) hashes cannot poison the dedup table.
+    IF p_ip_hash IS NULL OR octet_length(p_ip_hash) <> 32 THEN
+        RAISE EXCEPTION 'ip_hash must be a 32-byte HMAC-SHA256 digest'
+            USING ERRCODE = '22023';
+    END IF;
+    IF p_subnet_hash IS NULL OR octet_length(p_subnet_hash) <> 32 THEN
+        RAISE EXCEPTION 'subnet_hash must be a 32-byte HMAC-SHA256 digest'
+            USING ERRCODE = '22023';
     END IF;
 
     -- Serialize concurrent clicks for the same dedup tuple so the
@@ -359,7 +405,7 @@ BEGIN
        AND c.target_slug = p_target_slug
        AND c.ip_hash     = p_ip_hash
        AND c.qualified
-       AND c.created_at  >= now() - make_interval(days => v_policy.dedup_window_days)
+       AND c.created_at  >= v_now - make_interval(days => v_policy.dedup_window_days)
      ORDER BY c.created_at DESC
      LIMIT 1;
 
@@ -395,6 +441,9 @@ BEGIN
         -- idempotency keys as replays and returns the prior ledger_id.
         v_idem_key := (md5('referral.click:' || v_click_id::TEXT))::UUID;
 
+        -- wallet.service_credit invariant assumed: idempotent on
+        -- p_idempotency_key — re-calling with the same UUID returns
+        -- the prior ledger_id instead of inserting a second row.
         v_ledger_id := wallet.service_credit(
             v_account_id,
             'credits'::wallet.currency_kind,
@@ -467,6 +516,11 @@ AS $fn$
            (p_target_slug IS NOT NULL AND ut.target_slug = p_target_slug)
         OR (p_target_slug IS NULL AND ut.is_default)
        )
+     -- Deterministic tiebreak: prefer the default row, then the most
+     -- recently enabled. The (user_id, is_default WHERE active) partial
+     -- unique index already prevents duplicates; this ORDER BY just
+     -- pins behavior in case the query is reused with a relaxed filter.
+     ORDER BY ut.is_default DESC, ut.enabled_at DESC, ut.target_slug
      LIMIT 1;
 $fn$;
 

--- a/packages/data/sql/dbmate/migrations/20260515221756_referral_schema_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260515221756_referral_schema_init.sql
@@ -2,41 +2,32 @@
 
 -- Referral system Phase 1 — schema + click-recording RPC.
 --
--- Surface
+-- Depends on:
+--   wallet schema + wallet.service_credit (20260511104220_wallet_schema_init)
+--   wallet.source_kind = 'referral' (20260515220000_wallet_source_kind_referral)
+--   pgcrypto for gen_random_uuid()
+--
+-- Surface (consumed in Phase 2 by axum-kbve):
 --   /referral/@<handle>/             → user's default target
 --   /referral/@<handle>/<target>/    → specific target from the catalog
 --
--- Phase 1 (this migration) lays the rails:
---   - referral.target          — admin-curated catalog of redirect destinations
---   - referral.user_target     — which targets each user can refer to + their
---                                primary (one row per user marked is_default)
---   - referral.click           — append-only click log; one row per HTTP hit
---   - referral.reward_policy   — single-row config (credits per click + dedup
---                                window). Bumping the row is the only way to
---                                change reward economics without a redeploy.
---   - referral.record_click(...) — SECURITY DEFINER RPC the axum handler calls
---                                  to log a click and, when qualified under
---                                  the policy's dedup window, credit the
---                                  referrer's wallet.
---   - referral.resolve_user_target(...) — pick the (slug, url) for a click.
---
--- Phase 2 will add the axum-kbve route + astro page rewrite. Phase 2 only
--- consumes the surface defined here.
---
--- Privacy: raw IPs are NEVER stored. The axum handler hashes the visitor IP
--- via HMAC-SHA256(REFERRAL_HASH_SECRET, ip) and the /24 IPv4 (or /48 IPv6)
--- subnet prefix, then passes both digests. We only see opaque bytea.
+-- Privacy: raw IPs are NEVER stored. The Phase 2 axum handler hashes the
+-- visitor IP with HMAC-SHA256(REFERRAL_HASH_SECRET, ip) and the /24 IPv4
+-- (or /48 IPv6) subnet prefix, then passes both digests. We only see
+-- opaque bytea.
 
--- Extend the wallet source_kind enum with the 'referral' tag. service_credit
--- requires the value to exist before any referral row inserts a ledger entry.
--- ALTER TYPE ... ADD VALUE cannot run inside a transaction block, so this
--- statement must execute before the rest of the file is in a txn (dbmate
--- runs each .sql top-to-bottom under one tx by default; pgcrypto pattern is
--- to use the IF NOT EXISTS clause to make the ADD idempotent + tx-safe).
-ALTER TYPE wallet.source_kind ADD VALUE IF NOT EXISTS 'referral';
+-- Belt-and-suspenders: gen_random_uuid lives in pgcrypto on older
+-- Postgres, and is in core from 13+. Either way, this is a no-op on
+-- modern clusters.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 CREATE SCHEMA IF NOT EXISTS referral;
-GRANT USAGE ON SCHEMA referral TO authenticated, service_role;
+
+-- Schema usage is service-only for Phase 1. authenticated users go
+-- through the axum handler (service_role) -- they never touch this
+-- schema directly. Grant authenticated later when a client-side RPC
+-- needs it.
+GRANT USAGE ON SCHEMA referral TO service_role;
 
 -- ---------------------------------------------------------------------------
 -- target catalog
@@ -45,7 +36,11 @@ CREATE TABLE IF NOT EXISTS referral.target (
     slug         TEXT PRIMARY KEY
                    CHECK (slug ~ '^[a-z0-9][a-z0-9-]{0,62}$'),
     title        TEXT NOT NULL CHECK (length(title) BETWEEN 1 AND 120),
-    url          TEXT NOT NULL CHECK (url ~ '^https?://'),
+    -- Tight URL check: require http(s)://, forbid whitespace and control
+    -- chars. Application code does proper URL validation; this is just a
+    -- coarse safety net at the DB.
+    url          TEXT NOT NULL
+                   CHECK (url ~ '^https?://[^[:space:][:cntrl:]]+$'),
     description  TEXT,
     active       BOOLEAN NOT NULL DEFAULT TRUE,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -53,6 +48,8 @@ CREATE TABLE IF NOT EXISTS referral.target (
 COMMENT ON TABLE referral.target IS
     'Curated redirect destinations. Admin-only writes (no RLS policy grants).';
 
+-- Catalog rows ARE re-applied on re-run so URL fixes / title bumps land
+-- without manual SQL. Slug stays the primary key so links never break.
 INSERT INTO referral.target (slug, title, url, description) VALUES
     ('rareicon',
      'RareIcon on Steam',
@@ -62,7 +59,10 @@ INSERT INTO referral.target (slug, title, url, description) VALUES
      'KBVE Minecraft',
      'https://kbve.com/mc/',
      'KBVE Minecraft server hub.')
-ON CONFLICT (slug) DO NOTHING;
+ON CONFLICT (slug) DO UPDATE
+    SET title       = EXCLUDED.title,
+        url         = EXCLUDED.url,
+        description = EXCLUDED.description;
 
 -- ---------------------------------------------------------------------------
 -- per-user target opt-in + default
@@ -71,14 +71,18 @@ CREATE TABLE IF NOT EXISTS referral.user_target (
     user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     target_slug  TEXT NOT NULL REFERENCES referral.target(slug) ON DELETE CASCADE,
     is_default   BOOLEAN NOT NULL DEFAULT FALSE,
+    -- active = TRUE is the live state; flipping to FALSE keeps history
+    -- without losing the (user_id, target_slug) row. record_click +
+    -- resolve_user_target both honor this.
+    active       BOOLEAN NOT NULL DEFAULT TRUE,
     enabled_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    disabled_at  TIMESTAMPTZ,
     PRIMARY KEY (user_id, target_slug)
 );
--- A user has at most one default target. Partial unique index, not a
--- table-level constraint, so non-default rows don't fight for the slot.
+-- One default target per user, only counted among active rows.
 CREATE UNIQUE INDEX IF NOT EXISTS user_target_one_default
     ON referral.user_target (user_id)
-    WHERE is_default;
+    WHERE is_default AND active;
 
 -- ---------------------------------------------------------------------------
 -- click log
@@ -94,7 +98,10 @@ CREATE TABLE IF NOT EXISTS referral.click (
     accept_lang   TEXT,
     qualified     BOOLEAN NOT NULL DEFAULT FALSE,
     credited      BOOLEAN NOT NULL DEFAULT FALSE,
-    ledger_id     BIGINT,
+    -- FK so the ledger row a credit click points at must really exist.
+    -- ON DELETE SET NULL keeps the click history visible even if a ledger
+    -- entry is ever rolled back out-of-band.
+    ledger_id     BIGINT REFERENCES wallet.ledger(id) ON DELETE SET NULL,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS click_created_at ON referral.click (created_at);
@@ -107,10 +114,14 @@ COMMENT ON COLUMN referral.click.ip_hash IS
 COMMENT ON COLUMN referral.click.subnet_hash IS
     'HMAC-SHA256(server_secret, /24 IPv4 or /48 IPv6 prefix).';
 COMMENT ON COLUMN referral.click.qualified IS
-    'TRUE iff this click triggered a reward credit (no earlier qualified row
-     within the policy dedup window for the same referrer+target+ip_hash).';
+    'TRUE iff this click was the first inside the policy dedup window for
+     the (referrer, target, ip_hash) tuple. credited may still be FALSE
+     when credits_per_click = 0.';
+COMMENT ON COLUMN referral.click.credited IS
+    'TRUE iff wallet.service_credit actually ran for this click (qualified
+     AND credits_per_click > 0). ledger_id is populated iff credited.';
 COMMENT ON COLUMN referral.click.ledger_id IS
-    'wallet.ledger.id of the credit, when credited=true. NULL otherwise.';
+    'wallet.ledger.id of the credit. NULL when credited = FALSE.';
 
 -- ---------------------------------------------------------------------------
 -- reward policy — single row, easy to bump without a redeploy
@@ -128,10 +139,22 @@ VALUES (1, 10, 30)
 ON CONFLICT (id) DO NOTHING;
 
 -- ---------------------------------------------------------------------------
--- internal helper: resolve the wallet.account.id for a referrer's user_id.
--- Lazy-provisions the account + balance if the user has never been seen by
--- the wallet before. Mirrors the pattern in wallet.proxy_ensure_user_account
--- but is callable from the service path (no auth.uid()).
+-- Lock down direct table access. Only the SECURITY DEFINER functions
+-- below should read or write these tables. PostgREST never sees rows
+-- because RLS is on and no policy grants are issued.
+-- ---------------------------------------------------------------------------
+ALTER TABLE referral.target          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE referral.user_target     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE referral.click           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE referral.reward_policy   ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON ALL TABLES    IN SCHEMA referral FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA referral FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- ensure_referrer_account — lazy wallet account provisioning for a brand
+-- new user's first referral credit. Mirrors wallet.proxy_ensure_user_account
+-- but is callable from the service path (no auth.uid() dependency).
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.ensure_referrer_account(
     p_user_id UUID
@@ -184,15 +207,29 @@ GRANT EXECUTE ON FUNCTION referral.ensure_referrer_account(UUID)
     TO service_role;
 
 -- ---------------------------------------------------------------------------
--- record_click — the entry point for the axum-kbve referral handler.
+-- record_click — entry point for the axum-kbve referral handler.
 --
--- Resolves the target, checks the dedup window, optionally credits the
--- referrer's wallet, and writes one row to referral.click. Returns enough
--- for the handler to log + redirect.
+-- Order of operations is deliberate:
+--   1. Validate inputs.
+--   2. Take a transaction-scoped advisory lock on
+--      (referrer_id, target_slug, ip_hash) so two concurrent clicks for
+--      the same tuple cannot both pass the dedup check and both credit.
+--   3. Verify referrer has the target enabled (defense in depth — the
+--      handler is supposed to call resolve_user_target first, but if a
+--      future caller forgets we still cannot credit a target the user
+--      has not opted into).
+--   4. Run the dedup-window check.
+--   5. Insert the click row uncredited.
+--   6. If qualified AND credits_per_click > 0:
+--        - call wallet.service_credit with a deterministic idempotency
+--          key derived from the freshly-inserted click_id;
+--        - UPDATE the click row with credited = TRUE + ledger_id.
+--      Deterministic idem key makes wallet-level retries idempotent and
+--      keeps the ledger row pointed at a real referral.click.id via
+--      ref_id.
 --
--- Atomicity: the wallet credit + the click insert run in the same
--- transaction. If wallet.service_credit raises, the click row is rolled
--- back with it — credited / ledger_id never lie.
+-- Custom SQLSTATEs (RF...) let the axum handler distinguish referral
+-- errors from generic PL/pgSQL data-not-found paths.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.record_click(
     p_referrer_id  UUID,
@@ -204,24 +241,27 @@ CREATE OR REPLACE FUNCTION referral.record_click(
     p_accept_lang  TEXT DEFAULT NULL
 )
 RETURNS TABLE (
-    click_id    BIGINT,
-    qualified   BOOLEAN,
-    credited    BOOLEAN,
-    ledger_id   BIGINT,
-    target_url  TEXT
+    click_id     BIGINT,
+    target_slug  TEXT,
+    target_url   TEXT,
+    qualified    BOOLEAN,
+    credited     BOOLEAN,
+    ledger_id    BIGINT
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
-    v_policy        referral.reward_policy%ROWTYPE;
-    v_target        referral.target%ROWTYPE;
-    v_existing_id   BIGINT;
-    v_qualifies     BOOLEAN := FALSE;
-    v_account_id    UUID;
-    v_ledger_id     BIGINT;
-    v_click_id      BIGINT;
+    v_policy       referral.reward_policy%ROWTYPE;
+    v_target       referral.target%ROWTYPE;
+    v_existing_id  BIGINT;
+    v_qualifies    BOOLEAN := FALSE;
+    v_account_id   UUID;
+    v_ledger_id    BIGINT;
+    v_click_id     BIGINT;
+    v_idem_key     UUID;
+    v_credited     BOOLEAN := FALSE;
 BEGIN
     IF p_referrer_id IS NULL THEN
         RAISE EXCEPTION 'referrer_id is required' USING ERRCODE = '22023';
@@ -236,9 +276,21 @@ BEGIN
         RAISE EXCEPTION 'subnet_hash is required' USING ERRCODE = '22023';
     END IF;
 
+    -- Serialize concurrent clicks for the same dedup tuple so the
+    -- read-before-write dedup check is race-free.
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended(
+            'referral.click:'
+            || p_referrer_id::TEXT
+            || ':' || p_target_slug
+            || ':' || encode(p_ip_hash, 'hex'),
+            0
+        )
+    );
+
     SELECT * INTO v_policy FROM referral.reward_policy WHERE id = 1;
     IF NOT FOUND THEN
-        RAISE EXCEPTION 'reward policy missing' USING ERRCODE = 'P0002';
+        RAISE EXCEPTION 'reward policy missing' USING ERRCODE = 'RFP01';
     END IF;
 
     SELECT * INTO v_target
@@ -246,13 +298,25 @@ BEGIN
      WHERE slug = p_target_slug AND active;
     IF NOT FOUND THEN
         RAISE EXCEPTION 'target % not found or inactive', p_target_slug
-            USING ERRCODE = 'P0002';
+            USING ERRCODE = 'RFT01';
+    END IF;
+
+    -- Referrer must have this target enabled. The handler already
+    -- resolves via resolve_user_target, but defense in depth.
+    IF NOT EXISTS (
+        SELECT 1
+          FROM referral.user_target ut
+         WHERE ut.user_id      = p_referrer_id
+           AND ut.target_slug  = p_target_slug
+           AND ut.active
+    ) THEN
+        RAISE EXCEPTION 'referrer % has target % disabled or unset',
+                        p_referrer_id, p_target_slug
+            USING ERRCODE = 'RFU01';
     END IF;
 
     -- Has a qualified click for this (referrer, target, IP) landed inside
     -- the dedup window? If yes, this click logs but does not credit.
-    -- Table alias keeps PL/pgSQL OUT params (qualified, credited) from
-    -- shadowing the column name.
     SELECT c.id INTO v_existing_id
       FROM referral.click c
      WHERE c.referrer_id = p_referrer_id
@@ -265,21 +329,9 @@ BEGIN
 
     v_qualifies := v_existing_id IS NULL;
 
-    IF v_qualifies THEN
-        v_account_id := referral.ensure_referrer_account(p_referrer_id);
-
-        v_ledger_id := wallet.service_credit(
-            v_account_id,
-            'credits'::wallet.currency_kind,
-            v_policy.credits_per_click,
-            'referral'::wallet.source_kind,
-            'referral_click',
-            'referral_click',
-            NULL::BIGINT,
-            gen_random_uuid()
-        );
-    END IF;
-
+    -- Insert the click row first so the wallet credit can reference its
+    -- id via ref_id, and so the idempotency key is deterministic on the
+    -- fresh click_id (retries will not double-credit).
     INSERT INTO referral.click (
         referrer_id, target_slug, ip_hash, subnet_hash,
         user_agent, referer, accept_lang,
@@ -289,16 +341,44 @@ BEGIN
         NULLIF(left(p_user_agent, 256), ''),
         NULLIF(left(p_referer, 512), ''),
         NULLIF(left(p_accept_lang, 64), ''),
-        v_qualifies, v_qualifies, v_ledger_id
+        v_qualifies, FALSE, NULL
     )
     RETURNING id INTO v_click_id;
 
+    IF v_qualifies AND v_policy.credits_per_click > 0 THEN
+        v_account_id := referral.ensure_referrer_account(p_referrer_id);
+
+        -- md5 of click_id yields a stable 16-byte digest the UUID type
+        -- accepts unmodified. Wallet.service_credit treats matching
+        -- idempotency keys as replays and returns the prior ledger_id.
+        v_idem_key := (md5('referral.click:' || v_click_id::TEXT))::UUID;
+
+        v_ledger_id := wallet.service_credit(
+            v_account_id,
+            'credits'::wallet.currency_kind,
+            v_policy.credits_per_click,
+            'referral'::wallet.source_kind,
+            'referral_click',
+            'referral_click',
+            v_click_id,
+            v_idem_key
+        );
+
+        UPDATE referral.click
+           SET credited  = TRUE,
+               ledger_id = v_ledger_id
+         WHERE id = v_click_id;
+
+        v_credited := TRUE;
+    END IF;
+
     RETURN QUERY
     SELECT v_click_id,
+           v_target.slug,
+           v_target.url,
            v_qualifies,
-           v_qualifies,
-           v_ledger_id,
-           v_target.url;
+           v_credited,
+           v_ledger_id;
 END;
 $fn$;
 
@@ -316,16 +396,14 @@ GRANT EXECUTE ON FUNCTION referral.record_click(
 COMMENT ON FUNCTION referral.record_click(
     UUID, TEXT, BYTEA, BYTEA, TEXT, TEXT, TEXT
 ) IS
-    'Phase 1 referral entrypoint. axum-kbve handler calls this with a hashed
-     IP + subnet and request metadata. Returns the resolved target URL plus
-     whether the click qualified for a reward credit. Credit + log row are
-     transactional.';
+    'Phase 1 referral entrypoint. axum-kbve handler calls this with a
+     hashed IP + subnet and request metadata. Returns the resolved target
+     URL + slug plus whether the click qualified for a reward credit.
+     Click insert + wallet credit run inside the same transaction.';
 
 -- ---------------------------------------------------------------------------
--- resolve_user_target — picks (slug, title, url) for a click. Used by the
--- axum handler when the URL omits an explicit target (defaults to the row
--- marked is_default for the user) or to verify the user actually has that
--- target enabled when one is supplied.
+-- resolve_user_target — pick (slug, title, url) for a click. Used by the
+-- axum handler when the URL omits an explicit target.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.resolve_user_target(
     p_user_id      UUID,
@@ -341,6 +419,7 @@ AS $fn$
       FROM referral.user_target ut
       JOIN referral.target t ON t.slug = ut.target_slug
      WHERE ut.user_id = p_user_id
+       AND ut.active
        AND t.active
        AND (
            (p_target_slug IS NOT NULL AND ut.target_slug = p_target_slug)
@@ -356,8 +435,13 @@ GRANT EXECUTE ON FUNCTION referral.resolve_user_target(UUID, TEXT)
 
 -- migrate:down
 
--- Intentionally a no-op. Dropping referral.click loses click history and
--- referral.target drops the catalog out from under live links. Take the
--- cleanup path out of dbmate — write a dedicated script if we ever truly
--- need to tear this down.
+-- Intentionally a no-op. Tear-down order if ever needed (do it
+-- out-of-band):
+--   1. REVOKE EXECUTE ON FUNCTION referral.* FROM service_role;
+--   2. DROP FUNCTION referral.record_click(...), .resolve_user_target(...),
+--      .ensure_referrer_account(...);
+--   3. DROP TABLE referral.click, .user_target, .reward_policy, .target;
+--   4. DROP SCHEMA referral;
+--   5. Leave wallet.source_kind = 'referral' in place — Postgres has no
+--      DROP VALUE and removing it would orphan existing ledger rows.
 SELECT 1;

--- a/packages/data/sql/dbmate/migrations/20260515221756_referral_schema_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260515221756_referral_schema_init.sql
@@ -7,6 +7,11 @@
 --   wallet.source_kind = 'referral' (20260515220000_wallet_source_kind_referral)
 --   pgcrypto for gen_random_uuid()
 --
+-- Custom SQLSTATEs raised by record_click for the Phase 2 axum handler:
+--   RFP01 = referral.reward_policy row missing
+--   RFT01 = referral target not found / inactive
+--   RFU01 = referrer does not have target enabled in user_target
+--
 -- Surface (consumed in Phase 2 by axum-kbve):
 --   /referral/@<handle>/             → user's default target
 --   /referral/@<handle>/<target>/    → specific target from the catalog
@@ -77,7 +82,15 @@ CREATE TABLE IF NOT EXISTS referral.user_target (
     active       BOOLEAN NOT NULL DEFAULT TRUE,
     enabled_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
     disabled_at  TIMESTAMPTZ,
-    PRIMARY KEY (user_id, target_slug)
+    PRIMARY KEY (user_id, target_slug),
+    -- Active rows must have NULL disabled_at; inactive rows must have a
+    -- timestamp. Keeps the audit invariant that "disabled_at marks the
+    -- moment the row stopped being live" honest.
+    CONSTRAINT user_target_active_disabled_chk
+        CHECK (
+            (active AND disabled_at IS NULL)
+         OR (NOT active AND disabled_at IS NOT NULL)
+        )
 );
 -- One default target per user, only counted among active rows.
 CREATE UNIQUE INDEX IF NOT EXISTS user_target_one_default
@@ -98,10 +111,12 @@ CREATE TABLE IF NOT EXISTS referral.click (
     accept_lang   TEXT,
     qualified     BOOLEAN NOT NULL DEFAULT FALSE,
     credited      BOOLEAN NOT NULL DEFAULT FALSE,
-    -- FK so the ledger row a credit click points at must really exist.
-    -- ON DELETE SET NULL keeps the click history visible even if a ledger
-    -- entry is ever rolled back out-of-band.
-    ledger_id     BIGINT REFERENCES wallet.ledger(id) ON DELETE SET NULL,
+    -- FK so the ledger row a click points at must exist. ON DELETE
+    -- RESTRICT because credited = TRUE implies a real ledger row;
+    -- SET NULL would let a stray ledger DELETE silently drift the
+    -- invariant. wallet.ledger is append-only in practice, so RESTRICT
+    -- is the safe default.
+    ledger_id     BIGINT REFERENCES wallet.ledger(id) ON DELETE RESTRICT,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS click_created_at ON referral.click (created_at);
@@ -138,10 +153,31 @@ INSERT INTO referral.reward_policy (id, credits_per_click, dedup_window_days)
 VALUES (1, 10, 30)
 ON CONFLICT (id) DO NOTHING;
 
+-- Auto-bump updated_at on policy changes so audits don't have to trust
+-- that the admin remembered to set it manually.
+CREATE OR REPLACE FUNCTION referral.reward_policy_touch()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$fn$;
+DROP TRIGGER IF EXISTS reward_policy_set_updated_at ON referral.reward_policy;
+CREATE TRIGGER reward_policy_set_updated_at
+    BEFORE UPDATE ON referral.reward_policy
+    FOR EACH ROW EXECUTE FUNCTION referral.reward_policy_touch();
+
 -- ---------------------------------------------------------------------------
 -- Lock down direct table access. Only the SECURITY DEFINER functions
 -- below should read or write these tables. PostgREST never sees rows
 -- because RLS is on and no policy grants are issued.
+--
+-- service_role intentionally has schema USAGE + function EXECUTE only
+-- (granted below). It does NOT get direct table SELECT/INSERT etc.
+-- Every callable path is a SECURITY DEFINER function owned by postgres
+-- so the wallet writes carry the correct privileges.
 -- ---------------------------------------------------------------------------
 ALTER TABLE referral.target          ENABLE ROW LEVEL SECURITY;
 ALTER TABLE referral.user_target     ENABLE ROW LEVEL SECURITY;
@@ -329,9 +365,15 @@ BEGIN
 
     v_qualifies := v_existing_id IS NULL;
 
-    -- Insert the click row first so the wallet credit can reference its
-    -- id via ref_id, and so the idempotency key is deterministic on the
-    -- fresh click_id (retries will not double-credit).
+    -- Insert the click row first so the ledger entry can carry
+    -- ref_id = click_id for cross-table traceability AND so a wallet
+    -- credit failure rolls the row back with it (atomic strict mode —
+    -- no orphan click rows pointing at a missing ledger entry).
+    --
+    -- Cross-request retry guards live higher up: the advisory lock +
+    -- dedup window prevent the second logical click from re-entering
+    -- this branch. The wallet idempotency key here is just a stable
+    -- value per *successful* credit, not a cross-RPC replay shield.
     INSERT INTO referral.click (
         referrer_id, target_slug, ip_hash, subnet_hash,
         user_agent, referer, accept_lang,

--- a/packages/data/sql/dbmate/migrations/20260515221756_referral_schema_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260515221756_referral_schema_init.sql
@@ -1,0 +1,363 @@
+-- migrate:up
+
+-- Referral system Phase 1 — schema + click-recording RPC.
+--
+-- Surface
+--   /referral/@<handle>/             → user's default target
+--   /referral/@<handle>/<target>/    → specific target from the catalog
+--
+-- Phase 1 (this migration) lays the rails:
+--   - referral.target          — admin-curated catalog of redirect destinations
+--   - referral.user_target     — which targets each user can refer to + their
+--                                primary (one row per user marked is_default)
+--   - referral.click           — append-only click log; one row per HTTP hit
+--   - referral.reward_policy   — single-row config (credits per click + dedup
+--                                window). Bumping the row is the only way to
+--                                change reward economics without a redeploy.
+--   - referral.record_click(...) — SECURITY DEFINER RPC the axum handler calls
+--                                  to log a click and, when qualified under
+--                                  the policy's dedup window, credit the
+--                                  referrer's wallet.
+--   - referral.resolve_user_target(...) — pick the (slug, url) for a click.
+--
+-- Phase 2 will add the axum-kbve route + astro page rewrite. Phase 2 only
+-- consumes the surface defined here.
+--
+-- Privacy: raw IPs are NEVER stored. The axum handler hashes the visitor IP
+-- via HMAC-SHA256(REFERRAL_HASH_SECRET, ip) and the /24 IPv4 (or /48 IPv6)
+-- subnet prefix, then passes both digests. We only see opaque bytea.
+
+-- Extend the wallet source_kind enum with the 'referral' tag. service_credit
+-- requires the value to exist before any referral row inserts a ledger entry.
+-- ALTER TYPE ... ADD VALUE cannot run inside a transaction block, so this
+-- statement must execute before the rest of the file is in a txn (dbmate
+-- runs each .sql top-to-bottom under one tx by default; pgcrypto pattern is
+-- to use the IF NOT EXISTS clause to make the ADD idempotent + tx-safe).
+ALTER TYPE wallet.source_kind ADD VALUE IF NOT EXISTS 'referral';
+
+CREATE SCHEMA IF NOT EXISTS referral;
+GRANT USAGE ON SCHEMA referral TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- target catalog
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS referral.target (
+    slug         TEXT PRIMARY KEY
+                   CHECK (slug ~ '^[a-z0-9][a-z0-9-]{0,62}$'),
+    title        TEXT NOT NULL CHECK (length(title) BETWEEN 1 AND 120),
+    url          TEXT NOT NULL CHECK (url ~ '^https?://'),
+    description  TEXT,
+    active       BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE referral.target IS
+    'Curated redirect destinations. Admin-only writes (no RLS policy grants).';
+
+INSERT INTO referral.target (slug, title, url, description) VALUES
+    ('rareicon',
+     'RareIcon on Steam',
+     'https://store.steampowered.com/app/2238370/RareIcon/',
+     'Bullet-hell roguelite — Chip vs DaemonCorps.'),
+    ('mc',
+     'KBVE Minecraft',
+     'https://kbve.com/mc/',
+     'KBVE Minecraft server hub.')
+ON CONFLICT (slug) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- per-user target opt-in + default
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS referral.user_target (
+    user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    target_slug  TEXT NOT NULL REFERENCES referral.target(slug) ON DELETE CASCADE,
+    is_default   BOOLEAN NOT NULL DEFAULT FALSE,
+    enabled_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, target_slug)
+);
+-- A user has at most one default target. Partial unique index, not a
+-- table-level constraint, so non-default rows don't fight for the slot.
+CREATE UNIQUE INDEX IF NOT EXISTS user_target_one_default
+    ON referral.user_target (user_id)
+    WHERE is_default;
+
+-- ---------------------------------------------------------------------------
+-- click log
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS referral.click (
+    id            BIGSERIAL PRIMARY KEY,
+    referrer_id   UUID NOT NULL REFERENCES auth.users(id),
+    target_slug   TEXT NOT NULL REFERENCES referral.target(slug),
+    ip_hash       BYTEA NOT NULL,
+    subnet_hash   BYTEA NOT NULL,
+    user_agent    TEXT,
+    referer       TEXT,
+    accept_lang   TEXT,
+    qualified     BOOLEAN NOT NULL DEFAULT FALSE,
+    credited      BOOLEAN NOT NULL DEFAULT FALSE,
+    ledger_id     BIGINT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS click_created_at ON referral.click (created_at);
+-- Hot lookup path for the dedup check inside record_click().
+CREATE INDEX IF NOT EXISTS click_dedup_idx
+    ON referral.click (referrer_id, target_slug, ip_hash, created_at DESC)
+    WHERE qualified;
+COMMENT ON COLUMN referral.click.ip_hash IS
+    'HMAC-SHA256(server_secret, ip) — never store raw IP.';
+COMMENT ON COLUMN referral.click.subnet_hash IS
+    'HMAC-SHA256(server_secret, /24 IPv4 or /48 IPv6 prefix).';
+COMMENT ON COLUMN referral.click.qualified IS
+    'TRUE iff this click triggered a reward credit (no earlier qualified row
+     within the policy dedup window for the same referrer+target+ip_hash).';
+COMMENT ON COLUMN referral.click.ledger_id IS
+    'wallet.ledger.id of the credit, when credited=true. NULL otherwise.';
+
+-- ---------------------------------------------------------------------------
+-- reward policy — single row, easy to bump without a redeploy
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS referral.reward_policy (
+    id                  SMALLINT PRIMARY KEY CHECK (id = 1),
+    credits_per_click   BIGINT NOT NULL DEFAULT 10
+                        CHECK (credits_per_click >= 0),
+    dedup_window_days   INTEGER NOT NULL DEFAULT 30
+                        CHECK (dedup_window_days BETWEEN 1 AND 365),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+INSERT INTO referral.reward_policy (id, credits_per_click, dedup_window_days)
+VALUES (1, 10, 30)
+ON CONFLICT (id) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- internal helper: resolve the wallet.account.id for a referrer's user_id.
+-- Lazy-provisions the account + balance if the user has never been seen by
+-- the wallet before. Mirrors the pattern in wallet.proxy_ensure_user_account
+-- but is callable from the service path (no auth.uid()).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.ensure_referrer_account(
+    p_user_id UUID
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+    v_account_id UUID;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('referral.ensure_referrer_account:' || p_user_id::TEXT, 0)
+    );
+
+    SELECT id INTO v_account_id
+      FROM wallet.account
+     WHERE kind = 'user' AND user_id = p_user_id;
+    IF FOUND THEN
+        RETURN v_account_id;
+    END IF;
+
+    INSERT INTO wallet.account (kind, user_id, created_at)
+    VALUES ('user', p_user_id, now())
+    ON CONFLICT (user_id) WHERE kind = 'user' DO NOTHING
+    RETURNING id INTO v_account_id;
+
+    IF v_account_id IS NULL THEN
+        SELECT id INTO v_account_id
+          FROM wallet.account
+         WHERE kind = 'user' AND user_id = p_user_id;
+    END IF;
+
+    INSERT INTO wallet.balance (account_id)
+    VALUES (v_account_id)
+    ON CONFLICT (account_id) DO NOTHING;
+
+    RETURN v_account_id;
+END;
+$fn$;
+
+ALTER FUNCTION referral.ensure_referrer_account(UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.ensure_referrer_account(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.ensure_referrer_account(UUID)
+    TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- record_click — the entry point for the axum-kbve referral handler.
+--
+-- Resolves the target, checks the dedup window, optionally credits the
+-- referrer's wallet, and writes one row to referral.click. Returns enough
+-- for the handler to log + redirect.
+--
+-- Atomicity: the wallet credit + the click insert run in the same
+-- transaction. If wallet.service_credit raises, the click row is rolled
+-- back with it — credited / ledger_id never lie.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.record_click(
+    p_referrer_id  UUID,
+    p_target_slug  TEXT,
+    p_ip_hash      BYTEA,
+    p_subnet_hash  BYTEA,
+    p_user_agent   TEXT DEFAULT NULL,
+    p_referer      TEXT DEFAULT NULL,
+    p_accept_lang  TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    click_id    BIGINT,
+    qualified   BOOLEAN,
+    credited    BOOLEAN,
+    ledger_id   BIGINT,
+    target_url  TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+    v_policy        referral.reward_policy%ROWTYPE;
+    v_target        referral.target%ROWTYPE;
+    v_existing_id   BIGINT;
+    v_qualifies     BOOLEAN := FALSE;
+    v_account_id    UUID;
+    v_ledger_id     BIGINT;
+    v_click_id      BIGINT;
+BEGIN
+    IF p_referrer_id IS NULL THEN
+        RAISE EXCEPTION 'referrer_id is required' USING ERRCODE = '22023';
+    END IF;
+    IF p_target_slug IS NULL THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
+    IF p_ip_hash IS NULL OR octet_length(p_ip_hash) = 0 THEN
+        RAISE EXCEPTION 'ip_hash is required' USING ERRCODE = '22023';
+    END IF;
+    IF p_subnet_hash IS NULL OR octet_length(p_subnet_hash) = 0 THEN
+        RAISE EXCEPTION 'subnet_hash is required' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT * INTO v_policy FROM referral.reward_policy WHERE id = 1;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'reward policy missing' USING ERRCODE = 'P0002';
+    END IF;
+
+    SELECT * INTO v_target
+      FROM referral.target
+     WHERE slug = p_target_slug AND active;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'target % not found or inactive', p_target_slug
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    -- Has a qualified click for this (referrer, target, IP) landed inside
+    -- the dedup window? If yes, this click logs but does not credit.
+    -- Table alias keeps PL/pgSQL OUT params (qualified, credited) from
+    -- shadowing the column name.
+    SELECT c.id INTO v_existing_id
+      FROM referral.click c
+     WHERE c.referrer_id = p_referrer_id
+       AND c.target_slug = p_target_slug
+       AND c.ip_hash     = p_ip_hash
+       AND c.qualified
+       AND c.created_at  >= now() - make_interval(days => v_policy.dedup_window_days)
+     ORDER BY c.created_at DESC
+     LIMIT 1;
+
+    v_qualifies := v_existing_id IS NULL;
+
+    IF v_qualifies THEN
+        v_account_id := referral.ensure_referrer_account(p_referrer_id);
+
+        v_ledger_id := wallet.service_credit(
+            v_account_id,
+            'credits'::wallet.currency_kind,
+            v_policy.credits_per_click,
+            'referral'::wallet.source_kind,
+            'referral_click',
+            'referral_click',
+            NULL::BIGINT,
+            gen_random_uuid()
+        );
+    END IF;
+
+    INSERT INTO referral.click (
+        referrer_id, target_slug, ip_hash, subnet_hash,
+        user_agent, referer, accept_lang,
+        qualified, credited, ledger_id
+    ) VALUES (
+        p_referrer_id, p_target_slug, p_ip_hash, p_subnet_hash,
+        NULLIF(left(p_user_agent, 256), ''),
+        NULLIF(left(p_referer, 512), ''),
+        NULLIF(left(p_accept_lang, 64), ''),
+        v_qualifies, v_qualifies, v_ledger_id
+    )
+    RETURNING id INTO v_click_id;
+
+    RETURN QUERY
+    SELECT v_click_id,
+           v_qualifies,
+           v_qualifies,
+           v_ledger_id,
+           v_target.url;
+END;
+$fn$;
+
+ALTER FUNCTION referral.record_click(
+    UUID, TEXT, BYTEA, BYTEA, TEXT, TEXT, TEXT
+) OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION referral.record_click(
+    UUID, TEXT, BYTEA, BYTEA, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.record_click(
+    UUID, TEXT, BYTEA, BYTEA, TEXT, TEXT, TEXT
+) TO service_role;
+
+COMMENT ON FUNCTION referral.record_click(
+    UUID, TEXT, BYTEA, BYTEA, TEXT, TEXT, TEXT
+) IS
+    'Phase 1 referral entrypoint. axum-kbve handler calls this with a hashed
+     IP + subnet and request metadata. Returns the resolved target URL plus
+     whether the click qualified for a reward credit. Credit + log row are
+     transactional.';
+
+-- ---------------------------------------------------------------------------
+-- resolve_user_target — picks (slug, title, url) for a click. Used by the
+-- axum handler when the URL omits an explicit target (defaults to the row
+-- marked is_default for the user) or to verify the user actually has that
+-- target enabled when one is supplied.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.resolve_user_target(
+    p_user_id      UUID,
+    p_target_slug  TEXT DEFAULT NULL
+)
+RETURNS TABLE (slug TEXT, title TEXT, url TEXT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+    SELECT t.slug, t.title, t.url
+      FROM referral.user_target ut
+      JOIN referral.target t ON t.slug = ut.target_slug
+     WHERE ut.user_id = p_user_id
+       AND t.active
+       AND (
+           (p_target_slug IS NOT NULL AND ut.target_slug = p_target_slug)
+        OR (p_target_slug IS NULL AND ut.is_default)
+       )
+     LIMIT 1;
+$fn$;
+
+ALTER FUNCTION referral.resolve_user_target(UUID, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.resolve_user_target(UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.resolve_user_target(UUID, TEXT)
+    TO service_role;
+
+-- migrate:down
+
+-- Intentionally a no-op. Dropping referral.click loses click history and
+-- referral.target drops the catalog out from under live links. Take the
+-- cleanup path out of dbmate — write a dedicated script if we ever truly
+-- need to tear this down.
+SELECT 1;

--- a/packages/data/sql/schema/README.md
+++ b/packages/data/sql/schema/README.md
@@ -4,21 +4,22 @@ Hand-authored reference DDL grouped by Postgres schema. This tree is the **revie
 
 ## Schemas
 
-| Directory                    | Postgres schema | Owner / consumers                                                                   |
-| ---------------------------- | --------------- | ----------------------------------------------------------------------------------- |
-| [`discordsh/`](./discordsh/) | `discordsh`     | Discord game-data service (servers, votes, dungeon profiles, guild vault).          |
-| [`forum/`](./forum/)         | `forum`         | KBVE forum core (spaces, threads, engagement, moderation, RPCs).                    |
-| [`mc/`](./mc/)               | `mc`            | Minecraft server (auth, characters, containers, players, skills, transfers).        |
-| [`meme/`](./meme/)           | `meme`          | Meme social platform (cards, engagement, moderation, social, RPCs).                 |
-| [`n8n/`](./n8n/)             | `n8n`           | n8n workflow engine bootstrap.                                                      |
-| [`osrs/`](./osrs/)           | `osrs`          | OSRS data tables and read RPCs.                                                     |
-| [`ows/`](./ows/)             | `ows`           | Open World Server (characters, abilities, inventories, chat, areas of interest, …). |
-| [`profile/`](./profile/)     | `profile`       | Cross-app user profiles.                                                            |
-| [`realtime/`](./realtime/)   | `realtime`      | Supabase Realtime publication and broadcast helpers.                                |
-| [`staff/`](./staff/)         | `staff`         | Bitwise staff permission / access-control tables.                                   |
-| [`tracker/`](./tracker/)     | `tracker`       | Activity / metrics tracking.                                                        |
-| [`vault/`](./vault/)         | `vault`         | Encrypted secret storage helpers.                                                   |
-| [`wallet/`](./wallet/)       | `wallet`        | Multi-currency ledger + coupons + khash marketplace (listings, bids, treasury fee). |
+| Directory                    | Postgres schema | Owner / consumers                                                                                  |
+| ---------------------------- | --------------- | -------------------------------------------------------------------------------------------------- |
+| [`discordsh/`](./discordsh/) | `discordsh`     | Discord game-data service (servers, votes, dungeon profiles, guild vault).                         |
+| [`forum/`](./forum/)         | `forum`         | KBVE forum core (spaces, threads, engagement, moderation, RPCs).                                   |
+| [`mc/`](./mc/)               | `mc`            | Minecraft server (auth, characters, containers, players, skills, transfers).                       |
+| [`meme/`](./meme/)           | `meme`          | Meme social platform (cards, engagement, moderation, social, RPCs).                                |
+| [`n8n/`](./n8n/)             | `n8n`           | n8n workflow engine bootstrap.                                                                     |
+| [`osrs/`](./osrs/)           | `osrs`          | OSRS data tables and read RPCs.                                                                    |
+| [`ows/`](./ows/)             | `ows`           | Open World Server (characters, abilities, inventories, chat, areas of interest, …).                |
+| [`profile/`](./profile/)     | `profile`       | Cross-app user profiles.                                                                           |
+| [`realtime/`](./realtime/)   | `realtime`      | Supabase Realtime publication and broadcast helpers.                                               |
+| [`referral/`](./referral/)   | `referral`      | Per-user referral links, click log, reward policy. Credits to wallet via `'referral'` source_kind. |
+| [`staff/`](./staff/)         | `staff`         | Bitwise staff permission / access-control tables.                                                  |
+| [`tracker/`](./tracker/)     | `tracker`       | Activity / metrics tracking.                                                                       |
+| [`vault/`](./vault/)         | `vault`         | Encrypted secret storage helpers.                                                                  |
+| [`wallet/`](./wallet/)       | `wallet`        | Multi-currency ledger + coupons + khash marketplace (listings, bids, treasury fee).                |
 
 ## File layout convention
 

--- a/packages/data/sql/schema/referral/referral_core.sql
+++ b/packages/data/sql/schema/referral/referral_core.sql
@@ -80,7 +80,12 @@ CREATE TABLE IF NOT EXISTS referral.user_target (
     active       BOOLEAN NOT NULL DEFAULT TRUE,
     enabled_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
     disabled_at  TIMESTAMPTZ,
-    PRIMARY KEY (user_id, target_slug)
+    PRIMARY KEY (user_id, target_slug),
+    CONSTRAINT user_target_active_disabled_chk
+        CHECK (
+            (active AND disabled_at IS NULL)
+         OR (NOT active AND disabled_at IS NOT NULL)
+        )
 );
 -- One active default per user.
 CREATE UNIQUE INDEX IF NOT EXISTS user_target_one_default
@@ -99,7 +104,10 @@ CREATE TABLE IF NOT EXISTS referral.click (
     accept_lang   TEXT,
     qualified     BOOLEAN NOT NULL DEFAULT FALSE,
     credited      BOOLEAN NOT NULL DEFAULT FALSE,
-    ledger_id     BIGINT REFERENCES wallet.ledger(id) ON DELETE SET NULL,
+    -- ON DELETE RESTRICT because credited = TRUE implies a real ledger
+    -- row; SET NULL would let a stray ledger DELETE silently drift the
+    -- invariant. wallet.ledger is append-only in practice.
+    ledger_id     BIGINT REFERENCES wallet.ledger(id) ON DELETE RESTRICT,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS click_created_at ON referral.click (created_at);
@@ -133,6 +141,22 @@ CREATE TABLE IF NOT EXISTS referral.reward_policy (
 INSERT INTO referral.reward_policy (id, credits_per_click, dedup_window_days)
 VALUES (1, 10, 30)
 ON CONFLICT (id) DO NOTHING;
+
+-- Auto-bump updated_at on policy changes so audits don't have to trust
+-- that the admin remembered to set it manually.
+CREATE OR REPLACE FUNCTION referral.reward_policy_touch()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$fn$;
+DROP TRIGGER IF EXISTS reward_policy_set_updated_at ON referral.reward_policy;
+CREATE TRIGGER reward_policy_set_updated_at
+    BEFORE UPDATE ON referral.reward_policy
+    FOR EACH ROW EXECUTE FUNCTION referral.reward_policy_touch();
 
 COMMENT ON TABLE referral.target IS
     'Curated redirect destinations. Admin-only writes (no RLS policy

--- a/packages/data/sql/schema/referral/referral_core.sql
+++ b/packages/data/sql/schema/referral/referral_core.sql
@@ -108,13 +108,22 @@ CREATE TABLE IF NOT EXISTS referral.click (
     -- row; SET NULL would let a stray ledger DELETE silently drift the
     -- invariant. wallet.ledger is append-only in practice.
     ledger_id     BIGINT REFERENCES wallet.ledger(id) ON DELETE RESTRICT,
-    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT click_credit_ledger_chk
+        CHECK (
+            (credited AND ledger_id IS NOT NULL)
+         OR (NOT credited AND ledger_id IS NULL)
+        )
 );
 CREATE INDEX IF NOT EXISTS click_created_at ON referral.click (created_at);
 -- Hot lookup path for the dedup check inside record_click().
 CREATE INDEX IF NOT EXISTS click_dedup_idx
     ON referral.click (referrer_id, target_slug, ip_hash, created_at DESC)
     WHERE qualified;
+-- One click maps to at most one ledger row.
+CREATE UNIQUE INDEX IF NOT EXISTS click_ledger_id_uq
+    ON referral.click (ledger_id)
+    WHERE ledger_id IS NOT NULL;
 
 COMMENT ON COLUMN referral.click.ip_hash IS
     'HMAC-SHA256(server_secret, ip) — never store raw IP.';
@@ -149,7 +158,7 @@ RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $fn$
 BEGIN
-    NEW.updated_at := now();
+    NEW.updated_at := statement_timestamp();
     RETURN NEW;
 END;
 $fn$;
@@ -180,5 +189,8 @@ ALTER TABLE referral.user_target     ENABLE ROW LEVEL SECURITY;
 ALTER TABLE referral.click           ENABLE ROW LEVEL SECURITY;
 ALTER TABLE referral.reward_policy   ENABLE ROW LEVEL SECURITY;
 
-REVOKE ALL ON ALL TABLES    IN SCHEMA referral FROM PUBLIC, anon, authenticated;
-REVOKE ALL ON ALL SEQUENCES IN SCHEMA referral FROM PUBLIC, anon, authenticated;
+-- Revoke from service_role too so direct PostgREST table access stays
+-- closed. SECURITY DEFINER functions are owned by postgres and ignore
+-- service_role's table grants entirely.
+REVOKE ALL ON ALL TABLES    IN SCHEMA referral FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA referral FROM PUBLIC, anon, authenticated, service_role;

--- a/packages/data/sql/schema/referral/referral_core.sql
+++ b/packages/data/sql/schema/referral/referral_core.sql
@@ -1,0 +1,126 @@
+-- ============================================================
+-- REFERRAL SCHEMA — Per-user referral links, click log, reward policy
+--
+-- Surface
+--   /referral/@<handle>/             → user's default target
+--   /referral/@<handle>/<target>/    → specific target from the catalog
+--
+-- Source of truth (proto):
+--   packages/data/proto/referral/referral.proto
+--
+-- Applied migration:
+--   packages/data/sql/dbmate/migrations/20260515221756_referral_schema_init.sql
+--
+-- Privacy stance: raw IPs are never persisted. The axum referral handler
+-- hashes the visitor IP via HMAC-SHA256(REFERRAL_HASH_SECRET, ip) and the
+-- /24 IPv4 (or /48 IPv6) subnet prefix before calling record_click. Both
+-- digests are stored as opaque bytea — useful for dedup + fraud signals,
+-- useless for re-identification.
+--
+-- Depends on:
+--   - auth.users (Supabase)
+--   - wallet.account, wallet.balance
+--   - wallet.service_credit() — for the reward path
+--   - wallet.source_kind enum carries the 'referral' value
+--   - pgcrypto / gen_random_uuid() for idempotency keys
+-- ============================================================
+
+CREATE SCHEMA IF NOT EXISTS referral;
+GRANT USAGE ON SCHEMA referral TO authenticated, service_role;
+
+-- ============================================================
+-- TABLES
+-- ============================================================
+
+-- Catalog of redirect destinations. Admin-curated, small table.
+CREATE TABLE IF NOT EXISTS referral.target (
+    slug         TEXT PRIMARY KEY
+                   CHECK (slug ~ '^[a-z0-9][a-z0-9-]{0,62}$'),
+    title        TEXT NOT NULL CHECK (length(title) BETWEEN 1 AND 120),
+    url          TEXT NOT NULL CHECK (url ~ '^https?://'),
+    description  TEXT,
+    active       BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+INSERT INTO referral.target (slug, title, url, description) VALUES
+    ('rareicon',
+     'RareIcon on Steam',
+     'https://store.steampowered.com/app/2238370/RareIcon/',
+     'Bullet-hell roguelite — Chip vs DaemonCorps.'),
+    ('mc',
+     'KBVE Minecraft',
+     'https://kbve.com/mc/',
+     'KBVE Minecraft server hub.')
+ON CONFLICT (slug) DO NOTHING;
+
+-- Which targets each user can refer to + the primary target for short URLs.
+CREATE TABLE IF NOT EXISTS referral.user_target (
+    user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    target_slug  TEXT NOT NULL REFERENCES referral.target(slug) ON DELETE CASCADE,
+    is_default   BOOLEAN NOT NULL DEFAULT FALSE,
+    enabled_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, target_slug)
+);
+-- One default target per user. Partial unique index so non-default rows
+-- don't compete for the slot.
+CREATE UNIQUE INDEX IF NOT EXISTS user_target_one_default
+    ON referral.user_target (user_id)
+    WHERE is_default;
+
+-- Append-only click log. One row per HTTP hit.
+CREATE TABLE IF NOT EXISTS referral.click (
+    id            BIGSERIAL PRIMARY KEY,
+    referrer_id   UUID NOT NULL REFERENCES auth.users(id),
+    target_slug   TEXT NOT NULL REFERENCES referral.target(slug),
+    ip_hash       BYTEA NOT NULL,
+    subnet_hash   BYTEA NOT NULL,
+    user_agent    TEXT,
+    referer       TEXT,
+    accept_lang   TEXT,
+    qualified     BOOLEAN NOT NULL DEFAULT FALSE,
+    credited      BOOLEAN NOT NULL DEFAULT FALSE,
+    ledger_id     BIGINT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS click_created_at ON referral.click (created_at);
+-- Hot lookup path for the dedup check inside record_click().
+CREATE INDEX IF NOT EXISTS click_dedup_idx
+    ON referral.click (referrer_id, target_slug, ip_hash, created_at DESC)
+    WHERE qualified;
+
+COMMENT ON COLUMN referral.click.ip_hash IS
+    'HMAC-SHA256(server_secret, ip) — never store raw IP.';
+COMMENT ON COLUMN referral.click.subnet_hash IS
+    'HMAC-SHA256(server_secret, /24 IPv4 or /48 IPv6 prefix).';
+COMMENT ON COLUMN referral.click.qualified IS
+    'TRUE iff this click triggered a reward credit (no earlier qualified
+     row within the policy dedup window for the same referrer + target +
+     ip_hash).';
+COMMENT ON COLUMN referral.click.ledger_id IS
+    'wallet.ledger.id of the credit, when credited=true. NULL otherwise.';
+
+-- Single-row reward policy. Updating this row is the only way to change
+-- the economics without a redeploy.
+CREATE TABLE IF NOT EXISTS referral.reward_policy (
+    id                  SMALLINT PRIMARY KEY CHECK (id = 1),
+    credits_per_click   BIGINT NOT NULL DEFAULT 10
+                        CHECK (credits_per_click >= 0),
+    dedup_window_days   INTEGER NOT NULL DEFAULT 30
+                        CHECK (dedup_window_days BETWEEN 1 AND 365),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+INSERT INTO referral.reward_policy (id, credits_per_click, dedup_window_days)
+VALUES (1, 10, 30)
+ON CONFLICT (id) DO NOTHING;
+
+COMMENT ON TABLE referral.target IS
+    'Curated redirect destinations. Admin-only writes (no RLS policy grants).';
+COMMENT ON TABLE referral.user_target IS
+    'Per-user opt-in of which catalog entries a user can refer to, plus the
+     single is_default row that the short /referral/@<handle>/ URL resolves to.';
+COMMENT ON TABLE referral.click IS
+    'Append-only click log. Hashed-only IP / subnet, truncated headers.';
+COMMENT ON TABLE referral.reward_policy IS
+    'Single-row config: credits_per_click + dedup_window_days. UPDATE row id=1
+     to retune economics live (next click picks it up).';

--- a/packages/data/sql/schema/referral/referral_core.sql
+++ b/packages/data/sql/schema/referral/referral_core.sql
@@ -8,41 +8,55 @@
 -- Source of truth (proto):
 --   packages/data/proto/referral/referral.proto
 --
--- Applied migration:
---   packages/data/sql/dbmate/migrations/20260515221756_referral_schema_init.sql
+-- Applied migrations:
+--   - 20260515220000_wallet_source_kind_referral.sql
+--       Adds 'referral' to wallet.source_kind. Lives in its own
+--       migration because ALTER TYPE ... ADD VALUE is allowed inside a
+--       transaction in Postgres 12+ but the new value cannot be used in
+--       the same transaction it was added in.
+--   - 20260515221756_referral_schema_init.sql
+--       Schema, tables, RPCs.
 --
--- Privacy stance: raw IPs are never persisted. The axum referral handler
--- hashes the visitor IP via HMAC-SHA256(REFERRAL_HASH_SECRET, ip) and the
--- /24 IPv4 (or /48 IPv6) subnet prefix before calling record_click. Both
--- digests are stored as opaque bytea — useful for dedup + fraud signals,
--- useless for re-identification.
+-- Privacy: raw IPs are never persisted. The Phase 2 axum handler hashes
+-- the visitor IP via HMAC-SHA256(REFERRAL_HASH_SECRET, ip) and the
+-- /24 IPv4 (or /48 IPv6) subnet prefix before calling record_click.
 --
 -- Depends on:
 --   - auth.users (Supabase)
---   - wallet.account, wallet.balance
---   - wallet.service_credit() — for the reward path
---   - wallet.source_kind enum carries the 'referral' value
---   - pgcrypto / gen_random_uuid() for idempotency keys
+--   - wallet.account, wallet.balance, wallet.ledger
+--   - wallet.service_credit() — reward path
+--   - wallet.source_kind enum carries 'referral'
+--   - pgcrypto / gen_random_uuid()
 -- ============================================================
 
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 CREATE SCHEMA IF NOT EXISTS referral;
-GRANT USAGE ON SCHEMA referral TO authenticated, service_role;
+
+-- Service-only for Phase 1. authenticated users hit the axum handler
+-- (service_role); they never touch this schema directly.
+GRANT USAGE ON SCHEMA referral TO service_role;
 
 -- ============================================================
 -- TABLES
 -- ============================================================
 
--- Catalog of redirect destinations. Admin-curated, small table.
+-- Catalog of redirect destinations. Admin-curated.
 CREATE TABLE IF NOT EXISTS referral.target (
     slug         TEXT PRIMARY KEY
                    CHECK (slug ~ '^[a-z0-9][a-z0-9-]{0,62}$'),
     title        TEXT NOT NULL CHECK (length(title) BETWEEN 1 AND 120),
-    url          TEXT NOT NULL CHECK (url ~ '^https?://'),
+    -- Coarse safety net: require http(s)://, forbid whitespace / control
+    -- chars. Application code does proper URL validation.
+    url          TEXT NOT NULL
+                   CHECK (url ~ '^https?://[^[:space:][:cntrl:]]+$'),
     description  TEXT,
     active       BOOLEAN NOT NULL DEFAULT TRUE,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+-- Catalog rows ARE re-applied on re-run (DO UPDATE) so URL fixes and
+-- title bumps land without a separate migration.
 INSERT INTO referral.target (slug, title, url, description) VALUES
     ('rareicon',
      'RareIcon on Steam',
@@ -52,21 +66,26 @@ INSERT INTO referral.target (slug, title, url, description) VALUES
      'KBVE Minecraft',
      'https://kbve.com/mc/',
      'KBVE Minecraft server hub.')
-ON CONFLICT (slug) DO NOTHING;
+ON CONFLICT (slug) DO UPDATE
+    SET title       = EXCLUDED.title,
+        url         = EXCLUDED.url,
+        description = EXCLUDED.description;
 
--- Which targets each user can refer to + the primary target for short URLs.
+-- Which targets each user can refer to + the primary target for short
+-- URLs. active = FALSE disables a row without losing history.
 CREATE TABLE IF NOT EXISTS referral.user_target (
     user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     target_slug  TEXT NOT NULL REFERENCES referral.target(slug) ON DELETE CASCADE,
     is_default   BOOLEAN NOT NULL DEFAULT FALSE,
+    active       BOOLEAN NOT NULL DEFAULT TRUE,
     enabled_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    disabled_at  TIMESTAMPTZ,
     PRIMARY KEY (user_id, target_slug)
 );
--- One default target per user. Partial unique index so non-default rows
--- don't compete for the slot.
+-- One active default per user.
 CREATE UNIQUE INDEX IF NOT EXISTS user_target_one_default
     ON referral.user_target (user_id)
-    WHERE is_default;
+    WHERE is_default AND active;
 
 -- Append-only click log. One row per HTTP hit.
 CREATE TABLE IF NOT EXISTS referral.click (
@@ -80,7 +99,7 @@ CREATE TABLE IF NOT EXISTS referral.click (
     accept_lang   TEXT,
     qualified     BOOLEAN NOT NULL DEFAULT FALSE,
     credited      BOOLEAN NOT NULL DEFAULT FALSE,
-    ledger_id     BIGINT,
+    ledger_id     BIGINT REFERENCES wallet.ledger(id) ON DELETE SET NULL,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS click_created_at ON referral.click (created_at);
@@ -94,14 +113,15 @@ COMMENT ON COLUMN referral.click.ip_hash IS
 COMMENT ON COLUMN referral.click.subnet_hash IS
     'HMAC-SHA256(server_secret, /24 IPv4 or /48 IPv6 prefix).';
 COMMENT ON COLUMN referral.click.qualified IS
-    'TRUE iff this click triggered a reward credit (no earlier qualified
-     row within the policy dedup window for the same referrer + target +
-     ip_hash).';
+    'TRUE iff this click was the first inside the policy dedup window
+     for the (referrer, target, ip_hash) tuple.';
+COMMENT ON COLUMN referral.click.credited IS
+    'TRUE iff wallet.service_credit actually ran for this click
+     (qualified AND credits_per_click > 0).';
 COMMENT ON COLUMN referral.click.ledger_id IS
-    'wallet.ledger.id of the credit, when credited=true. NULL otherwise.';
+    'wallet.ledger.id of the credit. NULL when credited = FALSE.';
 
--- Single-row reward policy. Updating this row is the only way to change
--- the economics without a redeploy.
+-- Single-row reward economics. Updating the row retunes live.
 CREATE TABLE IF NOT EXISTS referral.reward_policy (
     id                  SMALLINT PRIMARY KEY CHECK (id = 1),
     credits_per_click   BIGINT NOT NULL DEFAULT 10
@@ -115,12 +135,26 @@ VALUES (1, 10, 30)
 ON CONFLICT (id) DO NOTHING;
 
 COMMENT ON TABLE referral.target IS
-    'Curated redirect destinations. Admin-only writes (no RLS policy grants).';
+    'Curated redirect destinations. Admin-only writes (no RLS policy
+     grants — only SECURITY DEFINER functions touch this table).';
 COMMENT ON TABLE referral.user_target IS
-    'Per-user opt-in of which catalog entries a user can refer to, plus the
-     single is_default row that the short /referral/@<handle>/ URL resolves to.';
+    'Per-user opt-in into the catalog plus the single is_default row
+     that the short /referral/@<handle>/ URL resolves to.';
 COMMENT ON TABLE referral.click IS
-    'Append-only click log. Hashed-only IP / subnet, truncated headers.';
+    'Append-only click log. Hashed-only IP + subnet, truncated headers.';
 COMMENT ON TABLE referral.reward_policy IS
-    'Single-row config: credits_per_click + dedup_window_days. UPDATE row id=1
-     to retune economics live (next click picks it up).';
+    'Single-row config. UPDATE row id=1 to retune economics live.';
+
+-- ============================================================
+-- ROW LEVEL SECURITY
+--
+-- Direct table access from PostgREST is denied. All reads / writes
+-- go through SECURITY DEFINER functions in referral_rpcs.sql.
+-- ============================================================
+ALTER TABLE referral.target          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE referral.user_target     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE referral.click           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE referral.reward_policy   ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON ALL TABLES    IN SCHEMA referral FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON ALL SEQUENCES IN SCHEMA referral FROM PUBLIC, anon, authenticated;

--- a/packages/data/sql/schema/referral/referral_rpcs.sql
+++ b/packages/data/sql/schema/referral/referral_rpcs.sql
@@ -9,11 +9,12 @@
 -- handler holds a service_role JWT and is the only consumer for
 -- Phase 1.
 --
--- Custom SQLSTATEs raised by record_click. Keep this list in sync with
--- the Phase 2 axum error mapper so users see the right 4xx code:
---   RFP01 = referral.reward_policy row missing
---   RFT01 = referral target not found / inactive
---   RFU01 = referrer does not have target enabled in user_target
+-- Custom SQLSTATEs. Keep this list in sync with the Phase 2 axum error
+-- mapper so users see the right 4xx code:
+--   RFP01  = referral.reward_policy row missing
+--   RFT01  = referral target not found / inactive
+--   RFU01  = referrer does not have target enabled in user_target
+--   RFWA1  = ensure_referrer_account failed to provision a wallet account
 --
 -- service_role intentionally holds USAGE on the schema + EXECUTE on
 -- these functions only. It does NOT have direct table privileges; the
@@ -54,6 +55,8 @@ BEGIN
         RETURN v_account_id;
     END IF;
 
+    -- ON CONFLICT target relies on the wallet partial unique index on
+    -- wallet.account (user_id) WHERE kind = 'user'.
     INSERT INTO wallet.account (kind, user_id, created_at)
     VALUES ('user', p_user_id, now())
     ON CONFLICT (user_id) WHERE kind = 'user' DO NOTHING
@@ -63,6 +66,12 @@ BEGIN
         SELECT id INTO v_account_id
           FROM wallet.account
          WHERE kind = 'user' AND user_id = p_user_id;
+    END IF;
+
+    IF v_account_id IS NULL THEN
+        RAISE EXCEPTION 'failed to provision wallet account for user %',
+                        p_user_id
+            USING ERRCODE = 'RFWA1';
     END IF;
 
     INSERT INTO wallet.balance (account_id)
@@ -117,6 +126,7 @@ SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
+    v_now          TIMESTAMPTZ := statement_timestamp();
     v_policy       referral.reward_policy%ROWTYPE;
     v_target       referral.target%ROWTYPE;
     v_existing_id  BIGINT;
@@ -133,11 +143,17 @@ BEGIN
     IF p_target_slug IS NULL THEN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
-    IF p_ip_hash IS NULL OR octet_length(p_ip_hash) = 0 THEN
-        RAISE EXCEPTION 'ip_hash is required' USING ERRCODE = '22023';
+    p_target_slug := lower(btrim(p_target_slug));
+    IF p_target_slug = '' THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
-    IF p_subnet_hash IS NULL OR octet_length(p_subnet_hash) = 0 THEN
-        RAISE EXCEPTION 'subnet_hash is required' USING ERRCODE = '22023';
+    IF p_ip_hash IS NULL OR octet_length(p_ip_hash) <> 32 THEN
+        RAISE EXCEPTION 'ip_hash must be a 32-byte HMAC-SHA256 digest'
+            USING ERRCODE = '22023';
+    END IF;
+    IF p_subnet_hash IS NULL OR octet_length(p_subnet_hash) <> 32 THEN
+        RAISE EXCEPTION 'subnet_hash must be a 32-byte HMAC-SHA256 digest'
+            USING ERRCODE = '22023';
     END IF;
 
     PERFORM pg_advisory_xact_lock(
@@ -181,7 +197,7 @@ BEGIN
        AND c.target_slug = p_target_slug
        AND c.ip_hash     = p_ip_hash
        AND c.qualified
-       AND c.created_at  >= now() - make_interval(days => v_policy.dedup_window_days)
+       AND c.created_at  >= v_now - make_interval(days => v_policy.dedup_window_days)
      ORDER BY c.created_at DESC
      LIMIT 1;
 
@@ -210,6 +226,9 @@ BEGIN
 
         v_idem_key := (md5('referral.click:' || v_click_id::TEXT))::UUID;
 
+        -- wallet.service_credit invariant assumed: idempotent on
+        -- p_idempotency_key — re-calling with the same UUID returns the
+        -- prior ledger_id instead of inserting a second row.
         v_ledger_id := wallet.service_credit(
             v_account_id,
             'credits'::wallet.currency_kind,
@@ -276,6 +295,7 @@ AS $fn$
            (p_target_slug IS NOT NULL AND ut.target_slug = p_target_slug)
         OR (p_target_slug IS NULL AND ut.is_default)
        )
+     ORDER BY ut.is_default DESC, ut.enabled_at DESC, ut.target_slug
      LIMIT 1;
 $fn$;
 

--- a/packages/data/sql/schema/referral/referral_rpcs.sql
+++ b/packages/data/sql/schema/referral/referral_rpcs.sql
@@ -9,11 +9,15 @@
 -- handler holds a service_role JWT and is the only consumer for
 -- Phase 1.
 --
--- Custom SQLSTATEs (RF...) let the handler distinguish referral errors
--- from generic PL/pgSQL data-not-found paths:
---   RFP01 = reward_policy row missing
---   RFT01 = target not found / inactive
---   RFU01 = referrer does not have target enabled
+-- Custom SQLSTATEs raised by record_click. Keep this list in sync with
+-- the Phase 2 axum error mapper so users see the right 4xx code:
+--   RFP01 = referral.reward_policy row missing
+--   RFT01 = referral target not found / inactive
+--   RFU01 = referrer does not have target enabled in user_target
+--
+-- service_role intentionally holds USAGE on the schema + EXECUTE on
+-- these functions only. It does NOT have direct table privileges; the
+-- definer-owned functions are the only callable surface.
 -- ============================================================
 
 -- ------------------------------------------------------------
@@ -183,6 +187,11 @@ BEGIN
 
     v_qualifies := v_existing_id IS NULL;
 
+    -- Insert click row first so the ledger entry can carry
+    -- ref_id = click_id, and so a wallet credit failure rolls the row
+    -- back with it (atomic strict mode — no orphan click rows pointing
+    -- at a missing ledger entry). Cross-RPC retry guards live higher up
+    -- (advisory lock + dedup window).
     INSERT INTO referral.click (
         referrer_id, target_slug, ip_hash, subnet_hash,
         user_agent, referer, accept_lang,

--- a/packages/data/sql/schema/referral/referral_rpcs.sql
+++ b/packages/data/sql/schema/referral/referral_rpcs.sql
@@ -1,12 +1,19 @@
 -- ============================================================
 -- REFERRAL RPCs
 --
--- All functions are SECURITY DEFINER with search_path locked, owned by
--- postgres (so they retain access to wallet.* + auth.* regardless of the
--- caller's role), and granted EXECUTE only to service_role.
+-- All functions are SECURITY DEFINER with search_path = '', owned by
+-- postgres (so they retain access to wallet.* + auth.* regardless of
+-- the caller's role), and granted EXECUTE only to service_role.
 --
 -- Public callers never touch these directly. The axum-kbve referral
--- handler holds a service_role JWT and is the only consumer.
+-- handler holds a service_role JWT and is the only consumer for
+-- Phase 1.
+--
+-- Custom SQLSTATEs (RF...) let the handler distinguish referral errors
+-- from generic PL/pgSQL data-not-found paths:
+--   RFP01 = reward_policy row missing
+--   RFT01 = target not found / inactive
+--   RFU01 = referrer does not have target enabled
 -- ============================================================
 
 -- ------------------------------------------------------------
@@ -15,8 +22,7 @@
 -- Lazy wallet account provisioning so a brand-new user's first referral
 -- click can still be credited. Mirrors wallet.proxy_ensure_user_account
 -- but is callable from the service path (no auth.uid() dependency) and
--- skips the welcome-coupon issuance — referral credits don't need to
--- bootstrap onboarding flow.
+-- skips welcome-coupon issuance.
 -- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.ensure_referrer_account(
     p_user_id UUID
@@ -69,17 +75,21 @@ GRANT EXECUTE ON FUNCTION referral.ensure_referrer_account(UUID)
     TO service_role;
 
 -- ------------------------------------------------------------
--- record_click(referrer_id, target_slug, ip_hash, subnet_hash,
---              ua, referer, accept_lang)
+-- record_click — entry point for the Phase 2 axum-kbve handler.
 --
--- Entry point for the axum-kbve referral handler. Resolves the target,
--- checks the dedup window, optionally credits the referrer's wallet,
--- and writes one row to referral.click. Returns enough for the handler
--- to log + redirect.
---
--- Atomicity: the wallet credit and click insert run inside the same
--- transaction. If wallet.service_credit raises, the click row rolls
--- back with it — credited / ledger_id never lie about wallet state.
+-- Order of operations:
+--   1. Validate inputs.
+--   2. Take xact-scoped advisory lock on (referrer, target, ip_hash) so
+--      two concurrent calls cannot both pass the dedup check and both
+--      credit.
+--   3. Verify referrer has the target enabled (defense in depth).
+--   4. Run dedup-window check.
+--   5. INSERT the click uncredited.
+--   6. If qualified AND credits_per_click > 0:
+--        - call wallet.service_credit with a deterministic idempotency
+--          key derived from the freshly-inserted click_id (retries are
+--          idempotent at the wallet level too);
+--        - UPDATE the click row with credited=true + ledger_id.
 -- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.record_click(
     p_referrer_id  UUID,
@@ -91,24 +101,27 @@ CREATE OR REPLACE FUNCTION referral.record_click(
     p_accept_lang  TEXT DEFAULT NULL
 )
 RETURNS TABLE (
-    click_id    BIGINT,
-    qualified   BOOLEAN,
-    credited    BOOLEAN,
-    ledger_id   BIGINT,
-    target_url  TEXT
+    click_id     BIGINT,
+    target_slug  TEXT,
+    target_url   TEXT,
+    qualified    BOOLEAN,
+    credited     BOOLEAN,
+    ledger_id    BIGINT
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
-    v_policy        referral.reward_policy%ROWTYPE;
-    v_target        referral.target%ROWTYPE;
-    v_existing_id   BIGINT;
-    v_qualifies     BOOLEAN := FALSE;
-    v_account_id    UUID;
-    v_ledger_id     BIGINT;
-    v_click_id      BIGINT;
+    v_policy       referral.reward_policy%ROWTYPE;
+    v_target       referral.target%ROWTYPE;
+    v_existing_id  BIGINT;
+    v_qualifies    BOOLEAN := FALSE;
+    v_account_id   UUID;
+    v_ledger_id    BIGINT;
+    v_click_id     BIGINT;
+    v_idem_key     UUID;
+    v_credited     BOOLEAN := FALSE;
 BEGIN
     IF p_referrer_id IS NULL THEN
         RAISE EXCEPTION 'referrer_id is required' USING ERRCODE = '22023';
@@ -123,9 +136,19 @@ BEGIN
         RAISE EXCEPTION 'subnet_hash is required' USING ERRCODE = '22023';
     END IF;
 
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended(
+            'referral.click:'
+            || p_referrer_id::TEXT
+            || ':' || p_target_slug
+            || ':' || encode(p_ip_hash, 'hex'),
+            0
+        )
+    );
+
     SELECT * INTO v_policy FROM referral.reward_policy WHERE id = 1;
     IF NOT FOUND THEN
-        RAISE EXCEPTION 'reward policy missing' USING ERRCODE = 'P0002';
+        RAISE EXCEPTION 'reward policy missing' USING ERRCODE = 'RFP01';
     END IF;
 
     SELECT * INTO v_target
@@ -133,12 +156,21 @@ BEGIN
      WHERE slug = p_target_slug AND active;
     IF NOT FOUND THEN
         RAISE EXCEPTION 'target % not found or inactive', p_target_slug
-            USING ERRCODE = 'P0002';
+            USING ERRCODE = 'RFT01';
     END IF;
 
-    -- Any qualified click for this (referrer, target, IP) inside the
-    -- dedup window? Aliased to keep PL/pgSQL OUT params from shadowing
-    -- the column name.
+    IF NOT EXISTS (
+        SELECT 1
+          FROM referral.user_target ut
+         WHERE ut.user_id      = p_referrer_id
+           AND ut.target_slug  = p_target_slug
+           AND ut.active
+    ) THEN
+        RAISE EXCEPTION 'referrer % has target % disabled or unset',
+                        p_referrer_id, p_target_slug
+            USING ERRCODE = 'RFU01';
+    END IF;
+
     SELECT c.id INTO v_existing_id
       FROM referral.click c
      WHERE c.referrer_id = p_referrer_id
@@ -151,21 +183,6 @@ BEGIN
 
     v_qualifies := v_existing_id IS NULL;
 
-    IF v_qualifies THEN
-        v_account_id := referral.ensure_referrer_account(p_referrer_id);
-
-        v_ledger_id := wallet.service_credit(
-            v_account_id,
-            'credits'::wallet.currency_kind,
-            v_policy.credits_per_click,
-            'referral'::wallet.source_kind,
-            'referral_click',
-            'referral_click',
-            NULL::BIGINT,
-            gen_random_uuid()
-        );
-    END IF;
-
     INSERT INTO referral.click (
         referrer_id, target_slug, ip_hash, subnet_hash,
         user_agent, referer, accept_lang,
@@ -175,16 +192,41 @@ BEGIN
         NULLIF(left(p_user_agent, 256), ''),
         NULLIF(left(p_referer, 512), ''),
         NULLIF(left(p_accept_lang, 64), ''),
-        v_qualifies, v_qualifies, v_ledger_id
+        v_qualifies, FALSE, NULL
     )
     RETURNING id INTO v_click_id;
 
+    IF v_qualifies AND v_policy.credits_per_click > 0 THEN
+        v_account_id := referral.ensure_referrer_account(p_referrer_id);
+
+        v_idem_key := (md5('referral.click:' || v_click_id::TEXT))::UUID;
+
+        v_ledger_id := wallet.service_credit(
+            v_account_id,
+            'credits'::wallet.currency_kind,
+            v_policy.credits_per_click,
+            'referral'::wallet.source_kind,
+            'referral_click',
+            'referral_click',
+            v_click_id,
+            v_idem_key
+        );
+
+        UPDATE referral.click
+           SET credited  = TRUE,
+               ledger_id = v_ledger_id
+         WHERE id = v_click_id;
+
+        v_credited := TRUE;
+    END IF;
+
     RETURN QUERY
     SELECT v_click_id,
+           v_target.slug,
+           v_target.url,
            v_qualifies,
-           v_qualifies,
-           v_ledger_id,
-           v_target.url;
+           v_credited,
+           v_ledger_id;
 END;
 $fn$;
 
@@ -202,9 +244,8 @@ GRANT EXECUTE ON FUNCTION referral.record_click(
 -- ------------------------------------------------------------
 -- resolve_user_target(user_id, slug?)
 --
--- Picks (slug, title, url) for a click. Used by the axum handler when
--- the URL omits an explicit target (returns the user's is_default row)
--- or to verify the user has the supplied target enabled.
+-- Picks (slug, title, url) for a click. Only ACTIVE user_target rows
+-- AND active catalog rows participate.
 -- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.resolve_user_target(
     p_user_id      UUID,
@@ -220,6 +261,7 @@ AS $fn$
       FROM referral.user_target ut
       JOIN referral.target t ON t.slug = ut.target_slug
      WHERE ut.user_id = p_user_id
+       AND ut.active
        AND t.active
        AND (
            (p_target_slug IS NOT NULL AND ut.target_slug = p_target_slug)

--- a/packages/data/sql/schema/referral/referral_rpcs.sql
+++ b/packages/data/sql/schema/referral/referral_rpcs.sql
@@ -1,0 +1,234 @@
+-- ============================================================
+-- REFERRAL RPCs
+--
+-- All functions are SECURITY DEFINER with search_path locked, owned by
+-- postgres (so they retain access to wallet.* + auth.* regardless of the
+-- caller's role), and granted EXECUTE only to service_role.
+--
+-- Public callers never touch these directly. The axum-kbve referral
+-- handler holds a service_role JWT and is the only consumer.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- ensure_referrer_account(user_id) → wallet.account.id
+--
+-- Lazy wallet account provisioning so a brand-new user's first referral
+-- click can still be credited. Mirrors wallet.proxy_ensure_user_account
+-- but is callable from the service path (no auth.uid() dependency) and
+-- skips the welcome-coupon issuance — referral credits don't need to
+-- bootstrap onboarding flow.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.ensure_referrer_account(
+    p_user_id UUID
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+    v_account_id UUID;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('referral.ensure_referrer_account:' || p_user_id::TEXT, 0)
+    );
+
+    SELECT id INTO v_account_id
+      FROM wallet.account
+     WHERE kind = 'user' AND user_id = p_user_id;
+    IF FOUND THEN
+        RETURN v_account_id;
+    END IF;
+
+    INSERT INTO wallet.account (kind, user_id, created_at)
+    VALUES ('user', p_user_id, now())
+    ON CONFLICT (user_id) WHERE kind = 'user' DO NOTHING
+    RETURNING id INTO v_account_id;
+
+    IF v_account_id IS NULL THEN
+        SELECT id INTO v_account_id
+          FROM wallet.account
+         WHERE kind = 'user' AND user_id = p_user_id;
+    END IF;
+
+    INSERT INTO wallet.balance (account_id)
+    VALUES (v_account_id)
+    ON CONFLICT (account_id) DO NOTHING;
+
+    RETURN v_account_id;
+END;
+$fn$;
+
+ALTER FUNCTION referral.ensure_referrer_account(UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.ensure_referrer_account(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.ensure_referrer_account(UUID)
+    TO service_role;
+
+-- ------------------------------------------------------------
+-- record_click(referrer_id, target_slug, ip_hash, subnet_hash,
+--              ua, referer, accept_lang)
+--
+-- Entry point for the axum-kbve referral handler. Resolves the target,
+-- checks the dedup window, optionally credits the referrer's wallet,
+-- and writes one row to referral.click. Returns enough for the handler
+-- to log + redirect.
+--
+-- Atomicity: the wallet credit and click insert run inside the same
+-- transaction. If wallet.service_credit raises, the click row rolls
+-- back with it — credited / ledger_id never lie about wallet state.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.record_click(
+    p_referrer_id  UUID,
+    p_target_slug  TEXT,
+    p_ip_hash      BYTEA,
+    p_subnet_hash  BYTEA,
+    p_user_agent   TEXT DEFAULT NULL,
+    p_referer      TEXT DEFAULT NULL,
+    p_accept_lang  TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    click_id    BIGINT,
+    qualified   BOOLEAN,
+    credited    BOOLEAN,
+    ledger_id   BIGINT,
+    target_url  TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+    v_policy        referral.reward_policy%ROWTYPE;
+    v_target        referral.target%ROWTYPE;
+    v_existing_id   BIGINT;
+    v_qualifies     BOOLEAN := FALSE;
+    v_account_id    UUID;
+    v_ledger_id     BIGINT;
+    v_click_id      BIGINT;
+BEGIN
+    IF p_referrer_id IS NULL THEN
+        RAISE EXCEPTION 'referrer_id is required' USING ERRCODE = '22023';
+    END IF;
+    IF p_target_slug IS NULL THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
+    IF p_ip_hash IS NULL OR octet_length(p_ip_hash) = 0 THEN
+        RAISE EXCEPTION 'ip_hash is required' USING ERRCODE = '22023';
+    END IF;
+    IF p_subnet_hash IS NULL OR octet_length(p_subnet_hash) = 0 THEN
+        RAISE EXCEPTION 'subnet_hash is required' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT * INTO v_policy FROM referral.reward_policy WHERE id = 1;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'reward policy missing' USING ERRCODE = 'P0002';
+    END IF;
+
+    SELECT * INTO v_target
+      FROM referral.target
+     WHERE slug = p_target_slug AND active;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'target % not found or inactive', p_target_slug
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    -- Any qualified click for this (referrer, target, IP) inside the
+    -- dedup window? Aliased to keep PL/pgSQL OUT params from shadowing
+    -- the column name.
+    SELECT c.id INTO v_existing_id
+      FROM referral.click c
+     WHERE c.referrer_id = p_referrer_id
+       AND c.target_slug = p_target_slug
+       AND c.ip_hash     = p_ip_hash
+       AND c.qualified
+       AND c.created_at  >= now() - make_interval(days => v_policy.dedup_window_days)
+     ORDER BY c.created_at DESC
+     LIMIT 1;
+
+    v_qualifies := v_existing_id IS NULL;
+
+    IF v_qualifies THEN
+        v_account_id := referral.ensure_referrer_account(p_referrer_id);
+
+        v_ledger_id := wallet.service_credit(
+            v_account_id,
+            'credits'::wallet.currency_kind,
+            v_policy.credits_per_click,
+            'referral'::wallet.source_kind,
+            'referral_click',
+            'referral_click',
+            NULL::BIGINT,
+            gen_random_uuid()
+        );
+    END IF;
+
+    INSERT INTO referral.click (
+        referrer_id, target_slug, ip_hash, subnet_hash,
+        user_agent, referer, accept_lang,
+        qualified, credited, ledger_id
+    ) VALUES (
+        p_referrer_id, p_target_slug, p_ip_hash, p_subnet_hash,
+        NULLIF(left(p_user_agent, 256), ''),
+        NULLIF(left(p_referer, 512), ''),
+        NULLIF(left(p_accept_lang, 64), ''),
+        v_qualifies, v_qualifies, v_ledger_id
+    )
+    RETURNING id INTO v_click_id;
+
+    RETURN QUERY
+    SELECT v_click_id,
+           v_qualifies,
+           v_qualifies,
+           v_ledger_id,
+           v_target.url;
+END;
+$fn$;
+
+ALTER FUNCTION referral.record_click(
+    UUID, TEXT, BYTEA, BYTEA, TEXT, TEXT, TEXT
+) OWNER TO postgres;
+
+REVOKE ALL ON FUNCTION referral.record_click(
+    UUID, TEXT, BYTEA, BYTEA, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.record_click(
+    UUID, TEXT, BYTEA, BYTEA, TEXT, TEXT, TEXT
+) TO service_role;
+
+-- ------------------------------------------------------------
+-- resolve_user_target(user_id, slug?)
+--
+-- Picks (slug, title, url) for a click. Used by the axum handler when
+-- the URL omits an explicit target (returns the user's is_default row)
+-- or to verify the user has the supplied target enabled.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.resolve_user_target(
+    p_user_id      UUID,
+    p_target_slug  TEXT DEFAULT NULL
+)
+RETURNS TABLE (slug TEXT, title TEXT, url TEXT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+    SELECT t.slug, t.title, t.url
+      FROM referral.user_target ut
+      JOIN referral.target t ON t.slug = ut.target_slug
+     WHERE ut.user_id = p_user_id
+       AND t.active
+       AND (
+           (p_target_slug IS NOT NULL AND ut.target_slug = p_target_slug)
+        OR (p_target_slug IS NULL AND ut.is_default)
+       )
+     LIMIT 1;
+$fn$;
+
+ALTER FUNCTION referral.resolve_user_target(UUID, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.resolve_user_target(UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.resolve_user_target(UUID, TEXT)
+    TO service_role;

--- a/packages/data/sql/schema/wallet/wallet_core.sql
+++ b/packages/data/sql/schema/wallet/wallet_core.sql
@@ -47,7 +47,8 @@ CREATE TYPE wallet.account_kind AS ENUM (
 
 CREATE TYPE wallet.source_kind AS ENUM (
     'reward', 'purchase', 'refund', 'admin', 'coupon',
-    'market_buy', 'market_sell', 'market_fee', 'transfer'
+    'market_buy', 'market_sell', 'market_fee', 'transfer',
+    'referral'
 );
 
 CREATE TYPE wallet.reward_kind AS ENUM (


### PR DESCRIPTION
## Why
Stand up the DB rails for the new referral system. Phase 2 (axum-kbve handler + astro page rewrite) consumes the surface defined here. Splitting keeps each PR independently deployable and reviewable.

Final URL shape (Phase 2):

\`\`\`
/referral/@<handle>/             → user's default target
/referral/@<handle>/<target>/    → specific target from the catalog
\`\`\`

## What's in this PR

### Wallet enum extension
\`ALTER TYPE wallet.source_kind ADD VALUE 'referral'\` — ledger entries from this system carry the new source kind so reporting can isolate referral economics from the rest of the wallet.

### Schema \`referral\`
- **\`referral.target\`** — admin-curated redirect catalog. Seeded with \`rareicon\` → Steam and \`mc\` → \`kbve.com/mc/\`. Slug check rejects uppercase / odd chars; url check requires \`http(s)://\`.
- **\`referral.user_target\`** — per-user opt-in + default target. Partial unique index enforces **one default per user**; non-default rows don't compete for the slot.
- **\`referral.click\`** — append-only click log. **No raw IPs**: stores \`HMAC-SHA256(server_secret, ip)\` and the hash of the /24 (IPv4) or /48 (IPv6) subnet prefix. Header values (UA / Referer / Accept-Language) are truncated to 256 / 512 / 64 chars.
- **\`referral.reward_policy\`** — single-row config: **10 credits per qualified click, 30-day rolling dedup window** per (referrer, target, ip_hash). Bumping this row is the only way to change reward economics without a redeploy.

### Functions
All \`SECURITY DEFINER\`, \`search_path = ''\`, owned by \`postgres\`, grant \`EXECUTE\` to \`service_role\` only.

- **\`referral.ensure_referrer_account(user_id)\`** — lazy wallet account provisioning so a brand-new user's first referral click can still be credited.
- **\`referral.record_click(referrer_id, target_slug, ip_hash, subnet_hash, ua, referer, accept_lang)\`** — entrypoint the axum handler calls. Resolves the target, runs the dedup-window check, conditionally calls \`wallet.service_credit('credits', 10, 'referral', ...)\`, inserts the click row carrying \`ledger_id\`. **Wallet credit + click insert run in the same tx** so they cannot diverge.
- **\`referral.resolve_user_target(user_id, slug?)\`** — picks the (slug, title, url) row a click should resolve to. Default when slug is NULL, exact match otherwise.

## Test coverage
Companion file \`migration-tests/20260515221756_referral_schema_init.test.sql\` exercises:
- seeded targets + reward_policy row present with documented defaults
- \`target.slug\` + \`target.url\` CHECK constraints reject malformed values
- partial unique index blocks a second is_default row per user
- \`resolve_user_target\` falls back to default vs honors explicit slug
- \`record_click\` first call credits 10, returns \`qualified=true\`, ledger_id is set
- second call within the dedup window logs but does **not** credit
- distinct \`ip_hash\` credits independently
- distinct \`target_slug\` credits independently
- missing args + unknown target raise
- down-migration is a no-op (schema + seeds survive intentional rollbacks)

Run locally:

\`\`\`bash
./packages/data/sql/dbmate/test-migration.sh 20260515221756_referral_schema_init
\`\`\`

## migrate:down policy
Intentionally a no-op (\`SELECT 1\`). Dropping \`referral.click\` would delete real click history; tear-down belongs in a dedicated script, not in dbmate rollback. CREATE TABLE / INDEX statements use \`IF NOT EXISTS\` so the migration can be re-applied locally for testing without colliding with itself.

## Privacy + safety notes
- Raw IPs are never persisted. Hashing happens server-side in the axum handler before this RPC is called.
- \`record_click\` requires \`service_role\` — there is no public path into the wallet credit.
- The wallet enum addition is gated by \`ADD VALUE IF NOT EXISTS\`, so re-running the migration doesn't fail on the second pass.

## Test plan
- [ ] PR merges to dev → main.
- [ ] \`gh workflow run ci-dbmate-deploy.yml --ref main -f confirm_sha=<HEAD>\` → approve the \`kilobase-prod\` env gate.
- [ ] After apply: \`\\d referral.*\` returns the four tables; \`SELECT * FROM referral.reward_policy\` returns the (10, 30) row; \`SELECT slug FROM referral.target\` returns \`rareicon\` and \`mc\`.

## Follow-up PRs
- **Phase 2** — axum-kbve route \`/api/v1/referral/...\` that hashes the IP via \`REFERRAL_HASH_SECRET\`, calls \`referral.record_click\`, and 302s to the returned \`target_url\`. Plus the astro \`/referral/@<handle>/[<target>]/\` page that proxies to it.
- **Phase 3** — profile UI for users to manage their enabled targets and pick a default.