### PR TITLE
feat(firecracker-ctl): /metrics + ServiceMonitor + PrometheusRule

### DIFF
--- a/apps/kube/firecracker/manifests/firecracker-alerts.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-alerts.yaml
@@ -1,0 +1,134 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+    name: firecracker-ctl
+    namespace: firecracker
+    labels:
+        prometheus: kube-prometheus
+        role: alert-rules
+spec:
+    groups:
+        - name: firecracker-ctl.endpoint
+          rules:
+              - alert: FirecrackerEndpointStuckStarting
+                annotations:
+                    summary: 'Firecracker endpoint {{ $labels.name }} stuck in Starting for >5m'
+                    description: |
+                        Endpoint {{ $labels.name }} ({{ $labels.visibility }}) has been in
+                        `starting` for over 5 minutes. Health prober never observed a 2xx
+                        from the guest — usually means the app inside the VM never bound
+                        its port, the rootfs is missing dependencies, or fctap egress is
+                        blocked. Check `kubectl logs firecracker-ctl-net` and the dashboard
+                        Logs modal for `/fc/{{ $labels.name }}/logs`.
+                expr: |
+                    fc_endpoint_status{status="starting"} == 1
+                    and on (name) (time() - fc_endpoint_uptime_seconds) > 300 == bool 1
+                for: 1m
+                labels:
+                    severity: warning
+
+              - alert: FirecrackerEndpointDegraded
+                annotations:
+                    summary: 'Firecracker endpoint {{ $labels.name }} is Degraded'
+                    description: |
+                        Endpoint {{ $labels.name }} ({{ $labels.visibility }}) has been
+                        `degraded` for >2 minutes. The health prober logged 3 consecutive
+                        non-2xx responses; the guest is likely crashed or unresponsive.
+                expr: |
+                    fc_endpoint_status{status="degraded"} == 1
+                for: 2m
+                labels:
+                    severity: warning
+
+              - alert: FirecrackerEndpointUpstreamErrorRate
+                annotations:
+                    summary: 'Firecracker endpoint {{ $labels.name }} upstream error rate elevated'
+                    description: |
+                        Endpoint {{ $labels.name }} is returning upstream errors at
+                        {{ $value | printf "%.2f" }}/s. The guest may be flapping or
+                        overloaded.
+                expr: |
+                    rate(fc_endpoint_requests_total{outcome="upstream_error"}[5m]) > 0.5
+                for: 5m
+                labels:
+                    severity: warning
+
+              - alert: FirecrackerEndpointThrottleStorm
+                annotations:
+                    summary: 'Firecracker endpoint {{ $labels.name }} sustained rate-limit throttling'
+                    description: |
+                        Endpoint {{ $labels.name }} is throttling {{ $value | printf "%.2f" }}
+                        requests/s for >5 minutes. Either traffic legitimately exceeds the
+                        configured rate_limit (consider bumping the cap), or there's anon
+                        abuse on the public tier worth investigating.
+                expr: |
+                    rate(fc_endpoint_requests_total{outcome="throttled"}[5m]) > 1
+                for: 5m
+                labels:
+                    severity: info
+
+        - name: firecracker-ctl.pool
+          rules:
+              - alert: FirecrackerIpPoolNearExhaustion
+                annotations:
+                    summary: 'Firecracker IP pool >85% used'
+                    description: |
+                        {{ $value | printf "%.0f" }}% of /30 slots in the persistent IP
+                        pool are in use. Once exhausted, new deploys will 507 (insufficient
+                        storage). Expand `FC_PERSISTENT_SUBNET` or sweep idle endpoints.
+                expr: |
+                    100 * (fc_ip_pool_used / fc_ip_pool_capacity) > 85
+                for: 5m
+                labels:
+                    severity: warning
+
+              - alert: FirecrackerIpPoolExhausted
+                annotations:
+                    summary: 'Firecracker IP pool 100% used — new deploys will fail'
+                    description: |
+                        All /30 slots are allocated. New `/fc/deploy` calls return 507 until
+                        an endpoint is destroyed or the idle sweeper reclaims one.
+                expr: |
+                    fc_ip_pool_used >= fc_ip_pool_capacity
+                for: 1m
+                labels:
+                    severity: critical
+
+        - name: firecracker-ctl.platform
+          rules:
+              - alert: FirecrackerCtlMetricsAbsent
+                annotations:
+                    summary: 'Firecracker-ctl metrics not being scraped'
+                    description: |
+                        No `fc_build_info` series observed for 10 minutes. Either the
+                        ServiceMonitor is misconfigured, the pod is unreachable on port
+                        9001, or the binary is crash-looping before the listener starts.
+                expr: |
+                    absent(fc_build_info{namespace="firecracker"})
+                for: 10m
+                labels:
+                    severity: warning
+
+              - alert: FirecrackerCtlPodCrashLooping
+                annotations:
+                    summary: 'Firecracker-ctl pod {{ $labels.pod }} restart rate elevated'
+                    description: |
+                        Pod {{ $labels.pod }} restarted {{ $value | printf "%.0f" }} times
+                        in 15 minutes. Likely panic, OOM, or jailer permission failure.
+                expr: |
+                    increase(kube_pod_container_status_restarts_total{namespace="firecracker",pod=~"firecracker-ctl.*"}[15m]) > 2
+                for: 5m
+                labels:
+                    severity: warning
+
+              - alert: FirecrackerCtlDeploymentDown
+                annotations:
+                    summary: 'Firecracker-ctl deployment {{ $labels.deployment }} has zero ready replicas'
+                    description: |
+                        Deployment {{ $labels.deployment }} has zero ready replicas. All
+                        `/fc/*` and `/proxy/*` traffic is failing.
+                expr: |
+                    kube_deployment_status_replicas_available{namespace="firecracker",deployment=~"firecracker-ctl.*"} == 0
+                for: 2m
+                labels:
+                    severity: critical

