### PR TITLE
fix(cert-manager): switch chuckrpg.com solver to nginx ingress

### DIFF
--- a/apps/kube/cert-manager/manifests/cluster-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/cluster-issuer.yaml
@@ -69,21 +69,20 @@ spec:
                               annotations:
                                   cert-manager.io/http01-ingress-path-type: 'Prefix'
 
-            # --- Solver 6: CHUCKRPG.COM domains (Cilium Gateway API) ---
-            # Uses gatewayHTTPRoute solver — cert-manager creates an HTTPRoute
-            # that attaches to the HTTP listener on the Cilium-managed gateway.
-            # sectionName: http ensures the route binds to port 80 (not HTTPS).
+            # --- Solver 6: CHUCKRPG.COM domains ---
+            # Stays on the nginx solver until the Cilium gateway VIP (.71)
+            # is reachable from Let's Encrypt; until then nginx-on-.74 is
+            # the only path that completes HTTP-01.
             - selector:
                   dnsZones:
                       - chuckrpg.com
               http01:
-                  gatewayHTTPRoute:
-                      serviceType: ClusterIP
-                      parentRefs:
-                          - name: kbve-gateway
-                            namespace: kbve
-                            kind: Gateway
-                            sectionName: http
+                  ingress:
+                      ingressClassName: nginx
+                      ingressTemplate:
+                          metadata:
+                              annotations:
+                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
 
             # --- Solver 7: RAREICON.COM domains ---
             # Stays on the nginx solver until the Cilium gateway VIP (.71)


### PR DESCRIPTION
## Summary
- Flip the `letsencrypt-http` ClusterIssuer solver for `chuckrpg.com` from `gatewayHTTPRoute` (Cilium `kbve-gateway`, VIP `.71`) to `ingress: nginx` (VIP `.74`).
- Unblocks `Certificate/chuckrpg-api-tls` in the `rows` namespace, which has been pending HTTP-01 for ~12h and is the sole reason `rows` is `Degraded` in ArgoCD.
- Matches the existing pattern used for `rareicon.com` (also held on nginx until the Cilium VIP is reachable from Let's Encrypt).

## Root cause
The chuckrpg solver was pointed at the Cilium gateway VIP `.71`. Cloudflare cannot reach that VIP (returns 522/526), so the ACME validator fetches an empty body and the Challenge stays `pending`:

```
Waiting for HTTP-01 challenge propagation: did not get expected response when querying endpoint,
expected "rhdF0KQdwn76lRmMFMVEfovZ-..." but got: 
```

`api.chuckrpg.com` is already DNS'd at the nginx LoadBalancer `.74`, and `rows/ows-api-ingress` is the path that actually serves traffic — only the cert solver was on the broken VIP.

## Test plan
- [ ] After Argo syncs `cert-manager`, delete the stuck `Order`/`Challenge`/`CertificateRequest` in `rows` so cert-manager re-issues against the nginx solver
- [ ] `kubectl -n rows get certificate chuckrpg-api-tls` reaches `READY=True`
- [ ] `kubectl get application.argoproj.io -n argocd rows` returns to `Healthy`
- [ ] `curl https://api.chuckrpg.com/` returns through the new cert (TLS chain validates)