### PR TITLE
feat(astro-irc): inline username setup + auto-refresh JWT so no logout needed

### DIFF
--- a/apps/irc/astro-irc/src/components/chat/auth.ts
+++ b/apps/irc/astro-irc/src/components/chat/auth.ts
@@ -29,6 +29,8 @@ export const PROVIDERS: { id: OAuthProvider; label: string }[] = [
 
 export const USERNAME_SETUP_URL = 'https://kbve.com/askama/profile';
 
+export const KBVE_API_BASE = 'https://kbve.com';
+
 export function decodeJwtUsername(token: string): string | null {
 	const parts = token.split('.');
 	if (parts.length < 2) return null;
@@ -111,4 +113,68 @@ export async function bootAuth(): Promise<void> {
 	})();
 
 	return booting;
+}
+
+export async function refreshAuth(): Promise<AuthState> {
+	try {
+		const { authBridge } = await import('../../lib/supa');
+		const session = await authBridge.refreshSession();
+		if (!session?.access_token) {
+			const { getSharedToken } = await import('@kbve/astro');
+			const sharedToken = getSharedToken();
+			if (sharedToken) {
+				$authToken.set(sharedToken);
+				const state = decodeJwtUsername(sharedToken)
+					? 'auth'
+					: 'no-username';
+				$authState.set(state);
+				return state;
+			}
+			$authState.set('anon');
+			return 'anon';
+		}
+		const meta = session.user?.user_metadata ?? {};
+		const avatar =
+			meta.avatar_url || meta.picture || meta.profile_image_url || '';
+		if (avatar) $avatarUrl.set(avatar);
+		$authToken.set(session.access_token);
+		const state = decodeJwtUsername(session.access_token)
+			? 'auth'
+			: 'no-username';
+		$authState.set(state);
+		return state;
+	} catch (err: any) {
+		console.error('[chat] refreshAuth failed:', err);
+		return $authState.get();
+	}
+}
+
+export async function setUsername(
+	username: string,
+	token: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+	const trimmed = username.trim().toLowerCase();
+	try {
+		const res = await fetch(`${KBVE_API_BASE}/api/v1/profile/username`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify({ username: trimmed }),
+		});
+		if (!res.ok) {
+			const body = await res.json().catch(() => ({}));
+			return {
+				ok: false,
+				error: body?.message || body?.error || `HTTP ${res.status}`,
+			};
+		}
+		return { ok: true };
+	} catch (err: any) {
+		return {
+			ok: false,
+			error: err?.message ?? 'Network error',
+		};
+	}
 }

--- a/apps/irc/astro-irc/src/components/chat/islands/AuthOverlay.tsx
+++ b/apps/irc/astro-irc/src/components/chat/islands/AuthOverlay.tsx
@@ -3,12 +3,25 @@ import { useCallback, useState } from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	$authState,
+	$authToken,
 	$idbReady,
 	$bootError,
 	PROVIDERS,
-	USERNAME_SETUP_URL,
+	refreshAuth,
+	setUsername,
 	type OAuthProvider,
 } from '../auth';
+
+const USERNAME_REGEX = /^[a-z][a-z0-9_]*$/;
+
+function validateUsername(raw: string): string | null {
+	const v = raw.trim().toLowerCase();
+	if (v.length < 3) return 'Must be at least 3 characters';
+	if (v.length > 24) return 'Must be 24 characters or fewer';
+	if (!USERNAME_REGEX.test(v))
+		return 'Letters, numbers, underscores; must start with a letter';
+	return null;
+}
 
 const LoginCard: React.FC = () => {
 	const [loading, setLoading] = useState<OAuthProvider | null>(null);
@@ -61,24 +74,114 @@ const LoginCard: React.FC = () => {
 	);
 };
 
