### PR TITLE
fix(firecracker-ctl): declare kbve/jedi/holy in Docker workspace stub (closes #11110)

### DIFF
--- a/apps/vm/firecracker-ctl/Cargo.workspace.toml
+++ b/apps/vm/firecracker-ctl/Cargo.workspace.toml
@@ -2,6 +2,9 @@
 resolver = "2"
 members = [
     "apps/vm/firecracker-ctl",
+    "packages/rust/kbve",
+    "packages/rust/jedi",
+    "packages/rust/holy",
 ]
 
 [profile.release]


### PR DESCRIPTION
## Summary
Closes #11110 — \`CI - Docker / firecracker-ctl\` has been failing since PR #11109 (Phase C.3) added the \`kbve\` workspace dep to fc-ctl's Cargo.toml.

\`\`\`
#15 0.064 Error: Failed to compute recipe
#15 0.064 Caused by:
#15 0.064     2: \`cargo metadata\` exited with an error: error: failed to load manifest for workspace member \`/app/apps/vm/firecracker-ctl\`
                referenced by workspace at \`/app/Cargo.toml\`
                Caused by:
                  failed to load manifest for dependency \`kbve\`
                Caused by:
                  failed to read \`/app/packages/rust/kbve/Cargo.toml\`
\`\`\`

## Root cause
The Dockerfile already \`COPY\`s \`packages/rust/{kbve,jedi,holy}\` into the build context, but the synthetic \`Cargo.workspace.toml\` only declared \`apps/vm/firecracker-ctl\` as a workspace member. cargo's resolver refuses to follow fc-ctl's \`path = "../../../packages/rust/kbve"\` because \`kbve\`'s own \`[package]\` is implicitly a member of \`/app/Cargo.toml\` — and \`/app/Cargo.toml\` doesn't claim it.

## Fix
Add \`kbve\`, \`jedi\`, \`holy\` to the workspace members list. Source is already on disk via the existing \`COPY\` directives; this just teaches cargo that they belong.

\`\`\`diff
 [workspace]
 resolver = "2"
 members = [
     "apps/vm/firecracker-ctl",
+    "packages/rust/kbve",
+    "packages/rust/jedi",
+    "packages/rust/holy",
 ]
\`\`\`

## Test plan
- [ ] Next \`CI - Docker / firecracker-ctl\` run on \`main\` finishes \`cargo chef prepare\` cleanly and pushes the image.