### PR TITLE
feat(axum-kbve,jedi): CH proxy commands for ROWS request telemetry

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -622,6 +622,10 @@ pub struct ClickHouseLogsRequest {
     /// always return up to 200 rows regardless of this value.
     #[serde(default)]
     pub limit: Option<u32>,
+    /// Time-bucket width in seconds for `rows_request_rate`. Defaults to 30,
+    /// clamped 5..=3600. Ignored by other commands.
+    #[serde(default)]
+    pub bucket_seconds: Option<u32>,
 }
 
 /// Response shape for the ClickHouse logs route. `rows` is the raw
@@ -699,12 +703,43 @@ pub async fn clickhouse_logs_proxy_handler(headers: HeaderMap, body: Bytes) -> R
             };
             ch_logs::run_stats(config, &params).await
         }
+        "rows_request_rate" => {
+            let params = ch_logs::RowsRequestRateParams {
+                minutes: req.minutes,
+                bucket_seconds: req.bucket_seconds,
+            };
+            ch_logs::run_rows_request_rate(config, &params).await
+        }
+        "rows_status_histogram" => {
+            let params = ch_logs::RowsStatusHistogramParams {
+                minutes: req.minutes,
+            };
+            ch_logs::run_rows_status_histogram(config, &params).await
+        }
+        "rows_top_endpoints" => {
+            let params = ch_logs::RowsTopEndpointsParams {
+                minutes: req.minutes,
+                limit: req.limit,
+            };
+            ch_logs::run_rows_top_endpoints(config, &params).await
+        }
+        "rows_errors" => {
+            let params = ch_logs::RowsErrorsParams {
+                minutes: req.minutes,
+                limit: req.limit,
+            };
+            ch_logs::run_rows_errors(config, &params).await
+        }
         other => {
             return (
                 StatusCode::BAD_REQUEST,
-                axum::Json(
-                    json!({"error": format!("unknown command '{other}', expected 'query' or 'stats'")}),
-                ),
+                axum::Json(json!({
+                    "error": format!(
+                        "unknown command '{other}', expected one of: \
+                         query, stats, rows_request_rate, rows_status_histogram, \
+                         rows_top_endpoints, rows_errors"
+                    )
+                })),
             )
                 .into_response();
         }

--- a/packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs
+++ b/packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs
@@ -170,6 +170,191 @@ pub async fn run_stats(
     })
 }
 
