### PR TITLE
fix(ingress): allowlist Content-Profile in supabase.kbve.com CORS

### DIFF
--- a/apps/kube/kong/manifests/ingress.yaml
+++ b/apps/kube/kong/manifests/ingress.yaml
@@ -17,7 +17,7 @@ metadata:
         nginx.ingress.kubernetes.io/enable-cors: 'true'
         nginx.ingress.kubernetes.io/cors-allow-origin: 'https://discord.sh,https://*.discord.sh,https://kbve.com,https://*.kbve.com,https://chat.kbve.com,https://supabase.kbve.com,https://forgejo.kbve.com,https://meme.sh,https://*.meme.sh,https://herbmail.com,https://*.herbmail.com,https://chuckrpg.com,https://*.chuckrpg.com,https://cryptothrone.com,https://*.cryptothrone.com,http://localhost:4321,http://localhost:3000,http://localhost:3333'
         nginx.ingress.kubernetes.io/cors-allow-methods: 'GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD'
-        nginx.ingress.kubernetes.io/cors-allow-headers: 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,apikey,x-client-info,x-supabase-api-version,Accept,Accept-Profile,Accept-Version'
+        nginx.ingress.kubernetes.io/cors-allow-headers: 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,apikey,x-client-info,x-supabase-api-version,Accept,Accept-Profile,Accept-Version,Content-Profile'
         nginx.ingress.kubernetes.io/cors-allow-credentials: 'true'
         nginx.ingress.kubernetes.io/proxy-http-version: '1.1'
         nginx.ingress.kubernetes.io/proxy-set-headers: 'Host $host;X-Real-IP $remote_addr;X-Forwarded-For $proxy_add_x_forwarded_for;X-Forwarded-Proto $scheme'


### PR DESCRIPTION
## Summary
\`/profile/\` was failing a CORS preflight on \`https://supabase.kbve.com/rest/v1/rpc/staff_permissions\`:

\`\`\`
Failed to load resource: Request header field content-profile is not allowed by Access-Control-Allow-Headers.
Fetch API cannot load https://supabase.kbve.com/rest/v1/rpc/staff_permissions due to access control checks.
[DB Worker] Error handling – "rpc" – ":" – {message: "TypeError: Load failed", ...}
\`\`\`

\`profile-controller.ts\` calls the RPC via the SupabaseGateway worker (\`supa.rpc('staff_permissions')\`), which goes through \`@supabase/supabase-js\`. postgrest-js attaches a \`Content-Profile\` header on RPC calls so PostgREST knows which schema to route to.

Kong's plugin config (\`apps/kube/kong/manifests/kong-config.yaml\`) already lists \`Content-Profile\` in its CORS allowlist, but the **ingress-nginx layer sitting in front of Kong** was missing it from \`nginx.ingress.kubernetes.io/cors-allow-headers\` — so the browser preflight failed before the request ever reached Kong.

## Change
\`\`\`diff
- nginx.ingress.kubernetes.io/cors-allow-headers: '...Accept,Accept-Profile,Accept-Version'
+ nginx.ingress.kubernetes.io/cors-allow-headers: '...Accept,Accept-Profile,Accept-Version,Content-Profile'
\`\`\`

No code change.

## Follow-up (separate PR)
The 6 s \`/profile/\` load is partly downstream of this failure but also blocked by \`await initSupa()\` running before the localStorage cache is read. Will land a follow-up that:
- Reads the existing \`cache:profile:me\` localStorage entry **before** \`await initSupa()\` to paint the profile card instantly.
- Wires the cache through a \`persistentMap\` from \`@nanostores/persistent\` so the same store backs both the controller and any React surface that subscribes.
- Keeps the existing direct-DOM populate path (no React rewrite this round).