### PR TITLE
feat(astro-kbve): marketplace enchant support (Phase 5.2)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -831,4 +831,119 @@ import MarketCreateForm from './MarketCreateForm';
 			position: static;
 		}
 	}
+
+	/* ---- Phase 5.2: enchants ---- */
+	.kbve-enchant-list {
+		list-style: none;
+		margin: 0.5rem 0 0;
+		padding: 0;
+		display: flex;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+	}
+	.kbve-enchant-chip {
+		padding: 0.15rem 0.6rem;
+		border-radius: 999px;
+		font-size: 0.75rem;
+		font-weight: 600;
+		letter-spacing: 0.01em;
+		background: color-mix(in srgb, var(--sl-color-accent) 14%, transparent);
+		border: 1px solid
+			color-mix(in srgb, var(--sl-color-accent) 50%, transparent);
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+	}
+	.kbve-enchant-chip--curse {
+		background: color-mix(
+			in srgb,
+			var(--color-red, var(--sl-color-text-accent)) 16%,
+			transparent
+		);
+		border-color: color-mix(
+			in srgb,
+			var(--color-red, var(--sl-color-text-accent)) 55%,
+			transparent
+		);
+		color: var(--color-red, var(--sl-color-text-accent));
+	}
+	.kbve-enchant-chip--treasure {
+		background: color-mix(
+			in srgb,
+			var(--color-gold-light, var(--sl-color-accent)) 16%,
+			transparent
+		);
+		border-color: color-mix(
+			in srgb,
+			var(--color-gold-light, var(--sl-color-accent)) 55%,
+			transparent
+		);
+		color: var(--color-gold-light, var(--sl-color-accent));
+	}
+	.kbve-enchant-marker {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.15rem;
+		margin-left: 0.4rem;
+		padding: 0.05rem 0.4rem;
+		border-radius: 6px;
+		background: color-mix(in srgb, var(--sl-color-accent) 14%, transparent);
+		border: 1px solid
+			color-mix(in srgb, var(--sl-color-accent) 50%, transparent);
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+		font-size: 0.7rem;
+		font-weight: 700;
+		vertical-align: middle;
+	}
+	.kbve-enchant-marker__count {
+		font-variant-numeric: tabular-nums;
+	}
+	.kbve-enchant-editor {
+		display: grid;
+		gap: 0.6rem;
+		padding: 0.85rem 1rem;
+		border-radius: 12px;
+		background: var(--sl-color-bg-sidebar, var(--sl-color-bg-nav));
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+	}
+	.kbve-enchant-editor__head {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 0.75rem;
+	}
+	.kbve-enchant-editor__label {
+		font-size: 0.85rem;
+		font-weight: 700;
+		color: var(--sl-color-text);
+	}
+	.kbve-enchant-editor__add {
+		padding: 0.35rem 0.75rem;
+		font-size: 0.85rem;
+	}
+	.kbve-enchant-editor__row {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) 8rem auto;
+		gap: 0.5rem;
+		align-items: center;
+	}
+	.kbve-enchant-editor__level {
+		width: 100%;
+	}
+	.kbve-enchant-editor__remove {
+		width: 2rem;
+		height: 2rem;
+		padding: 0;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 1.25rem;
+		line-height: 1;
+	}
+	@media (max-width: 540px) {
+		.kbve-enchant-editor__row {
+			grid-template-columns: 1fr;
+		}
+		.kbve-enchant-editor__remove {
+			justify-self: end;
+		}
+	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/market/EnchantEditor.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/EnchantEditor.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from 'react';
+import { VANILLA_ENCHANTS, enchantDef, type Enchant } from './enchants';
+
+type Props = {
+	value: Enchant[];
+	onChange: (next: Enchant[]) => void;
+	disabled?: boolean;
+};
+
+const SORTED = [...VANILLA_ENCHANTS].sort((a, b) =>
+	a.label.localeCompare(b.label),
+);
+
+export function EnchantEditor({ value, onChange, disabled }: Props) {
+	const used = useMemo(() => new Set(value.map((e) => e.id)), [value]);
+
+	const add = () => {
+		const next = SORTED.find((e) => !used.has(e.id));
+		if (!next) return;
+		onChange([...value, { id: next.id, level: 1 }]);
+	};
+
+	const remove = (idx: number) => {
+		onChange(value.filter((_, i) => i !== idx));
+	};
+
+	const update = (idx: number, patch: Partial<Enchant>) => {
+		onChange(value.map((e, i) => (i === idx ? { ...e, ...patch } : e)));
+	};
+
+	return (
+		<div className="kbve-enchant-editor">
+			<div className="kbve-enchant-editor__head">
+				<span className="kbve-enchant-editor__label">
+					Enchantments (optional)
+				</span>
+				<button
+					type="button"
+					className="kbve-market__btn kbve-enchant-editor__add"
+					onClick={add}
+					disabled={disabled || used.size >= SORTED.length}>
+					+ Add enchant
+				</button>
+			</div>
+			{value.length === 0 && (
+				<p className="kbve-market__hint">
+					No enchants. Click "Add enchant" if this item carries one.
+				</p>
+			)}
+			{value.map((e, i) => {
+				const def = enchantDef(e.id);
+				const maxLevel = def?.maxLevel ?? 5;
+				return (
+					<div key={i} className="kbve-enchant-editor__row">
+						<select
+							className="kbve-market__input"
+							value={e.id}
+							onChange={(ev) =>
+								update(i, { id: ev.target.value, level: 1 })
+							}
+							disabled={disabled}>
+							{SORTED.map((opt) => (
+								<option
+									key={opt.id}
+									value={opt.id}
+									disabled={
+										opt.id !== e.id && used.has(opt.id)
+									}>
+									{opt.label}
+								</option>
+							))}
+						</select>
+						<select
+							className="kbve-market__input kbve-enchant-editor__level"
+							value={e.level}
+							onChange={(ev) =>
+								update(i, {
+									level: Math.max(
+										1,
+										Math.min(
+											maxLevel,
+											Number(ev.target.value) || 1,
+										),
+									),
+								})
+							}
+							disabled={disabled || maxLevel === 1}>
+							{Array.from({ length: maxLevel }, (_, lvl) => (
+								<option key={lvl + 1} value={lvl + 1}>
+									Level {lvl + 1}
+								</option>
+							))}
+						</select>
+						<button
+							type="button"
+							className="kbve-market__btn kbve-market__btn--danger kbve-enchant-editor__remove"
+							onClick={() => remove(i)}
+							disabled={disabled}
+							aria-label={`Remove ${def?.label ?? e.id}`}>
+							×
+						</button>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+export default EnchantEditor;

--- a/apps/kbve/astro-kbve/src/components/market/EnchantList.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/EnchantList.tsx
@@ -1,0 +1,40 @@
+import { enchantDef, formatEnchant, parseEnchants } from './enchants';
+
+type Props = {
+	itemRef: unknown;
+	compact?: boolean;
+};
+
+export function EnchantList({ itemRef, compact = false }: Props) {
+	const enchants = parseEnchants(itemRef);
+	if (enchants.length === 0) return null;
+	if (compact) {
+		return (
+			<span
+				className="kbve-enchant-marker"
+				title={enchants.map(formatEnchant).join(', ')}>
+				✨{' '}
+				<span className="kbve-enchant-marker__count">
+					{enchants.length}
+				</span>
+			</span>
+		);
+	}
+	return (
+		<ul className="kbve-enchant-list" aria-label="Enchantments">
+			{enchants.map((e, i) => {
+				const def = enchantDef(e.id);
+				const cls = ['kbve-enchant-chip'];
+				if (def?.curse) cls.push('kbve-enchant-chip--curse');
+				if (def?.treasure) cls.push('kbve-enchant-chip--treasure');
+				return (
+					<li key={`${e.id}-${i}`} className={cls.join(' ')}>
+						{formatEnchant(e)}
+					</li>
+				);
+			})}
+		</ul>
+	);
+}
+
+export default EnchantList;

--- a/apps/kbve/astro-kbve/src/components/market/MarketBrowse.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketBrowse.tsx
@@ -3,6 +3,7 @@ import { listActive, type MarketListing, MarketApiError } from './api';
 import { formatKhash, itemRefLabel } from './format';
 import { useCountdown, formatCountdown } from './countdown';
 import { ItemIcon } from './ItemIcon';
+import { EnchantList } from './EnchantList';
 
 const PAGE_SIZE = 25;
 
@@ -26,6 +27,7 @@ function ListingCard({ row }: { row: MarketListing }) {
 			<div className="kbve-market__grid-body">
 				<div className="kbve-market__grid-title">
 					{itemRefLabel(row.item_ref)}
+					<EnchantList itemRef={row.item_ref} compact />
 				</div>
 				<div className="kbve-market__grid-prices">
 					{row.buy_now_price !== null && (

--- a/apps/kbve/astro-kbve/src/components/market/MarketCreateForm.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketCreateForm.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useSession } from '@kbve/astro';
 import { createListing, MarketApiError } from './api';
+import { EnchantEditor } from './EnchantEditor';
+import type { Enchant } from './enchants';
 
 const KIND_OPTIONS = [
 	{ value: 'mc_item', label: 'Minecraft item' },
@@ -22,6 +24,7 @@ export function MarketCreateForm() {
 	const [buyNow, setBuyNow] = useState('');
 	const [minBid, setMinBid] = useState('');
 	const [expires, setExpires] = useState(defaultExpiry());
+	const [enchants, setEnchants] = useState<Enchant[]>([]);
 	const [busy, setBusy] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState<number | null>(null);
@@ -60,6 +63,12 @@ export function MarketCreateForm() {
 		const expiryIso = new Date(expires).toISOString();
 		const item_ref: Record<string, unknown> = { kind, id: itemId.trim() };
 		if (instanceId.trim()) item_ref.instance_id = instanceId.trim();
+		if (kind === 'mc_item' && enchants.length > 0) {
+			item_ref.enchants = enchants.map((e) => ({
+				id: e.id,
+				level: e.level,
+			}));
+		}
 		setBusy(true);
 		try {
 			const res = await createListing({
@@ -74,6 +83,7 @@ export function MarketCreateForm() {
 			setInstanceId('');
 			setBuyNow('');
 			setMinBid('');
+			setEnchants([]);
 		} catch (err) {
 			setError(
 				err instanceof MarketApiError ? err.message : 'create failed',
@@ -155,6 +165,13 @@ export function MarketCreateForm() {
 					/>
 				</label>
 			</div>
+			{kind === 'mc_item' && (
+				<EnchantEditor
+					value={enchants}
+					onChange={setEnchants}
+					disabled={busy}
+				/>
+			)}
 			<div className="kbve-market__form-actions">
 				<button
 					type="submit"

--- a/apps/kbve/astro-kbve/src/components/market/MarketListingDetail.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketListingDetail.tsx
@@ -11,6 +11,7 @@ import {
 import { formatKhash, formatRelative, itemRefLabel } from './format';
 import { useCountdown, formatCountdown } from './countdown';
 import { ItemIcon } from './ItemIcon';
+import { EnchantList } from './EnchantList';
 
 function readListingId(): number | null {
 	if (typeof window === 'undefined') return null;
@@ -204,6 +205,7 @@ export function MarketListingDetail() {
 					<h1 className="kbve-market__item-title">
 						{itemRefLabel(row.item_ref)}
 					</h1>
+					<EnchantList itemRef={row.item_ref} />
 					<p className="kbve-market__hero-seller">
 						Seller{' '}
 						<code title={row.seller_account}>

--- a/apps/kbve/astro-kbve/src/components/market/MarketProfileShell.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketProfileShell.tsx
@@ -13,6 +13,7 @@ import {
 	formatRelative,
 	itemRefLabel,
 } from './format';
+import { EnchantList } from './EnchantList';
 
 type Tab = 'listings' | 'bids';
 
@@ -105,6 +106,7 @@ export function MarketProfileShell() {
 							<div className="kbve-market__card-head">
 								<span className="kbve-market__card-item">
 									{itemRefLabel(r.item_ref)}
+									<EnchantList itemRef={r.item_ref} compact />
 								</span>
 								<span
 									className={`kbve-market__badge kbve-market__badge--${r.listing_status}`}>

--- a/apps/kbve/astro-kbve/src/components/market/enchants.ts
+++ b/apps/kbve/astro-kbve/src/components/market/enchants.ts
@@ -1,0 +1,129 @@
+export type Enchant = {
+	id: string;
+	level: number;
+};
+
+type EnchantDef = {
+	id: string;
+	label: string;
+	maxLevel: number;
+	curse?: boolean;
+	treasure?: boolean;
+};
+
+export const VANILLA_ENCHANTS: EnchantDef[] = [
+	{ id: 'aqua_affinity', label: 'Aqua Affinity', maxLevel: 1 },
+	{ id: 'bane_of_arthropods', label: 'Bane of Arthropods', maxLevel: 5 },
+	{
+		id: 'binding_curse',
+		label: 'Curse of Binding',
+		maxLevel: 1,
+		curse: true,
+	},
+	{ id: 'blast_protection', label: 'Blast Protection', maxLevel: 4 },
+	{ id: 'breach', label: 'Breach', maxLevel: 4 },
+	{ id: 'channeling', label: 'Channeling', maxLevel: 1 },
+	{ id: 'density', label: 'Density', maxLevel: 5 },
+	{ id: 'depth_strider', label: 'Depth Strider', maxLevel: 3 },
+	{ id: 'efficiency', label: 'Efficiency', maxLevel: 5 },
+	{ id: 'feather_falling', label: 'Feather Falling', maxLevel: 4 },
+	{ id: 'fire_aspect', label: 'Fire Aspect', maxLevel: 2 },
+	{ id: 'fire_protection', label: 'Fire Protection', maxLevel: 4 },
+	{ id: 'flame', label: 'Flame', maxLevel: 1 },
+	{ id: 'fortune', label: 'Fortune', maxLevel: 3 },
+	{ id: 'frost_walker', label: 'Frost Walker', maxLevel: 2, treasure: true },
+	{ id: 'impaling', label: 'Impaling', maxLevel: 5 },
+	{ id: 'infinity', label: 'Infinity', maxLevel: 1 },
+	{ id: 'knockback', label: 'Knockback', maxLevel: 2 },
+	{ id: 'looting', label: 'Looting', maxLevel: 3 },
+	{ id: 'loyalty', label: 'Loyalty', maxLevel: 3 },
+	{ id: 'luck_of_the_sea', label: 'Luck of the Sea', maxLevel: 3 },
+	{ id: 'lure', label: 'Lure', maxLevel: 3 },
+	{ id: 'mending', label: 'Mending', maxLevel: 1, treasure: true },
+	{ id: 'multishot', label: 'Multishot', maxLevel: 1 },
+	{ id: 'piercing', label: 'Piercing', maxLevel: 4 },
+	{ id: 'power', label: 'Power', maxLevel: 5 },
+	{
+		id: 'projectile_protection',
+		label: 'Projectile Protection',
+		maxLevel: 4,
+	},
+	{ id: 'protection', label: 'Protection', maxLevel: 4 },
+	{ id: 'punch', label: 'Punch', maxLevel: 2 },
+	{ id: 'quick_charge', label: 'Quick Charge', maxLevel: 3 },
+	{ id: 'respiration', label: 'Respiration', maxLevel: 3 },
+	{ id: 'riptide', label: 'Riptide', maxLevel: 3 },
+	{ id: 'sharpness', label: 'Sharpness', maxLevel: 5 },
+	{ id: 'silk_touch', label: 'Silk Touch', maxLevel: 1 },
+	{ id: 'smite', label: 'Smite', maxLevel: 5 },
+	{ id: 'soul_speed', label: 'Soul Speed', maxLevel: 3, treasure: true },
+	{ id: 'sweeping_edge', label: 'Sweeping Edge', maxLevel: 3 },
+	{ id: 'swift_sneak', label: 'Swift Sneak', maxLevel: 3, treasure: true },
+	{ id: 'thorns', label: 'Thorns', maxLevel: 3 },
+	{ id: 'unbreaking', label: 'Unbreaking', maxLevel: 3 },
+	{
+		id: 'vanishing_curse',
+		label: 'Curse of Vanishing',
+		maxLevel: 1,
+		curse: true,
+	},
+	{ id: 'wind_burst', label: 'Wind Burst', maxLevel: 3, treasure: true },
+];
+
+const ENCHANT_INDEX: Map<string, EnchantDef> = new Map(
+	VANILLA_ENCHANTS.map((e) => [e.id, e]),
+);
+
+export function enchantLabel(id: string): string {
+	return (
+		ENCHANT_INDEX.get(id)?.label ??
+		id.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+	);
+}
+
+export function enchantDef(id: string): EnchantDef | undefined {
+	return ENCHANT_INDEX.get(id);
+}
+
+const ROMAN: Record<number, string> = {
+	1: 'I',
+	2: 'II',
+	3: 'III',
+	4: 'IV',
+	5: 'V',
+	6: 'VI',
+	7: 'VII',
+	8: 'VIII',
+	9: 'IX',
+	10: 'X',
+};
+
+export function roman(n: number): string {
+	if (n in ROMAN) return ROMAN[n];
+	return String(n);
+}
+
+export function formatEnchant(e: Enchant): string {
+	const label = enchantLabel(e.id);
+	if (e.level <= 1 && (enchantDef(e.id)?.maxLevel ?? 1) === 1) return label;
+	return `${label} ${roman(e.level)}`;
+}
+
+export function parseEnchants(itemRef: unknown): Enchant[] {
+	if (!itemRef || typeof itemRef !== 'object') return [];
+	const raw = (itemRef as { enchants?: unknown }).enchants;
+	if (!Array.isArray(raw)) return [];
+	const out: Enchant[] = [];
+	for (const e of raw) {
+		if (!e || typeof e !== 'object') continue;
+		const id = (e as { id?: unknown }).id;
+		const level = (e as { level?: unknown }).level;
+		if (typeof id !== 'string' || !id) continue;
+		const lvl =
+			typeof level === 'number' && Number.isFinite(level)
+				? Math.max(1, Math.floor(level))
+				: 1;
+		out.push({ id, level: lvl });
+	}
+	return out;
+}

--- a/apps/kbve/astro-kbve/src/components/market/format.ts
+++ b/apps/kbve/astro-kbve/src/components/market/format.ts
@@ -40,3 +40,9 @@ export function itemRefLabel(itemRef: unknown): string {
 	if (id) return id;
 	return JSON.stringify(itemRef).slice(0, 64);
 }
+
+export function itemRefHasEnchants(itemRef: unknown): boolean {
+	if (!itemRef || typeof itemRef !== 'object') return false;
+	const e = (itemRef as { enchants?: unknown }).enchants;
+	return Array.isArray(e) && e.length > 0;
+}


### PR DESCRIPTION
## Summary
- Lets sellers attach Minecraft enchantments to a listing's `item_ref`, and renders them across browse + detail + my-listings.
- **Zero backend changes.** `item_ref` is JSONB free-form on the wallet side; new optional `enchants: [{id, level}]` array is purely additive. DB constraint (`jsonb_typeof = 'object'` AND non-empty) unaffected.

## Frontend bits
- `enchants.ts` — vanilla 1.21+ enchant table (42 entries) with `maxLevel`, `curse` + `treasure` flags, Roman-numeral level formatter.
- `EnchantList` — full chip list for detail page (gold pill, red for curses, gold-light for treasure enchants); **compact `✨N` marker** for cards.
- `EnchantEditor` — dropdown + level picker rows, mounted inside the create form when `kind=mc_item`. Disables already-used enchant ids to avoid duplicates.
- Wires: detail hero, browse grid card title, my-listings card title, create form (mc_item only).
- `format.ts`: `itemRefHasEnchants` helper.

## Theming
Styles use Starlight + KBVE brand vars (`--sl-color-accent`, `--color-red`, `--color-gold-light`).

## Stack
Branched from `trunk/market-polish-1778936859` (#11101 — not yet merged). Once polish lands, this PR fast-forwards onto dev. If polish PR merges first, GitHub will auto-resolve.

## Tracking
Phase 5.2 of #10979. Phase 5 (UI scaffold) shipped via #11086; Phase 5.1 polish in #11101.

## Test plan
- [ ] `./kbve.sh -nx astro-kbve:build` — 5507 pages built locally, green
- [ ] CI astro-kbve pipeline green
- [ ] Visual smoke: create a listing with `kind=mc_item`, item id `diamond_sword`, add Sharpness V + Unbreaking III + Mending → verify chips on detail, ✨3 marker on browse + my-listings cards
- [ ] Curse of Vanishing renders red; Mending renders gold (treasure flag)

## Follow-up
- Phase 5.3 (next PR): Minecraft item database mirroring `/osrs/<item>` — generated MDX from `PrismarineJS/minecraft-data`, autocomplete picker in create form (replaces raw text input for `kind=mc_item`).