### PR TITLE
feat(astro-kbve): MC enchant + block landings + category browse (Phase 5.3-A2)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mcdb/MCBlockCategoryShell.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCBlockCategoryShell.astro
@@ -1,0 +1,25 @@
+---
+import MCBlocksBrowser from './MCBlocksBrowser';
+import MCTooltipMount from './MCTooltipMount.astro';
+
+interface Props {
+	material: string;
+	title: string;
+	description: string;
+}
+
+const { material, title, description } = Astro.props;
+---
+
+<MCTooltipMount />
+
+<section class="mcdb-browse__shell mcdb-panel not-content kbve-dashboard-page">
+	<header class="mcdb-browse__head">
+		<div>
+			<h1>{title}</h1>
+			<p>{description}</p>
+		</div>
+	</header>
+
+	<MCBlocksBrowser client:load lockedMaterial={material} />
+</section>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCBlocksBrowser.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCBlocksBrowser.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useMemo, useState } from 'react';
+import { mcTextureUrls } from './texture';
+
+type BlockEntry = {
+	id: number;
+	ref: string;
+	slug: string;
+	display_name: string;
+	material: string;
+	hardness: number;
+	blast_resistance: number;
+	best_tool: string;
+	required_tool_tier: number;
+	tags: string[];
+};
+
+type ManifestPayload = { count: number; items: BlockEntry[] };
+
+const PAGE_SIZE = 60;
+const ENDPOINT = '/api/mc-blocks.json';
+
+type Props = { lockedMaterial?: string };
+
+function BlockCard({ b }: { b: BlockEntry }) {
+	const tex = mcTextureUrls(b.ref, 'block');
+	return (
+		<a href={`/mc/blocks/${b.slug}/`} className="mcdb-browse__card">
+			<div className="mcdb-browse__icon">
+				<img
+					src={tex.primary}
+					alt={b.display_name}
+					loading="lazy"
+					onError={(ev) => {
+						const img = ev.currentTarget;
+						if (img.dataset.fb === '1') return;
+						img.dataset.fb = '1';
+						img.src = tex.fallback;
+					}}
+				/>
+			</div>
+			<div className="mcdb-browse__name">{b.display_name}</div>
+			<div className="mcdb-browse__meta">
+				<span className="mcdb-browse__cat">{b.material}</span>
+				{b.best_tool && b.best_tool !== 'hand' && (
+					<span className="mcdb-browse__tier">{b.best_tool}</span>
+				)}
+			</div>
+		</a>
+	);
+}
+
+export function MCBlocksBrowser({ lockedMaterial }: Props = {}) {
+	const [items, setItems] = useState<BlockEntry[] | null>(null);
+	const [query, setQuery] = useState('');
+	const [material, setMaterial] = useState<string>(lockedMaterial ?? 'all');
+	const [tool, setTool] = useState<string>('all');
+	const [page, setPage] = useState(0);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				const res = await fetch(ENDPOINT);
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				const payload = (await res.json()) as ManifestPayload;
+				if (!cancelled) setItems(payload.items);
+			} catch (e) {
+				if (!cancelled)
+					setError(e instanceof Error ? e.message : 'load failed');
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const materials = useMemo(() => {
+		if (!items) return [];
+		const set = new Set<string>();
+		for (const b of items) set.add(b.material);
+		return Array.from(set).sort();
+	}, [items]);
+
+	const tools = useMemo(() => {
+		if (!items) return [];
+		const set = new Set<string>();
+		for (const b of items) if (b.best_tool) set.add(b.best_tool);
+		return Array.from(set).sort();
+	}, [items]);
+
+	const filtered = useMemo(() => {
+		if (!items) return [];
+		const q = query.trim().toLowerCase();
+		return items.filter((b) => {
+			if (material !== 'all' && b.material !== material) return false;
+			if (tool !== 'all' && b.best_tool !== tool) return false;
+			if (
+				q &&
+				!b.ref.includes(q) &&
+				!b.display_name.toLowerCase().includes(q)
+			) {
+				return false;
+			}
+			return true;
+		});
+	}, [items, query, material, tool]);
+
+	useEffect(() => {
+		setPage(0);
+	}, [query, material, tool]);
+
+	if (error)
+		return (
+			<div className="mcdb-browse__status mcdb-browse__status--error">
+				{error}
+			</div>
+		);
+	if (!items)
+		return <div className="mcdb-browse__status">Loading blocks…</div>;
+
+	const pageStart = page * PAGE_SIZE;
+	const pageEnd = pageStart + PAGE_SIZE;
+	const visible = filtered.slice(pageStart, pageEnd);
+	const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+
+	return (
+		<div className="mcdb-browse">
+			<div className="mcdb-browse__filters">
+				<label className="mcdb-browse__filter mcdb-browse__filter--search">
+					<span>Search</span>
+					<input
+						type="search"
+						value={query}
+						onChange={(ev) => setQuery(ev.target.value)}
+						placeholder="stone, oak, dirt…"
+						className="mcdb-browse__input"
+						autoComplete="off"
+					/>
+				</label>
+				{!lockedMaterial && (
+					<label className="mcdb-browse__filter">
+						<span>Material</span>
+						<select
+							value={material}
+							onChange={(ev) => setMaterial(ev.target.value)}
+							className="mcdb-browse__input">
+							<option value="all">All</option>
+							{materials.map((m) => (
+								<option key={m} value={m}>
+									{m}
+								</option>
+							))}
+						</select>
+					</label>
+				)}
+				<label className="mcdb-browse__filter">
+					<span>Tool</span>
+					<select
+						value={tool}
+						onChange={(ev) => setTool(ev.target.value)}
+						className="mcdb-browse__input">
+						<option value="all">All</option>
+						{tools.map((t) => (
+							<option key={t} value={t}>
+								{t}
+							</option>
+						))}
+					</select>
+				</label>
+				<button
+					type="button"
+					className="mcdb-browse__reset"
+					onClick={() => {
+						setQuery('');
+						if (!lockedMaterial) setMaterial('all');
+						setTool('all');
+						setPage(0);
+					}}>
+					Reset
+				</button>
+			</div>
+
+			<div className="mcdb-browse__count">
+				{filtered.length.toLocaleString()} /{' '}
+				{items.length.toLocaleString()} blocks
+				{filtered.length > PAGE_SIZE && (
+					<>
+						{' '}
+						· page {page + 1} of {totalPages}
+					</>
+				)}
+			</div>
+
+			{visible.length === 0 ? (
+				<div className="mcdb-browse__status">No blocks match.</div>
+			) : (
+				<div className="mcdb-browse__grid">
+					{visible.map((b) => (
+						<BlockCard key={b.ref} b={b} />
+					))}
+				</div>
+			)}
+
+			{filtered.length > PAGE_SIZE && (
+				<div className="mcdb-browse__pager">
+					<button
+						type="button"
+						className="mcdb-browse__page-btn"
+						disabled={page === 0}
+						onClick={() => setPage((p) => Math.max(0, p - 1))}>
+						← Prev
+					</button>
+					<span className="mcdb-browse__page-info">
+						{page + 1} / {totalPages}
+					</span>
+					<button
+						type="button"
+						className="mcdb-browse__page-btn"
+						disabled={page >= totalPages - 1}
+						onClick={() =>
+							setPage((p) => Math.min(totalPages - 1, p + 1))
+						}>
+						Next →
+					</button>
+				</div>
+			)}
+		</div>
+	);
+}
+
+export default MCBlocksBrowser;

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCBlocksIndex.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCBlocksIndex.astro
@@ -1,0 +1,21 @@
+---
+import MCBlocksBrowser from './MCBlocksBrowser';
+import MCTooltipMount from './MCTooltipMount.astro';
+---
+
+<MCTooltipMount />
+
+<section class="mcdb-browse__shell mcdb-panel not-content kbve-dashboard-page">
+	<header class="mcdb-browse__head">
+		<div>
+			<h1>Minecraft Blocks</h1>
+			<p>
+				Every vanilla block we've published. Search by ref or display
+				name, filter by material or best mining tool, and jump to the
+				per-block page for hardness, blast resistance, drops, and tags.
+			</p>
+		</div>
+	</header>
+
+	<MCBlocksBrowser client:load />
+</section>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantCategoryShell.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantCategoryShell.astro
@@ -1,0 +1,32 @@
+---
+import MCEnchantsBrowser from './MCEnchantsBrowser';
+import MCTooltipMount from './MCTooltipMount.astro';
+
+interface Props {
+	group:
+		| 'armor'
+		| 'weapon'
+		| 'tool'
+		| 'ranged'
+		| 'fishing'
+		| 'treasure'
+		| 'curse';
+	title: string;
+	description: string;
+}
+
+const { group, title, description } = Astro.props;
+---
+
+<MCTooltipMount />
+
+<section class="mcdb-browse__shell mcdb-panel not-content kbve-dashboard-page">
+	<header class="mcdb-browse__head">
+		<div>
+			<h1>{title}</h1>
+			<p>{description}</p>
+		</div>
+	</header>
+
+	<MCEnchantsBrowser client:load lockedGroup={group} />
+</section>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantsBrowser.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantsBrowser.tsx
@@ -1,0 +1,258 @@
+import { useEffect, useMemo, useState } from 'react';
+
+type EnchantEntry = {
+	id: number;
+	ref: string;
+	slug: string;
+	display_name: string;
+	rarity: string;
+	max_level: number;
+	weight: number;
+	treasure: boolean;
+	curse: boolean;
+	targets: string[];
+	tags: string[];
+};
+
+type ManifestPayload = { count: number; items: EnchantEntry[] };
+
+const PAGE_SIZE = 60;
+const ENDPOINT = '/api/mc-enchants.json';
+
+type GroupFilter =
+	| 'all'
+	| 'armor'
+	| 'weapon'
+	| 'tool'
+	| 'ranged'
+	| 'fishing'
+	| 'treasure'
+	| 'curse';
+
+type Props = { lockedGroup?: GroupFilter };
+
+function matchesGroup(e: EnchantEntry, group: GroupFilter): boolean {
+	if (group === 'all') return true;
+	if (group === 'treasure') return e.treasure;
+	if (group === 'curse') return e.curse;
+	if (group === 'armor')
+		return e.targets.some(
+			(t) =>
+				t === 'armor' ||
+				t === 'armor_head' ||
+				t === 'armor_chest' ||
+				t === 'armor_legs' ||
+				t === 'armor_feet' ||
+				t === 'wearable',
+		);
+	if (group === 'weapon')
+		return e.targets.some((t) => t === 'weapon' || t === 'mace');
+	if (group === 'tool')
+		return e.targets.some((t) => t === 'digger' || t === 'breakable');
+	if (group === 'ranged')
+		return e.targets.some(
+			(t) => t === 'bow' || t === 'crossbow' || t === 'trident',
+		);
+	if (group === 'fishing') return e.targets.includes('fishing_rod');
+	return false;
+}
+
+function EnchantCard({ e }: { e: EnchantEntry }) {
+	return (
+		<a href={`/mc/enchants/${e.slug}/`} className="mcdb-browse__card">
+			<div className="mcdb-browse__icon mcdb-browse__icon--text">
+				<span>{e.display_name.charAt(0)}</span>
+			</div>
+			<div className="mcdb-browse__name">{e.display_name}</div>
+			<div className="mcdb-browse__meta">
+				<span className="mcdb-browse__cat">
+					{e.rarity.replace('_', ' ')}
+				</span>
+				{e.treasure && (
+					<span className="mcdb-browse__tier">treasure</span>
+				)}
+				{e.curse && <span className="mcdb-browse__tier">curse</span>}
+				<span className="mcdb-browse__tier">L{e.max_level}</span>
+			</div>
+		</a>
+	);
+}
+
+export function MCEnchantsBrowser({ lockedGroup }: Props = {}) {
+	const [items, setItems] = useState<EnchantEntry[] | null>(null);
+	const [query, setQuery] = useState('');
+	const [group, setGroup] = useState<GroupFilter>(lockedGroup ?? 'all');
+	const [rarity, setRarity] = useState<string>('all');
+	const [page, setPage] = useState(0);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				const res = await fetch(ENDPOINT);
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				const payload = (await res.json()) as ManifestPayload;
+				if (!cancelled) setItems(payload.items);
+			} catch (e) {
+				if (!cancelled)
+					setError(e instanceof Error ? e.message : 'load failed');
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const rarities = useMemo(() => {
+		if (!items) return [];
+		const set = new Set<string>();
+		for (const e of items) set.add(e.rarity);
+		return Array.from(set).sort();
+	}, [items]);
+
+	const filtered = useMemo(() => {
+		if (!items) return [];
+		const q = query.trim().toLowerCase();
+		return items.filter((e) => {
+			if (!matchesGroup(e, group)) return false;
+			if (rarity !== 'all' && e.rarity !== rarity) return false;
+			if (
+				q &&
+				!e.ref.includes(q) &&
+				!e.display_name.toLowerCase().includes(q)
+			) {
+				return false;
+			}
+			return true;
+		});
+	}, [items, query, group, rarity]);
+
+	useEffect(() => {
+		setPage(0);
+	}, [query, group, rarity]);
+
+	if (error)
+		return (
+			<div className="mcdb-browse__status mcdb-browse__status--error">
+				{error}
+			</div>
+		);
+	if (!items)
+		return <div className="mcdb-browse__status">Loading enchants…</div>;
+
+	const pageStart = page * PAGE_SIZE;
+	const pageEnd = pageStart + PAGE_SIZE;
+	const visible = filtered.slice(pageStart, pageEnd);
+	const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+
+	return (
+		<div className="mcdb-browse">
+			<div className="mcdb-browse__filters">
+				<label className="mcdb-browse__filter mcdb-browse__filter--search">
+					<span>Search</span>
+					<input
+						type="search"
+						value={query}
+						onChange={(ev) => setQuery(ev.target.value)}
+						placeholder="sharpness, looting, mending…"
+						className="mcdb-browse__input"
+						autoComplete="off"
+					/>
+				</label>
+				{!lockedGroup && (
+					<label className="mcdb-browse__filter">
+						<span>Group</span>
+						<select
+							value={group}
+							onChange={(ev) =>
+								setGroup(ev.target.value as GroupFilter)
+							}
+							className="mcdb-browse__input">
+							<option value="all">All</option>
+							<option value="armor">Armor</option>
+							<option value="weapon">Weapon</option>
+							<option value="tool">Tool</option>
+							<option value="ranged">Ranged</option>
+							<option value="fishing">Fishing</option>
+							<option value="treasure">Treasure</option>
+							<option value="curse">Curse</option>
+						</select>
+					</label>
+				)}
+				<label className="mcdb-browse__filter">
+					<span>Rarity</span>
+					<select
+						value={rarity}
+						onChange={(ev) => setRarity(ev.target.value)}
+						className="mcdb-browse__input">
+						<option value="all">All</option>
+						{rarities.map((r) => (
+							<option key={r} value={r}>
+								{r.replace('_', ' ')}
+							</option>
+						))}
+					</select>
+				</label>
+				<button
+					type="button"
+					className="mcdb-browse__reset"
+					onClick={() => {
+						setQuery('');
+						if (!lockedGroup) setGroup('all');
+						setRarity('all');
+						setPage(0);
+					}}>
+					Reset
+				</button>
+			</div>
+
+			<div className="mcdb-browse__count">
+				{filtered.length.toLocaleString()} /{' '}
+				{items.length.toLocaleString()} enchants
+				{filtered.length > PAGE_SIZE && (
+					<>
+						{' '}
+						· page {page + 1} of {totalPages}
+					</>
+				)}
+			</div>
+
+			{visible.length === 0 ? (
+				<div className="mcdb-browse__status">No enchants match.</div>
+			) : (
+				<div className="mcdb-browse__grid">
+					{visible.map((e) => (
+						<EnchantCard key={e.ref} e={e} />
+					))}
+				</div>
+			)}
+
+			{filtered.length > PAGE_SIZE && (
+				<div className="mcdb-browse__pager">
+					<button
+						type="button"
+						className="mcdb-browse__page-btn"
+						disabled={page === 0}
+						onClick={() => setPage((p) => Math.max(0, p - 1))}>
+						← Prev
+					</button>
+					<span className="mcdb-browse__page-info">
+						{page + 1} / {totalPages}
+					</span>
+					<button
+						type="button"
+						className="mcdb-browse__page-btn"
+						disabled={page >= totalPages - 1}
+						onClick={() =>
+							setPage((p) => Math.min(totalPages - 1, p + 1))
+						}>
+						Next →
+					</button>
+				</div>
+			)}
+		</div>
+	);
+}
+
+export default MCEnchantsBrowser;

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantsIndex.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantsIndex.astro
@@ -1,0 +1,23 @@
+---
+import MCEnchantsBrowser from './MCEnchantsBrowser';
+import MCTooltipMount from './MCTooltipMount.astro';
+---
+
+<MCTooltipMount />
+
+<section class="mcdb-browse__shell mcdb-panel not-content kbve-dashboard-page">
+	<header class="mcdb-browse__head">
+		<div>
+			<h1>Minecraft Enchants</h1>
+			<p>
+				Every vanilla enchantment we've published. Search by ref or
+				display name, filter by group (armor / weapon / tool / ranged /
+				fishing / treasure / curse), and pop into the per-enchant page
+				for max level, weight, anvil cost, targets, and
+				incompatibilities.
+			</p>
+		</div>
+	</header>
+
+	<MCEnchantsBrowser client:load />
+</section>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/dirt/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/dirt/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Dirt Blocks
+description: |
+    Grass, dirt, podzol, mycelium, mud, farmland, and dirt paths. Browse every published dirt block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Dirt
+    order: 4
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - dirt
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="dirt"
+    title="Minecraft Dirt Blocks"
+    description="Grass, dirt, podzol, mycelium, mud, farmland, and dirt paths."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/end/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/end/index.mdx
@@ -1,0 +1,24 @@
+---
+title: End Blocks
+description: |
+    End stone, purpur, chorus plants, end rod, end gateway, dragon egg. Browse every published end block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: End
+    order: 17
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - end
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="end"
+    title="Minecraft End Blocks"
+    description="End stone, purpur, chorus plants, end rod, end gateway, dragon egg."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/glass/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/glass/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Glass Blocks
+description: |
+    Glass blocks, glass panes, stained glass, tinted glass. Browse every published glass block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Glass
+    order: 8
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - glass
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="glass"
+    title="Minecraft Glass Blocks"
+    description="Glass blocks, glass panes, stained glass, tinted glass."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/gravel/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/gravel/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Gravel Blocks
+description: |
+    Gravel and falling-block variants. Browse every published gravel block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Gravel
+    order: 6
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - gravel
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="gravel"
+    title="Minecraft Gravel Blocks"
+    description="Gravel and falling-block variants."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/ice/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/ice/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Ice Blocks
+description: |
+    Ice, packed ice, blue ice, frosted ice. Browse every published ice block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Ice
+    order: 12
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - ice
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="ice"
+    title="Minecraft Ice Blocks"
+    description="Ice, packed ice, blue ice, frosted ice."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Minecraft Blocks
+description: |
+    Browse every vanilla Minecraft block with search and filtering by
+    material and preferred mining tool.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Blocks
+    order: 1
+tags:
+    - minecraft
+    - mc
+    - mc-block
+---
+
+import MCBlocksIndex from '@/components/mcdb/MCBlocksIndex.astro';
+
+<MCBlocksIndex />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/leaves/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/leaves/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Leaves Blocks
+description: |
+    Tree leaf blocks across every wood type. Browse every published leaves block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Leaves
+    order: 11
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - leaves
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="leaves"
+    title="Minecraft Leaves Blocks"
+    description="Tree leaf blocks across every wood type."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/liquid/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/liquid/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Liquid Blocks
+description: |
+    Water, lava, bubble columns. Browse every published liquid block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Liquid
+    order: 14
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - liquid
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="liquid"
+    title="Minecraft Liquid Blocks"
+    description="Water, lava, bubble columns."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/metal/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/metal/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Metal Blocks
+description: |
+    Iron, gold, copper, netherite blocks plus mechanical metal blocks (anvil, hopper, dispenser). Browse every published metal block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Metal
+    order: 7
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - metal
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="metal"
+    title="Minecraft Metal Blocks"
+    description="Iron, gold, copper, netherite blocks plus mechanical metal blocks (anvil, hopper, dispenser)."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/misc/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/misc/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Misc Blocks
+description: |
+    Everything that does not fit another material bucket. Browse every published misc block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Misc
+    order: 18
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - misc
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="misc"
+    title="Minecraft Misc Blocks"
+    description="Everything that does not fit another material bucket."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/nether/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/nether/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Nether Blocks
+description: |
+    Netherrack, blackstone, basalt, crimson + warped wood, soul fire, magma block. Browse every published nether block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Nether
+    order: 16
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - nether
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="nether"
+    title="Minecraft Nether Blocks"
+    description="Netherrack, blackstone, basalt, crimson + warped wood, soul fire, magma block."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/plant/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/plant/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Plant Blocks
+description: |
+    Saplings, flowers, mushrooms, crops, cacti, sugarcane, and other plant blocks. Browse every published plant block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Plant
+    order: 10
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - plant
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="plant"
+    title="Minecraft Plant Blocks"
+    description="Saplings, flowers, mushrooms, crops, cacti, sugarcane, and other plant blocks."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/redstone/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/redstone/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Redstone Blocks
+description: |
+    Redstone wire, repeaters, comparators, pistons, levers, buttons, observers, rails. Browse every published redstone block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Redstone
+    order: 15
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - redstone
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="redstone"
+    title="Minecraft Redstone Blocks"
+    description="Redstone wire, repeaters, comparators, pistons, levers, buttons, observers, rails."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/sand/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/sand/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Sand Blocks
+description: |
+    Sand, red sand, soul sand, soul soil, and sandstone variants. Browse every published sand block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Sand
+    order: 5
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - sand
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="sand"
+    title="Minecraft Sand Blocks"
+    description="Sand, red sand, soul sand, soul soil, and sandstone variants."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/snow/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/snow/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Snow Blocks
+description: |
+    Snow blocks and snow layers. Browse every published snow block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Snow
+    order: 13
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - snow
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="snow"
+    title="Minecraft Snow Blocks"
+    description="Snow blocks and snow layers."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/stone/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/stone/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Stone Blocks
+description: |
+    Stone, granite, andesite, diorite, deepslate, tuff, calcite, and the ore variants. Browse every published stone block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Stone
+    order: 2
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - stone
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="stone"
+    title="Minecraft Stone Blocks"
+    description="Stone, granite, andesite, diorite, deepslate, tuff, calcite, and the ore variants."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/wood/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/wood/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Wood Blocks
+description: |
+    Logs, planks, stripped wood, fences, doors, and other wooden building blocks. Browse every published wood block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Wood
+    order: 3
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - wood
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="wood"
+    title="Minecraft Wood Blocks"
+    description="Logs, planks, stripped wood, fences, doors, and other wooden building blocks."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/blocks/wool/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/blocks/wool/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Wool Blocks
+description: |
+    Wool, carpet, and cloth-textured decoration blocks. Browse every published wool block.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Wool
+    order: 9
+tags:
+    - minecraft
+    - mc
+    - mc-block
+    - wool
+---
+
+import MCBlockCategoryShell from '@/components/mcdb/MCBlockCategoryShell.astro';
+
+<MCBlockCategoryShell
+    material="wool"
+    title="Minecraft Wool Blocks"
+    description="Wool, carpet, and cloth-textured decoration blocks."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/enchants/armor/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/enchants/armor/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Armor Enchants
+description: |
+    Protection, Thorns, Aqua Affinity, Respiration, and other enchantments that apply to armor pieces. Browse every published enchantment in the armor enchants bucket.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Armor Enchants
+    order: 2
+tags:
+    - minecraft
+    - mc
+    - mc-enchant
+    - armor
+---
+
+import MCEnchantCategoryShell from '@/components/mcdb/MCEnchantCategoryShell.astro';
+
+<MCEnchantCategoryShell
+    group="armor"
+    title="Minecraft Armor Enchants"
+    description="Protection, Thorns, Aqua Affinity, Respiration, and other enchantments that apply to armor pieces."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/enchants/curse/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/enchants/curse/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Curse Enchants
+description: |
+    Curse of Binding and Curse of Vanishing — debuff enchantments that cannot be removed by a grindstone. Browse every published enchantment in the curse enchants bucket.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Curse Enchants
+    order: 8
+tags:
+    - minecraft
+    - mc
+    - mc-enchant
+    - curse
+---
+
+import MCEnchantCategoryShell from '@/components/mcdb/MCEnchantCategoryShell.astro';
+
+<MCEnchantCategoryShell
+    group="curse"
+    title="Minecraft Curse Enchants"
+    description="Curse of Binding and Curse of Vanishing — debuff enchantments that cannot be removed by a grindstone."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/enchants/fishing/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/enchants/fishing/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Fishing Enchants
+description: |
+    Lure and Luck of the Sea — applicable to fishing rods. Browse every published enchantment in the fishing enchants bucket.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Fishing Enchants
+    order: 6
+tags:
+    - minecraft
+    - mc
+    - mc-enchant
+    - fishing
+---
+
+import MCEnchantCategoryShell from '@/components/mcdb/MCEnchantCategoryShell.astro';
+
+<MCEnchantCategoryShell
+    group="fishing"
+    title="Minecraft Fishing Enchants"
+    description="Lure and Luck of the Sea — applicable to fishing rods."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/enchants/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/enchants/index.mdx
@@ -1,0 +1,21 @@
+---
+title: Minecraft Enchants
+description: |
+    Browse every vanilla Minecraft enchantment with search and filtering
+    by group (armor / weapon / tool / ranged / fishing) plus treasure
+    and curse toggles.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Enchants
+    order: 1
+tags:
+    - minecraft
+    - mc
+    - mc-enchant
+---
+
+import MCEnchantsIndex from '@/components/mcdb/MCEnchantsIndex.astro';
+
+<MCEnchantsIndex />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/enchants/ranged/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/enchants/ranged/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Ranged Enchants
+description: |
+    Power, Punch, Infinity, Flame for bows; Piercing, Multishot, Quick Charge for crossbows; Loyalty, Riptide, Channeling, Impaling for tridents. Browse every published enchantment in the ranged enchants bucket.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Ranged Enchants
+    order: 5
+tags:
+    - minecraft
+    - mc
+    - mc-enchant
+    - ranged
+---
+
+import MCEnchantCategoryShell from '@/components/mcdb/MCEnchantCategoryShell.astro';
+
+<MCEnchantCategoryShell
+    group="ranged"
+    title="Minecraft Ranged Enchants"
+    description="Power, Punch, Infinity, Flame for bows; Piercing, Multishot, Quick Charge for crossbows; Loyalty, Riptide, Channeling, Impaling for tridents."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/enchants/tool/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/enchants/tool/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Tool Enchants
+description: |
+    Efficiency, Fortune, Silk Touch, Unbreaking, Mending, and other diggers / general durability enchants. Browse every published enchantment in the tool enchants bucket.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Tool Enchants
+    order: 4
+tags:
+    - minecraft
+    - mc
+    - mc-enchant
+    - tool
+---
+
+import MCEnchantCategoryShell from '@/components/mcdb/MCEnchantCategoryShell.astro';
+
+<MCEnchantCategoryShell
+    group="tool"
+    title="Minecraft Tool Enchants"
+    description="Efficiency, Fortune, Silk Touch, Unbreaking, Mending, and other diggers / general durability enchants."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/enchants/treasure/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/enchants/treasure/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Treasure Enchants
+description: |
+    Treasure-only enchants — Mending, Frost Walker, Soul Speed, Swift Sneak, Wind Burst. Not obtainable from an enchantment table. Browse every published enchantment in the treasure enchants bucket.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Treasure Enchants
+    order: 7
+tags:
+    - minecraft
+    - mc
+    - mc-enchant
+    - treasure
+---
+
+import MCEnchantCategoryShell from '@/components/mcdb/MCEnchantCategoryShell.astro';
+
+<MCEnchantCategoryShell
+    group="treasure"
+    title="Minecraft Treasure Enchants"
+    description="Treasure-only enchants — Mending, Frost Walker, Soul Speed, Swift Sneak, Wind Burst. Not obtainable from an enchantment table."
+/>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/enchants/weapon/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/enchants/weapon/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Weapon Enchants
+description: |
+    Sharpness, Smite, Bane of Arthropods, Fire Aspect, Looting, plus mace enchants like Breach and Wind Burst. Browse every published enchantment in the weapon enchants bucket.
+tableOfContents: false
+graph:
+   visible: false
+sidebar:
+    label: Weapon Enchants
+    order: 3
+tags:
+    - minecraft
+    - mc
+    - mc-enchant
+    - weapon
+---
+
+import MCEnchantCategoryShell from '@/components/mcdb/MCEnchantCategoryShell.astro';
+
+<MCEnchantCategoryShell
+    group="weapon"
+    title="Minecraft Weapon Enchants"
+    description="Sharpness, Smite, Bane of Arthropods, Fire Aspect, Looting, plus mace enchants like Breach and Wind Burst."
+/>

