### PR TITLE
feat(firecracker-ctl): billing Phase C.3 — wallet wiring, gated on FC_BILLING_ENABLED

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6139,6 +6139,7 @@ dependencies = [
  "axum 0.8.9",
  "dashmap 6.1.0",
  "http-body-util",
+ "kbve",
  "libc",
  "reqwest 0.12.28",
  "serde",

--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,7 +12,7 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.38"
+version: "0.1.39"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml

--- a/apps/vm/firecracker-ctl/Cargo.toml
+++ b/apps/vm/firecracker-ctl/Cargo.toml
@@ -15,7 +15,8 @@ tower = { version = "0.5.3", features = ["util", "timeout"] }
 tower-http = { version = "0.6.8", features = ["trace", "cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "v5"] }
+kbve = { path = "../../../packages/rust/kbve", default-features = false, features = ["wallet"] }
 tokio-stream = "0.1"
 dashmap = "6"
 # Used by /fc/* persistent endpoint proxy (Phase 2d) to reverse-proxy

--- a/apps/vm/firecracker-ctl/src/billing_wallet.rs
+++ b/apps/vm/firecracker-ctl/src/billing_wallet.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+
+use axum::http::HeaderMap;
+use kbve::wallet::{
+    FirecrackerPlaceHoldRequest, FirecrackerSettleRequest, WalletClient, WalletError,
+};
+use uuid::Uuid;
+
+use crate::billing;
+
+pub const ACCOUNT_HEADER: &str = "x-kbve-account-id";
+
+#[derive(Clone)]
+pub struct BillingContext {
+    pub wallet: Arc<WalletClient>,
+    pub enabled: bool,
+}
+
+impl BillingContext {
+    pub fn new(wallet: Arc<WalletClient>, enabled: bool) -> Self {
+        Self { wallet, enabled }
+    }
+}
+
+pub fn extract_account_id(headers: &HeaderMap) -> Option<Uuid> {
+    headers
+        .get(ACCOUNT_HEADER)?
+        .to_str()
+        .ok()?
+        .parse::<Uuid>()
+        .ok()
+}
+
+pub fn settle_idempotency_key(vm_id: &str) -> Uuid {
+    Uuid::new_v5(
+        &Uuid::NAMESPACE_OID,
+        format!("fc-settle:{vm_id}").as_bytes(),
+    )
+}
+
+#[derive(Debug)]
+pub enum HoldOutcome {
+    Skipped,
+    Placed { amount: i64 },
+}
+
+#[derive(Debug)]
+pub enum HoldError {
+    MissingAccount,
+    Insufficient { balance_short_of: i64 },
+    Other(String),
+}
+
+pub async fn place_hold(
+    ctx: Option<&BillingContext>,
+    account_id: Option<Uuid>,
+    vm_id: &str,
+    vcpu_count: u8,
+    mem_size_mib: u16,
+    idle_ttl_secs: u32,
+    expected_requests: u64,
+) -> Result<HoldOutcome, HoldError> {
+    let ctx = match ctx {
+        Some(c) if c.enabled => c,
+        _ => return Ok(HoldOutcome::Skipped),
+    };
+    let account_id = match account_id {
+        Some(a) => a,
+        None => return Err(HoldError::MissingAccount),
+    };
+    let amount = billing::hold_amount(vcpu_count, mem_size_mib, idle_ttl_secs, expected_requests)
+        .min(i64::MAX as u64) as i64;
+    match ctx
+        .wallet
+        .firecracker_place_hold(FirecrackerPlaceHoldRequest {
+            account_id,
+            vm_id: vm_id.to_string(),
+            amount,
+        })
+        .await
+    {
+        Ok(_) => Ok(HoldOutcome::Placed { amount }),
+        Err(WalletError::InsufficientFunds) => Err(HoldError::Insufficient {
+            balance_short_of: amount,
+        }),
+        Err(e) => Err(HoldError::Other(e.to_string())),
+    }
+}
+
+pub async fn settle(ctx: Option<&BillingContext>, vm_id: &str, accumulated_credits: u64) {
+    let ctx = match ctx {
+        Some(c) if c.enabled => c,
+        _ => return,
+    };
+    let final_amount = accumulated_credits.min(i64::MAX as u64) as i64;
+    let key = settle_idempotency_key(vm_id);
+    match ctx
+        .wallet
+        .firecracker_settle(FirecrackerSettleRequest {
+            vm_id: vm_id.to_string(),
+            final_amount,
+            idempotency_key: key,
+            reason: None,
+        })
+        .await
+    {
+        Ok(r) => {
+            tracing::info!(
+                "fc-billing: settled vm_id={vm_id} status={:?} debited={} reserved={} released={} ledger={:?}",
+                r.status,
+                r.debited_amount,
+                r.reserved_amount,
+                r.released_amount,
+                r.ledger_id,
+            );
+        }
+        Err(e) => {
+            tracing::warn!("fc-billing: settle failed for vm_id={vm_id}: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn extract_account_id_returns_uuid_when_header_valid() {
+        let mut h = HeaderMap::new();
+        let id = Uuid::new_v4();
+        h.insert(
+            ACCOUNT_HEADER,
+            HeaderValue::from_str(&id.to_string()).unwrap(),
+        );
+        assert_eq!(extract_account_id(&h), Some(id));
+    }
+
+    #[test]
+    fn extract_account_id_returns_none_when_header_missing() {
+        let h = HeaderMap::new();
+        assert_eq!(extract_account_id(&h), None);
+    }
+
+    #[test]
+    fn extract_account_id_returns_none_when_header_malformed() {
+        let mut h = HeaderMap::new();
+        h.insert(ACCOUNT_HEADER, HeaderValue::from_static("not-a-uuid"));
+        assert_eq!(extract_account_id(&h), None);
+    }
+
+    #[test]
+    fn settle_idempotency_key_is_deterministic_per_vm_id() {
+        let a = settle_idempotency_key("fc-demo-1");
+        let b = settle_idempotency_key("fc-demo-1");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn settle_idempotency_key_differs_across_vm_ids() {
+        let a = settle_idempotency_key("fc-demo-1");
+        let b = settle_idempotency_key("fc-demo-2");
+        assert_ne!(a, b);
+    }
+}

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -23,6 +23,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 mod billing;
+mod billing_wallet;
 mod openapi;
 mod persistent;
 mod tap;
@@ -104,6 +105,9 @@ struct VmRecord {
     result: Option<VmResult>,
     created: Instant,
     kill_signal: Arc<Notify>,
+    billing_account_id: Option<Uuid>,
+    vcpu_count: u8,
+    mem_size_mib: u16,
 }
 
 // ---------------------------------------------------------------------------
@@ -137,6 +141,9 @@ struct AppState {
     /// Populated only when the binary runs as the networked deployment
     /// (firecracker-ctl-net). When `None`, all /fc/* handlers return 503.
     persistent: Option<Arc<PersistentState>>,
+    /// Wallet wiring for credit holds / settles. None = wallet not configured;
+    /// Some(ctx) where ctx.enabled controls whether holds + settles actually fire.
+    billing: Option<Arc<billing_wallet::BillingContext>>,
 }
 
 /// State block for persistent endpoints. Only constructed when the
@@ -237,6 +244,9 @@ struct PersistentEndpoint {
     idle_ttl_secs: u32,
     /// Per-endpoint VM stdout/stderr ring buffer. Capped at 256 KiB.
     logs: Arc<LogRing>,
+    /// Wallet account_id this endpoint bills against. Captured at deploy
+    /// from the upstream proxy's x-kbve-account-id header.
+    billing_account_id: Option<Uuid>,
 }
 
 /// Bounded byte ring backing `GET /fc/{name}/logs`. Drops oldest bytes
@@ -638,6 +648,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
 )]
 async fn create_vm(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<CreateVmRequest>,
 ) -> impl IntoResponse {
     // Validate entrypoint (prevents boot_args injection)
@@ -696,6 +707,53 @@ async fn create_vm(
     let now = iso8601_now();
     let kill_signal = Arc::new(Notify::new());
 
+    let want_network = req.network.unwrap_or(false);
+    let account_id = billing_wallet::extract_account_id(&headers);
+    let billing_account_id = if want_network { account_id } else { None };
+
+    if want_network {
+        let ttl_secs = (req.timeout_ms / 1000) as u32;
+        match billing_wallet::place_hold(
+            state.billing.as_deref(),
+            billing_account_id,
+            &vm_id,
+            req.vcpu_count,
+            req.mem_size_mib,
+            ttl_secs,
+            0,
+        )
+        .await
+        {
+            Ok(_) => {}
+            Err(billing_wallet::HoldError::MissingAccount) => {
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(serde_json::json!({
+                        "error": "billing requires x-kbve-account-id header for network=true VMs",
+                    })),
+                );
+            }
+            Err(billing_wallet::HoldError::Insufficient { balance_short_of }) => {
+                return (
+                    StatusCode::PAYMENT_REQUIRED,
+                    Json(serde_json::json!({
+                        "error": "insufficient credits to reserve session",
+                        "needed": balance_short_of,
+                    })),
+                );
+            }
+            Err(billing_wallet::HoldError::Other(detail)) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "error": "billing hold failed",
+                        "detail": detail,
+                    })),
+                );
+            }
+        }
+    }
+
     let info = VmInfo {
         vm_id: vm_id.clone(),
         status: VmStatus::Creating,
@@ -712,16 +770,30 @@ async fn create_vm(
             result: None,
             created: Instant::now(),
             kill_signal: kill_signal.clone(),
+            billing_account_id,
+            vcpu_count: req.vcpu_count,
+            mem_size_mib: req.mem_size_mib,
         },
     );
 
