### PR TITLE
feat(astro-irc): redesign /chat.kbve.com landing with custom Starlight components

### DIFF
--- a/apps/irc/astro-irc/src/components/home/BackgroundGlow.astro
+++ b/apps/irc/astro-irc/src/components/home/BackgroundGlow.astro
@@ -1,0 +1,121 @@
+---
+// Fixed-position radial gradient backdrop. Subtle accent halos that
+// drift slowly behind the page content. Tints derived from Starlight
+// theme vars so light/dark both look right.
+---
+
+<div class="bg-glow not-content" aria-hidden="true">
+	<span class="bg-glow__blob bg-glow__blob--a"></span>
+	<span class="bg-glow__blob bg-glow__blob--b"></span>
+	<span class="bg-glow__blob bg-glow__blob--c"></span>
+	<div class="bg-glow__grid"></div>
+</div>
+
+<style>
+	.bg-glow {
+		position: fixed;
+		inset: 0;
+		z-index: -1;
+		pointer-events: none;
+		overflow: hidden;
+	}
+
+	.bg-glow__blob {
+		position: absolute;
+		width: 48rem;
+		height: 48rem;
+		border-radius: 50%;
+		filter: blur(80px);
+		opacity: 0.45;
+		mix-blend-mode: screen;
+		will-change: transform;
+	}
+
+	.bg-glow__blob--a {
+		top: -16rem;
+		left: -12rem;
+		background: radial-gradient(
+			circle,
+			color-mix(in srgb, var(--sl-color-accent) 65%, transparent) 0%,
+			transparent 65%
+		);
+		animation: bg-glow-drift-a 22s ease-in-out infinite alternate;
+	}
+
+	.bg-glow__blob--b {
+		top: 20%;
+		right: -18rem;
+		background: radial-gradient(
+			circle,
+			color-mix(in srgb, var(--sl-color-text-accent) 55%, transparent) 0%,
+			transparent 65%
+		);
+		animation: bg-glow-drift-b 28s ease-in-out infinite alternate;
+	}
+
+	.bg-glow__blob--c {
+		bottom: -20rem;
+		left: 30%;
+		background: radial-gradient(
+			circle,
+			color-mix(in srgb, var(--sl-color-accent-high) 50%, transparent) 0%,
+			transparent 65%
+		);
+		animation: bg-glow-drift-c 32s ease-in-out infinite alternate;
+	}
+
+	.bg-glow__grid {
+		position: absolute;
+		inset: 0;
+		background-image:
+			linear-gradient(
+				to right,
+				color-mix(in srgb, var(--sl-color-gray-5) 14%, transparent) 1px,
+				transparent 1px
+			),
+			linear-gradient(
+				to bottom,
+				color-mix(in srgb, var(--sl-color-gray-5) 14%, transparent) 1px,
+				transparent 1px
+			);
+		background-size: 48px 48px;
+		mask-image: radial-gradient(
+			ellipse at center,
+			black 0%,
+			transparent 70%
+		);
+	}
+
+	@keyframes bg-glow-drift-a {
+		from {
+			transform: translate3d(0, 0, 0) scale(1);
+		}
+		to {
+			transform: translate3d(4rem, 3rem, 0) scale(1.1);
+		}
+	}
+
+	@keyframes bg-glow-drift-b {
+		from {
+			transform: translate3d(0, 0, 0) scale(1);
+		}
+		to {
+			transform: translate3d(-3rem, 4rem, 0) scale(0.95);
+		}
+	}
+
+	@keyframes bg-glow-drift-c {
+		from {
+			transform: translate3d(0, 0, 0) scale(1);
+		}
+		to {
+			transform: translate3d(2rem, -4rem, 0) scale(1.08);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.bg-glow__blob {
+			animation: none;
+		}
+	}
+</style>

--- a/apps/irc/astro-irc/src/components/home/CodeWindow.astro
+++ b/apps/irc/astro-irc/src/components/home/CodeWindow.astro
@@ -1,0 +1,105 @@
+---
+// Faux macOS-window code panel — title bar + traffic dots, slotted body
+// holds an MDX code fence. Styled to land in the page like a screenshot
+// without needing one.
+interface Props {
+	filename?: string;
+	lang?: string;
+}
+
+const { filename = 'snippet', lang } = Astro.props;
+---
+
+<div class="code-window">
+	<div class="code-window__chrome">
+		<span class="code-window__dot code-window__dot--r"></span>
+		<span class="code-window__dot code-window__dot--y"></span>
+		<span class="code-window__dot code-window__dot--g"></span>
+		<span class="code-window__title">{filename}</span>
+		{lang && <span class="code-window__lang">{lang}</span>}
+	</div>
+	<div class="code-window__body">
+		<slot />
+	</div>
+</div>
+
+<style>
+	.code-window {
+		margin: 1.25rem auto;
+		max-width: 760px;
+		border-radius: 14px;
+		overflow: hidden;
+		border: 1px solid var(--sl-color-border);
+		background: var(--sl-color-bg-nav, var(--sl-color-bg));
+		box-shadow:
+			0 24px 64px -24px
+				color-mix(in srgb, var(--sl-color-accent) 30%, transparent),
+			0 0 0 1px
+				color-mix(in srgb, var(--sl-color-accent) 10%, transparent);
+	}
+
+	.code-window__chrome {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.6rem 0.9rem;
+		border-bottom: 1px solid var(--sl-color-border);
+		background: color-mix(
+			in srgb,
+			var(--sl-color-bg-accent) 20%,
+			var(--sl-color-bg)
+		);
+		font-size: 0.78rem;
+	}
+
+	.code-window__dot {
+		width: 11px;
+		height: 11px;
+		border-radius: 50%;
+		flex-shrink: 0;
+	}
+
+	.code-window__dot--r {
+		background: #ff5f57;
+	}
+	.code-window__dot--y {
+		background: #febc2e;
+	}
+	.code-window__dot--g {
+		background: #28c840;
+	}
+
+	.code-window__title {
+		margin-left: 0.5rem;
+		color: var(--sl-color-gray-3);
+		font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+	}
+
+	.code-window__lang {
+		margin-left: auto;
+		font-size: 0.7rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		padding: 2px 8px;
+		border-radius: 4px;
+		background: color-mix(in srgb, var(--sl-color-accent) 22%, transparent);
+		color: var(--sl-color-text-accent);
+	}
+
+	.code-window__body :global(pre) {
+		margin: 0;
+		border-radius: 0;
+		border: none;
+	}
+
+	.code-window__body :global(.expressive-code) {
+		margin: 0;
+	}
+
+	.code-window__body :global(.expressive-code .frame) {
+		border-radius: 0;
+		border: none;
+		box-shadow: none;
+	}
+</style>

--- a/apps/irc/astro-irc/src/components/home/FeatureCard.astro
+++ b/apps/irc/astro-irc/src/components/home/FeatureCard.astro
@@ -1,0 +1,134 @@
+---
+// Glassy feature card with accent glow on hover.
+// MDX-friendly: drop in like Starlight Card, takes a `title`, optional
+// `icon` (emoji or short text), and slotted body.
+interface Props {
+	title: string;
+	icon?: string;
+	href?: string;
+}
+
+const { title, icon, href } = Astro.props;
+const Tag = href ? 'a' : 'div';
+---
+
+<Tag
+	class:list={['feature-card not-content', { 'feature-card--link': !!href }]}
+	href={href}>
+	{icon && <span class="feature-card__icon">{icon}</span>}
+	<h3 class="feature-card__title">{title}</h3>
+	<div class="feature-card__body">
+		<slot />
+	</div>
+	{
+		href && (
+			<span class="feature-card__arrow" aria-hidden="true">
+				→
+			</span>
+		)
+	}
+</Tag>
+
+<style>
+	.feature-card {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		padding: 1.25rem 1.25rem 1.5rem;
+		border-radius: 14px;
+		background: color-mix(
+			in srgb,
+			var(--sl-color-bg-accent) 14%,
+			var(--sl-color-bg)
+		);
+		border: 1px solid var(--sl-color-border);
+		color: var(--sl-color-text);
+		text-decoration: none;
+		overflow: hidden;
+		isolation: isolate;
+		transition:
+			transform 0.18s ease,
+			border-color 0.18s ease,
+			box-shadow 0.18s ease;
+	}
+
+	.feature-card::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		z-index: -1;
+		opacity: 0;
+		background: radial-gradient(
+			circle at top right,
+			color-mix(in srgb, var(--sl-color-accent) 35%, transparent) 0%,
+			transparent 65%
+		);
+		transition: opacity 0.25s ease;
+	}
+
+	.feature-card:hover {
+		transform: translateY(-2px);
+		border-color: color-mix(
+			in srgb,
+			var(--sl-color-accent) 55%,
+			var(--sl-color-border)
+		);
+		box-shadow: 0 16px 40px -16px
+			color-mix(in srgb, var(--sl-color-accent) 35%, transparent);
+	}
+
+	.feature-card:hover::before {
+		opacity: 1;
+	}
+
+	.feature-card__icon {
+		display: inline-flex;
+		width: 2.25rem;
+		height: 2.25rem;
+		align-items: center;
+		justify-content: center;
+		border-radius: 10px;
+		background: color-mix(in srgb, var(--sl-color-accent) 22%, transparent);
+		color: var(--sl-color-text-accent);
+		font-size: 1.15rem;
+		font-weight: 700;
+	}
+
+	.feature-card__title {
+		margin: 0;
+		font-size: 1.05rem;
+		font-weight: 700;
+		letter-spacing: -0.01em;
+		color: var(--sl-color-text);
+	}
+
+	.feature-card__body {
+		font-size: 0.92rem;
+		line-height: 1.55;
+		color: var(--sl-color-gray-2);
+	}
+
+	.feature-card__body :global(p) {
+		margin: 0;
+	}
+
+	.feature-card__body :global(code) {
+		font-size: 0.85em;
+		padding: 0.1em 0.35em;
+		border-radius: 4px;
+		background: var(--sl-color-bg-inline-code);
+	}
+
+	.feature-card__arrow {
+		margin-top: 0.5rem;
+		font-size: 1rem;
+		color: var(--sl-color-text-accent);
+		font-weight: 700;
+		transition: transform 0.18s ease;
+	}
+
+	.feature-card:hover .feature-card__arrow {
+		transform: translateX(3px);
+	}
+</style>

