### PR TITLE
feat(wallet): firecracker billing diesel-async wrappers + integration tests

### DIFF
--- a/packages/rust/kbve/src/wallet/service.rs
+++ b/packages/rust/kbve/src/wallet/service.rs
@@ -1,6 +1,7 @@
+use chrono::{DateTime, Utc};
 use diesel::QueryableByName;
 use diesel::sql_query;
-use diesel::sql_types::{BigInt, Bool, Jsonb, Nullable, Text};
+use diesel::sql_types::{BigInt, Bool, Jsonb, Nullable, Text, Timestamptz};
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
@@ -102,6 +103,36 @@ impl WalletClient {
     pub async fn verify_balance(&self, account_id: Uuid) -> Result<VerifyBalanceRow> {
         let mut conn = self.read().await?;
         verify_async(&mut conn, account_id).await
+    }
+
+    pub async fn firecracker_active_hold_total(&self, account_id: Uuid) -> Result<i64> {
+        let mut conn = self.read().await?;
+        firecracker_active_hold_total_async(&mut conn, account_id).await
+    }
+
+    pub async fn firecracker_place_hold(
+        &self,
+        req: FirecrackerPlaceHoldRequest,
+    ) -> Result<FirecrackerHoldRow> {
+        let mut conn = self.write().await?;
+        firecracker_place_hold_async(&mut conn, req).await
+    }
+
+    pub async fn firecracker_settle(
+        &self,
+        req: FirecrackerSettleRequest,
+    ) -> Result<FirecrackerSettleResult> {
+        let mut conn = self.write().await?;
+        firecracker_settle_async(&mut conn, req).await
+    }
+
+    pub async fn firecracker_update_watermark(
+        &self,
+        vm_id: &str,
+        watermark: i64,
+    ) -> Result<FirecrackerHoldRow> {
+        let mut conn = self.write().await?;
+        firecracker_update_watermark_async(&mut conn, vm_id, watermark).await
     }
 }
 
@@ -221,4 +252,132 @@ async fn verify_async(conn: &mut AsyncPgConnection, account_id: Uuid) -> Result<
         ledger_khash: row.ledger_khash,
         ok: row.ok,
     })
