### PR TITLE
fix(docker): force-overwrite existing .gz/.br in axum precompressor

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -52,8 +52,8 @@ RUN find . -type f \( \
         -name "*.html" \
     \) -print0 | \
     xargs -0 -P "$(nproc)" -n 1 sh -c ' \
-        gzip -9 -k "$1" && \
-        brotli -q 9 --keep "$1" \
+        gzip -9 -f -k "$1" && \
+        brotli -q 9 -f --keep "$1" \
     ' _ && \
     echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 

--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -52,8 +52,8 @@ RUN find . -type f \( \
         -name "*.html" \
     \) ! -path "*/askama/*" -print0 | \
     xargs -0 -P "$(nproc)" -n 1 sh -c ' \
-        gzip -9 -k "$1" && \
-        brotli -q 9 --keep "$1" \
+        gzip -9 -f -k "$1" && \
+        brotli -q 9 -f --keep "$1" \
     ' _ && \
     echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -58,8 +58,8 @@ RUN find . -type f \( \
         -name "*.html" \
     \) ! -path "*/askama/*" -print0 | \
     xargs -0 -P "$(nproc)" -n 1 sh -c ' \
-        gzip -9 -k "$1" && \
-        brotli -q 9 --keep "$1" \
+        gzip -9 -f -k "$1" && \
+        brotli -q 9 -f --keep "$1" \
     ' _ && \
     echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -51,8 +51,8 @@ RUN find . -type f \( \
         -name "*.html" \
     \) ! -path "*/askama/*" -print0 | \
     xargs -0 -P "$(nproc)" -n 1 sh -c ' \
-        gzip -9 -k "$1" && \
-        brotli -q 9 --keep "$1" \
+        gzip -9 -f -k "$1" && \
+        brotli -q 9 -f --keep "$1" \
     ' _ && \
     echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -51,8 +51,8 @@ RUN find . -type f \( \
         -name "*.html" \
     \) ! -path "*/askama/*" -print0 | \
     xargs -0 -P "$(nproc)" -n 1 sh -c ' \
-        gzip -9 -k "$1" && \
-        brotli -q 9 --keep "$1" \
+        gzip -9 -f -k "$1" && \
+        brotli -q 9 -f --keep "$1" \
     ' _ && \
     echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -77,8 +77,8 @@ RUN find . -type f \( \
         -name "*.html" \
     \) ! -path "*/askama/*" -print0 | \
     xargs -0 -P "$(nproc)" -n 1 sh -c ' \
-        gzip -9 -k "$1" && \
-        brotli -q 9 --keep "$1" \
+        gzip -9 -f -k "$1" && \
+        brotli -q 9 -f --keep "$1" \
     ' _ && \
     echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 

--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -57,8 +57,8 @@ RUN find . -type f \( \
         -name "*.html" \
     \) ! -path "*/askama/*" -print0 | \
     xargs -0 -P "$(nproc)" -n 1 sh -c ' \
-        gzip -9 -k "$1" && \
-        brotli -q 9 --keep "$1" \
+        gzip -9 -f -k "$1" && \
+        brotli -q 9 -f --keep "$1" \
     ' _ && \
     echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 

--- a/apps/rareicon/axum-rareicon/Dockerfile
+++ b/apps/rareicon/axum-rareicon/Dockerfile
@@ -53,8 +53,8 @@ RUN find . -type f \( \
         -name "*.html" \
     \) -print0 | \
     xargs -0 -P "$(nproc)" -n 1 sh -c ' \
-        gzip -9 -k "$1" && \
-        brotli -q 9 --keep "$1" \
+        gzip -9 -f -k "$1" && \
+        brotli -q 9 -f --keep "$1" \
     ' _ && \
     echo "Precompression complete (brotli-9 + gzip-9, parallel x $(nproc))"
 


### PR DESCRIPTION
## Summary
Fixes the regression in #11057 / run [25954295037](https://github.com/KBVE/kbve/actions/runs/25954295037).

### What broke
#11049 swapped the serial \`find -exec\` precompressor for parallel \`find -print0 | xargs -0 -P "\$(nproc)"\`. CI surfaced an issue the **old** serial version had been silently swallowing: the astro-kbve build ships pre-compressed \`.br\` files straight out of the isometric wasm-bindgen output:

\`\`\`
./isometric/assets/index.css.br
./isometric/assets/index.js.br
./isometric/assets/isometric_game.js.br
./isometric/assets/snippets/bevy_tasker-*/inline0.js.br
./isometric/bug-report-shim.js.br
./isometric/safari-shim.js.br
./isometric/wasm-worker.js.br
\`\`\`

\`brotli\` refuses to overwrite an existing output file by default. The old \`find -exec sh -c '…' _ {} \;\` ignored per-file exit codes — those files always errored ("File exists"), but find still returned 0, so the docker stage looked green. \`xargs\` is strict: any failed invocation returns 123 and aborts the \`RUN\`.

### Fix
Add \`-f\` to both compressors so the parallel pass overwrites existing output, matching the old silent-skip behavior but explicit. Applied across all 8 axum-* Dockerfiles that share the precompressor stage.

\`\`\`diff
-     gzip -9 -k "\$1" && \
+     gzip -9 -f -k "\$1" && \
-     brotli -q 9 --keep "\$1" \
+     brotli -q 9 -f --keep "\$1" \
\`\`\`

## Test plan
- [x] Diff verified — \`-f\` lands in all 8 axum-* Dockerfiles
- [ ] Next axum-kbve CI run — precompressor stage no longer aborts on \`.br\` already present