### PR TITLE
feat(astro-kbve): marketplace UI polish — hero layout + MC textures + grid

### DIFF
--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -141,18 +141,36 @@ import MarketCreateForm from './MarketCreateForm';
 		cursor: not-allowed;
 	}
 	.kbve-market__btn--primary {
-		background: rgba(59, 130, 246, 0.2);
-		border-color: rgba(59, 130, 246, 0.6);
+		background: color-mix(in srgb, var(--sl-color-accent) 25%, transparent);
+		border-color: color-mix(
+			in srgb,
+			var(--sl-color-accent) 65%,
+			transparent
+		);
+		color: var(--sl-color-white, var(--sl-color-text));
 	}
 	.kbve-market__btn--primary:hover {
-		background: rgba(59, 130, 246, 0.35);
+		background: color-mix(in srgb, var(--sl-color-accent) 45%, transparent);
 	}
 	.kbve-market__btn--danger {
-		background: rgba(239, 68, 68, 0.15);
-		border-color: rgba(239, 68, 68, 0.55);
+		background: color-mix(
+			in srgb,
+			var(--color-red, var(--sl-color-text-accent)) 18%,
+			transparent
+		);
+		border-color: color-mix(
+			in srgb,
+			var(--color-red, var(--sl-color-text-accent)) 55%,
+			transparent
+		);
+		color: var(--sl-color-white, var(--sl-color-text));
 	}
 	.kbve-market__btn--danger:hover {
-		background: rgba(239, 68, 68, 0.3);
+		background: color-mix(
+			in srgb,
+			var(--color-red, var(--sl-color-text-accent)) 35%,
+			transparent
+		);
 	}
 	.kbve-market__input {
 		padding: 0.5rem 0.75rem;
@@ -226,15 +244,27 @@ import MarketCreateForm from './MarketCreateForm';
 		border: 1px solid rgba(255, 255, 255, 0.15);
 	}
 	.kbve-market__badge--active {
-		background: rgba(34, 197, 94, 0.18);
-		border-color: rgba(34, 197, 94, 0.5);
-		color: rgb(187, 247, 208);
+		background: color-mix(in srgb, var(--sl-color-accent) 18%, transparent);
+		border-color: color-mix(
+			in srgb,
+			var(--sl-color-accent) 55%,
+			transparent
+		);
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
 	}
 	.kbve-market__badge--sold,
 	.kbve-market__badge--won {
-		background: rgba(59, 130, 246, 0.18);
-		border-color: rgba(59, 130, 246, 0.5);
-		color: rgb(191, 219, 254);
+		background: color-mix(
+			in srgb,
+			var(--color-gold-light, var(--sl-color-accent)) 18%,
+			transparent
+		);
+		border-color: color-mix(
+			in srgb,
+			var(--color-gold-light, var(--sl-color-accent)) 50%,
+			transparent
+		);
+		color: var(--color-gold-light, var(--sl-color-accent));
 	}
 	.kbve-market__badge--cancelled,
 	.kbve-market__badge--expired,
