### PR TITLE
fix(firecracker-ctl): copy path-dep crates in Dockerfile

### DIFF
--- a/apps/vm/firecracker-ctl/Dockerfile
+++ b/apps/vm/firecracker-ctl/Dockerfile
@@ -15,6 +15,10 @@ ENV CARGO_INCREMENTAL=0
 COPY apps/vm/firecracker-ctl/Cargo.workspace.toml Cargo.toml
 COPY apps/vm/firecracker-ctl/Cargo.toml apps/vm/firecracker-ctl/Cargo.toml
 
+COPY packages/rust/kbve packages/rust/kbve
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/holy packages/rust/holy
+
 RUN mkdir -p apps/vm/firecracker-ctl/src && \
     echo "fn main() {}" > apps/vm/firecracker-ctl/src/main.rs
 
@@ -29,6 +33,7 @@ ENV CARGO_INCREMENTAL=0
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml ./
 COPY --from=planner /app/apps apps
+COPY --from=planner /app/packages packages
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -47,6 +52,9 @@ COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
 COPY --from=planner /app/Cargo.toml ./
 
 COPY apps/vm/firecracker-ctl apps/vm/firecracker-ctl
+COPY packages/rust/kbve packages/rust/kbve
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/holy packages/rust/holy
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \


### PR DESCRIPTION
## Summary
- Stage A (planner) + Stage B (builder-deps) + Stage C (builder) now include `packages/rust/{kbve,jedi,holy}` so cargo chef + cargo build can resolve the `kbve` path dep.
- Unblocks the firecracker-ctl Docker publish that broke after #11109 (billing Phase C.3 wallet wiring added `kbve` as a path dep but Dockerfile was not updated).
- Closes #11110.

## Root cause
`apps/vm/firecracker-ctl/Cargo.toml`:
```toml
kbve = { path = "../../../packages/rust/kbve", default-features = false, features = ["wallet"] }
```
`kbve` transitively pulls in `jedi` + `holy` path deps. The Dockerfile only copied `apps/vm/firecracker-ctl/Cargo.toml` + workspace toml, so `cargo chef prepare` failed with:
```
failed to read `/app/packages/rust/kbve/Cargo.toml`
No such file or directory (os error 2)
```

## Test plan
- [ ] CI - Docker / firecracker-ctl turns green
- [ ] Resulting image still boots `firecracker-ctl` ENTRYPOINT