### PR TITLE
feat(mc/behavior_statetree): auto-claim the spawn cube through OPAC on boot

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
@@ -64,6 +64,11 @@ public class BehaviorStateTreeMod implements ModInitializer {
         McChatEvents.register();
         LOGGER.info("[{}] Chat bridge wired (env-gated)", MOD_ID);
 
+        // Seed the spawn-cube admin claim through OPAC on every server
+        // start. Idempotent: already-server-claimed chunks are skipped.
+        // No-op when OPAC isn't loaded.
+        SpawnAutoClaim.register();
+
         if (!NativeRuntime.isLoaded()) {
             LOGGER.error("[{}] Native library not loaded — NPC AI disabled (ships still work)", MOD_ID);
             return;

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/SpawnAutoClaim.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/SpawnAutoClaim.java
@@ -1,0 +1,121 @@
+package com.kbve.statetree;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class SpawnAutoClaim {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BehaviorStateTreeMod.MOD_ID);
+
+    private static final String OPAC_MOD_ID = "openpartiesandclaims";
+    private static final UUID SERVER_CLAIM_UUID = new UUID(0L, 0L);
+
+    private static final int FROM_CHUNK_X = -13;
+    private static final int FROM_CHUNK_Z = -13;
+    private static final int TO_CHUNK_X = 12;
+    private static final int TO_CHUNK_Z = 12;
+
+    private static final RegistryKey<World>[] DIMENSIONS = arr(World.OVERWORLD);
+
+    @SafeVarargs
+    private static <T> T[] arr(T... a) { return a; }
+
+    private SpawnAutoClaim() {}
+
+    public static void register() {
+        ServerLifecycleEvents.SERVER_STARTED.register(SpawnAutoClaim::onServerStarted);
+    }
+
+    private static void onServerStarted(MinecraftServer server) {
+        if (!FabricLoader.getInstance().isModLoaded(OPAC_MOD_ID)) {
+            LOGGER.info("[spawn-autoclaim] OPAC not loaded — skipping admin-claim seed");
+            return;
+        }
+        try {
+            Class<?> apiClass = Class.forName("xaero.pac.common.server.api.OpenPACServerAPI");
+            Object api = apiClass.getMethod("get", MinecraftServer.class).invoke(null, server);
+            Object claims = apiClass.getMethod("getServerClaimsManager").invoke(api);
+            Class<?> claimsCls = claims.getClass();
+
+            Method getMethod = findMethod(claimsCls, "get", Identifier.class, int.class, int.class);
+            Method claimMethod = findMethod(
+                    claimsCls,
+                    "claim",
+                    Identifier.class,
+                    UUID.class,
+                    int.class,
+                    int.class,
+                    int.class,
+                    boolean.class);
+            if (getMethod == null || claimMethod == null) {
+                LOGGER.warn("[spawn-autoclaim] OPAC API signature mismatch — get={} claim={}",
+                        getMethod, claimMethod);
+                return;
+            }
+
+            int totalClaimed = 0;
+            int totalSkipped = 0;
+            for (RegistryKey<World> dimKey : DIMENSIONS) {
+                Identifier dimId = dimKey.getValue();
+                for (int cx = FROM_CHUNK_X; cx <= TO_CHUNK_X; cx++) {
+                    for (int cz = FROM_CHUNK_Z; cz <= TO_CHUNK_Z; cz++) {
+                        Object existing = getMethod.invoke(claims, dimId, cx, cz);
+                        if (existing != null && isServerOwned(existing)) {
+                            totalSkipped++;
+                            continue;
+                        }
+                        claimMethod.invoke(claims, dimId, SERVER_CLAIM_UUID, cx, cz, 0, false);
+                        totalClaimed++;
+                    }
+                }
+                LOGGER.info(
+                        "[spawn-autoclaim] dimension={} chunks=({},{})..({},{}) claimed={} skipped={}",
+                        dimId,
+                        FROM_CHUNK_X,
+                        FROM_CHUNK_Z,
+                        TO_CHUNK_X,
+                        TO_CHUNK_Z,
+                        totalClaimed,
+                        totalSkipped);
+            }
+        } catch (Throwable t) {
+            LOGGER.warn("[spawn-autoclaim] OPAC integration failed (claim skipped): {}",
+                    t.toString());
+        }
+    }
+
+    private static boolean isServerOwned(Object playerChunkClaim) {
+        try {
+            Method getPlayerId = playerChunkClaim.getClass().getMethod("getPlayerId");
+            Object id = getPlayerId.invoke(playerChunkClaim);
+            return Objects.equals(id, SERVER_CLAIM_UUID);
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    private static Method findMethod(Class<?> cls, String name, Class<?>... params) {
+        for (Class<?> c = cls; c != null; c = c.getSuperclass()) {
+            for (Class<?> iface : c.getInterfaces()) {
+                try {
+                    Method m = iface.getMethod(name, params);
+                    return m;
+                } catch (NoSuchMethodException ignored) {}
+            }
+            try {
+                return c.getMethod(name, params);
+            } catch (NoSuchMethodException ignored) {}
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
Today the spawn city only stays locked down if an op manually runs `/openpac server-mode` + `claim-bulk` after every fresh world deploy. Agones rotates pods (world data lives on the PVC), but fresh worlds (new map / wipe) drop the admin claim and the spawn cube is wide open until someone notices.

This PR seeds the admin claim automatically on every server start.

## Implementation
- New [`SpawnAutoClaim`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/SpawnAutoClaim.java) registered from `BehaviorStateTreeMod.onInitialize` and listening on `ServerLifecycleEvents.SERVER_STARTED`.
- **Soft dep on OPAC.** Reflective load of `xaero.pac.common.server.api.OpenPACServerAPI` — behavior_statetree still compiles + runs cleanly without OPAC installed. Any reflection failure (signature drift across OPAC versions) is caught + logged, never blocks boot.
- Walks chunks `(-13..12) × (-13..12)` in `World.OVERWORLD` — matches the `-200..200` X/Z block cube from [#11007](https://github.com/KBVE/kbve/pull/11007).
- For each chunk: `claims.get(...)` → if already owned by `SERVER_CLAIM_UUID` (`new UUID(0L, 0L)`, OPAC's reserved server-claim sentinel) skip; otherwise `claims.claim(...)` it.
- Logs a single line per dimension with `claimed=` + `skipped=` counts. Fresh boot prints `claimed=676 skipped=0`; subsequent boots `claimed=0 skipped=676`.

## Not in scope (follow-ups)
- AI skeletons (behavior_statetree) still spawning near spawn cube edge after #11007 — needs investigation (likely spawn anchor outside cube + spawn radius lands inside, or despawn pass interval too coarse).
- The Nether / End cube ranges — `DIMENSIONS` array is wired for overworld only.

## Test plan
- [ ] `gradle compileJava` clean (verified locally).
- [ ] On fresh world / wipe: pod log shows `[spawn-autoclaim] dimension=minecraft:overworld chunks=(-13,-13)..(12,12) claimed=676 skipped=0` once.
- [ ] On subsequent restart: same log line with `claimed=0 skipped=676`.
- [ ] Non-op player inside spawn cube: cannot break / place / explosion-damage blocks.
- [ ] Op player inside spawn cube: full edit privileges (OPAC's existing op-bypass).
- [ ] Server without OPAC: log shows `OPAC not loaded — skipping`, no errors, server boots normally.