### PR TITLE
feat(droid): seed $auth from localStorage on module init

### DIFF
--- a/packages/npm/droid/src/lib/state/auth.ts
+++ b/packages/npm/droid/src/lib/state/auth.ts
@@ -54,7 +54,85 @@ const DEFAULT_AUTH: AuthState = {
 	error: undefined,
 };
 
-export const $auth = map<AuthState>({ ...DEFAULT_AUTH });
+const SB_AUTH_TOKEN_KEY = 'sb-auth-token';
+const PROFILE_CACHE_KEY = 'cache:profile:me';
+const STAFF_CACHE_KEY = 'cache:staff:perms';
+
+function seedAuthFromStorage(): AuthState {
+	if (typeof localStorage === 'undefined') return { ...DEFAULT_AUTH };
+
+	let session: {
+		user?: { id?: string; user_metadata?: Record<string, unknown> };
+	} | null = null;
+	try {
+		const raw = localStorage.getItem(SB_AUTH_TOKEN_KEY);
+		if (!raw) return { ...DEFAULT_AUTH };
+		const parsed = JSON.parse(raw);
+		const inner = parsed?.currentSession ?? parsed;
+		if (inner?.user?.id) session = inner;
+	} catch {
+		return { ...DEFAULT_AUTH };
+	}
+	if (!session?.user?.id) return { ...DEFAULT_AUTH };
+
+	const meta = (session.user.user_metadata ?? {}) as Record<string, unknown>;
+	let username: string | undefined;
+	let avatar: string | undefined =
+		typeof meta['avatar_url'] === 'string'
+			? (meta['avatar_url'] as string)
+			: undefined;
+
+	try {
+		const raw = localStorage.getItem(PROFILE_CACHE_KEY);
+		if (raw && raw !== 'null') {
+			const env = JSON.parse(raw);
+			if (env?.user_id === session.user.id) {
+				const profile = env.profile ?? {};
+				if (typeof profile.username === 'string')
+					username = profile.username;
+				avatar =
+					profile.discord?.avatar_url ||
+					profile.github?.avatar_url ||
+					profile.twitch?.avatar_url ||
+					avatar;
+			}
+		}
+	} catch {
+		/* best effort */
+	}
+
+	let flags: number = AuthPresets.USER;
+	try {
+		const raw = localStorage.getItem(STAFF_CACHE_KEY);
+		if (raw && raw !== 'null') {
+			const env = JSON.parse(raw);
+			if (
+				env?.user_id === session.user.id &&
+				typeof env?.bitmask === 'number' &&
+				env.bitmask > 0
+			) {
+				flags = AuthPresets.STAFF;
+			}
+		}
+	} catch {
+		/* best effort */
+	}
+
+	return {
+		tone: 'auth',
+		flags,
+		name:
+			typeof meta['full_name'] === 'string'
+				? (meta['full_name'] as string)
+				: '',
+		username,
+		avatar,
+		id: session.user.id,
+		error: undefined,
+	};
+}
+
+export const $auth = map<AuthState>(seedAuthFromStorage());
 
 export const $isStaff = computed($auth, (s) =>
 	hasAuthFlag(s.flags, AuthFlags.STAFF),


### PR DESCRIPTION
## Summary
Final piece of the \`/profile/\` + nav cold-start chain. The cache layers shipped in #11078 / #11082 / #11089 all paint downstream of \`\$auth\` flipping from \`tone:'loading'\` to \`tone:'auth'\`. Until bootAuth finishes that flip, the navbar, dashboard panels, and any \`client:visible\` island that reads \`\$auth\` sit in the loading state — hundreds of ms of flicker even on a warm cache.

Seed the initial \`map()\` value by reading the same localStorage keys the rest of droid already owns:

| Key | Source |
|---|---|
| \`sb-auth-token\` | supabase session (raw or \`{currentSession:…}\` shape) |
| \`cache:profile:me\` | DroidProfile envelope (#11078) |
| \`cache:staff:perms\` | staff bitmask envelope (#11082) |

When a valid session + matching profile + (optional) non-zero staff bitmask are all present synchronously, \`\$auth\` starts at:

\`\`\`
tone: 'auth'
flags: USER (or STAFF when cached bitmask > 0)
username, avatar, name: pre-populated
\`\`\`

bootAuth's existing \`pushSession()\` already preserves both \`username\` and any flags > USER, so when the gateway / bridge fast paths eventually return, they refresh tokens + email but won't downgrade the seeded state. SSR / non-browser contexts continue to get \`DEFAULT_AUTH\` via \`typeof localStorage\` guard.

## Result — final critical path
1. Module init: \`\$auth\` already at \`tone:'auth'\` w/ cached username + flags
2. localStorage warm cache → fast paint, μs (#11078)
3. \`installProfileSync\` → background refresh (#11089)
4. Sync-bus → cross-tab + worker fanout (#11082)

Nav, dashboard panels, profile card all paint signed-in **before any await** when the cache is warm.

## Trade-off
If the cached session has actually expired server-side (rare — supabase \`autoRefreshToken\` usually catches this), the user sees \`tone:'auth'\` for ~1 frame before bootAuth's expiry check kicks in and resets to anon. Alternative was \`tone:'loading'\` on every load, strictly worse.

## Test plan
- [x] \`./kbve.sh -nx droid:build\` clean
- [x] \`./kbve.sh -nx droid:test\` 118/118 pass
- [x] \`./kbve.sh -nx astro-kbve:check\` no new errors (same 1 pre-existing GamingHub)
- [x] \`./kbve.sh -nx astro-kbve:build\` clean
- [ ] In prod: hard reload \`/profile/\` with a warm cache — navbar shows username + avatar **before** the first network request finishes
- [ ] Sign out from another tab — both tabs flip to anon when the gateway broadcasts the auth event