### PR TITLE
feat(droid): installProfileSync — event + visibility + fallback timer

### DIFF
--- a/apps/kbve/astro-kbve/src/components/user/profile-controller.ts
+++ b/apps/kbve/astro-kbve/src/components/user/profile-controller.ts
@@ -7,6 +7,7 @@ import {
 	clearStaffPermsCache,
 	fetchAndCacheProfile,
 	getProfileFromCache,
+	installProfileSync,
 	installSyncBusListener,
 	readProfileForFastPaint,
 	setProfileCache as setDroidProfileCache,
@@ -430,6 +431,18 @@ export async function bootProfile() {
 	}
 
 	const supa = getSupa();
+
+	// Background sync: refresh profile + staff caches on auth events,
+	// tab focus / visibility, and a 15-min fallback timer. Updates the
+	// persistent atoms plus the BroadcastChannel bus so other tabs and
+	// surfaces stay in sync without ever blocking the UI.
+	installProfileSync({
+		apiBase: window.location.origin,
+		supabaseUrl: SUPABASE_URL,
+		supabaseAnonKey: SUPABASE_ANON_KEY,
+		subscribeAuth: (handler) =>
+			supa.on('auth', (msg: unknown) => handler(msg as never)),
+	});
 
 	// Get current session
 	const s = await supa.getSession().catch(() => null);

--- a/packages/npm/droid/src/lib/state/index.ts
+++ b/packages/npm/droid/src/lib/state/index.ts
@@ -78,3 +78,11 @@ export {
 	installSyncBusListener,
 	type SyncBusMessage,
 } from './sync-bus';
+
+export {
+	disposeProfileSync,
+	installProfileSync,
+	refreshProfileSyncNow,
+	type AuthEventLike,
+	type ProfileSyncOptions,
+} from './profile-sync';

--- a/packages/npm/droid/src/lib/state/profile-sync.ts
+++ b/packages/npm/droid/src/lib/state/profile-sync.ts
@@ -1,0 +1,214 @@
+import { broadcastProfileRefresh, broadcastStaffRefresh } from './sync-bus';
+import {
+	$profileCache,
+	PROFILE_CACHE_TTL_MS,
+	fetchProfileFromApi,
+	setProfileCache,
+	type DroidProfile,
+} from './profile';
+import {
+	$staffPermissions,
+	STAFF_CACHE_TTL_MS,
+	fetchStaffPermissionsFromApi,
+	setStaffPermsCache,
+} from './staff';
+
+const FALLBACK_REFRESH_MS = 15 * 60 * 1000;
+const DEBOUNCE_MS = 250;
+
+export interface AuthEventLike {
+	session?: {
+		access_token?: string;
+		user?: { id?: string } | null;
+	} | null;
+}
+
+export interface ProfileSyncOptions {
+	apiBase: string;
+	supabaseUrl: string;
+	supabaseAnonKey: string;
+	/** Provide a way to subscribe to auth events from the SharedWorker / gateway. */
+	subscribeAuth: (handler: (event: AuthEventLike) => void) => () => void;
+	/**
+	 * Optional override for the recurring fallback cadence. Defaults to
+	 * 15 minutes. Pass `0` to disable.
+	 */
+	fallbackIntervalMs?: number;
+}
+
+interface SyncState {
+	apiBase: string;
+	supabaseUrl: string;
+	supabaseAnonKey: string;
+	timer: ReturnType<typeof setInterval> | null;
+	debounce: ReturnType<typeof setTimeout> | null;
+	inflight: Promise<void> | null;
+	disposers: Array<() => void>;
+}
+
+let active: SyncState | null = null;
+
+async function refreshProfileAndStaff(state: SyncState): Promise<void> {
+	if (state.inflight) return state.inflight;
+	state.inflight = (async () => {
+		try {
+			const sessionRaw = readSession();
+			const userId = sessionRaw?.user?.id;
+			const token = sessionRaw?.access_token;
+			if (!userId || !token) return;
+
+			const profilePromise = fetchProfileFromApi({
+				token,
+				apiBase: state.apiBase,
+			});
+			const staffPromise = fetchStaffPermissionsFromApi({
+				token,
+				apikey: state.supabaseAnonKey,
+				supabaseUrl: state.supabaseUrl,
+			});
+
+			const [profile, staff] = await Promise.all([
+				profilePromise.catch(() => null),
+				staffPromise.catch(() => null),
+			]);
+
+			if (profile && profile.user_id) {
+				setProfileCache(profile);
+				broadcastProfileRefresh(profile);
+			}
+			if (typeof staff === 'number') {
+				setStaffPermsCache(userId, staff);
+				broadcastStaffRefresh(userId, staff);
+			}
+		} finally {
+			if (active === state) state.inflight = null;
+		}
+	})();
+	return state.inflight;
+}
+
+function readSession(): AuthEventLike['session'] {
+	if (typeof localStorage === 'undefined') return null;
+	const raw = localStorage.getItem('sb-auth-token');
+	if (!raw) return null;
+	try {
+		const parsed = JSON.parse(raw);
+		if (parsed?.currentSession?.access_token) return parsed.currentSession;
+		if (parsed?.access_token) return parsed;
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+function scheduleRefresh(state: SyncState): void {
+	if (state.debounce) clearTimeout(state.debounce);
+	state.debounce = setTimeout(() => {
+		state.debounce = null;
+		void refreshProfileAndStaff(state);
+	}, DEBOUNCE_MS);
+}
+
+function isProfileStale(): boolean {
+	const entry = $profileCache.get();
+	if (!entry) return true;
+	return Date.now() - entry.cached_at > PROFILE_CACHE_TTL_MS;
+}
+
+function isStaffStale(): boolean {
+	const entry = $staffPermissions.get();
+	if (!entry) return true;
+	return Date.now() - entry.cached_at > STAFF_CACHE_TTL_MS;
+}
+
+/**
+ * Install a profile + staff_permissions sync coordinator. Returns a
+ * dispose function that tears down listeners and the fallback timer.
+ *
+ * Refresh triggers:
+ *   - auth events from the SharedWorker (token refresh, sign-in)
+ *   - `document.visibilitychange` (only if at least one cache is stale)
+ *   - `window.focus`            (only if at least one cache is stale)
+ *   - fallback `setInterval` every `fallbackIntervalMs` (default 15m)
+ *
+ * Each refresh is debounced (250ms) and reentrancy-guarded; a refresh
+ * in flight is reused rather than queued.
+ *
+ * Idempotent — calling twice tears down the previous coordinator first
+ * so callers can re-run safely.
+ */
+export function installProfileSync(opts: ProfileSyncOptions): () => void {
+	disposeProfileSync();
+
+	const state: SyncState = {
+		apiBase: opts.apiBase,
+		supabaseUrl: opts.supabaseUrl,
+		supabaseAnonKey: opts.supabaseAnonKey,
+		timer: null,
+		debounce: null,
+		inflight: null,
+		disposers: [],
+	};
+	active = state;
+
+	const unsubscribeAuth = opts.subscribeAuth((evt) => {
+		if (!evt?.session?.user?.id) return;
+		scheduleRefresh(state);
+	});
+	state.disposers.push(unsubscribeAuth);
+
+	if (typeof document !== 'undefined') {
+		const onVisibility = () => {
+			if (document.visibilityState !== 'visible') return;
+			if (!isProfileStale() && !isStaffStale()) return;
+			scheduleRefresh(state);
+		};
+		document.addEventListener('visibilitychange', onVisibility);
+		state.disposers.push(() =>
+			document.removeEventListener('visibilitychange', onVisibility),
+		);
+	}
+	if (typeof window !== 'undefined') {
+		const onFocus = () => {
+			if (!isProfileStale() && !isStaffStale()) return;
+			scheduleRefresh(state);
+		};
+		window.addEventListener('focus', onFocus);
+		state.disposers.push(() =>
+			window.removeEventListener('focus', onFocus),
+		);
+	}
+
+	const interval = opts.fallbackIntervalMs ?? FALLBACK_REFRESH_MS;
+	if (interval > 0) {
+		state.timer = setInterval(() => {
+			void refreshProfileAndStaff(state);
+		}, interval);
+	}
+
+	return disposeProfileSync;
+}
+
+export function disposeProfileSync(): void {
+	if (!active) return;
+	const state = active;
+	active = null;
+	if (state.timer) clearInterval(state.timer);
+	if (state.debounce) clearTimeout(state.debounce);
+	for (const dispose of state.disposers) {
+		try {
+			dispose();
+		} catch {
+			/* best effort */
+		}
+	}
+	state.disposers.length = 0;
+}
+
+/** Trigger an immediate refresh if a sync coordinator is installed. */
+export async function refreshProfileSyncNow(): Promise<void> {
+	if (!active) return;
+	await refreshProfileAndStaff(active);
+}
+
+export type { DroidProfile };


### PR DESCRIPTION
## Summary
Follow-up to #11082. The sync-bus shipped there was the contract; this PR adds the **producer** that actually writes through it.

\`installProfileSync({apiBase, supabaseUrl, supabaseAnonKey, subscribeAuth, fallbackIntervalMs?})\` wires three refresh triggers that all funnel through one shared, debounced refresh of \`$profileCache\` + \`$staffPermissions\`:

1. **Auth events.** Caller supplies a \`subscribeAuth\` adapter; astro-kbve uses \`supa.on('auth', ...)\` so the SharedWorker's existing token-refresh / sign-in broadcast triggers a refresh. Free when the worker is idle.
2. **\`document.visibilitychange\` + \`window.focus\`.** Refresh only when at least one cache is stale (TTL exceeded). Returning to a tab with a hot cache costs nothing.
3. **Fallback \`setInterval\`.** Default 15 min. Catches edge cases where neither auth nor visibility fires (long-lived sessions, backgrounded PWAs). Configurable; \`0\` disables.

Each trigger funnels through the same path:
- **250 ms debounce** — collapses bursts (focus + visibility firing back-to-back).
- **Inflight reentrancy guard** — concurrent triggers reuse the running promise instead of stacking N fetches.
- Writes \`$profileCache\` / \`$staffPermissions\` directly (this tab) **plus** \`broadcastProfileRefresh\` / \`broadcastStaffRefresh\` through the sync-bus so other tabs + workers pick up the same payload.
- Per-fetch error handling — a transient profile failure doesn't kill the staff refresh and vice versa.

\`disposeProfileSync()\` is exposed for SPA navigations / test cleanup. \`refreshProfileSyncNow()\` lets any consumer force an immediate refresh.

## astro-kbve wiring
\`bootProfile()\` calls \`installProfileSync(...)\` once after \`initSupa()\` succeeds:

\`\`\`ts
installProfileSync({
  apiBase: window.location.origin,
  supabaseUrl: SUPABASE_URL,
  supabaseAnonKey: SUPABASE_ANON_KEY,
  subscribeAuth: (handler) =>
    supa.on('auth', (msg: unknown) => handler(msg as never)),
});
\`\`\`

## End-to-end profile path (after this PR)
1. localStorage warm cache → fast paint (μs) \[#11078\]
2. \`installProfileSync\` → background refresh on auth / visibility / focus / 15-min ticker \[**this PR**\]
3. Sync-bus → cross-tab + worker fanout via BroadcastChannel \[#11082\]
4. Persistent atoms → cross-tab fanout via storage events \[#11078 + #11082\]

## Test plan
- [x] \`./kbve.sh -nx droid:build\` — clean
- [x] \`./kbve.sh -nx droid:test\` — 118/118
- [x] \`./kbve.sh -nx astro-kbve:check\` — 1 pre-existing GamingHub error, no new errors
- [x] \`./kbve.sh -nx astro-kbve:build\` — clean
- [ ] In prod: load \`/profile/\` with a warm cache, switch tabs for 5 min, return — DevTools network should show **one** \`/api/v1/profile/me\` + \`/rpc/staff_permissions\` pair fire on visibility return (only if cache went stale)
- [ ] Sign in on tab A → tab B \`$profileCache\` should update via storage event within ~250 ms (debounce window) of the sync-bus broadcast