+// ─── ROWS-specific aggregates ─────────────────────────────────────────
+//
+// The ROWS service emits structured JSON traces into logs_distributed.message
+// (target = "rows::trace", fields.message = "request completed", span carrying
+// method/path/status/latency_ms/customer/id). These builders extract those
+// fields via JSONExtract* and pre-aggregate server-side so the dashboard
+// only renders shaped data.
+//
+// All queries hardcode `pod_namespace = 'rows'` AND
+// `JSONExtractString(message, 'fields', 'message') = 'request completed'`
+// to keep the surface narrow and self-documenting.
+
+pub const MAX_BUCKET_SECONDS: u32 = 3_600; // 1h buckets max
+pub const MIN_BUCKET_SECONDS: u32 = 5;
+pub const DEFAULT_BUCKET_SECONDS: u32 = 30;
+pub const MAX_TOP_ENDPOINTS: u32 = 50;
+pub const DEFAULT_TOP_ENDPOINTS: u32 = 20;
+pub const MAX_ERROR_ROWS: u32 = 200;
+pub const DEFAULT_ERROR_ROWS: u32 = 50;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RowsRequestRateParams {
+    #[serde(default)]
+    pub minutes: Option<u32>,
+    #[serde(default)]
+    pub bucket_seconds: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RowsStatusHistogramParams {
+    #[serde(default)]
+    pub minutes: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RowsTopEndpointsParams {
+    #[serde(default)]
+    pub minutes: Option<u32>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RowsErrorsParams {
+    #[serde(default)]
+    pub minutes: Option<u32>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+fn clamped_bucket_seconds(raw: Option<u32>) -> u32 {
+    raw.unwrap_or(DEFAULT_BUCKET_SECONDS)
+        .clamp(MIN_BUCKET_SECONDS, MAX_BUCKET_SECONDS)
+}
+
+fn clamped_top_endpoints(raw: Option<u32>) -> u32 {
+    raw.unwrap_or(DEFAULT_TOP_ENDPOINTS)
+        .clamp(1, MAX_TOP_ENDPOINTS)
+}
+
+fn clamped_error_rows(raw: Option<u32>) -> u32 {
+    raw.unwrap_or(DEFAULT_ERROR_ROWS).clamp(1, MAX_ERROR_ROWS)
+}
+
+const ROWS_REQUEST_FILTER: &str = "pod_namespace = 'rows' \
+     AND JSONExtractString(message, 'target') = 'rows::trace' \
+     AND JSONExtractString(message, 'fields', 'message') = 'request completed'";
+
+pub fn build_rows_request_rate_sql(params: &RowsRequestRateParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    let bucket = clamped_bucket_seconds(params.bucket_seconds);
+    format!(
+        "SELECT \
+            toStartOfInterval(timestamp, INTERVAL {bucket} SECOND) AS bucket, \
+            count() AS reqs \
+         FROM logs_distributed \
+         WHERE timestamp > now() - INTERVAL {minutes} MINUTE \
+            AND {ROWS_REQUEST_FILTER} \
+         GROUP BY bucket \
+         ORDER BY bucket"
+    )
+}
+
+pub fn build_rows_status_histogram_sql(params: &RowsStatusHistogramParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    format!(
+        "SELECT \
+            JSONExtractInt(message, 'span', 'status') AS status, \
+            count() AS n \
+         FROM logs_distributed \
+         WHERE timestamp > now() - INTERVAL {minutes} MINUTE \
+            AND {ROWS_REQUEST_FILTER} \
+         GROUP BY status \
+         ORDER BY status"
+    )
+}
+
+pub fn build_rows_top_endpoints_sql(params: &RowsTopEndpointsParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    let limit = clamped_top_endpoints(params.limit);
+    format!(
+        "SELECT \
+            JSONExtractString(message, 'span', 'path') AS path, \
+            count() AS n, \
+            quantile(0.5)(JSONExtractInt(message, 'span', 'latency_ms')) AS p50, \
+            quantile(0.95)(JSONExtractInt(message, 'span', 'latency_ms')) AS p95, \
+            quantile(0.99)(JSONExtractInt(message, 'span', 'latency_ms')) AS p99 \
+         FROM logs_distributed \
+         WHERE timestamp > now() - INTERVAL {minutes} MINUTE \
+            AND {ROWS_REQUEST_FILTER} \
+         GROUP BY path \
+         ORDER BY n DESC \
+         LIMIT {limit}"
+    )
+}
+
+pub fn build_rows_errors_sql(params: &RowsErrorsParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    let limit = clamped_error_rows(params.limit);
+    format!(
+        "SELECT \
+            timestamp, \
+            JSONExtractString(message, 'span', 'method') AS method, \
+            JSONExtractString(message, 'span', 'path') AS path, \
+            JSONExtractInt(message, 'span', 'status') AS status, \
+            JSONExtractInt(message, 'span', 'latency_ms') AS latency_ms, \
+            JSONExtractString(message, 'span', 'customer') AS customer, \
+            JSONExtractString(message, 'span', 'id') AS request_id \
+         FROM logs_distributed \
+         WHERE timestamp > now() - INTERVAL {minutes} MINUTE \
+            AND {ROWS_REQUEST_FILTER} \
+            AND JSONExtractInt(message, 'span', 'status') >= 400 \
+         ORDER BY timestamp DESC \
+         LIMIT {limit}"
+    )
+}
+
+pub async fn run_rows_request_rate(
+    config: &ClickHouseConfig,
+    params: &RowsRequestRateParams,
+) -> Result<LogsResult, JediError> {
+    let sql = build_rows_request_rate_sql(params);
+    let rows = config.execute_select(&sql).await?;
+    Ok(LogsResult {
+        count: rows.len(),
+        rows,
+    })
+}
+
+pub async fn run_rows_status_histogram(
+    config: &ClickHouseConfig,
+    params: &RowsStatusHistogramParams,
+) -> Result<LogsResult, JediError> {
+    let sql = build_rows_status_histogram_sql(params);
+    let rows = config.execute_select(&sql).await?;
+    Ok(LogsResult {
+        count: rows.len(),
+        rows,
+    })
+}
+
+pub async fn run_rows_top_endpoints(
+    config: &ClickHouseConfig,
+    params: &RowsTopEndpointsParams,
+) -> Result<LogsResult, JediError> {
+    let sql = build_rows_top_endpoints_sql(params);
+    let rows = config.execute_select(&sql).await?;
+    Ok(LogsResult {
+        count: rows.len(),
+        rows,
+    })
+}
+
+pub async fn run_rows_errors(
+    config: &ClickHouseConfig,
+    params: &RowsErrorsParams,
+) -> Result<LogsResult, JediError> {
+    let sql = build_rows_errors_sql(params);
+    let rows = config.execute_select(&sql).await?;
+    Ok(LogsResult {
+        count: rows.len(),
+        rows,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -225,5 +410,73 @@ mod tests {
         let sql = build_query_sql(&params);
         // Escaped single quote keeps the injection inside the literal.
         assert!(sql.contains("pod_namespace = 'kbve\\' OR 1=1 --'"));
+    }
+
+    #[test]
+    fn rows_request_rate_clamps_bucket() {
+        assert_eq!(clamped_bucket_seconds(None), DEFAULT_BUCKET_SECONDS);
+        assert_eq!(clamped_bucket_seconds(Some(0)), MIN_BUCKET_SECONDS);
+        assert_eq!(clamped_bucket_seconds(Some(99_999)), MAX_BUCKET_SECONDS);
+    }
+
+    #[test]
+    fn rows_request_rate_sql_shape() {
+        let sql = build_rows_request_rate_sql(&RowsRequestRateParams {
+            minutes: Some(15),
+            bucket_seconds: Some(60),
+        });
+        assert!(sql.contains("INTERVAL 60 SECOND"));
+        assert!(sql.contains("INTERVAL 15 MINUTE"));
+        assert!(sql.contains("pod_namespace = 'rows'"));
+        assert!(sql.contains("rows::trace"));
+        assert!(sql.contains("request completed"));
+        assert!(sql.contains("GROUP BY bucket"));
+    }
+
+    #[test]
+    fn rows_status_histogram_sql_shape() {
+        let sql = build_rows_status_histogram_sql(&RowsStatusHistogramParams { minutes: Some(30) });
+        assert!(sql.contains("INTERVAL 30 MINUTE"));
+        assert!(sql.contains("JSONExtractInt(message, 'span', 'status')"));
+        assert!(sql.contains("GROUP BY status"));
+    }
+
+    #[test]
+    fn rows_top_endpoints_sql_shape() {
+        let sql = build_rows_top_endpoints_sql(&RowsTopEndpointsParams {
+            minutes: Some(60),
+            limit: Some(10),
+        });
+        assert!(sql.contains("JSONExtractString(message, 'span', 'path')"));
+        assert!(sql.contains("quantile(0.5)"));
+        assert!(sql.contains("quantile(0.95)"));
+        assert!(sql.contains("quantile(0.99)"));
+        assert!(sql.contains("LIMIT 10"));
+    }
+
+    #[test]
+    fn rows_top_endpoints_clamps_limit() {
+        assert_eq!(clamped_top_endpoints(None), DEFAULT_TOP_ENDPOINTS);
+        assert_eq!(clamped_top_endpoints(Some(0)), 1);
+        assert_eq!(clamped_top_endpoints(Some(999)), MAX_TOP_ENDPOINTS);
+    }
+
+    #[test]
+    fn rows_errors_sql_filters_4xx_5xx() {
+        let sql = build_rows_errors_sql(&RowsErrorsParams {
+            minutes: Some(120),
+            limit: Some(25),
+        });
+        assert!(sql.contains("INTERVAL 120 MINUTE"));
+        assert!(sql.contains("JSONExtractInt(message, 'span', 'status') >= 400"));
+        assert!(sql.contains("ORDER BY timestamp DESC"));
+        assert!(sql.contains("LIMIT 25"));
+    }
+
+    #[test]
+    fn rows_errors_clamps_limit() {
+        assert_eq!(clamped_error_rows(None), DEFAULT_ERROR_ROWS);
+        assert_eq!(clamped_error_rows(Some(0)), 1);
+        assert_eq!(clamped_error_rows(Some(999)), MAX_ERROR_ROWS);
     }
 }


### PR DESCRIPTION
## Summary

PR-A of two for the ROWS telemetry dashboard work. Adds **server-side aggregated** ClickHouse query commands to the `/dashboard/clickhouse/proxy` endpoint so the upcoming Astro/React telemetry trio renders shaped data instead of pulling raw logs and aggregating in the browser.

PR-B (separate, lands after axum-kbve redeploys) will add `rowsTelemetryService.ts` + `ReactRowsTelemetry.tsx` + `AstroRowsTelemetry.astro`.

## What the dashboard needs

The ROWS service emits structured JSON traces into `observability.logs_distributed.message` with:
- `target = "rows::trace"`
- `fields.message = "request completed"`
- `span.{method,path,status,latency_ms,customer,id}`

Four panel queries cover the v1 telemetry surface:

| Command | Returns | Source SQL shape |
|---------|---------|------------------|
| `rows_request_rate` | `[{bucket, reqs}]` | `toStartOfInterval(timestamp, INTERVAL {bucket} SECOND)` count |
| `rows_status_histogram` | `[{status, n}]` | `JSONExtractInt(message,'span','status')` GROUP BY |
| `rows_top_endpoints` | `[{path, n, p50, p95, p99}]` | `quantile()` on `JSONExtractInt(message,'span','latency_ms')` |
| `rows_errors` | recent log rows where status >= 400 | filter + ORDER BY timestamp DESC |

## Files

- [packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs](packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs) — new `Rows*Params` structs, `build_rows_*_sql` builders, `run_rows_*` async runners, 6 new unit tests
- [apps/kbve/axum-kbve/src/transport/proxy.rs](apps/kbve/axum-kbve/src/transport/proxy.rs) — new `bucket_seconds` field on request struct + 4 new command arms in dispatch

2 files, +291/-3.

## Hardcoded scope (defense-in-depth)

All four queries pin:
```
pod_namespace = 'rows'
AND JSONExtractString(message, 'target') = 'rows::trace'
AND JSONExtractString(message, 'fields', 'message') = 'request completed'
```

Callers cannot widen the surface. No user-supplied SQL fragments.

## Clamps

| Field | Default | Range |
|-------|---------|-------|
| `minutes` | 60 | 1..=10080 (7d) |
| `bucket_seconds` | 30 | 5..=3600 |
| top_endpoints `limit` | 20 | 1..=50 |
| errors `limit` | 50 | 1..=200 |

## Verification

- `cargo test -p jedi --features clickhouse` — **53 passed** (12 in logs.rs, 6 new)
- `cargo clippy -p axum-kbve --no-deps` — no new warnings from this change

Sample SQL for `rows_request_rate` (bucket=60, minutes=15):

```sql
SELECT toStartOfInterval(timestamp, INTERVAL 60 SECOND) AS bucket,
       count() AS reqs
FROM logs_distributed
WHERE timestamp > now() - INTERVAL 15 MINUTE
  AND pod_namespace = 'rows'
  AND JSONExtractString(message, 'target') = 'rows::trace'
  AND JSONExtractString(message, 'fields', 'message') = 'request completed'
GROUP BY bucket
ORDER BY bucket
```

## Test plan

- [ ] CI green on dev
- [ ] axum-kbve auto-redeploys after merge (CI/CD pipeline)
- [ ] Once live: `curl -X POST /dashboard/clickhouse/proxy -d '{"command":"rows_status_histogram"}'` returns shaped JSON
- [ ] PR-B (telemetry trio) consumes the new commands

## Out of scope

- `/metrics` Prometheus endpoint on ROWS (separate future PR for app-level metrics)
- Dedicated Grafana dashboard for ROWS
- Astro/React telemetry trio (PR-B)