### PR TITLE
feat(astro-kbve): MC item category landings + sidebar entries (Phase 5.3-G)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mcdb/MCCategoryShell.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCCategoryShell.astro
@@ -1,0 +1,25 @@
+---
+import MCItemsBrowser from './MCItemsBrowser';
+import MCTooltipMount from './MCTooltipMount.astro';
+
+interface Props {
+	category: string;
+	title: string;
+	description: string;
+}
+
+const { category, title, description } = Astro.props;
+---
+
+<MCTooltipMount />
+
+<section class="mcdb-browse__shell mcdb-panel not-content kbve-dashboard-page">
+	<header class="mcdb-browse__head">
+		<div>
+			<h1>{title}</h1>
+			<p>{description}</p>
+		</div>
+	</header>
+
+	<MCItemsBrowser client:load lockedCategory={category} />
+</section>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemsBrowser.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemsBrowser.tsx
@@ -52,10 +52,14 @@ function ItemCard({ item }: { item: ItemEntry }) {
 	);
 }
 
-export function MCItemsBrowser() {
+type Props = {
+	lockedCategory?: string;
+};
+
+export function MCItemsBrowser({ lockedCategory }: Props = {}) {
 	const [items, setItems] = useState<ItemEntry[] | null>(null);
 	const [query, setQuery] = useState('');
-	const [category, setCategory] = useState<string>('all');
+	const [category, setCategory] = useState<string>(lockedCategory ?? 'all');
 	const [tier, setTier] = useState<string>('all');
 	const [page, setPage] = useState(0);
 	const [error, setError] = useState<string | null>(null);
@@ -143,20 +147,22 @@ export function MCItemsBrowser() {
 						autoComplete="off"
 					/>
 				</label>
-				<label className="mcdb-browse__filter">
-					<span>Category</span>
-					<select
-						value={category}
-						onChange={(e) => setCategory(e.target.value)}
-						className="mcdb-browse__input">
-						<option value="all">All</option>
-						{categories.map((c) => (
-							<option key={c} value={c}>
-								{c}
-							</option>
-						))}
-					</select>
-				</label>
+				{!lockedCategory && (
+					<label className="mcdb-browse__filter">
+						<span>Category</span>
+						<select
+							value={category}
+							onChange={(e) => setCategory(e.target.value)}
+							className="mcdb-browse__input">
+							<option value="all">All</option>
+							{categories.map((c) => (
+								<option key={c} value={c}>
+									{c}
+								</option>
+							))}
+						</select>
+					</label>
+				)}
 				<label className="mcdb-browse__filter">
 					<span>Tier</span>
 					<select
@@ -176,7 +182,7 @@ export function MCItemsBrowser() {
 					className="mcdb-browse__reset"
 					onClick={() => {
 						setQuery('');
-						setCategory('all');
+						if (!lockedCategory) setCategory('all');
 						setTier('all');
 						resetPage();
 					}}>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/armor/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/armor/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Armor
+description: |
+    Helmets, chestplates, leggings, boots, and the elytra. Browse every published Minecraft armor
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Armor
+    order: 4
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - armor
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="armor"
+    title="Minecraft Armor"
+    description="Helmets, chestplates, leggings, boots, and the elytra."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/banners/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/banners/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Banners
+description: |
+    Banner items and pattern unlocks. Browse every published Minecraft banners
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Banners
+    order: 14
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - banners
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="banner"
+    title="Minecraft Banners"
+    description="Banner items and pattern unlocks."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/blocks/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/blocks/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Blocks
+description: |
+    Placeable building blocks — stone, wood, ore, glass, and processed variants. Browse every published Minecraft blocks
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Blocks
+    order: 6
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - blocks
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="block"
+    title="Minecraft Blocks"
+    description="Placeable building blocks — stone, wood, ore, glass, and processed variants."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/brewing/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/brewing/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Brewing
+description: |
+    Potions, brewing reagents, and stand inputs. Browse every published Minecraft brewing
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Brewing
+    order: 11
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - brewing
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="brewing"
+    title="Minecraft Brewing"
+    description="Potions, brewing reagents, and stand inputs."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/decorations/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/decorations/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Decorations
+description: |
+    Doors, trapdoors, signs, flowers, candles, carpets, banners. Browse every published Minecraft decorations
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Decorations
+    order: 10
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - decorations
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="decoration"
+    title="Minecraft Decorations"
+    description="Doors, trapdoors, signs, flowers, candles, carpets, banners."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/food/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/food/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Food
+description: |
+    Edibles, soups, pies, and consumables that restore hunger. Browse every published Minecraft food
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Food
+    order: 5
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - food
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="food"
+    title="Minecraft Food"
+    description="Edibles, soups, pies, and consumables that restore hunger."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/maps/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/maps/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Maps
+description: |
+    Maps and explorer charts. Browse every published Minecraft maps
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Maps
+    order: 15
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - maps
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="map"
+    title="Minecraft Maps"
+    description="Maps and explorer charts."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/materials/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/materials/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Materials
+description: |
+    Ingots, gems, dusts, sticks, and other raw crafting inputs. Browse every published Minecraft materials
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Materials
+    order: 7
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - materials
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="material"
+    title="Minecraft Materials"
+    description="Ingots, gems, dusts, sticks, and other raw crafting inputs."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/misc/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/misc/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Misc
+description: |
+    Everything that does not fit another category. Browse every published Minecraft misc
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Misc
+    order: 16
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - misc
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="misc"
+    title="Minecraft Misc"
+    description="Everything that does not fit another category."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/music/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/music/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Music Discs
+description: |
+    Vanilla music discs. Browse every published Minecraft music discs
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Music Discs
+    order: 13
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - music
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="music"
+    title="Minecraft Music Discs"
+    description="Vanilla music discs."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/redstone/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/redstone/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Redstone
+description: |
+    Repeaters, comparators, pistons, rails, and redstone wiring components. Browse every published Minecraft redstone
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Redstone
+    order: 8
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - redstone
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="redstone"
+    title="Minecraft Redstone"
+    description="Repeaters, comparators, pistons, rails, and redstone wiring components."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/spawn-eggs/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/spawn-eggs/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Spawn Eggs
+description: |
+    Mob spawn eggs from the creative inventory. Browse every published Minecraft spawn eggs
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Spawn Eggs
+    order: 12
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - spawn-eggs
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="spawn_egg"
+    title="Minecraft Spawn Eggs"
+    description="Mob spawn eggs from the creative inventory."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/tools/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/tools/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Tools
+description: |
+    Pickaxes, axes, shovels, hoes, shears, and other gathering implements. Browse every published Minecraft tools
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Tools
+    order: 3
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - tools
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="tool"
+    title="Minecraft Tools"
+    description="Pickaxes, axes, shovels, hoes, shears, and other gathering implements."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/transport/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/transport/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Transport
+description: |
+    Boats, minecarts, saddles, and other movement gear. Browse every published Minecraft transport
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Transport
+    order: 9
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - transport
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="transport"
+    title="Minecraft Transport"
+    description="Boats, minecarts, saddles, and other movement gear."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/items/weapons/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/items/weapons/index.mdx
@@ -1,0 +1,26 @@
+---
+title: Weapons
+description: |
+    Swords, bows, crossbows, tridents, maces, and ranged ammunition. Browse every published Minecraft weapons
+    in the KBVE database — search by ref or display name, filter by tier,
+    click a card for the full item page.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Weapons
+    order: 2
+tags:
+    - minecraft
+    - mc
+    - mc-item
+    - weapons
+---
+
+import MCCategoryShell from '@/components/mcdb/MCCategoryShell.astro';
+
+<MCCategoryShell
+    category="weapon"
+    title="Minecraft Weapons"
+    description="Swords, bows, crossbows, tridents, maces, and ranged ammunition."
+/>


### PR DESCRIPTION
## Summary
Adds a landing page per `MCItemCategory` under `/mc/items/<slug>/`. Sidebar gets 15 new entries inside the Minecraft > items group so users can browse by Weapons / Armor / Tools / Food / Blocks / Materials / Redstone / Transport / Decorations / Brewing / Spawn Eggs / Music Discs / Banners / Maps / Misc.

## Implementation
- `MCItemsBrowser.tsx` — new optional `lockedCategory` prop. When set, the category dropdown is hidden and Reset only clears search + tier; the grid stays scoped to that category.
- `MCCategoryShell.astro` — thin Astro wrapper. Takes `category` + `title` + `description` props, mounts `MCTooltipMount` + `MCItemsBrowser`, carries `kbve-dashboard-page` for the wide layout.
- 15 × `content/docs/mc/items/<slug>/index.mdx` — generated via a one-off script (frontmatter only, no per-page hand tuning). Each mounts `<MCCategoryShell category="..." ... />`.

Sidebar autogen picks the new index pages up via their `sidebar.label` + `sidebar.order` frontmatter, so `Minecraft > items` now expands to:
  Items (all), Weapons, Tools, Armor, Food, Blocks, Materials, Redstone, Transport, Decorations, Brewing, Spawn Eggs, Music Discs, Banners, Maps, Misc.

The 972 individual item slug pages stay `sidebar.hidden: true` from #11139 — no change.

## Tracking
Phase 5.3-G of #10979.

## Build
`./kbve.sh -nx astro-kbve:build` — green, **7641 pages** (7626 baseline + 15 new categories).

## Test plan
- [ ] `/mc/items/weapons/` → grid shows only weapon-category items (swords, bows, mace, etc.), category dropdown is gone
- [ ] `/mc/items/armor/` → only armor pieces, Reset preserves the armor lock
- [ ] Sidebar Minecraft > items shows the 16 entries in declared order
- [ ] `/mc/items/` (all-items index) still works as the unconstrained browse