### PR TITLE
feat(mc_auth): player snapshot save/load against mc.player

### DIFF
--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
@@ -184,6 +184,31 @@ public final class AuthEventTicker {
                         khash);
                 break;
             }
+            case "PlayerSnapshotLoaded": {
+                String uuid = payload.get("player_uuid").getAsString();
+                String snapshotJson = (payload.has("snapshot_json") && !payload.get("snapshot_json").isJsonNull())
+                        ? payload.get("snapshot_json").getAsString()
+                        : null;
+                if (snapshotJson != null) {
+                    PlayerSnapshotHandler.applyLoadedSnapshot(server, uuid, snapshotJson);
+                }
+                LOGGER.debug(
+                        "[{}] PlayerSnapshotLoaded uuid={} present={}",
+                        McAuthMod.MOD_ID,
+                        uuid,
+                        snapshotJson != null);
+                break;
+            }
+            case "PlayerSnapshotSaved": {
+                String uuid = payload.get("player_uuid").getAsString();
+                boolean success = payload.has("success") && payload.get("success").getAsBoolean();
+                LOGGER.debug(
+                        "[{}] PlayerSnapshotSaved uuid={} success={}",
+                        McAuthMod.MOD_ID,
+                        uuid,
+                        success);
+                break;
+            }
             default:
                 LOGGER.debug("[{}] unknown PlayerEvent variant: {}", McAuthMod.MOD_ID, variant);
         }

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/McAuthMod.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/McAuthMod.java
@@ -40,10 +40,12 @@ public class McAuthMod implements ModInitializer {
 
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
             PlayerLoginHandler.onJoin(handler.getPlayer());
+            PlayerSnapshotHandler.requestLoad(handler.getPlayer());
         });
 
         ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> {
             if (handler.getPlayer() != null) {
+                PlayerSnapshotHandler.requestSave(handler.getPlayer());
                 LinkStatusRegistry.remove(handler.getPlayer().getUuidAsString());
             }
         });

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/NativeRuntime.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/NativeRuntime.java
@@ -117,6 +117,10 @@ public final class NativeRuntime {
      */
     public static native String mintChatToken(String uuid, String username);
 
+    public static native String loadPlayerSnapshot(String uuid, String serverId);
+
+    public static native String savePlayerSnapshot(String uuid, String snapshotJson);
+
     /** Check if the native library loaded successfully. */
     public static boolean isLoaded() {
         return loaded;

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/PlayerSnapshotHandler.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/PlayerSnapshotHandler.java
@@ -1,0 +1,142 @@
+package com.kbve.mcauth;
+
+import com.google.gson.JsonObject;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+
+public final class PlayerSnapshotHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(McAuthMod.MOD_ID);
+
+    public static final String SERVER_ID_ENV = "KBVE_MC_SERVER_ID";
+    public static final String DEFAULT_SERVER_ID = "kbve-mc-fabric";
+
+    private PlayerSnapshotHandler() {}
+
+    public static String serverId() {
+        String env = System.getenv(SERVER_ID_ENV);
+        return (env != null && !env.isEmpty()) ? env : DEFAULT_SERVER_ID;
+    }
+
+    public static void requestLoad(ServerPlayerEntity player) {
+        if (!NativeRuntime.isLoaded() || player == null) {
+            return;
+        }
+        try {
+            NativeRuntime.loadPlayerSnapshot(player.getUuidAsString(), serverId());
+        } catch (Throwable t) {
+            LOGGER.warn("[{}] loadPlayerSnapshot threw: {}", McAuthMod.MOD_ID, t.getMessage());
+        }
+    }
+
+    public static void requestSave(ServerPlayerEntity player) {
+        if (!NativeRuntime.isLoaded() || player == null) {
+            return;
+        }
+        try {
+            String json = buildSnapshotJson(player);
+            NativeRuntime.savePlayerSnapshot(player.getUuidAsString(), json);
+        } catch (Throwable t) {
+            LOGGER.warn("[{}] savePlayerSnapshot threw: {}", McAuthMod.MOD_ID, t.getMessage());
+        }
+    }
+
+    public static void applyLoadedSnapshot(MinecraftServer server, String uuid, String snapshotJson) {
+        if (server == null || snapshotJson == null || snapshotJson.isEmpty()) {
+            return;
+        }
+        ServerPlayerEntity player;
+        try {
+            player = server.getPlayerManager().getPlayer(java.util.UUID.fromString(uuid));
+        } catch (IllegalArgumentException e) {
+            return;
+        }
+        if (player == null) {
+            return;
+        }
+        try {
+            JsonObject row = com.google.gson.JsonParser.parseString(snapshotJson).getAsJsonObject();
+            double x = row.has("pos_x") ? row.get("pos_x").getAsDouble() : player.getX();
+            double y = row.has("pos_y") ? row.get("pos_y").getAsDouble() : player.getY();
+            double z = row.has("pos_z") ? row.get("pos_z").getAsDouble() : player.getZ();
+            float yaw = row.has("pos_yaw") ? row.get("pos_yaw").getAsFloat() : player.getYaw();
+            float pitch = row.has("pos_pitch") ? row.get("pos_pitch").getAsFloat() : player.getPitch();
+            String worldId = row.has("world") && !row.get("world").isJsonNull()
+                    ? row.get("world").getAsString()
+                    : "minecraft:overworld";
+
+            RegistryKey<World> worldKey = RegistryKey.of(
+                    net.minecraft.registry.RegistryKeys.WORLD,
+                    Identifier.of(worldId));
+            net.minecraft.server.world.ServerWorld targetWorld = server.getWorld(worldKey);
+            if (targetWorld == null) {
+                targetWorld = server.getOverworld();
+            }
+            player.teleport(targetWorld, x, y, z, java.util.EnumSet.noneOf(net.minecraft.network.packet.s2c.play.PositionFlag.class), yaw, pitch, false);
+
+            if (row.has("health") && !row.get("health").isJsonNull()) {
+                player.setHealth(row.get("health").getAsFloat());
+            }
+            if (row.has("food_level") && !row.get("food_level").isJsonNull()) {
+                player.getHungerManager().setFoodLevel(row.get("food_level").getAsInt());
+            }
+            if (row.has("saturation") && !row.get("saturation").isJsonNull()) {
+                player.getHungerManager().setSaturationLevel(row.get("saturation").getAsFloat());
+            }
+            if (row.has("xp_level") && !row.get("xp_level").isJsonNull()) {
+                player.experienceLevel = row.get("xp_level").getAsInt();
+            }
+            if (row.has("xp_points") && !row.get("xp_points").isJsonNull()) {
+                player.totalExperience = row.get("xp_points").getAsInt();
+            }
+            LOGGER.info(
+                    "[{}] Restored snapshot for {} at ({},{},{}) in {}",
+                    McAuthMod.MOD_ID,
+                    uuid,
+                    x,
+                    y,
+                    z,
+                    worldId);
+        } catch (Throwable t) {
+            LOGGER.warn("[{}] applyLoadedSnapshot failed for {}: {}", McAuthMod.MOD_ID, uuid, t.toString());
+        }
+    }
+
+    private static String buildSnapshotJson(ServerPlayerEntity player) {
+        JsonObject root = new JsonObject();
+        root.addProperty("player_uuid", player.getUuidAsString());
+        root.addProperty("server_id", serverId());
+        root.addProperty("player_name", player.getNameForScoreboard());
+
+        JsonObject position = new JsonObject();
+        position.addProperty("x", player.getX());
+        position.addProperty("y", player.getY());
+        position.addProperty("z", player.getZ());
+        position.addProperty("yaw", player.getYaw());
+        position.addProperty("pitch", player.getPitch());
+        position.addProperty("world", player.getEntityWorld().getRegistryKey().getValue().toString());
+        root.add("position", position);
+
+        root.addProperty("game_mode", player.interactionManager.getGameMode().getId());
+        root.addProperty("health", player.getHealth());
+        root.addProperty("food_level", player.getHungerManager().getFoodLevel());
+        root.addProperty("saturation", player.getHungerManager().getSaturationLevel());
+        root.addProperty("experience_level", player.experienceLevel);
+        root.addProperty("experience_points", player.totalExperience);
+
+        JsonObject inventory = new JsonObject();
+        inventory.add("slots", new com.google.gson.JsonArray());
+        root.add("inventory", inventory);
+        root.add("ender_chest", new com.google.gson.JsonArray());
+
+        root.addProperty("captured_at", Instant.now().toString());
+        return root.toString();
+    }
+}

--- a/apps/mc/mc_auth/src/lib.rs
+++ b/apps/mc/mc_auth/src/lib.rs
@@ -104,6 +104,56 @@ pub extern "system" fn Java_com_kbve_mcauth_NativeRuntime_verifyLink<'local>(
     make_jstring(&mut env, &response)
 }
 
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_kbve_mcauth_NativeRuntime_loadPlayerSnapshot<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    uuid: JString<'local>,
+    server_id: JString<'local>,
+) -> jstring {
+    let player_uuid: String = match env.get_string(&uuid) {
+        Ok(s) => s.into(),
+        Err(_) => return make_jstring(&mut env, &AuthResponse::error("invalid uuid string")),
+    };
+    let server_id_s: String = match env.get_string(&server_id) {
+        Ok(s) => s.into(),
+        Err(_) => return make_jstring(&mut env, &AuthResponse::error("invalid server_id string")),
+    };
+    let response = match RUNTIME.get() {
+        Some(rt) => rt.submit(AuthJob::LoadPlayerSnapshot {
+            player_uuid,
+            server_id: server_id_s,
+        }),
+        None => AuthResponse::error("runtime not initialized"),
+    };
+    make_jstring(&mut env, &response)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_kbve_mcauth_NativeRuntime_savePlayerSnapshot<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    uuid: JString<'local>,
+    snapshot_json: JString<'local>,
+) -> jstring {
+    let player_uuid: String = match env.get_string(&uuid) {
+        Ok(s) => s.into(),
+        Err(_) => return make_jstring(&mut env, &AuthResponse::error("invalid uuid string")),
+    };
+    let snapshot_s: String = match env.get_string(&snapshot_json) {
+        Ok(s) => s.into(),
+        Err(_) => return make_jstring(&mut env, &AuthResponse::error("invalid snapshot string")),
+    };
+    let response = match RUNTIME.get() {
+        Some(rt) => rt.submit(AuthJob::SavePlayerSnapshot {
+            player_uuid,
+            snapshot_json: snapshot_s,
+        }),
+        None => AuthResponse::error("runtime not initialized"),
+    };
+    make_jstring(&mut env, &response)
+}
+
 /// Poll all pending `PlayerEvent`s as a JSON array string. Called each
 /// server tick to drain results back into Fabric.
 #[unsafe(no_mangle)]

