### PR TITLE
feat(dashboard): reusable React Tooltip + IDE button animations

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/BillingErrorBanner.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/BillingErrorBanner.tsx
@@ -1,0 +1,75 @@
+import { motion } from 'framer-motion';
+import { Coins, CreditCard } from 'lucide-react';
+import { Tooltip } from './Tooltip';
+import type { BillingErrorInfo } from './billingError';
+
+export function BillingErrorBanner({ info }: { info: BillingErrorInfo }) {
+	return (
+		<motion.div
+			initial={{ opacity: 0, y: -4 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: 0.18 }}
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: '0.75rem',
+				padding: '0.65rem 0.9rem',
+				background: 'rgba(245, 158, 11, 0.08)',
+				border: '1px solid rgba(245, 158, 11, 0.25)',
+				borderRadius: '6px',
+				color: '#f59e0b',
+				fontSize: '0.85rem',
+			}}>
+			<Coins size={18} style={{ flexShrink: 0 }} />
+			<div style={{ flex: 1, minWidth: 0 }}>
+				<div style={{ fontWeight: 500 }}>{info.reason}</div>
+				{info.needed !== undefined && (
+					<div
+						style={{
+							opacity: 0.8,
+							fontSize: '0.75rem',
+							marginTop: 2,
+						}}>
+						Need {info.needed.toLocaleString()} more credits to
+						proceed.
+					</div>
+				)}
+				{info.hint && (
+					<div
+						style={{
+							opacity: 0.7,
+							fontSize: '0.72rem',
+							marginTop: 2,
+						}}>
+						{info.hint}
+					</div>
+				)}
+			</div>
+			<Tooltip content="Top-up isn't wired yet — coming soon" side="left">
+				<motion.button
+					type="button"
+					whileHover={{ scale: 1.04 }}
+					whileTap={{ scale: 0.96 }}
+					transition={{ duration: 0.1 }}
+					disabled
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.3rem',
+						padding: '0.35rem 0.75rem',
+						background: 'rgba(245, 158, 11, 0.15)',
+						border: '1px solid rgba(245, 158, 11, 0.35)',
+						borderRadius: '5px',
+						color: '#f59e0b',
+						fontSize: '0.78rem',
+						fontWeight: 500,
+						cursor: 'not-allowed',
+						opacity: 0.7,
+					}}>
+					<CreditCard size={12} />
+					Top up credits
+				</motion.button>
+			</Tooltip>
+		</motion.div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactCodeIDE.tsx
@@ -18,6 +18,7 @@ import {
 	Copy,
 	CheckCircle2,
 } from 'lucide-react';
+import { motion } from 'framer-motion';
 import { EditorView, basicSetup } from 'codemirror';
 import { keymap } from '@codemirror/view';
 import { EditorState, Compartment } from '@codemirror/state';
@@ -25,6 +26,9 @@ import { python } from '@codemirror/lang-python';
 import { javascript } from '@codemirror/lang-javascript';
 import { oneDark } from '@codemirror/theme-one-dark';
 import type { Extension } from '@codemirror/state';
