### PR TITLE
feat(astro-kbve): MC item market sidecar on detail + item pages (Phase 5.3-C/D)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -1209,4 +1209,164 @@ import MarketCreateForm from './MarketCreateForm';
 			transparent
 		);
 	}
+	.kbve-market__sidecar {
+		display: grid;
+		gap: 1rem;
+	}
+	.kbve-market__sidecar-head {
+		display: flex;
+		align-items: center;
+		gap: 0.65rem;
+	}
+	.kbve-market__sidecar-head h3 {
+		margin: 0;
+		font-size: 1.05rem;
+		font-weight: 800;
+		color: var(--sl-color-white, var(--sl-color-text));
+	}
+	.kbve-market__sidecar-count {
+		padding: 0.1rem 0.55rem;
+		border-radius: 999px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		font-size: 0.8rem;
+		color: var(--sl-color-gray-3);
+		font-variant-numeric: tabular-nums;
+	}
+	.kbve-market__sidecar-empty {
+		padding: 1rem 1.25rem;
+		border-radius: 12px;
+		background: var(--sl-color-bg-nav);
+		border: 1px dashed var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: var(--sl-color-gray-3);
+		text-align: center;
+		font-size: 0.9rem;
+	}
+	.kbve-market__sidecar-stats {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+		gap: 0.6rem;
+		margin: 0;
+	}
+	.kbve-market__sidecar-stats > div {
+		padding: 0.55rem 0.8rem;
+		border-radius: 10px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+	}
+	.kbve-market__sidecar-stats dt {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--sl-color-gray-3);
+		margin: 0;
+	}
+	.kbve-market__sidecar-stats dd {
+		margin: 0.15rem 0 0;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		color: var(--sl-color-text);
+	}
+	.kbve-market__sidecar-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+		gap: 0.65rem;
+	}
+	.kbve-market__sidecar-card {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		gap: 0.65rem;
+		align-items: center;
+		padding: 0.65rem 0.75rem;
+		border-radius: 12px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: inherit;
+		text-decoration: none;
+		transition:
+			transform 0.15s ease,
+			border-color 0.15s ease;
+	}
+	.kbve-market__sidecar-card:hover {
+		transform: translateY(-1px);
+		border-color: color-mix(
+			in srgb,
+			var(--sl-color-accent) 60%,
+			transparent
+		);
+	}
+	.kbve-market__sidecar-card-icon {
+		width: 48px;
+		height: 48px;
+		border-radius: 8px;
+		background: var(--sl-color-bg-sidebar, var(--sl-color-bg-nav));
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 4px;
+		flex-shrink: 0;
+	}
+	.kbve-market__sidecar-card-icon .kbve-mc-tex {
+		max-width: 100%;
+		max-height: 100%;
+	}
+	.kbve-market__sidecar-card-body {
+		display: grid;
+		gap: 0.15rem;
+		min-width: 0;
+	}
+	.kbve-market__sidecar-card-title {
+		font-weight: 700;
+		font-size: 0.9rem;
+		color: var(--sl-color-text);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.kbve-market__sidecar-card-prices {
+		display: flex;
+		gap: 0.5rem;
+		align-items: baseline;
+		flex-wrap: wrap;
+		font-variant-numeric: tabular-nums;
+	}
+	.kbve-market__sidecar-card-buy {
+		font-weight: 800;
+		font-size: 0.92rem;
+		color: var(--sl-color-text-accent);
+	}
+	.kbve-market__sidecar-card-bid {
+		font-size: 0.78rem;
+		color: var(--sl-color-gray-3);
+	}
+	.kbve-market__sidecar-card-foot {
+		font-size: 0.72rem;
+		color: var(--sl-color-gray-3);
+	}
+	.kbve-market__sidecar-skeleton {
+		display: grid;
+		gap: 0.4rem;
+	}
+	.kbve-market__sidecar-skeleton-row {
+		height: 48px;
+		border-radius: 10px;
+		background: linear-gradient(
+			90deg,
+			var(--sl-color-bg-nav) 0%,
+			var(--sl-color-bg-sidebar, var(--sl-color-bg-nav)) 50%,
+			var(--sl-color-bg-nav) 100%
+		);
+		background-size: 200% 100%;
+		animation: kbve-market-sidecar-shimmer 1.4s ease-in-out infinite;
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+	}
+	@keyframes kbve-market-sidecar-shimmer {
+		0% {
+			background-position: 200% 0;
+		}
+		100% {
+			background-position: -200% 0;
+		}
+	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/market/MCItemMarketSidecar.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MCItemMarketSidecar.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useMemo, useState } from 'react';
+import { listActive, type MarketListing, MarketApiError } from './api';
+import { formatKhash, formatRelative, itemRefLabel } from './format';
+import MCTextureImage from '../mcdb/MCTextureImage';
+
+type Props = {
+	ref: string;
+	excludeListingId?: number;
+};
+
+const PAGE_LIMIT = 100;
+const CARD_LIMIT = 6;
+
+type ItemRef = {
+	kind?: unknown;
+	id?: unknown;
+	display_name?: unknown;
+	category?: unknown;
+};
+
+function matches(itemRef: unknown, targetRef: string): boolean {
+	if (!itemRef || typeof itemRef !== 'object') return false;
+	const r = itemRef as ItemRef;
+	if (r.kind !== 'mc_item') return false;
+	if (r.id === null || r.id === undefined) return false;
+	return String(r.id) === targetRef;
+}
+
+function buyNowSort(a: MarketListing, b: MarketListing): number {
+	const av = a.buy_now_price;
+	const bv = b.buy_now_price;
+	if (av === null && bv === null) return 0;
+	if (av === null) return 1;
+	if (bv === null) return -1;
+	return av - bv;
+}
+
+function median(sortedAsc: number[]): number | null {
+	if (sortedAsc.length === 0) return null;
+	const mid = Math.floor(sortedAsc.length / 2);
+	if (sortedAsc.length % 2 === 1) return sortedAsc[mid];
+	return Math.round((sortedAsc[mid - 1] + sortedAsc[mid]) / 2);
+}
+
+function extractDisplayName(itemRef: unknown): string {
+	if (!itemRef || typeof itemRef !== 'object') return itemRefLabel(itemRef);
+	const r = itemRef as ItemRef;
+	if (typeof r.display_name === 'string' && r.display_name.length > 0)
+		return r.display_name;
+	if (typeof r.id === 'string' || typeof r.id === 'number')
+		return String(r.id);
+	return itemRefLabel(itemRef);
+}
+
+function extractCategory(itemRef: unknown): string | null {
+	if (!itemRef || typeof itemRef !== 'object') return null;
+	const r = itemRef as ItemRef;
+	return typeof r.category === 'string' ? r.category : null;
+}
+
+export function MCItemMarketSidecar({ ref, excludeListingId }: Props) {
+	const [rows, setRows] = useState<MarketListing[] | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		let cancelled = false;
+		setLoading(true);
+		setError(null);
+		(async () => {
+			try {
+				const first = await listActive({ limit: PAGE_LIMIT });
+				let combined = first;
+				if (first.length >= PAGE_LIMIT) {
+					const last = first[first.length - 1];
+					const second = await listActive({
+						limit: PAGE_LIMIT,
+						before_created_at: last.created_at,
+						before_id: last.listing_id,
+					});
+					combined = first.concat(second);
+				}
+				if (!cancelled) {
+					setRows(combined);
+					setLoading(false);
+				}
+			} catch (e) {
+				if (cancelled) return;
+				setError(
+					e instanceof MarketApiError
+						? e.message
+						: 'failed to load market listings',
+				);
+				setLoading(false);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [ref]);
+
+	const filtered = useMemo(() => {
+		if (!rows) return [];
+		return rows.filter(
+			(r) =>
+				matches(r.item_ref, ref) && r.listing_id !== excludeListingId,
+		);
+	}, [rows, ref, excludeListingId]);
+
+	const stats = useMemo(() => {
+		if (filtered.length === 0) return null;
+		const buyNows = filtered
+			.map((r) => r.buy_now_price)
+			.filter((v): v is number => v !== null)
+			.sort((a, b) => a - b);
+		const currentBids = filtered
+			.map((r) => r.current_bid)
+			.filter((v): v is number => v !== null)
+			.sort((a, b) => a - b);
+		const now = Date.now();
+		const futureExpiries = filtered
+			.map((r) => new Date(r.expires_at).getTime())
+			.filter((t) => Number.isFinite(t) && t > now)
+			.sort((a, b) => a - b);
+		return {
+			count: filtered.length,
+			minBuyNow: buyNows.length > 0 ? buyNows[0] : null,
+			maxBuyNow: buyNows.length > 0 ? buyNows[buyNows.length - 1] : null,
+			medianBuyNow: median(buyNows),
+			currentBidMin: currentBids.length > 0 ? currentBids[0] : null,
+			currentBidMax:
+				currentBids.length > 0
+					? currentBids[currentBids.length - 1]
+					: null,
+			nextExpiry:
+				futureExpiries.length > 0
+					? new Date(futureExpiries[0]).toISOString()
+					: null,
+		};
+	}, [filtered]);
+
+	const cards = useMemo(() => {
+		const sorted = filtered.slice().sort(buyNowSort);
+		return sorted.slice(0, CARD_LIMIT);
+	}, [filtered]);
+
+	if (loading) {
+		return (
+			<section className="kbve-market__sidecar mcdb-panel">
+				<header className="kbve-market__sidecar-head">
+					<h3>Other live listings for this item</h3>
+				</header>
+				<div className="kbve-market__sidecar-skeleton">
+					<div className="kbve-market__sidecar-skeleton-row" />
+					<div className="kbve-market__sidecar-skeleton-row" />
+					<div className="kbve-market__sidecar-skeleton-row" />
+				</div>
+			</section>
+		);
+	}
+
+	if (error) {
+		return (
+			<section className="kbve-market__sidecar mcdb-panel">
+				<header className="kbve-market__sidecar-head">
+					<h3>Other live listings for this item</h3>
+				</header>
+				<div className="kbve-market__status kbve-market__status--error">
+					{error}
+				</div>
+			</section>
+		);
+	}
+
+	if (!stats || filtered.length === 0) {
+		return (
+			<section className="kbve-market__sidecar mcdb-panel">
+				<header className="kbve-market__sidecar-head">
+					<h3>Other live listings for this item</h3>
+				</header>
+				<div className="kbve-market__sidecar-empty">
+					No other active listings for this item.
+				</div>
+			</section>
+		);
+	}
+
+	return (
+		<section className="kbve-market__sidecar mcdb-panel">
+			<header className="kbve-market__sidecar-head">
+				<h3>Other live listings for this item</h3>
+				<span className="kbve-market__sidecar-count">
+					{stats.count}
+				</span>
+			</header>
+
+			<dl className="kbve-market__sidecar-stats">
+				<div>
+					<dt>Listings</dt>
+					<dd>{stats.count}</dd>
+				</div>
+				<div>
+					<dt>Min Buy Now</dt>
+					<dd>{formatKhash(stats.minBuyNow)}</dd>
+				</div>
+				<div>
+					<dt>Median Buy Now</dt>
+					<dd>{formatKhash(stats.medianBuyNow)}</dd>
+				</div>
+				<div>
+					<dt>Max Buy Now</dt>
+					<dd>{formatKhash(stats.maxBuyNow)}</dd>
+				</div>
+				<div>
+					<dt>Bid Range</dt>
+					<dd>
+						{stats.currentBidMin === null
+							? '—'
+							: stats.currentBidMin === stats.currentBidMax
+								? formatKhash(stats.currentBidMin)
+								: `${formatKhash(stats.currentBidMin)} – ${formatKhash(stats.currentBidMax)}`}
+					</dd>
+				</div>
+				<div>
+					<dt>Next Expiry</dt>
+					<dd>
+						{stats.nextExpiry
+							? formatRelative(stats.nextExpiry)
+							: '—'}
+					</dd>
+				</div>
+			</dl>
+
+			<div className="kbve-market__sidecar-grid">
+				{cards.map((r) => {
+					const title = extractDisplayName(r.item_ref);
+					const category = extractCategory(r.item_ref);
+					return (
+						<a
+							key={r.listing_id}
+							href={`/market/listing/?id=${r.listing_id}`}
+							className="kbve-market__sidecar-card">
+							<div className="kbve-market__sidecar-card-icon">
+								<MCTextureImage
+									ref={ref}
+									category={category}
+									alt={title}
+									size={48}
+								/>
+							</div>
+							<div className="kbve-market__sidecar-card-body">
+								<div className="kbve-market__sidecar-card-title">
+									{title}
+								</div>
+								<div className="kbve-market__sidecar-card-prices">
+									<span className="kbve-market__sidecar-card-buy">
+										{formatKhash(r.buy_now_price)}
+									</span>
+									<span className="kbve-market__sidecar-card-bid">
+										Bid {formatKhash(r.current_bid)}
+									</span>
+								</div>
+								<div className="kbve-market__sidecar-card-foot">
+									{formatRelative(r.created_at)}
+								</div>
+							</div>
+						</a>
+					);
+				})}
+			</div>
+		</section>
+	);
+}
+
+export default MCItemMarketSidecar;

--- a/apps/kbve/astro-kbve/src/components/market/MarketListingDetail.tsx
+++ b/apps/kbve/astro-kbve/src/components/market/MarketListingDetail.tsx
@@ -13,6 +13,7 @@ import { useCountdown, formatCountdown } from './countdown';
 import { ItemIcon } from './ItemIcon';
 import { EnchantList } from './EnchantList';
 import { WatchToggle } from './WatchToggle';
+import { MCItemMarketSidecar } from './MCItemMarketSidecar';
 
 function readListingId(): number | null {
 	if (typeof window === 'undefined') return null;
@@ -397,6 +398,14 @@ export function MarketListingDetail() {
 					</div>
 				)}
 			</section>
+
+			{(row.item_ref as { kind?: unknown } | null)?.kind === 'mc_item' &&
+				(row.item_ref as { id?: unknown }).id != null && (
+					<MCItemMarketSidecar
+						ref={String((row.item_ref as { id: unknown }).id)}
+						excludeListingId={row.listing_id}
+					/>
+				)}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemPanel.astro
@@ -2,6 +2,7 @@
 import { MCItemSchema } from '@/data/schema';
 import MCTextureImage from './MCTextureImage';
 import MCTooltipMount from './MCTooltipMount.astro';
+import MCItemMarketSidecar from '@/components/market/MCItemMarketSidecar';
 
 const { data } = Astro.props;
 const item = MCItemSchema.parse(data);
@@ -303,6 +304,11 @@ const item = MCItemSchema.parse(data);
 			</section>
 		)
 	}
+
+	<section class="mcdb-section">
+		<h3>Marketplace</h3>
+		<MCItemMarketSidecar client:visible ref={item.ref} />
+	</section>
 
 	<footer class="mcdb-panel__foot">
 		<a


### PR DESCRIPTION
## Summary

Adds a shared **MCItemMarketSidecar** React island that surfaces live marketplace listings for a Minecraft item, wired into two places:

- **Task C — `/market/listing/?id=N`**: After the bid-history section on `MarketListingDetail.tsx`, when `item_ref.kind === 'mc_item'`, the sidecar renders aggregated stats + up to 6 cards of *other* active listings for the same `item_ref.id`, excluding the listing currently being viewed.
- **Task D — `/mc/items/<slug>/`**: After the recipes section (and before the panel footer) on `MCItemPanel.astro`, the sidecar is mounted with `client:visible` so it only fetches when scrolled into view.

## Shared component

`apps/kbve/astro-kbve/src/components/market/MCItemMarketSidecar.tsx`

Props: `{ ref: string; excludeListingId?: number }`.

- Reuses the existing typed `listActive(c)` API — **no new endpoints**.
- Scan bound: first page of 100 active listings, plus one cursor-paginated follow-up page if the first returns `>= 100`. Hard ceiling of ~200 listings per mount; never walks the whole market.
- Filters to `kind === 'mc_item'` and `id === ref`, excluding `excludeListingId`.
- Aggregates: `count`, `minBuyNow`, `maxBuyNow`, `medianBuyNow` (skips nulls), `currentBidMin/Max`, `nextExpiry` (earliest `expires_at` still in the future).
- Cards sorted by `buy_now_price` ASC with nulls last; max 6 rendered; texture via `MCTextureImage` from the mcdb folder.

## States

- **Loading** — themed shimmer skeleton (3 rows) inside the sidecar shell.
- **Error** — inline banner using the existing `.kbve-market__status--error` class.
- **Empty** — terse "No other active listings for this item." message; stats grid is hidden so it doesn't render zeroed.
- **Populated** — stats grid (auto-fit minmax 140px, mirrors `.mcdb-grid`) + card grid (auto-fit minmax 180px, tighter than `.mcdb-browse__grid`).

## Styles

All new `.kbve-market__sidecar*` rules appended to the global block in `AstroMarketShell.astro` and built from Starlight + KBVE brand vars (`--sl-color-bg-nav`, `--sl-color-accent`, etc.) — no hardcoded slate/blue.

## Build

`./kbve.sh -nx astro-kbve:build` — 7641 pages built (baseline-clean).

Tracks #10979.

## Test plan

- [ ] Visit `/mc/items/diamond-sword/` (or similar) — confirm the new "Marketplace" section renders below recipes; verify it fetches only after scrolling near it (`client:visible`).
- [ ] Visit `/market/listing/?id=<N>` for an active `mc_item` listing with siblings — confirm the sidecar lists *other* live listings, excluding the current one.
- [ ] Same page with no siblings — confirm the empty state copy renders without the stats grid.
- [ ] Confirm non-MC listings (rareicon / generic) do **not** render the sidecar on `/market/listing/`.
- [ ] Throw a network error (offline / blocked endpoint) — confirm the inline error banner appears.