### PR TITLE
fix(referral): skip record_click for crawler / preview UAs

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/referral.rs
+++ b/apps/kbve/axum-kbve/src/transport/referral.rs
@@ -95,6 +95,54 @@ fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
     headers.get(name).and_then(|h| h.to_str().ok())
 }
 
+const BOT_UA_TOKENS: &[&str] = &[
+    "bot",
+    "crawl",
+    "spider",
+    "scrape",
+    "preview",
+    "fetch",
+    "facebookexternalhit",
+    "meta-externalagent",
+    "discordbot",
+    "slackbot",
+    "slack-imgproxy",
+    "telegrambot",
+    "whatsapp",
+    "skypeuripreview",
+    "vkshare",
+    "pinterest",
+    "linkedinbot",
+    "twitterbot",
+    "x-clientuseragent",
+    "redditbot",
+    "googlebot",
+    "applebot",
+    "bingbot",
+    "duckduckbot",
+    "baiduspider",
+    "yandexbot",
+    "embedly",
+    "iframely",
+    "go-http-client",
+    "python-requests",
+    "curl/",
+    "wget/",
+    "httpx",
+    "node-fetch",
+    "okhttp",
+];
+
+fn is_likely_bot(user_agent: Option<&str>) -> bool {
+    match user_agent {
+        None => true,
+        Some(ua) => {
+            let lower = ua.to_ascii_lowercase();
+            BOT_UA_TOKENS.iter().any(|token| lower.contains(token))
+        }
+    }
+}
+
 /// `GET /api/v1/referral/{handle}` — resolves the user's default target.
 #[utoipa::path(
     get,
@@ -193,12 +241,21 @@ async fn handle_referral(headers: HeaderMap, handle: String, slug: Option<String
         }
     };
 
+    let user_agent = header_str(&headers, header::USER_AGENT.as_str());
+    if is_likely_bot(user_agent) {
+        tracing::info!(
+            handle = %normalized_handle,
+            target = %resolved.slug,
+            ua = %user_agent.unwrap_or("<none>"),
+            "bot UA detected — redirecting without recording click"
+        );
+        return redirect_to(&resolved.url);
+    }
+
     let client_ip = extract_client_ip(&headers);
     let ip_string = match client_ip {
         Some(ip) => ip.to_string(),
         None => {
-            // No upstream IP header → we cannot dedup or credit safely.
-            // Still redirect (don't lock out the visitor), but log the gap.
             tracing::warn!(
                 handle = %normalized_handle,
                 target = %resolved.slug,


### PR DESCRIPTION
## Summary
- Phase 3a verification caught a Meta link-preview crawler (\`meta-externalagent/1.1\`) crediting a real ledger entry against fudster — different IP hash → dedup didn't suppress it. Same risk for Discord / Slack / Twitter / Telegram / WhatsApp / etc. that hit \`/referral/@<handle>/\` whenever someone shares the URL.
- Add \`is_likely_bot(user_agent)\` substring filter against the lowercased UA. On match, **skip \`record_click\`** but still 302 to the resolved target so preview cards keep working.
- Tokens cover social-share crawlers, search-engine bots, generic crawl/spider/preview/scrape strings, and naked HTTP clients (curl / wget / python-requests / go-http-client / okhttp / httpx / node-fetch / embedly / iframely).
- Missing User-Agent header is treated as bot (no real browser omits it).

## Test plan
- [ ] Real browser visit → click row + ledger credit as before
- [ ] \`curl -A "meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)" https://kbve.com/referral/@fudster/\` → 302 to Steam page, **no new** \`referral.click\` row, **no new** \`wallet.ledger\` entry
- [ ] \`curl -A "Mozilla/5.0 ... Discordbot ..." ...\` → 302, no credit
- [ ] No-UA request → 302, no credit