--- a/apps/irc/astro-irc/src/components/home/HomeChatEmbed.astro
+++ b/apps/irc/astro-irc/src/components/home/HomeChatEmbed.astro
@@ -1,0 +1,60 @@
+---
+// Live preview of the chat embed bundle on the front page.
+// Dogfoods the public chat.js bundle (built by astro-irc:build-embed and
+// served from /embed/chat.js). Shadow DOM keeps it isolated from
+// Starlight's body styles.
+interface Props {
+	channel?: string;
+	height?: string;
+	theme?: 'dark' | 'light';
+}
+
+const { channel = '#general', height = '420px', theme = 'dark' } = Astro.props;
+---
+
+<div class="home-chat-embed not-content">
+	<div class="home-chat-embed__frame">
+		<div
+			id="kbve-home-chat"
+			data-channel={channel}
+			data-theme={theme}
+			data-height={height}>
+		</div>
+	</div>
+	<p class="home-chat-embed__caption">
+		Live preview powered by the same <code>chat.js</code> bundle any site can
+		drop in.
+	</p>
+</div>
+
+<script is:inline src="/embed/chat.js" defer></script>
+
+<style>
+	.home-chat-embed {
+		margin: 2rem auto;
+		max-width: 960px;
+	}
+
+	.home-chat-embed__frame {
+		border-radius: 16px;
+		overflow: hidden;
+		box-shadow:
+			0 24px 64px -20px rgba(0, 0, 0, 0.4),
+			0 0 0 1px var(--sl-color-border);
+		background: var(--sl-color-bg-nav, #0a0d14);
+	}
+
+	.home-chat-embed__caption {
+		text-align: center;
+		font-size: 0.85rem;
+		color: var(--sl-color-gray-3);
+		margin-top: 0.75rem;
+	}
+
+	.home-chat-embed__caption code {
+		font-size: 0.85em;
+		padding: 0.1em 0.35em;
+		border-radius: 4px;
+		background: var(--sl-color-bg-inline-code);
+	}
+</style>

--- a/apps/irc/astro-irc/src/components/home/SectionTitle.astro
+++ b/apps/irc/astro-irc/src/components/home/SectionTitle.astro
@@ -1,0 +1,58 @@
+---
+// Section header with optional eyebrow + center align.
+interface Props {
+	eyebrow?: string;
+	title: string;
+}
+
+const { eyebrow, title } = Astro.props;
+---
+
+<div class="section-title not-content">
+	{eyebrow && <div class="section-title__eyebrow">{eyebrow}</div>}
+	<h2 class="section-title__title">{title}</h2>
+	<div class="section-title__rule" aria-hidden="true"></div>
+</div>
+
+<style>
+	.section-title {
+		text-align: center;
+		margin: 4rem auto 1.5rem;
+		max-width: 720px;
+	}
+
+	.section-title__eyebrow {
+		display: inline-block;
+		padding: 4px 12px;
+		border-radius: 999px;
+		font-size: 0.72rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--sl-color-text-accent);
+		background: color-mix(in srgb, var(--sl-color-accent) 16%, transparent);
+		border: 1px solid
+			color-mix(in srgb, var(--sl-color-accent) 30%, transparent);
+		margin-bottom: 1rem;
+	}
+
+	.section-title__title {
+		font-size: clamp(1.6rem, 3vw, 2.25rem);
+		font-weight: 800;
+		letter-spacing: -0.02em;
+		margin: 0;
+		color: var(--sl-color-text);
+	}
+
+	.section-title__rule {
+		margin: 1rem auto 0;
+		height: 3px;
+		width: 56px;
+		border-radius: 999px;
+		background: linear-gradient(
+			90deg,
+			var(--sl-color-accent) 0%,
+			var(--sl-color-text-accent) 100%
+		);
+	}
+</style>