--- a/apps/kbve/astro-kbve/src/pages/api/mc-blocks.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/mc-blocks.json.ts
@@ -1,0 +1,60 @@
+import { getCollection } from 'astro:content';
+
+export const GET = async () => {
+	const entries = await getCollection(
+		'docs',
+		(entry: { id: string; data: Record<string, unknown> }) => {
+			return (
+				entry.id.startsWith('mc/blocks/') &&
+				Boolean(entry.data?.mc_block)
+			);
+		},
+	);
+
+	const items = entries
+		.map(
+			(entry: {
+				id: string;
+				data: { mc_block?: Record<string, unknown> };
+			}) => {
+				const b = entry.data.mc_block;
+				if (!b) return null;
+				return {
+					id: b.id,
+					ref: b.ref,
+					slug: b.slug,
+					display_name: b.display_name,
+					material: b.material,
+					hardness: b.hardness,
+					blast_resistance: b.blast_resistance,
+					best_tool: b.best_tool,
+					required_tool_tier: b.required_tool_tier ?? 0,
+					tags: Array.isArray(b.tags) ? b.tags : [],
+				};
+			},
+		)
+		.filter(Boolean)
+		.sort((a, b) =>
+			String(a!.display_name).localeCompare(String(b!.display_name)),
+		);
+
+	const byRef: Record<string, number> = {};
+	items.forEach((it, idx) => {
+		if (it && typeof it.ref === 'string') byRef[it.ref] = idx;
+	});
+
+	return new Response(
+		JSON.stringify({
+			items,
+			byRef,
+			count: items.length,
+			generated_at: new Date().toISOString(),
+		}),
+		{
+			headers: {
+				'Content-Type': 'application/json',
+				'Cache-Control': 'public, max-age=300',
+			},
+		},
+	);
+};

