### PR TITLE
fix(irc-e2e): track splash title rename KBVE IRC → KBVE Chat

### DIFF
--- a/apps/irc/irc-e2e/e2e/frontend.spec.ts
+++ b/apps/irc/irc-e2e/e2e/frontend.spec.ts
@@ -14,8 +14,8 @@ test.describe('Frontend: Index Page', () => {
 
 	test('index page title contains site name', async ({ page }) => {
 		await page.goto('/');
-		// Starlight sets <title> from the config: "KBVE IRC"
-		await expect(page).toHaveTitle(/KBVE\s*IRC/i);
+		// Starlight sets <title> from the splash MDX frontmatter: "KBVE Chat"
+		await expect(page).toHaveTitle(/KBVE\s*Chat/i);
 	});
 });
 


### PR DESCRIPTION
Closes #11124

## Summary

irc-e2e \`frontend.spec.ts\` index-title regex was hardcoded to \`/KBVE\s*IRC/i\`. The frontpage redesign (#11117) renamed the splash MDX frontmatter title from \`KBVE IRC\` → \`KBVE Chat\`, so the test fails on \`main\` post-merge.

Fix: update the regex to \`/KBVE\s*Chat/i\` and refresh the inline comment.

## Test plan

- [ ] \`nx e2e irc-e2e\` passes against a freshly-built container
- [ ] CI - Docker / irc-gateway returns to green on next dispatch