### PR TITLE
fix(rows): only report players currently on a map as active

### DIFF
--- a/apps/rows/src/rest/system.rs
+++ b/apps/rows/src/rest/system.rs
@@ -146,15 +146,14 @@ async fn active_players(
 ) -> Json<serde_json::Value> {
     let customer_guid = crate::middleware::extract_customer_guid(&headers);
 
-    // Query: sessions joined with characters and map instances
-    let rows: Vec<(String, String, Option<String>, Option<i32>)> = sqlx::query_as(
+    let rows: Vec<(String, String, Option<String>, i32)> = sqlx::query_as(
         "SELECT c.charname, us.usersessionguid::text,
                 m.zonename, cmi.mapinstanceid
          FROM usersessions us
          JOIN characters c ON c.userguid = us.userguid
             AND c.customerguid = us.customerguid
             AND c.charname = us.selectedcharactername
-         LEFT JOIN charonmapinstance cmi ON cmi.characterid = c.characterid
+         JOIN charonmapinstance cmi ON cmi.characterid = c.characterid
             AND cmi.customerguid = c.customerguid
          LEFT JOIN mapinstances mi ON mi.mapinstanceid = cmi.mapinstanceid
             AND mi.customerguid = cmi.customerguid


### PR DESCRIPTION
## Summary
The Rows dashboard "Active Players" card showed h0ly even though h0ly wasn't actually connected to a game — only a stale \`usersessions\` row remained from an earlier login.

## Cause
\`/api/System/ActivePlayers\` LEFT JOINed \`charonmapinstance\` and accepted every \`usersessions\` row whose character matched \`selectedcharactername\`. Auth/REST login inserts the session row but it is deleted only on explicit logout, so any abandoned session looked identical to a live in-world player.

## Fix
Switch the \`charonmapinstance\` join from \`LEFT\` to \`INNER\` in \`active_players\`. The row is inserted when the game server allocates the character onto a map and deleted on leave/disconnect, so it tracks the real "in-world" set rather than "has an open auth session" set. \`zone_instance_id\` column type tightens from \`Option<i32>\` to \`i32\` accordingly.

\`active_sessions\` in \`/api/System/Health\` still reports the cache size — that's intentionally a different signal (REST/auth-session count, not in-world presence).

## Test plan
- [ ] Login via auth without connecting a game client → "Active Players" stays 0
- [ ] Allocate a character onto an Agones GameServer → player shows up
- [ ] Disconnect → player drops within the existing cleanup interval