+import { Tooltip } from './Tooltip';
+import { BillingErrorBanner } from './BillingErrorBanner';
+import { parseBillingError } from './billingError';
 
 function langExtension(language: string): Extension {
 	switch (language) {
@@ -93,28 +97,42 @@ function PhaseIndicator({
 function CopyButton({ text }: { text: string }) {
 	const [copied, setCopied] = useState(false);
 	return (
-		<button
-			onClick={() => {
-				navigator.clipboard.writeText(text);
-				setCopied(true);
-				setTimeout(() => setCopied(false), 2000);
-			}}
-			title="Copy to clipboard"
-			style={{
-				display: 'inline-flex',
-				alignItems: 'center',
-				gap: '0.25rem',
-				padding: '0.2rem 0.5rem',
-				background: 'rgba(255,255,255,0.05)',
-				border: '1px solid rgba(255,255,255,0.1)',
-				borderRadius: '4px',
-				color: copied ? '#22c55e' : 'rgba(255,255,255,0.4)',
-				fontSize: '0.7rem',
-				cursor: 'pointer',
-			}}>
-			<Copy size={12} />
-			{copied ? 'Copied' : 'Copy'}
-		</button>
+		<Tooltip content={copied ? 'Copied!' : 'Copy to clipboard'}>
+			<motion.button
+				whileHover={{
+					scale: 1.04,
+					backgroundColor: 'rgba(255,255,255,0.1)',
+				}}
+				whileTap={{ scale: 0.95 }}
+				transition={{ duration: 0.1 }}
+				onClick={() => {
+					navigator.clipboard.writeText(text);
+					setCopied(true);
+					setTimeout(() => setCopied(false), 2000);
+				}}
+				style={{
+					display: 'inline-flex',
+					alignItems: 'center',
+					gap: '0.25rem',
+					padding: '0.2rem 0.5rem',
+					background: 'rgba(255,255,255,0.05)',
+					border: '1px solid rgba(255,255,255,0.1)',
+					borderRadius: '4px',
+					color: copied ? '#22c55e' : 'rgba(255,255,255,0.4)',
+					fontSize: '0.7rem',
+					cursor: 'pointer',
+				}}>
+				<motion.span
+					key={copied ? 'check' : 'copy'}
+					initial={{ opacity: 0, scale: 0.6 }}
+					animate={{ opacity: 1, scale: 1 }}
+					transition={{ duration: 0.12 }}
+					style={{ display: 'inline-flex', alignItems: 'center' }}>
+					{copied ? <CheckCircle2 size={12} /> : <Copy size={12} />}
+				</motion.span>
+				{copied ? 'Copied' : 'Copy'}
+			</motion.button>
+		</Tooltip>
 	);
 }
 
@@ -141,6 +159,14 @@ function OutputPanel({
 	const [tab, setTab] = useState<'output' | 'log'>('output');
 
 	if (error) {
+		const billing = parseBillingError(error);
+		if (billing) {
+			return (
+				<div style={{ padding: '0.85rem' }}>
+					<BillingErrorBanner info={billing} />
+				</div>
+			);
+		}
 		return (
 			<div
 				style={{
@@ -199,16 +225,20 @@ function OutputPanel({
 					borderBottom: '1px solid rgba(255,255,255,0.08)',
 					padding: '0 1rem',
 				}}>
-				<button
+				<motion.button
+					whileHover={{ color: '#e6edf3' }}
+					whileTap={{ scale: 0.96 }}
 					style={tabStyle(tab === 'output')}
 					onClick={() => setTab('output')}>
 					Output
-				</button>
-				<button
+				</motion.button>
+				<motion.button
+					whileHover={{ color: '#e6edf3' }}
+					whileTap={{ scale: 0.96 }}
 					style={tabStyle(tab === 'log')}
 					onClick={() => setTab('log')}>
 					Full Log
-				</button>
+				</motion.button>
 				<div style={{ flex: 1 }} />
 				<div style={{ padding: '0.25rem 0' }}>
 					<CopyButton text={displayText ?? ''} />
@@ -550,67 +580,98 @@ export default function ReactCodeIDE() {
 					}}>
 					<div style={{ display: 'flex', gap: '0.5rem' }}>
 						{isRunning ? (
-							<button
-								onClick={handleCancel}
-								style={{
-									display: 'inline-flex',
-									alignItems: 'center',
-									gap: '0.3rem',
-									padding: '0.4rem 1rem',
-									background: '#ef444422',
-									border: '1px solid #ef444444',
-									borderRadius: '6px',
-									color: '#ef4444',
-									fontSize: '0.85rem',
-									cursor: 'pointer',
-									fontWeight: 500,
-								}}>
-								<Square size={14} />
-								Cancel
-							</button>
-						) : (
-							<>
-								<button
-									onClick={handleRun}
+							<Tooltip
+								content="Send kill signal to the running VM"
+								side="bottom">
+								<motion.button
+									whileHover={{
+										scale: 1.03,
+										backgroundColor: '#ef444433',
+									}}
+									whileTap={{ scale: 0.96 }}
+									transition={{ duration: 0.1 }}
+									onClick={handleCancel}
 									style={{
 										display: 'inline-flex',
 										alignItems: 'center',
 										gap: '0.3rem',
 										padding: '0.4rem 1rem',
-										background: '#22c55e22',
-										border: '1px solid #22c55e44',
+										background: '#ef444422',
+										border: '1px solid #ef444444',
 										borderRadius: '6px',
-										color: '#22c55e',
+										color: '#ef4444',
 										fontSize: '0.85rem',
 										cursor: 'pointer',
 										fontWeight: 500,
 									}}>
-									<Play size={14} />
-									Run
-								</button>
-								{(result || error) && (
-									<button
-										onClick={() => {
-											ideService.$result.set(null);
-											ideService.$error.set(null);
-											ideService.$phase.set('idle');
+									<Square size={14} />
+									Cancel
+								</motion.button>
+							</Tooltip>
+						) : (
+							<>
+								<Tooltip
+									content="Run the current code (⌘/Ctrl+Enter)"
+									side="bottom">
+									<motion.button
+										whileHover={{
+											scale: 1.03,
+											backgroundColor: '#22c55e33',
 										}}
+										whileTap={{ scale: 0.96 }}
+										transition={{ duration: 0.1 }}
+										onClick={handleRun}
 										style={{
 											display: 'inline-flex',
 											alignItems: 'center',
 											gap: '0.3rem',
-											padding: '0.4rem 0.75rem',
-											background:
-												'rgba(255,255,255,0.03)',
-											border: '1px solid rgba(255,255,255,0.08)',
+											padding: '0.4rem 1rem',
+											background: '#22c55e22',
+											border: '1px solid #22c55e44',
 											borderRadius: '6px',
-											color: 'rgba(255,255,255,0.5)',
+											color: '#22c55e',
 											fontSize: '0.85rem',
 											cursor: 'pointer',
+											fontWeight: 500,
 										}}>
-										<Trash2 size={14} />
-										Clear
-									</button>
+										<Play size={14} />
+										Run
+									</motion.button>
+								</Tooltip>
+								{(result || error) && (
+									<Tooltip
+										content="Clear the last output"
+										side="bottom">
+										<motion.button
+											whileHover={{
+												scale: 1.03,
+												backgroundColor:
+													'rgba(255,255,255,0.08)',
+											}}
+											whileTap={{ scale: 0.96 }}
+											transition={{ duration: 0.1 }}
+											onClick={() => {
+												ideService.$result.set(null);
+												ideService.$error.set(null);
+												ideService.$phase.set('idle');
+											}}
+											style={{
+												display: 'inline-flex',
+												alignItems: 'center',
+												gap: '0.3rem',
+												padding: '0.4rem 0.75rem',
+												background:
+													'rgba(255,255,255,0.03)',
+												border: '1px solid rgba(255,255,255,0.08)',
+												borderRadius: '6px',
+												color: 'rgba(255,255,255,0.5)',
+												fontSize: '0.85rem',
+												cursor: 'pointer',
+											}}>
+											<Trash2 size={14} />
+											Clear
+										</motion.button>
+									</Tooltip>
 								)}
 							</>
 						)}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactDeployPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactDeployPanel.tsx
@@ -16,6 +16,10 @@ import {
 	FileText,
 	X,
 } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { Tooltip } from './Tooltip';
+import { BillingErrorBanner } from './BillingErrorBanner';
+import { parseBillingError } from './billingError';
 import { EditorView, basicSetup } from 'codemirror';
 import { keymap } from '@codemirror/view';
 import { EditorState, Compartment } from '@codemirror/state';
@@ -507,24 +511,48 @@ export default function ReactDeployPanel() {
 			<div ref={editorRef} className="deploy-editor" />
 
 			<div className="deploy-actions">
-				<button
-					type="button"
-					onClick={handleDeploy}
-					disabled={submitting || !token}
-					className="deploy-submit">
-					<Rocket size={14} /> {submitting ? 'Deploying…' : 'Deploy'}
-				</button>
-				<button
-					type="button"
-					onClick={() => token && void deployService.refresh(token)}
-					disabled={!token}
-					className="deploy-refresh"
-					aria-label="Refresh endpoint list">
-					<RefreshCw size={14} />
-				</button>
+				<Tooltip
+					content={
+						submitting
+							? 'Spawning the persistent VM…'
+							: 'Reserve credits + spawn this endpoint'
+					}
+					side="top">
+					<motion.button
+						type="button"
+						whileHover={{ scale: 1.03 }}
+						whileTap={{ scale: 0.96 }}
+						transition={{ duration: 0.1 }}
+						onClick={handleDeploy}
+						disabled={submitting || !token}
+						className="deploy-submit">
+						<Rocket size={14} />{' '}
+						{submitting ? 'Deploying…' : 'Deploy'}
+					</motion.button>
+				</Tooltip>
+				<Tooltip content="Refresh endpoint list" side="top">
+					<motion.button
+						type="button"
+						whileHover={{ scale: 1.05, rotate: 90 }}
+						whileTap={{ scale: 0.92 }}
+						transition={{ duration: 0.15 }}
+						onClick={() =>
+							token && void deployService.refresh(token)
+						}
+						disabled={!token}
+						className="deploy-refresh"
+						aria-label="Refresh endpoint list">
+						<RefreshCw size={14} />
+					</motion.button>
+				</Tooltip>
 			</div>
 
-			{error && <div className="deploy-error">{error}</div>}
+			{error &&
+				(parseBillingError(error) ? (
+					<BillingErrorBanner info={parseBillingError(error)!} />
+				) : (
+					<div className="deploy-error">{error}</div>
+				))}
 
 			{phase === 'ready' && lastDeployed && (
 				<div className="deploy-ready">

--- a/apps/kbve/astro-kbve/src/components/dashboard/Tooltip.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/Tooltip.tsx
@@ -1,0 +1,168 @@
+import {
+	cloneElement,
+	useCallback,
+	useEffect,
+	useId,
+	useRef,
+	useState,
+	type ReactElement,
+	type ReactNode,
+	type Ref,
+} from 'react';
+import { useStore } from '@nanostores/react';
+import { $activeTooltip, openTooltip, closeTooltip } from '@kbve/droid';
+import { motion, AnimatePresence } from 'framer-motion';
+
+type Side = 'top' | 'bottom' | 'left' | 'right';
+
+interface TooltipProps {
+	content: ReactNode;
+	side?: Side;
+	delay?: number;
+	disabled?: boolean;
+	className?: string;
+	children: ReactElement<
+		Record<string, unknown> & { ref?: Ref<HTMLElement> }
+	>;
+}
+
+const OFFSET = 8;
+
+function translateFor(side: Side): string {
+	switch (side) {
+		case 'top':
+			return 'translate(-50%, -100%)';
+		case 'bottom':
+			return 'translate(-50%, 0)';
+		case 'left':
+			return 'translate(-100%, -50%)';
+		case 'right':
+			return 'translate(0, -50%)';
+	}
+}
+
+export function Tooltip({
+	content,
+	side = 'top',
+	delay = 150,
+	disabled = false,
+	className,
+	children,
+}: TooltipProps) {
+	const id = useId();
+	const active = useStore($activeTooltip);
+	const isOpen = !disabled && active === id;
+	const triggerRef = useRef<HTMLElement | null>(null);
+	const timer = useRef<number>(0);
+	const [coords, setCoords] = useState({ x: 0, y: 0 });
+
+	const computePos = useCallback(() => {
+		const el = triggerRef.current;
+		if (!el) return;
+		const r = el.getBoundingClientRect();
+		let x = r.left + r.width / 2;
+		let y = r.top;
+		switch (side) {
+			case 'top':
+				y = r.top - OFFSET;
+				break;
+			case 'bottom':
+				y = r.bottom + OFFSET;
+				break;
+			case 'left':
+				x = r.left - OFFSET;
+				y = r.top + r.height / 2;
+				break;
+			case 'right':
+				x = r.right + OFFSET;
+				y = r.top + r.height / 2;
+				break;
+		}
+		setCoords({ x, y });
+	}, [side]);
+
+	const handleEnter = useCallback(() => {
+		if (disabled) return;
+		window.clearTimeout(timer.current);
+		timer.current = window.setTimeout(() => {
+			computePos();
+			openTooltip(id);
+		}, delay);
+	}, [id, delay, disabled, computePos]);
+
+	const handleLeave = useCallback(() => {
+		window.clearTimeout(timer.current);
+		closeTooltip(id);
+	}, [id]);
+
+	useEffect(() => {
+		if (!isOpen) return;
+		const onScroll = () => closeTooltip(id);
+		const onResize = () => computePos();
+		window.addEventListener('scroll', onScroll, true);
+		window.addEventListener('resize', onResize);
+		return () => {
+			window.removeEventListener('scroll', onScroll, true);
+			window.removeEventListener('resize', onResize);
+		};
+	}, [isOpen, id, computePos]);
+
+	useEffect(
+		() => () => {
+			window.clearTimeout(timer.current);
+		},
+		[],
+	);
+
+	const trigger = cloneElement(children, {
+		ref: (node: HTMLElement | null) => {
+			triggerRef.current = node;
+			const original = (
+				children as ReactElement<{ ref?: Ref<HTMLElement> }>
+			).props.ref;
+			if (typeof original === 'function') {
+				original(node);
+			} else if (
+				original &&
+				typeof original === 'object' &&
+				'current' in original
+			) {
+				(original as { current: HTMLElement | null }).current = node;
+			}
+		},
+		onMouseEnter: handleEnter,
+		onMouseLeave: handleLeave,
+		onFocus: handleEnter,
+		onBlur: handleLeave,
+	});
+
+	return (
+		<>
+			{trigger}
+			<AnimatePresence>
+				{isOpen && (
+					<motion.div
+						role="tooltip"
+						initial={{ opacity: 0, scale: 0.95 }}
+						animate={{ opacity: 1, scale: 1 }}
+						exit={{ opacity: 0, scale: 0.95 }}
+						transition={{ duration: 0.12, ease: 'easeOut' }}
+						style={{
+							position: 'fixed',
+							left: coords.x,
+							top: coords.y,
+							transform: translateFor(side),
+							zIndex: 9999,
+							pointerEvents: 'none',
+						}}
+						className={
+							className ??
+							'px-2 py-1 text-xs font-medium bg-zinc-900 text-zinc-100 rounded-md shadow-lg border border-zinc-700/70 whitespace-nowrap'
+						}>
+						{content}
+					</motion.div>
+				)}
+			</AnimatePresence>
+		</>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/billingError.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/billingError.ts
@@ -1,0 +1,22 @@
+export interface BillingErrorInfo {
+	reason: string;
+	needed?: number;
+	hint?: string;
+}
+
+export function parseBillingError(message: string): BillingErrorInfo | null {
+	if (!message.includes('402')) return null;
+	const jsonStart = message.indexOf('{');
+	if (jsonStart === -1) {
+		return { reason: 'Insufficient credits' };
+	}
+	const tail = message.slice(jsonStart);
+	const needMatch = tail.match(/"needed"\s*:\s*(\d+)/);
+	const reasonMatch = tail.match(/"error"\s*:\s*"([^"]+)"/);
+	const hintMatch = tail.match(/"hint"\s*:\s*"([^"]+)"/);
+	return {
+		reason: reasonMatch ? reasonMatch[1] : 'Insufficient credits',
+		needed: needMatch ? parseInt(needMatch[1], 10) : undefined,
+		hint: hintMatch ? hintMatch[1] : undefined,
+	};
+}


### PR DESCRIPTION
## Summary
Phase C.5a UX polish for #11048. Lands a reusable Tooltip primitive + a billing-aware error banner so the IDE page is dressed up for the next wave of billing rollout. No behavior change today — when \`FC_BILLING_ENABLED\` flips on in C.5c, the 402 path renders gracefully with a "Top up credits" CTA placeholder instead of a raw error string.

### New components

| File | Purpose |
|---|---|
| \`Tooltip.tsx\` | Reusable \`<Tooltip content="…" side="…">\` that plugs into droid's \`$activeTooltip\` so only one tooltip is visible app-wide. Forwards refs, honours focus + hover, closes on scroll/resize, AnimatePresence enter/exit at 120 ms. |
| \`billingError.ts\` | \`parseBillingError(message)\` extracts \`reason\` + \`needed\` + \`hint\` from the fc-ctl 402 JSON envelope. Returns null for non-billing errors so the existing red error path remains intact. |
| \`BillingErrorBanner.tsx\` | Amber banner with coin icon, \`Need X more credits\`, and a disabled "Top up credits" pill (Tooltip explains it's coming soon). |

### ReactCodeIDE.tsx
- \`CopyButton\` → \`motion.button\` with hover scale + bg tint, icon morphs Copy → CheckCircle2 via key-driven scale-in.
- Run / Cancel / Clear → same hover/tap polish + Tooltip captions explaining each action plus the ⌘/Ctrl+Enter shortcut.
- Output / Full Log tabs → tactile hover tint + tap nudge.
- Error branch: detects 402, renders the \`BillingErrorBanner\` instead of the raw red string.

### ReactDeployPanel.tsx
- Deploy + Refresh buttons swapped to \`motion.button\` with Tooltip captions. Refresh icon also rotates 90° on hover for affordance.
- Error region: same parse-and-swap as the IDE — 402 → \`BillingErrorBanner\`, anything else falls through to the legacy \`.deploy-error\` div.

### No new deps
\`framer-motion\` was already in astro-kbve's tree; \`lucide-react\` already provides \`Coins\` + \`CreditCard\`.

## Test plan
- [x] Project \`tsc --noEmit\` — no new errors on any of the touched files.
- [ ] Visit the dashboard IDE page: hover Run, see tooltip; click Copy, see icon morph + "Copied!" tooltip flip.
- [ ] Confirm one active tooltip — opening any (e.g. OSRS hover) closes any IDE tooltip.
- [ ] Manually trigger a 402-ish error string locally and confirm the amber banner renders with the "Top up credits" pill + tooltip "coming soon".

## Out of scope
- C.5b: credit backfill RPC for existing dashboard users.
- C.5c: flip \`FC_BILLING_ENABLED=true\` on \`firecracker-net-deployment.yaml\`.
- Stripe / actual top-up flow wired to the disabled pill.
- Rolling \`<Tooltip>\` across the rest of the dashboard (KASM, ArgoCD panels, etc.).