### PR TITLE
fix(astro-kbve/mc): stabilise wallet + mc-auth cards, eliminate hydration CLS

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mc/mc-auth/AstroMcAuthLink.astro
+++ b/apps/kbve/astro-kbve/src/components/mc/mc-auth/AstroMcAuthLink.astro
@@ -2,4 +2,28 @@
 import { ReactMcAuthLink } from './ReactMcAuthLink';
 ---
 
-<ReactMcAuthLink client:only="react" />
+<div class="kbve-mc-auth-shell" data-kbve-mc-auth-shell>
+	<noscript>
+		<div class="kbve-mc-auth-shell__nojs">
+			Enable JavaScript to link your Minecraft account.
+		</div>
+	</noscript>
+	<ReactMcAuthLink client:only="react" />
+</div>
+
+<style>
+	.kbve-mc-auth-shell {
+		min-height: 200px;
+		margin-bottom: 1.5rem;
+		display: block;
+		contain: layout;
+	}
+	.kbve-mc-auth-shell__nojs {
+		padding: 1rem 1.25rem;
+		border-radius: 0.5rem;
+		border: 1px solid var(--sl-color-gray-5);
+		background: var(--sl-color-bg-nav);
+		color: var(--sl-color-gray-3);
+		font-size: 0.9rem;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/mc/mc-auth/ReactMcAuthLink.tsx
+++ b/apps/kbve/astro-kbve/src/components/mc/mc-auth/ReactMcAuthLink.tsx
@@ -31,6 +31,9 @@ const styles = {
 		background: 'var(--sl-color-bg-nav)',
 		padding: '1rem 1.25rem',
 		marginBottom: '1.5rem',
+		minHeight: '152px',
+		display: 'flex',
+		flexDirection: 'column',
 	} as React.CSSProperties,
 	header: {
 		display: 'flex',

--- a/apps/kbve/astro-kbve/src/components/wallet/AstroWalletCard.astro
+++ b/apps/kbve/astro-kbve/src/components/wallet/AstroWalletCard.astro
@@ -5,8 +5,8 @@ import { ReactWalletCard } from './ReactWalletCard';
 <section
 	class="kbve-wallet-card not-content"
 	data-kbve-wallet-shell
-	aria-label="Your wallet"
-	hidden>
+	data-kbve-wallet-state="loading"
+	aria-label="Your wallet">
 	<header class="kbve-wallet-card__header">
 		<span class="kbve-wallet-card__title">Wallet</span>
 		<span
@@ -34,6 +34,10 @@ import { ReactWalletCard } from './ReactWalletCard';
 		</div>
 	</div>
 
+	<div class="kbve-wallet-card__signed-out" data-kbve-wallet-signed-out>
+		Sign in to view your credits, KHash, and pending coupons.
+	</div>
+
 	<ReactWalletCard client:only="react" />
 </section>
 
@@ -50,10 +54,27 @@ import { ReactWalletCard } from './ReactWalletCard';
 		border: 1px solid rgba(255, 255, 255, 0.08);
 		color: rgba(255, 255, 255, 0.9);
 		box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+		min-height: 168px;
 	}
 
-	.kbve-wallet-card[hidden] {
+	.kbve-wallet-card[data-kbve-wallet-state='signed-out']
+		.kbve-wallet-card__balances {
+		opacity: 0.35;
+		pointer-events: none;
+	}
+	.kbve-wallet-card[data-kbve-wallet-state='signed-out']
+		.kbve-wallet-card__updated {
+		visibility: hidden;
+	}
+	.kbve-wallet-card__signed-out {
+		margin-top: 0.85rem;
+		font-size: 0.85rem;
+		color: rgba(255, 255, 255, 0.6);
 		display: none;
+	}
+	.kbve-wallet-card[data-kbve-wallet-state='signed-out']
+		.kbve-wallet-card__signed-out {
+		display: block;
 	}
 
 	.kbve-wallet-card__header {

--- a/apps/kbve/astro-kbve/src/components/wallet/ReactWalletCard.tsx
+++ b/apps/kbve/astro-kbve/src/components/wallet/ReactWalletCard.tsx
@@ -32,6 +32,35 @@ const SHELL_SELECTOR = '[data-kbve-wallet-shell]';
 const SLOT_CREDITS = '[data-kbve-wallet-credits]';
 const SLOT_KHASH = '[data-kbve-wallet-khash]';
 const SLOT_UPDATED = '[data-kbve-wallet-updated]';
+const CACHE_KEY = 'kbve:wallet:balance:v1';
+const BROADCAST_CHANNEL = 'kbve-wallet-sync';
+
+function readCachedBalance(): Balance | null {
+	if (typeof localStorage === 'undefined') return null;
+	try {
+		const raw = localStorage.getItem(CACHE_KEY);
+		return raw ? (JSON.parse(raw) as Balance) : null;
+	} catch {
+		return null;
+	}
+}
+
+function writeCachedBalance(b: Balance | null) {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		if (b) localStorage.setItem(CACHE_KEY, JSON.stringify(b));
+		else localStorage.removeItem(CACHE_KEY);
+	} catch {}
+}
+
+function balancesEqual(a: Balance | null, b: Balance | null): boolean {
+	if (!a || !b) return a === b;
+	return (
+		a.credits === b.credits &&
+		a.khash === b.khash &&
+		a.updated_at === b.updated_at
+	);
+}
 
 async function authedFetch(path: string, init: RequestInit = {}) {
 	const token = await getAccessToken();
@@ -80,6 +109,7 @@ export function ReactWalletCard() {
 	const [coupons, setCoupons] = useState<Coupon[]>([]);
 	const [error, setError] = useState<string | null>(null);
 	const [claiming, setClaiming] = useState<number | null>(null);
+	const lastBalanceRef = useRef<Balance | null>(null);
 
 	useEffect(() => {
 		setShell(findShell(mountRef.current));
@@ -99,6 +129,7 @@ export function ReactWalletCard() {
 				SLOT_UPDATED,
 				b ? `updated ${new Date(b.updated_at).toLocaleString()}` : '…',
 			);
+			lastBalanceRef.current = b;
 		},
 		[shell],
 	);
@@ -109,7 +140,18 @@ export function ReactWalletCard() {
 				authedFetch('/api/v1/wallet/me/balance'),
 				authedFetch('/api/v1/wallet/me/coupons'),
 			]);
-			applyBalance(bal as Balance);
+			const balance = bal as Balance;
+			if (!balancesEqual(balance, lastBalanceRef.current)) {
+				applyBalance(balance);
+				writeCachedBalance(balance);
+				if (typeof BroadcastChannel !== 'undefined') {
+					try {
+						const ch = new BroadcastChannel(BROADCAST_CHANNEL);
+						ch.postMessage({ type: 'balance', balance });
+						ch.close();
+					} catch {}
+				}
+			}
 			setCoupons(cps as Coupon[]);
 			setError(null);
 		} catch (err) {
@@ -122,12 +164,41 @@ export function ReactWalletCard() {
 	useEffect(() => {
 		if (!shell || !ready) return;
 		if (!authenticated) {
-			shell.hidden = true;
+			shell.dataset.kbveWalletState = 'signed-out';
+			applyBalance(null);
+			writeCachedBalance(null);
 			return;
 		}
-		shell.hidden = false;
+		shell.dataset.kbveWalletState = 'authenticated';
+		const cached = readCachedBalance();
+		if (cached) {
+			applyBalance(cached);
+		}
 		void refresh();
-	}, [shell, ready, authenticated, refresh]);
+	}, [shell, ready, authenticated, applyBalance, refresh]);
+
+	useEffect(() => {
+		if (!authenticated || typeof BroadcastChannel === 'undefined') return;
+		let ch: BroadcastChannel;
+		try {
+			ch = new BroadcastChannel(BROADCAST_CHANNEL);
+		} catch {
+			return;
+		}
+		const onMessage = (event: MessageEvent) => {
+			const data = event.data as { type?: string; balance?: Balance };
+			if (data?.type === 'balance' && data.balance) {
+				if (!balancesEqual(data.balance, lastBalanceRef.current)) {
+					applyBalance(data.balance);
+				}
+			}
+		};
+		ch.addEventListener('message', onMessage);
+		return () => {
+			ch.removeEventListener('message', onMessage);
+			ch.close();
+		};
+	}, [authenticated, applyBalance]);
 
 	const claim = useCallback(
 		async (couponId: number) => {


### PR DESCRIPTION
## Summary
[/mc](https://kbve.com/mc/) lands with two React islands — the wallet card and the Minecraft account link card. Before this change both shipped from Astro with effectively zero reserved height: the wallet shell was rendered with `hidden`, and the mc-auth card was a bare `client:only` island with no surrounding shell. Hydration kicked the page down by ~300px the moment React mounted, and the wallet shifted a second time when the service worker raced the main-thread fetch and replaced the cached balance with the fresh one.

This PR moves to a stable-shell pattern (Astro owns the parent container + skeleton dimensions; React only writes the inner values), which is the same shape Million.js recommends for minimising repaints — small, isolated regions of the DOM under reactive control, everything else immutable.

## Changes

**Wallet card** ([`AstroWalletCard.astro`](apps/kbve/astro-kbve/src/components/wallet/AstroWalletCard.astro) + [`ReactWalletCard.tsx`](apps/kbve/astro-kbve/src/components/wallet/ReactWalletCard.tsx))
- Astro shell renders unconditionally with `min-height: 168px` and `data-kbve-wallet-state="loading"` by default. The signed-out fallback message lives inside the shell, gated by CSS off the state attribute.
- React replaces the legacy `shell.hidden = true/false` toggle with `shell.dataset.kbveWalletState = 'authenticated' | 'signed-out'`. Card never collapses / re-expands during auth resolution.
- Adds a localStorage snapshot (`kbve:wallet:balance:v1`) that the card paints immediately on mount; the network refresh only writes the DOM when the response differs from the snapshot, eliminating the second flicker when service-worker-cached and network responses agree.
- Adds `BroadcastChannel('kbve-wallet-sync')` so a balance update in one tab propagates to every other open wallet card without a second network round-trip.

**MC auth card** ([`AstroMcAuthLink.astro`](apps/kbve/astro-kbve/src/components/mc/mc-auth/AstroMcAuthLink.astro) + [`ReactMcAuthLink.tsx`](apps/kbve/astro-kbve/src/components/mc/mc-auth/ReactMcAuthLink.tsx))
- Wraps the React island in an Astro shell with `min-height: 200px` and `contain: layout`, so the surrounding markdown can paint at final position before hydration finishes. Includes a `<noscript>` copy for crawlers and NoJS visitors.
- React container picks up `min-height: 152px` + flex-column layout so `init` / `anon` / `unlinked` / `pending` / `verified` phases all occupy the same vertical envelope. No more vertical jumps as the status badge resolves.

## Test plan
- [ ] `nx build astro-kbve` passes (verified locally).
- [ ] Lighthouse CLS on `/mc/` ≤ 0.1 (anon visitor).
- [ ] Lighthouse CLS on `/mc/` ≤ 0.1 (signed-in visitor).
- [ ] Wallet snapshot survives a hard reload — the cached numbers paint before the network response arrives.
- [ ] Opening the page in two tabs and claiming a coupon in one of them updates the other within ~1 frame (`BroadcastChannel`).