-const UsernameCard: React.FC = () => (
-	<div className="kbve-chat__overlay-card">
-		<h2 className="kbve-chat__overlay-title">Pick a username first</h2>
-		<p className="kbve-chat__overlay-text">
-			IRC needs a canonical username before you can join. Set one once on
-			your KBVE profile and it will follow you everywhere.
-		</p>
-		<div className="kbve-chat__overlay-actions">
-			<a
-				href={USERNAME_SETUP_URL}
-				target="_blank"
-				rel="noopener noreferrer"
-				className="kbve-chat__overlay-btn kbve-chat__overlay-btn--primary">
-				Set a username on kbve.com
-			</a>
+const UsernameCard: React.FC = () => {
+	const token = useStore($authToken);
+	const [value, setValue] = useState('');
+	const [submitting, setSubmitting] = useState(false);
+	const [serverError, setServerError] = useState<string | null>(null);
+
+	const normalized = value.trim().toLowerCase();
+	const clientError = value.length > 0 ? validateUsername(value) : null;
+	const canSubmit =
+		!submitting && normalized.length >= 3 && clientError === null;
+
+	const handleSubmit = useCallback(
+		async (e: React.FormEvent) => {
+			e.preventDefault();
+			if (!canSubmit || !token) return;
+			setServerError(null);
+			setSubmitting(true);
+			const result = await setUsername(normalized, token);
+			if (!result.ok) {
+				setServerError(result.error);
+				setSubmitting(false);
+				return;
+			}
+			const next = await refreshAuth();
+			if (next !== 'auth') {
+				setServerError(
+					'Username saved but session did not refresh. Try reloading.',
+				);
+				setSubmitting(false);
+			}
+		},
+		[canSubmit, token, normalized],
+	);
+
+	return (
+		<div className="kbve-chat__overlay-card">
+			<h2 className="kbve-chat__overlay-title">Pick a username</h2>
+			<p className="kbve-chat__overlay-text">
+				One canonical username for every KBVE service. Letters, numbers,
+				underscores. 3–24 characters.
+			</p>
+			<form
+				onSubmit={handleSubmit}
+				className="kbve-chat__overlay-actions">
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 6,
+						padding: '10px 12px',
+						background: 'var(--chat-elev-2)',
+						border: '1px solid var(--sl-color-border)',
+						borderRadius: 10,
+					}}>
+					<span style={{ color: 'var(--sl-color-gray-3)' }}>@</span>
+					<input
+						type="text"
+						value={value}
+						onChange={(e) => setValue(e.target.value)}
+						placeholder="your_handle"
+						maxLength={24}
+						autoFocus
+						autoComplete="off"
+						spellCheck={false}
+						disabled={submitting || !token}
+						style={{
+							flex: 1,
+							background: 'transparent',
+							border: 'none',
+							outline: 'none',
+							color: 'var(--sl-color-text)',
+							fontFamily: 'ui-monospace, monospace',
+							fontSize: 14,
+						}}
+					/>
+				</div>
+				<div
+					style={{
+						fontSize: 12,
+						color: clientError
+							? '#ef4444'
+							: 'var(--sl-color-gray-4)',
+						textAlign: 'left',
+						minHeight: 16,
+					}}>
+					{clientError ??
+						'3–24 chars · letters, numbers, underscores'}
+				</div>
+				{serverError && (
+					<div
+						style={{
+							fontSize: 12,
+							color: '#ef4444',
+							textAlign: 'left',
+						}}>
+						{serverError}
+					</div>
+				)}
+				<button
+					type="submit"
+					disabled={!canSubmit || !token}
+					className="kbve-chat__overlay-btn kbve-chat__overlay-btn--primary">
+					{submitting ? 'Claiming…' : 'Claim username'}
+				</button>
+			</form>
 		</div>
-	</div>
-);
+	);
+};
 
 const LoadingCard: React.FC = () => (
 	<div className="kbve-chat__overlay-card">

--- a/apps/irc/astro-irc/src/components/chat/islands/ChatBootController.tsx
+++ b/apps/irc/astro-irc/src/components/chat/islands/ChatBootController.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	bootAuth,
+	refreshAuth,
 	$authState,
 	$authToken,
 	$bootReady,
@@ -53,6 +54,32 @@ export const ChatBootController: React.FC<ChatBootControllerProps> = ({
 			connect(wsUrl, token);
 		}
 	}, [authState, ready, token, wsUrl]);
