### PR TITLE
fix(mc/behavior_statetree): extend spawn protection with outer buffer + tighter despawn cadence

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
@@ -55,18 +55,13 @@ public class AiCreatureManager {
      */
     private static final String AI_MARKER_TAG = "kbve_ai_creature";
 
-    /**
-     * Spawn protection cuboid. Hostile mobs (owner == null) refuse to spawn
-     * if the picked surface lands inside this box. Pets are allowed because
-     * they follow their owner anywhere, including the hub. Must stay in
-     * lockstep with {@code WorldSpawnProtection} on the Rust side.
-     */
-    private static final int SPAWN_PROTECT_MIN_X = -200;
-    private static final int SPAWN_PROTECT_MIN_Y = -200;
-    private static final int SPAWN_PROTECT_MIN_Z = -200;
-    private static final int SPAWN_PROTECT_MAX_X = 200;
-    private static final int SPAWN_PROTECT_MAX_Y = 200;
-    private static final int SPAWN_PROTECT_MAX_Z = 200;
+    private static final int SPAWN_PROTECT_BUFFER = 64;
+    private static final int SPAWN_PROTECT_MIN_X = -200 - SPAWN_PROTECT_BUFFER;
+    private static final int SPAWN_PROTECT_MIN_Y = -200 - SPAWN_PROTECT_BUFFER;
+    private static final int SPAWN_PROTECT_MIN_Z = -200 - SPAWN_PROTECT_BUFFER;
+    private static final int SPAWN_PROTECT_MAX_X = 200 + SPAWN_PROTECT_BUFFER;
+    private static final int SPAWN_PROTECT_MAX_Y = 200 + SPAWN_PROTECT_BUFFER;
+    private static final int SPAWN_PROTECT_MAX_Z = 200 + SPAWN_PROTECT_BUFFER;
 
     /** Tracked creatures keyed by Minecraft entity ID. */
     private final ConcurrentHashMap<Integer, CreatureSlot> creatures = new ConcurrentHashMap<>();

--- a/apps/mc/behavior_statetree/src/ecs/components.rs
+++ b/apps/mc/behavior_statetree/src/ecs/components.rs
@@ -261,22 +261,31 @@ impl CooldownState for GlobalCallCooldown {
 pub struct WorldSpawnProtection {
     pub min: [i32; 3],
     pub max: [i32; 3],
+    pub buffer: i32,
 }
 
 impl WorldSpawnProtection {
-    /// Cheap inside-cube test against a floating-point world position. Mirrors
-    /// the Java safety net so both sides agree on the same boundary.
     #[inline]
     pub fn contains_pos(&self, pos: [f64; 3]) -> bool {
+        self.contains_pos_with_padding(pos, 0)
+    }
+
+    #[inline]
+    pub fn contains_pos_buffered(&self, pos: [f64; 3]) -> bool {
+        self.contains_pos_with_padding(pos, self.buffer)
+    }
+
+    #[inline]
+    fn contains_pos_with_padding(&self, pos: [f64; 3], pad: i32) -> bool {
         let x = pos[0].floor() as i32;
         let y = pos[1].floor() as i32;
         let z = pos[2].floor() as i32;
-        x >= self.min[0]
-            && x <= self.max[0]
-            && y >= self.min[1]
-            && y <= self.max[1]
-            && z >= self.min[2]
-            && z <= self.max[2]
+        x >= self.min[0] - pad
+            && x <= self.max[0] + pad
+            && y >= self.min[1] - pad
+            && y <= self.max[1] + pad
+            && z >= self.min[2] - pad
+            && z <= self.max[2] + pad
     }
 }
 
@@ -285,6 +294,7 @@ impl Default for WorldSpawnProtection {
         Self {
             min: [-200, -200, -200],
             max: [200, 200, 200],
+            buffer: 64,
         }
     }
 }
@@ -313,7 +323,7 @@ impl Default for SkeletonPopulationConfig {
             max_skeletons: 2,
             spawn_radius: 32,
             despawn_range: 64.0,
-            manage_interval_ticks: 200, // 20s at 100ms ECS ticks
+            manage_interval_ticks: 60,
         }
     }
 }

--- a/apps/mc/behavior_statetree/src/ecs/systems.rs
+++ b/apps/mc/behavior_statetree/src/ecs/systems.rs
@@ -320,9 +320,7 @@ pub fn manage_skeleton_population(
                 .fold(f64::INFINITY, f64::min)
                 > despawn_sq
         };
-        // Skeletons that wander into the protected hub also despawn so the
-        // spawn city stays clean even if pathing carries them past the edge.
-        let inside_spawn = protection.contains_pos(sk_xyz);
+        let inside_spawn = protection.contains_pos_buffered(sk_xyz);
         if too_far || inside_spawn {
             world_intents.ready.push(IntentReady {
                 entity_id: 0,
@@ -347,16 +345,12 @@ pub fn manage_skeleton_population(
         SkeletonArchetype::Melee,
         SkeletonArchetype::Mage,
     ];
-    // Skip players standing inside the spawn protection cube so the city
-    // never becomes a spawn anchor for hostile reinforcements. Java has a
-    // belt-and-suspenders surface check too, but filtering here saves a
-    // JNI hop on every doomed attempt.
     let mut anchor_idx: usize = 0;
     for (player_id, player_pos) in player_positions.iter() {
         if anchor_idx >= needed {
             break;
         }
-        if protection.contains_pos(*player_pos) {
+        if protection.contains_pos_buffered(*player_pos) {
             continue;
         }
         let archetype = archetype_cycle[anchor_idx % archetype_cycle.len()];


### PR DESCRIPTION
## Summary
Players were still seeing AI skeletons land right outside the spawn-cube wall after #11007. Two compounding causes:

- **Strict cube bounds**: spawn-anchor + Java safety-net checks both used `-200..200` exactly, so a player at `x=232` (just outside) with the default 32-block random spawn offset could land at `x=264` — visually hugging the spawn wall — without hitting either filter.
- **20-second despawn cadence**: `manage_interval_ticks = 200` meant anything that did spawn near the edge (or pathed inward through the boundary) took up to 20s to despawn. From inside spawn that's an eternity.

## Changes
- `WorldSpawnProtection` ([components.rs](apps/mc/behavior_statetree/src/ecs/components.rs)) picks up a `buffer: i32` (default 64) and a `contains_pos_buffered` helper that pads the cube by the buffer.
- `manage_skeleton_population` ([systems.rs](apps/mc/behavior_statetree/src/ecs/systems.rs)) now uses the buffered check on both spawn-anchor selection and the despawn pass — players inside the cube + 64-block ring never become spawn anchors, and any skeleton that lands in the ring gets a Despawn intent.
- [`AiCreatureManager`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java) picks up the same buffer constant so the Java surface-reject covers the ring too.
- `SkeletonPopulationConfig.manage_interval_ticks` drops `200 → 60` (~6s).

## Test plan
- [ ] `cargo check` on `behavior_statetree` clean (verified locally).
- [ ] `gradle compileJava` on the fabric mod clean (verified locally).
- [ ] Stand at `x=232 y=67 z=0` (32 blocks outside the cube wall) — no skeletons spawn anywhere visibly close to the wall over a 5-minute window.
- [ ] Manually `/summon` a skeleton inside the cube — confirm despawn within ~6s of next manage tick.
- [ ] Skeletons outside the cube + buffer ring still spawn normally.