### PR TITLE
feat(auth): cookie fallback for sb-access-token (server-side, additive)

### DIFF
--- a/apps/kbve/axum-kbve/src/auth/mod.rs
+++ b/apps/kbve/axum-kbve/src/auth/mod.rs
@@ -184,6 +184,46 @@ pub fn extract_bearer_token(auth_header: &str) -> Option<&str> {
         .or_else(|| auth_header.strip_prefix("bearer "))
 }
 
+pub const SB_ACCESS_TOKEN_COOKIE: &str = "sb-access-token";
+
+pub fn extract_cookie_value<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
+    for pair in cookie_header.split(';') {
+        let pair = pair.trim();
+        if let Some((k, v)) = pair.split_once('=') {
+            if k == name {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+pub fn extract_request_token(headers: &axum::http::HeaderMap) -> Option<String> {
+    if let Some(auth_header) = headers.get(axum::http::header::AUTHORIZATION) {
+        if let Ok(s) = auth_header.to_str() {
+            if let Some(t) = extract_bearer_token(s) {
+                let trimmed = t.trim();
+                if !trimmed.is_empty() {
+                    return Some(trimmed.to_string());
+                }
+            }
+        }
+    }
+
+    if let Some(cookie_header) = headers.get(axum::http::header::COOKIE) {
+        if let Ok(cookie_str) = cookie_header.to_str() {
+            if let Some(v) = extract_cookie_value(cookie_str, SB_ACCESS_TOKEN_COOKIE) {
+                let trimmed = v.trim();
+                if !trimmed.is_empty() {
+                    return Some(trimmed.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
 #[allow(dead_code)]
 pub fn is_token_expired(claims: &Claims, grace_seconds: i64) -> bool {
     let now = chrono::Utc::now().timestamp();

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -23,7 +23,7 @@ use crate::astro::askama::{
     ProfileForumCommentRowPartial, ProfileForumThreadRowPartial, ProfileNotFoundTemplate,
     ProfileTemplate, RentEarthCharacterDisplay, TemplateResponse,
 };
-use crate::auth::{extract_bearer_token, get_jwt_cache};
+use crate::auth::{extract_request_token, get_jwt_cache};
 use crate::db::{
     CommentRow, DiscordClient, FeedQuery, FeedRow, SpaceRow, ThreadRow, UserProfile,
     get_discord_client, get_forum_service, get_mc_service, get_osrs_cache, get_profile_cache,
@@ -1611,44 +1611,20 @@ pub(crate) async fn profile_api_handler(Path(username): Path<String>) -> impl In
     security(("bearerAuth" = [])),
 )]
 pub(crate) async fn profile_me_handler(headers: HeaderMap) -> impl IntoResponse {
-    let auth_header = match headers.get(header::AUTHORIZATION) {
-        Some(h) => match h.to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({
-                        "error": "Invalid Authorization header encoding"
-                    })),
-                )
-                    .into_response();
-            }
-        },
-        None => {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(json!({
-                    "error": "Missing Authorization header",
-                    "hint": "Include 'Authorization: Bearer <token>' header"
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    let token = match extract_bearer_token(auth_header) {
+    let token = match extract_request_token(&headers) {
         Some(t) => t,
         None => {
             return (
                 StatusCode::UNAUTHORIZED,
                 Json(json!({
-                    "error": "Invalid Authorization header format",
-                    "hint": "Use 'Bearer <token>' format"
+                    "error": "Missing authentication",
+                    "hint": "Include 'Authorization: Bearer <token>' header or 'sb-access-token' cookie"
                 })),
             )
                 .into_response();
         }
     };
+    let token = token.as_str();
 
     let jwt_cache = match get_jwt_cache() {
         Some(cache) => cache,
@@ -1771,44 +1747,20 @@ pub(crate) async fn set_username_handler(
     headers: HeaderMap,
     Json(body): Json<SetUsernameRequest>,
 ) -> impl IntoResponse {
-    let auth_header = match headers.get(header::AUTHORIZATION) {
-        Some(h) => match h.to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(json!({
-                        "error": "Invalid Authorization header encoding"
-                    })),
-                )
-                    .into_response();
-            }
-        },
-        None => {
-            return (
-                StatusCode::UNAUTHORIZED,
-                Json(json!({
-                    "error": "Missing Authorization header",
-                    "hint": "Include 'Authorization: Bearer <token>' header"
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    let token = match extract_bearer_token(auth_header) {
+    let token = match extract_request_token(&headers) {
         Some(t) => t,
         None => {
             return (
                 StatusCode::UNAUTHORIZED,
                 Json(json!({
-                    "error": "Invalid Authorization header format",
-                    "hint": "Use 'Bearer <token>' format"
+                    "error": "Missing authentication",
+                    "hint": "Include 'Authorization: Bearer <token>' header or 'sb-access-token' cookie"
                 })),
             )
                 .into_response();
         }
     };
+    let token = token.as_str();
 
     let jwt_cache = match get_jwt_cache() {
         Some(cache) => cache,
@@ -2830,24 +2782,11 @@ async fn forum_compose_handler(
     .into_response()
 }
 
-/// Helper: pull `Authorization: Bearer <token>` and verify via the JWT
-/// cache. Returns Ok(user_id) or an error response.
 pub(crate) async fn auth_user_id(headers: &HeaderMap) -> Result<String, Response> {
-    let auth_header = headers
-        .get(header::AUTHORIZATION)
-        .and_then(|h| h.to_str().ok())
-        .ok_or_else(|| {
-            (
-                StatusCode::UNAUTHORIZED,
-                Json(json!({"error": "Missing Authorization header"})),
-            )
-                .into_response()
-        })?;
-
-    let token = extract_bearer_token(auth_header).ok_or_else(|| {
+    let token = extract_request_token(headers).ok_or_else(|| {
         (
             StatusCode::UNAUTHORIZED,
-            Json(json!({"error": "Invalid bearer token"})),
+            Json(json!({"error": "Missing authentication"})),
         )
             .into_response()
     })?;
@@ -2861,7 +2800,7 @@ pub(crate) async fn auth_user_id(headers: &HeaderMap) -> Result<String, Response
     })?;
 
     cache
-        .verify_and_cache(token)
+        .verify_and_cache(&token)
         .await
         .map(|info| info.user_id)
         .map_err(|e| {

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -322,6 +322,7 @@ fn extract_auth_token(headers: &HeaderMap, query: Option<&str>) -> Option<String
                 if let Some(val) = pair
                     .strip_prefix("kasm_session=")
                     .or_else(|| pair.strip_prefix("dashboard_session="))
+                    .or_else(|| pair.strip_prefix("sb-access-token="))
                 {
                     if !val.is_empty() {
                         return Some(val.to_string());

--- a/apps/kbve/edge/functions/_shared/supabase.ts
+++ b/apps/kbve/edge/functions/_shared/supabase.ts
@@ -24,12 +24,32 @@ export async function parseJwt(token: string): Promise<JwtClaims> {
   return payload as JwtClaims;
 }
 
+export const SB_ACCESS_TOKEN_COOKIE = "sb-access-token";
+
+function readCookie(req: Request, name: string): string | null {
+  const raw = req.headers.get("cookie");
+  if (!raw) return null;
+  for (const piece of raw.split(";")) {
+    const pair = piece.trim();
+    const eq = pair.indexOf("=");
+    if (eq <= 0) continue;
+    if (pair.slice(0, eq) === name) {
+      const v = pair.slice(eq + 1).trim();
+      return v.length > 0 ? v : null;
+    }
+  }
+  return null;
+}
+
 export function extractToken(req: Request): string {
   const authHeader = req.headers.get("authorization");
-  if (!authHeader?.startsWith("Bearer ")) {
-    throw new Error("Missing or invalid authorization header");
+  if (authHeader?.startsWith("Bearer ")) {
+    const token = authHeader.slice(7).trim();
+    if (token.length > 0) return token;
   }
-  return authHeader.slice(7);
+  const cookieToken = readCookie(req, SB_ACCESS_TOKEN_COOKIE);
+  if (cookieToken) return cookieToken;
+  throw new Error("Missing or invalid authorization header");
 }
 
 export function jsonResponse(data: unknown, status = 200) {

--- a/apps/kbve/edge/functions/main/index.ts
+++ b/apps/kbve/edge/functions/main/index.ts
@@ -11,16 +11,37 @@ const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
 const PUBLIC_ROUTES = new Set(["health"]);
 const STAFF_ROUTES = new Set(["argo"]);
 
+const SB_ACCESS_TOKEN_COOKIE = "sb-access-token";
+
+function readCookieValue(req: Request, name: string): string | null {
+  const raw = req.headers.get("cookie");
+  if (!raw) return null;
+  for (const piece of raw.split(";")) {
+    const pair = piece.trim();
+    const eq = pair.indexOf("=");
+    if (eq <= 0) continue;
+    if (pair.slice(0, eq) === name) {
+      const v = pair.slice(eq + 1).trim();
+      return v.length > 0 ? v : null;
+    }
+  }
+  return null;
+}
+
 function getAuthToken(req: Request) {
   const authHeader = req.headers.get("authorization");
-  if (!authHeader) {
-    throw new Error("Missing authorization header");
+  if (authHeader) {
+    const [bearer, token] = authHeader.split(" ");
+    if (bearer !== "Bearer") {
+      throw new Error(`Auth header is not 'Bearer {token}'`);
+    }
+    if (token && token.trim().length > 0) {
+      return token.trim();
+    }
   }
-  const [bearer, token] = authHeader.split(" ");
-  if (bearer !== "Bearer") {
-    throw new Error(`Auth header is not 'Bearer {token}'`);
-  }
-  return token;
+  const cookieToken = readCookieValue(req, SB_ACCESS_TOKEN_COOKIE);
+  if (cookieToken) return cookieToken;
+  throw new Error("Missing authorization header");
 }
 
 async function verifyJWT(jwt: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
PR-1 of the cookie-auth migration discussed in #11153 follow-up. **Strictly additive** — the \`Authorization\` header stays the source of truth for every existing client, and no cookie is written anywhere in this PR. Backend just learns to read \`sb-access-token\` from the request when the header is missing.

> User confirmation: "We can use both right, having the cookies be a fallback right?" — yes, fallback model.

## Why
Three concrete pain points the cookie path eventually solves:
- Mobile webviews / some Androids drop localStorage aggressively. Authorization-bearer auth gets nuked even though the user is still signed in.
- Edge functions and server-rendered Askama templates can't fish a token out of localStorage. They depend on a JS-injected header — extra round-trips on first paint.
- Cross-subdomain SSO (\`.kbve.com\`) needs a shared cookie; the Authorization-header model can't bridge \`supabase.kbve.com\`, \`chat.kbve.com\`, etc.

This PR opens the read path so a future PR can flip on cookie *writes* (supabase-js storage adapter + GoTrue \`cookie_options\`) without touching every handler again.

## axum-kbve (`apps/kbve/axum-kbve/src/auth/mod.rs`)
- New \`SB_ACCESS_TOKEN_COOKIE = "sb-access-token"\` constant. Matches \`@supabase/ssr\` naming.
- New \`extract_cookie_value(raw, name)\`. Minimal RFC 6265 lookup, first match wins.
- New \`extract_request_token(&HeaderMap)\`. Returns the bearer token from \`Authorization: Bearer …\` (primary) or the \`sb-access-token\` cookie (fallback).

Migrated user-auth handlers in \`transport/https.rs\` to use the new helper:
- \`profile_me_handler\` (\`GET /api/v1/profile/me\`)
- \`set_username_handler\` (\`POST /api/v1/profile/username\`)
- \`auth_user_id(&HeaderMap)\` — used by every forum write + \`api_me\` + \`api_me_staff\` + \`api_staff_edit_comment\` + \`api_staff_*\` paths.

\`require_service_role\` in \`transport/wallet.rs\` deliberately left untouched — service-role tokens come from internal callers (MC mod, cron jobs) that always send the Authorization header. Adding a cookie path there would be a privilege-escalation risk.

\`transport/proxy.rs::extract_auth_token\` already supported \`Authorization\`, \`?access_token=\` query, and \`kasm_session\` / \`dashboard_session\` cookies. Just adds \`sb-access-token=\` to the cookie alternation.

## Edge functions
\`apps/kbve/edge/functions/_shared/supabase.ts\`:
- \`extractToken(req)\` falls back to the \`sb-access-token\` cookie after the Authorization header check. Throwing behavior preserved.

\`apps/kbve/edge/functions/main/index.ts\`:
- \`getAuthToken(req)\` same fallback. Bearer stays primary.

## Out of scope (future PRs)
- Writing the cookie from supabase-js (\`storage\` adapter in droid)
- GoTrue \`cookie_options\` config so Supabase Auth sets the cookie directly on sign-in
- HttpOnly flip + edge bootstrap session endpoint
- Service worker / SharedWorker cookie read
- Cross-subdomain \`.kbve.com\` cookie domain rollout

## Test plan
- [x] \`cargo check -p axum-kbve\` — clean
- [x] \`droid:test\` 118/118 (no client changes)
- [x] Read path manually verified by reading the new \`extract_request_token\` logic
- [ ] In prod once merged: existing clients keep working (Authorization header path unchanged). When a future PR starts writing the cookie, server side already accepts it.