### PR TITLE
fix(rows): align /api/System/Health with dashboard contract

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactRowsDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactRowsDashboard.tsx
@@ -10,7 +10,6 @@ import {
 	fetchAll,
 	statusColor,
 	formatUptime,
-	type ServiceStatus,
 	type HealthCheck,
 } from './rowsService';
 import {
@@ -18,14 +17,8 @@ import {
 	Server,
 	Users,
 	Clock,
-	CheckCircle2,
 	XCircle,
-	AlertTriangle,
 	Loader2,
-	RefreshCw,
-	Database,
-	Wifi,
-	Box,
 	Info,
 } from 'lucide-react';
 
@@ -69,7 +62,14 @@ const sub: React.CSSProperties = {
 // Health Check Dot
 // ---------------------------------------------------------------------------
 
-function HealthDot({ check, label }: { check: HealthCheck; label: string }) {
+function HealthDot({
+	check,
+	label,
+}: {
+	check: HealthCheck | undefined;
+	label: string;
+}) {
+	if (!check) return null;
 	const color = check.ok ? '#3fb950' : '#f85149';
 	return (
 		<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -219,7 +219,6 @@ function HealthCard() {
 				<HealthDot check={health.checks.postgres} label="Postgres" />
 				<HealthDot check={health.checks.rabbitmq} label="RabbitMQ" />
 				<HealthDot check={health.checks.agones} label="Agones" />
-				<HealthDot check={health.checks.valkey} label="Valkey" />
 			</div>
 			<div style={{ display: 'flex', gap: '1.5rem' }}>
 				<div>

--- a/apps/kbve/astro-kbve/src/components/dashboard/rowsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/rowsService.ts
@@ -18,10 +18,9 @@ export interface RowsHealth {
 	version: string;
 	uptime_seconds: number;
 	checks: {
-		postgres: HealthCheck;
-		rabbitmq: HealthCheck;
-		agones: HealthCheck;
-		valkey: HealthCheck;
+		postgres?: HealthCheck;
+		rabbitmq?: HealthCheck;
+		agones?: HealthCheck;
 	};
 	active_sessions: number;
 	active_instances: number;
@@ -161,7 +160,10 @@ export async function fetchHealth(): Promise<void> {
 	const data = await fetchRows<RowsHealth>('/api/System/Health');
 	if (data) {
 		$rowsHealth.set(data);
-		const allOk = Object.values(data.checks).every((c) => c.ok);
+		const checks = Object.values(data.checks ?? {}).filter(
+			(c): c is HealthCheck => !!c,
+		);
+		const allOk = checks.length > 0 && checks.every((c) => c.ok);
 		$rowsHealthStatus.set(allOk ? 'ok' : 'degraded');
 	} else {
 		$rowsHealthStatus.set('error');

--- a/apps/rows/src/rest/system.rs
+++ b/apps/rows/src/rest/system.rs
@@ -109,6 +109,7 @@ async fn aggregated_health(State(hs): State<HandlerState>) -> Json<serde_json::V
     let active_sessions = hs.app.sessions.len();
     let active_instances = hs.app.zone_servers.len();
     let spinup_locks = hs.app.zone_spinup_locks.len();
+    let uptime_seconds = hs.app.started_at.elapsed().as_secs();
 
     let overall = if pg_ok && agones_ok {
         "healthy"
@@ -121,6 +122,7 @@ async fn aggregated_health(State(hs): State<HandlerState>) -> Json<serde_json::V
     Json(serde_json::json!({
         "status": overall,
         "version": env!("CARGO_PKG_VERSION"),
+        "uptime_seconds": uptime_seconds,
         "checks": {
             "postgres": { "ok": pg_ok, "latency_ms": pg_latency },
             "rabbitmq": { "ok": mq_ok },

--- a/apps/rows/src/state.rs
+++ b/apps/rows/src/state.rs
@@ -28,6 +28,7 @@ pub struct AppState {
     pub supabase: SupabaseConfig,
     /// Instance lifecycle event log (ring buffer, max 200 entries)
     pub instance_log: crate::rest::system::InstanceEventLog,
+    pub started_at: Instant,
 }
 
 pub struct AppConfig {
@@ -96,6 +97,7 @@ impl AppStateBuilder {
             agones: self.agones,
             supabase: SupabaseConfig::from_env(),
             instance_log: crate::rest::system::InstanceEventLog::new(),
+            started_at: Instant::now(),
         }))
     }
 }


### PR DESCRIPTION
## Summary
Rows dashboard crashed with \`TypeError: undefined is not an object (evaluating 's.ok')\` after the proxy fix landed — proxy now successfully forwards to ROWS, ROWS returns 200, but the frontend was reading \`health.checks.valkey\` which the backend never emits (no Valkey client wired into \`AppState\` yet).

Two-sided fix so backend output and frontend type stay honest.

### Backend (`apps/rows`)
- `AppState` gains `started_at: Instant` captured in `build()`.
- `GET /api/System/Health` now returns `uptime_seconds` (the dashboard already renders it under "Uptime" but the field never existed).

### Frontend (`apps/kbve/astro-kbve`)
- `RowsHealth.checks` marks `postgres/rabbitmq/agones` as optional and **drops `valkey`** so the type matches actual ROWS output.
- `HealthDot` returns `null` when `check` is missing, so future check additions/removals never crash the page.
- `fetchHealth` filters undefined entries before computing ok/degraded.

When ROWS grows a Valkey integration we add it back to the type + grid at the same time as the new check.

## Test plan
- [ ] axum-kbve / rows images rebuild on merge → version bumps via CI
- [ ] After rollout, hit `https://kbve.com/dashboard/chuckrpg/proxy/api/System/Health` and confirm response includes `uptime_seconds`
- [ ] Dashboard renders 3 dots (Postgres / RabbitMQ / Agones) without console errors
- [ ] Uptime card shows real value (not NaN)