### PR TITLE
chore(astro-kbve): strip noisy comments from mc + market layer

### DIFF
--- a/apps/kbve/astro-kbve/scripts/enrich-mc-items.mjs
+++ b/apps/kbve/astro-kbve/scripts/enrich-mc-items.mjs
@@ -1,27 +1,3 @@
-/**
- * Phase 5.3-C: secondary enrichment pass for vanilla MC item MDX.
- *
- * Reads every existing apps/kbve/astro-kbve/src/content/docs/mc/items/*.mdx,
- * parses the frontmatter, and for each item fills in stat blocks from the
- * PrismarineJS/minecraft-data upstream registry + a hand-coded constant
- * table for damage / armor / durability — but ONLY for fields explicitly
- * listed in the allow-set below, and ONLY when the current value is missing
- * or empty. Already-populated fields (hand-curated diamond tier, etc.) are
- * left untouched.
- *
- * Allow-set:
- *   - max_durability        (only if 0 / missing)
- *   - damage block          (only if missing entirely)
- *   - mining block          (only if missing AND ref ends in pickaxe/axe/shovel/hoe)
- *   - equipment block       (only if missing AND ref ends in helmet/chestplate/leggings/boots)
- *   - food block            (only if missing AND ref appears in foods.json)
- *   - enchants block        (only if missing) — small static table by category
- *
- * Run:
- *   node scripts/enrich-mc-items.mjs --audit   dry-run, prints planned changes
- *   node scripts/enrich-mc-items.mjs           write changes
- */
-
 import { readFile, writeFile, readdir } from 'fs/promises';
 import { join } from 'path';
 import { parse as parseYaml } from 'yaml';
@@ -34,11 +10,6 @@ const OUTPUT_DIR = './src/content/docs/mc/items';
 const args = process.argv.slice(2);
 const auditMode = args.includes('--audit');
 