--- a/apps/irc/astro-irc/src/components/home/StatRow.astro
+++ b/apps/irc/astro-irc/src/components/home/StatRow.astro
@@ -1,0 +1,79 @@
+---
+// Simple stat strip. Each item rendered as { value, label }. Values
+// should be short ("4", "<70 KB", "MIT").
+interface Stat {
+	value: string;
+	label: string;
+	hint?: string;
+}
+
+interface Props {
+	stats: Stat[];
+}
+
+const { stats } = Astro.props as Props;
+---
+
+<div class="stat-row not-content">
+	{
+		stats.map((s) => (
+			<div class="stat-row__item" title={s.hint}>
+				<div class="stat-row__value">{s.value}</div>
+				<div class="stat-row__label">{s.label}</div>
+			</div>
+		))
+	}
+</div>
+
+<style>
+	.stat-row {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+		gap: 1px;
+		margin: 2rem auto;
+		max-width: 760px;
+		padding: 1px;
+		border-radius: 16px;
+		background: linear-gradient(
+			135deg,
+			color-mix(in srgb, var(--sl-color-accent) 45%, transparent) 0%,
+			color-mix(in srgb, var(--sl-color-text-accent) 25%, transparent)
+				100%
+		);
+		overflow: hidden;
+	}
+
+	.stat-row__item {
+		padding: 1.25rem 1rem;
+		text-align: center;
+		background: color-mix(
+			in srgb,
+			var(--sl-color-bg-accent) 14%,
+			var(--sl-color-bg)
+		);
+	}
+
+	.stat-row__value {
+		font-size: 1.85rem;
+		font-weight: 800;
+		letter-spacing: -0.02em;
+		background: linear-gradient(
+			135deg,
+			var(--sl-color-text-accent) 0%,
+			var(--sl-color-accent) 100%
+		);
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		background-clip: text;
+		color: transparent;
+	}
+
+	.stat-row__label {
+		margin-top: 0.25rem;
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--sl-color-gray-3);
+	}
+</style>

