### PR TITLE
fix(rows): chuckrpg proxy injects X-CustomerGUID + cross-ns ESO

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use axum::{
     body::{Body, Bytes},
     extract::{FromRequestParts, Path, Request},
-    http::{HeaderMap, HeaderValue, StatusCode, header},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use reqwest::Client;
@@ -23,6 +23,7 @@ struct ServiceProxy {
     /// If set, injected as `Authorization: Bearer <token>` on upstream requests.
     /// When `None`, no auth header is sent upstream (e.g. Grafana anonymous).
     upstream_token: Option<String>,
+    upstream_headers: Vec<(HeaderName, HeaderValue)>,
     /// When true, strip X-Frame-Options and Content-Security-Policy frame-ancestors
     /// from upstream responses so the proxied service can be embedded in an iframe
     /// (e.g. KASM workspace viewer).
@@ -114,6 +115,10 @@ impl ServiceProxy {
             if let Ok(val) = HeaderValue::from_str(&format!("Bearer {token}")) {
                 headers.insert(header::AUTHORIZATION, val);
             }
+        }
+
+        for (name, value) in &self.upstream_headers {
+            headers.insert(name.clone(), value.clone());
         }
 
         let body_bytes = match axum::body::to_bytes(req.into_body(), 10 * 1024 * 1024).await {
@@ -485,6 +490,7 @@ pub fn init_grafana_proxy() -> bool {
             client,
             upstream,
             upstream_token: None,
+            upstream_headers: Vec::new(),
             iframe_safe: false,
             streaming: false,
         })
@@ -548,6 +554,7 @@ pub fn init_argo_proxy() -> bool {
         client,
         upstream,
         upstream_token: Some(auth_token),
+        upstream_headers: Vec::new(),
         iframe_safe: false,
         streaming: false,
     })
@@ -819,6 +826,7 @@ pub fn init_forgejo_proxy() -> bool {
             client,
             upstream,
             upstream_token: Some(auth_token),
+            upstream_headers: Vec::new(),
             iframe_safe: false,
             streaming: false,
         })
@@ -896,6 +904,7 @@ pub fn init_kubevirt_proxy() -> bool {
             client,
             upstream,
             upstream_token: Some(auth_token),
+            upstream_headers: Vec::new(),
             iframe_safe: false,
             streaming: false,
         })
@@ -1045,6 +1054,7 @@ pub fn init_kasm_proxy() -> bool {
         client,
         upstream: upstream.trim_end_matches('/').to_string(),
         upstream_token: None,
+        upstream_headers: Vec::new(),
         iframe_safe: true,
         // websockify chunked responses fail when buffered.
         streaming: true,
@@ -1540,6 +1550,7 @@ pub fn init_firecracker_proxy() -> bool {
             client,
             upstream: upstream.trim_end_matches('/').to_string(),
             upstream_token: None,
+            upstream_headers: Vec::new(),
             iframe_safe: false,
             streaming: false,
         })
@@ -1602,6 +1613,7 @@ pub fn init_firecracker_net_proxy() -> bool {
             client,
             upstream: upstream.trim_end_matches('/').to_string(),
             upstream_token: None,
+            upstream_headers: Vec::new(),
             iframe_safe: false,
             streaming: false,
         })
@@ -1788,6 +1800,7 @@ pub fn init_guacamole_proxy() -> bool {
             client,
             upstream: upstream.trim_end_matches('/').to_string(),
             upstream_token: None,
+            upstream_headers: Vec::new(),
             iframe_safe: false,
             streaming: false,
         })
@@ -1946,6 +1959,7 @@ pub fn init_edge_proxy() -> bool {
         client,
         upstream,
         upstream_token: Some(service_role_key),
+        upstream_headers: Vec::new(),
         iframe_safe: false,
         streaming: false,
     })
@@ -1971,6 +1985,26 @@ pub fn init_chuckrpg_proxy() -> bool {
         Err(_) => return false,
     };
 
+    let mut upstream_headers: Vec<(HeaderName, HeaderValue)> = Vec::new();
+    match std::env::var("CHUCKRPG_CUSTOMER_GUID") {
+        Ok(guid) => {
+            let trimmed = guid.trim();
+            if trimmed.is_empty() {
+                warn!("CHUCKRPG_CUSTOMER_GUID set but empty — ROWS /api/System/* will return 401");
+            } else {
+                match HeaderValue::from_str(trimmed) {
+                    Ok(val) => {
+                        upstream_headers.push((HeaderName::from_static("x-customerguid"), val))
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "invalid CHUCKRPG_CUSTOMER_GUID, header not injected")
+                    }
+                }
+            }
+        }
+        Err(_) => warn!("CHUCKRPG_CUSTOMER_GUID unset — ROWS /api/System/* will return 401"),
+    }
+
     let client = Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .connect_timeout(Duration::from_secs(5))
