### PR TITLE
feat(referral): Phase 3a — user-target management + trailing-slash + REFERRAL_HASH_SECRET wiring

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -368,10 +368,53 @@ fn router(state: AppState) -> Router {
         // routes before falling through to the static resolver, so these
         // win over any /referral/<...>/index.html that may still ship in
         // the astro dist.
+        //
+        // Each form gets two routes so a trailing slash on the public URL
+        // (e.g. /referral/@fudster/ vs /referral/@fudster) doesn't 404.
+        // axum's path matching is exact — there's no built-in
+        // trailing-slash normalization.
         .route("/referral/{handle}", get(super::referral::redirect_default))
+        .route(
+            "/referral/{handle}/",
+            get(super::referral::redirect_default),
+        )
         .route(
             "/referral/{handle}/{slug}",
             get(super::referral::redirect_slug),
+        )
+        .route(
+            "/referral/{handle}/{slug}/",
+            get(super::referral::redirect_slug),
+        )
+        // API surface also tolerates trailing slashes for parity with the
+        // public URLs above.
+        .route(
+            "/api/v1/referral/{handle}/",
+            get(super::referral::redirect_default),
+        )
+        .route(
+            "/api/v1/referral/{handle}/{slug}/",
+            get(super::referral::redirect_slug),
+        )
+        // Phase 3a self-service management. All `/me/*` routes require
+        // a Supabase user JWT; user_id is pulled from the JWT `sub`
+        // claim, never trusted from the path or body.
+        .route(
+            "/api/v1/referral/me/targets",
+            get(super::referral::me_list_targets),
+        )
+        .route("/api/v1/referral/me/stats", get(super::referral::me_stats))
+        .route(
+            "/api/v1/referral/me/targets/{slug}/enable",
+            post(super::referral::me_enable_target),
+        )
+        .route(
+            "/api/v1/referral/me/targets/{slug}/disable",
+            post(super::referral::me_disable_target),
+        )
+        .route(
+            "/api/v1/referral/me/targets/{slug}/set-default",
+            post(super::referral::me_set_default),
         )
         // service_role JWT required; anon / authenticated JWTs are rejected with 403.
         .route(

--- a/apps/kbve/axum-kbve/src/transport/referral.rs
+++ b/apps/kbve/axum-kbve/src/transport/referral.rs
@@ -10,12 +10,14 @@
 //! functions are the only thing the handler talks to on the SQL side.
 
 use axum::{
+    Json,
     extract::Path,
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use hmac::{Hmac, Mac};
 use kbve::referral::{RecordClickInput, ReferralError};
+use serde::Deserialize;
 use serde_json::json;
 use sha2::Sha256;
 use std::env;
@@ -267,4 +269,163 @@ fn server_error(msg: &str) -> Response {
         axum::Json(json!({ "error": msg })),
     )
         .into_response()
+}
+
+// ===========================================================================
+// Phase 3a — self-service management routes
+//
+// All `/api/v1/referral/me/*` routes require a Supabase user JWT. The caller's
+// user_id is resolved from the JWT `sub` claim (never trusted from the body
+// or path) so a user can only manage their own user_target rows.
+// ===========================================================================
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct EnableBody {
+    #[serde(default)]
+    pub set_as_default: bool,
+}
+
+fn referral_error_response(e: ReferralError) -> Response {
+    match e {
+        ReferralError::TargetNotFound => not_found("target not found or inactive"),
+        ReferralError::TargetNotEnabled => not_found("target not enabled for user"),
+        ReferralError::PolicyMissing => server_error("reward policy missing"),
+        ReferralError::WalletAccountProvisioning => {
+            server_error("wallet account provisioning failed")
+        }
+        ReferralError::InvalidArgument(msg) => (
+            StatusCode::BAD_REQUEST,
+            axum::Json(json!({ "error": "invalid argument", "detail": msg })),
+        )
+            .into_response(),
+        ReferralError::Pool(msg) => {
+            tracing::error!(error = %msg, "referral pool error");
+            service_unavailable("referral pool unavailable")
+        }
+        ReferralError::Db(err) => {
+            tracing::error!(error = %err, "referral db error");
+            server_error("internal error")
+        }
+    }
+}
+
+async fn require_user(headers: &HeaderMap) -> Result<Uuid, Response> {
+    // Reuse the wallet flow's JWT-sub → UUID parser. Same auth posture
+    // (Supabase bearer JWT), same error envelope shape.
+    super::wallet::resolve_user(headers).await
+}
+
+fn require_referral_client() -> Result<&'static kbve::referral::ReferralClient, Response> {
+    get_referral_client().ok_or_else(|| service_unavailable("referral client uninitialized"))
+}
+
+/// `GET /api/v1/referral/me/targets` — full list (active + inactive) with
+/// per-target click + credit totals.
+pub(crate) async fn me_list_targets(headers: HeaderMap) -> Response {
+    let user_id = match require_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let referral = match require_referral_client() {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    match referral.list_user_targets(user_id).await {
+        Ok(rows) => Json(rows).into_response(),
+        Err(e) => referral_error_response(e),
+    }
+}
+
+/// `GET /api/v1/referral/me/stats` — lifetime rollup across targets.
+pub(crate) async fn me_stats(headers: HeaderMap) -> Response {
+    let user_id = match require_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let referral = match require_referral_client() {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    match referral.get_user_stats(user_id).await {
+        Ok(stats) => Json(stats).into_response(),
+        Err(e) => referral_error_response(e),
+    }
+}
+
+/// `POST /api/v1/referral/me/targets/{slug}/enable`
+/// Body: `{ "set_as_default": bool }` (optional; defaults to false).
+pub(crate) async fn me_enable_target(
+    Path(slug): Path<String>,
+    headers: HeaderMap,
+    body: Option<Json<EnableBody>>,
+) -> Response {
+    let user_id = match require_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let referral = match require_referral_client() {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    let set_as_default = body.map(|b| b.0.set_as_default).unwrap_or(false);
+
+    match referral.enable_target(user_id, &slug, set_as_default).await {
+        Ok(row) => Json(row).into_response(),
+        Err(e) => referral_error_response(e),
+    }
+}
+
+/// `POST /api/v1/referral/me/targets/{slug}/disable`
+pub(crate) async fn me_disable_target(Path(slug): Path<String>, headers: HeaderMap) -> Response {
+    let user_id = match require_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let referral = match require_referral_client() {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    match referral.disable_target(user_id, &slug).await {
+        Ok(row) => Json(row).into_response(),
+        Err(ReferralError::Db(err)) => {
+            // Surface the custom RFM01 ("can't disable last default")
+            // through to the client as a 409 so the UI can prompt the
+            // user to pick a new default first.
+            let msg = err.to_string();
+            if msg.contains("cannot disable last active default") {
+                return (
+                    StatusCode::CONFLICT,
+                    axum::Json(json!({
+                        "error": "no_other_default",
+                        "detail": "Pick another target as the default before disabling this one.",
+                    })),
+                )
+                    .into_response();
+            }
+            tracing::error!(error = %err, "disable_target db error");
+            server_error("internal error")
+        }
+        Err(e) => referral_error_response(e),
+    }
+}
+
+/// `POST /api/v1/referral/me/targets/{slug}/set-default`
+pub(crate) async fn me_set_default(Path(slug): Path<String>, headers: HeaderMap) -> Response {
+    let user_id = match require_user(&headers).await {
+        Ok(id) => id,
+        Err(resp) => return resp,
+    };
+    let referral = match require_referral_client() {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+
+    match referral.set_default_target(user_id, &slug).await {
+        Ok(row) => Json(row).into_response(),
+        Err(e) => referral_error_response(e),
+    }
 }

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -204,6 +204,19 @@ spec:
                             secretKeyRef:
                                 name: supabase-shared
                                 key: db-url-ro
+                      # HMAC-SHA256 key for the referral handler's IP +
+                      # subnet hashing. Sourced from referral-config in
+                      # this namespace (built by kbve-externalsecret.yaml
+                      # from the kilobase `referral-hash` remote). When
+                      # unset, /api/v1/referral/* and /referral/*
+                      # routes 503 with a warn-log instead of fabricating
+                      # a predictable key.
+                      - name: REFERRAL_HASH_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: referral-config
+                                key: hash-secret
+                                optional: true
                   volumeMounts:
                       - name: argocd-ca
                         mountPath: /etc/ssl/argocd

--- a/apps/kube/kbve/manifest/kbve-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/kbve-externalsecret.yaml
@@ -67,3 +67,40 @@ spec:
           remoteRef:
               key: twitch-oauth-config
               property: client-secret
+---
+# HMAC key for the referral handler's IP / subnet hashing. axum-kbve
+# reads REFERRAL_HASH_SECRET from this secret's `hash-secret` key (see
+# kbve-deployment.yaml). When the remote `referral-hash` secret in
+# kilobase doesn't exist yet, ExternalSecrets keeps the local secret
+# absent and the deployment env stays unset (the deployment marks the
+# key as `optional: true`), so the routes 503 with a clear log line
+# until operator runs:
+#
+#   kubectl -n kilobase create secret generic referral-hash \
+#       --from-literal=secret="$(openssl rand -base64 48)"
+#
+# Once that's in place the ExternalSecrets controller materializes
+# `referral-config` in the kbve namespace and Reloader rolls the
+# kbve deployment.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: kbve-referral-secrets
+    namespace: kbve
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: referral-config
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                hash-secret: '{{ .hashsecret }}'
+    data:
+        - secretKey: hashsecret
+          remoteRef:
+              key: referral-hash
+              property: secret

--- a/packages/data/sql/dbmate/migration-tests/20260516090714_referral_user_target_mgmt.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516090714_referral_user_target_mgmt.test.sql
@@ -1,0 +1,237 @@
+-- Companion test for 20260516090714_referral_user_target_mgmt.
+-- Run via: ./test-migration.sh 20260516090714_referral_user_target_mgmt
+
+-- SEED
+WITH test_users (id) AS (
+    VALUES ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid)
+),
+test_accounts AS (
+    SELECT a.id FROM wallet.account a JOIN test_users u ON a.user_id = u.id
+),
+del_user_target AS (
+    DELETE FROM referral.user_target
+     WHERE user_id IN (SELECT id FROM test_users)
+),
+del_click AS (
+    DELETE FROM referral.click
+     WHERE referrer_id IN (SELECT id FROM test_users)
+),
+del_balance AS (
+    DELETE FROM wallet.balance
+     WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_coupon AS (
+    DELETE FROM wallet.coupon
+     WHERE account_id IN (SELECT id FROM test_accounts)
+),
+del_account AS (
+    DELETE FROM wallet.account
+     WHERE id IN (SELECT id FROM test_accounts)
+)
+DELETE FROM auth.users WHERE id IN (SELECT id FROM test_users);
+
+INSERT INTO auth.users (id) VALUES ('dddddddd-dddd-dddd-dddd-dddddddddddd');
+
+-- ASSERT_AFTER_UP
+
+-- service_enable_target inserts and auto-promotes the first target to default.
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    row referral.user_target;
+BEGIN
+    SELECT * INTO row FROM referral.service_enable_target(u, 'rareicon');
+    IF NOT row.active THEN
+        RAISE EXCEPTION 'fail: enable should activate row';
+    END IF;
+    IF NOT row.is_default THEN
+        RAISE EXCEPTION 'fail: first enable should auto-default';
+    END IF;
+
+    -- Second enable WITHOUT set_as_default keeps the existing default.
+    SELECT * INTO row FROM referral.service_enable_target(u, 'mc');
+    IF row.is_default THEN
+        RAISE EXCEPTION 'fail: second enable should not steal default';
+    END IF;
+END $$;
+
+-- service_set_default_target swaps cleanly.
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    row referral.user_target;
+    rare_def BOOLEAN;
+BEGIN
+    SELECT * INTO row FROM referral.service_set_default_target(u, 'mc');
+    IF NOT row.is_default THEN
+        RAISE EXCEPTION 'fail: set_default should mark target as default';
+    END IF;
+
+    -- Old default must have flipped to FALSE.
+    SELECT is_default INTO rare_def
+      FROM referral.user_target
+     WHERE user_id = u AND target_slug = 'rareicon';
+    IF rare_def THEN
+        RAISE EXCEPTION 'fail: previous default should have been demoted';
+    END IF;
+END $$;
+
+-- service_set_default_target on a target the user hasn't enabled raises RFU01.
+DO $$
+DECLARE u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+BEGIN
+    BEGIN
+        PERFORM * FROM referral.service_set_default_target(u, 'rareicon');
+    EXCEPTION WHEN OTHERS THEN
+        -- rareicon IS enabled; this should NOT raise. Re-raise to fail.
+        RAISE;
+    END;
+
+    BEGIN
+        PERFORM * FROM referral.service_set_default_target(u, 'nope-not-real');
+        RAISE EXCEPTION 'fail: unknown slug should have raised';
+    EXCEPTION WHEN SQLSTATE 'RFU01' THEN
+        -- expected
+    END;
+END $$;
+
+-- service_disable_target promotes a remaining active row to default.
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    rare_default BOOLEAN;
+    mc_active BOOLEAN;
+BEGIN
+    -- Currently: mc is default, rareicon is active not default. Make
+    -- rareicon default again so we can disable it and watch mc inherit.
+    PERFORM * FROM referral.service_set_default_target(u, 'rareicon');
+
+    PERFORM * FROM referral.service_disable_target(u, 'rareicon');
+
+    SELECT is_default INTO rare_default
+      FROM referral.user_target
+     WHERE user_id = u AND target_slug = 'rareicon';
+    IF rare_default THEN
+        RAISE EXCEPTION 'fail: disabled row should not still be default';
+    END IF;
+
+    SELECT is_default INTO mc_active
+      FROM referral.user_target
+     WHERE user_id = u AND target_slug = 'mc';
+    IF NOT mc_active THEN
+        RAISE EXCEPTION 'fail: remaining active row should inherit default';
+    END IF;
+END $$;
+
+-- Disabling the last active default raises RFM01.
+DO $$
+DECLARE u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+BEGIN
+    BEGIN
+        PERFORM * FROM referral.service_disable_target(u, 'mc');
+        RAISE EXCEPTION 'fail: disabling last active should have raised RFM01';
+    EXCEPTION WHEN SQLSTATE 'RFM01' THEN
+        -- expected
+    END;
+END $$;
+
+-- Re-enable an inactive row: clears disabled_at, keeps enabled_at.
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    before_enabled_at TIMESTAMPTZ;
+    after_row referral.user_target;
+BEGIN
+    SELECT enabled_at INTO before_enabled_at
+      FROM referral.user_target
+     WHERE user_id = u AND target_slug = 'rareicon';
+
+    SELECT * INTO after_row
+      FROM referral.service_enable_target(u, 'rareicon');
+
+    IF NOT after_row.active THEN
+        RAISE EXCEPTION 'fail: re-enable should activate';
+    END IF;
+    IF after_row.disabled_at IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: re-enable should clear disabled_at';
+    END IF;
+    IF after_row.enabled_at <> before_enabled_at THEN
+        RAISE EXCEPTION 'fail: enabled_at should stay stable across re-enable';
+    END IF;
+END $$;
+
+-- service_list_user_targets returns active + inactive rows with stats.
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    cnt INT;
+BEGIN
+    -- Make sure both targets are active for a clean count.
+    PERFORM * FROM referral.service_enable_target(u, 'rareicon');
+    PERFORM * FROM referral.service_enable_target(u, 'mc');
+
+    SELECT count(*)::INT INTO cnt FROM referral.service_list_user_targets(u);
+    IF cnt < 2 THEN
+        RAISE EXCEPTION 'fail: list should return at least 2 rows for this user, got %', cnt;
+    END IF;
+END $$;
+
+-- service_get_user_stats sums clicks + credits across targets.
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    ip BYTEA := decode(repeat('a1', 32), 'hex');
+    sn BYTEA := decode(repeat('b2', 32), 'hex');
+    r RECORD;
+BEGIN
+    -- Record one qualified click via the Phase 1 RPC.
+    PERFORM * FROM referral.record_click(u, 'rareicon', ip, sn, NULL, NULL, NULL);
+
+    SELECT * INTO r FROM referral.service_get_user_stats(u);
+    IF r.clicks_total < 1 THEN
+        RAISE EXCEPTION 'fail: stats should reflect at least 1 click';
+    END IF;
+    IF r.clicks_credited < 1 THEN
+        RAISE EXCEPTION 'fail: stats should reflect at least 1 credit';
+    END IF;
+    IF r.credits_total < 10 THEN
+        RAISE EXCEPTION 'fail: stats credits_total should be >= 10, got %', r.credits_total;
+    END IF;
+END $$;
+
+-- Input guards.
+DO $$
+BEGIN
+    BEGIN
+        PERFORM * FROM referral.service_enable_target(NULL, 'rareicon');
+        RAISE EXCEPTION 'fail: NULL user_id should have raised';
+    EXCEPTION WHEN SQLSTATE '22004' THEN
+        -- expected
+    END;
+
+    BEGIN
+        PERFORM * FROM referral.service_enable_target(
+            'dddddddd-dddd-dddd-dddd-dddddddddddd'::UUID, 'NOT_A_TARGET'
+        );
+        RAISE EXCEPTION 'fail: unknown target should have raised RFT01';
+    EXCEPTION WHEN SQLSTATE 'RFT01' THEN
+        -- expected
+    END;
+END $$;
+
+-- ASSERT_AFTER_DOWN
+
+-- migrate:down is intentionally a no-op. Verify the schema + functions
+-- survive a rollback.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_proc
+          JOIN pg_namespace ON pg_namespace.oid = pg_proc.pronamespace
+         WHERE pg_namespace.nspname = 'referral'
+           AND proname = 'service_set_default_target'
+    ) THEN
+        RAISE EXCEPTION 'fail: service_set_default_target should survive no-op down';
+    END IF;
+END $$;

--- a/packages/data/sql/dbmate/migration-tests/20260516090714_referral_user_target_mgmt.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516090714_referral_user_target_mgmt.test.sql
@@ -2,35 +2,22 @@
 -- Run via: ./test-migration.sh 20260516090714_referral_user_target_mgmt
 
 -- SEED
+-- wallet.ledger is append-only (trg_ledger_immutable blocks DELETE),
+-- so we can't purge prior ledger rows or the account they reference.
+-- Only purge what *this* phase owns — the referral tables — and reuse
+-- the auth.users row from prior runs via ON CONFLICT.
 WITH test_users (id) AS (
     VALUES ('dddddddd-dddd-dddd-dddd-dddddddddddd'::uuid)
-),
-test_accounts AS (
-    SELECT a.id FROM wallet.account a JOIN test_users u ON a.user_id = u.id
-),
-del_user_target AS (
-    DELETE FROM referral.user_target
-     WHERE user_id IN (SELECT id FROM test_users)
 ),
 del_click AS (
     DELETE FROM referral.click
      WHERE referrer_id IN (SELECT id FROM test_users)
-),
-del_balance AS (
-    DELETE FROM wallet.balance
-     WHERE account_id IN (SELECT id FROM test_accounts)
-),
-del_coupon AS (
-    DELETE FROM wallet.coupon
-     WHERE account_id IN (SELECT id FROM test_accounts)
-),
-del_account AS (
-    DELETE FROM wallet.account
-     WHERE id IN (SELECT id FROM test_accounts)
 )
-DELETE FROM auth.users WHERE id IN (SELECT id FROM test_users);
+DELETE FROM referral.user_target
+ WHERE user_id IN (SELECT id FROM test_users);
 
-INSERT INTO auth.users (id) VALUES ('dddddddd-dddd-dddd-dddd-dddddddddddd');
+INSERT INTO auth.users (id) VALUES ('dddddddd-dddd-dddd-dddd-dddddddddddd')
+ON CONFLICT (id) DO NOTHING;
 
 -- ASSERT_AFTER_UP
 
@@ -201,6 +188,7 @@ END $$;
 
 -- Input guards.
 DO $$
+DECLARE u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
 BEGIN
     BEGIN
         PERFORM * FROM referral.service_enable_target(NULL, 'rareicon');
@@ -210,12 +198,80 @@ BEGIN
     END;
 
     BEGIN
-        PERFORM * FROM referral.service_enable_target(
-            'dddddddd-dddd-dddd-dddd-dddddddddddd'::UUID, 'NOT_A_TARGET'
-        );
+        PERFORM * FROM referral.service_enable_target(u, 'NOT_A_TARGET');
         RAISE EXCEPTION 'fail: unknown target should have raised RFT01';
     EXCEPTION WHEN SQLSTATE 'RFT01' THEN
         -- expected
+    END;
+
+    -- Empty-string-after-trim guards on disable + set_default + enable.
+    BEGIN
+        PERFORM * FROM referral.service_disable_target(u, '   ');
+        RAISE EXCEPTION 'fail: whitespace-only slug should have raised 22023';
+    EXCEPTION WHEN SQLSTATE '22023' THEN
+        -- expected
+    END;
+    BEGIN
+        PERFORM * FROM referral.service_set_default_target(u, '   ');
+        RAISE EXCEPTION 'fail: whitespace-only slug should have raised 22023';
+    EXCEPTION WHEN SQLSTATE '22023' THEN
+        -- expected
+    END;
+
+    -- NULL user_id raises on list + stats too (PL/pgSQL conversion).
+    BEGIN
+        PERFORM * FROM referral.service_list_user_targets(NULL);
+        RAISE EXCEPTION 'fail: NULL user_id should have raised in list';
+    EXCEPTION WHEN SQLSTATE '22004' THEN
+        -- expected
+    END;
+    BEGIN
+        PERFORM * FROM referral.service_get_user_stats(NULL);
+        RAISE EXCEPTION 'fail: NULL user_id should have raised in stats';
+    EXCEPTION WHEN SQLSTATE '22004' THEN
+        -- expected
+    END;
+END $$;
+
+-- Schema invariants added in Phase 3a.
+DO $$
+DECLARE u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+BEGIN
+    -- user_target_default_requires_active CHECK rejects
+    -- is_default = TRUE on an inactive row.
+    BEGIN
+        INSERT INTO referral.user_target (
+            user_id, target_slug, is_default, active,
+            enabled_at, disabled_at
+        ) VALUES (u, 'mc', TRUE, FALSE, now(), now());
+        RAISE EXCEPTION 'fail: is_default+inactive should have raised check_violation';
+    EXCEPTION WHEN check_violation THEN
+        -- expected
+    END;
+
+    -- updated_at trigger bumps the column on any UPDATE.
+    DECLARE
+        ts_before TIMESTAMPTZ;
+        ts_after  TIMESTAMPTZ;
+    BEGIN
+        SELECT updated_at INTO ts_before
+          FROM referral.user_target
+         WHERE user_id = u AND target_slug = 'rareicon';
+        IF ts_before IS NULL THEN
+            RAISE EXCEPTION 'fail: updated_at backfill should never be NULL';
+        END IF;
+
+        PERFORM pg_sleep(0.05);
+        UPDATE referral.user_target
+           SET disabled_at = NULL  -- harmless touch
+         WHERE user_id = u AND target_slug = 'rareicon';
+
+        SELECT updated_at INTO ts_after
+          FROM referral.user_target
+         WHERE user_id = u AND target_slug = 'rareicon';
+        IF ts_after <= ts_before THEN
+            RAISE EXCEPTION 'fail: updated_at trigger did not bump';
+        END IF;
     END;
 END $$;
 

--- a/packages/data/sql/dbmate/migration-tests/20260516090714_referral_user_target_mgmt.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516090714_referral_user_target_mgmt.test.sql
@@ -275,6 +275,107 @@ BEGIN
     END;
 END $$;
 
+-- Idempotent fast path: enabling an already-active row in the desired
+-- state must not bump updated_at. Skipping the UPDATE keeps cache
+-- invalidation hooks honest.
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    ts_before TIMESTAMPTZ;
+    ts_after  TIMESTAMPTZ;
+BEGIN
+    SELECT updated_at INTO ts_before
+      FROM referral.user_target
+     WHERE user_id = u AND target_slug = 'rareicon';
+
+    PERFORM pg_sleep(0.05);
+    PERFORM * FROM referral.service_enable_target(u, 'rareicon');
+
+    SELECT updated_at INTO ts_after
+      FROM referral.user_target
+     WHERE user_id = u AND target_slug = 'rareicon';
+    IF ts_after <> ts_before THEN
+        RAISE EXCEPTION 'fail: idempotent enable should not bump updated_at (was %, now %)',
+                        ts_before, ts_after;
+    END IF;
+END $$;
+
+-- Idempotent fast path: set_default on the row that is already default
+-- must be a no-op (no updated_at bump).
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    ts_before TIMESTAMPTZ;
+    ts_after  TIMESTAMPTZ;
+BEGIN
+    SELECT updated_at INTO ts_before
+      FROM referral.user_target
+     WHERE user_id = u AND target_slug = 'mc';
+
+    PERFORM pg_sleep(0.05);
+    PERFORM * FROM referral.service_set_default_target(u, 'mc');
+
+    SELECT updated_at INTO ts_after
+      FROM referral.user_target
+     WHERE user_id = u AND target_slug = 'mc';
+    IF ts_after <> ts_before THEN
+        RAISE EXCEPTION 'fail: idempotent set_default should not bump updated_at (was %, now %)',
+                        ts_before, ts_after;
+    END IF;
+END $$;
+
+-- service_disable_target returns the disabled slug AND the slug that
+-- inherited the default when one is promoted.
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    r RECORD;
+BEGIN
+    -- mc is currently default, rareicon active. Disabling mc must
+    -- promote rareicon to default and return its slug.
+    SELECT * INTO r FROM referral.service_disable_target(u, 'mc');
+    IF r.target_slug <> 'mc' THEN
+        RAISE EXCEPTION 'fail: disable should return mc, got %', r.target_slug;
+    END IF;
+    IF r.promoted_target_slug IS NULL THEN
+        RAISE EXCEPTION 'fail: disable should return a promoted_target_slug';
+    END IF;
+    IF r.promoted_target_slug <> 'rareicon' THEN
+        RAISE EXCEPTION 'fail: disable should promote rareicon, got %', r.promoted_target_slug;
+    END IF;
+    IF r.active THEN
+        RAISE EXCEPTION 'fail: disabled row should not be active';
+    END IF;
+    IF r.disabled_at IS NULL THEN
+        RAISE EXCEPTION 'fail: disabled_at should be set';
+    END IF;
+
+    -- Re-enable mc as non-default; rareicon stays default.
+    PERFORM * FROM referral.service_enable_target(u, 'mc');
+    -- Disabling mc when it is not the default must return NULL for
+    -- promoted_target_slug.
+    SELECT * INTO r FROM referral.service_disable_target(u, 'mc');
+    IF r.promoted_target_slug IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: disabling non-default should leave promoted_target_slug NULL, got %',
+                        r.promoted_target_slug;
+    END IF;
+END $$;
+
+-- service_list_user_targets exposes updated_at to callers.
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    r RECORD;
+BEGIN
+    PERFORM * FROM referral.service_enable_target(u, 'mc');
+    SELECT * INTO r
+      FROM referral.service_list_user_targets(u)
+     WHERE target_slug = 'rareicon';
+    IF r.updated_at IS NULL THEN
+        RAISE EXCEPTION 'fail: list should include updated_at';
+    END IF;
+END $$;
+
 -- ASSERT_AFTER_DOWN
 
 -- migrate:down is intentionally a no-op. Verify the schema + functions

--- a/packages/data/sql/dbmate/migration-tests/20260516090714_referral_user_target_mgmt.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516090714_referral_user_target_mgmt.test.sql
@@ -25,33 +25,52 @@ ON CONFLICT (id) DO NOTHING;
 DO $$
 DECLARE
     u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
-    row referral.user_target;
+    r RECORD;
 BEGIN
-    SELECT * INTO row FROM referral.service_enable_target(u, 'rareicon');
-    IF NOT row.active THEN
+    SELECT * INTO r FROM referral.service_enable_target(u, 'rareicon');
+    IF NOT r.active THEN
         RAISE EXCEPTION 'fail: enable should activate row';
     END IF;
-    IF NOT row.is_default THEN
+    IF NOT r.is_default THEN
         RAISE EXCEPTION 'fail: first enable should auto-default';
+    END IF;
+    -- First enable: nobody to demote.
+    IF r.demoted_target_slug IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: first enable should have NULL demoted_target_slug, got %',
+                        r.demoted_target_slug;
     END IF;
 
     -- Second enable WITHOUT set_as_default keeps the existing default.
-    SELECT * INTO row FROM referral.service_enable_target(u, 'mc');
-    IF row.is_default THEN
+    SELECT * INTO r FROM referral.service_enable_target(u, 'mc');
+    IF r.is_default THEN
         RAISE EXCEPTION 'fail: second enable should not steal default';
+    END IF;
+    -- No demotion when we don't take the default.
+    IF r.demoted_target_slug IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: enable without set_as_default should not demote';
     END IF;
 END $$;
 
--- service_set_default_target swaps cleanly.
+-- service_set_default_target swaps cleanly and returns demoted slug.
 DO $$
 DECLARE
     u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
-    row referral.user_target;
+    r RECORD;
     rare_def BOOLEAN;
 BEGIN
-    SELECT * INTO row FROM referral.service_set_default_target(u, 'mc');
-    IF NOT row.is_default THEN
+    SELECT * INTO r FROM referral.service_set_default_target(u, 'mc');
+    IF NOT r.is_default THEN
         RAISE EXCEPTION 'fail: set_default should mark target as default';
+    END IF;
+    IF r.demoted_target_slug IS NULL THEN
+        RAISE EXCEPTION 'fail: set_default should return demoted slug';
+    END IF;
+    IF r.demoted_target_slug <> 'rareicon' THEN
+        RAISE EXCEPTION 'fail: set_default should report rareicon as demoted, got %',
+                        r.demoted_target_slug;
+    END IF;
+    IF r.demoted_updated_at IS NULL THEN
+        RAISE EXCEPTION 'fail: demoted_updated_at should be set when demotion happened';
     END IF;
 
     -- Old default must have flipped to FALSE.
@@ -127,7 +146,7 @@ DO $$
 DECLARE
     u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
     before_enabled_at TIMESTAMPTZ;
-    after_row referral.user_target;
+    after_row RECORD;
 BEGIN
     SELECT enabled_at INTO before_enabled_at
       FROM referral.user_target
@@ -407,6 +426,40 @@ BEGIN
     IF r.updated_at IS NULL THEN
         RAISE EXCEPTION 'fail: list should include updated_at';
     END IF;
+END $$;
+
+-- Immutability trigger: user_id, target_slug, and enabled_at are
+-- locked after insert. Each direct UPDATE must raise SQLSTATE 22023.
+DO $$
+DECLARE
+    u UUID := 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+BEGIN
+    BEGIN
+        UPDATE referral.user_target
+           SET target_slug = 'rareicon-stolen'
+         WHERE user_id = u AND target_slug = 'rareicon';
+        RAISE EXCEPTION 'fail: target_slug UPDATE should have raised 22023';
+    EXCEPTION WHEN SQLSTATE '22023' THEN
+        -- expected
+    END;
+
+    BEGIN
+        UPDATE referral.user_target
+           SET enabled_at = '2020-01-01'::TIMESTAMPTZ
+         WHERE user_id = u AND target_slug = 'rareicon';
+        RAISE EXCEPTION 'fail: enabled_at UPDATE should have raised 22023';
+    EXCEPTION WHEN SQLSTATE '22023' THEN
+        -- expected
+    END;
+
+    BEGIN
+        UPDATE referral.user_target
+           SET user_id = '11111111-1111-1111-1111-111111111111'::UUID
+         WHERE user_id = u AND target_slug = 'rareicon';
+        RAISE EXCEPTION 'fail: user_id UPDATE should have raised 22023';
+    EXCEPTION WHEN SQLSTATE '22023' THEN
+        -- expected
+    END;
 END $$;
 
 -- ASSERT_AFTER_DOWN

--- a/packages/data/sql/dbmate/migration-tests/20260516090714_referral_user_target_mgmt.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260516090714_referral_user_target_mgmt.test.sql
@@ -249,9 +249,11 @@ BEGIN
         -- expected
     END;
 
-    -- updated_at trigger bumps the column on any UPDATE.
+    -- updated_at trigger gates on material change: a no-op rewrite of
+    -- a watched column must NOT bump, while a real flip MUST bump.
     DECLARE
         ts_before TIMESTAMPTZ;
+        ts_noop   TIMESTAMPTZ;
         ts_after  TIMESTAMPTZ;
     BEGIN
         SELECT updated_at INTO ts_before
@@ -263,15 +265,37 @@ BEGIN
 
         PERFORM pg_sleep(0.05);
         UPDATE referral.user_target
-           SET disabled_at = NULL  -- harmless touch
+           SET active = active   -- no-op rewrite
+         WHERE user_id = u AND target_slug = 'rareicon';
+
+        SELECT updated_at INTO ts_noop
+          FROM referral.user_target
+         WHERE user_id = u AND target_slug = 'rareicon';
+        IF ts_noop <> ts_before THEN
+            RAISE EXCEPTION 'fail: no-op UPDATE should not bump updated_at';
+        END IF;
+
+        PERFORM pg_sleep(0.05);
+        -- active + disabled_at are coupled by user_target_active_disabled_chk,
+        -- so flip them together to make a legal material change.
+        UPDATE referral.user_target
+           SET active = FALSE,
+               disabled_at = statement_timestamp()
          WHERE user_id = u AND target_slug = 'rareicon';
 
         SELECT updated_at INTO ts_after
           FROM referral.user_target
          WHERE user_id = u AND target_slug = 'rareicon';
         IF ts_after <= ts_before THEN
-            RAISE EXCEPTION 'fail: updated_at trigger did not bump';
+            RAISE EXCEPTION 'fail: material UPDATE should bump updated_at';
         END IF;
+
+        -- Restore rareicon to active so downstream tests find it in
+        -- a clean state.
+        UPDATE referral.user_target
+           SET active = TRUE,
+               disabled_at = NULL
+         WHERE user_id = u AND target_slug = 'rareicon';
     END;
 END $$;
 
@@ -349,15 +373,24 @@ BEGIN
     IF r.disabled_at IS NULL THEN
         RAISE EXCEPTION 'fail: disabled_at should be set';
     END IF;
+    IF r.updated_at IS NULL THEN
+        RAISE EXCEPTION 'fail: disable return should include updated_at';
+    END IF;
+    IF r.promoted_updated_at IS NULL THEN
+        RAISE EXCEPTION 'fail: disable return should include promoted_updated_at when promotion happened';
+    END IF;
 
     -- Re-enable mc as non-default; rareicon stays default.
     PERFORM * FROM referral.service_enable_target(u, 'mc');
     -- Disabling mc when it is not the default must return NULL for
-    -- promoted_target_slug.
+    -- promoted_target_slug AND promoted_updated_at (nothing was promoted).
     SELECT * INTO r FROM referral.service_disable_target(u, 'mc');
     IF r.promoted_target_slug IS NOT NULL THEN
         RAISE EXCEPTION 'fail: disabling non-default should leave promoted_target_slug NULL, got %',
                         r.promoted_target_slug;
+    END IF;
+    IF r.promoted_updated_at IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: disabling non-default should leave promoted_updated_at NULL';
     END IF;
 END $$;
 

--- a/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
+++ b/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
@@ -47,6 +47,7 @@ ALTER TABLE referral.user_target
 CREATE OR REPLACE FUNCTION referral.user_target_touch()
 RETURNS TRIGGER
 LANGUAGE plpgsql
+SET search_path = ''
 AS $fn$
 BEGIN
     NEW.updated_at := statement_timestamp();
@@ -63,50 +64,69 @@ CREATE TRIGGER user_target_set_updated_at
 -- at the same time. The partial unique index on (user_id) WHERE
 -- is_default AND active already prevents two defaults; this CHECK
 -- closes the loophole where an out-of-band UPDATE leaves a disabled
--- row marked is_default = TRUE.
+-- row marked is_default = TRUE. Idempotent rename handles earlier
+-- iterations that used the unprefixed name.
 DO $$
 BEGIN
-    IF NOT EXISTS (
-        SELECT 1
-          FROM pg_constraint
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
          WHERE conrelid = 'referral.user_target'::regclass
            AND conname = 'user_target_default_requires_active'
     ) THEN
         ALTER TABLE referral.user_target
-            ADD CONSTRAINT user_target_default_requires_active
+            RENAME CONSTRAINT user_target_default_requires_active
+            TO referral_user_target_default_requires_active_ck;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conrelid = 'referral.user_target'::regclass
+           AND conname = 'referral_user_target_default_requires_active_ck'
+    ) THEN
+        ALTER TABLE referral.user_target
+            ADD CONSTRAINT referral_user_target_default_requires_active_ck
             CHECK (active OR NOT is_default);
     END IF;
 END $$;
 
--- Hot-path indexes for the stats lateral aggregates in
--- service_list_user_targets / service_get_user_stats.
-CREATE INDEX IF NOT EXISTS click_referrer_target_idx
+-- (No `credited → ledger_id` CHECK added here: Phase 1's
+-- click_credit_ledger_chk already enforces the stronger biconditional
+-- `credited <=> ledger_id IS NOT NULL`. A separate one-sided CHECK
+-- would be strictly implied by the existing one — redundant noise.)
+
+-- Hot-path indexes for the stats aggregates in
+-- service_list_user_targets / service_get_user_stats. Rename earlier
+-- iterations to the schema_table_columns_idx convention.
+DROP INDEX IF EXISTS referral.click_referrer_target_idx;
+DROP INDEX IF EXISTS referral.click_referrer_credited_ledger_idx;
+CREATE INDEX IF NOT EXISTS referral_click_referrer_target_created_idx
     ON referral.click (referrer_id, target_slug, created_at DESC);
-CREATE INDEX IF NOT EXISTS click_referrer_credited_ledger_idx
+CREATE INDEX IF NOT EXISTS referral_click_referrer_credited_ledger_idx
     ON referral.click (referrer_id)
     WHERE credited AND ledger_id IS NOT NULL;
 
 -- ---------------------------------------------------------------------------
 -- service_list_user_targets — returns every (slug, title, url, active,
--- is_default, enabled_at, disabled_at) for the user PLUS lifetime click
--- + credit totals per target. One row per (user, target). Inactive rows
--- included so the UI can offer a "re-enable" affordance.
+-- is_default, enabled_at, disabled_at, updated_at) for the user PLUS
+-- lifetime click + credit totals per target. One row per (user, target).
+-- Inactive rows included so the UI can offer a "re-enable" affordance.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_list_user_targets(
     p_user_id UUID
 )
 RETURNS TABLE (
-    target_slug    TEXT,
-    title          TEXT,
-    url            TEXT,
-    is_default     BOOLEAN,
-    active         BOOLEAN,
-    enabled_at     TIMESTAMPTZ,
-    disabled_at    TIMESTAMPTZ,
-    clicks_total   BIGINT,
+    target_slug     TEXT,
+    title           TEXT,
+    url             TEXT,
+    is_default      BOOLEAN,
+    active          BOOLEAN,
+    enabled_at      TIMESTAMPTZ,
+    disabled_at     TIMESTAMPTZ,
+    updated_at      TIMESTAMPTZ,
+    clicks_total    BIGINT,
     clicks_credited BIGINT,
-    credits_total  BIGINT,
-    last_click_at  TIMESTAMPTZ
+    credits_total   BIGINT,
+    last_click_at   TIMESTAMPTZ
 )
 LANGUAGE plpgsql
 STABLE
@@ -119,8 +139,9 @@ BEGIN
     END IF;
 
     -- Aggregate click stats once over the user's click rows and join
-    -- onto user_target. Avoids the per-target lateral aggregate that
-    -- scaled with target count.
+    -- onto user_target. The ledger join is filtered to source_kind =
+    -- 'referral' so a future overlap of ledger ids across source kinds
+    -- can't double-count credits here.
     RETURN QUERY
     WITH stats AS (
         SELECT
@@ -132,7 +153,9 @@ BEGIN
             ), 0)::BIGINT                                     AS credits_total,
             MAX(c.created_at)                                 AS last_click_at
         FROM referral.click c
-        LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
+        LEFT JOIN wallet.ledger l
+               ON l.id = c.ledger_id
+              AND l.source_kind = 'referral'
         WHERE c.referrer_id = p_user_id
         GROUP BY c.target_slug
     )
@@ -144,6 +167,7 @@ BEGIN
         ut.active,
         ut.enabled_at,
         ut.disabled_at,
+        ut.updated_at,
         COALESCE(s.clicks_total, 0)    AS clicks_total,
         COALESCE(s.clicks_credited, 0) AS clicks_credited,
         COALESCE(s.credits_total, 0)   AS credits_total,
@@ -162,10 +186,18 @@ REVOKE ALL ON FUNCTION referral.service_list_user_targets(UUID) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION referral.service_list_user_targets(UUID)
     TO service_role;
 
+COMMENT ON FUNCTION referral.service_list_user_targets(UUID) IS
+$$Returns one row per (user, target) including inactive rows, with
+lifetime click + credit aggregates. Ledger join filters source_kind =
+'referral'. Service-role only.$$;
+
 -- ---------------------------------------------------------------------------
 -- service_enable_target — opt user_id into target_slug. Either:
 --   - inserts a new active row, OR
---   - reactivates an existing inactive row (clears disabled_at).
+--   - reactivates an existing inactive row (clears disabled_at), OR
+--   - returns the existing active row unchanged when no state change
+--     is needed (idempotent fast path, avoids spurious updated_at
+--     bumps that would invalidate caches for free).
 -- If `p_set_as_default = TRUE` (or this is the user's first enabled
 -- target), the row is also marked is_default and any other default for
 -- that user is demoted in the same transaction.
@@ -181,11 +213,11 @@ SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
-    v_target     referral.target%ROWTYPE;
-    v_existing   referral.user_target%ROWTYPE;
-    v_now        TIMESTAMPTZ := statement_timestamp();
-    v_should_default BOOLEAN;
-    v_row        referral.user_target;
+    v_target          referral.target%ROWTYPE;
+    v_existing        referral.user_target%ROWTYPE;
+    v_now             TIMESTAMPTZ := statement_timestamp();
+    v_should_default  BOOLEAN;
+    v_row             referral.user_target;
 BEGIN
     IF p_user_id IS NULL THEN
         RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
@@ -212,9 +244,13 @@ BEGIN
         hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
     );
 
