### PR TITLE
chore(kube): bump nginx for CVE-2026-42945

### DIFF
--- a/apps/kube/ingress/application.yaml
+++ b/apps/kube/ingress/application.yaml
@@ -7,7 +7,7 @@ spec:
     project: default
     sources:
         - repoURL: https://kubernetes.github.io/ingress-nginx
-          targetRevision: 4.13.0
+          targetRevision: 4.13.9
           chart: ingress-nginx
           helm:
               releaseName: ingress-nginx

--- a/apps/kube/irc/manifests/irc-redirect-deployment.yaml
+++ b/apps/kube/irc/manifests/irc-redirect-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         spec:
             containers:
                 - name: nginx
-                  image: nginx:1.27-alpine
+                  image: nginx:1.30.1-alpine
                   ports:
                       - containerPort: 80
                         protocol: TCP


### PR DESCRIPTION
## Summary

- ingress-nginx Helm chart `4.13.0` → `4.13.9` (controller v1.13.9, bundles nginx 1.30.1)
- irc-redirect Deployment `nginx:1.27-alpine` → `nginx:1.30.1-alpine`

Fixes [CVE-2026-42945](https://my.f5.com/manage/s/article/K000161019) — heap buffer overflow in `ngx_http_rewrite_module` (affected: nginx 0.6.27 – 1.30.0, fixed: 1.30.1+ / 1.31.0+).

## Exposure

- ingress-nginx is internet-facing on LB .74 and uses `rewrite-target` across multiple Ingresses (cityvote/memes/kong/storage/rentearth/discordsh) → exercises the vulnerable code path.
- irc-redirect config has zero rewrite directives → risk was low, bumping for hygiene.

## Follow-up (separate PR)

Audit Kong (`kong-kong-*` x2 in `kilobase` ns) — runs OpenResty/nginx as Supabase API gateway. Not addressed here.

## Test plan

- [ ] ArgoCD picks up chart 4.13.9 and syncs ingress-nginx-controller cleanly
- [ ] `kubectl exec -n ingress-nginx deploy/ingress-nginx-controller -- nginx -v` reports 1.30.1+
- [ ] Spot-check rewrite-target Ingresses (kbve.com, etc.) still route correctly
- [ ] irc-redirect pod rolls over, `kubectl exec -n irc deploy/irc-redirect -- nginx -v` reports 1.30.1
- [ ] HTTP redirect from irc subdomain to chat.kbve.com still works