### PR TITLE
feat(firecracker-ctl): per-endpoint VM log tail + dashboard modal

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactDeployPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactDeployPanel.tsx
@@ -13,6 +13,8 @@ import {
 	ExternalLink,
 	Copy,
 	CheckCircle2,
+	FileText,
+	X,
 } from 'lucide-react';
 import { EditorView, basicSetup } from 'codemirror';
 import { keymap } from '@codemirror/view';
@@ -61,10 +63,11 @@ function CopyButton({ value }: CopyButtonProps) {
 interface EndpointRowProps {
 	endpoint: DeployedEndpoint;
 	onStop: (name: string) => void;
+	onLogs: (name: string) => void;
 	stopping: boolean;
 }
 
-function EndpointRow({ endpoint, onStop, stopping }: EndpointRowProps) {
+function EndpointRow({ endpoint, onStop, onLogs, stopping }: EndpointRowProps) {
 	const url = deployService.urlFor(endpoint.name);
 	const publicUrl =
 		endpoint.visibility === 'public'
@@ -132,17 +135,92 @@ function EndpointRow({ endpoint, onStop, stopping }: EndpointRowProps) {
 				</div>
 			</td>
 			<td>
-				<button
-					type="button"
-					onClick={() => onStop(endpoint.name)}
-					disabled={stopping}
-					className="deploy-stop"
-					aria-label={`Stop ${endpoint.name}`}>
-					<Square size={12} />
-					Stop
-				</button>
+				<div className="deploy-row-actions">
+					<button
+						type="button"
+						onClick={() => onLogs(endpoint.name)}
+						className="deploy-logs-btn"
+						aria-label={`Logs for ${endpoint.name}`}>
+						<FileText size={12} />
+						Logs
+					</button>
+					<button
+						type="button"
+						onClick={() => onStop(endpoint.name)}
+						disabled={stopping}
+						className="deploy-stop"
+						aria-label={`Stop ${endpoint.name}`}>
+						<Square size={12} />
+						Stop
+					</button>
+				</div>
 			</td>
 		</tr>
+	);
+}
+
+interface LogsModalProps {
+	name: string;
+	token: string;
+	onClose: () => void;
+}
+
+function LogsModal({ name, token, onClose }: LogsModalProps) {
+	const [logs, setLogs] = useState<string>('');
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState<boolean>(true);
+	const preRef = useRef<HTMLPreElement | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		const tick = async () => {
+			try {
+				const text = await deployService.fetchLogs(token, name);
+				if (cancelled) return;
+				setLogs(text);
+				setError(null);
+				setLoading(false);
+				if (preRef.current) {
+					preRef.current.scrollTop = preRef.current.scrollHeight;
+				}
+			} catch (err) {
+				if (cancelled) return;
+				setError(err instanceof Error ? err.message : String(err));
+				setLoading(false);
+			}
+		};
+		void tick();
+		const id = window.setInterval(tick, 2000);
+		return () => {
+			cancelled = true;
+			window.clearInterval(id);
+		};
+	}, [name, token]);
+
+	return (
+		<div className="deploy-logs-overlay" role="dialog" aria-modal="true">
+			<div className="deploy-logs-modal">
+				<header className="deploy-logs-head">
+					<span>
+						<FileText size={14} /> Logs · <code>{name}</code>
+					</span>
+					<button
+						type="button"
+						onClick={onClose}
+						className="deploy-logs-close"
+						aria-label="Close logs">
+						<X size={14} />
+					</button>
+				</header>
+				{loading && !logs && (
+					<p className="deploy-logs-empty">Loading…</p>
+				)}
+				{error && <div className="deploy-error">{error}</div>}
+				<pre ref={preRef} className="deploy-logs-pre">
+					{logs || (loading ? '' : '(no output yet)')}
+				</pre>
+			</div>
+		</div>
 	);
 }
 
