### PR TITLE
fix(astro-kbve): mc textures via TSX island + recipe image grid (Phase 5.3c)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mcdb/MCBlockPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCBlockPanel.astro
@@ -1,17 +1,21 @@
 ---
 import { McBlockSchema } from '@/data/schema';
+import MCTextureImage from './MCTextureImage';
 
 const { data } = Astro.props;
 const b = McBlockSchema.parse(data);
-
-const MC_ASSET_VERSION = '1.21.5';
-const iconSrc = `https://mcasset.cloud/${MC_ASSET_VERSION}/assets/minecraft/textures/block/${b.ref}.png`;
 ---
 
 <section class="mcdb-panel not-content">
 	<header class="mcdb-panel__head">
 		<div class="mcdb-panel__icon">
-			<img src={iconSrc} alt={b.display_name} loading="lazy" />
+			<MCTextureImage
+				client:load
+				ref={b.ref}
+				category="block"
+				alt={b.display_name}
+				size={96}
+			/>
 		</div>
 		<div class="mcdb-panel__title">
 			<h2>{b.display_name}</h2>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemPanel.astro
@@ -1,22 +1,21 @@
 ---
 import { MCItemSchema } from '@/data/schema';
+import MCTextureImage from './MCTextureImage';
 
 const { data } = Astro.props;
 const item = MCItemSchema.parse(data);
-
-const MC_ASSET_VERSION = '1.21.5';
-const candidates = [
-	`https://mcasset.cloud/${MC_ASSET_VERSION}/assets/minecraft/textures/item/${item.ref}.png`,
-	`https://mcasset.cloud/${MC_ASSET_VERSION}/assets/minecraft/textures/block/${item.ref}.png`,
-];
-const iconSrc = item.icon || candidates[0];
-const fallbackSrc = candidates[1];
 ---
 
 <section class="mcdb-panel not-content">
 	<header class="mcdb-panel__head">
-		<div class="mcdb-panel__icon" data-fallback={fallbackSrc}>
-			<img src={iconSrc} alt={item.display_name} loading="lazy" />
+		<div class="mcdb-panel__icon">
+			<MCTextureImage
+				client:load
+				ref={item.ref}
+				category={item.category}
+				alt={item.display_name}
+				size={96}
+			/>
 		</div>
 		<div class="mcdb-panel__title">
 			<h2>{item.display_name}</h2>
@@ -221,35 +220,65 @@ const fallbackSrc = candidates[1];
 								<div
 									class="mcdb-grid-recipe"
 									style={`--cols: ${r.width};`}>
-									{grid.flat().map((cell) => (
-										<div class="mcdb-grid-cell">
-											{cell && (
-												<>
+									{grid.flat().map((cell) => {
+										if (!cell)
+											return (
+												<div class="mcdb-grid-cell" />
+											);
+										const ingRef = cell.ref || cell.tag_ref;
+										return (
+											<a
+												class="mcdb-grid-cell mcdb-grid-cell--filled"
+												href={`/mc/items/${ingRef.replace(/_/g, '-')}/`}
+												title={`${cell.qty}× ${ingRef}`}>
+												{cell.qty > 1 && (
 													<span class="mcdb-grid-qty">
 														{cell.qty}
 													</span>
+												)}
+												{cell.ref ? (
+													<MCTextureImage
+														client:load
+														ref={cell.ref}
+														alt={cell.ref}
+														size={56}
+														className="mcdb-grid-img"
+													/>
+												) : (
 													<span class="mcdb-grid-ref">
-														{cell.ref ||
-															`#${cell.tag_ref}`}
+														#{cell.tag_ref}
 													</span>
-												</>
-											)}
-										</div>
-									))}
+												)}
+											</a>
+										);
+									})}
 								</div>
 							) : (
 								<ul class="mcdb-recipes">
-									{r.ingredients.map((ing) => (
-										<li>
-											<span class="mcdb-recipe-yields">
-												× {ing.qty}
-											</span>
-											<a
-												href={`/mc/items/${(ing.ref || ing.tag_ref).replace(/_/g, '-')}/`}>
-												{ing.ref || `#${ing.tag_ref}`}
-											</a>
-										</li>
-									))}
+									{r.ingredients.map((ing) => {
+										const ingRef = ing.ref || ing.tag_ref;
+										return (
+											<li>
+												{ing.ref && (
+													<MCTextureImage
+														client:load
+														ref={ing.ref}
+														alt={ing.ref}
+														size={28}
+														className="mcdb-recipe-img"
+													/>
+												)}
+												<span class="mcdb-recipe-yields">
+													× {ing.qty}
+												</span>
+												<a
+													href={`/mc/items/${ingRef.replace(/_/g, '-')}/`}>
+													{ing.ref ||
+														`#${ing.tag_ref}`}
+												</a>
+											</li>
+										);
+									})}
 								</ul>
 							)}
 						</div>
