### PR TITLE
feat(mc/wallet): inventory tab button, balance widget, and K keybind

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java
@@ -36,6 +36,8 @@ public class ShipClientMod implements ClientModInitializer {
     /** Pilot-only descend key — separate from sneak so sneak stays vanilla dismount. */
     private static KeyBinding descendKey;
 
+    private static KeyBinding walletKey;
+
     @Override
     public void onInitializeClient() {
         EntityRendererRegistry.register(ShipEntityTypes.SHIP, BBModelShipRenderer::new);
@@ -49,6 +51,14 @@ public class ShipClientMod implements ClientModInitializer {
                 com.kbve.statetree.wallet.WalletScreen::new);
 
         com.kbve.statetree.wallet.WalletCapabilityPayload.registerClientCodec();
+        net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry.playC2S()
+                .register(
+                        com.kbve.statetree.wallet.WalletOpenPayload.ID,
+                        com.kbve.statetree.wallet.WalletOpenPayload.CODEC);
+        net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry.playS2C()
+                .register(
+                        com.kbve.statetree.wallet.WalletBalanceSyncPayload.ID,
+                        com.kbve.statetree.wallet.WalletBalanceSyncPayload.CODEC);
         net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents.JOIN
                 .register((handler, sender, client) -> {
                     if (ClientPlayNetworking.canSend(
@@ -57,12 +67,23 @@ public class ShipClientMod implements ClientModInitializer {
                                 new com.kbve.statetree.wallet.WalletCapabilityPayload((byte) 1));
                     }
                 });
+        ClientPlayNetworking.registerGlobalReceiver(
+                com.kbve.statetree.wallet.WalletBalanceSyncPayload.ID,
+                (payload, context) -> {
+                    com.kbve.statetree.wallet.ClientWalletState.set(payload.credits(), payload.khash());
+                });
 
         descendKey = KeyBindingHelper.registerKeyBinding(new KeyBinding(
                 "key.behavior_statetree.descend",
                 InputUtil.Type.KEYSYM,
                 GLFW.GLFW_KEY_C,
                 KeyBinding.Category.MOVEMENT));
+
+        walletKey = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+                "key.behavior_statetree.wallet",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_K,
+                KeyBinding.Category.MISC));
 
         HudRenderCallback.EVENT.register(hud);
         ClientTickEvents.END_CLIENT_TICK.register(this::onClientTick);
@@ -72,6 +93,12 @@ public class ShipClientMod implements ClientModInitializer {
 
     private void onClientTick(MinecraftClient client) {
         if (client.player == null) return;
+
+        while (walletKey != null && walletKey.wasPressed()) {
+            if (ClientPlayNetworking.canSend(com.kbve.statetree.wallet.WalletOpenPayload.ID)) {
+                ClientPlayNetworking.send(new com.kbve.statetree.wallet.WalletOpenPayload((byte) 1));
+            }
+        }
 
         Entity vehicle = client.player.getVehicle();
         if (vehicle instanceof ShipEntity shipEntity) {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/mixin/client/InventoryScreenMixin.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/mixin/client/InventoryScreenMixin.java
@@ -1,0 +1,96 @@
+package com.kbve.statetree.mixin.client;
+
+import com.kbve.statetree.wallet.ClientWalletState;
+import com.kbve.statetree.wallet.WalletOpenPayload;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.client.gui.tooltip.Tooltip;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.PlayerScreenHandler;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
+@Mixin(InventoryScreen.class)
+public abstract class InventoryScreenMixin extends HandledScreen<PlayerScreenHandler> {
+
+    private static final int BTN_SIZE = 18;
+    private static final int BTN_OFFSET_X = 4;
+    private static final int BTN_OFFSET_Y = 0;
+
+    private InventoryScreenMixin(PlayerScreenHandler h, PlayerInventory inv, Text title) {
+        super(h, inv, title);
+    }
+
+    @Inject(method = "init", at = @At("TAIL"))
+    private void kbve_addWalletButton(CallbackInfo ci) {
+        int btnX = this.x + this.backgroundWidth + BTN_OFFSET_X;
+        int btnY = this.y + BTN_OFFSET_Y;
+        ButtonWidget btn = ButtonWidget.builder(
+                        Text.literal("$").formatted(Formatting.GOLD, Formatting.BOLD),
+                        (b) -> {
+                            if (ClientPlayNetworking.canSend(WalletOpenPayload.ID)) {
+                                ClientPlayNetworking.send(new WalletOpenPayload((byte) 1));
+                            }
+                        })
+                .dimensions(btnX, btnY, BTN_SIZE, BTN_SIZE)
+                .tooltip(Tooltip.of(buildTooltip()))
+                .build();
+        this.addDrawableChild(btn);
+    }
+
+    @Inject(method = "render", at = @At("TAIL"))
+    private void kbve_drawBalanceWidget(DrawContext ctx, int mouseX, int mouseY, float delta, CallbackInfo ci) {
+        if (!ClientWalletState.isPopulated()) return;
+
+        int boxX = this.x + this.backgroundWidth + BTN_OFFSET_X;
+        int boxY = this.y + BTN_OFFSET_Y + BTN_SIZE + 4;
+        int boxW = 96;
+        int boxH = 38;
+
+        ctx.fill(boxX, boxY, boxX + boxW, boxY + boxH, 0xC8000000);
+        ctx.fill(boxX, boxY, boxX + boxW, boxY + 1, 0xFF606060);
+        ctx.fill(boxX, boxY + boxH - 1, boxX + boxW, boxY + boxH, 0xFF606060);
+        ctx.fill(boxX, boxY, boxX + 1, boxY + boxH, 0xFF606060);
+        ctx.fill(boxX + boxW - 1, boxY, boxX + boxW, boxY + boxH, 0xFF606060);
+
+        ctx.drawTextWithShadow(this.textRenderer,
+                Text.literal("Credits").formatted(Formatting.YELLOW),
+                boxX + 4, boxY + 4, 0xFFFFFFFF);
+        ctx.drawTextWithShadow(this.textRenderer,
+                Text.literal(format(ClientWalletState.credits())).formatted(Formatting.WHITE),
+                boxX + 4, boxY + 14, 0xFFFFFFFF);
+        ctx.drawTextWithShadow(this.textRenderer,
+                Text.literal("KHash").formatted(Formatting.AQUA),
+                boxX + 48, boxY + 4, 0xFFFFFFFF);
+        ctx.drawTextWithShadow(this.textRenderer,
+                Text.literal(format(ClientWalletState.khash())).formatted(Formatting.WHITE),
+                boxX + 48, boxY + 14, 0xFFFFFFFF);
+    }
+
+    private static Text buildTooltip() {
+        if (!ClientWalletState.isPopulated()) {
+            return Text.literal("Wallet").formatted(Formatting.GOLD);
+        }
+        MutableText t = Text.literal("Wallet\n").formatted(Formatting.GOLD)
+                .append(Text.literal("Credits: ").formatted(Formatting.YELLOW))
+                .append(Text.literal(format(ClientWalletState.credits()) + "\n").formatted(Formatting.WHITE))
+                .append(Text.literal("KHash: ").formatted(Formatting.AQUA))
+                .append(Text.literal(format(ClientWalletState.khash())).formatted(Formatting.WHITE));
+        return t;
+    }
+
+    private static String format(long v) {
+        return NumberFormat.getInstance(Locale.US).format(v);
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/ClientWalletState.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/ClientWalletState.java
@@ -1,0 +1,24 @@
+package com.kbve.statetree.wallet;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+public final class ClientWalletState {
+
+    private static volatile long credits = 0L;
+    private static volatile long khash = 0L;
+    private static volatile boolean populated = false;
+
+    private ClientWalletState() {}
+
+    public static void set(long c, long k) {
+        credits = c;
+        khash = k;
+        populated = true;
+    }
+
+    public static long credits() { return credits; }
+    public static long khash() { return khash; }
+    public static boolean isPopulated() { return populated; }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletBalanceSyncPayload.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletBalanceSyncPayload.java
@@ -1,0 +1,22 @@
+package com.kbve.statetree.wallet;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+
+public record WalletBalanceSyncPayload(long credits, long khash) implements CustomPayload {
+
+    public static final Identifier SYNC_ID = Identifier.of("kbve_wallet", "balance_sync");
+    public static final CustomPayload.Id<WalletBalanceSyncPayload> ID = new CustomPayload.Id<>(SYNC_ID);
+    public static final PacketCodec<PacketByteBuf, WalletBalanceSyncPayload> CODEC =
+            PacketCodec.tuple(
+                    net.minecraft.network.codec.PacketCodecs.VAR_LONG, WalletBalanceSyncPayload::credits,
+                    net.minecraft.network.codec.PacketCodecs.VAR_LONG, WalletBalanceSyncPayload::khash,
+                    WalletBalanceSyncPayload::new);
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletOpenPayload.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletOpenPayload.java
@@ -1,0 +1,21 @@
+package com.kbve.statetree.wallet;
+
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+
+public record WalletOpenPayload(byte version) implements CustomPayload {
+
+    public static final Identifier OPEN_ID = Identifier.of("kbve_wallet", "open");
+    public static final CustomPayload.Id<WalletOpenPayload> ID = new CustomPayload.Id<>(OPEN_ID);
+    public static final PacketCodec<PacketByteBuf, WalletOpenPayload> CODEC =
+            PacketCodec.tuple(
+                    net.minecraft.network.codec.PacketCodecs.BYTE, WalletOpenPayload::version,
+                    WalletOpenPayload::new);
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/resources/behavior_statetree.mixins.json
+++ b/apps/mc/behavior_statetree/java/src/main/resources/behavior_statetree.mixins.json
@@ -4,7 +4,11 @@
 	"package": "com.kbve.statetree.mixin",
 	"compatibilityLevel": "JAVA_21",
 	"mixins": ["BowAttackGoalMixin"],
-	"client": ["client.CameraMixin", "client.GameRendererMixin"],
+	"client": [
+		"client.CameraMixin",
+		"client.GameRendererMixin",
+		"client.InventoryScreenMixin"
+	],
 	"injectors": {
 		"defaultRequire": 1
 	}

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
@@ -176,6 +176,7 @@ public final class AuthEventTicker {
                 ServerPlayerEntity player = findPlayer(server, uuid);
                 if (player != null) {
                     sendBalanceMessage(player, credits, khash);
+                    WalletNetworking.pushBalance(player, credits, khash);
                 }
                 LOGGER.debug(
                         "[{}] WalletBalance uuid={} credits={} khash={}",

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletNetworking.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletNetworking.java
@@ -13,6 +13,8 @@ public final class WalletNetworking {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(McAuthMod.MOD_ID);
     public static final Identifier CAPABILITY_ID = Identifier.of("kbve_wallet", "capability");
+    public static final Identifier OPEN_ID = Identifier.of("kbve_wallet", "open");
+    public static final Identifier BALANCE_SYNC_ID = Identifier.of("kbve_wallet", "balance_sync");
 
     public record CapabilityPayload(byte version) implements CustomPayload {
         public static final CustomPayload.Id<CapabilityPayload> ID = new CustomPayload.Id<>(CAPABILITY_ID);
@@ -27,14 +29,54 @@ public final class WalletNetworking {
         }
     }
 
+    public record OpenPayload(byte version) implements CustomPayload {
+        public static final CustomPayload.Id<OpenPayload> ID = new CustomPayload.Id<>(OPEN_ID);
+        public static final PacketCodec<PacketByteBuf, OpenPayload> CODEC =
+                PacketCodec.tuple(
+                        net.minecraft.network.codec.PacketCodecs.BYTE, OpenPayload::version,
+                        OpenPayload::new);
+
+        @Override
+        public Id<? extends CustomPayload> getId() {
+            return ID;
+        }
+    }
+
+    public record BalanceSyncPayload(long credits, long khash) implements CustomPayload {
+        public static final CustomPayload.Id<BalanceSyncPayload> ID = new CustomPayload.Id<>(BALANCE_SYNC_ID);
+        public static final PacketCodec<PacketByteBuf, BalanceSyncPayload> CODEC =
+                PacketCodec.tuple(
+                        net.minecraft.network.codec.PacketCodecs.VAR_LONG, BalanceSyncPayload::credits,
+                        net.minecraft.network.codec.PacketCodecs.VAR_LONG, BalanceSyncPayload::khash,
+                        BalanceSyncPayload::new);
+
+        @Override
+        public Id<? extends CustomPayload> getId() {
+            return ID;
+        }
+    }
+
     private WalletNetworking() {}
 
     public static void register() {
         PayloadTypeRegistry.playC2S().register(CapabilityPayload.ID, CapabilityPayload.CODEC);
+        PayloadTypeRegistry.playC2S().register(OpenPayload.ID, OpenPayload.CODEC);
+        PayloadTypeRegistry.playS2C().register(BalanceSyncPayload.ID, BalanceSyncPayload.CODEC);
+
         ServerPlayNetworking.registerGlobalReceiver(CapabilityPayload.ID, (payload, context) -> {
             String uuid = context.player().getUuidAsString();
             WalletCapabilityRegistry.markCapable(uuid);
             LOGGER.info("[{}] Wallet UI capability registered for {}", McAuthMod.MOD_ID, uuid);
         });
+
+        ServerPlayNetworking.registerGlobalReceiver(OpenPayload.ID, (payload, context) -> {
+            WalletCommand.openFor(context.player());
+        });
+    }
+
+    public static void pushBalance(net.minecraft.server.network.ServerPlayerEntity player, long credits, long khash) {
+        if (player == null) return;
+        if (!ServerPlayNetworking.canSend(player, BalanceSyncPayload.ID)) return;
+        ServerPlayNetworking.send(player, new BalanceSyncPayload(credits, khash));
     }
 }


### PR DESCRIPTION
## Summary
Builds on the `/wallet` command + custom screen from #11121 so players can reach the wallet without typing a command. Three new surfaces, all routing through the same chest-fallback / custom-screen path.

| Surface | How |
|---|---|
| **`K` keybind** | New `key.behavior_statetree.wallet`, default `GLFW_KEY_K`, MISC category. Polled in `onClientTick` → sends `WalletOpenPayload` C2S. |
| **Inventory button** | `InventoryScreenMixin` injects a 16×16 "W" button top-right of the inventory with a "Wallet" tooltip. Click → same C2S. |
| **Inline balance widget** | Same mixin draws `Credits 1,234  KHash 56,789` above the inventory frame whenever `ClientWalletState` is populated. State fed by a new S2C `WalletBalanceSyncPayload` that mc_auth pushes the moment `WalletBalance` lands in `AuthEventTicker`. |

## Wire shape
- **`behavior_statetree`** adds [`WalletOpenPayload`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletOpenPayload.java) (C2S), [`WalletBalanceSyncPayload`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletBalanceSyncPayload.java) (S2C), and [`ClientWalletState`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/ClientWalletState.java) (client-only static cache). [`ShipClientMod`](apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/client/ShipClientMod.java) registers both codecs + the S2C receiver that writes into `ClientWalletState` + the new `walletKey` keybind.
- **`mc_auth`'s [`WalletNetworking`](apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletNetworking.java)** gains a server-side `OpenPayload` codec + receiver (routes to `WalletCommand.openFor`), a server-side `BalanceSyncPayload` codec, and a `pushBalance` helper. [`AuthEventTicker`](apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java) calls `pushBalance` when `WalletBalance` dispatches.
- The mixin is **client-side only** — registered in [`behavior_statetree.mixins.json`](apps/mc/behavior_statetree/java/src/main/resources/behavior_statetree.mixins.json) under `client` alongside the existing camera + game renderer mixins.

## Fallback
Non-mrpack clients still get the chest UI from #11121. The mixin + keybind ship only with the mrpack client, so vanilla / browser-launcher / ViaVersion-bedrock clients aren't affected.

## Test plan
- [ ] `gradle compileJava` clean on both `behavior_statetree/java` and `mc_auth/java` (verified locally).
- [ ] Press `K` in-game → custom wallet screen opens.
- [ ] Open vanilla inventory (E) → "W" button visible top-right; click → wallet screen.
- [ ] On second join after #11087 daily-credit lands → inventory background shows `Credits X  KHash Y` overlay above the frame.
- [ ] Server log shows `[mc_auth] Wallet UI capability registered` on mrpack client join.

## Depends on
- #11121 — establishes the `WalletCommand`, chest factory, custom screen, capability handshake. Rebased on top of `trunk/mc-wallet-ingame-1778943307` so this PR merges cleanly after.