### PR TITLE
feat(astro-kbve): KBVE universal search palette (Phase 5.3-E2)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketShell.astro
@@ -13,6 +13,30 @@ import MarketCreateForm from './MarketCreateForm';
 				until you're outbid or the listing settles.
 			</p>
 		</div>
+		<button
+			type="button"
+			class="kbve-search-trigger"
+			data-kbve-search-trigger
+			aria-label="Open universal search">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="16"
+				height="16"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				aria-hidden="true">
+				<circle cx="11" cy="11" r="7"></circle>
+				<path d="m20 20-3-3"></path>
+			</svg>
+			<span class="kbve-search-trigger__label">Search…</span>
+			<span class="kbve-search-trigger__keycap" data-kbve-search-keycap>
+				Ctrl+K
+			</span>
+		</button>
 	</header>
 
 	<details class="kbve-market__create">
@@ -33,9 +57,18 @@ import MarketCreateForm from './MarketCreateForm';
 		color: rgba(255, 255, 255, 0.9);
 	}
 	.kbve-market__header {
+		display: flex;
+		gap: 1rem;
+		align-items: flex-start;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		margin-bottom: 1.5rem;
+	}
+	.kbve-market__header > div {
 		display: grid;
 		gap: 0.5rem;
-		margin-bottom: 1.5rem;
+		flex: 1;
+		min-width: 0;
 	}
 	.kbve-market__header h1 {
 		font-size: clamp(1.75rem, 3.5vw, 2.25rem);

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemsIndex.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemsIndex.astro
@@ -18,6 +18,30 @@ import MCTooltipMount from './MCTooltipMount.astro';
 				same index powers the marketplace create-form picker.
 			</p>
 		</div>
+		<button
+			type="button"
+			class="kbve-search-trigger"
+			data-kbve-search-trigger
+			aria-label="Open universal search">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="16"
+				height="16"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				aria-hidden="true">
+				<circle cx="11" cy="11" r="7"></circle>
+				<path d="m20 20-3-3"></path>
+			</svg>
+			<span class="kbve-search-trigger__label">Search…</span>
+			<span class="kbve-search-trigger__keycap" data-kbve-search-keycap>
+				Ctrl+K
+			</span>
+		</button>
 	</header>
 
 	<MCItemsBrowser client:load />
@@ -27,6 +51,17 @@ import MCTooltipMount from './MCTooltipMount.astro';
 	.mcdb-browse__shell {
 		display: grid;
 		gap: 1rem;
+	}
+	.mcdb-browse__head {
+		display: flex;
+		gap: 1rem;
+		align-items: flex-start;
+		justify-content: space-between;
+		flex-wrap: wrap;
+	}
+	.mcdb-browse__head > div {
+		flex: 1;
+		min-width: 0;
 	}
 	.mcdb-browse__head h1 {
 		margin: 0;

--- a/apps/kbve/astro-kbve/src/components/navigation/Header.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/Header.astro
@@ -1,5 +1,7 @@
 ---
 import Default from '@astrojs/starlight/components/Header.astro';
+import AstroKbveSearch from '../search/AstroKbveSearch.astro';
 ---
 
 <Default />
+<AstroKbveSearch />

--- a/apps/kbve/astro-kbve/src/components/search/AstroKbveSearch.astro
+++ b/apps/kbve/astro-kbve/src/components/search/AstroKbveSearch.astro
@@ -1,0 +1,292 @@
+---
+import KbveSearchPalette from './KbveSearchPalette.tsx';
+---
+
+<KbveSearchPalette client:only="react" />
+
+<style is:global>
+	.kbve-search {
+		position: fixed;
+		inset: 0;
+		z-index: 9999;
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		padding: clamp(2rem, 10vh, 7rem) 1rem 1rem;
+		background: color-mix(in srgb, var(--sl-color-black) 60%, transparent);
+		backdrop-filter: blur(4px);
+	}
+	.kbve-search__modal {
+		width: min(640px, 100%);
+		max-height: min(70vh, 640px);
+		display: grid;
+		grid-template-rows: auto 1fr auto;
+		gap: 0;
+		background: linear-gradient(
+			165deg,
+			var(--sl-color-bg-sidebar) 0%,
+			var(--sl-color-bg) 100%
+		);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		border-radius: 14px;
+		box-shadow: 0 30px 60px -20px
+			color-mix(in srgb, var(--sl-color-black) 60%, transparent);
+		overflow: hidden;
+		color: var(--sl-color-text);
+	}
+	.kbve-search__input-row {
+		display: flex;
+		align-items: center;
+		gap: 0.65rem;
+		padding: 0.85rem 1rem;
+		border-bottom: 1px solid
+			var(--sl-color-hairline, var(--sl-color-gray-5));
+		background: var(--sl-color-bg-nav);
+	}
+	.kbve-search__icon {
+		color: var(--sl-color-gray-3);
+		flex-shrink: 0;
+	}
+	.kbve-search__input {
+		flex: 1;
+		background: transparent;
+		border: none;
+		outline: none;
+		color: var(--sl-color-white, var(--sl-color-text));
+		font-size: 1rem;
+		font-weight: 500;
+	}
+	.kbve-search__input::placeholder {
+		color: var(--sl-color-gray-3);
+	}
+	.kbve-search__esc {
+		font-family: var(--sl-font-mono, monospace);
+		font-size: 0.7rem;
+		padding: 0.15rem 0.45rem;
+		border-radius: 6px;
+		background: var(--sl-color-bg);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: var(--sl-color-gray-3);
+	}
+	.kbve-search__list {
+		overflow-y: auto;
+		padding: 0.4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+	}
+	.kbve-search__empty {
+		padding: 1.5rem 1rem;
+		text-align: center;
+		color: var(--sl-color-gray-3);
+		font-size: 0.9rem;
+	}
+	.kbve-search__group {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--sl-color-gray-3);
+		padding: 0.5rem 0.65rem 0.3rem;
+		font-weight: 700;
+	}
+	.kbve-search__row {
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		gap: 0.75rem;
+		align-items: center;
+		width: 100%;
+		padding: 0.55rem 0.65rem;
+		border-radius: 9px;
+		background: transparent;
+		border: 1px solid transparent;
+		color: inherit;
+		text-align: left;
+		cursor: pointer;
+		font: inherit;
+	}
+	.kbve-search__row--active {
+		background: color-mix(in srgb, var(--sl-color-accent) 22%, transparent);
+		border-color: color-mix(
+			in srgb,
+			var(--sl-color-accent) 55%,
+			transparent
+		);
+	}
+	.kbve-search__thumb {
+		width: 36px;
+		height: 36px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		border-radius: 8px;
+		padding: 4px;
+		flex-shrink: 0;
+		overflow: hidden;
+	}
+	.kbve-search__thumb img {
+		max-width: 100%;
+		max-height: 100%;
+		object-fit: contain;
+	}
+	.kbve-search__thumb--mc img {
+		image-rendering: pixelated;
+	}
+	.kbve-search__thumb-fallback {
+		color: var(--sl-color-gray-3);
+		font-weight: 800;
+		font-size: 0.85rem;
+	}
+	.kbve-search__body {
+		display: grid;
+		gap: 0.1rem;
+		min-width: 0;
+	}
+	.kbve-search__name {
+		font-weight: 700;
+		color: var(--sl-color-white, var(--sl-color-text));
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.kbve-search__meta {
+		display: flex;
+		gap: 0.65rem;
+		font-size: 0.78rem;
+		color: var(--sl-color-gray-3);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.kbve-search__ref {
+		font-family: var(--sl-font-mono, monospace);
+	}
+	.kbve-search__sub {
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		font-size: 0.7rem;
+		color: var(--sl-color-accent-high, var(--sl-color-accent));
+	}
+	.kbve-search__kind {
+		font-size: 0.65rem;
+		padding: 0.15rem 0.5rem;
+		border-radius: 999px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: var(--sl-color-gray-3);
+		flex-shrink: 0;
+	}
+	.kbve-search__kind--mc {
+		color: color-mix(
+			in srgb,
+			var(--sl-color-accent) 80%,
+			var(--sl-color-text)
+		);
+		border-color: color-mix(
+			in srgb,
+			var(--sl-color-accent) 45%,
+			transparent
+		);
+	}
+	.kbve-search__kind--rareicon {
+		color: var(--color-gold-light, var(--sl-color-accent));
+		border-color: color-mix(
+			in srgb,
+			var(--color-gold-light, var(--sl-color-accent)) 45%,
+			transparent
+		);
+	}
+	.kbve-search__kind--osrs {
+		color: var(--color-red, var(--sl-color-text-accent));
+		border-color: color-mix(
+			in srgb,
+			var(--color-red, var(--sl-color-text-accent)) 45%,
+			transparent
+		);
+	}
+	.kbve-search__footer {
+		display: flex;
+		gap: 1rem;
+		padding: 0.55rem 1rem;
+		border-top: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		background: var(--sl-color-bg-nav);
+		font-size: 0.75rem;
+		color: var(--sl-color-gray-3);
+		flex-wrap: wrap;
+		align-items: center;
+	}
+	.kbve-search__footer kbd {
+		font-family: var(--sl-font-mono, monospace);
+		font-size: 0.7rem;
+		padding: 0.05rem 0.35rem;
+		border-radius: 4px;
+		background: var(--sl-color-bg);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		margin: 0 0.1rem;
+	}
+	.kbve-search__warn {
+		margin-left: auto;
+		color: var(--color-red, var(--sl-color-text-accent));
+		font-weight: 600;
+	}
+
+	.kbve-search-trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.4rem 0.7rem;
+		border-radius: 9px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: var(--sl-color-gray-3);
+		font-size: 0.85rem;
+		font-weight: 600;
+		cursor: pointer;
+		transition:
+			border-color 0.15s ease,
+			background 0.15s ease,
+			color 0.15s ease;
+	}
+	.kbve-search-trigger:hover {
+		border-color: var(--sl-color-accent);
+		color: var(--sl-color-text);
+	}
+	.kbve-search-trigger__keycap {
+		font-family: var(--sl-font-mono, monospace);
+		font-size: 0.7rem;
+		padding: 0.1rem 0.4rem;
+		border-radius: 5px;
+		background: var(--sl-color-bg);
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		color: var(--sl-color-gray-3);
+	}
+	@media (max-width: 540px) {
+		.kbve-search-trigger__label {
+			display: none;
+		}
+	}
+</style>
+
+<script>
+	const isMac =
+		typeof navigator !== 'undefined' &&
+		/Mac|iPhone|iPad/.test(navigator.platform);
+	document
+		.querySelectorAll<HTMLElement>('[data-kbve-search-keycap]')
+		.forEach((el) => {
+			el.textContent = isMac ? '⌘K' : 'Ctrl+K';
+		});
+	document.addEventListener('click', (e) => {
+		const btn = (e.target as HTMLElement | null)?.closest?.(
+			'[data-kbve-search-trigger]',
+		);
+		if (btn) {
+			e.preventDefault();
+			window.dispatchEvent(new CustomEvent('kbve:search:open'));
+		}
+	});
+</script>

--- a/apps/kbve/astro-kbve/src/components/search/KbveSearchPalette.tsx
+++ b/apps/kbve/astro-kbve/src/components/search/KbveSearchPalette.tsx
@@ -1,0 +1,553 @@
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { mcTextureUrls } from '../mcdb/texture';
+
+type MCItem = {
+	id: number;
+	ref: string;
+	slug: string;
+	display_name: string;
+	category: string;
+	rarity: string;
+};
+
+type RareiconItem = {
+	id: string;
+	key: number;
+	ref: string;
+	name?: string;
+	img?: string;
+	rarity?: string;
+};
+
+type OSRSItem = {
+	id: number;
+	name: string;
+	slug: string;
+	icon: string;
+};
+
+type Kind = 'mc' | 'rareicon' | 'osrs';
+
+type SearchResult = {
+	kind: Kind;
+	ref: string;
+	name: string;
+	href: string;
+	thumb: string | null;
+	thumbFallback: string | null;
+	sub: string | null;
+};
+
+type ManifestState<T> = {
+	items: T[] | null;
+	failed: boolean;
+};
+
+type CachedPayload<T> = { items: T[]; cachedAt: number };
+
+const CACHE_TTL_MS = 1000 * 60 * 60 * 24;
+const CACHE_PREFIX = 'kbve:search';
+const MAX_RESULTS = 50;
+const TOP_PER_KIND = 10;
+
+const KIND_LABELS: Record<Kind, string> = {
+	mc: 'Minecraft',
+	rareicon: 'Rareicon',
+	osrs: 'OSRS',
+};
+
+function readCache<T>(key: string): T[] | null {
+	if (typeof localStorage === 'undefined') return null;
+	try {
+		const raw = localStorage.getItem(key);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as CachedPayload<T>;
+		if (Date.now() - parsed.cachedAt > CACHE_TTL_MS) return null;
+		return parsed.items;
+	} catch {
+		return null;
+	}
+}
+
+function writeCache<T>(key: string, items: T[]) {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(
+			key,
+			JSON.stringify({
+				items,
+				cachedAt: Date.now(),
+			} satisfies CachedPayload<T>),
+		);
+	} catch {}
+}
+
+const OSRS_ICON_BASE = 'https://oldschool.runescape.wiki/images/';
+
+function osrsIcon(icon: string | null | undefined): string | null {
+	if (!icon) return null;
+	if (icon.startsWith('http') || icon.startsWith('/')) return icon;
+	return OSRS_ICON_BASE + encodeURIComponent(icon.replace(/ /g, '_'));
+}
+
+function rareiconImg(img: string | null | undefined): string | null {
+	if (!img) return null;
+	if (img.startsWith('http') || img.startsWith('/')) return img;
+	return `/${img}`;
+}
+
+function mcResult(item: MCItem): SearchResult {
+	const tex = mcTextureUrls(item.ref, item.category);
+	return {
+		kind: 'mc',
+		ref: item.ref,
+		name: item.display_name,
+		href: `/mc/items/${item.slug}/`,
+		thumb: tex.primary,
+		thumbFallback: tex.fallback,
+		sub: item.category || null,
+	};
+}
+
+function rareiconResult(item: RareiconItem): SearchResult {
+	return {
+		kind: 'rareicon',
+		ref: item.ref,
+		name: item.name || item.ref,
+		href: `/itemdb/${item.ref}/`,
+		thumb: rareiconImg(item.img),
+		thumbFallback: null,
+		sub: item.rarity || null,
+	};
+}
+
+function osrsResult(item: OSRSItem): SearchResult {
+	return {
+		kind: 'osrs',
+		ref: item.slug,
+		name: item.name,
+		href: `/osrs/${item.slug}/`,
+		thumb: osrsIcon(item.icon),
+		thumbFallback: null,
+		sub: null,
+	};
+}
+
+function rankScore(name: string, ref: string, q: string): number {
+	const n = name.toLowerCase();
+	const r = ref.toLowerCase();
+	if (r === q) return 0;
+	if (n === q) return 1;
+	if (n.startsWith(q)) return 2;
+	if (n.includes(q)) return 3;
+	if (r.includes(q)) return 4;
+	return 99;
+}
+
+function fmtSub(kind: Kind, sub: string | null): string | null {
+	if (!sub) return null;
+	if (kind === 'mc') return sub;
+	if (kind === 'rareicon') return `rarity: ${sub}`;
+	return sub;
+}
+
+export function KbveSearchPalette() {
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState('');
+	const [selected, setSelected] = useState(0);
+	const [mc, setMc] = useState<ManifestState<MCItem>>({
+		items: null,
+		failed: false,
+	});
+	const [rareicon, setRareicon] = useState<ManifestState<RareiconItem>>({
+		items: null,
+		failed: false,
+	});
+	const [osrs, setOsrs] = useState<ManifestState<OSRSItem>>({
+		items: null,
+		failed: false,
+	});
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const listRef = useRef<HTMLDivElement | null>(null);
+	const loadedRef = useRef(false);
+
+	const loadManifests = useCallback(() => {
+		if (loadedRef.current) return;
+		loadedRef.current = true;
+
+		const mcCached = readCache<MCItem>(`${CACHE_PREFIX}:mc:v1`);
+		if (mcCached) setMc({ items: mcCached, failed: false });
+		const rareiconCached = readCache<RareiconItem>(
+			`${CACHE_PREFIX}:rareicon:v1`,
+		);
+		if (rareiconCached)
+			setRareicon({ items: rareiconCached, failed: false });
+		const osrsCached = readCache<OSRSItem>(`${CACHE_PREFIX}:osrs:v1`);
+		if (osrsCached) setOsrs({ items: osrsCached, failed: false });
+
+		void fetch('/api/mc-items.json')
+			.then((r) => {
+				if (!r.ok) throw new Error(`${r.status}`);
+				return r.json() as Promise<{ items: MCItem[] }>;
+			})
+			.then((json) => {
+				setMc({ items: json.items, failed: false });
+				writeCache(`${CACHE_PREFIX}:mc:v1`, json.items);
+			})
+			.catch(() => {
+				setMc((prev) =>
+					prev.items ? prev : { items: null, failed: true },
+				);
+			});
+
+		void fetch('/api/itemdb.json')
+			.then((r) => {
+				if (!r.ok) throw new Error(`${r.status}`);
+				return r.json() as Promise<{ items: RareiconItem[] }>;
+			})
+			.then((json) => {
+				setRareicon({ items: json.items, failed: false });
+				writeCache(`${CACHE_PREFIX}:rareicon:v1`, json.items);
+			})
+			.catch(() => {
+				setRareicon((prev) =>
+					prev.items ? prev : { items: null, failed: true },
+				);
+			});
+
+		void fetch('/api/osrs.json')
+			.then((r) => {
+				if (!r.ok) throw new Error(`${r.status}`);
+				return r.json() as Promise<{ items: OSRSItem[] }>;
+			})
+			.then((json) => {
+				setOsrs({ items: json.items, failed: false });
+				writeCache(`${CACHE_PREFIX}:osrs:v1`, json.items);
+			})
+			.catch(() => {
+				setOsrs((prev) =>
+					prev.items ? prev : { items: null, failed: true },
+				);
+			});
+	}, []);
+
+	const openPalette = useCallback(() => {
+		setOpen(true);
+		setQuery('');
+		setSelected(0);
+		loadManifests();
+	}, [loadManifests]);
+
+	const closePalette = useCallback(() => {
+		setOpen(false);
+	}, []);
+
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			const target = e.target as HTMLElement | null;
+			const inField =
+				target &&
+				(target.tagName === 'INPUT' ||
+					target.tagName === 'TEXTAREA' ||
+					target.tagName === 'SELECT' ||
+					(target as HTMLElement).isContentEditable);
+
+			const isToggle =
+				(e.key === 'k' || e.key === 'K') && (e.metaKey || e.ctrlKey);
+			if (isToggle) {
+				e.preventDefault();
+				if (open) closePalette();
+				else openPalette();
+				return;
+			}
+			if (e.key === '/' && !inField && !open) {
+				e.preventDefault();
+				openPalette();
+				return;
+			}
+			if (e.key === 'Escape' && open) {
+				e.preventDefault();
+				closePalette();
+			}
+		};
+		const onOpenEvent = () => openPalette();
+		window.addEventListener('keydown', onKey);
+		window.addEventListener(
+			'kbve:search:open',
+			onOpenEvent as EventListener,
+		);
+		return () => {
+			window.removeEventListener('keydown', onKey);
+			window.removeEventListener(
+				'kbve:search:open',
+				onOpenEvent as EventListener,
+			);
+		};
+	}, [open, openPalette, closePalette]);
+
+	useEffect(() => {
+		if (open) {
+			const t = window.setTimeout(() => inputRef.current?.focus(), 30);
+			document.documentElement.style.overflow = 'hidden';
+			return () => {
+				window.clearTimeout(t);
+				document.documentElement.style.overflow = '';
+			};
+		}
+	}, [open]);
+
+	const results = useMemo<SearchResult[]>(() => {
+		const q = query.trim().toLowerCase();
+		const mcItems = mc.items ?? [];
+		const rareiconItems = rareicon.items ?? [];
+		const osrsItems = osrs.items ?? [];
+
+		if (!q) {
+			const a = mcItems
+				.slice()
+				.sort((x, y) => x.display_name.localeCompare(y.display_name))
+				.slice(0, TOP_PER_KIND)
+				.map(mcResult);
+			const b = rareiconItems
+				.slice()
+				.sort((x, y) =>
+					(x.name ?? x.ref).localeCompare(y.name ?? y.ref),
+				)
+				.slice(0, TOP_PER_KIND)
+				.map(rareiconResult);
+			const c = osrsItems
+				.slice()
+				.sort((x, y) => x.name.localeCompare(y.name))
+				.slice(0, TOP_PER_KIND)
+				.map(osrsResult);
+			return [...a, ...b, ...c];
+		}
+
+		type Scored = { score: number; result: SearchResult };
+		const scored: Scored[] = [];
+
+		for (const it of mcItems) {
+			const s = rankScore(it.display_name, it.ref, q);
+			if (s < 99) scored.push({ score: s, result: mcResult(it) });
+		}
+		for (const it of rareiconItems) {
+			const s = rankScore(it.name ?? it.ref, it.ref, q);
+			if (s < 99) scored.push({ score: s, result: rareiconResult(it) });
+		}
+		for (const it of osrsItems) {
+			const s = rankScore(it.name, it.slug, q);
+			if (s < 99) scored.push({ score: s, result: osrsResult(it) });
+		}
+
+		scored.sort((a, b) => {
+			if (a.score !== b.score) return a.score - b.score;
+			return a.result.name.localeCompare(b.result.name);
+		});
+
+		return scored.slice(0, MAX_RESULTS).map((s) => s.result);
+	}, [query, mc.items, rareicon.items, osrs.items]);
+
+	useEffect(() => {
+		setSelected(0);
+	}, [query]);
+
+	useEffect(() => {
+		if (!open) return;
+		const list = listRef.current;
+		if (!list) return;
+		const row = list.querySelector<HTMLElement>(
+			`[data-row-index="${selected}"]`,
+		);
+		if (row) row.scrollIntoView({ block: 'nearest' });
+	}, [selected, open, results.length]);
+
+	const onKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+		if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			setSelected((s) =>
+				Math.min(s + 1, Math.max(0, results.length - 1)),
+			);
+		} else if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			setSelected((s) => Math.max(s - 1, 0));
+		} else if (e.key === 'Enter') {
+			e.preventDefault();
+			const r = results[selected];
+			if (r) {
+				closePalette();
+				window.location.assign(r.href);
+			}
+		}
+	};
+
+	if (!open) return null;
+
+	const showGroups = query.trim().length === 0;
+	const failureNotes: string[] = [];
+	if (mc.failed && !mc.items) failureNotes.push('(MC index unavailable)');
+	if (rareicon.failed && !rareicon.items)
+		failureNotes.push('(Rareicon index unavailable)');
+	if (osrs.failed && !osrs.items)
+		failureNotes.push('(OSRS index unavailable)');
+
+	const loading =
+		!mc.items &&
+		!rareicon.items &&
+		!osrs.items &&
+		failureNotes.length === 0;
+
+	const rendered: ReactNode[] = [];
+	{
+		let lastGroup: Kind | null = null;
+		results.forEach((r, i) => {
+			if (showGroups && r.kind !== lastGroup) {
+				rendered.push(
+					<div key={`h-${r.kind}`} className="kbve-search__group">
+						{KIND_LABELS[r.kind]}
+					</div>,
+				);
+				lastGroup = r.kind;
+			}
+			const isSelected = i === selected;
+			const sub = fmtSub(r.kind, r.sub);
+			rendered.push(
+				<button
+					type="button"
+					key={`${r.kind}:${r.ref}:${i}`}
+					data-row-index={i}
+					className={
+						'kbve-search__row' +
+						(isSelected ? ' kbve-search__row--active' : '')
+					}
+					onMouseEnter={() => setSelected(i)}
+					onClick={() => {
+						closePalette();
+						window.location.assign(r.href);
+					}}>
+					<span
+						className={
+							'kbve-search__thumb kbve-search__thumb--' + r.kind
+						}>
+						{r.thumb ? (
+							<img
+								src={r.thumb}
+								alt=""
+								loading="lazy"
+								onError={(ev) => {
+									const img = ev.currentTarget;
+									if (
+										img.dataset.fb === '1' ||
+										!r.thumbFallback
+									) {
+										img.style.visibility = 'hidden';
+										return;
+									}
+									img.dataset.fb = '1';
+									img.src = r.thumbFallback;
+								}}
+							/>
+						) : (
+							<span className="kbve-search__thumb-fallback">
+								{r.name.slice(0, 1).toUpperCase()}
+							</span>
+						)}
+					</span>
+					<span className="kbve-search__body">
+						<span className="kbve-search__name">{r.name}</span>
+						<span className="kbve-search__meta">
+							<span className="kbve-search__ref">{r.ref}</span>
+							{sub && (
+								<span className="kbve-search__sub">{sub}</span>
+							)}
+						</span>
+					</span>
+					<span
+						className={
+							'kbve-search__kind kbve-search__kind--' + r.kind
+						}>
+						{KIND_LABELS[r.kind]}
+					</span>
+				</button>,
+			);
+		});
+	}
+
+	return (
+		<div
+			className="kbve-search"
+			role="dialog"
+			aria-modal="true"
+			aria-label="KBVE search"
+			onMouseDown={(e) => {
+				if (e.target === e.currentTarget) closePalette();
+			}}>
+			<div
+				className="kbve-search__modal"
+				onMouseDown={(e) => e.stopPropagation()}>
+				<div className="kbve-search__input-row">
+					<svg
+						className="kbve-search__icon"
+						viewBox="0 0 24 24"
+						width="20"
+						height="20"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						aria-hidden="true">
+						<circle cx="11" cy="11" r="7" />
+						<path d="m20 20-3-3" />
+					</svg>
+					<input
+						ref={inputRef}
+						className="kbve-search__input"
+						type="text"
+						placeholder="Search MC, Rareicon, OSRS…"
+						value={query}
+						onChange={(e) => setQuery(e.target.value)}
+						onKeyDown={onKeyDown}
+						autoComplete="off"
+						spellCheck={false}
+					/>
+					<kbd className="kbve-search__esc">Esc</kbd>
+				</div>
+				<div ref={listRef} className="kbve-search__list" role="listbox">
+					{loading && (
+						<div className="kbve-search__empty">
+							Loading indexes…
+						</div>
+					)}
+					{!loading && results.length === 0 && (
+						<div className="kbve-search__empty">
+							{query.trim()
+								? `No matches for "${query.trim()}"`
+								: 'No items indexed.'}
+						</div>
+					)}
+					{rendered}
+				</div>
+				<footer className="kbve-search__footer">
+					<span>
+						<kbd>↑</kbd>
+						<kbd>↓</kbd> navigate
+					</span>
+					<span>
+						<kbd>Enter</kbd> open
+					</span>
+					<span>
+						<kbd>Esc</kbd> close
+					</span>
+					{failureNotes.length > 0 && (
+						<span className="kbve-search__warn">
+							{failureNotes.join(' ')}
+						</span>
+					)}
+				</footer>
+			</div>
+		</div>
+	);
+}
+
+export default KbveSearchPalette;


