### PR TITLE
fix(droid): Android worker-stall fallback + tab-resume tolerance

### DIFF
--- a/apps/kbve/astro-kbve/src/components/user/profile-controller.ts
+++ b/apps/kbve/astro-kbve/src/components/user/profile-controller.ts
@@ -10,6 +10,7 @@ import {
 	installProfileSync,
 	installSyncBusListener,
 	readProfileForFastPaint,
+	readSupabaseSessionFromStorage,
 	setProfileCache as setDroidProfileCache,
 	type DroidProfile,
 } from '@kbve/droid';
@@ -293,8 +294,20 @@ function wireLogout() {
 
 // ── Session handler (shared between boot and auth listener) ─────────────────
 
-async function handleSession(session: any) {
+async function handleSession(
+	session: any,
+	source: 'init' | 'auth-event' = 'init',
+) {
 	if (!session?.user) {
+		if (source === 'init') {
+			const storageSession = readSupabaseSessionFromStorage();
+			if (storageSession?.user?.id) {
+				console.log(
+					'[profile] Gateway returned no session, but localStorage still has one — keeping cached auth.',
+				);
+				return;
+			}
+		}
 		clearProfileCache();
 		setAuth({
 			tone: 'anon',
@@ -449,11 +462,11 @@ export async function bootProfile() {
 	const session = s?.session ?? null;
 
 	// Handle current state — refresh whatever the fast paint already showed.
-	await handleSession(session);
+	await handleSession(session, 'init');
 
 	// Listen for auth changes (sign-in / sign-out from other tabs or navbar)
 	supa.on('auth', async (msg: any) => {
 		const newSession = msg.session ?? null;
-		await handleSession(newSession);
+		await handleSession(newSession, 'auth-event');
 	});
 }

--- a/apps/kbve/astro-kbve/src/lib/supa.ts
+++ b/apps/kbve/astro-kbve/src/lib/supa.ts
@@ -79,24 +79,18 @@ export function initSupa(options?: Record<string, unknown>): Promise<void> {
 		await migrateAuthStorage();
 		console.log(`[Supabase] Using ${gateway.getStrategyDescription()}`);
 
-		const init = (async () => {
-			await gateway.init(SUPABASE_URL, SUPABASE_ANON_KEY, options);
-			await bootAuth(gateway);
-		})();
-
-		const timeout = new Promise<never>((_, reject) =>
-			setTimeout(
-				() => reject(new Error('init timeout')),
-				INIT_TIMEOUT_MS,
-			),
-		);
-
 		try {
-			await Promise.race([init, timeout]);
+			await gateway.init(SUPABASE_URL, SUPABASE_ANON_KEY, options);
 		} catch (err) {
+			console.warn(
+				'[Supabase] Gateway init failed in both worker and direct modes — falling back to localStorage-seeded auth only.',
+				err,
+			);
 			void autoRecoverStaleClient();
 			throw err;
 		}
+
+		await bootAuth(gateway);
 
 		void resolveStaffFlag(gateway, SUPABASE_URL, SUPABASE_ANON_KEY);
 	})()

--- a/packages/npm/droid/src/lib/gateway/SupabaseGateway.ts
+++ b/packages/npm/droid/src/lib/gateway/SupabaseGateway.ts
@@ -102,12 +102,47 @@ export class SupabaseGateway implements ISupabaseStrategy {
 
 	// Delegate all methods to the selected strategy
 
-	init(
+	async init(
 		url: string,
 		anonKey: string,
 		options?: Record<string, unknown>,
 	): Promise<SessionResponse> {
-		return this.strategy.init(url, anonKey, options);
+		if (this.strategyType === 'direct') {
+			return this.strategy.init(url, anonKey, options);
+		}
+
+		const WORKER_INIT_FALLBACK_MS = 3500;
+		const primary = this.strategy.init(url, anonKey, options);
+
+		let timer: ReturnType<typeof setTimeout> | null = null;
+		const fallback = new Promise<never>((_, reject) => {
+			timer = setTimeout(
+				() => reject(new Error('worker init stalled')),
+				WORKER_INIT_FALLBACK_MS,
+			);
+		});
+
+		try {
+			const result = await Promise.race([primary, fallback]);
+			if (timer) clearTimeout(timer);
+			return result;
+		} catch (err) {
+			if (timer) clearTimeout(timer);
+			const previousType = this.strategyType;
+			console.warn(
+				`[SupabaseGateway] ${previousType} init did not respond in ${WORKER_INIT_FALLBACK_MS}ms — switching to direct strategy.`,
+				err,
+			);
+			this.strategy = new DirectStrategy();
+			this.strategyType = 'direct';
+			DroidEvents.emit('gateway-strategy-fallback', {
+				timestamp: Date.now(),
+				from: previousType,
+				to: 'direct',
+				reason: err instanceof Error ? err.message : String(err),
+			});
+			return this.strategy.init(url, anonKey, options);
+		}
 	}
 
 	on(event: string, callback: (payload: unknown) => void): () => void {

--- a/packages/npm/droid/src/lib/types/event-types.spec.ts
+++ b/packages/npm/droid/src/lib/types/event-types.spec.ts
@@ -27,8 +27,8 @@ describe('DroidEventSchemas', () => {
 		expect(keys).toContain('auth-error');
 	});
 
-	it('has exactly 19 event types', () => {
-		expect(Object.keys(DroidEventSchemas)).toHaveLength(19);
+	it('has exactly 20 event types', () => {
+		expect(Object.keys(DroidEventSchemas)).toHaveLength(20);
 	});
 });
 

--- a/packages/npm/droid/src/lib/types/event-types.ts
+++ b/packages/npm/droid/src/lib/types/event-types.ts
@@ -61,6 +61,13 @@ export const WorkerErrorSchema = z.object({
 	message: z.string(),
 });
 
+export const GatewayStrategyFallbackSchema = z.object({
+	timestamp: z.number(),
+	from: z.enum(['shared-worker', 'web-worker', 'direct']),
+	to: z.enum(['shared-worker', 'web-worker', 'direct']),
+	reason: z.string(),
+});
+
 // Page lifecycle — emitted by @kbve/astro's onMount/onSwap helpers so any
 // module on the bus (mods, plugins, vanilla driver) can react to navigation
 // without knowing whether the host is using ClientRouter, native cross-doc
@@ -88,6 +95,7 @@ export const DroidEventSchemas = {
 	'auth-ready': AuthReadySchema,
 	'auth-error': AuthErrorSchema,
 	'worker-error': WorkerErrorSchema,
+	'gateway-strategy-fallback': GatewayStrategyFallbackSchema,
 	'page-mount': PageLifecycleSchema,
 	'page-swap': PageLifecycleSchema,
 	'page-hide': PageLifecycleSchema,


### PR DESCRIPTION
## Symptoms
1. **Android phones (no SharedWorker)** — \`/profile/\` sits in a loop, browser console eventually prints \`init auth timeout\`. \`autoRecoverStaleClient()\` clears caches + reloads, the reload trips the same stall, loops until the 60 s cooldown gives up.
2. **Tab inactive → returned to** — 3–5 s flicker of "signed out" before the cached profile reappears.

## Root cause

1. \`WebWorkerStrategy\` (the Android/Safari path) inits 4 workers (1 WS + 3 DB pool) and \`await\`s a \`Promise.all\` of their inits. Mobile WebView throttling or backgrounded tabs can stall one of them indefinitely. \`supa.ts\` was wrapping that in a 10 s outer timeout that nuked caches + reloaded on failure — straight into the same stall.
2. On tab-resume, workers are paused or killed. Calling \`gateway.getSession()\` returns \`null\` for a few seconds while the worker rehydrates. \`handleSession(null)\` was wiping the localStorage profile cache and flipping \`\$auth\` to anon, then flipping back once the real session landed — visible UX flicker.

## Fixes

### \`SupabaseGateway.init()\` — race + auto-fallback to direct
Worker-backed strategies race their own init against a **3.5 s timer**. If the timer wins, the gateway swaps \`this.strategy\` for a \`DirectStrategy\` and re-runs \`init()\` against that. Direct path = \`@supabase/supabase-js\` on the main thread — no worker handshake, never stalls.

Emits new \`gateway-strategy-fallback\` event with \`{from, to, reason}\` so the worker-health surface in the dashboard can show actual path in use.

### \`supa.ts\` — drop the redundant outer timeout
Gateway owns its timeout + fallback now, so \`initSupa()\` just \`await\`s \`gateway.init()\`. \`autoRecoverStaleClient()\` kept as a final recovery, but only fires when **direct mode also fails to init** — i.e. an actually broken client, not a slow worker. No more Android reload loops.

### \`profile-controller.handleSession()\` — source-aware tolerance
Added \`source: 'init' | 'auth-event'\` parameter:

- \`'auth-event'\` (from \`supa.on('auth', …)\`) stays authoritative — explicit sign-out from another tab still flips to anon immediately.
- \`'init'\` (from the post-\`initSupa()\` \`getSession()\` call) cross-checks \`readSupabaseSessionFromStorage()\` before tearing down the cache. Gateway null + localStorage session present = trust localStorage. Matches the principle "if supabase on the main thread says we are authenticated, we are then."

## Test plan
- [x] \`droid:build\` clean
- [x] \`droid:test\` 118/118 (updated event-count assertion 19 → 20)
- [x] \`astro-kbve:check\` no new errors
- [x] \`astro-kbve:build\` clean
- [ ] Android device test: load \`/profile/\` cold — should never print \`init auth timeout\`; if workers stall, console prints \`[SupabaseGateway] web-worker init did not respond in 3500ms — switching to direct strategy.\` and page continues to load
- [ ] Background a tab for 5+ min, return: should not flicker to signed-out state — cached profile stays until the real refresh confirms