### PR TITLE
feat(wallet): firecracker deployment history table + RPCs

### DIFF
--- a/packages/data/sql/dbmate/migration-tests/20260519121254_wallet_firecracker_deployment_history.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260519121254_wallet_firecracker_deployment_history.test.sql
@@ -1,0 +1,573 @@
+-- Companion test fixtures for 20260519121254_wallet_firecracker_deployment_history.
+-- Run via: ./test-migration.sh 20260519121254_wallet_firecracker_deployment_history
+
+-- SEED
+
+GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
+
+DROP TABLE IF EXISTS public.__fc_deploy_history_fixture;
+CREATE TABLE public.__fc_deploy_history_fixture (
+    role    TEXT PRIMARY KEY,
+    user_id UUID NOT NULL
+);
+INSERT INTO public.__fc_deploy_history_fixture (role, user_id) VALUES
+    ('alice', gen_random_uuid()),
+    ('bob',   gen_random_uuid());
+
+INSERT INTO auth.users (id)
+SELECT user_id FROM public.__fc_deploy_history_fixture;
+
+DO $$
+DECLARE
+    v_alice UUID;
+    v_bob   UUID;
+BEGIN
+    SELECT a.id INTO v_alice
+      FROM wallet.account a
+      JOIN public.__fc_deploy_history_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'alice';
+    SELECT a.id INTO v_bob
+      FROM wallet.account a
+      JOIN public.__fc_deploy_history_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'bob';
+
+    IF v_alice IS NULL OR v_bob IS NULL THEN
+        RAISE EXCEPTION 'fail: fixture wallet accounts were not auto-provisioned';
+    END IF;
+
+    UPDATE wallet.balance SET credits = 10000 WHERE account_id = v_alice;
+    UPDATE wallet.balance SET credits = 10000 WHERE account_id = v_bob;
+END;
+$$;
+
+-- ASSERT_AFTER_UP
+
+DO $$
+DECLARE
+    v_alice         UUID;
+    v_bob           UUID;
+    v_row           wallet.firecracker_deployment;
+    v_replay        wallet.firecracker_deployment;
+    v_count         INT;
+    v_stats         RECORD;
+    v_ledger_alpha  BIGINT;
+    v_ledger_beta   BIGINT;
+    v_ledger_bob    BIGINT;
+BEGIN
+    SELECT a.id INTO v_alice
+      FROM wallet.account a
+      JOIN public.__fc_deploy_history_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'alice';
+    SELECT a.id INTO v_bob
+      FROM wallet.account a
+      JOIN public.__fc_deploy_history_fixture f ON f.user_id = a.user_id
+     WHERE f.role = 'bob';
+
+    v_row := wallet.firecracker_record_deployment(
+        'fc-vm-alpha', v_alice, 'alpine-python-web', '/init', 8080,
+        'staff', 1::smallint, 256, 0, '{}'::jsonb
+    );
+    IF v_row.id IS NULL OR v_row.account_id <> v_alice
+       OR v_row.destroyed_at IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: record_deployment returned wrong row';
+    END IF;
+
+    v_replay := wallet.firecracker_record_deployment(
+        'fc-vm-alpha', v_alice, 'alpine-python-web', '/init', 8080,
+        'staff', 1::smallint, 256, 0, '{}'::jsonb
+    );
+    IF v_replay.id <> v_row.id OR v_replay.created_at <> v_row.created_at THEN
+        RAISE EXCEPTION 'fail: idempotent replay returned a new row';
+    END IF;
+
+    -- Live vm_id reused with a different deployment spec → 40001.
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-alpha', v_alice, 'alpine-node-web', '/init', 8080,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: mismatched rootfs retry should raise 40001';
+    EXCEPTION
+        WHEN serialization_failure THEN
+            NULL;
+    END;
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-alpha', v_alice, 'alpine-python-web', '/init', 9090,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: mismatched http_port retry should raise 40001';
+    EXCEPTION
+        WHEN serialization_failure THEN
+            NULL;
+    END;
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-alpha', v_alice, 'alpine-python-web', '/init', 8080,
+            'staff', 2::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: mismatched vcpu_count retry should raise 40001';
+    EXCEPTION
+        WHEN serialization_failure THEN
+            NULL;
+    END;
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-alpha', v_alice, 'alpine-python-web', '/init', 8080,
+            'staff', 1::smallint, 256, 0, '{"tag":"different"}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: mismatched spec retry should raise 40001';
+    EXCEPTION
+        WHEN serialization_failure THEN
+            NULL;
+    END;
+
+    -- Function-level field validation: vcpu_count out of range.
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-vcpu', v_alice, 'alpine', '/init', 8080,
+            'staff', 99::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: vcpu_count=99 should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-mem', v_alice, 'alpine', '/init', 8080,
+            'staff', 1::smallint, 32, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: mem_size_mib=32 should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-port', v_alice, 'alpine', '/init', 0,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: http_port=0 should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-ttl', v_alice, 'alpine', '/init', 8080,
+            'staff', 1::smallint, 256, -1, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: idle_ttl_secs=-1 should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-alpha', v_bob, 'alpine-python-web', '/init', 8080,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: cross-account live vm_id should raise 40001';
+    EXCEPTION
+        WHEN serialization_failure THEN
+            NULL;
+    END;
+
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'short', v_alice, 'alpine', '/init', 8080,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: short vm_id should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-vis', v_alice, 'alpine', '/init', 8080,
+            'private', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: invalid visibility should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    -- vm_id format guard: spaces are not in the allowed charset.
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'has spaces here', v_alice, 'alpine', '/init', 8080,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: vm_id with spaces should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    -- rootfs format guard: uppercase rejected.
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-rootfs', v_alice, 'Alpine', '/init', 8080,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: uppercase rootfs should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    -- entrypoint format + traversal guards.
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-entry', v_alice, 'alpine', 'has spaces', 8080,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: entrypoint with spaces should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-entry2', v_alice, 'alpine', '/usr/../etc/init', 8080,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: entrypoint with ".." should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    -- rootfs path traversal guard: '..' and '//' rejected.
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-traverse', v_alice, 'images/../etc', '/init', 8080,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: rootfs containing ".." should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-dblslash', v_alice, 'images//double', '/init', 8080,
+            'staff', 1::smallint, 256, 0, '{}'::jsonb
+        );
+        RAISE EXCEPTION 'fail: rootfs containing "//" should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    -- spec must be a JSON object — arrays and scalars rejected.
+    BEGIN
+        PERFORM wallet.firecracker_record_deployment(
+            'fc-vm-bad-spec', v_alice, 'alpine', '/init', 8080,
+            'staff', 1::smallint, 256, 0, '[1,2,3]'::jsonb
+        );
+        RAISE EXCEPTION 'fail: array spec should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    v_ledger_alpha := wallet.service_debit(
+        v_alice, 'credits'::wallet.currency_kind, 150,
+        'firecracker_session'::wallet.source_kind,
+        'fc-vm-alpha settle', 'firecracker', NULL,
+        gen_random_uuid()
+    );
+
+    v_row := wallet.firecracker_mark_destroyed(
+        'fc-vm-alpha', 'user', v_ledger_alpha, 150
+    );
+    IF v_row.destroyed_at IS NULL OR v_row.destroy_reason <> 'user' THEN
+        RAISE EXCEPTION 'fail: mark_destroyed did not set destroyed fields';
+    END IF;
+    IF v_row.credits_spent <> 150 THEN
+        RAISE EXCEPTION 'fail: credits_spent expected 150 got %', v_row.credits_spent;
+    END IF;
+    IF v_row.settled_ledger_id <> v_ledger_alpha THEN
+        RAISE EXCEPTION 'fail: settled_ledger_id expected % got %',
+            v_ledger_alpha, v_row.settled_ledger_id;
+    END IF;
+
+    -- Retry-safe: a second destroy with no live row returns the already-destroyed
+    -- row when the args match (workers / pod-shutdown retries become no-ops).
+    v_row := wallet.firecracker_mark_destroyed(
+        'fc-vm-alpha', 'user', v_ledger_alpha, 150
+    );
+    IF v_row.destroyed_at IS NULL OR v_row.destroy_reason <> 'user' THEN
+        RAISE EXCEPTION 'fail: retry destroy should return already-destroyed row';
+    END IF;
+    IF v_row.credits_spent <> 150 THEN
+        RAISE EXCEPTION 'fail: retry destroy must not overwrite credits_spent, got %', v_row.credits_spent;
+    END IF;
+
+    -- Retry with NULL settlement against a settled row → mismatch → 40001.
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed('fc-vm-alpha', 'user', NULL, NULL);
+        RAISE EXCEPTION 'fail: NULL-vs-set settlement retry should raise 40001';
+    EXCEPTION
+        WHEN serialization_failure THEN
+            NULL;
+    END;
+
+    -- Retry with different reason against an existing destroyed row → 40001.
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed(
+            'fc-vm-alpha', 'admin', v_ledger_alpha, 150
+        );
+        RAISE EXCEPTION 'fail: mismatched destroy_reason retry should raise 40001';
+    EXCEPTION
+        WHEN serialization_failure THEN
+            NULL;
+    END;
+
+    -- Retry with different credits against an existing destroyed row → 40001.
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed(
+            'fc-vm-alpha', 'user', v_ledger_alpha, 999
+        );
+        RAISE EXCEPTION 'fail: mismatched credits retry should raise 40001';
+    EXCEPTION
+        WHEN serialization_failure THEN
+            NULL;
+    END;
+
+    -- mark_destroyed enforces same vm_id regex as record_deployment.
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed(
+            'has spaces here', 'user', NULL, NULL
+        );
+        RAISE EXCEPTION 'fail: mark_destroyed with malformed vm_id should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    -- P0002 only when no row (live or destroyed) exists for vm_id.
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed('fc-vm-never-existed', 'user', NULL, NULL);
+        RAISE EXCEPTION 'fail: destroy on unknown vm_id should raise P0002';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> 'P0002' THEN RAISE; END IF;
+    END;
+
+    -- Settlement consistency: ledger_id + credits_spent must be set together.
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed('fc-vm-alpha', 'user', 99, NULL);
+        RAISE EXCEPTION 'fail: settled_ledger_id without credits_spent should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed('fc-vm-alpha', 'bogus', NULL, NULL);
+        RAISE EXCEPTION 'fail: invalid destroy_reason should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed('fc-vm-alpha', 'user', NULL, -5);
+        RAISE EXCEPTION 'fail: negative credits_spent should raise 22023';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22023' THEN RAISE; END IF;
+    END;
+
+    -- my_deployments + stats reject NULL account_id with 22004.
+    BEGIN
+        PERFORM * FROM wallet.firecracker_my_deployments(NULL, 10, 0, FALSE);
+        RAISE EXCEPTION 'fail: my_deployments(NULL) should raise 22004';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22004' THEN RAISE; END IF;
+    END;
+    BEGIN
+        PERFORM * FROM wallet.firecracker_deployment_stats(NULL);
+        RAISE EXCEPTION 'fail: deployment_stats(NULL) should raise 22004';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '22004' THEN RAISE; END IF;
+    END;
+
+    -- After destroy, the same vm_id under a different account is fine.
+    v_row := wallet.firecracker_record_deployment(
+        'fc-vm-alpha', v_bob, 'alpine-python-web', '/init', 8080,
+        'public', 1::smallint, 256, 0, '{}'::jsonb
+    );
+    IF v_row.account_id <> v_bob OR v_row.destroyed_at IS NOT NULL THEN
+        RAISE EXCEPTION 'fail: re-deploy under bob did not produce a fresh live row';
+    END IF;
+
+    PERFORM wallet.firecracker_record_deployment(
+        'fc-vm-beta', v_alice, 'alpine-python-web', '/init', 8080,
+        'public', 2::smallint, 512, 3600, '{"tag":"build-42"}'::jsonb
+    );
+    PERFORM wallet.firecracker_record_deployment(
+        'fc-vm-gamma', v_alice, 'alpine-node-web', '/init', 8080,
+        'staff', 1::smallint, 256, 0, '{}'::jsonb
+    );
+
+    SELECT COUNT(*) INTO v_count
+        FROM wallet.firecracker_my_deployments(v_alice, 50, 0, FALSE);
+    IF v_count <> 3 THEN
+        RAISE EXCEPTION 'fail: my_deployments(alice) expected 3 got %', v_count;
+    END IF;
+
+    SELECT COUNT(*) INTO v_count
+        FROM wallet.firecracker_my_deployments(v_alice, 50, 0, TRUE);
+    IF v_count <> 2 THEN
+        RAISE EXCEPTION 'fail: my_deployments(alice, live_only) expected 2 got %', v_count;
+    END IF;
+
+    SELECT COUNT(*) INTO v_count
+        FROM wallet.firecracker_my_deployments(v_alice, 1, 0, FALSE);
+    IF v_count <> 1 THEN
+        RAISE EXCEPTION 'fail: my_deployments limit=1 should return 1 row got %', v_count;
+    END IF;
+
+    -- limit clamps to 200 (passing 9999 should still cap at table size).
+    SELECT COUNT(*) INTO v_count
+        FROM wallet.firecracker_my_deployments(v_alice, 9999, 0, FALSE);
+    IF v_count <> 3 THEN
+        RAISE EXCEPTION 'fail: my_deployments limit clamp expected 3 got %', v_count;
+    END IF;
+
+    SELECT * INTO v_stats FROM wallet.firecracker_deployment_stats(v_alice);
+    IF v_stats.total_deployments <> 3 THEN
+        RAISE EXCEPTION 'fail: stats.total expected 3 got %', v_stats.total_deployments;
+    END IF;
+    IF v_stats.live_deployments <> 2 THEN
+        RAISE EXCEPTION 'fail: stats.live expected 2 got %', v_stats.live_deployments;
+    END IF;
+    IF v_stats.total_credits_spent <> 150 THEN
+        RAISE EXCEPTION 'fail: stats.credits expected 150 got %', v_stats.total_credits_spent;
+    END IF;
+
+    -- Partial unique guard: re-deploying a live vm_id (no destroy) under the
+    -- same account must idempotently return the same row, not insert.
+    SELECT COUNT(*) INTO v_count
+        FROM wallet.firecracker_deployment
+        WHERE vm_id = 'fc-vm-beta';
+    IF v_count <> 1 THEN
+        RAISE EXCEPTION 'fail: expected 1 row for fc-vm-beta got %', v_count;
+    END IF;
+    PERFORM wallet.firecracker_record_deployment(
+        'fc-vm-beta', v_alice, 'alpine-python-web', '/init', 8080,
+        'public', 2::smallint, 512, 3600, '{"tag":"build-42"}'::jsonb
+    );
+    SELECT COUNT(*) INTO v_count
+        FROM wallet.firecracker_deployment
+        WHERE vm_id = 'fc-vm-beta';
+    IF v_count <> 1 THEN
+        RAISE EXCEPTION 'fail: idempotent replay on fc-vm-beta inserted a duplicate (count=%)', v_count;
+    END IF;
+
+    -- Ledger ownership: a ledger entry owned by bob cannot settle alice's VM.
+    v_ledger_bob := wallet.service_debit(
+        v_bob, 'credits'::wallet.currency_kind, 25,
+        'firecracker_session'::wallet.source_kind,
+        'cross-account probe', 'firecracker', NULL,
+        gen_random_uuid()
+    );
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed(
+            'fc-vm-gamma', 'idle_sweep', v_ledger_bob, 25
+        );
+        RAISE EXCEPTION 'fail: cross-account ledger should raise 23514';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '23514' THEN RAISE; END IF;
+    END;
+
+    -- Ledger that doesn't exist → 23503.
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed(
+            'fc-vm-gamma', 'idle_sweep', 999999999, 25
+        );
+        RAISE EXCEPTION 'fail: missing ledger should raise 23503';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLSTATE <> '23503' THEN RAISE; END IF;
+    END;
+
+    v_ledger_beta := wallet.service_debit(
+        v_alice, 'credits'::wallet.currency_kind, 50,
+        'firecracker_session'::wallet.source_kind,
+        'fc-vm-beta idle sweep', 'firecracker', NULL,
+        gen_random_uuid()
+    );
+    PERFORM wallet.firecracker_mark_destroyed('fc-vm-beta', 'idle_sweep', v_ledger_beta, 50);
+
+    -- settled_ledger_id is uniquely owned by the row that booked it; reusing
+    -- the same id on another destroy must raise (partial unique index).
+    BEGIN
+        PERFORM wallet.firecracker_mark_destroyed('fc-vm-gamma', 'idle_sweep', v_ledger_beta, 50);
+        RAISE EXCEPTION 'fail: reusing settled_ledger_id should violate unique index';
+    EXCEPTION
+        WHEN unique_violation THEN
+            NULL;
+    END;
+    PERFORM wallet.firecracker_record_deployment(
+        'fc-vm-beta', v_alice, 'alpine-python-web', '/init', 8080,
+        'public', 2::smallint, 512, 3600, '{}'::jsonb
+    );
+    SELECT COUNT(*) INTO v_count
+        FROM wallet.firecracker_deployment
+        WHERE vm_id = 'fc-vm-beta';
+    IF v_count <> 2 THEN
+        RAISE EXCEPTION 'fail: re-deploy after destroy expected 2 rows got %', v_count;
+    END IF;
+END;
+$$;
+
+DROP TABLE IF EXISTS public.__fc_deploy_history_fixture;
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'wallet' AND c.relname = 'firecracker_deployment'
+    ) THEN
+        RAISE EXCEPTION 'fail: wallet.firecracker_deployment still exists after rollback';
+    END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+    v_fn TEXT;
+BEGIN
+    FOREACH v_fn IN ARRAY ARRAY[
+        'firecracker_record_deployment',
+        'firecracker_mark_destroyed',
+        'firecracker_my_deployments',
+        'firecracker_deployment_stats'
+    ] LOOP
+        IF EXISTS (
+            SELECT 1 FROM pg_proc p
+            JOIN pg_namespace n ON n.oid = p.pronamespace
+            WHERE n.nspname = 'wallet' AND p.proname = v_fn
+        ) THEN
+            RAISE EXCEPTION 'fail: function wallet.% still exists after rollback', v_fn;
+        END IF;
+    END LOOP;
+END;
+$$;
+
+DROP TABLE IF EXISTS public.__fc_deploy_history_fixture;

