### PR TITLE
feat(astro-kbve): marketplace UI at /market + /profile/market (Phase 5)

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -216,6 +216,11 @@ export default defineConfig({
 					items: [{ autogenerate: { directory: 'mc' } }],
 				},
 				{
+					label: 'Marketplace',
+					collapsed: true,
+					items: [{ autogenerate: { directory: 'market' } }],
+				},
+				{
 					label: 'Gaming',
 					collapsed: true,
 					items: [

--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketAccountSummary.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketAccountSummary.astro
@@ -1,0 +1,7 @@
+---
+import MarketAccountSummary from './MarketAccountSummary';
+---
+
+<div class="not-content">
+	<MarketAccountSummary client:only="react" />
+</div>

--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketDetailShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketDetailShell.astro
@@ -1,0 +1,7 @@
+---
+import MarketListingDetail from './MarketListingDetail';
+---
+
+<section class="kbve-market not-content">
+	<MarketListingDetail client:only="react" />
+</section>

--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketProfileShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketProfileShell.astro
@@ -1,0 +1,14 @@
+---
+import MarketProfileShell from './MarketProfileShell';
+---
+
+<section class="kbve-market not-content">
+	<header class="kbve-market__header">
+		<div>
+			<h1>My Marketplace</h1>
+			<p>Your active listings and bids across the KBVE marketplace.</p>
+		</div>
+		<a href="/market/" class="kbve-market__back">← Browse</a>
+	</header>
+	<MarketProfileShell client:only="react" />
+</section>

--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -1,0 +1,415 @@
+---
+import MarketBrowse from './MarketBrowse';
+import MarketCreateForm from './MarketCreateForm';
+---
+
+<section class="kbve-market not-content">
+	<header class="kbve-market__header">
+		<div>
+			<h1>Marketplace</h1>
+			<p>
+				Player-driven listings settled in KHash. A 1% KBVE Treasury fee
+				applies on every sale. Auction bids hold your KHash in escrow
+				until you're outbid or the listing settles.
+			</p>
+		</div>
+	</header>
+
+	<details class="kbve-market__create">
+		<summary>Create a listing</summary>
+		<MarketCreateForm client:only="react" />
+	</details>
+
+	<h2 class="kbve-market__section">Active Listings</h2>
+	<MarketBrowse client:only="react" />
+</section>
+
+<style is:global>
+	.kbve-market {
+		max-width: 960px;
+		margin: 1.25rem auto 4rem;
+		padding: 0 1rem;
+		color: rgba(255, 255, 255, 0.9);
+	}
+	.kbve-market__header {
+		display: grid;
+		gap: 0.5rem;
+		margin-bottom: 1.5rem;
+	}
+	.kbve-market__header h1 {
+		font-size: clamp(1.75rem, 3.5vw, 2.25rem);
+		font-weight: 800;
+		letter-spacing: -0.01em;
+		margin: 0;
+	}
+	.kbve-market__header p {
+		margin: 0;
+		color: rgba(255, 255, 255, 0.65);
+		font-size: 0.95rem;
+		line-height: 1.5;
+	}
+	.kbve-market__section {
+		font-size: 1.25rem;
+		font-weight: 700;
+		margin: 2rem 0 0.75rem;
+	}
+	.kbve-market__create {
+		margin: 1rem 0 1.5rem;
+		padding: 1rem 1.25rem;
+		border-radius: 14px;
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+	}
+	.kbve-market__create summary {
+		cursor: pointer;
+		font-weight: 700;
+		font-size: 1rem;
+	}
+	.kbve-market__list {
+		display: grid;
+		gap: 0.75rem;
+	}
+	.kbve-market__card {
+		display: grid;
+		gap: 0.5rem;
+		padding: 1rem 1.25rem;
+		border-radius: 14px;
+		background: rgba(30, 41, 59, 0.55);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		color: inherit;
+		text-decoration: none;
+		transition:
+			transform 0.15s ease,
+			border-color 0.15s ease;
+	}
+	.kbve-market__card:hover {
+		transform: translateY(-1px);
+		border-color: rgba(96, 165, 250, 0.5);
+	}
+	.kbve-market__card-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 0.75rem;
+	}
+	.kbve-market__card-item {
+		font-weight: 700;
+	}
+	.kbve-market__card-expiry {
+		font-size: 0.85rem;
+		color: rgba(255, 255, 255, 0.55);
+	}
+	.kbve-market__card-prices {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1.25rem;
+		font-size: 0.9rem;
+	}
+	.kbve-market__price {
+		display: grid;
+		gap: 0.1rem;
+	}
+	.kbve-market__price-label {
+		color: rgba(255, 255, 255, 0.5);
+		font-size: 0.75rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+	.kbve-market__price-value {
+		font-weight: 600;
+	}
+	.kbve-market__load-more,
+	.kbve-market__btn,
+	.kbve-market__refresh {
+		padding: 0.55rem 1rem;
+		border-radius: 10px;
+		border: 1px solid rgba(255, 255, 255, 0.15);
+		background: rgba(255, 255, 255, 0.04);
+		color: inherit;
+		font-weight: 600;
+		cursor: pointer;
+		transition: background 0.15s ease;
+	}
+	.kbve-market__btn:hover,
+	.kbve-market__load-more:hover,
+	.kbve-market__refresh:hover {
+		background: rgba(255, 255, 255, 0.08);
+	}
+	.kbve-market__btn:disabled,
+	.kbve-market__load-more:disabled {
+		opacity: 0.55;
+		cursor: not-allowed;
+	}
+	.kbve-market__btn--primary {
+		background: rgba(59, 130, 246, 0.2);
+		border-color: rgba(59, 130, 246, 0.6);
+	}
+	.kbve-market__btn--primary:hover {
+		background: rgba(59, 130, 246, 0.35);
+	}
+	.kbve-market__btn--danger {
+		background: rgba(239, 68, 68, 0.15);
+		border-color: rgba(239, 68, 68, 0.55);
+	}
+	.kbve-market__btn--danger:hover {
+		background: rgba(239, 68, 68, 0.3);
+	}
+	.kbve-market__input {
+		padding: 0.5rem 0.75rem;
+		border-radius: 8px;
+		background: rgba(15, 23, 42, 0.6);
+		border: 1px solid rgba(255, 255, 255, 0.12);
+		color: inherit;
+		font: inherit;
+	}
+	.kbve-market__status {
+		padding: 0.75rem 1rem;
+		border-radius: 10px;
+		background: rgba(255, 255, 255, 0.04);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		font-size: 0.9rem;
+		color: rgba(255, 255, 255, 0.7);
+	}
+	.kbve-market__status--error {
+		background: rgba(239, 68, 68, 0.12);
+		border-color: rgba(239, 68, 68, 0.45);
+		color: rgba(254, 202, 202, 0.95);
+	}
+	.kbve-market__status--ok {
+		background: rgba(34, 197, 94, 0.12);
+		border-color: rgba(34, 197, 94, 0.45);
+		color: rgba(187, 247, 208, 0.95);
+	}
+	.kbve-market__hint {
+		font-size: 0.85rem;
+		color: rgba(255, 255, 255, 0.55);
+		margin: 0.25rem 0 0;
+	}
+	.kbve-market__detail {
+		display: grid;
+		gap: 1.25rem;
+	}
+	.kbve-market__detail-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+	.kbve-market__detail-item {
+		font-size: 1.4rem;
+		font-weight: 800;
+	}
+	.kbve-market__detail-status {
+		margin-top: 0.35rem;
+		display: flex;
+		gap: 0.6rem;
+		align-items: center;
+		color: rgba(255, 255, 255, 0.6);
+		font-size: 0.9rem;
+	}
+	.kbve-market__back {
+		color: rgba(255, 255, 255, 0.65);
+		text-decoration: none;
+		font-weight: 600;
+	}
+	.kbve-market__back:hover {
+		color: white;
+	}
+	.kbve-market__badge {
+		padding: 0.15rem 0.55rem;
+		border-radius: 999px;
+		font-size: 0.75rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		background: rgba(255, 255, 255, 0.08);
+		border: 1px solid rgba(255, 255, 255, 0.15);
+	}
+	.kbve-market__badge--active {
+		background: rgba(34, 197, 94, 0.18);
+		border-color: rgba(34, 197, 94, 0.5);
+		color: rgb(187, 247, 208);
+	}
+	.kbve-market__badge--sold,
+	.kbve-market__badge--won {
+		background: rgba(59, 130, 246, 0.18);
+		border-color: rgba(59, 130, 246, 0.5);
+		color: rgb(191, 219, 254);
+	}
+	.kbve-market__badge--cancelled,
+	.kbve-market__badge--expired,
+	.kbve-market__badge--refunded,
+	.kbve-market__badge--outbid {
+		background: rgba(148, 163, 184, 0.12);
+		border-color: rgba(148, 163, 184, 0.3);
+		color: rgba(226, 232, 240, 0.85);
+	}
+	.kbve-market__detail-prices {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+		gap: 1rem;
+		margin: 0;
+	}
+	.kbve-market__detail-prices > div {
+		padding: 0.85rem 1rem;
+		border-radius: 12px;
+		background: rgba(255, 255, 255, 0.04);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+	}
+	.kbve-market__detail-prices dt {
+		font-size: 0.75rem;
+		color: rgba(255, 255, 255, 0.55);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+	.kbve-market__detail-prices dd {
+		margin: 0.25rem 0 0;
+		font-weight: 700;
+	}
+	.kbve-market__actions {
+		display: grid;
+		gap: 0.75rem;
+		padding: 1rem 1.25rem;
+		border-radius: 12px;
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+	}
+	.kbve-market__bid-row {
+		display: flex;
+		gap: 0.5rem;
+	}
+	.kbve-market__bid-row .kbve-market__input {
+		flex: 1;
+	}
+	.kbve-market__bids ol {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		gap: 0.4rem;
+	}
+	.kbve-market__bids li {
+		display: flex;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		border-radius: 8px;
+		background: rgba(255, 255, 255, 0.02);
+		border: 1px solid rgba(255, 255, 255, 0.06);
+		font-size: 0.9rem;
+	}
+	.kbve-market__bid-meta {
+		color: rgba(255, 255, 255, 0.55);
+		font-size: 0.8rem;
+	}
+	.kbve-market__form {
+		display: grid;
+		gap: 0.75rem;
+		margin-top: 1rem;
+	}
+	.kbve-market__form-row {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+		gap: 0.75rem;
+	}
+	.kbve-market__form label {
+		display: grid;
+		gap: 0.35rem;
+		font-size: 0.85rem;
+		color: rgba(255, 255, 255, 0.7);
+	}
+	.kbve-market__form-actions {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+	.kbve-market__tabs {
+		display: flex;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+		align-items: center;
+	}
+	.kbve-market__tab {
+		padding: 0.45rem 0.95rem;
+		border-radius: 8px;
+		border: 1px solid rgba(255, 255, 255, 0.1);
+		background: transparent;
+		color: rgba(255, 255, 255, 0.65);
+		font-weight: 600;
+		cursor: pointer;
+	}
+	.kbve-market__tab--active {
+		background: rgba(59, 130, 246, 0.18);
+		border-color: rgba(59, 130, 246, 0.5);
+		color: white;
+	}
+	.kbve-market__refresh {
+		margin-left: auto;
+		padding: 0.4rem 0.7rem;
+	}
+	.kbve-market-summary {
+		margin-top: 1rem;
+		padding: 1.25rem;
+		border-radius: 16px;
+		background: linear-gradient(
+			145deg,
+			rgba(30, 41, 59, 0.9) 0%,
+			rgba(15, 23, 42, 0.95) 100%
+		);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		color: rgba(255, 255, 255, 0.9);
+	}
+	.kbve-market-summary__head {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 0.85rem;
+	}
+	.kbve-market-summary__head h2 {
+		margin: 0;
+		font-size: 1.05rem;
+		font-weight: 800;
+		letter-spacing: -0.005em;
+	}
+	.kbve-market-summary__link {
+		color: rgba(96, 165, 250, 0.9);
+		font-weight: 600;
+		text-decoration: none;
+	}
+	.kbve-market-summary__link:hover {
+		color: white;
+	}
+	.kbve-market-summary__grid {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 0.75rem;
+		margin: 0;
+	}
+	.kbve-market-summary__grid > div {
+		padding: 0.6rem 0.75rem;
+		border-radius: 10px;
+		background: rgba(255, 255, 255, 0.04);
+	}
+	.kbve-market-summary__grid dt {
+		font-size: 0.7rem;
+		color: rgba(255, 255, 255, 0.55);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+	.kbve-market-summary__grid dd {
+		margin: 0.25rem 0 0;
+		font-weight: 700;
+		font-size: 1.1rem;
+	}
+	.kbve-market-summary__error {
+		margin-top: 0.75rem;
+		font-size: 0.85rem;
+		color: rgba(254, 202, 202, 0.95);
+	}
+	@media (max-width: 540px) {
+		.kbve-market-summary__grid {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/market/MarketAccountSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketAccountSummary.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { useSession } from '@kbve/astro';
+import { MarketApiError, myBids, myListings } from './api';
+
+type Counts = {
+	activeListings: number;
+	soldListings: number;
+	activeBids: number;
+	wonBids: number;
+};
+
+const EMPTY: Counts = {
+	activeListings: 0,
+	soldListings: 0,
+	activeBids: 0,
+	wonBids: 0,
+};
+
+export function MarketAccountSummary() {
+	const { ready, authenticated } = useSession();
+	const [counts, setCounts] = useState<Counts>(EMPTY);
+	const [error, setError] = useState<string | null>(null);
+	const [loaded, setLoaded] = useState(false);
+
+	useEffect(() => {
+		if (!ready || !authenticated) {
+			setCounts(EMPTY);
+			setLoaded(false);
+			return;
+		}
+		let cancelled = false;
+		(async () => {
+			try {
+				const [ls, bs] = await Promise.all([
+					myListings({ limit: 100 }),
+					myBids({ limit: 100 }),
+				]);
+				if (cancelled) return;
+				setCounts({
+					activeListings: ls.filter(
+						(l) => l.listing_status === 'active',
+					).length,
+					soldListings: ls.filter((l) => l.listing_status === 'sold')
+						.length,
+					activeBids: bs.filter((b) => b.bid_status === 'active')
+						.length,
+					wonBids: bs.filter((b) => b.bid_status === 'won').length,
+				});
+				setError(null);
+				setLoaded(true);
+			} catch (e) {
+				if (!cancelled)
+					setError(
+						e instanceof MarketApiError
+							? e.message
+							: 'market summary failed',
+					);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [ready, authenticated]);
+
+	if (!ready || !authenticated) return null;
+
+	return (
+		<section className="kbve-market-summary">
+			<header className="kbve-market-summary__head">
+				<h2>Marketplace</h2>
+				<a
+					className="kbve-market-summary__link"
+					href="/profile/market/">
+					Open →
+				</a>
+			</header>
+			<dl className="kbve-market-summary__grid">
+				<div>
+					<dt>Active listings</dt>
+					<dd>{loaded ? counts.activeListings : '—'}</dd>
+				</div>
+				<div>
+					<dt>Sold</dt>
+					<dd>{loaded ? counts.soldListings : '—'}</dd>
+				</div>
+				<div>
+					<dt>Active bids</dt>
+					<dd>{loaded ? counts.activeBids : '—'}</dd>
+				</div>
+				<div>
+					<dt>Won</dt>
+					<dd>{loaded ? counts.wonBids : '—'}</dd>
+				</div>
+			</dl>
+			{error && <div className="kbve-market-summary__error">{error}</div>}
+		</section>
+	);
+}
+
+export default MarketAccountSummary;

--- a/apps/kbve/astro-kbve/src/components/market/MarketBrowse.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketBrowse.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useState } from 'react';
+import { listActive, type MarketListing, MarketApiError } from './api';
+import { formatExpiry, formatKhash, itemRefLabel } from './format';
+
+const PAGE_SIZE = 25;
+
+export function MarketBrowse() {
+	const [rows, setRows] = useState<MarketListing[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [hasMore, setHasMore] = useState(false);
+
+	const load = useCallback(async (after?: MarketListing) => {
+		setLoading(true);
+		setError(null);
+		try {
+			const page = await listActive({
+				limit: PAGE_SIZE,
+				before_created_at: after?.created_at ?? null,
+				before_id: after?.listing_id ?? null,
+			});
+			setRows((prev) => (after ? [...prev, ...page] : page));
+			setHasMore(page.length === PAGE_SIZE);
+		} catch (e) {
+			setError(
+				e instanceof MarketApiError
+					? e.message
+					: 'failed to load listings',
+			);
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		void load();
+	}, [load]);
+
+	const loadMore = () => {
+		const tail = rows[rows.length - 1];
+		if (tail) void load(tail);
+	};
+
+	if (loading && rows.length === 0) {
+		return <div className="kbve-market__status">Loading listings…</div>;
+	}
+	if (error && rows.length === 0) {
+		return (
+			<div className="kbve-market__status kbve-market__status--error">
+				{error}
+			</div>
+		);
+	}
+	if (rows.length === 0) {
+		return (
+			<div className="kbve-market__status">
+				No active listings yet. Check back soon.
+			</div>
+		);
+	}
+
+	return (
+		<div className="kbve-market__list">
+			{rows.map((r) => (
+				<a
+					key={r.listing_id}
+					href={`/market/listing/?id=${r.listing_id}`}
+					className="kbve-market__card">
+					<div className="kbve-market__card-head">
+						<span className="kbve-market__card-item">
+							{itemRefLabel(r.item_ref)}
+						</span>
+						<span className="kbve-market__card-expiry">
+							{formatExpiry(r.expires_at)}
+						</span>
+					</div>
+					<div className="kbve-market__card-prices">
+						{r.buy_now_price !== null && (
+							<span className="kbve-market__price">
+								<span className="kbve-market__price-label">
+									Buy Now
+								</span>
+								<span className="kbve-market__price-value">
+									{formatKhash(r.buy_now_price)}
+								</span>
+							</span>
+						)}
+						{(r.current_bid !== null || r.min_bid !== null) && (
+							<span className="kbve-market__price">
+								<span className="kbve-market__price-label">
+									{r.current_bid !== null ? 'Bid' : 'Min Bid'}
+								</span>
+								<span className="kbve-market__price-value">
+									{formatKhash(r.current_bid ?? r.min_bid)}
+								</span>
+							</span>
+						)}
+					</div>
+				</a>
+			))}
+			{hasMore && (
+				<button
+					type="button"
+					className="kbve-market__load-more"
+					onClick={loadMore}
+					disabled={loading}>
+					{loading ? 'Loading…' : 'Load more'}
+				</button>
+			)}
+			{error && (
+				<div className="kbve-market__status kbve-market__status--error">
+					{error}
+				</div>
+			)}
+		</div>
+	);
+}
+
+export default MarketBrowse;

--- a/apps/kbve/astro-kbve/src/components/market/MarketCreateForm.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketCreateForm.tsx
@@ -1,0 +1,186 @@
+import { useState } from 'react';
+import { useSession } from '@kbve/astro';
+import { createListing, MarketApiError } from './api';
+
+const KIND_OPTIONS = [
+	{ value: 'mc_item', label: 'Minecraft item' },
+	{ value: 'rareicon_item', label: 'Rareicon item' },
+	{ value: 'generic', label: 'Other' },
+];
+
+function defaultExpiry(): string {
+	const d = new Date(Date.now() + 1000 * 60 * 60 * 24);
+	d.setSeconds(0, 0);
+	return d.toISOString().slice(0, 16);
+}
+
+export function MarketCreateForm() {
+	const { ready, authenticated } = useSession();
+	const [kind, setKind] = useState('mc_item');
+	const [itemId, setItemId] = useState('');
+	const [instanceId, setInstanceId] = useState('');
+	const [buyNow, setBuyNow] = useState('');
+	const [minBid, setMinBid] = useState('');
+	const [expires, setExpires] = useState(defaultExpiry());
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [success, setSuccess] = useState<number | null>(null);
+
+	if (!ready) return null;
+	if (!authenticated) {
+		return (
+			<div className="kbve-market__status">
+				Sign in to list an item for sale.
+			</div>
+		);
+	}
+
+	const onSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setError(null);
+		setSuccess(null);
+		if (!itemId.trim()) {
+			setError('item id is required');
+			return;
+		}
+		const bn = buyNow.trim() ? Number(buyNow) : null;
+		const mb = minBid.trim() ? Number(minBid) : null;
+		if (bn === null && mb === null) {
+			setError('set a buy-now price or a min bid');
+			return;
+		}
+		if (bn !== null && (!Number.isFinite(bn) || bn <= 0)) {
+			setError('buy-now must be a positive integer');
+			return;
+		}
+		if (mb !== null && (!Number.isFinite(mb) || mb <= 0)) {
+			setError('min bid must be a positive integer');
+			return;
+		}
+		const expiryIso = new Date(expires).toISOString();
+		const item_ref: Record<string, unknown> = { kind, id: itemId.trim() };
+		if (instanceId.trim()) item_ref.instance_id = instanceId.trim();
+		setBusy(true);
+		try {
+			const res = await createListing({
+				item_ref,
+				buy_now_price: bn !== null ? Math.floor(bn) : null,
+				min_bid: mb !== null ? Math.floor(mb) : null,
+				expires_at: expiryIso,
+				idempotency_key: crypto.randomUUID(),
+			});
+			setSuccess(res.id);
+			setItemId('');
+			setInstanceId('');
+			setBuyNow('');
+			setMinBid('');
+		} catch (err) {
+			setError(
+				err instanceof MarketApiError ? err.message : 'create failed',
+			);
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	return (
+		<form className="kbve-market__form" onSubmit={onSubmit}>
+			<div className="kbve-market__form-row">
+				<label>
+					Kind
+					<select
+						value={kind}
+						onChange={(e) => setKind(e.target.value)}
+						className="kbve-market__input">
+						{KIND_OPTIONS.map((k) => (
+							<option key={k.value} value={k.value}>
+								{k.label}
+							</option>
+						))}
+					</select>
+				</label>
+				<label>
+					Item ID
+					<input
+						type="text"
+						required
+						placeholder="diamond_sword"
+						value={itemId}
+						onChange={(e) => setItemId(e.target.value)}
+						className="kbve-market__input"
+					/>
+				</label>
+				<label>
+					Instance ID (optional)
+					<input
+						type="text"
+						placeholder="uuid for unique instances"
+						value={instanceId}
+						onChange={(e) => setInstanceId(e.target.value)}
+						className="kbve-market__input"
+					/>
+				</label>
+			</div>
+			<div className="kbve-market__form-row">
+				<label>
+					Buy Now (KHash)
+					<input
+						type="number"
+						min={1}
+						step={1}
+						value={buyNow}
+						onChange={(e) => setBuyNow(e.target.value)}
+						className="kbve-market__input"
+					/>
+				</label>
+				<label>
+					Min Bid (KHash)
+					<input
+						type="number"
+						min={1}
+						step={1}
+						value={minBid}
+						onChange={(e) => setMinBid(e.target.value)}
+						className="kbve-market__input"
+					/>
+				</label>
+				<label>
+					Expires At
+					<input
+						type="datetime-local"
+						required
+						value={expires}
+						onChange={(e) => setExpires(e.target.value)}
+						className="kbve-market__input"
+					/>
+				</label>
+			</div>
+			<div className="kbve-market__form-actions">
+				<button
+					type="submit"
+					className="kbve-market__btn kbve-market__btn--primary"
+					disabled={busy}>
+					{busy ? 'Listing…' : 'Create Listing'}
+				</button>
+				<span className="kbve-market__hint">
+					1% KBVE Treasury fee applies on sale.
+				</span>
+			</div>
+			{error && (
+				<div className="kbve-market__status kbve-market__status--error">
+					{error}
+				</div>
+			)}
+			{success !== null && (
+				<div className="kbve-market__status kbve-market__status--ok">
+					Listing #{success} created.{' '}
+					<a href={`/market/listing/?id=${success}`}>
+						View listing →
+					</a>
+				</div>
+			)}
+		</form>
+	);
+}
+
+export default MarketCreateForm;

--- a/apps/kbve/astro-kbve/src/components/market/MarketListingDetail.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketListingDetail.tsx
@@ -1,0 +1,318 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getAccessToken, useSession } from '@kbve/astro';
+import {
+	buyNow,
+	cancelListing,
+	listingDetail,
+	placeBid,
+	type MarketListingDetail as MarketListingDetailRow,
+	MarketApiError,
+} from './api';
+import {
+	formatExpiry,
+	formatKhash,
+	formatRelative,
+	itemRefLabel,
+} from './format';
+
+async function fetchMyAccountId(): Promise<string | null> {
+	const token = await getAccessToken();
+	if (!token) return null;
+	const res = await fetch('/api/v1/wallet/me/balance', {
+		headers: { Authorization: `Bearer ${token}` },
+	});
+	if (!res.ok) return null;
+	const b = (await res.json()) as { account_id?: string };
+	return b.account_id ?? null;
+}
+
+function readListingId(): number | null {
+	if (typeof window === 'undefined') return null;
+	const raw = new URLSearchParams(window.location.search).get('id');
+	if (!raw) return null;
+	const n = Number(raw);
+	return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+export function MarketListingDetail() {
+	const { ready, authenticated } = useSession();
+	const [listingId, setListingId] = useState<number | null>(null);
+	const [row, setRow] = useState<MarketListingDetailRow | null>(null);
+	const [myAccount, setMyAccount] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [actionError, setActionError] = useState<string | null>(null);
+	const [actionBusy, setActionBusy] = useState<string | null>(null);
+	const [bidInput, setBidInput] = useState('');
+
+	useEffect(() => {
+		setListingId(readListingId());
+	}, []);
+
+	useEffect(() => {
+		if (!ready || !authenticated) {
+			setMyAccount(null);
+			return;
+		}
+		void fetchMyAccountId().then(setMyAccount);
+	}, [ready, authenticated]);
+
+	const refresh = useCallback(async () => {
+		if (listingId == null) return;
+		setLoading(true);
+		try {
+			const d = await listingDetail(listingId);
+			setRow(d);
+			setError(null);
+		} catch (e) {
+			setError(
+				e instanceof MarketApiError
+					? e.message
+					: 'failed to load listing',
+			);
+		} finally {
+			setLoading(false);
+		}
+	}, [listingId]);
+
+	useEffect(() => {
+		void refresh();
+	}, [refresh]);
+
+	const isSeller = useMemo(() => {
+		if (!row || !myAccount) return false;
+		return row.seller_account === myAccount;
+	}, [row, myAccount]);
+
+	const onBid = async () => {
+		if (!row) return;
+		const amount = Number(bidInput);
+		if (!Number.isFinite(amount) || amount <= 0) {
+			setActionError('bid must be a positive integer');
+			return;
+		}
+		setActionBusy('bid');
+		setActionError(null);
+		try {
+			await placeBid(row.listing_id, {
+				amount: Math.floor(amount),
+				idempotency_key: crypto.randomUUID(),
+			});
+			setBidInput('');
+			await refresh();
+		} catch (e) {
+			setActionError(
+				e instanceof MarketApiError ? e.message : 'bid failed',
+			);
+		} finally {
+			setActionBusy(null);
+		}
+	};
+
+	const onBuyNow = async () => {
+		if (!row) return;
+		setActionBusy('buy');
+		setActionError(null);
+		try {
+			await buyNow(row.listing_id, {
+				idempotency_key: crypto.randomUUID(),
+			});
+			await refresh();
+		} catch (e) {
+			setActionError(
+				e instanceof MarketApiError ? e.message : 'buy-now failed',
+			);
+		} finally {
+			setActionBusy(null);
+		}
+	};
+
+	const onCancel = async () => {
+		if (!row) return;
+		setActionBusy('cancel');
+		setActionError(null);
+		try {
+			await cancelListing(row.listing_id, { reason: null });
+			await refresh();
+		} catch (e) {
+			setActionError(
+				e instanceof MarketApiError ? e.message : 'cancel failed',
+			);
+		} finally {
+			setActionBusy(null);
+		}
+	};
+
+	if (listingId == null) {
+		return (
+			<div className="kbve-market__status">
+				Missing or invalid <code>?id=</code> query parameter.
+			</div>
+		);
+	}
+	if (loading && !row)
+		return <div className="kbve-market__status">Loading listing…</div>;
+	if (error && !row)
+		return (
+			<div className="kbve-market__status kbve-market__status--error">
+				{error}
+			</div>
+		);
+	if (!row) return null;
+
+	const active = row.listing_status === 'active';
+	const minNextBid =
+		(row.current_bid ?? (row.min_bid !== null ? row.min_bid - 1 : 0)) + 1;
+
+	return (
+		<div className="kbve-market__detail">
+			<header className="kbve-market__detail-head">
+				<div>
+					<div className="kbve-market__detail-item">
+						{itemRefLabel(row.item_ref)}
+					</div>
+					<div className="kbve-market__detail-status">
+						<span
+							className={`kbve-market__badge kbve-market__badge--${row.listing_status}`}>
+							{row.listing_status}
+						</span>
+						<span>
+							{active
+								? formatExpiry(row.expires_at)
+								: `closed ${row.settled_at ? formatRelative(row.settled_at) : ''}`}
+						</span>
+					</div>
+				</div>
+				<a href="/market/" className="kbve-market__back">
+					← Browse
+				</a>
+			</header>
+
+			<dl className="kbve-market__detail-prices">
+				<div>
+					<dt>Buy Now</dt>
+					<dd>
+						{row.buy_now_price !== null
+							? formatKhash(row.buy_now_price)
+							: '—'}
+					</dd>
+				</div>
+				<div>
+					<dt>Current Bid</dt>
+					<dd>
+						{row.current_bid !== null
+							? formatKhash(row.current_bid)
+							: '—'}
+					</dd>
+				</div>
+				<div>
+					<dt>Min Bid</dt>
+					<dd>
+						{row.min_bid !== null ? formatKhash(row.min_bid) : '—'}
+					</dd>
+				</div>
+			</dl>
+
+			{ready && authenticated && active && !isSeller && (
+				<div className="kbve-market__actions">
+					<div className="kbve-market__bid-row">
+						<input
+							type="number"
+							min={minNextBid}
+							step={1}
+							placeholder={`min ${minNextBid}`}
+							value={bidInput}
+							onChange={(e) => setBidInput(e.target.value)}
+							className="kbve-market__input"
+						/>
+						<button
+							type="button"
+							className="kbve-market__btn"
+							onClick={() => void onBid()}
+							disabled={actionBusy !== null}>
+							{actionBusy === 'bid' ? 'Bidding…' : 'Place Bid'}
+						</button>
+					</div>
+					{row.buy_now_price !== null && (
+						<button
+							type="button"
+							className="kbve-market__btn kbve-market__btn--primary"
+							onClick={() => void onBuyNow()}
+							disabled={actionBusy !== null}>
+							{actionBusy === 'buy'
+								? 'Buying…'
+								: `Buy Now ${formatKhash(row.buy_now_price)}`}
+						</button>
+					)}
+				</div>
+			)}
+
+			{ready && authenticated && active && isSeller && (
+				<div className="kbve-market__actions">
+					<button
+						type="button"
+						className="kbve-market__btn kbve-market__btn--danger"
+						onClick={() => void onCancel()}
+						disabled={actionBusy !== null}>
+						{actionBusy === 'cancel'
+							? 'Cancelling…'
+							: 'Cancel Listing'}
+					</button>
+					<p className="kbve-market__hint">
+						Cancelling refunds the active high bidder's escrow.
+					</p>
+				</div>
+			)}
+
+			{ready && !authenticated && active && (
+				<div className="kbve-market__status">
+					Sign in to bid or buy.
+				</div>
+			)}
+
+			{actionError && (
+				<div className="kbve-market__status kbve-market__status--error">
+					{actionError}
+				</div>
+			)}
+
+			<section className="kbve-market__bids">
+				<h3>Recent Bids</h3>
+				{Array.isArray(row.bids) && row.bids.length > 0 ? (
+					<ol className="kbve-market__bid-list">
+						{row.bids.slice(0, 25).map((b, i) => {
+							const amount =
+								typeof (b as { amount?: number }).amount ===
+								'number'
+									? (b as { amount: number }).amount
+									: null;
+							const placedAt = (b as { placed_at?: string })
+								.placed_at;
+							const status = (b as { bid_status?: string })
+								.bid_status;
+							return (
+								<li key={i}>
+									<span>
+										{amount !== null
+											? formatKhash(amount)
+											: '—'}
+									</span>
+									<span className="kbve-market__bid-meta">
+										{status ?? 'unknown'} ·{' '}
+										{placedAt
+											? formatRelative(placedAt)
+											: '—'}
+									</span>
+								</li>
+							);
+						})}
+					</ol>
+				) : (
+					<p className="kbve-market__hint">No bids yet.</p>
+				)}
+			</section>
+		</div>
+	);
+}
+
+export default MarketListingDetail;

--- a/apps/kbve/astro-kbve/src/components/market/MarketProfileShell.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketProfileShell.tsx
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useSession } from '@kbve/astro';
+import {
+	MarketApiError,
+	type MyBid,
+	type MyListing,
+	myBids,
+	myListings,
+} from './api';
+import {
+	formatExpiry,
+	formatKhash,
+	formatRelative,
+	itemRefLabel,
+} from './format';
+
+type Tab = 'listings' | 'bids';
+
+export function MarketProfileShell() {
+	const { ready, authenticated } = useSession();
+	const [tab, setTab] = useState<Tab>('listings');
+	const [listings, setListings] = useState<MyListing[]>([]);
+	const [bids, setBids] = useState<MyBid[]>([]);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+
+	const refresh = useCallback(async () => {
+		setLoading(true);
+		setError(null);
+		try {
+			const [ls, bs] = await Promise.all([
+				myListings({ limit: 50 }),
+				myBids({ limit: 50 }),
+			]);
+			setListings(ls);
+			setBids(bs);
+		} catch (e) {
+			setError(
+				e instanceof MarketApiError ? e.message : 'failed to load',
+			);
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (ready && authenticated) void refresh();
+	}, [ready, authenticated, refresh]);
+
+	if (!ready) return null;
+	if (!authenticated) {
+		return (
+			<div className="kbve-market__status">
+				Sign in to view your marketplace activity.
+			</div>
+		);
+	}
+
+	return (
+		<div className="kbve-market__profile">
+			<div className="kbve-market__tabs" role="tablist">
+				<button
+					type="button"
+					role="tab"
+					aria-selected={tab === 'listings'}
+					className={`kbve-market__tab${tab === 'listings' ? ' kbve-market__tab--active' : ''}`}
+					onClick={() => setTab('listings')}>
+					Listings ({listings.length})
+				</button>
+				<button
+					type="button"
+					role="tab"
+					aria-selected={tab === 'bids'}
+					className={`kbve-market__tab${tab === 'bids' ? ' kbve-market__tab--active' : ''}`}
+					onClick={() => setTab('bids')}>
+					Bids ({bids.length})
+				</button>
+				<button
+					type="button"
+					className="kbve-market__refresh"
+					onClick={() => void refresh()}
+					disabled={loading}>
+					{loading ? '…' : '↻'}
+				</button>
+			</div>
+
+			{error && (
+				<div className="kbve-market__status kbve-market__status--error">
+					{error}
+				</div>
+			)}
+
+			{tab === 'listings' && (
+				<div className="kbve-market__list">
+					{listings.length === 0 && !loading && (
+						<div className="kbve-market__status">
+							No listings yet. <a href="/market/">Create one →</a>
+						</div>
+					)}
+					{listings.map((r) => (
+						<a
+							key={r.listing_id}
+							href={`/market/listing/?id=${r.listing_id}`}
+							className="kbve-market__card">
+							<div className="kbve-market__card-head">
+								<span className="kbve-market__card-item">
+									{itemRefLabel(r.item_ref)}
+								</span>
+								<span
+									className={`kbve-market__badge kbve-market__badge--${r.listing_status}`}>
+									{r.listing_status}
+								</span>
+							</div>
+							<div className="kbve-market__card-prices">
+								{r.buy_now_price !== null && (
+									<span className="kbve-market__price">
+										<span className="kbve-market__price-label">
+											Buy Now
+										</span>
+										<span className="kbve-market__price-value">
+											{formatKhash(r.buy_now_price)}
+										</span>
+									</span>
+								)}
+								{r.current_bid !== null && (
+									<span className="kbve-market__price">
+										<span className="kbve-market__price-label">
+											Bid
+										</span>
+										<span className="kbve-market__price-value">
+											{formatKhash(r.current_bid)}
+										</span>
+									</span>
+								)}
+								<span className="kbve-market__card-expiry">
+									{r.listing_status === 'active'
+										? formatExpiry(r.expires_at)
+										: r.settled_at
+											? formatRelative(r.settled_at)
+											: '—'}
+								</span>
+							</div>
+						</a>
+					))}
+				</div>
+			)}
+
+			{tab === 'bids' && (
+				<div className="kbve-market__list">
+					{bids.length === 0 && !loading && (
+						<div className="kbve-market__status">No bids yet.</div>
+					)}
+					{bids.map((b) => (
+						<a
+							key={b.bid_id}
+							href={`/market/listing/?id=${b.listing_id}`}
+							className="kbve-market__card">
+							<div className="kbve-market__card-head">
+								<span className="kbve-market__card-item">
+									Listing #{b.listing_id}
+								</span>
+								<span
+									className={`kbve-market__badge kbve-market__badge--${b.bid_status}`}>
+									{b.bid_status}
+								</span>
+							</div>
+							<div className="kbve-market__card-prices">
+								<span className="kbve-market__price">
+									<span className="kbve-market__price-label">
+										Amount
+									</span>
+									<span className="kbve-market__price-value">
+										{formatKhash(b.amount)}
+									</span>
+								</span>
+								<span className="kbve-market__card-expiry">
+									{formatRelative(b.placed_at)}
+								</span>
+							</div>
+						</a>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+export default MarketProfileShell;

--- a/apps/kbve/astro-kbve/src/components/market/api.ts
+++ b/apps/kbve/astro-kbve/src/components/market/api.ts
@@ -1,0 +1,202 @@
+import { getAccessToken } from '@kbve/astro';
+
+export type MarketListing = {
+	listing_id: number;
+	seller_account: string;
+	item_ref: Record<string, unknown>;
+	currency: string;
+	buy_now_price: number | null;
+	min_bid: number | null;
+	current_bid: number | null;
+	expires_at: string;
+	created_at: string;
+};
+
+export type MarketListingDetail = MarketListing & {
+	current_bid_id: number | null;
+	listing_status: 'active' | 'sold' | 'cancelled' | 'expired';
+	updated_at: string;
+	settled_at: string | null;
+	bids: Array<Record<string, unknown>>;
+};
+
+export type MyListing = {
+	listing_id: number;
+	item_ref: Record<string, unknown>;
+	currency: string;
+	buy_now_price: number | null;
+	min_bid: number | null;
+	current_bid: number | null;
+	current_bid_account: string | null;
+	buyer_account: string | null;
+	listing_status: 'active' | 'sold' | 'cancelled' | 'expired';
+	expires_at: string;
+	created_at: string;
+	settled_at: string | null;
+};
+
+export type MyBid = {
+	bid_id: number;
+	listing_id: number;
+	amount: number;
+	bid_status: 'active' | 'outbid' | 'won' | 'refunded' | 'cancelled';
+	placed_at: string;
+	settled_at: string | null;
+	escrow_ledger_id: number;
+	refund_ledger_id: number | null;
+};
+
+export type IdResponse = { id: number };
+
+export class MarketApiError extends Error {
+	status: number;
+	code?: string;
+	constructor(message: string, status: number, code?: string) {
+		super(message);
+		this.status = status;
+		this.code = code;
+	}
+}
+
+async function parseError(res: Response): Promise<MarketApiError> {
+	let detail = '';
+	let code: string | undefined;
+	try {
+		const txt = await res.text();
+		try {
+			const parsed = JSON.parse(txt);
+			detail = parsed.message || parsed.error || txt;
+			code = parsed.error;
+		} catch {
+			detail = txt;
+		}
+	} catch {}
+	return new MarketApiError(detail || res.statusText, res.status, code);
+}
+
+async function publicGet<T>(path: string): Promise<T> {
+	const res = await fetch(path);
+	if (!res.ok) throw await parseError(res);
+	return (await res.json()) as T;
+}
+
+async function authedFetch<T>(
+	path: string,
+	init: RequestInit = {},
+): Promise<T> {
+	const token = await getAccessToken();
+	if (!token)
+		throw new MarketApiError('not authenticated', 401, 'not_authenticated');
+	const headers = new Headers(init.headers);
+	headers.set('Authorization', `Bearer ${token}`);
+	if (init.body && !headers.has('Content-Type'))
+		headers.set('Content-Type', 'application/json');
+	const res = await fetch(path, { ...init, headers });
+	if (!res.ok) throw await parseError(res);
+	if (res.status === 204) return undefined as T;
+	return (await res.json()) as T;
+}
+
+type Cursor = {
+	limit?: number;
+	before_created_at?: string | null;
+	before_id?: number | null;
+};
+
+function buildQuery(
+	params: Record<string, string | number | null | undefined>,
+): string {
+	const usp = new URLSearchParams();
+	for (const [k, v] of Object.entries(params)) {
+		if (v === null || v === undefined || v === '') continue;
+		usp.set(k, String(v));
+	}
+	const s = usp.toString();
+	return s ? `?${s}` : '';
+}
+
+export function listActive(c: Cursor = {}): Promise<MarketListing[]> {
+	return publicGet<MarketListing[]>(
+		`/api/v1/market/listings${buildQuery({
+			limit: c.limit ?? 25,
+			before_created_at: c.before_created_at,
+			before_id: c.before_id,
+		})}`,
+	);
+}
+
+export function listingDetail(id: number): Promise<MarketListingDetail> {
+	return publicGet<MarketListingDetail>(`/api/v1/market/listings/${id}`);
+}
+
+export function myListings(c: Cursor = {}): Promise<MyListing[]> {
+	return authedFetch<MyListing[]>(
+		`/api/v1/market/me/listings${buildQuery({
+			limit: c.limit ?? 25,
+			before_created_at: c.before_created_at,
+			before_id: c.before_id,
+		})}`,
+	);
+}
+
+export function myBids(
+	c: {
+		limit?: number;
+		before_placed_at?: string | null;
+		before_id?: number | null;
+	} = {},
+): Promise<MyBid[]> {
+	return authedFetch<MyBid[]>(
+		`/api/v1/market/me/bids${buildQuery({
+			limit: c.limit ?? 25,
+			before_placed_at: c.before_placed_at,
+			before_id: c.before_id,
+		})}`,
+	);
+}
+
+export function createListing(body: {
+	item_ref: Record<string, unknown>;
+	buy_now_price: number | null;
+	min_bid: number | null;
+	expires_at: string;
+	idempotency_key: string;
+}): Promise<IdResponse> {
+	return authedFetch<IdResponse>('/api/v1/market/listings', {
+		method: 'POST',
+		body: JSON.stringify(body),
+	});
+}
+
+export function placeBid(
+	listingId: number,
+	body: { amount: number; idempotency_key: string },
+): Promise<IdResponse> {
+	return authedFetch<IdResponse>(`/api/v1/market/listings/${listingId}/bid`, {
+		method: 'POST',
+		body: JSON.stringify(body),
+	});
+}
+
+export function buyNow(
+	listingId: number,
+	body: { idempotency_key: string },
+): Promise<IdResponse> {
+	return authedFetch<IdResponse>(
+		`/api/v1/market/listings/${listingId}/buy-now`,
+		{
+			method: 'POST',
+			body: JSON.stringify(body),
+		},
+	);
+}
+
+export function cancelListing(
+	listingId: number,
+	body: { reason?: string | null },
+): Promise<void> {
+	return authedFetch<void>(`/api/v1/market/listings/${listingId}/cancel`, {
+		method: 'POST',
+		body: JSON.stringify(body),
+	});
+}

--- a/apps/kbve/astro-kbve/src/components/market/format.ts
+++ b/apps/kbve/astro-kbve/src/components/market/format.ts
@@ -1,0 +1,42 @@
+export function formatKhash(n: number | null | undefined): string {
+	if (n === null || n === undefined) return '—';
+	return `${n.toLocaleString()} KHash`;
+}
+
+export function formatRelative(iso: string): string {
+	const diff = Date.now() - new Date(iso).getTime();
+	const sec = Math.round(diff / 1000);
+	if (sec < 60) return `${sec}s ago`;
+	const min = Math.round(sec / 60);
+	if (min < 60) return `${min}m ago`;
+	const hr = Math.round(min / 60);
+	if (hr < 48) return `${hr}h ago`;
+	const day = Math.round(hr / 24);
+	return `${day}d ago`;
+}
+
+export function formatExpiry(iso: string): string {
+	const ms = new Date(iso).getTime() - Date.now();
+	if (ms <= 0) return 'expired';
+	const sec = Math.round(ms / 1000);
+	if (sec < 60) return `${sec}s left`;
+	const min = Math.round(sec / 60);
+	if (min < 60) return `${min}m left`;
+	const hr = Math.round(min / 60);
+	if (hr < 48) return `${hr}h left`;
+	const day = Math.round(hr / 24);
+	return `${day}d left`;
+}
+
+export function itemRefLabel(itemRef: unknown): string {
+	if (!itemRef || typeof itemRef !== 'object') return 'Unknown item';
+	const r = itemRef as Record<string, unknown>;
+	const kind = typeof r.kind === 'string' ? r.kind : '';
+	const id =
+		typeof r.id === 'string' || typeof r.id === 'number'
+			? String(r.id)
+			: '';
+	if (kind && id) return `${kind}:${id}`;
+	if (id) return id;
+	return JSON.stringify(itemRef).slice(0, 64);
+}

--- a/apps/kbve/astro-kbve/src/components/wallet/AccountPage.astro
+++ b/apps/kbve/astro-kbve/src/components/wallet/AccountPage.astro
@@ -1,6 +1,7 @@
 ---
 import AstroWalletCard from '@/components/wallet/AstroWalletCard.astro';
 import AccountSignInFallback from '@/components/wallet/AccountSignInFallback.astro';
+import AstroMarketAccountSummary from '@/components/market/AstroMarketAccountSummary.astro';
 ---
 
 <div class="not-content account-page">
@@ -13,6 +14,7 @@ import AccountSignInFallback from '@/components/wallet/AccountSignInFallback.ast
 	</header>
 
 	<AstroWalletCard />
+	<AstroMarketAccountSummary />
 	<AccountSignInFallback />
 </div>
 

--- a/apps/kbve/astro-kbve/src/content/docs/market/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/market/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Marketplace
+description: |
+    Browse active KBVE marketplace listings, place bids, and buy items
+    settled in KHash. A 1% Treasury fee applies on every sale.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Browse
+    order: 1
+tags:
+    - marketplace
+    - wallet
+    - khash
+---
+
+import AstroMarketShell from '@/components/market/AstroMarketShell.astro';
+
+<AstroMarketShell />

--- a/apps/kbve/astro-kbve/src/content/docs/market/listing.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/market/listing.mdx
@@ -1,0 +1,19 @@
+---
+title: Listing
+description: |
+    KBVE marketplace listing detail — current bid, buy-now price, bid
+    history, and your bid / buy / cancel actions.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    hidden: true
+tags:
+    - marketplace
+    - wallet
+    - khash
+---
+
+import AstroMarketDetailShell from '@/components/market/AstroMarketDetailShell.astro';
+
+<AstroMarketDetailShell />

--- a/apps/kbve/astro-kbve/src/content/docs/profile/market.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/profile/market.mdx
@@ -1,0 +1,20 @@
+---
+title: Marketplace
+description: |
+    Your KBVE marketplace activity — listings you've created and bids
+    you've placed.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Marketplace
+    order: 2
+tags:
+    - tools
+    - marketplace
+    - wallet
+---
+
+import AstroMarketProfileShell from '@/components/market/AstroMarketProfileShell.astro';
+
+<AstroMarketProfileShell />


### PR DESCRIPTION
## Summary
- Wires the axum-kbve marketplace surface (#11079) up to the Astro storefront as a generic `/market` route, plus a caller-scoped `/profile/market` and a Marketplace summary card on `/profile/account`.
- Generic by design: listings carry an `item_ref` JSON (`kind` + `id` + optional `instance_id`), so the same surface serves MC items, Rareicon drops, or anything else once the inventory layer exists.

## Routes
- `GET /market/` — public browse, keyset paged (anon)
- `GET /market/listing/?id=N` — listing detail + bid / buy-now / cancel
- `GET /profile/market/` — my listings + my bids tabs (auth)
- `GET /profile/account/` — adds a Marketplace summary card

## Components
- `format.ts` / `api.ts` — typed clients for all 8 market endpoints
- `MarketBrowse` / `MarketListingDetail` / `MarketCreateForm`
- `MarketProfileShell` — tabs (Listings / Bids)
- `MarketAccountSummary` — small card on `/profile/account`

## Tracking
Phase 5 of #10979. Phase 4 (axum surface) merged via #11079.

## Test plan
- [ ] `nx run astro-kbve:build` — green (5508 pages built locally)
- [ ] CI astro-kbve pipeline green
- [ ] Visual smoke: `/market`, `/market/listing/?id=N`, `/profile/market`, `/profile/account` render correctly signed-in + signed-out
- [ ] Manual flow: create listing → browse picks it up → bid + outbid refunds → buy-now settles → cancel refunds high bidder