### PR TITLE
feat(jedi,rows): shared pipe_prometheus + ROWS /metrics endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-prometheus"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd44522c72edf6a45dfdd73ea201937bdaa8610cdf473151f694900837ab3879"
+dependencies = [
+ "axum 0.8.9",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "matchit 0.8.4",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "pin-project-lite",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+]
+
+[[package]]
 name = "axum-rareicon"
 version = "0.1.3"
 dependencies = [
@@ -8489,6 +8509,7 @@ dependencies = [
  "async-trait",
  "axum 0.8.9",
  "axum-extra",
+ "axum-prometheus",
  "bb8",
  "bb8-postgres",
  "bitflags 2.11.0",
@@ -10136,6 +10157,20 @@ checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
 dependencies = [
  "ahash",
  "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.13.1",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/apps/kube/rows/manifest/rows-deployment.yaml
+++ b/apps/kube/rows/manifest/rows-deployment.yaml
@@ -87,12 +87,17 @@ spec:
                         value: '2000'
                       - name: ROWS_SPINUP_INITIAL_DELAY_MS
                         value: '3000'
+                      - name: METRICS_PORT
+                        value: '4324'
                   ports:
                       - name: http
                         containerPort: 4322
                         protocol: TCP
                       - name: docs
                         containerPort: 4323
+                        protocol: TCP
+                      - name: metrics
+                        containerPort: 4324
                         protocol: TCP
                   resources:
                       requests:
@@ -138,6 +143,10 @@ spec:
         - name: docs
           port: 4323
           targetPort: 4323
+          protocol: TCP
+        - name: metrics
+          port: 4324
+          targetPort: 4324
           protocol: TCP
 ---
 # PodDisruptionBudget — ensure at least 1 pod during rolling updates

--- a/apps/kube/rows/manifest/servicemonitor.yaml
+++ b/apps/kube/rows/manifest/servicemonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+    name: rows-metrics
+    namespace: rows
+    labels:
+        app: rows
+        release: prometheus
+spec:
+    selector:
+        matchLabels:
+            app: rows
+    endpoints:
+        - port: metrics
+          interval: 30s
+          path: /metrics

--- a/apps/rows/Cargo.toml
+++ b/apps/rows/Cargo.toml
@@ -69,7 +69,7 @@ tokio-stream = "0.1"
 rustls = { version = "0.23", features = ["ring"] }
 
 # Workspace path dependencies
-jedi = { path = "../../packages/rust/jedi" }
+jedi = { path = "../../packages/rust/jedi", features = ["prometheus"] }
 kbve = { path = "../../packages/rust/kbve" }
 
 [build-dependencies]

--- a/apps/rows/src/main.rs
+++ b/apps/rows/src/main.rs
@@ -148,17 +148,31 @@ async fn main() -> anyhow::Result<()> {
     // WebSocket routes
     let ws_router = ws::router(svc);
 
-    // Multiplex: gRPC + REST + WebSocket on single port (public)
+    let (prom_layer, prom_handle) = jedi::entity::pipe_prometheus::build_metrics_layer("rows");
+
     let app = rest_router
         .merge(ws_router)
         .merge(grpc_router.into_axum_router())
+        .layer(prom_layer)
         .layer(axum::middleware::from_fn(trace::request_trace))
         .layer(TimeoutLayer::with_status_code(
             http::StatusCode::GATEWAY_TIMEOUT,
             std::time::Duration::from_secs(90),
-        )) // 90s global request timeout → 504
-        .layer(RequestBodyLimitLayer::new(10 * 1024 * 1024)) // 10MB max body
+        ))
+        .layer(RequestBodyLimitLayer::new(10 * 1024 * 1024))
         .layer(CorsLayer::permissive());
+
+    let metrics_port: u16 = std::env::var("METRICS_PORT")
+        .unwrap_or_else(|_| "4324".into())
+        .parse()
+        .unwrap_or(4324);
+    tokio::spawn(jedi::entity::pipe_prometheus::serve_metrics(
+        jedi::entity::pipe_prometheus::MetricsConfig {
+            service_name: "rows",
+            port: metrics_port,
+        },
+        prom_handle,
+    ));
 
     // Swagger UI on internal-only port (not exposed via HTTPRoute/gateway)
     let docs_port: u16 = std::env::var("DOCS_PORT")

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -81,9 +81,12 @@ regex = "1.10.3"
 once_cell = "1.21.1"
 # ClickHouse (optional)
 clickhouse = { version = "0.14", optional = true }
+# Prometheus metrics (optional)
+axum-prometheus = { version = "0.10", optional = true }
 
 [features]
 default = []
 clickhouse = ["dep:clickhouse"]
+prometheus = ["dep:axum-prometheus"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/rust/jedi/src/entity/mod.rs
+++ b/packages/rust/jedi/src/entity/mod.rs
@@ -8,6 +8,8 @@ pub mod hash;
 pub mod pipe;
 #[cfg(feature = "clickhouse")]
 pub mod pipe_clickhouse;
+#[cfg(feature = "prometheus")]
+pub mod pipe_prometheus;
 pub mod pipe_redis;
 pub mod regex;
 pub mod serde_arc_str;

--- a/packages/rust/jedi/src/entity/pipe_prometheus/mod.rs
+++ b/packages/rust/jedi/src/entity/pipe_prometheus/mod.rs
@@ -1,0 +1,110 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{Router, extract::State, response::IntoResponse, routing::get};
+use axum_prometheus::{
+    AXUM_HTTP_REQUESTS_DURATION_SECONDS, PrometheusMetricLayer, PrometheusMetricLayerBuilder,
+    metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle},
+};
+use tokio::net::TcpListener;
+use tracing::{info, warn};
+
+const DEFAULT_BUCKETS: &[f64] = &[
+    0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+pub struct MetricsConfig {
+    pub service_name: &'static str,
+    pub port: u16,
+}
+
+#[derive(Clone)]
+pub struct MetricsState {
+    pub handle: Arc<PrometheusHandle>,
+}
+
+pub fn build_metrics_layer(
+    service_name: &'static str,
+) -> (PrometheusMetricLayer<'static>, PrometheusHandle) {
+    PrometheusMetricLayerBuilder::new()
+        .with_metrics_from_fn(|| {
+            PrometheusBuilder::new()
+                .set_buckets_for_metric(
+                    Matcher::Full(AXUM_HTTP_REQUESTS_DURATION_SECONDS.to_string()),
+                    DEFAULT_BUCKETS,
+                )
+                .expect("histogram bucket matcher must accept the axum duration metric name")
+                .add_global_label("service", service_name)
+                .install_recorder()
+                .expect("prometheus recorder must install exactly once per process")
+        })
+        .build_pair()
+}
+
+pub fn metrics_router(handle: PrometheusHandle) -> Router {
+    let state = MetricsState {
+        handle: Arc::new(handle),
+    };
+    Router::new()
+        .route("/metrics", get(render_metrics))
+        .route("/health", get(metrics_health))
+        .with_state(state)
+}
+
+async fn render_metrics(State(state): State<MetricsState>) -> impl IntoResponse {
+    let body = state.handle.render();
+    (
+        [("Content-Type", "text/plain; version=0.0.4; charset=utf-8")],
+        body,
+    )
+}
+
+async fn metrics_health() -> impl IntoResponse {
+    (axum::http::StatusCode::OK, "ok")
+}
+
+pub async fn serve_metrics(config: MetricsConfig, handle: PrometheusHandle) {
+    let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
+    let router = metrics_router(handle);
+    match TcpListener::bind(addr).await {
+        Ok(listener) => {
+            info!(
+                "{} metrics endpoint listening on http://{}/metrics",
+                config.service_name, addr
+            );
+            if let Err(e) = axum::serve(listener, router).await {
+                warn!("{} metrics server error: {e}", config.service_name);
+            }
+        }
+        Err(e) => {
+            warn!(
+                "{} metrics endpoint failed to bind {}: {e}",
+                config.service_name, addr
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn builds_layer_and_renders_empty_metrics() {
+        let (_layer, handle) = build_metrics_layer("test-service");
+        let rendered = handle.render();
+        assert!(rendered.contains("# TYPE") || rendered.is_empty());
+    }
+
+    #[test]
+    fn default_buckets_are_monotonic() {
+        let mut prev = 0.0;
+        for &b in DEFAULT_BUCKETS {
+            assert!(
+                b > prev,
+                "buckets must be strictly increasing: {prev} -> {b}"
+            );
+            prev = b;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Thread A of two for observability. Adds a **reusable** Prometheus metrics surface to `jedi` and wires ROWS as the first consumer. Every other axum service in the monorepo adopts with two lines once this lands.

Thread B (Alertmanager → ClickHouse 30d retention, belt-and-suspenders) is a separate PR, in progress.

## The shared module

New: [packages/rust/jedi/src/entity/pipe_prometheus/mod.rs](packages/rust/jedi/src/entity/pipe_prometheus/mod.rs) — mirrors the existing `pipe_clickhouse` / `pipe_redis` namespacing.

```rust
let (layer, handle) = jedi::entity::pipe_prometheus::build_metrics_layer("svc");
app.layer(layer);
tokio::spawn(jedi::entity::pipe_prometheus::serve_metrics(
    jedi::entity::pipe_prometheus::MetricsConfig {
        service_name: "svc",
        port: 4324,
    },
    handle,
));
```

API:
- `build_metrics_layer(service_name)` → `(PrometheusMetricLayer, PrometheusHandle)`
  - 13-bucket histogram (1ms → 10s) bound to `axum_http_requests_duration_seconds`
  - Global `service=<name>` label on every metric
- `metrics_router(handle)` → `axum::Router` serving `GET /metrics` + `GET /health`
- `serve_metrics(config, handle)` → spawnable loop, binds dedicated listener

`axum-prometheus 0.10` lives behind a new `prometheus` Cargo feature on jedi (mirrors the existing `clickhouse` feature pattern). Services opt in via `features = ["prometheus"]`.

## ROWS adoption

- [apps/rows/Cargo.toml](apps/rows/Cargo.toml) — jedi dep gains `features = ["prometheus"]`
- [apps/rows/src/main.rs](apps/rows/src/main.rs) — `.layer(prom_layer)` on the public app; spawned metrics listener on `METRICS_PORT` (default 4324)

## K8s

- [apps/kube/rows/manifest/rows-deployment.yaml](apps/kube/rows/manifest/rows-deployment.yaml) — new `METRICS_PORT` env, `containerPort: 4324` named `metrics`, Service port mapping
- [apps/kube/rows/manifest/servicemonitor.yaml](apps/kube/rows/manifest/servicemonitor.yaml) — new ServiceMonitor scraping the `metrics` port every 30s

## Why a separate port (4324)

The existing HTTPRoute matches `PathPrefix: /` so anything served on 4322 is reachable via `api.chuckrpg.com`. Binding `/metrics` on its own internal-only port keeps scrape data off the public surface without adding HTTPRoute filter rules.

8 files / +193 / -4.

## Verified

- `cargo test -p jedi --features prometheus -- pipe_prometheus` — **2 / 2 passed**
  - `builds_layer_and_renders_empty_metrics`
  - `default_buckets_are_monotonic`
- `cargo check -p jedi --features prometheus` — clean
- `cargo check -p rows` — clean

## What this unlocks

- Real Prometheus histograms for req/s + p50/p95/p99/p999 latency, letting the ROWS telemetry dashboard drop the ClickHouse log-parse path for those panels (Phase C)
- AlertManager rules backed by per-endpoint p95 thresholds
- Dedicated Grafana dashboard with pod metrics + Agones fleet state + ROWS-specific `http_requests` panels
- Trivial adoption by every other axum service (axum-kbve, axum-herbmail, axum-memes, axum-discordsh, axum-rareicon, axum-cryptothrone, axum-chuckrpg, firecracker-ctl, irc-gateway, discordsh-bot)

## Test plan

- [ ] CI green on dev
- [ ] axum-kbve / dispatch picks up jedi change, ROWS image rebuilds with new feature flag
- [ ] After cluster deploy: `kubectl exec -n rows <rows-pod> -- curl localhost:4324/metrics` returns Prometheus exposition with `axum_http_requests_total{service="rows",...}`
- [ ] Prometheus targets list shows `rows-metrics` ServiceMonitor as UP
- [ ] HTTPRoute does NOT expose `/metrics` (4324 not in Service hostnames external to gateway)