### PR TITLE
feat(astro-kbve): profile market thumbnails + client-side watchlist

### DIFF
--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -519,6 +519,7 @@ import MarketCreateForm from './MarketCreateForm';
 		gap: 0.9rem;
 	}
 	.kbve-market__grid-card {
+		position: relative;
 		display: flex;
 		flex-direction: column;
 		gap: 0.65rem;
@@ -536,6 +537,12 @@ import MarketCreateForm from './MarketCreateForm';
 			transform 0.15s ease,
 			border-color 0.15s ease,
 			box-shadow 0.15s ease;
+	}
+	.kbve-market__grid-watch {
+		position: absolute;
+		top: 0.5rem;
+		right: 0.5rem;
+		z-index: 2;
 	}
 	.kbve-market__grid-card:hover {
 		transform: translateY(-2px);
@@ -1070,5 +1077,103 @@ import MarketCreateForm from './MarketCreateForm';
 		padding: 0.05rem 0.35rem;
 		border-radius: 4px;
 		background: var(--sl-color-bg-inline-code);
+	}
+
+	.kbve-market__watch {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		padding: 0;
+		border-radius: 8px;
+		background: color-mix(in srgb, var(--sl-color-bg) 75%, transparent);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: var(--sl-color-gray-3);
+		font-size: 1.05rem;
+		line-height: 1;
+		cursor: pointer;
+		transition:
+			background 0.15s ease,
+			color 0.15s ease,
+			border-color 0.15s ease,
+			transform 0.15s ease;
+		backdrop-filter: blur(2px);
+	}
+	.kbve-market__watch:hover {
+		color: var(--color-gold-light, var(--sl-color-accent));
+		border-color: color-mix(
+			in srgb,
+			var(--color-gold-light, var(--sl-color-accent)) 60%,
+			transparent
+		);
+		transform: scale(1.05);
+	}
+	.kbve-market__watch--on {
+		color: var(--color-gold-light, var(--sl-color-accent));
+		border-color: color-mix(
+			in srgb,
+			var(--color-gold-light, var(--sl-color-accent)) 65%,
+			transparent
+		);
+		background: color-mix(
+			in srgb,
+			var(--color-gold-light, var(--sl-color-accent)) 15%,
+			var(--sl-color-bg-nav)
+		);
+	}
+	.kbve-market__watch--sm {
+		width: 1.7rem;
+		height: 1.7rem;
+		font-size: 0.95rem;
+		border-radius: 6px;
+	}
+
+	.kbve-market__card--tiled {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr);
+		align-items: center;
+		gap: 0.85rem;
+	}
+	.kbve-market__card-thumb {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 48px;
+		height: 48px;
+		padding: 4px;
+		border-radius: 10px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		flex-shrink: 0;
+	}
+	.kbve-market__card-thumb img,
+	.kbve-market__card-thumb .kbve-mc-tex {
+		max-width: 100%;
+		max-height: 100%;
+	}
+	.kbve-market__card-body {
+		display: grid;
+		gap: 0.5rem;
+		min-width: 0;
+	}
+	.kbve-market__watch-remove {
+		margin-left: auto;
+		padding: 0.25rem 0.65rem;
+		border-radius: 8px;
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		background: transparent;
+		color: var(--sl-color-gray-3);
+		font-size: 0.78rem;
+		font-weight: 600;
+		cursor: pointer;
+	}
+	.kbve-market__watch-remove:hover {
+		color: var(--color-red, var(--sl-color-text-accent));
+		border-color: color-mix(
+			in srgb,
+			var(--color-red, var(--sl-color-text-accent)) 55%,
+			transparent
+		);
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/market/MarketBrowse.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketBrowse.tsx
@@ -4,6 +4,7 @@ import { formatKhash, itemRefLabel } from './format';
 import { useCountdown, formatCountdown } from './countdown';
 import { ItemIcon } from './ItemIcon';
 import { EnchantList } from './EnchantList';
+import { WatchToggle } from './WatchToggle';
 
 const PAGE_SIZE = 25;
 
@@ -17,10 +18,21 @@ const KIND_FILTERS: { value: string; label: string }[] = [
 function ListingCard({ row }: { row: MarketListing }) {
 	const countdown = useCountdown(row.expires_at);
 	const urgent = countdown.totalMs < 60 * 60 * 1000;
+	const refObj = (row.item_ref ?? {}) as { kind?: unknown; id?: unknown };
+	const refKind = typeof refObj.kind === 'string' ? refObj.kind : '';
+	const refId =
+		typeof refObj.id === 'string' || typeof refObj.id === 'number'
+			? String(refObj.id)
+			: '';
 	return (
 		<a
 			href={`/market/listing/?id=${row.listing_id}`}
 			className="kbve-market__grid-card">
+			{refKind && refId && (
+				<div className="kbve-market__grid-watch">
+					<WatchToggle kind={refKind} ref={refId} size="sm" />
+				</div>
+			)}
 			<div className="kbve-market__grid-icon">
 				<ItemIcon itemRef={row.item_ref} size={96} />
 			</div>

--- a/apps/kbve/astro-kbve/src/components/market/MarketListingDetail.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketListingDetail.tsx
@@ -12,6 +12,7 @@ import { formatKhash, formatRelative, itemRefLabel } from './format';
 import { useCountdown, formatCountdown } from './countdown';
 import { ItemIcon } from './ItemIcon';
 import { EnchantList } from './EnchantList';
+import { WatchToggle } from './WatchToggle';
 
 function readListingId(): number | null {
 	if (typeof window === 'undefined') return null;
@@ -176,9 +177,15 @@ export function MarketListingDetail() {
 	const active = row.listing_status === 'active';
 	const minNextBid =
 		(row.current_bid ?? (row.min_bid !== null ? row.min_bid - 1 : 0)) + 1;
-	const kind = String(
-		((row.item_ref ?? {}) as { kind?: unknown }).kind ?? 'generic',
-	);
+	const itemRefObj = (row.item_ref ?? {}) as {
+		kind?: unknown;
+		id?: unknown;
+	};
+	const kind = String(itemRefObj.kind ?? 'generic');
+	const watchRef =
+		typeof itemRefObj.id === 'string' || typeof itemRefObj.id === 'number'
+			? String(itemRefObj.id)
+			: '';
 
 	return (
 		<div className="kbve-market__detail-v2">
@@ -201,6 +208,7 @@ export function MarketListingDetail() {
 							className={`kbve-market__badge kbve-market__badge--${row.listing_status}`}>
 							{row.listing_status}
 						</span>
+						{watchRef && <WatchToggle kind={kind} ref={watchRef} />}
 					</div>
 					<h1 className="kbve-market__item-title">
 						{itemRefLabel(row.item_ref)}

--- a/apps/kbve/astro-kbve/src/components/market/MarketProfileShell.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketProfileShell.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSession } from '@kbve/astro';
 import {
 	MarketApiError,
+	listingDetail,
 	type MyBid,
 	type MyListing,
 	myBids,
@@ -14,8 +15,76 @@ import {
 	itemRefLabel,
 } from './format';
 import { EnchantList } from './EnchantList';
+import { MCTextureImage } from '@/components/mcdb/MCTextureImage';
+import {
+	getWatchList,
+	removeFromWatch,
+	subscribe,
+	type WatchEntry,
+} from './watchlist';
 
-type Tab = 'listings' | 'bids';
+type Tab = 'listings' | 'bids' | 'watching';
+
+type ItemRefMeta = {
+	kind: string;
+	id: string;
+};
+
+type McManifestEntry = {
+	ref: string;
+	display_name: string;
+	category: string;
+};
+
+let mcManifestPromise: Promise<Map<string, McManifestEntry>> | null = null;
+
+function loadMcManifest(): Promise<Map<string, McManifestEntry>> {
+	if (mcManifestPromise) return mcManifestPromise;
+	mcManifestPromise = fetch('/api/mc-items.json')
+		.then((r) => (r.ok ? r.json() : { items: [] }))
+		.then((payload: { items?: McManifestEntry[] }) => {
+			const m = new Map<string, McManifestEntry>();
+			for (const it of payload.items ?? []) m.set(it.ref, it);
+			return m;
+		})
+		.catch(() => new Map<string, McManifestEntry>());
+	return mcManifestPromise;
+}
+
+function readItemRefMeta(itemRef: unknown): ItemRefMeta {
+	const r = (itemRef ?? {}) as { kind?: unknown; id?: unknown };
+	const kind = typeof r.kind === 'string' ? r.kind : '';
+	const id =
+		typeof r.id === 'string' || typeof r.id === 'number'
+			? String(r.id)
+			: '';
+	return { kind, id };
+}
+
+function ItemThumb({
+	itemRef,
+	size = 40,
+}: {
+	itemRef: unknown;
+	size?: number;
+}) {
+	const { kind, id } = readItemRefMeta(itemRef);
+	if (kind === 'mc_item' && id) {
+		return <MCTextureImage ref={id} size={size} />;
+	}
+	return null;
+}
+
+function ItemThumbPlaceholder({ size = 40 }: { size?: number }) {
+	return (
+		<span
+			className="kbve-mcpicker__row-img kbve-mcpicker__row-img--missing"
+			style={{ width: size, height: size }}
+			aria-hidden="true">
+			…
+		</span>
+	);
+}
 
 export function MarketProfileShell() {
 	const { ready, authenticated } = useSession();
@@ -24,6 +93,14 @@ export function MarketProfileShell() {
 	const [bids, setBids] = useState<MyBid[]>([]);
 	const [error, setError] = useState<string | null>(null);
 	const [loading, setLoading] = useState(false);
+	const [bidRefs, setBidRefs] = useState<
+		Map<number, Record<string, unknown>>
+	>(() => new Map());
+	const [watchEntries, setWatchEntries] = useState<WatchEntry[]>([]);
+	const [mcManifest, setMcManifest] = useState<Map<
+		string,
+		McManifestEntry
+	> | null>(null);
 
 	const refresh = useCallback(async () => {
 		setLoading(true);
@@ -47,6 +124,62 @@ export function MarketProfileShell() {
 	useEffect(() => {
 		if (ready && authenticated) void refresh();
 	}, [ready, authenticated, refresh]);
+
+	useEffect(() => {
+		setWatchEntries(getWatchList());
+		const unsub = subscribe(() => setWatchEntries(getWatchList()));
+		return unsub;
+	}, []);
+
+	useEffect(() => {
+		void loadMcManifest().then(setMcManifest);
+	}, []);
+
+	useEffect(() => {
+		if (bids.length === 0) return;
+		let cancelled = false;
+		const missing = Array.from(
+			new Set(
+				bids.map((b) => b.listing_id).filter((id) => !bidRefs.has(id)),
+			),
+		);
+		if (missing.length === 0) return;
+		(async () => {
+			const pairs = await Promise.all(
+				missing.map(async (id) => {
+					try {
+						const d = await listingDetail(id);
+						return [id, d.item_ref] as const;
+					} catch {
+						return null;
+					}
+				}),
+			);
+			if (cancelled) return;
+			setBidRefs((prev) => {
+				const next = new Map(prev);
+				for (const p of pairs) {
+					if (p) next.set(p[0], p[1]);
+				}
+				return next;
+			});
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [bids, bidRefs]);
+
+	const watchedDisplay = useMemo(
+		() =>
+			watchEntries.map((e) => {
+				const mc =
+					e.kind === 'mc_item' && mcManifest
+						? (mcManifest.get(e.ref) ?? null)
+						: null;
+				return { entry: e, mc };
+			}),
+		[watchEntries, mcManifest],
+	);
 
 	if (!ready) return null;
 	if (!authenticated) {
@@ -78,6 +211,14 @@ export function MarketProfileShell() {
 				</button>
 				<button
 					type="button"
+					role="tab"
+					aria-selected={tab === 'watching'}
+					className={`kbve-market__tab${tab === 'watching' ? ' kbve-market__tab--active' : ''}`}
+					onClick={() => setTab('watching')}>
+					Watching ({watchEntries.length})
+				</button>
+				<button
+					type="button"
 					className="kbve-market__refresh"
 					onClick={() => void refresh()}
 					disabled={loading}>
@@ -98,52 +239,74 @@ export function MarketProfileShell() {
 							No listings yet. <a href="/market/">Create one →</a>
 						</div>
 					)}
-					{listings.map((r) => (
-						<a
-							key={r.listing_id}
-							href={`/market/listing/?id=${r.listing_id}`}
-							className="kbve-market__card">
-							<div className="kbve-market__card-head">
-								<span className="kbve-market__card-item">
-									{itemRefLabel(r.item_ref)}
-									<EnchantList itemRef={r.item_ref} compact />
-								</span>
-								<span
-									className={`kbve-market__badge kbve-market__badge--${r.listing_status}`}>
-									{r.listing_status}
-								</span>
-							</div>
-							<div className="kbve-market__card-prices">
-								{r.buy_now_price !== null && (
-									<span className="kbve-market__price">
-										<span className="kbve-market__price-label">
-											Buy Now
+					{listings.map((r) => {
+						const meta = readItemRefMeta(r.item_ref);
+						return (
+							<a
+								key={r.listing_id}
+								href={`/market/listing/?id=${r.listing_id}`}
+								className="kbve-market__card kbve-market__card--tiled">
+								<div className="kbve-market__card-thumb">
+									{meta.kind === 'mc_item' && meta.id ? (
+										<MCTextureImage
+											ref={meta.id}
+											size={40}
+										/>
+									) : (
+										<ItemThumb itemRef={r.item_ref} />
+									)}
+								</div>
+								<div className="kbve-market__card-body">
+									<div className="kbve-market__card-head">
+										<span className="kbve-market__card-item">
+											{itemRefLabel(r.item_ref)}
+											<EnchantList
+												itemRef={r.item_ref}
+												compact
+											/>
 										</span>
-										<span className="kbve-market__price-value">
-											{formatKhash(r.buy_now_price)}
+										<span
+											className={`kbve-market__badge kbve-market__badge--${r.listing_status}`}>
+											{r.listing_status}
 										</span>
-									</span>
-								)}
-								{r.current_bid !== null && (
-									<span className="kbve-market__price">
-										<span className="kbve-market__price-label">
-											Bid
+									</div>
+									<div className="kbve-market__card-prices">
+										{r.buy_now_price !== null && (
+											<span className="kbve-market__price">
+												<span className="kbve-market__price-label">
+													Buy Now
+												</span>
+												<span className="kbve-market__price-value">
+													{formatKhash(
+														r.buy_now_price,
+													)}
+												</span>
+											</span>
+										)}
+										{r.current_bid !== null && (
+											<span className="kbve-market__price">
+												<span className="kbve-market__price-label">
+													Bid
+												</span>
+												<span className="kbve-market__price-value">
+													{formatKhash(r.current_bid)}
+												</span>
+											</span>
+										)}
+										<span className="kbve-market__card-expiry">
+											{r.listing_status === 'active'
+												? formatExpiry(r.expires_at)
+												: r.settled_at
+													? formatRelative(
+															r.settled_at,
+														)
+													: '—'}
 										</span>
-										<span className="kbve-market__price-value">
-											{formatKhash(r.current_bid)}
-										</span>
-									</span>
-								)}
-								<span className="kbve-market__card-expiry">
-									{r.listing_status === 'active'
-										? formatExpiry(r.expires_at)
-										: r.settled_at
-											? formatRelative(r.settled_at)
-											: '—'}
-								</span>
-							</div>
-						</a>
-					))}
+									</div>
+								</div>
+							</a>
+						);
+					})}
 				</div>
 			)}
 
@@ -152,35 +315,137 @@ export function MarketProfileShell() {
 					{bids.length === 0 && !loading && (
 						<div className="kbve-market__status">No bids yet.</div>
 					)}
-					{bids.map((b) => (
-						<a
-							key={b.bid_id}
-							href={`/market/listing/?id=${b.listing_id}`}
-							className="kbve-market__card">
-							<div className="kbve-market__card-head">
-								<span className="kbve-market__card-item">
-									Listing #{b.listing_id}
-								</span>
-								<span
-									className={`kbve-market__badge kbve-market__badge--${b.bid_status}`}>
-									{b.bid_status}
-								</span>
+					{bids.map((b) => {
+						const itemRef = bidRefs.get(b.listing_id);
+						const meta = itemRef ? readItemRefMeta(itemRef) : null;
+						return (
+							<a
+								key={b.bid_id}
+								href={`/market/listing/?id=${b.listing_id}`}
+								className="kbve-market__card kbve-market__card--tiled">
+								<div className="kbve-market__card-thumb">
+									{meta &&
+									meta.kind === 'mc_item' &&
+									meta.id ? (
+										<MCTextureImage
+											ref={meta.id}
+											size={40}
+										/>
+									) : itemRef ? (
+										<ItemThumb itemRef={itemRef} />
+									) : (
+										<ItemThumbPlaceholder />
+									)}
+								</div>
+								<div className="kbve-market__card-body">
+									<div className="kbve-market__card-head">
+										<span className="kbve-market__card-item">
+											{itemRef
+												? itemRefLabel(itemRef)
+												: `Listing #${b.listing_id}`}
+											{itemRef && (
+												<EnchantList
+													itemRef={itemRef}
+													compact
+												/>
+											)}
+										</span>
+										<span
+											className={`kbve-market__badge kbve-market__badge--${b.bid_status}`}>
+											{b.bid_status}
+										</span>
+									</div>
+									<div className="kbve-market__card-prices">
+										<span className="kbve-market__price">
+											<span className="kbve-market__price-label">
+												Amount
+											</span>
+											<span className="kbve-market__price-value">
+												{formatKhash(b.amount)}
+											</span>
+										</span>
+										<span className="kbve-market__card-expiry">
+											{formatRelative(b.placed_at)}
+										</span>
+									</div>
+								</div>
+							</a>
+						);
+					})}
+				</div>
+			)}
+
+			{tab === 'watching' && (
+				<div className="kbve-market__list">
+					{watchEntries.length === 0 && (
+						<div className="kbve-market__status">
+							No items watched yet. Star any item to track it
+							here.
+						</div>
+					)}
+					{watchedDisplay.map(({ entry, mc }) => {
+						const href =
+							entry.kind === 'mc_item' && mc
+								? `/mc/items/${mc.ref.replace(/^minecraft:/, '')}/`
+								: null;
+						const inner = (
+							<>
+								<div className="kbve-market__card-thumb">
+									{entry.kind === 'mc_item' ? (
+										<MCTextureImage
+											ref={entry.ref}
+											size={40}
+											category={mc?.category}
+										/>
+									) : (
+										<ItemThumbPlaceholder />
+									)}
+								</div>
+								<div className="kbve-market__card-body">
+									<div className="kbve-market__card-head">
+										<span className="kbve-market__card-item">
+											{entry.kind === 'mc_item' && mc
+												? mc.display_name
+												: entry.ref}
+										</span>
+										<span className="kbve-market__kind-pill">
+											{entry.kind}
+										</span>
+									</div>
+									<div className="kbve-market__card-prices">
+										<span className="kbve-market__card-expiry">
+											{entry.ref}
+										</span>
+										<button
+											type="button"
+											className="kbve-market__watch-remove"
+											onClick={(ev) => {
+												ev.preventDefault();
+												ev.stopPropagation();
+												removeFromWatch(entry);
+											}}>
+											Unwatch
+										</button>
+									</div>
+								</div>
+							</>
+						);
+						const key = `${entry.kind}::${entry.ref}`;
+						return href ? (
+							<a
+								key={key}
+								href={href}
+								className="kbve-market__card kbve-market__card--tiled">
+								{inner}
+							</a>
+						) : (
+							<div
+								key={key}
+								className="kbve-market__card kbve-market__card--tiled">
+								{inner}
 							</div>
-							<div className="kbve-market__card-prices">
-								<span className="kbve-market__price">
-									<span className="kbve-market__price-label">
-										Amount
-									</span>
-									<span className="kbve-market__price-value">
-										{formatKhash(b.amount)}
-									</span>
-								</span>
-								<span className="kbve-market__card-expiry">
-									{formatRelative(b.placed_at)}
-								</span>
-							</div>
-						</a>
-					))}
+						);
+					})}
 				</div>
 			)}
 		</div>

--- a/apps/kbve/astro-kbve/src/components/market/WatchToggle.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/WatchToggle.tsx
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+	isWatched as readIsWatched,
+	subscribe,
+	toggleWatch,
+	type WatchEntry,
+} from './watchlist';
+
+type Props = {
+	kind: string;
+	ref: string;
+	className?: string;
+	size?: 'sm' | 'md';
+};
+
+export function WatchToggle({ kind, ref, className, size = 'md' }: Props) {
+	const [watched, setWatched] = useState(false);
+
+	useEffect(() => {
+		const entry: WatchEntry = { kind, ref };
+		setWatched(readIsWatched(entry));
+		const unsub = subscribe(() => setWatched(readIsWatched(entry)));
+		return unsub;
+	}, [kind, ref]);
+
+	const onClick = useCallback(
+		(ev: React.MouseEvent<HTMLButtonElement>) => {
+			ev.preventDefault();
+			ev.stopPropagation();
+			toggleWatch({ kind, ref });
+		},
+		[kind, ref],
+	);
+
+	const label = watched ? 'Remove from watch list' : 'Add to watch list';
+	const cls = [
+		'kbve-market__watch',
+		`kbve-market__watch--${size}`,
+		watched ? 'kbve-market__watch--on' : '',
+		className ?? '',
+	]
+		.filter(Boolean)
+		.join(' ');
+
+	return (
+		<button
+			type="button"
+			aria-pressed={watched}
+			aria-label={label}
+			title={label}
+			className={cls}
+			onClick={onClick}>
+			<span aria-hidden="true">{watched ? '★' : '☆'}</span>
+		</button>
+	);
+}
+
+export default WatchToggle;

--- a/apps/kbve/astro-kbve/src/components/market/watchlist.ts
+++ b/apps/kbve/astro-kbve/src/components/market/watchlist.ts
@@ -1,0 +1,113 @@
+export type WatchEntry = {
+	kind: string;
+	ref: string;
+};
+
+const STORAGE_KEY = 'kbve:market:watchlist:v1';
+const subscribers = new Set<() => void>();
+
+function isBrowser(): boolean {
+	return typeof window !== 'undefined' && typeof localStorage !== 'undefined';
+}
+
+function entryKey(e: WatchEntry): string {
+	return `${e.kind}::${e.ref}`;
+}
+
+function readRaw(): WatchEntry[] {
+	if (!isBrowser()) return [];
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		const out: WatchEntry[] = [];
+		const seen = new Set<string>();
+		for (const e of parsed) {
+			if (
+				e &&
+				typeof e === 'object' &&
+				typeof e.kind === 'string' &&
+				typeof e.ref === 'string'
+			) {
+				const k = entryKey(e);
+				if (!seen.has(k)) {
+					seen.add(k);
+					out.push({ kind: e.kind, ref: e.ref });
+				}
+			}
+		}
+		return out;
+	} catch {
+		return [];
+	}
+}
+
+function writeRaw(entries: WatchEntry[]): void {
+	if (!isBrowser()) return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+	} catch {}
+}
+
+function notify(): void {
+	for (const fn of subscribers) {
+		try {
+			fn();
+		} catch {}
+	}
+}
+
+export function getWatchList(): WatchEntry[] {
+	return readRaw();
+}
+
+export function isWatched(entry: WatchEntry): boolean {
+	const list = readRaw();
+	const k = entryKey(entry);
+	return list.some((e) => entryKey(e) === k);
+}
+
+export function addToWatch(entry: WatchEntry): void {
+	const list = readRaw();
+	const k = entryKey(entry);
+	if (list.some((e) => entryKey(e) === k)) return;
+	list.push({ kind: entry.kind, ref: entry.ref });
+	writeRaw(list);
+	notify();
+}
+
+export function removeFromWatch(entry: WatchEntry): void {
+	const list = readRaw();
+	const k = entryKey(entry);
+	const next = list.filter((e) => entryKey(e) !== k);
+	if (next.length === list.length) return;
+	writeRaw(next);
+	notify();
+}
+
+export function toggleWatch(entry: WatchEntry): boolean {
+	if (isWatched(entry)) {
+		removeFromWatch(entry);
+		return false;
+	}
+	addToWatch(entry);
+	return true;
+}
+
+export function subscribe(fn: () => void): () => void {
+	subscribers.add(fn);
+	if (isBrowser()) {
+		const onStorage = (ev: StorageEvent) => {
+			if (ev.key === STORAGE_KEY) fn();
+		};
+		window.addEventListener('storage', onStorage);
+		return () => {
+			subscribers.delete(fn);
+			window.removeEventListener('storage', onStorage);
+		};
+	}
+	return () => {
+		subscribers.delete(fn);
+	};
+}

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemsBrowser.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemsBrowser.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { mcTextureUrls } from './texture';
+import { WatchToggle } from '@/components/market/WatchToggle';
 
 type ItemEntry = {
 	id: number;
@@ -27,6 +28,9 @@ function ItemCard({ item }: { item: ItemEntry }) {
 			className="mcdb-browse__card"
 			data-mc-tooltip
 			data-mc-ref={item.ref}>
+			<div className="mcdb-browse__watch">
+				<WatchToggle kind="mc_item" ref={item.ref} size="sm" />
+			</div>
 			<div className="mcdb-browse__icon">
 				<img
 					ref={fbRef}

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemsIndex.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemsIndex.astro
@@ -96,6 +96,7 @@ import MCTooltipMount from './MCTooltipMount.astro';
 		gap: 0.6rem;
 	}
 	.mcdb-browse__card {
+		position: relative;
 		display: grid;
 		gap: 0.3rem;
 		padding: 0.75rem;
@@ -108,6 +109,12 @@ import MCTooltipMount from './MCTooltipMount.astro';
 			transform 0.15s ease,
 			border-color 0.15s ease,
 			box-shadow 0.15s ease;
+	}
+	.mcdb-browse__watch {
+		position: absolute;
+		top: 0.4rem;
+		right: 0.4rem;
+		z-index: 2;
 	}
 	.mcdb-browse__card:hover {
 		transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- **Task B** — `/profile/market/` Listings and Bids tabs now render a left-side item thumbnail. Listings reads `kind`/`id` from `item_ref`; Bids lazily resolves `item_ref` per `listing_id` via `listingDetail` with an in-memory cache (placeholder shown while loading). Rareicon/generic items show no thumbnail (no texture in payload).
- **Task F** — New client-side watch list (`localStorage` keyed `kbve:market:watchlist:v1`) with tiny pub/sub. `WatchToggle` (★/☆) wired into the listing detail hero meta, every `MarketBrowse` grid card (top-right overlay, `stopPropagation` on the parent `<a>`), and every `MCItemsBrowser` card. A new third **Watching** tab on `/profile/market/` renders one card per entry (MC items hydrated with `display_name`/category from `/api/mc-items.json`) plus an Unwatch button. Empty state copy: \"No items watched yet. Star any item to track it here.\"
- All new CSS lives in the existing `<style is:global>` of `AstroMarketShell.astro` using Starlight + KBVE brand vars (no hardcoded slate/blue). No backend changes, no notifications.

Tracks #10979.

## Test plan
- [ ] Visit `/market/` — every card shows a star overlay; clicking it toggles ★/☆ without navigating to the detail page.
- [ ] Visit `/mc/items/` — same star overlay behaviour on the MC items grid.
- [ ] Visit a listing detail page — star toggle appears next to the kind/status pills and persists state across reloads.
- [ ] Visit `/profile/market/` while signed in — Listings tab shows MC thumbs; Bids tab shows placeholder then resolves thumbs as `listingDetail` returns; Watching tab lists every starred item with name+ref and an Unwatch button.
- [ ] Clear localStorage `kbve:market:watchlist:v1` and confirm Watching tab shows the empty-state copy.