### PR TITLE
fix(astro-kbve): market form 2-col layout + wider container (Phase 5.3-F)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -26,7 +26,8 @@ import MarketCreateForm from './MarketCreateForm';
 
 <style is:global>
 	.kbve-market {
-		max-width: 960px;
+		width: 100%;
+		max-width: 1280px;
 		margin: 1.25rem auto 4rem;
 		padding: 0 1rem;
 		color: rgba(255, 255, 255, 0.9);
@@ -339,8 +340,16 @@ import MarketCreateForm from './MarketCreateForm';
 	}
 	.kbve-market__form-row {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-		gap: 0.75rem;
+		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+		gap: 0.85rem;
+	}
+	@media (min-width: 720px) {
+		.kbve-market__form-row {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
+	.kbve-market__form-label--wide {
+		grid-column: 1 / -1;
 	}
 	.kbve-market__form label {
 		display: grid;

--- a/apps/kbve/astro-kbve/src/components/market/MarketCreateForm.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketCreateForm.tsx
@@ -152,7 +152,9 @@ export function MarketCreateForm() {
 						</a>
 					)}
 				</label>
-				<label>
+			</div>
+			<div className="kbve-market__form-row">
+				<label className="kbve-market__form-label--wide">
 					Instance ID (optional)
 					<input
 						type="text"
@@ -186,7 +188,9 @@ export function MarketCreateForm() {
 						className="kbve-market__input"
 					/>
 				</label>
-				<label>
+			</div>
+			<div className="kbve-market__form-row">
+				<label className="kbve-market__form-label--wide">
 					Expires At
 					<input
 						type="datetime-local"


### PR DESCRIPTION
## Summary
Cramped 3-fields-per-row create form in a 960px container — picker dropdown spilled over, right side of the Starlight column was empty. Now 2 columns at desktop with two full-width rows for the long fields.

## Changes
- `.kbve-market` — `max-width: 960px → 1280px`, `width: 100%` so it utilises the full Starlight content column.
- `.kbve-market__form-row` — clamped to two columns (`1fr 1fr`) at `min-width: 720px`; `auto-fit minmax(280px, 1fr)` below for mobile stacking.
- New `.kbve-market__form-label--wide` modifier — `grid-column: 1 / -1` for labels that should span the whole row.
- Create-form reflowed:
  1. **Kind + Item ID**
  2. **Instance ID** *(full width)*
  3. **Buy Now + Min Bid**
  4. **Expires At** *(full width)*

## Build
`./kbve.sh -nx astro-kbve:build` — green, 7627 pages.

## Test plan
- [ ] `/market/` create form — at >= 720px viewport, fields lay out 2 per row, Instance ID + Expires At span full width; picker dropdown fits inside the column without horizontal clipping
- [ ] At mobile (<540px), every label stacks one per row
- [ ] Container utilises full Starlight column width on wide screens