--- a/apps/irc/astro-irc/src/content/docs/index.mdx
+++ b/apps/irc/astro-irc/src/content/docs/index.mdx
@@ -1,16 +1,100 @@
 ---
-title: KBVE IRC
-description: Authenticated chat powered by Ergo IRC
+title: KBVE Chat
+description: Real-time IRC chat for the KBVE community — sign in with GitHub, Discord, or Twitch and hop in.
 template: splash
 hero:
-  tagline: Sign in with your KBVE account to start chatting.
+  title: Real-time chat. Open by default.
+  tagline: Authenticated IRC for the KBVE community. Sign in once, chat from anywhere on the web.
   actions:
     - text: Open Chat
       link: /chat/
       icon: right-arrow
       variant: primary
-    - text: Getting Started
+    - text: View Guides
       link: /guides/getting-started/
-      icon: right-arrow
+      icon: open-book
+      variant: minimal
+    - text: GitHub
+      link: https://github.com/kbve/kbve
+      icon: external
       variant: minimal
 ---
+
+import { LinkCard } from '@astrojs/starlight/components';
+import BackgroundGlow from '../../components/home/BackgroundGlow.astro';
+import HomeChatEmbed from '../../components/home/HomeChatEmbed.astro';
+import FeatureCard from '../../components/home/FeatureCard.astro';
+import StatRow from '../../components/home/StatRow.astro';
+import SectionTitle from '../../components/home/SectionTitle.astro';
+import CodeWindow from '../../components/home/CodeWindow.astro';
+
+<BackgroundGlow />
+
+<StatRow stats={[
+	{ value: '4', label: 'Channels & growing' },
+	{ value: '67 KB', label: 'Embed gzipped' },
+	{ value: '3', label: 'OAuth providers' },
+	{ value: 'MIT', label: 'License' },
+]} />
+
+<SectionTitle eyebrow="Why KBVE Chat" title="Built to feel like the web should" />
+
+<div class="not-content" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin: 1.5rem 0;">
+	<FeatureCard title="One identity, everywhere" icon="ID">
+		Sign in with GitHub, Discord, or Twitch. Your `kbve_username` follows
+		you across every KBVE service — no per-tool nicks.
+	</FeatureCard>
+	<FeatureCard title="Drop-in embed" icon="JS">
+		One `<script>` tag puts chat on your blog, dashboard, or stream overlay.
+		Shadow-DOM isolated, ~67 KB gzipped.
+	</FeatureCard>
+	<FeatureCard title="Open protocol" icon="IRC">
+		Plain IRC under the hood (Ergo server). Use any IRC client if the web UI
+		isn't your jam — same channels, same identity.
+	</FeatureCard>
+	<FeatureCard title="Built for builders" icon=">_">
+		Astro + React islands on the front, Rust gateway in the middle, Ergo IRC
+		at the core. Every piece is in the open monorepo.
+	</FeatureCard>
+</div>
+
+<SectionTitle eyebrow="Live preview" title="Read along — sign in to send" />
+
+<HomeChatEmbed channel="#general" height="440px" theme="dark" />
+
+<SectionTitle eyebrow="Embed it" title="Three lines of HTML, zero npm install" />
+
+<CodeWindow filename="index.html" lang="html">
+
+```html
+<div id="kbve-chat" data-channel="#general" data-theme="dark"></div>
+<script src="https://chat.kbve.com/embed/chat.js" defer></script>
+```
+
+</CodeWindow>
+
+<CodeWindow filename="programmatic.js" lang="js">
+
+```js
+window.KbveChat.mount({
+  el: '#kbve-chat',
+  channel: '#general',
+  theme: 'light',
+  height: '480px',
+});
+```
+
+</CodeWindow>
+
+<div class="not-content" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin: 1.5rem 0;">
+	<FeatureCard title="Open Chat" href="/chat/" icon="→">
+		Jump straight into `#general`.
+	</FeatureCard>
+	<FeatureCard title="Embed guide" href="/guides/getting-started/" icon="GD">
+		Config, theming, programmatic mount, cross-origin auth.
+	</FeatureCard>
+	<FeatureCard title="Source on GitHub" href="https://github.com/kbve/kbve" icon="GH">
+		MIT-licensed monorepo. PRs welcome.
+	</FeatureCard>
+</div>
+