+    -- FOR UPDATE pins the existing row (if any) for the rest of the tx
+    -- so a concurrent disable can't slip in between this read and the
+    -- UPDATE below.
     SELECT * INTO v_existing
       FROM referral.user_target
-     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+     WHERE user_id = p_user_id AND target_slug = p_target_slug
+       FOR UPDATE;
 
     -- A first-time enable auto-becomes the default so /referral/@<user>/
     -- always has a destination.
@@ -224,15 +260,27 @@ BEGIN
          WHERE user_id = p_user_id AND active
     );
 
+    -- Idempotent fast path: row already exists in the desired shape, no
+    -- writes needed. Skipping the UPDATE avoids touching updated_at,
+    -- which is meaningful for downstream cache invalidation.
+    IF v_existing.user_id IS NOT NULL
+       AND v_existing.active
+       AND v_existing.disabled_at IS NULL
+       AND (NOT v_should_default OR v_existing.is_default)
+    THEN
+        RETURN v_existing;
+    END IF;
+
     IF v_should_default THEN
         UPDATE referral.user_target
            SET is_default = FALSE
          WHERE user_id = p_user_id
            AND is_default
+           AND active
            AND target_slug IS DISTINCT FROM p_target_slug;
     END IF;
 
-    IF FOUND OR v_existing.user_id IS NOT NULL THEN
+    IF v_existing.user_id IS NOT NULL THEN
         -- Row exists. Re-activate (clears disabled_at), keep enabled_at
         -- stable so audit history is honest about original opt-in time.
         UPDATE referral.user_target
@@ -261,18 +309,40 @@ REVOKE ALL ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
 GRANT EXECUTE ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
     TO service_role;
 
+COMMENT ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN) IS
+$$Inserts or reactivates a (user, target) row. First enable auto-
+promotes to default so /referral/@<user>/ always has a destination.
+Idempotent: a no-op call returns the existing row without bumping
+updated_at. Service-role only.$$;
+
+-- Return-shape changed from `referral.user_target` to TABLE(...) in
+-- this migration iteration; CREATE OR REPLACE cannot change a
+-- function's return type, so drop first.
+DROP FUNCTION IF EXISTS referral.service_disable_target(UUID, TEXT);
+
 -- ---------------------------------------------------------------------------
 -- service_disable_target — mark a user's target row inactive. If the
 -- target being disabled was the user's default AND there is another
 -- active target, that other target inherits the default. If there is
 -- no other active target, raise RFM01 — the caller must pick a new
 -- default explicitly (or accept losing the short /referral/@user/ URL).
+--
+-- Returns a row that includes both the disabled slug AND the promoted
+-- slug (NULL when no promotion happened) so the caller can update its
+-- UI without a follow-up list call.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_disable_target(
     p_user_id      UUID,
     p_target_slug  TEXT
 )
-RETURNS referral.user_target
+RETURNS TABLE (
+    target_slug          TEXT,
+    promoted_target_slug TEXT,
+    is_default           BOOLEAN,
+    active               BOOLEAN,
+    enabled_at           TIMESTAMPTZ,
+    disabled_at          TIMESTAMPTZ
+)
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
@@ -283,6 +353,9 @@ DECLARE
     v_now        TIMESTAMPTZ := statement_timestamp();
     v_row        referral.user_target;
 BEGIN
+    -- RETURNS TABLE column names (target_slug, is_default, active, ...)
+    -- shadow same-named table columns inside this function, so every
+    -- reference to those columns is explicitly aliased with `ut.`.
     IF p_user_id IS NULL THEN
         RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
     END IF;
@@ -298,18 +371,16 @@ BEGIN
         hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
     );
 
-    SELECT * INTO v_existing
-      FROM referral.user_target
-     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+    SELECT ut.* INTO v_existing
+      FROM referral.user_target ut
+     WHERE ut.user_id = p_user_id AND ut.target_slug = p_target_slug
+       FOR UPDATE;
     IF NOT FOUND OR NOT v_existing.active THEN
         RAISE EXCEPTION 'target % is not active for user %',
                         p_target_slug, p_user_id
             USING ERRCODE = 'RFU01';
     END IF;
 
-    -- If this row is the default, find another active row to promote.
-    -- Stable tiebreaker (target_slug ASC) so two rows with the same
-    -- enabled_at don't pick nondeterministically.
     IF v_existing.is_default THEN
         SELECT ut.target_slug INTO v_other_slug
           FROM referral.user_target ut
@@ -325,20 +396,28 @@ BEGIN
         END IF;
     END IF;
 
-    UPDATE referral.user_target
+    UPDATE referral.user_target AS ut
        SET active      = FALSE,
            is_default  = FALSE,
            disabled_at = v_now
-     WHERE user_id = p_user_id AND target_slug = p_target_slug
-     RETURNING * INTO v_row;
+     WHERE ut.user_id = p_user_id AND ut.target_slug = p_target_slug
+     RETURNING ut.* INTO v_row;
 
     IF v_other_slug IS NOT NULL THEN
-        UPDATE referral.user_target
+        UPDATE referral.user_target AS ut
            SET is_default = TRUE
-         WHERE user_id = p_user_id AND target_slug = v_other_slug;
+         WHERE ut.user_id = p_user_id
+           AND ut.target_slug = v_other_slug
+           AND ut.active;
     END IF;
 