### PR DESCRIPTION
## Summary

Adds a universal Cmd-K / Ctrl-K command palette React island that searches across all three KBVE item indexes (Minecraft, Rareicon, OSRS) in one modal. Tracks #10979.

## Components

- `src/components/search/KbveSearchPalette.tsx` — React island. Fixed overlay (`z-index: 9999`), centered ~640px modal, scrollable result list, accent-mix selection ring. Cmd/Ctrl+K toggles, `/` opens from outside any input, Esc closes, backdrop click closes, Up/Down navigates, Enter calls `window.location.assign`. Lazy-loads all three manifests in parallel on first open, caches each in localStorage under `kbve:search:<kind>:v1` with a 24h TTL.
- `src/components/search/AstroKbveSearch.astro` — thin wrapper that mounts the palette `client:only="react"` and ships the modal + trigger CSS in `<style is:global>`. A tiny inline script swaps `Ctrl+K` → `⌘K` on Mac and dispatches a `kbve:search:open` CustomEvent on any `[data-kbve-search-trigger]` click.

## Manifests pulled

- `/api/mc-items.json` → `kind: 'mc'`, href `/mc/items/<slug>/`, thumb via `mcTextureUrls(ref, category)` with fallback chain, `sub` = category.
- `/api/itemdb.json` → `kind: 'rareicon'`, href `/itemdb/<ref>/`, thumb = `item.img` (may be null → letter fallback), `sub` = rarity.
- `/api/osrs.json` → `kind: 'osrs'`, href `/osrs/<slug>/`, thumb = OSRS Wiki icon URL built from the bare filename (matches existing `OSRSItemBrowser`).
- A failing manifest degrades to a per-kind `(MC/Rareicon/OSRS index unavailable)` footer note; other kinds still render.

