### PR TITLE
fix(dashboard/clickhouse): surface upstream errors instead of silent 0s

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroClickHouseDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroClickHouseDashboard.astro
@@ -1,6 +1,7 @@
 ---
 import ReactCHAuth from './ReactCHAuth';
 import ReactCHHeader from './ReactCHHeader';
+import ReactCHErrorBanner from './ReactCHErrorBanner';
 import ReactCHSummary from './ReactCHSummary';
 import ReactCHNamespaceGrid from './ReactCHNamespaceGrid';
 import ReactCHFilterBar from './ReactCHFilterBar';
@@ -18,6 +19,10 @@ import ReactCHQueryTabs from './ReactCHQueryTabs';
 				<!-- Island: Header (time range selector, refresh) -->
 				<div id="ch-header">
 					<ReactCHHeader client:only="react" />
+				</div>
+
+				<div id="ch-error-banner">
+					<ReactCHErrorBanner client:only="react" />
 				</div>
 
 				<!-- Island: Summary bar (total logs, errors, warnings, namespace count) -->

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactCHErrorBanner.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactCHErrorBanner.tsx
@@ -1,0 +1,95 @@
+import { useStore } from '@nanostores/react';
+import { AlertOctagon, RefreshCw, X } from 'lucide-react';
+import { clickhouseService } from './clickhouseService';
+
+export default function ReactCHErrorBanner() {
+	const err = useStore(clickhouseService.$upstreamError);
+	if (!err) return null;
+
+	const label =
+		err.status === 0
+			? 'Network error'
+			: err.status === 503
+				? 'ClickHouse proxy unavailable (503)'
+				: err.status === 502
+					? 'ClickHouse upstream error (502)'
+					: `Upstream error (${err.status})`;
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'flex-start',
+				gap: '0.75rem',
+				padding: '0.75rem 1rem',
+				borderRadius: 10,
+				border: '1px solid rgba(239, 68, 68, 0.4)',
+				background: 'rgba(239, 68, 68, 0.08)',
+				color: 'var(--sl-color-text)',
+			}}>
+			<AlertOctagon
+				size={18}
+				style={{ color: '#ef4444', flexShrink: 0, marginTop: 2 }}
+			/>
+			<div style={{ flex: 1, minWidth: 0 }}>
+				<div
+					style={{
+						fontWeight: 700,
+						fontSize: '0.9rem',
+						color: '#ef4444',
+					}}>
+					{label} on {err.source}
+				</div>
+				{err.body ? (
+					<pre
+						style={{
+							margin: '0.35rem 0 0 0',
+							fontSize: '0.75rem',
+							lineHeight: 1.4,
+							whiteSpace: 'pre-wrap',
+							wordBreak: 'break-word',
+							color: 'rgba(255, 255, 255, 0.75)',
+							maxHeight: 120,
+							overflow: 'auto',
+						}}>
+						{err.body}
+					</pre>
+				) : null}
+			</div>
+			<button
+				onClick={() => clickhouseService.refreshAll()}
+				title="Retry"
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 6,
+					padding: '4px 10px',
+					borderRadius: 6,
+					border: '1px solid rgba(239, 68, 68, 0.4)',
+					background: 'rgba(239, 68, 68, 0.12)',
+					color: '#ef4444',
+					cursor: 'pointer',
+					fontSize: '0.8rem',
+					fontWeight: 600,
+				}}>
+				<RefreshCw size={13} />
+				Retry
+			</button>
+			<button
+				onClick={() => clickhouseService.$upstreamError.set(null)}
+				title="Dismiss"
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					padding: 4,
+					borderRadius: 6,
+					border: 'none',
+					background: 'transparent',
+					color: 'rgba(255, 255, 255, 0.6)',
+					cursor: 'pointer',
+				}}>
+				<X size={14} />
+			</button>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/clickhouseService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/clickhouseService.ts
@@ -185,6 +185,15 @@ function queryParamsKey(params: QueryParams): string {
 	return JSON.stringify(params, Object.keys(params).sort());
 }
 
