### PR TITLE
fix(mc): wire AXUM_KBVE_URL + WALLET_SERVICE_JWT and add lazy /wallet fetch

### DIFF
--- a/apps/kube/agones/mc/manifests/fleet.yaml
+++ b/apps/kube/agones/mc/manifests/fleet.yaml
@@ -114,6 +114,14 @@ spec:
                                         name: mc-supabase-credentials
                                         key: service-role-key
                                         optional: true
+                              - name: AXUM_KBVE_URL
+                                value: 'http://kbve-service.kbve.svc.cluster.local:4321'
+                              - name: WALLET_SERVICE_JWT
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: mc-supabase-credentials
+                                        key: service-role-key
+                                        optional: true
                               - name: MOTD
                                 value: 'KBVE Minecraft Server'
                               - name: MAX_PLAYERS

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/AuthEventTicker.java
@@ -177,6 +177,9 @@ public final class AuthEventTicker {
                 if (player != null) {
                     sendBalanceMessage(player, credits, khash);
                     WalletNetworking.pushBalance(player, credits, khash);
+                    if (WalletCommand.consumePending(uuid)) {
+                        WalletCommand.openFor(player);
+                    }
                 }
                 LOGGER.debug(
                         "[{}] WalletBalance uuid={} credits={} khash={}",

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/McAuthMod.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/McAuthMod.java
@@ -50,6 +50,7 @@ public class McAuthMod implements ModInitializer {
                 LinkStatusRegistry.remove(uuid);
                 WalletBalanceCache.remove(uuid);
                 WalletCapabilityRegistry.remove(uuid);
+                WalletCommand.clearPending(uuid);
             }
         });
 

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/NativeRuntime.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/NativeRuntime.java
@@ -121,6 +121,8 @@ public final class NativeRuntime {
 
     public static native String savePlayerSnapshot(String uuid, String snapshotJson);
 
+    public static native String fetchBalance(String uuid, String supabaseUserId);
+
     /** Check if the native library loaded successfully. */
     public static boolean isLoaded() {
         return loaded;

--- a/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletCommand.java
+++ b/apps/mc/mc_auth/java/src/main/java/com/kbve/mcauth/WalletCommand.java
@@ -9,6 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static net.minecraft.server.command.CommandManager.literal;
 
@@ -18,7 +20,17 @@ public final class WalletCommand {
     private static final String CUSTOM_OPENER_CLASS = "com.kbve.statetree.wallet.WalletScreens";
     private static final String CUSTOM_OPENER_METHOD = "openCustom";
 
+    private static final Set<String> PENDING_OPEN = ConcurrentHashMap.newKeySet();
+
     private WalletCommand() {}
+
+    public static boolean consumePending(String uuid) {
+        return uuid != null && PENDING_OPEN.remove(uuid);
+    }
+
+    public static void clearPending(String uuid) {
+        if (uuid != null) PENDING_OPEN.remove(uuid);
+    }
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
         dispatcher.register(literal("wallet").executes(ctx -> {
@@ -45,10 +57,7 @@ public final class WalletCommand {
         String uuid = player.getUuidAsString();
         WalletBalanceCache.Entry cached = WalletBalanceCache.get(uuid);
         if (cached == null) {
-            player.sendMessage(
-                    Text.literal("[KBVE] Wallet balance not loaded yet — try again in a moment.")
-                            .formatted(Formatting.GRAY),
-                    false);
+            requestLazyFetch(player, uuid);
             return;
         }
 
@@ -59,6 +68,40 @@ public final class WalletCommand {
             return;
         }
         player.openHandledScreen(WalletChestFactory.build(credits, khash));
+    }
+
+    private static void requestLazyFetch(ServerPlayerEntity player, String uuid) {
+        LinkStatusRegistry.Entry link = LinkStatusRegistry.get(uuid);
+        if (link == null
+                || link.state != LinkStatusRegistry.State.LINKED
+                || link.supabaseUserId == null) {
+            player.sendMessage(
+                    Text.literal("[KBVE] Wallet is only available for linked accounts. Run /link first.")
+                            .formatted(Formatting.GRAY),
+                    false);
+            return;
+        }
+        if (!NativeRuntime.isLoaded()) {
+            player.sendMessage(
+                    Text.literal("[KBVE] Wallet runtime offline — try again later.")
+                            .formatted(Formatting.GRAY),
+                    false);
+            return;
+        }
+        PENDING_OPEN.add(uuid);
+        try {
+            NativeRuntime.fetchBalance(uuid, link.supabaseUserId);
+            player.sendMessage(
+                    Text.literal("[KBVE] Fetching wallet balance…").formatted(Formatting.GRAY),
+                    false);
+        } catch (Throwable t) {
+            PENDING_OPEN.remove(uuid);
+            LOGGER.warn("[{}] fetchBalance threw: {}", McAuthMod.MOD_ID, t.getMessage());
+            player.sendMessage(
+                    Text.literal("[KBVE] Wallet fetch failed — try again later.")
+                            .formatted(Formatting.RED),
+                    false);
+        }
     }
 
     private static boolean tryCustom(ServerPlayerEntity player, long credits, long khash) {

--- a/apps/mc/mc_auth/src/lib.rs
+++ b/apps/mc/mc_auth/src/lib.rs
@@ -154,6 +154,31 @@ pub extern "system" fn Java_com_kbve_mcauth_NativeRuntime_savePlayerSnapshot<'lo
     make_jstring(&mut env, &response)
 }
 
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_com_kbve_mcauth_NativeRuntime_fetchBalance<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    uuid: JString<'local>,
+    user_id: JString<'local>,
+) -> jstring {
+    let player_uuid: String = match env.get_string(&uuid) {
+        Ok(s) => s.into(),
+        Err(_) => return make_jstring(&mut env, &AuthResponse::error("invalid uuid string")),
+    };
+    let supabase_user_id: String = match env.get_string(&user_id) {
+        Ok(s) => s.into(),
+        Err(_) => return make_jstring(&mut env, &AuthResponse::error("invalid user_id string")),
+    };
+    let response = match RUNTIME.get() {
+        Some(rt) => rt.submit(AuthJob::FetchBalance {
+            player_uuid,
+            supabase_user_id,
+        }),
+        None => AuthResponse::error("runtime not initialized"),
+    };
+    make_jstring(&mut env, &response)
+}
+
 /// Poll all pending `PlayerEvent`s as a JSON array string. Called each
 /// server tick to drain results back into Fabric.
 #[unsafe(no_mangle)]

--- a/apps/mc/mc_auth/src/runtime.rs
+++ b/apps/mc/mc_auth/src/runtime.rs
@@ -252,6 +252,37 @@ async fn handle_job(
                 }
             }
         }
+        AuthJob::FetchBalance {
+            player_uuid,
+            supabase_user_id,
+        } => {
+            debug!(%player_uuid, %supabase_user_id, "mc_auth: processing fetch_balance");
+            match wallet {
+                Some(client) => match client.balance_for_user(&supabase_user_id).await {
+                    Ok(snapshot) => PlayerEvent::WalletBalance {
+                        player_uuid,
+                        credits: snapshot.credits,
+                        khash: snapshot.khash,
+                    },
+                    Err(e) => {
+                        warn!(%player_uuid, error = %e, "mc_auth: lazy balance fetch failed");
+                        PlayerEvent::WalletBalance {
+                            player_uuid,
+                            credits: 0,
+                            khash: 0,
+                        }
+                    }
+                },
+                None => {
+                    warn!(%player_uuid, "mc_auth: wallet client disabled — emitting zero balance");
+                    PlayerEvent::WalletBalance {
+                        player_uuid,
+                        credits: 0,
+                        khash: 0,
+                    }
+                }
+            }
+        }
     };
 
     // Pull the player_uuid + user_id BEFORE moving `event` into the channel

--- a/apps/mc/mc_auth/src/types.rs
+++ b/apps/mc/mc_auth/src/types.rs
@@ -30,6 +30,10 @@ pub enum AuthJob {
         player_uuid: String,
         snapshot_json: String,
     },
+    FetchBalance {
+        player_uuid: String,
+        supabase_user_id: String,
+    },
 }
 
 /// Immediate response returned synchronously from JNI entry points.


### PR DESCRIPTION
## Summary
Screenshot showed `[KBVE] Welcome back` followed by repeated `[KBVE] Wallet balance not loaded yet — try again in a moment` every time the player ran `/wallet`. Two compounding bugs:

### 1. Missing fleet env
`kubectl describe pod -n arc-runners mc-fabric-…` confirmed the pod ships only `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`. **No `AXUM_KBVE_URL`. No `WALLET_SERVICE_JWT`.**

`WalletClient::from_env()` returns `None` when either is missing, so the post-`AlreadyLinked` balance-fetch task in `runtime.rs` (guarded by `if let Some(client) = wallet`) was silently skipped. The `WalletBalance` event never fired → `WalletBalanceCache` stayed empty for every player.

Fix: [`apps/kube/agones/mc/manifests/fleet.yaml`](apps/kube/agones/mc/manifests/fleet.yaml) now plumbs:
- `AXUM_KBVE_URL=http://kbve-service.kbve.svc.cluster.local:4321` (in-cluster ClusterIP, confirmed via `kubectl get svc -n kbve`).
- `WALLET_SERVICE_JWT` projected from `mc-supabase-credentials/service-role-key` with `optional: true` so missing secret doesn't break boot.

### 2. No lazy-fetch fallback
Even after fixing env, the first `/wallet` invoked before the join-time balance fetch lands still shows "not loaded yet" — no retry path. Subsequent invocations also show the same message until next join.

Fix:
- **Rust** — new `AuthJob::FetchBalance { player_uuid, supabase_user_id }` variant + matching arm in `runtime.rs` that calls `WalletClient::balance_for_user` and emits a `WalletBalance` event (with zeros on failure).
- **JNI** — `Java_com_kbve_mcauth_NativeRuntime_fetchBalance` export + matching `NativeRuntime.fetchBalance` declaration.
- **WalletCommand** — when cache is empty and the player is `LINKED`, submit `FetchBalance` + register player in a `PENDING_OPEN` set + reply "Fetching wallet balance…". `AuthEventTicker`'s `WalletBalance` dispatch drains the pending set and calls `openFor` again, which now hits the freshly populated cache and actually opens the UI.
- **McAuthMod disconnect** clears the pending entry so a player who quits mid-fetch doesn't leak the reservation.

## Test plan
- [ ] `cargo check -p mc_auth` + `gradle compileJava` clean (verified locally).
- [ ] After fleet rollout: `kubectl describe pod -n arc-runners mc-fabric-...` shows `AXUM_KBVE_URL` + `WALLET_SERVICE_JWT` env entries.
- [ ] Run `/wallet` on first join → either opens immediately with values OR shows "Fetching wallet balance…" followed shortly by the auto-opened UI.
- [ ] Run `/wallet` as an unlinked player → graceful "Wallet is only available for linked accounts." message.
- [ ] Disconnect mid-fetch, reconnect → no stale reservation.