### PR TITLE
feat(mc_auth+behavior_statetree): /wallet command with chest fallback and custom screen

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
@@ -69,6 +69,8 @@ public class BehaviorStateTreeMod implements ModInitializer {
         // No-op when OPAC isn't loaded.
         SpawnAutoClaim.register();
 
+        com.kbve.statetree.wallet.WalletScreens.register();
+
         if (!NativeRuntime.isLoaded()) {
             LOGGER.error("[{}] Native library not loaded — NPC AI disabled (ships still work)", MOD_ID);
             return;

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -44,6 +44,19 @@ public class ShipClientMod implements ClientModInitializer {
                 .registerReloadListener(new BBModelLoader());
 
         HandledScreens.register(ShipScreenHandlerTypes.SHIP, ShipScreen::new);
+        HandledScreens.register(
+                com.kbve.statetree.wallet.WalletScreens.HANDLER_TYPE,
+                com.kbve.statetree.wallet.WalletScreen::new);
+
+        com.kbve.statetree.wallet.WalletCapabilityPayload.registerClientCodec();
+        net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents.JOIN
+                .register((handler, sender, client) -> {
+                    if (ClientPlayNetworking.canSend(
+                            com.kbve.statetree.wallet.WalletCapabilityPayload.ID)) {
+                        ClientPlayNetworking.send(
+                                new com.kbve.statetree.wallet.WalletCapabilityPayload((byte) 1));
+                    }
+                });
 
         descendKey = KeyBindingHelper.registerKeyBinding(new KeyBinding(
                 "key.behavior_statetree.descend",

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletCapabilityPayload.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletCapabilityPayload.java
@@ -1,0 +1,26 @@
+package com.kbve.statetree.wallet;
+
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+
+public record WalletCapabilityPayload(byte version) implements CustomPayload {
+
+    public static final Identifier CAPABILITY_ID = Identifier.of("kbve_wallet", "capability");
+    public static final CustomPayload.Id<WalletCapabilityPayload> ID = new CustomPayload.Id<>(CAPABILITY_ID);
+    public static final PacketCodec<PacketByteBuf, WalletCapabilityPayload> CODEC =
+            PacketCodec.tuple(
+                    net.minecraft.network.codec.PacketCodecs.BYTE, WalletCapabilityPayload::version,
+                    WalletCapabilityPayload::new);
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+
+    public static void registerClientCodec() {
+        PayloadTypeRegistry.playC2S().register(ID, CODEC);
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreen.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreen.java
@@ -1,0 +1,69 @@
+package com.kbve.statetree.wallet;
+
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
+public class WalletScreen extends HandledScreen<WalletScreenHandler> {
+
+    private static final int BG_WIDTH = 220;
+    private static final int BG_HEIGHT = 156;
+
+    public WalletScreen(WalletScreenHandler handler, PlayerInventory inv, Text title) {
+        super(handler, inv, title);
+        this.backgroundWidth = BG_WIDTH;
+        this.backgroundHeight = BG_HEIGHT;
+    }
+
+    @Override
+    protected void drawBackground(DrawContext ctx, float delta, int mouseX, int mouseY) {
+        int x = (this.width - this.backgroundWidth) / 2;
+        int y = (this.height - this.backgroundHeight) / 2;
+        ctx.fill(x, y, x + backgroundWidth, y + backgroundHeight, 0xFF1B1B1F);
+        ctx.fill(x + 2, y + 2, x + backgroundWidth - 2, y + backgroundHeight - 2, 0xFF2A2A33);
+        ctx.fill(x + 2, y + 2, x + backgroundWidth - 2, y + 22, 0xFF3F3F4A);
+    }
+
+    @Override
+    public void render(DrawContext ctx, int mouseX, int mouseY, float delta) {
+        this.renderBackground(ctx, mouseX, mouseY, delta);
+        super.render(ctx, mouseX, mouseY, delta);
+    }
+
+    @Override
+    protected void drawForeground(DrawContext ctx, int mouseX, int mouseY) {
+        int titleColor = 0xFFFFD66B;
+        int valueColor = 0xFFFFFFFF;
+        int labelColor = 0xFFA0A0B0;
+
+        ctx.drawText(this.textRenderer, Text.literal("KBVE Wallet").formatted(Formatting.GOLD), 10, 8, titleColor, false);
+
+        long credits = handler.getCredits();
+        long khash = handler.getKhash();
+
+        ctx.drawText(this.textRenderer, Text.literal("Credits"), 14, 36, labelColor, false);
+        ctx.drawText(this.textRenderer, Text.literal(format(credits)).formatted(Formatting.YELLOW),
+                14, 50, valueColor, false);
+
+        ctx.drawText(this.textRenderer, Text.literal("KHash"), 14, 74, labelColor, false);
+        ctx.drawText(this.textRenderer, Text.literal(format(khash)).formatted(Formatting.AQUA),
+                14, 88, valueColor, false);
+
+        ctx.drawText(this.textRenderer, Text.literal("Merchant — coming soon").formatted(Formatting.GRAY),
+                14, 120, labelColor, false);
+    }
+
+    @Override
+    public boolean shouldPause() {
+        return false;
+    }
+
+    private static String format(long v) {
+        return NumberFormat.getInstance(Locale.US).format(v);
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreenData.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreenData.java
@@ -1,0 +1,12 @@
+package com.kbve.statetree.wallet;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+
+public record WalletScreenData(long credits, long khash) {
+    public static final PacketCodec<PacketByteBuf, WalletScreenData> PACKET_CODEC =
+            PacketCodec.tuple(
+                    net.minecraft.network.codec.PacketCodecs.VAR_LONG, WalletScreenData::credits,
+                    net.minecraft.network.codec.PacketCodecs.VAR_LONG, WalletScreenData::khash,
+                    WalletScreenData::new);
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreenHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreenHandler.java
@@ -1,0 +1,39 @@
+package com.kbve.statetree.wallet;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
+
+public class WalletScreenHandler extends ScreenHandler {
+
+    private final long credits;
+    private final long khash;
+
+    public WalletScreenHandler(int syncId, PlayerInventory inv, WalletScreenData data) {
+        super(WalletScreens.HANDLER_TYPE, syncId);
+        this.credits = data.credits();
+        this.khash = data.khash();
+    }
+
+    public WalletScreenHandler(int syncId, PlayerInventory inv) {
+        this(syncId, inv, new WalletScreenData(0L, 0L));
+    }
+
+    public long getCredits() { return credits; }
+    public long getKhash() { return khash; }
+
+    @Override
+    public net.minecraft.item.ItemStack quickMove(PlayerEntity player, int slot) {
+        return net.minecraft.item.ItemStack.EMPTY;
+    }
+
+    @Override
+    public boolean canUse(PlayerEntity player) {
+        return true;
+    }
+
+    public static ScreenHandlerType<WalletScreenHandler> registerType() {
+        return null;
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreens.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreens.java
@@ -1,0 +1,61 @@
+package com.kbve.statetree.wallet;
+
+import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerType;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.screen.NamedScreenHandlerFactory;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.Nullable;
+
+public final class WalletScreens {
+
+    public static final Identifier HANDLER_ID = Identifier.of("behavior_statetree", "wallet");
+
+    public static ScreenHandlerType<WalletScreenHandler> HANDLER_TYPE;
+
+    private WalletScreens() {}
+
+    public static void register() {
+        HANDLER_TYPE = Registry.register(
+                Registries.SCREEN_HANDLER,
+                HANDLER_ID,
+                new ExtendedScreenHandlerType<>(WalletScreenHandler::new, WalletScreenData.PACKET_CODEC));
+    }
+
+    public static boolean openCustom(ServerPlayerEntity player, long credits, long khash) {
+        if (player == null || HANDLER_TYPE == null) return false;
+        WalletScreenData data = new WalletScreenData(credits, khash);
+        player.openHandledScreen(new ExtendedFactory(data));
+        return true;
+    }
+
+    private static final class ExtendedFactory
+            implements net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory<WalletScreenData> {
+
+        private final WalletScreenData data;
+
+        ExtendedFactory(WalletScreenData data) {
+            this.data = data;
+        }
+
+        @Override
+        public Text getDisplayName() {
+            return Text.literal("Wallet");
+        }
+
+        @Override
+        public WalletScreenData getScreenOpeningData(ServerPlayerEntity player) {
+            return data;
+        }
+
+        @Override
+        @Nullable
+        public ScreenHandler createMenu(int syncId, net.minecraft.entity.player.PlayerInventory inv, net.minecraft.entity.player.PlayerEntity player) {
+            return new WalletScreenHandler(syncId, inv, data);
+        }
+    }
+}

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
@@ -172,6 +172,7 @@ public final class AuthEventTicker {
                 String uuid = payload.get("player_uuid").getAsString();
                 long credits = payload.get("credits").getAsLong();
                 long khash = payload.get("khash").getAsLong();
+                WalletBalanceCache.put(uuid, credits, khash);
                 ServerPlayerEntity player = findPlayer(server, uuid);
                 if (player != null) {
                     sendBalanceMessage(player, credits, khash);

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/McAuthMod.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/McAuthMod.java
@@ -46,15 +46,21 @@ public class McAuthMod implements ModInitializer {
         ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> {
             if (handler.getPlayer() != null) {
                 PlayerSnapshotHandler.requestSave(handler.getPlayer());
-                LinkStatusRegistry.remove(handler.getPlayer().getUuidAsString());
+                String uuid = handler.getPlayer().getUuidAsString();
+                LinkStatusRegistry.remove(uuid);
+                WalletBalanceCache.remove(uuid);
+                WalletCapabilityRegistry.remove(uuid);
             }
         });
 
         ServerTickEvents.END_SERVER_TICK.register(AuthEventTicker::onEndTick);
 
+        WalletNetworking.register();
+
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
             LinkCommand.register(dispatcher);
             ChatTokenCommand.register(dispatcher);
+            WalletCommand.register(dispatcher);
         });
 
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> {

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletBalanceCache.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletBalanceCache.java
@@ -1,0 +1,35 @@
+package com.kbve.mcauth;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class WalletBalanceCache {
+
+    public static final class Entry {
+        public final long credits;
+        public final long khash;
+        public final long updatedAt;
+
+        public Entry(long credits, long khash, long updatedAt) {
+            this.credits = credits;
+            this.khash = khash;
+            this.updatedAt = updatedAt;
+        }
+    }
+
+    private static final ConcurrentHashMap<String, Entry> CACHE = new ConcurrentHashMap<>();
+
+    private WalletBalanceCache() {}
+
+    public static void put(String playerUuid, long credits, long khash) {
+        if (playerUuid == null || playerUuid.isEmpty()) return;
+        CACHE.put(playerUuid, new Entry(credits, khash, System.currentTimeMillis()));
+    }
+
+    public static Entry get(String playerUuid) {
+        return playerUuid == null ? null : CACHE.get(playerUuid);
+    }
+
+    public static void remove(String playerUuid) {
+        if (playerUuid != null) CACHE.remove(playerUuid);
+    }
+}

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletCapabilityRegistry.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletCapabilityRegistry.java
@@ -1,0 +1,23 @@
+package com.kbve.mcauth;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class WalletCapabilityRegistry {
+
+    private static final Set<String> UI_CAPABLE = ConcurrentHashMap.newKeySet();
+
+    private WalletCapabilityRegistry() {}
+
+    public static void markCapable(String playerUuid) {
+        if (playerUuid != null && !playerUuid.isEmpty()) UI_CAPABLE.add(playerUuid);
+    }
+
+    public static boolean isCapable(String playerUuid) {
+        return playerUuid != null && UI_CAPABLE.contains(playerUuid);
+    }
+
+    public static void remove(String playerUuid) {
+        if (playerUuid != null) UI_CAPABLE.remove(playerUuid);
+    }
+}

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletChestFactory.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletChestFactory.java
@@ -1,0 +1,81 @@
+package com.kbve.mcauth;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.SimpleInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.screen.GenericContainerScreenHandler;
+import net.minecraft.screen.NamedScreenHandlerFactory;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.jetbrains.annotations.Nullable;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
+public final class WalletChestFactory {
+
+    private WalletChestFactory() {}
+
+    public static NamedScreenHandlerFactory build(long credits, long khash) {
+        return new NamedScreenHandlerFactory() {
+            @Override
+            public Text getDisplayName() {
+                return Text.literal("Wallet").formatted(Formatting.GOLD);
+            }
+
+            @Override
+            @Nullable
+            public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
+                SimpleInventory container = new SimpleInventory(9) {
+                    @Override
+                    public boolean canPlayerUse(PlayerEntity p) {
+                        return true;
+                    }
+                };
+
+                container.setStack(2, named(Items.GOLD_INGOT,
+                        Text.literal("Credits: ").formatted(Formatting.YELLOW)
+                                .append(Text.literal(format(credits)).formatted(Formatting.WHITE))));
+
+                container.setStack(4, named(Items.EMERALD,
+                        Text.literal("KHash: ").formatted(Formatting.AQUA)
+                                .append(Text.literal(format(khash)).formatted(Formatting.WHITE))));
+
+                container.setStack(6, named(Items.WRITABLE_BOOK,
+                        Text.literal("Merchant").formatted(Formatting.LIGHT_PURPLE)
+                                .append(Text.literal(" (coming soon)").formatted(Formatting.GRAY))));
+
+                return new ReadOnlyGenericChestHandler(syncId, inv, container);
+            }
+        };
+    }
+
+    private static ItemStack named(net.minecraft.item.Item item, Text name) {
+        ItemStack stack = new ItemStack(item);
+        stack.set(net.minecraft.component.DataComponentTypes.CUSTOM_NAME, name);
+        return stack;
+    }
+
+    private static String format(long v) {
+        return NumberFormat.getInstance(Locale.US).format(v);
+    }
+
+    private static final class ReadOnlyGenericChestHandler extends GenericContainerScreenHandler {
+        private ReadOnlyGenericChestHandler(int syncId, PlayerInventory inv, SimpleInventory container) {
+            super(net.minecraft.screen.ScreenHandlerType.GENERIC_9X1, syncId, inv, container, 1);
+        }
+
+        @Override
+        public ItemStack quickMove(PlayerEntity player, int slot) {
+            return ItemStack.EMPTY;
+        }
+
+        @Override
+        public void onSlotClick(int slotIndex, int button, net.minecraft.screen.slot.SlotActionType actionType, PlayerEntity player) {
+            // swallow all clicks — display-only.
+        }
+    }
+}

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletCommand.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletCommand.java
@@ -1,0 +1,77 @@
+package com.kbve.mcauth;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+
+import static net.minecraft.server.command.CommandManager.literal;
+
+public final class WalletCommand {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(McAuthMod.MOD_ID);
+    private static final String CUSTOM_OPENER_CLASS = "com.kbve.statetree.wallet.WalletScreens";
+    private static final String CUSTOM_OPENER_METHOD = "openCustom";
+
+    private WalletCommand() {}
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal("wallet").executes(ctx -> {
+            ServerPlayerEntity player = ctx.getSource().getPlayer();
+            if (player == null) {
+                ctx.getSource().sendError(Text.literal("Only players can run /wallet."));
+                return 0;
+            }
+            openFor(player);
+            return 1;
+        }));
+        dispatcher.register(literal("balance").executes(ctx -> {
+            ServerPlayerEntity player = ctx.getSource().getPlayer();
+            if (player == null) {
+                ctx.getSource().sendError(Text.literal("Only players can run /balance."));
+                return 0;
+            }
+            openFor(player);
+            return 1;
+        }));
+    }
+
+    public static void openFor(ServerPlayerEntity player) {
+        String uuid = player.getUuidAsString();
+        WalletBalanceCache.Entry cached = WalletBalanceCache.get(uuid);
+        if (cached == null) {
+            player.sendMessage(
+                    Text.literal("[KBVE] Wallet balance not loaded yet — try again in a moment.")
+                            .formatted(Formatting.GRAY),
+                    false);
+            return;
+        }
+
+        long credits = cached.credits;
+        long khash = cached.khash;
+
+        if (WalletCapabilityRegistry.isCapable(uuid) && tryCustom(player, credits, khash)) {
+            return;
+        }
+        player.openHandledScreen(WalletChestFactory.build(credits, khash));
+    }
+
+    private static boolean tryCustom(ServerPlayerEntity player, long credits, long khash) {
+        try {
+            Class<?> cls = Class.forName(CUSTOM_OPENER_CLASS);
+            Method opener = cls.getMethod(CUSTOM_OPENER_METHOD, ServerPlayerEntity.class, long.class, long.class);
+            Object result = opener.invoke(null, player, credits, khash);
+            return result instanceof Boolean b && b;
+        } catch (ClassNotFoundException e) {
+            return false;
+        } catch (Throwable t) {
+            LOGGER.warn("[{}] custom wallet open failed, falling back: {}", McAuthMod.MOD_ID, t.toString());
+            return false;
+        }
+    }
+}

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletNetworking.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletNetworking.java
@@ -1,0 +1,40 @@
+package com.kbve.mcauth;
+
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class WalletNetworking {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(McAuthMod.MOD_ID);
+    public static final Identifier CAPABILITY_ID = Identifier.of("kbve_wallet", "capability");
+
+    public record CapabilityPayload(byte version) implements CustomPayload {
+        public static final CustomPayload.Id<CapabilityPayload> ID = new CustomPayload.Id<>(CAPABILITY_ID);
+        public static final PacketCodec<PacketByteBuf, CapabilityPayload> CODEC =
+                PacketCodec.tuple(
+                        net.minecraft.network.codec.PacketCodecs.BYTE, CapabilityPayload::version,
+                        CapabilityPayload::new);
+
+        @Override
+        public Id<? extends CustomPayload> getId() {
+            return ID;
+        }
+    }
+
+    private WalletNetworking() {}
+
+    public static void register() {
+        PayloadTypeRegistry.playC2S().register(CapabilityPayload.ID, CapabilityPayload.CODEC);
+        ServerPlayNetworking.registerGlobalReceiver(CapabilityPayload.ID, (payload, context) -> {
+            String uuid = context.player().getUuidAsString();
+            WalletCapabilityRegistry.markCapable(uuid);
+            LOGGER.info("[{}] Wallet UI capability registered for {}", McAuthMod.MOD_ID, uuid);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
Adds an in-game wallet UI so linked players can check credits + KHash without leaving the game. Two delivery paths so every connecting client sees something:

| Client | UI |
|---|---|
| Vanilla / browser-launcher / Bedrock-via-ViaVersion | 9-slot chest with named items (Gold Ingot = Credits, Emerald = KHash, Writable Book = Merchant placeholder). Read-only — every `onSlotClick` swallowed. |
| Mrpack (behavior_statetree on client) | Real custom `HandledScreen` with labeled balance lines + Merchant tab placeholder. |

Server decides which to open per-player via a capability handshake the mrpack client sends on join.

## Architecture
- **`mc_auth`** (server-only):
  - [`WalletBalanceCache`](apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletBalanceCache.java) — populated by `AuthEventTicker` whenever a `WalletBalance` event arrives.
  - [`WalletCapabilityRegistry`](apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletCapabilityRegistry.java) — set when a client sends `kbve_wallet:capability` on join.
  - [`WalletNetworking`](apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletNetworking.java) — server-side codec + receiver.
  - [`WalletChestFactory`](apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletChestFactory.java) — vanilla `GenericContainerScreenHandler` with named ItemStacks. `onSlotClick` cancels all interaction.
  - [`WalletCommand`](apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletCommand.java) — registers `/wallet` + `/balance`. Reads cache, checks capability, opens chest by default or **reflectively** invokes `com.kbve.statetree.wallet.WalletScreens.openCustom(player, credits, khash)`. Reflection keeps mc_auth from hard-depending on behavior_statetree.

- **`behavior_statetree`** (server + client via mrpack):
  - [`wallet/WalletScreens`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreens.java) — registers `ExtendedScreenHandlerType<WalletScreenData>` on both env.
  - [`wallet/WalletScreenHandler`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreenHandler.java) — holds the credits/khash snapshot.
  - [`wallet/WalletScreen`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreen.java) — custom draw, no inventory grid.
  - [`wallet/WalletCapabilityPayload`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletCapabilityPayload.java) — mirrors the mc_auth wire shape.
  - [`ShipClientMod`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java) — registers the custom screen + sends the capability handshake on `ClientPlayConnectionEvents.JOIN`.

## Verify
- `gradle compileJava` on both `mc_auth/java` and `behavior_statetree/java` clean (verified locally).
- Disconnect path clears `WalletBalanceCache` + `WalletCapabilityRegistry` for the leaving player so memory stays bounded.

## Test plan
- [ ] `/wallet` on a vanilla client → chest UI opens with the three named items, slot clicks do nothing.
- [ ] `/wallet` on a mrpack client → custom screen with the same numbers, no inventory grid.
- [ ] `/balance` is an alias for `/wallet`.
- [ ] First `/wallet` immediately after join while balance is still pending → graceful "balance not loaded yet" chat line, no crash.
- [ ] Disconnect + reconnect → cache reseeds via the `WalletBalance` event after `AlreadyLinked`.

## Follow-ups
- Merchant catalog (`mc.merchant_listing` table + clickable purchase entries in the same screen pair).
- Inventory + ender_chest sync (continues from #11114).