+
+	useEffect(() => {
+		if (authState !== 'no-username') return;
+		let cancelled = false;
+		const tick = async () => {
+			if (cancelled) return;
+			const next = await refreshAuth();
+			if (cancelled) return;
+			if (next === 'no-username') {
+				timer = window.setTimeout(tick, 15_000);
+			}
+		};
+		let timer = window.setTimeout(tick, 15_000);
+		const onVisibility = () => {
+			if (document.visibilityState === 'visible') {
+				window.clearTimeout(timer);
+				void tick();
+			}
+		};
+		document.addEventListener('visibilitychange', onVisibility);
+		return () => {
+			cancelled = true;
+			window.clearTimeout(timer);
+			document.removeEventListener('visibilitychange', onVisibility);
+		};
+	}, [authState]);
 
 	useEffect(() => {
 		const handleUnload = () => {

--- a/packages/npm/astro/src/auth/AuthBridge.ts
+++ b/packages/npm/astro/src/auth/AuthBridge.ts
@@ -81,6 +81,14 @@ export class AuthBridge {
 		this.client = null;
 	}
 
+	async refreshSession() {
+		const client = this.ensureClient();
+		const { data, error } = await client.auth.refreshSession();
+		if (error || !data.session) return null;
+		setSharedToken(data.session.access_token);
+		return data.session;
+	}
+
 	async getSession(refreshBufferSec = 30) {
 		const client = this.ensureClient();
 		const { data, error } = await client.auth.getSession();


### PR DESCRIPTION
## Summary

Two onboarding issues that came up during test casing:

1. After OAuth, users had to leave chat.kbve.com and visit kbve.com/askama/profile to claim a username.
2. After claiming, the UI still showed \"Set a username\" until the user logged out and back in — the in-flight JWT lacked the new \`kbve_username\` claim until a refresh.

Both fixed without logout/login.

## What changed

### 1. Inline username form

\`AuthOverlay\`'s \"no-username\" card now renders an inline form (same validation shape as astro-kbve's \`UsernameSetup\`: 3–24 chars, leading letter, alphanumeric + underscore). On submit it POSTs the user's Supabase JWT to:

\`\`\`
POST https://kbve.com/api/v1/profile/username
Authorization: Bearer <jwt>
{ \"username\": \"...\" }
\`\`\`

axum-kbve already runs \`CorsLayer::permissive()\` so chat.kbve.com → kbve.com cross-origin works out of the box.

### 2. Force JWT refresh after server-side claim change

Added \`AuthBridge.refreshSession()\` to \`@kbve/astro\` — \`getSession()\` only refreshes on stale tokens, but we need an unconditional refresh after \`/api/v1/profile/username\` succeeds so GoTrue's Custom Access Token hook re-runs and injects the new \`kbve_username\` claim into the next JWT.

Chat side gets a new \`refreshAuth()\` that calls \`refreshSession()\`, updates \`\$authToken\` / \`\$avatarUrl\` / \`\$authState\` from the new claims. AuthOverlay calls it right after the POST resolves — UI flips to authenticated immediately.

### 3. Polling fallback for external sets

If the user claims their username elsewhere (kbve.com tab, another device), \`ChatBootController\` polls \`refreshAuth\` every 15s while \`authState === 'no-username'\`. A \`visibilitychange\` listener triggers an immediate retry when the chat tab regains focus — switching back from kbve.com after a username set updates in <1s instead of waiting for the timer.

## Test plan

- [ ] Sign in fresh, see new inline username card (no \"Set a username on kbve.com\" link)
- [ ] Submit invalid username → inline error, no POST
- [ ] Submit valid username → \"Claiming…\" → card disappears, chat connects, composer enabled
- [ ] Reject duplicate username server-side → error surfaces below input
- [ ] Reproduce original bug: set username via \`/api/v1/profile/username\` directly in another tab → chat tab updates within 15s automatically; refocus updates faster
- [ ] Reload page after setup → still authed, JWT carries \`kbve_username\`