-// ---------------------------------------------------------------------------
-// Hand-coded vanilla stat tables (1.21.5)
-// ---------------------------------------------------------------------------
-
-// max_durability — index = tier
 const TOOL_DURABILITY = {
 	wooden: 59,
 	stone: 131,
@@ -55,12 +26,10 @@ const ARMOR_DURABILITY = {
 	boots:      { leather: 65, chainmail: 195, iron: 195, golden: 91,  diamond: 429, netherite: 481 },
 };
 
-// Sword: attack_damage by tier, attack_speed 1.6 across
 const SWORD_DAMAGE = {
 	wooden: 4, stone: 5, iron: 6, golden: 4, diamond: 7, netherite: 8,
 };
 
-// Axe: per-tier damage + speed
 const AXE_DAMAGE = {
 	wooden:    { damage: 7,  speed: 0.8 },
 	stone:     { damage: 9,  speed: 0.9 },
@@ -70,12 +39,10 @@ const AXE_DAMAGE = {
 	netherite: { damage: 10, speed: 1.0 },
 };
 
-// Pickaxe: attack_damage by tier, attack_speed 1.2 across
 const PICKAXE_DAMAGE = {
 	wooden: 2, stone: 3, iron: 4, golden: 2, diamond: 5, netherite: 6,
 };
 
-// Shovel: pickaxe + 0.5 (matches existing diamond-shovel.mdx hand-curated value), speed 1.0
 const SHOVEL_DAMAGE = {
 	wooden:    { damage: 2.5, speed: 1.0 },
 	stone:     { damage: 3.5, speed: 1.0 },
@@ -85,7 +52,6 @@ const SHOVEL_DAMAGE = {
 	netherite: { damage: 6.5, speed: 1.0 },
 };
 
-// Hoe: damage 1, speed varies (gold/wooden 1.0, stone 2.0, iron 3.0, diamond/netherite 4.0)
 const HOE_DAMAGE = {
 	wooden:    { damage: 1, speed: 1.0 },
 	stone:     { damage: 1, speed: 2.0 },
@@ -95,7 +61,6 @@ const HOE_DAMAGE = {
 	netherite: { damage: 1, speed: 4.0 },
 };
 
-// Mining tier: 1..5 (netherite). schema bound is 1..6.
 const MINING_TIER = {
 	wooden:    1,
 	golden:    1,
@@ -105,8 +70,6 @@ const MINING_TIER = {
 	netherite: 5,
 };
 
-// Armor points + toughness + knockback_resistance per slot/tier
-// Source: minecraft.wiki/w/Armor (1.21.5 vanilla values)
 const ARMOR_STATS = {
 	helmet: {
 		leather:   { armor_points: 1, toughness: 0, knockback_resistance: 0 },
@@ -143,9 +106,6 @@ const ARMOR_STATS = {
 	},
 };
 
-// Enchant allow-lists by category (mirrors the hand-curated diamond tier MDX
-// pages — sword/pickaxe/axe/shovel/hoe/helmet/chestplate/leggings/boots/bow/
-// crossbow/trident/mace).
 const ENCHANTS_SWORD = [
 	'sharpness', 'smite', 'bane_of_arthropods', 'knockback', 'fire_aspect',
 	'looting', 'sweeping_edge', 'unbreaking', 'mending', 'vanishing_curse',
@@ -196,10 +156,6 @@ const ENCHANTS_FISHING_ROD = [
 	'lure', 'luck_of_the_sea', 'unbreaking', 'mending', 'vanishing_curse',
 ];
 const ENCHANTS_SHEARS = ['efficiency', 'unbreaking', 'mending', 'vanishing_curse'];
-
-// ---------------------------------------------------------------------------
-// Inference helpers
-// ---------------------------------------------------------------------------
 
 const TIERS_FROM_REF = ['netherite', 'diamond', 'golden', 'iron', 'stone', 'wooden', 'leather', 'chainmail', 'turtle'];
 
@@ -261,10 +217,6 @@ function enchantsForRef(ref) {
 	if (ref === 'fishing_rod') return ENCHANTS_FISHING_ROD;
 	return null;
 }
-
-// ---------------------------------------------------------------------------
-// Stat lookups
-// ---------------------------------------------------------------------------
 
 function lookupMaxDurability(ref) {
 	const tier = tierFromRef(ref);
@@ -351,10 +303,6 @@ function lookupFood(ref, foodsByRef) {
 	return { nutrition, saturation };
 }
 
-// ---------------------------------------------------------------------------
-// MDX parsing / surgical injection
-// ---------------------------------------------------------------------------
-
 const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
 const MC_ITEM_BLOCK_RE = /^(mc_item:\s*\n)((?:    [^\n]*\n?)+)/m;
 
@@ -366,11 +314,6 @@ function parseFrontmatter(content) {
 	return { frontmatter: fm, raw: content };
 }
 
-/**
- * Format a small structured object as 4-space-indented YAML lines that fit
- * under `mc_item:`. Hand-rolled to keep the existing MDX formatting (no
- * roundtrip noise from the yaml library). Only handles the shapes we emit.
- */
 function formatYamlBlock(key, value, baseIndent = '    ') {
 	const lines = [];
 	const child = baseIndent + '    ';
@@ -404,21 +347,12 @@ function formatScalar(v) {
 	return String(v);
 }
 
-/**
- * Inject new YAML lines into the mc_item: block of a frontmatter string.
- * `insertions` is an array of objects describing where to put each block.
- *   { lines: string[], beforeKey?: string, afterKey?: string }
- * If beforeKey matches a `    <key>:` line in mc_item, insert above it.
- * Otherwise append to end of mc_item block (before next top-level key or
- * end of frontmatter).
- */
 function injectIntoMcItem(rawMdx, insertions) {
 	const m = rawMdx.match(FRONTMATTER_RE);
 	if (!m) return null;
 	const fmBlock = m[1];
 	const body = m[2];
 
-	// Split the frontmatter into lines and find the mc_item: section bounds.
 	const lines = fmBlock.split('\n');
 	let mcItemStart = -1;
 	let mcItemEnd = lines.length; // exclusive
@@ -426,7 +360,6 @@ function injectIntoMcItem(rawMdx, insertions) {
 		if (mcItemStart === -1) {
 			if (/^mc_item:\s*$/.test(lines[i])) mcItemStart = i + 1;
 		} else {
-			// mc_item ends at next top-level key (non-indented, non-blank starting with letter)
 			if (/^[A-Za-z]/.test(lines[i]) && !lines[i].startsWith(' ')) {
 				mcItemEnd = i;
 				break;
@@ -435,13 +368,9 @@ function injectIntoMcItem(rawMdx, insertions) {
 	}
 	if (mcItemStart === -1) return null;
 
-	// Find each insertion's target line index within mc_item block.
-	// We process inserts in order; each insert grabs its index against the
-	// current array, which may have grown from previous inserts.
 	let working = lines.slice();
 	const shift = (target, count) => {
 		if (target <= mcItemStart) return;
-		// adjust mcItemEnd accordingly
 		mcItemEnd += count;
 	};
 
@@ -473,46 +402,36 @@ function injectIntoMcItem(rawMdx, insertions) {
 	return `---\n${newFm}\n---\n${body}`;
 }
 
-// ---------------------------------------------------------------------------
-// Per-item plan
-// ---------------------------------------------------------------------------
-
 function planEnrichment(mc, foodsByRef) {
 	const plan = [];
 	if (!mc || !mc.ref) return plan;
 	const ref = mc.ref;
 
-	// max_durability — only if currently 0/missing
 	if (!mc.max_durability || mc.max_durability === 0) {
 		const v = lookupMaxDurability(ref);
 		if (v) plan.push({ field: 'max_durability', value: v });
 	}
 
-	// damage — only if block missing entirely
 	if (!mc.damage) {
 		const v = lookupDamage(ref);
 		if (v) plan.push({ field: 'damage', value: v });
 	}
 
-	// mining — only if missing AND ref ends in pickaxe/axe/shovel/hoe
 	if (!mc.mining) {
 		const v = lookupMining(ref);
 		if (v) plan.push({ field: 'mining', value: v });
 	}
 
-	// equipment — only if missing AND armor slot inferrable
 	if (!mc.equipment) {
 		const v = lookupEquipment(ref);
 		if (v) plan.push({ field: 'equipment', value: v });
 	}
 
-	// food — only if missing AND in foods.json
 	if (!mc.food) {
 		const v = lookupFood(ref, foodsByRef);
 		if (v) plan.push({ field: 'food', value: v });
 	}
 
-	// enchants — only if missing AND we have a category list
 	if (!mc.enchants) {
 		const list = enchantsForRef(ref);
 		if (list && list.length > 0) plan.push({ field: 'enchants', value: { allowed: list } });
@@ -523,7 +442,6 @@ function planEnrichment(mc, foodsByRef) {
 
 function planToInsertions(plan) {
 	const insertions = [];
-	// max_durability is a scalar — insert before `tier:` if present, else before `tags:`
 	for (const step of plan) {
 		if (step.field === 'max_durability') {
 			insertions.push({
@@ -565,10 +483,6 @@ function planToInsertions(plan) {
 	}
 	return insertions;
 }
-
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
 
 async function fetchJson(url) {
 	const res = await fetch(url);

--- a/apps/kbve/astro-kbve/scripts/fetch-mc-textures.mjs
+++ b/apps/kbve/astro-kbve/scripts/fetch-mc-textures.mjs
@@ -1,16 +1,3 @@
-/**
- * Fetch Minecraft vanilla item + block textures from
- * InventivetalentDev/minecraft-assets and write them under
- * apps/kbve/astro-kbve/public/mc/textures/{item,block}/.
- *
- * Reads refs from each MDX page under src/content/docs/mc/items/<slug>.mdx
- * (frontmatter `mc_item.ref` + every `recipes[*].ingredients[*].ref`) and
- * src/content/docs/mc/blocks/<slug>.mdx (`mc_block.ref` + drops). Skips refs
- * we already have on disk. Pinned to MC_ASSET_VERSION below.
- *
- * Run: node scripts/fetch-mc-textures.mjs
- */
-
 import { mkdir, readdir, readFile, writeFile, stat } from 'fs/promises';
 import { join } from 'path';
 import { parse as parseYaml } from 'yaml';

--- a/apps/kbve/astro-kbve/scripts/generate-mc-blocks.mjs
+++ b/apps/kbve/astro-kbve/scripts/generate-mc-blocks.mjs
@@ -1,14 +1,3 @@
-/**
- * Bootstrap new Minecraft block MDX files from the
- * PrismarineJS/minecraft-data registry. Skips blocks whose MDX already
- * exists (matched by `mc_block.ref` in frontmatter). Generates a
- * minimal frontmatter block that validates against McBlockSchema; drops,
- * required_tool_tier, and tag enrichment are left for manual passes.
- *
- * Run: node scripts/generate-mc-blocks.mjs
- *   --audit   print would-be new MDX files; no writes
- */
-
 import { mkdir, readdir, readFile, writeFile, stat } from 'fs/promises';
 import { join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -30,8 +19,6 @@ function clamp(n, lo, hi) {
 	return Math.max(lo, Math.min(hi, n));
 }
 
-// Best-effort material guess from ref name. Used as a name-based
-// override before falling back to the upstream `material` string.
 function inferMaterialFromRef(ref) {
 	if (ref === 'air' || ref === 'cave_air' || ref === 'void_air') return 'air';
 	if (/(water|lava|bubble_column)/.test(ref)) return 'liquid';
@@ -87,7 +74,6 @@ function mapMaterial(ref, upstream) {
 	if (upstream === 'default' || upstream === 'incorrect_for_wooden_tool') {
 		return 'stone';
 	}
-	// Compound markers like `plant;mineable/axe`.
 	const parts = upstream.split(';');
 	if (parts.includes('leaves')) return 'leaves';
 	if (parts.includes('plant') || parts.includes('gourd') || parts.includes('vine_or_glow_lichen')) {

--- a/apps/kbve/astro-kbve/scripts/generate-mc-enchants.mjs
+++ b/apps/kbve/astro-kbve/scripts/generate-mc-enchants.mjs
@@ -1,14 +1,3 @@
-/**
- * Bootstrap new Minecraft enchant MDX files from the
- * PrismarineJS/minecraft-data registry. Skips enchants whose MDX already
- * exists (matched by `mc_enchant.ref` in frontmatter). Generates a
- * minimal frontmatter block that validates against McEnchantSchema; rich
- * descriptions and rarity tuning are left for manual enrichment.
- *
- * Run: node scripts/generate-mc-enchants.mjs
- *   --audit   print would-be new MDX files; no writes
- */
-
 import { mkdir, readdir, readFile, writeFile, stat } from 'fs/promises';
 import { join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -22,13 +11,6 @@ const OUTPUT_DIR = resolve(__dirname, '../src/content/docs/mc/enchants');
 const args = process.argv.slice(2);
 const auditMode = args.includes('--audit');
 
-// Map upstream `category` strings → schema MCEnchantTarget enum.
-// Upstream uses gameplay buckets (e.g. `sharp_weapon`, `mining_loot`)
-// that don't appear in our proto enum — fold them into the closest
-// existing target. `equippable` and `durability` apply to anything that
-// can be worn / broken, so they map to the catch-all `wearable` /
-// `breakable` targets. `vanishing` (curse of vanishing) maps to
-// `vanishable`.
 const CATEGORY_TO_TARGET = {
 	armor: 'armor',
 	head_armor: 'armor_head',

--- a/apps/kbve/astro-kbve/scripts/generate-mc-items.mjs
+++ b/apps/kbve/astro-kbve/scripts/generate-mc-items.mjs
@@ -1,15 +1,3 @@
-/**
- * Bootstrap new Minecraft item MDX files from the
- * PrismarineJS/minecraft-data registry. Skips items whose MDX already
- * exists (matched by `mc_item.ref` in frontmatter) so hand-curated rich
- * pages stay intact. Generates a minimal frontmatter block — display_name,
- * stack_size, plus best-effort category + tier guessed from the ref —
- * everything else is left for manual enrichment.
- *
- * Run: node scripts/generate-mc-items.mjs
- *   --audit   print would-be new MDX files; no writes
- */
-
 import { mkdir, readdir, readFile, writeFile, stat } from 'fs/promises';
 import { join } from 'path';
 import { parse as parseYaml } from 'yaml';

--- a/apps/kbve/astro-kbve/scripts/validate-mc-mdx.mjs
+++ b/apps/kbve/astro-kbve/scripts/validate-mc-mdx.mjs
@@ -1,12 +1,3 @@
-/**
- * Local validator: parse every MDX file under content/docs/mc/{enchants,blocks}
- * and validate frontmatter against a self-contained Zod mirror of the
- * proto-aligned schemas. Used to verify generator output without the
- * full astro/nx build (which mis-resolves paths across git worktrees).
- *
- * Run: node scripts/validate-mc-mdx.mjs
- */
-
 import { readdir, readFile, stat } from 'fs/promises';
 import { join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';

--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -452,7 +452,6 @@ import MarketCreateForm from './MarketCreateForm';
 		}
 	}
 
-	/* ---- Polish v2: shared icon (themed against Starlight + KBVE brand) ---- */
 	.kbve-item-icon {
 		display: flex;
 		align-items: center;
@@ -486,7 +485,6 @@ import MarketCreateForm from './MarketCreateForm';
 		letter-spacing: -0.02em;
 	}
 
-	/* ---- Polish v2: browse grid + filters ---- */
 	.kbve-market__filters {
 		display: flex;
 		align-items: center;
@@ -598,7 +596,6 @@ import MarketCreateForm from './MarketCreateForm';
 		justify-content: center;
 	}
 
-	/* ---- Polish v2: detail hero + panel ---- */
 	.kbve-market__detail-v2 {
 		display: grid;
 		gap: 1.5rem;
@@ -841,7 +838,6 @@ import MarketCreateForm from './MarketCreateForm';
 		}
 	}
 
-	/* ---- Phase 5.2: enchants ---- */
 	.kbve-enchant-list {
 		list-style: none;
 		margin: 0.5rem 0 0;
@@ -956,7 +952,6 @@ import MarketCreateForm from './MarketCreateForm';
 		}
 	}
 
-	/* ---- Phase 5.3b: MC item picker ---- */
 	.kbve-mcpicker {
 		position: relative;
 		display: grid;

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCTextureImage.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCTextureImage.tsx
@@ -9,12 +9,6 @@ type Props = {
 	className?: string;
 };
 
-/**
- * `<MCTextureImage>` resolves a vanilla MC texture URL via the
- * texture.ts util, then walks the [primary, fallback] pair on `onError`.
- * Pure React — no global DOM walks, no scripts-after-parse races.
- * Drop in anywhere we'd otherwise emit a raw `<img>` for an item / block.
- */
 export function MCTextureImage({
 	ref,
 	category,

--- a/apps/kbve/astro-kbve/src/components/mcdb/texture.ts
+++ b/apps/kbve/astro-kbve/src/components/mcdb/texture.ts
@@ -1,16 +1,3 @@
-/**
- * Resolve Minecraft texture URLs for a given vanilla ref.
- *
- * Textures are self-hosted at `apps/kbve/astro-kbve/public/mc/textures/`
- * (downloaded from InventivetalentDev/minecraft-assets at the version
- * pinned by MC_ASSET_VERSION). Same-origin avoids the mcasset.cloud CORS /
- * availability issues we hit with the prior implementation.
- *
- * Returns both `item/` and `block/` URLs; the caller (`MCTextureImage`)
- * tries the most likely path first based on category and falls back to
- * the alternate on `onError`. Missing PNGs in either path resolve to a
- * themed initial-letter placeholder rendered by the component.
- */
 export const MC_ASSET_VERSION = '1.21.5';
 const ITEM_BASE = '/mc/textures/item';
 const BLOCK_BASE = '/mc/textures/block';

--- a/apps/kbve/astro-kbve/src/data/schema/mc/blocks.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/blocks.ts
@@ -1,11 +1,3 @@
-/**
- * Proto-aligned Zod schema for kbve.mc.McBlock.
- *
- * Mirrors packages/data/proto/kbve/mc/mc_blocks.proto. Validates frontmatter
- * for content/docs/mc/blocks/<slug>.mdx. Placeable blocks share `ref` with
- * the mc_items.proto MCItem of the same name (item form).
- */
-
 import { z } from 'astro/zod';
 import {
 	MCIdentitySchema,
@@ -13,7 +5,6 @@ import {
 	McBlockToolSchema,
 } from './enums';
 
-// proto: McBlockDrop
 export const McBlockDropSchema = z.object({
 	ref: z.string().min(1),
 	qty_min: z.number().int().nonnegative().default(1),
@@ -23,14 +14,10 @@ export const McBlockDropSchema = z.object({
 });
 export type McBlockDrop = z.infer<typeof McBlockDropSchema>;
 
-/**
- * proto: McBlock — top-level block record.
- */
 export const McBlockSchema = MCIdentitySchema.extend({
 	display_name: z.string().min(1),
 	material: McBlockMaterialSchema,
 
-	// hardness can be -1 for indestructible blocks (bedrock); allow negatives.
 	hardness: z.number(),
 	blast_resistance: z.number().nonnegative(),
 

--- a/apps/kbve/astro-kbve/src/data/schema/mc/enchants.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/enchants.ts
@@ -1,11 +1,3 @@
-/**
- * Proto-aligned Zod schema for kbve.mc.McEnchant.
- *
- * Mirrors packages/data/proto/kbve/mc/mc_enchants.proto. Validates
- * frontmatter for content/docs/mc/enchants/<slug>.mdx. The marketplace
- * `enchants.ts` table (Phase 5.2) MUST stay aligned with refs here.
- */
-
 import { z } from 'astro/zod';
 import {
 	MCEnchantRaritySchema,
@@ -13,7 +5,6 @@ import {
 	MCIdentitySchema,
 } from './enums';
 
-// proto: MCEnchantCostRange
 export const MCEnchantCostRangeSchema = z.object({
 	a_min: z.number().int(),
 	b_min: z.number().int(),
@@ -22,9 +13,6 @@ export const MCEnchantCostRangeSchema = z.object({
 });
 export type MCEnchantCostRange = z.infer<typeof MCEnchantCostRangeSchema>;
 
-/**
- * proto: McEnchant — top-level enchantment record.
- */
 export const McEnchantSchema = MCIdentitySchema.extend({
 	display_name: z.string().min(1),
 	rarity: MCEnchantRaritySchema,

--- a/apps/kbve/astro-kbve/src/data/schema/mc/enums.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/enums.ts
@@ -1,20 +1,9 @@
-/**
- * Proto-aligned MC enum tables.
- *
- * Each `as const` array mirrors a proto enum in packages/data/proto/kbve/mc/.
- * Stored on the MDX side as lowercase strings (we strip the proto prefix and
- * lowercase the suffix — e.g. `MC_RARITY_COMMON` → `"common"`). Zod uses
- * z.enum on these arrays so frontmatter validation rejects unknown values.
- */
-
 import { z } from 'astro/zod';
 
-// proto: MCRarity
 export const MCRarities = ['common', 'uncommon', 'rare', 'epic'] as const;
 export const MCRaritySchema = z.enum(MCRarities);
 export type MCRarity = z.infer<typeof MCRaritySchema>;
 
-// proto: MCItemCategory
 export const MCItemCategories = [
 	'tool',
 	'weapon',
@@ -35,9 +24,6 @@ export const MCItemCategories = [
 export const MCItemCategorySchema = z.enum(MCItemCategories);
 export type MCItemCategory = z.infer<typeof MCItemCategorySchema>;
 
-// proto: MCToolTier. Applies to both mining tools and armor — vanilla
-// armor adds `leather`, `chainmail`, and `turtle` to the mining-tool
-// hierarchy (wooden..netherite).
 export const MCToolTiers = [
 	'wooden',
 	'stone',
@@ -52,7 +38,6 @@ export const MCToolTiers = [
 export const MCToolTierSchema = z.enum(MCToolTiers);
 export type MCToolTier = z.infer<typeof MCToolTierSchema>;
 
-// proto: MCEnchantRarity
 export const MCEnchantRarities = [
 	'common',
 	'uncommon',
@@ -62,7 +47,6 @@ export const MCEnchantRarities = [
 export const MCEnchantRaritySchema = z.enum(MCEnchantRarities);
 export type MCEnchantRarity = z.infer<typeof MCEnchantRaritySchema>;
 
-// proto: MCEnchantTarget
 export const MCEnchantTargets = [
 	'armor',
 	'armor_head',
@@ -83,7 +67,6 @@ export const MCEnchantTargets = [
 export const MCEnchantTargetSchema = z.enum(MCEnchantTargets);
 export type MCEnchantTarget = z.infer<typeof MCEnchantTargetSchema>;
 
-// proto: McBlockTool
 export const McBlockTools = [
 	'hand',
 	'pickaxe',
@@ -96,7 +79,6 @@ export const McBlockTools = [
 export const McBlockToolSchema = z.enum(McBlockTools);
 export type McBlockTool = z.infer<typeof McBlockToolSchema>;
 
-// proto: McBlockMaterial
 export const McBlockMaterials = [
 	'air',
 	'stone',
@@ -120,7 +102,6 @@ export const McBlockMaterials = [
 export const McBlockMaterialSchema = z.enum(McBlockMaterials);
 export type McBlockMaterial = z.infer<typeof McBlockMaterialSchema>;
 
-// proto: McRecipeKind
 export const McRecipeKinds = [
 	'shaped',
 	'shapeless',
@@ -136,7 +117,6 @@ export const McRecipeKinds = [
 export const McRecipeKindSchema = z.enum(McRecipeKinds);
 export type McRecipeKind = z.infer<typeof McRecipeKindSchema>;
 
-// proto: McCraftingStation
 export const McCraftingStations = [
 	'crafting_table',
 	'furnace',
@@ -152,10 +132,6 @@ export const McCraftingStations = [
 export const McCraftingStationSchema = z.enum(McCraftingStations);
 export type McCraftingStation = z.infer<typeof McCraftingStationSchema>;
 
-/**
- * Shared identity fields. Every top-level MC record (item, enchant, block,
- * recipe) carries an int id, a stable string ref, and a kebab-case slug.
- */
 export const MCIdentitySchema = z.object({
 	id: z.number().int().nonnegative(),
 	ref: z

--- a/apps/kbve/astro-kbve/src/data/schema/mc/items.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/items.ts
@@ -1,12 +1,3 @@
-/**
- * Proto-aligned Zod schema for kbve.mc.MCItem.
- *
- * Mirrors packages/data/proto/kbve/mc/mc_items.proto. Validates frontmatter
- * for content/docs/mc/items/<slug>.mdx. Marketplace listings whose
- * item_ref.kind === 'mc_item' MUST carry an item_ref.id that matches an
- * MCItem.ref defined here — that's the cross-system contract.
- */
-
 import { z } from 'astro/zod';
 import {
 	MCIdentitySchema,
@@ -17,7 +8,6 @@ import {
 	McRecipeKindSchema,
 } from './enums';
 
-// proto: MCEquipment
 export const MCEquipmentSchema = z.object({
 	slot: z.enum(['head', 'chest', 'legs', 'feet', 'offhand', '']).default(''),
 	armor_points: z.number().int().nonnegative().default(0),
@@ -26,15 +16,12 @@ export const MCEquipmentSchema = z.object({
 });
 export type MCEquipment = z.infer<typeof MCEquipmentSchema>;
 
-// proto: MCDamage. MC tools deal fractional base damage (e.g. shovel +1.5)
-// — accept float; the in-game tooltip rounds to display.
 export const MCDamageSchema = z.object({
 	attack_damage: z.number().nonnegative(),
 	attack_speed: z.number(),
 });
 export type MCDamage = z.infer<typeof MCDamageSchema>;
 
-// proto: MCFood
 export const MCFoodSchema = z.object({
 	nutrition: z.number().int().nonnegative(),
 	saturation: z.number().nonnegative(),
@@ -42,23 +29,17 @@ export const MCFoodSchema = z.object({
 });
 export type MCFood = z.infer<typeof MCFoodSchema>;
 
-// proto: MCMiningProfile
 export const MCMiningProfileSchema = z.object({
 	tool_type: z.enum(['pickaxe', 'axe', 'shovel', 'hoe', 'shears', 'sword']),
 	tier: z.number().int().min(1).max(6),
 });
 export type MCMiningProfile = z.infer<typeof MCMiningProfileSchema>;
 
-// proto: MCEnchantCompat
 export const MCEnchantCompatSchema = z.object({
 	allowed: z.array(z.string().min(1)).default([]),
 });
 export type MCEnchantCompat = z.infer<typeof MCEnchantCompatSchema>;
 
-// proto: MCRecipeIngredient (inline). `tag_ref` covers vanilla item tags
-// like "minecraft:planks" — when set, the slot accepts any item matching
-// the tag. `row` + `col` are 0-indexed within the crafting grid (shaped
-// recipes only).
 export const MCItemRecipeIngredientSchema = z
 	.object({
 		ref: z.string().default(''),
@@ -71,9 +52,6 @@ export const MCItemRecipeIngredientSchema = z
 		message: 'ingredient must set ref or tag_ref',
 	});
 
-// proto: MCRecipe (inline on the item). Carries the full vanilla recipe
-// shape (grid dimensions, cook time, XP, smithing template, brewing base)
-// so the per-item MDX is self-contained — no separate recipe registry.
 export const MCItemRecipeSchema = z.object({
 	kind: McRecipeKindSchema,
 	station: McCraftingStationSchema.default('none'),
@@ -88,17 +66,12 @@ export const MCItemRecipeSchema = z.object({
 });
 export type MCItemRecipe = z.infer<typeof MCItemRecipeSchema>;
 
-// proto: MCAbout
 export const MCAboutSchema = z.object({
 	description: z.string().default(''),
 	lore: z.string().default(''),
 });
 export type MCAbout = z.infer<typeof MCAboutSchema>;
 
-/**
- * proto: MCItem — top-level item record. Used as the Zod schema for MDX
- * frontmatter under content/docs/mc/items/.
- */
 export const MCItemSchema = MCIdentitySchema.extend({
 	display_name: z.string().min(1),
 	category: MCItemCategorySchema,

--- a/apps/kbve/astro-kbve/src/pages/api/mc-items.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/mc-items.json.ts
@@ -1,11 +1,5 @@
 import { getCollection } from 'astro:content';
 
-/**
- * `/api/mc-items.json` — flat index of every MC item with a published MDX
- * page. Built at SSG time from the docs collection (frontmatter
- * `mc_item:` block). Consumed by the marketplace create-form picker and
- * any future autocomplete surface.
- */
 export const GET = async () => {
 	const entries = await getCollection(
 		'docs',


### PR DESCRIPTION
## Summary
Removes JSDoc preambles, section banners, and inline tour-comments from the MC + market layer. Code unchanged; identifier names + git history carry the why.

## Files
- `src/data/schema/mc/{enums,items,enchants,blocks}.ts`
- `src/components/mcdb/{texture.ts,MCTextureImage.tsx}`
- `src/components/market/AstroMarketShell.astro` (CSS section banners)
- `src/pages/api/mc-items.json.ts`
- `scripts/{generate-mc-items,generate-mc-enchants,generate-mc-blocks,enrich-mc-items,fetch-mc-textures,validate-mc-mdx}.mjs`

## Build
`./kbve.sh -nx astro-kbve:build` — green, 7627 pages.

## Test plan
- [ ] CI astro-kbve build passes
- [ ] Diff is comment-only (14 files, -258 lines)