### PR TITLE
feat(astro-kbve): ROWS telemetry trio (request rate, status, top endpoints, errors)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroRowsTelemetry.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroRowsTelemetry.astro
@@ -1,0 +1,43 @@
+---
+import ReactHomeAuth from './ReactHomeAuth';
+import ReactRowsTelemetry from './ReactRowsTelemetry';
+---
+
+<section
+	id="rows-telemetry-wrapper"
+	class="rows-telemetry-wrapper kbve-dashboard-page"
+	aria-label="ROWS Telemetry — ClickHouse-backed request metrics">
+	<div id="rows-telemetry-content" class="rows-telemetry-content">
+		<ReactHomeAuth client:only="react">
+			<div class="not-content rows-telemetry">
+				<ReactRowsTelemetry client:only="react" />
+			</div>
+		</ReactHomeAuth>
+	</div>
+</section>
+
+<style>
+	.rows-telemetry-wrapper {
+		background: transparent;
+		position: relative;
+		width: 100%;
+	}
+
+	.rows-telemetry-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 0 1rem 2rem;
+	}
+
+	@media (min-width: 768px) {
+		.rows-telemetry-content {
+			padding: 0 1.5rem 2rem;
+		}
+	}
+
+	.rows-telemetry {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactRowsTelemetry.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactRowsTelemetry.tsx
@@ -1,0 +1,379 @@
+import React, { useEffect, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	Activity,
+	AlertCircle,
+	Loader2,
+	RefreshCw,
+	TrendingUp,
+	Layers,
+} from 'lucide-react';
+import {
+	Area,
+	AreaChart,
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Cell,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from 'recharts';
+import {
+	$requestRate,
+	$requestRateStatus,
+	$statusHistogram,
+	$statusHistogramStatus,
+	$topEndpoints,
+	$topEndpointsStatus,
+	$errorRows,
+	$errorRowsStatus,
+	$telemetryRange,
+	fetchAllTelemetry,
+	formatBucketTick,
+	invalidateTelemetryCache,
+	statusColorClass,
+	TELEMETRY_RANGES,
+	TELEMETRY_RANGE_KEYS,
+	type TelemetryRange,
+} from './rowsTelemetryService';
+
+const POLL_MS = 30_000;
+
+const STATUS_BAR_COLOR = (status: number): string => {
+	if (status >= 500) return '#ef4444';
+	if (status >= 400) return '#f59e0b';
+	if (status >= 300) return '#3b82f6';
+	if (status >= 200) return '#10b981';
+	return '#6b7280';
+};
+
+const tooltipStyle = {
+	background: 'var(--sl-color-bg-nav, #111)',
+	border: '1px solid var(--sl-color-gray-5, #262626)',
+	borderRadius: '0.375rem',
+	fontSize: '0.75rem',
+};
+
+function PanelShell({
+	icon,
+	title,
+	status,
+	children,
+}: {
+	icon: React.ReactNode;
+	title: string;
+	status: 'idle' | 'loading' | 'ok' | 'error';
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="rounded-lg border border-[var(--sl-color-gray-5)] bg-[var(--sl-color-bg-nav)] p-4">
+			<div className="mb-3 flex items-center justify-between">
+				<div className="flex items-center gap-2 text-sm font-semibold">
+					{icon}
+					<span>{title}</span>
+				</div>
+				{status === 'loading' && (
+					<Loader2 className="size-4 animate-spin text-gray-400" />
+				)}
+				{status === 'error' && (
+					<AlertCircle className="size-4 text-red-500" />
+				)}
+			</div>
+			{children}
+		</div>
+	);
+}
+
+export default function ReactRowsTelemetry() {
+	const range = useStore($telemetryRange);
+	const requestRate = useStore($requestRate);
+	const requestRateStatus = useStore($requestRateStatus);
+	const statusHistogram = useStore($statusHistogram);
+	const statusHistogramStatus = useStore($statusHistogramStatus);
+	const topEndpoints = useStore($topEndpoints);
+	const topEndpointsStatus = useStore($topEndpointsStatus);
+	const errorRows = useStore($errorRows);
+	const errorRowsStatus = useStore($errorRowsStatus);
+	const [refreshing, setRefreshing] = useState(false);
+
+	useEffect(() => {
+		void fetchAllTelemetry(range);
+		const id = window.setInterval(() => {
+			void fetchAllTelemetry(range);
+		}, POLL_MS);
+		return () => window.clearInterval(id);
+	}, [range]);
+
+	const onRefresh = async () => {
+		setRefreshing(true);
+		invalidateTelemetryCache();
+		await fetchAllTelemetry(range);
+		setRefreshing(false);
+	};
+
+	const onRangeChange = (r: TelemetryRange) => {
+		$telemetryRange.set(r);
+	};
+
+	return (
+		<div className="space-y-4">
+			<div className="flex flex-wrap items-center justify-between gap-2">
+				<div className="flex items-center gap-2 text-sm font-semibold">
+					<Activity className="size-4 text-emerald-500" />
+					<span>ROWS Telemetry</span>
+					<span className="text-xs font-normal text-gray-500">
+						(via ClickHouse aggregates · 30s poll)
+					</span>
+				</div>
+				<div className="flex items-center gap-2">
+					<div className="flex rounded-md border border-[var(--sl-color-gray-5)] overflow-hidden text-xs">
+						{TELEMETRY_RANGE_KEYS.map((r) => (
+							<button
+								key={r}
+								onClick={() => onRangeChange(r)}
+								className={`px-2 py-1 ${
+									r === range
+										? 'bg-emerald-500/20 text-emerald-400'
+										: 'text-gray-400 hover:text-gray-200'
+								}`}>
+								{TELEMETRY_RANGES[r].label}
+							</button>
+						))}
+					</div>
+					<button
+						onClick={onRefresh}
+						disabled={refreshing}
+						className="rounded-md border border-[var(--sl-color-gray-5)] p-1 text-gray-400 hover:text-gray-200 disabled:opacity-50">
+						<RefreshCw
+							className={`size-4 ${refreshing ? 'animate-spin' : ''}`}
+						/>
+					</button>
+				</div>
+			</div>
+
+			<div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+				<PanelShell
+					icon={<TrendingUp className="size-4 text-emerald-500" />}
+					title="Request rate"
+					status={requestRateStatus}>
+					{requestRate && requestRate.length > 0 ? (
+						<ResponsiveContainer width="100%" height={180}>
+							<AreaChart data={requestRate}>
+								<defs>
+									<linearGradient
+										id="reqFill"
+										x1="0"
+										y1="0"
+										x2="0"
+										y2="1">
+										<stop
+											offset="0%"
+											stopColor="#10b981"
+											stopOpacity={0.4}
+										/>
+										<stop
+											offset="100%"
+											stopColor="#10b981"
+											stopOpacity={0}
+										/>
+									</linearGradient>
+								</defs>
+								<CartesianGrid
+									stroke="#262626"
+									strokeDasharray="3 3"
+								/>
+								<XAxis
+									dataKey="bucket"
+									tickFormatter={formatBucketTick}
+									tick={{ fontSize: 10, fill: '#9ca3af' }}
+								/>
+								<YAxis
+									tick={{ fontSize: 10, fill: '#9ca3af' }}
+								/>
+								<Tooltip
+									contentStyle={tooltipStyle}
+									labelFormatter={(v) =>
+										new Date(v as string).toLocaleString()
+									}
+								/>
+								<Area
+									type="monotone"
+									dataKey="reqs"
+									stroke="#10b981"
+									fill="url(#reqFill)"
+								/>
+							</AreaChart>
+						</ResponsiveContainer>
+					) : (
+						<div className="py-12 text-center text-xs text-gray-500">
+							{requestRateStatus === 'loading'
+								? 'Loading…'
+								: 'No data'}
+						</div>
+					)}
+				</PanelShell>
+
+				<PanelShell
+					icon={<Layers className="size-4 text-amber-500" />}
+					title="Status code distribution"
+					status={statusHistogramStatus}>
+					{statusHistogram && statusHistogram.length > 0 ? (
+						<ResponsiveContainer width="100%" height={180}>
+							<BarChart data={statusHistogram}>
+								<CartesianGrid
+									stroke="#262626"
+									strokeDasharray="3 3"
+								/>
+								<XAxis
+									dataKey="status"
+									tick={{ fontSize: 10, fill: '#9ca3af' }}
+								/>
+								<YAxis
+									tick={{ fontSize: 10, fill: '#9ca3af' }}
+								/>
+								<Tooltip contentStyle={tooltipStyle} />
+								<Bar dataKey="n">
+									{statusHistogram.map((s, i) => (
+										<Cell
+											key={i}
+											fill={STATUS_BAR_COLOR(s.status)}
+										/>
+									))}
+								</Bar>
+							</BarChart>
+						</ResponsiveContainer>
+					) : (
+						<div className="py-12 text-center text-xs text-gray-500">
+							{statusHistogramStatus === 'loading'
+								? 'Loading…'
+								: 'No data'}
+						</div>
+					)}
+				</PanelShell>
+			</div>
+
+			<PanelShell
+				icon={<TrendingUp className="size-4 text-blue-500" />}
+				title="Top endpoints (by request count)"
+				status={topEndpointsStatus}>
+				{topEndpoints && topEndpoints.length > 0 ? (
+					<div className="overflow-x-auto">
+						<table className="w-full text-xs">
+							<thead className="border-b border-[var(--sl-color-gray-5)] text-left text-gray-400">
+								<tr>
+									<th className="py-2 pr-4">Path</th>
+									<th className="py-2 pr-4 text-right">
+										Reqs
+									</th>
+									<th className="py-2 pr-4 text-right">
+										p50 ms
+									</th>
+									<th className="py-2 pr-4 text-right">
+										p95 ms
+									</th>
+									<th className="py-2 text-right">p99 ms</th>
+								</tr>
+							</thead>
+							<tbody>
+								{topEndpoints.map((e) => (
+									<tr
+										key={e.path}
+										className="border-b border-[var(--sl-color-gray-5)]/40 last:border-0">
+										<td className="py-1.5 pr-4 font-mono">
+											{e.path}
+										</td>
+										<td className="py-1.5 pr-4 text-right tabular-nums">
+											{e.n.toLocaleString()}
+										</td>
+										<td className="py-1.5 pr-4 text-right tabular-nums">
+											{e.p50}
+										</td>
+										<td className="py-1.5 pr-4 text-right tabular-nums">
+											{e.p95}
+										</td>
+										<td className="py-1.5 text-right tabular-nums">
+											{e.p99}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				) : (
+					<div className="py-8 text-center text-xs text-gray-500">
+						{topEndpointsStatus === 'loading'
+							? 'Loading…'
+							: 'No data'}
+					</div>
+				)}
+			</PanelShell>
+
+			<PanelShell
+				icon={<AlertCircle className="size-4 text-red-500" />}
+				title="Recent errors (status >= 400)"
+				status={errorRowsStatus}>
+				{errorRows && errorRows.length > 0 ? (
+					<div className="max-h-80 overflow-y-auto">
+						<table className="w-full text-xs">
+							<thead className="sticky top-0 border-b border-[var(--sl-color-gray-5)] bg-[var(--sl-color-bg-nav)] text-left text-gray-400">
+								<tr>
+									<th className="py-2 pr-4">Time</th>
+									<th className="py-2 pr-4">Method</th>
+									<th className="py-2 pr-4">Path</th>
+									<th className="py-2 pr-4 text-right">
+										Status
+									</th>
+									<th className="py-2 pr-4 text-right">
+										Latency
+									</th>
+									<th className="py-2">Customer</th>
+								</tr>
+							</thead>
+							<tbody>
+								{errorRows.map((e) => (
+									<tr
+										key={e.request_id}
+										className="border-b border-[var(--sl-color-gray-5)]/40 last:border-0">
+										<td className="py-1 pr-4 font-mono text-gray-400">
+											{new Date(
+												e.timestamp,
+											).toLocaleTimeString()}
+										</td>
+										<td className="py-1 pr-4 font-mono">
+											{e.method}
+										</td>
+										<td className="py-1 pr-4 font-mono">
+											{e.path}
+										</td>
+										<td
+											className={`py-1 pr-4 text-right font-mono ${statusColorClass(e.status)}`}>
+											{e.status}
+										</td>
+										<td className="py-1 pr-4 text-right tabular-nums">
+											{e.latency_ms} ms
+										</td>
+										<td className="py-1 font-mono text-gray-400">
+											{e.customer && e.customer !== '-'
+												? e.customer.slice(0, 8)
+												: '—'}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				) : (
+					<div className="py-8 text-center text-xs text-gray-500">
+						{errorRowsStatus === 'loading'
+							? 'Loading…'
+							: errorRowsStatus === 'error'
+								? 'Failed to load'
+								: 'No errors in window'}
+					</div>
+				)}
+			</PanelShell>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/rowsTelemetryService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/rowsTelemetryService.ts
@@ -1,0 +1,279 @@
+import { atom } from 'nanostores';
+import { initSupa, getSupa } from '@/lib/supa';
+
+// ---------------------------------------------------------------------------
+// Types — match the axum-kbve /dashboard/clickhouse/proxy rows_* commands
+// ---------------------------------------------------------------------------
+
+export type FetchStatus = 'idle' | 'loading' | 'ok' | 'error';
+
+export interface RequestRatePoint {
+	bucket: string;
+	reqs: number;
+}
+
+export interface StatusBucket {
+	status: number;
+	n: number;
+}
+
+export interface EndpointStat {
+	path: string;
+	n: number;
+	p50: number;
+	p95: number;
+	p99: number;
+}
+
+export interface ErrorRow {
+	timestamp: string;
+	method: string;
+	path: string;
+	status: number;
+	latency_ms: number;
+	customer: string;
+	request_id: string;
+}
+
+export type TelemetryRange = '15m' | '1h' | '6h' | '24h';
+
+export interface TelemetryRangeConfig {
+	minutes: number;
+	bucket_seconds: number;
+	label: string;
+}
+
+export const TELEMETRY_RANGES: Record<TelemetryRange, TelemetryRangeConfig> = {
+	'15m': { minutes: 15, bucket_seconds: 15, label: '15m' },
+	'1h': { minutes: 60, bucket_seconds: 60, label: '1h' },
+	'6h': { minutes: 360, bucket_seconds: 300, label: '6h' },
+	'24h': { minutes: 1440, bucket_seconds: 900, label: '24h' },
+};
+
+export const TELEMETRY_RANGE_KEYS = Object.keys(
+	TELEMETRY_RANGES,
+) as TelemetryRange[];
+
+// ---------------------------------------------------------------------------
+// Stores
+// ---------------------------------------------------------------------------
+
+export const $telemetryRange = atom<TelemetryRange>('1h');
+
+export const $requestRate = atom<RequestRatePoint[] | null>(null);
+export const $requestRateStatus = atom<FetchStatus>('idle');
+
+export const $statusHistogram = atom<StatusBucket[] | null>(null);
+export const $statusHistogramStatus = atom<FetchStatus>('idle');
+
+export const $topEndpoints = atom<EndpointStat[] | null>(null);
+export const $topEndpointsStatus = atom<FetchStatus>('idle');
+
+export const $errorRows = atom<ErrorRow[] | null>(null);
+export const $errorRowsStatus = atom<FetchStatus>('idle');
+
+// ---------------------------------------------------------------------------
+// Proxy + auth
+// ---------------------------------------------------------------------------
+
+const PROXY_URL = '/dashboard/clickhouse/proxy';
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+	const supa = getSupa() ?? initSupa();
+	if (!supa) return {};
+	const { session } = await supa.getSession();
+	if (!session?.access_token) return {};
+	return {
+		Authorization: `Bearer ${session.access_token}`,
+		'Content-Type': 'application/json',
+	};
+}
+
+// ---------------------------------------------------------------------------
+// TTL cache — keyed by (command, range)
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 30_000;
+
+type CacheEntry<T> = { at: number; data: T };
+const cache = new Map<string, CacheEntry<unknown>>();
+
+function getCached<T>(key: string): T | null {
+	const e = cache.get(key) as CacheEntry<T> | undefined;
+	if (!e) return null;
+	if (Date.now() - e.at > CACHE_TTL_MS) {
+		cache.delete(key);
+		return null;
+	}
+	return e.data;
+}
+
+function setCached<T>(key: string, data: T): void {
+	cache.set(key, { at: Date.now(), data });
+}
+
+// ---------------------------------------------------------------------------
+// Core POST helper
+// ---------------------------------------------------------------------------
+
+interface ProxyResponse<T> {
+	rows: T[];
+	count: number;
+}
+
+async function proxyCommand<T>(
+	body: Record<string, unknown>,
+): Promise<T[] | null> {
+	const headers = await getAuthHeaders();
+	if (!headers.Authorization) return null;
+	try {
+		const resp = await fetch(PROXY_URL, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify(body),
+			signal: AbortSignal.timeout(15000),
+		});
+		if (!resp.ok) {
+			console.warn(
+				`[rows-telemetry] ${body.command} → HTTP ${resp.status}`,
+			);
+			return null;
+		}
+		const data = (await resp.json()) as ProxyResponse<T>;
+		return data.rows ?? [];
+	} catch (e) {
+		console.error(`[rows-telemetry] ${body.command} failed:`, e);
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Public fetchers — each writes its atom + caches
+// ---------------------------------------------------------------------------
+
+export async function fetchRequestRate(range: TelemetryRange): Promise<void> {
+	const config = TELEMETRY_RANGES[range];
+	const key = `request_rate:${range}`;
+	const cached = getCached<RequestRatePoint[]>(key);
+	if (cached) {
+		$requestRate.set(cached);
+		$requestRateStatus.set('ok');
+		return;
+	}
+	$requestRateStatus.set('loading');
+	const rows = await proxyCommand<RequestRatePoint>({
+		command: 'rows_request_rate',
+		minutes: config.minutes,
+		bucket_seconds: config.bucket_seconds,
+	});
+	if (rows === null) {
+		$requestRateStatus.set('error');
+		return;
+	}
+	setCached(key, rows);
+	$requestRate.set(rows);
+	$requestRateStatus.set('ok');
+}
+
+export async function fetchStatusHistogram(
+	range: TelemetryRange,
+): Promise<void> {
+	const config = TELEMETRY_RANGES[range];
+	const key = `status_histogram:${range}`;
+	const cached = getCached<StatusBucket[]>(key);
+	if (cached) {
+		$statusHistogram.set(cached);
+		$statusHistogramStatus.set('ok');
+		return;
+	}
+	$statusHistogramStatus.set('loading');
+	const rows = await proxyCommand<StatusBucket>({
+		command: 'rows_status_histogram',
+		minutes: config.minutes,
+	});
+	if (rows === null) {
+		$statusHistogramStatus.set('error');
+		return;
+	}
+	setCached(key, rows);
+	$statusHistogram.set(rows);
+	$statusHistogramStatus.set('ok');
+}
+
+export async function fetchTopEndpoints(range: TelemetryRange): Promise<void> {
+	const config = TELEMETRY_RANGES[range];
+	const key = `top_endpoints:${range}`;
+	const cached = getCached<EndpointStat[]>(key);
+	if (cached) {
+		$topEndpoints.set(cached);
+		$topEndpointsStatus.set('ok');
+		return;
+	}
+	$topEndpointsStatus.set('loading');
+	const rows = await proxyCommand<EndpointStat>({
+		command: 'rows_top_endpoints',
+		minutes: config.minutes,
+		limit: 20,
+	});
+	if (rows === null) {
+		$topEndpointsStatus.set('error');
+		return;
+	}
+	setCached(key, rows);
+	$topEndpoints.set(rows);
+	$topEndpointsStatus.set('ok');
+}
+
+export async function fetchErrors(range: TelemetryRange): Promise<void> {
+	const config = TELEMETRY_RANGES[range];
+	const key = `errors:${range}`;
+	const cached = getCached<ErrorRow[]>(key);
+	if (cached) {
+		$errorRows.set(cached);
+		$errorRowsStatus.set('ok');
+		return;
+	}
+	$errorRowsStatus.set('loading');
+	const rows = await proxyCommand<ErrorRow>({
+		command: 'rows_errors',
+		minutes: config.minutes,
+		limit: 50,
+	});
+	if (rows === null) {
+		$errorRowsStatus.set('error');
+		return;
+	}
+	setCached(key, rows);
+	$errorRows.set(rows);
+	$errorRowsStatus.set('ok');
+}
+
+export async function fetchAllTelemetry(range: TelemetryRange): Promise<void> {
+	await Promise.all([
+		fetchRequestRate(range),
+		fetchStatusHistogram(range),
+		fetchTopEndpoints(range),
+		fetchErrors(range),
+	]);
+}
+
+export function invalidateTelemetryCache(): void {
+	cache.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+export function statusColorClass(status: number): string {
+	if (status >= 500) return 'text-red-500';
+	if (status >= 400) return 'text-amber-500';
+	if (status >= 300) return 'text-blue-400';
+	if (status >= 200) return 'text-emerald-500';
+	return 'text-gray-400';
+}
+
+export function formatBucketTick(iso: string): string {
+	const d = new Date(iso);
+	return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/rows/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/rows/index.mdx
@@ -17,5 +17,7 @@ tags:
 ---
 
 import AstroRowsDashboard from '@/components/dashboard/AstroRowsDashboard.astro';
+import AstroRowsTelemetry from '@/components/dashboard/AstroRowsTelemetry.astro';
 
 <AstroRowsDashboard />
+<AstroRowsTelemetry />


### PR DESCRIPTION
## Summary

PR-B of two for the ROWS telemetry dashboard. Consumes the four server-side ClickHouse aggregates shipped in #11066 (axum-kbve v1.0.159, already live in cluster) and renders them as a second section on `/dashboard/rows/`.

No iframes. Pure data → recharts.

## Files

| File | Purpose |
|------|---------|
| [src/components/dashboard/rowsTelemetryService.ts](apps/kbve/astro-kbve/src/components/dashboard/rowsTelemetryService.ts) | Types, nanostore atoms, 30s TTL cache, fetchers for `rows_request_rate` / `rows_status_histogram` / `rows_top_endpoints` / `rows_errors` |
| [src/components/dashboard/ReactRowsTelemetry.tsx](apps/kbve/astro-kbve/src/components/dashboard/ReactRowsTelemetry.tsx) | 4 panels: Area chart (req/s), Bar chart (status histogram), tables for top endpoints + recent errors. Time-range selector (15m / 1h / 6h / 24h) + 30s auto-poll + manual refresh |
| [src/components/dashboard/AstroRowsTelemetry.astro](apps/kbve/astro-kbve/src/components/dashboard/AstroRowsTelemetry.astro) | Astro wrapper with `ReactHomeAuth` gate |
| [src/content/docs/dashboard/rows/index.mdx](apps/kbve/astro-kbve/src/content/docs/dashboard/rows/index.mdx) | Appends `<AstroRowsTelemetry />` below the existing `<AstroRowsDashboard />` |

4 files, +703 lines.

## Data flow

```
Browser
  └─> POST /dashboard/clickhouse/proxy  (Bearer JWT)
        └─> axum-kbve  (rows_request_rate | rows_status_histogram |
                        rows_top_endpoints | rows_errors)
              └─> jedi::pipe_clickhouse::logs  (SQL with JSONExtract*)
                    └─> ClickHouse  observability.logs_distributed
```

Shaped JSON comes back; component renders. No raw log pull, no client-side `JSON.parse` per row, no iframe.

## Browser cache

`Map<key, {at, data}>` keyed by `(command, range)`. TTL 30s. Range flips re-read from cache when warm. Manual refresh button calls `invalidateTelemetryCache()` then re-fetches all four.

## Panels in v1

1. **Request rate** — recharts AreaChart, time-series, configurable bucket via `bucket_seconds` per range
2. **Status code distribution** — recharts BarChart, GROUP BY status, colored cells (green 2xx / blue 3xx / amber 4xx / red 5xx)
3. **Top endpoints** — table with path, count, p50/p95/p99 latency (server-side `quantile()` over `latency_ms`)
4. **Recent errors** — scrollable table of last 50 rows where status >= 400. Columns: time, method, path, status (colored), latency, customer (first 8 chars of UUID)

## Verification

- `tsc --noEmit` clean on the three new files
- `nx run astro-kbve:build` succeeds with new MDX import
- ROWS pod currently emits ~1500 logs/hour with `target='rows::trace'`, fields populate cleanly via `JSONExtract*`

## Test plan

- [ ] CI green on dev
- [ ] After merge → astro-kbve rebuild → visit `https://kbve.com/dashboard/rows/` as staff:
  - [ ] Telemetry section appears below the existing System Health section
  - [ ] All 4 panels populate within ~2s
  - [ ] Range buttons (15m / 1h / 6h / 24h) switch all panels in sync
  - [ ] Refresh button reloads all 4 panels
  - [ ] 30s auto-poll keeps data fresh

## Out of scope

- Custom Grafana dashboard for ROWS (separate future PR — wire pod metrics + Agones fleet state)
- `/metrics` Prometheus endpoint on ROWS (separate PR for app-level metrics)
- Per-customer breakdown (could be Phase C — needs UI surface)