### PR TITLE
feat(astro-kbve): alerts panel on dashboard / grafana / argo pages

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAlerts.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAlerts.astro
@@ -1,0 +1,43 @@
+---
+import ReactHomeAuth from './ReactHomeAuth';
+import ReactAlerts from './ReactAlerts';
+---
+
+<section
+	id="alerts-wrapper"
+	class="alerts-wrapper kbve-dashboard-page"
+	aria-label="Prometheus Alerts — ClickHouse-backed history">
+	<div id="alerts-content" class="alerts-content">
+		<ReactHomeAuth client:only="react">
+			<div class="not-content alerts-panel">
+				<ReactAlerts client:only="react" variant="full" />
+			</div>
+		</ReactHomeAuth>
+	</div>
+</section>
+
+<style>
+	.alerts-wrapper {
+		background: transparent;
+		position: relative;
+		width: 100%;
+	}
+
+	.alerts-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 0 1rem 2rem;
+	}
+
+	@media (min-width: 768px) {
+		.alerts-content {
+			padding: 0 1.5rem 2rem;
+		}
+	}
+
+	.alerts-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAlertsSummary.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAlertsSummary.astro
@@ -1,0 +1,35 @@
+---
+import ReactHomeAuth from './ReactHomeAuth';
+import ReactAlerts from './ReactAlerts';
+---
+
+<section
+	class="alerts-summary-wrapper kbve-dashboard-page"
+	aria-label="Alerts summary — firing count by severity">
+	<div class="alerts-summary-content">
+		<ReactHomeAuth client:only="react">
+			<div class="not-content">
+				<ReactAlerts client:only="react" variant="compact" />
+			</div>
+		</ReactHomeAuth>
+	</div>
+</section>
+
+<style>
+	.alerts-summary-wrapper {
+		background: transparent;
+		width: 100%;
+	}
+
+	.alerts-summary-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 0 1rem 1rem;
+	}
+
+	@media (min-width: 768px) {
+		.alerts-summary-content {
+			padding: 0 1.5rem 1rem;
+		}
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAlerts.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAlerts.tsx
@@ -1,0 +1,407 @@
+import React, { useEffect, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	AlertTriangle,
+	AlertCircle,
+	Bell,
+	Loader2,
+	RefreshCw,
+	Activity,
+} from 'lucide-react';
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Cell,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from 'recharts';
+import {
+	$alertsFiring,
+	$alertsFiringStatus,
+	$alertsRecent,
+	$alertsRecentStatus,
+	$alertsSeverity,
+	$alertsSeverityStatus,
+	$alertsTop,
+	$alertsTopStatus,
+	$alertsRange,
+	fetchAllAlerts,
+	fetchAlertsFiring,
+	invalidateAlertsCache,
+	severityColor,
+	severityTextClass,
+	formatRelative,
+	ALERTS_RANGES,
+	ALERTS_RANGE_KEYS,
+	type AlertsRange,
+} from './alertsService';
+
+const POLL_MS = 30_000;
+const tooltipStyle = {
+	background: 'var(--sl-color-bg-nav, #111)',
+	border: '1px solid var(--sl-color-gray-5, #262626)',
+	borderRadius: '0.375rem',
+	fontSize: '0.75rem',
+};
+
+export type AlertsVariant = 'compact' | 'full';
+
+interface Props {
+	variant?: AlertsVariant;
+}
+
+export default function ReactAlerts({ variant = 'full' }: Props) {
+	const range = useStore($alertsRange);
+	const firing = useStore($alertsFiring);
+	const firingStatus = useStore($alertsFiringStatus);
+	const recent = useStore($alertsRecent);
+	const recentStatus = useStore($alertsRecentStatus);
+	const severity = useStore($alertsSeverity);
+	const severityStatus = useStore($alertsSeverityStatus);
+	const top = useStore($alertsTop);
+	const topStatus = useStore($alertsTopStatus);
+	const [refreshing, setRefreshing] = useState(false);
+
+	useEffect(() => {
+		if (variant === 'compact') {
+			void fetchAlertsFiring(range);
+			const id = window.setInterval(
+				() => fetchAlertsFiring(range),
+				POLL_MS,
+			);
+			return () => window.clearInterval(id);
+		}
+		void fetchAllAlerts(range);
+		const id = window.setInterval(() => fetchAllAlerts(range), POLL_MS);
+		return () => window.clearInterval(id);
+	}, [range, variant]);
+
+	const onRefresh = async () => {
+		setRefreshing(true);
+		invalidateAlertsCache();
+		if (variant === 'compact') await fetchAlertsFiring(range);
+		else await fetchAllAlerts(range);
+		setRefreshing(false);
+	};
+
+	if (variant === 'compact') {
+		const firingByLevel: Record<string, number> = {};
+		(firing ?? []).forEach((a) => {
+			const s = (a.severity || 'unknown').toLowerCase();
+			firingByLevel[s] = (firingByLevel[s] ?? 0) + 1;
+		});
+		const total = firing?.length ?? 0;
+		return (
+			<div className="rounded-lg border border-[var(--sl-color-gray-5)] bg-[var(--sl-color-bg-nav)] p-3">
+				<div className="flex items-center justify-between gap-2">
+					<div className="flex items-center gap-2 text-sm font-semibold">
+						<Bell className="size-4 text-amber-500" />
+						<a
+							href="/dashboard/grafana/"
+							className="hover:underline">
+							Alerts firing
+						</a>
+						<span className="text-lg font-bold tabular-nums">
+							{total}
+						</span>
+					</div>
+					<div className="flex items-center gap-2 text-xs">
+						{['critical', 'warning', 'info'].map(
+							(s) =>
+								firingByLevel[s] > 0 && (
+									<span
+										key={s}
+										className={`flex items-center gap-1 ${severityTextClass(s)}`}>
+										<span
+											className="inline-block size-2 rounded-full"
+											style={{
+												background: severityColor(s),
+											}}
+										/>
+										<span className="tabular-nums">
+											{firingByLevel[s]}
+										</span>
+										<span className="opacity-60">{s}</span>
+									</span>
+								),
+						)}
+						{firingStatus === 'loading' && (
+							<Loader2 className="size-3 animate-spin text-gray-400" />
+						)}
+						{firingStatus === 'error' && (
+							<AlertCircle className="size-3 text-red-500" />
+						)}
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			<div className="flex flex-wrap items-center justify-between gap-2">
+				<div className="flex items-center gap-2 text-sm font-semibold">
+					<Bell className="size-4 text-amber-500" />
+					<span>Alerts</span>
+					<span className="text-xs font-normal text-gray-500">
+						(Alertmanager → ClickHouse · 30s poll · 30d retention)
+					</span>
+				</div>
+				<div className="flex items-center gap-2">
+					<div className="flex rounded-md border border-[var(--sl-color-gray-5)] overflow-hidden text-xs">
+						{ALERTS_RANGE_KEYS.map((r) => (
+							<button
+								key={r}
+								onClick={() => $alertsRange.set(r)}
+								className={`px-2 py-1 ${
+									r === range
+										? 'bg-amber-500/20 text-amber-400'
+										: 'text-gray-400 hover:text-gray-200'
+								}`}>
+								{ALERTS_RANGES[r].label}
+							</button>
+						))}
+					</div>
+					<button
+						onClick={onRefresh}
+						disabled={refreshing}
+						className="rounded-md border border-[var(--sl-color-gray-5)] p-1 text-gray-400 hover:text-gray-200 disabled:opacity-50">
+						<RefreshCw
+							className={`size-4 ${refreshing ? 'animate-spin' : ''}`}
+						/>
+					</button>
+				</div>
+			</div>
+
+			<div className="rounded-lg border border-[var(--sl-color-gray-5)] bg-[var(--sl-color-bg-nav)] p-4">
+				<div className="mb-3 flex items-center gap-2 text-sm font-semibold">
+					<AlertTriangle className="size-4 text-red-500" />
+					<span>Currently firing</span>
+					{firingStatus === 'loading' && (
+						<Loader2 className="size-4 animate-spin text-gray-400" />
+					)}
+				</div>
+				{firing && firing.length > 0 ? (
+					<div className="max-h-72 overflow-y-auto">
+						<table className="w-full text-xs">
+							<thead className="sticky top-0 border-b border-[var(--sl-color-gray-5)] bg-[var(--sl-color-bg-nav)] text-left text-gray-400">
+								<tr>
+									<th className="py-1.5 pr-3">Severity</th>
+									<th className="py-1.5 pr-3">Alert</th>
+									<th className="py-1.5 pr-3">Namespace</th>
+									<th className="py-1.5 pr-3">Service</th>
+									<th className="py-1.5 pr-3">Summary</th>
+									<th className="py-1.5">Started</th>
+								</tr>
+							</thead>
+							<tbody>
+								{firing.map((a) => (
+									<tr
+										key={a.fingerprint}
+										className="border-b border-[var(--sl-color-gray-5)]/40 last:border-0">
+										<td
+											className={`py-1 pr-3 ${severityTextClass(a.severity)}`}>
+											● {a.severity || '—'}
+										</td>
+										<td className="py-1 pr-3 font-mono">
+											{a.alertname}
+										</td>
+										<td className="py-1 pr-3 font-mono text-gray-400">
+											{a.namespace || '—'}
+										</td>
+										<td className="py-1 pr-3 font-mono text-gray-400">
+											{a.service || '—'}
+										</td>
+										<td className="py-1 pr-3">
+											{a.summary || '—'}
+										</td>
+										<td className="py-1 text-gray-400">
+											{formatRelative(a.starts_at)}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				) : (
+					<div className="py-6 text-center text-xs text-gray-500">
+						{firingStatus === 'loading'
+							? 'Loading…'
+							: firingStatus === 'error'
+								? 'Failed to load'
+								: '✓ No alerts firing in window'}
+					</div>
+				)}
+			</div>
+
+			<div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+				<div className="rounded-lg border border-[var(--sl-color-gray-5)] bg-[var(--sl-color-bg-nav)] p-4">
+					<div className="mb-3 flex items-center gap-2 text-sm font-semibold">
+						<Activity className="size-4 text-amber-500" />
+						<span>By severity</span>
+						{severityStatus === 'loading' && (
+							<Loader2 className="size-4 animate-spin text-gray-400" />
+						)}
+					</div>
+					{severity && severity.length > 0 ? (
+						<ResponsiveContainer width="100%" height={180}>
+							<BarChart data={severity}>
+								<CartesianGrid
+									stroke="#262626"
+									strokeDasharray="3 3"
+								/>
+								<XAxis
+									dataKey="severity"
+									tick={{ fontSize: 10, fill: '#9ca3af' }}
+								/>
+								<YAxis
+									tick={{ fontSize: 10, fill: '#9ca3af' }}
+								/>
+								<Tooltip contentStyle={tooltipStyle} />
+								<Bar dataKey="firing_events">
+									{severity.map((s, i) => (
+										<Cell
+											key={i}
+											fill={severityColor(s.severity)}
+										/>
+									))}
+								</Bar>
+							</BarChart>
+						</ResponsiveContainer>
+					) : (
+						<div className="py-10 text-center text-xs text-gray-500">
+							{severityStatus === 'loading'
+								? 'Loading…'
+								: 'No data'}
+						</div>
+					)}
+				</div>
+
+				<div className="rounded-lg border border-[var(--sl-color-gray-5)] bg-[var(--sl-color-bg-nav)] p-4">
+					<div className="mb-3 flex items-center gap-2 text-sm font-semibold">
+						<Bell className="size-4 text-blue-500" />
+						<span>Top alertnames</span>
+						{topStatus === 'loading' && (
+							<Loader2 className="size-4 animate-spin text-gray-400" />
+						)}
+					</div>
+					{top && top.length > 0 ? (
+						<div className="max-h-44 overflow-y-auto">
+							<table className="w-full text-xs">
+								<thead className="border-b border-[var(--sl-color-gray-5)] text-left text-gray-400">
+									<tr>
+										<th className="py-1 pr-3">Alert</th>
+										<th className="py-1 pr-3 text-right">
+											Instances
+										</th>
+										<th className="py-1 pr-3 text-right">
+											Events
+										</th>
+										<th className="py-1 text-right">
+											Firing
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									{top.map((t) => (
+										<tr
+											key={t.alertname}
+											className="border-b border-[var(--sl-color-gray-5)]/40 last:border-0">
+											<td className="py-1 pr-3 font-mono">
+												{t.alertname}
+											</td>
+											<td className="py-1 pr-3 text-right tabular-nums">
+												{t.distinct_instances}
+											</td>
+											<td className="py-1 pr-3 text-right tabular-nums text-gray-400">
+												{t.total_events}
+											</td>
+											<td className="py-1 text-right tabular-nums text-amber-400">
+												{t.firing_events}
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					) : (
+						<div className="py-10 text-center text-xs text-gray-500">
+							{topStatus === 'loading' ? 'Loading…' : 'No data'}
+						</div>
+					)}
+				</div>
+			</div>
+
+			<div className="rounded-lg border border-[var(--sl-color-gray-5)] bg-[var(--sl-color-bg-nav)] p-4">
+				<div className="mb-3 flex items-center gap-2 text-sm font-semibold">
+					<Activity className="size-4 text-gray-400" />
+					<span>Recent timeline</span>
+					{recentStatus === 'loading' && (
+						<Loader2 className="size-4 animate-spin text-gray-400" />
+					)}
+				</div>
+				{recent && recent.length > 0 ? (
+					<div className="max-h-80 overflow-y-auto">
+						<table className="w-full text-xs">
+							<thead className="sticky top-0 border-b border-[var(--sl-color-gray-5)] bg-[var(--sl-color-bg-nav)] text-left text-gray-400">
+								<tr>
+									<th className="py-1.5 pr-3">Time</th>
+									<th className="py-1.5 pr-3">Status</th>
+									<th className="py-1.5 pr-3">Severity</th>
+									<th className="py-1.5 pr-3">Alert</th>
+									<th className="py-1.5 pr-3">Namespace</th>
+									<th className="py-1.5 pr-3">Source</th>
+									<th className="py-1.5">Summary</th>
+								</tr>
+							</thead>
+							<tbody>
+								{recent.map((a, i) => (
+									<tr
+										key={`${a.fingerprint}-${a.timestamp}-${i}`}
+										className="border-b border-[var(--sl-color-gray-5)]/40 last:border-0">
+										<td className="py-1 pr-3 font-mono text-gray-400">
+											{formatRelative(a.timestamp)}
+										</td>
+										<td
+											className={`py-1 pr-3 ${
+												a.status === 'firing'
+													? 'text-red-400'
+													: 'text-emerald-400'
+											}`}>
+											{a.status}
+										</td>
+										<td
+											className={`py-1 pr-3 ${severityTextClass(a.severity)}`}>
+											{a.severity || '—'}
+										</td>
+										<td className="py-1 pr-3 font-mono">
+											{a.alertname}
+										</td>
+										<td className="py-1 pr-3 font-mono text-gray-400">
+											{a.namespace || '—'}
+										</td>
+										<td className="py-1 pr-3 text-gray-500">
+											{a.source}
+										</td>
+										<td className="py-1 text-gray-300">
+											{a.summary || '—'}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				) : (
+					<div className="py-6 text-center text-xs text-gray-500">
+						{recentStatus === 'loading'
+							? 'Loading…'
+							: 'No alert events in window'}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/alertsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/alertsService.ts
@@ -1,0 +1,275 @@
+import { atom } from 'nanostores';
+import { initSupa, getSupa } from '@/lib/supa';
+
+export type FetchStatus = 'idle' | 'loading' | 'ok' | 'error';
+
+export interface AlertFiringRow {
+	timestamp: string;
+	status: string;
+	alertname: string;
+	severity: string;
+	namespace: string;
+	pod: string;
+	service: string;
+	summary: string;
+	starts_at: string;
+	fingerprint: string;
+}
+
+export interface AlertRecentRow {
+	timestamp: string;
+	status: string;
+	alertname: string;
+	severity: string;
+	namespace: string;
+	pod: string;
+	service: string;
+	summary: string;
+	description: string;
+	fingerprint: string;
+	starts_at: string;
+	ends_at: string | null;
+	source: string;
+}
+
+export interface AlertSeverityRow {
+	severity: string;
+	distinct_alerts: number;
+	total_events: number;
+	firing_events: number;
+	resolved_events: number;
+}
+
+export interface AlertTopRow {
+	alertname: string;
+	distinct_instances: number;
+	total_events: number;
+	firing_events: number;
+}
+
+export type AlertsRange = '15m' | '1h' | '6h' | '24h' | '7d';
+
+export interface AlertsRangeConfig {
+	minutes: number;
+	label: string;
+}
+
+export const ALERTS_RANGES: Record<AlertsRange, AlertsRangeConfig> = {
+	'15m': { minutes: 15, label: '15m' },
+	'1h': { minutes: 60, label: '1h' },
+	'6h': { minutes: 360, label: '6h' },
+	'24h': { minutes: 1440, label: '24h' },
+	'7d': { minutes: 10080, label: '7d' },
+};
+
+export const ALERTS_RANGE_KEYS = Object.keys(ALERTS_RANGES) as AlertsRange[];
+
+export const $alertsRange = atom<AlertsRange>('1h');
+
+export const $alertsFiring = atom<AlertFiringRow[] | null>(null);
+export const $alertsFiringStatus = atom<FetchStatus>('idle');
+
+export const $alertsRecent = atom<AlertRecentRow[] | null>(null);
+export const $alertsRecentStatus = atom<FetchStatus>('idle');
+
+export const $alertsSeverity = atom<AlertSeverityRow[] | null>(null);
+export const $alertsSeverityStatus = atom<FetchStatus>('idle');
+
+export const $alertsTop = atom<AlertTopRow[] | null>(null);
+export const $alertsTopStatus = atom<FetchStatus>('idle');
+
+const PROXY_URL = '/dashboard/clickhouse/proxy';
+const CACHE_TTL_MS = 30_000;
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+	const supa = getSupa() ?? initSupa();
+	if (!supa) return {};
+	const { session } = await supa.getSession();
+	if (!session?.access_token) return {};
+	return {
+		Authorization: `Bearer ${session.access_token}`,
+		'Content-Type': 'application/json',
+	};
+}
+
+type CacheEntry<T> = { at: number; data: T };
+const cache = new Map<string, CacheEntry<unknown>>();
+
+function getCached<T>(key: string): T | null {
+	const e = cache.get(key) as CacheEntry<T> | undefined;
+	if (!e) return null;
+	if (Date.now() - e.at > CACHE_TTL_MS) {
+		cache.delete(key);
+		return null;
+	}
+	return e.data;
+}
+
+function setCached<T>(key: string, data: T): void {
+	cache.set(key, { at: Date.now(), data });
+}
+
+interface ProxyResponse<T> {
+	rows: T[];
+	count: number;
+}
+
+async function proxyCommand<T>(
+	body: Record<string, unknown>,
+): Promise<T[] | null> {
+	const headers = await getAuthHeaders();
+	if (!headers.Authorization) return null;
+	try {
+		const resp = await fetch(PROXY_URL, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify(body),
+			signal: AbortSignal.timeout(15000),
+		});
+		if (!resp.ok) {
+			console.warn(`[alerts] ${body.command} → HTTP ${resp.status}`);
+			return null;
+		}
+		const data = (await resp.json()) as ProxyResponse<T>;
+		return data.rows ?? [];
+	} catch (e) {
+		console.error(`[alerts] ${body.command} failed:`, e);
+		return null;
+	}
+}
+
+export async function fetchAlertsFiring(range: AlertsRange): Promise<void> {
+	const config = ALERTS_RANGES[range];
+	const key = `firing:${range}`;
+	const cached = getCached<AlertFiringRow[]>(key);
+	if (cached) {
+		$alertsFiring.set(cached);
+		$alertsFiringStatus.set('ok');
+		return;
+	}
+	$alertsFiringStatus.set('loading');
+	const rows = await proxyCommand<AlertFiringRow>({
+		command: 'alerts_firing',
+		minutes: config.minutes,
+	});
+	if (rows === null) {
+		$alertsFiringStatus.set('error');
+		return;
+	}
+	setCached(key, rows);
+	$alertsFiring.set(rows);
+	$alertsFiringStatus.set('ok');
+}
+
+export async function fetchAlertsRecent(range: AlertsRange): Promise<void> {
+	const config = ALERTS_RANGES[range];
+	const key = `recent:${range}`;
+	const cached = getCached<AlertRecentRow[]>(key);
+	if (cached) {
+		$alertsRecent.set(cached);
+		$alertsRecentStatus.set('ok');
+		return;
+	}
+	$alertsRecentStatus.set('loading');
+	const rows = await proxyCommand<AlertRecentRow>({
+		command: 'alerts_recent',
+		minutes: config.minutes,
+		limit: 100,
+	});
+	if (rows === null) {
+		$alertsRecentStatus.set('error');
+		return;
+	}
+	setCached(key, rows);
+	$alertsRecent.set(rows);
+	$alertsRecentStatus.set('ok');
+}
+
+export async function fetchAlertsSeverity(range: AlertsRange): Promise<void> {
+	const config = ALERTS_RANGES[range];
+	const key = `severity:${range}`;
+	const cached = getCached<AlertSeverityRow[]>(key);
+	if (cached) {
+		$alertsSeverity.set(cached);
+		$alertsSeverityStatus.set('ok');
+		return;
+	}
+	$alertsSeverityStatus.set('loading');
+	const rows = await proxyCommand<AlertSeverityRow>({
+		command: 'alerts_by_severity',
+		minutes: config.minutes,
+	});
+	if (rows === null) {
+		$alertsSeverityStatus.set('error');
+		return;
+	}
+	setCached(key, rows);
+	$alertsSeverity.set(rows);
+	$alertsSeverityStatus.set('ok');
+}
+
+export async function fetchAlertsTop(range: AlertsRange): Promise<void> {
+	const config = ALERTS_RANGES[range];
+	const key = `top:${range}`;
+	const cached = getCached<AlertTopRow[]>(key);
+	if (cached) {
+		$alertsTop.set(cached);
+		$alertsTopStatus.set('ok');
+		return;
+	}
+	$alertsTopStatus.set('loading');
+	const rows = await proxyCommand<AlertTopRow>({
+		command: 'alerts_top',
+		minutes: config.minutes,
+		limit: 20,
+	});
+	if (rows === null) {
+		$alertsTopStatus.set('error');
+		return;
+	}
+	setCached(key, rows);
+	$alertsTop.set(rows);
+	$alertsTopStatus.set('ok');
+}
+
+export async function fetchAllAlerts(range: AlertsRange): Promise<void> {
+	await Promise.all([
+		fetchAlertsFiring(range),
+		fetchAlertsRecent(range),
+		fetchAlertsSeverity(range),
+		fetchAlertsTop(range),
+	]);
+}
+
+export function invalidateAlertsCache(): void {
+	cache.clear();
+}
+
+export function severityColor(sev: string): string {
+	const s = sev.toLowerCase();
+	if (s === 'critical') return '#ef4444';
+	if (s === 'warning') return '#f59e0b';
+	if (s === 'info') return '#3b82f6';
+	return '#6b7280';
+}
+
+export function severityTextClass(sev: string): string {
+	const s = sev.toLowerCase();
+	if (s === 'critical') return 'text-red-500';
+	if (s === 'warning') return 'text-amber-500';
+	if (s === 'info') return 'text-blue-400';
+	return 'text-gray-400';
+}
+
+export function formatRelative(ts: string): string {
+	const t = new Date(ts).getTime();
+	if (!Number.isFinite(t)) return ts;
+	const diff = Date.now() - t;
+	const m = Math.floor(diff / 60_000);
+	if (m < 1) return 'just now';
+	if (m < 60) return `${m}m ago`;
+	const h = Math.floor(m / 60);
+	if (h < 24) return `${h}h ago`;
+	const d = Math.floor(h / 24);
+	return `${d}d ago`;
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/argo/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/argo/index.mdx
@@ -15,5 +15,7 @@ tags:
 ---
 
 import AstroArgoDashboard from '@/components/dashboard/AstroArgoDashboard.astro';
+import AstroAlerts from '@/components/dashboard/AstroAlerts.astro';
 
 <AstroArgoDashboard />
+<AstroAlerts />

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/grafana/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/grafana/index.mdx
@@ -15,5 +15,7 @@ tags:
 ---
 
 import AstroGrafanaDashboard from '@/components/dashboard/AstroGrafanaDashboard.astro';
+import AstroAlerts from '@/components/dashboard/AstroAlerts.astro';
 
 <AstroGrafanaDashboard />
+<AstroAlerts />

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/index.mdx
@@ -15,5 +15,7 @@ tags:
 ---
 
 import AstroDashboardHome from '@/components/dashboard/AstroDashboardHome.astro';
+import AstroAlertsSummary from '@/components/dashboard/AstroAlertsSummary.astro';
 
+<AstroAlertsSummary />
 <AstroDashboardHome />


### PR DESCRIPTION
## Summary

Surfaces the `observability.alerts_distributed` data (PR #11088) on **three** dashboard pages with two density variants. One shared service, one shared component, two thin Astro wrappers.

| Page | Component | Variant |
|------|-----------|---------|
| [/dashboard/](apps/kbve/astro-kbve/src/content/docs/dashboard/index.mdx) | `<AstroAlertsSummary />` | `compact` — firing count + per-severity badges, one row |
| [/dashboard/grafana/](apps/kbve/astro-kbve/src/content/docs/dashboard/grafana/index.mdx) | `<AstroAlerts />` | `full` — 4 sections |
| [/dashboard/argo/](apps/kbve/astro-kbve/src/content/docs/dashboard/argo/index.mdx) | `<AstroAlerts />` | `full` |

## Files (7, +723)

| Path | Purpose |
|------|---------|
| [src/components/dashboard/alertsService.ts](apps/kbve/astro-kbve/src/components/dashboard/alertsService.ts) | Types, nanostore atoms, 30s TTL cache keyed by `(command, range)`. Fetchers for `alerts_firing`, `alerts_recent`, `alerts_by_severity`, `alerts_top`. Helpers: `severityColor`, `severityTextClass`, `formatRelative` |
| [src/components/dashboard/ReactAlerts.tsx](apps/kbve/astro-kbve/src/components/dashboard/ReactAlerts.tsx) | Variant-aware component. `compact` only polls `alerts_firing`. `full` polls all four. recharts BarChart for severity histogram, tables for the rest. Manual refresh invalidates cache |
| [src/components/dashboard/AstroAlerts.astro](apps/kbve/astro-kbve/src/components/dashboard/AstroAlerts.astro) | Full-variant wrapper with `ReactHomeAuth` gate |
| [src/components/dashboard/AstroAlertsSummary.astro](apps/kbve/astro-kbve/src/components/dashboard/AstroAlertsSummary.astro) | Compact-variant wrapper |
| `src/content/docs/dashboard/{index,grafana/index,argo/index}.mdx` | Append the matching component |

## Full variant sections

1. **Currently firing** — `alerts_firing` (argMax-dedup by fingerprint, HAVING status='firing'). Sortable table: severity badge, alertname, namespace, service, summary, started-ago
2. **By severity** — recharts BarChart, colored cells (red critical / amber warning / blue info). Counts only `firing_events`
3. **Top alertnames** — table: alertname, distinct instances, total events, firing count
4. **Recent timeline** — `alerts_recent` (100 rows): time-ago, status (fire/resolve), severity, alertname, namespace, source (`webhook` / `poll`), summary

## Compact variant

```
Bell  Alerts firing  N    ● critical X  ● warning Y  ● info Z
```

Total firing count + per-severity badges. Click the header label → links to `/dashboard/grafana/` for the full view. Polls only `alerts_firing` so it's cheap on the main dashboard page.

## Data flow

```
Browser
  └─> POST /dashboard/clickhouse/proxy  (Bearer JWT)
        └─> axum-kbve  (alerts_recent | alerts_firing |
                        alerts_by_severity | alerts_top)
              └─> jedi::pipe_clickhouse::alerts
                    └─> ClickHouse  observability.alerts_distributed
```

## Verified

- `npx nx run astro-kbve:build` succeeds with three new MDX imports
- Component variant prop boundary covered: compact path skips heavy fetches

## Test plan

- [ ] CI green on dev
- [ ] PR #11088 cluster sync complete (alerts_distributed populated)
- [ ] After merge → astro-kbve rebuild → visit each of the three pages as a staff user:
  - [ ] `/dashboard/` shows compact summary above the existing home content
  - [ ] `/dashboard/grafana/` shows full panel below Grafana content
  - [ ] `/dashboard/argo/` shows full panel below Argo content
- [ ] Range switcher (15m / 1h / 6h / 24h / 7d) updates all panels in sync
- [ ] 30s auto-poll keeps data fresh; manual refresh forces re-fetch
- [ ] Source column distinguishes `webhook` (Vector) vs `poll` (CronJob) entries

## Out of scope

- Per-alert detail drawer (click a row → labels/annotations JSON)
- Alert grouping by `groupKey` for batched UI
- Silenced-alerts overlay from Alertmanager `/api/v2/silences`