### PR TITLE
fix(clickhouse): resolve CRD ownership conflict between operator + crds apps

### DIFF
--- a/apps/kube/clickhouse-crds/manifests/kustomization.yaml
+++ b/apps/kube/clickhouse-crds/manifests/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - namespace.yaml
-  # Remote CRDs from clickhouse-operator repository
-  - https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
-  - https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
-  - https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhousekeeperinstallations.clickhouse-keeper.altinity.com.yaml
-  - https://raw.githubusercontent.com/Altinity/clickhouse-operator/master/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+    - namespace.yaml
+    # Remote CRDs from clickhouse-operator repository
+    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.25.4/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
+    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.25.4/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
+    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.25.4/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhousekeeperinstallations.clickhouse-keeper.altinity.com.yaml
+    - https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.25.4/deploy/helm/clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml

--- a/apps/kube/clickhouse-operator/application.yaml
+++ b/apps/kube/clickhouse-operator/application.yaml
@@ -1,42 +1,43 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: clickhouse-operator
-  namespace: argocd
-  annotations:
-    argocd.argoproj.io/sync-wave: "2"
+    name: clickhouse-operator
+    namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '2'
 spec:
-  project: default
-  sources:
-    - repoURL: https://docs.altinity.com/clickhouse-operator/
-      targetRevision: 0.25.4
-      chart: altinity-clickhouse-operator
-      helm:
-        releaseName: clickhouse-operator
-        valueFiles:
-          - $values/apps/kube/clickhouse-operator/manifests/values.yaml
-    - repoURL: https://github.com/kbve/kbve
-      targetRevision: main
-      ref: values
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: clickhouse
-  syncPolicy:
-    automated:
-      selfHeal: true
-      prune: true
-    syncOptions:
-      - CreateNamespace=true
-      - ServerSideApply=true
-  ignoreDifferences:
-    - group: apps
-      kind: Deployment
-      jsonPointers:
-        - /spec/template/spec/containers/0/env/5/valueFrom/resourceFieldRef/divisor
-        - /spec/template/spec/containers/0/env/6/valueFrom/resourceFieldRef/divisor
-        - /spec/template/spec/containers/0/env/7/valueFrom/resourceFieldRef/divisor
-        - /spec/template/spec/containers/0/env/8/valueFrom/resourceFieldRef/divisor
-        - /spec/template/spec/containers/1/env/5/valueFrom/resourceFieldRef/divisor
-        - /spec/template/spec/containers/1/env/6/valueFrom/resourceFieldRef/divisor
-        - /spec/template/spec/containers/1/env/7/valueFrom/resourceFieldRef/divisor
-        - /spec/template/spec/containers/1/env/8/valueFrom/resourceFieldRef/divisor
+    project: default
+    sources:
+        - repoURL: https://docs.altinity.com/clickhouse-operator/
+          targetRevision: 0.25.4
+          chart: altinity-clickhouse-operator
+          helm:
+              releaseName: clickhouse-operator
+              skipCrds: true
+              valueFiles:
+                  - $values/apps/kube/clickhouse-operator/manifests/values.yaml
+        - repoURL: https://github.com/kbve/kbve
+          targetRevision: main
+          ref: values
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: clickhouse
+    syncPolicy:
+        automated:
+            selfHeal: true
+            prune: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+    ignoreDifferences:
+        - group: apps
+          kind: Deployment
+          jsonPointers:
+              - /spec/template/spec/containers/0/env/5/valueFrom/resourceFieldRef/divisor
+              - /spec/template/spec/containers/0/env/6/valueFrom/resourceFieldRef/divisor
+              - /spec/template/spec/containers/0/env/7/valueFrom/resourceFieldRef/divisor
+              - /spec/template/spec/containers/0/env/8/valueFrom/resourceFieldRef/divisor
+              - /spec/template/spec/containers/1/env/5/valueFrom/resourceFieldRef/divisor
+              - /spec/template/spec/containers/1/env/6/valueFrom/resourceFieldRef/divisor
+              - /spec/template/spec/containers/1/env/7/valueFrom/resourceFieldRef/divisor
+              - /spec/template/spec/containers/1/env/8/valueFrom/resourceFieldRef/divisor