@@ -1984,6 +2018,7 @@ pub fn init_chuckrpg_proxy() -> bool {
             client,
             upstream,
             upstream_token: None,
+            upstream_headers,
             iframe_safe: false,
             streaming: false,
         })

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -134,6 +134,11 @@ spec:
                         value: '/etc/ssl/webtransport-selfsigned/tls.key'
                       - name: CHUCKRPG_UPSTREAM_URL
                         value: 'http://rows.rows.svc.cluster.local:4322'
+                      - name: CHUCKRPG_CUSTOMER_GUID
+                        valueFrom:
+                            secretKeyRef:
+                                name: chuckrpg-customer-guid
+                                key: customer-guid
                       # MC RCON (multi-server) — drives /api/v1/mc/players.
                       # axum-kbve polls both backends in parallel, tags each
                       # player with the server they're on, and writes

--- a/apps/kube/kbve/manifest/kustomization.yaml
+++ b/apps/kube/kbve/manifest/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
     - kbve-externalsecret.yaml
     - mc-rcon-externalsecret.yaml
     - clickhouse-externalsecret.yaml
+    - rows-customer-guid-externalsecret.yaml
     - forgejo-externalsecret.yaml
     - argocd-auth-sealedsecret.yaml
     - kbve-internal-ca-cert.yaml

--- a/apps/kube/kbve/manifest/rows-customer-guid-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/rows-customer-guid-externalsecret.yaml
@@ -1,0 +1,39 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: rows-remote-secret-store
+    namespace: kbve
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: rows
+            auth:
+                serviceAccount:
+                    name: kbve-external-secrets
+                    namespace: kbve
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: chuckrpg-customer-guid
+    namespace: kbve
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: rows-remote-secret-store
+        kind: SecretStore
+    target:
+        name: chuckrpg-customer-guid
+        creationPolicy: Owner
+    data:
+        - secretKey: customer-guid
+          remoteRef:
+              key: ows-customer-guid
+              property: customer-guid

--- a/apps/kube/rows/manifest/kbve-customer-guid-rbac.yaml
+++ b/apps/kube/rows/manifest/kbve-customer-guid-rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: customer-guid-reader-for-kbve
+    namespace: rows
+    labels:
+        app.kubernetes.io/part-of: rows
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      verbs: ['get', 'list', 'watch']
+      resourceNames: ['ows-customer-guid']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kbve-read-customer-guid
+    namespace: rows
+    labels:
+        app.kubernetes.io/part-of: rows
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: customer-guid-reader-for-kbve
+subjects:
+    - kind: ServiceAccount
+      name: kbve-external-secrets
+      namespace: kbve


### PR DESCRIPTION
## Summary
ROWS `/api/System/*` requires an `X-CustomerGUID` header. axum-kbve's chuckrpg proxy was forwarding browser requests untouched, so every dashboard call returned `401 "Missing or invalid X-CustomerGUID header"` and the **rows dashboard showed "Unable to reach ROWS"** even though the pod was healthy.

## Changes
**Rust (`axum-kbve`)**
- `ServiceProxy` gains `upstream_headers: Vec<(HeaderName, HeaderValue)>`, applied after hop-by-hop cleanup so static credentials are injected on every forwarded request. All ten existing init sites default to an empty Vec; only chuckrpg currently populates it.
- `init_chuckrpg_proxy` reads `CHUCKRPG_CUSTOMER_GUID` from env and seeds `X-CustomerGUID`. Empty/invalid values log a `warn!` and leave the header off (proxy still serves; ROWS will return 401).

**Manifests — single source of truth, no duplicated secrets**
- `rows/sealed-customer-guid.yaml` stays the **sole** SealedSecret. Rotation flows from there.
- `apps/kube/rows/manifest/kbve-customer-guid-rbac.yaml` — Role + RoleBinding granting `kbve-external-secrets` SA read on the single `ows-customer-guid` secret.
- `apps/kube/kbve/manifest/rows-customer-guid-externalsecret.yaml` — new `rows-remote-secret-store` SecretStore + `chuckrpg-customer-guid` ExternalSecret that syncs into `kbve/chuckrpg-customer-guid` with a 1h refresh.
- `apps/kube/kbve/manifest/kbve-deployment.yaml` — new `CHUCKRPG_CUSTOMER_GUID` env from the synced secret.

## Why this shape
- One sealed manifest, one source of truth — rotating the GUID in `rows/sealed-customer-guid.yaml` propagates to `kbve` automatically.
- Explicit Role on just the `ows-customer-guid` secret name (least privilege).
- Mirrors the existing pattern used for `clickhouse-vector-credentials` (see `apps/kube/vector/manifests/kbve-ch-credentials-rbac.yaml`).

## Test plan
- [ ] axum-kbve picks up new env, ExternalSecret reconciled (`kubectl -n kbve get externalsecret chuckrpg-customer-guid` → SecretSynced)
- [ ] In-cluster: `curl -H "X-CustomerGUID: <guid>" http://rows.rows:4322/api/System/Health` returns 200 (existing behaviour)
- [ ] Browser: hit the dashboard, "System Health" card transitions from "Unable to reach ROWS" → live status
- [ ] Logs show `init_chuckrpg_proxy` did NOT emit the missing-guid warn