### PR TITLE
feat(billing): Phase C.4 — axum-kbve injects x-kbve-account-id + fc-ctl-net wallet env

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -11,7 +11,10 @@ use serde_json::json;
 use std::time::Duration;
 use tracing::{debug, warn};
 
-use crate::auth::{extract_bearer_token, get_jwt_cache, jwt_cache::staff_perm};
+use crate::auth::{
+    extract_bearer_token, get_jwt_cache,
+    jwt_cache::{TokenInfo, staff_perm},
+};
 
 struct ServiceProxy {
     name: &'static str,
@@ -341,7 +344,7 @@ async fn require_dashboard_manage_with_query(
     headers: &HeaderMap,
     query: Option<&str>,
     service_name: &str,
-) -> Result<(), Response> {
+) -> Result<TokenInfo, Response> {
     let auth_token = match extract_auth_token(headers, query) {
         Some(t) => t,
         None => {
@@ -395,7 +398,7 @@ async fn require_dashboard_manage_with_query(
             .into_response());
     }
 
-    Ok(())
+    Ok(token_info)
 }
 
 async fn require_dashboard_view_with_query(
@@ -1497,6 +1500,27 @@ pub async fn kasm_launch_handler(req: Request<Body>) -> Response {
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }
 
+async fn resolve_account_for_token(token: &TokenInfo) -> Option<uuid::Uuid> {
+    let user_id = token.user_id.parse::<uuid::Uuid>().ok()?;
+    let wallet = crate::db::get_wallet_client()?;
+    match wallet.service_account_for_user(user_id).await {
+        Ok(a) => Some(a),
+        Err(e) => {
+            warn!(%user_id, "fc-billing: account resolution failed: {e}");
+            None
+        }
+    }
+}
+
+fn set_account_id_header(req: &mut Request<Body>, account_id: Option<uuid::Uuid>) {
+    req.headers_mut().remove("x-kbve-account-id");
+    if let Some(acc) = account_id {
+        if let Ok(v) = HeaderValue::from_str(&acc.to_string()) {
+            req.headers_mut().insert("x-kbve-account-id", v);
+        }
+    }
+}
+
 static FIRECRACKER: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_firecracker_proxy() -> bool {
@@ -1586,19 +1610,22 @@ pub fn init_firecracker_net_proxy() -> bool {
 
 pub async fn firecracker_net_proxy_handler(
     path: Option<Path<String>>,
-    req: Request<Body>,
+    mut req: Request<Body>,
 ) -> Response {
     let headers = req.headers().clone();
     let query = req.uri().query().map(str::to_owned);
-    if let Err(resp) =
-        require_dashboard_manage_with_query(&headers, query.as_deref(), "Firecracker-Net").await
-    {
-        return resp;
-    }
+    let token =
+        match require_dashboard_manage_with_query(&headers, query.as_deref(), "Firecracker-Net")
+            .await
+        {
+            Ok(t) => t,
+            Err(resp) => return resp,
+        };
+
+    let account_id = resolve_account_for_token(&token).await;
+    set_account_id_header(&mut req, account_id);
 
     match FIRECRACKER_NET.get() {
-        // DASHBOARD_MANAGE already authenticated above — skip the inner
-        // DASHBOARD_VIEW check to avoid a double JWT fetch.
         Some(proxy) => proxy.handle_preauthorized(path, req).await,
         None => (
             StatusCode::SERVICE_UNAVAILABLE,
@@ -1611,15 +1638,20 @@ pub async fn firecracker_net_proxy_handler(
 /// Stable `/api/v1/fc/<rest>` → `/fc/<rest>` alias under the staff gate.
 pub async fn firecracker_fc_alias_handler(
     Path(rest): Path<String>,
-    req: Request<Body>,
+    mut req: Request<Body>,
 ) -> Response {
     let headers = req.headers().clone();
     let query = req.uri().query().map(str::to_owned);
-    if let Err(resp) =
-        require_dashboard_manage_with_query(&headers, query.as_deref(), "Firecracker-FC").await
-    {
-        return resp;
-    }
+    let token =
+        match require_dashboard_manage_with_query(&headers, query.as_deref(), "Firecracker-FC")
+            .await
+        {
+            Ok(t) => t,
+            Err(resp) => return resp,
+        };
+
+    let account_id = resolve_account_for_token(&token).await;
+    set_account_id_header(&mut req, account_id);
 
     match FIRECRACKER_NET.get() {
         Some(proxy) => {
@@ -1645,7 +1677,9 @@ pub async fn firecracker_fc_handler(
     let headers = req.headers().clone();
     let query = req.uri().query().map(str::to_owned);
     if let Err(resp) =
-        require_dashboard_manage_with_query(&headers, query.as_deref(), "Firecracker-FC").await
+        require_dashboard_manage_with_query(&headers, query.as_deref(), "Firecracker-FC")
+            .await
+            .map(|_| ())
     {
         return resp;
     }

--- a/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
@@ -144,6 +144,18 @@ spec:
                         value: 'true'
                       - name: FC_TUNNEL_IFACE
                         value: 'tun0'
+                      - name: FC_BILLING_ENABLED
+                        value: 'false'
+                      - name: WALLET_DATABASE_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: db-url
+                      - name: WALLET_DATABASE_URL_RO
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: db-url-ro
                   securityContext:
                       # jailer pivot_root requires Unconfined seccomp.
                       seccompProfile:

--- a/apps/kube/firecracker/manifests/firecracker-net-externalsecret.yaml
+++ b/apps/kube/firecracker/manifests/firecracker-net-externalsecret.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: firecracker-external-secrets
+    namespace: firecracker
+    labels:
+        app.kubernetes.io/name: firecracker-ctl-net
+        app.kubernetes.io/component: rbac
+        app.kubernetes.io/managed-by: argocd
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-remote-secret-store
+    namespace: firecracker
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: firecracker-external-secrets
+                    namespace: firecracker
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: firecracker-supabase-secrets
+    namespace: firecracker
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: supabase-shared
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                db-url: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
+                db-url-ro: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-pooler-ro.kilobase.svc.cluster.local:5432/supabase'
+    data:
+        - secretKey: dbpassword
+          remoteRef:
+              key: supabase-postgres
+              property: password

--- a/apps/kube/firecracker/manifests/kustomization.yaml
+++ b/apps/kube/firecracker/manifests/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
     - firecracker-keda.yaml
     - firecracker-net-deployment.yaml
     - firecracker-net-service.yaml
+    - firecracker-net-externalsecret.yaml
     - firecracker-servicemonitor.yaml
     - firecracker-net-servicemonitor.yaml
     - firecracker-alerts.yaml

--- a/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
@@ -66,6 +66,9 @@ subjects:
     - kind: ServiceAccount
       name: cryptothrone-external-secrets
       namespace: cryptothrone
+    - kind: ServiceAccount
+      name: firecracker-external-secrets
+      namespace: firecracker
 ---
 # Additional role for reading services/endpoints if needed
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary
Phase C.4 of #11048. Wires the missing identity hop between the dashboard JWT and fc-ctl-net's wallet billing logic. Stays **safe-by-default** with \`FC_BILLING_ENABLED=false\` in the manifest — fc-ctl parses the new header but no-ops every billing call until C.5 flips the flag in prod.

\`\`\`
dashboard JWT
  → axum-kbve auth (DASHBOARD_MANAGE)
  → axum-kbve resolves user_id → wallet.account_id via WalletClient
  → x-kbve-account-id header injected on the upstream request
  → fc-ctl-net reads header and feeds it to firecracker_place_hold / settle
\`\`\`

### axum-kbve (\`apps/kbve/axum-kbve/src/transport/proxy.rs\`)
- \`require_dashboard_manage_with_query\` now returns \`Result<TokenInfo, Response>\` (was \`Result<()>\`); three call sites adapted: \`firecracker_net_proxy_handler\`, \`firecracker_fc_alias_handler\`, \`firecracker_fc_handler\`.
- New \`resolve_account_for_token(token) -> Option<Uuid>\` — parses \`user_id\`, calls \`wallet.service_account_for_user\`, returns the wallet \`account_id\`.
- New \`set_account_id_header(req, account_id)\` — **strips any client-supplied \`x-kbve-account-id\` first**, then inserts the server-resolved value. Spoof-safe.
- \`firecracker_net_proxy_handler\` and \`firecracker_fc_alias_handler\` call both before forwarding. \`firecracker_fc_handler\` (the inner VM proxy) is left untouched — billing is keyed off the outer \`/fc/deploy\` + \`/vm/create\` path, not the per-request proxy.

### Kube manifests
| File | Change |
|---|---|
| \`firecracker/manifests/firecracker-net-externalsecret.yaml\` (new) | \`ServiceAccount firecracker-external-secrets\` + \`SecretStore\` + \`ExternalSecret\` materializing \`supabase-shared\` (\`db-url\` + \`db-url-ro\` only). |
| \`kilobase/manifests/cross-namespace-rbac.yaml\` | New SA added to the existing \`RoleBinding\` subjects so ESO can read kilobase secrets. |
| \`firecracker/manifests/firecracker-net-deployment.yaml\` | \`FC_BILLING_ENABLED=false\` + \`WALLET_DATABASE_URL\` + \`WALLET_DATABASE_URL_RO\` from the supabase-shared secret. |
| \`firecracker/manifests/kustomization.yaml\` | Picks up the new externalsecret manifest. |

### Merge-order safety
- If this lands **before** #11109 (C.3): fc-ctl 0.1.37/8 ignores the unknown env vars + header — no harm.
- If #11109 lands first: post-publish bumps the manifest to 0.1.39+, this PR adds env on top — billing wired but flagged off.
- Either order, dashboards keep working since \`FC_BILLING_ENABLED=false\`.

## Test plan
- [x] \`cargo build -p axum-kbve\` — clean
- [x] \`cargo build firecracker-ctl\` — clean
- [ ] After ArgoCD sync: \`kubectl describe externalsecret -n firecracker firecracker-supabase-secrets\` shows \`SecretSynced=True\`.
- [ ] \`kubectl get secret -n firecracker supabase-shared\` exists with \`db-url\` + \`db-url-ro\` keys.
- [ ] Dashboard \`/fc/list\` still works (billing off → wallet calls no-op).
- [ ] \`kubectl logs -n firecracker fc-ctl-net\` shows \`fc-billing: wallet client ready, billing_enabled=false\` after restart.

## Out of scope
- **C.5**: flip \`FC_BILLING_ENABLED=true\` once monitoring confirms wallet round-trips are clean. Dashboard 402 handling + "Top up credits" CTA lives there.