-    // Spawn VM lifecycle in background
     let vms = state.vms.clone();
     let rootfs_dir = state.rootfs_dir.clone();
     let jailer = state.jailer.clone();
     let persistent = state.persistent.clone();
+    let billing = state.billing.clone();
     tokio::spawn(async move {
-        run_vm_lifecycle(vms, vm_id, req, rootfs_dir, kill_signal, jailer, persistent).await;
+        run_vm_lifecycle(
+            vms,
+            vm_id,
+            req,
+            rootfs_dir,
+            kill_signal,
+            jailer,
+            persistent,
+            billing,
+            billing_account_id,
+        )
+        .await;
     });
 
     (StatusCode::CREATED, Json(serde_json::json!(info)))
@@ -914,6 +986,7 @@ fn not_enabled() -> (StatusCode, Json<serde_json::Value>) {
 )]
 async fn fc_deploy(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<DeployFcRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
     if req.name.is_empty()
@@ -983,7 +1056,47 @@ async fn fc_deploy(
         );
     }
 
-    // --- Allocate IP ---
+    let billing_account_id = billing_wallet::extract_account_id(&headers);
+    match billing_wallet::place_hold(
+        state.billing.as_deref(),
+        billing_account_id,
+        &req.name,
+        req.vcpu_count,
+        req.mem_size_mib,
+        req.idle_ttl_secs,
+        0,
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(billing_wallet::HoldError::MissingAccount) => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": "billing requires x-kbve-account-id header",
+                })),
+            );
+        }
+        Err(billing_wallet::HoldError::Insufficient { balance_short_of }) => {
+            return (
+                StatusCode::PAYMENT_REQUIRED,
+                Json(serde_json::json!({
+                    "error": "insufficient credits to reserve endpoint",
+                    "needed": balance_short_of,
+                })),
+            );
+        }
+        Err(billing_wallet::HoldError::Other(detail)) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "billing hold failed",
+                    "detail": detail,
+                })),
+            );
+        }
+    }
+
     let allocation = match persistent.pool.allocate() {
         Ok(a) => a,
         Err(e) => {
@@ -1109,6 +1222,7 @@ async fn fc_deploy(
         metrics: Arc::new(EndpointMetrics::default()),
         idle_ttl_secs: req.idle_ttl_secs,
         logs,
+        billing_account_id,
     };
     let info = PersistentEndpointInfo::from(&endpoint);
     persistent.endpoints.insert(req.name.clone(), endpoint);
@@ -1528,6 +1642,11 @@ async fn fc_destroy(
     }
     persistent.pool.release(&endpoint.allocation);
 
+    if endpoint.billing_account_id.is_some() {
+        let accumulated = endpoint.metrics.accumulated_credits.load(Ordering::Relaxed);
+        billing_wallet::settle(state.billing.as_deref(), &endpoint.name, accumulated).await;
+    }
+
     tracing::info!(
         "fc_destroy: removed endpoint {name} (pid={:?})",
         endpoint.pid
@@ -1559,7 +1678,11 @@ fn accumulate_meter(ep: &PersistentEndpoint, now: i64) {
     }
 }
 
-async fn idle_sweeper_task(persistent: Arc<PersistentState>, interval: Duration) {
+async fn idle_sweeper_task(
+    persistent: Arc<PersistentState>,
+    interval: Duration,
+    billing: Option<Arc<billing_wallet::BillingContext>>,
+) {
     let mut ticker = tokio::time::interval(interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
@@ -1598,6 +1721,10 @@ async fn idle_sweeper_task(persistent: Arc<PersistentState>, interval: Duration)
                 );
             }
             persistent.pool.release(&endpoint.allocation);
+            if endpoint.billing_account_id.is_some() {
+                let accumulated = endpoint.metrics.accumulated_credits.load(Ordering::Relaxed);
+                billing_wallet::settle(billing.as_deref(), &endpoint.name, accumulated).await;
+            }
             tracing::info!(
                 "idle_sweeper: tore down idle endpoint {name} (ttl={}s)",
                 endpoint.idle_ttl_secs
@@ -2092,6 +2219,8 @@ async fn run_vm_lifecycle(
     kill_signal: Arc<Notify>,
     jailer: Option<Arc<JailerConfig>>,
     persistent: Option<Arc<PersistentState>>,
+    billing: Option<Arc<billing_wallet::BillingContext>>,
+    billing_account_id: Option<Uuid>,
 ) {
     let start = Instant::now();
 
@@ -2379,6 +2508,12 @@ async fn run_vm_lifecycle(
             let cgroup_path = format!("/sys/fs/cgroup/firecracker/{}", vm_id);
             let _ = tokio::fs::remove_dir(&cgroup_path).await;
         }
+    }
+
+    if billing_account_id.is_some() {
+        let duration_secs = start.elapsed().as_secs();
+        let accumulated = billing::meter_tick(req.vcpu_count, req.mem_size_mib, duration_secs, 0);
+        billing_wallet::settle(billing.as_deref(), &vm_id, accumulated).await;
     }
 }
 
@@ -3100,16 +3235,47 @@ async fn main() {
         None
     };
 
+    let billing_enabled = std::env::var("FC_BILLING_ENABLED")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
+    let billing = match kbve::wallet::WalletClient::from_env().await {
+        Ok(client) => {
+            tracing::info!(
+                "fc-billing: wallet client ready, billing_enabled={}",
+                billing_enabled
+            );
+            Some(Arc::new(billing_wallet::BillingContext::new(
+                Arc::new(client),
+                billing_enabled,
+            )))
+        }
+        Err(e) => {
+            if billing_enabled {
+                tracing::error!(
+                    "fc-billing: FC_BILLING_ENABLED=true but wallet init failed: {e}. Billing OFF."
+                );
+            } else {
+                tracing::info!("fc-billing: wallet not configured ({e}); billing OFF");
+            }
+            None
+        }
+    };
+
     let state = AppState {
         vms,
         rootfs_dir,
         max_concurrent_vms,
         jailer,
         persistent: persistent.clone(),
+        billing,
     };
 
     if let Some(p) = persistent.clone() {
-        tokio::spawn(idle_sweeper_task(p, Duration::from_secs(60)));
+        tokio::spawn(idle_sweeper_task(
+            p,
+            Duration::from_secs(60),
+            state.billing.clone(),
+        ));
     }
 
     tracing::info!(
@@ -3706,6 +3872,9 @@ mod tests {
             result: None,
             created: Instant::now(),
             kill_signal: Arc::new(Notify::new()),
+            billing_account_id: None,
+            vcpu_count: 1,
+            mem_size_mib: 128,
         }
     }
 
@@ -3757,6 +3926,7 @@ mod tests {
             max_concurrent_vms: 4,
             jailer: None,
             persistent,
+            billing: None,
         };
         Router::new()
             .route("/health", get(health))
@@ -4302,6 +4472,7 @@ mod tests {
             metrics: Arc::new(EndpointMetrics::default()),
             idle_ttl_secs: 0,
             logs: Arc::new(LogRing::new()),
+            billing_account_id: None,
         }
     }
 
@@ -4332,6 +4503,7 @@ mod tests {
             max_concurrent_vms: 4,
             jailer: None,
             persistent: Some(persistent),
+            billing: None,
         };
         Router::new()
             .route("/fc/list", get(fc_list))
@@ -4722,6 +4894,7 @@ mod tests {
             max_concurrent_vms: 1,
             jailer: None,
             persistent: None,
+            billing: None,
         };
         let app = Router::new()
             .route("/vm/create", post(create_vm))
@@ -4768,6 +4941,7 @@ mod tests {
             max_concurrent_vms: 4,
             jailer: None,
             persistent: None,
+            billing: None,
         };
         let app = Router::new()
             .route("/vm/{vm_id}", get(get_vm_status))
@@ -4817,6 +4991,7 @@ mod tests {
             max_concurrent_vms: 4,
             jailer: None,
             persistent: None,
+            billing: None,
         };
         let app = Router::new()
             .route("/vm/{vm_id}", delete(destroy_vm))


### PR DESCRIPTION
## Summary
Phase C.3 of #11048. fc-ctl picks up the \`kbve\` crate's \`WalletClient\` and wires pre-flight holds + on-teardown settles into every billable VM lifecycle path. All wallet calls are **gated on \`FC_BILLING_ENABLED\`** so the code lands wired-but-dormant until \`axum-kbve\` injects the per-request \`x-kbve-account-id\` header in C.4.

### New module: \`apps/vm/firecracker-ctl/src/billing_wallet.rs\`
| Symbol | Purpose |
|---|---|
| \`BillingContext { wallet: Arc<WalletClient>, enabled: bool }\` | held in \`AppState.billing: Option<Arc<…>>\` |
| \`extract_account_id(headers)\` | parses \`x-kbve-account-id\` → \`Option<Uuid>\` |
| \`settle_idempotency_key(vm_id)\` | UUID v5 of \`"fc-settle:<vm_id>"\` — deterministic per vm |
| \`place_hold(ctx, account, vm_id, vcpu, mem, ttl, req)\` | no-op when \`!enabled\` or wallet absent |
| \`settle(ctx, vm_id, accumulated)\` | no-op when \`!enabled\` or wallet absent |

### Handler wiring
| Path | Behavior |
|---|---|
| \`POST /vm/create\` (\`network=true\`) | Extracts header, computes \`billing::hold_amount\`, calls \`firecracker_place_hold\`. 401 on missing account, **402 on insufficient funds** with \`needed\` field, 500 otherwise. \`account_id\` threads into \`VmRecord\`. |
| \`POST /fc/deploy\` | Same as above. Persistent endpoints are never free; \`x-kbve-account-id\` is required once \`FC_BILLING_ENABLED=true\`. \`account_id\` threads into \`PersistentEndpoint\`. |
| \`run_vm_lifecycle\` exit | Settles network-true ephemerals using \`billing::meter_tick(spec, duration_secs, 0)\`. |
| \`DELETE /fc/{name}\` | Settles with \`EndpointMetrics.accumulated_credits\`. |
| \`idle_sweeper_task\` | Settles each torn-down endpoint the same way. |

\`billing_account_id == None\` ⇒ no settle call (skip path identical to pre-billing behavior). This keeps the 138 pre-existing tests passing unchanged.

### Dependencies added
- \`kbve = { path = "../../../packages/rust/kbve", features = ["wallet"] }\`
- \`uuid\` gains \`"v5"\` alongside \`"v4"\` (for the settle idempotency_key)

### Env
| Var | Default | Effect |
|---|---|---|
| \`WALLET_DATABASE_URL\` | (unset) | When set, \`WalletClient::from_env()\` succeeds → \`AppState.billing\` is Some. Otherwise \`None\` and billing is a no-op regardless of the next var. |
| \`FC_BILLING_ENABLED\` | \`false\` | When \`true\` AND wallet is wired, holds + settles actually fire. |

Both manifests (\`firecracker-net-deployment.yaml\` + \`firecracker-deployment.yaml\`) intentionally do **not** set either var in this PR — flip-the-switch happens in C.4 after \`axum-kbve\` proxy injects the account header.

## Test plan
- [x] \`cargo build --manifest-path apps/vm/firecracker-ctl/Cargo.toml\` — clean
- [x] \`cargo test --bin firecracker-ctl\` — **143 passed** (was 138 + 5 new for \`billing_wallet\` header / key tests)
- [ ] After publish + ArgoCD sync, deploy works exactly as before (billing OFF by default).

Bumps \`firecracker-ctl\` 0.1.38 → 0.1.39 via MDX.

## Out of scope
- **C.4**: flip \`FC_BILLING_ENABLED=true\` on the net deployment, set \`WALLET_DATABASE_URL\` secret, and have axum-kbve inject \`x-kbve-account-id\` on every \`/fc/*\` and \`/vm/create\` proxy hop.
- **C.5**: dashboard 402 handling + "Top up credits" CTA wired to the Quote API.