### PR TITLE
feat(astro-irc): chat.js embed bundle for cross-site IRC mounting

### DIFF
--- a/apps/irc/astro-irc/.gitignore
+++ b/apps/irc/astro-irc/.gitignore
@@ -1,0 +1,3 @@
+# Embed bundle is built per deploy (Dockerfile + nx build-embed).
+# Never commit the artifact — keeps source-of-truth in src/embed/.
+public/embed/chat.js

--- a/apps/irc/astro-irc/project.json
+++ b/apps/irc/astro-irc/project.json
@@ -7,6 +7,12 @@
 	"targets": {
 		"dev": {
 			"executor": "nx:run-commands",
+			"dependsOn": [
+				{
+					"target": "build-embed",
+					"projects": "self"
+				}
+			],
 			"options": {
 				"cwd": "apps/irc/astro-irc",
 				"commands": [
@@ -20,6 +26,12 @@
 		"build": {
 			"executor": "nx:run-commands",
 			"outputs": ["{workspaceRoot}/dist/apps/astro-irc"],
+			"dependsOn": [
+				{
+					"target": "build-embed",
+					"projects": "self"
+				}
+			],
 			"options": {
 				"cwd": "apps/irc/astro-irc",
 				"commands": [
@@ -27,6 +39,16 @@
 					"npx astro sync",
 					"UV_THREADPOOL_SIZE=4 NODE_OPTIONS=\"--max-old-space-size=4096\" npx astro build"
 				],
+				"parallel": false
+			},
+			"cache": true
+		},
+		"build-embed": {
+			"executor": "nx:run-commands",
+			"outputs": ["{projectRoot}/public/embed"],
+			"options": {
+				"cwd": "apps/irc/astro-irc",
+				"commands": ["npx vite build --config vite.embed.config.ts"],
 				"parallel": false
 			},
 			"cache": true

--- a/apps/irc/astro-irc/public/embed/example.html
+++ b/apps/irc/astro-irc/public/embed/example.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>KbveChat embed — example</title>
+		<style>
+			body {
+				font-family:
+					-apple-system, system-ui, sans-serif;
+				margin: 0;
+				padding: 24px;
+				background: #f4f5f7;
+				color: #1a1f2c;
+			}
+			h1 {
+				font-size: 18px;
+				margin: 0 0 16px;
+			}
+			.row {
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+				gap: 24px;
+				margin-top: 16px;
+			}
+			.card {
+				background: white;
+				border: 1px solid #d8dde5;
+				border-radius: 12px;
+				padding: 16px;
+				box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+			}
+			.label {
+				font-size: 12px;
+				color: #5b6373;
+				text-transform: uppercase;
+				letter-spacing: 0.08em;
+				margin: 0 0 12px;
+			}
+			.host {
+				width: 100%;
+				height: 480px;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>KbveChat embed bundle — smoke test</h1>
+		<div class="row">
+			<div class="card">
+				<p class="label">Auto-discover (#kbve-chat)</p>
+				<div
+					id="kbve-chat"
+					class="host"
+					data-channel="#general"
+					data-ws="wss://chat.kbve.com/ws"
+					data-theme="dark"></div>
+			</div>
+			<div class="card">
+				<p class="label">Programmatic mount (light theme)</p>
+				<div id="kbve-chat-2" class="host"></div>
+			</div>
+		</div>
+
+		<script src="/embed/chat.js" defer></script>
+		<script>
+			window.addEventListener('load', () => {
+				if (window.KbveChat) {
+					window.KbveChat.mount({
+						el: '#kbve-chat-2',
+						channel: '#general',
+						ws: 'wss://chat.kbve.com/ws',
+						theme: 'light',
+						height: '480px',
+					});
+				}
+			});
+		</script>
+	</body>
+</html>

--- a/apps/irc/astro-irc/src/embed/EmbedChat.tsx
+++ b/apps/irc/astro-irc/src/embed/EmbedChat.tsx
@@ -1,0 +1,330 @@
+/** @jsxImportSource react */
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type FormEvent,
+} from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	$activeChannel,
+	$activeMessages,
+	$activeUsers,
+	$avatarUrl,
+	$canSend,
+	$channelList,
+	$connectionStatus,
+	$error,
+	$nick,
+	onMessage,
+	switchChannel,
+	type ChatMessage,
+	type ConnectionStatus,
+} from './state';
+import { joinChannel, partChannel, sendChat } from './transport';
+import { formatTime, nickColor, nickInitial } from './format';
+
+const STATUS_LABEL: Record<ConnectionStatus, string> = {
+	connected: 'Online',
+	connecting: 'Connecting…',
+	disconnected: 'Offline',
+	error: 'Error',
+};
+
+const PROTECTED = new Set(['#general']);
+
+const TopBar: React.FC = () => {
+	const channel = useStore($activeChannel);
+	const status = useStore($connectionStatus);
+	const error = useStore($error);
+	const avatar = useStore($avatarUrl);
+	const nick = useStore($nick);
+	const channelName = channel.replace(/^#/, '');
+
+	return (
+		<header className="topbar">
+			<div className="brand">
+				<span className="brand-dot">K</span>
+				<span>KBVE Chat</span>
+			</div>
+			<div className="channel-pill">
+				<span className="channel-pill-hash">#</span>
+				<span>{channelName}</span>
+			</div>
+			<div className="spacer" />
+			<div className="status" title={error || STATUS_LABEL[status]}>
+				<span className={`status-dot ${status}`} />
+				<span>{STATUS_LABEL[status]}</span>
+			</div>
+			{nick && avatar ? (
+				<img
+					src={avatar}
+					alt={nick}
+					title={nick}
+					className="me-avatar"
+				/>
+			) : nick ? (
+				<span
+					className="me-avatar"
+					title={nick}
+					style={{ background: nickColor(nick) }}>
+					{nickInitial(nick)}
+				</span>
+			) : null}
+		</header>
+	);
+};
+
+const ChannelRail: React.FC = () => {
+	const channels = useStore($channelList);
+	const active = useStore($activeChannel);
+
+	return (
+		<aside className="rail">
+			<div className="rail-head">Channels</div>
+			<div className="rail-list">
+				{channels.length === 0 && (
+					<div className="empty">No channels yet</div>
+				)}
+				{channels.map((ch) => (
+					<div
+						key={ch.name}
+						style={{ position: 'relative', display: 'flex' }}>
+						<button
+							type="button"
+							className={`channel-item ${active === ch.name ? 'active' : ''}`}
+							onClick={() => switchChannel(ch.name)}>
+							<span className="channel-item-name">{ch.name}</span>
+							{ch.unread > 0 && (
+								<span className="badge">
+									{ch.unread > 99 ? '99+' : ch.unread}
+								</span>
+							)}
+						</button>
+						{!PROTECTED.has(ch.name.toLowerCase()) && (
+							<button
+								type="button"
+								onClick={(e) => {
+									e.stopPropagation();
+									partChannel(ch.name);
+								}}
+								title={`Leave ${ch.name}`}
+								aria-label={`Leave ${ch.name}`}
+								style={{
+									position: 'absolute',
+									right: 4,
+									top: '50%',
+									transform: 'translateY(-50%)',
+									width: 18,
+									height: 18,
+									border: 'none',
+									background: 'transparent',
+									color: 'var(--kbc-text-muted)',
+									cursor: 'pointer',
+									fontSize: 13,
+								}}>
+								×
+							</button>
+						)}
+					</div>
+				))}
+			</div>
+		</aside>
+	);
+};
+
+const MessageRow: React.FC<{ msg: ChatMessage }> = ({ msg }) => {
+	if (msg.type === 'message') {
+		return (
+			<div className={`msg ${msg.type}`}>
+				<span className="msg-time">{formatTime(msg.timestamp)}</span>
+				<span
+					className="msg-nick"
+					style={{ color: nickColor(msg.nick) }}>
+					{msg.nick}
+				</span>
+				<span className="msg-content">{msg.content}</span>
+			</div>
+		);
+	}
+	return (
+		<div className={`msg ${msg.type}`}>
+			<span className="msg-time">{formatTime(msg.timestamp)}</span>
+			<span className="msg-content">{msg.content}</span>
+		</div>
+	);
+};
+
+const Feed: React.FC = () => {
+	const messages = useStore($activeMessages);
+	const channel = useStore($activeChannel);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const isNearBottom = useRef(true);
+
+	const handleScroll = useCallback(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		isNearBottom.current =
+			el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+	}, []);
+
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		el.scrollTop = el.scrollHeight;
+	}, [channel]);
+
+	useEffect(() => {
+		const unsub = onMessage(() => {
+			if (!isNearBottom.current) return;
+			queueMicrotask(() => {
+				const el = containerRef.current;
+				if (el) el.scrollTop = el.scrollHeight;
+			});
+		});
+		return unsub;
+	}, []);
+
+	return (
+		<div className="feed" ref={containerRef} onScroll={handleScroll}>
+			{messages.length === 0 && (
+				<div className="empty">No messages yet — be the first.</div>
+			)}
+			{messages.map((m) => (
+				<MessageRow key={m.id} msg={m} />
+			))}
+		</div>
+	);
+};
+
+const Composer: React.FC = () => {
+	const status = useStore($connectionStatus);
+	const canSend = useStore($canSend);
+	const nick = useStore($nick);
+	const avatar = useStore($avatarUrl);
+	const [value, setValue] = useState('');
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const disabled = status !== 'connected' || !canSend;
+
+	const handleSubmit = useCallback(
+		(e: FormEvent) => {
+			e.preventDefault();
+			const trimmed = value.trim();
+			if (!trimmed || disabled) return;
+			if (trimmed.startsWith('/join ')) {
+				const ch = trimmed.slice(6).trim();
+				if (ch) joinChannel(ch.startsWith('#') ? ch : `#${ch}`);
+			} else if (trimmed.startsWith('/part')) {
+				const ch = trimmed.slice(5).trim();
+				partChannel(ch || $activeChannel.get());
+			} else {
+				sendChat(trimmed);
+			}
+			setValue('');
+			inputRef.current?.focus();
+		},
+		[value, disabled],
+	);
+
+	if (!canSend) {
+		return (
+			<div className="readonly-notice">
+				Read-only mode.{' '}
+				<a
+					href="https://chat.kbve.com/auth"
+					target="_blank"
+					rel="noopener noreferrer">
+					Sign in at chat.kbve.com →
+				</a>
+			</div>
+		);
+	}
+
+	return (
+		<form className="composer" onSubmit={handleSubmit}>
+			<div className="composer-row">
+				{avatar ? (
+					<img src={avatar} alt={nick} className="composer-avatar" />
+				) : (
+					<span
+						className="composer-avatar"
+						style={{
+							background: nick ? nickColor(nick) : undefined,
+						}}>
+						{nickInitial(nick || '?')}
+					</span>
+				)}
+				<input
+					ref={inputRef}
+					type="text"
+					value={value}
+					onChange={(e) => setValue(e.target.value)}
+					placeholder={disabled ? 'Not connected' : 'Send a message…'}
+					disabled={disabled}
+					className="composer-input"
+				/>
+				<button
+					type="submit"
+					disabled={disabled || !value.trim()}
+					className="send">
+					Send
+				</button>
+			</div>
+		</form>
+	);
+};
+
+const Users: React.FC = () => {
+	const users = useStore($activeUsers);
+	const self = useStore($nick);
+	const selfAvatar = useStore($avatarUrl);
+
+	return (
+		<aside className="users">
+			<div className="users-head">Members ({users.length})</div>
+			<div className="users-list">
+				{users.length === 0 && (
+					<div className="empty">No one here yet</div>
+				)}
+				{users.map((u) => {
+					const color = nickColor(u);
+					const isSelf = u === self;
+					return (
+						<div key={u} className="user-item">
+							{isSelf && selfAvatar ? (
+								<img
+									src={selfAvatar}
+									alt={u}
+									className="user-avatar"
+								/>
+							) : (
+								<span
+									className="user-avatar"
+									style={{ background: color }}>
+									{nickInitial(u)}
+								</span>
+							)}
+							<span style={{ color }}>{u}</span>
+						</div>
+					);
+				})}
+			</div>
+		</aside>
+	);
+};
+
+export const EmbedChat: React.FC = () => (
+	<div className="root">
+		<TopBar />
+		<div className="body">
+			<ChannelRail />
+			<div className="main">
+				<Feed />
+				<Composer />
+			</div>
+			<Users />
+		</div>
+	</div>
+);

--- a/apps/irc/astro-irc/src/embed/auth.ts
+++ b/apps/irc/astro-irc/src/embed/auth.ts
@@ -1,0 +1,59 @@
+import { $avatarUrl } from './state';
+
+// Cross-domain shared-token cookie reader.
+// Mirrors @kbve/astro's getSharedToken so the embed bundle can read the
+// same cookie set by chat.kbve.com / kbve.com after auth, without pulling
+// the full @kbve/astro barrel (which drags in React/DroidProvider).
+const SHARED_TOKEN_COOKIE = 'kbve_session';
+
+function readSharedTokenCookie(): string {
+	if (typeof document === 'undefined') return '';
+	const target = `${SHARED_TOKEN_COOKIE}=`;
+	const parts = document.cookie.split(';');
+	for (const part of parts) {
+		const trimmed = part.trim();
+		if (trimmed.startsWith(target)) {
+			return decodeURIComponent(trimmed.slice(target.length));
+		}
+	}
+	return '';
+}
+
+function decodeJwtAvatar(token: string): string | null {
+	const parts = token.split('.');
+	if (parts.length < 2) return null;
+	try {
+		const padded = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+		const padLen = padded.length + ((4 - (padded.length % 4)) % 4);
+		const payload = JSON.parse(atob(padded.padEnd(padLen, '=')));
+		return (
+			payload?.kbve_avatar ||
+			payload?.user_metadata?.avatar_url ||
+			payload?.user_metadata?.picture ||
+			null
+		);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Resolve the JWT to use for WS auth. Resolution order:
+ *   1. Explicit `opts.token` passed by the host page (takes priority)
+ *   2. Shared cookie on *.kbve.com origins (`kbve_session`)
+ *   3. Empty string → embed runs in anonymous read-only mode
+ */
+export function resolveToken(explicit?: string): string {
+	if (explicit && explicit.length > 0) {
+		hydrateAvatarFromToken(explicit);
+		return explicit;
+	}
+	const cookie = readSharedTokenCookie();
+	if (cookie) hydrateAvatarFromToken(cookie);
+	return cookie;
+}
+
+function hydrateAvatarFromToken(token: string): void {
+	const avatar = decodeJwtAvatar(token);
+	if (avatar) $avatarUrl.set(avatar);
+}

--- a/apps/irc/astro-irc/src/embed/format.ts
+++ b/apps/irc/astro-irc/src/embed/format.ts
@@ -1,0 +1,31 @@
+const NICK_COLORS = [
+	'#fb7185',
+	'#fb923c',
+	'#facc15',
+	'#a3e635',
+	'#34d399',
+	'#2dd4bf',
+	'#22d3ee',
+	'#38bdf8',
+	'#a78bfa',
+	'#e879f9',
+	'#f472b6',
+	'#818cf8',
+];
+
+export function nickColor(nick: string): string {
+	let hash = 0;
+	for (let i = 0; i < nick.length; i++) {
+		hash = nick.charCodeAt(i) + ((hash << 5) - hash);
+	}
+	return NICK_COLORS[Math.abs(hash) % NICK_COLORS.length];
+}
+
+export function nickInitial(nick: string): string {
+	return nick.trim().charAt(0).toUpperCase() || '?';
+}
+
+export function formatTime(ts: number): string {
+	const d = new Date(ts);
+	return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}

--- a/apps/irc/astro-irc/src/embed/index.tsx
+++ b/apps/irc/astro-irc/src/embed/index.tsx
@@ -1,0 +1,155 @@
+import { StrictMode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EmbedChat } from './EmbedChat';
+import { EMBED_CSS } from './styles';
+import { resolveToken } from './auth';
+import { connect, disconnect } from './transport';
+import { resetState } from './state';
+
+export interface KbveChatOptions {
+	/** Mount target. Accepts a DOM element or a CSS selector. */
+	el: HTMLElement | string;
+	/** Default channel to auto-join (defaults to "#general"). */
+	channel?: string;
+	/** WebSocket endpoint (defaults to "wss://chat.kbve.com/ws"). */
+	ws?: string;
+	/** "dark" | "light" — defaults to "dark". */
+	theme?: 'dark' | 'light';
+	/**
+	 * Pixel height of the embed shell. Accepts any CSS length string.
+	 * Defaults to "480px". Pass "100%" or "100vh" for full-bleed hosts.
+	 */
+	height?: string;
+	/**
+	 * Optional explicit JWT. If omitted, the embed reads the
+	 * `kbve_session` cross-domain cookie. Empty token = read-only mode.
+	 */
+	token?: string;
+}
+
+interface MountedInstance {
+	root: Root;
+	host: HTMLElement;
+	shadow: ShadowRoot;
+	wrapper: HTMLDivElement;
+}
+
+const DEFAULT_WS = 'wss://chat.kbve.com/ws';
+const DEFAULT_CHANNEL = '#general';
+const DEFAULT_HEIGHT = '480px';
+
+const instances = new WeakMap<HTMLElement, MountedInstance>();
+
+function resolveEl(el: HTMLElement | string): HTMLElement | null {
+	if (typeof el === 'string') {
+		const found = document.querySelector<HTMLElement>(el);
+		return found;
+	}
+	return el instanceof HTMLElement ? el : null;
+}
+
+export function mount(opts: KbveChatOptions): void {
+	const target = resolveEl(opts.el);
+	if (!target) {
+		console.error('[KbveChat] mount target not found:', opts.el);
+		return;
+	}
+	if (instances.has(target)) {
+		console.warn(
+			'[KbveChat] already mounted on this element; unmount first',
+		);
+		return;
+	}
+
+	const channel = opts.channel ?? DEFAULT_CHANNEL;
+	const wsUrl = opts.ws ?? DEFAULT_WS;
+	const theme = opts.theme ?? 'dark';
+	const height = opts.height ?? DEFAULT_HEIGHT;
+	const token = resolveToken(opts.token);
+
+	target.style.display = 'block';
+	target.style.height = height;
+	target.style.width = '100%';
+
+	const shadow = target.attachShadow({ mode: 'open' });
+	shadow.host.setAttribute('data-theme', theme);
+
+	const styleEl = document.createElement('style');
+	styleEl.textContent = EMBED_CSS;
+	shadow.appendChild(styleEl);
+
+	const wrapper = document.createElement('div');
+	wrapper.style.width = '100%';
+	wrapper.style.height = '100%';
+	shadow.appendChild(wrapper);
+
+	const root = createRoot(wrapper);
+	root.render(
+		<StrictMode>
+			<EmbedChat />
+		</StrictMode>,
+	);
+
+	instances.set(target, { root, host: target, shadow, wrapper });
+
+	void connect(wsUrl, token, channel);
+}
+
+export function unmount(el: HTMLElement | string): void {
+	const target = resolveEl(el);
+	if (!target) return;
+	const inst = instances.get(target);
+	if (!inst) return;
+	try {
+		disconnect();
+		inst.root.unmount();
+	} finally {
+		instances.delete(target);
+		resetState();
+		// Detaching the shadow root is unsupported; clearing children is the
+		// closest we get. The host element is left in place for the page.
+		while (target.firstChild) target.removeChild(target.firstChild);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auto-discover: scan the page on script load for elements tagged with
+//   <div id="kbve-chat" data-channel="..." data-ws="..." data-theme="..." />
+// and mount them. Hosts that prefer programmatic control can ignore this
+// and call window.KbveChat.mount({...}) themselves.
+// ---------------------------------------------------------------------------
+function autoMount(): void {
+	const targets = document.querySelectorAll<HTMLElement>(
+		'[data-kbve-chat], #kbve-chat',
+	);
+	for (const el of Array.from(targets)) {
+		if (instances.has(el)) continue;
+		mount({
+			el,
+			channel: el.dataset.channel,
+			ws: el.dataset.ws,
+			theme: (el.dataset.theme as 'dark' | 'light') ?? undefined,
+			height: el.dataset.height,
+			token: el.dataset.token,
+		});
+	}
+}
+
+if (typeof document !== 'undefined') {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', autoMount, {
+			once: true,
+		});
+	} else {
+		autoMount();
+	}
+}
+
+// Expose API surface for programmatic callers.
+const api = { mount, unmount, version: '0.1.0' as const };
+
+if (typeof window !== 'undefined') {
+	(window as any).KbveChat = api;
+}
+
+export default api;

--- a/apps/irc/astro-irc/src/embed/state.ts
+++ b/apps/irc/astro-irc/src/embed/state.ts
@@ -1,0 +1,258 @@
+import { atom, computed } from 'nanostores';
+
+export interface ChatMessage {
+	id: string;
+	nick: string;
+	content: string;
+	channel: string;
+	timestamp: number;
+	type: 'message' | 'join' | 'part' | 'system';
+}
+
+export interface ChannelState {
+	name: string;
+	topic: string;
+	users: string[];
+	unread: number;
+}
+
+export type ConnectionStatus =
+	| 'disconnected'
+	| 'connecting'
+	| 'connected'
+	| 'error';
+
+export const $connectionStatus = atom<ConnectionStatus>('disconnected');
+export const $activeChannel = atom<string>('#general');
+export const $channels = atom<Map<string, ChannelState>>(new Map());
+export const $nick = atom<string>('');
+export const $error = atom<string>('');
+export const $canSend = atom<boolean>(false);
+export const $avatarUrl = atom<string>('');
+
+const $messageStore = atom<Map<string, ChatMessage[]>>(new Map());
+
+export const $activeMessages = computed(
+	[$messageStore, $activeChannel],
+	(store, channel) => store.get(channel) ?? [],
+);
+
+export const $channelList = computed([$channels], (channels) =>
+	Array.from(channels.values()).sort((a, b) => a.name.localeCompare(b.name)),
+);
+
+export const $activeUsers = computed(
+	[$channels, $activeChannel],
+	(channels, active) => channels.get(active)?.users ?? [],
+);
+
+type MessageListener = (msg: ChatMessage) => void;
+const listeners = new Set<MessageListener>();
+
+export function onMessage(fn: MessageListener): () => void {
+	listeners.add(fn);
+	return () => listeners.delete(fn);
+}
+
+const MAX_MESSAGES_PER_CHANNEL = 500;
+
+export function pushMessage(msg: ChatMessage): void {
+	const store = new Map($messageStore.get());
+	const msgs = store.get(msg.channel) ?? [];
+	const updated = [...msgs, msg].slice(-MAX_MESSAGES_PER_CHANNEL);
+	store.set(msg.channel, updated);
+	$messageStore.set(store);
+
+	for (const fn of listeners) fn(msg);
+
+	if (msg.channel !== $activeChannel.get() && msg.type === 'message') {
+		const channels = new Map($channels.get());
+		const ch = channels.get(msg.channel);
+		if (ch) {
+			channels.set(msg.channel, { ...ch, unread: ch.unread + 1 });
+			$channels.set(channels);
+		}
+	}
+}
+
+export function makeId(): string {
+	return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function systemMessage(channel: string, content: string): void {
+	pushMessage({
+		id: makeId(),
+		nick: '',
+		content,
+		channel,
+		timestamp: Date.now(),
+		type: 'system',
+	});
+}
+
+export function switchChannel(channel: string): void {
+	$activeChannel.set(channel);
+	const channels = new Map($channels.get());
+	const ch = channels.get(channel);
+	if (ch) {
+		channels.set(channel, { ...ch, unread: 0 });
+		$channels.set(channels);
+	}
+}
+
+export function resetState(): void {
+	$connectionStatus.set('disconnected');
+	$channels.set(new Map());
+	$nick.set('');
+	$error.set('');
+	$messageStore.set(new Map());
+	$canSend.set(false);
+	$avatarUrl.set('');
+}
+
+// IRC line parser ------------------------------------------------------------
+
+interface ParsedIrcMessage {
+	nick: string;
+	command: string;
+	params: string[];
+	trailing?: string;
+}
+
+export function parseIrcLine(line: string): ParsedIrcMessage | null {
+	let nick = '';
+	let rest = line;
+
+	if (rest.startsWith(':')) {
+		const spaceIdx = rest.indexOf(' ');
+		if (spaceIdx === -1) return null;
+		const prefix = rest.slice(1, spaceIdx);
+		nick = prefix.split('!')[0];
+		rest = rest.slice(spaceIdx + 1);
+	}
+
+	let trailing: string | undefined;
+	const trailIdx = rest.indexOf(' :');
+	if (trailIdx !== -1) {
+		trailing = rest.slice(trailIdx + 2);
+		rest = rest.slice(0, trailIdx);
+	}
+
+	const parts = rest.split(' ').filter(Boolean);
+	if (parts.length === 0) return null;
+
+	return { nick, command: parts[0], params: parts.slice(1), trailing };
+}
+
+// Handler — invoked by the transport on each inbound IRC text frame.
+// `respondPong` lets the transport reply to PING without coupling state.ts
+// to a WebSocket reference.
+export function handleIncoming(
+	raw: string,
+	respondPong: (token: string) => void,
+): void {
+	const lines = raw.split('\r\n').filter(Boolean);
+
+	for (const line of lines) {
+		if (line.startsWith('PING')) {
+			respondPong(line.slice(5));
+			continue;
+		}
+
+		const parsed = parseIrcLine(line);
+		if (!parsed) continue;
+
+		switch (parsed.command) {
+			case 'PRIVMSG': {
+				pushMessage({
+					id: makeId(),
+					nick: parsed.nick,
+					content: parsed.trailing ?? '',
+					channel: parsed.params[0],
+					timestamp: Date.now(),
+					type: 'message',
+				});
+				break;
+			}
+			case 'JOIN': {
+				const channel = parsed.params[0] || parsed.trailing || '';
+				const channels = new Map($channels.get());
+				const ch = channels.get(channel);
+				if (ch && !ch.users.includes(parsed.nick)) {
+					channels.set(channel, {
+						...ch,
+						users: [...ch.users, parsed.nick],
+					});
+					$channels.set(channels);
+				}
+				pushMessage({
+					id: makeId(),
+					nick: parsed.nick,
+					content: `${parsed.nick} joined ${channel}`,
+					channel,
+					timestamp: Date.now(),
+					type: 'join',
+				});
+				break;
+			}
+			case 'PART': {
+				const channel = parsed.params[0];
+				const channels = new Map($channels.get());
+				const ch = channels.get(channel);
+				if (ch) {
+					channels.set(channel, {
+						...ch,
+						users: ch.users.filter((u) => u !== parsed.nick),
+					});
+					$channels.set(channels);
+				}
+				pushMessage({
+					id: makeId(),
+					nick: parsed.nick,
+					content: `${parsed.nick} left ${channel}`,
+					channel,
+					timestamp: Date.now(),
+					type: 'part',
+				});
+				break;
+			}
+			case '332': {
+				const channel = parsed.params[1];
+				const topic = parsed.trailing ?? '';
+				const channels = new Map($channels.get());
+				const ch = channels.get(channel);
+				if (ch) {
+					channels.set(channel, { ...ch, topic });
+					$channels.set(channels);
+				}
+				break;
+			}
+			case '353': {
+				const channel = parsed.params[2];
+				const nicks = (parsed.trailing ?? '')
+					.split(' ')
+					.filter(Boolean);
+				const channels = new Map($channels.get());
+				const ch = channels.get(channel);
+				if (ch) {
+					channels.set(channel, {
+						...ch,
+						users: Array.from(new Set([...ch.users, ...nicks])),
+					});
+					$channels.set(channels);
+				}
+				break;
+			}
+			case '001': {
+				if (parsed.params[0]) $nick.set(parsed.params[0]);
+				systemMessage(
+					$activeChannel.get(),
+					parsed.trailing ?? 'Connected',
+				);
+				break;
+			}
+			default:
+				break;
+		}
+	}
+}

--- a/apps/irc/astro-irc/src/embed/styles.ts
+++ b/apps/irc/astro-irc/src/embed/styles.ts
@@ -1,0 +1,448 @@
+// Self-contained CSS for the embed bundle. Injected into shadow root so
+// host page styles can't reach in and our utilities can't leak out.
+// No Starlight tokens — all colors baked in for portability.
+
+export const EMBED_CSS = `
+:host {
+  all: initial;
+  display: block;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, 'Segoe UI', Roboto, sans-serif;
+  color: var(--kbc-text);
+  --kbc-bg: #0a0d14;
+  --kbc-elev-1: #11161f;
+  --kbc-elev-2: #161c28;
+  --kbc-hover: #1c2433;
+  --kbc-border: #1f2735;
+  --kbc-text: #e6ebf2;
+  --kbc-text-dim: #8a93a3;
+  --kbc-text-muted: #5b6373;
+  --kbc-accent: #7c5cff;
+  --kbc-accent-soft: rgba(124, 92, 255, 0.16);
+  --kbc-success: #22c55e;
+  --kbc-warn: #f59e0b;
+  --kbc-danger: #ef4444;
+  --kbc-radius: 12px;
+  --kbc-radius-sm: 8px;
+}
+
+:host([data-theme="light"]) {
+  --kbc-bg: #ffffff;
+  --kbc-elev-1: #f7f8fa;
+  --kbc-elev-2: #eef0f4;
+  --kbc-hover: #e6e9ef;
+  --kbc-border: #d8dde5;
+  --kbc-text: #1a1f2c;
+  --kbc-text-dim: #515b6b;
+  --kbc-text-muted: #8a93a3;
+}
+
+.root {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+  background: var(--kbc-bg);
+  border: 1px solid var(--kbc-border);
+  border-radius: var(--kbc-radius);
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.root *, .root *::before, .root *::after { box-sizing: border-box; }
+
+.topbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--kbc-border);
+  background: var(--kbc-elev-1);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: -0.01em;
+}
+
+.brand-dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, var(--kbc-accent) 0%, #22d3ee 100%);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.channel-pill {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--kbc-elev-2);
+  border: 1px solid var(--kbc-border);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.channel-pill-hash { color: var(--kbc-text-muted); font-weight: 400; }
+
+.spacer { flex: 1; }
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--kbc-text-dim);
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--kbc-text-muted);
+}
+.status-dot.connected { background: var(--kbc-success); box-shadow: 0 0 6px rgba(34, 197, 94, 0.6); }
+.status-dot.connecting { background: var(--kbc-warn); animation: kbc-pulse 1.2s ease-in-out infinite; }
+.status-dot.error { background: var(--kbc-danger); }
+
+@keyframes kbc-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.icon-btn {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--kbc-text-dim);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-family: inherit;
+  transition: all 0.12s ease;
+}
+.icon-btn:hover {
+  background: var(--kbc-hover);
+  color: var(--kbc-text);
+  border-color: var(--kbc-border);
+}
+.icon-btn.active {
+  background: var(--kbc-accent-soft);
+  color: var(--kbc-accent);
+  border-color: var(--kbc-accent);
+}
+
+.me-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--kbc-border);
+  background: var(--kbc-elev-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+
+.body {
+  flex: 1 1 auto;
+  display: flex;
+  min-height: 0;
+}
+
+.rail {
+  flex: 0 0 160px;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--kbc-border);
+  background: var(--kbc-elev-1);
+  min-height: 0;
+}
+
+.rail-head {
+  padding: 10px 12px 4px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--kbc-text-muted);
+}
+
+.rail-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 6px 12px;
+}
+
+.channel-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: var(--kbc-radius-sm);
+  background: transparent;
+  border: none;
+  color: var(--kbc-text-dim);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  font-family: inherit;
+  transition: all 0.1s ease;
+}
+.channel-item:hover { background: var(--kbc-hover); color: var(--kbc-text); }
+.channel-item.active {
+  background: var(--kbc-accent-soft);
+  color: var(--kbc-accent);
+  font-weight: 600;
+}
+
+.channel-item-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badge {
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 8px;
+  background: var(--kbc-accent);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.main {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.feed {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.feed::-webkit-scrollbar { width: 6px; }
+.feed::-webkit-scrollbar-thumb { background: var(--kbc-border); border-radius: 3px; }
+.feed::-webkit-scrollbar-thumb:hover { background: var(--kbc-text-muted); }
+
+.msg {
+  display: grid;
+  grid-template-columns: 44px auto 1fr;
+  gap: 8px;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.msg:hover { background: var(--kbc-hover); }
+
+.msg-time {
+  color: var(--kbc-text-muted);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  padding-top: 3px;
+  user-select: none;
+}
+
+.msg-nick {
+  font-weight: 700;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.msg-content {
+  color: var(--kbc-text);
+  min-width: 0;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.msg.system .msg-content,
+.msg.join .msg-content,
+.msg.part .msg-content {
+  grid-column: 2 / -1;
+  color: var(--kbc-text-muted);
+  font-style: italic;
+  font-size: 12px;
+}
+
+.composer {
+  flex: 0 0 auto;
+  padding: 10px 12px 12px;
+  border-top: 1px solid var(--kbc-border);
+  background: var(--kbc-elev-1);
+}
+
+.composer-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+  background: var(--kbc-elev-2);
+  border: 1px solid var(--kbc-border);
+  border-radius: var(--kbc-radius);
+  padding: 3px 3px 3px 10px;
+  transition: border-color 0.12s ease;
+}
+.composer-row:focus-within {
+  border-color: var(--kbc-accent);
+  box-shadow: 0 0 0 3px var(--kbc-accent-soft);
+}
+
+.composer-avatar {
+  align-self: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--kbc-border);
+  background: var(--kbc-elev-1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+
+.composer-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--kbc-text);
+  font-size: 13px;
+  outline: none;
+  padding: 8px 0;
+  font-family: inherit;
+  min-width: 0;
+}
+.composer-input::placeholder { color: var(--kbc-text-muted); }
+
+.send {
+  padding: 0 14px;
+  border-radius: 9px;
+  border: none;
+  background: linear-gradient(135deg, var(--kbc-accent) 0%, #6c47ff 100%);
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition: transform 0.1s ease, opacity 0.1s ease;
+}
+.send:hover:not(:disabled) { transform: translateY(-1px); }
+.send:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.readonly-notice {
+  padding: 12px;
+  border-top: 1px solid var(--kbc-border);
+  background: var(--kbc-elev-1);
+  font-size: 12px;
+  color: var(--kbc-text-dim);
+  text-align: center;
+}
+.readonly-notice a {
+  color: var(--kbc-accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+.readonly-notice a:hover { text-decoration: underline; }
+
+.users {
+  flex: 0 0 140px;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--kbc-border);
+  background: var(--kbc-elev-1);
+  min-height: 0;
+}
+
+.users-head {
+  padding: 10px 12px 4px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--kbc-text-muted);
+}
+
+.users-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 6px 12px;
+}
+
+.user-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: var(--kbc-radius-sm);
+  font-size: 12px;
+  color: var(--kbc-text-dim);
+}
+.user-item:hover { background: var(--kbc-hover); color: var(--kbc-text); }
+
+.user-avatar {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  color: white;
+}
+
+.empty {
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--kbc-text-muted);
+}
+
+@media (max-width: 600px) {
+  .rail, .users { display: none; }
+}
+`;

--- a/apps/irc/astro-irc/src/embed/transport.ts
+++ b/apps/irc/astro-irc/src/embed/transport.ts
@@ -1,0 +1,233 @@
+import {
+	$activeChannel,
+	$canSend,
+	$channels,
+	$connectionStatus,
+	$error,
+	$nick,
+	handleIncoming,
+	makeId,
+	pushMessage,
+	switchChannel,
+	systemMessage,
+} from './state';
+
+// Plain WebSocket transport for the embed bundle.
+// Wraps a single ws connection, decodes binary frames as IRC text, and
+// drives state.ts via handleIncoming. No SharedWorker / no cross-tab dedup.
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+interface TransportState {
+	ws: WebSocket | null;
+	url: string;
+	token: string;
+	defaultChannel: string;
+	reconnectAttempts: number;
+	reconnectTimer: number | null;
+	manualClose: boolean;
+}
+
+const state: TransportState = {
+	ws: null,
+	url: '',
+	token: '',
+	defaultChannel: '#general',
+	reconnectAttempts: 0,
+	reconnectTimer: null,
+	manualClose: false,
+};
+
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_BASE_MS = 1500;
+
+function buildUrl(wsUrl: string, token: string): string {
+	if (!token) return wsUrl;
+	const sep = wsUrl.includes('?') ? '&' : '?';
+	return `${wsUrl}${sep}token=${encodeURIComponent(token)}`;
+}
+
+function scheduleReconnect(): void {
+	if (state.manualClose) return;
+	if (state.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+		$connectionStatus.set('error');
+		$error.set('Reconnect failed after max attempts');
+		systemMessage(
+			$activeChannel.get(),
+			'Disconnected. Reload the page to retry.',
+		);
+		return;
+	}
+	const delay = RECONNECT_BASE_MS * Math.pow(1.6, state.reconnectAttempts);
+	state.reconnectAttempts += 1;
+	state.reconnectTimer = window.setTimeout(() => {
+		$connectionStatus.set('connecting');
+		systemMessage(
+			$activeChannel.get(),
+			`Reconnecting (attempt ${state.reconnectAttempts})…`,
+		);
+		void openSocket();
+	}, delay);
+}
+
+async function openSocket(): Promise<void> {
+	return new Promise((resolve, reject) => {
+		try {
+			const ws = new WebSocket(buildUrl(state.url, state.token));
+			ws.binaryType = 'arraybuffer';
+			state.ws = ws;
+
+			ws.onopen = () => {
+				state.reconnectAttempts = 0;
+				$connectionStatus.set('connected');
+				$error.set('');
+				// Auto-join the default channel once authenticated handshake
+				// settles. Ergo will send 001 → we already system-log, but the
+				// JOIN must come from the client.
+				const ch = state.defaultChannel;
+				ws.send(encoder.encode(`JOIN ${ch}\r\n`));
+				const channels = new Map($channels.get());
+				if (!channels.has(ch)) {
+					channels.set(ch, {
+						name: ch,
+						topic: '',
+						users: [],
+						unread: 0,
+					});
+					$channels.set(channels);
+				}
+				switchChannel(ch);
+				resolve();
+			};
+
+			ws.onmessage = (e) => {
+				const data = e.data;
+				const text =
+					typeof data === 'string'
+						? data
+						: decoder.decode(
+								data instanceof ArrayBuffer
+									? new Uint8Array(data)
+									: data,
+							);
+				handleIncoming(text, (token) => {
+					if (state.ws?.readyState === WebSocket.OPEN) {
+						state.ws.send(encoder.encode(`PONG ${token}\r\n`));
+					}
+				});
+			};
+
+			ws.onclose = (e) => {
+				const wasConnected = $connectionStatus.get() === 'connected';
+				$connectionStatus.set('disconnected');
+				if (state.manualClose) return;
+				$error.set(`Disconnected (code=${e.code})`);
+				if (wasConnected) {
+					systemMessage(
+						$activeChannel.get(),
+						`Disconnected (code=${e.code}). Reconnecting…`,
+					);
+				}
+				scheduleReconnect();
+			};
+
+			ws.onerror = () => {
+				$connectionStatus.set('error');
+				$error.set('WebSocket error');
+				// Let onclose handle reconnect — onerror always precedes it.
+				reject(new Error('WebSocket error'));
+			};
+		} catch (err: any) {
+			$connectionStatus.set('error');
+			$error.set(err?.message ?? 'Connect failed');
+			reject(err);
+		}
+	});
+}
+
+export async function connect(
+	wsUrl: string,
+	token: string,
+	defaultChannel: string,
+): Promise<void> {
+	if (
+		$connectionStatus.get() === 'connected' ||
+		$connectionStatus.get() === 'connecting'
+	) {
+		return;
+	}
+	state.url = wsUrl;
+	state.token = token;
+	state.defaultChannel = defaultChannel;
+	state.manualClose = false;
+	state.reconnectAttempts = 0;
+	$canSend.set(token.length > 0);
+	$connectionStatus.set('connecting');
+	$error.set('');
+	try {
+		await openSocket();
+	} catch {
+		// onclose will schedule a reconnect; nothing else to do here.
+	}
+}
+
+export function disconnect(): void {
+	state.manualClose = true;
+	if (state.reconnectTimer !== null) {
+		clearTimeout(state.reconnectTimer);
+		state.reconnectTimer = null;
+	}
+	try {
+		state.ws?.close(1000, 'client-close');
+	} catch {
+		/* ignore */
+	}
+	state.ws = null;
+	$connectionStatus.set('disconnected');
+}
+
+export function sendRaw(line: string): void {
+	if (state.ws?.readyState !== WebSocket.OPEN) return;
+	state.ws.send(encoder.encode(line.endsWith('\r\n') ? line : `${line}\r\n`));
+}
+
+export function sendChat(content: string): void {
+	if (!$canSend.get()) return;
+	const channel = $activeChannel.get();
+	sendRaw(`PRIVMSG ${channel} :${content}`);
+	// Echo locally so the sender sees their own message immediately
+	// (the IRC server won't echo PRIVMSG back to the originator).
+	pushMessage({
+		id: makeId(),
+		nick: $nick.get() || 'me',
+		content,
+		channel,
+		timestamp: Date.now(),
+		type: 'message',
+	});
+}
+
+export function joinChannel(channel: string): void {
+	sendRaw(`JOIN ${channel}`);
+	const channels = new Map($channels.get());
+	if (!channels.has(channel)) {
+		channels.set(channel, {
+			name: channel,
+			topic: '',
+			users: [],
+			unread: 0,
+		});
+		$channels.set(channels);
+	}
+	switchChannel(channel);
+}
+
+export function partChannel(channel: string): void {
+	sendRaw(`PART ${channel}`);
+	const channels = new Map($channels.get());
+	channels.delete(channel);
+	$channels.set(channels);
+	const remaining = Array.from(channels.keys());
+	if (remaining.length > 0) switchChannel(remaining[0]);
+}

--- a/apps/irc/astro-irc/vite.embed.config.ts
+++ b/apps/irc/astro-irc/vite.embed.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'node:path';
+
+// Standalone library build for the chat.js embed bundle.
+// Output: apps/irc/astro-irc/public/embed/chat.js (served from chat.kbve.com/embed/chat.js)
+//
+// Bundles React, nanostores, IRC parser, transport, and the entire shadow-DOM
+// chat UI into a single self-contained IIFE. Host pages drop in:
+//   <div id="kbve-chat" data-channel="#general"></div>
+//   <script src="https://chat.kbve.com/embed/chat.js" defer></script>
+export default defineConfig({
+	plugins: [react()],
+	publicDir: false,
+	define: {
+		'process.env.NODE_ENV': JSON.stringify('production'),
+	},
+	build: {
+		outDir: 'public/embed',
+		emptyOutDir: true,
+		minify: 'terser',
+		sourcemap: false,
+		target: 'es2020',
+		lib: {
+			entry: resolve(__dirname, 'src/embed/index.tsx'),
+			name: 'KbveChat',
+			formats: ['iife'],
+			fileName: () => 'chat.js',
+		},
+		rollupOptions: {
+			output: {
+				inlineDynamicImports: true,
+				exports: 'named',
+			},
+		},
+	},
+});

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -26,6 +26,12 @@ COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 COPY apps/irc/astro-irc/ apps/irc/astro-irc/
 
 WORKDIR /app/apps/irc/astro-irc
+
+# Build the embed bundle FIRST — output lands in public/embed/chat.js so
+# the subsequent astro build picks it up and ships it under /embed/chat.js.
+# Host pages drop in `<script src="https://chat.kbve.com/embed/chat.js">`.
+RUN npx vite build --config vite.embed.config.ts
+
 RUN rm -rf .astro && npx astro sync && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
 


### PR DESCRIPTION
Closes #11018

## Summary

Single-file IIFE bundle that lets any KBVE site (or third-party host) drop in the IRC chat panel — no Astro, no Tailwind preflight collisions, no auth plumbing required.

\`\`\`html
<div id=\"kbve-chat\" data-channel=\"#general\" data-theme=\"dark\"></div>
<script src=\"https://chat.kbve.com/embed/chat.js\" defer></script>
\`\`\`

Or programmatic:

\`\`\`js
window.KbveChat.mount({
  el: '#kbve-chat-2',
  channel: '#general',
  ws: 'wss://chat.kbve.com/ws',
  theme: 'light',
  height: '480px',
});
\`\`\`

## Build pipeline

- New Vite IIFE library config at \`apps/irc/astro-irc/vite.embed.config.ts\` → outputs to \`apps/irc/astro-irc/public/embed/chat.js\`, served from \`chat.kbve.com/embed/chat.js\` via the existing astro static pipeline
- Nx target \`astro-irc:build-embed\` (cached) — wired as a \`dependsOn\` for both \`dev\` and \`build\` so chat.js is always present alongside astro output
- Dockerfile runs \`vite build --config vite.embed.config.ts\` before \`astro build\` so the container image ships \`/embed/chat.js\` automatically (no manual pre-step)
- Bundle size: 213kb raw, **67kb gzipped** (under 80kb target)
- chat.js itself gitignored — built per deploy

## Architecture

- **Shadow DOM root** — full style isolation from host page, no Tailwind/Starlight leakage in either direction
- **Plain WebSocket transport** (\`src/embed/transport.ts\`) — no \`@kbve/droid\` SharedWorker dependency, so any third-party origin can embed; auto-reconnect with exponential backoff (5 attempts max)
- **Self-contained state** (\`src/embed/state.ts\`) — own nanostores + IRC parser, parallel to \`components/chat/service.ts\`. Kept separate so the live chat island code on \`/chat\` stays untouched
- **Inline CSS** (\`src/embed/styles.ts\`) — all colors baked in (no Starlight tokens), light/dark via \`data-theme\` attribute on shadow host

## Auth resolution

Priority order in \`src/embed/auth.ts\`:
1. Explicit \`opts.token\` from host page
2. \`kbve_session\` cross-domain cookie (works on \*.kbve.com origins)
3. Empty → read-only mode with \"Sign in at chat.kbve.com\" link

Avatar pulled from JWT \`kbve_avatar\` / \`user_metadata.avatar_url\` / \`user_metadata.picture\` claims, rendered in composer, topbar, and member list.

## API surface

- \`window.KbveChat.mount({ el, channel, ws, theme, height, token })\`
- \`window.KbveChat.unmount(el)\`
- Auto-discovery: scans \`[data-kbve-chat]\` and \`#kbve-chat\` on \`DOMContentLoaded\` and mounts them

## Test plan

- [ ] Visit \`/embed/example.html\` after deploy — two embeds render side-by-side, one dark, one light
- [ ] Anonymous host sees read-only notice + \"Sign in at chat.kbve.com\" link
- [ ] On \`*.kbve.com\` after sign-in, \`kbve_session\` cookie auto-fills token → composer enabled
- [ ] Send a message in embed, verify it appears in \`chat.kbve.com/chat\` for other users
- [ ] WS drop + reconnect — bundle retries 5 times then surfaces error
- [ ] Mobile (< 600px) — rails collapse, message feed stays usable
- [ ] Bundle size in CI ≤ 80kb gzipped