### PR TITLE
feat(astro-kbve): add ROWS dashboard to sidebar

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -192,6 +192,7 @@ export default defineConfig({
 						{ label: 'Grafana', link: '/dashboard/grafana/', attrs: { 'data-auth-visibility': 'staff' } },
 						{ label: 'Virtual Machines', link: '/dashboard/vm/', attrs: { 'data-auth-visibility': 'staff' } },
 						{ label: 'IDE', link: '/dashboard/ide/', attrs: { 'data-auth-visibility': 'staff' } },
+						{ label: 'ROWS (Game Ops)', link: '/dashboard/rows/', attrs: { 'data-auth-visibility': 'staff' } },
 					],
 				},
 				{


### PR DESCRIPTION
## Summary

Slots the existing `/dashboard/rows/` page into the Dashboard sidebar group as a staff-gated entry. The page and React/Astro components already exist — this just makes it reachable from the nav.

## Change

One line added to [apps/kbve/astro-kbve/astro.config.mjs](apps/kbve/astro-kbve/astro.config.mjs) after the IDE entry:

```js
{ label: 'ROWS (Game Ops)', link: '/dashboard/rows/', attrs: { 'data-auth-visibility': 'staff' } },
```

## End-to-end wiring (already in place)

| Layer | Path / Resource |
|-------|-----------------|
| Astro page | [apps/kbve/astro-kbve/src/content/docs/dashboard/rows/index.mdx](apps/kbve/astro-kbve/src/content/docs/dashboard/rows/index.mdx) |
| Astro component | [apps/kbve/astro-kbve/src/components/dashboard/AstroRowsDashboard.astro](apps/kbve/astro-kbve/src/components/dashboard/AstroRowsDashboard.astro) |
| Service / fetcher | [apps/kbve/astro-kbve/src/components/dashboard/rowsService.ts](apps/kbve/astro-kbve/src/components/dashboard/rowsService.ts) — `PROXY_BASE = '/dashboard/chuckrpg/proxy'` |
| Browser → axum-kbve | `https://kbve.com/dashboard/chuckrpg/proxy/api/System/*` |
| axum-kbve env | `CHUCKRPG_UPSTREAM_URL=http://rows.rows.svc.cluster.local:4322` (Phase 2 update, verified live) |
| ROWS pod | `rows.rows.svc.cluster.local:4322` — serves `/api/System/Health`, `/FleetStatus`, `/ActivePlayers`, `/InstanceLog`, `/DeploymentInfo` |

## Verified live

- ROWS pod healthy in `rows` ns (`kubectl get pods -n rows`)
- axum-kbve env points at new internal DNS
- `axum_kbve` boot log: `ChuckRPG proxy initialized - /dashboard/chuckrpg/proxy enabled`
- External proxy returns HTTP 401 without auth — correct gate behavior

## Test plan

- [ ] CI green on dev base
- [ ] After merge to main + astro-kbve rebuild + axum-kbve serve: sidebar shows "ROWS (Game Ops)" for staff users
- [ ] `/dashboard/rows/` loads + populates Health/Fleet/Players/InstanceLog/Deployment panels from live ROWS