### PR TITLE
feat(mc_auth): show credits + KHash in chat when a linked player joins

### DIFF
--- a/apps/kbve/axum-kbve/src/openapi.rs
+++ b/apps/kbve/axum-kbve/src/openapi.rs
@@ -106,6 +106,7 @@ impl Modify for SecurityAddon {
         crate::transport::wallet::me_coupons,
         crate::transport::wallet::me_redeem_coupon,
         // wallet — service surface (service_role JWT)
+        crate::transport::wallet::service_balance,
         crate::transport::wallet::service_credit,
         crate::transport::wallet::service_credit_user,
         crate::transport::wallet::service_debit,

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -375,6 +375,10 @@ fn router(state: AppState) -> Router {
         )
         // service_role JWT required; anon / authenticated JWTs are rejected with 403.
         .route(
+            "/api/v1/wallet/service/balance/{user_id}",
+            get(super::wallet::service_balance),
+        )
+        .route(
             "/api/v1/wallet/service/credit",
             post(super::wallet::service_credit),
         )

--- a/apps/kbve/axum-kbve/src/transport/wallet.rs
+++ b/apps/kbve/axum-kbve/src/transport/wallet.rs
@@ -393,6 +393,45 @@ pub(crate) fn wallet_error_response(err: WalletError) -> Response {
         .into_response()
 }
 
+/// `GET /api/v1/wallet/service/balance/{user_id}` — read another user's
+/// wallet balance from a trusted backend (mc server). Same response shape
+/// as `/api/v1/wallet/me/balance`, but identity comes from the path
+/// instead of the bearer's `sub`. Service-role only.
+#[utoipa::path(
+    get,
+    path = "/api/v1/wallet/service/balance/{user_id}",
+    tag = "wallet",
+    params(
+        ("user_id" = String, Path, description = "Supabase user UUID")
+    ),
+    responses(
+        (status = 200, description = "User's balance", body = BalanceDto),
+        (status = 401, description = "Missing / invalid bearer token"),
+        (status = 403, description = "service_role required"),
+        (status = 503, description = "Wallet service unavailable"),
+    ),
+    security(("bearerAuth" = [])),
+)]
+pub(crate) async fn service_balance(headers: HeaderMap, Path(user_id): Path<Uuid>) -> Response {
+    if let Err(resp) = require_service_role(&headers).await {
+        return resp;
+    }
+    let client = match get_wallet_client() {
+        Some(c) => c,
+        None => return service_unavailable(),
+    };
+    match client.user_balance(user_id).await {
+        Ok(b) => Json(BalanceDto {
+            account_id: b.account_id,
+            credits: b.credits,
+            khash: b.khash,
+            updated_at: b.updated_at.to_rfc3339(),
+        })
+        .into_response(),
+        Err(e) => wallet_error_response(e),
+    }
+}
+
 /// `POST /api/v1/wallet/service/credit` — credit a positive delta to any
 /// account. Returns the resulting ledger id. Idempotent: replays with the
 /// same `idempotency_key` return the original id; mismatched payloads on

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
@@ -168,6 +168,22 @@ public final class AuthEventTicker {
                 LOGGER.warn("[{}] AuthFailure uuid={} reason={}", McAuthMod.MOD_ID, uuid, reason);
                 break;
             }
+            case "WalletBalance": {
+                String uuid = payload.get("player_uuid").getAsString();
+                long credits = payload.get("credits").getAsLong();
+                long khash = payload.get("khash").getAsLong();
+                ServerPlayerEntity player = findPlayer(server, uuid);
+                if (player != null) {
+                    sendBalanceMessage(player, credits, khash);
+                }
+                LOGGER.debug(
+                        "[{}] WalletBalance uuid={} credits={} khash={}",
+                        McAuthMod.MOD_ID,
+                        uuid,
+                        credits,
+                        khash);
+                break;
+            }
             default:
                 LOGGER.debug("[{}] unknown PlayerEvent variant: {}", McAuthMod.MOD_ID, variant);
         }
@@ -189,6 +205,20 @@ public final class AuthEventTicker {
     }
 
     private static final String LINK_URL = "https://kbve.com/mc";
