### PR TITLE
feat(droid): $staffPermissions persistent atom + sync-bus for worker writes

### DIFF
--- a/apps/kbve/astro-kbve/src/components/user/profile-controller.ts
+++ b/apps/kbve/astro-kbve/src/components/user/profile-controller.ts
@@ -1,14 +1,18 @@
 import {
 	setAuth,
 	AuthPresets,
+	applyStaffFlagFromCache,
+	bootStaffPermissions,
 	clearProfileCache as clearDroidProfileCache,
+	clearStaffPermsCache,
 	fetchAndCacheProfile,
 	getProfileFromCache,
+	installSyncBusListener,
 	readProfileForFastPaint,
 	setProfileCache as setDroidProfileCache,
 	type DroidProfile,
 } from '@kbve/droid';
-import { initSupa, getSupa } from '@/lib/supa';
+import { initSupa, getSupa, SUPABASE_URL, SUPABASE_ANON_KEY } from '@/lib/supa';
 import {
 	bootMinecraftCard,
 	clearMinecraftCardCache,
@@ -80,6 +84,7 @@ function switchState(
 
 function clearProfileCache() {
 	clearDroidProfileCache();
+	clearStaffPermsCache();
 	try {
 		clearMinecraftCardCache();
 	} catch {
@@ -94,22 +99,18 @@ async function fetchProfile(token: string): Promise<ApiProfile | null> {
 // ── Staff permissions check ─────────────────────────────────────────────────
 
 /**
- * Call the Supabase staff_permissions RPC to check if the user has
- * dashboard access. Updates the global $auth flags so dashboard panels
- * (Grafana, ArgoCD, ClickHouse, etc.) become visible.
+ * Boot staff permissions via the droid cache: synchronously apply the
+ * cached bitmask to `$auth` (paints staff-only panels instantly on a
+ * warm cache) and kick off a background refresh that updates the
+ * persistent atom for the next paint.
  */
-async function fetchStaffFlags(_token: string): Promise<void> {
-	try {
-		const supa = getSupa();
-		const data = await supa.rpc('staff_permissions');
-		// data is the integer bitmask from the RPC
-		const perms = typeof data === 'number' ? data : 0;
-		if (perms > 0) {
-			setAuth({ flags: AuthPresets.STAFF });
-		}
-	} catch {
-		// Non-critical — staff panels just won't show
-	}
+function bootStaff(userId: string, token: string): void {
+	bootStaffPermissions({
+		userId,
+		token,
+		apikey: SUPABASE_ANON_KEY,
+		supabaseUrl: SUPABASE_URL,
+	});
 }
 
 // ── Populate profile card slots ─────────────────────────────────────────────
@@ -318,8 +319,8 @@ async function handleSession(session: any) {
 		avatar: session.user.user_metadata?.avatar_url,
 	});
 
-	// Check staff permissions via Supabase RPC (non-blocking for UI)
-	fetchStaffFlags(token).catch(() => {});
+	// Apply cached staff flag synchronously, refresh in background.
+	bootStaff(userId, token);
 
 	// Cache-first for instant display
 	const cached = getProfileFromCache(userId);
@@ -369,6 +370,11 @@ export async function bootProfile() {
 	switchState('loading');
 	wireLogout();
 
+	// Subscribe to the cross-context cache bus so a service worker /
+	// shared worker can push a profile or staff refresh into the
+	// persistent stores. Idempotent — safe to call repeatedly.
+	installSyncBusListener();
+
 	// Fast paint: read session + cached profile straight from localStorage
 	// before awaiting the Supabase SharedWorker init. With a warm cache the
 	// profile card paints in tens of ms instead of the multi-second
@@ -376,10 +382,31 @@ export async function bootProfile() {
 	const fastPaint = readProfileForFastPaint();
 	let painted = false;
 	if (fastPaint && fastPaint.profile.username) {
+		const fpUserId = fastPaint.session.user?.id;
 		populateProfile(fastPaint.profile, fastPaint.session);
 		switchState('profile');
 		painted = true;
-		const fpUserId = fastPaint.session.user?.id;
+		if (fpUserId) {
+			// Paint USER flags immediately so the staff cache can lift them
+			// to STAFF without flicker, then paint cached staff state.
+			setAuth({
+				tone: 'auth',
+				flags: AuthPresets.USER,
+				id: fpUserId,
+				name:
+					((
+						fastPaint.session.user?.user_metadata as
+							| Record<string, unknown>
+							| undefined
+					)?.full_name as string | undefined) ?? '',
+				avatar: (
+					fastPaint.session.user?.user_metadata as
+						| Record<string, unknown>
+						| undefined
+				)?.avatar_url as string | undefined,
+			});
+			applyStaffFlagFromCache(fpUserId);
+		}
 		const fpToken = fastPaint.session.access_token;
 		if (fpUserId && fpToken) {
 			bootMinecraftCard(fpUserId, fpToken).catch(() => {});

--- a/packages/npm/astro/src/auth/bootAuth.ts
+++ b/packages/npm/astro/src/auth/bootAuth.ts
@@ -2,6 +2,8 @@ import {
 	$auth,
 	DroidEvents,
 	AuthPresets,
+	applyStaffFlagFromCache,
+	setStaffPermsCache,
 	type SupabaseGateway,
 } from '@kbve/droid';
 import type { AuthBridge } from './AuthBridge';
@@ -192,6 +194,10 @@ export async function resolveStaffFlag(
 	const state = $auth.get();
 	if (state.tone !== 'auth' || !state.id) return;
 
+	// Cache fast path — apply STAFF synchronously if the bitmask is
+	// still fresh, so the UI doesn't flicker while the RPC is in flight.
+	applyStaffFlagFromCache(state.id);
+
 	try {
 		const session = await gateway.getSession().catch(() => null);
 		const token = session?.session?.access_token;
@@ -220,15 +226,18 @@ export async function resolveStaffFlag(
 
 		const permissions = await res.json();
 		// staff_permissions returns an integer bitmask; any non-zero value means staff
-		if (typeof permissions === 'number' && permissions > 0) {
-			console.log(
-				'[resolveStaffFlag] Staff permissions resolved:',
-				permissions,
-			);
-			$auth.set({
-				...state,
-				flags: AuthPresets.STAFF,
-			});
+		if (typeof permissions === 'number') {
+			setStaffPermsCache(state.id, permissions);
+			if (permissions > 0) {
+				console.log(
+					'[resolveStaffFlag] Staff permissions resolved:',
+					permissions,
+				);
+				$auth.set({
+					...state,
+					flags: AuthPresets.STAFF,
+				});
+			}
 		}
 	} catch {
 		// Staff check failure is non-fatal — user stays at USER flags

--- a/packages/npm/droid/src/lib/state/index.ts
+++ b/packages/npm/droid/src/lib/state/index.ts
@@ -55,3 +55,26 @@ export {
 	type ProfileCacheEnvelope,
 	type ProfileFastPaintResult,
 } from './profile';
+
+export {
+	$staffPermissions,
+	applyStaffFlagFromCache,
+	bootStaffPermissions,
+	clearStaffPermsCache,
+	fetchAndCacheStaffPermissions,
+	fetchStaffPermissionsFromApi,
+	getStaffPermsFromCache,
+	setStaffPermsCache,
+	STAFF_CACHE_TTL_MS,
+	type FetchStaffPermsOptions,
+	type StaffPermsEnvelope,
+} from './staff';
+
+export {
+	broadcastProfileClear,
+	broadcastProfileRefresh,
+	broadcastStaffClear,
+	broadcastStaffRefresh,
+	installSyncBusListener,
+	type SyncBusMessage,
+} from './sync-bus';

--- a/packages/npm/droid/src/lib/state/staff.ts
+++ b/packages/npm/droid/src/lib/state/staff.ts
@@ -1,0 +1,128 @@
+import { persistentAtom } from '@nanostores/persistent';
+import { $auth, setAuth, AuthPresets } from './auth';
+
+export interface StaffPermsEnvelope {
+	bitmask: number;
+	cached_at: number;
+	user_id: string;
+}
+
+const STAFF_CACHE_KEY = 'cache:staff:perms';
+const SUPABASE_DEFAULT_URL = 'https://supabase.kbve.com';
+export const STAFF_CACHE_TTL_MS = 10 * 60 * 1000;
+
+export const $staffPermissions = persistentAtom<StaffPermsEnvelope | null>(
+	STAFF_CACHE_KEY,
+	null,
+	{
+		encode: (value) => JSON.stringify(value),
+		decode: (raw) => {
+			if (!raw || raw === 'null') return null;
+			try {
+				return JSON.parse(raw) as StaffPermsEnvelope;
+			} catch {
+				return null;
+			}
+		},
+	},
+);
+
+export function getStaffPermsFromCache(userId: string): number | null {
+	const entry = $staffPermissions.get();
+	if (!entry) return null;
+	if (entry.user_id !== userId) return null;
+	if (Date.now() - entry.cached_at > STAFF_CACHE_TTL_MS) return null;
+	return entry.bitmask;
+}
+
+export function setStaffPermsCache(userId: string, bitmask: number): void {
+	if (!userId) return;
+	$staffPermissions.set({ bitmask, cached_at: Date.now(), user_id: userId });
+}
+
+export function clearStaffPermsCache(): void {
+	$staffPermissions.set(null);
+}
+
+export interface FetchStaffPermsOptions {
+	token: string;
+	apikey: string;
+	supabaseUrl?: string;
+	signal?: AbortSignal;
+}
+
+export async function fetchStaffPermissionsFromApi(
+	opts: FetchStaffPermsOptions,
+): Promise<number | null> {
+	const base = opts.supabaseUrl ?? SUPABASE_DEFAULT_URL;
+	const res = await fetch(`${base}/rest/v1/rpc/staff_permissions`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${opts.token}`,
+			'Content-Type': 'application/json',
+			apikey: opts.apikey,
+		},
+		body: '{}',
+		signal: opts.signal,
+	});
+	if (!res.ok) return null;
+	try {
+		const data = await res.json();
+		if (typeof data === 'number') return data;
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+export async function fetchAndCacheStaffPermissions(
+	opts: FetchStaffPermsOptions & { userId: string },
+): Promise<number | null> {
+	const bitmask = await fetchStaffPermissionsFromApi(opts);
+	if (bitmask === null) return null;
+	setStaffPermsCache(opts.userId, bitmask);
+	return bitmask;
+}
+
+/**
+ * Apply STAFF flag to `$auth` if the cached staff permissions for
+ * `userId` are non-zero. Returns the bitmask (or null when no cache /
+ * stale / non-matching user).
+ */
+export function applyStaffFlagFromCache(userId: string): number | null {
+	const bitmask = getStaffPermsFromCache(userId);
+	if (bitmask === null) return null;
+	if (bitmask > 0) {
+		const state = $auth.get();
+		if (state.tone === 'auth' && state.id === userId) {
+			setAuth({ flags: AuthPresets.STAFF });
+		}
+	}
+	return bitmask;
+}
+
+/**
+ * Compose: synchronously paint STAFF flag from cache, then refresh in
+ * the background. Caller decides whether to await the returned
+ * promise.
+ */
+export function bootStaffPermissions(opts: {
+	userId: string;
+	token: string;
+	apikey: string;
+	supabaseUrl?: string;
+}): { cachedBitmask: number | null; refresh: Promise<number | null> } {
+	const cachedBitmask = applyStaffFlagFromCache(opts.userId);
+	const refresh = fetchAndCacheStaffPermissions(opts)
+		.then((bitmask) => {
+			if (bitmask !== null && bitmask > 0) {
+				const state = $auth.get();
+				if (state.tone === 'auth' && state.id === opts.userId) {
+					setAuth({ flags: AuthPresets.STAFF });
+				}
+			}
+			return bitmask;
+		})
+		.catch(() => null);
+	return { cachedBitmask, refresh };
+}

--- a/packages/npm/droid/src/lib/state/sync-bus.ts
+++ b/packages/npm/droid/src/lib/state/sync-bus.ts
@@ -1,0 +1,109 @@
+import {
+	clearProfileCache,
+	setProfileCache,
+	type DroidProfile,
+} from './profile';
+import { clearStaffPermsCache, setStaffPermsCache } from './staff';
+
+const CHANNEL_NAME = 'kbve-droid-sync';
+
+export type SyncBusMessage =
+	| { type: 'profile-refresh'; profile: DroidProfile }
+	| { type: 'profile-clear' }
+	| {
+			type: 'staff-refresh';
+			user_id: string;
+			bitmask: number;
+	  }
+	| { type: 'staff-clear' };
+
+let channel: BroadcastChannel | null = null;
+let installed = false;
+
+function getChannel(): BroadcastChannel | null {
+	if (typeof BroadcastChannel === 'undefined') return null;
+	if (!channel) {
+		try {
+			channel = new BroadcastChannel(CHANNEL_NAME);
+		} catch {
+			channel = null;
+		}
+	}
+	return channel;
+}
+
+/**
+ * Subscribe to cross-context cache refresh messages. The service
+ * worker / shared worker / other tabs can post `SyncBusMessage`
+ * values to update the persistent stores. localStorage `storage`
+ * events already handle cross-tab sync for the persistentAtom
+ * itself; this bus exists so workers (which have no localStorage)
+ * can drive writes through.
+ */
+const noop = (): void => {
+	/* no-op cleanup */
+};
+
+export function installSyncBusListener(): () => void {
+	if (installed) return noop;
+	const bc = getChannel();
+	if (!bc) return noop;
+	installed = true;
+
+	const onMessage = (event: MessageEvent<SyncBusMessage>) => {
+		const msg = event.data;
+		if (!msg || typeof msg !== 'object') return;
+		switch (msg.type) {
+			case 'profile-refresh':
+				if (msg.profile?.user_id) setProfileCache(msg.profile);
+				break;
+			case 'profile-clear':
+				clearProfileCache();
+				break;
+			case 'staff-refresh':
+				if (msg.user_id && typeof msg.bitmask === 'number') {
+					setStaffPermsCache(msg.user_id, msg.bitmask);
+				}
+				break;
+			case 'staff-clear':
+				clearStaffPermsCache();
+				break;
+		}
+	};
+
+	bc.addEventListener('message', onMessage);
+
+	return () => {
+		bc.removeEventListener('message', onMessage);
+		installed = false;
+	};
+}
+
+export function broadcastProfileRefresh(profile: DroidProfile): void {
+	if (!profile?.user_id) return;
+	getChannel()?.postMessage({
+		type: 'profile-refresh',
+		profile,
+	} satisfies SyncBusMessage);
+}
+
+export function broadcastProfileClear(): void {
+	getChannel()?.postMessage({
+		type: 'profile-clear',
+	} satisfies SyncBusMessage);
+}
+
+export function broadcastStaffRefresh(userId: string, bitmask: number): void {
+	if (!userId) return;
+	getChannel()?.postMessage({
+		type: 'staff-refresh',
+		user_id: userId,
+		bitmask,
+	} satisfies SyncBusMessage);
+}
+
+export function broadcastStaffClear(): void {
+	getChannel()?.postMessage({
+		type: 'staff-clear',
+	} satisfies SyncBusMessage);
+}


### PR DESCRIPTION
## Summary
Follow-up to #11078. Two adjacent droid-level pieces:

1. **\`$staffPermissions\` persistent atom** — same fast-paint pattern \`$profileCache\` got, applied to the other RPC on the \`/profile/\` critical path. Closes the lingering CORS-adjacent path that #11075 fixed by also caching the result so the post-CORS-fix RPC only runs in the background.
2. **\`sync-bus\` (\`BroadcastChannel\`-backed write bus)** — a writer surface so a service worker / shared worker can push profile or staff refreshes into the persistent stores without needing localStorage access (workers can't touch localStorage directly).

## Droid changes

\`lib/state/staff.ts\` (new):
- \`$staffPermissions\` — \`persistentAtom\` over \`cache:staff:perms\`, 10-min TTL.
- \`getStaffPermsFromCache\` / \`setStaffPermsCache\` / \`clearStaffPermsCache\`.
- \`fetchStaffPermissionsFromApi({token, apikey, supabaseUrl})\` — direct \`fetch\` against \`/rest/v1/rpc/staff_permissions\` (drops the worker hop entirely, returns the bitmask).
- \`applyStaffFlagFromCache(userId)\` — lifts \`$auth\` to STAFF synchronously when the cached bitmask is fresh + non-zero + user matches.
- \`bootStaffPermissions(...)\` — paint from cache + background refresh in one call.

\`lib/state/sync-bus.ts\` (new):
- \`installSyncBusListener()\` — idempotent main-thread subscriber on \`BroadcastChannel('kbve-droid-sync')\`. Maps \`{type: 'profile-refresh' | 'profile-clear' | 'staff-refresh' | 'staff-clear', ...}\` payloads to \`setProfileCache\` / \`clearProfileCache\` / \`setStaffPermsCache\` / \`clearStaffPermsCache\`.
- \`broadcastProfileRefresh\` / \`broadcastStaffRefresh\` / \`broadcastProfileClear\` / \`broadcastStaffClear\` — emitters callable from any context. localStorage \`storage\` events already handle cross-tab sync among main threads; this bus exists for the worker-to-main direction.

All exported through \`lib/state/index.ts\` → \`@kbve/droid\` root.

## astro-kbve — \`profile-controller.ts\`
- \`installSyncBusListener()\` once on \`bootProfile()\`.
- Fast-paint pass now also calls \`applyStaffFlagFromCache(userId)\` straight after \`populateProfile\`, so staff dashboards (Grafana, Argo, ClickHouse) appear before \`initSupa()\` resolves on a warm cache.
- \`fetchStaffFlags()\` → \`bootStaff(userId, token)\` — thin wrapper around droid's \`bootStaffPermissions\`.
- Logout / unauth clears both stores.

## astro pkg — \`bootAuth.resolveStaffFlag\`
- Reads from cache first (\`applyStaffFlagFromCache\`).
- On a successful RPC, writes the bitmask through \`setStaffPermsCache\` so subsequent paints (this tab and others) skip the round-trip.

## Test plan
- [x] \`./kbve.sh -nx droid:build\` — clean
- [x] \`./kbve.sh -nx droid:test\` — 118/118 pass
- [x] \`./kbve.sh -nx astro:build\` (@kbve/astro) — clean
- [x] \`./kbve.sh -nx astro-kbve:check\` — no new errors (same 1 pre-existing GamingHub error)
- [x] \`./kbve.sh -nx astro-kbve:build\` — clean
- [ ] In prod: open \`/profile/\` with a warm staff cache — Grafana / Argo / CH cards visible before \`initSupa\` completes
- [ ] Open a second tab — staff state syncs automatically via \`storage\` events; profile refreshes in this PR's flow once SW picks up the bus contract (future PR)