@@ -274,25 +303,6 @@ const fallbackSrc = candidates[1];
 		}
 	</footer>
 </section>
-
-<script>
-	for (const node of document.querySelectorAll(
-		'.mcdb-panel__icon[data-fallback]',
-	)) {
-		const img = node.querySelector('img');
-		const fallback = (node as HTMLElement).dataset.fallback;
-		if (!img || !fallback) continue;
-		img.addEventListener(
-			'error',
-			() => {
-				if (img.dataset.fb === 'done') return;
-				img.dataset.fb = 'done';
-				img.src = fallback;
-			},
-			{ once: true },
-		);
-	}
-</script>
 
 <style is:global>
 	.mcdb-panel {
@@ -545,5 +555,28 @@ const fallbackSrc = candidates[1];
 		font-size: 0.65rem;
 		line-height: 1.1;
 		word-break: break-all;
+	}
+	.kbve-mc-tex {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		image-rendering: pixelated;
+		object-fit: contain;
+	}
+	.kbve-mc-tex--missing {
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		border-radius: 6px;
+		color: var(--sl-color-gray-3);
+		font-weight: 800;
+	}
+	.mcdb-grid-cell .kbve-mc-tex,
+	.mcdb-grid-img.kbve-mc-tex {
+		max-width: 80%;
+		max-height: 80%;
+	}
+	.mcdb-recipe-img.kbve-mc-tex {
+		flex-shrink: 0;
+		margin-right: 0.25rem;
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCTextureImage.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCTextureImage.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { mcTextureUrls } from './texture';
+
+type Props = {
+	ref: string;
+	category?: string | null;
+	size?: number;
+	alt?: string;
+	className?: string;
+};
+
+/**
+ * `<MCTextureImage>` resolves a vanilla MC texture URL via the
+ * texture.ts util, then walks the [primary, fallback] pair on `onError`.
+ * Pure React — no global DOM walks, no scripts-after-parse races.
+ * Drop in anywhere we'd otherwise emit a raw `<img>` for an item / block.
+ */
+export function MCTextureImage({
+	ref,
+	category,
+	size = 32,
+	alt,
+	className,
+}: Props) {
+	const { primary, fallback } = mcTextureUrls(ref, category);
+	const [src, setSrc] = useState(primary);
+	const [failed, setFailed] = useState(false);
+
+	const onError = () => {
+		if (src === primary) {
+			setSrc(fallback);
+			return;
+		}
+		setFailed(true);
+	};
+
+	if (failed) {
+		const initial = ref.charAt(0).toUpperCase();
+		return (
+			<span
+				className={`kbve-mc-tex kbve-mc-tex--missing${className ? ` ${className}` : ''}`}
+				style={{ width: size, height: size, fontSize: size * 0.5 }}
+				aria-label={alt ?? ref}>
+				{initial}
+			</span>
+		);
+	}
+
+	return (
+		<img
+			src={src}
+			alt={alt ?? ref}
+			width={size}
+			height={size}
+			onError={onError}
+			loading="lazy"
+			className={`kbve-mc-tex${className ? ` ${className}` : ''}`}
+			style={{ imageRendering: 'pixelated' }}
+		/>
+	);
+}
+
+export default MCTextureImage;

--- a/apps/kbve/astro-kbve/src/components/mcdb/texture.ts
+++ b/apps/kbve/astro-kbve/src/components/mcdb/texture.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolve mcasset.cloud texture URLs for a Minecraft vanilla item / block
+ * ref. We try `assets/minecraft/textures/item/<ref>.png` first for regular
+ * items, and `assets/minecraft/textures/block/<ref>.png` first for blocks —
+ * fallback to the other path on error.
+ *
+ * Returning both candidates lets the caller wire an `onerror` swap once
+ * without re-doing the URL build.
+ */
+export const MC_ASSET_VERSION = '1.21.5';
+const ITEM_BASE = `https://mcasset.cloud/${MC_ASSET_VERSION}/assets/minecraft/textures/item`;
+const BLOCK_BASE = `https://mcasset.cloud/${MC_ASSET_VERSION}/assets/minecraft/textures/block`;
+
+type Pair = { primary: string; fallback: string };
+
+const BLOCK_CATEGORIES = new Set([
+	'block',
+	'decoration',
+	'redstone',
+	'transport',
+]);
+
+export function mcTextureUrls(ref: string, category?: string | null): Pair {
+	const clean = ref.replace(/^minecraft:/, '').toLowerCase();
+	const isBlockish = category ? BLOCK_CATEGORIES.has(category) : false;
+	if (isBlockish) {
+		return {
+			primary: `${BLOCK_BASE}/${clean}.png`,
+			fallback: `${ITEM_BASE}/${clean}.png`,
+		};
+	}
+	return {
+		primary: `${ITEM_BASE}/${clean}.png`,
+		fallback: `${BLOCK_BASE}/${clean}.png`,
+	};
+}


### PR DESCRIPTION
## Summary
Fixes the `diamond_block` (and any block-form item) texture not loading on `/mc/items/<slug>` and renders crafting grids visually with **inline item textures** instead of bare refs.

## Cause
The old `MCItemPanel` emitted a raw `<img>` with the item-path texture URL and an inline `<script>` to swap to the block-path on `onerror`. Astro hydrates inline scripts **after** parse, so any image that 404'd before the script attached its `error` listener went silent.

## Fix
- **`components/mcdb/texture.ts`** — pure TS util `mcTextureUrls(ref, category)` returning `{ primary, fallback }`. Block-ish categories (`block` / `decoration` / `redstone` / `transport`) try `assets/.../textures/block/` first; everything else tries `item/` first.
- **`components/mcdb/MCTextureImage.tsx`** — React island that walks `[primary, fallback]` via `useState` + `onError`, then renders a themed initial-letter placeholder if both 404. **No DOM walks, no hydration race**. Pure component, reusable anywhere.
- **`MCItemPanel.astro` + `MCBlockPanel.astro`** — replace raw `<img>` + inline `<script>` with `<MCTextureImage client:load />`. Drop the script block entirely.
- **Recipe grid + recipe list** — each ingredient slot now renders the item texture via `<MCTextureImage>` (deep-links to the item page on click). Falls back to `#tag_ref` text for ingredients that reference a vanilla item tag rather than a specific item.

CSS adds `.kbve-mc-tex` + `.kbve-mc-tex--missing` themed against Starlight + KBVE brand vars.

## Tracking
Follow-up polish on Phase 5.3b (#11130). Tracks #10979.

## Test plan
- [ ] `./kbve.sh -nx astro-kbve:build` — green (5520 pages locally)
- [ ] `/mc/items/diamond-block` — block texture loads via block/ path on first try
- [ ] `/mc/items/diamond-pickaxe` — item texture loads via item/ path on first try
- [ ] `/mc/items/diamond-chestplate` — 3×3 shaped grid renders 6 diamond textures, click jumps to /mc/items/diamond/
- [ ] `/mc/items/diamond` (drop sources etc., no recipe) — main icon resolves