@@ -169,6 +247,9 @@ export default function ReactDeployPanel() {
 	const langCompartment = useRef(new Compartment());
 
 	const [stoppingName, setStoppingName] = useState<string | null>(null);
+	const [logsName, setLogsName] = useState<string | null>(null);
+	const handleLogs = useCallback((name: string) => setLogsName(name), []);
+	const handleCloseLogs = useCallback(() => setLogsName(null), []);
 
 	// Mount editor once.
 	useEffect(() => {
@@ -489,6 +570,7 @@ export default function ReactDeployPanel() {
 									key={ep.name}
 									endpoint={ep}
 									onStop={handleStop}
+									onLogs={handleLogs}
 									stopping={stoppingName === ep.name}
 								/>
 							))}
@@ -533,7 +615,22 @@ export default function ReactDeployPanel() {
 				.deploy-url-tag--public { background: rgba(34,197,94,0.14); border-color: rgba(34,197,94,0.35); color: rgba(134,239,172,0.95); opacity: 1; }
 				.deploy-tier { font-size: 0.65rem; padding: 0.05rem 0.35rem; border-radius: 0.2rem; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1); opacity: 0.75; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 				.deploy-tier--public { background: rgba(34,197,94,0.14); border-color: rgba(34,197,94,0.35); color: rgba(134,239,172,0.95); opacity: 1; }
+				.deploy-row-actions { display: inline-flex; gap: 0.4rem; align-items: center; }
+				.deploy-logs-btn { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.3rem 0.55rem; border: 1px solid rgba(255,255,255,0.12); border-radius: 0.25rem; background: rgba(255,255,255,0.04); color: inherit; cursor: pointer; font: inherit; font-size: 0.78rem; }
+				.deploy-logs-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; padding: 1rem; z-index: 50; }
+				.deploy-logs-modal { width: min(900px, 100%); max-height: 80vh; display: flex; flex-direction: column; background: #111; border: 1px solid rgba(255,255,255,0.12); border-radius: 0.5rem; overflow: hidden; }
+				.deploy-logs-head { display: flex; justify-content: space-between; align-items: center; padding: 0.5rem 0.8rem; border-bottom: 1px solid rgba(255,255,255,0.08); font-size: 0.85rem; }
+				.deploy-logs-close { background: transparent; border: none; color: inherit; cursor: pointer; padding: 0.2rem; }
+				.deploy-logs-pre { margin: 0; padding: 0.8rem 1rem; overflow: auto; flex: 1; white-space: pre-wrap; word-break: break-word; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.78rem; background: #0a0a0a; }
+				.deploy-logs-empty { padding: 1rem; opacity: 0.6; font-size: 0.85rem; }
 			`}</style>
+			{logsName && token && (
+				<LogsModal
+					name={logsName}
+					token={token}
+					onClose={handleCloseLogs}
+				/>
+			)}
 		</section>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/deployService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/deployService.ts
@@ -380,6 +380,22 @@ class DeployService {
 			this.$error.set(err instanceof Error ? err.message : String(err));
 		}
 	}
+
+	public async fetchLogs(token: string, name: string): Promise<string> {
+		const resp = await fetch(
+			`${FC_BASE}/${encodeURIComponent(name)}/logs`,
+			{
+				method: 'GET',
+				headers: { Authorization: `Bearer ${token}` },
+				signal: AbortSignal.timeout(20000),
+			},
+		);
+		if (!resp.ok) {
+			const text = await resp.text().catch(() => '');
+			throw new Error(`fc ${resp.status}: ${text.slice(0, 300)}`);
+		}
+		return resp.text();
+	}
 }
 
 export const deployService = new DeployService();

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -235,6 +235,48 @@ struct PersistentEndpoint {
     metrics: Arc<EndpointMetrics>,
     /// Idle TTL in seconds. 0 disables auto-teardown.
     idle_ttl_secs: u32,
+    /// Per-endpoint VM stdout/stderr ring buffer. Capped at 256 KiB.
+    logs: Arc<LogRing>,
+}
+
+/// Bounded byte ring backing `GET /fc/{name}/logs`. Drops oldest bytes
+/// when full. Drainer tasks call `push` from the VM stdio reader; readers
+/// snapshot via `bytes`.
+struct LogRing {
+    inner: std::sync::Mutex<std::collections::VecDeque<u8>>,
+    cap: usize,
+}
+
+impl LogRing {
+    const CAP_BYTES: usize = 256 * 1024;
+
+    fn new() -> Self {
+        Self {
+            inner: std::sync::Mutex::new(std::collections::VecDeque::with_capacity(
+                Self::CAP_BYTES,
+            )),
+            cap: Self::CAP_BYTES,
+        }
+    }
+
+    fn push(&self, chunk: &[u8]) {
+        let mut buf = self.inner.lock().expect("poisoned");
+        if chunk.len() >= self.cap {
+            buf.clear();
+            buf.extend(chunk[chunk.len() - self.cap..].iter().copied());
+            return;
+        }
+        let overflow = (buf.len() + chunk.len()).saturating_sub(self.cap);
+        for _ in 0..overflow {
+            buf.pop_front();
+        }
+        buf.extend(chunk.iter().copied());
+    }
+
+    fn snapshot(&self) -> Vec<u8> {
+        let buf = self.inner.lock().expect("poisoned");
+        buf.iter().copied().collect()
+    }
 }
 
 #[derive(Default)]
@@ -1011,14 +1053,24 @@ async fn fc_deploy(
         };
 
     let pid = spawn_result.child.id();
+    let logs = Arc::new(LogRing::new());
 
-    // Spawn a background task that monitors the child process. If it
-    // exits unexpectedly, mark the endpoint as degraded so the proxy
-    // returns 502 with a meaningful message rather than silently timing out.
+    // Drain stdout + stderr into the LogRing while mirroring to ctl-net's
+    // own stdout for the k8s pod log. Without a reader the pipe fills and
+    // stalls the guest mid-boot (#11044).
     {
+        let mut child = spawn_result.child;
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        if let Some(out) = stdout {
+            tokio::spawn(drain_vm_stream(out, logs.clone(), false));
+        }
+        if let Some(err) = stderr {
+            tokio::spawn(drain_vm_stream(err, logs.clone(), true));
+        }
+
         let ps = persistent.clone();
         let name = req.name.clone();
-        let mut child = spawn_result.child;
         let config_path = spawn_result.config_path;
         let socket_path = spawn_result.socket_path;
         let code_path = spawn_result.code_path;
@@ -1056,6 +1108,7 @@ async fn fc_deploy(
         http_config: req.http_config.clone(),
         metrics: Arc::new(EndpointMetrics::default()),
         idle_ttl_secs: req.idle_ttl_secs,
+        logs,
     };
     let info = PersistentEndpointInfo::from(&endpoint);
     persistent.endpoints.insert(req.name.clone(), endpoint);
@@ -1075,6 +1128,33 @@ async fn fc_deploy(
         StatusCode::CREATED,
         Json(serde_json::json!({ "endpoint": info })),
     )
+}
+
+/// Read a VM stdio stream, mirror to ctl-net's own stdout/stderr for the
+/// pod log, and tee into the per-endpoint LogRing for `/fc/{name}/logs`.
+async fn drain_vm_stream<R>(reader: R, logs: Arc<LogRing>, is_stderr: bool)
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
+
+    let mut reader = reader;
+    let mut buf = [0u8; 4096];
+    loop {
+        match reader.read(&mut buf).await {
+            Ok(0) => return,
+            Ok(n) => {
+                logs.push(&buf[..n]);
+                if is_stderr {
+                    let _ = tokio::io::stderr().write_all(&buf[..n]).await;
+                } else {
+                    let _ = tokio::io::stdout().write_all(&buf[..n]).await;
+                }
+            }
+            Err(_) => return,
+        }
+    }
 }
 
 /// Polls the guest health path on 2s cadence. First 2xx flips
@@ -1199,6 +1279,43 @@ async fn fc_get(
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({"error": "endpoint not found", "name": name})),
         ),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/fc/{name}/logs",
+    tag = "persistent",
+    params(("name" = String, Path, description = "Persistent endpoint name")),
+    responses(
+        (status = 200, description = "VM stdout/stderr ring (up to 256 KiB)", content_type = "text/plain"),
+        (status = 404, description = "Endpoint not found"),
+        (status = 503, description = "Persistent endpoints not enabled")
+    )
+)]
+async fn fc_logs(State(state): State<AppState>, Path(name): Path<String>) -> Response {
+    let persistent = match state.persistent.as_ref() {
+        Some(p) => p,
+        None => {
+            let (status, body) = not_enabled();
+            return (status, body).into_response();
+        }
+    };
+    match persistent.endpoints.get(&name) {
+        Some(entry) => {
+            let body = entry.value().logs.snapshot();
+            (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+                body,
+            )
+                .into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "endpoint not found", "name": name})),
+        )
+            .into_response(),
     }
 }
 
@@ -2467,12 +2584,14 @@ async fn spawn_persistent(
         .await
         .map_err(|e| format!("config write failed: {e}"))?;
 
-    // Inherit stdio. `piped()` without a reader fills the 64 KiB pipe
-    // mid-boot and stalls the guest on the next serial write.
+    // Pipe stdio. Drainer tasks (spawned in fc_deploy) read continuously
+    // into the per-endpoint LogRing and mirror to ctl-net's own stdout
+    // so the pod log still carries the VM serial console. Without a
+    // reader the 64 KiB pipe fills mid-boot and stalls the guest.
     let child = tokio::process::Command::new("firecracker")
         .args(["--api-sock", &socket_path, "--config-file", &config_path])
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| format!("firecracker spawn failed: {e}"))?;
 
@@ -2859,6 +2978,7 @@ async fn main() {
         .route("/fc/list", get(fc_list))
         .route("/fc/{name}", get(fc_get))
         .route("/fc/{name}", delete(fc_destroy))
+        .route("/fc/{name}/logs", get(fc_logs))
         .route("/proxy/{name}", axum::routing::any(fc_proxy))
         .route("/proxy/{name}/{*path}", axum::routing::any(fc_proxy))
         // Sibling prefix, not nested. `/proxy/public/{name}` overlapped
@@ -4027,6 +4147,7 @@ mod tests {
             http_config: http_config.clone(),
             metrics: Arc::new(EndpointMetrics::default()),
             idle_ttl_secs: 0,
+            logs: Arc::new(LogRing::new()),
         }
     }
 


### PR DESCRIPTION
## Summary
Eliminates blank-screen guessing during VM boot / app crash by surfacing per-endpoint stdout/stderr without kubectl pod log scraping.

## ctl-net
- \`LogRing\` — 256 KiB bounded byte ring per \`PersistentEndpoint\`. \`push()\` drops oldest bytes on overflow; \`snapshot()\` returns a \`Vec<u8>\` for the HTTP response.
- \`drain_vm_stream\` — async task per stream (stdout + stderr) that mirrors bytes to ctl-net's own stdio (so the k8s pod log still carries boot + app output) and appends to the ring.
- \`spawn_persistent\` reverts to \`Stdio::piped()\`. The #11044 \`Stdio::inherit()\` hack was a workaround for the unread-pipe stall; the drainer keeps the pipe flowing.
- \`GET /fc/{name}/logs\` returns the ring as \`text/plain; charset=utf-8\`. 404 / 503 follow the same shape as the other \`/fc\` routes.

## astro-kbve
- \`deployService.fetchLogs(token, name)\` — single-shot fetch returning text.
- \`Logs\` button on each row in the deploy table; opens a centered modal that polls every 2s and auto-scrolls.

## Test plan
- [ ] Deploy a public python-web endpoint; click \`Logs\` while it's still \`starting\` — modal shows kernel boot + /init + uvicorn startup
- [ ] Hit \`/api/v1/fc/<name>/logs\` directly with curl — returns plain text
- [ ] Kill app inside guest; logs modal shows the crash backtrace
- [ ] No regression on \`kubectl logs firecracker-ctl-net\` — pod log still has the same VM output