### PR TITLE
feat(itch): rebuild /itch/ page — left sidebar + game grid + hero CTA

### DIFF
--- a/apps/kbve/astro-kbve/src/components/itch/ItchGames.astro
+++ b/apps/kbve/astro-kbve/src/components/itch/ItchGames.astro
@@ -1,0 +1,200 @@
+---
+import {
+	KBVE_ITCH_GAMES,
+	ITCH_PROFILE_URL,
+	ITCH_PLATFORM_META,
+	type ItchGame,
+} from './itchGames';
+
+interface Props {
+	games?: ItchGame[];
+}
+
+const games = (Astro.props.games ?? KBVE_ITCH_GAMES).slice();
+games.sort((a, b) => (a.featured === b.featured ? 0 : a.featured ? -1 : 1));
+---
+
+<section class="itch-games" aria-label="KBVE games on itch.io">
+	{
+		games.map((g) => {
+			const url = `${ITCH_PROFILE_URL}/${g.slug}`;
+			const fallbackBg = g.thumbColor ?? '#1f1f24';
+			return (
+				<a
+					class:list={[
+						'itch-card',
+						g.featured && 'itch-card--featured',
+					]}
+					href={url}
+					target="_blank"
+					rel="noopener noreferrer"
+					data-game-id={g.id}>
+					<div
+						class="itch-card__thumb"
+						style={`background-color:${fallbackBg}`}>
+						{g.thumb ? (
+							<img
+								src={g.thumb}
+								alt={`${g.title} thumbnail`}
+								loading="lazy"
+								width="315"
+								height="250"
+							/>
+						) : (
+							<span
+								class="itch-card__thumb-fallback"
+								aria-hidden="true">
+								{g.title.charAt(0)}
+							</span>
+						)}
+						{g.featured && (
+							<span class="itch-card__badge">Featured</span>
+						)}
+					</div>
+					<div class="itch-card__body">
+						<div class="itch-card__title">{g.title}</div>
+						{g.desc && <div class="itch-card__desc">{g.desc}</div>}
+						<div class="itch-card__meta">
+							{g.genre && (
+								<span class="itch-card__genre">{g.genre}</span>
+							)}
+							<span class="itch-card__platforms">
+								{g.platforms.map((p) => (
+									<span
+										class:list={[
+											'itch-card__plat',
+											`itch-card__plat--${p}`,
+										]}
+										title={ITCH_PLATFORM_META[p].label}>
+										{ITCH_PLATFORM_META[p].label}
+									</span>
+								))}
+							</span>
+						</div>
+					</div>
+				</a>
+			);
+		})
+	}
+</section>
+
+<style>
+	.itch-games {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+		gap: 1rem;
+		margin: 1.25rem 0;
+	}
+	.itch-card {
+		display: flex;
+		flex-direction: column;
+		border-radius: 12px;
+		overflow: hidden;
+		border: 1px solid var(--sl-color-gray-5, #2a2a33);
+		background: var(--sl-color-bg-nav, #131318);
+		color: var(--sl-color-text, #e6edf3);
+		text-decoration: none;
+		transition:
+			transform 0.15s ease,
+			border-color 0.15s ease,
+			box-shadow 0.15s ease;
+	}
+	.itch-card:hover {
+		transform: translateY(-3px);
+		border-color: #fa5c5c;
+		box-shadow: 0 8px 24px color-mix(in srgb, #fa5c5c 22%, transparent);
+	}
+	.itch-card--featured {
+		grid-column: span 2;
+		border-color: #fa5c5c;
+		box-shadow: 0 4px 18px color-mix(in srgb, #fa5c5c 18%, transparent);
+	}
+	@media (max-width: 600px) {
+		.itch-card--featured {
+			grid-column: span 1;
+		}
+	}
+	.itch-card__thumb {
+		position: relative;
+		aspect-ratio: 315 / 250;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+	}
+	.itch-card__thumb img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+	.itch-card__thumb-fallback {
+		font-size: 3rem;
+		font-weight: 700;
+		color: rgba(255, 255, 255, 0.55);
+		letter-spacing: -2px;
+	}
+	.itch-card__badge {
+		position: absolute;
+		top: 8px;
+		right: 8px;
+		background: #fa5c5c;
+		color: #fff;
+		font-size: 11px;
+		font-weight: 600;
+		padding: 3px 8px;
+		border-radius: 999px;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+	.itch-card__body {
+		padding: 0.85rem 1rem 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		flex: 1;
+	}
+	.itch-card__title {
+		font-weight: 600;
+		font-size: 1rem;
+		color: var(--sl-color-white, #f3f4f6);
+	}
+	.itch-card__desc {
+		font-size: 0.85rem;
+		color: var(--sl-color-gray-2, #a1a1aa);
+		line-height: 1.45;
+	}
+	.itch-card__meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		margin-top: auto;
+		padding-top: 0.4rem;
+	}
+	.itch-card__genre {
+		font-size: 0.7rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		padding: 2px 8px;
+		border-radius: 4px;
+		background: rgba(250, 92, 92, 0.12);
+		color: #fa8080;
+	}
+	.itch-card__platforms {
+		display: inline-flex;
+		flex-wrap: wrap;
+		gap: 4px;
+	}
+	.itch-card__plat {
+		font-size: 0.68rem;
+		font-weight: 500;
+		padding: 2px 7px;
+		border-radius: 4px;
+		background: rgba(148, 163, 184, 0.12);
+		color: #94a3b8;
+	}
+	.itch-card__plat--web {
+		background: rgba(102, 192, 244, 0.14);
+		color: #a5d8ff;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/itch/ItchHero.astro
+++ b/apps/kbve/astro-kbve/src/components/itch/ItchHero.astro
@@ -1,0 +1,157 @@
+---
+import { ITCH_PROFILE_URL, KBVE_ITCH_GAMES } from './itchGames';
+
+const totalGames = KBVE_ITCH_GAMES.length;
+const webPlayable = KBVE_ITCH_GAMES.filter((g) =>
+	g.platforms.includes('web'),
+).length;
+const downloadable = KBVE_ITCH_GAMES.filter(
+	(g) =>
+		g.platforms.includes('windows') ||
+		g.platforms.includes('linux') ||
+		g.platforms.includes('mac') ||
+		g.platforms.includes('android'),
+).length;
+---
+
+<section class="itch-hero">
+	<div class="itch-hero__main">
+		<div class="itch-hero__title">KBVE on itch.io</div>
+		<div class="itch-hero__copy">
+			Indie demos, jam entries, and small experiments. Ship-when-ready, no
+			storefront queue.
+		</div>
+		<div class="itch-hero__actions">
+			<a
+				class="itch-cta itch-cta--primary"
+				href={ITCH_PROFILE_URL}
+				target="_blank"
+				rel="noopener noreferrer">
+				<span aria-hidden="true">▣</span>
+				Visit kbve.itch.io
+			</a>
+			<a
+				class="itch-cta itch-cta--ghost"
+				href={`${ITCH_PROFILE_URL}/devlog.rss`}
+				target="_blank"
+				rel="noopener noreferrer">
+				<span aria-hidden="true">›</span>
+				Devlog RSS
+			</a>
+		</div>
+	</div>
+	<dl class="itch-hero__stats" aria-label="Catalog stats">
+		<div class="itch-hero__stat">
+			<dt>{totalGames}</dt>
+			<dd>games</dd>
+		</div>
+		<div class="itch-hero__stat">
+			<dt>{webPlayable}</dt>
+			<dd>play in browser</dd>
+		</div>
+		<div class="itch-hero__stat">
+			<dt>{downloadable}</dt>
+			<dd>downloadable</dd>
+		</div>
+	</dl>
+</section>
+
+<style>
+	.itch-hero {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 1.25rem;
+		padding: 1.5rem 1.5rem;
+		border-radius: 16px;
+		border: 1px solid color-mix(in srgb, #fa5c5c 22%, transparent);
+		background: linear-gradient(
+			135deg,
+			rgba(250, 92, 92, 0.08),
+			rgba(15, 23, 42, 0.5)
+		);
+		margin: 1rem 0 1.5rem;
+	}
+	@media (min-width: 720px) {
+		.itch-hero {
+			grid-template-columns: 1fr auto;
+			align-items: center;
+		}
+	}
+	.itch-hero__title {
+		font-size: 1.6rem;
+		font-weight: 700;
+		letter-spacing: -0.01em;
+		color: var(--sl-color-white, #f9fafb);
+	}
+	.itch-hero__copy {
+		margin-top: 0.4rem;
+		color: var(--sl-color-gray-2, #cbd5e1);
+		line-height: 1.55;
+		max-width: 56ch;
+	}
+	.itch-hero__actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.6rem;
+		margin-top: 1rem;
+	}
+	.itch-cta {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		padding: 0.6rem 1rem;
+		border-radius: 8px;
+		font-weight: 600;
+		text-decoration: none;
+		font-size: 0.9rem;
+		transition:
+			transform 0.12s ease,
+			background 0.12s ease;
+	}
+	.itch-cta:hover {
+		transform: translateY(-1px);
+	}
+	.itch-cta--primary {
+		background: #fa5c5c;
+		color: #fff;
+		box-shadow: 0 6px 20px color-mix(in srgb, #fa5c5c 30%, transparent);
+	}
+	.itch-cta--ghost {
+		background: transparent;
+		color: var(--sl-color-white, #f3f4f6);
+		border: 1px solid var(--sl-color-gray-5, #2a2a33);
+	}
+	.itch-cta--ghost:hover {
+		border-color: #fa5c5c;
+	}
+	.itch-hero__stats {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(72px, 1fr));
+		gap: 0.5rem;
+		margin: 0;
+		padding: 0;
+	}
+	.itch-hero__stat {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 2px;
+		padding: 0.6rem 0.9rem;
+		border-radius: 10px;
+		background: rgba(15, 23, 42, 0.55);
+		border: 1px solid rgba(148, 163, 184, 0.14);
+	}
+	.itch-hero__stat dt {
+		font-size: 1.6rem;
+		font-weight: 700;
+		color: #fa8080;
+		line-height: 1;
+	}
+	.itch-hero__stat dd {
+		margin: 0;
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--sl-color-gray-3, #9ca3af);
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/itch/itchGames.ts
+++ b/apps/kbve/astro-kbve/src/components/itch/itchGames.ts
@@ -1,0 +1,118 @@
+export type ItchPlatform = 'web' | 'windows' | 'linux' | 'mac' | 'android';
+
+export interface ItchGame {
+	id: number;
+	slug: string;
+	title: string;
+	desc?: string;
+	genre?: string;
+	platforms: ItchPlatform[];
+	thumb?: string;
+	thumbColor?: string;
+	featured?: boolean;
+}
+
+export const ITCH_PROFILE_URL = 'https://kbve.itch.io';
+export const ITCH_DEVLOG_RSS = 'https://kbve.itch.io/devlog.rss';
+
+export const KBVE_ITCH_GAMES: ItchGame[] = [
+	{
+		id: 2285869,
+		slug: 'rareicon',
+		title: 'RareIcon',
+		desc: '2D sci-fi Action-RPG bullet-hell roguelite. Chip vs DaemonCorps.',
+		genre: 'Action-RPG',
+		platforms: ['linux', 'mac', 'android'],
+		thumbColor: '#000000',
+		featured: true,
+	},
+	{
+		id: 4245453,
+		slug: 'slick',
+		title: 'SLICK',
+		platforms: ['web'],
+	},
+	{
+		id: 4147439,
+		slug: 'rentearth',
+		title: 'RentEarth',
+		platforms: ['windows', 'linux', 'mac'],
+	},
+	{
+		id: 4030676,
+		slug: 'bugwars',
+		title: 'Bug Wars',
+		platforms: ['web'],
+	},
+	{
+		id: 3994260,
+		slug: 'cityvote',
+		title: 'CityVote',
+		platforms: ['web'],
+	},
+	{
+		id: 3973386,
+		slug: 'afk',
+		title: 'AFK Cat Lord',
+		desc: 'From Whiskers to Throne, lead the Haus of Kats.',
+		platforms: ['web'],
+		thumb: 'https://img.itch.zone/aW1nLzIzODAyODk2LnBuZw==/315x250%23c/wsx7Wp.png',
+		thumbColor: '#8ec48d',
+	},
+	{
+		id: 3737646,
+		slug: 'airship',
+		title: 'Airship',
+		genre: 'Adventure',
+		platforms: ['web'],
+		thumbColor: '#1E3A8A',
+	},
+	{
+		id: 3340442,
+		slug: 'asteroids-driods',
+		title: 'Asteroids & Droids',
+		desc: 'All about dat h e a t.',
+		genre: 'Shooter',
+		platforms: ['web'],
+		thumb: 'https://img.itch.zone/aW1nLzE5OTc0Mjk1LnBuZw==/315x250%23c/lr0HA2.png',
+		thumbColor: '#193d3f',
+	},
+	{
+		id: 2590929,
+		slug: 'travelbox',
+		title: 'TravelBox',
+		genre: 'Action',
+		platforms: ['web'],
+		thumb: 'https://img.itch.zone/aW1nLzE1NDMyODQyLnBuZw==/315x250%23c/x%2BsivB.png',
+		thumbColor: '#141414',
+	},
+	{
+		id: 2561506,
+		slug: 'fishchip',
+		title: 'Fish & Chip',
+		desc: 'Chip loves to fish.',
+		genre: 'Educational',
+		platforms: ['web'],
+		thumb: 'https://img.itch.zone/aW1nLzE1MjU3MzgwLnBuZw==/315x250%23c/fczRHT.png',
+		thumbColor: '#eeeeee',
+	},
+	{
+		id: 2345082,
+		slug: 'dev-saber',
+		title: 'Saber: Red Scale Dragon',
+		desc: 'Developer pipeline build of SABER.',
+		genre: 'Adventure',
+		platforms: ['web', 'windows'],
+	},
+];
+
+export const ITCH_PLATFORM_META: Record<
+	ItchPlatform,
+	{ label: string; icon: string }
+> = {
+	web: { label: 'Play in browser', icon: '▶' },
+	windows: { label: 'Windows', icon: '⊞' },
+	linux: { label: 'Linux', icon: '🐧' },
+	mac: { label: 'macOS', icon: '' },
+	android: { label: 'Android', icon: '▲' },
+};

--- a/apps/kbve/astro-kbve/src/content/docs/itch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/itch.mdx
@@ -3,7 +3,6 @@ title: Itch.io
 description: Browse KBVE indie games, jam entries, and demos on itch.io.
 ogTitle: "KBVE on itch.io — Indie Games, Jam Entries, Demos"
 ogDescription: "Ship-when-ready indie projects from KBVE. Browse demos, jam entries, and free downloads."
-template: splash
 sidebar:
   label: Itch
   order: 9
@@ -13,66 +12,20 @@ tableOfContents: false
 ---
 
 import Adsense from '@/components/astropad/adsense/Adsense.astro';
+import ItchHero from '@/components/itch/ItchHero.astro';
+import ItchGames from '@/components/itch/ItchGames.astro';
 
-## KBVE on itch.io
+<ItchHero />
 
-Indie demos, jam entries, and small projects. Ship-when-ready, no Steam queue.
+## Games
 
-<div class="itch-page">
-  <a
-    class="itch-cta"
-    href="https://kbve.itch.io"
-    target="_blank"
-    rel="noopener noreferrer">
-    <span class="itch-cta__icon" aria-hidden="true">▣</span>
-    <span class="itch-cta__label">Visit kbve.itch.io</span>
-  </a>
+Click any card to jump straight to its itch.io page.
 
-  <div class="itch-embed">
-    <iframe
-      src="https://itch.io/embed/kbve"
-      title="KBVE on itch.io"
-      frameborder="0"
-      loading="lazy"></iframe>
-  </div>
-</div>
+<ItchGames />
+
+## What's the difference vs Steam?
+
+- **itch.io** is where KBVE ships early prototypes, jam builds, and demos. No queue, no review gate — fast iteration.
+- **Steam** is where flagship titles land once they're past the demo stage. Wishlist on [the KBVE curator](/steam/) to follow those.
 
 <Adsense />
-
-<style is:global>{`
-  .itch-page {
-    max-width: 720px;
-    margin: 1.5rem auto;
-    display: grid;
-    gap: 1rem;
-  }
-  .itch-cta {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    padding: 0.75rem 1.25rem;
-    border-radius: 10px;
-    background: #fa5c5c;
-    color: #fff;
-    font-weight: 600;
-    text-decoration: none;
-    width: fit-content;
-    box-shadow: 0 6px 20px color-mix(in srgb, #fa5c5c 30%, transparent);
-    transition: transform 0.12s ease;
-  }
-  .itch-cta:hover { transform: translateY(-1px); }
-  .itch-cta__icon { font-size: 1.1rem; line-height: 1; }
-  .itch-embed {
-    width: 100%;
-    min-height: 167px;
-    border-radius: 12px;
-    overflow: hidden;
-    border: 1px solid var(--sl-color-gray-5, #2a2a33);
-    background: var(--sl-color-bg-nav, #131318);
-  }
-  .itch-embed iframe {
-    width: 100%;
-    min-height: 167px;
-    border: 0;
-  }
-`}</style>


### PR DESCRIPTION
## Summary
The old \`/itch/\` page used Starlight's \`splash\` template, which strips both the left navigation sidebar and the right TOC. The body was a single \`https://itch.io/embed/kbve\` iframe — small, empty, and disconnected from the rest of the site.

## Changes
- **Drop \`template: splash\`** from the frontmatter so the page inherits the default \`doc\` layout. Left sidebar (KBVE site nav) is back; right TOC stays hidden via the existing \`tableOfContents: false\`.
- **New \`ItchHero.astro\`** — gradient hero with title, copy, primary "Visit kbve.itch.io" CTA, ghost "Devlog RSS" CTA, and a 3-stat strip (total games / web-playable / downloadable) computed from the games array at build time.
- **New \`ItchGames.astro\`** — auto-fill responsive card grid driven by a typed \`KBVE_ITCH_GAMES\` array in \`itchGames.ts\`. Each card has a thumbnail (real itch.zone CDN image where available, color fallback otherwise), title, optional description / genre, and per-platform badges (web / Win / Linux / mac / Android). The flagship card (RareIcon) is marked \`featured\` and spans two columns on wider viewports.
- All **11 KBVE titles** pulled from the public profile: RareIcon, SLICK, RentEarth, Bug Wars, CityVote, AFK Cat Lord, Airship, Asteroids & Droids, TravelBox, Fish & Chip, and the Saber dev pipeline build.

All SSG — no client JS shipped for this page.

## Test plan
- [x] \`./kbve.sh -nx astro-kbve:check\` — no new errors (1 pre-existing GamingHub error unrelated)
- [x] \`./kbve.sh -nx astro-kbve:build\` — emits \`/itch/index.html\` with the sidebar nav, 11 game cards, and \`itch-hero\` block
- [ ] Visual check at \`/itch/\` post-deploy