### PR TITLE
feat(argocd): wire health alerts to vector-sink

### DIFF
--- a/apps/kube/argocd/manifests/kustomization.yaml
+++ b/apps/kube/argocd/manifests/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
     - ingress.yaml
     - argocd-server-cert.yaml
     - httproute.yaml
+    - servicemonitor.yaml
+    - prometheusrule.yaml
 patches:
     - path: patch-argocd-cm-cert-health.yaml
       target:

--- a/apps/kube/argocd/manifests/prometheusrule.yaml
+++ b/apps/kube/argocd/manifests/prometheusrule.yaml
@@ -1,0 +1,71 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+    name: argocd-app-health
+    namespace: argocd
+    labels:
+        release: monitoring
+        prometheus: kube-prometheus
+        role: alert-rules
+spec:
+    groups:
+        - name: argocd.apps
+          rules:
+              - alert: ArgoCDAppDegraded
+                expr: |
+                    argocd_app_info{health_status="Degraded"} == 1
+                for: 10m
+                labels:
+                    severity: warning
+                    service: argocd
+                annotations:
+                    summary: 'ArgoCD app {{ $labels.name }} is Degraded'
+                    description: 'Application {{ $labels.name }} in project {{ $labels.project }} has been Degraded for >10m (sync={{ $labels.sync_status }}).'
+
+              - alert: ArgoCDAppMissing
+                expr: |
+                    argocd_app_info{health_status="Missing"} == 1
+                for: 15m
+                labels:
+                    severity: warning
+                    service: argocd
+                annotations:
+                    summary: 'ArgoCD app {{ $labels.name }} is Missing'
+                    description: 'Application {{ $labels.name }} resources are Missing for >15m (sync={{ $labels.sync_status }}).'
+
+              - alert: ArgoCDAppSyncFailed
+                expr: |
+                    sum by (name, namespace, project) (
+                        increase(argocd_app_sync_total{phase="Failed"}[15m])
+                    ) > 0
+                for: 5m
+                labels:
+                    severity: warning
+                    service: argocd
+                annotations:
+                    summary: 'ArgoCD app {{ $labels.name }} sync failing'
+                    description: 'Application {{ $labels.name }} has had {{ $value | printf "%.0f" }} failed sync(s) in the last 15m.'
+
+              - alert: ArgoCDAppOutOfSync
+                expr: |
+                    argocd_app_info{sync_status="OutOfSync", autosync_enabled="true"} == 1
+                for: 1h
+                labels:
+                    severity: info
+                    service: argocd
+                annotations:
+                    summary: 'ArgoCD app {{ $labels.name }} OutOfSync (autosync on)'
+                    description: 'Application {{ $labels.name }} is OutOfSync for >1h despite autosync being enabled — automation may be stuck.'
+
+        - name: argocd.controllers
+          rules:
+              - alert: ArgoCDControllerDown
+                expr: |
+                    up{job=~"argocd-metrics|argocd-server-metrics|argocd-notifications-controller-metrics"} == 0
+                for: 10m
+                labels:
+                    severity: critical
+                    service: argocd
+                annotations:
+                    summary: 'ArgoCD component {{ $labels.job }} scrape down'
+                    description: '{{ $labels.job }} ({{ $labels.pod }}) has not been scrapable for >10m.'

--- a/apps/kube/argocd/manifests/servicemonitor.yaml
+++ b/apps/kube/argocd/manifests/servicemonitor.yaml
@@ -1,0 +1,59 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+    name: argocd-metrics
+    namespace: argocd
+    labels:
+        release: monitoring
+        app.kubernetes.io/part-of: argocd
+spec:
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: argocd-metrics
+    namespaceSelector:
+        matchNames:
+            - argocd
+    endpoints:
+        - port: metrics
+          interval: 30s
+          scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+    name: argocd-server-metrics
+    namespace: argocd
+    labels:
+        release: monitoring
+        app.kubernetes.io/part-of: argocd
+spec:
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: argocd-server-metrics
+    namespaceSelector:
+        matchNames:
+            - argocd
+    endpoints:
+        - port: metrics
+          interval: 30s
+          scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+    name: argocd-notifications-controller-metrics
+    namespace: argocd
+    labels:
+        release: monitoring
+        app.kubernetes.io/part-of: argocd
+spec:
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: argocd-notifications-controller-metrics
+    namespaceSelector:
+        matchNames:
+            - argocd
+    endpoints:
+        - port: metrics
+          interval: 30s
+          scrapeTimeout: 10s


### PR DESCRIPTION
## Summary
Wire ArgoCD application health into the existing alert pipeline so silent degradations (like the recent 12h `rows` outage) page out automatically.

Adds:
- **ServiceMonitors** (release: `monitoring`) for `argocd-metrics`, `argocd-server-metrics`, `argocd-notifications-controller-metrics`.
- **PrometheusRule** `argocd-app-health` with five alerts:
  - `ArgoCDAppDegraded` — `argocd_app_info{health_status="Degraded"} == 1` for 10m (warning)
  - `ArgoCDAppMissing` — `argocd_app_info{health_status="Missing"} == 1` for 15m (warning)
  - `ArgoCDAppSyncFailed` — `increase(argocd_app_sync_total{phase="Failed"}[15m]) > 0` for 5m (warning)
  - `ArgoCDAppOutOfSync` — `argocd_app_info{sync_status="OutOfSync", autosync_enabled="true"}` for 1h (info)
  - `ArgoCDControllerDown` — `up{job=~"argocd-*-metrics"} == 0` for 10m (critical)

## Routing
All alerts inherit `severity` labels matching the existing `AlertmanagerConfig/vector-sink` matcher (`critical|warning|info`). So they fan out:

```
PrometheusRule → kube-prometheus alertmanager → vector :9002/alertmanager
              → alertmanager_explode → alertmanager_flatten
              → ClickHouse observability.alerts_distributed
```

No vector or alertmanager config changes required — pipeline already exists.

## Test plan
- [ ] ServiceMonitors picked up by Prometheus (`up{job=~"argocd-*-metrics"} == 1`)
- [ ] `argocd_app_info` series visible in Prometheus after sync
- [ ] Rules show in `/api/v1/rules` under the `argocd.apps` group
- [ ] Force-degrade a test app and confirm row lands in `observability.alerts_distributed`