--- a/apps/mc/mc_auth/src/runtime.rs
+++ b/apps/mc/mc_auth/src/runtime.rs
@@ -209,6 +209,49 @@ async fn handle_job(
                 }
             }
         }
+        AuthJob::LoadPlayerSnapshot {
+            player_uuid,
+            server_id,
+        } => {
+            debug!(%player_uuid, %server_id, "mc_auth: processing load_player_snapshot");
+            match supabase
+                .load_player_snapshot(&player_uuid, &server_id)
+                .await
+            {
+                Ok(snapshot_json) => PlayerEvent::PlayerSnapshotLoaded {
+                    player_uuid,
+                    snapshot_json,
+                },
+                Err(reason) => {
+                    warn!(%player_uuid, %reason, "mc_auth: load snapshot failed");
+                    PlayerEvent::PlayerSnapshotLoaded {
+                        player_uuid,
+                        snapshot_json: None,
+                    }
+                }
+            }
+        }
+        AuthJob::SavePlayerSnapshot {
+            player_uuid,
+            snapshot_json,
+        } => {
+            debug!(%player_uuid, "mc_auth: processing save_player_snapshot");
+            match supabase.save_player_snapshot(&snapshot_json).await {
+                Ok(()) => PlayerEvent::PlayerSnapshotSaved {
+                    player_uuid,
+                    success: true,
+                    error: None,
+                },
+                Err(reason) => {
+                    warn!(%player_uuid, %reason, "mc_auth: save snapshot failed");
+                    PlayerEvent::PlayerSnapshotSaved {
+                        player_uuid,
+                        success: false,
+                        error: Some(reason),
+                    }
+                }
+            }
+        }
     };
 
     // Pull the player_uuid + user_id BEFORE moving `event` into the channel

