### PR TITLE
fix(firecracker-ctl-net): OUTPUT ACCEPT for VM subnet so prober reaches guest

### DIFF
--- a/apps/vm/firecracker-ctl/src/tap.rs
+++ b/apps/vm/firecracker-ctl/src/tap.rs
@@ -298,6 +298,32 @@ pub fn build_input_accept_check(vm_subnet: &str) -> Vec<String> {
     ]
 }
 
+/// Allow OUTPUT to the VM subnet. Without this the pod's OUTPUT chain (DROP
+/// policy on firecracker-ctl-net via Gluetun) silently drops every prober /
+/// proxy SYN heading for the guest; TAP TX stays at 0 and endpoints sit in
+/// `Starting` forever.
+pub fn build_output_accept(vm_subnet: &str) -> Vec<String> {
+    vec![
+        "-I".into(),
+        "OUTPUT".into(),
+        "-d".into(),
+        vm_subnet.into(),
+        "-j".into(),
+        "ACCEPT".into(),
+    ]
+}
+
+pub fn build_output_accept_check(vm_subnet: &str) -> Vec<String> {
+    vec![
+        "-C".into(),
+        "OUTPUT".into(),
+        "-d".into(),
+        vm_subnet.into(),
+        "-j".into(),
+        "ACCEPT".into(),
+    ]
+}
+
 // Gluetun installs `from all to 172.16.0.0/12 lookup 199` at pref 99 and
 // table 199 routes 172.16.0.0/12 via eth0. That swallows VM-bound return
 // traffic (the VM subnet is inside 172.16/12), so DNS replies from
@@ -449,6 +475,10 @@ impl TapManager {
 
         if !iptables_rule_exists(&build_input_accept_check(&self.config.vm_subnet)).await? {
             run_iptables(&build_input_accept(&self.config.vm_subnet)).await?;
+        }
+
+        if !iptables_rule_exists(&build_output_accept_check(&self.config.vm_subnet)).await? {
+            run_iptables(&build_output_accept(&self.config.vm_subnet)).await?;
         }
 
         // ip rule that beats Gluetun's `from all to 172.16/12 lookup 199`


### PR DESCRIPTION
## Bug
Every persistent endpoint sat in \`Starting\` forever:
\`\`\`
GET /fc/public/<name>/
→ {"error":"endpoint starting","status":"starting"}
\`\`\`
Yet the guest's uvicorn was clearly up (\`kubectl logs firecracker-ctl-net\` showed \`Uvicorn running on http://0.0.0.0:8080\`).

## Root cause
\`firecracker-ctl-net\` pod runs Gluetun, which sets \`iptables OUTPUT\` to default \`DROP\`. The existing TapManager bootstrap only installs an INPUT ACCEPT for replies from the VM subnet — there's no matching OUTPUT ACCEPT for traffic heading INTO the VM subnet. Every prober / proxy SYN to \`172.18.0.x:port\` hit the OUTPUT DROP and never made it to \`fctap-N\`.

Confirmed in-cluster:
- \`ip -s link show fctap-0\`: TX bytes/packets = 0 (RX > 0 from gratuitous ARP only)
- \`iptables -nvL OUTPUT\`: 6423 packets dropped; no rule covered the VM subnet
- \`ip route get 172.18.0.2\` correctly resolved to \`fctap-0\` (so routing was fine; only iptables blocked it)

## Fix
Add \`build_output_accept\` / \`build_output_accept_check\` (mirror of the existing INPUT pair) and install on \`TapManager\` init. Idempotent via \`iptables -C\`.

## Test plan
- [ ] After image ships, deploy a public python-web endpoint
- [ ] Prober flips status \`Starting\` → \`Healthy\` within ~5s
- [ ] \`/fc/public/<name>/\` returns 200
- [ ] \`iptables -nvL OUTPUT\` on the pod shows ACCEPT rule for \`-d 172.18.0.0/16\` with non-zero packet count
- [ ] Stop endpoint, verify rule survives subsequent deploys (idempotent)