### PR TITLE
fix(vector): correct Lua v2 transform schema for alertmanager fanout

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -360,45 +360,21 @@ data:
               del(.severity)
               del(.project)
 
-          alertmanager_unnest:
-            type: remap
-            inputs:
-              - alertmanager_webhook
-            source: |-
-              # Alertmanager v4 payload: { alerts: [...], commonLabels, status, ... }
-              # Drop the wrapper batch; emit only the array. The next transform
-              # fans it out via Vector's unnest semantics.
-              alerts = array(.alerts) ?? []
-              if length(alerts) == 0 { abort }
-              . = { "alerts": alerts }
-
-          alertmanager_fanout:
-            type: remap
-            inputs:
-              - alertmanager_unnest
-            drop_on_error: true
-            source: |-
-              # Vector remap doesn't natively explode arrays — we keep one
-              # event per webhook here and let the downstream `unnest`
-              # transform spread it. Identity passthrough.
-              .
-
           alertmanager_explode:
             type: lua
             version: "2"
             inputs:
-              - alertmanager_fanout
+              - alertmanager_webhook
+            hooks:
+              process: process_alert_batch
             source: |-
-              function process(event, emit)
+              function process_alert_batch(event, emit)
                 local alerts = event.log.alerts
-                if not alerts then return end
+                if type(alerts) ~= "table" then return end
                 for _, a in ipairs(alerts) do
-                  local out = {}
-                  out.alert = a
-                  emit({ log = out })
+                  emit({ log = { alert = a } })
                 end
               end
-              hooks = { process = process }
 
           alertmanager_flatten:
             type: remap


### PR DESCRIPTION
## Summary

Vector pod has been crashlooping for ~3h since #11088 with:

```
ERROR vector::cli: Configuration error.
error=data did not match any variant of untagged enum LuaConfig
in `transforms.alertmanager_explode`
```

The DaemonSet failure also blocked the ArgoCD `vector` app from rolling out PR #11103 (poll.py rewrite) because Argo waits for the DS to be Healthy before applying downstream resources (ConfigMap, CronJob).

## Root cause

Two issues in [apps/kube/vector/manifests/vector-config.yaml](apps/kube/vector/manifests/vector-config.yaml):

1. **Lua v2 `hooks` placement wrong.** The original config wrote `hooks = { process = process }` as Lua code at the bottom of the `source:` block. Vector's Lua v2 schema requires `hooks` to be a **YAML field** on the transform, each entry pointing at a named function inside `source:`.
2. **Two upstream remap transforms (`alertmanager_unnest` + `alertmanager_fanout`) were dead weight** — leftovers from an aborted "fan out via remap" approach. Vector's `lua` v2 transform can read the raw webhook batch and emit per-alert events directly.

## Fix

- Delete `alertmanager_unnest` + `alertmanager_fanout`
- `alertmanager_explode` now reads directly from `alertmanager_webhook`, declares `hooks.process: process_alert_batch` as a YAML field, and defines `process_alert_batch(event, emit)` as a top-level Lua function in `source:`
- `alertmanager_flatten` downstream unchanged — still consumes the `alert` field on each fanned-out event

1 file, +6 / -30.

## Verified

- Vector docs: `lua` v2 spec requires `hooks` as a top-level YAML field on the transform.
- New config trivially testable: feed a JSON batch with `alerts: [{...}, {...}]` and confirm two events emit with `event.log.alert.*` populated.

## Test plan

- [ ] CI green on dev
- [ ] After merge → ArgoCD syncs `vector` app → DaemonSet rolls Healthy
- [ ] `kubectl logs supabase-vector-... -n vector` shows `INFO vector::app: Vector has started` (no LuaConfig error)
- [ ] ArgoCD finally lands PR #11103's `ConfigMap/alerts-poll-script` (poll.py) and `CronJob/alerts-poll` (`command: python3 /scripts/poll.py`)
- [ ] Next 5m CronJob cycle: pod succeeds, inserts rows with `source='poll'` into `observability.alerts_distributed`
- [ ] First Alertmanager firing transition: row arrives with `source='webhook'`