### PR DESCRIPTION
## Summary

Two ArgoCD apps were both claiming the same 4 ClickHouse/Keeper CRDs, causing a permanent OutOfSync state on `clickhouse-operator` and (today) the **Keeper StatefulSets sitting at `0/0` replicas** — which blocked every `ON CLUSTER` DDL across the entire CH cluster and broke the alerts pipeline from PR #11088 before it could run.

## Root cause

```
clickhouse-crds  (sync-wave 1)   ──┐
                                   ├──→ Both write the same 4 CRDs
clickhouse-operator (sync-wave 2) ─┘
```

- **clickhouse-crds**: pulls CRDs from `Altinity/clickhouse-operator/master/...` — drifts as upstream master moves
- **clickhouse-operator**: Helm chart `altinity-clickhouse-operator 0.25.4` ships CRDs in `crds/` directory. ArgoCD's helm renderer pulls them in by default (`helm template --include-crds`).

Two sources, different schemas. ArgoCD reported the CRDs OutOfSync on the operator app because `master` had drifted from `release-0.25.4`. The chk operator reconciler then ran against a CRD schema it didn't recognize, the ActionPlan came back empty, and the Keeper StatefulSets stayed at 0 replicas. Reconcile happily logged `ActionPlan has no actions - abort reconcile` every cycle.

## Fix

| File | Change |
|------|--------|
| [apps/kube/clickhouse-operator/application.yaml](apps/kube/clickhouse-operator/application.yaml) | Add `helm.skipCrds: true`. Operator app no longer claims CRDs at all. |
| [apps/kube/clickhouse-crds/manifests/kustomization.yaml](apps/kube/clickhouse-crds/manifests/kustomization.yaml) | Pin all 4 CRD URLs from `master` to `release-0.25.4`. Schema now matches the operator binary version exactly. |

2 files, +5/-4.

## Why this version, not 0.27.0

Chart 0.25.4 has no `crdHook.enabled` toggle — that's a 0.27.0 chart feature. The ArgoCD-level `helm.skipCrds: true` is the right lever for 0.25.4. When we eventually bump the operator chart, we can revisit using `crdHook` if it offers benefits.

## Cluster recovery (already done manually today, out of scope)

- Scaled all 3 Keeper StatefulSets back to `1/1` — Keeper quorum restored
- Created `observability.alerts_raw` + `alerts_distributed` via `clickhouse-client` on shard 0-0
- Operator pod restarted

This PR prevents the OOS battle (and the Keeper-zero state) from recurring on the next ArgoCD reconcile.

## Verified

- All 4 CRD URLs at `release-0.25.4` return HTTP 200
- `master` vs `release-0.25.4` CRD content differs (md5 confirmed) — drift was real
- Chart 0.25.4 `crds/` directory contains the same 4 files as the operator app's reported OOS list

## Future operator upgrades

When bumping the operator (e.g. `0.25.4 → 0.27.0`):
1. Bump `apps/kube/clickhouse-operator/application.yaml` `targetRevision`
2. Bump all 4 URLs in `apps/kube/clickhouse-crds/manifests/kustomization.yaml` to `release-X.Y.Z`
3. Apply order is enforced by sync-waves: crds first (1), operator second (2)

## Test plan

- [ ] CI green on dev
- [ ] After merge → ArgoCD reconciles both apps
- [ ] `clickhouse-operator` app goes Synced + Healthy (no more CRD OOS)
- [ ] `clickhouse-crds` stays the sole owner of the 4 CRDs
- [ ] Operator reconciles chk normally; Keeper STS stays at `1/1`
- [ ] `kubectl get application clickhouse-operator -n argocd` shows `Status.Sync: Synced` and `Status.Health: Healthy`