### PR TITLE
fix(mc/smoke): isolate runClient session and exit fast on success

### DIFF
--- a/apps/mc/scripts/headless-client-smoke.sh
+++ b/apps/mc/scripts/headless-client-smoke.sh
@@ -18,6 +18,7 @@ JAVA_DIR="${JAVA_DIR:-apps/mc/behavior_statetree/java}"
 TIMEOUT_SECS="${TIMEOUT_SECS:-300}"
 LOG_FILE="${LOG_FILE:-/tmp/mc-headless-client.log}"
 GRACE_SECS="${GRACE_SECS:-5}"
+PID_FILE="${PID_FILE:-/tmp/mc-headless-client.pid}"
 
 if ! command -v xvfb-run >/dev/null 2>&1; then
     echo "xvfb-run not found — install xvfb" >&2
@@ -30,22 +31,51 @@ fi
 
 cd "$JAVA_DIR"
 : > "$LOG_FILE"
+: > "$PID_FILE"
 
-setsid bash -c "
+# `setsid --fork` always forks before setsid(2), so the launched bash is
+# guaranteed to be a new session leader (pid == pgid) instead of inheriting
+# the runner shell's group. Without --fork, util-linux may exec setsid in
+# place when called from a non-group-leader, leaving the child in the
+# parent's group — then `kill -- -<pgid>` hits the GHA runner agent itself
+# and the step surfaces as `##[error]The operation was canceled`. The
+# new leader's pid is written to $PID_FILE because $! after --fork points
+# at the parent setsid that exits immediately.
+SCRIPT_PGID=$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' ' || true)
+
+setsid --fork bash -c "
+    echo \$\$ > '$PID_FILE'
     exec xvfb-run --auto-servernum --server-args='-screen 0 1280x720x24' \
         ./gradlew runClient --no-daemon --console=plain \
         -Pfabric.client.gameDir=run/smoke
 " >"$LOG_FILE" 2>&1 &
-RUN_PID=$!
+SETSID_PID=$!
 
-PGID=""
-for _ in 1 2 3 4 5; do
-    PGID=$(ps -o pgid= -p "$RUN_PID" 2>/dev/null | tr -d ' ' || true)
-    [ -n "$PGID" ] && break
-    sleep 0.2
+RUN_PID=""
+for _ in $(seq 1 50); do
+    if [ -s "$PID_FILE" ]; then
+        candidate=$(tr -d '\n' < "$PID_FILE")
+        if [ -n "$candidate" ] && kill -0 "$candidate" 2>/dev/null; then
+            RUN_PID="$candidate"
+            break
+        fi
+    fi
+    sleep 0.1
 done
+if [ -z "$RUN_PID" ]; then
+    echo "[smoke] could not read child pid from $PID_FILE — falling back to setsid parent pid $SETSID_PID" >&2
+    RUN_PID="$SETSID_PID"
+fi
+
+PGID=$(ps -o pgid= -p "$RUN_PID" 2>/dev/null | tr -d ' ' || true)
 if [ -z "$PGID" ]; then
-    echo "[smoke] could not resolve PGID for $RUN_PID — falling back to single-process kill" >&2
+    PGID="$RUN_PID"
+fi
+# Saw this in run #25956270979: the resolved pgid matched the script's own
+# group, so `kill -- -<pgid>` cancelled the entire GHA job. Fall back to
+# single-process kill in that case.
+if [ -n "$SCRIPT_PGID" ] && [ "$PGID" = "$SCRIPT_PGID" ]; then
+    echo "[smoke] resolved pgid matches script pgid ($PGID) — using single-process kill" >&2
     PGID="$RUN_PID"
 fi
 echo "[smoke] launched runClient pid=$RUN_PID pgid=$PGID, watching $LOG_FILE (timeout=${TIMEOUT_SECS}s)"
@@ -61,6 +91,13 @@ kill_group() {
 
 shutdown_and_exit() {
     local code="$1"
+    # Success path: GHA reaps orphans on step exit, so don't burn five
+    # seconds on a TERM grace that gives the cancel-in-progress concurrency
+    # group a window to race against us.
+    if [ "$code" = "0" ]; then
+        kill_group KILL
+        exit 0
+    fi
     kill_group TERM
     local waited=0
     while kill -0 "$RUN_PID" 2>/dev/null && [ "$waited" -lt "$GRACE_SECS" ]; do


### PR DESCRIPTION
## Summary
Run [#25956270979](https://github.com/KBVE/kbve/actions/runs/25956270979/job/76303356403) ([issue #11062](https://github.com/KBVE/kbve/issues/11062)) marked the headless client smoke as **failed** even though the log shows `[smoke] SUCCESS marker detected: Setting user:`. The job got cancelled five seconds later with `##[error]The operation was canceled`.

## Root cause
Two compounding bugs in the smoke's shutdown path:

- `setsid bash -c …` ran without `--fork`, so util-linux execed setsid in place from a non-group-leader script. The resulting `pgid` matched the GHA runner shell's group (`pid=3102 pgid=2067` in the log — clearly different from `pid`), and `kill -- -<pgid>` on the success path TERM'd the runner agent itself. That's exactly the signature the runner reports as `##[error]The operation was canceled`.
- Even after isolation, the success branch went through the full `TERM → 5s grace → KILL` cascade. That five-second wait gave `cancel-in-progress: true` on the workflow's concurrency group a window to cancel the job before our `exit 0` reached the runner.

## Fix
- Launch with `setsid --fork`. The new bash is guaranteed to be a session leader (pid == pgid) rather than inheriting the runner shell group. The child writes its own pid to `/tmp/mc-headless-client.pid` because `$!` after `--fork` points at the throwaway setsid parent.
- Defensive: if the resolved pgid still matches the script's pgid (paranoia / future regressions), fall back to single-process kill so the runner agent is never signalled.
- Success path in `shutdown_and_exit` immediately `kill -KILL`s the group and `exit 0`. GHA reaps orphan JVM / Xvfb / gradle children on step exit — there is no reason to burn five seconds gracefully on a passing test.
- Failure / timeout / `INT`/`TERM` paths keep the existing graceful `TERM → grace → KILL` pattern (we still want a chance to flush meaningful logs on the failure side).

## Test plan
- [ ] `bash -n` syntax check passes (verified locally).
- [ ] Next mc-smoke run on dev / main completes the headless client step in well under the 25-minute timeout, with no `##[error]The operation was canceled` line tailing the success marker.
- [ ] On a forced fail (e.g. inject an invalid mixin temporarily), the failure path still cleanly hits the 5s grace window.

Fixes #11062.