### PR TITLE
feat(astro-kbve): show public URL + visibility tag in deploy table

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactDeployPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactDeployPanel.tsx
@@ -66,14 +66,32 @@ interface EndpointRowProps {
 
 function EndpointRow({ endpoint, onStop, stopping }: EndpointRowProps) {
 	const url = deployService.urlFor(endpoint.name);
+	const publicUrl =
+		endpoint.visibility === 'public'
+			? deployService.publicUrlFor(endpoint.name)
+			: null;
 	const absolute =
 		typeof window !== 'undefined'
 			? new URL(url, window.location.origin).toString()
 			: url;
+	const publicAbsolute =
+		publicUrl && typeof window !== 'undefined'
+			? new URL(publicUrl, window.location.origin).toString()
+			: (publicUrl ?? '');
+	const visibilityLabel = endpoint.visibility ?? 'staff';
 	return (
 		<tr>
 			<td>
-				<code>{endpoint.name}</code>
+				<code>{endpoint.name}</code>{' '}
+				<span
+					className={`deploy-tier deploy-tier--${visibilityLabel}`}
+					title={
+						visibilityLabel === 'public'
+							? 'Reachable via /fc/public/* without auth'
+							: 'Staff JWT required'
+					}>
+					{visibilityLabel}
+				</span>
 			</td>
 			<td>
 				<code>{endpoint.rootfs}</code>
@@ -84,14 +102,34 @@ function EndpointRow({ endpoint, onStop, stopping }: EndpointRowProps) {
 				</code>
 			</td>
 			<td>
-				<a
-					href={url}
-					target="_blank"
-					rel="noopener noreferrer"
-					className="deploy-link">
-					{url} <ExternalLink size={12} />
-				</a>{' '}
-				<CopyButton value={absolute} />
+				<div className="deploy-urls">
+					<div className="deploy-url-row">
+						<span className="deploy-url-tag">staff</span>
+						<a
+							href={url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="deploy-link">
+							{url} <ExternalLink size={12} />
+						</a>
+						<CopyButton value={absolute} />
+					</div>
+					{publicUrl && (
+						<div className="deploy-url-row">
+							<span className="deploy-url-tag deploy-url-tag--public">
+								public
+							</span>
+							<a
+								href={publicUrl}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="deploy-link">
+								{publicUrl} <ExternalLink size={12} />
+							</a>
+							<CopyButton value={publicAbsolute} />
+						</div>
+					)}
+				</div>
 			</td>
 			<td>
 				<button
@@ -489,6 +527,12 @@ export default function ReactDeployPanel() {
 				.deploy-table th, .deploy-table td { text-align: left; padding: 0.4rem 0.5rem; border-bottom: 1px solid rgba(255,255,255,0.06); }
 				.deploy-table th { font-weight: 500; opacity: 0.7; }
 				.deploy-link { display: inline-flex; align-items: center; gap: 0.25rem; }
+				.deploy-urls { display: flex; flex-direction: column; gap: 0.3rem; }
+				.deploy-url-row { display: inline-flex; align-items: center; gap: 0.4rem; }
+				.deploy-url-tag { font-size: 0.65rem; padding: 0.05rem 0.35rem; border-radius: 0.2rem; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1); opacity: 0.75; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+				.deploy-url-tag--public { background: rgba(34,197,94,0.14); border-color: rgba(34,197,94,0.35); color: rgba(134,239,172,0.95); opacity: 1; }
+				.deploy-tier { font-size: 0.65rem; padding: 0.05rem 0.35rem; border-radius: 0.2rem; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1); opacity: 0.75; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+				.deploy-tier--public { background: rgba(34,197,94,0.14); border-color: rgba(34,197,94,0.35); color: rgba(134,239,172,0.95); opacity: 1; }
 			`}</style>
 		</section>
 	);


### PR DESCRIPTION
## Summary
Running-endpoints row in the deploy panel only showed the staff proxy URL. Endpoints deployed \`visibility: "public"\` had no UI affordance for their anonymous URL — users had to reconstruct \`/fc/public/<name>/\` by hand.

## Changes
- \`EndpointRow\` reads \`endpoint.visibility\` (already in \`DeployedEndpoint\` / \`PersistentEndpointInfo\`)
- \`staff\` / \`public\` chip next to the endpoint name; chip turns green for public
- URL column stacks both rows when visibility=public, each with its own \`staff\` / \`public\` tag + copy button
- Pure CSS; no new deps

## Test plan
- [ ] Deploy with visibility=public, table shows two URL rows; both clickable; copy works for both
- [ ] Deploy with visibility=staff, table shows one row tagged staff
- [ ] Existing endpoints without explicit visibility default to staff (chip + single URL row)