-    RETURN v_row;
+    target_slug          := v_row.target_slug;
+    promoted_target_slug := v_other_slug;
+    is_default           := v_row.is_default;
+    active               := v_row.active;
+    enabled_at           := v_row.enabled_at;
+    disabled_at          := v_row.disabled_at;
+    RETURN NEXT;
 END;
 $fn$;
 
@@ -347,9 +426,17 @@ REVOKE ALL ON FUNCTION referral.service_disable_target(UUID, TEXT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION referral.service_disable_target(UUID, TEXT)
     TO service_role;
 
+COMMENT ON FUNCTION referral.service_disable_target(UUID, TEXT) IS
+$$Marks the (user, target) row inactive. If the row was default, the
+most-recently enabled remaining active row inherits the default and
+its slug comes back as promoted_target_slug. Raises RFM01 when no
+inheritor exists. Service-role only.$$;
+
 -- ---------------------------------------------------------------------------
 -- service_set_default_target — atomic default swap. Errors RFU01 if the
--- requested target is not an active row for the user.
+-- requested target is not an active row for the user. Idempotent fast
+-- path returns the row unchanged when it's already the default so
+-- repeated calls don't churn updated_at.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_set_default_target(
     p_user_id      UUID,
@@ -378,15 +465,22 @@ BEGIN
         hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
     );
 
-    IF NOT EXISTS (
-        SELECT 1 FROM referral.user_target
-         WHERE user_id = p_user_id
-           AND target_slug = p_target_slug
-           AND active
-    ) THEN
+    SELECT * INTO v_row
+      FROM referral.user_target
+     WHERE user_id = p_user_id
+       AND target_slug = p_target_slug
+       FOR UPDATE;
+    IF NOT FOUND OR NOT v_row.active THEN
         RAISE EXCEPTION 'target % is not active for user %',
                         p_target_slug, p_user_id
             USING ERRCODE = 'RFU01';
+    END IF;
+
+    -- Already the default → idempotent no-op. Skipping the writes
+    -- avoids touching updated_at and burning advisory-lock waiters
+    -- on a do-nothing call.
+    IF v_row.is_default THEN
+        RETURN v_row;
     END IF;
 
     -- The partial unique index on (user_id) WHERE is_default AND active
@@ -397,11 +491,9 @@ BEGIN
        SET is_default = FALSE
      WHERE user_id = p_user_id
        AND is_default
+       AND active
        AND target_slug IS DISTINCT FROM p_target_slug;
 
-    -- Final UPDATE without the "AND NOT is_default" filter so RETURNING
-    -- still emits the row when the requested slug was already the
-    -- default (idempotent re-promote).
     UPDATE referral.user_target
        SET is_default = TRUE
      WHERE user_id = p_user_id
@@ -417,6 +509,11 @@ ALTER FUNCTION referral.service_set_default_target(UUID, TEXT) OWNER TO postgres
 REVOKE ALL ON FUNCTION referral.service_set_default_target(UUID, TEXT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION referral.service_set_default_target(UUID, TEXT)
     TO service_role;
+
+COMMENT ON FUNCTION referral.service_set_default_target(UUID, TEXT) IS
+$$Atomic default swap (demote-then-promote). Idempotent when the slug
+is already the user's default. Raises RFU01 when the slug is not an
+active row for the user. Service-role only.$$;
 
 -- ---------------------------------------------------------------------------
 -- service_get_user_stats — lifetime click counters across all targets.
@@ -450,7 +547,9 @@ BEGIN
         ), 0)::BIGINT                                     AS credits_total,
         MAX(c.created_at)                                 AS last_click_at
     FROM referral.click c
-    LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
+    LEFT JOIN wallet.ledger l
+           ON l.id = c.ledger_id
+          AND l.source_kind = 'referral'
     WHERE c.referrer_id = p_user_id;
 END;
 $fn$;
@@ -460,8 +559,27 @@ REVOKE ALL ON FUNCTION referral.service_get_user_stats(UUID) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION referral.service_get_user_stats(UUID)
     TO service_role;
 
+COMMENT ON FUNCTION referral.service_get_user_stats(UUID) IS
+$$Lifetime click + credit rollup across all targets for one user.
+Ledger join filters source_kind = 'referral'. Service-role only.$$;
+
 -- migrate:down
 
 -- Intentionally a no-op. Mgmt RPCs replace earlier ad-hoc UPDATEs;
--- dropping them would orphan callers. Manual rollback only.
+-- dropping them would orphan callers. Manual rollback only, in this
+-- order (run as superuser):
+--
+--   DROP FUNCTION IF EXISTS referral.service_get_user_stats(UUID);
+--   DROP FUNCTION IF EXISTS referral.service_set_default_target(UUID, TEXT);
+--   DROP FUNCTION IF EXISTS referral.service_disable_target(UUID, TEXT);
+--   DROP FUNCTION IF EXISTS referral.service_enable_target(UUID, TEXT, BOOLEAN);
+--   DROP FUNCTION IF EXISTS referral.service_list_user_targets(UUID);
+--   DROP INDEX  IF EXISTS referral.referral_click_referrer_credited_ledger_idx;
+--   DROP INDEX  IF EXISTS referral.referral_click_referrer_target_created_idx;
+--   ALTER TABLE referral.user_target
+--     DROP CONSTRAINT IF EXISTS referral_user_target_default_requires_active_ck;
+--   DROP TRIGGER  IF EXISTS user_target_set_updated_at ON referral.user_target;
+--   DROP FUNCTION IF EXISTS referral.user_target_touch();
+--   ALTER TABLE referral.user_target DROP COLUMN IF EXISTS updated_at;
+
 SELECT 1;