--- a/apps/kube/firecracker/manifests/firecracker-net-servicemonitor.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+    name: firecracker-ctl-net
+    namespace: firecracker
+    labels:
+        app: firecracker-ctl-net
+        release: prometheus
+spec:
+    selector:
+        matchLabels:
+            app: firecracker-ctl-net
+    endpoints:
+        - port: api
+          interval: 30s
+          path: /metrics
+          scrapeTimeout: 10s

--- a/apps/kube/firecracker/manifests/firecracker-networkpolicy.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-networkpolicy.yaml
@@ -33,6 +33,14 @@ spec:
           ports:
               - protocol: TCP
                 port: 9001
+        # Prometheus scrape (monitoring/prometheus) → /metrics
+        - from:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: monitoring
+          ports:
+              - protocol: TCP
+                port: 9001
     egress:
         # DNS resolution (required for any service discovery)
         - to:
@@ -115,6 +123,14 @@ spec:
                 podSelector:
                     matchLabels:
                         app: kbve
+          ports:
+              - protocol: TCP
+                port: 9001
+        # Prometheus scrape (monitoring/prometheus) → /metrics
+        - from:
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: monitoring
           ports:
               - protocol: TCP
                 port: 9001

--- a/apps/kube/firecracker/manifests/firecracker-servicemonitor.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+    name: firecracker-ctl
+    namespace: firecracker
+    labels:
+        app: firecracker-ctl
+        release: prometheus
+spec:
+    selector:
+        matchLabels:
+            app: firecracker-ctl
+    endpoints:
+        - port: api
+          interval: 30s
+          path: /metrics
+          scrapeTimeout: 10s

--- a/apps/kube/firecracker/manifests/kustomization.yaml
+++ b/apps/kube/firecracker/manifests/kustomization.yaml
@@ -28,4 +28,7 @@ resources:
     - firecracker-keda.yaml
     - firecracker-net-deployment.yaml
     - firecracker-net-service.yaml
+    - firecracker-servicemonitor.yaml
+    - firecracker-net-servicemonitor.yaml
+    - firecracker-alerts.yaml
     - sealed-vpn-wireguard.yaml

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -1218,6 +1218,159 @@ async fn health_prober_task(persistent: Arc<PersistentState>, name: String) {
     }
 }
 
