### PR TITLE
fix(kyverno): ignore phantom empty labels/annotations on policies.kyverno.io CRDs

### DIFF
--- a/apps/kube/kyverno/application.yaml
+++ b/apps/kube/kyverno/application.yaml
@@ -60,6 +60,9 @@ spec:
     ignoreDifferences:
         - group: apiextensions.k8s.io
           kind: CustomResourceDefinition
+          jsonPointers:
+              - /metadata/labels
+              - /metadata/annotations
           managedFieldsManagers:
               - kubectl-kyverno
     syncPolicy:


### PR DESCRIPTION
## Summary
- Chart `kyverno` 3.8.0 renders the new `policies.kyverno.io` CRDs with literal `metadata.labels: {}` and `metadata.annotations: {}` empty maps. Kubernetes drops empty maps on apply, so argo diff engine sees the rendered `labels: {}` as missing from the live CRD and flags every one of those CRDs `OutOfSync` on every reconcile.
- Adds `/metadata/labels` and `/metadata/annotations` json pointers to the existing `ignoreDifferences` entry (alongside the `kubectl-kyverno` managed-fields guard from #11149). Combined with `RespectIgnoreDifferences=true` the eleven `policies.kyverno.io` CRDs (validating, mutating, generating, deleting, imagevalidating, their namespaced variants, and policyexceptions) finally settle as `Synced`.

## Evidence
`argocd app diff kyverno` (run via port-forwarded CLI against the cluster) consistently produced:
```
===== apiextensions.k8s.io/CustomResourceDefinition /validatingpolicies.policies.kyverno.io ======
5a6
>   labels: {}
```
… for all 11 drifted CRDs. `kubectl diff -f <rendered> --server-side --field-manager=argocd-controller --force-conflicts` returned exit 0 — i.e. server-side apply itself sees no change, only argo's static diff trips on the dropped empty map.

The chart source confirms the empty map:
```yaml
metadata:
  labels:
    {}
  annotations:
    {}
  name: validatingpolicies.policies.kyverno.io
```

## Test plan
- [ ] `kyverno` Application reconciles to `Synced` after merge (currently 11 CRDs OutOfSync)
- [ ] No regression in existing `kyverno.io/v1` ClusterPolicy validation (covered by `apps/kube/kilobase/manifests/dbmate-runner-kyverno-policy.yaml`)
- [ ] If a future chart bump removes the empty maps, this ignore rule remains harmless