### PR TITLE
fix(kbve): gate character re-export to fix axum-rareicon clippy

### DIFF
--- a/packages/rust/kbve/src/entity/model/mod.rs
+++ b/packages/rust/kbve/src/entity/model/mod.rs
@@ -1,2 +1,3 @@
 pub mod character;
+#[cfg(feature = "legacy-sync-db")]
 pub use character::*;


### PR DESCRIPTION
## Summary
- `packages/rust/kbve/src/entity/model/mod.rs` had unconditional `pub use character::*;` while the `character` module itself is gated behind `legacy-sync-db`. When a downstream crate (axum-rareicon) builds `kbve` without that feature, the re-export resolves to nothing → clippy `unused_imports` → `-D warnings` fail.
- Added `#[cfg(feature = "legacy-sync-db")]` to the `pub use` so the re-export only fires when the gated module has contents.

## Test plan
- [x] `cargo clippy -p axum-rareicon --all-targets -- -D warnings` clean locally
- [ ] CI `Validate Dev→Main PR / Lint and Test` green

Closes #11201