### PR TITLE
fix(mc_auth): read wallet balance via Supabase RPC, bypass axum-kbve service_role

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreen.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/wallet/WalletScreen.java
@@ -3,6 +3,8 @@ package com.kbve.statetree.wallet;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
@@ -11,8 +13,21 @@ import java.util.Locale;
 
 public class WalletScreen extends HandledScreen<WalletScreenHandler> {
 
-    private static final int BG_WIDTH = 220;
-    private static final int BG_HEIGHT = 156;
+    private static final int BG_WIDTH = 224;
+    private static final int BG_HEIGHT = 166;
+
+    private static final int COLOR_BORDER_DARK = 0xFF373737;
+    private static final int COLOR_BORDER_LIGHT = 0xFFFFFFFF;
+    private static final int COLOR_BG_BASE = 0xFFC6C6C6;
+    private static final int COLOR_BG_INSET_DARK = 0xFF8B8B8B;
+    private static final int COLOR_BG_INSET_LIGHT = 0xFFFFFFFF;
+    private static final int COLOR_TITLE_STRIP = 0xFF555555;
+    private static final int COLOR_DIVIDER = 0xFF8B8B8B;
+    private static final int COLOR_TEXT_DARK = 0xFF404040;
+
+    private static final ItemStack CREDITS_ICON = new ItemStack(Items.GOLD_INGOT);
+    private static final ItemStack KHASH_ICON = new ItemStack(Items.EMERALD);
+    private static final ItemStack MERCHANT_ICON = new ItemStack(Items.WRITABLE_BOOK);
 
     public WalletScreen(WalletScreenHandler handler, PlayerInventory inv, Text title) {
         super(handler, inv, title);
@@ -24,38 +39,77 @@ public class WalletScreen extends HandledScreen<WalletScreenHandler> {
     protected void drawBackground(DrawContext ctx, float delta, int mouseX, int mouseY) {
         int x = (this.width - this.backgroundWidth) / 2;
         int y = (this.height - this.backgroundHeight) / 2;
-        ctx.fill(x, y, x + backgroundWidth, y + backgroundHeight, 0xFF1B1B1F);
-        ctx.fill(x + 2, y + 2, x + backgroundWidth - 2, y + backgroundHeight - 2, 0xFF2A2A33);
-        ctx.fill(x + 2, y + 2, x + backgroundWidth - 2, y + 22, 0xFF3F3F4A);
+
+        drawBeveledPanel(ctx, x, y, BG_WIDTH, BG_HEIGHT, COLOR_BG_BASE, COLOR_BORDER_LIGHT, COLOR_BORDER_DARK);
+
+        ctx.fill(x + 4, y + 4, x + BG_WIDTH - 4, y + 22, COLOR_TITLE_STRIP);
+        ctx.fill(x + 4, y + 22, x + BG_WIDTH - 4, y + 24, COLOR_BORDER_DARK);
+
+        drawInsetPanel(ctx, x + 6, y + 30, BG_WIDTH - 12, 24);
+        drawInsetPanel(ctx, x + 6, y + 60, BG_WIDTH - 12, 24);
+
+        ctx.fill(x + 6, y + 94, x + BG_WIDTH - 6, y + 95, COLOR_DIVIDER);
+
+        drawInsetPanel(ctx, x + 6, y + 102, BG_WIDTH - 12, 22);
+    }
+
+    private static void drawBeveledPanel(DrawContext ctx, int x, int y, int w, int h, int fill, int light, int dark) {
+        ctx.fill(x, y, x + w, y + h, fill);
+        ctx.fill(x, y, x + w, y + 1, light);
+        ctx.fill(x, y, x + 1, y + h, light);
+        ctx.fill(x + w - 1, y, x + w, y + h, dark);
+        ctx.fill(x, y + h - 1, x + w, y + h, dark);
+    }
+
+    private static void drawInsetPanel(DrawContext ctx, int x, int y, int w, int h) {
+        ctx.fill(x, y, x + w, y + h, COLOR_BG_INSET_DARK);
+        ctx.fill(x, y, x + w, y + 1, COLOR_BORDER_DARK);
+        ctx.fill(x, y, x + 1, y + h, COLOR_BORDER_DARK);
+        ctx.fill(x + w - 1, y, x + w, y + h, COLOR_BG_INSET_LIGHT);
+        ctx.fill(x, y + h - 1, x + w, y + h, COLOR_BG_INSET_LIGHT);
     }
 
     @Override
     public void render(DrawContext ctx, int mouseX, int mouseY, float delta) {
         this.renderBackground(ctx, mouseX, mouseY, delta);
         super.render(ctx, mouseX, mouseY, delta);
+        renderIcons(ctx);
+    }
+
+    private void renderIcons(DrawContext ctx) {
+        int x = (this.width - this.backgroundWidth) / 2;
+        int y = (this.height - this.backgroundHeight) / 2;
+        ctx.drawItem(CREDITS_ICON, x + 10, y + 34);
+        ctx.drawItem(KHASH_ICON, x + 10, y + 64);
+        ctx.drawItem(MERCHANT_ICON, x + 10, y + 104);
     }
 
     @Override
     protected void drawForeground(DrawContext ctx, int mouseX, int mouseY) {
-        int titleColor = 0xFFFFD66B;
-        int valueColor = 0xFFFFFFFF;
-        int labelColor = 0xFFA0A0B0;
-
-        ctx.drawText(this.textRenderer, Text.literal("KBVE Wallet").formatted(Formatting.GOLD), 10, 8, titleColor, false);
+        ctx.drawText(this.textRenderer,
+                Text.literal("KBVE Wallet").formatted(Formatting.GOLD, Formatting.BOLD),
+                10, 9, 0xFFFFD66B, true);
 
         long credits = handler.getCredits();
         long khash = handler.getKhash();
 
-        ctx.drawText(this.textRenderer, Text.literal("Credits"), 14, 36, labelColor, false);
-        ctx.drawText(this.textRenderer, Text.literal(format(credits)).formatted(Formatting.YELLOW),
-                14, 50, valueColor, false);
+        ctx.drawText(this.textRenderer,
+                Text.literal("Credits").formatted(Formatting.DARK_GRAY),
+                32, 33, COLOR_TEXT_DARK, false);
+        ctx.drawText(this.textRenderer,
+                Text.literal(format(credits)).formatted(Formatting.YELLOW),
+                32, 45, 0xFFFFFFFF, true);
 
-        ctx.drawText(this.textRenderer, Text.literal("KHash"), 14, 74, labelColor, false);
-        ctx.drawText(this.textRenderer, Text.literal(format(khash)).formatted(Formatting.AQUA),
-                14, 88, valueColor, false);
+        ctx.drawText(this.textRenderer,
+                Text.literal("KHash").formatted(Formatting.DARK_GRAY),
+                32, 63, COLOR_TEXT_DARK, false);
+        ctx.drawText(this.textRenderer,
+                Text.literal(format(khash)).formatted(Formatting.AQUA),
+                32, 75, 0xFFFFFFFF, true);
 
-        ctx.drawText(this.textRenderer, Text.literal("Merchant — coming soon").formatted(Formatting.GRAY),
-                14, 120, labelColor, false);
+        ctx.drawText(this.textRenderer,
+                Text.literal("Merchant — coming soon").formatted(Formatting.GRAY, Formatting.ITALIC),
+                32, 108, COLOR_TEXT_DARK, false);
     }
 
     @Override

--- a/apps/mc/mc_auth/src/runtime.rs
+++ b/apps/mc/mc_auth/src/runtime.rs
@@ -257,24 +257,19 @@ async fn handle_job(
             supabase_user_id,
         } => {
             debug!(%player_uuid, %supabase_user_id, "mc_auth: processing fetch_balance");
-            match wallet {
-                Some(client) => match client.balance_for_user(&supabase_user_id).await {
-                    Ok(snapshot) => PlayerEvent::WalletBalance {
-                        player_uuid,
-                        credits: snapshot.credits,
-                        khash: snapshot.khash,
-                    },
-                    Err(e) => {
-                        warn!(%player_uuid, error = %e, "mc_auth: lazy balance fetch failed");
-                        PlayerEvent::WalletBalance {
-                            player_uuid,
-                            credits: 0,
-                            khash: 0,
-                        }
-                    }
+            match supabase.user_balance(&supabase_user_id).await {
+                Ok(Some((credits, khash))) => PlayerEvent::WalletBalance {
+                    player_uuid,
+                    credits,
+                    khash,
                 },
-                None => {
-                    warn!(%player_uuid, "mc_auth: wallet client disabled — emitting zero balance");
+                Ok(None) => PlayerEvent::WalletBalance {
+                    player_uuid,
+                    credits: 0,
+                    khash: 0,
+                },
+                Err(e) => {
+                    warn!(%player_uuid, error = %e, "mc_auth: lazy balance fetch failed");
                     PlayerEvent::WalletBalance {
                         player_uuid,
                         credits: 0,
@@ -303,16 +298,8 @@ async fn handle_job(
         warn!("mc_auth: event channel full dropping primary event");
     }
 
-    // Fire daily-khash credit + emit a WalletBalance follow-up for any
-    // newly-confirmed linked player. Both calls are best-effort: errors
-    // are logged and swallowed — they must not block the player. The
-    // daily credit's idempotency key (UUIDv5 over user_id + UTC date)
-    // dedups multiple joins on the same day, so calling on every
-    // confirmation is safe.
-    if let (Some(client), Some((player_uuid, uid))) = (wallet, linked_pair) {
-        let client = client.clone();
-        let tx = event_tx.clone();
-        tokio::spawn(async move {
+    if let Some((player_uuid, uid)) = linked_pair {
+        if let Some(client) = wallet {
             match client.daily_credit_khash(&uid).await {
                 Ok(resp) => debug!(
                     user_id = %uid,
@@ -321,24 +308,23 @@ async fn handle_job(
                 ),
                 Err(e) => warn!(user_id = %uid, error = %e, "mc_auth: daily khash credit failed"),
             }
+        }
 
-            match client.balance_for_user(&uid).await {
-                Ok(snapshot) => {
-                    let evt = PlayerEvent::WalletBalance {
-                        player_uuid,
-                        credits: snapshot.credits,
-                        khash: snapshot.khash,
-                    };
-                    if tx.try_send(evt).is_err() {
-                        warn!("mc_auth: event channel full dropping WalletBalance");
-                    }
-                }
-                Err(e) => warn!(
-                    user_id = %uid,
-                    error = %e,
-                    "mc_auth: balance fetch failed — skipping WalletBalance event"
-                ),
+        let (credits, khash) = match supabase.user_balance(&uid).await {
+            Ok(Some((c, k))) => (c, k),
+            Ok(None) => (0, 0),
+            Err(e) => {
+                warn!(user_id = %uid, error = %e, "mc_auth: balance fetch failed");
+                (0, 0)
             }
-        });
+        };
+        let evt = PlayerEvent::WalletBalance {
+            player_uuid,
+            credits,
+            khash,
+        };
+        if event_tx.try_send(evt).is_err() {
+            warn!("mc_auth: event channel full dropping WalletBalance");
+        }
     }
 }

--- a/apps/mc/mc_auth/src/supabase.rs
+++ b/apps/mc/mc_auth/src/supabase.rs
@@ -205,6 +205,37 @@ impl SupabaseClient {
         }
     }
 
+    pub async fn user_balance(&self, user_id: &str) -> Result<Option<(i64, i64)>, String> {
+        let client = self
+            .inner
+            .as_ref()
+            .ok_or_else(|| "auth disabled (no supabase env)".to_string())?;
+        let params = json!({ "p_user_id": user_id });
+        let resp = client
+            .rpc_schema("service_user_balance", params, "wallet")
+            .await
+            .map_err(|e| format!("supa: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("http {}: {}", status, truncate(&body, 200)));
+        }
+        #[derive(serde::Deserialize)]
+        struct Row {
+            credits: i64,
+            khash: i64,
+        }
+        let rows: Vec<Row> = resp.json().await.map_err(|e| format!("decode: {e}"))?;
+        if rows.len() > 1 {
+            warn!(
+                user_id = %user_id,
+                row_count = rows.len(),
+                "wallet.service_user_balance returned multiple rows — wallet_account_user_uq invariant violated"
+            );
+        }
+        Ok(rows.into_iter().next().map(|r| (r.credits, r.khash)))
+    }
+
     pub async fn save_player_snapshot(&self, snapshot_json: &str) -> Result<(), String> {
         let client = self
             .inner

--- a/packages/data/sql/dbmate/migrations/20260518142326_wallet_service_user_balance.sql
+++ b/packages/data/sql/dbmate/migrations/20260518142326_wallet_service_user_balance.sql
@@ -1,0 +1,31 @@
+-- migrate:up
+
+CREATE OR REPLACE FUNCTION wallet.service_user_balance(p_user_id uuid)
+RETURNS TABLE(
+    account_id uuid,
+    credits bigint,
+    khash bigint,
+    updated_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT b.account_id, b.credits, b.khash, b.updated_at
+    FROM wallet.account a
+    JOIN wallet.balance b ON b.account_id = a.id
+    WHERE a.kind = 'user'
+      AND a.user_id = p_user_id;
+$$;
+
+REVOKE ALL ON FUNCTION wallet.service_user_balance(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_user_balance(uuid) TO service_role;
+ALTER FUNCTION wallet.service_user_balance(uuid) OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.service_user_balance(uuid) IS
+'Service-role read of the current wallet balance for a Supabase user. Returns the row from wallet.balance for the user-kind account, or no rows if the user has no wallet yet OR (corruption case) the account row exists with no matching balance row. The partial unique index wallet_account_user_uq guarantees at most one user-kind account per user_id, so LIMIT 1 is intentionally omitted — duplicate rows surface as multiple results rather than silently selecting one. STABLE because the function only reads tables and never writes. Used by backend bridges (mc_auth) that hold service-role JWTs and cannot authenticate against /auth/v1/user.';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS wallet.service_user_balance(uuid);

--- a/packages/data/sql/schema/wallet/wallet_rpcs.sql
+++ b/packages/data/sql/schema/wallet/wallet_rpcs.sql
@@ -925,5 +925,45 @@ ALTER FUNCTION public.proxy_wallet_list_coupons_readonly(INTEGER, TIMESTAMPTZ, B
 COMMENT ON FUNCTION public.proxy_wallet_list_coupons_readonly(INTEGER, TIMESTAMPTZ, BIGINT) IS
     'Read-only paged coupon list. Keyset pagination on (granted_at DESC, id DESC). Limit clamped to [1, 100], default 50. Raises SQLSTATE WLT01 (wallet_account_missing) when the caller has no wallet account; the client falls back to the rw pool.';
 
+-- ============================================================================
+-- wallet.service_user_balance — read a user's balance via service-role JWT
+--
+-- Used by backend bridges (mc_auth) that hold a Supabase service-role key
+-- and cannot authenticate against /auth/v1/user. PostgREST trusts the
+-- service-role role unconditionally, so this RPC is the read-side bypass
+-- for axum-kbve's per-user wallet endpoints.
+--
+-- The partial unique index wallet_account_user_uq guarantees at most one
+-- user-kind account per user_id, so LIMIT 1 is intentionally omitted —
+-- duplicate rows surface as multiple results rather than silently
+-- selecting one. Rust callers should warn loudly when rows > 1.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.service_user_balance(p_user_id uuid)
+RETURNS TABLE(
+    account_id uuid,
+    credits bigint,
+    khash bigint,
+    updated_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT b.account_id, b.credits, b.khash, b.updated_at
+    FROM wallet.account a
+    JOIN wallet.balance b ON b.account_id = a.id
+    WHERE a.kind = 'user'
+      AND a.user_id = p_user_id;
+$$;
+
+REVOKE ALL ON FUNCTION wallet.service_user_balance(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.service_user_balance(uuid) TO service_role;
+ALTER FUNCTION wallet.service_user_balance(uuid) OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.service_user_balance(uuid) IS
+'Service-role read of the current wallet balance for a Supabase user. Returns the row from wallet.balance for the user-kind account, or no rows if the user has no wallet yet or (corruption case) the account row exists without a matching balance row. STABLE because the function only reads tables. The wallet_account_user_uq partial unique index makes LIMIT 1 unnecessary — duplicates surface as multiple rows so corruption is visible.';
+
 -- PostgREST schema cache refresh after the public.* surface lands.
 NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
Screenshot showed `Credits: 0  KHash: 0` for a player with 1,000 KHash on the web wallet. Root cause confirmed via `kubectl exec` + direct `curl`:

```
GET /api/v1/wallet/service/balance/{user_id}
Authorization: Bearer <service-role JWT>
→ HTTP 401 {"error":"Invalid or expired token"}
```

`require_service_role` in [`apps/kbve/axum-kbve/src/transport/wallet.rs`](apps/kbve/axum-kbve/src/transport/wallet.rs) calls `verify_with_supabase` which hits `GET /auth/v1/user` on Supabase. **Service-role JWTs have no user binding**, so `/auth/v1/user` rejects them. Architectural, not env. No amount of `WALLET_SERVICE_JWT` plumbing from the mc fleet fixes it — every balance fetch path was hitting the same broken endpoint and falling into the `Err → emit (0, 0)` branch, which is why the UI rendered zeros.

The other half — the spawn-cube claim — **already worked**. Pod log:
```
[spawn-autoclaim] dimension=minecraft:overworld chunks=(-13,-13)..(12,12) claimed=650 skipped=26 failed=0
```
Full 676-chunk cube is admin-claimed server-side. The "strip" in the screenshot is Xaero's stale tile cache; flying around the perimeter once forces a redraw.

## Fix
Bypass axum-kbve for reads. Add a Supabase RPC that the service-role JWT can call directly via PostgREST (PostgREST trusts service-role unconditionally), and route every `WalletBalance` event through it.

- [`packages/data/sql/dbmate/migrations/20260518142326_wallet_service_user_balance.sql`](packages/data/sql/dbmate/migrations/20260518142326_wallet_service_user_balance.sql) — creates `wallet.service_user_balance(p_user_id uuid)`. `SECURITY DEFINER`, empty `search_path`, `service_role` only. Returns the row from `wallet.balance` joined to `wallet.account` where `kind = 'user'`.
- [`apps/mc/mc_auth/src/supabase.rs`](apps/mc/mc_auth/src/supabase.rs) — new `SupabaseClient::user_balance` that posts to the RPC and returns `Option<(credits, khash)>`.
- [`apps/mc/mc_auth/src/runtime.rs`](apps/mc/mc_auth/src/runtime.rs):
  - `AuthJob::FetchBalance` arm now calls `supabase.user_balance` instead of `wallet.balance_for_user`.
  - Post-`AlreadyLinked` / `LinkVerified` block does the balance fetch inline against `supabase.user_balance`, no extra `tokio::spawn`. `daily_credit_khash` stays on the wallet client because the write path needs axum-kbve's idempotency — that's its own follow-up once axum-kbve learns to verify service-role JWTs locally.

`wallet.balance_for_user` + `BalanceSnapshot` are intentionally left in place so the axum-kbve path is easy to flip back to once that auth path is fixed.

## Test plan
- [ ] `cargo check -p mc_auth` clean (verified locally).
- [ ] Migration applies via `ci-dbmate-deploy.yml` against `kilobase-prod` with manual approval.
- [ ] After mc image rebuild + rollout: `/wallet` for a linked player with non-zero balance shows the real credits + KHash.
- [ ] Player with no wallet account yet sees `0 / 0` (Supabase returns no rows → `Ok(None)` → zeros, same shape).
- [ ] `kubectl logs … | grep mc_auth` shows no more `lazy balance fetch failed` warnings.