+async function readErrorBody(resp: Response): Promise<string | undefined> {
+	try {
+		const text = await resp.text();
+		return text.slice(0, 500) || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 let _nextTabId = 1;
 function genTabId(): string {
 	return `qt-${Date.now()}-${_nextTabId++}`;
@@ -193,6 +202,12 @@ function genTabId(): string {
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
+
+export interface UpstreamErrorInfo {
+	source: 'stats' | 'logs';
+	status: number;
+	body?: string;
+}
 
 class ClickHouseService {
 	// Auth
@@ -206,6 +221,8 @@ class ClickHouseService {
 	// Loading
 	public readonly $statsLoading = atom<boolean>(true);
 	public readonly $logsLoading = atom<boolean>(false);
+
+	public readonly $upstreamError = atom<UpstreamErrorInfo | null>(null);
 
 	// Time range
 	public readonly $minutes = atom<number>(60);
@@ -330,14 +347,25 @@ class ClickHouseService {
 				return;
 			}
 			if (!resp.ok) {
+				this.$upstreamError.set({
+					source: 'stats',
+					status: resp.status,
+					body: await readErrorBody(resp),
+				});
 				this.$statsLoading.set(false);
 				return;
 			}
 			const data: StatsData = await resp.json();
 			setCache(cacheKey, data);
 			this.$stats.set(data);
-		} catch {
-			// network error
+			const current = this.$upstreamError.get();
+			if (current?.source === 'stats') this.$upstreamError.set(null);
+		} catch (err) {
+			this.$upstreamError.set({
+				source: 'stats',
+				status: 0,
+				body: err instanceof Error ? err.message : 'network error',
+			});
 		}
 		this.$statsLoading.set(false);
 	}
@@ -375,13 +403,24 @@ class ClickHouseService {
 				return;
 			}
 			if (!resp.ok) {
+				this.$upstreamError.set({
+					source: 'logs',
+					status: resp.status,
+					body: await readErrorBody(resp),
+				});
 				this.$logsLoading.set(false);
 				return;
 			}
 			const data: QueryData = await resp.json();
 			this.$logs.set(data);
-		} catch {
-			// network error
+			const current = this.$upstreamError.get();
+			if (current?.source === 'logs') this.$upstreamError.set(null);
+		} catch (err) {
+			this.$upstreamError.set({
+				source: 'logs',
+				status: 0,
+				body: err instanceof Error ? err.message : 'network error',
+			});
 		}
 		this.$logsLoading.set(false);
 	}


### PR DESCRIPTION
## Summary
- \`/dashboard/clickhouse/\` was rendering "0 total logs / 0 errors / 0 warnings" whenever the proxy returned 502/503 or the network failed; \`loadStats\`/\`loadLogs\` in \`clickhouseService.ts\` swallowed every non-403 response with a bare \`return\` and an empty \`catch\`.
- Added a \`$upstreamError\` atom on the nanostore service, set on non-ok HTTP responses and caught network errors (with a truncated body excerpt for context), and cleared on the next successful fetch of the same source.
- New \`ReactCHErrorBanner\` island (mounted above \`ReactCHSummary\` in \`AstroClickHouseDashboard.astro\`) shows a labelled banner with retry + dismiss controls so the dashboard no longer disguises infrastructure failures as empty data.

## Test plan
- [ ] Visit \`/dashboard/clickhouse/\` while the proxy is healthy and confirm the banner stays hidden and summary tiles populate.
- [ ] Temporarily stop the ClickHouse proxy (or set \`CLICKHOUSE_DIRECT\` to an unreachable target) and confirm the banner renders 502/503 + body excerpt with the Retry button refreshing both stats and logs.
- [ ] Toggle \`X\` (dismiss) and verify the banner clears until the next failure.