+
+    private static String formatThousands(long value) {
+        return java.text.NumberFormat.getInstance(java.util.Locale.US).format(value);
+    }
+
+    private static void sendBalanceMessage(ServerPlayerEntity player, long credits, long khash) {
+        MutableText line = Text.literal("[KBVE] ").formatted(Formatting.GRAY)
+                .append(Text.literal("Credits: ").formatted(Formatting.YELLOW))
+                .append(Text.literal(formatThousands(credits)).formatted(Formatting.WHITE))
+                .append(Text.literal("  ·  ").formatted(Formatting.DARK_GRAY))
+                .append(Text.literal("KHash: ").formatted(Formatting.AQUA))
+                .append(Text.literal(formatThousands(khash)).formatted(Formatting.WHITE));
+        player.sendMessage(line, false);
+    }
 
     private static void sendLinkPrompt(ServerPlayerEntity player, String username) {
         MutableText url = Text.literal(LINK_URL)

--- a/apps/mc/mc_auth/src/runtime.rs
+++ b/apps/mc/mc_auth/src/runtime.rs
@@ -211,41 +211,60 @@ async fn handle_job(
         }
     };
 
-    // Fire daily-khash credit for any newly-confirmed linked player. The
-    // server's idempotency key (UUIDv5 over user_id + UTC date) dedups
-    // multiple joins on the same day, so we can call this on every link
-    // confirmation without tracking per-player state on the mod side.
-    // Errors are logged and swallowed — they must not block the player.
-    if let Some(client) = wallet {
-        let user_id = match &event {
-            PlayerEvent::AlreadyLinked {
-                supabase_user_id, ..
-            } => Some(supabase_user_id.clone()),
-            PlayerEvent::LinkVerified {
-                supabase_user_id, ..
-            } => Some(supabase_user_id.clone()),
-            _ => None,
-        };
-        if let Some(uid) = user_id {
-            let client = client.clone();
-            tokio::spawn(async move {
-                match client.daily_credit_khash(&uid).await {
-                    Ok(resp) => {
-                        debug!(
-                            user_id = %uid,
-                            ledger_id = resp.ledger_id,
-                            "mc_auth: daily khash credit ok (or replay)"
-                        );
-                    }
-                    Err(e) => {
-                        warn!(user_id = %uid, error = %e, "mc_auth: daily khash credit failed");
-                    }
-                }
-            });
-        }
-    }
+    // Pull the player_uuid + user_id BEFORE moving `event` into the channel
+    // so the post-emit wallet tasks can reference both.
+    let linked_pair = match &event {
+        PlayerEvent::AlreadyLinked {
+            player_uuid,
+            supabase_user_id,
+        } => Some((player_uuid.clone(), supabase_user_id.clone())),
+        PlayerEvent::LinkVerified {
+            player_uuid,
+            supabase_user_id,
+        } => Some((player_uuid.clone(), supabase_user_id.clone())),
+        _ => None,
+    };
 
     if event_tx.try_send(event).is_err() {
         warn!("mc_auth: event channel full dropping primary event");
+    }
+
+    // Fire daily-khash credit + emit a WalletBalance follow-up for any
+    // newly-confirmed linked player. Both calls are best-effort: errors
+    // are logged and swallowed — they must not block the player. The
+    // daily credit's idempotency key (UUIDv5 over user_id + UTC date)
+    // dedups multiple joins on the same day, so calling on every
+    // confirmation is safe.
+    if let (Some(client), Some((player_uuid, uid))) = (wallet, linked_pair) {
+        let client = client.clone();
+        let tx = event_tx.clone();
+        tokio::spawn(async move {
+            match client.daily_credit_khash(&uid).await {
+                Ok(resp) => debug!(
+                    user_id = %uid,
+                    ledger_id = resp.ledger_id,
+                    "mc_auth: daily khash credit ok (or replay)"
+                ),
+                Err(e) => warn!(user_id = %uid, error = %e, "mc_auth: daily khash credit failed"),
+            }
+
+            match client.balance_for_user(&uid).await {
+                Ok(snapshot) => {
+                    let evt = PlayerEvent::WalletBalance {
+                        player_uuid,
+                        credits: snapshot.credits,
+                        khash: snapshot.khash,
+                    };
+                    if tx.try_send(evt).is_err() {
+                        warn!("mc_auth: event channel full dropping WalletBalance");
+                    }
+                }
+                Err(e) => warn!(
+                    user_id = %uid,
+                    error = %e,
+                    "mc_auth: balance fetch failed — skipping WalletBalance event"
+                ),
+            }
+        });
     }
 }

--- a/apps/mc/mc_auth/src/types.rs
+++ b/apps/mc/mc_auth/src/types.rs
@@ -97,4 +97,12 @@ pub enum PlayerEvent {
     /// Supabase lookup / verify failed for a transport reason (network,
     /// 5xx, bad JSON). Treat as unlinked in graceful mode — never kick.
     AuthFailure { player_uuid: String, reason: String },
+    /// Wallet balance snapshot for a linked player, emitted after a
+    /// successful AlreadyLinked or LinkVerified so the JVM side can chat
+    /// the current credits + khash without a second JNI round trip.
+    WalletBalance {
+        player_uuid: String,
+        credits: i64,
+        khash: i64,
+    },
 }

