### PR TITLE
feat(astro-kbve): diamond tier items + /api/mc-items + create-form picker (Phase 5.3b)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -946,4 +946,88 @@ import MarketCreateForm from './MarketCreateForm';
 			justify-self: end;
 		}
 	}
+
+	/* ---- Phase 5.3b: MC item picker ---- */
+	.kbve-mcpicker {
+		position: relative;
+		display: grid;
+		gap: 0.35rem;
+	}
+	.kbve-mcpicker__input {
+		width: 100%;
+	}
+	.kbve-mcpicker__known {
+		font-size: 0.78rem;
+		font-weight: 700;
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+		text-decoration: none;
+	}
+	.kbve-mcpicker__known:hover {
+		text-decoration: underline;
+	}
+	.kbve-mcpicker__list {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		margin: 0.25rem 0 0;
+		padding: 0.3rem;
+		list-style: none;
+		display: grid;
+		gap: 0.15rem;
+		max-height: 280px;
+		overflow-y: auto;
+		background: var(--sl-color-bg-sidebar, var(--sl-color-bg-nav));
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		border-radius: 10px;
+		z-index: 50;
+		box-shadow: 0 12px 24px -8px
+			color-mix(in srgb, var(--sl-color-black) 50%, transparent);
+	}
+	.kbve-mcpicker__list button {
+		width: 100%;
+		text-align: left;
+		display: grid;
+		grid-template-columns: 1fr auto auto;
+		gap: 0.5rem;
+		align-items: baseline;
+		padding: 0.4rem 0.6rem;
+		border-radius: 6px;
+		background: transparent;
+		border: none;
+		color: var(--sl-color-text);
+		cursor: pointer;
+		font: inherit;
+	}
+	.kbve-mcpicker__list button:hover {
+		background: var(--sl-color-bg-nav);
+	}
+	.kbve-mcpicker__name {
+		font-weight: 700;
+	}
+	.kbve-mcpicker__ref {
+		font-size: 0.78rem;
+		color: var(--sl-color-gray-3);
+		font-family: var(--sl-font-mono, monospace);
+	}
+	.kbve-mcpicker__cat {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+	}
+	.kbve-mcpicker__empty {
+		margin-top: 0.3rem;
+		padding: 0.5rem 0.65rem;
+		border-radius: 8px;
+		font-size: 0.8rem;
+		color: var(--sl-color-gray-3);
+		background: var(--sl-color-bg-nav);
+		border: 1px dashed var(--sl-color-hairline, var(--sl-color-gray-5));
+	}
+	.kbve-mcpicker__empty code {
+		padding: 0.05rem 0.35rem;
+		border-radius: 4px;
+		background: var(--sl-color-bg-inline-code);
+	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/market/MCItemPicker.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MCItemPicker.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useMemo, useState } from 'react';
+
+type MCItemIndexEntry = {
+	id: number;
+	ref: string;
+	slug: string;
+	display_name: string;
+	category: string;
+	rarity: string;
+	stack_size: number;
+	tier: string | null;
+	tags: string[];
+};
+
+type Props = {
+	value: string;
+	onChange: (next: string) => void;
+	disabled?: boolean;
+	placeholder?: string;
+};
+
+const CACHE_KEY = 'kbve:mc-items:index:v1';
+const ENDPOINT = '/api/mc-items.json';
+
+type CachedPayload = { items: MCItemIndexEntry[]; cachedAt: number };
+
+function readCache(): MCItemIndexEntry[] | null {
+	if (typeof localStorage === 'undefined') return null;
+	try {
+		const raw = localStorage.getItem(CACHE_KEY);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as CachedPayload;
+		if (Date.now() - parsed.cachedAt > 1000 * 60 * 60 * 24) return null;
+		return parsed.items;
+	} catch {
+		return null;
+	}
+}
+
+function writeCache(items: MCItemIndexEntry[]) {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(
+			CACHE_KEY,
+			JSON.stringify({
+				items,
+				cachedAt: Date.now(),
+			} satisfies CachedPayload),
+		);
+	} catch {}
+}
+
+export function MCItemPicker({
+	value,
+	onChange,
+	disabled,
+	placeholder = 'diamond_sword',
+}: Props) {
+	const [items, setItems] = useState<MCItemIndexEntry[] | null>(null);
+	const [query, setQuery] = useState(value);
+	const [open, setOpen] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		setQuery(value);
+	}, [value]);
+
+	useEffect(() => {
+		const cached = readCache();
+		if (cached) setItems(cached);
+		let cancelled = false;
+		(async () => {
+			try {
+				const res = await fetch(ENDPOINT);
+				if (!res.ok) throw new Error(`${res.status}`);
+				const json = (await res.json()) as {
+					items: MCItemIndexEntry[];
+				};
+				if (cancelled) return;
+				setItems(json.items);
+				writeCache(json.items);
+			} catch (e) {
+				if (!cancelled)
+					setError(e instanceof Error ? e.message : 'load failed');
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const matches = useMemo(() => {
+		if (!items) return [];
+		const q = query.trim().toLowerCase();
+		if (!q) return items.slice(0, 25);
+		return items
+			.filter(
+				(it) =>
+					it.ref.includes(q) ||
+					it.display_name.toLowerCase().includes(q),
+			)
+			.slice(0, 25);
+	}, [items, query]);
+
+	const known = useMemo(() => {
+		if (!items || !value) return null;
+		return items.find((it) => it.ref === value) ?? null;
+	}, [items, value]);
+
+	const onPick = (ref: string) => {
+		onChange(ref);
+		setQuery(ref);
+		setOpen(false);
+	};
+
+	return (
+		<div className="kbve-mcpicker">
+			<input
+				type="text"
+				className="kbve-market__input kbve-mcpicker__input"
+				placeholder={placeholder}
+				value={query}
+				disabled={disabled}
+				onChange={(e) => {
+					setQuery(e.target.value);
+					onChange(e.target.value);
+					setOpen(true);
+				}}
+				onFocus={() => setOpen(true)}
+				onBlur={() => window.setTimeout(() => setOpen(false), 150)}
+				autoComplete="off"
+				spellCheck={false}
+			/>
+			{known && (
+				<a
+					className="kbve-mcpicker__known"
+					href={`/mc/items/${known.slug}/`}
+					target="_blank"
+					rel="noopener"
+					title={`${known.display_name} — open page`}>
+					✓ {known.display_name}
+				</a>
+			)}
+			{open && matches.length > 0 && (
+				<ul className="kbve-mcpicker__list" role="listbox">
+					{matches.map((it) => (
+						<li key={it.ref} role="option">
+							<button
+								type="button"
+								onMouseDown={(e) => e.preventDefault()}
+								onClick={() => onPick(it.ref)}>
+								<span className="kbve-mcpicker__name">
+									{it.display_name}
+								</span>
+								<span className="kbve-mcpicker__ref">
+									{it.ref}
+								</span>
+								<span className="kbve-mcpicker__cat">
+									{it.category}
+								</span>
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
+			{open && items && matches.length === 0 && query.trim() && (
+				<div className="kbve-mcpicker__empty">
+					Unknown ref. You can still list <code>{query}</code> — but
+					it won't link to a /mc/items page.
+				</div>
+			)}
+			{error && (
+				<div className="kbve-market__status kbve-market__status--error">
+					item index failed: {error}
+				</div>
+			)}
+		</div>
+	);
+}
+
+export default MCItemPicker;

--- a/apps/kbve/astro-kbve/src/components/market/MarketCreateForm.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketCreateForm.tsx
@@ -3,6 +3,7 @@ import { useSession } from '@kbve/astro';
 import { createListing, MarketApiError } from './api';
 import { EnchantEditor } from './EnchantEditor';
 import type { Enchant } from './enchants';
+import { MCItemPicker } from './MCItemPicker';
 
 const KIND_OPTIONS = [
 	{ value: 'mc_item', label: 'Minecraft item' },
@@ -111,14 +112,22 @@ export function MarketCreateForm() {
 				</label>
 				<label>
 					Item ID
-					<input
-						type="text"
-						required
-						placeholder="diamond_sword"
-						value={itemId}
-						onChange={(e) => setItemId(e.target.value)}
-						className="kbve-market__input"
-					/>
+					{kind === 'mc_item' ? (
+						<MCItemPicker
+							value={itemId}
+							onChange={setItemId}
+							disabled={busy}
+						/>
+					) : (
+						<input
+							type="text"
+							required
+							placeholder="diamond_sword"
+							value={itemId}
+							onChange={(e) => setItemId(e.target.value)}
+							className="kbve-market__input"
+						/>
+					)}
 				</label>
 				<label>
 					Instance ID (optional)

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-axe.mdx
@@ -1,0 +1,80 @@
+---
+title: Diamond Axe
+description: |
+    Diamond Axe — high damage weapon + tier 5 wood-mining tool. 9 attack
+    damage, 1561 durability.
+sidebar:
+    label: Diamond Axe
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 826
+    ref: diamond_axe
+    slug: diamond-axe
+    display_name: Diamond Axe
+    category: tool
+    rarity: common
+    stack_size: 1
+    max_durability: 1561
+    tier: diamond
+    damage:
+        attack_damage: 9
+        attack_speed: 1.0
+    mining:
+        tool_type: axe
+        tier: 5
+    enchants:
+        allowed:
+            - efficiency
+            - fortune
+            - silk_touch
+            - sharpness
+            - smite
+            - bane_of_arthropods
+            - unbreaking
+            - mending
+            - vanishing_curse
+    tags:
+        - melee
+        - mining
+        - tier_diamond
+    recipes:
+        - kind: shaped
+          station: crafting_table
+          yields: 1
+          width: 2
+          height: 3
+          ingredients:
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 1
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 0
+              - ref: stick
+                qty: 1
+                row: 1
+                col: 1
+              - ref: stick
+                qty: 1
+                row: 2
+                col: 1
+    about:
+        description: |
+            The Diamond Axe deals more damage per hit than the Diamond
+            Sword (9 vs 7), trading attack speed (1.0 vs 1.6). Also chops
+            wood and harvests pumpkins / melons faster than swords.
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-block.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-block.mdx
@@ -1,0 +1,77 @@
+---
+title: Block of Diamond
+description: |
+    Block of Diamond — storage form for 9 diamonds. Doubles as a beacon
+    pyramid base.
+sidebar:
+    label: Block of Diamond
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 113
+    ref: diamond_block
+    slug: diamond-block
+    display_name: Block of Diamond
+    category: block
+    rarity: common
+    stack_size: 64
+    tags:
+        - storage
+        - tier_diamond
+        - beacon_base
+    recipes:
+        - kind: shaped
+          station: crafting_table
+          yields: 1
+          width: 3
+          height: 3
+          ingredients:
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 1
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 2
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 1
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 2
+              - ref: diamond
+                qty: 1
+                row: 2
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 2
+                col: 1
+              - ref: diamond
+                qty: 1
+                row: 2
+                col: 2
+    about:
+        description: |
+            Compacts 9 diamonds into one storage block. Crafting back
+            into 9 individual diamonds at any time. Counts as a tier-2
+            beacon pyramid material.
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-boots.mdx
@@ -1,0 +1,72 @@
+---
+title: Diamond Boots
+description: |
+    Diamond Boots — foot armor. 3 armor + 2 toughness. 429 durability.
+sidebar:
+    label: Diamond Boots
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 833
+    ref: diamond_boots
+    slug: diamond-boots
+    display_name: Diamond Boots
+    category: armor
+    rarity: common
+    stack_size: 1
+    max_durability: 429
+    tier: diamond
+    equipment:
+        slot: feet
+        armor_points: 3
+        toughness: 2
+        knockback_resistance: 0
+    enchants:
+        allowed:
+            - blast_protection
+            - depth_strider
+            - feather_falling
+            - fire_protection
+            - frost_walker
+            - projectile_protection
+            - protection
+            - soul_speed
+            - thorns
+            - unbreaking
+            - mending
+            - binding_curse
+            - vanishing_curse
+    tags:
+        - armor
+        - tier_diamond
+    recipes:
+        - kind: shaped
+          station: crafting_table
+          yields: 1
+          width: 3
+          height: 2
+          ingredients:
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 2
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 2
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-chestplate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-chestplate.mdx
@@ -1,0 +1,84 @@
+---
+title: Diamond Chestplate
+description: |
+    Diamond Chestplate — chest armor. 8 armor + 2 toughness. 528 durability.
+sidebar:
+    label: Diamond Chestplate
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 831
+    ref: diamond_chestplate
+    slug: diamond-chestplate
+    display_name: Diamond Chestplate
+    category: armor
+    rarity: common
+    stack_size: 1
+    max_durability: 528
+    tier: diamond
+    equipment:
+        slot: chest
+        armor_points: 8
+        toughness: 2
+        knockback_resistance: 0
+    enchants:
+        allowed:
+            - blast_protection
+            - fire_protection
+            - projectile_protection
+            - protection
+            - thorns
+            - unbreaking
+            - mending
+            - binding_curse
+            - vanishing_curse
+    tags:
+        - armor
+        - tier_diamond
+    recipes:
+        - kind: shaped
+          station: crafting_table
+          yields: 1
+          width: 3
+          height: 3
+          ingredients:
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 2
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 1
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 2
+              - ref: diamond
+                qty: 1
+                row: 2
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 2
+                col: 1
+              - ref: diamond
+                qty: 1
+                row: 2
+                col: 2
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-helmet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-helmet.mdx
@@ -1,0 +1,74 @@
+---
+title: Diamond Helmet
+description: |
+    Diamond Helmet — head armor. 3 armor + 2 toughness. 363 durability.
+sidebar:
+    label: Diamond Helmet
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 830
+    ref: diamond_helmet
+    slug: diamond-helmet
+    display_name: Diamond Helmet
+    category: armor
+    rarity: common
+    stack_size: 1
+    max_durability: 363
+    tier: diamond
+    equipment:
+        slot: head
+        armor_points: 3
+        toughness: 2
+        knockback_resistance: 0
+    enchants:
+        allowed:
+            - aqua_affinity
+            - blast_protection
+            - fire_protection
+            - projectile_protection
+            - protection
+            - respiration
+            - thorns
+            - unbreaking
+            - mending
+            - binding_curse
+            - vanishing_curse
+    tags:
+        - armor
+        - tier_diamond
+    recipes:
+        - kind: shaped
+          station: crafting_table
+          yields: 1
+          width: 3
+          height: 2
+          ingredients:
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 1
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 2
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 2
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-hoe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-hoe.mdx
@@ -1,0 +1,66 @@
+---
+title: Diamond Hoe
+description: |
+    Diamond Hoe — tier 5 farming tool. 1561 durability.
+sidebar:
+    label: Diamond Hoe
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 827
+    ref: diamond_hoe
+    slug: diamond-hoe
+    display_name: Diamond Hoe
+    category: tool
+    rarity: common
+    stack_size: 1
+    max_durability: 1561
+    tier: diamond
+    damage:
+        attack_damage: 1
+        attack_speed: 4.0
+    mining:
+        tool_type: hoe
+        tier: 5
+    enchants:
+        allowed:
+            - efficiency
+            - fortune
+            - silk_touch
+            - unbreaking
+            - mending
+            - vanishing_curse
+    tags:
+        - farming
+        - tier_diamond
+    recipes:
+        - kind: shaped
+          station: crafting_table
+          yields: 1
+          width: 2
+          height: 3
+          ingredients:
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 1
+              - ref: stick
+                qty: 1
+                row: 1
+                col: 1
+              - ref: stick
+                qty: 1
+                row: 2
+                col: 1
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-leggings.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-leggings.mdx
@@ -1,0 +1,81 @@
+---
+title: Diamond Leggings
+description: |
+    Diamond Leggings — leg armor. 6 armor + 2 toughness. 495 durability.
+sidebar:
+    label: Diamond Leggings
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 832
+    ref: diamond_leggings
+    slug: diamond-leggings
+    display_name: Diamond Leggings
+    category: armor
+    rarity: common
+    stack_size: 1
+    max_durability: 495
+    tier: diamond
+    equipment:
+        slot: legs
+        armor_points: 6
+        toughness: 2
+        knockback_resistance: 0
+    enchants:
+        allowed:
+            - blast_protection
+            - fire_protection
+            - projectile_protection
+            - protection
+            - swift_sneak
+            - thorns
+            - unbreaking
+            - mending
+            - binding_curse
+            - vanishing_curse
+    tags:
+        - armor
+        - tier_diamond
+    recipes:
+        - kind: shaped
+          station: crafting_table
+          yields: 1
+          width: 3
+          height: 3
+          ingredients:
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 1
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 2
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 1
+                col: 2
+              - ref: diamond
+                qty: 1
+                row: 2
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 2
+                col: 2
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-pickaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-pickaxe.mdx
@@ -1,0 +1,77 @@
+---
+title: Diamond Pickaxe
+description: |
+    Diamond Pickaxe — tier 5 mining tool. Required to mine obsidian,
+    ancient debris, and netherite. 1561 durability.
+sidebar:
+    label: Diamond Pickaxe
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 825
+    ref: diamond_pickaxe
+    slug: diamond-pickaxe
+    display_name: Diamond Pickaxe
+    category: tool
+    rarity: common
+    stack_size: 1
+    max_durability: 1561
+    tier: diamond
+    damage:
+        attack_damage: 5
+        attack_speed: 1.2
+    mining:
+        tool_type: pickaxe
+        tier: 5
+    enchants:
+        allowed:
+            - efficiency
+            - fortune
+            - silk_touch
+            - unbreaking
+            - mending
+            - vanishing_curse
+    tags:
+        - mining
+        - tier_diamond
+    recipes:
+        - kind: shaped
+          station: crafting_table
+          yields: 1
+          width: 3
+          height: 3
+          ingredients:
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 0
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 1
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 2
+              - ref: stick
+                qty: 1
+                row: 1
+                col: 1
+              - ref: stick
+                qty: 1
+                row: 2
+                col: 1
+    about:
+        description: |
+            The Diamond Pickaxe is the cheapest tool capable of mining
+            obsidian (and the gate to Netherite). 1561 durability matches
+            the diamond family; pair with Unbreaking + Mending for an
+            endgame mining setup.
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-shovel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond-shovel.mdx
@@ -1,0 +1,62 @@
+---
+title: Diamond Shovel
+description: |
+    Diamond Shovel — tier 5 dirt/sand/gravel/snow tool. 1561 durability.
+sidebar:
+    label: Diamond Shovel
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 824
+    ref: diamond_shovel
+    slug: diamond-shovel
+    display_name: Diamond Shovel
+    category: tool
+    rarity: common
+    stack_size: 1
+    max_durability: 1561
+    tier: diamond
+    damage:
+        attack_damage: 5.5
+        attack_speed: 1.0
+    mining:
+        tool_type: shovel
+        tier: 5
+    enchants:
+        allowed:
+            - efficiency
+            - fortune
+            - silk_touch
+            - unbreaking
+            - mending
+            - vanishing_curse
+    tags:
+        - mining
+        - tier_diamond
+    recipes:
+        - kind: shaped
+          station: crafting_table
+          yields: 1
+          width: 1
+          height: 3
+          ingredients:
+              - ref: diamond
+                qty: 1
+                row: 0
+                col: 0
+              - ref: stick
+                qty: 1
+                row: 1
+                col: 0
+              - ref: stick
+                qty: 1
+                row: 2
+                col: 0
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/diamond.mdx
@@ -1,0 +1,37 @@
+---
+title: Diamond
+description: |
+    Diamond — material gem. Crafts all diamond tools, armor, and the
+    diamond block. Smelts from diamond ore.
+sidebar:
+    label: Diamond
+tags:
+    - minecraft
+    - mc
+    - mc-item
+mc_item:
+    id: 814
+    ref: diamond
+    slug: diamond
+    display_name: Diamond
+    category: material
+    rarity: common
+    stack_size: 64
+    drop_sources:
+        - diamond_ore
+        - deepslate_diamond_ore
+    tags:
+        - gem
+        - tier_diamond
+    about:
+        description: |
+            Diamonds are the staple endgame material before Netherite.
+            Mined with iron pickaxe or better, drops 1 per ore (Fortune
+            III can yield up to 4). Trades, jungle temples, and shipwreck
+            chests are alternative sources.
+    data_version: "1.21.5"
+---
+
+import MCItemPanel from '@/components/mcdb/MCItemPanel.astro';
+
+<MCItemPanel data={frontmatter.mc_item} />

--- a/apps/kbve/astro-kbve/src/data/schema/mc/items.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/items.ts
@@ -26,9 +26,10 @@ export const MCEquipmentSchema = z.object({
 });
 export type MCEquipment = z.infer<typeof MCEquipmentSchema>;
 
-// proto: MCDamage
+// proto: MCDamage. MC tools deal fractional base damage (e.g. shovel +1.5)
+// — accept float; the in-game tooltip rounds to display.
 export const MCDamageSchema = z.object({
-	attack_damage: z.number().int().nonnegative(),
+	attack_damage: z.number().nonnegative(),
 	attack_speed: z.number(),
 });
 export type MCDamage = z.infer<typeof MCDamageSchema>;

--- a/apps/kbve/astro-kbve/src/pages/api/mc-items.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/mc-items.json.ts
@@ -1,0 +1,64 @@
+import { getCollection } from 'astro:content';
+
+/**
+ * `/api/mc-items.json` — flat index of every MC item with a published MDX
+ * page. Built at SSG time from the docs collection (frontmatter
+ * `mc_item:` block). Consumed by the marketplace create-form picker and
+ * any future autocomplete surface.
+ */
+export const GET = async () => {
+	const entries = await getCollection(
+		'docs',
+		(entry: { id: string; data: Record<string, unknown> }) => {
+			return (
+				entry.id.startsWith('mc/items/') && Boolean(entry.data?.mc_item)
+			);
+		},
+	);
+
+	const items = entries
+		.map(
+			(entry: {
+				id: string;
+				data: { mc_item?: Record<string, unknown> };
+			}) => {
+				const mc = entry.data.mc_item;
+				if (!mc) return null;
+				return {
+					id: mc.id,
+					ref: mc.ref,
+					slug: mc.slug,
+					display_name: mc.display_name,
+					category: mc.category,
+					rarity: mc.rarity,
+					stack_size: mc.stack_size,
+					tier: mc.tier ?? null,
+					tags: mc.tags ?? [],
+				};
+			},
+		)
+		.filter(Boolean)
+		.sort((a, b) =>
+			String(a!.display_name).localeCompare(String(b!.display_name)),
+		);
+
+	const byRef: Record<string, number> = {};
+	items.forEach((it, idx) => {
+		if (it && typeof it.ref === 'string') byRef[it.ref] = idx;
+	});
+
+	return new Response(
+		JSON.stringify({
+			items,
+			byRef,
+			count: items.length,
+			generated_at: new Date().toISOString(),
+		}),
+		{
+			headers: {
+				'Content-Type': 'application/json',
+				'Cache-Control': 'public, max-age=300',
+			},
+		},
+	);
+};

--- a/packages/data/proto/kbve/mc/mc_items.proto
+++ b/packages/data/proto/kbve/mc/mc_items.proto
@@ -78,9 +78,10 @@ message MCEquipment {
   int32  knockback_resistance = 4;
 }
 
-// MCDamage models tool/weapon damage profile.
+// MCDamage models tool/weapon damage profile. attack_damage is float
+// because MC tools deal fractional base damage (shovel +1.5, hoe +1.0).
 message MCDamage {
-  int32 attack_damage = 1;
+  float attack_damage = 1;
   float attack_speed  = 2;
 }
 


### PR DESCRIPTION
## Summary
- Fleshes out the Minecraft item database with the **full diamond tier (10 items)** and wires the marketplace create form to an **autocomplete picker** backed by the MDX collection.
- Builds on Phase 5.3a (#11125) — uses the proto-aligned Zod schema + MDX content collection it introduced.

## Items added (`src/content/docs/mc/items/`)
- `diamond`, `diamond-block`
- `diamond-pickaxe`, `diamond-axe`, `diamond-shovel`, `diamond-hoe`
- `diamond-helmet`, `diamond-chestplate`, `diamond-leggings`, `diamond-boots`

Each MDX carries the full vanilla recipe inline (shaped grid layout), compatible enchant list, durability, equipment slot/armor/toughness, and mining tier where applicable.

## API
- `GET /api/mc-items.json` — flat index built at SSG time from `getCollection('docs')` filtered to `mc/items/*` with a `mc_item` block.
- Emits `{ items: [...], byRef, count, generated_at }` sorted by display_name. Cache-Control: `public, max-age=300`.

## Marketplace picker
- New `<MCItemPicker>` React component — autocomplete input with 24h localStorage cache.
- Substring match on `ref` + `display_name`. Shows `display_name + ref + category` per row.
- Shows a `✓ <name>` deep-link badge when typed ref resolves to a known item.
- **Graceful fallback**: free-text mode if the seller types a ref we don't have yet — they aren't gated on MDX existing first.
- Wired into `MarketCreateForm` — replaces the raw text input only when `kind=mc_item`. Other kinds keep the original input.

## Schema fix
- `MCDamage.attack_damage` relaxed from `int` → `float` in both proto and Zod. MC tools deal fractional base damage (shovel +1.5, hoe +1.0); int rejected `diamond-shovel`'s 5.5 at build time.

## Theming
All picker styles use Starlight + KBVE brand vars (`--sl-color-bg-sidebar`, `--sl-color-accent`, `--sl-color-hairline`).

## Tracking
Phase 5.3b of #10979. Phase 5.3a (proto + schema + content collections + panels) shipped via #11125.

## Test plan
- [ ] `./kbve.sh -nx astro-kbve:build` — green (5520 pages locally; 10 new MC items emitted)
- [ ] CI astro-kbve pipeline green
- [ ] Visual smoke at:
  - `/mc/items/diamond-pickaxe` — shaped 3-wide grid renders, durability 1561, mining tier 5
  - `/mc/items/diamond-chestplate` — 3×3 grid with center+slots, armor 8 / toughness 2
- [ ] `GET /api/mc-items.json` — returns 11 items (10 new + diamond-sword from 5.3a)
- [ ] `/market` create-listing flow: set kind=Minecraft → picker autocompletes; typing "diamond" surfaces all 11; selecting one populates ref + shows ✓ deep-link

## Follow-up
- More item tiers (iron, netherite, gold, leather, food, common blocks) — fill at our own pace; picker grows with each MDX file.
- Possible `/mc/items/index.mdx` landing page with a category grid.