+/// Prometheus text-format exposition. Emits per-endpoint counters
+/// (requests, errors, throttled, forbidden, bytes, status) plus pool +
+/// process gauges. Hand-rolled to avoid a crate dependency for ~80 lines
+/// of output. Scraped by the ServiceMonitor in
+/// `apps/kube/firecracker/manifests/firecracker-net-servicemonitor.yaml`.
+async fn metrics_handler(State(state): State<AppState>) -> Response {
+    let mut out = String::with_capacity(2048);
+
+    out.push_str("# HELP fc_build_info Build identity (always 1).\n");
+    out.push_str("# TYPE fc_build_info gauge\n");
+    out.push_str(&format!(
+        "fc_build_info{{version=\"{}\"}} 1\n",
+        env!("CARGO_PKG_VERSION")
+    ));
+
+    out.push_str("# HELP fc_jailer_enabled 1 if jailer is configured.\n");
+    out.push_str("# TYPE fc_jailer_enabled gauge\n");
+    out.push_str(&format!(
+        "fc_jailer_enabled {}\n",
+        i32::from(state.jailer.is_some())
+    ));
+
+    let Some(persistent) = state.persistent.as_ref() else {
+        out.push_str("# HELP fc_persistent_enabled 1 if /fc/* endpoints are wired.\n");
+        out.push_str("# TYPE fc_persistent_enabled gauge\n");
+        out.push_str("fc_persistent_enabled 0\n");
+        return (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
+            out,
+        )
+            .into_response();
+    };
+
+    out.push_str("# HELP fc_persistent_enabled 1 if /fc/* endpoints are wired.\n");
+    out.push_str("# TYPE fc_persistent_enabled gauge\n");
+    out.push_str("fc_persistent_enabled 1\n");
+
+    let pool_used = persistent.pool.in_use();
+    let pool_capacity = persistent.pool.capacity();
+    out.push_str("# HELP fc_ip_pool_used Currently-allocated /30 slots.\n");
+    out.push_str("# TYPE fc_ip_pool_used gauge\n");
+    out.push_str(&format!("fc_ip_pool_used {pool_used}\n"));
+    out.push_str("# HELP fc_ip_pool_capacity Maximum /30 slots available.\n");
+    out.push_str("# TYPE fc_ip_pool_capacity gauge\n");
+    out.push_str(&format!("fc_ip_pool_capacity {pool_capacity}\n"));
+
+    out.push_str("# HELP fc_endpoint_status Status of each persistent endpoint (1 = current).\n");
+    out.push_str("# TYPE fc_endpoint_status gauge\n");
+    out.push_str("# HELP fc_endpoint_requests_total Total proxied requests by outcome.\n");
+    out.push_str("# TYPE fc_endpoint_requests_total counter\n");
+    out.push_str("# HELP fc_endpoint_bytes_total Bytes proxied by direction.\n");
+    out.push_str("# TYPE fc_endpoint_bytes_total counter\n");
+    out.push_str(
+        "# HELP fc_endpoint_last_request_age_seconds Seconds since last forwarded request (NaN if never).\n",
+    );
+    out.push_str("# TYPE fc_endpoint_last_request_age_seconds gauge\n");
+    out.push_str("# HELP fc_endpoint_uptime_seconds Seconds since endpoint registered.\n");
+    out.push_str("# TYPE fc_endpoint_uptime_seconds gauge\n");
+
+    let mut status_counts: [u64; 5] = [0; 5];
+
+    for entry in persistent.endpoints.iter() {
+        let ep = entry.value();
+        let name = &ep.name;
+        let visibility = match ep.visibility {
+            EndpointVisibility::Staff => "staff",
+            EndpointVisibility::Public => "public",
+        };
+        let common = format!("name=\"{name}\",visibility=\"{visibility}\"");
+
+        let status_idx = match ep.status {
+            EndpointStatus::Pending => 0,
+            EndpointStatus::Starting => 1,
+            EndpointStatus::Healthy => 2,
+            EndpointStatus::Degraded => 3,
+            EndpointStatus::Stopping => 4,
+        };
+        status_counts[status_idx] += 1;
+        for (idx, label) in ["pending", "starting", "healthy", "degraded", "stopping"]
+            .iter()
+            .enumerate()
+        {
+            out.push_str(&format!(
+                "fc_endpoint_status{{{common},status=\"{label}\"}} {}\n",
+                i32::from(idx == status_idx)
+            ));
+        }
+
+        let m = &ep.metrics;
+        let total = m.requests_total.load(Ordering::Relaxed);
+        let throttled = m.requests_throttled.load(Ordering::Relaxed);
+        let forbidden = m.requests_forbidden.load(Ordering::Relaxed);
+        let upstream_errors = m.upstream_errors.load(Ordering::Relaxed);
+        let ok = total.saturating_sub(upstream_errors);
+        out.push_str(&format!(
+            "fc_endpoint_requests_total{{{common},outcome=\"ok\"}} {ok}\n"
+        ));
+        out.push_str(&format!(
+            "fc_endpoint_requests_total{{{common},outcome=\"throttled\"}} {throttled}\n"
+        ));
+        out.push_str(&format!(
+            "fc_endpoint_requests_total{{{common},outcome=\"forbidden\"}} {forbidden}\n"
+        ));
+        out.push_str(&format!(
+            "fc_endpoint_requests_total{{{common},outcome=\"upstream_error\"}} {upstream_errors}\n"
+        ));
+
+        out.push_str(&format!(
+            "fc_endpoint_bytes_total{{{common},direction=\"in\"}} {}\n",
+            m.bytes_in.load(Ordering::Relaxed)
+        ));
+        out.push_str(&format!(
+            "fc_endpoint_bytes_total{{{common},direction=\"out\"}} {}\n",
+            m.bytes_out.load(Ordering::Relaxed)
+        ));
+
+        let last = m.last_request_micros.load(Ordering::Relaxed);
+        let age = if last == 0 {
+            "NaN".to_string()
+        } else {
+            format!("{:.0}", ((now_micros() - last).max(0) as f64) / 1_000_000.0)
+        };
+        out.push_str(&format!(
+            "fc_endpoint_last_request_age_seconds{{{common}}} {age}\n"
+        ));
+
+        out.push_str(&format!(
+            "fc_endpoint_uptime_seconds{{{common}}} {}\n",
+            ep.created.elapsed().as_secs()
+        ));
+    }
+
+    out.push_str("# HELP fc_endpoints_total Endpoints in registry by status.\n");
+    out.push_str("# TYPE fc_endpoints_total gauge\n");
+    for (idx, label) in ["pending", "starting", "healthy", "degraded", "stopping"]
+        .iter()
+        .enumerate()
+    {
+        out.push_str(&format!(
+            "fc_endpoints_total{{status=\"{label}\"}} {}\n",
+            status_counts[idx]
+        ));
+    }
+
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
+        out,
+    )
+        .into_response()
+}
+
 #[utoipa::path(
     get,
     path = "/fc/list",
