### PR TITLE
fix(kube): unfreeze kube-root by removing dead agones/ows + standalone ows entries

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -56,15 +56,9 @@ resources:
     - memes/application.yaml
     - n8n/application.yaml
     - rabbitmq/application.yaml
-    # Agones — game server operator (GameServer/Fleet/Allocator CRDs)
     - agones/application.yaml
-    # Agones OWS — HubWorldMMO game server fleet
-    - agones/ows/application.yaml
-    # Agones MC — Fabric Minecraft server fleet
+    - agones/rows/application.yaml
     - agones/mc/application.yaml
-    # OWS — Open World Server .NET microservices (5 services + ValKey)
-    - ows/application.yaml
-    # ChuckRPG — game website + API
     - chuckrpg/application.yaml
     # RareIcon — bullet-hell roguelite website + API
     - rareicon/application.yaml


### PR DESCRIPTION
## Summary
- `kube-root` Application has been failing manifest generation with two `evalsymlink` errors against `apps/kube/agones/ows/application.yaml` and `apps/kube/ows/application.yaml` — neither directory exists anymore. While `kube-root` is broken, every child Application is frozen at its last-known spec, which is why the recently-merged kyverno fix (#11149) has not propagated to the cluster.
- Drops `agones/ows/application.yaml` and replaces it with `agones/rows/application.yaml` (the renamed game-server fleet that already lives on disk).
- Drops `ows/application.yaml` entirely — the standalone OWS service was removed.
- Validated with `kubectl kustomize apps/kube/` from the worktree (renders clean).

## Live error from `kube-root`
```
Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc =
Manifest generation error (cached): `kustomize build <path to cached source>/apps/kube` failed exit status 1:
Error: accumulating resources: accumulation err='accumulating resources from 'agones/ows/application.yaml':
evalsymlink failure on '<path to cached source>/apps/kube/agones/ows/application.yaml' :
lstat <path to cached source>/apps/kube/agones/ows: no such file or directory':
must build at directory: not a valid directory
```

## Test plan
- [ ] `kube-root` Application reconciles cleanly after merge (no ComparisonError)
- [ ] Child Applications under `apps/kube/` resume normal sync
- [ ] `kyverno` Application picks up the `ignoreDifferences` + `RespectIgnoreDifferences` from #11149 and flips to `Synced`
- [ ] `agones-rows` still healthy (path is `apps/kube/agones/rows/manifests`, unchanged)