### PR TITLE
fix(ci): unbreak rows + firecracker-ctl-e2e docker builds

### DIFF
--- a/apps/rows/Dockerfile
+++ b/apps/rows/Dockerfile
@@ -44,7 +44,7 @@ COPY packages/data/proto/ packages/data/proto/
 COPY apps/rows/build.rs apps/rows/build.rs
 
 # Cook deps from recipe — this layer is cached until Cargo.toml/Cargo.lock change
-COPY --from=planner /src/recipe.json recipe.json
+COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/sccache,id=sccache \
     cargo chef cook --release --recipe-path recipe.json -p rows

--- a/apps/vm/firecracker-ctl-e2e/mock/Dockerfile.mock
+++ b/apps/vm/firecracker-ctl-e2e/mock/Dockerfile.mock
@@ -15,6 +15,10 @@ ENV CARGO_INCREMENTAL=0
 COPY apps/vm/firecracker-ctl/Cargo.workspace.toml Cargo.toml
 COPY apps/vm/firecracker-ctl/Cargo.toml apps/vm/firecracker-ctl/Cargo.toml
 
+COPY packages/rust/kbve packages/rust/kbve
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/holy packages/rust/holy
+
 RUN mkdir -p apps/vm/firecracker-ctl/src && \
     echo "fn main() {}" > apps/vm/firecracker-ctl/src/main.rs
 
@@ -29,6 +33,7 @@ ENV CARGO_INCREMENTAL=0
 COPY --from=planner /app/recipe.json recipe.json
 COPY --from=planner /app/Cargo.toml ./
 COPY --from=planner /app/apps apps
+COPY --from=planner /app/packages packages
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -47,6 +52,9 @@ COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
 COPY --from=planner /app/Cargo.toml ./
 
 COPY apps/vm/firecracker-ctl apps/vm/firecracker-ctl
+COPY packages/rust/kbve packages/rust/kbve
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/holy packages/rust/holy
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \


### PR DESCRIPTION
## Summary

Follow-up to #11209 / #11212. Two more of the 7 failing E2E suites from the daily \`CI - E2E / main\` run have actual code-level fixes; this PR lands them. The other five are accounted for below.

### \`rows-e2e\` — stale recipe path

\`apps/rows/Dockerfile\` cooked from \`/src/recipe.json\`, but cargo-chef writes \`recipe.json\` into the planner's WORKDIR, which is \`/app\` on \`ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder\`. BuildKit failed during cache-key computation before any compile ran:

\`\`\`
ERROR: failed to compute cache key: \"/src/recipe.json\": not found
\`\`\`

Every other axum-* Dockerfile reads \`/app/recipe.json\`. Aligned this one.

### \`firecracker-ctl-e2e\` — mock Dockerfile missing workspace members

\`Cargo.workspace.toml\` lists \`packages/rust/{kbve,jedi,holy}\` as workspace members. The mock Dockerfile copied only the firecracker-ctl crate, so \`cargo chef prepare\` resolved the workspace, reached for those members, and bailed:

\`\`\`
ERROR: failed to build: resolve : lstat apps: no such file or directory
\`\`\`

Mirrored what the production \`firecracker-ctl/Dockerfile\` already does: \`COPY packages/rust/{kbve,jedi,holy}\` in both planner and builder stages, and forward \`packages\` from planner → builder-deps. Verified local: \`docker buildx build -f apps/vm/firecracker-ctl-e2e/mock/Dockerfile.mock\` now produces \`kbve/firecracker-ctl:mock\`.

### Already-resolved-on-dev

- **\`discordsh-bot-e2e\`** (61 × E0432 \`unresolved imports kbve::MemberStatus / FontDb / render_svg_to_png / entity\`). Fixed by c2ffdd93a — \`pub mod entity\` was clobbered by the \`legacy-sync-db\` gate during the wallet/diesel-async refactor; that commit ungates it and moves the gate to the individually-legacy submodules. \`cargo check -p discordsh-bot --release\` runs clean on dev.
- **\`astro-kbve-e2e\`** (favicon 404 + \`/account\` redirect drift). Fixed by #11209.

### Still unresolved (left for separate work)

- **\`astro-e2e\`** — \`astro build\` hits \`ERR_UNSUPPORTED_ESM_URL_SCHEME\` on \`astro:react:opts\`. The renderer entry is externalized by Astro 6's prerender environment regardless of \`vite.ssr.noExternal\` / \`vite.environments.prerender.resolve.noExternal\`, so Node 24's loader sees the bare \`astro:\` scheme on the live import inside \`@astrojs/react/dist/server.js\`. Needs an upstream patch on \`@astrojs/react\` (we don't open issues against outside repos for security reasons — handled internally via local patch when scope allows).
- **\`edge-e2e firecracker.spec.ts\`** — 3 × timeouts via OWS to a MicroVM that isn't reachable from CI. Infra, not code.
- **\`arc-runner-e2e runner pod has no docker CLI bound directly\`** — image now ships \`/usr/bin/docker\` against the test's architectural intent. Left failing intentionally so we decide whether the docker-CLI install was deliberate before relaxing the guard.

## Test plan
- [x] Local \`docker buildx build -f apps/vm/firecracker-ctl-e2e/mock/Dockerfile.mock\` succeeds
- [ ] Next \`CI - E2E / main\` run: \`rows-e2e\` + \`firecracker-ctl-e2e\` green
- [ ] Same run: \`discordsh-bot-e2e\` no longer fails on \`kbve::entity\` imports