### PR TITLE
feat(astro-irc): make chat.js embed theme-agnostic via CSS var fallback chain

### DIFF
--- a/apps/irc/astro-irc/public/embed/example.html
+++ b/apps/irc/astro-irc/public/embed/example.html
@@ -19,9 +19,37 @@
 			}
 			.row {
 				display: grid;
-				grid-template-columns: 1fr 1fr;
+				grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
 				gap: 24px;
 				margin-top: 16px;
+			}
+			/* Host-theme override demo — sets --kbve-chat-* vars on the embed
+			 * host element. These cross the shadow boundary and override the
+			 * baked palette without changing the bundle. */
+			.kbve-themed {
+				--kbve-chat-bg: #fff7ed;
+				--kbve-chat-elev-1: #ffedd5;
+				--kbve-chat-elev-2: #fed7aa;
+				--kbve-chat-hover: #fdba74;
+				--kbve-chat-border: #fb923c;
+				--kbve-chat-text: #431407;
+				--kbve-chat-text-dim: #7c2d12;
+				--kbve-chat-text-muted: #c2410c;
+				--kbve-chat-accent: #ea580c;
+			}
+			/* Starlight-style host — exposes --sl-color-* so the embed picks
+			 * them up automatically (this is what Rareicon / astro-kbve
+			 * already provide via the Starlight integration). */
+			.sl-themed {
+				--sl-color-bg: #0f172a;
+				--sl-color-bg-nav: #1e293b;
+				--sl-color-bg-sidebar: #1e293b;
+				--sl-color-gray-2: #cbd5e1;
+				--sl-color-gray-4: #64748b;
+				--sl-color-gray-6: #334155;
+				--sl-color-border: #334155;
+				--sl-color-text: #e2e8f0;
+				--sl-color-accent: #22d3ee;
 			}
 			.card {
 				background: white;
@@ -47,7 +75,7 @@
 		<h1>KbveChat embed bundle — smoke test</h1>
 		<div class="row">
 			<div class="card">
-				<p class="label">Auto-discover (#kbve-chat)</p>
+				<p class="label">Default dark (auto-discover)</p>
 				<div
 					id="kbve-chat"
 					class="host"
@@ -56,23 +84,42 @@
 					data-theme="dark"></div>
 			</div>
 			<div class="card">
-				<p class="label">Programmatic mount (light theme)</p>
+				<p class="label">Programmatic light theme</p>
 				<div id="kbve-chat-2" class="host"></div>
+			</div>
+			<div class="card">
+				<p class="label">Host override via --kbve-chat-* vars (warm)</p>
+				<div id="kbve-chat-3" class="host kbve-themed"></div>
+			</div>
+			<div class="card">
+				<p class="label">Starlight host via --sl-color-* vars</p>
+				<div id="kbve-chat-4" class="host sl-themed"></div>
 			</div>
 		</div>
 
 		<script src="/embed/chat.js" defer></script>
 		<script>
 			window.addEventListener('load', () => {
-				if (window.KbveChat) {
-					window.KbveChat.mount({
-						el: '#kbve-chat-2',
-						channel: '#general',
-						ws: 'wss://chat.kbve.com/ws',
-						theme: 'light',
-						height: '480px',
-					});
-				}
+				if (!window.KbveChat) return;
+				window.KbveChat.mount({
+					el: '#kbve-chat-2',
+					channel: '#general',
+					ws: 'wss://chat.kbve.com/ws',
+					theme: 'light',
+					height: '480px',
+				});
+				window.KbveChat.mount({
+					el: '#kbve-chat-3',
+					channel: '#general',
+					ws: 'wss://chat.kbve.com/ws',
+					height: '480px',
+				});
+				window.KbveChat.mount({
+					el: '#kbve-chat-4',
+					channel: '#general',
+					ws: 'wss://chat.kbve.com/ws',
+					height: '480px',
+				});
 			});
 		</script>
 	</body>

--- a/apps/irc/astro-irc/src/embed/styles.ts
+++ b/apps/irc/astro-irc/src/embed/styles.ts
@@ -1,6 +1,15 @@
 // Self-contained CSS for the embed bundle. Injected into shadow root so
 // host page styles can't reach in and our utilities can't leak out.
-// No Starlight tokens — all colors baked in for portability.
+//
+// Token resolution (CSS custom properties cross the shadow boundary):
+//   --kbve-chat-*    host-page override (highest priority — opinionated)
+//   --sl-color-*     Starlight theme var if host is a Starlight site
+//   <baked default>  built-in dark palette (or light when [data-theme="light"])
+//
+// Embedding on Rareicon / astro-kbve / any Starlight site picks up that
+// site's colors automatically. Bare HTML hosts get the default palette.
+// Set --kbve-chat-accent on the host element to override a single token
+// without writing a full theme.
 
 export const EMBED_CSS = `
 :host {
@@ -8,32 +17,35 @@ export const EMBED_CSS = `
   display: block;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, 'Segoe UI', Roboto, sans-serif;
   color: var(--kbc-text);
-  --kbc-bg: #0a0d14;
-  --kbc-elev-1: #11161f;
-  --kbc-elev-2: #161c28;
-  --kbc-hover: #1c2433;
-  --kbc-border: #1f2735;
-  --kbc-text: #e6ebf2;
-  --kbc-text-dim: #8a93a3;
-  --kbc-text-muted: #5b6373;
-  --kbc-accent: #7c5cff;
-  --kbc-accent-soft: rgba(124, 92, 255, 0.16);
-  --kbc-success: #22c55e;
-  --kbc-warn: #f59e0b;
-  --kbc-danger: #ef4444;
-  --kbc-radius: 12px;
-  --kbc-radius-sm: 8px;
+
+  --kbc-bg:         var(--kbve-chat-bg,         var(--sl-color-bg,         #0a0d14));
+  --kbc-elev-1:     var(--kbve-chat-elev-1,     var(--sl-color-bg-nav,     #11161f));
+  --kbc-elev-2:     var(--kbve-chat-elev-2,     var(--sl-color-bg-sidebar, #161c28));
+  --kbc-hover:      var(--kbve-chat-hover,      var(--sl-color-gray-6,     #1c2433));
+  --kbc-border:     var(--kbve-chat-border,     var(--sl-color-border,     #1f2735));
+  --kbc-text:       var(--kbve-chat-text,       var(--sl-color-text,       #e6ebf2));
+  --kbc-text-dim:   var(--kbve-chat-text-dim,   var(--sl-color-gray-2,     #8a93a3));
+  --kbc-text-muted: var(--kbve-chat-text-muted, var(--sl-color-gray-4,     #5b6373));
+  --kbc-accent:     var(--kbve-chat-accent,     var(--sl-color-accent,     #7c5cff));
+  --kbc-accent-soft: color-mix(in srgb, var(--kbc-accent) 16%, transparent);
+  --kbc-success:    var(--kbve-chat-success, #22c55e);
+  --kbc-warn:       var(--kbve-chat-warn,    #f59e0b);
+  --kbc-danger:     var(--kbve-chat-danger,  #ef4444);
+  --kbc-radius:     var(--kbve-chat-radius,    12px);
+  --kbc-radius-sm:  var(--kbve-chat-radius-sm, 8px);
 }
 
+/* Explicit light-theme overrides only kick in when the host page didn't
+ * supply --sl-color-* / --kbve-chat-* vars to begin with. */
 :host([data-theme="light"]) {
-  --kbc-bg: #ffffff;
-  --kbc-elev-1: #f7f8fa;
-  --kbc-elev-2: #eef0f4;
-  --kbc-hover: #e6e9ef;
-  --kbc-border: #d8dde5;
-  --kbc-text: #1a1f2c;
-  --kbc-text-dim: #515b6b;
-  --kbc-text-muted: #8a93a3;
+  --kbc-bg:         var(--kbve-chat-bg,         var(--sl-color-bg,         #ffffff));
+  --kbc-elev-1:     var(--kbve-chat-elev-1,     var(--sl-color-bg-nav,     #f7f8fa));
+  --kbc-elev-2:     var(--kbve-chat-elev-2,     var(--sl-color-bg-sidebar, #eef0f4));
+  --kbc-hover:      var(--kbve-chat-hover,      var(--sl-color-gray-6,     #e6e9ef));
+  --kbc-border:     var(--kbve-chat-border,     var(--sl-color-border,     #d8dde5));
+  --kbc-text:       var(--kbve-chat-text,       var(--sl-color-text,       #1a1f2c));
+  --kbc-text-dim:   var(--kbve-chat-text-dim,   var(--sl-color-gray-2,     #515b6b));
+  --kbc-text-muted: var(--kbve-chat-text-muted, var(--sl-color-gray-4,     #8a93a3));
 }
 
 .root {


### PR DESCRIPTION
## Summary

The embed bundle's color tokens were hardcoded — Rareicon (or any other Starlight host) couldn't pass through its own theme. Refactor every \`--kbc-*\` token to resolve via a layered \`var()\` fallback chain so the embed inherits host CSS without bundle changes.

\`\`\`css
--kbc-bg: var(--kbve-chat-bg, var(--sl-color-bg, #0a0d14));
\`\`\`

### Resolution order

1. **\`--kbve-chat-*\`** — opinionated host override (highest priority). Set one token or all.
2. **\`--sl-color-*\`** — Starlight theme var, auto-picked-up on Rareicon / astro-kbve / any Starlight site.
3. **Baked default** — original dark palette (light variant when \`[data-theme="light"]\`). Bare HTML hosts get this.

CSS custom properties inherit through the shadow boundary, so host-page vars flow into the embed's shadow root automatically — no JS theme prop needed.

### How a host themes it

\`\`\`html
<!-- Rareicon / astro-kbve / any Starlight site: zero config -->
<div id="kbve-chat" data-channel="#general"></div>

<!-- Custom one-off override -->
<div id="kbve-chat" style="--kbve-chat-accent: #ea580c"></div>

<!-- Full custom palette -->
<style>
  #kbve-chat {
    --kbve-chat-bg: #fff7ed;
    --kbve-chat-elev-1: #ffedd5;
    --kbve-chat-accent: #ea580c;
    /* ... */
  }
</style>
\`\`\`

### Demo

\`public/embed/example.html\` gains two new panels:
- **Warm** — \`--kbve-chat-*\` override on host div
- **Navy Starlight** — \`--sl-color-*\` exposure mimicking a Starlight host

## Test plan

- [ ] Visit \`/embed/example.html\` post-deploy — four panels render with distinct color palettes from one chat.js bundle
- [ ] Drop \`<div id="kbve-chat">\` on Rareicon — colors match Rareicon's Starlight theme without any data-theme attr
- [ ] Toggle Rareicon dark/light — embed colors follow
- [ ] Override single token (\`--kbve-chat-accent: red\`) on a host element — only accent shifts, rest of palette stays Starlight-derived