--- a/apps/kbve/astro-kbve/src/pages/api/mc-enchants.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/mc-enchants.json.ts
@@ -1,0 +1,61 @@
+import { getCollection } from 'astro:content';
+
+export const GET = async () => {
+	const entries = await getCollection(
+		'docs',
+		(entry: { id: string; data: Record<string, unknown> }) => {
+			return (
+				entry.id.startsWith('mc/enchants/') &&
+				Boolean(entry.data?.mc_enchant)
+			);
+		},
+	);
+
+	const items = entries
+		.map(
+			(entry: {
+				id: string;
+				data: { mc_enchant?: Record<string, unknown> };
+			}) => {
+				const e = entry.data.mc_enchant;
+				if (!e) return null;
+				return {
+					id: e.id,
+					ref: e.ref,
+					slug: e.slug,
+					display_name: e.display_name,
+					rarity: e.rarity,
+					max_level: e.max_level,
+					weight: e.weight,
+					treasure: e.treasure ?? false,
+					curse: e.curse ?? false,
+					targets: Array.isArray(e.targets) ? e.targets : [],
+					tags: Array.isArray(e.tags) ? e.tags : [],
+				};
+			},
+		)
+		.filter(Boolean)
+		.sort((a, b) =>
+			String(a!.display_name).localeCompare(String(b!.display_name)),
+		);
+
+	const byRef: Record<string, number> = {};
+	items.forEach((it, idx) => {
+		if (it && typeof it.ref === 'string') byRef[it.ref] = idx;
+	});
+
+	return new Response(
+		JSON.stringify({
+			items,
+			byRef,
+			count: items.length,
+			generated_at: new Date().toISOString(),
+		}),
+		{
+			headers: {
+				'Content-Type': 'application/json',
+				'Cache-Control': 'public, max-age=300',
+			},
+		},
+	);
+};