--- a/apps/mc/mc_auth/src/wallet.rs
+++ b/apps/mc/mc_auth/src/wallet.rs
@@ -79,6 +79,15 @@ pub struct CreditUserResp {
     pub ledger_id: i64,
 }
 
+/// Decodes the `BalanceDto` shape served by `/api/v1/wallet/service/balance/{user_id}`.
+#[derive(Deserialize, Debug, Clone)]
+pub struct BalanceSnapshot {
+    pub account_id: String,
+    pub credits: i64,
+    pub khash: i64,
+    pub updated_at: String,
+}
+
 impl WalletClient {
     /// Read env and build a client. Returns `None` if the integration is
     /// disabled (missing URL or JWT) — caller should log and skip wallet
@@ -177,6 +186,40 @@ impl WalletClient {
 
     pub fn daily_amount(&self) -> i64 {
         self.daily_amount
+    }
+
+    /// Read a linked user's wallet balance via the service-role endpoint.
+    /// Used on player join to surface credits + khash in chat.
+    pub async fn balance_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<BalanceSnapshot, WalletCallError> {
+        let user_uuid = uuid::Uuid::parse_str(user_id)
+            .map_err(|e| WalletCallError::InvalidUserId(format!("{user_id}: {e}")))?;
+
+        let resp = self
+            .http
+            .get(format!(
+                "{}/api/v1/wallet/service/balance/{}",
+                self.base_url, user_uuid
+            ))
+            .bearer_auth(&self.service_jwt)
+            .send()
+            .await
+            .map_err(|e| WalletCallError::Http(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(WalletCallError::Upstream {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        resp.json::<BalanceSnapshot>()
+            .await
+            .map_err(|e| WalletCallError::Http(e.to_string()))
     }
 }
 


### PR DESCRIPTION
## Summary
Right now a linked player's mc join message is just "Welcome back — your account is linked." Nothing surfaces credits / KHash unless they tab out to kbve.com/mc. This PR pipes the service-side wallet balance straight into chat on join.

## Pipeline
1. **axum-kbve** — new `GET /api/v1/wallet/service/balance/{user_id}` ([wallet.rs](apps/kbve/axum-kbve/src/transport/wallet.rs)). Service-role-gated mirror of `/me/balance` that takes the user id on the path instead of resolving from the bearer. Reuses `wallet_client.user_balance` so coupon-provisioning + `updated_at` shape match the user-facing endpoint exactly. Registered in [`https.rs`](apps/kbve/axum-kbve/src/transport/https.rs) + [`openapi.rs`](apps/kbve/axum-kbve/src/openapi.rs).
2. **mc_auth Rust** — `WalletClient::balance_for_user` ([wallet.rs](apps/mc/mc_auth/src/wallet.rs)) GETs that endpoint with the service JWT and decodes `BalanceSnapshot`. New `PlayerEvent::WalletBalance { player_uuid, credits, khash }` variant in [types.rs](apps/mc/mc_auth/src/types.rs).
3. **mc_auth runtime** — the join path that fires daily-khash credit on `AlreadyLinked` / `LinkVerified` now also fetches the balance immediately afterward and emits `WalletBalance` through the existing `pollEvents()` channel ([runtime.rs](apps/mc/mc_auth/src/runtime.rs)). No second JNI round trip.
4. **mc_auth Java** — `AuthEventTicker` ([AuthEventTicker.java](apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java)) grows a `WalletBalance` dispatch arm that prints one chat line — `[KBVE] Credits: 1,234  ·  KHash: 56,789` — shortly after the existing welcome / link-verified greeting.

## Graceful failure
Both the daily credit and the balance fetch are best-effort: failures are logged and swallowed exactly the way the daily credit already was. A degraded wallet path can never block a player join.

## Test plan
- [ ] `cargo check -p axum-kbve` and `cargo check -p mc_auth` clean (verified locally).
- [ ] `gradle compileJava` on mc_auth/java clean (verified locally).
- [ ] After deploy: a linked player joins → sees the welcome line and a balance line within 1–2 seconds.
- [ ] An unlinked player still gets the clickable `/link` prompt from #11081 — no balance line.
- [ ] If `AXUM_KBVE_URL` / `WALLET_SERVICE_JWT` is unset the balance line silently disappears, no errors in the player's chat.

## Follow-ups
- mc.player snapshot sync on join + logout (still on deck).
- Surface coupons-claimable count beside the balance line if there are unredeemed coupons (small follow-up).