### PR TITLE
feat(axum-kbve): expose ROWS openapi at /api/rows/openapi.json

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/api.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Reference
-description: Live OpenAPI 3.1 specifications for the KBVE public API and the staff-only firecracker-ctl service.
+description: Live OpenAPI 3.1 specifications for the KBVE public API, the staff-only firecracker-ctl service, and the ROWS (ChuckRPG) game-services API.
 template: splash
 tableOfContents: false
 pagefind: false
@@ -21,5 +21,6 @@ import AstroApiDashboard from '@/components/dashboard/AstroApiDashboard.astro';
     sources={[
         { slug: 'kbve', title: 'KBVE Public API', url: '/api/openapi.json', default: true },
         { slug: 'firecracker', title: 'Firecracker Control', url: '/api/firecracker/openapi.json' },
+        { slug: 'rows', title: 'ROWS (ChuckRPG)', url: '/api/rows/openapi.json' },
     ]}
 />

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -201,6 +201,12 @@ async fn main() -> anyhow::Result<()> {
         info!("ChuckRPG proxy not configured (CHUCKRPG_UPSTREAM_URL not set)");
     }
 
+    if transport::proxy::init_chuckrpg_docs_proxy() {
+        info!("ChuckRPG docs proxy initialized - /api/rows/openapi.json enabled");
+    } else {
+        info!("ChuckRPG docs proxy not configured (CHUCKRPG_DOCS_URL not set)");
+    }
+
     // Initialize game server (headless Bevy + lightyear + avian3d)
     // Runs in its own thread; lightyear binds WebSocket on GAME_WS_ADDR (default :5000)
     gameserver::init_gameserver();

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -268,6 +268,10 @@ fn router(state: AppState) -> Router {
             "/api/firecracker/openapi.json",
             get(super::proxy::firecracker_openapi_handler),
         )
+        .route(
+            "/api/rows/openapi.json",
+            get(super::proxy::chuckrpg_openapi_handler),
+        )
         .route("/api/v1/osrs/{item_id}", get(osrs_api_handler))
         .route("/api/v1/profile/me", get(profile_me_handler))
         .route("/api/v1/profile/username", post(set_username_handler))

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -2037,6 +2037,47 @@ pub async fn chuckrpg_proxy_handler(path: Option<Path<String>>, req: Request<Bod
     }
 }
 
+static CHUCKRPG_DOCS: OnceLock<ServiceProxy> = OnceLock::new();
+
+pub fn init_chuckrpg_docs_proxy() -> bool {
+    let upstream = std::env::var("CHUCKRPG_DOCS_URL")
+        .unwrap_or_else(|_| "http://rows.rows.svc.cluster.local:4323".into());
+
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(15))
+        .build()
+        .expect("failed to build reqwest client for chuckrpg docs proxy");
+
+    CHUCKRPG_DOCS
+        .set(ServiceProxy {
+            name: "ChuckRPG-Docs",
+            client,
+            upstream: upstream.trim_end_matches('/').to_string(),
+            upstream_token: None,
+            upstream_headers: Vec::new(),
+            iframe_safe: false,
+            streaming: false,
+        })
+        .is_ok()
+}
+
+pub async fn chuckrpg_openapi_handler(req: Request<Body>) -> Response {
+    match CHUCKRPG_DOCS.get() {
+        Some(proxy) => {
+            proxy
+                .handle_preauthorized(Some(Path("api-docs/openapi.json".to_string())), req)
+                .await
+        }
+        None => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(json!({"error": "ChuckRPG docs proxy not configured"})),
+        )
+            .into_response(),
+    }
+}
+
 fn reqwest_headers(headers: &HeaderMap) -> reqwest::header::HeaderMap {
     let mut out = reqwest::header::HeaderMap::new();
     for (k, v) in headers {

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -134,6 +134,8 @@ spec:
                         value: '/etc/ssl/webtransport-selfsigned/tls.key'
                       - name: CHUCKRPG_UPSTREAM_URL
                         value: 'http://rows.rows.svc.cluster.local:4322'
+                      - name: CHUCKRPG_DOCS_URL
+                        value: 'http://rows.rows.svc.cluster.local:4323'
                       - name: CHUCKRPG_CUSTOMER_GUID
                         valueFrom:
                             secretKeyRef:


### PR DESCRIPTION
## Summary
Surface the ROWS OpenAPI document on the dashboard /api page alongside \`#kbve\` and \`#firecracker\`. Adding the matching \`#rows\` tab to https://kbve.com/dashboard/api/.

## Why
ROWS publishes its OpenAPI 3.1 spec via utoipa_swagger_ui on an internal-only listener (4323), separate from the customer-gated REST/gRPC port (4322). With no public path the spec was unreachable from the dashboard.

## Changes
- **axum-kbve**: new \`CHUCKRPG_DOCS\` ServiceProxy + \`chuckrpg_openapi_handler\` (handle_preauthorized — same pattern as firecracker) mounted at \`/api/rows/openapi.json\`. Reads \`CHUCKRPG_DOCS_URL\`, defaults to \`http://rows.rows.svc.cluster.local:4323\`.
- **kbve-deployment**: \`CHUCKRPG_DOCS_URL\` env wired to rows:4323.
- **astro-kbve**: \`dashboard/api.mdx\` adds \`{ slug: 'rows', title: 'ROWS (ChuckRPG)', url: '/api/rows/openapi.json' }\` so Scalar resolves \`#rows\` to the new spec.

The spec only describes endpoint shapes — live operations stay gated by the existing chuckrpg proxy (X-CustomerGUID) and ROWS middleware.

## Test plan
- [ ] After rollout, \`curl https://kbve.com/api/rows/openapi.json\` returns ROWS spec JSON
- [ ] https://kbve.com/dashboard/api/#rows renders ROWS endpoints in Scalar
- [ ] \`#kbve\` and \`#firecracker\` still work