### PR TITLE
docs(rows): expose /api/System/* in OpenAPI + correct server URL

### DIFF
--- a/apps/rows/src/openapi.rs
+++ b/apps/rows/src/openapi.rs
@@ -7,12 +7,30 @@ use crate::models::*;
 #[openapi(
     info(
         title = "ROWS — Rust Open World Server",
-        description = "Single-binary game backend (REST + gRPC) replacing the OWS .NET microservices.",
+        description = "Single-binary game backend (REST + gRPC + WS) replacing the OWS .NET microservices for ChuckRPG. Surfaced through the kbve.com dashboard via a same-origin proxy that injects the tenant X-CustomerGUID header.",
+        contact(
+            name = "KBVE",
+            url = "https://kbve.com",
+            email = "support@kbve.com"
+        ),
+        license(name = "MIT"),
         version = env!("CARGO_PKG_VERSION"),
+    ),
+    servers(
+        (url = "/dashboard/chuckrpg/proxy", description = "Same-origin staff proxy (DASHBOARD_VIEW, X-CustomerGUID injected by axum-kbve)"),
+        (url = "http://localhost:4322", description = "Local ROWS (set X-CustomerGUID manually)"),
     ),
     paths(
         crate::rest::root,
         crate::rest::health,
+        crate::rest::system::fleet_status,
+        crate::rest::system::aggregated_health,
+        crate::rest::system::active_players,
+        crate::rest::system::instance_log,
+        crate::rest::system::deployment_info,
+        crate::rest::system::restart_game_server,
+        crate::rest::system::restart_fleet,
+        crate::rest::system::verify_deployment,
     ),
     components(schemas(
         HealthResponse,
@@ -33,9 +51,11 @@ use crate::models::*;
         CharacterStatus,
         PlayerGroupMembership,
         UserInfo,
+        crate::rest::system::InstanceEvent,
     )),
     tags(
         (name = "health", description = "Health and readiness probes"),
+        (name = "system", description = "Dashboard endpoints — fleet, health, active players, instance log, deployment metadata, restart + verification ops."),
         (name = "auth", description = "Login, registration, session management"),
         (name = "characters", description = "Character CRUD, stats, custom data"),
         (name = "instances", description = "Server instance lifecycle"),

--- a/apps/rows/src/rest/system.rs
+++ b/apps/rows/src/rest/system.rs
@@ -36,7 +36,17 @@ pub fn system_routes(hs: HandlerState) -> Router {
 
 // ─── Fleet Status ────────────────────────────────────────────
 
-async fn fleet_status(State(hs): State<HandlerState>) -> Json<serde_json::Value> {
+#[utoipa::path(
+    get,
+    path = "/api/System/FleetStatus",
+    tag = "system",
+    summary = "Agones fleet status",
+    description = "Returns the current Agones GameServer fleet state — ready, allocated, shutdown counts plus per-server detail (name, address, port, age).",
+    responses(
+        (status = 200, description = "Fleet status (or { error } if Agones is not configured)"),
+    )
+)]
+pub async fn fleet_status(State(hs): State<HandlerState>) -> Json<serde_json::Value> {
     match &hs.app.agones {
         Some(agones) => match agones.fleet_status().await {
             Ok(status) => Json(serde_json::json!(status)),
@@ -61,7 +71,17 @@ struct HealthCheck {
     error: Option<String>,
 }
 
-async fn aggregated_health(State(hs): State<HandlerState>) -> Json<serde_json::Value> {
+#[utoipa::path(
+    get,
+    path = "/api/System/Health",
+    tag = "system",
+    summary = "Aggregated health",
+    description = "Per-dependency health (postgres, rabbitmq, agones) plus overall status, uptime, in-memory session/instance/spinup-lock counts.",
+    responses(
+        (status = 200, description = "Aggregated health document"),
+    )
+)]
+pub async fn aggregated_health(State(hs): State<HandlerState>) -> Json<serde_json::Value> {
     // Postgres
     let pg_start = Instant::now();
     let pg_ok = sqlx::query("SELECT 1").execute(&hs.app.db).await.is_ok();
@@ -140,7 +160,17 @@ async fn aggregated_health(State(hs): State<HandlerState>) -> Json<serde_json::V
 
 // ─── Active Players ──────────────────────────────────────────
 
-async fn active_players(
+#[utoipa::path(
+    get,
+    path = "/api/System/ActivePlayers",
+    tag = "system",
+    summary = "Active players",
+    description = "Characters currently bound to a live MapInstance (INNER JOIN charonmapinstance) — represents in-world presence, not the count of open auth sessions.",
+    responses(
+        (status = 200, description = "List of in-world players { total, players[{ character_name, user_session_guid, zone_name, zone_instance_id }] }"),
+    )
+)]
+pub async fn active_players(
     State(hs): State<HandlerState>,
     headers: HeaderMap,
 ) -> Json<serde_json::Value> {
@@ -228,7 +258,20 @@ impl InstanceEventLog {
     }
 }
 
-async fn instance_log(
+#[utoipa::path(
+    get,
+    path = "/api/System/InstanceLog",
+    tag = "system",
+    summary = "Instance lifecycle events",
+    description = "Recent zone-instance events from the in-memory ring buffer (allocate, deallocate, restart, verify_*). Max 200 entries retained; default page size 50, capped at 200 via `limit`.",
+    params(
+        ("limit" = Option<usize>, Query, description = "Max entries to return (default 50, max 200)")
+    ),
+    responses(
+        (status = 200, description = "{ events: InstanceEvent[] }"),
+    )
+)]
+pub async fn instance_log(
     State(hs): State<HandlerState>,
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
 ) -> Json<serde_json::Value> {
@@ -247,7 +290,17 @@ async fn instance_log(
 
 // ─── Deployment Info ─────────────────────────────────────────
 
-async fn deployment_info(State(hs): State<HandlerState>) -> Json<serde_json::Value> {
+#[utoipa::path(
+    get,
+    path = "/api/System/DeploymentInfo",
+    tag = "system",
+    summary = "Deployment metadata",
+    description = "Build identity (version, rust_version), Agones binding (namespace, fleet), runtime ports, and Supabase configuration flags.",
+    responses(
+        (status = 200, description = "Static deployment metadata"),
+    )
+)]
+pub async fn deployment_info(State(hs): State<HandlerState>) -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         "rust_version": env!("CARGO_PKG_RUST_VERSION", "unknown"),
@@ -273,7 +326,21 @@ async fn deployment_info(State(hs): State<HandlerState>) -> Json<serde_json::Val
 /// Restart a specific GameServer by zone_instance_id.
 /// Flow: send MQ shutdown → delete Agones GameServer → watcher auto-cleans DB.
 /// Agones auto-replaces with a fresh pod from the fleet.
-async fn restart_game_server(
+#[utoipa::path(
+    post,
+    path = "/api/System/RestartGameServer",
+    tag = "system",
+    summary = "Restart a single GameServer",
+    description = "Sends MQ shutdown, deletes the Agones GameServer for the target zone_instance_id, and lets the fleet auto-replace. DB cleanup runs via the GameServer watcher.",
+    request_body(
+        description = "{ zone_instance_id: i32 } — accepts either snake or camelCase",
+        content_type = "application/json"
+    ),
+    responses(
+        (status = 200, description = "{ success: bool, message?: string, error?: string }"),
+    )
+)]
+pub async fn restart_game_server(
     State(hs): State<HandlerState>,
     Json(body): Json<serde_json::Value>,
 ) -> Json<serde_json::Value> {
@@ -354,7 +421,21 @@ async fn restart_game_server(
 
 /// Restart the entire fleet — scale to 0, clean all DB entries, scale back up.
 /// Use with caution — disconnects all players.
-async fn restart_fleet(
+#[utoipa::path(
+    post,
+    path = "/api/System/RestartFleet",
+    tag = "system",
+    summary = "Restart the full fleet",
+    description = "Scales the Agones fleet to 0, deletes all map instances + deactivates world servers, clears in-memory tracking, then scales back up to `replicas` (default 2). Disconnects every player — use with caution.",
+    request_body(
+        description = "{ replicas?: i32 } (default 2)",
+        content_type = "application/json"
+    ),
+    responses(
+        (status = 200, description = "{ success: bool, message?: string, error?: string }"),
+    )
+)]
+pub async fn restart_fleet(
     State(hs): State<HandlerState>,
     Json(body): Json<serde_json::Value>,
 ) -> Json<serde_json::Value> {
@@ -423,7 +504,21 @@ async fn restart_fleet(
 /// Post-deployment verification — checks that the fleet is healthy after restart.
 /// Polls Agones for Ready servers, verifies count matches desired, checks DB is clean.
 /// Returns a detailed report with per-check pass/fail status.
-async fn verify_deployment(
+#[utoipa::path(
+    post,
+    path = "/api/System/VerifyDeployment",
+    tag = "system",
+    summary = "Verify deployment health",
+    description = "Polls Agones until `expected_ready` servers report Ready (up to `max_wait_secs`), confirms DB has no stale map instances, runs an allocate/deallocate smoke test, and reports per-check pass/fail.",
+    request_body(
+        description = "{ expected_ready?: i32 (default 2), max_wait_secs?: i64 (default 90) }",
+        content_type = "application/json"
+    ),
+    responses(
+        (status = 200, description = "{ success, elapsed_secs, checks[], summary }"),
+    )
+)]
+pub async fn verify_deployment(
     State(hs): State<HandlerState>,
     Json(body): Json<serde_json::Value>,
 ) -> Json<serde_json::Value> {


### PR DESCRIPTION
## Summary
Scalar at \`/dashboard/api/#rows\` only listed \`/\` and \`/health\` and defaulted "Test Request" to \`https://kbve.com\` (no chuckrpg proxy prefix), so live calls 404'd. Two-part fix: add a \`servers\` block + annotate every \`/api/System/*\` handler with \`#[utoipa::path]\`.

## Changes
- **servers**: \`/dashboard/chuckrpg/proxy\` (same-origin staff proxy — axum-kbve injects X-CustomerGUID) and \`http://localhost:4322\` (raw ROWS). Scalar now routes test calls through axum-kbve, so the customer-guid header lands automatically.
- **paths**: all eight \`/api/System/*\` operations registered:
  \`FleetStatus\`, \`Health\`, \`ActivePlayers\`, \`InstanceLog\`, \`DeploymentInfo\`, \`RestartGameServer\`, \`RestartFleet\`, \`VerifyDeployment\`.
- Each handler picks up \`#[utoipa::path]\` with a real summary, description, request_body / params, and tagged \`system\` so Scalar groups them under a System section.
- Handlers promoted from \`async fn\` to \`pub async fn\` for macro visibility.
- \`InstanceEvent\` registered as a schema component.
- Tightened the top-level title/description (REST + gRPC + WS, ChuckRPG tenancy) and added contact/license metadata.

Follow-up tickets (deferred):
- Annotate \`/api/Users/*\`, \`/api/Characters/*\`, \`/api/Abilities/*\`, \`/api/Instance/*\` (~16 handlers).
- Replace \`Json<serde_json::Value>\` returns with typed response structs so Scalar can render real response schemas, not just descriptions.

## Test plan
- [ ] After rollout, https://kbve.com/dashboard/api/#rows lists all eight System operations under a "System" sidebar group
- [ ] "Test Request" on \`Health\` runs against \`/dashboard/chuckrpg/proxy/api/System/Health\` and returns 200 from the browser session
- [ ] \`https://kbve.com/api/rows/openapi.json\` carries the new \`servers\` block