### PR TITLE
fix(firecracker-ctl): route /proxy/{name}/ trailing slash to fc_proxy

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx
@@ -12,7 +12,7 @@ tags:
 key: firecracker_ctl
 pipeline: docker
 app_name: firecracker-ctl
-version: "0.1.40"
+version: "0.1.41"
 source_path: apps/vm/firecracker-ctl
 version_toml: apps/vm/firecracker-ctl/version.toml
 version_target: apps/vm/firecracker-ctl/Cargo.toml

--- a/apps/vm/firecracker-ctl/src/main.rs
+++ b/apps/vm/firecracker-ctl/src/main.rs
@@ -3333,10 +3333,12 @@ async fn main() {
         .route("/fc/{name}", delete(fc_destroy))
         .route("/fc/{name}/logs", get(fc_logs))
         .route("/proxy/{name}", axum::routing::any(fc_proxy))
+        .route("/proxy/{name}/", axum::routing::any(fc_proxy))
         .route("/proxy/{name}/{*path}", axum::routing::any(fc_proxy))
         // Sibling prefix, not nested. `/proxy/public/{name}` overlapped
         // `/proxy/{name}/{*path}` and matchit kept routing to fc_proxy.
         .route("/public-proxy/{name}", axum::routing::any(fc_proxy_public))
+        .route("/public-proxy/{name}/", axum::routing::any(fc_proxy_public))
         .route(
             "/public-proxy/{name}/{*path}",
             axum::routing::any(fc_proxy_public),
@@ -4543,8 +4545,10 @@ mod tests {
             .route("/fc/{name}", get(fc_get))
             .route("/fc/{name}", delete(fc_destroy))
             .route("/proxy/{name}", axum::routing::any(fc_proxy))
+            .route("/proxy/{name}/", axum::routing::any(fc_proxy))
             .route("/proxy/{name}/{*path}", axum::routing::any(fc_proxy))
             .route("/public-proxy/{name}", axum::routing::any(fc_proxy_public))
+            .route("/public-proxy/{name}/", axum::routing::any(fc_proxy_public))
             .route(
                 "/public-proxy/{name}/{*path}",
                 axum::routing::any(fc_proxy_public),
@@ -4572,6 +4576,44 @@ mod tests {
         assert_eq!(&bytes[..], b"root-ok");
         let snapshot = ps.endpoints.get("demo").unwrap().metrics.snapshot();
         assert_eq!(snapshot.requests_total, 1);
+    }
+
+    #[tokio::test]
+    async fn proxy_staff_trailing_slash_hits_upstream_root() {
+        let port = spawn_upstream().await;
+        let ep = make_endpoint("demo", port, EndpointVisibility::Staff, http_cfg());
+        let app = test_app_with_persistent(make_persistent_state(ep));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/proxy/demo/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&bytes[..], b"root-ok");
+    }
+
+    #[tokio::test]
+    async fn proxy_public_trailing_slash_hits_upstream_root() {
+        let port = spawn_upstream().await;
+        let ep = make_endpoint("demo", port, EndpointVisibility::Public, http_cfg());
+        let app = test_app_with_persistent(make_persistent_state(ep));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/public-proxy/demo/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&bytes[..], b"root-ok");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
\`GET /dashboard/firecracker-net/proxy/proxy/lol/\` (trailing slash) returned a blank page. \`GET /dashboard/firecracker-net/proxy/proxy/lol/health\` worked fine.

\`\`\`
axum-kbve receives /dashboard/firecracker-net/proxy/proxy/lol/
  → strips the dashboard prefix, forwards /proxy/lol/ to fc-ctl
  → fc-ctl matchit router:
      /proxy/{name}          matches /proxy/lol         (no trailing slash)
      /proxy/{name}/{*path}  needs ≥1 segment after the slash
      → no match for /proxy/lol/
      → default 404 with empty body
  → browser shows a white page
\`\`\`

## Fix
Add explicit trailing-slash variants alongside the existing routes:

\`\`\`diff
 .route("/proxy/{name}", any(fc_proxy))
+.route("/proxy/{name}/", any(fc_proxy))
 .route("/proxy/{name}/{*path}", any(fc_proxy))
 .route("/public-proxy/{name}", any(fc_proxy_public))
+.route("/public-proxy/{name}/", any(fc_proxy_public))
 .route("/public-proxy/{name}/{*path}", any(fc_proxy_public))
\`\`\`

The handler already treats an absent \`path\` param as an empty tail, so the upstream URL still becomes \`http://{guest_ip}:{http_port}/\` — FastAPI's \`/\` route matches.

## Test plan
- [x] \`cargo test --bin firecracker-ctl proxy\` — **12 passed**, including 2 new tests covering \`/proxy/{name}/\` and \`/public-proxy/{name}/\` hitting the upstream root.
- [ ] After publish + ArgoCD sync, retry \`/dashboard/firecracker-net/proxy/proxy/lol/\` — expect FastAPI's root JSON instead of a blank page.

Bumps \`firecracker-ctl\` 0.1.40 → 0.1.41 via MDX.