### PR TITLE
fix(kyverno): ignore kubectl-kyverno managed fields on CRDs

### DIFF
--- a/apps/kube/kyverno/application.yaml
+++ b/apps/kube/kyverno/application.yaml
@@ -10,24 +10,10 @@ spec:
     source:
         repoURL: https://kyverno.github.io/kyverno
         chart: kyverno
-        # Bumped from 3.4.4 (Kyverno v1.14) to 3.8.0 (Kyverno v1.18) to
-        # drop the chart's dependency on `bitnami/kubectl:1.32.3`. That
-        # image was deleted from docker.io's public tier when Bitnami
-        # moved its catalog to the authenticated `bitnamisecure` repo
-        # in August 2025, and the helm-hook cleanup Jobs were stuck in
-        # ImagePullBackOff. Chart 3.8.0 replaces every bitnami/kubectl
-        # reference with `ghcr.io/kyverno/readiness-checker` and
-        # `reg.kyverno.io/kyverno/kyverno-cli`, both pulling from
-        # registries Kyverno itself controls. ClusterPolicy CRD still
-        # serves v1, v2, and v1beta1 in 3.8.0, so the existing
-        # apps/kube/kilobase/manifests/dbmate-runner-kyverno-policy.yaml
-        # (kyverno.io/v1) keeps working without changes.
         targetRevision: 3.8.0
         helm:
             values: |
                 fullnameOverride: kyverno
-                # Admission controller: 2 replicas for HA. Background
-                # controller: handle generate/synchronize rules.
                 admissionController:
                     replicas: 2
                     resources:
@@ -42,8 +28,6 @@ spec:
                     replicas: 1
                 reportsController:
                     replicas: 1
-                # Skip enforcing on system namespaces so we don't lock
-                # ourselves out of cluster bootstrap.
                 config:
                     excludeKyvernoNamespace: true
                     resourceFilters:
@@ -73,6 +57,11 @@ spec:
     destination:
         server: https://kubernetes.default.svc
         namespace: kyverno
+    ignoreDifferences:
+        - group: apiextensions.k8s.io
+          kind: CustomResourceDefinition
+          managedFieldsManagers:
+              - kubectl-kyverno
     syncPolicy:
         automated:
             prune: true
@@ -80,3 +69,4 @@ spec:
         syncOptions:
             - CreateNamespace=true
             - ServerSideApply=true
+            - RespectIgnoreDifferences=true


### PR DESCRIPTION
## Summary
- Kyverno v1.18 controllers (`kubectl-kyverno` field manager) mutate the new `policies.kyverno.io` CRDs at runtime. Under ServerSideApply argo sees those fields as drift, so the app sits `OutOfSync` permanently.
- Adds `ignoreDifferences` for `CustomResourceDefinition` fields owned by `kubectl-kyverno` plus `RespectIgnoreDifferences=true` (without it the ignore block only affects the UI diff, not the auto-sync decision).
- Drops the chart-bump prose from the manifest; rationale lives in 60ae18899.

## Context
The chart bump in #10564 (3.4.4 → 3.8.0) merged on 2026-05-07 but argo never reconciled it. The Application status had been stuck `Running` for 11 days waiting on the Helm hook `kyverno-clean-reports`, whose `bitnami/kubectl:1.32.3` image is gone from docker.io. The chart bump removed that dependency, but argo could not start a new sync while the old operation was pending.

Manual fix already applied to the cluster to recover from the deadlock:
```
kubectl -n kyverno delete job kyverno-clean-reports
kubectl -n argocd patch application kyverno --type merge -p '{"operation": null}'
```
After that the pods rolled to v1.18 cleanly, but the new `policies.kyverno.io` CRDs (validatingpolicies, mutatingpolicies, generatingpolicies, deletingpolicies, imagevalidatingpolicies and their namespaced variants) remained `OutOfSync` because of the field-manager conflict this PR fixes.

## Test plan
- [ ] Argo reconciles `kyverno` Application to `Synced` after merge
- [ ] No new pending operations on the Application
- [ ] `kubectl -n kyverno get pods` still shows v1.18 controllers running
- [ ] Existing `apps/kube/kilobase/manifests/dbmate-runner-kyverno-policy.yaml` (kyverno.io/v1 ClusterPolicy) still validates