### PR TITLE
feat(mc_auth): clickable link in the in-game unlinked-account prompt

### DIFF
--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
@@ -6,6 +6,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.HoverEvent;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import org.slf4j.Logger;
@@ -184,13 +188,30 @@ public final class AuthEventTicker {
         }
     }
 
+    private static final String LINK_URL = "https://kbve.com/mc";
+
     private static void sendLinkPrompt(ServerPlayerEntity player, String username) {
+        MutableText url = Text.literal(LINK_URL)
+                .setStyle(Style.EMPTY
+                        .withFormatting(Formatting.AQUA, Formatting.UNDERLINE)
+                        .withClickEvent(new ClickEvent.OpenUrl(java.net.URI.create(LINK_URL)))
+                        .withHoverEvent(new HoverEvent.ShowText(
+                                Text.literal("Open " + LINK_URL))));
+
+        MutableText command = Text.literal("/link <code>")
+                .setStyle(Style.EMPTY
+                        .withFormatting(Formatting.GOLD, Formatting.UNDERLINE)
+                        .withClickEvent(new ClickEvent.SuggestCommand("/link "))
+                        .withHoverEvent(new HoverEvent.ShowText(
+                                Text.literal("Click to pre-fill /link "))));
+
         player.sendMessage(
                 Text.literal("[KBVE] Your account isn't linked yet. Visit ")
                         .formatted(Formatting.YELLOW)
-                        .append(Text.literal("https://kbve.com/mc").formatted(Formatting.AQUA))
-                        .append(Text.literal(" to get a code, then run ").formatted(Formatting.YELLOW))
-                        .append(Text.literal("/link <code>").formatted(Formatting.GOLD))
+                        .append(url)
+                        .append(Text.literal(" to get a code, then run ")
+                                .formatted(Formatting.YELLOW))
+                        .append(command)
                         .append(Text.literal(".").formatted(Formatting.YELLOW)),
                 false);
     }


### PR DESCRIPTION
## Summary
Today's unlinked-account nag in mc chat prints `https://kbve.com/mc` and `/link <code>` as plain text. Players have to copy-paste the URL into a browser and retype the slash command. This PR wraps both spans with Minecraft text-component click events so a single chat click does the right thing.

## Changes
[`AuthEventTicker.sendLinkPrompt`](apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java):
- `https://kbve.com/mc` → `Style.withClickEvent(new ClickEvent.OpenUrl(...))` + hover tooltip with the destination URL.
- `/link <code>` → `Style.withClickEvent(new ClickEvent.SuggestCommand("/link "))` so clicking pre-fills the chat box with `/link ` (trailing space, cursor right after) — player just pastes the 6-digit code and presses enter.
- Both spans gain an underline so they read as actionable in the scrollback.

## Test plan
- [ ] `gradle compileJava` clean (verified locally).
- [ ] After deploy: join the server with an unlinked account, see the prompt, click the URL → browser opens kbve.com/mc.
- [ ] Click `/link <code>` in chat → chat box opens pre-filled with `/link ` and the cursor positioned after.
- [ ] Hovering either span shows the corresponding tooltip.