### PR TITLE
feat(wallet): firecracker session billing schema + SourceKind variant

### DIFF
--- a/packages/data/sql/dbmate/migration-tests/20260516094907_wallet_source_kind_firecracker.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516094907_wallet_source_kind_firecracker.test.sql
@@ -1,0 +1,36 @@
+-- Companion test fixtures for 20260516094907_wallet_source_kind_firecracker.
+-- Run via: ./test-migration.sh 20260516094907_wallet_source_kind_firecracker
+
+-- SEED
+
+SELECT 1;
+
+-- ASSERT_AFTER_UP
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_enum e
+        JOIN pg_type t ON t.oid = e.enumtypid
+        WHERE t.typname = 'source_kind'
+          AND e.enumlabel = 'firecracker_session'
+    ) THEN
+        RAISE EXCEPTION 'fail: source_kind missing firecracker_session value';
+    END IF;
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_enum e
+        JOIN pg_type t ON t.oid = e.enumtypid
+        WHERE t.typname = 'source_kind'
+          AND e.enumlabel = 'firecracker_session'
+    ) THEN
+        RAISE EXCEPTION 'fail: enum value should remain after rollback (Postgres limitation; documented in migration)';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migration-tests/20260516094908_wallet_firecracker_billing.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516094908_wallet_firecracker_billing.test.sql
@@ -1,0 +1,285 @@
+-- Companion test fixtures for 20260516094908_wallet_firecracker_billing.
+-- Run via: ./test-migration.sh 20260516094908_wallet_firecracker_billing
+
+-- SEED
+
+GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
+
+DROP TABLE IF EXISTS public.__fc_billing_fixture;
+CREATE TABLE public.__fc_billing_fixture (
+    role    TEXT PRIMARY KEY,
+    user_id UUID NOT NULL
+);
+INSERT INTO public.__fc_billing_fixture (role, user_id) VALUES
+    ('payer', gen_random_uuid()),
+    ('broke', gen_random_uuid());
+
+INSERT INTO auth.users (id)
+SELECT user_id FROM public.__fc_billing_fixture;
+
+DO $$
+DECLARE
+    v_payer_acc UUID;
+    v_broke_acc UUID;
+BEGIN
+    SELECT a.id INTO v_payer_acc
+      FROM wallet.account a
+      JOIN public.__fc_billing_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'payer';
+    SELECT a.id INTO v_broke_acc
+      FROM wallet.account a
+      JOIN public.__fc_billing_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'broke';
+
+    IF v_payer_acc IS NULL OR v_broke_acc IS NULL THEN
+        RAISE EXCEPTION 'fail: fixture wallet accounts were not auto-provisioned';
+    END IF;
+
+    UPDATE wallet.balance SET credits = 1000 WHERE account_id = v_payer_acc;
+    UPDATE wallet.balance SET credits = 25   WHERE account_id = v_broke_acc;
+END;
+$$;
+
+-- ASSERT_AFTER_UP
+
+DO $$
+DECLARE
+    v_payer_acc UUID;
+    v_broke_acc UUID;
+    v_hold      wallet.firecracker_hold;
+    v_total     BIGINT;
+    v_existing  wallet.firecracker_hold;
+    v_balance   BIGINT;
+    v_settle    RECORD;
+BEGIN
+    SELECT a.id INTO v_payer_acc
+      FROM wallet.account a
+      JOIN public.__fc_billing_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'payer';
+    SELECT a.id INTO v_broke_acc
+      FROM wallet.account a
+      JOIN public.__fc_billing_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'broke';
+
+    v_hold := wallet.firecracker_place_hold(v_payer_acc, 'fc-vm-aaa', 300);
+    IF v_hold.amount <> 300 OR v_hold.account_id <> v_payer_acc THEN
+        RAISE EXCEPTION 'fail: place_hold returned wrong row';
+    END IF;
+
+    v_total := wallet.firecracker_active_hold_total(v_payer_acc);
+    IF v_total <> 300 THEN
+        RAISE EXCEPTION 'fail: active_hold_total expected 300 got %', v_total;
+    END IF;
+
+    v_existing := wallet.firecracker_place_hold(v_payer_acc, 'fc-vm-aaa', 300);
+    IF v_existing.vm_id <> v_hold.vm_id OR v_existing.created_at <> v_hold.created_at THEN
+        RAISE EXCEPTION 'fail: place_hold not idempotent on identical payload';
+    END IF;
+
+    BEGIN
+        PERFORM wallet.firecracker_place_hold(v_payer_acc, 'fc-vm-aaa', 999);
+        RAISE EXCEPTION 'fail: mismatched payload should have raised 40001';
+    EXCEPTION
+        WHEN serialization_failure THEN
+            NULL;
+    END;
+
+    PERFORM wallet.firecracker_place_hold(v_payer_acc, 'fc-vm-bbb', 400);
+    v_total := wallet.firecracker_active_hold_total(v_payer_acc);
+    IF v_total <> 700 THEN
+        RAISE EXCEPTION 'fail: active_hold_total expected 700 got %', v_total;
+    END IF;
+
+    BEGIN
+        PERFORM wallet.firecracker_place_hold(v_payer_acc, 'fc-vm-ccc', 500);
+        RAISE EXCEPTION 'fail: over-balance hold should have raised 53100';
+    EXCEPTION
+        WHEN insufficient_resources THEN
+            NULL;
+    END;
+
+    SELECT * INTO v_settle FROM wallet.firecracker_settle(
+        'fc-vm-aaa', 150, gen_random_uuid(), 'demo settle');
+    IF v_settle.status <> 'settled' THEN
+        RAISE EXCEPTION 'fail: settle status expected settled got %', v_settle.status;
+    END IF;
+    IF v_settle.debited_amount <> 150 OR v_settle.reserved_amount <> 300
+       OR v_settle.released_amount <> 150 THEN
+        RAISE EXCEPTION 'fail: settle amounts mismatched (got debited=%, reserved=%, released=%)',
+            v_settle.debited_amount, v_settle.reserved_amount, v_settle.released_amount;
+    END IF;
+    IF v_settle.ledger_id IS NULL THEN
+        RAISE EXCEPTION 'fail: settle ledger_id should be set';
+    END IF;
+    IF EXISTS (SELECT 1 FROM wallet.firecracker_hold WHERE vm_id = 'fc-vm-aaa') THEN
+        RAISE EXCEPTION 'fail: settle did not remove the hold';
+    END IF;
+
+    SELECT credits INTO v_balance FROM wallet.balance WHERE account_id = v_payer_acc;
+    IF v_balance <> 850 THEN
+        RAISE EXCEPTION 'fail: balance expected 850 got %', v_balance;
+    END IF;
+
+    v_total := wallet.firecracker_active_hold_total(v_payer_acc);
+    IF v_total <> 400 THEN
+        RAISE EXCEPTION 'fail: post-settle active_hold_total expected 400 got %', v_total;
+    END IF;
+
+    SELECT * INTO v_settle FROM wallet.firecracker_settle(
+        'fc-vm-ghost', 100, gen_random_uuid(), NULL);
+    IF v_settle.status <> 'already_missing' THEN
+        RAISE EXCEPTION 'fail: missing vm_id status expected already_missing got %', v_settle.status;
+    END IF;
+    IF v_settle.ledger_id IS NOT NULL OR v_settle.debited_amount <> 0 THEN
+        RAISE EXCEPTION 'fail: already_missing must report zero amounts';
+    END IF;
+
+    SELECT * INTO v_settle FROM wallet.firecracker_settle(
+        'fc-vm-bbb', 999_999_999, gen_random_uuid(), NULL);
+    IF v_settle.status <> 'settled_capped' THEN
+        RAISE EXCEPTION 'fail: overrun settle status expected settled_capped got %', v_settle.status;
+    END IF;
+    IF v_settle.debited_amount <> 400 OR v_settle.released_amount <> 0 THEN
+        RAISE EXCEPTION 'fail: cap-at-hold expected debited=400 got %', v_settle.debited_amount;
+    END IF;
+    SELECT credits INTO v_balance FROM wallet.balance WHERE account_id = v_payer_acc;
+    IF v_balance <> 450 THEN
+        RAISE EXCEPTION 'fail: cap-at-hold expected balance 450 got %', v_balance;
+    END IF;
+
+    PERFORM wallet.firecracker_place_hold(v_payer_acc, 'fc-vm-mark', 200);
+    v_existing := wallet.firecracker_update_watermark('fc-vm-mark', 50);
+    IF v_existing.watermark <> 50 THEN
+        RAISE EXCEPTION 'fail: watermark expected 50 got %', v_existing.watermark;
+    END IF;
+    v_existing := wallet.firecracker_update_watermark('fc-vm-mark', 9_999);
+    IF v_existing.watermark <> 200 THEN
+        RAISE EXCEPTION 'fail: watermark cap expected 200 got %', v_existing.watermark;
+    END IF;
+    v_existing := wallet.firecracker_update_watermark('fc-vm-mark', 10);
+    IF v_existing.watermark <> 200 THEN
+        RAISE EXCEPTION 'fail: watermark regressed to %', v_existing.watermark;
+    END IF;
+
+    BEGIN
+        PERFORM wallet.firecracker_update_watermark('fc-vm-mark', NULL);
+        RAISE EXCEPTION 'fail: NULL watermark should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN
+                RAISE;
+            END IF;
+    END;
+
+    BEGIN
+        PERFORM wallet.firecracker_update_watermark('fc-vm-mark', -1);
+        RAISE EXCEPTION 'fail: negative watermark should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN
+                RAISE;
+            END IF;
+    END;
+
+    BEGIN
+        PERFORM wallet.firecracker_update_watermark('fc-vm-zzz', 1);
+        RAISE EXCEPTION 'fail: missing vm_id should raise P0002';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> 'P0002' THEN
+                RAISE;
+            END IF;
+    END;
+
+    v_total := wallet.firecracker_active_hold_total(v_payer_acc);
+    IF v_total <> 0 THEN
+        RAISE EXCEPTION 'fail: post-watermark active_hold_total expected 0 got %', v_total;
+    END IF;
+
+    BEGIN
+        PERFORM wallet.firecracker_place_hold(v_broke_acc, 'fc-vm-poor', 100);
+        RAISE EXCEPTION 'fail: broke account hold should have raised 53100';
+    EXCEPTION
+        WHEN insufficient_resources THEN
+            NULL;
+    END;
+
+    BEGIN
+        PERFORM wallet.firecracker_place_hold(v_payer_acc, 'short', 1);
+        RAISE EXCEPTION 'fail: short vm_id should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN
+                RAISE;
+            END IF;
+    END;
+
+    BEGIN
+        PERFORM wallet.firecracker_place_hold(v_payer_acc, repeat('x', 129), 1);
+        RAISE EXCEPTION 'fail: oversize vm_id should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN
+                RAISE;
+            END IF;
+    END;
+
+    SELECT * INTO v_settle FROM wallet.firecracker_settle(
+        'fc-vm-mark', 0, gen_random_uuid(), NULL);
+    IF v_settle.status <> 'released_zero_charge' THEN
+        RAISE EXCEPTION 'fail: zero-amount settle status expected released_zero_charge got %', v_settle.status;
+    END IF;
+    IF v_settle.debited_amount <> 0 OR v_settle.released_amount <> 200
+       OR v_settle.ledger_id IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: released_zero_charge amounts mismatched';
+    END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+    v_count INT;
+BEGIN
+    SELECT COUNT(*) INTO v_count FROM wallet.firecracker_hold;
+    IF v_count <> 0 THEN
+        RAISE EXCEPTION 'fail: expected zero holds after cleanup got %', v_count;
+    END IF;
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'wallet' AND c.relname = 'firecracker_hold'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet.firecracker_hold still exists after rollback';
+    END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+    v_fn TEXT;
+BEGIN
+    FOREACH v_fn IN ARRAY ARRAY[
+        'firecracker_active_hold_total',
+        'firecracker_place_hold',
+        'firecracker_settle',
+        'firecracker_update_watermark'
+    ] LOOP
+        IF EXISTS (
+            SELECT 1 FROM pg_proc p
+            JOIN pg_namespace n ON n.oid = p.pronamespace
+            WHERE n.nspname = 'wallet' AND p.proname = v_fn
+        ) THEN
+            RAISE EXCEPTION 'fail: function wallet.% still exists after rollback', v_fn;
+        END IF;
+    END LOOP;
+END;
+$$;
+
+DROP TABLE IF EXISTS public.__fc_billing_fixture;

