### PR TITLE
fix(referral): redirect to rareicon when handle has no user_target opt-in

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/referral.rs
+++ b/apps/kbve/axum-kbve/src/transport/referral.rs
@@ -30,6 +30,8 @@ use crate::db::{get_profile_service, get_referral_client};
 
 type HmacSha256 = Hmac<Sha256>;
 
+const SITE_DEFAULT_URL: &str = "https://store.steampowered.com/app/2238370/RareIcon/";
+
 /// Stores the resolved HMAC secret (read once from env). A missing secret
 /// is fatal for the route — we refuse to fabricate placeholder bytes that
 /// would be predictable across deploys.
@@ -178,7 +180,13 @@ async fn handle_referral(headers: HeaderMap, handle: String, slug: Option<String
         .await
     {
         Ok(Some(row)) => row,
-        Ok(None) => return not_found("no matching referral target"),
+        Ok(None) => {
+            tracing::info!(
+                handle = %normalized_handle,
+                "no user_target opt-in — redirecting to site default"
+            );
+            return redirect_to(SITE_DEFAULT_URL);
+        }
         Err(e) => {
             tracing::warn!(error = %e, "resolve_user_target failed");
             return server_error("resolve_user_target failed");


### PR DESCRIPTION
## Summary
- `/referral/@<handle>/` 404'd whenever a real user row had no `referral.user_target` opt-in yet (e.g. fudster post-merge).
- On `Ok(None)` from `resolve_user_target`, redirect to the rareicon Steam URL instead of returning 404.
- Skip `record_click` on the fallback path — the user has no opt-in row, so `record_click` would raise RFU01 anyway, and we shouldn't credit clicks against a non-participant.

## Test plan
- [ ] Hit `/referral/@fudster/` post-deploy → 302 to https://store.steampowered.com/app/2238370/RareIcon/
- [ ] Hit `/referral/@<user-with-opt-in>/` → still 302s to that user's resolved target (no regression on the credited path)
- [ ] Hit `/referral/@<nonexistent-handle>/` → still 404 (handle-not-found path unchanged)