## Mount strategy (global)

Mounted globally via the existing Starlight `Header` override at `src/components/navigation/Header.astro` — every page already wraps the Starlight default header here, so a single `<AstroKbveSearch />` invocation underneath `<Default />` ships the palette on every route. Cmd/Ctrl+K and `/` are active everywhere; the palette renders into a `position: fixed` overlay outside Starlight's layout flow.

In addition, a visible trigger button (`Search… ⌘K`) is added top-right of:
- `AstroMarketShell.astro` — marketplace header
- `MCItemsIndex.astro` — MC items index header

Both surfaces had their header containers flexed to push the trigger to the right while keeping the existing copy block wrapped.

## Ranking

Substring-match against `name.toLowerCase()` + `ref.toLowerCase()`:

0. exact-ref match
1. exact-name match
2. prefix-name match
3. substring-name match
4. substring-ref match

Hard-cap render at 50 results. Empty query renders the top 10 of each kind alphabetically with `MINECRAFT / RAREICON / OSRS` subheaders; with a query, scored results are interleaved (no subheaders, kind shown as a pill on each row).

## Constraints honored

- Schema unchanged.
- No new endpoints — reuses the three existing JSON manifests.
- All client-side, no SSR coupling.
- Theming uses Starlight `--sl-color-*` vars + KBVE `--color-red` / `--color-gold-light`. No hardcoded slate/blue.
- MC thumbnails inherit `image-rendering: pixelated`.

## Test plan

- [ ] `./kbve.sh -nx astro-kbve:build` — green, 7641 page(s) built (matches baseline).
- [ ] On any page: press Cmd+K (macOS) / Ctrl+K (Linux/Windows) — palette opens, input is focused.
- [ ] Press `/` while not in an input — palette opens.
- [ ] Type a query — results interleave from all three kinds, ranked exact-ref first.
- [ ] Up/Down arrows move the selection; Enter navigates to the row's URL.
- [ ] Esc closes; clicking the backdrop closes; clicking a result navigates.
- [ ] Visit `/market/` — `Search…` button appears top-right of the header.
- [ ] Visit `/mc/items/` — same button appears top-right.
- [ ] First open fetches all three manifests in parallel; subsequent opens within 24h hit localStorage.
- [ ] Block `/api/osrs.json` in DevTools → palette still renders MC + Rareicon, footer shows `(OSRS index unavailable)`.