--- a/apps/mc/mc_auth/src/supabase.rs
+++ b/apps/mc/mc_auth/src/supabase.rs
@@ -204,6 +204,52 @@ impl SupabaseClient {
             },
         }
     }
+
+    pub async fn save_player_snapshot(&self, snapshot_json: &str) -> Result<(), String> {
+        let client = self
+            .inner
+            .as_ref()
+            .ok_or_else(|| "auth disabled (no supabase env)".to_string())?;
+        let snapshot: serde_json::Value =
+            serde_json::from_str(snapshot_json).map_err(|e| format!("bad snapshot json: {e}"))?;
+        let params = json!({ "p_snapshot": snapshot });
+        let resp = client
+            .rpc_schema("service_save_player", params, "mc")
+            .await
+            .map_err(|e| format!("supa: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("http {}: {}", status, truncate(&body, 200)));
+        }
+        Ok(())
+    }
+
+    pub async fn load_player_snapshot(
+        &self,
+        player_uuid: &str,
+        server_id: &str,
+    ) -> Result<Option<String>, String> {
+        let client = self
+            .inner
+            .as_ref()
+            .ok_or_else(|| "auth disabled (no supabase env)".to_string())?;
+        let params = json!({ "p_player_uuid": player_uuid, "p_server_id": server_id });
+        let resp = client
+            .rpc_schema("service_load_player", params, "mc")
+            .await
+            .map_err(|e| format!("supa: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("http {}: {}", status, truncate(&body, 200)));
+        }
+        let rows: Vec<serde_json::Value> = resp.json().await.map_err(|e| format!("decode: {e}"))?;
+        match rows.into_iter().next() {
+            Some(row) => Ok(Some(row.to_string())),
+            None => Ok(None),
+        }
+    }
 }
 
 fn truncate(s: &str, n: usize) -> &str {

--- a/apps/mc/mc_auth/src/types.rs
+++ b/apps/mc/mc_auth/src/types.rs
@@ -22,6 +22,14 @@ pub enum AuthJob {
         player_uuid: String,
         code: i32,
     },
+    LoadPlayerSnapshot {
+        player_uuid: String,
+        server_id: String,
+    },
+    SavePlayerSnapshot {
+        player_uuid: String,
+        snapshot_json: String,
+    },
 }
 
 /// Immediate response returned synchronously from JNI entry points.
@@ -104,5 +112,14 @@ pub enum PlayerEvent {
         player_uuid: String,
         credits: i64,
         khash: i64,
+    },
+    PlayerSnapshotLoaded {
+        player_uuid: String,
+        snapshot_json: Option<String>,
+    },
+    PlayerSnapshotSaved {
+        player_uuid: String,
+        success: bool,
+        error: Option<String>,
     },
 }


