### PR TITLE
fix(vector): inline alertmanager_explode Lua hook for v0.54 schema

### DIFF
--- a/apps/kube/vector/manifests/vector-config.yaml
+++ b/apps/kube/vector/manifests/vector-config.yaml
@@ -5,8 +5,8 @@ metadata:
     name: vector-config
     namespace: vector
     annotations:
-        kbve.sh/last-updated: '2026-05-15T00:00:00Z'
-        kbve.sh/config-version: 'v6-mc-multiline'
+        kbve.sh/last-updated: '2026-05-19T00:00:00Z'
+        kbve.sh/config-version: 'v7-lua-inline-hooks'
 data:
     vector.yml: |
         api:
@@ -366,15 +366,14 @@ data:
             inputs:
               - alertmanager_webhook
             hooks:
-              process: process_alert_batch
-            source: |-
-              function process_alert_batch(event, emit)
-                local alerts = event.log.alerts
-                if type(alerts) ~= "table" then return end
-                for _, a in ipairs(alerts) do
-                  emit({ log = { alert = a } })
+              process: |
+                function(event, emit)
+                  local alerts = event.log.alerts
+                  if type(alerts) ~= "table" then return end
+                  for _, a in ipairs(alerts) do
+                    emit({ log = { alert = a } })
+                  end
                 end
-              end
 
           alertmanager_flatten:
             type: remap


### PR DESCRIPTION
## Summary
- \`supabase-vector\` DaemonSet has been in CrashLoopBackOff for ~3 days (865 restarts, age 3d1h) with \`Configuration error. error=data did not match any variant of untagged enum LuaConfig in transforms.alertmanager_explode\` on Vector 0.54.0-alpine. No logs have hit \`observability.logs_distributed\` since 2026-05-16 12:14 UTC, which is why every <7d window on \`/dashboard/clickhouse/\` shows 0 rows.
- PR #11116 split the alertmanager fanout into a named function in \`source:\` referenced by \`hooks.process: process_alert_batch\` — that combo is rejected by the v0.54 Lua v2 schema.
- Inlined the function literal directly into \`hooks.process\` (the form the schema accepts) and dropped the separate \`source:\` block; bumped the configmap version annotation to \`v7-lua-inline-hooks\`.

## Verification
- CH probe (run from cluster) confirms the data side, not the query:
  \`\`\`
  max_ts:       2026-05-16 12:14:21.438
  max_ingested: 2026-05-16 12:14:21.503
  lag_event_s:  264398  (~73h)
  lag_ingest_s: 264398
  \`\`\`
- Validated the patched config against the same image:
  \`\`\`
  docker run --rm -v /tmp/vector-rendered.yml:/etc/vector/vector.yml \\
    -e VECTOR_SELF_NODE_NAME=stub \\
    -e CLICKHOUSE_ENDPOINT=http://stub:8123 \\
    -e CLICKHOUSE_USER=stub -e CLICKHOUSE_PASSWORD=stub \\
    timberio/vector:0.54.0-alpine validate --no-environment \\
    /etc/vector/vector.yml
  Loaded ["/etc/vector/vector.yml"]
  Validated
  \`\`\`

## Test plan
- [ ] Merge + wait for ArgoCD to sync the configmap and roll the daemonset.
- [ ] \`kubectl -n vector get pods\` shows the pod Ready, no CrashLoopBackOff.
- [ ] CH freshness probe (\`SELECT max(timestamp), max(ingested_at), now()\`) shows lag back under a minute.
- [ ] \`/dashboard/clickhouse/\` 15m/1h/6h/24h windows populate again.
- [ ] After PR #11181 lands, a future Vector outage surfaces as a banner on the dashboard instead of silent 0s.