### PR TITLE
feat(axum-kbve): marketplace REST surface (Phase 4)

### DIFF
--- a/apps/kbve/axum-kbve/src/openapi.rs
+++ b/apps/kbve/axum-kbve/src/openapi.rs
@@ -69,7 +69,8 @@ impl Modify for SecurityAddon {
         (name = "mc", description = "Minecraft RCON-backed live data: player list, head textures."),
         (name = "telemetry", description = "Client-side error reporting from WASM/JS."),
         (name = "dashboard", description = "Staff-only routes powering kbve.com/dashboard. Gated on DASHBOARD_VIEW."),
-        (name = "wallet", description = "Authenticated wallet surface: balance, coupons, claim flows.")
+        (name = "wallet", description = "Authenticated wallet surface: balance, coupons, claim flows."),
+        (name = "market", description = "Player marketplace: list, browse, bid, buy-now. Khash-only with a 1% KBVE Treasury fee.")
     ),
     paths(
         // system
@@ -112,6 +113,17 @@ impl Modify for SecurityAddon {
         crate::transport::wallet::service_redeem_coupon,
         crate::transport::wallet::service_revoke_coupon,
         crate::transport::wallet::service_verify_balance,
+        // marketplace — public browse
+        crate::transport::market::list_active,
+        crate::transport::market::listing_detail,
+        // marketplace — caller scope
+        crate::transport::market::me_listings,
+        crate::transport::market::me_bids,
+        // marketplace — write
+        crate::transport::market::create_listing,
+        crate::transport::market::place_bid,
+        crate::transport::market::buy_now,
+        crate::transport::market::cancel_listing,
     ),
     components(
         schemas(
@@ -152,6 +164,16 @@ impl Modify for SecurityAddon {
             crate::transport::wallet::ServiceRevokeCouponBody,
             crate::transport::wallet::ServiceRevokeDto,
             crate::transport::wallet::ServiceVerifyBalanceDto,
+            // marketplace
+            crate::transport::market::MarketListingDto,
+            crate::transport::market::MarketListingDetailDto,
+            crate::transport::market::MarketMyListingDto,
+            crate::transport::market::MarketMyBidDto,
+            crate::transport::market::CreateListingBody,
+            crate::transport::market::PlaceBidBody,
+            crate::transport::market::BuyNowBody,
+            crate::transport::market::CancelListingBody,
+            crate::transport::market::MarketIdDto,
         )
     ),
     modifiers(&SecurityAddon)

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -380,6 +380,32 @@ fn router(state: AppState) -> Router {
             "/api/v1/wallet/service/verify-balance/{account_id}",
             get(super::wallet::service_verify_balance),
         )
+        // marketplace — anon browse + authenticated trade/management.
+        .route(
+            "/api/v1/market/listings",
+            get(super::market::list_active).post(super::market::create_listing),
+        )
+        .route(
+            "/api/v1/market/listings/{listing_id}",
+            get(super::market::listing_detail),
+        )
+        .route(
+            "/api/v1/market/listings/{listing_id}/bid",
+            post(super::market::place_bid),
+        )
+        .route(
+            "/api/v1/market/listings/{listing_id}/buy-now",
+            post(super::market::buy_now),
+        )
+        .route(
+            "/api/v1/market/listings/{listing_id}/cancel",
+            post(super::market::cancel_listing),
+        )
+        .route(
+            "/api/v1/market/me/listings",
+            get(super::market::me_listings),
+        )
+        .route("/api/v1/market/me/bids", get(super::market::me_bids))
         .route("/forum/c/", get(forum_c_root_redirect))
         .route("/forum/c/{slug}", get(forum_c_redirect))
         .route("/forum/c/{slug}/", get(forum_c_redirect));

--- a/apps/kbve/axum-kbve/src/transport/market.rs
+++ b/apps/kbve/axum-kbve/src/transport/market.rs
@@ -1,0 +1,518 @@
+//! Marketplace HTTP surface.
+//!
+//! Browse routes (`GET /api/v1/market/listings*`) are anon-callable and hit
+//! the read pool via `proxy_market_*_readonly`. Authenticated routes resolve
+//! the caller via `auth_user_id` and delegate to `WalletClient::market_*`,
+//! which sets `request.jwt.claims` inside the txn so `auth.uid()` resolves
+//! on the SQL side and the proxy authorizes by seller/bidder ownership.
+
+use axum::{
+    Json,
+    extract::{Path, Query},
+    http::HeaderMap,
+    response::{IntoResponse, Response},
+};
+use chrono::{DateTime, Utc};
+use kbve::wallet::{
+    MarketBuyNowRequest, MarketCancelListingRequest, MarketCreateListingRequest,
+    MarketPlaceBidRequest,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::wallet::{resolve_user, service_unavailable, wallet_error_response};
+use crate::db::get_wallet_client;
+
+const DEFAULT_PAGE_LIMIT: i32 = 25;
+const MAX_PAGE_LIMIT: i32 = 100;
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct MarketListingDto {
+    pub listing_id: i64,
+    pub seller_account: Uuid,
+    pub item_ref: serde_json::Value,
+    pub currency: String,
+    pub buy_now_price: Option<i64>,
+    pub min_bid: Option<i64>,
+    pub current_bid: Option<i64>,
+    pub expires_at: String,
+    pub created_at: String,
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct MarketListingDetailDto {
+    pub listing_id: i64,
+    pub seller_account: Uuid,
+    pub item_ref: serde_json::Value,
+    pub currency: String,
+    pub buy_now_price: Option<i64>,
+    pub min_bid: Option<i64>,
+    pub current_bid: Option<i64>,
+    pub current_bid_id: Option<i64>,
+    pub listing_status: String,
+    pub expires_at: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub settled_at: Option<String>,
+    /// JSONB array of up to 50 most recent bids. Bidder UUIDs, ledger ids,
+    /// and settled_at are redacted by the SQL proxy.
+    pub bids: serde_json::Value,
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct MarketMyListingDto {
+    pub listing_id: i64,
+    pub item_ref: serde_json::Value,
+    pub currency: String,
+    pub buy_now_price: Option<i64>,
+    pub min_bid: Option<i64>,
+    pub current_bid: Option<i64>,
+    pub current_bid_account: Option<Uuid>,
+    pub buyer_account: Option<Uuid>,
+    pub listing_status: String,
+    pub expires_at: String,
+    pub created_at: String,
+    pub settled_at: Option<String>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct MarketMyBidDto {
+    pub bid_id: i64,
+    pub listing_id: i64,
+    pub amount: i64,
+    pub bid_status: String,
+    pub placed_at: String,
+    pub settled_at: Option<String>,
+    pub escrow_ledger_id: i64,
+    pub refund_ledger_id: Option<i64>,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct ListingsQuery {
+    /// Page size. Clamped to [1, 100]. Default 25.
+    pub limit: Option<i32>,
+    /// Keyset cursor: previous page's last `created_at` (RFC3339).
+    pub before_created_at: Option<DateTime<Utc>>,
+    /// Keyset cursor: previous page's last `listing_id`.
+    pub before_id: Option<i64>,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct BidsQuery {
+    /// Page size. Clamped to [1, 100]. Default 25.
+    pub limit: Option<i32>,
+    /// Keyset cursor: previous page's last `placed_at` (RFC3339).
+    pub before_placed_at: Option<DateTime<Utc>>,
+    /// Keyset cursor: previous page's last `bid_id`.
+    pub before_id: Option<i64>,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct CreateListingBody {
+    /// Free-form JSON ref to the listed item. Schema is enforced by the
+    /// inventory layer, not the wallet.
+    pub item_ref: serde_json::Value,
+    pub buy_now_price: Option<i64>,
+    pub min_bid: Option<i64>,
+    pub expires_at: DateTime<Utc>,
+    /// Caller-supplied. Replays return the original listing_id.
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct PlaceBidBody {
+    pub amount: i64,
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct BuyNowBody {
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(crate) struct CancelListingBody {
+    pub reason: Option<String>,
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct MarketIdDto {
+    /// listing_id (create) / bid_id (bid) / ledger_id (buy-now).
+    pub id: i64,
+}
+
+fn clamp_limit(raw: Option<i32>) -> i32 {
+    raw.unwrap_or(DEFAULT_PAGE_LIMIT).clamp(1, MAX_PAGE_LIMIT)
+}
+
+/// `GET /api/v1/market/listings` — paged active listings, public/anon.
+#[utoipa::path(
+    get,
+    path = "/api/v1/market/listings",
+    tag = "market",
+    params(
+        ("limit" = Option<i32>, Query, description = "Page size (1-100, default 25)"),
+        ("before_created_at" = Option<String>, Query, description = "Keyset cursor: previous page's last created_at (RFC3339)"),
+        ("before_id" = Option<i64>, Query, description = "Keyset cursor: previous page's last listing_id"),
+    ),
+    responses(
+        (status = 200, description = "Active listings page", body = [MarketListingDto]),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+)]
+pub(crate) async fn list_active(Query(q): Query<ListingsQuery>) -> Response {
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    match client
+        .market_list_active(clamp_limit(q.limit), q.before_created_at, q.before_id)
+        .await
+    {
+        Ok(rows) => Json(
+            rows.into_iter()
+                .map(|r| MarketListingDto {
+                    listing_id: r.listing_id,
+                    seller_account: r.seller_account,
+                    item_ref: r.item_ref,
+                    currency: r.currency.as_pg().to_string(),
+                    buy_now_price: r.buy_now_price,
+                    min_bid: r.min_bid,
+                    current_bid: r.current_bid,
+                    expires_at: r.expires_at.to_rfc3339(),
+                    created_at: r.created_at.to_rfc3339(),
+                })
+                .collect::<Vec<_>>(),
+        )
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `GET /api/v1/market/listings/:id` — listing detail + up to 50 recent bids.
+#[utoipa::path(
+    get,
+    path = "/api/v1/market/listings/{listing_id}",
+    tag = "market",
+    params(
+        ("listing_id" = i64, Path, description = "Listing id")
+    ),
+    responses(
+        (status = 200, description = "Listing detail", body = MarketListingDetailDto),
+        (status = 404, description = "Listing not found"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+)]
+pub(crate) async fn listing_detail(Path(listing_id): Path<i64>) -> Response {
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    match client.market_listing_detail(listing_id).await {
+        Ok(d) => Json(MarketListingDetailDto {
+            listing_id: d.listing_id,
+            seller_account: d.seller_account,
+            item_ref: d.item_ref,
+            currency: d.currency.as_pg().to_string(),
+            buy_now_price: d.buy_now_price,
+            min_bid: d.min_bid,
+            current_bid: d.current_bid,
+            current_bid_id: d.current_bid_id,
+            listing_status: d.listing_status.as_pg().to_string(),
+            expires_at: d.expires_at.to_rfc3339(),
+            created_at: d.created_at.to_rfc3339(),
+            updated_at: d.updated_at.to_rfc3339(),
+            settled_at: d.settled_at.map(|t| t.to_rfc3339()),
+            bids: d.bids,
+        })
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `GET /api/v1/market/me/listings` — caller's listings (seller scope).
+#[utoipa::path(
+    get,
+    path = "/api/v1/market/me/listings",
+    tag = "market",
+    params(
+        ("limit" = Option<i32>, Query, description = "Page size (1-100, default 25)"),
+        ("before_created_at" = Option<String>, Query, description = "Keyset cursor: previous page's last created_at (RFC3339)"),
+        ("before_id" = Option<i64>, Query, description = "Keyset cursor: previous page's last listing_id"),
+    ),
+    responses(
+        (status = 200, description = "Caller's listings", body = [MarketMyListingDto]),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn me_listings(headers: HeaderMap, Query(q): Query<ListingsQuery>) -> Response {
+    let user_id = match resolve_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    match client
+        .market_my_listings(
+            user_id,
+            clamp_limit(q.limit),
+            q.before_created_at,
+            q.before_id,
+        )
+        .await
+    {
+        Ok(rows) => Json(
+            rows.into_iter()
+                .map(|r| MarketMyListingDto {
+                    listing_id: r.listing_id,
+                    item_ref: r.item_ref,
+                    currency: r.currency.as_pg().to_string(),
+                    buy_now_price: r.buy_now_price,
+                    min_bid: r.min_bid,
+                    current_bid: r.current_bid,
+                    current_bid_account: r.current_bid_account,
+                    buyer_account: r.buyer_account,
+                    listing_status: r.listing_status.as_pg().to_string(),
+                    expires_at: r.expires_at.to_rfc3339(),
+                    created_at: r.created_at.to_rfc3339(),
+                    settled_at: r.settled_at.map(|t| t.to_rfc3339()),
+                })
+                .collect::<Vec<_>>(),
+        )
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `GET /api/v1/market/me/bids` — caller's bids across listings.
+#[utoipa::path(
+    get,
+    path = "/api/v1/market/me/bids",
+    tag = "market",
+    params(
+        ("limit" = Option<i32>, Query, description = "Page size (1-100, default 25)"),
+        ("before_placed_at" = Option<String>, Query, description = "Keyset cursor: previous page's last placed_at (RFC3339)"),
+        ("before_id" = Option<i64>, Query, description = "Keyset cursor: previous page's last bid_id"),
+    ),
+    responses(
+        (status = 200, description = "Caller's bids", body = [MarketMyBidDto]),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn me_bids(headers: HeaderMap, Query(q): Query<BidsQuery>) -> Response {
+    let user_id = match resolve_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    match client
+        .market_my_bids(
+            user_id,
+            clamp_limit(q.limit),
+            q.before_placed_at,
+            q.before_id,
+        )
+        .await
+    {
+        Ok(rows) => Json(
+            rows.into_iter()
+                .map(|r| MarketMyBidDto {
+                    bid_id: r.bid_id,
+                    listing_id: r.listing_id,
+                    amount: r.amount,
+                    bid_status: r.bid_status.as_pg().to_string(),
+                    placed_at: r.placed_at.to_rfc3339(),
+                    settled_at: r.settled_at.map(|t| t.to_rfc3339()),
+                    escrow_ledger_id: r.escrow_ledger_id,
+                    refund_ledger_id: r.refund_ledger_id,
+                })
+                .collect::<Vec<_>>(),
+        )
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `POST /api/v1/market/listings` — create a listing. Returns the new
+/// listing_id. Idempotent on `idempotency_key` — replays return the same id.
+#[utoipa::path(
+    post,
+    path = "/api/v1/market/listings",
+    tag = "market",
+    request_body = CreateListingBody,
+    responses(
+        (status = 200, description = "Listing created", body = MarketIdDto),
+        (status = 400, description = "Invalid payload (price/expiry/ref)"),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 409, description = "Idempotency replay mismatch"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn create_listing(
+    headers: HeaderMap,
+    Json(body): Json<CreateListingBody>,
+) -> Response {
+    let user_id = match resolve_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    let req = MarketCreateListingRequest {
+        item_ref: body.item_ref,
+        buy_now_price: body.buy_now_price,
+        min_bid: body.min_bid,
+        expires_at: body.expires_at,
+        idempotency_key: body.idempotency_key,
+    };
+    match client.market_create_listing(user_id, req).await {
+        Ok(id) => Json(MarketIdDto { id }).into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `POST /api/v1/market/listings/:id/bid` — place a bid. Returns the new
+/// bid_id. Bid funds are debited and held in escrow.
+#[utoipa::path(
+    post,
+    path = "/api/v1/market/listings/{listing_id}/bid",
+    tag = "market",
+    params(
+        ("listing_id" = i64, Path, description = "Listing id")
+    ),
+    request_body = PlaceBidBody,
+    responses(
+        (status = 200, description = "Bid placed", body = MarketIdDto),
+        (status = 400, description = "Invalid bid (amount below min_bid / current_bid)"),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 402, description = "Insufficient funds for escrow"),
+        (status = 403, description = "Cannot bid on own listing / listing not active"),
+        (status = 404, description = "Listing not found"),
+        (status = 409, description = "Idempotency replay mismatch"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn place_bid(
+    headers: HeaderMap,
+    Path(listing_id): Path<i64>,
+    Json(body): Json<PlaceBidBody>,
+) -> Response {
+    let user_id = match resolve_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    let req = MarketPlaceBidRequest {
+        listing_id,
+        amount: body.amount,
+        idempotency_key: body.idempotency_key,
+    };
+    match client.market_place_bid(user_id, req).await {
+        Ok(id) => Json(MarketIdDto { id }).into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `POST /api/v1/market/listings/:id/buy-now` — buy a listing at its
+/// `buy_now_price`. Returns the buyer ledger_id.
+#[utoipa::path(
+    post,
+    path = "/api/v1/market/listings/{listing_id}/buy-now",
+    tag = "market",
+    params(
+        ("listing_id" = i64, Path, description = "Listing id")
+    ),
+    request_body = BuyNowBody,
+    responses(
+        (status = 200, description = "Listing purchased", body = MarketIdDto),
+        (status = 400, description = "Listing has no buy_now_price"),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 402, description = "Insufficient funds"),
+        (status = 403, description = "Cannot buy own listing / listing not active"),
+        (status = 404, description = "Listing not found"),
+        (status = 409, description = "Idempotency replay mismatch"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn buy_now(
+    headers: HeaderMap,
+    Path(listing_id): Path<i64>,
+    Json(body): Json<BuyNowBody>,
+) -> Response {
+    let user_id = match resolve_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    let req = MarketBuyNowRequest {
+        listing_id,
+        idempotency_key: body.idempotency_key,
+    };
+    match client.market_buy_now(user_id, req).await {
+        Ok(id) => Json(MarketIdDto { id }).into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
+/// `POST /api/v1/market/listings/:id/cancel` — cancel an active listing.
+/// Seller-only. Refunds the current high bidder's escrow.
+#[utoipa::path(
+    post,
+    path = "/api/v1/market/listings/{listing_id}/cancel",
+    tag = "market",
+    params(
+        ("listing_id" = i64, Path, description = "Listing id")
+    ),
+    request_body = CancelListingBody,
+    responses(
+        (status = 204, description = "Listing cancelled"),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 403, description = "Not the seller / listing not active"),
+        (status = 404, description = "Listing not found"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn cancel_listing(
+    headers: HeaderMap,
+    Path(listing_id): Path<i64>,
+    Json(body): Json<CancelListingBody>,
+) -> Response {
+    let user_id = match resolve_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    let req = MarketCancelListingRequest {
+        listing_id,
+        reason: body.reason,
+    };
+    match client.market_cancel_listing(user_id, req).await {
+        Ok(()) => axum::http::StatusCode::NO_CONTENT.into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}

--- a/apps/kbve/axum-kbve/src/transport/mod.rs
+++ b/apps/kbve/axum-kbve/src/transport/mod.rs
@@ -1,4 +1,5 @@
 pub mod https;
+pub mod market;
 pub mod proxy;
 pub mod vnc_hub;
 pub mod wallet;

--- a/apps/kbve/axum-kbve/src/transport/wallet.rs
+++ b/apps/kbve/axum-kbve/src/transport/wallet.rs
@@ -274,7 +274,7 @@ pub(crate) async fn me_redeem_coupon(
     }
 }
 
-async fn resolve_user(headers: &HeaderMap) -> Result<Uuid, Response> {
+pub(crate) async fn resolve_user(headers: &HeaderMap) -> Result<Uuid, Response> {
     let s = auth_user_id(headers).await?;
     Uuid::parse_str(&s).map_err(|_| {
         (
@@ -285,7 +285,7 @@ async fn resolve_user(headers: &HeaderMap) -> Result<Uuid, Response> {
     })
 }
 
-fn service_unavailable() -> Response {
+pub(crate) fn service_unavailable() -> Response {
     (
         StatusCode::SERVICE_UNAVAILABLE,
         Json(json!({"error": "Wallet service unavailable"})),
@@ -363,7 +363,7 @@ fn parse_source_kind(s: &str) -> Result<SourceKind, Response> {
     })
 }
 
-fn wallet_error_response(err: WalletError) -> Response {
+pub(crate) fn wallet_error_response(err: WalletError) -> Response {
     let (status, code) = match &err {
         WalletError::InsufficientFunds => (StatusCode::PAYMENT_REQUIRED, "insufficient_funds"),
         WalletError::ReplayMismatch => (StatusCode::CONFLICT, "replay_mismatch"),

--- a/packages/rust/kbve/src/wallet/market.rs
+++ b/packages/rust/kbve/src/wallet/market.rs
@@ -1,0 +1,497 @@
+//! Marketplace client surface. Wraps the Phase 3 PostgREST proxies:
+//!
+//!   public.proxy_market_list_active_readonly
+//!   public.proxy_market_listing_detail_readonly
+//!   public.proxy_market_my_listings_readonly
+//!   public.proxy_market_my_bids_readonly
+//!   public.proxy_market_create_listing
+//!   public.proxy_market_place_bid
+//!   public.proxy_market_buy_now
+//!   public.proxy_market_cancel_listing
+//!
+//! Read methods use the rw/ro pool split (PR #10941); on AccountMissing
+//! (SQLSTATE WLT01) for the authenticated paths the client falls back
+//! to the rw pool so the trigger from PR #10920 still lazy-provisions.
+//! The anon-callable browse + detail pair never carries auth claims.
+
+use chrono::{DateTime, Utc};
+use diesel::QueryableByName;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Jsonb, Nullable, Text, Timestamptz};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use uuid::Uuid;
+
+use super::client::{WalletClient, set_user_claims};
+use super::error::{Result, WalletError};
+use super::types::*;
+
+#[derive(QueryableByName)]
+struct ListingRowDb {
+    #[diesel(sql_type = BigInt)]
+    listing_id: i64,
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    seller_account: Uuid,
+    #[diesel(sql_type = Jsonb)]
+    item_ref: serde_json::Value,
+    #[diesel(sql_type = Text)]
+    currency: String,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    buy_now_price: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    min_bid: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    current_bid: Option<i64>,
+    #[diesel(sql_type = Timestamptz)]
+    expires_at: DateTime<Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    created_at: DateTime<Utc>,
+}
+
+#[derive(QueryableByName)]
+struct ListingDetailDb {
+    #[diesel(sql_type = BigInt)]
+    listing_id: i64,
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    seller_account: Uuid,
+    #[diesel(sql_type = Jsonb)]
+    item_ref: serde_json::Value,
+    #[diesel(sql_type = Text)]
+    currency: String,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    buy_now_price: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    min_bid: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    current_bid: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    current_bid_id: Option<i64>,
+    #[diesel(sql_type = Text)]
+    listing_status: String,
+    #[diesel(sql_type = Timestamptz)]
+    expires_at: DateTime<Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    created_at: DateTime<Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    updated_at: DateTime<Utc>,
+    #[diesel(sql_type = Nullable<Timestamptz>)]
+    settled_at: Option<DateTime<Utc>>,
+    #[diesel(sql_type = Jsonb)]
+    bids: serde_json::Value,
+}
+
+#[derive(QueryableByName)]
+struct MyListingRowDb {
+    #[diesel(sql_type = BigInt)]
+    listing_id: i64,
+    #[diesel(sql_type = Jsonb)]
+    item_ref: serde_json::Value,
+    #[diesel(sql_type = Text)]
+    currency: String,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    buy_now_price: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    min_bid: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    current_bid: Option<i64>,
+    #[diesel(sql_type = Nullable<diesel::sql_types::Uuid>)]
+    current_bid_account: Option<Uuid>,
+    #[diesel(sql_type = Nullable<diesel::sql_types::Uuid>)]
+    buyer_account: Option<Uuid>,
+    #[diesel(sql_type = Text)]
+    listing_status: String,
+    #[diesel(sql_type = Timestamptz)]
+    expires_at: DateTime<Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    created_at: DateTime<Utc>,
+    #[diesel(sql_type = Nullable<Timestamptz>)]
+    settled_at: Option<DateTime<Utc>>,
+}
+
+#[derive(QueryableByName)]
+struct MyBidRowDb {
+    #[diesel(sql_type = BigInt)]
+    bid_id: i64,
+    #[diesel(sql_type = BigInt)]
+    listing_id: i64,
+    #[diesel(sql_type = BigInt)]
+    amount: i64,
+    #[diesel(sql_type = Text)]
+    bid_status: String,
+    #[diesel(sql_type = Timestamptz)]
+    placed_at: DateTime<Utc>,
+    #[diesel(sql_type = Nullable<Timestamptz>)]
+    settled_at: Option<DateTime<Utc>>,
+    #[diesel(sql_type = BigInt)]
+    escrow_ledger_id: i64,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    refund_ledger_id: Option<i64>,
+}
+
+#[derive(QueryableByName)]
+struct ScalarBigInt {
+    #[diesel(sql_type = BigInt)]
+    value: i64,
+}
+
+fn map_listing_row(r: ListingRowDb) -> Result<MarketListingRow> {
+    let currency = CurrencyKind::from_pg(&r.currency)
+        .ok_or_else(|| WalletError::InvalidArgument(format!("unknown currency: {}", r.currency)))?;
+    Ok(MarketListingRow {
+        listing_id: r.listing_id,
+        seller_account: r.seller_account,
+        item_ref: r.item_ref,
+        currency,
+        buy_now_price: r.buy_now_price,
+        min_bid: r.min_bid,
+        current_bid: r.current_bid,
+        expires_at: r.expires_at,
+        created_at: r.created_at,
+    })
+}
+
+fn map_listing_detail(r: ListingDetailDb) -> Result<MarketListingDetail> {
+    let currency = CurrencyKind::from_pg(&r.currency)
+        .ok_or_else(|| WalletError::InvalidArgument(format!("unknown currency: {}", r.currency)))?;
+    let status = ListingStatus::from_pg(&r.listing_status).ok_or_else(|| {
+        WalletError::InvalidArgument(format!("unknown listing_status: {}", r.listing_status))
+    })?;
+    Ok(MarketListingDetail {
+        listing_id: r.listing_id,
+        seller_account: r.seller_account,
+        item_ref: r.item_ref,
+        currency,
+        buy_now_price: r.buy_now_price,
+        min_bid: r.min_bid,
+        current_bid: r.current_bid,
+        current_bid_id: r.current_bid_id,
+        listing_status: status,
+        expires_at: r.expires_at,
+        created_at: r.created_at,
+        updated_at: r.updated_at,
+        settled_at: r.settled_at,
+        bids: r.bids,
+    })
+}
+
+fn map_my_listing(r: MyListingRowDb) -> Result<MarketMyListingRow> {
+    let currency = CurrencyKind::from_pg(&r.currency)
+        .ok_or_else(|| WalletError::InvalidArgument(format!("unknown currency: {}", r.currency)))?;
+    let status = ListingStatus::from_pg(&r.listing_status).ok_or_else(|| {
+        WalletError::InvalidArgument(format!("unknown listing_status: {}", r.listing_status))
+    })?;
+    Ok(MarketMyListingRow {
+        listing_id: r.listing_id,
+        item_ref: r.item_ref,
+        currency,
+        buy_now_price: r.buy_now_price,
+        min_bid: r.min_bid,
+        current_bid: r.current_bid,
+        current_bid_account: r.current_bid_account,
+        buyer_account: r.buyer_account,
+        listing_status: status,
+        expires_at: r.expires_at,
+        created_at: r.created_at,
+        settled_at: r.settled_at,
+    })
+}
+
+fn map_my_bid(r: MyBidRowDb) -> Result<MarketMyBidRow> {
+    let status = BidStatus::from_pg(&r.bid_status).ok_or_else(|| {
+        WalletError::InvalidArgument(format!("unknown bid_status: {}", r.bid_status))
+    })?;
+    Ok(MarketMyBidRow {
+        bid_id: r.bid_id,
+        listing_id: r.listing_id,
+        amount: r.amount,
+        bid_status: status,
+        placed_at: r.placed_at,
+        settled_at: r.settled_at,
+        escrow_ledger_id: r.escrow_ledger_id,
+        refund_ledger_id: r.refund_ledger_id,
+    })
+}
+
+impl WalletClient {
+    // -------------------------------------------------------------------
+    // Anon-safe browse (no auth claims; uses read pool)
+    // -------------------------------------------------------------------
+
+    pub async fn market_list_active(
+        &self,
+        limit: i32,
+        before_created_at: Option<DateTime<Utc>>,
+        before_id: Option<i64>,
+    ) -> Result<Vec<MarketListingRow>> {
+        let mut conn = self.read().await?;
+        let rows: Vec<ListingRowDb> = sql_query(
+            "SELECT listing_id, seller_account, item_ref, currency::text AS currency, \
+                    buy_now_price, min_bid, current_bid, expires_at, created_at \
+             FROM public.proxy_market_list_active_readonly($1, $2, $3)",
+        )
+        .bind::<diesel::sql_types::Integer, _>(limit)
+        .bind::<Nullable<Timestamptz>, _>(before_created_at)
+        .bind::<Nullable<BigInt>, _>(before_id)
+        .get_results(&mut *conn)
+        .await
+        .map_err(WalletError::from_diesel)?;
+        rows.into_iter().map(map_listing_row).collect()
+    }
+
+    pub async fn market_listing_detail(&self, listing_id: i64) -> Result<MarketListingDetail> {
+        let mut conn = self.read().await?;
+        let row: ListingDetailDb = sql_query(
+            "SELECT listing_id, seller_account, item_ref, currency::text AS currency, \
+                    buy_now_price, min_bid, current_bid, current_bid_id, \
+                    listing_status::text AS listing_status, expires_at, created_at, \
+                    updated_at, settled_at, bids \
+             FROM public.proxy_market_listing_detail_readonly($1)",
+        )
+        .bind::<BigInt, _>(listing_id)
+        .get_result(&mut *conn)
+        .await
+        .map_err(WalletError::from_diesel)?;
+        map_listing_detail(row)
+    }
+
+    // -------------------------------------------------------------------
+    // Authenticated reads (rw on WLT01 fallback)
+    // -------------------------------------------------------------------
+
+    pub async fn market_my_listings(
+        &self,
+        user_id: Uuid,
+        limit: i32,
+        before_created_at: Option<DateTime<Utc>>,
+        before_id: Option<i64>,
+    ) -> Result<Vec<MarketMyListingRow>> {
+        match self
+            .read_my_listings(user_id, limit, before_created_at, before_id)
+            .await
+        {
+            Ok(rows) => Ok(rows),
+            Err(WalletError::AccountMissing) => {
+                self.write_my_listings(user_id, limit, before_created_at, before_id)
+                    .await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn read_my_listings(
+        &self,
+        user_id: Uuid,
+        limit: i32,
+        before_created_at: Option<DateTime<Utc>>,
+        before_id: Option<i64>,
+    ) -> Result<Vec<MarketMyListingRow>> {
+        let mut conn = self.read().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Vec<MarketMyListingRow>, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                my_listings_async(conn, limit, before_created_at, before_id).await
+            })
+            .await
+    }
+
+    async fn write_my_listings(
+        &self,
+        user_id: Uuid,
+        limit: i32,
+        before_created_at: Option<DateTime<Utc>>,
+        before_id: Option<i64>,
+    ) -> Result<Vec<MarketMyListingRow>> {
+        let mut conn = self.write().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Vec<MarketMyListingRow>, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                my_listings_async(conn, limit, before_created_at, before_id).await
+            })
+            .await
+    }
+
+    pub async fn market_my_bids(
+        &self,
+        user_id: Uuid,
+        limit: i32,
+        before_placed_at: Option<DateTime<Utc>>,
+        before_id: Option<i64>,
+    ) -> Result<Vec<MarketMyBidRow>> {
+        match self
+            .read_my_bids(user_id, limit, before_placed_at, before_id)
+            .await
+        {
+            Ok(rows) => Ok(rows),
+            Err(WalletError::AccountMissing) => {
+                self.write_my_bids(user_id, limit, before_placed_at, before_id)
+                    .await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn read_my_bids(
+        &self,
+        user_id: Uuid,
+        limit: i32,
+        before_placed_at: Option<DateTime<Utc>>,
+        before_id: Option<i64>,
+    ) -> Result<Vec<MarketMyBidRow>> {
+        let mut conn = self.read().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Vec<MarketMyBidRow>, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                my_bids_async(conn, limit, before_placed_at, before_id).await
+            })
+            .await
+    }
+
+    async fn write_my_bids(
+        &self,
+        user_id: Uuid,
+        limit: i32,
+        before_placed_at: Option<DateTime<Utc>>,
+        before_id: Option<i64>,
+    ) -> Result<Vec<MarketMyBidRow>> {
+        let mut conn = self.write().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Vec<MarketMyBidRow>, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                my_bids_async(conn, limit, before_placed_at, before_id).await
+            })
+            .await
+    }
+
+    // -------------------------------------------------------------------
+    // Write proxies (rw pool only)
+    // -------------------------------------------------------------------
+
+    pub async fn market_create_listing(
+        &self,
+        user_id: Uuid,
+        req: MarketCreateListingRequest,
+    ) -> Result<i64> {
+        let mut conn = self.write().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<i64, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                let row: ScalarBigInt = sql_query(
+                    "SELECT public.proxy_market_create_listing($1, $2, $3, $4, $5) AS value",
+                )
+                .bind::<Jsonb, _>(req.item_ref)
+                .bind::<Nullable<BigInt>, _>(req.buy_now_price)
+                .bind::<Nullable<BigInt>, _>(req.min_bid)
+                .bind::<Timestamptz, _>(req.expires_at)
+                .bind::<diesel::sql_types::Uuid, _>(req.idempotency_key)
+                .get_result(conn)
+                .await
+                .map_err(WalletError::from_diesel)?;
+                Ok(row.value)
+            })
+            .await
+    }
+
+    pub async fn market_place_bid(&self, user_id: Uuid, req: MarketPlaceBidRequest) -> Result<i64> {
+        let mut conn = self.write().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<i64, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                let row: ScalarBigInt =
+                    sql_query("SELECT public.proxy_market_place_bid($1, $2, $3) AS value")
+                        .bind::<BigInt, _>(req.listing_id)
+                        .bind::<BigInt, _>(req.amount)
+                        .bind::<diesel::sql_types::Uuid, _>(req.idempotency_key)
+                        .get_result(conn)
+                        .await
+                        .map_err(WalletError::from_diesel)?;
+                Ok(row.value)
+            })
+            .await
+    }
+
+    pub async fn market_buy_now(&self, user_id: Uuid, req: MarketBuyNowRequest) -> Result<i64> {
+        let mut conn = self.write().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<i64, WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                let row: ScalarBigInt =
+                    sql_query("SELECT public.proxy_market_buy_now($1, $2) AS value")
+                        .bind::<BigInt, _>(req.listing_id)
+                        .bind::<diesel::sql_types::Uuid, _>(req.idempotency_key)
+                        .get_result(conn)
+                        .await
+                        .map_err(WalletError::from_diesel)?;
+                Ok(row.value)
+            })
+            .await
+    }
+
+    pub async fn market_cancel_listing(
+        &self,
+        user_id: Uuid,
+        req: MarketCancelListingRequest,
+    ) -> Result<()> {
+        let mut conn = self.write().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<(), WalletError, _>(async |conn| {
+                set_user_claims(conn, user_id).await?;
+                sql_query("SELECT public.proxy_market_cancel_listing($1, $2)")
+                    .bind::<BigInt, _>(req.listing_id)
+                    .bind::<Nullable<Text>, _>(req.reason)
+                    .execute(conn)
+                    .await
+                    .map_err(WalletError::from_diesel)?;
+                Ok(())
+            })
+            .await
+    }
+}
+
+async fn my_listings_async(
+    conn: &mut AsyncPgConnection,
+    limit: i32,
+    before_created_at: Option<DateTime<Utc>>,
+    before_id: Option<i64>,
+) -> Result<Vec<MarketMyListingRow>> {
+    let rows: Vec<MyListingRowDb> = sql_query(
+        "SELECT listing_id, item_ref, currency::text AS currency, \
+                buy_now_price, min_bid, current_bid, current_bid_account, \
+                buyer_account, listing_status::text AS listing_status, \
+                expires_at, created_at, settled_at \
+         FROM public.proxy_market_my_listings_readonly($1, $2, $3)",
+    )
+    .bind::<diesel::sql_types::Integer, _>(limit)
+    .bind::<Nullable<Timestamptz>, _>(before_created_at)
+    .bind::<Nullable<BigInt>, _>(before_id)
+    .get_results(conn)
+    .await
+    .map_err(WalletError::from_diesel)?;
+    rows.into_iter().map(map_my_listing).collect()
+}
+
+async fn my_bids_async(
+    conn: &mut AsyncPgConnection,
+    limit: i32,
+    before_placed_at: Option<DateTime<Utc>>,
+    before_id: Option<i64>,
+) -> Result<Vec<MarketMyBidRow>> {
+    let rows: Vec<MyBidRowDb> = sql_query(
+        "SELECT bid_id, listing_id, amount, bid_status::text AS bid_status, \
+                placed_at, settled_at, escrow_ledger_id, refund_ledger_id \
+         FROM public.proxy_market_my_bids_readonly($1, $2, $3)",
+    )
+    .bind::<diesel::sql_types::Integer, _>(limit)
+    .bind::<Nullable<Timestamptz>, _>(before_placed_at)
+    .bind::<Nullable<BigInt>, _>(before_id)
+    .get_results(conn)
+    .await
+    .map_err(WalletError::from_diesel)?;
+    rows.into_iter().map(map_my_bid).collect()
+}

--- a/packages/rust/kbve/src/wallet/mod.rs
+++ b/packages/rust/kbve/src/wallet/mod.rs
@@ -29,6 +29,7 @@
 
 pub mod client;
 pub mod error;
+pub mod market;
 pub mod proxy;
 pub mod service;
 pub mod types;

--- a/packages/rust/kbve/src/wallet/tests.rs
+++ b/packages/rust/kbve/src/wallet/tests.rs
@@ -10,9 +10,11 @@ use serial_test::serial;
 use uuid::Uuid;
 
 use super::{
-    CouponStatus, CreditRequest, CurrencyKind, DebitRequest, RewardKind, SourceKind,
-    TransferRequest, WalletClient, WalletError,
+    BidStatus, CouponStatus, CreditRequest, CurrencyKind, DebitRequest, ListingStatus,
+    MarketBuyNowRequest, MarketCancelListingRequest, MarketCreateListingRequest,
+    MarketPlaceBidRequest, RewardKind, SourceKind, TransferRequest, WalletClient, WalletError,
 };
+use chrono::{Duration, Utc};
 
 const TEST_URL_ENV: &str = "WALLET_TEST_DATABASE_URL";
 
@@ -328,4 +330,273 @@ async fn null_currency_raises_null_argument() {
     );
 
     let _ = account;
+}
+
+fn fresh_item_ref() -> serde_json::Value {
+    serde_json::json!({
+        "kind": "test_item",
+        "id": Uuid::new_v4().to_string(),
+        "instance_id": Uuid::new_v4().to_string(),
+    })
+}
+
+async fn credit_khash(client: &WalletClient, account: Uuid, amount: i64) {
+    client
+        .credit(req_credit(account, amount, Uuid::new_v4()))
+        .await
+        .expect("seed khash credit");
+}
+
+#[tokio::test]
+#[serial]
+async fn market_create_listing_replay_returns_same_id() {
+    let Some(client) = client().await else {
+        eprintln!("SKIP: WALLET_TEST_DATABASE_URL unset");
+        return;
+    };
+    let (user, _account) = fixture_account().await.expect("fixture");
+    let key = Uuid::new_v4();
+    let req = MarketCreateListingRequest {
+        item_ref: fresh_item_ref(),
+        buy_now_price: Some(500),
+        min_bid: Some(100),
+        expires_at: Utc::now() + Duration::hours(2),
+        idempotency_key: key,
+    };
+    let id1 = client
+        .market_create_listing(user, req.clone())
+        .await
+        .expect("create");
+    let id2 = client
+        .market_create_listing(user, req)
+        .await
+        .expect("replay");
+    assert_eq!(id1, id2, "replay must return same listing id");
+}
+
+#[tokio::test]
+#[serial]
+async fn market_my_listings_and_browse_include_new_listing() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (user, _account) = fixture_account().await.expect("fixture");
+    let req = MarketCreateListingRequest {
+        item_ref: fresh_item_ref(),
+        buy_now_price: Some(750),
+        min_bid: Some(50),
+        expires_at: Utc::now() + Duration::hours(2),
+        idempotency_key: Uuid::new_v4(),
+    };
+    let listing_id = client
+        .market_create_listing(user, req)
+        .await
+        .expect("create");
+
+    let mine = client
+        .market_my_listings(user, 25, None, None)
+        .await
+        .expect("my listings");
+    assert!(
+        mine.iter().any(|r| r.listing_id == listing_id),
+        "my listings missing newly-created id"
+    );
+    let row = mine
+        .iter()
+        .find(|r| r.listing_id == listing_id)
+        .expect("row");
+    assert!(matches!(row.listing_status, ListingStatus::Active));
+
+    let active = client
+        .market_list_active(100, None, None)
+        .await
+        .expect("browse");
+    assert!(
+        active.iter().any(|r| r.listing_id == listing_id),
+        "browse missing new listing"
+    );
+
+    let detail = client
+        .market_listing_detail(listing_id)
+        .await
+        .expect("detail");
+    assert_eq!(detail.listing_id, listing_id);
+    assert!(matches!(detail.listing_status, ListingStatus::Active));
+}
+
+#[tokio::test]
+#[serial]
+async fn market_place_bid_outbid_refunds_previous_bidder() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (seller, _) = fixture_account().await.expect("seller");
+    let (bidder_a, account_a) = fixture_account().await.expect("bidder a");
+    let (bidder_b, account_b) = fixture_account().await.expect("bidder b");
+
+    credit_khash(&client, account_a, 5_000).await;
+    credit_khash(&client, account_b, 5_000).await;
+
+    let listing_id = client
+        .market_create_listing(
+            seller,
+            MarketCreateListingRequest {
+                item_ref: fresh_item_ref(),
+                buy_now_price: Some(10_000),
+                min_bid: Some(100),
+                expires_at: Utc::now() + Duration::hours(2),
+                idempotency_key: Uuid::new_v4(),
+            },
+        )
+        .await
+        .expect("create");
+
+    let bid_a = client
+        .market_place_bid(
+            bidder_a,
+            MarketPlaceBidRequest {
+                listing_id,
+                amount: 200,
+                idempotency_key: Uuid::new_v4(),
+            },
+        )
+        .await
+        .expect("bid a");
+
+    let bal_a_after = client.user_balance(bidder_a).await.unwrap();
+    assert_eq!(bal_a_after.khash, 5_000 - 200, "bidder a escrow held");
+
+    let _bid_b = client
+        .market_place_bid(
+            bidder_b,
+            MarketPlaceBidRequest {
+                listing_id,
+                amount: 500,
+                idempotency_key: Uuid::new_v4(),
+            },
+        )
+        .await
+        .expect("bid b");
+
+    let bal_a_refunded = client.user_balance(bidder_a).await.unwrap();
+    assert_eq!(bal_a_refunded.khash, 5_000, "bidder a refunded on outbid");
+    let bal_b_after = client.user_balance(bidder_b).await.unwrap();
+    assert_eq!(bal_b_after.khash, 5_000 - 500, "bidder b escrow held");
+
+    let bids_a = client
+        .market_my_bids(bidder_a, 25, None, None)
+        .await
+        .expect("a bids");
+    let a_row = bids_a
+        .iter()
+        .find(|b| b.bid_id == bid_a)
+        .expect("a bid row");
+    assert!(
+        matches!(a_row.bid_status, BidStatus::Outbid | BidStatus::Refunded),
+        "a bid status: {:?}",
+        a_row.bid_status
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn market_buy_now_pays_seller_minus_fee() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (seller, seller_account) = fixture_account().await.expect("seller");
+    let (buyer, buyer_account) = fixture_account().await.expect("buyer");
+    credit_khash(&client, buyer_account, 10_000).await;
+
+    let listing_id = client
+        .market_create_listing(
+            seller,
+            MarketCreateListingRequest {
+                item_ref: fresh_item_ref(),
+                buy_now_price: Some(1_000),
+                min_bid: Some(50),
+                expires_at: Utc::now() + Duration::hours(2),
+                idempotency_key: Uuid::new_v4(),
+            },
+        )
+        .await
+        .expect("create");
+
+    let _bid_id = client
+        .market_buy_now(
+            buyer,
+            MarketBuyNowRequest {
+                listing_id,
+                idempotency_key: Uuid::new_v4(),
+            },
+        )
+        .await
+        .expect("buy_now");
+
+    let seller_bal = client.user_balance(seller).await.unwrap();
+    assert_eq!(
+        seller_bal.khash, 990,
+        "seller paid out 1000 - 1% fee = 990 khash"
+    );
+    let buyer_bal = client.user_balance(buyer).await.unwrap();
+    assert_eq!(buyer_bal.khash, 9_000, "buyer paid 1000 khash");
+
+    let detail = client.market_listing_detail(listing_id).await.unwrap();
+    assert!(matches!(detail.listing_status, ListingStatus::Sold));
+
+    let _ = (seller_account, buyer_account);
+}
+
+#[tokio::test]
+#[serial]
+async fn market_cancel_listing_refunds_active_bidder() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (seller, _) = fixture_account().await.expect("seller");
+    let (bidder, bidder_account) = fixture_account().await.expect("bidder");
+    credit_khash(&client, bidder_account, 5_000).await;
+
+    let listing_id = client
+        .market_create_listing(
+            seller,
+            MarketCreateListingRequest {
+                item_ref: fresh_item_ref(),
+                buy_now_price: Some(10_000),
+                min_bid: Some(100),
+                expires_at: Utc::now() + Duration::hours(2),
+                idempotency_key: Uuid::new_v4(),
+            },
+        )
+        .await
+        .expect("create");
+
+    client
+        .market_place_bid(
+            bidder,
+            MarketPlaceBidRequest {
+                listing_id,
+                amount: 250,
+                idempotency_key: Uuid::new_v4(),
+            },
+        )
+        .await
+        .expect("bid");
+
+    client
+        .market_cancel_listing(
+            seller,
+            MarketCancelListingRequest {
+                listing_id,
+                reason: Some("test cancel".into()),
+            },
+        )
+        .await
+        .expect("cancel");
+
+    let bal = client.user_balance(bidder).await.unwrap();
+    assert_eq!(bal.khash, 5_000, "bidder fully refunded on cancel");
+
+    let detail = client.market_listing_detail(listing_id).await.unwrap();
+    assert!(matches!(detail.listing_status, ListingStatus::Cancelled));
 }

--- a/packages/rust/kbve/src/wallet/types.rs
+++ b/packages/rust/kbve/src/wallet/types.rs
@@ -119,6 +119,27 @@ pg_text_enum! {
     }
 }
 
+pg_text_enum! {
+    /// `wallet.listing_status`
+    ListingStatus {
+        Active    => "active",
+        Sold      => "sold",
+        Cancelled => "cancelled",
+        Expired   => "expired",
+    }
+}
+
+pg_text_enum! {
+    /// `wallet.bid_status`
+    BidStatus {
+        Active    => "active",
+        Outbid    => "outbid",
+        Won       => "won",
+        Refunded  => "refunded",
+        Cancelled => "cancelled",
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Request payloads (input to service ops)
 // ---------------------------------------------------------------------------
@@ -191,4 +212,104 @@ pub struct VerifyBalanceRow {
     pub stored_khash: i64,
     pub ledger_khash: i64,
     pub ok: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Marketplace
+// ---------------------------------------------------------------------------
+
+/// Public browse row. Wallet account UUIDs other than the seller are
+/// redacted by the SQL proxy; the wire shape matches
+/// `public.proxy_market_list_active_readonly`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketListingRow {
+    pub listing_id: i64,
+    pub seller_account: Uuid,
+    pub item_ref: serde_json::Value,
+    pub currency: CurrencyKind,
+    pub buy_now_price: Option<i64>,
+    pub min_bid: Option<i64>,
+    pub current_bid: Option<i64>,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Detail view including up to 50 most recent bids as a JSONB array.
+/// Bidder UUIDs + settled_at + ledger ids are redacted by the SQL proxy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketListingDetail {
+    pub listing_id: i64,
+    pub seller_account: Uuid,
+    pub item_ref: serde_json::Value,
+    pub currency: CurrencyKind,
+    pub buy_now_price: Option<i64>,
+    pub min_bid: Option<i64>,
+    pub current_bid: Option<i64>,
+    pub current_bid_id: Option<i64>,
+    pub listing_status: ListingStatus,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub settled_at: Option<DateTime<Utc>>,
+    pub bids: serde_json::Value,
+}
+
+/// Seller-scoped listing row. Authenticated only; can carry
+/// current_bid_account + buyer_account since the caller owns the row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketMyListingRow {
+    pub listing_id: i64,
+    pub item_ref: serde_json::Value,
+    pub currency: CurrencyKind,
+    pub buy_now_price: Option<i64>,
+    pub min_bid: Option<i64>,
+    pub current_bid: Option<i64>,
+    pub current_bid_account: Option<Uuid>,
+    pub buyer_account: Option<Uuid>,
+    pub listing_status: ListingStatus,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub settled_at: Option<DateTime<Utc>>,
+}
+
+/// Bidder-scoped bid row. Authenticated only.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketMyBidRow {
+    pub bid_id: i64,
+    pub listing_id: i64,
+    pub amount: i64,
+    pub bid_status: BidStatus,
+    pub placed_at: DateTime<Utc>,
+    pub settled_at: Option<DateTime<Utc>>,
+    pub escrow_ledger_id: i64,
+    pub refund_ledger_id: Option<i64>,
+}
+
+/// Write-side request payload for `proxy_market_create_listing`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketCreateListingRequest {
+    pub item_ref: serde_json::Value,
+    pub buy_now_price: Option<i64>,
+    pub min_bid: Option<i64>,
+    pub expires_at: DateTime<Utc>,
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketPlaceBidRequest {
+    pub listing_id: i64,
+    pub amount: i64,
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketBuyNowRequest {
+    pub listing_id: i64,
+    pub idempotency_key: Uuid,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MarketCancelListingRequest {
+    pub listing_id: i64,
+    pub reason: Option<String>,
 }


### PR DESCRIPTION
## Summary
- Adds `WalletClient::market_*` methods covering list/detail/my-listings/my-bids/create/bid/buy-now/cancel against the Phase 3 public proxies. Read paths use the rw/ro split with WLT01 fallback; writes hit the rw pool and set `auth.uid()` claims in-txn.
- Wires the wallet-side surface up to axum-kbve at `/api/v1/market/*` with utoipa schemas, keyset pagination, and anon-callable browse routes.
- 13/13 wallet integration tests pass locally (5 new market_* cases covering replay, escrow/outbid refund, buy-now fee split, and cancel-refund).

## Routes
- `GET  /api/v1/market/listings` — anon, keyset paged
- `GET  /api/v1/market/listings/{id}` — anon, detail + recent bids
- `POST /api/v1/market/listings` — auth, create
- `POST /api/v1/market/listings/{id}/bid` — auth
- `POST /api/v1/market/listings/{id}/buy-now` — auth
- `POST /api/v1/market/listings/{id}/cancel` — auth, seller-only
- `GET  /api/v1/market/me/listings` — auth
- `GET  /api/v1/market/me/bids` — auth

## Tracking
Phase 4 of #10979. Phases 1–3 (schema + RPCs + proxies) are already merged + deployed.

## Test plan
- [ ] `cargo check -p axum-kbve` — clean
- [ ] `WALLET_TEST_DATABASE_URL=... cargo test -p kbve --features wallet wallet::` — 13/13 green
- [ ] CI rust pipeline green
- [ ] Manual smoke once dev runner picks the branch up: `curl /api/v1/market/listings` returns `[]` against a fresh DB

## Follow-up
- Phase 5: Astro UI at `/mc/market` + `/profile/market`