### PR DESCRIPTION
## Summary
Wires the existing `mc.service_save_player` + `mc.service_load_player` Supabase RPCs into the mc_auth bridge so a connecting player's last position / world / health / hunger / xp restores on join, and dirty state flushes on disconnect.

This is the template for the rest of the schema (`mc_character`, `mc_skill`, `mc_container`, `mc_transfer`) — same JNI shape, same client style, same event loop — so the follow-up PRs become small adaptations of this one.

## Pipeline

1. **`mc_auth/types`** — two new `AuthJob` variants (`LoadPlayerSnapshot`, `SavePlayerSnapshot`) and two new `PlayerEvent` variants (`PlayerSnapshotLoaded` with optional `snapshot_json`, `PlayerSnapshotSaved` with `success` / `error`).
2. **`mc_auth/supabase`** — `save_player_snapshot` + `load_player_snapshot` on `SupabaseClient`. Both return `Result` so the runtime can downgrade failures to graceful no-op events.
3. **`mc_auth/runtime`** — `handle_job` arms for the new jobs that wrap the Supabase calls and convert outcomes into `PlayerEvent`s.
4. **`mc_auth/lib`** — two new JNI entry points (`loadPlayerSnapshot`, `savePlayerSnapshot`) that submit jobs and return the standard `AuthResponse` ack.
5. **`mc_auth/java NativeRuntime`** — matching `native` method declarations.
6. **`mc_auth/java McAuthMod`** — `ServerPlayConnectionEvents.JOIN` now also requests a snapshot load; `DISCONNECT` now also requests a save before the `LinkStatusRegistry` entry is dropped.
7. **`mc_auth/java PlayerSnapshotHandler`** (new) — builds the snapshot JSON shape the SQL expects (`position`, `world`, `game_mode`, `health`, `food`, `xp`) and applies a loaded snapshot back onto a player via `teleport` + `setHealth` / hunger / xp.
8. **`mc_auth/java AuthEventTicker`** — dispatch arms for `PlayerSnapshotLoaded` (call `applyLoadedSnapshot`) and `PlayerSnapshotSaved` (debug-log).

## Server identity
`KBVE_MC_SERVER_ID` env var, falls back to `kbve-mc-fabric`. Dev pods without the env still boot — the server just persists under the fallback id.

## Not in scope (next PRs)
- **Inventory + ender_chest serialization.** Both are empty arrays for now. `ItemStack` → JSON round-trip is its own follow-up and shipping a position+xp snapshot independently keeps the diff reviewable.
- **Periodic mid-session save.** Right now we only save on disconnect — crash-loss is bounded by session length. A 5-minute autosave tick can come next.
- **Same shape applied to `mc_character` / `mc_skill` / `mc_container`.**

## Test plan
- [ ] `cargo check -p mc_auth` clean (verified locally).
- [ ] `gradle compileJava` on `mc_auth/java` clean (verified locally).
- [ ] After deploy: a fresh player joins → no prior row → no teleport → spawns at world spawn as usual.
- [ ] A linked player runs around, disconnects, reconnects → spawns at the disconnect location with the same hp / hunger / xp / world.
- [ ] Server log shows `[mc_auth] Restored snapshot for <uuid> at (x,y,z) in <world>` on the second join.
- [ ] With `SUPABASE_URL` unset: snapshot calls fail silently — no kicks, no errors in the player's chat.