### PR DESCRIPTION
## Summary
Parity with the items pattern from #11179. Enchants + blocks now each get a top-level browse landing and category sub-landings, plus matching SSG JSON manifests.

### Enchants
- `/api/mc-enchants.json` — manifest of every `mc_enchant` MDX page
- `MCEnchantsBrowser.tsx` — search + group (armor / weapon / tool / ranged / fishing / treasure / curse) + rarity filters, 60/page
- `MCEnchantsIndex.astro` + `MCEnchantCategoryShell.astro` shells
- 1 + 7 landing pages under `/mc/enchants/`

### Blocks
- `/api/mc-blocks.json` — manifest of every `mc_block` MDX page
- `MCBlocksBrowser.tsx` — search + material + best-tool filters, 60/page, block textures via `mcTextureUrls`
- `MCBlocksIndex.astro` + `MCBlockCategoryShell.astro` shells
- 1 + 17 landing pages under `/mc/blocks/` (stone, wood, dirt, sand, gravel, metal, glass, wool, plant, leaves, ice, snow, liquid, redstone, nether, end, misc)

Sidebar autogen picks them up via `sidebar.label` + `sidebar.order` frontmatter. Individual slug pages stay `sidebar.hidden: true` from #11139.

## Build
`./kbve.sh -nx astro-kbve:build` — green, 7660 pages.

## Tracking
Phase 5.3-A2 of #10979.

## Test plan
- [ ] `/mc/enchants/` — search + group filter shrinks list
- [ ] `/mc/enchants/curse/` — only Curse of Binding + Vanishing show; group dropdown hidden
- [ ] `/mc/blocks/` — block textures load same-origin, search + material works
- [ ] `/mc/blocks/wood/` — only wood-material blocks visible; material dropdown hidden
- [ ] Sidebar: Minecraft > enchants expands to 8 entries; Minecraft > blocks expands to 18