--- a/packages/data/sql/dbmate/migrations/20260516094907_wallet_source_kind_firecracker.sql
+++ b/packages/data/sql/dbmate/migrations/20260516094907_wallet_source_kind_firecracker.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+
+ALTER TYPE wallet.source_kind ADD VALUE IF NOT EXISTS 'firecracker_session';
+
+-- migrate:down
+
+-- Postgres does not support removing enum values without a full type rewrite.
+-- Leaving 'firecracker_session' in place on rollback is harmless: it stays
+-- inert until a later migration re-adds the dependent table.
+SELECT 1;

--- a/packages/data/sql/dbmate/migrations/20260516094908_wallet_firecracker_billing.sql
+++ b/packages/data/sql/dbmate/migrations/20260516094908_wallet_firecracker_billing.sql
@@ -1,0 +1,253 @@
+-- migrate:up
+
+CREATE TABLE wallet.firecracker_hold (
+    vm_id           TEXT PRIMARY KEY CHECK (length(vm_id) BETWEEN 8 AND 128),
+    account_id      UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    amount          BIGINT NOT NULL CHECK (amount > 0),
+    watermark       BIGINT NOT NULL DEFAULT 0 CHECK (watermark >= 0 AND watermark <= amount),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp()
+);
+
+CREATE INDEX firecracker_hold_account_cover_idx
+    ON wallet.firecracker_hold(account_id)
+    INCLUDE (amount, watermark);
+
+COMMENT ON TABLE wallet.firecracker_hold IS
+    'Pre-flight credit reservation for a live firecracker VM/endpoint session. Removed on settle. updated_at tracks the last watermark mutation; idempotent place_hold replays do not bump it.';
+
+CREATE OR REPLACE FUNCTION wallet.firecracker_active_hold_total(p_account_id UUID)
+RETURNS BIGINT
+LANGUAGE sql STABLE SET search_path = '' AS $$
+    SELECT COALESCE(SUM(amount - watermark), 0)::BIGINT
+    FROM wallet.firecracker_hold
+    WHERE account_id = p_account_id;
+$$;
+REVOKE ALL ON FUNCTION wallet.firecracker_active_hold_total(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.firecracker_active_hold_total(UUID) TO service_role;
+ALTER FUNCTION wallet.firecracker_active_hold_total(UUID) OWNER TO service_role;
+
+CREATE OR REPLACE FUNCTION wallet.firecracker_place_hold(
+    p_account_id    UUID,
+    p_vm_id         TEXT,
+    p_amount        BIGINT
+)
+RETURNS wallet.firecracker_hold
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_balance   BIGINT;
+    v_holds     BIGINT;
+    v_row       wallet.firecracker_hold;
+BEGIN
+    IF p_account_id IS NULL THEN
+        RAISE EXCEPTION 'account_id is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_vm_id IS NULL OR length(p_vm_id) NOT BETWEEN 8 AND 128 THEN
+        RAISE EXCEPTION 'vm_id must be 8-128 chars' USING ERRCODE = '22023';
+    END IF;
+    IF p_amount IS NULL OR p_amount <= 0 THEN
+        RAISE EXCEPTION 'hold amount must be positive' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT * INTO v_row FROM wallet.firecracker_hold WHERE vm_id = p_vm_id;
+    IF FOUND THEN
+        IF v_row.account_id <> p_account_id OR v_row.amount <> p_amount THEN
+            RAISE EXCEPTION
+                'vm_id reused with different payload'
+                USING ERRCODE = '40001';
+        END IF;
+        RETURN v_row;
+    END IF;
+
+    PERFORM wallet.lock_account(p_account_id);
+
+    SELECT credits INTO v_balance FROM wallet.balance
+        WHERE account_id = p_account_id FOR UPDATE;
+    IF v_balance IS NULL THEN
+        RAISE EXCEPTION 'no balance row for account %', p_account_id
+            USING ERRCODE = '23503';
+    END IF;
+
+    v_holds := wallet.firecracker_active_hold_total(p_account_id);
+
+    IF (v_balance - v_holds) < p_amount THEN
+        RAISE EXCEPTION
+            'insufficient credits: balance=%, active_holds=%, needed=%',
+            v_balance, v_holds, p_amount
+            USING ERRCODE = '53100';
+    END IF;
+
+    INSERT INTO wallet.firecracker_hold (vm_id, account_id, amount)
+    VALUES (p_vm_id, p_account_id, p_amount)
+    ON CONFLICT (vm_id) DO NOTHING
+    RETURNING * INTO v_row;
+
+    IF v_row.vm_id IS NULL THEN
+        SELECT * INTO v_row FROM wallet.firecracker_hold WHERE vm_id = p_vm_id;
+        IF v_row.account_id <> p_account_id OR v_row.amount <> p_amount THEN
+            RAISE EXCEPTION
+                'vm_id reused with different payload'
+                USING ERRCODE = '40001';
+        END IF;
+    END IF;
+
+    RETURN v_row;
+END;
+$$;
+REVOKE ALL ON FUNCTION wallet.firecracker_place_hold(UUID, TEXT, BIGINT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.firecracker_place_hold(UUID, TEXT, BIGINT) TO service_role;
+ALTER FUNCTION wallet.firecracker_place_hold(UUID, TEXT, BIGINT) OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.firecracker_place_hold(UUID, TEXT, BIGINT) IS
+    'Idempotent on (vm_id, account_id, amount). Performs an optimistic vm_id replay check before locking for cheap network retries; first-time placement then serializes by account advisory lock, balance row lock, and INSERT ... ON CONFLICT (vm_id) DO NOTHING (the loser re-reads and verifies payload). Mismatch on reuse raises 40001. Shortfall against (balance - active_holds) raises 53100 BEFORE inserting.';
+
+CREATE OR REPLACE FUNCTION wallet.firecracker_settle(
+    p_vm_id             TEXT,
+    p_final_amount      BIGINT,
+    p_idempotency_key   UUID,
+    p_reason            TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    status              TEXT,
+    ledger_id           BIGINT,
+    account_id          UUID,
+    reserved_amount     BIGINT,
+    debited_amount      BIGINT,
+    released_amount     BIGINT
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_account   UUID;
+    v_hold      wallet.firecracker_hold;
+    v_debit     BIGINT;
+    v_release   BIGINT;
+    v_ledger    BIGINT := NULL;
+    v_status    TEXT;
+BEGIN
+    IF p_vm_id IS NULL OR length(p_vm_id) NOT BETWEEN 8 AND 128 THEN
+        RAISE EXCEPTION 'vm_id must be 8-128 chars' USING ERRCODE = '22023';
+    END IF;
+    IF p_final_amount IS NULL OR p_final_amount < 0 THEN
+        RAISE EXCEPTION 'final_amount must be >= 0' USING ERRCODE = '22023';
+    END IF;
+    IF p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'idempotency_key is required' USING ERRCODE = '22004';
+    END IF;
+
+    SELECT h.account_id INTO v_account
+    FROM wallet.firecracker_hold h
+    WHERE h.vm_id = p_vm_id;
+
+    IF v_account IS NULL THEN
+        status := 'already_missing';
+        ledger_id := NULL;
+        account_id := NULL;
+        reserved_amount := 0;
+        debited_amount := 0;
+        released_amount := 0;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    PERFORM wallet.lock_account(v_account);
+
+    SELECT * INTO v_hold FROM wallet.firecracker_hold WHERE vm_id = p_vm_id FOR UPDATE;
+    IF NOT FOUND THEN
+        status := 'already_missing';
+        ledger_id := NULL;
+        account_id := v_account;
+        reserved_amount := 0;
+        debited_amount := 0;
+        released_amount := 0;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    v_debit := LEAST(p_final_amount, v_hold.amount);
+    v_release := v_hold.amount - v_debit;
+
+    IF v_debit > 0 THEN
+        v_ledger := wallet.service_debit(
+            v_hold.account_id,
+            'credits',
+            v_debit,
+            'firecracker_session',
+            p_reason,
+            'firecracker',
+            NULL,
+            p_idempotency_key
+        );
+        IF p_final_amount > v_hold.amount THEN
+            v_status := 'settled_capped';
+        ELSE
+            v_status := 'settled';
+        END IF;
+    ELSE
+        v_status := 'released_zero_charge';
+    END IF;
+
+    DELETE FROM wallet.firecracker_hold WHERE vm_id = p_vm_id;
+
+    status := v_status;
+    ledger_id := v_ledger;
+    account_id := v_hold.account_id;
+    reserved_amount := v_hold.amount;
+    debited_amount := v_debit;
+    released_amount := v_release;
+    RETURN NEXT;
+END;
+$$;
+REVOKE ALL ON FUNCTION wallet.firecracker_settle(TEXT, BIGINT, UUID, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.firecracker_settle(TEXT, BIGINT, UUID, TEXT) TO service_role;
+ALTER FUNCTION wallet.firecracker_settle(TEXT, BIGINT, UUID, TEXT) OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.firecracker_settle(TEXT, BIGINT, UUID, TEXT) IS
+    'Returns a structured row. status in (settled, settled_capped, released_zero_charge, already_missing). settled_capped fires when p_final_amount > hold.amount — the function still debits the full hold but surfaces the metering overrun for ops. Lock order: initial hold lookup discovers account_id, then wallet.lock_account(account_id) is the account-level serialization boundary before hold lock FOR UPDATE, debit, ledger insert, and hold delete. Idempotency: while the hold exists, wallet.service_debit dedups on p_idempotency_key via replay_fingerprint. After a successful settle the hold is deleted; retries with the same key return already_missing with ledger_id=NULL — callers needing receipt replay must persist the first response.';
+
+CREATE OR REPLACE FUNCTION wallet.firecracker_update_watermark(
+    p_vm_id     TEXT,
+    p_watermark BIGINT
+)
+RETURNS wallet.firecracker_hold
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_row wallet.firecracker_hold;
+BEGIN
+    IF p_vm_id IS NULL OR length(p_vm_id) NOT BETWEEN 8 AND 128 THEN
+        RAISE EXCEPTION 'vm_id must be 8-128 chars' USING ERRCODE = '22023';
+    END IF;
+    IF p_watermark IS NULL OR p_watermark < 0 THEN
+        RAISE EXCEPTION 'watermark must be >= 0' USING ERRCODE = '22023';
+    END IF;
+
+    UPDATE wallet.firecracker_hold
+       SET watermark  = LEAST(GREATEST(watermark, p_watermark), amount),
+           updated_at = statement_timestamp()
+     WHERE vm_id = p_vm_id
+    RETURNING * INTO v_row;
+
+    IF v_row.vm_id IS NULL THEN
+        RAISE EXCEPTION 'firecracker hold not found for vm_id %', p_vm_id
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    RETURN v_row;
+END;
+$$;
+REVOKE ALL ON FUNCTION wallet.firecracker_update_watermark(TEXT, BIGINT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.firecracker_update_watermark(TEXT, BIGINT) TO service_role;
+ALTER FUNCTION wallet.firecracker_update_watermark(TEXT, BIGINT) OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.firecracker_update_watermark(TEXT, BIGINT) IS
+    'Monotonic — supplied watermark replaces the stored one only when larger, then clamps to [0, amount]. NULL / negative inputs raise 22023. Missing vm_id raises P0002 (no_data_found).';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS wallet.firecracker_update_watermark(TEXT, BIGINT);
+DROP FUNCTION IF EXISTS wallet.firecracker_settle(TEXT, BIGINT, UUID, TEXT);
+DROP FUNCTION IF EXISTS wallet.firecracker_place_hold(UUID, TEXT, BIGINT);
+DROP FUNCTION IF EXISTS wallet.firecracker_active_hold_total(UUID);
+DROP TABLE IF EXISTS wallet.firecracker_hold;

--- a/packages/data/sql/schema/wallet/wallet_core.sql
+++ b/packages/data/sql/schema/wallet/wallet_core.sql
@@ -48,7 +48,8 @@ CREATE TYPE wallet.account_kind AS ENUM (
 CREATE TYPE wallet.source_kind AS ENUM (
     'reward', 'purchase', 'refund', 'admin', 'coupon',
     'market_buy', 'market_sell', 'market_fee', 'transfer',
-    'referral'
+    'referral',
+    'firecracker_session'
 );
 
 CREATE TYPE wallet.reward_kind AS ENUM (

--- a/packages/data/sql/schema/wallet/wallet_firecracker.sql
+++ b/packages/data/sql/schema/wallet/wallet_firecracker.sql
@@ -1,0 +1,247 @@
+-- ============================================================================
+-- WALLET FIRECRACKER — pre-flight hold + settle for fc-ctl session billing
+--
+-- Reference mirror of dbmate migrations:
+--   20260516094907_wallet_source_kind_firecracker.sql  (enum value add)
+--   20260516094908_wallet_firecracker_billing.sql      (table + functions)
+--
+-- Hand-authored review surface — do not run directly. Promote changes via a
+-- new dbmate migration under ../../dbmate/migrations/.
+--
+-- Lifecycle (issue #11048):
+--   1. fc-ctl /fc/deploy calls firecracker_place_hold(account, vm_id, max_cost).
+--      Hold is a soft reservation; wallet.balance is untouched. Insufficient
+--      balance raises SQLSTATE 53100.
+--   2. fc-ctl accumulates billing::meter_tick in memory (Phase B, PR #11055).
+--   3. Any teardown path calls firecracker_settle(vm_id, accumulated,
+--      idempotency_key, reason). LEAST(accumulated, hold.amount) flows
+--      through wallet.service_debit; the hold row is then deleted. Returns
+--      a structured row with status + amounts for observability.
+--
+-- Idempotency contract:
+--   * place_hold     idempotent on (vm_id, account_id, amount). Mismatch → 40001.
+--   * settle         idempotent on idempotency_key (service_debit guards
+--                    payload via replay_fingerprint). Missing vm_id →
+--                    status='already_missing' with zeroed amounts.
+--   * update_watermark monotonic — never regresses. Missing vm_id → P0002.
+-- ============================================================================
+
+CREATE TABLE wallet.firecracker_hold (
+    vm_id           TEXT PRIMARY KEY CHECK (length(vm_id) BETWEEN 8 AND 128),
+    account_id      UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    amount          BIGINT NOT NULL CHECK (amount > 0),
+    watermark       BIGINT NOT NULL DEFAULT 0 CHECK (watermark >= 0 AND watermark <= amount),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp()
+);
+
+CREATE INDEX firecracker_hold_account_cover_idx
+    ON wallet.firecracker_hold(account_id)
+    INCLUDE (amount, watermark);
+
+COMMENT ON TABLE wallet.firecracker_hold IS
+    'Pre-flight credit reservation for a live firecracker VM/endpoint session. Removed on settle. updated_at tracks the last watermark mutation; idempotent place_hold replays do not bump it.';
+
+CREATE OR REPLACE FUNCTION wallet.firecracker_active_hold_total(p_account_id UUID)
+RETURNS BIGINT
+LANGUAGE sql STABLE SET search_path = '' AS $$
+    SELECT COALESCE(SUM(amount - watermark), 0)::BIGINT
+    FROM wallet.firecracker_hold
+    WHERE account_id = p_account_id;
+$$;
+
+CREATE OR REPLACE FUNCTION wallet.firecracker_place_hold(
+    p_account_id    UUID,
+    p_vm_id         TEXT,
+    p_amount        BIGINT
+)
+RETURNS wallet.firecracker_hold
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_balance   BIGINT;
+    v_holds     BIGINT;
+    v_row       wallet.firecracker_hold;
+BEGIN
+    IF p_account_id IS NULL THEN
+        RAISE EXCEPTION 'account_id is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_vm_id IS NULL OR length(p_vm_id) NOT BETWEEN 8 AND 128 THEN
+        RAISE EXCEPTION 'vm_id must be 8-128 chars' USING ERRCODE = '22023';
+    END IF;
+    IF p_amount IS NULL OR p_amount <= 0 THEN
+        RAISE EXCEPTION 'hold amount must be positive' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT * INTO v_row FROM wallet.firecracker_hold WHERE vm_id = p_vm_id;
+    IF FOUND THEN
+        IF v_row.account_id <> p_account_id OR v_row.amount <> p_amount THEN
+            RAISE EXCEPTION
+                'vm_id reused with different payload'
+                USING ERRCODE = '40001';
+        END IF;
+        RETURN v_row;
+    END IF;
+
+    PERFORM wallet.lock_account(p_account_id);
+
+    SELECT credits INTO v_balance FROM wallet.balance
+        WHERE account_id = p_account_id FOR UPDATE;
+    IF v_balance IS NULL THEN
+        RAISE EXCEPTION 'no balance row for account %', p_account_id
+            USING ERRCODE = '23503';
+    END IF;
+
+    v_holds := wallet.firecracker_active_hold_total(p_account_id);
+
+    IF (v_balance - v_holds) < p_amount THEN
+        RAISE EXCEPTION
+            'insufficient credits: balance=%, active_holds=%, needed=%',
+            v_balance, v_holds, p_amount
+            USING ERRCODE = '53100';
+    END IF;
+
+    INSERT INTO wallet.firecracker_hold (vm_id, account_id, amount)
+    VALUES (p_vm_id, p_account_id, p_amount)
+    ON CONFLICT (vm_id) DO NOTHING
+    RETURNING * INTO v_row;
+
+    IF v_row.vm_id IS NULL THEN
+        SELECT * INTO v_row FROM wallet.firecracker_hold WHERE vm_id = p_vm_id;
+        IF v_row.account_id <> p_account_id OR v_row.amount <> p_amount THEN
+            RAISE EXCEPTION
+                'vm_id reused with different payload'
+                USING ERRCODE = '40001';
+        END IF;
+    END IF;
+
+    RETURN v_row;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION wallet.firecracker_settle(
+    p_vm_id             TEXT,
+    p_final_amount      BIGINT,
+    p_idempotency_key   UUID,
+    p_reason            TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    status              TEXT,
+    ledger_id           BIGINT,
+    account_id          UUID,
+    reserved_amount     BIGINT,
+    debited_amount      BIGINT,
+    released_amount     BIGINT
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_account   UUID;
+    v_hold      wallet.firecracker_hold;
+    v_debit     BIGINT;
+    v_release   BIGINT;
+    v_ledger    BIGINT := NULL;
+    v_status    TEXT;
+BEGIN
+    IF p_vm_id IS NULL OR length(p_vm_id) NOT BETWEEN 8 AND 128 THEN
+        RAISE EXCEPTION 'vm_id must be 8-128 chars' USING ERRCODE = '22023';
+    END IF;
+    IF p_final_amount IS NULL OR p_final_amount < 0 THEN
+        RAISE EXCEPTION 'final_amount must be >= 0' USING ERRCODE = '22023';
+    END IF;
+    IF p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'idempotency_key is required' USING ERRCODE = '22004';
+    END IF;
+
+    SELECT h.account_id INTO v_account
+    FROM wallet.firecracker_hold h
+    WHERE h.vm_id = p_vm_id;
+
+    IF v_account IS NULL THEN
+        status := 'already_missing';
+        ledger_id := NULL;
+        account_id := NULL;
+        reserved_amount := 0;
+        debited_amount := 0;
+        released_amount := 0;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    PERFORM wallet.lock_account(v_account);
+
+    SELECT * INTO v_hold FROM wallet.firecracker_hold WHERE vm_id = p_vm_id FOR UPDATE;
+    IF NOT FOUND THEN
+        status := 'already_missing';
+        ledger_id := NULL;
+        account_id := v_account;
+        reserved_amount := 0;
+        debited_amount := 0;
+        released_amount := 0;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    v_debit := LEAST(p_final_amount, v_hold.amount);
+    v_release := v_hold.amount - v_debit;
+
+    IF v_debit > 0 THEN
+        v_ledger := wallet.service_debit(
+            v_hold.account_id,
+            'credits',
+            v_debit,
+            'firecracker_session',
+            p_reason,
+            'firecracker',
+            NULL,
+            p_idempotency_key
+        );
+        IF p_final_amount > v_hold.amount THEN
+            v_status := 'settled_capped';
+        ELSE
+            v_status := 'settled';
+        END IF;
+    ELSE
+        v_status := 'released_zero_charge';
+    END IF;
+
+    DELETE FROM wallet.firecracker_hold WHERE vm_id = p_vm_id;
+
+    status := v_status;
+    ledger_id := v_ledger;
+    account_id := v_hold.account_id;
+    reserved_amount := v_hold.amount;
+    debited_amount := v_debit;
+    released_amount := v_release;
+    RETURN NEXT;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION wallet.firecracker_update_watermark(
+    p_vm_id     TEXT,
+    p_watermark BIGINT
+)
+RETURNS wallet.firecracker_hold
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_row wallet.firecracker_hold;
+BEGIN
+    IF p_vm_id IS NULL OR length(p_vm_id) NOT BETWEEN 8 AND 128 THEN
+        RAISE EXCEPTION 'vm_id must be 8-128 chars' USING ERRCODE = '22023';
+    END IF;
+    IF p_watermark IS NULL OR p_watermark < 0 THEN
+        RAISE EXCEPTION 'watermark must be >= 0' USING ERRCODE = '22023';
+    END IF;
+
+    UPDATE wallet.firecracker_hold
+       SET watermark  = LEAST(GREATEST(watermark, p_watermark), amount),
+           updated_at = statement_timestamp()
+     WHERE vm_id = p_vm_id
+    RETURNING * INTO v_row;
+
+    IF v_row.vm_id IS NULL THEN
+        RAISE EXCEPTION 'firecracker hold not found for vm_id %', p_vm_id
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    RETURN v_row;
+END;
+$$;

--- a/packages/rust/kbve/src/wallet/types.rs
+++ b/packages/rust/kbve/src/wallet/types.rs
@@ -87,15 +87,16 @@ pg_text_enum! {
 pg_text_enum! {
     /// `wallet.source_kind`
     SourceKind {
-        Reward     => "reward",
-        Purchase   => "purchase",
-        Refund     => "refund",
-        Admin      => "admin",
-        Coupon     => "coupon",
-        MarketBuy  => "market_buy",
-        MarketSell => "market_sell",
-        MarketFee  => "market_fee",
-        Transfer   => "transfer",
+        Reward             => "reward",
+        Purchase           => "purchase",
+        Refund             => "refund",
+        Admin              => "admin",
+        Coupon             => "coupon",
+        MarketBuy          => "market_buy",
+        MarketSell         => "market_sell",
+        MarketFee          => "market_fee",
+        Transfer           => "transfer",
+        FirecrackerSession => "firecracker_session",
     }
 }
 
@@ -312,4 +313,53 @@ pub struct MarketBuyNowRequest {
 pub struct MarketCancelListingRequest {
     pub listing_id: i64,
     pub reason: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Firecracker session billing
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirecrackerHoldRow {
+    pub vm_id: String,
+    pub account_id: Uuid,
+    pub amount: i64,
+    pub watermark: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirecrackerPlaceHoldRequest {
+    pub account_id: Uuid,
+    pub vm_id: String,
+    pub amount: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirecrackerSettleRequest {
+    pub vm_id: String,
+    pub final_amount: i64,
+    pub idempotency_key: Uuid,
+    pub reason: Option<String>,
+}
+
+pg_text_enum! {
+    /// `wallet.firecracker_settle` status column.
+    FirecrackerSettleStatus {
+        Settled            => "settled",
+        SettledCapped      => "settled_capped",
+        ReleasedZeroCharge => "released_zero_charge",
+        AlreadyMissing     => "already_missing",
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirecrackerSettleResult {
+    pub status: FirecrackerSettleStatus,
+    pub ledger_id: Option<i64>,
+    pub account_id: Option<Uuid>,
+    pub reserved_amount: i64,
+    pub debited_amount: i64,
+    pub released_amount: i64,
 }


### PR DESCRIPTION
## Summary
Phase C.1 of #11048. Schema-only foundation for fc-ctl ↔ wallet billing. **No service / diesel wiring yet** — that's C.2.

### Files

| File | Purpose |
|---|---|
| \`migrations/20260516094907_wallet_source_kind_firecracker.sql\` | \`ALTER TYPE ... ADD VALUE 'firecracker_session'\` — isolated so the new enum value commits before any function references it. |
| \`migrations/20260516094908_wallet_firecracker_billing.sql\` | Table + four SQL functions. |
| \`schema/wallet/wallet_core.sql\` | Adds \`'firecracker_session'\` to the enum mirror. |
| \`schema/wallet/wallet_firecracker.sql\` | New schema mirror. |
| \`migration-tests/20260516094907_wallet_source_kind_firecracker.test.sql\` | Enum present after UP; remains after DOWN (Postgres limitation). |
| \`migration-tests/20260516094908_wallet_firecracker_billing.test.sql\` | Comprehensive SEED + ASSERT_AFTER_UP + ASSERT_AFTER_DOWN. |
| \`packages/rust/kbve/src/wallet/types.rs\` | \`SourceKind::FirecrackerSession\`, \`FirecrackerSettleStatus\` enum, \`FirecrackerHoldRow\` / \`PlaceHoldRequest\` / \`SettleRequest\` / \`SettleResult\`. |

### SQL surface (all \`SECURITY DEFINER\`, \`search_path=''\`, service_role-only)

| Function | Behavior |
|---|---|
| \`firecracker_active_hold_total(account)\` | \`SUM(amount - watermark)\` over an index that covers \`(account_id) INCLUDE (amount, watermark)\` for index-only scan. |
| \`firecracker_place_hold(account, vm_id, amount)\` | Fast-path idempotent replay returns existing row; mismatch → 40001. Otherwise lock account → balance row → check \`balance - active_holds >= amount\` (53100 on shortfall) → \`INSERT ... ON CONFLICT (vm_id) DO NOTHING RETURNING\`. ON-CONFLICT loser re-reads + compares payload. \`vm_id\` is 8–128 chars. |
| \`firecracker_settle(vm_id, final, idem, reason)\` | Returns \`TABLE (status, ledger_id, account_id, reserved_amount, debited_amount, released_amount)\`. Status ∈ \`{settled, released_zero_charge, already_missing}\`. Locks account first (consistent ordering with place_hold) then the hold row \`FOR UPDATE\`. \`wallet.service_debit\` enforces its own \`replay_fingerprint\` guard for idempotency. |
| \`firecracker_update_watermark(vm_id, watermark)\` | Monotonic — \`LEAST(GREATEST(stored, supplied), amount)\`. NULL / negative inputs raise 22023. Missing vm_id raises **P0002** (no_data_found) instead of silent NULL. |

### Review-round 2 fixes (relative to first push)
- **#1 covering index** — \`firecracker_hold_account_cover_idx\` on \`(account_id) INCLUDE (amount, watermark)\`.
- **#2 balance check before insert** — \`place_hold\` rejects shortfall before any write.
- **#4 structured settle return** — \`RETURNS TABLE\` with status enum + per-amount fields. Rust binds via new \`FirecrackerSettleResult\` + \`FirecrackerSettleStatus\` enum.
- **#5 vm_id min 8 chars** — \`CHECK (length(vm_id) BETWEEN 8 AND 128)\` on the table + all three RPCs.
- **#6 update_watermark raises on missing** — P0002 instead of silent NULL return.
- **#10 lock-order alignment** — settle now locks the account first (via initial id lookup → \`lock_account\` → hold row \`FOR UPDATE\` → \`service_debit\`). Matches place_hold's account → balance → hold sequence.

### Deferred — tracked in #11083
- #3 abandoned-hold expiry sweep (needs business-rules decision)
- #7 \`updated_at\` heartbeat semantics
- #8 generated \`reserved_remaining\` column (revisit if covering index isn't enough under observed load)
- vm_id format-tighten regex (wait for fc-ctl to emit one canonical shape)

### Test coverage (\`migration-tests/...094908...test.sql\`)
- Auto-provisioned wallet account from the auth.users trigger.
- \`place_hold\` happy / idempotent / 40001 mismatch / 53100 shortfall (single + accumulated).
- \`place_hold\` rejects 7-char + 129-char \`vm_id\` with 22023.
- \`settle\` returns \`status='settled'\` with correct \`debited/reserved/released\` triple.
- \`settle\` on missing vm_id returns \`status='already_missing'\` with zero amounts.
- \`settle\` caps debit at \`hold.amount\` when \`final_amount > hold.amount\`.
- \`settle\` with \`final=0\` returns \`status='released_zero_charge'\` and no ledger row.
- \`update_watermark\` clamp high, raises low, monotonic (no regress).
- \`update_watermark\` NULL + negative + missing vm_id raise (22023, 22023, P0002).
- Active-hold contribution reflects \`amount - watermark\`.
- ASSERT_AFTER_DOWN: \`094908\` rollback drops the table + four functions.

Run locally:
\`\`\`
./packages/data/sql/dbmate/test-migration.sh 20260516094907_wallet_source_kind_firecracker
./packages/data/sql/dbmate/test-migration.sh 20260516094908_wallet_firecracker_billing
\`\`\`

## Out of scope
- C.2: \`packages/rust/kbve/src/wallet/service.rs\` diesel-async wrappers + Rust integration tests.
- C.3: fc-ctl picks up kbve crate dep + calls \`firecracker_place_hold\` on deploy + \`firecracker_settle\` on every teardown.