@@ -2967,6 +3120,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/health", get(health))
+        .route("/metrics", get(metrics_handler))
         .route("/openapi.json", get(openapi::openapi_json))
         .route("/vm/create", post(create_vm))
         .route("/vm", get(list_vms))


### PR DESCRIPTION
## Summary
Maps out the alert surface before full public-tier integration. Stuck \`Starting\` endpoints, upstream-error storms, pool exhaustion, and pod crash loops now page through the existing kube-prometheus pipeline instead of getting noticed by users.

## firecracker-ctl
- New \`GET /metrics\` route serving Prometheus text format. Hand-rolled (~150 lines, no new crate).
- Metrics exposed:
  - \`fc_build_info\`, \`fc_jailer_enabled\`, \`fc_persistent_enabled\`
  - \`fc_ip_pool_used\` / \`fc_ip_pool_capacity\`
  - \`fc_endpoint_status{name,visibility,status}\` (1 for current state per endpoint)
  - \`fc_endpoint_requests_total{name,visibility,outcome="ok|throttled|forbidden|upstream_error"}\`
  - \`fc_endpoint_bytes_total{name,visibility,direction="in|out"}\`
  - \`fc_endpoint_last_request_age_seconds{name,visibility}\` (NaN if never)
  - \`fc_endpoint_uptime_seconds{name,visibility}\`
  - \`fc_endpoints_total{status}\` (rollup)

## k8s manifests
- \`firecracker-servicemonitor.yaml\` + \`firecracker-net-servicemonitor.yaml\`
- \`firecracker-networkpolicy.yaml\` adds ingress exception for \`monitoring\` namespace on port 9001
- \`firecracker-alerts.yaml\` (PrometheusRule):

| Alert | Severity | For | Trigger |
|---|---|---|---|
| FirecrackerEndpointStuckStarting | warning | 1m | status=starting + uptime>5min |
| FirecrackerEndpointDegraded | warning | 2m | status=degraded |
| FirecrackerEndpointUpstreamErrorRate | warning | 5m | rate(upstream_error) > 0.5/s |
| FirecrackerEndpointThrottleStorm | info | 5m | rate(throttled) > 1/s |
| FirecrackerIpPoolNearExhaustion | warning | 5m | used/capacity > 85% |
| FirecrackerIpPoolExhausted | critical | 1m | used >= capacity |
| FirecrackerCtlMetricsAbsent | warning | 10m | absent(fc_build_info) |
| FirecrackerCtlPodCrashLooping | warning | 5m | >2 restarts/15m |
| FirecrackerCtlDeploymentDown | critical | 2m | 0 ready replicas |

## Test plan
- [ ] After image + manifests ship, \`kubectl exec -n monitoring prometheus-... -- promtool tsdb list\` shows \`fc_*\` series
- [ ] Grafana Explore: \`fc_endpoint_status{status="starting"}\` returns rows for active endpoints
- [ ] Force a stuck endpoint (deploy with bad health path); \`FirecrackerEndpointStuckStarting\` fires within 6m
- [ ] Scrape NetworkPolicy verified via \`kubectl describe servicemonitor\` (UP=1)
- [ ] No regression: existing pooler / cert alerts still fire normally