### PR TITLE
feat(droid): persistent profile cache + fast-paint on /profile/

### DIFF
--- a/apps/kbve/astro-kbve/src/components/user/profile-controller.ts
+++ b/apps/kbve/astro-kbve/src/components/user/profile-controller.ts
@@ -1,5 +1,13 @@
-import { setAuth, AuthPresets } from '@kbve/droid';
-import { kbveApi } from '@kbve/devops';
+import {
+	setAuth,
+	AuthPresets,
+	clearProfileCache as clearDroidProfileCache,
+	fetchAndCacheProfile,
+	getProfileFromCache,
+	readProfileForFastPaint,
+	setProfileCache as setDroidProfileCache,
+	type DroidProfile,
+} from '@kbve/droid';
 import { initSupa, getSupa } from '@/lib/supa';
 import {
 	bootMinecraftCard,
@@ -9,8 +17,6 @@ import {
 // ── Constants ───────────────────────────────────────────────────────────────
 
 const INIT_TIMEOUT_MS = 12_000;
-const PROFILE_CACHE_KEY = 'cache:profile:me';
-const CACHE_TTL_MS = 5 * 60 * 1000;
 const USERNAME_RE = /^[a-zA-Z][a-zA-Z0-9_]{2,23}$/;
 
 // ── Element IDs (must match AstroProfileShell.astro) ────────────────────────
@@ -36,20 +42,7 @@ const IDs = {
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
-interface ApiProfile {
-	username: string;
-	user_id: string;
-	email?: string;
-	profile_exists: boolean;
-	discord?: {
-		username?: string;
-		avatar_url?: string;
-		is_guild_member?: boolean;
-	};
-	github?: { username?: string; avatar_url?: string };
-	twitch?: { username?: string; avatar_url?: string; is_live?: boolean };
-	connected_providers?: string[];
-}
+type ApiProfile = DroidProfile;
 
 // ── DOM helpers ─────────────────────────────────────────────────────────────
 
@@ -83,60 +76,19 @@ function switchState(
 	}
 }
 
-// ── Cache ───────────────────────────────────────────────────────────────────
-
-function getCachedProfile(userId: string): ApiProfile | null {
-	try {
-		const raw = localStorage.getItem(PROFILE_CACHE_KEY);
-		if (!raw) return null;
-		const cached = JSON.parse(raw);
-		if (cached.user_id !== userId) return null;
-		if (Date.now() - cached.cached_at > CACHE_TTL_MS) return null;
-		return cached.profile;
-	} catch {
-		return null;
-	}
-}
-
-function setCachedProfile(profile: ApiProfile) {
-	try {
-		localStorage.setItem(
-			PROFILE_CACHE_KEY,
-			JSON.stringify({
-				profile,
-				cached_at: Date.now(),
-				user_id: profile.user_id,
-			}),
-		);
-	} catch {
-		/* best effort */
-	}
-}
+// ── Cache (delegates to @kbve/droid) ────────────────────────────────────────
 
 function clearProfileCache() {
+	clearDroidProfileCache();
 	try {
-		localStorage.removeItem(PROFILE_CACHE_KEY);
 		clearMinecraftCardCache();
 	} catch {
 		/* best effort */
 	}
 }
 
-// ── Profile API ─────────────────────────────────────────────────────────────
-
 async function fetchProfile(token: string): Promise<ApiProfile | null> {
-	try {
-		const { data, error, response } = await kbveApi.GET(
-			'/api/v1/profile/me',
-			{ headers: { Authorization: `Bearer ${token}` } },
-		);
-		if (error !== undefined || !response.ok || !data) return null;
-		const profile = data as unknown as ApiProfile;
-		setCachedProfile(profile);
-		return profile;
-	} catch {
-		return null;
-	}
+	return fetchAndCacheProfile({ token, apiBase: window.location.origin });
 }
 
 // ── Staff permissions check ─────────────────────────────────────────────────
@@ -370,7 +322,7 @@ async function handleSession(session: any) {
 	fetchStaffFlags(token).catch(() => {});
 
 	// Cache-first for instant display
-	const cached = getCachedProfile(userId);
+	const cached = getProfileFromCache(userId);
 	if (cached?.username) {
 		populateProfile(cached, session);
 		switchState('profile');
@@ -393,7 +345,7 @@ async function handleSession(session: any) {
 					username: newUsername,
 					profile_exists: true,
 				};
-				setCachedProfile(updated);
+				setDroidProfileCache(updated);
 				populateProfile(updated, session);
 				setAuth({ username: newUsername });
 				switchState('profile');
@@ -417,6 +369,23 @@ export async function bootProfile() {
 	switchState('loading');
 	wireLogout();
 
+	// Fast paint: read session + cached profile straight from localStorage
+	// before awaiting the Supabase SharedWorker init. With a warm cache the
+	// profile card paints in tens of ms instead of the multi-second
+	// initSupa round-trip (#11075).
+	const fastPaint = readProfileForFastPaint();
+	let painted = false;
+	if (fastPaint && fastPaint.profile.username) {
+		populateProfile(fastPaint.profile, fastPaint.session);
+		switchState('profile');
+		painted = true;
+		const fpUserId = fastPaint.session.user?.id;
+		const fpToken = fastPaint.session.access_token;
+		if (fpUserId && fpToken) {
+			bootMinecraftCard(fpUserId, fpToken).catch(() => {});
+		}
+	}
+
 	// Init with timeout — never hang forever
 	try {
 		await Promise.race([
@@ -429,7 +398,7 @@ export async function bootProfile() {
 			),
 		]);
 	} catch {
-		switchState('unauth');
+		if (!painted) switchState('unauth');
 		return;
 	}
 
@@ -439,7 +408,7 @@ export async function bootProfile() {
 	const s = await supa.getSession().catch(() => null);
 	const session = s?.session ?? null;
 
-	// Handle current state
+	// Handle current state — refresh whatever the fast paint already showed.
 	await handleSession(session);
 
 	// Listen for auth changes (sign-in / sign-out from other tabs or navbar)

--- a/packages/npm/droid/src/lib/state/index.ts
+++ b/packages/npm/droid/src/lib/state/index.ts
@@ -37,3 +37,21 @@ export {
 
 export { OverlayManager } from './overlay-manager';
 export type { RenderPath } from './overlay-manager';
+
+export {
+	$profileCache,
+	clearProfileCache,
+	fetchAndCacheProfile,
+	fetchProfileFromApi,
+	getProfileFromCache,
+	PROFILE_CACHE_TTL_MS,
+	PROFILE_DEFAULT_API_BASE,
+	readProfileForFastPaint,
+	readSupabaseSessionFromStorage,
+	setProfileCache,
+	type CachedSupabaseSession,
+	type DroidProfile,
+	type FetchProfileOptions,
+	type ProfileCacheEnvelope,
+	type ProfileFastPaintResult,
+} from './profile';

--- a/packages/npm/droid/src/lib/state/profile.ts
+++ b/packages/npm/droid/src/lib/state/profile.ts
@@ -1,0 +1,155 @@
+import { persistentAtom } from '@nanostores/persistent';
+
+export interface DroidProfile {
+	user_id: string;
+	username?: string;
+	email?: string;
+	profile_exists?: boolean;
+	discord?: {
+		username?: string;
+		avatar_url?: string;
+		is_guild_member?: boolean;
+	};
+	github?: { username?: string; avatar_url?: string };
+	twitch?: { username?: string; avatar_url?: string; is_live?: boolean };
+	connected_providers?: string[];
+	[k: string]: unknown;
+}
+
+export interface ProfileCacheEnvelope {
+	profile: DroidProfile;
+	cached_at: number;
+	user_id: string;
+}
+
+const PROFILE_CACHE_KEY = 'cache:profile:me';
+const SUPABASE_SESSION_STORAGE_KEY = 'sb-auth-token';
+export const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000;
+export const PROFILE_DEFAULT_API_BASE = 'https://kbve.com';
+
+export const $profileCache = persistentAtom<ProfileCacheEnvelope | null>(
+	PROFILE_CACHE_KEY,
+	null,
+	{
+		encode: (value) => JSON.stringify(value),
+		decode: (raw) => {
+			if (!raw || raw === 'null') return null;
+			try {
+				return JSON.parse(raw) as ProfileCacheEnvelope;
+			} catch {
+				return null;
+			}
+		},
+	},
+);
+
+export function getProfileFromCache(userId: string): DroidProfile | null {
+	const entry = $profileCache.get();
+	if (!entry) return null;
+	if (entry.user_id !== userId) return null;
+	if (Date.now() - entry.cached_at > PROFILE_CACHE_TTL_MS) return null;
+	return entry.profile;
+}
+
+export function setProfileCache(profile: DroidProfile): void {
+	if (!profile.user_id) return;
+	$profileCache.set({
+		profile,
+		cached_at: Date.now(),
+		user_id: profile.user_id,
+	});
+}
+
+export function clearProfileCache(): void {
+	$profileCache.set(null);
+}
+
+export interface CachedSupabaseSession {
+	access_token: string;
+	refresh_token?: string;
+	expires_at?: number;
+	user?: {
+		id: string;
+		email?: string;
+		user_metadata?: Record<string, unknown>;
+		[k: string]: unknown;
+	};
+	[k: string]: unknown;
+}
+
+export function readSupabaseSessionFromStorage(): CachedSupabaseSession | null {
+	if (typeof localStorage === 'undefined') return null;
+	const raw = localStorage.getItem(SUPABASE_SESSION_STORAGE_KEY);
+	if (!raw) return null;
+	try {
+		const parsed = JSON.parse(raw);
+		if (!parsed || typeof parsed !== 'object') return null;
+		if (
+			parsed.currentSession &&
+			typeof parsed.currentSession === 'object' &&
+			'access_token' in parsed.currentSession
+		) {
+			return parsed.currentSession as CachedSupabaseSession;
+		}
+		if ('access_token' in parsed) {
+			return parsed as CachedSupabaseSession;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+export interface FetchProfileOptions {
+	token: string;
+	apiBase?: string;
+	signal?: AbortSignal;
+}
+
+export async function fetchProfileFromApi(
+	opts: FetchProfileOptions,
+): Promise<DroidProfile | null> {
+	const base = opts.apiBase ?? PROFILE_DEFAULT_API_BASE;
+	const res = await fetch(`${base}/api/v1/profile/me`, {
+		method: 'GET',
+		headers: {
+			Authorization: `Bearer ${opts.token}`,
+			Accept: 'application/json',
+		},
+		signal: opts.signal,
+	});
+	if (!res.ok) return null;
+	try {
+		const json = (await res.json()) as DroidProfile;
+		if (!json || !json.user_id) return null;
+		return json;
+	} catch {
+		return null;
+	}
+}
+
+export async function fetchAndCacheProfile(
+	opts: FetchProfileOptions,
+): Promise<DroidProfile | null> {
+	const profile = await fetchProfileFromApi(opts);
+	if (profile) setProfileCache(profile);
+	return profile;
+}
+
+export interface ProfileFastPaintResult {
+	session: CachedSupabaseSession;
+	profile: DroidProfile;
+	stale: boolean;
+}
+
+export function readProfileForFastPaint(): ProfileFastPaintResult | null {
+	const session = readSupabaseSessionFromStorage();
+	if (!session?.user?.id || !session.access_token) return null;
+	const entry = $profileCache.get();
+	if (!entry || entry.user_id !== session.user.id) return null;
+	return {
+		session,
+		profile: entry.profile,
+		stale: Date.now() - entry.cached_at > PROFILE_CACHE_TTL_MS,
+	};
+}


### PR DESCRIPTION
## Summary
Follow-up to #11075. Two blockers on the slow \`/profile/\` paint:

1. Profile cache primitives lived in \`astro-kbve\`'s \`profile-controller.ts\`, so any other KBVE site duplicates the pattern.
2. Bootstrap waited on \`await initSupa()\` (the Supabase SharedWorker init, up to 12 s) **before** the cache was even read. Even with a warm localStorage cache, the card couldn't paint until the worker came up.

This PR moves the cache + fetcher into \`@kbve/droid\` and short-circuits the boot with a localStorage-only fast path.

## @kbve/droid — new \`lib/state/profile.ts\`
- \`$profileCache\` — \`persistentAtom\` over \`localStorage['cache:profile:me']\`. Same envelope shape (\`{profile, cached_at, user_id}\`) the previous direct-localStorage code used, so warm caches keep working with no migration.
- \`getProfileFromCache(userId)\` / \`setProfileCache(profile)\` / \`clearProfileCache()\` — typed helpers, 5-min TTL, user-id guard.
- \`readSupabaseSessionFromStorage()\` — sync read of \`sb-auth-token\`. Returns the session without ever touching the SharedWorker. Handles both the raw shape and the legacy \`{currentSession: ...}\` wrapper.
- \`fetchProfileFromApi({token, apiBase})\` + \`fetchAndCacheProfile()\` — native \`fetch\` against \`/api/v1/profile/me\`. Caller supplies the base URL so droid stays framework-free (no dependency on \`@kbve/devops\`).
- \`readProfileForFastPaint()\` — combines session + cache reads, returns \`{session, profile, stale}\` when both match the same user.

All exported through \`lib/state/index.ts\` → \`@kbve/droid\` root.

## astro-kbve — \`profile-controller.ts\`
- Drop local \`PROFILE_CACHE_KEY\`, \`CACHE_TTL_MS\`, \`ApiProfile\`, \`getCachedProfile\`, \`setCachedProfile\`, \`fetchProfile\` and the \`kbveApi\` import. Thin imports from \`@kbve/droid\` instead.
- \`bootProfile()\` fast-paint pass:
  1. \`readProfileForFastPaint()\` looks up session + cached profile sync from localStorage.
  2. If both line up, \`populateProfile()\` + \`switchState('profile')\` + minecraft-card boot fire immediately.
  3. Normal \`initSupa\` → \`getSession\` → \`handleSession\` runs in the background and refreshes the same DOM slots once fresh data lands.
  4. If \`initSupa\` times out AND fast paint already happened, keep the cached UI up rather than flipping to \`unauth\`.

No React rewrite this round — Astro shell + DOM IDs untouched.

## Test plan
- [x] \`./kbve.sh -nx droid:build\` — clean
- [x] \`./kbve.sh -nx droid:test\` — 118/118 pass
- [x] \`./kbve.sh -nx astro-kbve:check\` — no new errors (1 pre-existing GamingHub error unrelated)
- [x] \`./kbve.sh -nx astro-kbve:build\` — clean
- [ ] In prod: load \`/profile/\` with a warm cache — card paints from localStorage well under 1 s, then refreshes in place when \`initSupa\` completes