### PR TITLE
feat(astro-kbve): minecraft item/enchant/block data layer (Phase 5.3a)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mcdb/MCBlockPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCBlockPanel.astro
@@ -1,0 +1,113 @@
+---
+import { McBlockSchema } from '@/data/schema';
+
+const { data } = Astro.props;
+const b = McBlockSchema.parse(data);
+
+const MC_ASSET_VERSION = '1.21.5';
+const iconSrc = `https://mcasset.cloud/${MC_ASSET_VERSION}/assets/minecraft/textures/block/${b.ref}.png`;
+---
+
+<section class="mcdb-panel not-content">
+	<header class="mcdb-panel__head">
+		<div class="mcdb-panel__icon">
+			<img src={iconSrc} alt={b.display_name} loading="lazy" />
+		</div>
+		<div class="mcdb-panel__title">
+			<h2>{b.display_name}</h2>
+			<div class="mcdb-panel__meta">
+				<span class="mcdb-pill mcdb-pill--kind">{b.material}</span>
+				{b.placeable && <span class="mcdb-pill">placeable</span>}
+				{
+					!b.diggable && (
+						<span class="mcdb-pill mcdb-pill--curse">
+							indestructible
+						</span>
+					)
+				}
+			</div>
+			<code class="mcdb-panel__ref">minecraft:{b.ref}</code>
+		</div>
+	</header>
+
+	<dl class="mcdb-grid">
+		<div><dt>Hardness</dt><dd>{b.hardness < 0 ? '∞' : b.hardness}</dd></div>
+		<div><dt>Blast Res.</dt><dd>{b.blast_resistance}</dd></div>
+		<div><dt>Best Tool</dt><dd>{b.best_tool}</dd></div>
+		{
+			b.required_tool_tier > 0 && (
+				<div>
+					<>
+						<dt>Tool Tier</dt>
+						<dd>{b.required_tool_tier}</dd>
+					</>
+				</div>
+			)
+		}
+		{
+			b.light_emission > 0 && (
+				<div>
+					<>
+						<dt>Light</dt>
+						<dd>{b.light_emission}</dd>
+					</>
+				</div>
+			)
+		}
+		<div><dt>Transparent</dt><dd>{b.transparent ? 'yes' : 'no'}</dd></div>
+	</dl>
+
+	{
+		b.drops.length > 0 && (
+			<section class="mcdb-section">
+				<h3>Drops</h3>
+				<ul class="mcdb-recipes">
+					{b.drops.map((d) => (
+						<li>
+							<a href={`/mc/items/${d.ref.replace(/_/g, '-')}/`}>
+								{d.ref}
+							</a>
+							<span class="mcdb-recipe-yields">
+								{d.qty_min === d.qty_max
+									? `× ${d.qty_min}`
+									: `× ${d.qty_min}–${d.qty_max}`}
+							</span>
+							{d.silk_touch_only && (
+								<span class="mcdb-recipe-kind">silk-touch</span>
+							)}
+							{d.affected_by_fortune && (
+								<span class="mcdb-recipe-kind">fortune</span>
+							)}
+						</li>
+					))}
+				</ul>
+			</section>
+		)
+	}
+
+	{
+		b.tags.length > 0 && (
+			<section class="mcdb-section">
+				<h3>Tags</h3>
+				<ul class="mcdb-chips mcdb-chips--muted">
+					{b.tags.map((t) => (
+						<li>{t}</li>
+					))}
+				</ul>
+			</section>
+		)
+	}
+
+	<footer class="mcdb-panel__foot">
+		<a
+			href={`/mc/items/${b.ref.replace(/_/g, '-')}/`}
+			class="mcdb-panel__market">
+			View item form →
+		</a>
+		{
+			b.data_version && (
+				<span class="mcdb-panel__version">data: {b.data_version}</span>
+			)
+		}
+	</footer>
+</section>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantPanel.astro
@@ -1,0 +1,128 @@
+---
+import { McEnchantSchema } from '@/data/schema';
+
+const { data } = Astro.props;
+const e = McEnchantSchema.parse(data);
+---
+
+<section class="mcdb-panel not-content">
+	<header class="mcdb-panel__head">
+		<div class="mcdb-panel__icon mcdb-panel__icon--text">
+			<span>{e.display_name.charAt(0)}</span>
+		</div>
+		<div class="mcdb-panel__title">
+			<h2>{e.display_name}</h2>
+			<div class="mcdb-panel__meta">
+				<span
+					class={`mcdb-pill mcdb-pill--rarity mcdb-pill--rarity-${e.rarity}`}>
+					{e.rarity}
+				</span>
+				{
+					e.curse && (
+						<span class="mcdb-pill mcdb-pill--curse">curse</span>
+					)
+				}
+				{
+					e.treasure && (
+						<span class="mcdb-pill mcdb-pill--treasure">
+							treasure
+						</span>
+					)
+				}
+			</div>
+			<code class="mcdb-panel__ref">minecraft:{e.ref}</code>
+		</div>
+	</header>
+
+	{e.description && <p class="mcdb-panel__desc">{e.description}</p>}
+
+	<dl class="mcdb-grid">
+		<div><dt>Max Level</dt><dd>{e.max_level}</dd></div>
+		<div><dt>Weight</dt><dd>{e.weight}</dd></div>
+		<div><dt>Anvil Cost</dt><dd>{e.anvil_cost}</dd></div>
+		<div><dt>Tradeable</dt><dd>{e.tradeable ? 'yes' : 'no'}</dd></div>
+		<div><dt>From Table</dt><dd>{e.discoverable ? 'yes' : 'no'}</dd></div>
+	</dl>
+
+	{
+		e.targets.length > 0 && (
+			<section class="mcdb-section">
+				<h3>Applies to</h3>
+				<ul class="mcdb-chips mcdb-chips--muted">
+					{e.targets.map((t) => (
+						<li>{t.replace(/_/g, ' ')}</li>
+					))}
+				</ul>
+			</section>
+		)
+	}
+
+	{
+		e.incompatible_with.length > 0 && (
+			<section class="mcdb-section">
+				<h3>Incompatible with</h3>
+				<ul class="mcdb-chips mcdb-chips--muted">
+					{e.incompatible_with.map((ref) => (
+						<li>
+							<a href={`/mc/enchants/${ref.replace(/_/g, '-')}/`}>
+								{ref.replace(/_/g, ' ')}
+							</a>
+						</li>
+					))}
+				</ul>
+			</section>
+		)
+	}
+
+	<footer class="mcdb-panel__foot">
+		<a
+			href={`/market/?kind=mc_item&enchant=${e.ref}`}
+			class="mcdb-panel__market">
+			Find enchanted listings →
+		</a>
+		{
+			e.data_version && (
+				<span class="mcdb-panel__version">data: {e.data_version}</span>
+			)
+		}
+	</footer>
+</section>
+
+<style is:global>
+	.mcdb-panel__icon--text {
+		font-size: 2.5rem;
+		font-weight: 800;
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+		background: linear-gradient(
+			135deg,
+			var(--sl-color-bg-sidebar) 0%,
+			var(--sl-color-bg) 100%
+		);
+	}
+	.mcdb-pill--curse {
+		background: color-mix(
+			in srgb,
+			var(--color-red, var(--sl-color-text-accent)) 18%,
+			transparent
+		);
+		border-color: color-mix(
+			in srgb,
+			var(--color-red, var(--sl-color-text-accent)) 55%,
+			transparent
+		);
+		color: var(--color-red, var(--sl-color-text-accent));
+	}
+	.mcdb-pill--treasure {
+		background: color-mix(
+			in srgb,
+			var(--color-gold-light, var(--sl-color-accent)) 18%,
+			transparent
+		);
+		border-color: color-mix(
+			in srgb,
+			var(--color-gold-light, var(--sl-color-accent)) 50%,
+			transparent
+		);
+		color: var(--color-gold-light, var(--sl-color-accent));
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemPanel.astro
@@ -1,0 +1,549 @@
+---
+import { MCItemSchema } from '@/data/schema';
+
+const { data } = Astro.props;
+const item = MCItemSchema.parse(data);
+
+const MC_ASSET_VERSION = '1.21.5';
+const candidates = [
+	`https://mcasset.cloud/${MC_ASSET_VERSION}/assets/minecraft/textures/item/${item.ref}.png`,
+	`https://mcasset.cloud/${MC_ASSET_VERSION}/assets/minecraft/textures/block/${item.ref}.png`,
+];
+const iconSrc = item.icon || candidates[0];
+const fallbackSrc = candidates[1];
+---
+
+<section class="mcdb-panel not-content">
+	<header class="mcdb-panel__head">
+		<div class="mcdb-panel__icon" data-fallback={fallbackSrc}>
+			<img src={iconSrc} alt={item.display_name} loading="lazy" />
+		</div>
+		<div class="mcdb-panel__title">
+			<h2>{item.display_name}</h2>
+			<div class="mcdb-panel__meta">
+				<span class="mcdb-pill mcdb-pill--kind">{item.category}</span>
+				{
+					item.rarity !== 'common' && (
+						<span
+							class={`mcdb-pill mcdb-pill--rarity mcdb-pill--rarity-${item.rarity}`}>
+							{item.rarity}
+						</span>
+					)
+				}
+				{
+					item.tier && (
+						<span class="mcdb-pill mcdb-pill--tier">
+							{item.tier}
+						</span>
+					)
+				}
+			</div>
+			<code class="mcdb-panel__ref">minecraft:{item.ref}</code>
+		</div>
+	</header>
+
+	{
+		item.about?.description && (
+			<p class="mcdb-panel__desc">{item.about.description}</p>
+		)
+	}
+
+	<dl class="mcdb-grid">
+		<div><dt>Stack</dt><dd>{item.stack_size}</dd></div>
+		{
+			item.max_durability > 0 && (
+				<div>
+					<>
+						<dt>Durability</dt>
+						<dd>{item.max_durability.toLocaleString()}</dd>
+					</>
+				</div>
+			)
+		}
+		{
+			item.damage && (
+				<>
+					<div>
+						<>
+							<dt>Attack Damage</dt>
+							<dd>{item.damage.attack_damage}</dd>
+						</>
+					</div>
+					<div>
+						<>
+							<dt>Attack Speed</dt>
+							<dd>{item.damage.attack_speed}</dd>
+						</>
+					</div>
+				</>
+			)
+		}
+		{
+			item.equipment?.slot && (
+				<>
+					<div>
+						<>
+							<dt>Slot</dt>
+							<dd>{item.equipment.slot}</dd>
+						</>
+					</div>
+					{item.equipment.armor_points > 0 && (
+						<div>
+							<dt>Armor</dt>
+							<dd>{item.equipment.armor_points}</dd>
+						</div>
+					)}
+					{item.equipment.toughness > 0 && (
+						<div>
+							<dt>Toughness</dt>
+							<dd>{item.equipment.toughness}</dd>
+						</div>
+					)}
+				</>
+			)
+		}
+		{
+			item.food && (
+				<>
+					<div>
+						<>
+							<dt>Nutrition</dt>
+							<dd>{item.food.nutrition}</dd>
+						</>
+					</div>
+					<div>
+						<>
+							<dt>Saturation</dt>
+							<dd>{item.food.saturation}</dd>
+						</>
+					</div>
+				</>
+			)
+		}
+		{
+			item.mining && (
+				<>
+					<div>
+						<>
+							<dt>Tool</dt>
+							<dd>{item.mining.tool_type}</dd>
+						</>
+					</div>
+					<div>
+						<>
+							<dt>Mining Tier</dt>
+							<dd>{item.mining.tier}</dd>
+						</>
+					</div>
+				</>
+			)
+		}
+	</dl>
+
+	{
+		item.enchants && item.enchants.allowed.length > 0 && (
+			<section class="mcdb-section">
+				<h3>Compatible Enchants</h3>
+				<ul class="mcdb-chips">
+					{item.enchants.allowed.map((ref) => (
+						<li>
+							<a href={`/mc/enchants/${ref.replace(/_/g, '-')}/`}>
+								{ref.replace(/_/g, ' ')}
+							</a>
+						</li>
+					))}
+				</ul>
+			</section>
+		)
+	}
+
+	{
+		item.tags.length > 0 && (
+			<section class="mcdb-section">
+				<h3>Tags</h3>
+				<ul class="mcdb-chips mcdb-chips--muted">
+					{item.tags.map((t) => (
+						<li>{t}</li>
+					))}
+				</ul>
+			</section>
+		)
+	}
+
+	{
+		item.recipes.length > 0 && (
+			<section class="mcdb-section">
+				<h3>Recipes</h3>
+				{item.recipes.map((r) => {
+					const isShaped =
+						r.kind === 'shaped' && r.width > 0 && r.height > 0;
+					const grid: ((typeof r.ingredients)[number] | null)[][] =
+						[];
+					if (isShaped) {
+						for (let row = 0; row < r.height; row++) {
+							grid.push(
+								Array.from({ length: r.width }, () => null),
+							);
+						}
+						for (const ing of r.ingredients) {
+							if (
+								grid[ing.row] &&
+								grid[ing.row][ing.col] === null
+							) {
+								grid[ing.row][ing.col] = ing;
+							}
+						}
+					}
+					return (
+						<div class="mcdb-recipe-card">
+							<div class="mcdb-recipe-card__meta">
+								<span class="mcdb-recipe-kind">{r.kind}</span>
+								{r.station !== 'none' && (
+									<span class="mcdb-recipe-station">
+										@ {r.station}
+									</span>
+								)}
+								<span class="mcdb-recipe-yields">
+									yields × {r.yields}
+								</span>
+								{r.cook_time_ticks > 0 && (
+									<span class="mcdb-recipe-station">
+										{(r.cook_time_ticks / 20).toFixed(1)}s
+									</span>
+								)}
+								{r.experience > 0 && (
+									<span class="mcdb-recipe-station">
+										{r.experience} XP
+									</span>
+								)}
+							</div>
+							{isShaped ? (
+								<div
+									class="mcdb-grid-recipe"
+									style={`--cols: ${r.width};`}>
+									{grid.flat().map((cell) => (
+										<div class="mcdb-grid-cell">
+											{cell && (
+												<>
+													<span class="mcdb-grid-qty">
+														{cell.qty}
+													</span>
+													<span class="mcdb-grid-ref">
+														{cell.ref ||
+															`#${cell.tag_ref}`}
+													</span>
+												</>
+											)}
+										</div>
+									))}
+								</div>
+							) : (
+								<ul class="mcdb-recipes">
+									{r.ingredients.map((ing) => (
+										<li>
+											<span class="mcdb-recipe-yields">
+												× {ing.qty}
+											</span>
+											<a
+												href={`/mc/items/${(ing.ref || ing.tag_ref).replace(/_/g, '-')}/`}>
+												{ing.ref || `#${ing.tag_ref}`}
+											</a>
+										</li>
+									))}
+								</ul>
+							)}
+						</div>
+					);
+				})}
+			</section>
+		)
+	}
+
+	<footer class="mcdb-panel__foot">
+		<a
+			href={`/market/?kind=mc_item&q=${item.ref}`}
+			class="mcdb-panel__market">
+			Open marketplace listings →
+		</a>
+		{
+			item.data_version && (
+				<span class="mcdb-panel__version">
+					data: {item.data_version}
+				</span>
+			)
+		}
+	</footer>
+</section>
+
+<script>
+	for (const node of document.querySelectorAll(
+		'.mcdb-panel__icon[data-fallback]',
+	)) {
+		const img = node.querySelector('img');
+		const fallback = (node as HTMLElement).dataset.fallback;
+		if (!img || !fallback) continue;
+		img.addEventListener(
+			'error',
+			() => {
+				if (img.dataset.fb === 'done') return;
+				img.dataset.fb = 'done';
+				img.src = fallback;
+			},
+			{ once: true },
+		);
+	}
+</script>
+
+<style is:global>
+	.mcdb-panel {
+		display: grid;
+		gap: 1rem;
+		padding: 1.25rem 1.5rem;
+		border-radius: 18px;
+		background: linear-gradient(
+			165deg,
+			var(--sl-color-bg-nav) 0%,
+			var(--sl-color-bg) 100%
+		);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: var(--sl-color-text);
+	}
+	.mcdb-panel__head {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		gap: 1rem;
+		align-items: center;
+	}
+	.mcdb-panel__icon {
+		width: 96px;
+		height: 96px;
+		border-radius: 14px;
+		background:
+			repeating-linear-gradient(
+				45deg,
+				color-mix(in srgb, var(--sl-color-black) 18%, transparent) 0 6px,
+				transparent 6px 12px
+			),
+			linear-gradient(
+				135deg,
+				var(--sl-color-bg-nav) 0%,
+				var(--sl-color-bg-sidebar) 100%
+			);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		padding: 10%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+	.mcdb-panel__icon img {
+		width: 100%;
+		height: 100%;
+		image-rendering: pixelated;
+		object-fit: contain;
+	}
+	.mcdb-panel__title h2 {
+		margin: 0;
+		font-size: clamp(1.4rem, 2.5vw, 1.75rem);
+		font-weight: 800;
+		letter-spacing: -0.01em;
+		color: var(--sl-color-white, var(--sl-color-text));
+	}
+	.mcdb-panel__meta {
+		display: flex;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+		margin: 0.4rem 0 0.3rem;
+	}
+	.mcdb-pill {
+		padding: 0.15rem 0.6rem;
+		border-radius: 999px;
+		font-size: 0.7rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: var(--sl-color-text);
+	}
+	.mcdb-pill--kind {
+		background: color-mix(in srgb, var(--sl-color-accent) 18%, transparent);
+		border-color: color-mix(
+			in srgb,
+			var(--sl-color-accent) 50%,
+			transparent
+		);
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+	}
+	.mcdb-pill--rarity-uncommon {
+		color: rgb(120, 200, 120);
+	}
+	.mcdb-pill--rarity-rare {
+		color: rgb(120, 180, 240);
+	}
+	.mcdb-pill--rarity-epic {
+		color: rgb(210, 120, 240);
+	}
+	.mcdb-panel__ref {
+		display: inline-block;
+		font-size: 0.78rem;
+		padding: 0.05rem 0.45rem;
+		border-radius: 6px;
+		background: var(--sl-color-bg-inline-code);
+		color: var(--sl-color-text);
+	}
+	.mcdb-panel__desc {
+		margin: 0;
+		color: var(--sl-color-gray-3);
+		line-height: 1.55;
+	}
+	.mcdb-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+		gap: 0.6rem;
+		margin: 0;
+	}
+	.mcdb-grid > div {
+		padding: 0.55rem 0.8rem;
+		border-radius: 10px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+	}
+	.mcdb-grid dt {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--sl-color-gray-3);
+	}
+	.mcdb-grid dd {
+		margin: 0.15rem 0 0;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+	}
+	.mcdb-section h3 {
+		margin: 0 0 0.5rem;
+		font-size: 1rem;
+		font-weight: 800;
+	}
+	.mcdb-chips {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		gap: 0.4rem;
+		flex-wrap: wrap;
+	}
+	.mcdb-chips li {
+		padding: 0.15rem 0.6rem;
+		border-radius: 999px;
+		font-size: 0.78rem;
+		font-weight: 600;
+		background: color-mix(in srgb, var(--sl-color-accent) 14%, transparent);
+		border: 1px solid
+			color-mix(in srgb, var(--sl-color-accent) 50%, transparent);
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+	}
+	.mcdb-chips--muted li {
+		background: var(--sl-color-bg-nav);
+		border-color: var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: var(--sl-color-gray-3);
+	}
+	.mcdb-chips a {
+		color: inherit;
+		text-decoration: none;
+	}
+	.mcdb-recipes {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		gap: 0.4rem;
+	}
+	.mcdb-recipes li {
+		padding: 0.5rem 0.75rem;
+		border-radius: 10px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		display: flex;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+		font-size: 0.85rem;
+	}
+	.mcdb-recipe-kind {
+		font-weight: 700;
+		text-transform: uppercase;
+		font-size: 0.7rem;
+		letter-spacing: 0.05em;
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+	}
+	.mcdb-panel__foot {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+		padding-top: 0.5rem;
+		border-top: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+	}
+	.mcdb-panel__market {
+		color: var(--sl-color-text-accent);
+		font-weight: 700;
+		text-decoration: none;
+	}
+	.mcdb-panel__market:hover {
+		text-decoration: underline;
+	}
+	.mcdb-panel__version {
+		color: var(--sl-color-gray-3);
+		font-size: 0.78rem;
+		font-variant-numeric: tabular-nums;
+	}
+	.mcdb-recipe-card {
+		display: grid;
+		gap: 0.5rem;
+		padding: 0.75rem;
+		border-radius: 12px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		margin-top: 0.5rem;
+	}
+	.mcdb-recipe-card__meta {
+		display: flex;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+		align-items: center;
+	}
+	.mcdb-recipe-station {
+		font-size: 0.78rem;
+		color: var(--sl-color-gray-3);
+	}
+	.mcdb-grid-recipe {
+		display: grid;
+		grid-template-columns: repeat(var(--cols, 3), 72px);
+		gap: 0.4rem;
+		justify-content: start;
+	}
+	.mcdb-grid-cell {
+		width: 72px;
+		height: 72px;
+		border-radius: 10px;
+		background: var(--sl-color-bg-sidebar, var(--sl-color-bg-nav));
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.15rem;
+		padding: 0.3rem;
+		font-size: 0.7rem;
+		text-align: center;
+	}
+	.mcdb-grid-qty {
+		font-weight: 800;
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+	}
+	.mcdb-grid-ref {
+		color: var(--sl-color-gray-3);
+		font-size: 0.65rem;
+		line-height: 1.1;
+		word-break: break-all;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -13,6 +13,9 @@ import {
 	INpcSchema,
 	OSRSExtendedSchema,
 	ICiProjectSchema,
+	MCItemSchema,
+	McEnchantSchema,
+	McBlockSchema,
 } from '@/data/schema';
 
 const OSRSFrontmatterSchema = OSRSExtendedSchema;
@@ -128,6 +131,9 @@ export const collections = {
 				mapdb: z.array(IMapObjectSchema).optional(),
 				npcdb: z.array(INpcSchema).optional(),
 				osrs: OSRSFrontmatterSchema.optional(),
+				mc_item: MCItemSchema.optional(),
+				mc_enchant: McEnchantSchema.optional(),
+				mc_block: McBlockSchema.optional(),
 				'yt-tracks': z.array(z.string()).optional(),
 				'yt-sets': z.array(z.string()).optional(),
 				// Per-page social-meta overrides consumed by

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/oak-log.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/oak-log.mdx
@@ -1,0 +1,42 @@
+---
+title: Oak Log
+description: |
+    Oak Log — basic wood block. Mineable by hand or axe, drops itself.
+sidebar:
+    label: Oak Log
+tags:
+    - minecraft
+    - mc
+    - mc-block
+mc_block:
+    id: 47
+    ref: oak_log
+    slug: oak-log
+    display_name: Oak Log
+    material: wood
+    hardness: 2
+    blast_resistance: 2
+    best_tool: axe
+    required_tool_tier: 0
+    light_emission: 0
+    light_opacity: 15
+    transparent: false
+    placeable: true
+    solid: true
+    renewable: true
+    diggable: true
+    drops:
+        - ref: oak_log
+          qty_min: 1
+          qty_max: 1
+          silk_touch_only: false
+          affected_by_fortune: false
+    tags:
+        - log
+        - flammable
+    data_version: "1.21.5"
+---
+
+import MCBlockPanel from '@/components/mcdb/MCBlockPanel.astro';
+
+<MCBlockPanel data={frontmatter.mc_block} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/enchants/sharpness.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/enchants/sharpness.mdx
@@ -1,0 +1,48 @@
+---
+title: Sharpness
+description: |
+    Sharpness — common melee damage enchant. +0.5 base damage per level
+    on top of +1 flat. Max level V.
+sidebar:
+    label: Sharpness
+tags:
+    - minecraft
+    - mc
+    - mc-enchant
+mc_enchant:
+    id: 12
+    ref: sharpness
+    slug: sharpness
+    display_name: Sharpness
+    rarity: common
+    max_level: 5
+    weight: 10
+    treasure: false
+    curse: false
+    tradeable: true
+    discoverable: true
+    available_in_creative: true
+    targets:
+        - weapon
+    incompatible_with:
+        - smite
+        - bane_of_arthropods
+    anvil_cost: 1
+    cost:
+        a_min: 1
+        b_min: 11
+        a_max: 21
+        b_max: 11
+    tags:
+        - damage
+        - melee
+    description: |
+        Increases melee damage on swords (and axes, since 1.9). Each
+        level adds 0.5 damage on top of a flat 1.0 baseline. Cannot
+        coexist with Smite or Bane of Arthropods on the same weapon.
+    data_version: "1.21.5"
+---
+
+import MCEnchantPanel from '@/components/mcdb/MCEnchantPanel.astro';
+
+<MCEnchantPanel data={frontmatter.mc_enchant} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-sword.mdx
@@ -1,0 +1,75 @@
+---
+title: Diamond Sword
+description: |
+    Diamond Sword — high-tier melee weapon. 7 attack damage, 1561
+    durability. Accepts every melee enchant.
+sidebar:
+    label: Diamond Sword
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 829
+    ref: diamond_sword
+    slug: diamond-sword
+    display_name: Diamond Sword
+    category: weapon
+    rarity: common
+    stack_size: 1
+    max_durability: 1561
+    tier: diamond
+    damage:
+        attack_damage: 7
+        attack_speed: 1.6
+    enchants:
+        allowed:
+            - sharpness
+            - smite
+            - bane_of_arthropods
+            - knockback
+            - fire_aspect
+            - looting
+            - sweeping_edge
+            - unbreaking
+            - mending
+            - vanishing_curse
+    tags:
+        - melee
+        - tier_diamond
+    recipes:
+        - kind: shaped
+          station: crafting_table
+          yields: 1
+          width: 1
+          height: 3
+          ingredients:
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 0
+              - ref: stick
+                qty: 1
+                row: 2
+                col: 0
+    drop_sources:
+        - vindicator
+        - piglin_brute
+    about:
+        description: |
+            The Diamond Sword is a mid-late game weapon crafted from two
+            diamonds and a stick. Deals 7 base attack damage with a 1.6
+            attack speed, putting it just below Netherite in raw damage.
+        lore: |
+            For decades the meta — until Netherite displaced it. Still
+            the cheapest blade that can carry a full enchant stack.
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/data/schema/index.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/index.ts
@@ -3,6 +3,7 @@ export * from './IQuestSchema';
 export * from './IMapSchema';
 export * from './INpcSchema';
 export * from './osrs';
+export * from './mc';
 export * from './ICiProjectSchema';
 export * from './IClickHouseSchema';
 export * from './IForumSchema';

--- a/apps/kbve/astro-kbve/src/data/schema/mc/blocks.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/blocks.ts
@@ -1,0 +1,54 @@
+/**
+ * Proto-aligned Zod schema for kbve.mc.McBlock.
+ *
+ * Mirrors packages/data/proto/kbve/mc/mc_blocks.proto. Validates frontmatter
+ * for content/docs/mc/blocks/<slug>.mdx. Placeable blocks share `ref` with
+ * the mc_items.proto MCItem of the same name (item form).
+ */
+
+import { z } from 'astro/zod';
+import {
+	MCIdentitySchema,
+	McBlockMaterialSchema,
+	McBlockToolSchema,
+} from './enums';
+
+// proto: McBlockDrop
+export const McBlockDropSchema = z.object({
+	ref: z.string().min(1),
+	qty_min: z.number().int().nonnegative().default(1),
+	qty_max: z.number().int().positive().default(1),
+	silk_touch_only: z.boolean().default(false),
+	affected_by_fortune: z.boolean().default(false),
+});
+export type McBlockDrop = z.infer<typeof McBlockDropSchema>;
+
+/**
+ * proto: McBlock — top-level block record.
+ */
+export const McBlockSchema = MCIdentitySchema.extend({
+	display_name: z.string().min(1),
+	material: McBlockMaterialSchema,
+
+	// hardness can be -1 for indestructible blocks (bedrock); allow negatives.
+	hardness: z.number(),
+	blast_resistance: z.number().nonnegative(),
+
+	best_tool: McBlockToolSchema.default('hand'),
+	required_tool_tier: z.number().int().min(0).max(6).default(0),
+
+	light_emission: z.number().int().min(0).max(15).default(0),
+	light_opacity: z.number().int().min(0).max(15).default(15),
+
+	transparent: z.boolean().default(false),
+	placeable: z.boolean().default(true),
+	solid: z.boolean().default(true),
+	renewable: z.boolean().default(false),
+	diggable: z.boolean().default(true),
+
+	drops: z.array(McBlockDropSchema).default([]),
+	tags: z.array(z.string().min(1)).default([]),
+
+	data_version: z.string().default(''),
+});
+export type McBlock = z.infer<typeof McBlockSchema>;

--- a/apps/kbve/astro-kbve/src/data/schema/mc/enchants.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/enchants.ts
@@ -1,0 +1,52 @@
+/**
+ * Proto-aligned Zod schema for kbve.mc.McEnchant.
+ *
+ * Mirrors packages/data/proto/kbve/mc/mc_enchants.proto. Validates
+ * frontmatter for content/docs/mc/enchants/<slug>.mdx. The marketplace
+ * `enchants.ts` table (Phase 5.2) MUST stay aligned with refs here.
+ */
+
+import { z } from 'astro/zod';
+import {
+	MCEnchantRaritySchema,
+	MCEnchantTargetSchema,
+	MCIdentitySchema,
+} from './enums';
+
+// proto: MCEnchantCostRange
+export const MCEnchantCostRangeSchema = z.object({
+	a_min: z.number().int(),
+	b_min: z.number().int(),
+	a_max: z.number().int(),
+	b_max: z.number().int(),
+});
+export type MCEnchantCostRange = z.infer<typeof MCEnchantCostRangeSchema>;
+
+/**
+ * proto: McEnchant — top-level enchantment record.
+ */
+export const McEnchantSchema = MCIdentitySchema.extend({
+	display_name: z.string().min(1),
+	rarity: MCEnchantRaritySchema,
+
+	max_level: z.number().int().min(1).max(10),
+	weight: z.number().int().positive(),
+
+	treasure: z.boolean().default(false),
+	curse: z.boolean().default(false),
+	tradeable: z.boolean().default(true),
+	discoverable: z.boolean().default(true),
+	available_in_creative: z.boolean().default(true),
+
+	targets: z.array(MCEnchantTargetSchema).default([]),
+	incompatible_with: z.array(z.string().min(1)).default([]),
+
+	anvil_cost: z.number().int().nonnegative().default(1),
+	cost: MCEnchantCostRangeSchema.optional(),
+
+	tags: z.array(z.string().min(1)).default([]),
+	description: z.string().default(''),
+
+	data_version: z.string().default(''),
+});
+export type McEnchant = z.infer<typeof McEnchantSchema>;

--- a/apps/kbve/astro-kbve/src/data/schema/mc/enums.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/enums.ts
@@ -1,0 +1,168 @@
+/**
+ * Proto-aligned MC enum tables.
+ *
+ * Each `as const` array mirrors a proto enum in packages/data/proto/kbve/mc/.
+ * Stored on the MDX side as lowercase strings (we strip the proto prefix and
+ * lowercase the suffix — e.g. `MC_RARITY_COMMON` → `"common"`). Zod uses
+ * z.enum on these arrays so frontmatter validation rejects unknown values.
+ */
+
+import { z } from 'astro/zod';
+
+// proto: MCRarity
+export const MCRarities = ['common', 'uncommon', 'rare', 'epic'] as const;
+export const MCRaritySchema = z.enum(MCRarities);
+export type MCRarity = z.infer<typeof MCRaritySchema>;
+
+// proto: MCItemCategory
+export const MCItemCategories = [
+	'tool',
+	'weapon',
+	'armor',
+	'food',
+	'block',
+	'material',
+	'redstone',
+	'transport',
+	'decoration',
+	'brewing',
+	'spawn_egg',
+	'music',
+	'banner',
+	'map',
+	'misc',
+] as const;
+export const MCItemCategorySchema = z.enum(MCItemCategories);
+export type MCItemCategory = z.infer<typeof MCItemCategorySchema>;
+
+// proto: MCToolTier
+export const MCToolTiers = [
+	'wooden',
+	'stone',
+	'golden',
+	'iron',
+	'diamond',
+	'netherite',
+] as const;
+export const MCToolTierSchema = z.enum(MCToolTiers);
+export type MCToolTier = z.infer<typeof MCToolTierSchema>;
+
+// proto: MCEnchantRarity
+export const MCEnchantRarities = [
+	'common',
+	'uncommon',
+	'rare',
+	'very_rare',
+] as const;
+export const MCEnchantRaritySchema = z.enum(MCEnchantRarities);
+export type MCEnchantRarity = z.infer<typeof MCEnchantRaritySchema>;
+
+// proto: MCEnchantTarget
+export const MCEnchantTargets = [
+	'armor',
+	'armor_head',
+	'armor_chest',
+	'armor_legs',
+	'armor_feet',
+	'weapon',
+	'digger',
+	'fishing_rod',
+	'trident',
+	'crossbow',
+	'bow',
+	'wearable',
+	'breakable',
+	'vanishable',
+	'mace',
+] as const;
+export const MCEnchantTargetSchema = z.enum(MCEnchantTargets);
+export type MCEnchantTarget = z.infer<typeof MCEnchantTargetSchema>;
+
+// proto: McBlockTool
+export const McBlockTools = [
+	'hand',
+	'pickaxe',
+	'axe',
+	'shovel',
+	'hoe',
+	'shears',
+	'sword',
+] as const;
+export const McBlockToolSchema = z.enum(McBlockTools);
+export type McBlockTool = z.infer<typeof McBlockToolSchema>;
+
+// proto: McBlockMaterial
+export const McBlockMaterials = [
+	'air',
+	'stone',
+	'wood',
+	'dirt',
+	'sand',
+	'gravel',
+	'metal',
+	'glass',
+	'wool',
+	'plant',
+	'leaves',
+	'ice',
+	'snow',
+	'liquid',
+	'redstone',
+	'nether',
+	'end',
+	'misc',
+] as const;
+export const McBlockMaterialSchema = z.enum(McBlockMaterials);
+export type McBlockMaterial = z.infer<typeof McBlockMaterialSchema>;
+
+// proto: McRecipeKind
+export const McRecipeKinds = [
+	'shaped',
+	'shapeless',
+	'smelting',
+	'blasting',
+	'smoking',
+	'campfire_cooking',
+	'stonecutting',
+	'smithing',
+	'brewing',
+	'trade',
+] as const;
+export const McRecipeKindSchema = z.enum(McRecipeKinds);
+export type McRecipeKind = z.infer<typeof McRecipeKindSchema>;
+
+// proto: McCraftingStation
+export const McCraftingStations = [
+	'crafting_table',
+	'furnace',
+	'blast_furnace',
+	'smoker',
+	'campfire',
+	'stonecutter',
+	'smithing_table',
+	'brewing_stand',
+	'villager',
+	'none',
+] as const;
+export const McCraftingStationSchema = z.enum(McCraftingStations);
+export type McCraftingStation = z.infer<typeof McCraftingStationSchema>;
+
+/**
+ * Shared identity fields. Every top-level MC record (item, enchant, block,
+ * recipe) carries an int id, a stable string ref, and a kebab-case slug.
+ */
+export const MCIdentitySchema = z.object({
+	id: z.number().int().nonnegative(),
+	ref: z
+		.string()
+		.min(1)
+		.regex(
+			/^[a-z0-9_]+(?:\/[a-z0-9_]+)*$/,
+			'ref must be lowercase snake_case (slashes allowed for recipe namespaces)',
+		),
+	slug: z
+		.string()
+		.min(1)
+		.regex(/^[a-z0-9-]+$/, 'slug must be kebab-case'),
+});
+export type MCIdentity = z.infer<typeof MCIdentitySchema>;

--- a/apps/kbve/astro-kbve/src/data/schema/mc/index.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/index.ts
@@ -1,0 +1,4 @@
+export * from './enums';
+export * from './items';
+export * from './enchants';
+export * from './blocks';

--- a/apps/kbve/astro-kbve/src/data/schema/mc/items.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/items.ts
@@ -1,0 +1,124 @@
+/**
+ * Proto-aligned Zod schema for kbve.mc.MCItem.
+ *
+ * Mirrors packages/data/proto/kbve/mc/mc_items.proto. Validates frontmatter
+ * for content/docs/mc/items/<slug>.mdx. Marketplace listings whose
+ * item_ref.kind === 'mc_item' MUST carry an item_ref.id that matches an
+ * MCItem.ref defined here — that's the cross-system contract.
+ */
+
+import { z } from 'astro/zod';
+import {
+	MCIdentitySchema,
+	MCItemCategorySchema,
+	MCRaritySchema,
+	MCToolTierSchema,
+	McCraftingStationSchema,
+	McRecipeKindSchema,
+} from './enums';
+
+// proto: MCEquipment
+export const MCEquipmentSchema = z.object({
+	slot: z.enum(['head', 'chest', 'legs', 'feet', 'offhand', '']).default(''),
+	armor_points: z.number().int().nonnegative().default(0),
+	toughness: z.number().int().nonnegative().default(0),
+	knockback_resistance: z.number().int().nonnegative().default(0),
+});
+export type MCEquipment = z.infer<typeof MCEquipmentSchema>;
+
+// proto: MCDamage
+export const MCDamageSchema = z.object({
+	attack_damage: z.number().int().nonnegative(),
+	attack_speed: z.number(),
+});
+export type MCDamage = z.infer<typeof MCDamageSchema>;
+
+// proto: MCFood
+export const MCFoodSchema = z.object({
+	nutrition: z.number().int().nonnegative(),
+	saturation: z.number().nonnegative(),
+	eatable: z.enum(['always', 'when_hungry', '']).default('when_hungry'),
+});
+export type MCFood = z.infer<typeof MCFoodSchema>;
+
+// proto: MCMiningProfile
+export const MCMiningProfileSchema = z.object({
+	tool_type: z.enum(['pickaxe', 'axe', 'shovel', 'hoe', 'shears', 'sword']),
+	tier: z.number().int().min(1).max(6),
+});
+export type MCMiningProfile = z.infer<typeof MCMiningProfileSchema>;
+
+// proto: MCEnchantCompat
+export const MCEnchantCompatSchema = z.object({
+	allowed: z.array(z.string().min(1)).default([]),
+});
+export type MCEnchantCompat = z.infer<typeof MCEnchantCompatSchema>;
+
+// proto: MCRecipeIngredient (inline). `tag_ref` covers vanilla item tags
+// like "minecraft:planks" — when set, the slot accepts any item matching
+// the tag. `row` + `col` are 0-indexed within the crafting grid (shaped
+// recipes only).
+export const MCItemRecipeIngredientSchema = z
+	.object({
+		ref: z.string().default(''),
+		tag_ref: z.string().default(''),
+		qty: z.number().int().positive().default(1),
+		row: z.number().int().min(0).max(2).default(0),
+		col: z.number().int().min(0).max(2).default(0),
+	})
+	.refine((v) => v.ref.length > 0 || v.tag_ref.length > 0, {
+		message: 'ingredient must set ref or tag_ref',
+	});
+
+// proto: MCRecipe (inline on the item). Carries the full vanilla recipe
+// shape (grid dimensions, cook time, XP, smithing template, brewing base)
+// so the per-item MDX is self-contained — no separate recipe registry.
+export const MCItemRecipeSchema = z.object({
+	kind: McRecipeKindSchema,
+	station: McCraftingStationSchema.default('none'),
+	yields: z.number().int().positive().default(1),
+	ingredients: z.array(MCItemRecipeIngredientSchema).default([]),
+	width: z.number().int().min(0).max(3).default(0),
+	height: z.number().int().min(0).max(3).default(0),
+	cook_time_ticks: z.number().int().nonnegative().default(0),
+	experience: z.number().nonnegative().default(0),
+	smithing_template_ref: z.string().default(''),
+	brewing_base_ref: z.string().default(''),
+});
+export type MCItemRecipe = z.infer<typeof MCItemRecipeSchema>;
+
+// proto: MCAbout
+export const MCAboutSchema = z.object({
+	description: z.string().default(''),
+	lore: z.string().default(''),
+});
+export type MCAbout = z.infer<typeof MCAboutSchema>;
+
+/**
+ * proto: MCItem — top-level item record. Used as the Zod schema for MDX
+ * frontmatter under content/docs/mc/items/.
+ */
+export const MCItemSchema = MCIdentitySchema.extend({
+	display_name: z.string().min(1),
+	category: MCItemCategorySchema,
+	rarity: MCRaritySchema.default('common'),
+	stack_size: z.number().int().positive().default(64),
+	max_durability: z.number().int().nonnegative().default(0),
+
+	equipment: MCEquipmentSchema.optional(),
+	damage: MCDamageSchema.optional(),
+	food: MCFoodSchema.optional(),
+	mining: MCMiningProfileSchema.optional(),
+	enchants: MCEnchantCompatSchema.optional(),
+	tier: MCToolTierSchema.optional(),
+
+	tags: z.array(z.string().min(1)).default([]),
+	recipes: z.array(MCItemRecipeSchema).default([]),
+	drop_sources: z.array(z.string().min(1)).default([]),
+
+	about: MCAboutSchema.default({ description: '', lore: '' }),
+
+	data_version: z.string().default(''),
+	icon: z.string().default(''),
+});
+export type MCItem = z.infer<typeof MCItemSchema>;

--- a/packages/data/proto/kbve/mc/mc_blocks.proto
+++ b/packages/data/proto/kbve/mc/mc_blocks.proto
@@ -1,0 +1,121 @@
+syntax = "proto3";
+
+package kbve.mc;
+
+// =============================================================================
+// Minecraft vanilla block registry — companion to mcitems.proto. Source of
+// truth for `/mc/blocks/<slug>` MDX pages, the world-builder UI, and bot/AI
+// pathfinding hints. Bootstrapped by scripts/generate-mc-blocks.mjs from the
+// PrismarineJS `minecraft-data` registry.
+//
+// Identity:
+//   id    numeric registry id (NOT stable across versions — use ref)
+//   ref   namespaced id without "minecraft:" prefix ("oak_log", "stone")
+//   slug  kebab-case URL slug ("oak-log", "deepslate-redstone-ore")
+//
+// Most blocks have a 1:1 item form (placeable). The link is via `ref` —
+// `mcitems.proto MCItem.ref == mcblocks.proto McBlock.ref` for placeable
+// blocks. Block-only refs (e.g. "fire", "water") have no item.
+// =============================================================================
+
+// McBlockTool is the preferred tool category for harvesting.
+enum McBlockTool {
+  MC_BLOCK_TOOL_UNSPECIFIED = 0;
+  MC_BLOCK_TOOL_HAND        = 1;
+  MC_BLOCK_TOOL_PICKAXE     = 2;
+  MC_BLOCK_TOOL_AXE         = 3;
+  MC_BLOCK_TOOL_SHOVEL      = 4;
+  MC_BLOCK_TOOL_HOE         = 5;
+  MC_BLOCK_TOOL_SHEARS      = 6;
+  MC_BLOCK_TOOL_SWORD       = 7;
+}
+
+// McBlockMaterial groups blocks by physical / sound profile.
+enum McBlockMaterial {
+  MC_BLOCK_MATERIAL_UNSPECIFIED = 0;
+  MC_BLOCK_MATERIAL_AIR         = 1;
+  MC_BLOCK_MATERIAL_STONE       = 2;
+  MC_BLOCK_MATERIAL_WOOD        = 3;
+  MC_BLOCK_MATERIAL_DIRT        = 4;
+  MC_BLOCK_MATERIAL_SAND        = 5;
+  MC_BLOCK_MATERIAL_GRAVEL      = 6;
+  MC_BLOCK_MATERIAL_METAL       = 7;
+  MC_BLOCK_MATERIAL_GLASS       = 8;
+  MC_BLOCK_MATERIAL_WOOL        = 9;
+  MC_BLOCK_MATERIAL_PLANT       = 10;
+  MC_BLOCK_MATERIAL_LEAVES      = 11;
+  MC_BLOCK_MATERIAL_ICE         = 12;
+  MC_BLOCK_MATERIAL_SNOW        = 13;
+  MC_BLOCK_MATERIAL_LIQUID      = 14;
+  MC_BLOCK_MATERIAL_REDSTONE    = 15;
+  MC_BLOCK_MATERIAL_NETHER      = 16;
+  MC_BLOCK_MATERIAL_END         = 17;
+  MC_BLOCK_MATERIAL_MISC        = 99;
+}
+
+// McBlockDrop is one possible drop from breaking this block.
+message McBlockDrop {
+  // namespaced ref of the dropped item, e.g. "cobblestone"
+  string ref      = 1;
+  // base drop quantity (silk touch / fortune handled elsewhere)
+  int32  qty_min  = 2;
+  int32  qty_max  = 3;
+  // requires silk touch to drop the block as itself
+  bool   silk_touch_only = 4;
+  // fortune multiplier applies (true for ores etc.)
+  bool   affected_by_fortune = 5;
+}
+
+// McBlock — top-level block record (one MDX file == one McBlock).
+message McBlock {
+  int32  id           = 1;
+  string ref          = 2;
+  string slug         = 3;
+  string display_name = 4;
+
+  McBlockMaterial material = 5;
+
+  // Base hardness in vanilla units (-1 == indestructible like bedrock).
+  float hardness = 6;
+
+  // Blast resistance vs explosions.
+  float blast_resistance = 7;
+
+  // Preferred mining tool (informational; vanilla allows hand mining for many).
+  McBlockTool best_tool = 8;
+
+  // Minimum tool tier required to drop (0 = hand OK, 1..6 = wooden..netherite).
+  // Matches mcitems.proto MCToolTier band.
+  int32 required_tool_tier = 9;
+
+  // Light emission level (0..15).
+  int32 light_emission = 10;
+
+  // Opacity to light (0 = transparent, 15 = opaque).
+  int32 light_opacity = 11;
+
+  bool transparent = 12;
+
+  // Block has its own item form (placeable from inventory).
+  bool placeable = 13;
+
+  // Solid for entity collision (false for water, air, plants).
+  bool solid = 14;
+
+  // Renewable in vanilla (informational for collector flows).
+  bool renewable = 15;
+
+  // Diggable at all (false for bedrock, command_block).
+  bool diggable = 16;
+
+  // Default drops when broken without silk touch / fortune.
+  repeated McBlockDrop drops = 17;
+
+  // Free-form tags for filtering ("ore", "log", "wool", "sapling",
+  // "redstone_component").
+  repeated string tags = 18;
+
+  // Vanilla version this record was generated from ("1.21.5"). Set by the
+  // generator script.
+  string data_version = 19;
+}

--- a/packages/data/proto/kbve/mc/mc_enchants.proto
+++ b/packages/data/proto/kbve/mc/mc_enchants.proto
@@ -1,0 +1,114 @@
+syntax = "proto3";
+
+package kbve.mc;
+
+// =============================================================================
+// Minecraft vanilla enchantment registry — source of truth for the marketplace
+// enchant picker, `/mc/enchants/<slug>` MDX pages, and bot/dialog code that
+// needs to validate / display enchantments. Bootstrapped by
+// scripts/generate-mc-enchants.mjs from the PrismarineJS `minecraft-data`
+// registry.
+//
+// Identity:
+//   id    numeric registry id (NOT stable across versions — use ref)
+//   ref   namespaced id without "minecraft:" prefix ("sharpness", "mending")
+//   slug  kebab-case URL slug ("sharpness", "curse-of-binding")
+//
+// Cross-system contracts: marketplace listings store `enchants[].id` as the
+// ref string; the Astro `enchants.ts` table and the in-game NBT must agree.
+// =============================================================================
+
+// MCEnchantRarity is the vanilla rarity used to compute table cost weights.
+enum MCEnchantRarity {
+  MC_ENCHANT_RARITY_UNSPECIFIED = 0;
+  MC_ENCHANT_RARITY_COMMON      = 1;
+  MC_ENCHANT_RARITY_UNCOMMON    = 2;
+  MC_ENCHANT_RARITY_RARE        = 3;
+  MC_ENCHANT_RARITY_VERY_RARE   = 4;
+}
+
+// MCEnchantTarget describes which equipment classes an enchant can apply to.
+// Multiple targets may overlap — Mending applies to all damageable items.
+enum MCEnchantTarget {
+  MC_ENCHANT_TARGET_UNSPECIFIED = 0;
+  MC_ENCHANT_TARGET_ARMOR       = 1;
+  MC_ENCHANT_TARGET_ARMOR_HEAD  = 2;
+  MC_ENCHANT_TARGET_ARMOR_CHEST = 3;
+  MC_ENCHANT_TARGET_ARMOR_LEGS  = 4;
+  MC_ENCHANT_TARGET_ARMOR_FEET  = 5;
+  MC_ENCHANT_TARGET_WEAPON      = 6;
+  MC_ENCHANT_TARGET_DIGGER      = 7;
+  MC_ENCHANT_TARGET_FISHING_ROD = 8;
+  MC_ENCHANT_TARGET_TRIDENT     = 9;
+  MC_ENCHANT_TARGET_CROSSBOW    = 10;
+  MC_ENCHANT_TARGET_BOW         = 11;
+  MC_ENCHANT_TARGET_WEARABLE    = 12;
+  MC_ENCHANT_TARGET_BREAKABLE   = 13;
+  MC_ENCHANT_TARGET_VANISHABLE  = 14;
+  MC_ENCHANT_TARGET_MACE        = 15;
+}
+
+// MCEnchantCostRange models the minimum + maximum table cost for a given
+// level (vanilla formula: a + b*level). Both client UI and bots use this
+// to display "needs level N" hints.
+message MCEnchantCostRange {
+  // a + b*level where level is the enchant level (1..max_level).
+  int32 a_min = 1;
+  int32 b_min = 2;
+  int32 a_max = 3;
+  int32 b_max = 4;
+}
+
+// MCEnchant — top-level enchantment record (one MDX file == one McEnchant).
+message McEnchant {
+  int32  id           = 1;
+  string ref          = 2;
+  string slug         = 3;
+  string display_name = 4;
+
+  MCEnchantRarity rarity = 5;
+
+  // Maximum vanilla level (1..5 typically; some treasure enchants stay at 1).
+  int32 max_level = 6;
+
+  // Selection weight at the enchantment table; bigger == more likely.
+  int32 weight = 7;
+
+  // Treasure: only obtainable via loot / trading / fishing, not the table.
+  bool treasure = 8;
+
+  // Curse: cannot be removed by grindstone; persists across death.
+  bool curse = 9;
+
+  // Tradeable with librarians (controls early-game accessibility).
+  bool tradeable = 10;
+
+  // Discoverable at the enchantment table (false implies treasure-only).
+  bool discoverable = 11;
+
+  // Available in the creative-mode enchanting reagent list.
+  bool available_in_creative = 12;
+
+  // Targets this enchant can natively apply to (vanilla rules).
+  repeated MCEnchantTarget targets = 13;
+
+  // Other enchant refs that cannot coexist on the same item
+  // ("sharpness" ↔ "smite" ↔ "bane_of_arthropods", etc.).
+  repeated string incompatible_with = 14;
+
+  // Anvil cost multiplier per stored level (vanilla 1..10).
+  int32 anvil_cost = 15;
+
+  MCEnchantCostRange cost = 16;
+
+  // Free-form tags for filtering ("damage", "protection", "utility",
+  // "mining", "ranged", "tridents", "books_only").
+  repeated string tags = 17;
+
+  // Short description for the MDX body / tooltip overlay.
+  string description = 18;
+
+  // Vanilla version this record was generated from ("1.21.5"). Set by the
+  // generator script.
+  string data_version = 19;
+}

--- a/packages/data/proto/kbve/mc/mc_items.proto
+++ b/packages/data/proto/kbve/mc/mc_items.proto
@@ -1,0 +1,226 @@
+syntax = "proto3";
+
+package kbve.mc;
+
+import "kbve/common.proto";
+
+// =============================================================================
+// Minecraft vanilla item registry — source of truth for /mc/items/<slug> MDX
+// pages and the marketplace item picker. Mirror the OSRS proto + Zod pipeline;
+// data lives in apps/kbve/astro-kbve/src/content/docs/mc/items/<slug>.mdx and
+// is bootstrapped by scripts/generate-mc-items.mjs from the PrismarineJS
+// `minecraft-data` registry.
+//
+// File layout: this folder (proto/kbve/mc/) is the home for all Minecraft-
+// scoped vanilla data — items today; future enchants.proto, blocks.proto,
+// recipes.proto follow the same pattern (one .proto per domain, package
+// kbve.mc shared).
+//
+// Item identity:
+//   id          numeric registry id (e.g. 829)
+//   ref         namespaced id, no prefix (e.g. "diamond_sword"); used by
+//               item_ref.id in marketplace listings — keep these stable
+//   slug        kebab-case URL slug (e.g. "diamond-sword")
+// =============================================================================
+
+// MCRarity mirrors the in-game tooltip colour band. Values come from
+// vanilla data and tooltip overrides.
+enum MCRarity {
+  MC_RARITY_UNSPECIFIED = 0;
+  MC_RARITY_COMMON      = 1;
+  MC_RARITY_UNCOMMON    = 2;
+  MC_RARITY_RARE        = 3;
+  MC_RARITY_EPIC        = 4;
+}
+
+// MCItemCategory is the high-level UI bucket. Not 1:1 with vanilla
+// creative tabs; tuned for marketplace filtering.
+enum MCItemCategory {
+  MC_ITEM_CATEGORY_UNSPECIFIED   = 0;
+  MC_ITEM_CATEGORY_TOOL          = 1;
+  MC_ITEM_CATEGORY_WEAPON        = 2;
+  MC_ITEM_CATEGORY_ARMOR         = 3;
+  MC_ITEM_CATEGORY_FOOD          = 4;
+  MC_ITEM_CATEGORY_BLOCK         = 5;
+  MC_ITEM_CATEGORY_MATERIAL      = 6;
+  MC_ITEM_CATEGORY_REDSTONE      = 7;
+  MC_ITEM_CATEGORY_TRANSPORT     = 8;
+  MC_ITEM_CATEGORY_DECORATION    = 9;
+  MC_ITEM_CATEGORY_BREWING       = 10;
+  MC_ITEM_CATEGORY_SPAWN_EGG     = 11;
+  MC_ITEM_CATEGORY_MUSIC         = 12;
+  MC_ITEM_CATEGORY_BANNER        = 13;
+  MC_ITEM_CATEGORY_MAP           = 14;
+  MC_ITEM_CATEGORY_MISC          = 99;
+}
+
+// MCToolTier is the durability/damage band for tools and armor.
+enum MCToolTier {
+  MC_TOOL_TIER_UNSPECIFIED = 0;
+  MC_TOOL_TIER_WOODEN      = 1;
+  MC_TOOL_TIER_STONE       = 2;
+  MC_TOOL_TIER_GOLDEN      = 3;
+  MC_TOOL_TIER_IRON        = 4;
+  MC_TOOL_TIER_DIAMOND     = 5;
+  MC_TOOL_TIER_NETHERITE   = 6;
+}
+
+// =============================================================================
+// Sub-messages
+// =============================================================================
+
+// MCEquipment describes the slot + protection if this is wearable.
+message MCEquipment {
+  // "head", "chest", "legs", "feet", "offhand", or empty
+  string slot           = 1;
+  int32  armor_points   = 2;
+  int32  toughness      = 3;
+  int32  knockback_resistance = 4;
+}
+
+// MCDamage models tool/weapon damage profile.
+message MCDamage {
+  int32 attack_damage = 1;
+  float attack_speed  = 2;
+}
+
+// MCFood is set for consumables.
+message MCFood {
+  int32 nutrition  = 1;
+  float saturation = 2;
+  // "always", "when_hungry", or empty
+  string eatable   = 3;
+}
+
+// MCMiningProfile is set for pickaxes / shovels / axes / hoes / shears.
+message MCMiningProfile {
+  // "pickaxe", "axe", "shovel", "hoe", "shears", "sword"
+  string tool_type = 1;
+  // mining level (1 = wood, 2 = stone, ..., 6 = netherite)
+  int32  tier      = 2;
+}
+
+// MCEnchantCompat lists enchantment ids this item natively accepts.
+// e.g. swords accept ["sharpness", "smite", "knockback", ...].
+message MCEnchantCompat {
+  repeated string allowed = 1;
+}
+
+// MCRecipeIngredient is a single ingredient inside a recipe. Either `ref`
+// (specific item like "iron_ingot") or `tag_ref` (vanilla item tag like
+// "planks") must be set. `row`+`col` are 0-indexed within the crafting
+// grid for SHAPED recipes — ignored otherwise.
+message MCRecipeIngredient {
+  string ref     = 1;
+  string tag_ref = 2;
+  int32  qty     = 3;
+  int32  row     = 4;
+  int32  col     = 5;
+}
+
+// MCRecipeKind / MCCraftingStation mirror the standalone mc_recipes.proto
+// values; embedded as strings here so the item is fully self-describing.
+// Recipes for an item live inline on MCItem.recipes — there is no separate
+// recipe registry. The full vanilla recipe shape (grid, cook time, xp,
+// smithing template, brewing base) is captured so the per-item MDX page
+// renders without a join.
+message MCRecipe {
+  // "shaped" | "shapeless" | "smelting" | "blasting" | "smoking" |
+  // "campfire_cooking" | "stonecutting" | "smithing" | "brewing" | "trade"
+  string kind = 1;
+
+  // "crafting_table" | "furnace" | "blast_furnace" | "smoker" | "campfire" |
+  // "stonecutter" | "smithing_table" | "brewing_stand" | "villager" | "none"
+  string station = 2;
+
+  // produced quantity per recipe (e.g. 4 for sticks-from-planks)
+  int32 yields = 3;
+
+  repeated MCRecipeIngredient ingredients = 4;
+
+  // SHAPED only: grid dimensions (rows = height, cols = width).
+  int32 width  = 5;
+  int32 height = 6;
+
+  // Cooking recipes: time in ticks (20 ticks == 1 second).
+  int32 cook_time_ticks = 7;
+  // XP awarded on completion (cooking + smithing).
+  float experience = 8;
+
+  // Smithing recipes: namespaced template ref (1.20+ smithing rework).
+  string smithing_template_ref = 9;
+  // Brewing recipes: namespaced base potion ref ("awkward_potion").
+  string brewing_base_ref = 10;
+}
+
+// MCAbout is generic prose for the MDX page.
+message MCAbout {
+  string description = 1;
+  string lore        = 2;
+}
+
+// =============================================================================
+// MCItem — top-level item record (one MDX file == one MCItem).
+// =============================================================================
+message MCItem {
+  // Numeric registry id from minecraft-data. NOT a stable contract — newer
+  // vanilla versions may renumber. Use `ref` for cross-system references.
+  int32 id = 1;
+
+  // Namespaced id without the "minecraft:" prefix, e.g. "diamond_sword".
+  // This IS the cross-system contract: marketplace item_ref.id matches.
+  string ref = 2;
+
+  // URL slug (kebab-case).
+  string slug = 3;
+
+  // Display name as shown in-game ("Diamond Sword").
+  string display_name = 4;
+
+  MCItemCategory category = 5;
+  MCRarity       rarity   = 6;
+
+  // Vanilla max stack size (1, 16, 64).
+  int32 stack_size = 7;
+
+  // 0 if not damageable.
+  int32 max_durability = 8;
+
+  // Set if equippable.
+  MCEquipment equipment = 9;
+
+  // Set for tools/weapons that deal damage.
+  MCDamage damage = 10;
+
+  // Set if consumable.
+  MCFood food = 11;
+
+  // Set for mining/digging tools.
+  MCMiningProfile mining = 12;
+
+  // Compatible enchantments (vanilla rules).
+  MCEnchantCompat enchants = 13;
+
+  // Tool tier if applicable.
+  MCToolTier tier = 14;
+
+  // Free-form tags for filtering ("redstone_component", "wool", "music_disc").
+  repeated string tags = 15;
+
+  // Recipes that produce this item.
+  repeated MCRecipe recipes = 16;
+
+  // Mobs / entities / blocks that drop this item, by ref.
+  repeated string drop_sources = 17;
+
+  // Prose for the MDX body.
+  MCAbout about = 18;
+
+  // Optional: mc:datapack vanilla version this record was generated from
+  // ("1.21.5"). Set by the generator script.
+  string data_version = 19;
+
+  // Optional: relative path to the bundled texture asset (UI only). Leave
+  // empty to fall back to mcasset.cloud per the marketplace ItemIcon logic.
+  string icon = 20;
+}


### PR DESCRIPTION
## Summary
- Bootstraps a Minecraft vanilla data layer modelled after the OSRS itemdb pipeline: **proto → Zod → MDX content collection → Starlight pages**. Foundation for the marketplace `kind=mc_item` create-form picker (Phase 5.3b).
- **Recipes live inline on items** — there is no standalone recipe registry. Per-item MDX is self-contained; no cross-item recipe browsing in v1.

## Proto layout (`packages/data/proto/kbve/mc/`)
- `mc_items.proto` — `MCItem` with inline `MCRecipe` + `MCEquipment` + `MCDamage` + `MCFood` + `MCMiningProfile` + `MCEnchantCompat`. Full shaped/shapeless/smelting/smithing/brewing shape captured.
- `mc_enchants.proto` — `McEnchant` with rarity, weight, targets, conflict list.
- `mc_blocks.proto` — `McBlock` with hardness, blast resistance, tool requirements, drops.

## Zod (`src/data/schema/mc/`)
- `enums.ts` — proto-aligned enum tables + shared `MCIdentitySchema` (id + ref + slug, regex-validated)
- `items.ts` / `enchants.ts` / `blocks.ts` — one Zod schema per proto top-level message
- `index.ts` — barrel; re-exported from `@/data/schema`

## Content collection (`src/content.config.ts`)
- Extends `docsSchema` with optional `mc_item` / `mc_enchant` / `mc_block` frontmatter blocks, mirroring how OSRS pages embed `osrs:`.
- Pages live under `content/docs/mc/{items,enchants,blocks}/<slug>.mdx`.

## Pages (`src/components/mcdb/`)
- `MCItemPanel.astro` — hero card + stats grid + enchant chips + tags + **per-recipe shaped crafting grid** + cook time + XP. Pulls textures from `mcasset.cloud` (same source as the marketplace `ItemIcon`, with item→block fallback).
- `MCEnchantPanel.astro` — rarity / curse / treasure pills, level + weight + anvil cost, targets, incompatibility list.
- `MCBlockPanel.astro` — hardness/tool/drops grid; deep-links to item form.

## Seed MDX (proves pipeline)
- `/mc/items/diamond-sword` — full shape including shaped crafting recipe inline
- `/mc/enchants/sharpness` — enchant table cost range + conflicts
- `/mc/blocks/oak-log` — material + drops

Sidebar autogen from `directory: 'mc'` cascades the new subdirs as collapsible groups (Items / Enchants / Blocks). No config change.

## Theming
All styles use Starlight + KBVE brand vars (`--sl-color-bg-nav`, `--sl-color-accent`, `--color-red`, `--color-gold-light`).

## Tracking
Phase 5.3a of #10979.

## Test plan
- [ ] `./kbve.sh -nx astro-kbve:build` — green (5510 pages built locally; 3 new MC pages emitted)
- [ ] CI astro-kbve pipeline green
- [ ] Visual smoke at:
  - `/mc/items/diamond-sword` — texture loads from mcasset.cloud, shaped grid renders 1×3 with diamond/diamond/stick
  - `/mc/enchants/sharpness` — red incompatibility chips link out to `/mc/enchants/smite` etc.
  - `/mc/blocks/oak-log` — block texture, drop list, "View item form →" deep-link works

## Follow-up
**Phase 5.3b** (next PR): bulk-import vanilla data from PrismarineJS `minecraft-data` via `scripts/generate-mc-items.mjs` (mirrors `generate-osrs-items.mjs` — never overwrites existing slugs), then wire a `<MCItemPicker>` into the marketplace create form so sellers pick from a typed list instead of free-typing `diamond_sword`.