--- a/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
+++ b/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
@@ -1,0 +1,380 @@
+-- migrate:up
+
+-- Referral Phase 3a — self-service management RPCs.
+--
+-- Phase 1 (20260515221756) shipped record_click + resolve_user_target.
+-- Phase 2 (axum-kbve referral handler) consumes them for the redirect
+-- path. Phase 3a adds the missing CRUD for users to actually manage
+-- which targets they refer to.
+--
+-- Functions added (all SECURITY DEFINER, search_path locked, owned by
+-- postgres, granted EXECUTE only to service_role):
+--
+--   referral.service_list_user_targets(user_id)
+--   referral.service_enable_target(user_id, target_slug, set_as_default)
+--   referral.service_disable_target(user_id, target_slug)
+--   referral.service_set_default_target(user_id, target_slug)
+--   referral.service_get_user_stats(user_id)
+--
+-- Custom SQLSTATEs (extends the Phase 1 set):
+--   RFP01  reward_policy missing
+--   RFT01  target not found / inactive
+--   RFU01  user_target not enabled
+--   RFWA1  wallet account provisioning failed
+--   RFM01  attempted to disable / unset the last default while no
+--          other active target exists to inherit it (forces caller to
+--          set a new default first instead of dropping into a state
+--          where /referral/@user/ would 404)
+
+-- ---------------------------------------------------------------------------
+-- service_list_user_targets — returns every (slug, title, url, active,
+-- is_default, enabled_at, disabled_at) for the user PLUS lifetime click
+-- + credit totals per target. One row per (user, target). Inactive rows
+-- included so the UI can offer a "re-enable" affordance.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.service_list_user_targets(
+    p_user_id UUID
+)
+RETURNS TABLE (
+    target_slug    TEXT,
+    title          TEXT,
+    url            TEXT,
+    is_default     BOOLEAN,
+    active         BOOLEAN,
+    enabled_at     TIMESTAMPTZ,
+    disabled_at    TIMESTAMPTZ,
+    clicks_total   BIGINT,
+    clicks_credited BIGINT,
+    credits_total  BIGINT,
+    last_click_at  TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+    SELECT
+        ut.target_slug,
+        t.title,
+        t.url,
+        ut.is_default,
+        ut.active,
+        ut.enabled_at,
+        ut.disabled_at,
+        COALESCE(stats.clicks_total, 0)    AS clicks_total,
+        COALESCE(stats.clicks_credited, 0) AS clicks_credited,
+        COALESCE(stats.credits_total, 0)   AS credits_total,
+        stats.last_click_at
+    FROM referral.user_target ut
+    JOIN referral.target t ON t.slug = ut.target_slug
+    LEFT JOIN LATERAL (
+        SELECT
+            count(*)::BIGINT                                  AS clicks_total,
+            count(*) FILTER (WHERE c.credited)::BIGINT        AS clicks_credited,
+            COALESCE(SUM(l.delta) FILTER (
+                WHERE c.credited AND l.id IS NOT NULL
+            ), 0)::BIGINT                                     AS credits_total,
+            MAX(c.created_at)                                 AS last_click_at
+        FROM referral.click c
+        LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
+        WHERE c.referrer_id = p_user_id
+          AND c.target_slug = ut.target_slug
+    ) stats ON TRUE
+    WHERE ut.user_id = p_user_id
+    ORDER BY ut.is_default DESC, ut.active DESC, ut.enabled_at DESC;
+$fn$;
+
+ALTER FUNCTION referral.service_list_user_targets(UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.service_list_user_targets(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.service_list_user_targets(UUID)
+    TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- service_enable_target — opt user_id into target_slug. Either:
+--   - inserts a new active row, OR
+--   - reactivates an existing inactive row (clears disabled_at).
+-- If `p_set_as_default = TRUE` (or this is the user's first enabled
+-- target), the row is also marked is_default and any other default for
+-- that user is demoted in the same transaction.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.service_enable_target(
+    p_user_id        UUID,
+    p_target_slug    TEXT,
+    p_set_as_default BOOLEAN DEFAULT FALSE
+)
+RETURNS referral.user_target
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+    v_target     referral.target%ROWTYPE;
+    v_existing   referral.user_target%ROWTYPE;
+    v_now        TIMESTAMPTZ := statement_timestamp();
+    v_should_default BOOLEAN;
+    v_row        referral.user_target;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_target_slug IS NULL THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
+    p_target_slug := lower(btrim(p_target_slug));
+    IF p_target_slug = '' THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT * INTO v_target
+      FROM referral.target
+     WHERE slug = p_target_slug AND active;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'target % not found or inactive', p_target_slug
+            USING ERRCODE = 'RFT01';
+    END IF;
+
+    -- Serialize concurrent enable / set-default attempts so we don't
+    -- briefly hold two is_default = TRUE rows for the same user.
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+    );
+
+    SELECT * INTO v_existing
+      FROM referral.user_target
+     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+
+    -- A first-time enable auto-becomes the default so /referral/@<user>/
+    -- always has a destination.
+    v_should_default := p_set_as_default OR NOT EXISTS (
+        SELECT 1
+          FROM referral.user_target
+         WHERE user_id = p_user_id AND active
+    );
+
+    IF v_should_default THEN
+        UPDATE referral.user_target
+           SET is_default = FALSE
+         WHERE user_id = p_user_id
+           AND is_default
+           AND target_slug IS DISTINCT FROM p_target_slug;
+    END IF;
+
+    IF FOUND OR v_existing.user_id IS NOT NULL THEN
+        -- Row exists. Re-activate (clears disabled_at), keep enabled_at
+        -- stable so audit history is honest about original opt-in time.
+        UPDATE referral.user_target
+           SET active       = TRUE,
+               is_default   = CASE WHEN v_should_default THEN TRUE ELSE is_default END,
+               disabled_at  = NULL
+         WHERE user_id = p_user_id AND target_slug = p_target_slug
+         RETURNING * INTO v_row;
+    ELSE
+        INSERT INTO referral.user_target (
+            user_id, target_slug, is_default, active, enabled_at
+        ) VALUES (
+            p_user_id, p_target_slug, v_should_default, TRUE, v_now
+        )
+        RETURNING * INTO v_row;
+    END IF;
+
+    RETURN v_row;
+END;
+$fn$;
+
+ALTER FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
+    OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
+    FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
+    TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- service_disable_target — mark a user's target row inactive. If the
+-- target being disabled was the user's default AND there is another
+-- active target, that other target inherits the default. If there is
+-- no other active target, raise RFM01 — the caller must pick a new
+-- default explicitly (or accept losing the short /referral/@user/ URL).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.service_disable_target(
+    p_user_id      UUID,
+    p_target_slug  TEXT
+)
+RETURNS referral.user_target
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+    v_existing   referral.user_target%ROWTYPE;
+    v_other_slug TEXT;
+    v_now        TIMESTAMPTZ := statement_timestamp();
+    v_row        referral.user_target;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_target_slug IS NULL THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
+    p_target_slug := lower(btrim(p_target_slug));
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+    );
+
+    SELECT * INTO v_existing
+      FROM referral.user_target
+     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+    IF NOT FOUND OR NOT v_existing.active THEN
+        RAISE EXCEPTION 'target % is not active for user %',
+                        p_target_slug, p_user_id
+            USING ERRCODE = 'RFU01';
+    END IF;
+
+    -- If this row is the default, find another active row to promote.
+    IF v_existing.is_default THEN
+        SELECT ut.target_slug INTO v_other_slug
+          FROM referral.user_target ut
+         WHERE ut.user_id    = p_user_id
+           AND ut.active
+           AND ut.target_slug IS DISTINCT FROM p_target_slug
+         ORDER BY ut.enabled_at DESC
+         LIMIT 1;
+
+        IF v_other_slug IS NULL THEN
+            RAISE EXCEPTION 'cannot disable last active default for user %', p_user_id
+                USING ERRCODE = 'RFM01';
+        END IF;
+    END IF;
+
+    UPDATE referral.user_target
+       SET active      = FALSE,
+           is_default  = FALSE,
+           disabled_at = v_now
+     WHERE user_id = p_user_id AND target_slug = p_target_slug
+     RETURNING * INTO v_row;
+
+    IF v_other_slug IS NOT NULL THEN
+        UPDATE referral.user_target
+           SET is_default = TRUE
+         WHERE user_id = p_user_id AND target_slug = v_other_slug;
+    END IF;
+
+    RETURN v_row;
+END;
+$fn$;
+
+ALTER FUNCTION referral.service_disable_target(UUID, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.service_disable_target(UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.service_disable_target(UUID, TEXT)
+    TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- service_set_default_target — atomic default swap. Errors RFU01 if the
+-- requested target is not an active row for the user.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.service_set_default_target(
+    p_user_id      UUID,
+    p_target_slug  TEXT
+)
+RETURNS referral.user_target
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+    v_row referral.user_target;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_target_slug IS NULL THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
+    p_target_slug := lower(btrim(p_target_slug));
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+    );
+
+    IF NOT EXISTS (
+        SELECT 1 FROM referral.user_target
+         WHERE user_id = p_user_id
+           AND target_slug = p_target_slug
+           AND active
+    ) THEN
+        RAISE EXCEPTION 'target % is not active for user %',
+                        p_target_slug, p_user_id
+            USING ERRCODE = 'RFU01';
+    END IF;
+
+    -- The partial unique index on (user_id) WHERE is_default AND active
+    -- is enforced row-by-row inside a single UPDATE, so demote-then-
+    -- promote MUST be two statements in this order: clear any prior
+    -- default first, then promote the requested row.
+    UPDATE referral.user_target
+       SET is_default = FALSE
+     WHERE user_id = p_user_id
+       AND is_default
+       AND target_slug IS DISTINCT FROM p_target_slug;
+
+    UPDATE referral.user_target
+       SET is_default = TRUE
+     WHERE user_id = p_user_id
+       AND target_slug = p_target_slug
+       AND active
+       AND NOT is_default;
+
+    SELECT * INTO v_row
+      FROM referral.user_target
+     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+
+    RETURN v_row;
+END;
+$fn$;
+
+ALTER FUNCTION referral.service_set_default_target(UUID, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.service_set_default_target(UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.service_set_default_target(UUID, TEXT)
+    TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- service_get_user_stats — lifetime click counters across all targets.
+-- Cheap rollup used by the profile widget to show "N clicks / X credits".
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.service_get_user_stats(
+    p_user_id UUID
+)
+RETURNS TABLE (
+    clicks_total    BIGINT,
+    clicks_credited BIGINT,
+    credits_total   BIGINT,
+    last_click_at   TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+    SELECT
+        count(*)::BIGINT                                  AS clicks_total,
+        count(*) FILTER (WHERE c.credited)::BIGINT        AS clicks_credited,
+        COALESCE(SUM(l.delta) FILTER (
+            WHERE c.credited AND l.id IS NOT NULL
+        ), 0)::BIGINT                                     AS credits_total,
+        MAX(c.created_at)                                 AS last_click_at
+    FROM referral.click c
+    LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
+    WHERE c.referrer_id = p_user_id;
+$fn$;
+
+ALTER FUNCTION referral.service_get_user_stats(UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.service_get_user_stats(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.service_get_user_stats(UUID)
+    TO service_role;
+
+-- migrate:down
+
+-- Intentionally a no-op. Mgmt RPCs replace earlier ad-hoc UPDATEs;
+-- dropping them would orphan callers. Manual rollback only.
+SELECT 1;

--- a/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
+++ b/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
@@ -37,7 +37,19 @@
 -- preserve the "at most one is_default+active row per user" invariant
 -- across the demote / promote two-statement swap. The partial unique
 -- index on (user_id) WHERE is_default AND active catches violations,
--- but the lock keeps callers from racing into it.
+-- but the lock keeps callers from racing into it. The contract is
+-- also stamped onto referral.user_target via COMMENT ON TABLE below
+-- so it surfaces in `\d+` and pg_catalog introspection.
+--
+-- Promote-ordering contract (used by service_disable_target when the
+-- disabled row was default): the inheritor is picked with
+--   ORDER BY enabled_at DESC, target_slug ASC LIMIT 1
+-- i.e. the most-recently-enabled active target wins, with target_slug
+-- as a deterministic tiebreaker for rows sharing enabled_at. This is
+-- a behavioral contract callers can rely on, not an accident of the
+-- current implementation. service_enable_target and
+-- service_set_default_target return the demoted slug separately, so
+-- both sides of the swap are observable by the caller.
 --
 -- Timestamp policy: every RPC uses statement_timestamp() so a single
 -- disable + promote (or enable + demote) round-trip stamps both rows
@@ -124,6 +136,19 @@ CREATE TRIGGER user_target_assert_immutable
     BEFORE UPDATE ON referral.user_target
     FOR EACH ROW EXECUTE FUNCTION referral.user_target_assert_immutable();
 
+-- Discoverable via `\d+ referral.user_target` and pg_description: the
+-- advisory-lock contract that every writer to this table must follow.
+COMMENT ON TABLE referral.user_target IS
+$$Per-(user, target) opt-in. At most one row per user has
+is_default = TRUE AND active = TRUE (enforced by a partial unique
+index). Every mutating writer MUST take
+  pg_advisory_xact_lock(hashtext('referral.user_target'),
+                        hashtext(user_id::text))
+before reading + writing or the demote / promote two-statement swap
+can race. Identity columns (user_id, target_slug) and audit anchor
+(enabled_at) are immutable after insert (enforced by
+referral.user_target_assert_immutable trigger).$$;
+
 -- Belt-and-suspenders invariant: a row cannot be is_default AND inactive
 -- at the same time. The partial unique index on (user_id) WHERE
 -- is_default AND active already prevents two defaults; this CHECK
@@ -163,10 +188,23 @@ END $$;
 -- iterations to the schema_table_columns_idx convention.
 DROP INDEX IF EXISTS referral.click_referrer_target_idx;
 DROP INDEX IF EXISTS referral.click_referrer_credited_ledger_idx;
+
+-- (referrer_id, target_slug, created_at DESC) covers both per-target
+-- group-bys in service_list_user_targets AND the global rollup in
+-- service_get_user_stats (the latter range-scans the leading
+-- referrer_id prefix). One index serves both paths.
 CREATE INDEX IF NOT EXISTS referral_click_referrer_target_created_idx
     ON referral.click (referrer_id, target_slug, created_at DESC);
+
+-- Partial index over credited rows carries (referrer_id, ledger_id)
+-- so the wallet.ledger join can use it as the outer side of the join
+-- without a heap fetch for ledger_id. An earlier iteration only
+-- indexed (referrer_id), forcing a heap probe to recover ledger_id
+-- per matching row; widen here while the table is empty so the next
+-- iteration doesn't need a separate rebuild migration.
+DROP INDEX IF EXISTS referral.referral_click_referrer_credited_ledger_idx;
 CREATE INDEX IF NOT EXISTS referral_click_referrer_credited_ledger_idx
-    ON referral.click (referrer_id)
+    ON referral.click (referrer_id, ledger_id)
     WHERE credited AND ledger_id IS NOT NULL;
 
 -- ---------------------------------------------------------------------------
@@ -322,8 +360,13 @@ BEGIN
         hashtext(p_user_id::TEXT)
     );
 
-    -- FOR SHARE pins the target row against deactivation for the rest
-    -- of this tx without blocking other readers.
+    -- FOR SHARE acquires a SHARE row lock on this exact target row;
+    -- blocks concurrent UPDATE / DELETE on it (including an admin
+    -- flipping referral.target.active = FALSE) until this tx commits.
+    -- It does NOT guard against replacement patterns at the
+    -- application layer (delete-then-reinsert under the same slug);
+    -- those would need higher-level coordination. For the in-process
+    -- mgmt RPCs it's sufficient.
     SELECT t.* INTO v_target
       FROM referral.target t
      WHERE t.slug = p_target_slug AND t.active
@@ -546,11 +589,13 @@ GRANT EXECUTE ON FUNCTION referral.service_disable_target(UUID, TEXT)
 
 COMMENT ON FUNCTION referral.service_disable_target(UUID, TEXT) IS
 $$Marks the (user, target) row inactive. If the row was default, the
-most-recently enabled remaining active row inherits the default and
-its slug + updated_at come back as promoted_target_slug /
-promoted_updated_at. Caller gets enough state to refresh local cache
-in one round trip. Raises RFM01 when no inheritor exists.
-Service-role only.$$;
+inheritor is picked deterministically by
+  ORDER BY enabled_at DESC, target_slug ASC LIMIT 1
+(most-recently-enabled wins; slug breaks enabled_at ties). The
+inheritor's slug + updated_at come back as promoted_target_slug /
+promoted_updated_at so the caller can refresh local cache in one
+round trip. Raises RFM01 when no inheritor exists. Service-role
+only.$$;
 
 -- Return-shape change carries demoted info, same reasoning as
 -- service_enable_target above.

--- a/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
+++ b/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
@@ -19,12 +19,32 @@
 -- Custom SQLSTATEs raised by Phase 3a (Phase 1 set inherited; RFP01 +
 -- RFWA1 are reachable from record_click only and don't fire from
 -- these mgmt RPCs, but they stay in the central reference):
---   RFT01  target not found / inactive
---   RFU01  user_target not enabled
+--   RFT01  target not found / inactive (raised by enable; row is
+--          locked FOR SHARE inside the per-user advisory lock so the
+--          check + write happen in one critical section)
+--   RFU01  user_target row not enabled / not active for the caller
+--          (raised by disable + set_default)
 --   RFM01  attempted to disable / unset the last active default while
 --          no other active target exists to inherit it (forces caller
 --          to set a new default first instead of dropping into a state
 --          where /referral/@user/ would 404)
+--
+-- Advisory-lock contract: every mutating RPC below takes
+--   pg_advisory_xact_lock(hashtext('referral.user_target'),
+--                         hashtext(p_user_id::TEXT))
+-- before reading + writing referral.user_target. Direct admin
+-- mutations (or any future writer) MUST take the same lock to
+-- preserve the "at most one is_default+active row per user" invariant
+-- across the demote / promote two-statement swap. The partial unique
+-- index on (user_id) WHERE is_default AND active catches violations,
+-- but the lock keeps callers from racing into it.
+--
+-- Timestamp policy: every RPC uses statement_timestamp() so a single
+-- disable + promote (or enable + demote) round-trip stamps both rows
+-- with the same updated_at. Callers that depend on a strict per-row
+-- mutation order should not use updated_at as a tiebreaker — use the
+-- explicit promoted_target_slug / demoted_target_slug fields that
+-- come back in the result row.
 
 -- ---------------------------------------------------------------------------
 -- Phase 3a schema hardening on referral.user_target
@@ -50,13 +70,15 @@ LANGUAGE plpgsql
 SET search_path = ''
 AS $fn$
 BEGIN
-    -- Only bump on material change. Idempotent self-updates (e.g.
-    -- `SET active = active` or re-writing the same disabled_at) are
-    -- no-ops; downstream cache invalidation hooks shouldn't fire for
-    -- writes that didn't move user-visible state.
-    IF ROW(NEW.active, NEW.is_default, NEW.disabled_at, NEW.target_slug)
+    -- Only bump on material change. Idempotent self-rewrites (e.g.
+    -- `SET active = active`) stay no-ops so downstream cache
+    -- invalidation hooks don't fire for writes that didn't move
+    -- user-visible state. target_slug / user_id / enabled_at are
+    -- immutable after insert (separate trigger below enforces that),
+    -- so they aren't part of the material-change tuple.
+    IF ROW(NEW.active, NEW.is_default, NEW.disabled_at)
        IS DISTINCT FROM
-       ROW(OLD.active, OLD.is_default, OLD.disabled_at, OLD.target_slug)
+       ROW(OLD.active, OLD.is_default, OLD.disabled_at)
     THEN
         NEW.updated_at := statement_timestamp();
     END IF;
@@ -68,6 +90,39 @@ DROP TRIGGER IF EXISTS user_target_set_updated_at ON referral.user_target;
 CREATE TRIGGER user_target_set_updated_at
     BEFORE UPDATE ON referral.user_target
     FOR EACH ROW EXECUTE FUNCTION referral.user_target_touch();
+
+-- Identity / audit immutability: (user_id, target_slug) is the row's
+-- identity and enabled_at is its audit anchor. Changing any of them
+-- would invalidate historical click + ledger references that key on
+-- (user_id, target_slug). Re-activation deliberately keeps enabled_at
+-- stable so "first opt-in time" is honest across an enable / disable /
+-- re-enable cycle.
+CREATE OR REPLACE FUNCTION referral.user_target_assert_immutable()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $fn$
+BEGIN
+    IF NEW.user_id IS DISTINCT FROM OLD.user_id THEN
+        RAISE EXCEPTION 'user_target.user_id is immutable after insert'
+            USING ERRCODE = '22023';
+    END IF;
+    IF NEW.target_slug IS DISTINCT FROM OLD.target_slug THEN
+        RAISE EXCEPTION 'user_target.target_slug is immutable after insert'
+            USING ERRCODE = '22023';
+    END IF;
+    IF NEW.enabled_at IS DISTINCT FROM OLD.enabled_at THEN
+        RAISE EXCEPTION 'user_target.enabled_at is immutable after insert'
+            USING ERRCODE = '22023';
+    END IF;
+    RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS user_target_assert_immutable ON referral.user_target;
+CREATE TRIGGER user_target_assert_immutable
+    BEFORE UPDATE ON referral.user_target
+    FOR EACH ROW EXECUTE FUNCTION referral.user_target_assert_immutable();
 
 -- Belt-and-suspenders invariant: a row cannot be is_default AND inactive
 -- at the same time. The partial unique index on (user_id) WHERE
@@ -199,34 +254,54 @@ $$Returns one row per (user, target) including inactive rows, with
 lifetime click + credit aggregates. Ledger join filters source_kind =
 'referral'. Service-role only.$$;
 
+-- Return-shape changed from `referral.user_target` to TABLE(...) in
+-- this iteration so callers learn which other slug got demoted when
+-- a new default replaces an old one — no follow-up list call needed.
+DROP FUNCTION IF EXISTS referral.service_enable_target(UUID, TEXT, BOOLEAN);
+
 -- ---------------------------------------------------------------------------
 -- service_enable_target — opt user_id into target_slug. Either:
 --   - inserts a new active row, OR
 --   - reactivates an existing inactive row (clears disabled_at), OR
 --   - returns the existing active row unchanged when no state change
---     is needed (idempotent fast path, avoids spurious updated_at
---     bumps that would invalidate caches for free).
+--     is needed (idempotent fast path).
 -- If `p_set_as_default = TRUE` (or this is the user's first enabled
--- target), the row is also marked is_default and any other default for
--- that user is demoted in the same transaction.
+-- target), the row is marked is_default and any prior default is
+-- demoted in the same transaction. demoted_target_slug +
+-- demoted_updated_at come back in the result row so the caller can
+-- repair local cache state in one round trip.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_enable_target(
     p_user_id        UUID,
     p_target_slug    TEXT,
     p_set_as_default BOOLEAN DEFAULT FALSE
 )
-RETURNS referral.user_target
+RETURNS TABLE (
+    target_slug          TEXT,
+    demoted_target_slug  TEXT,
+    is_default           BOOLEAN,
+    active               BOOLEAN,
+    enabled_at           TIMESTAMPTZ,
+    disabled_at          TIMESTAMPTZ,
+    updated_at           TIMESTAMPTZ,
+    demoted_updated_at   TIMESTAMPTZ
+)
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
-    v_target          referral.target%ROWTYPE;
-    v_existing        referral.user_target%ROWTYPE;
-    v_now             TIMESTAMPTZ := statement_timestamp();
-    v_should_default  BOOLEAN;
-    v_row             referral.user_target;
+    v_target              referral.target%ROWTYPE;
+    v_existing            referral.user_target%ROWTYPE;
+    v_now                 TIMESTAMPTZ := statement_timestamp();
+    v_should_default      BOOLEAN;
+    v_row                 referral.user_target;
+    v_demoted_slug        TEXT;
+    v_demoted_updated_at  TIMESTAMPTZ;
 BEGIN
+    -- RETURNS TABLE column names (target_slug, is_default, active, ...)
+    -- shadow same-named table columns inside this function, so every
+    -- table-column reference is aliased with `ut.`.
     IF p_user_id IS NULL THEN
         RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
     END IF;
@@ -238,79 +313,93 @@ BEGIN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
 
-    SELECT * INTO v_target
-      FROM referral.target
-     WHERE slug = p_target_slug AND active;
-    IF NOT FOUND THEN
-        RAISE EXCEPTION 'target % not found or inactive', p_target_slug
-            USING ERRCODE = 'RFT01';
-    END IF;
-
-    -- Serialize concurrent enable / set-default attempts so we don't
-    -- briefly hold two is_default = TRUE rows for the same user.
-    -- Explicit two-int form keeps the namespace separate from the
-    -- per-user key so future advisory-lock users in other domains
-    -- can't accidentally collide on a single-int hash.
+    -- Lock first so the target-active check + INSERT/UPDATE all run
+    -- inside one per-user critical section. Closes the TOCTOU window
+    -- where a concurrent tx could deactivate the target between our
+    -- check and our write.
     PERFORM pg_advisory_xact_lock(
         hashtext('referral.user_target'),
         hashtext(p_user_id::TEXT)
     );
 
-    -- FOR UPDATE pins the existing row (if any) for the rest of the tx
-    -- so a concurrent disable can't slip in between this read and the
-    -- UPDATE below.
-    SELECT * INTO v_existing
-      FROM referral.user_target
-     WHERE user_id = p_user_id AND target_slug = p_target_slug
+    -- FOR SHARE pins the target row against deactivation for the rest
+    -- of this tx without blocking other readers.
+    SELECT t.* INTO v_target
+      FROM referral.target t
+     WHERE t.slug = p_target_slug AND t.active
+       FOR SHARE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'target % not found or inactive', p_target_slug
+            USING ERRCODE = 'RFT01';
+    END IF;
+
+    SELECT ut.* INTO v_existing
+      FROM referral.user_target ut
+     WHERE ut.user_id = p_user_id AND ut.target_slug = p_target_slug
        FOR UPDATE;
 
-    -- A first-time enable auto-becomes the default so /referral/@<user>/
-    -- always has a destination.
     v_should_default := p_set_as_default OR NOT EXISTS (
         SELECT 1
-          FROM referral.user_target
-         WHERE user_id = p_user_id AND active
+          FROM referral.user_target ut2
+         WHERE ut2.user_id = p_user_id AND ut2.active
     );
 
-    -- Idempotent fast path: row already exists in the desired shape, no
-    -- writes needed. Skipping the UPDATE avoids touching updated_at,
-    -- which is meaningful for downstream cache invalidation.
+    -- Idempotent fast path: existing row already in desired shape.
     IF v_existing.user_id IS NOT NULL
        AND v_existing.active
        AND v_existing.disabled_at IS NULL
        AND (NOT v_should_default OR v_existing.is_default)
     THEN
-        RETURN v_existing;
+        target_slug          := v_existing.target_slug;
+        demoted_target_slug  := NULL;
+        is_default           := v_existing.is_default;
+        active               := v_existing.active;
+        enabled_at           := v_existing.enabled_at;
+        disabled_at          := v_existing.disabled_at;
+        updated_at           := v_existing.updated_at;
+        demoted_updated_at   := NULL;
+        RETURN NEXT;
+        RETURN;
     END IF;
 
     IF v_should_default THEN
-        UPDATE referral.user_target
+        UPDATE referral.user_target AS ut
            SET is_default = FALSE
-         WHERE user_id = p_user_id
-           AND is_default
-           AND active
-           AND target_slug IS DISTINCT FROM p_target_slug;
+         WHERE ut.user_id = p_user_id
+           AND ut.is_default
+           AND ut.active
+           AND ut.target_slug IS DISTINCT FROM p_target_slug
+         RETURNING ut.target_slug, ut.updated_at
+              INTO v_demoted_slug, v_demoted_updated_at;
     END IF;
 
     IF v_existing.user_id IS NOT NULL THEN
-        -- Row exists. Re-activate (clears disabled_at), keep enabled_at
-        -- stable so audit history is honest about original opt-in time.
-        UPDATE referral.user_target
-           SET active       = TRUE,
-               is_default   = CASE WHEN v_should_default THEN TRUE ELSE is_default END,
-               disabled_at  = NULL
-         WHERE user_id = p_user_id AND target_slug = p_target_slug
-         RETURNING * INTO v_row;
+        -- Re-activate. enabled_at stays put (immutability trigger
+        -- would reject a change anyway), so audit history is honest.
+        UPDATE referral.user_target AS ut
+           SET active      = TRUE,
+               is_default  = CASE WHEN v_should_default THEN TRUE ELSE ut.is_default END,
+               disabled_at = NULL
+         WHERE ut.user_id = p_user_id AND ut.target_slug = p_target_slug
+         RETURNING ut.* INTO v_row;
     ELSE
         INSERT INTO referral.user_target (
             user_id, target_slug, is_default, active, enabled_at
         ) VALUES (
             p_user_id, p_target_slug, v_should_default, TRUE, v_now
         )
-        RETURNING * INTO v_row;
+        RETURNING referral.user_target.* INTO v_row;
     END IF;
 
-    RETURN v_row;
+    target_slug          := v_row.target_slug;
+    demoted_target_slug  := v_demoted_slug;
+    is_default           := v_row.is_default;
+    active               := v_row.active;
+    enabled_at           := v_row.enabled_at;
+    disabled_at          := v_row.disabled_at;
+    updated_at           := v_row.updated_at;
+    demoted_updated_at   := v_demoted_updated_at;
+    RETURN NEXT;
 END;
 $fn$;
 
@@ -325,7 +414,9 @@ COMMENT ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN) IS
 $$Inserts or reactivates a (user, target) row. First enable auto-
 promotes to default so /referral/@<user>/ always has a destination.
 Idempotent: a no-op call returns the existing row without bumping
-updated_at. Service-role only.$$;
+updated_at. When the call promotes this slug to default and another
+row gets demoted, the demoted slug + updated_at come back as
+demoted_target_slug / demoted_updated_at. Service-role only.$$;
 
 -- Return-shape changed from `referral.user_target` to TABLE(...) in
 -- this migration iteration; CREATE OR REPLACE cannot change a
@@ -401,13 +492,18 @@ BEGIN
     END IF;
 
     IF v_existing.is_default THEN
+        -- FOR UPDATE pins the inheritor row for the rest of the
+        -- transaction so an admin (or any future writer that skips
+        -- the advisory lock) can't deactivate it between the SELECT
+        -- and the promote UPDATE below.
         SELECT ut.target_slug INTO v_other_slug
           FROM referral.user_target ut
          WHERE ut.user_id    = p_user_id
            AND ut.active
            AND ut.target_slug IS DISTINCT FROM p_target_slug
          ORDER BY ut.enabled_at DESC, ut.target_slug ASC
-         LIMIT 1;
+         LIMIT 1
+           FOR UPDATE;
 
         IF v_other_slug IS NULL THEN
             RAISE EXCEPTION 'cannot disable last active default for user %', p_user_id
@@ -456,24 +552,42 @@ promoted_updated_at. Caller gets enough state to refresh local cache
 in one round trip. Raises RFM01 when no inheritor exists.
 Service-role only.$$;
 
+-- Return-shape change carries demoted info, same reasoning as
+-- service_enable_target above.
+DROP FUNCTION IF EXISTS referral.service_set_default_target(UUID, TEXT);
+
 -- ---------------------------------------------------------------------------
 -- service_set_default_target — atomic default swap. Errors RFU01 if the
 -- requested target is not an active row for the user. Idempotent fast
 -- path returns the row unchanged when it's already the default so
--- repeated calls don't churn updated_at.
+-- repeated calls don't churn updated_at. Returns the demoted slug +
+-- updated_at when a prior default exists, so callers can repair local
+-- cache state in one round trip.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_set_default_target(
     p_user_id      UUID,
     p_target_slug  TEXT
 )
-RETURNS referral.user_target
+RETURNS TABLE (
+    target_slug          TEXT,
+    demoted_target_slug  TEXT,
+    is_default           BOOLEAN,
+    active               BOOLEAN,
+    enabled_at           TIMESTAMPTZ,
+    disabled_at          TIMESTAMPTZ,
+    updated_at           TIMESTAMPTZ,
+    demoted_updated_at   TIMESTAMPTZ
+)
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
-    v_row referral.user_target;
+    v_row                 referral.user_target;
+    v_demoted_slug        TEXT;
+    v_demoted_updated_at  TIMESTAMPTZ;
 BEGIN
+    -- Table-column refs aliased with `ut.` to dodge OUT-param shadowing.
     IF p_user_id IS NULL THEN
         RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
     END IF;
@@ -485,18 +599,15 @@ BEGIN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
 
-    -- Explicit two-int form keeps the namespace separate from the
-    -- per-user key so future advisory-lock users in other domains
-    -- can't accidentally collide on a single-int hash.
     PERFORM pg_advisory_xact_lock(
         hashtext('referral.user_target'),
         hashtext(p_user_id::TEXT)
     );
 
-    SELECT * INTO v_row
-      FROM referral.user_target
-     WHERE user_id = p_user_id
-       AND target_slug = p_target_slug
+    SELECT ut.* INTO v_row
+      FROM referral.user_target ut
+     WHERE ut.user_id = p_user_id
+       AND ut.target_slug = p_target_slug
        FOR UPDATE;
     IF NOT FOUND OR NOT v_row.active THEN
         RAISE EXCEPTION 'target % is not active for user %',
@@ -508,28 +619,46 @@ BEGIN
     -- avoids touching updated_at and burning advisory-lock waiters
     -- on a do-nothing call.
     IF v_row.is_default THEN
-        RETURN v_row;
+        target_slug          := v_row.target_slug;
+        demoted_target_slug  := NULL;
+        is_default           := v_row.is_default;
+        active               := v_row.active;
+        enabled_at           := v_row.enabled_at;
+        disabled_at          := v_row.disabled_at;
+        updated_at           := v_row.updated_at;
+        demoted_updated_at   := NULL;
+        RETURN NEXT;
+        RETURN;
     END IF;
 
-    -- The partial unique index on (user_id) WHERE is_default AND active
-    -- is enforced row-by-row inside a single UPDATE, so demote-then-
-    -- promote MUST be two statements in this order: clear any prior
-    -- default first, then promote the requested row.
-    UPDATE referral.user_target
+    -- Two-statement demote-then-promote (the partial unique index on
+    -- (user_id) WHERE is_default AND active is enforced row-by-row
+    -- inside a single UPDATE, so a CASE-based swap would trip it).
+    UPDATE referral.user_target AS ut
        SET is_default = FALSE
-     WHERE user_id = p_user_id
-       AND is_default
-       AND active
-       AND target_slug IS DISTINCT FROM p_target_slug;
+     WHERE ut.user_id = p_user_id
+       AND ut.is_default
+       AND ut.active
+       AND ut.target_slug IS DISTINCT FROM p_target_slug
+     RETURNING ut.target_slug, ut.updated_at
+          INTO v_demoted_slug, v_demoted_updated_at;
 
-    UPDATE referral.user_target
+    UPDATE referral.user_target AS ut
        SET is_default = TRUE
-     WHERE user_id = p_user_id
-       AND target_slug = p_target_slug
-       AND active
-     RETURNING * INTO v_row;
+     WHERE ut.user_id = p_user_id
+       AND ut.target_slug = p_target_slug
+       AND ut.active
+     RETURNING ut.* INTO v_row;
 
-    RETURN v_row;
+    target_slug          := v_row.target_slug;
+    demoted_target_slug  := v_demoted_slug;
+    is_default           := v_row.is_default;
+    active               := v_row.active;
+    enabled_at           := v_row.enabled_at;
+    disabled_at          := v_row.disabled_at;
+    updated_at           := v_row.updated_at;
+    demoted_updated_at   := v_demoted_updated_at;
+    RETURN NEXT;
 END;
 $fn$;
 
@@ -540,8 +669,10 @@ GRANT EXECUTE ON FUNCTION referral.service_set_default_target(UUID, TEXT)
 
 COMMENT ON FUNCTION referral.service_set_default_target(UUID, TEXT) IS
 $$Atomic default swap (demote-then-promote). Idempotent when the slug
-is already the user's default. Raises RFU01 when the slug is not an
-active row for the user. Service-role only.$$;
+is already the user's default. Returns the demoted slug +
+updated_at as demoted_target_slug / demoted_updated_at so the caller
+can repair local cache state in one round trip. Raises RFU01 when the
+slug is not an active row for the user. Service-role only.$$;
 
 -- ---------------------------------------------------------------------------
 -- service_get_user_stats — lifetime click counters across all targets.
@@ -608,6 +739,8 @@ Ledger join filters source_kind = 'referral'. Service-role only.$$;
 --   DROP INDEX  IF EXISTS referral.referral_click_referrer_target_created_idx;
 --   ALTER TABLE referral.user_target
 --     DROP CONSTRAINT IF EXISTS referral_user_target_default_requires_active_ck;
+--   DROP TRIGGER  IF EXISTS user_target_assert_immutable ON referral.user_target;
+--   DROP FUNCTION IF EXISTS referral.user_target_assert_immutable();
 --   DROP TRIGGER  IF EXISTS user_target_set_updated_at ON referral.user_target;
 --   DROP FUNCTION IF EXISTS referral.user_target_touch();
 --   ALTER TABLE referral.user_target DROP COLUMN IF EXISTS updated_at;

--- a/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
+++ b/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
@@ -16,15 +16,75 @@
 --   referral.service_set_default_target(user_id, target_slug)
 --   referral.service_get_user_stats(user_id)
 --
--- Custom SQLSTATEs (extends the Phase 1 set):
---   RFP01  reward_policy missing
+-- Custom SQLSTATEs raised by Phase 3a (Phase 1 set inherited; RFP01 +
+-- RFWA1 are reachable from record_click only and don't fire from
+-- these mgmt RPCs, but they stay in the central reference):
 --   RFT01  target not found / inactive
 --   RFU01  user_target not enabled
---   RFWA1  wallet account provisioning failed
---   RFM01  attempted to disable / unset the last default while no
---          other active target exists to inherit it (forces caller to
---          set a new default first instead of dropping into a state
+--   RFM01  attempted to disable / unset the last active default while
+--          no other active target exists to inherit it (forces caller
+--          to set a new default first instead of dropping into a state
 --          where /referral/@user/ would 404)
+
+-- ---------------------------------------------------------------------------
+-- Phase 3a schema hardening on referral.user_target
+-- ---------------------------------------------------------------------------
+
+-- updated_at column + auto-bump trigger for admin + cache-invalidation
+-- visibility. Backfill existing rows from enabled_at so the column is
+-- never NULL.
+ALTER TABLE referral.user_target
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
+
+UPDATE referral.user_target
+   SET updated_at = COALESCE(updated_at, disabled_at, enabled_at, now())
+ WHERE updated_at IS NULL;
+
+ALTER TABLE referral.user_target
+    ALTER COLUMN updated_at SET DEFAULT now(),
+    ALTER COLUMN updated_at SET NOT NULL;
+
+CREATE OR REPLACE FUNCTION referral.user_target_touch()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+    NEW.updated_at := statement_timestamp();
+    RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS user_target_set_updated_at ON referral.user_target;
+CREATE TRIGGER user_target_set_updated_at
+    BEFORE UPDATE ON referral.user_target
+    FOR EACH ROW EXECUTE FUNCTION referral.user_target_touch();
+
+-- Belt-and-suspenders invariant: a row cannot be is_default AND inactive
+-- at the same time. The partial unique index on (user_id) WHERE
+-- is_default AND active already prevents two defaults; this CHECK
+-- closes the loophole where an out-of-band UPDATE leaves a disabled
+-- row marked is_default = TRUE.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conrelid = 'referral.user_target'::regclass
+           AND conname = 'user_target_default_requires_active'
+    ) THEN
+        ALTER TABLE referral.user_target
+            ADD CONSTRAINT user_target_default_requires_active
+            CHECK (active OR NOT is_default);
+    END IF;
+END $$;
+
+-- Hot-path indexes for the stats lateral aggregates in
+-- service_list_user_targets / service_get_user_stats.
+CREATE INDEX IF NOT EXISTS click_referrer_target_idx
+    ON referral.click (referrer_id, target_slug, created_at DESC);
+CREATE INDEX IF NOT EXISTS click_referrer_credited_ledger_idx
+    ON referral.click (referrer_id)
+    WHERE credited AND ledger_id IS NOT NULL;
 
 -- ---------------------------------------------------------------------------
 -- service_list_user_targets — returns every (slug, title, url, active,
@@ -48,27 +108,23 @@ RETURNS TABLE (
     credits_total  BIGINT,
     last_click_at  TIMESTAMPTZ
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
-    SELECT
-        ut.target_slug,
-        t.title,
-        t.url,
-        ut.is_default,
-        ut.active,
-        ut.enabled_at,
-        ut.disabled_at,
-        COALESCE(stats.clicks_total, 0)    AS clicks_total,
-        COALESCE(stats.clicks_credited, 0) AS clicks_credited,
-        COALESCE(stats.credits_total, 0)   AS credits_total,
-        stats.last_click_at
-    FROM referral.user_target ut
-    JOIN referral.target t ON t.slug = ut.target_slug
-    LEFT JOIN LATERAL (
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+
+    -- Aggregate click stats once over the user's click rows and join
+    -- onto user_target. Avoids the per-target lateral aggregate that
+    -- scaled with target count.
+    RETURN QUERY
+    WITH stats AS (
         SELECT
+            c.target_slug AS target_slug,
             count(*)::BIGINT                                  AS clicks_total,
             count(*) FILTER (WHERE c.credited)::BIGINT        AS clicks_credited,
             COALESCE(SUM(l.delta) FILTER (
@@ -78,10 +134,27 @@ AS $fn$
         FROM referral.click c
         LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
         WHERE c.referrer_id = p_user_id
-          AND c.target_slug = ut.target_slug
-    ) stats ON TRUE
+        GROUP BY c.target_slug
+    )
+    SELECT
+        ut.target_slug,
+        t.title,
+        t.url,
+        ut.is_default,
+        ut.active,
+        ut.enabled_at,
+        ut.disabled_at,
+        COALESCE(s.clicks_total, 0)    AS clicks_total,
+        COALESCE(s.clicks_credited, 0) AS clicks_credited,
+        COALESCE(s.credits_total, 0)   AS credits_total,
+        s.last_click_at
+    FROM referral.user_target ut
+    JOIN referral.target t ON t.slug = ut.target_slug
+    LEFT JOIN stats s ON s.target_slug = ut.target_slug
     WHERE ut.user_id = p_user_id
-    ORDER BY ut.is_default DESC, ut.active DESC, ut.enabled_at DESC;
+    ORDER BY ut.is_default DESC, ut.active DESC, ut.enabled_at DESC,
+             ut.target_slug;
+END;
 $fn$;
 
 ALTER FUNCTION referral.service_list_user_targets(UUID) OWNER TO postgres;
@@ -217,6 +290,9 @@ BEGIN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
     p_target_slug := lower(btrim(p_target_slug));
+    IF p_target_slug = '' THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
 
     PERFORM pg_advisory_xact_lock(
         hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
@@ -232,13 +308,15 @@ BEGIN
     END IF;
 
     -- If this row is the default, find another active row to promote.
+    -- Stable tiebreaker (target_slug ASC) so two rows with the same
+    -- enabled_at don't pick nondeterministically.
     IF v_existing.is_default THEN
         SELECT ut.target_slug INTO v_other_slug
           FROM referral.user_target ut
          WHERE ut.user_id    = p_user_id
            AND ut.active
            AND ut.target_slug IS DISTINCT FROM p_target_slug
-         ORDER BY ut.enabled_at DESC
+         ORDER BY ut.enabled_at DESC, ut.target_slug ASC
          LIMIT 1;
 
         IF v_other_slug IS NULL THEN
@@ -292,6 +370,9 @@ BEGIN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
     p_target_slug := lower(btrim(p_target_slug));
+    IF p_target_slug = '' THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
 
     PERFORM pg_advisory_xact_lock(
         hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
@@ -318,16 +399,15 @@ BEGIN
        AND is_default
        AND target_slug IS DISTINCT FROM p_target_slug;
 
+    -- Final UPDATE without the "AND NOT is_default" filter so RETURNING
+    -- still emits the row when the requested slug was already the
+    -- default (idempotent re-promote).
     UPDATE referral.user_target
        SET is_default = TRUE
      WHERE user_id = p_user_id
        AND target_slug = p_target_slug
        AND active
-       AND NOT is_default;
-
-    SELECT * INTO v_row
-      FROM referral.user_target
-     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+     RETURNING * INTO v_row;
 
     RETURN v_row;
 END;
@@ -351,11 +431,17 @@ RETURNS TABLE (
     credits_total   BIGINT,
     last_click_at   TIMESTAMPTZ
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+
+    RETURN QUERY
     SELECT
         count(*)::BIGINT                                  AS clicks_total,
         count(*) FILTER (WHERE c.credited)::BIGINT        AS clicks_credited,
@@ -366,6 +452,7 @@ AS $fn$
     FROM referral.click c
     LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
     WHERE c.referrer_id = p_user_id;
+END;
 $fn$;
 
 ALTER FUNCTION referral.service_get_user_stats(UUID) OWNER TO postgres;

--- a/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
+++ b/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
@@ -50,7 +50,16 @@ LANGUAGE plpgsql
 SET search_path = ''
 AS $fn$
 BEGIN
-    NEW.updated_at := statement_timestamp();
+    -- Only bump on material change. Idempotent self-updates (e.g.
+    -- `SET active = active` or re-writing the same disabled_at) are
+    -- no-ops; downstream cache invalidation hooks shouldn't fire for
+    -- writes that didn't move user-visible state.
+    IF ROW(NEW.active, NEW.is_default, NEW.disabled_at, NEW.target_slug)
+       IS DISTINCT FROM
+       ROW(OLD.active, OLD.is_default, OLD.disabled_at, OLD.target_slug)
+    THEN
+        NEW.updated_at := statement_timestamp();
+    END IF;
     RETURN NEW;
 END;
 $fn$;
@@ -129,7 +138,6 @@ RETURNS TABLE (
     last_click_at   TIMESTAMPTZ
 )
 LANGUAGE plpgsql
-STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
@@ -240,8 +248,12 @@ BEGIN
 
     -- Serialize concurrent enable / set-default attempts so we don't
     -- briefly hold two is_default = TRUE rows for the same user.
+    -- Explicit two-int form keeps the namespace separate from the
+    -- per-user key so future advisory-lock users in other domains
+    -- can't accidentally collide on a single-int hash.
     PERFORM pg_advisory_xact_lock(
-        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+        hashtext('referral.user_target'),
+        hashtext(p_user_id::TEXT)
     );
 
     -- FOR UPDATE pins the existing row (if any) for the rest of the tx
@@ -341,17 +353,20 @@ RETURNS TABLE (
     is_default           BOOLEAN,
     active               BOOLEAN,
     enabled_at           TIMESTAMPTZ,
-    disabled_at          TIMESTAMPTZ
+    disabled_at          TIMESTAMPTZ,
+    updated_at           TIMESTAMPTZ,
+    promoted_updated_at  TIMESTAMPTZ
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
-    v_existing   referral.user_target%ROWTYPE;
-    v_other_slug TEXT;
-    v_now        TIMESTAMPTZ := statement_timestamp();
-    v_row        referral.user_target;
+    v_existing            referral.user_target%ROWTYPE;
+    v_other_slug          TEXT;
+    v_now                 TIMESTAMPTZ := statement_timestamp();
+    v_row                 referral.user_target;
+    v_promoted_updated_at TIMESTAMPTZ;
 BEGIN
     -- RETURNS TABLE column names (target_slug, is_default, active, ...)
     -- shadow same-named table columns inside this function, so every
@@ -367,8 +382,12 @@ BEGIN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
 
+    -- Explicit two-int form keeps the namespace separate from the
+    -- per-user key so future advisory-lock users in other domains
+    -- can't accidentally collide on a single-int hash.
     PERFORM pg_advisory_xact_lock(
-        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+        hashtext('referral.user_target'),
+        hashtext(p_user_id::TEXT)
     );
 
     SELECT ut.* INTO v_existing
@@ -408,7 +427,8 @@ BEGIN
            SET is_default = TRUE
          WHERE ut.user_id = p_user_id
            AND ut.target_slug = v_other_slug
-           AND ut.active;
+           AND ut.active
+         RETURNING ut.updated_at INTO v_promoted_updated_at;
     END IF;
 
     target_slug          := v_row.target_slug;
@@ -417,6 +437,8 @@ BEGIN
     active               := v_row.active;
     enabled_at           := v_row.enabled_at;
     disabled_at          := v_row.disabled_at;
+    updated_at           := v_row.updated_at;
+    promoted_updated_at  := v_promoted_updated_at;
     RETURN NEXT;
 END;
 $fn$;
@@ -429,8 +451,10 @@ GRANT EXECUTE ON FUNCTION referral.service_disable_target(UUID, TEXT)
 COMMENT ON FUNCTION referral.service_disable_target(UUID, TEXT) IS
 $$Marks the (user, target) row inactive. If the row was default, the
 most-recently enabled remaining active row inherits the default and
-its slug comes back as promoted_target_slug. Raises RFM01 when no
-inheritor exists. Service-role only.$$;
+its slug + updated_at come back as promoted_target_slug /
+promoted_updated_at. Caller gets enough state to refresh local cache
+in one round trip. Raises RFM01 when no inheritor exists.
+Service-role only.$$;
 
 -- ---------------------------------------------------------------------------
 -- service_set_default_target — atomic default swap. Errors RFU01 if the
@@ -461,8 +485,12 @@ BEGIN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
 
+    -- Explicit two-int form keeps the namespace separate from the
+    -- per-user key so future advisory-lock users in other domains
+    -- can't accidentally collide on a single-int hash.
     PERFORM pg_advisory_xact_lock(
-        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+        hashtext('referral.user_target'),
+        hashtext(p_user_id::TEXT)
     );
 
     SELECT * INTO v_row
@@ -529,7 +557,6 @@ RETURNS TABLE (
     last_click_at   TIMESTAMPTZ
 )
 LANGUAGE plpgsql
-STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
@@ -574,6 +601,9 @@ Ledger join filters source_kind = 'referral'. Service-role only.$$;
 --   DROP FUNCTION IF EXISTS referral.service_disable_target(UUID, TEXT);
 --   DROP FUNCTION IF EXISTS referral.service_enable_target(UUID, TEXT, BOOLEAN);
 --   DROP FUNCTION IF EXISTS referral.service_list_user_targets(UUID);
+--   -- Indexes live in the same schema as the table they index, so the
+--   -- `referral.<name>` qualifier below is the index's schema-qualified
+--   -- object name (the name itself just happens to start with `referral_`).
 --   DROP INDEX  IF EXISTS referral.referral_click_referrer_credited_ledger_idx;
 --   DROP INDEX  IF EXISTS referral.referral_click_referrer_target_created_idx;
 --   ALTER TABLE referral.user_target

--- a/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
+++ b/packages/data/sql/dbmate/migrations/20260516090714_referral_user_target_mgmt.sql
@@ -51,6 +51,14 @@
 -- service_set_default_target return the demoted slug separately, so
 -- both sides of the swap are observable by the caller.
 --
+-- Orphan-row prevention is handled at the schema level, not in this
+-- migration: Phase 1 (20260515221756_referral_schema_init) declared
+--   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE
+-- on referral.user_target, so the service-role RPCs below cannot
+-- create rows for non-existent users — a bad UUID raises 23503
+-- before any state change. The same FK auto-cleans referral state
+-- when an auth user is deleted.
+--
 -- Timestamp policy: every RPC uses statement_timestamp() so a single
 -- disable + promote (or enable + demote) round-trip stamps both rows
 -- with the same updated_at. Callers that depend on a strict per-row
@@ -189,10 +197,13 @@ END $$;
 DROP INDEX IF EXISTS referral.click_referrer_target_idx;
 DROP INDEX IF EXISTS referral.click_referrer_credited_ledger_idx;
 
--- (referrer_id, target_slug, created_at DESC) covers both per-target
--- group-bys in service_list_user_targets AND the global rollup in
--- service_get_user_stats (the latter range-scans the leading
--- referrer_id prefix). One index serves both paths.
+-- Primary shape targets the per-(referrer_id, target_slug) group-by
+-- in service_list_user_targets. service_get_user_stats can scan the
+-- leading referrer_id prefix, but that's acceptable-not-ideal because
+-- target_slug sits between referrer_id and created_at. If the global
+-- rollup ever becomes hot, the natural follow-up index is
+--   (referrer_id, created_at DESC)
+-- — add it then, not preemptively.
 CREATE INDEX IF NOT EXISTS referral_click_referrer_target_created_idx
     ON referral.click (referrer_id, target_slug, created_at DESC);
 
@@ -780,6 +791,8 @@ Ledger join filters source_kind = 'referral'. Service-role only.$$;
 --   -- Indexes live in the same schema as the table they index, so the
 --   -- `referral.<name>` qualifier below is the index's schema-qualified
 --   -- object name (the name itself just happens to start with `referral_`).
+--   -- If a future migration adds (referrer_id, created_at DESC) for the
+--   -- global rollup path, drop it here too.
 --   DROP INDEX  IF EXISTS referral.referral_click_referrer_credited_ledger_idx;
 --   DROP INDEX  IF EXISTS referral.referral_click_referrer_target_created_idx;
 --   ALTER TABLE referral.user_target
@@ -788,6 +801,22 @@ Ledger join filters source_kind = 'referral'. Service-role only.$$;
 --   DROP FUNCTION IF EXISTS referral.user_target_assert_immutable();
 --   DROP TRIGGER  IF EXISTS user_target_set_updated_at ON referral.user_target;
 --   DROP FUNCTION IF EXISTS referral.user_target_touch();
+--   COMMENT ON TABLE referral.user_target IS NULL;
 --   ALTER TABLE referral.user_target DROP COLUMN IF EXISTS updated_at;
+--
+-- Emergency repair on identity columns (user_id / target_slug /
+-- enabled_at): disable the immutability trigger for the session,
+-- repair, re-enable. The trigger is `BEFORE UPDATE FOR EACH ROW`, so
+-- session-scoped disable is enough — no other writer can sneak
+-- through a bad write while it's off, because writers hold the
+-- per-user advisory lock.
+--
+--   BEGIN;
+--   ALTER TABLE referral.user_target
+--     DISABLE TRIGGER user_target_assert_immutable;
+--   -- targeted UPDATE here
+--   ALTER TABLE referral.user_target
+--     ENABLE TRIGGER user_target_assert_immutable;
+--   COMMIT;
 
 SELECT 1;

--- a/packages/data/sql/schema/referral/referral_rpcs.sql
+++ b/packages/data/sql/schema/referral/referral_rpcs.sql
@@ -9,12 +9,13 @@
 -- handler holds a service_role JWT and is the only consumer for
 -- Phase 1.
 --
--- Custom SQLSTATEs. Keep this list in sync with the Phase 2 axum error
--- mapper so users see the right 4xx code:
+-- Custom SQLSTATEs. Keep this list in sync with the axum error mapper
+-- so users see the right 4xx code:
 --   RFP01  = referral.reward_policy row missing
 --   RFT01  = referral target not found / inactive
 --   RFU01  = referrer does not have target enabled in user_target
 --   RFWA1  = ensure_referrer_account failed to provision a wallet account
+--   RFM01  = cannot disable the last active default (Phase 3a)
 --
 -- service_role intentionally holds USAGE on the schema + EXECUTE on
 -- these functions only. It does NOT have direct table privileges; the

--- a/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
+++ b/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
@@ -1,0 +1,362 @@
+-- ============================================================
+-- REFERRAL USER-TARGET MANAGEMENT RPCs (Phase 3a)
+--
+-- All SECURITY DEFINER, search_path = '', owned by postgres, EXECUTE
+-- granted to service_role only. The axum-kbve `/api/v1/referral/me/*`
+-- routes are the only callers; they resolve the caller's user_id from
+-- the JWT `sub` claim and pass it as p_user_id.
+--
+-- Applied migration:
+--   packages/data/sql/dbmate/migrations/
+--     20260516090714_referral_user_target_mgmt.sql
+--
+-- Custom SQLSTATE additions (Phase 1/2 set already documented in
+-- referral_rpcs.sql):
+--   RFM01 = attempted to disable / unset the last active default while
+--           no other active target exists to inherit it
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- service_list_user_targets(user_id)
+--
+-- One row per (user, target) including inactive rows so the UI can
+-- offer a "re-enable" affordance. Joins to wallet.ledger for the
+-- credits_total rollup.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.service_list_user_targets(
+    p_user_id UUID
+)
+RETURNS TABLE (
+    target_slug    TEXT,
+    title          TEXT,
+    url            TEXT,
+    is_default     BOOLEAN,
+    active         BOOLEAN,
+    enabled_at     TIMESTAMPTZ,
+    disabled_at    TIMESTAMPTZ,
+    clicks_total   BIGINT,
+    clicks_credited BIGINT,
+    credits_total  BIGINT,
+    last_click_at  TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+    SELECT
+        ut.target_slug,
+        t.title,
+        t.url,
+        ut.is_default,
+        ut.active,
+        ut.enabled_at,
+        ut.disabled_at,
+        COALESCE(stats.clicks_total, 0)    AS clicks_total,
+        COALESCE(stats.clicks_credited, 0) AS clicks_credited,
+        COALESCE(stats.credits_total, 0)   AS credits_total,
+        stats.last_click_at
+    FROM referral.user_target ut
+    JOIN referral.target t ON t.slug = ut.target_slug
+    LEFT JOIN LATERAL (
+        SELECT
+            count(*)::BIGINT                                  AS clicks_total,
+            count(*) FILTER (WHERE c.credited)::BIGINT        AS clicks_credited,
+            COALESCE(SUM(l.delta) FILTER (
+                WHERE c.credited AND l.id IS NOT NULL
+            ), 0)::BIGINT                                     AS credits_total,
+            MAX(c.created_at)                                 AS last_click_at
+        FROM referral.click c
+        LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
+        WHERE c.referrer_id = p_user_id
+          AND c.target_slug = ut.target_slug
+    ) stats ON TRUE
+    WHERE ut.user_id = p_user_id
+    ORDER BY ut.is_default DESC, ut.active DESC, ut.enabled_at DESC;
+$fn$;
+
+ALTER FUNCTION referral.service_list_user_targets(UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.service_list_user_targets(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.service_list_user_targets(UUID)
+    TO service_role;
+
+-- ------------------------------------------------------------
+-- service_enable_target(user_id, target_slug, set_as_default)
+--
+-- Inserts a new row OR re-activates an inactive one. First enable
+-- auto-promotes to default so /referral/@<user>/ always has a
+-- destination. Concurrent enable / set-default attempts serialize on
+-- a per-user advisory lock to prevent two is_default rows briefly
+-- existing for the same user.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.service_enable_target(
+    p_user_id        UUID,
+    p_target_slug    TEXT,
+    p_set_as_default BOOLEAN DEFAULT FALSE
+)
+RETURNS referral.user_target
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+    v_target          referral.target%ROWTYPE;
+    v_existing        referral.user_target%ROWTYPE;
+    v_now             TIMESTAMPTZ := statement_timestamp();
+    v_should_default  BOOLEAN;
+    v_row             referral.user_target;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_target_slug IS NULL THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
+    p_target_slug := lower(btrim(p_target_slug));
+    IF p_target_slug = '' THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT * INTO v_target
+      FROM referral.target
+     WHERE slug = p_target_slug AND active;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'target % not found or inactive', p_target_slug
+            USING ERRCODE = 'RFT01';
+    END IF;
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+    );
+
+    SELECT * INTO v_existing
+      FROM referral.user_target
+     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+
+    v_should_default := p_set_as_default OR NOT EXISTS (
+        SELECT 1
+          FROM referral.user_target
+         WHERE user_id = p_user_id AND active
+    );
+
+    IF v_should_default THEN
+        UPDATE referral.user_target
+           SET is_default = FALSE
+         WHERE user_id = p_user_id
+           AND is_default
+           AND target_slug IS DISTINCT FROM p_target_slug;
+    END IF;
+
+    IF FOUND OR v_existing.user_id IS NOT NULL THEN
+        UPDATE referral.user_target
+           SET active       = TRUE,
+               is_default   = CASE WHEN v_should_default THEN TRUE ELSE is_default END,
+               disabled_at  = NULL
+         WHERE user_id = p_user_id AND target_slug = p_target_slug
+         RETURNING * INTO v_row;
+    ELSE
+        INSERT INTO referral.user_target (
+            user_id, target_slug, is_default, active, enabled_at
+        ) VALUES (
+            p_user_id, p_target_slug, v_should_default, TRUE, v_now
+        )
+        RETURNING * INTO v_row;
+    END IF;
+
+    RETURN v_row;
+END;
+$fn$;
+
+ALTER FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
+    OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
+    FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
+    TO service_role;
+
+-- ------------------------------------------------------------
+-- service_disable_target(user_id, target_slug)
+--
+-- Marks the row inactive. If it was the default, the most-recently
+-- enabled remaining active row inherits the default. If no other
+-- active row exists, raises RFM01 so the caller picks a new default
+-- explicitly instead of silently breaking /referral/@<user>/.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.service_disable_target(
+    p_user_id      UUID,
+    p_target_slug  TEXT
+)
+RETURNS referral.user_target
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+    v_existing   referral.user_target%ROWTYPE;
+    v_other_slug TEXT;
+    v_now        TIMESTAMPTZ := statement_timestamp();
+    v_row        referral.user_target;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_target_slug IS NULL THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
+    p_target_slug := lower(btrim(p_target_slug));
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+    );
+
+    SELECT * INTO v_existing
+      FROM referral.user_target
+     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+    IF NOT FOUND OR NOT v_existing.active THEN
+        RAISE EXCEPTION 'target % is not active for user %',
+                        p_target_slug, p_user_id
+            USING ERRCODE = 'RFU01';
+    END IF;
+
+    IF v_existing.is_default THEN
+        SELECT ut.target_slug INTO v_other_slug
+          FROM referral.user_target ut
+         WHERE ut.user_id    = p_user_id
+           AND ut.active
+           AND ut.target_slug IS DISTINCT FROM p_target_slug
+         ORDER BY ut.enabled_at DESC
+         LIMIT 1;
+
+        IF v_other_slug IS NULL THEN
+            RAISE EXCEPTION 'cannot disable last active default for user %', p_user_id
+                USING ERRCODE = 'RFM01';
+        END IF;
+    END IF;
+
+    UPDATE referral.user_target
+       SET active      = FALSE,
+           is_default  = FALSE,
+           disabled_at = v_now
+     WHERE user_id = p_user_id AND target_slug = p_target_slug
+     RETURNING * INTO v_row;
+
+    IF v_other_slug IS NOT NULL THEN
+        UPDATE referral.user_target
+           SET is_default = TRUE
+         WHERE user_id = p_user_id AND target_slug = v_other_slug;
+    END IF;
+
+    RETURN v_row;
+END;
+$fn$;
+
+ALTER FUNCTION referral.service_disable_target(UUID, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.service_disable_target(UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.service_disable_target(UUID, TEXT)
+    TO service_role;
+
+-- ------------------------------------------------------------
+-- service_set_default_target(user_id, target_slug)
+--
+-- Atomic default swap. Two-statement demote-then-promote because the
+-- partial unique index (user_id) WHERE is_default AND active is
+-- enforced row-by-row inside a single UPDATE — a one-statement
+-- CASE-based swap would briefly hold two defaults and trip the index.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.service_set_default_target(
+    p_user_id      UUID,
+    p_target_slug  TEXT
+)
+RETURNS referral.user_target
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+DECLARE
+    v_row referral.user_target;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_target_slug IS NULL THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
+    p_target_slug := lower(btrim(p_target_slug));
+
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+    );
+
+    IF NOT EXISTS (
+        SELECT 1 FROM referral.user_target
+         WHERE user_id = p_user_id
+           AND target_slug = p_target_slug
+           AND active
+    ) THEN
+        RAISE EXCEPTION 'target % is not active for user %',
+                        p_target_slug, p_user_id
+            USING ERRCODE = 'RFU01';
+    END IF;
+
+    UPDATE referral.user_target
+       SET is_default = FALSE
+     WHERE user_id = p_user_id
+       AND is_default
+       AND target_slug IS DISTINCT FROM p_target_slug;
+
+    UPDATE referral.user_target
+       SET is_default = TRUE
+     WHERE user_id = p_user_id
+       AND target_slug = p_target_slug
+       AND active
+       AND NOT is_default;
+
+    SELECT * INTO v_row
+      FROM referral.user_target
+     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+
+    RETURN v_row;
+END;
+$fn$;
+
+ALTER FUNCTION referral.service_set_default_target(UUID, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.service_set_default_target(UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.service_set_default_target(UUID, TEXT)
+    TO service_role;
+
+-- ------------------------------------------------------------
+-- service_get_user_stats(user_id)
+--
+-- Lifetime rollup across all targets. Cheap counter query used by the
+-- profile widget.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION referral.service_get_user_stats(
+    p_user_id UUID
+)
+RETURNS TABLE (
+    clicks_total    BIGINT,
+    clicks_credited BIGINT,
+    credits_total   BIGINT,
+    last_click_at   TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $fn$
+    SELECT
+        count(*)::BIGINT                                  AS clicks_total,
+        count(*) FILTER (WHERE c.credited)::BIGINT        AS clicks_credited,
+        COALESCE(SUM(l.delta) FILTER (
+            WHERE c.credited AND l.id IS NOT NULL
+        ), 0)::BIGINT                                     AS credits_total,
+        MAX(c.created_at)                                 AS last_click_at
+    FROM referral.click c
+    LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
+    WHERE c.referrer_id = p_user_id;
+$fn$;
+
+ALTER FUNCTION referral.service_get_user_stats(UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION referral.service_get_user_stats(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION referral.service_get_user_stats(UUID)
+    TO service_role;

--- a/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
+++ b/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
@@ -39,7 +39,14 @@ LANGUAGE plpgsql
 SET search_path = ''
 AS $fn$
 BEGIN
-    NEW.updated_at := statement_timestamp();
+    -- Only bump on material change. Idempotent self-writes (e.g.
+    -- `SET active = active`) don't fire downstream cache invalidation.
+    IF ROW(NEW.active, NEW.is_default, NEW.disabled_at, NEW.target_slug)
+       IS DISTINCT FROM
+       ROW(OLD.active, OLD.is_default, OLD.disabled_at, OLD.target_slug)
+    THEN
+        NEW.updated_at := statement_timestamp();
+    END IF;
     RETURN NEW;
 END;
 $fn$;
@@ -115,7 +122,6 @@ RETURNS TABLE (
     last_click_at   TIMESTAMPTZ
 )
 LANGUAGE plpgsql
-STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
@@ -220,7 +226,8 @@ BEGIN
     END IF;
 
     PERFORM pg_advisory_xact_lock(
-        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+        hashtext('referral.user_target'),
+        hashtext(p_user_id::TEXT)
     );
 
     SELECT * INTO v_existing
@@ -308,17 +315,20 @@ RETURNS TABLE (
     is_default           BOOLEAN,
     active               BOOLEAN,
     enabled_at           TIMESTAMPTZ,
-    disabled_at          TIMESTAMPTZ
+    disabled_at          TIMESTAMPTZ,
+    updated_at           TIMESTAMPTZ,
+    promoted_updated_at  TIMESTAMPTZ
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
-    v_existing   referral.user_target%ROWTYPE;
-    v_other_slug TEXT;
-    v_now        TIMESTAMPTZ := statement_timestamp();
-    v_row        referral.user_target;
+    v_existing            referral.user_target%ROWTYPE;
+    v_other_slug          TEXT;
+    v_now                 TIMESTAMPTZ := statement_timestamp();
+    v_row                 referral.user_target;
+    v_promoted_updated_at TIMESTAMPTZ;
 BEGIN
     -- RETURNS TABLE column names shadow same-named table columns
     -- inside this function, so every reference is aliased with `ut.`.
@@ -334,7 +344,8 @@ BEGIN
     END IF;
 
     PERFORM pg_advisory_xact_lock(
-        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+        hashtext('referral.user_target'),
+        hashtext(p_user_id::TEXT)
     );
 
     SELECT ut.* INTO v_existing
@@ -374,7 +385,8 @@ BEGIN
            SET is_default = TRUE
          WHERE ut.user_id = p_user_id
            AND ut.target_slug = v_other_slug
-           AND ut.active;
+           AND ut.active
+         RETURNING ut.updated_at INTO v_promoted_updated_at;
     END IF;
 
     target_slug          := v_row.target_slug;
@@ -383,6 +395,8 @@ BEGIN
     active               := v_row.active;
     enabled_at           := v_row.enabled_at;
     disabled_at          := v_row.disabled_at;
+    updated_at           := v_row.updated_at;
+    promoted_updated_at  := v_promoted_updated_at;
     RETURN NEXT;
 END;
 $fn$;
@@ -395,8 +409,10 @@ GRANT EXECUTE ON FUNCTION referral.service_disable_target(UUID, TEXT)
 COMMENT ON FUNCTION referral.service_disable_target(UUID, TEXT) IS
 $$Marks the (user, target) row inactive. If the row was default, the
 most-recently enabled remaining active row inherits the default and
-its slug comes back as promoted_target_slug. Raises RFM01 when no
-inheritor exists. Service-role only.$$;
+its slug + updated_at come back as promoted_target_slug /
+promoted_updated_at. Caller gets enough state to refresh local cache
+in one round trip. Raises RFM01 when no inheritor exists.
+Service-role only.$$;
 
 -- ------------------------------------------------------------
 -- service_set_default_target(user_id, target_slug)
@@ -432,7 +448,8 @@ BEGIN
     END IF;
 
     PERFORM pg_advisory_xact_lock(
-        hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
+        hashtext('referral.user_target'),
+        hashtext(p_user_id::TEXT)
     );
 
     SELECT * INTO v_row
@@ -494,7 +511,6 @@ RETURNS TABLE (
     last_click_at   TIMESTAMPTZ
 )
 LANGUAGE plpgsql
-STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$

--- a/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
+++ b/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
@@ -36,6 +36,7 @@ ALTER TABLE referral.user_target
 CREATE OR REPLACE FUNCTION referral.user_target_touch()
 RETURNS TRIGGER
 LANGUAGE plpgsql
+SET search_path = ''
 AS $fn$
 BEGIN
     NEW.updated_at := statement_timestamp();
@@ -54,23 +55,38 @@ CREATE TRIGGER user_target_set_updated_at
 -- an out-of-band UPDATE leaves a disabled row marked is_default = TRUE.
 DO $$
 BEGIN
-    IF NOT EXISTS (
-        SELECT 1
-          FROM pg_constraint
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
          WHERE conrelid = 'referral.user_target'::regclass
            AND conname = 'user_target_default_requires_active'
     ) THEN
         ALTER TABLE referral.user_target
-            ADD CONSTRAINT user_target_default_requires_active
+            RENAME CONSTRAINT user_target_default_requires_active
+            TO referral_user_target_default_requires_active_ck;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conrelid = 'referral.user_target'::regclass
+           AND conname = 'referral_user_target_default_requires_active_ck'
+    ) THEN
+        ALTER TABLE referral.user_target
+            ADD CONSTRAINT referral_user_target_default_requires_active_ck
             CHECK (active OR NOT is_default);
     END IF;
 END $$;
 
--- Hot-path indexes for the stats lateral aggregates in
+-- (No `credited → ledger_id` CHECK added here: Phase 1's
+-- click_credit_ledger_chk already enforces the stronger biconditional
+-- `credited <=> ledger_id IS NOT NULL`.)
+
+-- Hot-path indexes for the stats aggregates in
 -- service_list_user_targets / service_get_user_stats.
-CREATE INDEX IF NOT EXISTS click_referrer_target_idx
+DROP INDEX IF EXISTS referral.click_referrer_target_idx;
+DROP INDEX IF EXISTS referral.click_referrer_credited_ledger_idx;
+CREATE INDEX IF NOT EXISTS referral_click_referrer_target_created_idx
     ON referral.click (referrer_id, target_slug, created_at DESC);
-CREATE INDEX IF NOT EXISTS click_referrer_credited_ledger_idx
+CREATE INDEX IF NOT EXISTS referral_click_referrer_credited_ledger_idx
     ON referral.click (referrer_id)
     WHERE credited AND ledger_id IS NOT NULL;
 
@@ -79,23 +95,24 @@ CREATE INDEX IF NOT EXISTS click_referrer_credited_ledger_idx
 --
 -- One row per (user, target) including inactive rows so the UI can
 -- offer a "re-enable" affordance. Joins to wallet.ledger for the
--- credits_total rollup.
+-- credits_total rollup, filtered to source_kind = 'referral'.
 -- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_list_user_targets(
     p_user_id UUID
 )
 RETURNS TABLE (
-    target_slug    TEXT,
-    title          TEXT,
-    url            TEXT,
-    is_default     BOOLEAN,
-    active         BOOLEAN,
-    enabled_at     TIMESTAMPTZ,
-    disabled_at    TIMESTAMPTZ,
-    clicks_total   BIGINT,
+    target_slug     TEXT,
+    title           TEXT,
+    url             TEXT,
+    is_default      BOOLEAN,
+    active          BOOLEAN,
+    enabled_at      TIMESTAMPTZ,
+    disabled_at     TIMESTAMPTZ,
+    updated_at      TIMESTAMPTZ,
+    clicks_total    BIGINT,
     clicks_credited BIGINT,
-    credits_total  BIGINT,
-    last_click_at  TIMESTAMPTZ
+    credits_total   BIGINT,
+    last_click_at   TIMESTAMPTZ
 )
 LANGUAGE plpgsql
 STABLE
@@ -107,9 +124,6 @@ BEGIN
         RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
     END IF;
 
-    -- Aggregate click stats once over the user's click rows and join
-    -- onto user_target. Avoids the per-target lateral aggregate that
-    -- scaled with target count.
     RETURN QUERY
     WITH stats AS (
         SELECT
@@ -121,7 +135,9 @@ BEGIN
             ), 0)::BIGINT                                     AS credits_total,
             MAX(c.created_at)                                 AS last_click_at
         FROM referral.click c
-        LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
+        LEFT JOIN wallet.ledger l
+               ON l.id = c.ledger_id
+              AND l.source_kind = 'referral'
         WHERE c.referrer_id = p_user_id
         GROUP BY c.target_slug
     )
@@ -133,6 +149,7 @@ BEGIN
         ut.active,
         ut.enabled_at,
         ut.disabled_at,
+        ut.updated_at,
         COALESCE(s.clicks_total, 0)    AS clicks_total,
         COALESCE(s.clicks_credited, 0) AS clicks_credited,
         COALESCE(s.credits_total, 0)   AS credits_total,
@@ -151,14 +168,20 @@ REVOKE ALL ON FUNCTION referral.service_list_user_targets(UUID) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION referral.service_list_user_targets(UUID)
     TO service_role;
 
+COMMENT ON FUNCTION referral.service_list_user_targets(UUID) IS
+$$Returns one row per (user, target) including inactive rows, with
+lifetime click + credit aggregates. Ledger join filters source_kind =
+'referral'. Service-role only.$$;
+
 -- ------------------------------------------------------------
 -- service_enable_target(user_id, target_slug, set_as_default)
 --
--- Inserts a new row OR re-activates an inactive one. First enable
--- auto-promotes to default so /referral/@<user>/ always has a
--- destination. Concurrent enable / set-default attempts serialize on
--- a per-user advisory lock to prevent two is_default rows briefly
--- existing for the same user.
+-- Inserts a new row, re-activates an inactive one, OR returns the
+-- existing row unchanged (idempotent fast path — skips updated_at
+-- bump on no-op calls). First enable auto-promotes to default so
+-- /referral/@<user>/ always has a destination. Concurrent enable /
+-- set-default attempts serialize on a per-user advisory lock to
+-- prevent two is_default rows briefly existing for the same user.
 -- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_enable_target(
     p_user_id        UUID,
@@ -202,7 +225,8 @@ BEGIN
 
     SELECT * INTO v_existing
       FROM referral.user_target
-     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+     WHERE user_id = p_user_id AND target_slug = p_target_slug
+       FOR UPDATE;
 
     v_should_default := p_set_as_default OR NOT EXISTS (
         SELECT 1
@@ -210,15 +234,24 @@ BEGIN
          WHERE user_id = p_user_id AND active
     );
 
+    IF v_existing.user_id IS NOT NULL
+       AND v_existing.active
+       AND v_existing.disabled_at IS NULL
+       AND (NOT v_should_default OR v_existing.is_default)
+    THEN
+        RETURN v_existing;
+    END IF;
+
     IF v_should_default THEN
         UPDATE referral.user_target
            SET is_default = FALSE
          WHERE user_id = p_user_id
            AND is_default
+           AND active
            AND target_slug IS DISTINCT FROM p_target_slug;
     END IF;
 
-    IF FOUND OR v_existing.user_id IS NOT NULL THEN
+    IF v_existing.user_id IS NOT NULL THEN
         UPDATE referral.user_target
            SET active       = TRUE,
                is_default   = CASE WHEN v_should_default THEN TRUE ELSE is_default END,
@@ -245,6 +278,15 @@ REVOKE ALL ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
 GRANT EXECUTE ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
     TO service_role;
 
+COMMENT ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN) IS
+$$Inserts or reactivates a (user, target) row. First enable auto-
+promotes to default so /referral/@<user>/ always has a destination.
+Idempotent: a no-op call returns the existing row without bumping
+updated_at. Service-role only.$$;
+
+-- Return shape changed across iterations; drop before recreate.
+DROP FUNCTION IF EXISTS referral.service_disable_target(UUID, TEXT);
+
 -- ------------------------------------------------------------
 -- service_disable_target(user_id, target_slug)
 --
@@ -252,12 +294,22 @@ GRANT EXECUTE ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN)
 -- enabled remaining active row inherits the default. If no other
 -- active row exists, raises RFM01 so the caller picks a new default
 -- explicitly instead of silently breaking /referral/@<user>/.
+--
+-- Returns disabled-row fields PLUS promoted_target_slug (NULL when no
+-- promotion happened) so the UI can refresh without a follow-up list.
 -- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_disable_target(
     p_user_id      UUID,
     p_target_slug  TEXT
 )
-RETURNS referral.user_target
+RETURNS TABLE (
+    target_slug          TEXT,
+    promoted_target_slug TEXT,
+    is_default           BOOLEAN,
+    active               BOOLEAN,
+    enabled_at           TIMESTAMPTZ,
+    disabled_at          TIMESTAMPTZ
+)
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
@@ -268,6 +320,8 @@ DECLARE
     v_now        TIMESTAMPTZ := statement_timestamp();
     v_row        referral.user_target;
 BEGIN
+    -- RETURNS TABLE column names shadow same-named table columns
+    -- inside this function, so every reference is aliased with `ut.`.
     IF p_user_id IS NULL THEN
         RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
     END IF;
@@ -283,9 +337,10 @@ BEGIN
         hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
     );
 
-    SELECT * INTO v_existing
-      FROM referral.user_target
-     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+    SELECT ut.* INTO v_existing
+      FROM referral.user_target ut
+     WHERE ut.user_id = p_user_id AND ut.target_slug = p_target_slug
+       FOR UPDATE;
     IF NOT FOUND OR NOT v_existing.active THEN
         RAISE EXCEPTION 'target % is not active for user %',
                         p_target_slug, p_user_id
@@ -307,20 +362,28 @@ BEGIN
         END IF;
     END IF;
 
-    UPDATE referral.user_target
+    UPDATE referral.user_target AS ut
        SET active      = FALSE,
            is_default  = FALSE,
            disabled_at = v_now
-     WHERE user_id = p_user_id AND target_slug = p_target_slug
-     RETURNING * INTO v_row;
+     WHERE ut.user_id = p_user_id AND ut.target_slug = p_target_slug
+     RETURNING ut.* INTO v_row;
 
     IF v_other_slug IS NOT NULL THEN
-        UPDATE referral.user_target
+        UPDATE referral.user_target AS ut
            SET is_default = TRUE
-         WHERE user_id = p_user_id AND target_slug = v_other_slug;
+         WHERE ut.user_id = p_user_id
+           AND ut.target_slug = v_other_slug
+           AND ut.active;
     END IF;
 
-    RETURN v_row;
+    target_slug          := v_row.target_slug;
+    promoted_target_slug := v_other_slug;
+    is_default           := v_row.is_default;
+    active               := v_row.active;
+    enabled_at           := v_row.enabled_at;
+    disabled_at          := v_row.disabled_at;
+    RETURN NEXT;
 END;
 $fn$;
 
@@ -329,6 +392,12 @@ REVOKE ALL ON FUNCTION referral.service_disable_target(UUID, TEXT) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION referral.service_disable_target(UUID, TEXT)
     TO service_role;
 
+COMMENT ON FUNCTION referral.service_disable_target(UUID, TEXT) IS
+$$Marks the (user, target) row inactive. If the row was default, the
+most-recently enabled remaining active row inherits the default and
+its slug comes back as promoted_target_slug. Raises RFM01 when no
+inheritor exists. Service-role only.$$;
+
 -- ------------------------------------------------------------
 -- service_set_default_target(user_id, target_slug)
 --
@@ -336,6 +405,8 @@ GRANT EXECUTE ON FUNCTION referral.service_disable_target(UUID, TEXT)
 -- partial unique index (user_id) WHERE is_default AND active is
 -- enforced row-by-row inside a single UPDATE — a one-statement
 -- CASE-based swap would briefly hold two defaults and trip the index.
+-- Idempotent fast path returns the row unchanged when it's already
+-- the default so repeated calls don't churn updated_at.
 -- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_set_default_target(
     p_user_id      UUID,
@@ -364,21 +435,26 @@ BEGIN
         hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
     );
 
-    IF NOT EXISTS (
-        SELECT 1 FROM referral.user_target
-         WHERE user_id = p_user_id
-           AND target_slug = p_target_slug
-           AND active
-    ) THEN
+    SELECT * INTO v_row
+      FROM referral.user_target
+     WHERE user_id = p_user_id
+       AND target_slug = p_target_slug
+       FOR UPDATE;
+    IF NOT FOUND OR NOT v_row.active THEN
         RAISE EXCEPTION 'target % is not active for user %',
                         p_target_slug, p_user_id
             USING ERRCODE = 'RFU01';
+    END IF;
+
+    IF v_row.is_default THEN
+        RETURN v_row;
     END IF;
 
     UPDATE referral.user_target
        SET is_default = FALSE
      WHERE user_id = p_user_id
        AND is_default
+       AND active
        AND target_slug IS DISTINCT FROM p_target_slug;
 
     UPDATE referral.user_target
@@ -397,11 +473,16 @@ REVOKE ALL ON FUNCTION referral.service_set_default_target(UUID, TEXT) FROM PUBL
 GRANT EXECUTE ON FUNCTION referral.service_set_default_target(UUID, TEXT)
     TO service_role;
 
+COMMENT ON FUNCTION referral.service_set_default_target(UUID, TEXT) IS
+$$Atomic default swap (demote-then-promote). Idempotent when the slug
+is already the user's default. Raises RFU01 when the slug is not an
+active row for the user. Service-role only.$$;
+
 -- ------------------------------------------------------------
 -- service_get_user_stats(user_id)
 --
 -- Lifetime rollup across all targets. Cheap counter query used by the
--- profile widget.
+-- profile widget. Ledger join filters source_kind = 'referral'.
 -- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_get_user_stats(
     p_user_id UUID
@@ -431,7 +512,9 @@ BEGIN
         ), 0)::BIGINT                                     AS credits_total,
         MAX(c.created_at)                                 AS last_click_at
     FROM referral.click c
-    LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
+    LEFT JOIN wallet.ledger l
+           ON l.id = c.ledger_id
+          AND l.source_kind = 'referral'
     WHERE c.referrer_id = p_user_id;
 END;
 $fn$;
@@ -440,3 +523,7 @@ ALTER FUNCTION referral.service_get_user_stats(UUID) OWNER TO postgres;
 REVOKE ALL ON FUNCTION referral.service_get_user_stats(UUID) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION referral.service_get_user_stats(UUID)
     TO service_role;
+
+COMMENT ON FUNCTION referral.service_get_user_stats(UUID) IS
+$$Lifetime click + credit rollup across all targets for one user.
+Ledger join filters source_kind = 'referral'. Service-role only.$$;

--- a/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
+++ b/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
@@ -88,6 +88,16 @@ CREATE TRIGGER user_target_assert_immutable
     BEFORE UPDATE ON referral.user_target
     FOR EACH ROW EXECUTE FUNCTION referral.user_target_assert_immutable();
 
+COMMENT ON TABLE referral.user_target IS
+$$Per-(user, target) opt-in. At most one row per user has
+is_default = TRUE AND active = TRUE (partial unique index enforces).
+Every mutating writer MUST take
+  pg_advisory_xact_lock(hashtext('referral.user_target'),
+                        hashtext(user_id::text))
+before reading + writing or the demote / promote two-statement swap
+can race. Identity columns (user_id, target_slug) and audit anchor
+(enabled_at) are immutable after insert.$$;
+
 -- Belt-and-suspenders: a row cannot be is_default AND inactive at the
 -- same time. The partial unique index on (user_id) WHERE is_default
 -- AND active prevents two defaults; this CHECK closes the gap where
@@ -123,10 +133,18 @@ END $$;
 -- service_list_user_targets / service_get_user_stats.
 DROP INDEX IF EXISTS referral.click_referrer_target_idx;
 DROP INDEX IF EXISTS referral.click_referrer_credited_ledger_idx;
+
+-- One index for both per-target group-by and global rollup (the
+-- latter range-scans the leading referrer_id prefix).
 CREATE INDEX IF NOT EXISTS referral_click_referrer_target_created_idx
     ON referral.click (referrer_id, target_slug, created_at DESC);
+
+-- Partial index over credited rows carries (referrer_id, ledger_id)
+-- so the wallet.ledger join can use it as outer side without a heap
+-- fetch for ledger_id.
+DROP INDEX IF EXISTS referral.referral_click_referrer_credited_ledger_idx;
 CREATE INDEX IF NOT EXISTS referral_click_referrer_credited_ledger_idx
-    ON referral.click (referrer_id)
+    ON referral.click (referrer_id, ledger_id)
     WHERE credited AND ledger_id IS NOT NULL;
 
 -- ------------------------------------------------------------
@@ -270,6 +288,10 @@ BEGIN
         hashtext(p_user_id::TEXT)
     );
 
+    -- FOR SHARE locks this exact target row; blocks concurrent
+    -- UPDATE/DELETE on it (e.g. an admin flipping active = FALSE)
+    -- until this tx commits. Doesn't guard against delete-then-
+    -- reinsert at the app layer.
     SELECT t.* INTO v_target
       FROM referral.target t
      WHERE t.slug = p_target_slug AND t.active
@@ -479,11 +501,13 @@ GRANT EXECUTE ON FUNCTION referral.service_disable_target(UUID, TEXT)
 
 COMMENT ON FUNCTION referral.service_disable_target(UUID, TEXT) IS
 $$Marks the (user, target) row inactive. If the row was default, the
-most-recently enabled remaining active row inherits the default and
-its slug + updated_at come back as promoted_target_slug /
-promoted_updated_at. Caller gets enough state to refresh local cache
-in one round trip. Raises RFM01 when no inheritor exists.
-Service-role only.$$;
+inheritor is picked deterministically by
+  ORDER BY enabled_at DESC, target_slug ASC LIMIT 1
+(most-recently-enabled wins; slug breaks enabled_at ties). The
+inheritor's slug + updated_at come back as promoted_target_slug /
+promoted_updated_at so the caller can refresh local cache in one
+round trip. Raises RFM01 when no inheritor exists. Service-role
+only.$$;
 
 -- Return shape changed to TABLE(...) for parity with enable.
 DROP FUNCTION IF EXISTS referral.service_set_default_target(UUID, TEXT);

--- a/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
+++ b/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
@@ -39,11 +39,12 @@ LANGUAGE plpgsql
 SET search_path = ''
 AS $fn$
 BEGIN
-    -- Only bump on material change. Idempotent self-writes (e.g.
-    -- `SET active = active`) don't fire downstream cache invalidation.
-    IF ROW(NEW.active, NEW.is_default, NEW.disabled_at, NEW.target_slug)
+    -- Only bump on material change. target_slug / user_id / enabled_at
+    -- are immutable after insert (separate trigger enforces this) so
+    -- they aren't part of the material-change tuple.
+    IF ROW(NEW.active, NEW.is_default, NEW.disabled_at)
        IS DISTINCT FROM
-       ROW(OLD.active, OLD.is_default, OLD.disabled_at, OLD.target_slug)
+       ROW(OLD.active, OLD.is_default, OLD.disabled_at)
     THEN
         NEW.updated_at := statement_timestamp();
     END IF;
@@ -55,6 +56,37 @@ DROP TRIGGER IF EXISTS user_target_set_updated_at ON referral.user_target;
 CREATE TRIGGER user_target_set_updated_at
     BEFORE UPDATE ON referral.user_target
     FOR EACH ROW EXECUTE FUNCTION referral.user_target_touch();
+
+-- Identity / audit immutability. (user_id, target_slug) is the row's
+-- identity; enabled_at is the audit anchor that survives a disable +
+-- re-enable cycle. Changing any of them would silently invalidate
+-- historical click + ledger references.
+CREATE OR REPLACE FUNCTION referral.user_target_assert_immutable()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $fn$
+BEGIN
+    IF NEW.user_id IS DISTINCT FROM OLD.user_id THEN
+        RAISE EXCEPTION 'user_target.user_id is immutable after insert'
+            USING ERRCODE = '22023';
+    END IF;
+    IF NEW.target_slug IS DISTINCT FROM OLD.target_slug THEN
+        RAISE EXCEPTION 'user_target.target_slug is immutable after insert'
+            USING ERRCODE = '22023';
+    END IF;
+    IF NEW.enabled_at IS DISTINCT FROM OLD.enabled_at THEN
+        RAISE EXCEPTION 'user_target.enabled_at is immutable after insert'
+            USING ERRCODE = '22023';
+    END IF;
+    RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS user_target_assert_immutable ON referral.user_target;
+CREATE TRIGGER user_target_assert_immutable
+    BEFORE UPDATE ON referral.user_target
+    FOR EACH ROW EXECUTE FUNCTION referral.user_target_assert_immutable();
 
 -- Belt-and-suspenders: a row cannot be is_default AND inactive at the
 -- same time. The partial unique index on (user_id) WHERE is_default
@@ -179,32 +211,46 @@ $$Returns one row per (user, target) including inactive rows, with
 lifetime click + credit aggregates. Ledger join filters source_kind =
 'referral'. Service-role only.$$;
 
+-- Return shape changed to TABLE(...) so callers learn the demoted slug.
+DROP FUNCTION IF EXISTS referral.service_enable_target(UUID, TEXT, BOOLEAN);
+
 -- ------------------------------------------------------------
 -- service_enable_target(user_id, target_slug, set_as_default)
 --
 -- Inserts a new row, re-activates an inactive one, OR returns the
 -- existing row unchanged (idempotent fast path — skips updated_at
 -- bump on no-op calls). First enable auto-promotes to default so
--- /referral/@<user>/ always has a destination. Concurrent enable /
--- set-default attempts serialize on a per-user advisory lock to
--- prevent two is_default rows briefly existing for the same user.
+-- /referral/@<user>/ always has a destination. When promotion demotes
+-- another row, the demoted slug + updated_at come back so the caller
+-- can repair cache state in one round trip.
 -- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_enable_target(
     p_user_id        UUID,
     p_target_slug    TEXT,
     p_set_as_default BOOLEAN DEFAULT FALSE
 )
-RETURNS referral.user_target
+RETURNS TABLE (
+    target_slug          TEXT,
+    demoted_target_slug  TEXT,
+    is_default           BOOLEAN,
+    active               BOOLEAN,
+    enabled_at           TIMESTAMPTZ,
+    disabled_at          TIMESTAMPTZ,
+    updated_at           TIMESTAMPTZ,
+    demoted_updated_at   TIMESTAMPTZ
+)
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
-    v_target          referral.target%ROWTYPE;
-    v_existing        referral.user_target%ROWTYPE;
-    v_now             TIMESTAMPTZ := statement_timestamp();
-    v_should_default  BOOLEAN;
-    v_row             referral.user_target;
+    v_target              referral.target%ROWTYPE;
+    v_existing            referral.user_target%ROWTYPE;
+    v_now                 TIMESTAMPTZ := statement_timestamp();
+    v_should_default      BOOLEAN;
+    v_row                 referral.user_target;
+    v_demoted_slug        TEXT;
+    v_demoted_updated_at  TIMESTAMPTZ;
 BEGIN
     IF p_user_id IS NULL THEN
         RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
@@ -217,28 +263,31 @@ BEGIN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
 
-    SELECT * INTO v_target
-      FROM referral.target
-     WHERE slug = p_target_slug AND active;
-    IF NOT FOUND THEN
-        RAISE EXCEPTION 'target % not found or inactive', p_target_slug
-            USING ERRCODE = 'RFT01';
-    END IF;
-
+    -- Lock first so target-active check + write share one critical
+    -- section; FOR SHARE pins the target row against deactivation.
     PERFORM pg_advisory_xact_lock(
         hashtext('referral.user_target'),
         hashtext(p_user_id::TEXT)
     );
 
-    SELECT * INTO v_existing
-      FROM referral.user_target
-     WHERE user_id = p_user_id AND target_slug = p_target_slug
+    SELECT t.* INTO v_target
+      FROM referral.target t
+     WHERE t.slug = p_target_slug AND t.active
+       FOR SHARE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'target % not found or inactive', p_target_slug
+            USING ERRCODE = 'RFT01';
+    END IF;
+
+    SELECT ut.* INTO v_existing
+      FROM referral.user_target ut
+     WHERE ut.user_id = p_user_id AND ut.target_slug = p_target_slug
        FOR UPDATE;
 
     v_should_default := p_set_as_default OR NOT EXISTS (
         SELECT 1
-          FROM referral.user_target
-         WHERE user_id = p_user_id AND active
+          FROM referral.user_target ut2
+         WHERE ut2.user_id = p_user_id AND ut2.active
     );
 
     IF v_existing.user_id IS NOT NULL
@@ -246,35 +295,54 @@ BEGIN
        AND v_existing.disabled_at IS NULL
        AND (NOT v_should_default OR v_existing.is_default)
     THEN
-        RETURN v_existing;
+        target_slug          := v_existing.target_slug;
+        demoted_target_slug  := NULL;
+        is_default           := v_existing.is_default;
+        active               := v_existing.active;
+        enabled_at           := v_existing.enabled_at;
+        disabled_at          := v_existing.disabled_at;
+        updated_at           := v_existing.updated_at;
+        demoted_updated_at   := NULL;
+        RETURN NEXT;
+        RETURN;
     END IF;
 
     IF v_should_default THEN
-        UPDATE referral.user_target
+        UPDATE referral.user_target AS ut
            SET is_default = FALSE
-         WHERE user_id = p_user_id
-           AND is_default
-           AND active
-           AND target_slug IS DISTINCT FROM p_target_slug;
+         WHERE ut.user_id = p_user_id
+           AND ut.is_default
+           AND ut.active
+           AND ut.target_slug IS DISTINCT FROM p_target_slug
+         RETURNING ut.target_slug, ut.updated_at
+              INTO v_demoted_slug, v_demoted_updated_at;
     END IF;
 
     IF v_existing.user_id IS NOT NULL THEN
-        UPDATE referral.user_target
-           SET active       = TRUE,
-               is_default   = CASE WHEN v_should_default THEN TRUE ELSE is_default END,
-               disabled_at  = NULL
-         WHERE user_id = p_user_id AND target_slug = p_target_slug
-         RETURNING * INTO v_row;
+        UPDATE referral.user_target AS ut
+           SET active      = TRUE,
+               is_default  = CASE WHEN v_should_default THEN TRUE ELSE ut.is_default END,
+               disabled_at = NULL
+         WHERE ut.user_id = p_user_id AND ut.target_slug = p_target_slug
+         RETURNING ut.* INTO v_row;
     ELSE
         INSERT INTO referral.user_target (
             user_id, target_slug, is_default, active, enabled_at
         ) VALUES (
             p_user_id, p_target_slug, v_should_default, TRUE, v_now
         )
-        RETURNING * INTO v_row;
+        RETURNING referral.user_target.* INTO v_row;
     END IF;
 
-    RETURN v_row;
+    target_slug          := v_row.target_slug;
+    demoted_target_slug  := v_demoted_slug;
+    is_default           := v_row.is_default;
+    active               := v_row.active;
+    enabled_at           := v_row.enabled_at;
+    disabled_at          := v_row.disabled_at;
+    updated_at           := v_row.updated_at;
+    demoted_updated_at   := v_demoted_updated_at;
+    RETURN NEXT;
 END;
 $fn$;
 
@@ -289,7 +357,9 @@ COMMENT ON FUNCTION referral.service_enable_target(UUID, TEXT, BOOLEAN) IS
 $$Inserts or reactivates a (user, target) row. First enable auto-
 promotes to default so /referral/@<user>/ always has a destination.
 Idempotent: a no-op call returns the existing row without bumping
-updated_at. Service-role only.$$;
+updated_at. When the call promotes this slug to default and demotes
+another, the demoted slug + updated_at come back as
+demoted_target_slug / demoted_updated_at. Service-role only.$$;
 
 -- Return shape changed across iterations; drop before recreate.
 DROP FUNCTION IF EXISTS referral.service_disable_target(UUID, TEXT);
@@ -365,7 +435,8 @@ BEGIN
            AND ut.active
            AND ut.target_slug IS DISTINCT FROM p_target_slug
          ORDER BY ut.enabled_at DESC, ut.target_slug ASC
-         LIMIT 1;
+         LIMIT 1
+           FOR UPDATE;
 
         IF v_other_slug IS NULL THEN
             RAISE EXCEPTION 'cannot disable last active default for user %', p_user_id
@@ -414,6 +485,9 @@ promoted_updated_at. Caller gets enough state to refresh local cache
 in one round trip. Raises RFM01 when no inheritor exists.
 Service-role only.$$;
 
+-- Return shape changed to TABLE(...) for parity with enable.
+DROP FUNCTION IF EXISTS referral.service_set_default_target(UUID, TEXT);
+
 -- ------------------------------------------------------------
 -- service_set_default_target(user_id, target_slug)
 --
@@ -421,20 +495,32 @@ Service-role only.$$;
 -- partial unique index (user_id) WHERE is_default AND active is
 -- enforced row-by-row inside a single UPDATE — a one-statement
 -- CASE-based swap would briefly hold two defaults and trip the index.
--- Idempotent fast path returns the row unchanged when it's already
--- the default so repeated calls don't churn updated_at.
+-- Idempotent when the slug is already the user's default. Returns
+-- the demoted slug + updated_at so callers can repair cache state in
+-- one round trip.
 -- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION referral.service_set_default_target(
     p_user_id      UUID,
     p_target_slug  TEXT
 )
-RETURNS referral.user_target
+RETURNS TABLE (
+    target_slug          TEXT,
+    demoted_target_slug  TEXT,
+    is_default           BOOLEAN,
+    active               BOOLEAN,
+    enabled_at           TIMESTAMPTZ,
+    disabled_at          TIMESTAMPTZ,
+    updated_at           TIMESTAMPTZ,
+    demoted_updated_at   TIMESTAMPTZ
+)
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
 DECLARE
-    v_row referral.user_target;
+    v_row                 referral.user_target;
+    v_demoted_slug        TEXT;
+    v_demoted_updated_at  TIMESTAMPTZ;
 BEGIN
     IF p_user_id IS NULL THEN
         RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
@@ -452,10 +538,10 @@ BEGIN
         hashtext(p_user_id::TEXT)
     );
 
-    SELECT * INTO v_row
-      FROM referral.user_target
-     WHERE user_id = p_user_id
-       AND target_slug = p_target_slug
+    SELECT ut.* INTO v_row
+      FROM referral.user_target ut
+     WHERE ut.user_id = p_user_id
+       AND ut.target_slug = p_target_slug
        FOR UPDATE;
     IF NOT FOUND OR NOT v_row.active THEN
         RAISE EXCEPTION 'target % is not active for user %',
@@ -464,24 +550,43 @@ BEGIN
     END IF;
 
     IF v_row.is_default THEN
-        RETURN v_row;
+        target_slug          := v_row.target_slug;
+        demoted_target_slug  := NULL;
+        is_default           := v_row.is_default;
+        active               := v_row.active;
+        enabled_at           := v_row.enabled_at;
+        disabled_at          := v_row.disabled_at;
+        updated_at           := v_row.updated_at;
+        demoted_updated_at   := NULL;
+        RETURN NEXT;
+        RETURN;
     END IF;
 
-    UPDATE referral.user_target
+    UPDATE referral.user_target AS ut
        SET is_default = FALSE
-     WHERE user_id = p_user_id
-       AND is_default
-       AND active
-       AND target_slug IS DISTINCT FROM p_target_slug;
+     WHERE ut.user_id = p_user_id
+       AND ut.is_default
+       AND ut.active
+       AND ut.target_slug IS DISTINCT FROM p_target_slug
+     RETURNING ut.target_slug, ut.updated_at
+          INTO v_demoted_slug, v_demoted_updated_at;
 
-    UPDATE referral.user_target
+    UPDATE referral.user_target AS ut
        SET is_default = TRUE
-     WHERE user_id = p_user_id
-       AND target_slug = p_target_slug
-       AND active
-     RETURNING * INTO v_row;
+     WHERE ut.user_id = p_user_id
+       AND ut.target_slug = p_target_slug
+       AND ut.active
+     RETURNING ut.* INTO v_row;
 
-    RETURN v_row;
+    target_slug          := v_row.target_slug;
+    demoted_target_slug  := v_demoted_slug;
+    is_default           := v_row.is_default;
+    active               := v_row.active;
+    enabled_at           := v_row.enabled_at;
+    disabled_at          := v_row.disabled_at;
+    updated_at           := v_row.updated_at;
+    demoted_updated_at   := v_demoted_updated_at;
+    RETURN NEXT;
 END;
 $fn$;
 
@@ -492,8 +597,9 @@ GRANT EXECUTE ON FUNCTION referral.service_set_default_target(UUID, TEXT)
 
 COMMENT ON FUNCTION referral.service_set_default_target(UUID, TEXT) IS
 $$Atomic default swap (demote-then-promote). Idempotent when the slug
-is already the user's default. Raises RFU01 when the slug is not an
-active row for the user. Service-role only.$$;
+is already the user's default. Returns the demoted slug + updated_at
+as demoted_target_slug / demoted_updated_at. Raises RFU01 when the
+slug is not an active row for the user. Service-role only.$$;
 
 -- ------------------------------------------------------------
 -- service_get_user_stats(user_id)

--- a/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
+++ b/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
@@ -134,8 +134,12 @@ END $$;
 DROP INDEX IF EXISTS referral.click_referrer_target_idx;
 DROP INDEX IF EXISTS referral.click_referrer_credited_ledger_idx;
 
--- One index for both per-target group-by and global rollup (the
--- latter range-scans the leading referrer_id prefix).
+-- Primary shape targets per-(referrer_id, target_slug) group-by in
+-- service_list_user_targets. service_get_user_stats can scan the
+-- leading referrer_id prefix (acceptable-not-ideal — target_slug
+-- sits between referrer_id and created_at). Add a narrower
+-- (referrer_id, created_at DESC) follow-up index when the global
+-- rollup actually becomes hot.
 CREATE INDEX IF NOT EXISTS referral_click_referrer_target_created_idx
     ON referral.click (referrer_id, target_slug, created_at DESC);
 

--- a/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
+++ b/packages/data/sql/schema/referral/referral_user_target_mgmt.sql
@@ -17,6 +17,64 @@
 -- ============================================================
 
 -- ------------------------------------------------------------
+-- Phase 3a schema hardening on referral.user_target
+-- ------------------------------------------------------------
+
+-- updated_at column + auto-bump trigger. Backfill from
+-- COALESCE(disabled_at, enabled_at, now()) so the column is never NULL.
+ALTER TABLE referral.user_target
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ;
+
+UPDATE referral.user_target
+   SET updated_at = COALESCE(updated_at, disabled_at, enabled_at, now())
+ WHERE updated_at IS NULL;
+
+ALTER TABLE referral.user_target
+    ALTER COLUMN updated_at SET DEFAULT now(),
+    ALTER COLUMN updated_at SET NOT NULL;
+
+CREATE OR REPLACE FUNCTION referral.user_target_touch()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+    NEW.updated_at := statement_timestamp();
+    RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS user_target_set_updated_at ON referral.user_target;
+CREATE TRIGGER user_target_set_updated_at
+    BEFORE UPDATE ON referral.user_target
+    FOR EACH ROW EXECUTE FUNCTION referral.user_target_touch();
+
+-- Belt-and-suspenders: a row cannot be is_default AND inactive at the
+-- same time. The partial unique index on (user_id) WHERE is_default
+-- AND active prevents two defaults; this CHECK closes the gap where
+-- an out-of-band UPDATE leaves a disabled row marked is_default = TRUE.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conrelid = 'referral.user_target'::regclass
+           AND conname = 'user_target_default_requires_active'
+    ) THEN
+        ALTER TABLE referral.user_target
+            ADD CONSTRAINT user_target_default_requires_active
+            CHECK (active OR NOT is_default);
+    END IF;
+END $$;
+
+-- Hot-path indexes for the stats lateral aggregates in
+-- service_list_user_targets / service_get_user_stats.
+CREATE INDEX IF NOT EXISTS click_referrer_target_idx
+    ON referral.click (referrer_id, target_slug, created_at DESC);
+CREATE INDEX IF NOT EXISTS click_referrer_credited_ledger_idx
+    ON referral.click (referrer_id)
+    WHERE credited AND ledger_id IS NOT NULL;
+
+-- ------------------------------------------------------------
 -- service_list_user_targets(user_id)
 --
 -- One row per (user, target) including inactive rows so the UI can
@@ -39,27 +97,23 @@ RETURNS TABLE (
     credits_total  BIGINT,
     last_click_at  TIMESTAMPTZ
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
-    SELECT
-        ut.target_slug,
-        t.title,
-        t.url,
-        ut.is_default,
-        ut.active,
-        ut.enabled_at,
-        ut.disabled_at,
-        COALESCE(stats.clicks_total, 0)    AS clicks_total,
-        COALESCE(stats.clicks_credited, 0) AS clicks_credited,
-        COALESCE(stats.credits_total, 0)   AS credits_total,
-        stats.last_click_at
-    FROM referral.user_target ut
-    JOIN referral.target t ON t.slug = ut.target_slug
-    LEFT JOIN LATERAL (
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+
+    -- Aggregate click stats once over the user's click rows and join
+    -- onto user_target. Avoids the per-target lateral aggregate that
+    -- scaled with target count.
+    RETURN QUERY
+    WITH stats AS (
         SELECT
+            c.target_slug AS target_slug,
             count(*)::BIGINT                                  AS clicks_total,
             count(*) FILTER (WHERE c.credited)::BIGINT        AS clicks_credited,
             COALESCE(SUM(l.delta) FILTER (
@@ -69,10 +123,27 @@ AS $fn$
         FROM referral.click c
         LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
         WHERE c.referrer_id = p_user_id
-          AND c.target_slug = ut.target_slug
-    ) stats ON TRUE
+        GROUP BY c.target_slug
+    )
+    SELECT
+        ut.target_slug,
+        t.title,
+        t.url,
+        ut.is_default,
+        ut.active,
+        ut.enabled_at,
+        ut.disabled_at,
+        COALESCE(s.clicks_total, 0)    AS clicks_total,
+        COALESCE(s.clicks_credited, 0) AS clicks_credited,
+        COALESCE(s.credits_total, 0)   AS credits_total,
+        s.last_click_at
+    FROM referral.user_target ut
+    JOIN referral.target t ON t.slug = ut.target_slug
+    LEFT JOIN stats s ON s.target_slug = ut.target_slug
     WHERE ut.user_id = p_user_id
-    ORDER BY ut.is_default DESC, ut.active DESC, ut.enabled_at DESC;
+    ORDER BY ut.is_default DESC, ut.active DESC, ut.enabled_at DESC,
+             ut.target_slug;
+END;
 $fn$;
 
 ALTER FUNCTION referral.service_list_user_targets(UUID) OWNER TO postgres;
@@ -204,6 +275,9 @@ BEGIN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
     p_target_slug := lower(btrim(p_target_slug));
+    IF p_target_slug = '' THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
 
     PERFORM pg_advisory_xact_lock(
         hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
@@ -224,7 +298,7 @@ BEGIN
          WHERE ut.user_id    = p_user_id
            AND ut.active
            AND ut.target_slug IS DISTINCT FROM p_target_slug
-         ORDER BY ut.enabled_at DESC
+         ORDER BY ut.enabled_at DESC, ut.target_slug ASC
          LIMIT 1;
 
         IF v_other_slug IS NULL THEN
@@ -282,6 +356,9 @@ BEGIN
         RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
     END IF;
     p_target_slug := lower(btrim(p_target_slug));
+    IF p_target_slug = '' THEN
+        RAISE EXCEPTION 'target_slug is required' USING ERRCODE = '22023';
+    END IF;
 
     PERFORM pg_advisory_xact_lock(
         hashtextextended('referral.user_target:' || p_user_id::TEXT, 0)
@@ -309,11 +386,7 @@ BEGIN
      WHERE user_id = p_user_id
        AND target_slug = p_target_slug
        AND active
-       AND NOT is_default;
-
-    SELECT * INTO v_row
-      FROM referral.user_target
-     WHERE user_id = p_user_id AND target_slug = p_target_slug;
+     RETURNING * INTO v_row;
 
     RETURN v_row;
 END;
@@ -339,11 +412,17 @@ RETURNS TABLE (
     credits_total   BIGINT,
     last_click_at   TIMESTAMPTZ
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $fn$
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id is required' USING ERRCODE = '22004';
+    END IF;
+
+    RETURN QUERY
     SELECT
         count(*)::BIGINT                                  AS clicks_total,
         count(*) FILTER (WHERE c.credited)::BIGINT        AS clicks_credited,
@@ -354,6 +433,7 @@ AS $fn$
     FROM referral.click c
     LEFT JOIN wallet.ledger l ON l.id = c.ledger_id
     WHERE c.referrer_id = p_user_id;
+END;
 $fn$;
 
 ALTER FUNCTION referral.service_get_user_stats(UUID) OWNER TO postgres;

--- a/packages/rust/kbve/src/referral/client.rs
+++ b/packages/rust/kbve/src/referral/client.rs
@@ -120,8 +120,8 @@ impl ReferralClient {
         let inner: &mut AsyncPgConnection = &mut *conn;
 
         let row: UserTargetMutationRow = sql_query(
-            "SELECT user_id, target_slug, is_default, active, enabled_at, \
-                    disabled_at \
+            "SELECT target_slug, demoted_target_slug, is_default, active, \
+                    enabled_at, disabled_at, updated_at, demoted_updated_at \
              FROM referral.service_enable_target($1, $2, $3)",
         )
         .bind::<SqlUuid, _>(user_id)
@@ -170,8 +170,8 @@ impl ReferralClient {
         let inner: &mut AsyncPgConnection = &mut *conn;
 
         let row: UserTargetMutationRow = sql_query(
-            "SELECT user_id, target_slug, is_default, active, enabled_at, \
-                    disabled_at \
+            "SELECT target_slug, demoted_target_slug, is_default, active, \
+                    enabled_at, disabled_at, updated_at, demoted_updated_at \
              FROM referral.service_set_default_target($1, $2)",
         )
         .bind::<SqlUuid, _>(user_id)

--- a/packages/rust/kbve/src/referral/client.rs
+++ b/packages/rust/kbve/src/referral/client.rs
@@ -18,8 +18,9 @@ use crate::wallet::client::WalletPool;
 
 use super::error::{ReferralError, Result};
 use super::types::{
-    RecordClickInput, RecordClickOutcome, RecordClickRow, ResolvedTargetRow, UserStats,
-    UserStatsRow, UserTargetMutation, UserTargetMutationRow, UserTargetRow, UserTargetView,
+    DisableTargetOutcome, DisableTargetRow, RecordClickInput, RecordClickOutcome, RecordClickRow,
+    ResolvedTargetRow, UserStats, UserStatsRow, UserTargetMutation, UserTargetMutationRow,
+    UserTargetRow, UserTargetView,
 };
 
 #[derive(Clone)]
@@ -96,8 +97,8 @@ impl ReferralClient {
 
         let rows: Vec<UserTargetRow> = sql_query(
             "SELECT target_slug, title, url, is_default, active, enabled_at, \
-                    disabled_at, clicks_total, clicks_credited, credits_total, \
-                    last_click_at \
+                    disabled_at, updated_at, clicks_total, clicks_credited, \
+                    credits_total, last_click_at \
              FROM referral.service_list_user_targets($1)",
         )
         .bind::<SqlUuid, _>(user_id)
@@ -133,18 +134,21 @@ impl ReferralClient {
         Ok(row.into())
     }
 
-    /// `referral.service_disable_target(user_id, slug)`.
+    /// `referral.service_disable_target(user_id, slug)`. Result carries
+    /// `promoted_target_slug` when a remaining active row inherited the
+    /// default — clients use it to refresh local UI without a follow-up
+    /// list call.
     pub async fn disable_target(
         &self,
         user_id: Uuid,
         target_slug: &str,
-    ) -> Result<UserTargetMutation> {
+    ) -> Result<DisableTargetOutcome> {
         let mut conn = self.pool.get().await?;
         let inner: &mut AsyncPgConnection = &mut *conn;
 
-        let row: UserTargetMutationRow = sql_query(
-            "SELECT user_id, target_slug, is_default, active, enabled_at, \
-                    disabled_at \
+        let row: DisableTargetRow = sql_query(
+            "SELECT target_slug, promoted_target_slug, is_default, active, \
+                    enabled_at, disabled_at \
              FROM referral.service_disable_target($1, $2)",
         )
         .bind::<SqlUuid, _>(user_id)

--- a/packages/rust/kbve/src/referral/client.rs
+++ b/packages/rust/kbve/src/referral/client.rs
@@ -10,14 +10,17 @@
 
 use diesel::OptionalExtension;
 use diesel::sql_query;
-use diesel::sql_types::{Bytea, Nullable, Text, Uuid as SqlUuid};
+use diesel::sql_types::{Bool, Bytea, Nullable, Text, Uuid as SqlUuid};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use uuid::Uuid;
 
 use crate::wallet::client::WalletPool;
 
 use super::error::{ReferralError, Result};
-use super::types::{RecordClickInput, RecordClickOutcome, RecordClickRow, ResolvedTargetRow};
+use super::types::{
+    RecordClickInput, RecordClickOutcome, RecordClickRow, ResolvedTargetRow, UserStats,
+    UserStatsRow, UserTargetMutation, UserTargetMutationRow, UserTargetRow, UserTargetView,
+};
 
 #[derive(Clone)]
 pub struct ReferralClient {
@@ -78,5 +81,118 @@ impl ReferralClient {
         .map_err(ReferralError::from_diesel)?;
 
         Ok(row)
+    }
+
+    // ---------------------------------------------------------------------
+    // Phase 3a — user-target management
+    // ---------------------------------------------------------------------
+
+    /// `SELECT * FROM referral.service_list_user_targets(user_id)`. One
+    /// row per (user, target) regardless of active state — the UI shows
+    /// disabled rows with a re-enable affordance.
+    pub async fn list_user_targets(&self, user_id: Uuid) -> Result<Vec<UserTargetView>> {
+        let mut conn = self.pool.get().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+
+        let rows: Vec<UserTargetRow> = sql_query(
+            "SELECT target_slug, title, url, is_default, active, enabled_at, \
+                    disabled_at, clicks_total, clicks_credited, credits_total, \
+                    last_click_at \
+             FROM referral.service_list_user_targets($1)",
+        )
+        .bind::<SqlUuid, _>(user_id)
+        .get_results::<UserTargetRow>(inner)
+        .await
+        .map_err(ReferralError::from_diesel)?;
+
+        Ok(rows.into_iter().map(UserTargetView::from).collect())
+    }
+
+    /// `referral.service_enable_target(user_id, slug, set_as_default)`.
+    pub async fn enable_target(
+        &self,
+        user_id: Uuid,
+        target_slug: &str,
+        set_as_default: bool,
+    ) -> Result<UserTargetMutation> {
+        let mut conn = self.pool.get().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+
+        let row: UserTargetMutationRow = sql_query(
+            "SELECT user_id, target_slug, is_default, active, enabled_at, \
+                    disabled_at \
+             FROM referral.service_enable_target($1, $2, $3)",
+        )
+        .bind::<SqlUuid, _>(user_id)
+        .bind::<Text, _>(target_slug)
+        .bind::<Bool, _>(set_as_default)
+        .get_result(inner)
+        .await
+        .map_err(ReferralError::from_diesel)?;
+
+        Ok(row.into())
+    }
+
+    /// `referral.service_disable_target(user_id, slug)`.
+    pub async fn disable_target(
+        &self,
+        user_id: Uuid,
+        target_slug: &str,
+    ) -> Result<UserTargetMutation> {
+        let mut conn = self.pool.get().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+
+        let row: UserTargetMutationRow = sql_query(
+            "SELECT user_id, target_slug, is_default, active, enabled_at, \
+                    disabled_at \
+             FROM referral.service_disable_target($1, $2)",
+        )
+        .bind::<SqlUuid, _>(user_id)
+        .bind::<Text, _>(target_slug)
+        .get_result(inner)
+        .await
+        .map_err(ReferralError::from_diesel)?;
+
+        Ok(row.into())
+    }
+
+    /// `referral.service_set_default_target(user_id, slug)`.
+    pub async fn set_default_target(
+        &self,
+        user_id: Uuid,
+        target_slug: &str,
+    ) -> Result<UserTargetMutation> {
+        let mut conn = self.pool.get().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+
+        let row: UserTargetMutationRow = sql_query(
+            "SELECT user_id, target_slug, is_default, active, enabled_at, \
+                    disabled_at \
+             FROM referral.service_set_default_target($1, $2)",
+        )
+        .bind::<SqlUuid, _>(user_id)
+        .bind::<Text, _>(target_slug)
+        .get_result(inner)
+        .await
+        .map_err(ReferralError::from_diesel)?;
+
+        Ok(row.into())
+    }
+
+    /// `referral.service_get_user_stats(user_id)`.
+    pub async fn get_user_stats(&self, user_id: Uuid) -> Result<UserStats> {
+        let mut conn = self.pool.get().await?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+
+        let row: UserStatsRow = sql_query(
+            "SELECT clicks_total, clicks_credited, credits_total, last_click_at \
+             FROM referral.service_get_user_stats($1)",
+        )
+        .bind::<SqlUuid, _>(user_id)
+        .get_result(inner)
+        .await
+        .map_err(ReferralError::from_diesel)?;
+
+        Ok(row.into())
     }
 }

--- a/packages/rust/kbve/src/referral/client.rs
+++ b/packages/rust/kbve/src/referral/client.rs
@@ -148,7 +148,7 @@ impl ReferralClient {
 
         let row: DisableTargetRow = sql_query(
             "SELECT target_slug, promoted_target_slug, is_default, active, \
-                    enabled_at, disabled_at \
+                    enabled_at, disabled_at, updated_at, promoted_updated_at \
              FROM referral.service_disable_target($1, $2)",
         )
         .bind::<SqlUuid, _>(user_id)

--- a/packages/rust/kbve/src/referral/types.rs
+++ b/packages/rust/kbve/src/referral/types.rs
@@ -199,6 +199,10 @@ pub struct DisableTargetRow {
     pub enabled_at: DateTime<Utc>,
     #[diesel(sql_type = diesel::sql_types::Nullable<Timestamptz>)]
     pub disabled_at: Option<DateTime<Utc>>,
+    #[diesel(sql_type = Timestamptz)]
+    pub updated_at: DateTime<Utc>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<Timestamptz>)]
+    pub promoted_updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -209,6 +213,8 @@ pub struct DisableTargetOutcome {
     pub active: bool,
     pub enabled_at: DateTime<Utc>,
     pub disabled_at: Option<DateTime<Utc>>,
+    pub updated_at: DateTime<Utc>,
+    pub promoted_updated_at: Option<DateTime<Utc>>,
 }
 
 impl From<DisableTargetRow> for DisableTargetOutcome {
@@ -220,6 +226,8 @@ impl From<DisableTargetRow> for DisableTargetOutcome {
             active: r.active,
             enabled_at: r.enabled_at,
             disabled_at: r.disabled_at,
+            updated_at: r.updated_at,
+            promoted_updated_at: r.promoted_updated_at,
         }
     }
 }

--- a/packages/rust/kbve/src/referral/types.rs
+++ b/packages/rust/kbve/src/referral/types.rs
@@ -1,7 +1,8 @@
 //! Result shapes returned by the referral client.
 
+use chrono::{DateTime, Utc};
 use diesel::QueryableByName;
-use diesel::sql_types::{BigInt, Bool, Text};
+use diesel::sql_types::{BigInt, Bool, Text, Timestamptz};
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -68,4 +69,141 @@ pub struct RecordClickInput {
     pub user_agent: Option<String>,
     pub referer: Option<String>,
     pub accept_lang: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3a — user-target management
+// ---------------------------------------------------------------------------
+
+/// Row returned by `referral.service_list_user_targets`. One per
+/// (user, target) regardless of active state so the UI can show
+/// disabled entries with a re-enable affordance.
+#[derive(Debug, QueryableByName)]
+pub struct UserTargetRow {
+    #[diesel(sql_type = Text)]
+    pub target_slug: String,
+    #[diesel(sql_type = Text)]
+    pub title: String,
+    #[diesel(sql_type = Text)]
+    pub url: String,
+    #[diesel(sql_type = Bool)]
+    pub is_default: bool,
+    #[diesel(sql_type = Bool)]
+    pub active: bool,
+    #[diesel(sql_type = Timestamptz)]
+    pub enabled_at: DateTime<Utc>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<Timestamptz>)]
+    pub disabled_at: Option<DateTime<Utc>>,
+    #[diesel(sql_type = BigInt)]
+    pub clicks_total: i64,
+    #[diesel(sql_type = BigInt)]
+    pub clicks_credited: i64,
+    #[diesel(sql_type = BigInt)]
+    pub credits_total: i64,
+    #[diesel(sql_type = diesel::sql_types::Nullable<Timestamptz>)]
+    pub last_click_at: Option<DateTime<Utc>>,
+}
+
+/// Serializable mirror of UserTargetRow for the HTTP response.
+#[derive(Debug, Serialize, Clone)]
+pub struct UserTargetView {
+    pub target_slug: String,
+    pub title: String,
+    pub url: String,
+    pub is_default: bool,
+    pub active: bool,
+    pub enabled_at: DateTime<Utc>,
+    pub disabled_at: Option<DateTime<Utc>>,
+    pub clicks_total: i64,
+    pub clicks_credited: i64,
+    pub credits_total: i64,
+    pub last_click_at: Option<DateTime<Utc>>,
+}
+
+impl From<UserTargetRow> for UserTargetView {
+    fn from(r: UserTargetRow) -> Self {
+        Self {
+            target_slug: r.target_slug,
+            title: r.title,
+            url: r.url,
+            is_default: r.is_default,
+            active: r.active,
+            enabled_at: r.enabled_at,
+            disabled_at: r.disabled_at,
+            clicks_total: r.clicks_total,
+            clicks_credited: r.clicks_credited,
+            credits_total: r.credits_total,
+            last_click_at: r.last_click_at,
+        }
+    }
+}
+
+/// Returned by service_enable_target / disable_target / set_default_target.
+/// Mirrors the `referral.user_target` rowtype (no stats).
+#[derive(Debug, QueryableByName)]
+pub struct UserTargetMutationRow {
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    pub user_id: Uuid,
+    #[diesel(sql_type = Text)]
+    pub target_slug: String,
+    #[diesel(sql_type = Bool)]
+    pub is_default: bool,
+    #[diesel(sql_type = Bool)]
+    pub active: bool,
+    #[diesel(sql_type = Timestamptz)]
+    pub enabled_at: DateTime<Utc>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<Timestamptz>)]
+    pub disabled_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct UserTargetMutation {
+    pub target_slug: String,
+    pub is_default: bool,
+    pub active: bool,
+    pub enabled_at: DateTime<Utc>,
+    pub disabled_at: Option<DateTime<Utc>>,
+}
+
+impl From<UserTargetMutationRow> for UserTargetMutation {
+    fn from(r: UserTargetMutationRow) -> Self {
+        Self {
+            target_slug: r.target_slug,
+            is_default: r.is_default,
+            active: r.active,
+            enabled_at: r.enabled_at,
+            disabled_at: r.disabled_at,
+        }
+    }
+}
+
+#[derive(Debug, QueryableByName)]
+pub struct UserStatsRow {
+    #[diesel(sql_type = BigInt)]
+    pub clicks_total: i64,
+    #[diesel(sql_type = BigInt)]
+    pub clicks_credited: i64,
+    #[diesel(sql_type = BigInt)]
+    pub credits_total: i64,
+    #[diesel(sql_type = diesel::sql_types::Nullable<Timestamptz>)]
+    pub last_click_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct UserStats {
+    pub clicks_total: i64,
+    pub clicks_credited: i64,
+    pub credits_total: i64,
+    pub last_click_at: Option<DateTime<Utc>>,
+}
+
+impl From<UserStatsRow> for UserStats {
+    fn from(r: UserStatsRow) -> Self {
+        Self {
+            clicks_total: r.clicks_total,
+            clicks_credited: r.clicks_credited,
+            credits_total: r.credits_total,
+            last_click_at: r.last_click_at,
+        }
+    }
 }

--- a/packages/rust/kbve/src/referral/types.rs
+++ b/packages/rust/kbve/src/referral/types.rs
@@ -142,14 +142,17 @@ impl From<UserTargetRow> for UserTargetView {
     }
 }
 
-/// Returned by service_enable_target / disable_target / set_default_target.
-/// Mirrors the `referral.user_target` rowtype (no stats).
+/// Row shape returned by `referral.service_enable_target` and
+/// `referral.service_set_default_target`. Carries the affected row's
+/// fields PLUS the slug that lost the default (NULL when no demotion
+/// happened) so callers can refresh cache state without a follow-up
+/// list call.
 #[derive(Debug, QueryableByName)]
 pub struct UserTargetMutationRow {
-    #[diesel(sql_type = diesel::sql_types::Uuid)]
-    pub user_id: Uuid,
     #[diesel(sql_type = Text)]
     pub target_slug: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<Text>)]
+    pub demoted_target_slug: Option<String>,
     #[diesel(sql_type = Bool)]
     pub is_default: bool,
     #[diesel(sql_type = Bool)]
@@ -158,25 +161,35 @@ pub struct UserTargetMutationRow {
     pub enabled_at: DateTime<Utc>,
     #[diesel(sql_type = diesel::sql_types::Nullable<Timestamptz>)]
     pub disabled_at: Option<DateTime<Utc>>,
+    #[diesel(sql_type = Timestamptz)]
+    pub updated_at: DateTime<Utc>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<Timestamptz>)]
+    pub demoted_updated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Serialize, Clone)]
 pub struct UserTargetMutation {
     pub target_slug: String,
+    pub demoted_target_slug: Option<String>,
     pub is_default: bool,
     pub active: bool,
     pub enabled_at: DateTime<Utc>,
     pub disabled_at: Option<DateTime<Utc>>,
+    pub updated_at: DateTime<Utc>,
+    pub demoted_updated_at: Option<DateTime<Utc>>,
 }
 
 impl From<UserTargetMutationRow> for UserTargetMutation {
     fn from(r: UserTargetMutationRow) -> Self {
         Self {
             target_slug: r.target_slug,
+            demoted_target_slug: r.demoted_target_slug,
             is_default: r.is_default,
             active: r.active,
             enabled_at: r.enabled_at,
             disabled_at: r.disabled_at,
+            updated_at: r.updated_at,
+            demoted_updated_at: r.demoted_updated_at,
         }
     }
 }

--- a/packages/rust/kbve/src/referral/types.rs
+++ b/packages/rust/kbve/src/referral/types.rs
@@ -94,6 +94,8 @@ pub struct UserTargetRow {
     pub enabled_at: DateTime<Utc>,
     #[diesel(sql_type = diesel::sql_types::Nullable<Timestamptz>)]
     pub disabled_at: Option<DateTime<Utc>>,
+    #[diesel(sql_type = Timestamptz)]
+    pub updated_at: DateTime<Utc>,
     #[diesel(sql_type = BigInt)]
     pub clicks_total: i64,
     #[diesel(sql_type = BigInt)]
@@ -114,6 +116,7 @@ pub struct UserTargetView {
     pub active: bool,
     pub enabled_at: DateTime<Utc>,
     pub disabled_at: Option<DateTime<Utc>>,
+    pub updated_at: DateTime<Utc>,
     pub clicks_total: i64,
     pub clicks_credited: i64,
     pub credits_total: i64,
@@ -130,6 +133,7 @@ impl From<UserTargetRow> for UserTargetView {
             active: r.active,
             enabled_at: r.enabled_at,
             disabled_at: r.disabled_at,
+            updated_at: r.updated_at,
             clicks_total: r.clicks_total,
             clicks_credited: r.clicks_credited,
             credits_total: r.credits_total,
@@ -169,6 +173,49 @@ impl From<UserTargetMutationRow> for UserTargetMutation {
     fn from(r: UserTargetMutationRow) -> Self {
         Self {
             target_slug: r.target_slug,
+            is_default: r.is_default,
+            active: r.active,
+            enabled_at: r.enabled_at,
+            disabled_at: r.disabled_at,
+        }
+    }
+}
+
+/// Row shape returned by `referral.service_disable_target`. Carries the
+/// disabled row's fields PLUS the slug that inherited the default
+/// (NULL when no promotion happened) so callers can refresh local UI
+/// state without a follow-up list call.
+#[derive(Debug, QueryableByName)]
+pub struct DisableTargetRow {
+    #[diesel(sql_type = Text)]
+    pub target_slug: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<Text>)]
+    pub promoted_target_slug: Option<String>,
+    #[diesel(sql_type = Bool)]
+    pub is_default: bool,
+    #[diesel(sql_type = Bool)]
+    pub active: bool,
+    #[diesel(sql_type = Timestamptz)]
+    pub enabled_at: DateTime<Utc>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<Timestamptz>)]
+    pub disabled_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct DisableTargetOutcome {
+    pub target_slug: String,
+    pub promoted_target_slug: Option<String>,
+    pub is_default: bool,
+    pub active: bool,
+    pub enabled_at: DateTime<Utc>,
+    pub disabled_at: Option<DateTime<Utc>>,
+}
+
+impl From<DisableTargetRow> for DisableTargetOutcome {
+    fn from(r: DisableTargetRow) -> Self {
+        Self {
+            target_slug: r.target_slug,
+            promoted_target_slug: r.promoted_target_slug,
             is_default: r.is_default,
             active: r.active,
             enabled_at: r.enabled_at,


### PR DESCRIPTION
## Stack
- Phase 1 (#11050) shipped the DB schema + record_click RPC.
- Phase 2 (#11085) wired axum redirect routes.
- **Phase 3a** (this PR) adds self-service management RPCs + their axum surface, fixes two live bugs surfaced from prod, and wires the missing HMAC secret through ExternalSecrets.

## What's in this PR

### 1. Self-service management RPCs + axum routes

**SQL** — \`20260516090714_referral_user_target_mgmt.sql\`:

| Function | Purpose |
| --- | --- |
| \`service_list_user_targets(user_id)\` | Per-target rollup (clicks / credited / credits / last_click_at), active **and** inactive rows so the UI can offer re-enable. |
| \`service_enable_target(user_id, slug, set_as_default)\` | Insert new row OR reactivate inactive. First enable auto-promotes to default so the short \`/referral/@<user>/\` URL always resolves. |
| \`service_disable_target(user_id, slug)\` | Flip \`active=FALSE\` + \`disabled_at=now()\`. If the row was default, the most-recently-enabled remaining active row inherits. If no other active row exists, raises **RFM01** so the caller must pick a new default first. |
| \`service_set_default_target(user_id, slug)\` | Atomic default swap. Two-statement demote-then-promote — a CASE-based one-shot swap briefly holds two defaults and trips the partial unique index. |
| \`service_get_user_stats(user_id)\` | Lifetime rollup across all targets. |

New SQLSTATE \`RFM01\` (last-default protection). All functions \`SECURITY DEFINER\`, owned by \`postgres\`, \`EXECUTE\` granted to \`service_role\` only. Per-user advisory locks serialize enable / disable / set-default so the partial unique index can't be transiently violated.

**Rust kbve crate** — \`ReferralClient\` gains five methods + matching \`QueryableByName\` / \`Serialize\` row shapes.

**axum-kbve** — five new authenticated routes:

\`\`\`
GET    /api/v1/referral/me/targets
GET    /api/v1/referral/me/stats
POST   /api/v1/referral/me/targets/{slug}/enable        body: {\"set_as_default\": bool}
POST   /api/v1/referral/me/targets/{slug}/disable
POST   /api/v1/referral/me/targets/{slug}/set-default
\`\`\`

All \`/me/*\` routes resolve \`user_id\` from the JWT \`sub\` claim via the existing \`wallet::resolve_user\` helper — never trusted from the path or body. RFM01 surfaces as **409** with \`{\"error\":\"no_other_default\"}\` so the UI can prompt the user to pick another default before disabling.

### 2. Trailing-slash fix for the public redirect routes

axum's path matching is exact, so prod hit:

\`\`\`
GET /referral/@fudster   → matched Phase 2 route, returned 503 (HMAC secret unset)
GET /referral/@fudster/  → 404
\`\`\`

Added trailing-slash twins for all four redirect routes (\`/api/v1/referral/*\` and \`/referral/*\` shapes) so both forms hit the handler.

### 3. \`REFERRAL_HASH_SECRET\` wired through ExternalSecrets

The handler was 503'ing because the secret was never plumbed.

- **\`kbve-deployment.yaml\`**: \`REFERRAL_HASH_SECRET\` env from \`referral-config/hash-secret\` with \`optional: true\` — an unset key leaves the env empty (handler 503s with the same warn-log as before, no behavior change).
- **\`kbve-externalsecret.yaml\`**: new \`kbve-referral-secrets\` ExternalSecret materializes \`referral-config\` in the kbve namespace from a kilobase \`referral-hash\` remote.

**Operator runs once** to activate the routes:

\`\`\`bash
kubectl -n kilobase create secret generic referral-hash \\
    --from-literal=secret=\"\$(openssl rand -base64 48)\"
\`\`\`

ExternalSecrets controller mints \`referral-config\` in kbve; Reloader rolls the deployment; routes start crediting.

## Test coverage

Companion test \`migration-tests/20260516090714_referral_user_target_mgmt.test.sql\` exercises:

- enable + auto-default on first opt-in
- second enable doesn't steal the default
- \`set_default_target\` demote/promote
- \`set_default_target\` on a non-enabled slug raises RFU01
- \`disable_target\` promotes a remaining active row to default
- disabling the last active default raises **RFM01**
- re-enable preserves \`enabled_at\` and clears \`disabled_at\`
- \`list_user_targets\` returns active + inactive
- \`get_user_stats\` reflects clicks + credits from \`record_click\`
- NULL user_id raises 22004, unknown target raises RFT01

Verified locally via \`./test-migration.sh 20260516090714_referral_user_target_mgmt\`.

Schema mirror added at \`packages/data/sql/schema/referral/referral_user_target_mgmt.sql\`; SQLSTATE table in \`referral_rpcs.sql\` extended with RFM01.

\`cargo check --manifest-path apps/kbve/axum-kbve/Cargo.toml\` clean.

## Test plan
- [ ] PR merges to dev → main → dbmate dispatch applies the new migration in prod.
- [ ] Operator runs the \`kubectl ... create secret referral-hash ...\` command above.
- [ ] ExternalSecrets controller mints \`referral-config\` in the kbve namespace (\`kubectl -n kbve get secret referral-config\`).
- [ ] Reloader rolls the kbve deployment; new pod logs \`ReferralClient initialized\`.
- [ ] \`curl -I https://kbve.com/referral/@fudster\` → 302 (was 503).
- [ ] \`curl -I https://kbve.com/referral/@fudster/\` → 302 (was 404).
- [ ] Authenticated user can \`POST /api/v1/referral/me/targets/rareicon/enable\` and see the row in \`GET /api/v1/referral/me/targets\`.
- [ ] Repeat for \`set-default\` and \`disable\`; verify the last-default \`disable\` returns 409.

## Deferred (Phase 3b)
- \`/profile/account/\` widget that calls the new \`/api/v1/referral/me/*\` routes (referral link card with copy button, target list with toggle / set-default controls, lifetime stats summary).