@@ -410,6 +440,395 @@ import MarketCreateForm from './MarketCreateForm';
 	@media (max-width: 540px) {
 		.kbve-market-summary__grid {
 			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+
+	/* ---- Polish v2: shared icon (themed against Starlight + KBVE brand) ---- */
+	.kbve-item-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 14px;
+		overflow: hidden;
+		flex-shrink: 0;
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+	}
+	.kbve-item-icon--mc {
+		background:
+			repeating-linear-gradient(
+				45deg,
+				color-mix(in srgb, var(--sl-color-black) 18%, transparent) 0 6px,
+				transparent 6px 12px
+			),
+			linear-gradient(
+				135deg,
+				var(--sl-color-bg-nav) 0%,
+				var(--sl-color-bg-sidebar) 100%
+			);
+		padding: 8%;
+	}
+	.kbve-item-icon--mc img {
+		display: block;
+		object-fit: contain;
+	}
+	.kbve-item-icon--placeholder {
+		color: var(--sl-color-white, #fff);
+		font-weight: 800;
+		letter-spacing: -0.02em;
+	}
+
+	/* ---- Polish v2: browse grid + filters ---- */
+	.kbve-market__filters {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		margin-bottom: 1.25rem;
+		padding: 0.75rem 1rem;
+		border-radius: 12px;
+		background: var(--sl-color-bg-sidebar, var(--sl-color-bg-nav));
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		flex-wrap: wrap;
+	}
+	.kbve-market__filter {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.85rem;
+		color: var(--sl-color-text);
+	}
+	.kbve-market__filter .kbve-market__input {
+		padding: 0.4rem 0.65rem;
+	}
+	.kbve-market__filter-count {
+		font-size: 0.85rem;
+		color: var(--sl-color-gray-3);
+	}
+	.kbve-market__filters .kbve-market__refresh {
+		margin-left: auto;
+	}
+	.kbve-market__grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+		gap: 0.9rem;
+	}
+	.kbve-market__grid-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.65rem;
+		padding: 1rem;
+		border-radius: 16px;
+		background: linear-gradient(
+			165deg,
+			var(--sl-color-bg-nav) 0%,
+			var(--sl-color-bg) 100%
+		);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: inherit;
+		text-decoration: none;
+		transition:
+			transform 0.15s ease,
+			border-color 0.15s ease,
+			box-shadow 0.15s ease;
+	}
+	.kbve-market__grid-card:hover {
+		transform: translateY(-2px);
+		border-color: var(--sl-color-accent);
+		box-shadow: 0 18px 30px -20px
+			color-mix(in srgb, var(--sl-color-accent) 45%, transparent);
+	}
+	.kbve-market__grid-icon {
+		display: flex;
+		justify-content: center;
+		padding: 0.6rem 0;
+	}
+	.kbve-market__grid-body {
+		display: grid;
+		gap: 0.4rem;
+	}
+	.kbve-market__grid-title {
+		font-weight: 700;
+		font-size: 0.95rem;
+		word-break: break-word;
+		color: var(--sl-color-white, var(--sl-color-text));
+	}
+	.kbve-market__grid-prices {
+		display: flex;
+		gap: 0.85rem;
+		flex-wrap: wrap;
+		font-size: 0.85rem;
+	}
+	.kbve-market__grid-price {
+		display: grid;
+		gap: 0.1rem;
+	}
+	.kbve-market__grid-price-label {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--sl-color-gray-3);
+	}
+	.kbve-market__grid-price-value {
+		font-weight: 700;
+		color: var(--sl-color-text);
+	}
+	.kbve-market__grid-price--primary .kbve-market__grid-price-value {
+		color: var(--sl-color-text-accent);
+	}
+	.kbve-market__grid-expiry {
+		font-size: 0.8rem;
+		color: var(--sl-color-gray-3);
+		font-variant-numeric: tabular-nums;
+	}
+	.kbve-market__grid-expiry--urgent {
+		color: var(--color-red, var(--sl-color-text-accent));
+		font-weight: 700;
+	}
+	.kbve-market__pagination {
+		margin-top: 1.25rem;
+		display: flex;
+		justify-content: center;
+	}
+
+	/* ---- Polish v2: detail hero + panel ---- */
+	.kbve-market__detail-v2 {
+		display: grid;
+		gap: 1.5rem;
+	}
+	.kbve-market__breadcrumb {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+	.kbve-market__breadcrumb a {
+		color: var(--sl-color-text);
+		text-decoration: none;
+		font-weight: 600;
+	}
+	.kbve-market__breadcrumb a:hover {
+		color: var(--sl-color-text-accent);
+	}
+	.kbve-market__copy {
+		padding: 0.4rem 0.85rem;
+		border-radius: 8px;
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		background: var(--sl-color-bg-nav);
+		color: var(--sl-color-text);
+		font-size: 0.85rem;
+		cursor: pointer;
+		font-weight: 600;
+	}
+	.kbve-market__copy:hover {
+		background: var(--sl-color-bg-sidebar);
+		border-color: var(--sl-color-accent);
+	}
+	.kbve-market__hero {
+		display: grid;
+		grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+		gap: 1.5rem;
+		align-items: start;
+	}
+	.kbve-market__hero-visual {
+		display: grid;
+		gap: 0.75rem;
+		padding: 1.5rem;
+		border-radius: 18px;
+		background:
+			radial-gradient(
+				circle at 20% 0%,
+				color-mix(in srgb, var(--sl-color-accent) 22%, transparent) 0%,
+				transparent 60%
+			),
+			linear-gradient(
+				165deg,
+				var(--sl-color-bg-nav) 0%,
+				var(--sl-color-bg) 100%
+			);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+	}
+	.kbve-market__hero-visual .kbve-item-icon {
+		margin: 0 auto;
+		border-radius: 22px;
+	}
+	.kbve-market__hero-meta {
+		display: flex;
+		gap: 0.45rem;
+		flex-wrap: wrap;
+	}
+	.kbve-market__kind-pill {
+		padding: 0.2rem 0.65rem;
+		border-radius: 999px;
+		font-size: 0.7rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		background: color-mix(in srgb, var(--sl-color-accent) 18%, transparent);
+		border: 1px solid
+			color-mix(in srgb, var(--sl-color-accent) 55%, transparent);
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+	}
+	.kbve-market__item-title {
+		margin: 0.25rem 0 0;
+		font-size: clamp(1.4rem, 3vw, 1.85rem);
+		font-weight: 800;
+		letter-spacing: -0.01em;
+		color: var(--sl-color-white, var(--sl-color-text));
+	}
+	.kbve-market__hero-seller,
+	.kbve-market__hero-created {
+		margin: 0;
+		font-size: 0.85rem;
+		color: var(--sl-color-gray-3);
+	}
+	.kbve-market__hero-seller code {
+		font-size: 0.8rem;
+		padding: 0.05rem 0.4rem;
+		border-radius: 6px;
+		background: var(--sl-color-bg-inline-code);
+		color: var(--sl-color-text);
+	}
+	.kbve-market__panel {
+		display: grid;
+		gap: 1rem;
+		padding: 1.5rem;
+		border-radius: 18px;
+		background: linear-gradient(
+			165deg,
+			var(--sl-color-bg-sidebar) 0%,
+			var(--sl-color-bg) 100%
+		);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		box-shadow: 0 30px 50px -30px
+			color-mix(in srgb, var(--sl-color-black) 60%, transparent);
+		position: sticky;
+		top: 1rem;
+	}
+	.kbve-market__panel-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+	.kbve-market__panel-countdown {
+		display: grid;
+		gap: 0.15rem;
+	}
+	.kbve-market__panel-label {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--sl-color-gray-3);
+	}
+	.kbve-market__panel-clock {
+		font-size: 1.4rem;
+		font-weight: 800;
+		letter-spacing: -0.01em;
+		font-variant-numeric: tabular-nums;
+		color: var(--sl-color-white, var(--sl-color-text));
+	}
+	.kbve-market__panel-clock--urgent {
+		color: var(--color-red, var(--sl-color-text-accent));
+	}
+	.kbve-market__panel-prices {
+		display: grid;
+		gap: 0.6rem;
+	}
+	.kbve-market__panel-price {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		padding: 0.85rem 1rem;
+		border-radius: 12px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+	}
+	.kbve-market__panel-price--primary {
+		background: color-mix(
+			in srgb,
+			var(--sl-color-accent) 12%,
+			var(--sl-color-bg-nav)
+		);
+		border-color: color-mix(
+			in srgb,
+			var(--sl-color-accent) 45%,
+			transparent
+		);
+	}
+	.kbve-market__panel-value {
+		font-weight: 800;
+		font-size: 1.15rem;
+		color: var(--sl-color-text);
+	}
+	.kbve-market__panel-price--primary .kbve-market__panel-value {
+		color: var(--sl-color-text-accent);
+	}
+	.kbve-market__panel-actions {
+		display: grid;
+		gap: 0.6rem;
+	}
+	.kbve-market__btn--block {
+		width: 100%;
+		display: block;
+		text-align: center;
+		text-decoration: none;
+		padding: 0.75rem 1rem;
+		font-size: 1rem;
+	}
+	.kbve-market__panel-bid {
+		display: flex;
+		gap: 0.5rem;
+	}
+	.kbve-market__panel-bid .kbve-market__input {
+		flex: 1;
+	}
+	.kbve-market__bids-head {
+		display: flex;
+		align-items: center;
+		gap: 0.65rem;
+		margin-bottom: 0.85rem;
+	}
+	.kbve-market__bids-head h3 {
+		margin: 0;
+		font-size: 1.05rem;
+		font-weight: 800;
+		color: var(--sl-color-white, var(--sl-color-text));
+	}
+	.kbve-market__bids-count {
+		padding: 0.1rem 0.55rem;
+		border-radius: 999px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		font-size: 0.8rem;
+		color: var(--sl-color-gray-3);
+		font-variant-numeric: tabular-nums;
+	}
+	.kbve-market__bid-amount {
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		color: var(--sl-color-text);
+	}
+	.kbve-market__bids-empty {
+		padding: 1.5rem;
+		border-radius: 14px;
+		background: var(--sl-color-bg-nav);
+		border: 1px dashed var(--sl-color-hairline, var(--sl-color-gray-5));
+		text-align: center;
+	}
+	.kbve-market__bids-empty-title {
+		margin: 0;
+		font-weight: 700;
+		font-size: 0.95rem;
+		color: var(--sl-color-text);
+	}
+	.kbve-market__bids-empty-sub {
+		margin: 0.25rem 0 0;
+		color: var(--sl-color-gray-3);
+		font-size: 0.85rem;
+	}
+	@media (max-width: 720px) {
+		.kbve-market__hero {
+			grid-template-columns: 1fr;
+		}
+		.kbve-market__panel {
+			position: static;
 		}
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/market/ItemIcon.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/ItemIcon.tsx
@@ -1,0 +1,91 @@
+import { useMemo, useState } from 'react';
+
+const MC_ASSET_VERSION = '1.21.5';
+const MC_TEXTURE_BASE = `https://mcasset.cloud/${MC_ASSET_VERSION}/assets/minecraft/textures/item`;
+const MC_BLOCK_BASE = `https://mcasset.cloud/${MC_ASSET_VERSION}/assets/minecraft/textures/block`;
+
+type Props = {
+	itemRef: Record<string, unknown> | null | undefined;
+	size?: number;
+	className?: string;
+};
+
+function kindInitial(kind: string): string {
+	if (kind === 'mc_item') return 'M';
+	if (kind === 'rareicon_item') return 'R';
+	if (kind === 'generic') return 'G';
+	return kind.charAt(0).toUpperCase() || '?';
+}
+
+function kindGradient(kind: string): string {
+	switch (kind) {
+		case 'mc_item':
+			return 'linear-gradient(135deg, #16a34a 0%, #065f46 100%)';
+		case 'rareicon_item':
+			return 'linear-gradient(135deg, #a855f7 0%, #4c1d95 100%)';
+		default:
+			return 'linear-gradient(135deg, #475569 0%, #1e293b 100%)';
+	}
+}
+
+function mcCandidates(id: string): string[] {
+	const clean = id.replace(/^minecraft:/, '').toLowerCase();
+	return [`${MC_TEXTURE_BASE}/${clean}.png`, `${MC_BLOCK_BASE}/${clean}.png`];
+}
+
+export function ItemIcon({ itemRef, size = 64, className }: Props) {
+	const [errIdx, setErrIdx] = useState(0);
+	const meta = useMemo(() => {
+		const r = (itemRef ?? {}) as Record<string, unknown>;
+		const kind = typeof r.kind === 'string' ? r.kind : 'generic';
+		const id =
+			typeof r.id === 'string' || typeof r.id === 'number'
+				? String(r.id)
+				: '';
+		return { kind, id };
+	}, [itemRef]);
+
+	const candidates =
+		meta.kind === 'mc_item' && meta.id ? mcCandidates(meta.id) : [];
+	const src = candidates[errIdx];
+	const exhausted = errIdx >= candidates.length;
+
+	if (candidates.length > 0 && !exhausted) {
+		return (
+			<div
+				className={`kbve-item-icon kbve-item-icon--mc${className ? ` ${className}` : ''}`}
+				style={{ width: size, height: size }}>
+				<img
+					src={src}
+					alt={`${meta.kind} ${meta.id}`}
+					width={size}
+					height={size}
+					onError={() => setErrIdx((i) => i + 1)}
+					style={{
+						imageRendering: 'pixelated',
+						width: '100%',
+						height: '100%',
+					}}
+					loading="lazy"
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className={`kbve-item-icon kbve-item-icon--placeholder${className ? ` ${className}` : ''}`}
+			style={{
+				width: size,
+				height: size,
+				background: kindGradient(meta.kind),
+			}}
+			aria-label={`${meta.kind} ${meta.id || 'unknown'}`}>
+			<span style={{ fontSize: size * 0.42 }}>
+				{kindInitial(meta.kind)}
+			</span>
+		</div>
+	);
+}
+
+export default ItemIcon;

--- a/apps/kbve/astro-kbve/src/components/market/MarketBrowse.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketBrowse.tsx
@@ -1,14 +1,69 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { listActive, type MarketListing, MarketApiError } from './api';
-import { formatExpiry, formatKhash, itemRefLabel } from './format';
+import { formatKhash, itemRefLabel } from './format';
+import { useCountdown, formatCountdown } from './countdown';
+import { ItemIcon } from './ItemIcon';
 
 const PAGE_SIZE = 25;
+
+const KIND_FILTERS: { value: string; label: string }[] = [
+	{ value: 'all', label: 'All kinds' },
+	{ value: 'mc_item', label: 'Minecraft' },
+	{ value: 'rareicon_item', label: 'Rareicon' },
+	{ value: 'generic', label: 'Other' },
+];
+
+function ListingCard({ row }: { row: MarketListing }) {
+	const countdown = useCountdown(row.expires_at);
+	const urgent = countdown.totalMs < 60 * 60 * 1000;
+	return (
+		<a
+			href={`/market/listing/?id=${row.listing_id}`}
+			className="kbve-market__grid-card">
+			<div className="kbve-market__grid-icon">
+				<ItemIcon itemRef={row.item_ref} size={96} />
+			</div>
+			<div className="kbve-market__grid-body">
+				<div className="kbve-market__grid-title">
+					{itemRefLabel(row.item_ref)}
+				</div>
+				<div className="kbve-market__grid-prices">
+					{row.buy_now_price !== null && (
+						<span className="kbve-market__grid-price kbve-market__grid-price--primary">
+							<span className="kbve-market__grid-price-label">
+								Buy
+							</span>
+							<span className="kbve-market__grid-price-value">
+								{formatKhash(row.buy_now_price)}
+							</span>
+						</span>
+					)}
+					{(row.current_bid !== null || row.min_bid !== null) && (
+						<span className="kbve-market__grid-price">
+							<span className="kbve-market__grid-price-label">
+								{row.current_bid !== null ? 'Bid' : 'Min'}
+							</span>
+							<span className="kbve-market__grid-price-value">
+								{formatKhash(row.current_bid ?? row.min_bid)}
+							</span>
+						</span>
+					)}
+				</div>
+				<div
+					className={`kbve-market__grid-expiry${urgent ? ' kbve-market__grid-expiry--urgent' : ''}`}>
+					{formatCountdown(countdown)}
+				</div>
+			</div>
+		</a>
+	);
+}
 
 export function MarketBrowse() {
 	const [rows, setRows] = useState<MarketListing[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 	const [hasMore, setHasMore] = useState(false);
+	const [kindFilter, setKindFilter] = useState<string>('all');
 
 	const load = useCallback(async (after?: MarketListing) => {
 		setLoading(true);
@@ -41,73 +96,84 @@ export function MarketBrowse() {
 		if (tail) void load(tail);
 	};
 
-	if (loading && rows.length === 0) {
-		return <div className="kbve-market__status">Loading listings…</div>;
-	}
-	if (error && rows.length === 0) {
-		return (
-			<div className="kbve-market__status kbve-market__status--error">
-				{error}
-			</div>
-		);
-	}
-	if (rows.length === 0) {
-		return (
-			<div className="kbve-market__status">
-				No active listings yet. Check back soon.
-			</div>
-		);
-	}
+	const filtered = useMemo(() => {
+		if (kindFilter === 'all') return rows;
+		return rows.filter((r) => {
+			const k = (r.item_ref as { kind?: unknown })?.kind;
+			return typeof k === 'string'
+				? k === kindFilter
+				: kindFilter === 'generic';
+		});
+	}, [rows, kindFilter]);
 
 	return (
-		<div className="kbve-market__list">
-			{rows.map((r) => (
-				<a
-					key={r.listing_id}
-					href={`/market/listing/?id=${r.listing_id}`}
-					className="kbve-market__card">
-					<div className="kbve-market__card-head">
-						<span className="kbve-market__card-item">
-							{itemRefLabel(r.item_ref)}
-						</span>
-						<span className="kbve-market__card-expiry">
-							{formatExpiry(r.expires_at)}
-						</span>
-					</div>
-					<div className="kbve-market__card-prices">
-						{r.buy_now_price !== null && (
-							<span className="kbve-market__price">
-								<span className="kbve-market__price-label">
-									Buy Now
-								</span>
-								<span className="kbve-market__price-value">
-									{formatKhash(r.buy_now_price)}
-								</span>
-							</span>
-						)}
-						{(r.current_bid !== null || r.min_bid !== null) && (
-							<span className="kbve-market__price">
-								<span className="kbve-market__price-label">
-									{r.current_bid !== null ? 'Bid' : 'Min Bid'}
-								</span>
-								<span className="kbve-market__price-value">
-									{formatKhash(r.current_bid ?? r.min_bid)}
-								</span>
-							</span>
-						)}
-					</div>
-				</a>
-			))}
-			{hasMore && (
+		<div>
+			<div className="kbve-market__filters">
+				<label className="kbve-market__filter">
+					<span>Kind</span>
+					<select
+						className="kbve-market__input"
+						value={kindFilter}
+						onChange={(e) => setKindFilter(e.target.value)}>
+						{KIND_FILTERS.map((k) => (
+							<option key={k.value} value={k.value}>
+								{k.label}
+							</option>
+						))}
+					</select>
+				</label>
+				<span className="kbve-market__filter-count">
+					{filtered.length} / {rows.length} shown
+				</span>
 				<button
 					type="button"
-					className="kbve-market__load-more"
-					onClick={loadMore}
+					className="kbve-market__refresh"
+					onClick={() => void load()}
 					disabled={loading}>
-					{loading ? 'Loading…' : 'Load more'}
+					{loading ? '…' : '↻ Refresh'}
 				</button>
+			</div>
+
+			{loading && rows.length === 0 && (
+				<div className="kbve-market__status">Loading listings…</div>
 			)}
-			{error && (
+			{error && rows.length === 0 && (
+				<div className="kbve-market__status kbve-market__status--error">
+					{error}
+				</div>
+			)}
+			{!loading && rows.length === 0 && !error && (
+				<div className="kbve-market__status">
+					No active listings yet. Check back soon.
+				</div>
+			)}
+
+			{filtered.length > 0 && (
+				<div className="kbve-market__grid">
+					{filtered.map((r) => (
+						<ListingCard key={r.listing_id} row={r} />
+					))}
+				</div>
+			)}
+
+			{rows.length > 0 && filtered.length === 0 && (
+				<div className="kbve-market__status">
+					No active listings match this filter.
+				</div>
+			)}
+
+			{hasMore && (
+				<div className="kbve-market__pagination">
+					<button
+						type="button"
+						className="kbve-market__btn"
+						onClick={loadMore}
+						disabled={loading}>
+						{loading ? 'Loading…' : 'Load more'}
+					</button>
+				</div>
+			)}
+			{error && rows.length > 0 && (
 				<div className="kbve-market__status kbve-market__status--error">
 					{error}
 				</div>

--- a/apps/kbve/astro-kbve/src/components/market/MarketListingDetail.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketListingDetail.tsx
@@ -8,12 +8,17 @@ import {
 	type MarketListingDetail as MarketListingDetailRow,
 	MarketApiError,
 } from './api';
-import {
-	formatExpiry,
-	formatKhash,
-	formatRelative,
-	itemRefLabel,
-} from './format';
+import { formatKhash, formatRelative, itemRefLabel } from './format';
+import { useCountdown, formatCountdown } from './countdown';
+import { ItemIcon } from './ItemIcon';
+
+function readListingId(): number | null {
+	if (typeof window === 'undefined') return null;
+	const raw = new URLSearchParams(window.location.search).get('id');
+	if (!raw) return null;
+	const n = Number(raw);
+	return Number.isFinite(n) && n > 0 ? n : null;
+}
 
 async function fetchMyAccountId(): Promise<string | null> {
 	const token = await getAccessToken();
@@ -26,12 +31,8 @@ async function fetchMyAccountId(): Promise<string | null> {
 	return b.account_id ?? null;
 }
 
-function readListingId(): number | null {
-	if (typeof window === 'undefined') return null;
-	const raw = new URLSearchParams(window.location.search).get('id');
-	if (!raw) return null;
-	const n = Number(raw);
-	return Number.isFinite(n) && n > 0 ? n : null;
+function shortId(uuid: string): string {
+	return `${uuid.slice(0, 6)}…${uuid.slice(-4)}`;
 }
 
 export function MarketListingDetail() {
@@ -44,6 +45,7 @@ export function MarketListingDetail() {
 	const [actionError, setActionError] = useState<string | null>(null);
 	const [actionBusy, setActionBusy] = useState<string | null>(null);
 	const [bidInput, setBidInput] = useState('');
+	const [copied, setCopied] = useState(false);
 
 	useEffect(() => {
 		setListingId(readListingId());
@@ -78,6 +80,8 @@ export function MarketListingDetail() {
 	useEffect(() => {
 		void refresh();
 	}, [refresh]);
+
+	const countdown = useCountdown(row?.expires_at);
 
 	const isSeller = useMemo(() => {
 		if (!row || !myAccount) return false;
@@ -143,6 +147,14 @@ export function MarketListingDetail() {
 		}
 	};
 
+	const onCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(window.location.href);
+			setCopied(true);
+			window.setTimeout(() => setCopied(false), 1500);
+		} catch {}
+	};
+
 	if (listingId == null) {
 		return (
 			<div className="kbve-market__status">
@@ -163,121 +175,171 @@ export function MarketListingDetail() {
 	const active = row.listing_status === 'active';
 	const minNextBid =
 		(row.current_bid ?? (row.min_bid !== null ? row.min_bid - 1 : 0)) + 1;
+	const kind = String(
+		((row.item_ref ?? {}) as { kind?: unknown }).kind ?? 'generic',
+	);
 
 	return (
-		<div className="kbve-market__detail">
-			<header className="kbve-market__detail-head">
-				<div>
-					<div className="kbve-market__detail-item">
-						{itemRefLabel(row.item_ref)}
-					</div>
-					<div className="kbve-market__detail-status">
+		<div className="kbve-market__detail-v2">
+			<nav className="kbve-market__breadcrumb">
+				<a href="/market/">← Browse</a>
+				<button
+					type="button"
+					className="kbve-market__copy"
+					onClick={() => void onCopy()}>
+					{copied ? '✓ Copied' : 'Share'}
+				</button>
+			</nav>
+
+			<div className="kbve-market__hero">
+				<aside className="kbve-market__hero-visual">
+					<ItemIcon itemRef={row.item_ref} size={224} />
+					<div className="kbve-market__hero-meta">
+						<span className="kbve-market__kind-pill">{kind}</span>
 						<span
 							className={`kbve-market__badge kbve-market__badge--${row.listing_status}`}>
 							{row.listing_status}
 						</span>
-						<span>
-							{active
-								? formatExpiry(row.expires_at)
-								: `closed ${row.settled_at ? formatRelative(row.settled_at) : ''}`}
-						</span>
 					</div>
-				</div>
-				<a href="/market/" className="kbve-market__back">
-					← Browse
-				</a>
-			</header>
-
-			<dl className="kbve-market__detail-prices">
-				<div>
-					<dt>Buy Now</dt>
-					<dd>
-						{row.buy_now_price !== null
-							? formatKhash(row.buy_now_price)
-							: '—'}
-					</dd>
-				</div>
-				<div>
-					<dt>Current Bid</dt>
-					<dd>
-						{row.current_bid !== null
-							? formatKhash(row.current_bid)
-							: '—'}
-					</dd>
-				</div>
-				<div>
-					<dt>Min Bid</dt>
-					<dd>
-						{row.min_bid !== null ? formatKhash(row.min_bid) : '—'}
-					</dd>
-				</div>
-			</dl>
-
-			{ready && authenticated && active && !isSeller && (
-				<div className="kbve-market__actions">
-					<div className="kbve-market__bid-row">
-						<input
-							type="number"
-							min={minNextBid}
-							step={1}
-							placeholder={`min ${minNextBid}`}
-							value={bidInput}
-							onChange={(e) => setBidInput(e.target.value)}
-							className="kbve-market__input"
-						/>
-						<button
-							type="button"
-							className="kbve-market__btn"
-							onClick={() => void onBid()}
-							disabled={actionBusy !== null}>
-							{actionBusy === 'bid' ? 'Bidding…' : 'Place Bid'}
-						</button>
-					</div>
-					{row.buy_now_price !== null && (
-						<button
-							type="button"
-							className="kbve-market__btn kbve-market__btn--primary"
-							onClick={() => void onBuyNow()}
-							disabled={actionBusy !== null}>
-							{actionBusy === 'buy'
-								? 'Buying…'
-								: `Buy Now ${formatKhash(row.buy_now_price)}`}
-						</button>
-					)}
-				</div>
-			)}
-
-			{ready && authenticated && active && isSeller && (
-				<div className="kbve-market__actions">
-					<button
-						type="button"
-						className="kbve-market__btn kbve-market__btn--danger"
-						onClick={() => void onCancel()}
-						disabled={actionBusy !== null}>
-						{actionBusy === 'cancel'
-							? 'Cancelling…'
-							: 'Cancel Listing'}
-					</button>
-					<p className="kbve-market__hint">
-						Cancelling refunds the active high bidder's escrow.
+					<h1 className="kbve-market__item-title">
+						{itemRefLabel(row.item_ref)}
+					</h1>
+					<p className="kbve-market__hero-seller">
+						Seller{' '}
+						<code title={row.seller_account}>
+							{shortId(row.seller_account)}
+						</code>
 					</p>
-				</div>
-			)}
+					<p className="kbve-market__hero-created">
+						Listed {formatRelative(row.created_at)}
+					</p>
+				</aside>
 
-			{ready && !authenticated && active && (
-				<div className="kbve-market__status">
-					Sign in to bid or buy.
-				</div>
-			)}
+				<section className="kbve-market__panel">
+					<div className="kbve-market__panel-head">
+						<div className="kbve-market__panel-countdown">
+							<span className="kbve-market__panel-label">
+								{active ? 'Ends in' : 'Closed'}
+							</span>
+							<span
+								className={`kbve-market__panel-clock${countdown.totalMs < 60_000 && active ? ' kbve-market__panel-clock--urgent' : ''}`}>
+								{active
+									? formatCountdown(countdown)
+									: row.settled_at
+										? formatRelative(row.settled_at)
+										: '—'}
+							</span>
+						</div>
+					</div>
 
-			{actionError && (
-				<div className="kbve-market__status kbve-market__status--error">
-					{actionError}
-				</div>
-			)}
+					<div className="kbve-market__panel-prices">
+						{row.buy_now_price !== null && (
+							<div className="kbve-market__panel-price kbve-market__panel-price--primary">
+								<span className="kbve-market__panel-label">
+									Buy Now
+								</span>
+								<span className="kbve-market__panel-value">
+									{formatKhash(row.buy_now_price)}
+								</span>
+							</div>
+						)}
+						<div className="kbve-market__panel-price">
+							<span className="kbve-market__panel-label">
+								{row.current_bid !== null
+									? 'Current Bid'
+									: 'Min Bid'}
+							</span>
+							<span className="kbve-market__panel-value">
+								{formatKhash(row.current_bid ?? row.min_bid)}
+							</span>
+						</div>
+					</div>
+
+					{ready && authenticated && active && !isSeller && (
+						<div className="kbve-market__panel-actions">
+							{row.buy_now_price !== null && (
+								<button
+									type="button"
+									className="kbve-market__btn kbve-market__btn--primary kbve-market__btn--block"
+									onClick={() => void onBuyNow()}
+									disabled={actionBusy !== null}>
+									{actionBusy === 'buy'
+										? 'Buying…'
+										: `Buy Now · ${formatKhash(row.buy_now_price)}`}
+								</button>
+							)}
+							{row.min_bid !== null && (
+								<div className="kbve-market__panel-bid">
+									<input
+										type="number"
+										min={minNextBid}
+										step={1}
+										placeholder={`min ${minNextBid}`}
+										value={bidInput}
+										onChange={(e) =>
+											setBidInput(e.target.value)
+										}
+										className="kbve-market__input"
+									/>
+									<button
+										type="button"
+										className="kbve-market__btn"
+										onClick={() => void onBid()}
+										disabled={actionBusy !== null}>
+										{actionBusy === 'bid'
+											? 'Bidding…'
+											: 'Bid'}
+									</button>
+								</div>
+							)}
+							<p className="kbve-market__hint">
+								Bids hold your KHash in escrow until you're
+								outbid.
+							</p>
+						</div>
+					)}
+
+					{ready && authenticated && active && isSeller && (
+						<div className="kbve-market__panel-actions">
+							<button
+								type="button"
+								className="kbve-market__btn kbve-market__btn--danger kbve-market__btn--block"
+								onClick={() => void onCancel()}
+								disabled={actionBusy !== null}>
+								{actionBusy === 'cancel'
+									? 'Cancelling…'
+									: 'Cancel Listing'}
+							</button>
+							<p className="kbve-market__hint">
+								You're the seller. Cancelling refunds the active
+								high bidder.
+							</p>
+						</div>
+					)}
+
+					{ready && !authenticated && active && (
+						<a
+							className="kbve-market__btn kbve-market__btn--primary kbve-market__btn--block"
+							href="/login/">
+							Sign in to bid or buy
+						</a>
+					)}
+
+					{actionError && (
+						<div className="kbve-market__status kbve-market__status--error">
+							{actionError}
+						</div>
+					)}
+				</section>
+			</div>
 
 			<section className="kbve-market__bids">
-				<h3>Recent Bids</h3>
+				<header className="kbve-market__bids-head">
+					<h3>Bid History</h3>
+					<span className="kbve-market__bids-count">
+						{Array.isArray(row.bids) ? row.bids.length : 0}
+					</span>
+				</header>
 				{Array.isArray(row.bids) && row.bids.length > 0 ? (
 					<ol className="kbve-market__bid-list">
 						{row.bids.slice(0, 25).map((b, i) => {
@@ -292,23 +354,37 @@ export function MarketListingDetail() {
 								.bid_status;
 							return (
 								<li key={i}>
-									<span>
+									<span className="kbve-market__bid-amount">
 										{amount !== null
 											? formatKhash(amount)
 											: '—'}
 									</span>
 									<span className="kbve-market__bid-meta">
-										{status ?? 'unknown'} ·{' '}
-										{placedAt
-											? formatRelative(placedAt)
-											: '—'}
+										<span
+											className={`kbve-market__badge kbve-market__badge--${status ?? 'unknown'}`}>
+											{status ?? 'unknown'}
+										</span>
+										<span>
+											{placedAt
+												? formatRelative(placedAt)
+												: '—'}
+										</span>
 									</span>
 								</li>
 							);
 						})}
 					</ol>
 				) : (
-					<p className="kbve-market__hint">No bids yet.</p>
+					<div className="kbve-market__bids-empty">
+						<p className="kbve-market__bids-empty-title">
+							No bids yet
+						</p>
+						<p className="kbve-market__bids-empty-sub">
+							{active && row.min_bid !== null
+								? `Open at ${formatKhash(row.min_bid)} — be the first.`
+								: 'Bidding closed.'}
+						</p>
+					</div>
 				)}
 			</section>
 		</div>

--- a/apps/kbve/astro-kbve/src/components/market/countdown.ts
+++ b/apps/kbve/astro-kbve/src/components/market/countdown.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+
+export type Countdown = {
+	expired: boolean;
+	days: number;
+	hours: number;
+	minutes: number;
+	seconds: number;
+	totalMs: number;
+};
+
+function compute(iso: string): Countdown {
+	const ms = new Date(iso).getTime() - Date.now();
+	if (ms <= 0)
+		return {
+			expired: true,
+			days: 0,
+			hours: 0,
+			minutes: 0,
+			seconds: 0,
+			totalMs: 0,
+		};
+	const totalSec = Math.floor(ms / 1000);
+	return {
+		expired: false,
+		days: Math.floor(totalSec / 86400),
+		hours: Math.floor((totalSec % 86400) / 3600),
+		minutes: Math.floor((totalSec % 3600) / 60),
+		seconds: totalSec % 60,
+		totalMs: ms,
+	};
+}
+
+export function useCountdown(iso: string | null | undefined): Countdown {
+	const [state, setState] = useState<Countdown>(() =>
+		iso
+			? compute(iso)
+			: {
+					expired: true,
+					days: 0,
+					hours: 0,
+					minutes: 0,
+					seconds: 0,
+					totalMs: 0,
+				},
+	);
+	useEffect(() => {
+		if (!iso) return;
+		setState(compute(iso));
+		const tick = () => setState(compute(iso));
+		const intervalMs = compute(iso).totalMs < 60_000 ? 1000 : 30_000;
+		const id = window.setInterval(tick, intervalMs);
+		return () => window.clearInterval(id);
+	}, [iso]);
+	return state;
+}
+
+export function formatCountdown(c: Countdown): string {
+	if (c.expired) return 'expired';
+	if (c.days > 0) return `${c.days}d ${c.hours}h`;
+	if (c.hours > 0) return `${c.hours}h ${c.minutes}m`;
+	if (c.minutes > 0)
+		return `${c.minutes}m ${c.seconds.toString().padStart(2, '0')}s`;
+	return `${c.seconds}s`;
+}


### PR DESCRIPTION
## Summary
- Polishes `/market` + `/market/listing/?id=N` after Phase 5 landed (#11086). Two-column hero, sticky action panel, live countdown, real Minecraft item textures, themed against Starlight + KBVE brand vars.

## Detail page (`/market/listing/?id=N`)
- Two-column hero: item visual + meta on the left, sticky price + action panel on the right. Stacks on mobile.
- **Live countdown** ticker — refreshes per-minute, per-second under 1m, urgent colour under 1m.
- **`ItemIcon` component** — renders real Minecraft item textures from `mcasset.cloud` for `kind=mc_item` (tries `textures/item/…` then `textures/block/…` with `onerror` fallback to a kind-themed gradient initial). Other kinds (rareicon_item / generic) get themed placeholders.
- Bigger price display, primary Buy Now button, kind pill + status badge, share/copy-link button.
- Better empty-bid state with a "be the first" CTA.

## Browse page (`/market`)
- Card grid (auto-fill, 240px min).
- Kind filter dropdown (Minecraft / Rareicon / Other) + refresh.
- Per-card live countdown with urgency colouring under 1h.

## Theming
All new styles use Starlight CSS variables (`--sl-color-bg-*`, `--sl-color-text-*`, `--sl-color-accent`, `--sl-color-hairline`) and KBVE brand vars (`--color-gold`, `--color-red`). Replaces the prior hardcoded slate/blue palette so the marketplace matches the rest of kbve.com in both light + dark modes.

Also retheme buttons + badges (active / sold / won / cancelled) to brand palette.

## Tracking
Phase 5.1 of #10979. Phase 5 (UI scaffold) shipped via #11086.

## Test plan
- [ ] `./kbve.sh -nx astro-kbve:build` — 5507 pages built locally
- [ ] CI astro-kbve pipeline green
- [ ] Visual smoke against listing #1 (`mc_item:diamond_sword`) — texture loads from mcasset.cloud, countdown ticks live, sticky panel works on desktop, stacks on mobile
- [ ] Toggle kind filter on browse, verify filtered counts
- [ ] Copy share link — verifies clipboard write