### PR TITLE
feat(astro-kbve): marketplace pickers — Rareicon parity + texture previews (Phase 5.3-E)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -988,9 +988,9 @@ import MarketCreateForm from './MarketCreateForm';
 		width: 100%;
 		text-align: left;
 		display: grid;
-		grid-template-columns: 1fr auto auto;
+		grid-template-columns: auto 1fr auto auto;
 		gap: 0.5rem;
-		align-items: baseline;
+		align-items: center;
 		padding: 0.4rem 0.6rem;
 		border-radius: 6px;
 		background: transparent;
@@ -998,6 +998,43 @@ import MarketCreateForm from './MarketCreateForm';
 		color: var(--sl-color-text);
 		cursor: pointer;
 		font: inherit;
+	}
+	.kbve-mcpicker__input-row {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+	}
+	.kbve-mcpicker__input-row .kbve-mcpicker__input {
+		flex: 1;
+	}
+	.kbve-mcpicker__preview {
+		width: 32px;
+		height: 32px;
+		image-rendering: pixelated;
+		border-radius: 6px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		padding: 3px;
+		object-fit: contain;
+		flex-shrink: 0;
+	}
+	.kbve-mcpicker__row-img {
+		width: 24px;
+		height: 24px;
+		image-rendering: pixelated;
+		border-radius: 4px;
+		background: var(--sl-color-bg-nav);
+		padding: 2px;
+		object-fit: contain;
+		flex-shrink: 0;
+	}
+	.kbve-mcpicker__row-img--missing {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--sl-color-gray-3);
+		font-weight: 800;
+		font-size: 0.7rem;
 	}
 	.kbve-mcpicker__list button:hover {
 		background: var(--sl-color-bg-nav);

--- a/apps/kbve/astro-kbve/src/components/market/MarketCreateForm.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketCreateForm.tsx
@@ -4,6 +4,12 @@ import { createListing, MarketApiError } from './api';
 import { EnchantEditor } from './EnchantEditor';
 import type { Enchant } from './enchants';
 import { MCItemPicker } from './MCItemPicker';
+import { RareiconItemPicker } from './RareiconItemPicker';
+
+const BROWSE_LINKS: Record<string, { label: string; href: string }> = {
+	mc_item: { label: 'Browse Minecraft items →', href: '/mc/items/' },
+	rareicon_item: { label: 'Browse Rareicon items →', href: '/itemdb/' },
+};
 
 const KIND_OPTIONS = [
 	{ value: 'mc_item', label: 'Minecraft item' },
@@ -112,21 +118,38 @@ export function MarketCreateForm() {
 				</label>
 				<label>
 					Item ID
-					{kind === 'mc_item' ? (
+					{kind === 'mc_item' && (
 						<MCItemPicker
 							value={itemId}
 							onChange={setItemId}
 							disabled={busy}
 						/>
-					) : (
+					)}
+					{kind === 'rareicon_item' && (
+						<RareiconItemPicker
+							value={itemId}
+							onChange={setItemId}
+							disabled={busy}
+						/>
+					)}
+					{kind !== 'mc_item' && kind !== 'rareicon_item' && (
 						<input
 							type="text"
 							required
-							placeholder="diamond_sword"
+							placeholder="custom_ref"
 							value={itemId}
 							onChange={(e) => setItemId(e.target.value)}
 							className="kbve-market__input"
 						/>
+					)}
+					{BROWSE_LINKS[kind] && (
+						<a
+							className="kbve-market__hint"
+							href={BROWSE_LINKS[kind].href}
+							target="_blank"
+							rel="noopener">
+							{BROWSE_LINKS[kind].label}
+						</a>
 					)}
 				</label>
 				<label>

--- a/apps/kbve/astro-kbve/src/components/market/RareiconItemPicker.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/RareiconItemPicker.tsx
@@ -1,16 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
-import { mcTextureUrls } from '../mcdb/texture';
 
-type MCItemIndexEntry = {
-	id: number;
+type RareiconItem = {
+	id: string;
+	key: number;
 	ref: string;
-	slug: string;
-	display_name: string;
-	category: string;
-	rarity: string;
-	stack_size: number;
-	tier: string | null;
-	tags: string[];
+	name?: string;
+	img?: string;
+	rarity?: string;
+	type_flags?: number;
 };
 
 type Props = {
@@ -20,12 +17,12 @@ type Props = {
 	placeholder?: string;
 };
 
-const CACHE_KEY = 'kbve:mc-items:index:v1';
-const ENDPOINT = '/api/mc-items.json';
+const CACHE_KEY = 'kbve:rareicon-items:index:v1';
+const ENDPOINT = '/api/itemdb.json';
 
-type CachedPayload = { items: MCItemIndexEntry[]; cachedAt: number };
+type CachedPayload = { items: RareiconItem[]; cachedAt: number };
 
-function readCache(): MCItemIndexEntry[] | null {
+function readCache(): RareiconItem[] | null {
 	if (typeof localStorage === 'undefined') return null;
 	try {
 		const raw = localStorage.getItem(CACHE_KEY);
@@ -38,7 +35,7 @@ function readCache(): MCItemIndexEntry[] | null {
 	}
 }
 
-function writeCache(items: MCItemIndexEntry[]) {
+function writeCache(items: RareiconItem[]) {
 	if (typeof localStorage === 'undefined') return;
 	try {
 		localStorage.setItem(
@@ -51,13 +48,13 @@ function writeCache(items: MCItemIndexEntry[]) {
 	} catch {}
 }
 
-export function MCItemPicker({
+export function RareiconItemPicker({
 	value,
 	onChange,
 	disabled,
-	placeholder = 'diamond_sword',
+	placeholder = 'coal',
 }: Props) {
-	const [items, setItems] = useState<MCItemIndexEntry[] | null>(null);
+	const [items, setItems] = useState<RareiconItem[] | null>(null);
 	const [query, setQuery] = useState(value);
 	const [open, setOpen] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -74,9 +71,7 @@ export function MCItemPicker({
 			try {
 				const res = await fetch(ENDPOINT);
 				if (!res.ok) throw new Error(`${res.status}`);
-				const json = (await res.json()) as {
-					items: MCItemIndexEntry[];
-				};
+				const json = (await res.json()) as { items: RareiconItem[] };
 				if (cancelled) return;
 				setItems(json.items);
 				writeCache(json.items);
@@ -97,8 +92,8 @@ export function MCItemPicker({
 		return items
 			.filter(
 				(it) =>
-					it.ref.includes(q) ||
-					it.display_name.toLowerCase().includes(q),
+					it.ref.toLowerCase().includes(q) ||
+					(it.name?.toLowerCase().includes(q) ?? false),
 			)
 			.slice(0, 25);
 	}, [items, query]);
@@ -114,22 +109,14 @@ export function MCItemPicker({
 		setOpen(false);
 	};
 
-	const knownTex = known ? mcTextureUrls(known.ref, known.category) : null;
-
 	return (
 		<div className="kbve-mcpicker">
 			<div className="kbve-mcpicker__input-row">
-				{knownTex && (
+				{known?.img && (
 					<img
 						className="kbve-mcpicker__preview"
-						src={knownTex.primary}
-						alt={known?.display_name ?? ''}
-						onError={(ev) => {
-							const img = ev.currentTarget;
-							if (img.dataset.fb === '1') return;
-							img.dataset.fb = '1';
-							img.src = knownTex.fallback;
-						}}
+						src={known.img}
+						alt={known.name ?? known.ref}
 						loading="lazy"
 					/>
 				)}
@@ -153,54 +140,57 @@ export function MCItemPicker({
 			{known && (
 				<a
 					className="kbve-mcpicker__known"
-					href={`/mc/items/${known.slug}/`}
+					href={`/itemdb/${known.ref}/`}
 					target="_blank"
 					rel="noopener"
-					title={`${known.display_name} — open page`}>
-					✓ {known.display_name}
+					title={`${known.name ?? known.ref} — open page`}>
+					✓ {known.name ?? known.ref}
 				</a>
 			)}
 			{open && matches.length > 0 && (
 				<ul className="kbve-mcpicker__list" role="listbox">
-					{matches.map((it) => {
-						const tex = mcTextureUrls(it.ref, it.category);
-						return (
-							<li key={it.ref} role="option">
-								<button
-									type="button"
-									onMouseDown={(e) => e.preventDefault()}
-									onClick={() => onPick(it.ref)}>
+					{matches.map((it) => (
+						<li key={it.ref} role="option">
+							<button
+								type="button"
+								onMouseDown={(e) => e.preventDefault()}
+								onClick={() => onPick(it.ref)}>
+								{it.img ? (
 									<img
 										className="kbve-mcpicker__row-img"
-										src={tex.primary}
-										alt={it.display_name}
-										onError={(ev) => {
-											const img = ev.currentTarget;
-											if (img.dataset.fb === '1') return;
-											img.dataset.fb = '1';
-											img.src = tex.fallback;
-										}}
+										src={it.img}
+										alt={it.name ?? it.ref}
 										loading="lazy"
 									/>
-									<span className="kbve-mcpicker__name">
-										{it.display_name}
+								) : (
+									<span
+										className="kbve-mcpicker__row-img kbve-mcpicker__row-img--missing"
+										aria-hidden>
+										{(it.name ?? it.ref)
+											.charAt(0)
+											.toUpperCase()}
 									</span>
-									<span className="kbve-mcpicker__ref">
-										{it.ref}
-									</span>
+								)}
+								<span className="kbve-mcpicker__name">
+									{it.name ?? it.ref}
+								</span>
+								<span className="kbve-mcpicker__ref">
+									{it.ref}
+								</span>
+								{it.rarity && (
 									<span className="kbve-mcpicker__cat">
-										{it.category}
+										{it.rarity}
 									</span>
-								</button>
-							</li>
-						);
-					})}
+								)}
+							</button>
+						</li>
+					))}
 				</ul>
 			)}
 			{open && items && matches.length === 0 && query.trim() && (
 				<div className="kbve-mcpicker__empty">
 					Unknown ref. You can still list <code>{query}</code> — but
-					it won't link to a /mc/items page.
+					it won't link to a /itemdb page.
 				</div>
 			)}
 			{error && (
@@ -212,4 +202,4 @@ export function MCItemPicker({
 	);
 }
 
-export default MCItemPicker;
+export default RareiconItemPicker;


### PR DESCRIPTION
## Summary
Make listing creation easier for both vanilla Minecraft and Rareicon items — sellers can search by ref or display name, see a thumbnail preview of the texture, and jump to the full item DB via a one-click browse link.

## Files
- **`src/components/market/RareiconItemPicker.tsx`** *(new)* — mirrors the MC picker pattern. Fetches `/api/itemdb.json` (existing endpoint built from the `itemdb` content collection), 24h localStorage cache, autocomplete on `ref` + `name`, deep-link to `/itemdb/<ref>` on selection. Renders `item.img` thumbnails when present; falls back to a themed initial-letter placeholder for items without an image.
- **`src/components/market/MCItemPicker.tsx`** — now renders a texture preview alongside the selected ref AND in every dropdown row. Uses the existing `mcTextureUrls()` util so the resolver already handles `block/` vs `item/` fallback. Inline `<img onError>` falls back to the alt path in one hop.
- **`src/components/market/MarketCreateForm.tsx`** — picker selection per kind:
  - `kind=mc_item` → `<MCItemPicker>`
  - `kind=rareicon_item` → `<RareiconItemPicker>`
  - everything else → raw text input (custom refs etc.)
  Each kind also gets a one-click **"Browse <library> items →"** deep-link under the input so users can pop the full DB in a new tab if autocomplete doesn't cover their search.
- **`src/components/market/AstroMarketShell.astro`** — CSS adds the preview thumbnail, row-img, input-row layout, and missing-image placeholder. Themed against the existing Starlight + KBVE brand vars; no hardcoded colours.

## Tracking
Phase 5.3-E of #10979.

## Test plan
- [ ] `./kbve.sh -nx astro-kbve:build` — green (7627 pages locally)
- [ ] `/market/` create form:
  - kind=Minecraft → picker autocompletes, type "diamond" surfaces all matching items with item-texture thumbnails on each row; pick one → preview thumbnail appears next to the input, ✓ deep-link badge appears
  - kind=Rareicon → picker autocompletes against ~180 itemdb entries; items with `img:` set show thumbnails, items without get a themed initial-letter placeholder; pick one → preview + ✓ deep-link to `/itemdb/<ref>/`
  - kind=Other → raw text input as before
- [ ] **Browse <library> items →** link routes to `/mc/items/` and `/itemdb/` respectively in a new tab