--- a/apps/irc/astro-irc/tsconfig.json
+++ b/apps/irc/astro-irc/tsconfig.json
@@ -1,15 +1,15 @@
 {
-  "extends": "astro/tsconfigs/strict",
-  "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"],
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "jsxImportSource": "react",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"],
-      "@kbve/astro": ["../../../packages/npm/astro/src/index.ts"],
-      "@kbve/droid": ["../../../packages/npm/droid/src/index.ts"]
-    }
-  }
+	"extends": "astro/tsconfigs/strict",
+	"include": [".astro/types.d.ts", "**/*"],
+	"exclude": ["dist", "public/embed"],
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"jsxImportSource": "react",
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["src/*"],
+			"@kbve/astro": ["../../../packages/npm/astro/src/index.ts"],
+			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"]
+		}
+	}
 }

--- a/apps/irc/astro-irc/vite.embed.config.ts
+++ b/apps/irc/astro-irc/vite.embed.config.ts
@@ -17,7 +17,9 @@ export default defineConfig({
 	},
 	build: {
 		outDir: 'public/embed',
-		emptyOutDir: true,
+		// Don't wipe — public/embed also holds example.html (live docs).
+		// Only chat.js gets overwritten on each build.
+		emptyOutDir: false,
 		minify: 'terser',
 		sourcemap: false,
 		target: 'es2020',


### PR DESCRIPTION
## Summary

Replaces the bare two-button Starlight splash with a marketing-quality landing page that dogfoods the embed bundle. Everything is themed through Starlight CSS vars (\`--sl-color-*\`) so light/dark/system themes carry over without one-off color baking.

### New sections (in order)

1. **Hero** — tightened tagline + 3 actions (Open Chat / Guides / GitHub)
2. **Stat row** — 4 gradient-bordered tiles (channels / embed size / OAuth providers / license)
3. **Why KBVE Chat** — 4 FeatureCards with hover glow (identity, embed, open protocol, builders)
4. **Live preview** — \`HomeChatEmbed\` mounts \`/embed/chat.js\` so the landing literally runs the same widget any host can drop in
5. **Embed it** — two macOS-window code panels (HTML drop-in, programmatic mount)
6. **Stay in the loop** — 3 link cards (Open Chat / Embed guide / GitHub)

### New \`src/components/home/\` set

- \`BackgroundGlow\` — fixed-position drifting radial halos + masked grid (\`prefers-reduced-motion\` aware)
- \`StatRow\` — gradient-bordered stat tiles with text-clipped accent values
- \`SectionTitle\` — pill eyebrow + centered headline + accent rule
- \`FeatureCard\` — hover-glow card, optional \`href\` turns it into a link card with animated arrow
- \`CodeWindow\` — macOS-window chrome wrapping expressive-code blocks
- \`HomeChatEmbed\` — mounts \`/embed/chat.js\` for the live preview

All custom wrappers carry \`not-content\` so Starlight prose styles don't fight the layout.

### Build pipeline fixes

- \`vite.embed.config.ts\`: \`emptyOutDir\` flipped to \`false\` so \`public/embed/example.html\` (live embed docs committed in #11102) survives chat.js rebuilds
- \`tsconfig\` excludes \`public/embed\` so the IIFE bundle isn't typechecked by \`astro check\`

## Test plan

- [ ] Hit \`/\` and confirm: hero → stat row → 4 feature cards → live embed → 2 code windows → 3 link cards
- [ ] Toggle theme — colors flip correctly, no hardcoded greys
- [ ] Hover a FeatureCard — accent glow, lift, arrow shifts
- [ ] Live embed in section 4 connects and shows messages
- [ ] Reduced-motion users don't see the background glows drifting
- [ ] Mobile (<480px) — grids collapse cleanly