### PR TITLE
fix(astro-kbve): full-width market + mcdb via kbve-dashboard-page

### DIFF
--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketDetailShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketDetailShell.astro
@@ -2,6 +2,6 @@
 import MarketListingDetail from './MarketListingDetail';
 ---
 
-<section class="kbve-market not-content">
+<section class="kbve-market not-content kbve-dashboard-page">
 	<MarketListingDetail client:only="react" />
 </section>

--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketProfileShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketProfileShell.astro
@@ -2,7 +2,7 @@
 import MarketProfileShell from './MarketProfileShell';
 ---
 
-<section class="kbve-market not-content">
+<section class="kbve-market not-content kbve-dashboard-page">
 	<header class="kbve-market__header">
 		<div>
 			<h1>My Marketplace</h1>

--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -3,7 +3,7 @@ import MarketBrowse from './MarketBrowse';
 import MarketCreateForm from './MarketCreateForm';
 ---
 
-<section class="kbve-market not-content">
+<section class="kbve-market not-content kbve-dashboard-page">
 	<header class="kbve-market__header">
 		<div>
 			<h1>Marketplace</h1>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCBlockPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCBlockPanel.astro
@@ -6,7 +6,7 @@ const { data } = Astro.props;
 const b = McBlockSchema.parse(data);
 ---
 
-<section class="mcdb-panel not-content">
+<section class="mcdb-panel not-content kbve-dashboard-page">
 	<header class="mcdb-panel__head">
 		<div class="mcdb-panel__icon">
 			<MCTextureImage

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantPanel.astro
@@ -5,7 +5,7 @@ const { data } = Astro.props;
 const e = McEnchantSchema.parse(data);
 ---
 
-<section class="mcdb-panel not-content">
+<section class="mcdb-panel not-content kbve-dashboard-page">
 	<header class="mcdb-panel__head">
 		<div class="mcdb-panel__icon mcdb-panel__icon--text">
 			<span>{e.display_name.charAt(0)}</span>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemPanel.astro
@@ -9,7 +9,7 @@ const item = MCItemSchema.parse(data);
 
 <MCTooltipMount />
 
-<section class="mcdb-panel not-content">
+<section class="mcdb-panel not-content kbve-dashboard-page">
 	<header class="mcdb-panel__head">
 		<div class="mcdb-panel__icon">
 			<MCTextureImage

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemsIndex.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemsIndex.astro
@@ -5,7 +5,7 @@ import MCTooltipMount from './MCTooltipMount.astro';
 
 <MCTooltipMount />
 
-<section class="mcdb-browse__shell mcdb-panel not-content">
+<section class="mcdb-browse__shell mcdb-panel not-content kbve-dashboard-page">
 	<header class="mcdb-browse__head">
 		<div>
 			<h1>Minecraft Items</h1>


### PR DESCRIPTION
## Summary
Marketplace + MC database pages stayed at Starlight's default ~50rem content column even after the create-form 2-col fix (#11151). The dashboard pages already expand to 100% via a `body:has(.kbve-dashboard-page)` selector in global.css — markets just needed the same class.

Tagged: AstroMarketShell, AstroMarketDetailShell, AstroMarketProfileShell, MCItemsIndex, MCItemPanel, MCEnchantPanel, MCBlockPanel.

No CSS changes — the existing :has() rule in global.css does the work.

## Build
`./kbve.sh -nx astro-kbve:build` — green, 7627 pages.

## Test plan
- [ ] /market/ — full Starlight column width, picker dropdown no longer cramped
- [ ] /market/listing/?id=N — hero spans full column
- [ ] /profile/market/ — listings + bids grid uses full width
- [ ] /mc/items/ — browse grid uses full width
- [ ] /mc/items/diamond-pickaxe/ — panel expands