### PR TITLE
fix(ci): retry direct PR merge on transient 405/409/422

### DIFF
--- a/.github/workflows/ci-atom.yml
+++ b/.github/workflows/ci-atom.yml
@@ -464,22 +464,38 @@ jobs:
                         console.log(`Auto-merge (squash) enabled for PR #${prNumber}`);
                       } catch (error) {
                         console.log(`Failed to enable auto-merge: ${error.message}`);
+                        console.log('Attempting direct squash merge with retry…');
 
-                        // Fallback: try to squash merge directly if no branch protections
-                        console.log('Attempting direct squash merge...');
-                        try {
-                          await github.rest.pulls.merge({
-                            owner: context.repo.owner,
-                            repo: context.repo.repo,
-                            pull_number: parseInt(prNumber),
-                            merge_method: 'squash',
-                            commit_title: `Atomic: ${context.ref.replace('refs/heads/', '')}`
-                          });
-
-                          console.log(`PR #${prNumber} squash merged successfully`);
-                        } catch (mergeError) {
-                          console.log(`Direct squash merge also failed: ${mergeError.message}`);
-                          core.setFailed(`Unable to merge PR: ${mergeError.message}`);
+                        const attempts = [0, 60, 120, 120];
+                        let merged = false;
+                        let lastErr = null;
+                        for (let i = 0; i < attempts.length; i++) {
+                          if (attempts[i] > 0) {
+                            console.log(`Waiting ${attempts[i]}s before retry ${i}/${attempts.length - 1}…`);
+                            await new Promise(r => setTimeout(r, attempts[i] * 1000));
+                          }
+                          try {
+                            await github.rest.pulls.merge({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              pull_number: parseInt(prNumber),
+                              merge_method: 'squash',
+                              commit_title: `Atomic: ${context.ref.replace('refs/heads/', '')}`
+                            });
+                            console.log(`PR #${prNumber} squash merged successfully (attempt ${i + 1}).`);
+                            merged = true;
+                            break;
+                          } catch (mergeError) {
+                            lastErr = mergeError;
+                            const status = mergeError.status ?? mergeError.response?.status;
+                            const transient = status === 405 || status === 409 || status === 422;
+                            if (!transient || i === attempts.length - 1) {
+                              console.log(`Direct squash merge failed: ${mergeError.message}`);
+                              core.setFailed(`Unable to merge PR: ${mergeError.message}`);
+                              break;
+                            }
+                            console.log(`Merge attempt ${i + 1} failed (status ${status}): ${mergeError.message}. Retrying…`);
+                          }
                         }
                       }
 

--- a/.github/workflows/ci-auto-merge-bot-prs.yml
+++ b/.github/workflows/ci-auto-merge-bot-prs.yml
@@ -330,13 +330,36 @@ jobs:
                         core.info(`Auto-merge (squash) enabled for PR #${prNumber}`);
                       } catch (err) {
                         core.info(`enableAutoMerge unavailable (${err.message}), attempting direct merge`);
-                        await github.rest.pulls.merge({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          pull_number: prNumber,
-                          merge_method: 'squash',
-                        });
-                        core.info(`PR #${prNumber} squash-merged directly`);
+
+                        const attempts = [0, 60, 120, 120];
+                        let merged = false;
+                        let lastErr = null;
+                        for (let i = 0; i < attempts.length; i++) {
+                          if (attempts[i] > 0) {
+                            core.info(`Waiting ${attempts[i]}s before retry ${i}/${attempts.length - 1}…`);
+                            await new Promise(r => setTimeout(r, attempts[i] * 1000));
+                          }
+                          try {
+                            await github.rest.pulls.merge({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              pull_number: prNumber,
+                              merge_method: 'squash',
+                            });
+                            core.info(`PR #${prNumber} squash-merged directly (attempt ${i + 1}).`);
+                            merged = true;
+                            break;
+                          } catch (mergeErr) {
+                            lastErr = mergeErr;
+                            const status = mergeErr.status ?? mergeErr.response?.status;
+                            const transient = status === 405 || status === 409 || status === 422;
+                            if (!transient || i === attempts.length - 1) {
+                              throw mergeErr;
+                            }
+                            core.warning(`Merge attempt ${i + 1} failed (status ${status}): ${mergeErr.message}. Retrying…`);
+                          }
+                        }
+                        if (!merged) throw lastErr;
                       }
 
     track_failure:

--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -1336,14 +1336,37 @@ jobs:
                         core.info(`Auto-merge (squash) enabled for PR #${prNumber}`);
                       } catch (err) {
                         core.info(`enableAutoMerge unavailable (${err.message}), attempting direct squash merge`);
-                        await github.rest.pulls.merge({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          pull_number: prNumber,
-                          merge_method: 'squash',
-                          commit_title: 'chore(dashboard): daily sync',
-                        });
-                        core.info(`PR #${prNumber} squash-merged directly`);
+
+                        const attempts = [0, 60, 120, 120];
+                        let merged = false;
+                        let lastErr = null;
+                        for (let i = 0; i < attempts.length; i++) {
+                          if (attempts[i] > 0) {
+                            core.info(`Waiting ${attempts[i]}s before retry ${i}/${attempts.length - 1}…`);
+                            await new Promise(r => setTimeout(r, attempts[i] * 1000));
+                          }
+                          try {
+                            await github.rest.pulls.merge({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              pull_number: prNumber,
+                              merge_method: 'squash',
+                              commit_title: 'chore(dashboard): daily sync',
+                            });
+                            core.info(`PR #${prNumber} squash-merged directly (attempt ${i + 1}).`);
+                            merged = true;
+                            break;
+                          } catch (mergeErr) {
+                            lastErr = mergeErr;
+                            const status = mergeErr.status ?? mergeErr.response?.status;
+                            const transient = status === 405 || status === 409 || status === 422;
+                            if (!transient || i === attempts.length - 1) {
+                              throw mergeErr;
+                            }
+                            core.warning(`Merge attempt ${i + 1} failed (status ${status}): ${mergeErr.message}. Retrying…`);
+                          }
+                        }
+                        if (!merged) throw lastErr;
                       }
 
     # ── Failure tracker ──────────────────────────────────────


### PR DESCRIPTION
## Summary
Run [26024701797](https://github.com/KBVE/kbve/actions/runs/26024701797/job/76495714841) failed \`chore(dashboard): daily sync — 2026-05-18\` (#11168) at the direct-merge fallback:

\`\`\`
HttpError: Base branch was modified. Review and try the merge again.
status: 405
PATCH https://api.github.com/repos/KBVE/kbve/pulls/11168/merge
\`\`\`

Another PR squash-merged into \`dev\` between the mergeable check and the \`pulls.merge\` call. The fallback path threw immediately — no retry. Daily dashboard PR sits open until someone notices.

## Fix
Wrap the direct \`github.rest.pulls.merge(...)\` call in a 4-attempt retry across three workflows:

| Workflow | Step |
|---|---|
| \`.github/workflows/ci-dashboard.yml\` | Auto-approve and merge |
| \`.github/workflows/ci-auto-merge-bot-prs.yml\` | Enable auto-merge |
| \`.github/workflows/ci-atom.yml\` | Atom auto-merge |

Cadence: **0s → 60s → 120s → 120s ≈ 5 minutes total**. Each retry re-fires the merge API; GitHub recomputes mergeable state each call.

Retry only on transient statuses:
- \`405\` — Base branch was modified
- \`409\` — Mergeable conflict (will clear after GitHub finishes recheck)
- \`422\` — Unprocessable (e.g. recheck still running)

Anything else (404, 403, 500, etc.) still throws on first attempt. The \`enableAutoMerge\` path stays preferred — GitHub waits natively for the merge to be safe; only repos / PRs without branch protections fall through to this direct path.

## Test plan
- [x] \`actionlint\` clean on touched workflows (only pre-existing self-hosted-runner label warnings)
- [ ] Next daily-dashboard run that races a parallel merge — should retry instead of failing outright
- [ ] If the racing PR keeps the base moving for >5 min the workflow still fails. Acceptable; the daily dashboard runs again next day. Future PR could move to \`enableAutoMerge\` for these too.