+}
+
+#[derive(QueryableByName)]
+struct FirecrackerActiveHoldRow {
+    #[diesel(sql_type = BigInt)]
+    total: i64,
+}
+
+#[derive(QueryableByName)]
+struct FirecrackerHoldRowDb {
+    #[diesel(sql_type = Text)]
+    vm_id: String,
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    account_id: Uuid,
+    #[diesel(sql_type = BigInt)]
+    amount: i64,
+    #[diesel(sql_type = BigInt)]
+    watermark: i64,
+    #[diesel(sql_type = Timestamptz)]
+    created_at: DateTime<Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    updated_at: DateTime<Utc>,
+}
+
+impl From<FirecrackerHoldRowDb> for FirecrackerHoldRow {
+    fn from(r: FirecrackerHoldRowDb) -> Self {
+        Self {
+            vm_id: r.vm_id,
+            account_id: r.account_id,
+            amount: r.amount,
+            watermark: r.watermark,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+#[derive(QueryableByName)]
+struct FirecrackerSettleResultDb {
+    #[diesel(sql_type = Text)]
+    status: String,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    ledger_id: Option<i64>,
+    #[diesel(sql_type = Nullable<diesel::sql_types::Uuid>)]
+    account_id: Option<Uuid>,
+    #[diesel(sql_type = BigInt)]
+    reserved_amount: i64,
+    #[diesel(sql_type = BigInt)]
+    debited_amount: i64,
+    #[diesel(sql_type = BigInt)]
+    released_amount: i64,
+}
+
+async fn firecracker_active_hold_total_async(
+    conn: &mut AsyncPgConnection,
+    account_id: Uuid,
+) -> Result<i64> {
+    let row: FirecrackerActiveHoldRow =
+        sql_query("SELECT wallet.firecracker_active_hold_total($1) AS total")
+            .bind::<diesel::sql_types::Uuid, _>(account_id)
+            .get_result(conn)
+            .await
+            .map_err(WalletError::from_diesel)?;
+    Ok(row.total)
+}
+
+async fn firecracker_place_hold_async(
+    conn: &mut AsyncPgConnection,
+    req: FirecrackerPlaceHoldRequest,
+) -> Result<FirecrackerHoldRow> {
+    let row: FirecrackerHoldRowDb = sql_query(
+        "SELECT vm_id, account_id, amount, watermark, created_at, updated_at \
+         FROM (SELECT wallet.firecracker_place_hold($1, $2, $3) AS h) s, \
+              LATERAL (SELECT (s.h).*) t",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(req.account_id)
+    .bind::<Text, _>(req.vm_id)
+    .bind::<BigInt, _>(req.amount)
+    .get_result(conn)
+    .await
+    .map_err(WalletError::from_diesel)?;
+    Ok(row.into())
+}
+
+async fn firecracker_settle_async(
+    conn: &mut AsyncPgConnection,
+    req: FirecrackerSettleRequest,
+) -> Result<FirecrackerSettleResult> {
+    let row: FirecrackerSettleResultDb = sql_query(
+        "SELECT status, ledger_id, account_id, reserved_amount, debited_amount, released_amount \
+         FROM wallet.firecracker_settle($1, $2, $3, $4)",
+    )
+    .bind::<Text, _>(req.vm_id)
+    .bind::<BigInt, _>(req.final_amount)
+    .bind::<diesel::sql_types::Uuid, _>(req.idempotency_key)
+    .bind::<Nullable<Text>, _>(req.reason)
+    .get_result(conn)
+    .await
+    .map_err(WalletError::from_diesel)?;
+    let status = FirecrackerSettleStatus::from_pg(&row.status).ok_or_else(|| {
+        WalletError::InvalidArgument(format!("unknown settle status: {}", row.status))
+    })?;
+    Ok(FirecrackerSettleResult {
+        status,
+        ledger_id: row.ledger_id,
+        account_id: row.account_id,
+        reserved_amount: row.reserved_amount,
+        debited_amount: row.debited_amount,
+        released_amount: row.released_amount,
+    })
+}
+
+async fn firecracker_update_watermark_async(
+    conn: &mut AsyncPgConnection,
+    vm_id: &str,
+    watermark: i64,
+) -> Result<FirecrackerHoldRow> {
+    let row: FirecrackerHoldRowDb = sql_query(
+        "SELECT vm_id, account_id, amount, watermark, created_at, updated_at \
+         FROM (SELECT wallet.firecracker_update_watermark($1, $2) AS h) s, \
+              LATERAL (SELECT (s.h).*) t",
+    )
+    .bind::<Text, _>(vm_id)
+    .bind::<BigInt, _>(watermark)
+    .get_result(conn)
+    .await
+    .map_err(WalletError::from_diesel)?;
+    Ok(row.into())
 }

--- a/packages/rust/kbve/src/wallet/tests.rs
+++ b/packages/rust/kbve/src/wallet/tests.rs
@@ -10,7 +10,8 @@ use serial_test::serial;
 use uuid::Uuid;
 
 use super::{
-    BidStatus, CouponStatus, CreditRequest, CurrencyKind, DebitRequest, ListingStatus,
+    BidStatus, CouponStatus, CreditRequest, CurrencyKind, DebitRequest,
+    FirecrackerPlaceHoldRequest, FirecrackerSettleRequest, FirecrackerSettleStatus, ListingStatus,
     MarketBuyNowRequest, MarketCancelListingRequest, MarketCreateListingRequest,
     MarketPlaceBidRequest, RewardKind, SourceKind, TransferRequest, WalletClient, WalletError,
 };
@@ -599,4 +600,318 @@ async fn market_cancel_listing_refunds_active_bidder() {
 
     let detail = client.market_listing_detail(listing_id).await.unwrap();
     assert!(matches!(detail.listing_status, ListingStatus::Cancelled));
+}
+
+fn req_credit_credits(account: Uuid, amount: i64, key: Uuid) -> CreditRequest {
+    CreditRequest {
+        account_id: account,
+        currency: CurrencyKind::Credits,
+        amount,
+        source_kind: SourceKind::Admin,
+        reason: Some("fc-test credits seed".into()),
+        ref_type: None,
+        ref_id: None,
+        idempotency_key: key,
+    }
+}
+
+async fn seed_credits(client: &WalletClient, account: Uuid, amount: i64) {
+    client
+        .credit(req_credit_credits(account, amount, Uuid::new_v4()))
+        .await
+        .expect("seed credits");
+}
+
+fn fresh_vm_id() -> String {
+    format!("fc-{}", Uuid::new_v4().as_simple())
+}
+
+#[tokio::test]
+#[serial]
+async fn firecracker_place_hold_happy_path_and_idempotent_replay() {
+    let Some(client) = client().await else {
+        eprintln!("SKIP: WALLET_TEST_DATABASE_URL unset");
+        return;
+    };
+    let (_user, account) = fixture_account().await.expect("fixture");
+    seed_credits(&client, account, 1_000).await;
+    let vm_id = fresh_vm_id();
+
+    let req = FirecrackerPlaceHoldRequest {
+        account_id: account,
+        vm_id: vm_id.clone(),
+        amount: 300,
+    };
+    let r1 = client.firecracker_place_hold(req.clone()).await.unwrap();
+    assert_eq!(r1.amount, 300);
+    assert_eq!(r1.watermark, 0);
+    assert_eq!(r1.account_id, account);
+
+    let r2 = client.firecracker_place_hold(req).await.unwrap();
+    assert_eq!(r2.vm_id, r1.vm_id);
+    assert_eq!(
+        r2.created_at, r1.created_at,
+        "idempotent replay returns same row"
+    );
+
+    let total = client.firecracker_active_hold_total(account).await.unwrap();
+    assert_eq!(total, 300);
+}
+
+#[tokio::test]
+#[serial]
+async fn firecracker_place_hold_payload_mismatch_raises_replay_mismatch() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (_user, account) = fixture_account().await.expect("fixture");
+    seed_credits(&client, account, 1_000).await;
+    let vm_id = fresh_vm_id();
+
+    client
+        .firecracker_place_hold(FirecrackerPlaceHoldRequest {
+            account_id: account,
+            vm_id: vm_id.clone(),
+            amount: 300,
+        })
+        .await
+        .unwrap();
+    let err = client
+        .firecracker_place_hold(FirecrackerPlaceHoldRequest {
+            account_id: account,
+            vm_id,
+            amount: 999,
+        })
+        .await
+        .expect_err("must raise");
+    assert!(matches!(err, WalletError::ReplayMismatch), "got: {err:?}");
+}
+
+#[tokio::test]
+#[serial]
+async fn firecracker_place_hold_shortfall_raises_insufficient_funds() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (_user, account) = fixture_account().await.expect("fixture");
+    seed_credits(&client, account, 25).await;
+
+    let err = client
+        .firecracker_place_hold(FirecrackerPlaceHoldRequest {
+            account_id: account,
+            vm_id: fresh_vm_id(),
+            amount: 100,
+        })
+        .await
+        .expect_err("must raise");
+    assert!(
+        matches!(err, WalletError::InsufficientFunds),
+        "got: {err:?}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn firecracker_place_hold_short_vm_id_raises_invalid_argument() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (_user, account) = fixture_account().await.expect("fixture");
+    seed_credits(&client, account, 1_000).await;
+
+    let err = client
+        .firecracker_place_hold(FirecrackerPlaceHoldRequest {
+            account_id: account,
+            vm_id: "short".into(),
+            amount: 100,
+        })
+        .await
+        .expect_err("must raise");
+    assert!(
+        matches!(err, WalletError::InvalidArgument(_)),
+        "got: {err:?}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn firecracker_settle_debits_below_hold() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (_user, account) = fixture_account().await.expect("fixture");
+    seed_credits(&client, account, 1_000).await;
+    let vm_id = fresh_vm_id();
+
+    client
+        .firecracker_place_hold(FirecrackerPlaceHoldRequest {
+            account_id: account,
+            vm_id: vm_id.clone(),
+            amount: 300,
+        })
+        .await
+        .unwrap();
+
+    let r = client
+        .firecracker_settle(FirecrackerSettleRequest {
+            vm_id: vm_id.clone(),
+            final_amount: 120,
+            idempotency_key: Uuid::new_v4(),
+            reason: Some("test".into()),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(r.status, FirecrackerSettleStatus::Settled));
+    assert_eq!(r.debited_amount, 120);
+    assert_eq!(r.reserved_amount, 300);
+    assert_eq!(r.released_amount, 180);
+    assert!(r.ledger_id.is_some());
+
+    let total = client.firecracker_active_hold_total(account).await.unwrap();
+    assert_eq!(total, 0, "hold released after settle");
+}
+
+#[tokio::test]
+#[serial]
+async fn firecracker_settle_caps_when_final_exceeds_hold() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (_user, account) = fixture_account().await.expect("fixture");
+    seed_credits(&client, account, 1_000).await;
+    let vm_id = fresh_vm_id();
+
+    client
+        .firecracker_place_hold(FirecrackerPlaceHoldRequest {
+            account_id: account,
+            vm_id: vm_id.clone(),
+            amount: 200,
+        })
+        .await
+        .unwrap();
+
+    let r = client
+        .firecracker_settle(FirecrackerSettleRequest {
+            vm_id,
+            final_amount: 999_999,
+            idempotency_key: Uuid::new_v4(),
+            reason: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(r.status, FirecrackerSettleStatus::SettledCapped));
+    assert_eq!(r.debited_amount, 200);
+    assert_eq!(r.released_amount, 0);
+}
+
+#[tokio::test]
+#[serial]
+async fn firecracker_settle_zero_amount_releases_without_charge() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (_user, account) = fixture_account().await.expect("fixture");
+    seed_credits(&client, account, 1_000).await;
+    let vm_id = fresh_vm_id();
+
+    client
+        .firecracker_place_hold(FirecrackerPlaceHoldRequest {
+            account_id: account,
+            vm_id: vm_id.clone(),
+            amount: 200,
+        })
+        .await
+        .unwrap();
+
+    let r = client
+        .firecracker_settle(FirecrackerSettleRequest {
+            vm_id,
+            final_amount: 0,
+            idempotency_key: Uuid::new_v4(),
+            reason: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        r.status,
+        FirecrackerSettleStatus::ReleasedZeroCharge
+    ));
+    assert!(r.ledger_id.is_none());
+    assert_eq!(r.debited_amount, 0);
+    assert_eq!(r.released_amount, 200);
+}
+
+#[tokio::test]
+#[serial]
+async fn firecracker_settle_missing_vm_is_already_missing() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let _ = fixture_account().await.expect("fixture");
+
+    let r = client
+        .firecracker_settle(FirecrackerSettleRequest {
+            vm_id: fresh_vm_id(),
+            final_amount: 100,
+            idempotency_key: Uuid::new_v4(),
+            reason: None,
+        })
+        .await
+        .unwrap();
+    assert!(matches!(r.status, FirecrackerSettleStatus::AlreadyMissing));
+    assert!(r.ledger_id.is_none());
+    assert_eq!(r.debited_amount, 0);
+}
+
+#[tokio::test]
+#[serial]
+async fn firecracker_update_watermark_clamps_and_is_monotonic() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let (_user, account) = fixture_account().await.expect("fixture");
+    seed_credits(&client, account, 1_000).await;
+    let vm_id = fresh_vm_id();
+
+    client
+        .firecracker_place_hold(FirecrackerPlaceHoldRequest {
+            account_id: account,
+            vm_id: vm_id.clone(),
+            amount: 200,
+        })
+        .await
+        .unwrap();
+
+    let r1 = client
+        .firecracker_update_watermark(&vm_id, 50)
+        .await
+        .unwrap();
+    assert_eq!(r1.watermark, 50);
+
+    let r2 = client
+        .firecracker_update_watermark(&vm_id, 9_999)
+        .await
+        .unwrap();
+    assert_eq!(r2.watermark, 200, "clamped to amount");
+
+    let r3 = client
+        .firecracker_update_watermark(&vm_id, 10)
+        .await
+        .unwrap();
+    assert_eq!(r3.watermark, 200, "monotonic — no regress");
+}
+
+#[tokio::test]
+#[serial]
+async fn firecracker_update_watermark_missing_vm_raises_not_found() {
+    let Some(client) = client().await else {
+        return;
+    };
+    let _ = fixture_account().await.expect("fixture");
+
+    let err = client
+        .firecracker_update_watermark(&fresh_vm_id(), 10)
+        .await
+        .expect_err("must raise");
+    assert!(matches!(err, WalletError::NotFound(_)), "got: {err:?}");
 }


### PR DESCRIPTION
## Summary
Phase C.2 of #11048. Wraps the four \`wallet.firecracker_*\` SQL functions landed in C.1 (#11074) with diesel-async helpers on \`WalletClient\`. **Zero new \`WalletError\` variants** — every SQLSTATE the migration raises (53100, 40001, P0002, 22023, 22004) already maps through \`WalletError::from_diesel\`.

### New on \`WalletClient\`

| Method | SQL | Returns |
|---|---|---|
| \`firecracker_active_hold_total(account_id)\` | \`wallet.firecracker_active_hold_total\` | \`i64\` |
| \`firecracker_place_hold(req)\` | \`wallet.firecracker_place_hold\` | \`FirecrackerHoldRow\` |
| \`firecracker_settle(req)\` | \`wallet.firecracker_settle\` | \`FirecrackerSettleResult\` |
| \`firecracker_update_watermark(vm_id, watermark)\` | \`wallet.firecracker_update_watermark\` | \`FirecrackerHoldRow\` |

Composite-returning functions (\`place_hold\`, \`update_watermark\`) are unwrapped with the \`(call).*\` pattern via \`LATERAL\` so \`QueryableByName\` decodes column-wise into \`FirecrackerHoldRowDb\`. \`settle\` uses \`RETURNS TABLE\` so a plain \`SELECT * FROM\` works.

### Test coverage (\`wallet/tests.rs\`, gated on \`WALLET_TEST_DATABASE_URL\`)

- Happy path: \`place_hold\` inserts, \`active_hold_total\` reflects amount.
- Idempotent replay returns same row (same \`created_at\`).
- Payload mismatch on reuse → \`ReplayMismatch\` (40001).
- Shortfall → \`InsufficientFunds\` (53100).
- \`vm_id\` < 8 chars → \`InvalidArgument\` (22023).
- \`settle\` below hold → \`Settled\` with correct debited/reserved/released triple.
- \`settle\` above hold → \`SettledCapped\`, full hold debited, released = 0.
- \`settle\` 0 → \`ReleasedZeroCharge\`, no ledger row, full release.
- \`settle\` missing vm → \`AlreadyMissing\`, zero amounts.
- \`update_watermark\` clamp + monotonic.
- \`update_watermark\` missing vm → \`NotFound\` (P0002).

\`cargo build -p kbve\` clean. \`cargo test -p kbve --no-run\` clean.

## Out of scope
- C.3: fc-ctl picks up kbve crate dep + calls \`firecracker_place_hold\` on deploy + \`firecracker_settle\` on every teardown. Account-id resolution from JWT.