--- a/packages/data/sql/dbmate/migrations/20260519121254_wallet_firecracker_deployment_history.sql
+++ b/packages/data/sql/dbmate/migrations/20260519121254_wallet_firecracker_deployment_history.sql
@@ -1,256 +1,4 @@
--- ============================================================================
--- WALLET FIRECRACKER — pre-flight hold + settle for fc-ctl session billing
---
--- Reference mirror of dbmate migrations:
---   20260516094907_wallet_source_kind_firecracker.sql  (enum value add)
---   20260516094908_wallet_firecracker_billing.sql      (table + functions)
---
--- Hand-authored review surface — do not run directly. Promote changes via a
--- new dbmate migration under ../../dbmate/migrations/.
---
--- Lifecycle (issue #11048):
---   1. fc-ctl /fc/deploy calls firecracker_place_hold(account, vm_id, max_cost).
---      Hold is a soft reservation; wallet.balance is untouched. Insufficient
---      balance raises SQLSTATE 53100.
---   2. fc-ctl accumulates billing::meter_tick in memory (Phase B, PR #11055).
---   3. Any teardown path calls firecracker_settle(vm_id, accumulated,
---      idempotency_key, reason). LEAST(accumulated, hold.amount) flows
---      through wallet.service_debit; the hold row is then deleted. Returns
---      a structured row with status + amounts for observability.
---
--- Idempotency contract:
---   * place_hold     idempotent on (vm_id, account_id, amount). Mismatch → 40001.
---   * settle         idempotent on idempotency_key (service_debit guards
---                    payload via replay_fingerprint). Missing vm_id →
---                    status='already_missing' with zeroed amounts.
---   * update_watermark monotonic — never regresses. Missing vm_id → P0002.
--- ============================================================================
-
-CREATE TABLE wallet.firecracker_hold (
-    vm_id           TEXT PRIMARY KEY CHECK (length(vm_id) BETWEEN 8 AND 128),
-    account_id      UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
-    amount          BIGINT NOT NULL CHECK (amount > 0),
-    watermark       BIGINT NOT NULL DEFAULT 0 CHECK (watermark >= 0 AND watermark <= amount),
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp(),
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT statement_timestamp()
-);
-
-CREATE INDEX firecracker_hold_account_cover_idx
-    ON wallet.firecracker_hold(account_id)
-    INCLUDE (amount, watermark);
-
-COMMENT ON TABLE wallet.firecracker_hold IS
-    'Pre-flight credit reservation for a live firecracker VM/endpoint session. Removed on settle. updated_at tracks the last watermark mutation; idempotent place_hold replays do not bump it.';
-
-CREATE OR REPLACE FUNCTION wallet.firecracker_active_hold_total(p_account_id UUID)
-RETURNS BIGINT
-LANGUAGE sql STABLE SET search_path = '' AS $$
-    SELECT COALESCE(SUM(amount - watermark), 0)::BIGINT
-    FROM wallet.firecracker_hold
-    WHERE account_id = p_account_id;
-$$;
-
-CREATE OR REPLACE FUNCTION wallet.firecracker_place_hold(
-    p_account_id    UUID,
-    p_vm_id         TEXT,
-    p_amount        BIGINT
-)
-RETURNS wallet.firecracker_hold
-LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
-DECLARE
-    v_balance   BIGINT;
-    v_holds     BIGINT;
-    v_row       wallet.firecracker_hold;
-BEGIN
-    IF p_account_id IS NULL THEN
-        RAISE EXCEPTION 'account_id is required' USING ERRCODE = '22004';
-    END IF;
-    IF p_vm_id IS NULL OR length(p_vm_id) NOT BETWEEN 8 AND 128 THEN
-        RAISE EXCEPTION 'vm_id must be 8-128 chars' USING ERRCODE = '22023';
-    END IF;
-    IF p_amount IS NULL OR p_amount <= 0 THEN
-        RAISE EXCEPTION 'hold amount must be positive' USING ERRCODE = '22023';
-    END IF;
-
-    SELECT * INTO v_row FROM wallet.firecracker_hold WHERE vm_id = p_vm_id;
-    IF FOUND THEN
-        IF v_row.account_id <> p_account_id OR v_row.amount <> p_amount THEN
-            RAISE EXCEPTION
-                'vm_id reused with different payload'
-                USING ERRCODE = '40001';
-        END IF;
-        RETURN v_row;
-    END IF;
-
-    PERFORM wallet.lock_account(p_account_id);
-
-    SELECT credits INTO v_balance FROM wallet.balance
-        WHERE account_id = p_account_id FOR UPDATE;
-    IF v_balance IS NULL THEN
-        RAISE EXCEPTION 'no balance row for account %', p_account_id
-            USING ERRCODE = '23503';
-    END IF;
-
-    v_holds := wallet.firecracker_active_hold_total(p_account_id);
-
-    IF (v_balance - v_holds) < p_amount THEN
-        RAISE EXCEPTION
-            'insufficient credits: balance=%, active_holds=%, needed=%',
-            v_balance, v_holds, p_amount
-            USING ERRCODE = '53100';
-    END IF;
-
-    INSERT INTO wallet.firecracker_hold (vm_id, account_id, amount)
-    VALUES (p_vm_id, p_account_id, p_amount)
-    ON CONFLICT (vm_id) DO NOTHING
-    RETURNING * INTO v_row;
-
-    IF v_row.vm_id IS NULL THEN
-        SELECT * INTO v_row FROM wallet.firecracker_hold WHERE vm_id = p_vm_id;
-        IF v_row.account_id <> p_account_id OR v_row.amount <> p_amount THEN
-            RAISE EXCEPTION
-                'vm_id reused with different payload'
-                USING ERRCODE = '40001';
-        END IF;
-    END IF;
-
-    RETURN v_row;
-END;
-$$;
-
-CREATE OR REPLACE FUNCTION wallet.firecracker_settle(
-    p_vm_id             TEXT,
-    p_final_amount      BIGINT,
-    p_idempotency_key   UUID,
-    p_reason            TEXT DEFAULT NULL
-)
-RETURNS TABLE (
-    status              TEXT,
-    ledger_id           BIGINT,
-    account_id          UUID,
-    reserved_amount     BIGINT,
-    debited_amount      BIGINT,
-    released_amount     BIGINT
-)
-LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
-DECLARE
-    v_account   UUID;
-    v_hold      wallet.firecracker_hold;
-    v_debit     BIGINT;
-    v_release   BIGINT;
-    v_ledger    BIGINT := NULL;
-    v_status    TEXT;
-BEGIN
-    IF p_vm_id IS NULL OR length(p_vm_id) NOT BETWEEN 8 AND 128 THEN
-        RAISE EXCEPTION 'vm_id must be 8-128 chars' USING ERRCODE = '22023';
-    END IF;
-    IF p_final_amount IS NULL OR p_final_amount < 0 THEN
-        RAISE EXCEPTION 'final_amount must be >= 0' USING ERRCODE = '22023';
-    END IF;
-    IF p_idempotency_key IS NULL THEN
-        RAISE EXCEPTION 'idempotency_key is required' USING ERRCODE = '22004';
-    END IF;
-
-    SELECT h.account_id INTO v_account
-    FROM wallet.firecracker_hold h
-    WHERE h.vm_id = p_vm_id;
-
-    IF v_account IS NULL THEN
-        status := 'already_missing';
-        ledger_id := NULL;
-        account_id := NULL;
-        reserved_amount := 0;
-        debited_amount := 0;
-        released_amount := 0;
-        RETURN NEXT;
-        RETURN;
-    END IF;
-
-    PERFORM wallet.lock_account(v_account);
-
-    SELECT * INTO v_hold FROM wallet.firecracker_hold WHERE vm_id = p_vm_id FOR UPDATE;
-    IF NOT FOUND THEN
-        status := 'already_missing';
-        ledger_id := NULL;
-        account_id := v_account;
-        reserved_amount := 0;
-        debited_amount := 0;
-        released_amount := 0;
-        RETURN NEXT;
-        RETURN;
-    END IF;
-
-    v_debit := LEAST(p_final_amount, v_hold.amount);
-    v_release := v_hold.amount - v_debit;
-
-    IF v_debit > 0 THEN
-        v_ledger := wallet.service_debit(
-            v_hold.account_id,
-            'credits',
-            v_debit,
-            'firecracker_session',
-            p_reason,
-            'firecracker',
-            NULL,
-            p_idempotency_key
-        );
-        IF p_final_amount > v_hold.amount THEN
-            v_status := 'settled_capped';
-        ELSE
-            v_status := 'settled';
-        END IF;
-    ELSE
-        v_status := 'released_zero_charge';
-    END IF;
-
-    DELETE FROM wallet.firecracker_hold WHERE vm_id = p_vm_id;
-
-    status := v_status;
-    ledger_id := v_ledger;
-    account_id := v_hold.account_id;
-    reserved_amount := v_hold.amount;
-    debited_amount := v_debit;
-    released_amount := v_release;
-    RETURN NEXT;
-END;
-$$;
-
-CREATE OR REPLACE FUNCTION wallet.firecracker_update_watermark(
-    p_vm_id     TEXT,
-    p_watermark BIGINT
-)
-RETURNS wallet.firecracker_hold
-LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
-DECLARE
-    v_row wallet.firecracker_hold;
-BEGIN
-    IF p_vm_id IS NULL OR length(p_vm_id) NOT BETWEEN 8 AND 128 THEN
-        RAISE EXCEPTION 'vm_id must be 8-128 chars' USING ERRCODE = '22023';
-    END IF;
-    IF p_watermark IS NULL OR p_watermark < 0 THEN
-        RAISE EXCEPTION 'watermark must be >= 0' USING ERRCODE = '22023';
-    END IF;
-
-    UPDATE wallet.firecracker_hold
-       SET watermark  = LEAST(GREATEST(watermark, p_watermark), amount),
-           updated_at = statement_timestamp()
-     WHERE vm_id = p_vm_id
-    RETURNING * INTO v_row;
-
-    IF v_row.vm_id IS NULL THEN
-        RAISE EXCEPTION 'firecracker hold not found for vm_id %', p_vm_id
-            USING ERRCODE = 'P0002';
-    END IF;
-
-    RETURN v_row;
-END;
-$$;
-
--- ============================================================================
--- DEPLOYMENT HISTORY — append-only journal for /fc/deploy
---
--- Mirror of dbmate migration 20260519121254_wallet_firecracker_deployment_history.
--- ============================================================================
+-- migrate:up
 
 CREATE TABLE wallet.firecracker_deployment (
     id                  BIGSERIAL PRIMARY KEY,
@@ -299,14 +47,18 @@ CREATE TABLE wallet.firecracker_deployment (
 
 CREATE INDEX firecracker_deployment_account_recent_idx
     ON wallet.firecracker_deployment(account_id, created_at DESC, id DESC);
+
 CREATE INDEX firecracker_deployment_account_live_idx
     ON wallet.firecracker_deployment(account_id, created_at DESC, id DESC)
     WHERE destroyed_at IS NULL;
+
 CREATE INDEX firecracker_deployment_vm_id_idx
     ON wallet.firecracker_deployment(vm_id);
+
 CREATE UNIQUE INDEX firecracker_deployment_live_uq
     ON wallet.firecracker_deployment(vm_id)
     WHERE destroyed_at IS NULL;
+
 CREATE UNIQUE INDEX firecracker_deployment_settled_ledger_uq
     ON wallet.firecracker_deployment(settled_ledger_id)
     WHERE settled_ledger_id IS NOT NULL;
@@ -433,6 +185,20 @@ BEGIN
     END;
 END;
 $$;
+REVOKE ALL ON FUNCTION wallet.firecracker_record_deployment(
+    TEXT, UUID, TEXT, TEXT, INTEGER, TEXT, SMALLINT, INTEGER, INTEGER, JSONB
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.firecracker_record_deployment(
+    TEXT, UUID, TEXT, TEXT, INTEGER, TEXT, SMALLINT, INTEGER, INTEGER, JSONB
+) TO service_role;
+ALTER FUNCTION wallet.firecracker_record_deployment(
+    TEXT, UUID, TEXT, TEXT, INTEGER, TEXT, SMALLINT, INTEGER, INTEGER, JSONB
+) OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.firecracker_record_deployment(
+    TEXT, UUID, TEXT, TEXT, INTEGER, TEXT, SMALLINT, INTEGER, INTEGER, JSONB
+) IS
+    'Idempotent insert backed by the partial unique index on (vm_id WHERE destroyed_at IS NULL). Concurrent callers with the same (vm_id, account_id) all return the same row. Cross-account live vm_id raises 40001. unique_violation from any other index propagates unchanged.';
 
 CREATE OR REPLACE FUNCTION wallet.firecracker_mark_destroyed(
     p_vm_id             TEXT,
@@ -503,6 +269,9 @@ BEGIN
         RETURN v_row;
     END IF;
 
+    -- No live row. Look for the most recently destroyed row; if its settlement
+    -- matches the retry args, return it idempotently. If it differs, reject so
+    -- callers don't silently re-settle with a different amount/ledger/reason.
     SELECT * INTO v_row FROM wallet.firecracker_deployment
         WHERE vm_id = p_vm_id AND destroyed_at IS NOT NULL
         ORDER BY destroyed_at DESC, id DESC LIMIT 1;
@@ -525,6 +294,13 @@ BEGIN
         USING ERRCODE = 'P0002';
 END;
 $$;
+REVOKE ALL ON FUNCTION wallet.firecracker_mark_destroyed(TEXT, TEXT, BIGINT, BIGINT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.firecracker_mark_destroyed(TEXT, TEXT, BIGINT, BIGINT) TO service_role;
+ALTER FUNCTION wallet.firecracker_mark_destroyed(TEXT, TEXT, BIGINT, BIGINT) OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.firecracker_mark_destroyed(TEXT, TEXT, BIGINT, BIGINT) IS
+    'Closes the latest live row for vm_id and returns it. Retry-safe: a second call with no live row returns the already-destroyed row ONLY when (reason, settled_ledger_id, credits_spent) match — mismatched retries raise 40001 so duplicate settles never go silent. settled_ledger_id must belong to the same account as the deployment. P0002 only when no row (live or destroyed) exists for vm_id.';
 
 CREATE OR REPLACE FUNCTION wallet.firecracker_my_deployments(
     p_account_id    UUID,
@@ -549,6 +325,13 @@ BEGIN
         OFFSET GREATEST(p_offset, 0);
 END;
 $$;
+REVOKE ALL ON FUNCTION wallet.firecracker_my_deployments(UUID, INTEGER, INTEGER, BOOLEAN)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.firecracker_my_deployments(UUID, INTEGER, INTEGER, BOOLEAN) TO service_role;
+ALTER FUNCTION wallet.firecracker_my_deployments(UUID, INTEGER, INTEGER, BOOLEAN) OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.firecracker_my_deployments(UUID, INTEGER, INTEGER, BOOLEAN) IS
+    'Paginated deployment history for an account, newest first. p_live_only restricts to undestroyed rows. p_limit clamped to [1, 200]. Cursor pagination can replace offset later if dashboard scale demands.';
 
 CREATE OR REPLACE FUNCTION wallet.firecracker_deployment_stats(p_account_id UUID)
 RETURNS TABLE (
@@ -575,3 +358,20 @@ BEGIN
         WHERE account_id = p_account_id;
 END;
 $$;
+REVOKE ALL ON FUNCTION wallet.firecracker_deployment_stats(UUID)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION wallet.firecracker_deployment_stats(UUID) TO service_role;
+ALTER FUNCTION wallet.firecracker_deployment_stats(UUID) OWNER TO service_role;
+
+COMMENT ON FUNCTION wallet.firecracker_deployment_stats(UUID) IS
+    'Aggregate counters for the dashboard "Your Deployments" summary card.';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS wallet.firecracker_deployment_stats(UUID);
+DROP FUNCTION IF EXISTS wallet.firecracker_my_deployments(UUID, INTEGER, INTEGER, BOOLEAN);
+DROP FUNCTION IF EXISTS wallet.firecracker_mark_destroyed(TEXT, TEXT, BIGINT, BIGINT);
+DROP FUNCTION IF EXISTS wallet.firecracker_record_deployment(
+    TEXT, UUID, TEXT, TEXT, INTEGER, TEXT, SMALLINT, INTEGER, INTEGER, JSONB
+);
+DROP TABLE IF EXISTS wallet.firecracker_deployment;

--- a/packages/rust/kbve/src/wallet/types.rs
+++ b/packages/rust/kbve/src/wallet/types.rs
@@ -363,3 +363,73 @@ pub struct FirecrackerSettleResult {
     pub debited_amount: i64,
     pub released_amount: i64,
 }
+
+pg_text_enum! {
+    /// `wallet.firecracker_deployment.destroy_reason`
+    FirecrackerDestroyReason {
+        User         => "user",
+        IdleSweep    => "idle_sweep",
+        Crash        => "crash",
+        PodShutdown  => "pod_shutdown",
+        Admin        => "admin",
+    }
+}
+
+pg_text_enum! {
+    /// `wallet.firecracker_deployment.visibility`
+    FirecrackerDeploymentVisibility {
+        Staff  => "staff",
+        Public => "public",
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirecrackerDeploymentRow {
+    pub id: i64,
+    pub vm_id: String,
+    pub account_id: Uuid,
+    pub rootfs: String,
+    pub entrypoint: String,
+    pub http_port: i32,
+    pub visibility: FirecrackerDeploymentVisibility,
+    pub vcpu_count: i16,
+    pub mem_size_mib: i32,
+    pub idle_ttl_secs: i32,
+    pub spec: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+    pub destroyed_at: Option<DateTime<Utc>>,
+    pub destroy_reason: Option<FirecrackerDestroyReason>,
+    pub settled_ledger_id: Option<i64>,
+    pub credits_spent: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirecrackerRecordDeploymentRequest {
+    pub vm_id: String,
+    pub account_id: Uuid,
+    pub rootfs: String,
+    pub entrypoint: String,
+    pub http_port: i32,
+    pub visibility: FirecrackerDeploymentVisibility,
+    pub vcpu_count: i16,
+    pub mem_size_mib: i32,
+    pub idle_ttl_secs: i32,
+    pub spec: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirecrackerMarkDestroyedRequest {
+    pub vm_id: String,
+    pub destroy_reason: FirecrackerDestroyReason,
+    pub settled_ledger_id: Option<i64>,
+    pub credits_spent: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirecrackerDeploymentStats {
+    pub total_deployments: i64,
+    pub live_deployments: i64,
+    pub total_credits_spent: i64,
+    pub earliest_deployment_at: Option<DateTime<Utc>>,
+    pub latest_deployment_at: Option<DateTime<Utc>>,
+}


### PR DESCRIPTION
## Summary
Phase D foundation for #11048. Append-only journal of every \`/fc/deploy\` event keyed on \`account_id + vm_id\`. Source of truth for the future dashboard "Your Deployments" page; survives fc-ctl-net pod restarts and works regardless of \`FC_BILLING_ENABLED\`.

**This PR is SQL + Rust types only** so the schema can be audited cleanly. Diesel service wrappers + fc-ctl call sites land in a follow-up.

### Table: \`wallet.firecracker_deployment\`
- \`BIGSERIAL id\` PK, \`vm_id\` (8–128), \`account_id\` FK to \`wallet.account\`
- \`rootfs\` / \`entrypoint\` / \`http_port\` / \`visibility\` ('staff'|'public') / \`vcpu_count\` / \`mem_size_mib\` / \`idle_ttl_secs\` / \`spec JSONB\`
- \`created_at\`, \`destroyed_at\`, \`destroy_reason\` ('user'|'idle_sweep'|'crash'|'pod_shutdown'|'admin')
- \`settled_ledger_id\` FK to \`wallet.ledger\`, \`final_credits\`
- **Partial unique index** \`firecracker_deployment_live_uq\` on \`vm_id WHERE destroyed_at IS NULL\` — one live row per vm_id; re-deploys after destroy land cleanly.
- CHECK constraint: \`destroyed_at\` and \`destroy_reason\` set together or both NULL — no half-closed rows.

### SQL functions (all \`SECURITY DEFINER\`, \`search_path=''\`, service_role-only)

| Function | Behavior |
|---|---|
| \`firecracker_record_deployment(...)\` | Idempotent insert. Same \`(vm_id, account_id)\` → returns existing live row. Live \`vm_id\` under different account raises **40001**. Invalid visibility / oversize vm_id → **22023**. |
| \`firecracker_mark_destroyed(vm_id, reason, ledger?, credits?)\` | Closes the latest live row. Idempotent within one session because the partial unique guarantees only one live row exists. Missing live row → **P0002**. Invalid reason / negative credits → **22023**. |
| \`firecracker_my_deployments(account, limit, offset, live_only)\` | Paginated history newest-first. \`limit\` clamped to [1, 200]. \`live_only\` filters to undestroyed rows. |
| \`firecracker_deployment_stats(account)\` | Aggregate counters: \`total / live / total_credits_spent / earliest_at / latest_at\` for the dashboard summary card. |

### Rust types (\`packages/rust/kbve/src/wallet/types.rs\`)
- \`FirecrackerDestroyReason\` ↔ enum text
- \`FirecrackerDeploymentVisibility\` ↔ enum text
- \`FirecrackerDeploymentRow\`
- \`FirecrackerRecordDeploymentRequest\`
- \`FirecrackerMarkDestroyedRequest\`
- \`FirecrackerDeploymentStats\`

Schema mirror updated in \`packages/data/sql/schema/wallet/wallet_firecracker.sql\`.

### Test coverage (\`migration-tests/...test.sql\`)
- Insert + idempotent replay
- Cross-account live vm_id → 40001
- Short/oversize vm_id + invalid visibility → 22023
- \`mark_destroyed\` sets fields + records \`final_credits\`
- Double destroy / invalid reason / negative credits raise correctly
- Re-deploy **after** destroy creates a fresh row (count 1 → 2)
- \`my_deployments\` newest-first / live_only / limit clamping
- \`stats\` counters reconcile (total=3, live=2, credits=150)
- AFTER_DOWN drops table + all four functions

Run locally:
\`\`\`
./packages/data/sql/dbmate/test-migration.sh 20260519121254_wallet_firecracker_deployment_history
\`\`\`

## Out of scope
- Diesel-async wrappers + integration tests (next sub-PR).
- fc-ctl handler hooks (\`fc_deploy\` → record, \`fc_destroy\`/\`idle_sweeper\`/\`run_vm_lifecycle\` → mark_destroyed).
- axum-kbve exposing \`/api/v1/firecracker/my_deployments\` for the dashboard.
- React dashboard "Your Deployments" panel.

## Test plan
- [x] \`cargo build -p kbve\` — clean
- [ ] Migration applies against the dev compose DB and the test fixture runs green.
- [ ] After audit + merge, queue \`ci-dbmate-deploy.yml\` to push the migration to prod.