### PR TITLE
feat(inventory,wallet): listing wire foundation (6.1a)

### DIFF
--- a/.github/workflows/ci-dbmate-validate.yml
+++ b/.github/workflows/ci-dbmate-validate.yml
@@ -49,6 +49,15 @@ jobs:
 
         env:
             DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable&search_path=dbmate,public
+            # Opt into destructive-rollback guards so the "Roll back the
+            # most recent migration" step can exercise migrate:down even
+            # when the head migration is one that refuses unguarded
+            # rollbacks (inventory schema, marketplace listing wire).
+            # Prod URLs never set these GUCs, so a stray rollback against
+            # prod still aborts before any drop.
+            PGOPTIONS: >-
+                -c app.allow_destructive_inventory_down=true
+                -c app.allow_marketplace_unsafe_down=on
 
         steps:
             - name: Checkout

--- a/.github/workflows/ci-dbmate-validate.yml
+++ b/.github/workflows/ci-dbmate-validate.yml
@@ -58,6 +58,7 @@ jobs:
             PGOPTIONS: >-
                 -c app.allow_destructive_inventory_down=true
                 -c app.allow_marketplace_unsafe_down=on
+                -c app.allow_legacy_marketplace_proxy_restore=on
 
         steps:
             - name: Checkout

--- a/packages/data/sql/dbmate/migration-tests/20260520114243_wallet_inventory_listing_wire.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260520114243_wallet_inventory_listing_wire.test.sql
@@ -1,0 +1,361 @@
+-- Tests for wallet ↔ inventory listing wire foundation.
+
+-- SEED
+INSERT INTO auth.users (id) VALUES
+    ('33333333-3333-3333-3333-333333333333'),
+    ('44444444-4444-4444-4444-444444444444')
+ON CONFLICT DO NOTHING;
+
+-- ASSERT_AFTER_UP
+
+DO $$
+DECLARE
+    v_alice UUID;
+    v_bob   UUID;
+BEGIN
+    SELECT id INTO v_alice FROM wallet.account
+     WHERE kind = 'user' AND user_id = '33333333-3333-3333-3333-333333333333';
+    SELECT id INTO v_bob   FROM wallet.account
+     WHERE kind = 'user' AND user_id = '44444444-4444-4444-4444-444444444444';
+    PERFORM set_config('test.alice', v_alice::text, false);
+    PERFORM set_config('test.bob',   v_bob::text,   false);
+END;
+$$;
+
+SELECT inventory.service_register_bridge_secret(
+    'mc_listing_test',
+    'this-is-a-test-secret-that-is-long-enough-32',
+    'listing test bridge'
+);
+
+-- Deposit a stackable 64-row for Alice. Use random ref per test run to
+-- avoid stackable-merge accumulation across re-runs (6.0 schema persists
+-- between dbmate test-migration invocations).
+DO $$
+DECLARE
+    v_alice UUID := current_setting('test.alice')::uuid;
+    v_secret TEXT := 'this-is-a-test-secret-that-is-long-enough-32';
+    v_req BIGINT;
+    v_payload TEXT; v_sig TEXT; v_payload_hash TEXT;
+    v_item UUID;
+    v_ref  TEXT := 'oak_planks_' || gen_random_uuid()::text;
+BEGIN
+    v_req := inventory.service_deposit_begin(
+        v_alice, 'mc_item', v_ref, 64, '{}'::jsonb,
+        'mc_listing_test', '{}'::jsonb, gen_random_uuid());
+    v_payload := 'deposit:' || v_req::text || ':listing_test_stack';
+    v_sig := encode(extensions.hmac(v_payload::bytea, v_secret::bytea, 'sha256'), 'hex');
+    v_payload_hash := encode(extensions.digest(v_payload, 'sha256'), 'hex');
+    v_item := inventory.service_deposit_settle(
+        v_req,
+        encode(extensions.digest('listing_test_stack_' || gen_random_uuid()::text, 'sha256'), 'hex'),
+        v_secret, v_sig, v_payload_hash, v_payload);
+    PERFORM set_config('test.alice_stack_item', v_item::text, false);
+END;
+$$;
+
+-- T1: service_split_for_listing happy path — 64 split into src=48 + escrow=16.
+DO $$
+DECLARE
+    v_alice    UUID := current_setting('test.alice')::uuid;
+    v_src      UUID := current_setting('test.alice_stack_item')::uuid;
+    v_new      UUID;
+    v_src_qty  BIGINT;
+    v_new_qty  BIGINT;
+    v_new_state inventory.item_state;
+BEGIN
+    v_new := inventory.service_split_for_listing(v_alice, v_src, 16);
+    SELECT qty INTO v_src_qty FROM inventory.item WHERE id = v_src;
+    SELECT qty, state INTO v_new_qty, v_new_state FROM inventory.item WHERE id = v_new;
+    IF v_src_qty <> 48 THEN
+        RAISE EXCEPTION 'T1 source qty=% expected 48', v_src_qty;
+    END IF;
+    IF v_new_qty <> 16 THEN
+        RAISE EXCEPTION 'T1 new qty=% expected 16', v_new_qty;
+    END IF;
+    IF v_new_state <> 'listing_escrow' THEN
+        RAISE EXCEPTION 'T1 new state=% expected listing_escrow', v_new_state;
+    END IF;
+END;
+$$;
+
+-- T2: split rejects whole-row.
+DO $$
+DECLARE
+    v_alice  UUID := current_setting('test.alice')::uuid;
+    v_src    UUID := current_setting('test.alice_stack_item')::uuid;
+    v_caught BOOLEAN := false;
+BEGIN
+    BEGIN
+        PERFORM inventory.service_split_for_listing(v_alice, v_src, 48);
+    EXCEPTION WHEN SQLSTATE 'INV13' THEN
+        v_caught := true;
+    END;
+    IF NOT v_caught THEN
+        RAISE EXCEPTION 'T2 whole-row split did not raise INV13';
+    END IF;
+END;
+$$;
+
+-- T3: split rejects instanced item.
+DO $$
+DECLARE
+    v_alice  UUID := current_setting('test.alice')::uuid;
+    v_secret TEXT := 'this-is-a-test-secret-that-is-long-enough-32';
+    v_req    BIGINT; v_item UUID; v_caught BOOLEAN := false;
+    v_payload TEXT; v_sig TEXT; v_payload_hash TEXT;
+BEGIN
+    v_req := inventory.service_deposit_begin(
+        v_alice, 'mc_item', 'enchanted_pickaxe', 1,
+        jsonb_build_object('enchants', jsonb_build_array(jsonb_build_object('id','efficiency','level',5))),
+        'mc_listing_test', '{}'::jsonb, gen_random_uuid());
+    v_payload := 'deposit:' || v_req::text || ':instanced';
+    v_sig := encode(extensions.hmac(v_payload::bytea, v_secret::bytea, 'sha256'), 'hex');
+    v_payload_hash := encode(extensions.digest(v_payload, 'sha256'), 'hex');
+    v_item := inventory.service_deposit_settle(
+        v_req,
+        encode(extensions.digest('instanced_' || gen_random_uuid()::text, 'sha256'), 'hex'),
+        v_secret, v_sig, v_payload_hash, v_payload);
+
+    BEGIN
+        PERFORM inventory.service_split_for_listing(v_alice, v_item, 1);
+    EXCEPTION WHEN SQLSTATE 'INV15' THEN
+        v_caught := true;
+    END;
+    IF NOT v_caught THEN
+        RAISE EXCEPTION 'T3 instanced split did not raise INV15';
+    END IF;
+END;
+$$;
+
+-- T4: wallet.listing.item_id required for status='active'.
+DO $$
+DECLARE
+    v_alice  UUID := current_setting('test.alice')::uuid;
+    v_caught BOOLEAN := false;
+BEGIN
+    BEGIN
+        INSERT INTO wallet.listing (
+            seller_account, item_ref, currency,
+            buy_now_price, expires_at, idempotency_key
+        ) VALUES (
+            v_alice,
+            jsonb_build_object('kind','mc_item','id','no_inv'),
+            'khash', 100, now() + interval '1 hour', gen_random_uuid()
+        );
+    EXCEPTION WHEN check_violation THEN
+        v_caught := true;
+    END;
+    IF NOT v_caught THEN
+        RAISE EXCEPTION 'T4 active listing without item_id was accepted';
+    END IF;
+END;
+$$;
+
+-- T5: service_create_listing_with_item, whole-row path — locks the entire row.
+DO $$
+DECLARE
+    v_alice    UUID := current_setting('test.alice')::uuid;
+    v_secret   TEXT := 'this-is-a-test-secret-that-is-long-enough-32';
+    v_req      BIGINT; v_item UUID; v_listing BIGINT;
+    v_state    inventory.item_state;
+    v_listing_item UUID;
+    v_payload TEXT; v_sig TEXT; v_payload_hash TEXT;
+BEGIN
+    v_req := inventory.service_deposit_begin(
+        v_alice, 'mc_item', 't5_diamond_sword', 1,
+        jsonb_build_object('enchants', jsonb_build_array(jsonb_build_object('id','sharpness','level',3))),
+        'mc_listing_test', '{}'::jsonb, gen_random_uuid());
+    v_payload := 'deposit:' || v_req::text || ':t5';
+    v_sig := encode(extensions.hmac(v_payload::bytea, v_secret::bytea, 'sha256'), 'hex');
+    v_payload_hash := encode(extensions.digest(v_payload, 'sha256'), 'hex');
+    v_item := inventory.service_deposit_settle(
+        v_req,
+        encode(extensions.digest('t5_' || gen_random_uuid()::text, 'sha256'), 'hex'),
+        v_secret, v_sig, v_payload_hash, v_payload);
+
+    v_listing := wallet.service_create_listing_with_item(
+        v_alice, v_item, NULL, 'khash'::wallet.currency_kind,
+        500, NULL, now() + interval '1 hour', gen_random_uuid()
+    );
+    SELECT state INTO v_state FROM inventory.item WHERE id = v_item;
+    IF v_state <> 'listing_escrow' THEN
+        RAISE EXCEPTION 'T5 whole-row item not in listing_escrow (state=%)', v_state;
+    END IF;
+    SELECT item_id INTO v_listing_item FROM wallet.listing WHERE id = v_listing;
+    IF v_listing_item <> v_item THEN
+        RAISE EXCEPTION 'T5 listing.item_id mismatch';
+    END IF;
+END;
+$$;
+
+-- T6: service_create_listing_with_item, split path — listing references new escrow row.
+DO $$
+DECLARE
+    v_alice    UUID := current_setting('test.alice')::uuid;
+    v_src      UUID := current_setting('test.alice_stack_item')::uuid;
+    v_listing  BIGINT;
+    v_src_state inventory.item_state;
+    v_src_qty   BIGINT;
+    v_listing_item UUID;
+    v_listing_qty BIGINT;
+    v_listing_state inventory.item_state;
+BEGIN
+    -- src currently has 48 after T1's split.
+    v_listing := wallet.service_create_listing_with_item(
+        v_alice, v_src, 10, 'khash'::wallet.currency_kind,
+        200, NULL, now() + interval '1 hour', gen_random_uuid()
+    );
+    SELECT state, qty INTO v_src_state, v_src_qty FROM inventory.item WHERE id = v_src;
+    IF v_src_state <> 'held' OR v_src_qty <> 38 THEN
+        RAISE EXCEPTION 'T6 source state/qty=%/%; expected held/38', v_src_state, v_src_qty;
+    END IF;
+    SELECT item_id INTO v_listing_item FROM wallet.listing WHERE id = v_listing;
+    SELECT state, qty INTO v_listing_state, v_listing_qty FROM inventory.item WHERE id = v_listing_item;
+    IF v_listing_state <> 'listing_escrow' OR v_listing_qty <> 10 THEN
+        RAISE EXCEPTION 'T6 listing item state/qty=%/%; expected listing_escrow/10',
+            v_listing_state, v_listing_qty;
+    END IF;
+END;
+$$;
+
+-- T7: cross-owner listing refused.
+DO $$
+DECLARE
+    v_bob    UUID := current_setting('test.bob')::uuid;
+    v_src    UUID := current_setting('test.alice_stack_item')::uuid;
+    v_caught BOOLEAN := false;
+BEGIN
+    BEGIN
+        PERFORM wallet.service_create_listing_with_item(
+            v_bob, v_src, NULL, 'khash'::wallet.currency_kind,
+            100, NULL, now() + interval '1 hour', gen_random_uuid()
+        );
+    EXCEPTION WHEN SQLSTATE 'INV11' THEN
+        v_caught := true;
+    END;
+    IF NOT v_caught THEN
+        RAISE EXCEPTION 'T7 cross-owner listing did not raise INV11';
+    END IF;
+END;
+$$;
+
+-- T8: aal2 gate via proxy_market_create_listing_with_item.
+DO $$
+DECLARE
+    v_alice    UUID := current_setting('test.alice')::uuid;
+    v_secret   TEXT := 'this-is-a-test-secret-that-is-long-enough-32';
+    v_req      BIGINT; v_item UUID; v_caught BOOLEAN := false;
+    v_payload TEXT; v_sig TEXT; v_payload_hash TEXT;
+BEGIN
+    v_req := inventory.service_deposit_begin(
+        v_alice, 'mc_item', 't8_listing', 1, '{}'::jsonb,
+        'mc_listing_test', '{}'::jsonb, gen_random_uuid());
+    v_payload := 'deposit:' || v_req::text || ':t8';
+    v_sig := encode(extensions.hmac(v_payload::bytea, v_secret::bytea, 'sha256'), 'hex');
+    v_payload_hash := encode(extensions.digest(v_payload, 'sha256'), 'hex');
+    v_item := inventory.service_deposit_settle(
+        v_req,
+        encode(extensions.digest('t8_' || gen_random_uuid()::text, 'sha256'), 'hex'),
+        v_secret, v_sig, v_payload_hash, v_payload);
+
+    PERFORM inventory.service_set_security_policy(v_alice, false, true, 0);
+
+    PERFORM set_config('request.jwt.claims',
+        jsonb_build_object('sub', '33333333-3333-3333-3333-333333333333',
+                           'aal', 'aal1')::text,
+        true);
+    BEGIN
+        PERFORM public.proxy_market_create_listing_with_item(
+            v_item, NULL, 100, NULL, now() + interval '1 hour', gen_random_uuid()
+        );
+    EXCEPTION WHEN SQLSTATE 'INV30' THEN
+        v_caught := true;
+    END;
+    IF NOT v_caught THEN
+        RAISE EXCEPTION 'T8 aal1 bypassed listing 2FA';
+    END IF;
+
+    PERFORM set_config('request.jwt.claims',
+        jsonb_build_object('sub', '33333333-3333-3333-3333-333333333333',
+                           'aal', 'aal2')::text,
+        true);
+    PERFORM public.proxy_market_create_listing_with_item(
+        v_item, NULL, 100, NULL, now() + interval '1 hour', gen_random_uuid()
+    );
+
+    PERFORM inventory.service_set_security_policy(v_alice, false, false, 0);
+    PERFORM set_config('request.jwt.claims', NULL, true);
+END;
+$$;
+
+-- T9: high_value_khash_threshold gate.
+DO $$
+DECLARE
+    v_alice    UUID := current_setting('test.alice')::uuid;
+    v_secret   TEXT := 'this-is-a-test-secret-that-is-long-enough-32';
+    v_req      BIGINT; v_item UUID; v_caught BOOLEAN := false;
+    v_payload TEXT; v_sig TEXT; v_payload_hash TEXT;
+BEGIN
+    v_req := inventory.service_deposit_begin(
+        v_alice, 'mc_item', 't9_highvalue', 1, '{}'::jsonb,
+        'mc_listing_test', '{}'::jsonb, gen_random_uuid());
+    v_payload := 'deposit:' || v_req::text || ':t9';
+    v_sig := encode(extensions.hmac(v_payload::bytea, v_secret::bytea, 'sha256'), 'hex');
+    v_payload_hash := encode(extensions.digest(v_payload, 'sha256'), 'hex');
+    v_item := inventory.service_deposit_settle(
+        v_req,
+        encode(extensions.digest('t9_' || gen_random_uuid()::text, 'sha256'), 'hex'),
+        v_secret, v_sig, v_payload_hash, v_payload);
+
+    PERFORM inventory.service_set_security_policy(v_alice, false, false, 1000);
+
+    PERFORM set_config('request.jwt.claims',
+        jsonb_build_object('sub', '33333333-3333-3333-3333-333333333333',
+                           'aal', 'aal1')::text,
+        true);
+    BEGIN
+        PERFORM public.proxy_market_create_listing_with_item(
+            v_item, NULL, 1500, NULL, now() + interval '1 hour', gen_random_uuid()
+        );
+    EXCEPTION WHEN SQLSTATE 'INV30' THEN
+        v_caught := true;
+    END;
+    IF NOT v_caught THEN
+        RAISE EXCEPTION 'T9 high-value listing bypassed aal2 gate';
+    END IF;
+
+    PERFORM set_config('request.jwt.claims',
+        jsonb_build_object('sub', '33333333-3333-3333-3333-333333333333',
+                           'aal', 'aal2')::text,
+        true);
+    PERFORM public.proxy_market_create_listing_with_item(
+        v_item, NULL, 1500, NULL, now() + interval '1 hour', gen_random_uuid()
+    );
+
+    PERFORM inventory.service_set_security_policy(v_alice, false, false, 0);
+    PERFORM set_config('request.jwt.claims', NULL, true);
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_attribute
+         WHERE attrelid = 'wallet.listing'::regclass
+           AND attname = 'item_id'
+           AND NOT attisdropped
+    ) THEN
+        RAISE EXCEPTION 'wallet.listing.item_id still present after down';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'inventory' AND p.proname = 'service_split_for_listing'
+    ) THEN
+        RAISE EXCEPTION 'inventory.service_split_for_listing still present after down';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migration-tests/20260520124536_wallet_listing_settle_inventory.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260520124536_wallet_listing_settle_inventory.test.sql
@@ -1,0 +1,209 @@
+-- Tests for the wallet listing ↔ inventory settle/cancel/expire hooks.
+
+-- SEED
+INSERT INTO auth.users (id) VALUES
+    ('55555555-5555-5555-5555-555555555555'),
+    ('66666666-6666-6666-6666-666666666666')
+ON CONFLICT DO NOTHING;
+
+-- ASSERT_AFTER_UP
+
+DO $$
+DECLARE
+    v_alice UUID;
+    v_bob   UUID;
+BEGIN
+    SELECT id INTO v_alice FROM wallet.account
+     WHERE kind = 'user' AND user_id = '55555555-5555-5555-5555-555555555555';
+    SELECT id INTO v_bob   FROM wallet.account
+     WHERE kind = 'user' AND user_id = '66666666-6666-6666-6666-666666666666';
+    PERFORM set_config('test.alice', v_alice::text, false);
+    PERFORM set_config('test.bob',   v_bob::text,   false);
+END;
+$$;
+
+SELECT inventory.service_register_bridge_secret(
+    'mc_settle_test',
+    'this-is-a-test-secret-that-is-long-enough-32',
+    'settle test bridge'
+);
+
+-- Helper: deposit a stackable for Alice; returns item id via session var.
+DO $$
+DECLARE
+    v_alice UUID := current_setting('test.alice')::uuid;
+    v_secret TEXT := 'this-is-a-test-secret-that-is-long-enough-32';
+    v_req BIGINT;
+    v_payload TEXT; v_sig TEXT; v_payload_hash TEXT;
+    v_item UUID;
+    v_ref  TEXT := 'settle_test_' || gen_random_uuid()::text;
+BEGIN
+    v_req := inventory.service_deposit_begin(
+        v_alice, 'mc_item', v_ref, 32, '{}'::jsonb,
+        'mc_settle_test', '{}'::jsonb, gen_random_uuid());
+    v_payload := 'deposit:' || v_req::text || ':settle_seed';
+    v_sig := encode(extensions.hmac(v_payload::bytea, v_secret::bytea, 'sha256'), 'hex');
+    v_payload_hash := encode(extensions.digest(v_payload, 'sha256'), 'hex');
+    v_item := inventory.service_deposit_settle(
+        v_req,
+        encode(extensions.digest('settle_seed_' || gen_random_uuid()::text, 'sha256'), 'hex'),
+        v_secret, v_sig, v_payload_hash, v_payload);
+    PERFORM set_config('test.alice_item', v_item::text, false);
+END;
+$$;
+
+-- T1: cancel a listing releases the item back to held.
+DO $$
+DECLARE
+    v_alice    UUID := current_setting('test.alice')::uuid;
+    v_item     UUID := current_setting('test.alice_item')::uuid;
+    v_listing  BIGINT;
+    v_state    inventory.item_state;
+BEGIN
+    v_listing := wallet.service_create_listing_with_item(
+        v_alice, v_item, NULL, 'khash'::wallet.currency_kind,
+        500, NULL, now() + interval '1 hour', gen_random_uuid()
+    );
+    SELECT state INTO v_state FROM inventory.item WHERE id = v_item;
+    IF v_state <> 'listing_escrow' THEN
+        RAISE EXCEPTION 'T1 pre-cancel state=% expected listing_escrow', v_state;
+    END IF;
+
+    PERFORM wallet.service_cancel_listing(v_listing, v_alice, 'test_cancel');
+
+    SELECT state INTO v_state FROM inventory.item WHERE id = v_item;
+    IF v_state <> 'held' THEN
+        RAISE EXCEPTION 'T1 post-cancel state=% expected held', v_state;
+    END IF;
+END;
+$$;
+
+-- T2: buy-now settle hands the item to the buyer (state=held under buyer).
+DO $$
+DECLARE
+    v_alice UUID := current_setting('test.alice')::uuid;
+    v_bob   UUID := current_setting('test.bob')::uuid;
+    v_secret TEXT := 'this-is-a-test-secret-that-is-long-enough-32';
+    v_req BIGINT;
+    v_payload TEXT; v_sig TEXT; v_payload_hash TEXT;
+    v_item UUID;
+    v_listing BIGINT;
+    v_bid BIGINT;
+    v_buyer_holdings INT;
+    v_listing_item_state inventory.item_state;
+    v_ref TEXT := 'buynow_' || gen_random_uuid()::text;
+BEGIN
+    -- Fresh held row for Alice.
+    v_req := inventory.service_deposit_begin(
+        v_alice, 'mc_item', v_ref, 1, '{}'::jsonb,
+        'mc_settle_test', '{}'::jsonb, gen_random_uuid());
+    v_payload := 'deposit:' || v_req::text || ':t2';
+    v_sig := encode(extensions.hmac(v_payload::bytea, v_secret::bytea, 'sha256'), 'hex');
+    v_payload_hash := encode(extensions.digest(v_payload, 'sha256'), 'hex');
+    v_item := inventory.service_deposit_settle(
+        v_req,
+        encode(extensions.digest('t2_' || gen_random_uuid()::text, 'sha256'), 'hex'),
+        v_secret, v_sig, v_payload_hash, v_payload);
+
+    -- Credit Bob enough khash to buy-now.
+    PERFORM wallet.service_credit(
+        v_bob, 'khash'::wallet.currency_kind, 10000,
+        'admin'::wallet.source_kind, 'test seed', NULL, NULL,
+        gen_random_uuid()
+    );
+
+    v_listing := wallet.service_create_listing_with_item(
+        v_alice, v_item, NULL, 'khash'::wallet.currency_kind,
+        100, NULL, now() + interval '1 hour', gen_random_uuid()
+    );
+
+    v_bid := wallet.service_buy_now(v_listing, v_bob, gen_random_uuid());
+
+    -- Seller's row is consumed.
+    SELECT state INTO v_listing_item_state FROM inventory.item WHERE id = v_item;
+    IF v_listing_item_state <> 'consumed' THEN
+        RAISE EXCEPTION 'T2 seller item state=% expected consumed', v_listing_item_state;
+    END IF;
+
+    -- Buyer now owns an inventory.item for that ref.
+    SELECT count(*)::int INTO v_buyer_holdings
+      FROM inventory.item
+     WHERE owner_account = v_bob AND ref = v_ref AND state = 'held';
+    IF v_buyer_holdings = 0 THEN
+        RAISE EXCEPTION 'T2 buyer did not receive item; no held rows for ref=%', v_ref;
+    END IF;
+END;
+$$;
+
+-- T3: expire-no-bid sweep returns the item to the seller as held.
+DO $$
+DECLARE
+    v_alice UUID := current_setting('test.alice')::uuid;
+    v_secret TEXT := 'this-is-a-test-secret-that-is-long-enough-32';
+    v_req BIGINT;
+    v_payload TEXT; v_sig TEXT; v_payload_hash TEXT;
+    v_item UUID;
+    v_listing BIGINT;
+    v_state inventory.item_state;
+    v_sweep_total BIGINT;
+    v_sweep_settled BIGINT;
+    v_sweep_expired BIGINT;
+    v_ref TEXT := 'expire_' || gen_random_uuid()::text;
+BEGIN
+    v_req := inventory.service_deposit_begin(
+        v_alice, 'mc_item', v_ref, 1, '{}'::jsonb,
+        'mc_settle_test', '{}'::jsonb, gen_random_uuid());
+    v_payload := 'deposit:' || v_req::text || ':t3';
+    v_sig := encode(extensions.hmac(v_payload::bytea, v_secret::bytea, 'sha256'), 'hex');
+    v_payload_hash := encode(extensions.digest(v_payload, 'sha256'), 'hex');
+    v_item := inventory.service_deposit_settle(
+        v_req,
+        encode(extensions.digest('t3_' || gen_random_uuid()::text, 'sha256'), 'hex'),
+        v_secret, v_sig, v_payload_hash, v_payload);
+
+    v_listing := wallet.service_create_listing_with_item(
+        v_alice, v_item, NULL, 'khash'::wallet.currency_kind,
+        500, NULL, now() + interval '1 hour', gen_random_uuid()
+    );
+
+    -- Force-expire by backdating both created_at + expires_at so the
+    -- duration CHECK (expires_at >= created_at + 1h) stays satisfied.
+    UPDATE wallet.listing
+       SET created_at = now() - interval '3 hours',
+           expires_at = now() - interval '1 second'
+     WHERE id = v_listing;
+
+    SELECT total, settled, expired
+      INTO v_sweep_total, v_sweep_settled, v_sweep_expired
+      FROM wallet.service_expire_listings(100);
+
+    IF v_sweep_expired < 1 THEN
+        RAISE EXCEPTION 'T3 expire sweep reported %/%/%; expected at least one expired',
+            v_sweep_total, v_sweep_settled, v_sweep_expired;
+    END IF;
+
+    SELECT state INTO v_state FROM inventory.item WHERE id = v_item;
+    IF v_state <> 'held' THEN
+        RAISE EXCEPTION 'T3 post-expire item state=% expected held', v_state;
+    END IF;
+END;
+$$;
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+DECLARE
+    v_src text;
+BEGIN
+    -- Down should restore the legacy bodies (no inventory.service_listing_*
+    -- references). Grep prosrc for the call we added.
+    SELECT prosrc INTO v_src
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'wallet' AND p.proname = 'service_settle_listing'
+     LIMIT 1;
+    IF v_src LIKE '%inventory.service_listing_settle%' THEN
+        RAISE EXCEPTION 'service_settle_listing still calls inventory hook after down';
+    END IF;
+END;
+$$;

--- a/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
+++ b/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
@@ -782,6 +782,24 @@ ALTER TABLE wallet.listing DROP COLUMN IF EXISTS item_id;
 
 DROP FUNCTION IF EXISTS inventory.service_split_for_listing(UUID, UUID, BIGINT);
 
+-- Belt-and-suspenders: restoring the legacy JSONB listing proxy
+-- reopens the non-inventory-backed listing path on the PostgREST
+-- surface. Even though the outer app.allow_marketplace_unsafe_down
+-- gate must already be 'on' to reach here, the legacy proxy
+-- restoration carries its own GUC so an operator running a partial
+-- rollback (e.g. dropping only the sibling) doesn't accidentally
+-- resurrect public JSONB-only listing creation. Dev/test sets both
+-- via PGOPTIONS — see test-migration.sh.
+DO $$
+BEGIN
+    IF current_setting('app.allow_legacy_marketplace_proxy_restore', true)
+       IS DISTINCT FROM 'on' THEN
+        RAISE EXCEPTION
+            'refusing to restore legacy JSONB marketplace proxy: set app.allow_legacy_marketplace_proxy_restore=on to proceed (the P1011 stub stays in place)';
+    END IF;
+END
+$$;
+
 -- Restore the pre-6.1a legacy proxy body so rollback leaves the
 -- original public listing path functional rather than stuck at the
 -- P1011 stub. Body lifted from 20260516015242_wallet_marketplace_proxies.sql.

--- a/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
+++ b/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
@@ -30,6 +30,26 @@
 -- migration 20260520114244_wallet_listing_settle_inventory.sql.
 -- ============================================================================
 
+-- Preflight: fail fast if the 6.0 inventory hooks + JWT helpers the
+-- new wallet RPCs depend on are missing. Without these, the
+-- migration would technically succeed and only fail at runtime.
+DO $$
+BEGIN
+    IF to_regprocedure('inventory.service_listing_lock(uuid, uuid, bigint)') IS NULL THEN
+        RAISE EXCEPTION 'missing inventory.service_listing_lock(uuid, uuid, bigint) — apply 6.0 foundation first';
+    END IF;
+    IF to_regprocedure('inventory.caller_jwt_aal()') IS NULL THEN
+        RAISE EXCEPTION 'missing inventory.caller_jwt_aal() — apply 6.0 foundation first';
+    END IF;
+    IF to_regprocedure('inventory.is_2fa_required_for_listing(uuid)') IS NULL THEN
+        RAISE EXCEPTION 'missing inventory.is_2fa_required_for_listing(uuid) — apply 6.0 foundation first';
+    END IF;
+    IF to_regprocedure('private.proxy_market_caller_account()') IS NULL THEN
+        RAISE EXCEPTION 'missing private.proxy_market_caller_account() — wallet marketplace proxies migration must be applied first';
+    END IF;
+END
+$$;
+
 -- ---------------------------------------------------------------------------
 -- 1. inventory.service_split_for_listing
 --    Atomically: src.qty -= p_qty, INSERT new row in 'listing_escrow'
@@ -86,9 +106,27 @@ BEGIN
             p_qty, v_src.qty USING ERRCODE = 'INV13';
     END IF;
 
-    UPDATE inventory.item
-       SET qty = qty - p_qty, updated_at = now()
-     WHERE id = p_src_item_id;
+    -- Status-guarded UPDATE. Row is already locked FOR UPDATE above,
+    -- so the WHERE-recheck + RETURNING is purely defensive against
+    -- future refactors that might weaken the lock chain. If the
+    -- preconditions changed between the lock and the update, the
+    -- RETURNING is empty and we raise.
+    DECLARE
+        v_updated_src_id UUID;
+    BEGIN
+        UPDATE inventory.item
+           SET qty = qty - p_qty, updated_at = now()
+         WHERE id = p_src_item_id
+           AND owner_account = p_seller_account
+           AND state = 'held'
+           AND is_stackable
+           AND qty > p_qty
+        RETURNING id INTO v_updated_src_id;
+        IF v_updated_src_id IS NULL THEN
+            RAISE EXCEPTION 'split source % invariant violated between lock and update', p_src_item_id
+                USING ERRCODE = 'INV12';
+        END IF;
+    END;
 
     -- Preserve v_src.nbt rather than hardcoding '{}'::jsonb. Today the
     -- is_stackable CHECK above guarantees v_src.nbt = '{}', so the two
@@ -167,10 +205,11 @@ $$;
 -- listing MUST flow through the inventory ledger via the
 -- *_with_item path. The preflight above guarantees no active bids,
 -- so no ledger work is needed; this is pure schema hygiene.
-DO $$
-DECLARE
-    v_cancelled_count INT;
-BEGIN
+--
+-- One audit row PER cancelled listing so reconciliation can replay
+-- the exact set of legacy ids without a snapshot. CTE pipes the
+-- RETURNING set into the audit_log INSERT.
+WITH cancelled AS (
     UPDATE wallet.listing
        SET status              = 'cancelled',
            settled_at          = COALESCE(settled_at, now()),
@@ -178,23 +217,20 @@ BEGIN
            current_bid_account = NULL,
            current_bid_id      = NULL
      WHERE status = 'active'
-       AND item_id IS NULL;
-    GET DIAGNOSTICS v_cancelled_count = ROW_COUNT;
-
-    IF v_cancelled_count > 0 THEN
-        INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
-        VALUES (
-            'marketplace.legacy_cleanup',
-            'migration',
-            '20260520114243_wallet_inventory_listing_wire',
-            jsonb_build_object(
-                'cancelled_listings', v_cancelled_count,
-                'reason',             'pre-inventory-ledger active listings cleared'
-            )
-        );
-    END IF;
-END
-$$;
+       AND item_id IS NULL
+    RETURNING id, seller_account
+)
+INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+SELECT
+    'marketplace.legacy_cleanup',
+    'listing',
+    id::TEXT,
+    jsonb_build_object(
+        'seller_account', seller_account,
+        'migration',      '20260520114243_wallet_inventory_listing_wire',
+        'reason',         'pre-inventory-ledger active listing cleared'
+    )
+FROM cancelled;
 
 -- VALID CHECK: every active listing MUST now carry item_id. Legacy
 -- service_create_listing(UUID, JSONB, ...) callers fail loudly on
@@ -249,6 +285,10 @@ DECLARE
     v_currency    wallet.currency_kind := COALESCE(p_currency, 'khash'::wallet.currency_kind);
     v_now         TIMESTAMPTZ := transaction_timestamp();
     v_existing_id BIGINT;
+    v_existing_item_id     UUID;
+    v_existing_buy_now     BIGINT;
+    v_existing_min_bid     BIGINT;
+    v_existing_expires_at  TIMESTAMPTZ;
     v_listing_id  BIGINT;
     v_listing_qty BIGINT;
     v_listed_id   UUID;
@@ -281,16 +321,35 @@ BEGIN
     IF p_expires_at IS NULL OR p_expires_at <= v_now THEN
         RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
     END IF;
+    -- Upfront max-duration check. Table-level listing_max_duration_chk
+    -- enforces the same cap via created_at + 30d, but raising here
+    -- surfaces a clean 22023 instead of a raw check_violation.
+    IF p_expires_at > v_now + interval '30 days' THEN
+        RAISE EXCEPTION 'expires_at exceeds 30-day maximum listing duration'
+            USING ERRCODE = '22023';
+    END IF;
     IF p_qty IS NOT NULL AND p_qty <= 0 THEN
         RAISE EXCEPTION 'qty must be positive' USING ERRCODE = '22023';
     END IF;
 
-    -- Replay shortcut.
-    SELECT id INTO v_existing_id
+    -- Replay with payload validation. Reusing the same idempotency_key
+    -- against different parameters (different price / expiry) is a
+    -- caller bug; surface as P1012 instead of silently aliasing the
+    -- original row. wallet_listing_seller_idempotency_uq serializes
+    -- concurrent same-key inserts at the table level.
+    SELECT id, item_id, buy_now_price, min_bid, expires_at
+      INTO v_existing_id, v_existing_item_id, v_existing_buy_now,
+           v_existing_min_bid, v_existing_expires_at
       FROM wallet.listing
      WHERE seller_account = p_seller_account
        AND idempotency_key = p_idempotency_key;
     IF v_existing_id IS NOT NULL THEN
+        IF v_existing_buy_now    IS DISTINCT FROM p_buy_now_price
+           OR v_existing_min_bid IS DISTINCT FROM p_min_bid
+           OR v_existing_expires_at IS DISTINCT FROM p_expires_at THEN
+            RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing %',
+                p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
+        END IF;
         RETURN v_existing_id;
     END IF;
 
@@ -358,8 +417,11 @@ BEGIN
     IF NOT v_was_split THEN
         PERFORM inventory.service_listing_lock(p_seller_account, v_listed_id, v_listing_id);
     ELSE
+        -- COALESCE in case a future schema relaxation makes
+        -- source_ref nullable; today the column is NOT NULL DEFAULT
+        -- '{}'::jsonb so the COALESCE is defensive.
         UPDATE inventory.item
-           SET source_ref = source_ref
+           SET source_ref = COALESCE(source_ref, '{}'::jsonb)
                             || jsonb_build_object(
                                    'listing_id',         v_listing_id,
                                    'listing_created_at', v_now
@@ -501,6 +563,12 @@ BEGIN
 END;
 $$;
 
+-- Restate the privilege contract explicitly. CREATE OR REPLACE
+-- preserves grants/owner, but for a security-definer public RPC the
+-- intent should be visible in this migration.
+ALTER FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
     'DEPRECATED. Phase 6.1a stubbed this proxy to raise P1011 so axum/Astro see a clean migration error during the 6.1b cutover. Dropped entirely in Phase 6.1c.';
 

--- a/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
+++ b/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
@@ -197,6 +197,28 @@ BEGIN
         RAISE EXCEPTION
             'legacy active listings with active bids exist; reconcile escrow manually before re-running 20260520114243';
     END IF;
+
+    -- Catch corrupted current_bid_id pointers (listing claims a
+    -- current bid but no matching active wallet.bid row exists).
+    -- The cleanup below would silently null these out; surface them
+    -- as a hard failure so they get manual review first.
+    IF EXISTS (
+        SELECT 1
+          FROM wallet.listing l
+         WHERE l.status = 'active'
+           AND l.item_id IS NULL
+           AND l.current_bid_id IS NOT NULL
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM wallet.bid b
+                WHERE b.id = l.current_bid_id
+                  AND b.listing_id = l.id
+                  AND b.status = 'active'
+           )
+    ) THEN
+        RAISE EXCEPTION
+            'legacy active listings with stale current_bid_id pointers exist; manual reconciliation required';
+    END IF;
 END
 $$;
 
@@ -213,6 +235,7 @@ WITH cancelled AS (
     UPDATE wallet.listing
        SET status              = 'cancelled',
            settled_at          = COALESCE(settled_at, now()),
+           buyer_account       = NULL,
            current_bid         = NULL,
            current_bid_account = NULL,
            current_bid_id      = NULL
@@ -289,6 +312,7 @@ DECLARE
     v_existing_buy_now     BIGINT;
     v_existing_min_bid     BIGINT;
     v_existing_expires_at  TIMESTAMPTZ;
+    v_existing_qty         BIGINT;
     v_listing_id  BIGINT;
     v_listing_qty BIGINT;
     v_listed_id   UUID;
@@ -332,22 +356,47 @@ BEGIN
         RAISE EXCEPTION 'qty must be positive' USING ERRCODE = '22023';
     END IF;
 
-    -- Replay with payload validation. Reusing the same idempotency_key
-    -- against different parameters (different price / expiry) is a
-    -- caller bug; surface as P1012 instead of silently aliasing the
-    -- original row. wallet_listing_seller_idempotency_uq serializes
+    -- Replay with full payload validation. Reusing the same
+    -- idempotency_key against different parameters is a caller bug;
+    -- surface as P1012 instead of silently aliasing the original row.
+    -- wallet_listing_seller_idempotency_uq (lives in the original
+    -- 20260514113538_wallet_marketplace_schema migration) serializes
     -- concurrent same-key inserts at the table level.
-    SELECT id, item_id, buy_now_price, min_bid, expires_at
+    --
+    -- Source-item check: the listing's item_id is either p_src_item_id
+    -- itself (whole-row path) or a split-derived row whose source_ref
+    -- ->>'split_from' points back at p_src_item_id (partial path).
+    -- Both replay variants must resolve to the originally requested
+    -- source.
+    SELECT l.id, l.item_id, l.buy_now_price, l.min_bid, l.expires_at,
+           COALESCE((l.item_ref ->> 'qty')::BIGINT, 0)
       INTO v_existing_id, v_existing_item_id, v_existing_buy_now,
-           v_existing_min_bid, v_existing_expires_at
-      FROM wallet.listing
-     WHERE seller_account = p_seller_account
-       AND idempotency_key = p_idempotency_key;
+           v_existing_min_bid, v_existing_expires_at, v_existing_qty
+      FROM wallet.listing l
+     WHERE l.seller_account = p_seller_account
+       AND l.idempotency_key = p_idempotency_key;
     IF v_existing_id IS NOT NULL THEN
         IF v_existing_buy_now    IS DISTINCT FROM p_buy_now_price
            OR v_existing_min_bid IS DISTINCT FROM p_min_bid
            OR v_existing_expires_at IS DISTINCT FROM p_expires_at THEN
-            RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing %',
+            RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (price/expiry differs)',
+                p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
+        END IF;
+        -- Source-item identity. Direct match for whole-row OR
+        -- source_ref split_from match for partial.
+        IF v_existing_item_id IS DISTINCT FROM p_src_item_id
+           AND NOT EXISTS (
+               SELECT 1 FROM inventory.item
+                WHERE id = v_existing_item_id
+                  AND source_ref ->> 'split_from' = p_src_item_id::text
+           ) THEN
+            RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (src_item_id differs)',
+                p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
+        END IF;
+        -- Qty check. NULL p_qty (whole-row request) must match the
+        -- listed item's full qty as recorded in item_ref.
+        IF p_qty IS NOT NULL AND v_existing_qty IS DISTINCT FROM p_qty THEN
+            RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (qty differs)',
                 p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
         END IF;
         RETURN v_existing_id;
@@ -497,6 +546,12 @@ BEGIN
     IF p_expires_at IS NULL OR p_expires_at <= statement_timestamp() THEN
         RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
     END IF;
+    -- Mirror the service-side 30-day cap so the proxy boundary
+    -- surfaces a clean error before any service work runs.
+    IF p_expires_at > statement_timestamp() + interval '30 days' THEN
+        RAISE EXCEPTION 'expires_at exceeds 30-day maximum listing duration'
+            USING ERRCODE = '22023';
+    END IF;
 
     -- 2FA gate: if the account opted into require_2fa_for_listing,
     -- the JWT must carry aal=aal2. Don't leak the account UUID into
@@ -603,5 +658,50 @@ ALTER TABLE wallet.listing DROP CONSTRAINT IF EXISTS wallet_listing_active_item_
 ALTER TABLE wallet.listing DROP COLUMN IF EXISTS item_id;
 
 DROP FUNCTION IF EXISTS inventory.service_split_for_listing(UUID, UUID, BIGINT);
+
+-- Restore the pre-6.1a legacy proxy body so rollback leaves the
+-- original public listing path functional rather than stuck at the
+-- P1011 stub. Body lifted from 20260516015242_wallet_marketplace_proxies.sql.
+CREATE OR REPLACE FUNCTION public.proxy_market_create_listing(
+    p_item_ref        JSONB,
+    p_buy_now_price   BIGINT,
+    p_min_bid         BIGINT,
+    p_expires_at      TIMESTAMPTZ,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_seller UUID := private.proxy_market_caller_account();
+BEGIN
+    IF p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'idempotency_key is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_item_ref IS NULL OR jsonb_typeof(p_item_ref) <> 'object' THEN
+        RAISE EXCEPTION 'item_ref must be a JSON object' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NULL AND p_min_bid IS NULL THEN
+        RAISE EXCEPTION 'listing requires buy_now_price or min_bid' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NOT NULL AND p_buy_now_price <= 0 THEN
+        RAISE EXCEPTION 'buy_now_price must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_min_bid IS NOT NULL AND p_min_bid <= 0 THEN
+        RAISE EXCEPTION 'min_bid must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_expires_at IS NULL OR p_expires_at <= statement_timestamp() THEN
+        RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
+    END IF;
+    RETURN wallet.service_create_listing(
+        v_seller, p_item_ref, 'khash'::wallet.currency_kind,
+        p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
+    );
+END;
+$$;
+ALTER FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
+    'PUBLIC marketplace proxy. Authenticated create-listing wrapper. Resolves auth.uid() → seller wallet account, then calls wallet.service_create_listing with currency=khash.';
 
 NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
+++ b/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
@@ -1,0 +1,458 @@
+-- migrate:up
+-- ============================================================================
+-- WALLET ↔ INVENTORY LISTING WIRE — foundation (Phase 6.1a)
+--
+-- Lands:
+--   1. inventory.service_split_for_listing — split a HELD stackable row
+--      directly into a NEW listing_escrow row + a smaller held source.
+--      Combines "split + lock" so the partial-unique invariant on
+--      held-stackable rows is never violated (the new row leaves the
+--      partial index immediately because it's in listing_escrow).
+--   2. wallet.listing.item_id column + active-uniqueness + CHECK so
+--      active listings MUST reference an inventory.item row. Existing
+--      legacy non-active rows keep working because the CHECK only
+--      fires for status='active'.
+--   3. wallet.service_create_listing_with_item — new authoritative
+--      listing creator that takes (p_item_id, p_qty). When p_qty is
+--      NULL or equals the source row qty, the whole row is locked via
+--      inventory.service_listing_lock. Otherwise it splits via
+--      inventory.service_split_for_listing.
+--   4. public.proxy_market_create_listing_with_item — authenticated
+--      wrapper. Enforces inventory.is_2fa_required_for_listing aal2
+--      gate + the high_value_khash_threshold gate.
+--
+-- The legacy wallet.service_create_listing(UUID, JSONB, ...) +
+-- proxy_market_create_listing(JSONB, ...) STAY in place. axum + Astro
+-- migrate to the *_with_item variants in Phase 6.1b. The legacy
+-- functions get dropped in 6.1c once all callers move over.
+--
+-- Settle / cancel / expire / buy_now hooks land in the sibling
+-- migration 20260520114244_wallet_listing_settle_inventory.sql.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. inventory.service_split_for_listing
+--    Atomically: src.qty -= p_qty, INSERT new row in 'listing_escrow'
+--    with the same kind/ref/source as src. src stays 'held' and
+--    inside the partial unique index; the new row sits in
+--    listing_escrow so it never collides with the held-stackable
+--    invariant. Caller (wallet) then INSERTs wallet.listing with
+--    item_id = returned new id.
+--
+--    p_qty MUST be strictly less than src.qty — a whole-row "split"
+--    is a no-op the caller should handle via service_listing_lock.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION inventory.service_split_for_listing(
+    p_seller_account UUID,
+    p_src_item_id    UUID,
+    p_qty            BIGINT
+) RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_src    inventory.item%ROWTYPE;
+    v_new_id UUID;
+BEGIN
+    IF p_seller_account IS NULL OR p_src_item_id IS NULL THEN
+        RAISE EXCEPTION 'seller_account, src_item_id are required' USING ERRCODE = '22004';
+    END IF;
+    IF p_qty IS NULL OR p_qty <= 0 THEN
+        RAISE EXCEPTION 'qty must be positive' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT * INTO v_src
+      FROM inventory.item
+     WHERE id = p_src_item_id
+     FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'item % not found', p_src_item_id USING ERRCODE = 'INV10';
+    END IF;
+    IF v_src.owner_account <> p_seller_account THEN
+        RAISE EXCEPTION 'item % not owned by seller', p_src_item_id USING ERRCODE = 'INV11';
+    END IF;
+    IF v_src.state <> 'held' THEN
+        RAISE EXCEPTION 'item % not in held state (state=%)',
+            p_src_item_id, v_src.state USING ERRCODE = 'INV12';
+    END IF;
+    IF NOT v_src.is_stackable THEN
+        RAISE EXCEPTION 'item % is instanced; cannot split', p_src_item_id
+            USING ERRCODE = 'INV15';
+    END IF;
+    IF v_src.qty <= p_qty THEN
+        RAISE EXCEPTION 'split qty % must be strictly less than source qty %',
+            p_qty, v_src.qty USING ERRCODE = 'INV13';
+    END IF;
+
+    UPDATE inventory.item
+       SET qty = qty - p_qty, updated_at = now()
+     WHERE id = p_src_item_id;
+
+    INSERT INTO inventory.item (
+        owner_account, kind, ref, qty, nbt, state, source, source_ref
+    ) VALUES (
+        v_src.owner_account, v_src.kind, v_src.ref, p_qty,
+        '{}'::jsonb, 'listing_escrow', v_src.source,
+        jsonb_build_object(
+            'split_from',        v_src.id::text,
+            'parent_source_ref', v_src.source_ref
+        )
+    )
+    RETURNING id INTO v_new_id;
+
+    -- New row was minted directly into listing_escrow via a "virtual"
+    -- transit_in -> listing_escrow transition. Carries split metadata
+    -- so the audit stream can reconcile both halves.
+    INSERT INTO inventory.transition (item_id, from_state, to_state, actor, reason, metadata)
+    VALUES (v_new_id, 'transit_in', 'listing_escrow', 'wallet',
+            'split_for_listing',
+            jsonb_build_object(
+                'split_from',     v_src.id::text,
+                'seller_account', p_seller_account,
+                'qty',            p_qty,
+                'previous_src_qty', v_src.qty,
+                'new_src_qty',    v_src.qty - p_qty
+            ));
+
+    RETURN v_new_id;
+END;
+$$;
+
+ALTER FUNCTION inventory.service_split_for_listing(UUID, UUID, BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION inventory.service_split_for_listing(UUID, UUID, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION inventory.service_split_for_listing(UUID, UUID, BIGINT) TO service_role;
+COMMENT ON FUNCTION inventory.service_split_for_listing(UUID, UUID, BIGINT) IS
+    'Atomic split-for-listing helper. Splits a HELD stackable row, producing a new row directly in listing_escrow state (never held). Used by wallet.service_create_listing_with_item when a partial-stack listing is requested. Returns the new row id, which the caller must INSERT into wallet.listing.item_id. Refuses instanced rows and refuses whole-row splits (caller should service_listing_lock the source directly in that case).';
+
+-- ---------------------------------------------------------------------------
+-- 2. wallet.listing.item_id column + active-uniqueness + CHECK
+--    Active listings MUST carry item_id. Legacy non-active rows keep
+--    item_id NULL.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE wallet.listing
+    ADD COLUMN item_id UUID
+        REFERENCES inventory.item(id) ON DELETE NO ACTION;
+
+-- Hard cut. Cancel every pre-existing ACTIVE listing — none of them
+-- have item_id (column was just added), and going forward every
+-- listing MUST flow through the inventory ledger via the
+-- *_with_item path. Production has no listings yet; this handles
+-- dev / test fixtures so the CHECK below can be plain VALID.
+DO $$
+DECLARE
+    v_cancelled_count INT;
+    v_refunded_count  INT;
+BEGIN
+    -- Refund any active bids on the about-to-be-cancelled listings.
+    -- No ledger work here — legacy market never went live so there
+    -- shouldn't be real escrowed khash. If there is, the audit_log
+    -- row makes it visible for manual reconciliation.
+    UPDATE wallet.bid
+       SET status     = 'refunded',
+           settled_at = COALESCE(settled_at, now())
+     WHERE listing_id IN (
+         SELECT id FROM wallet.listing
+          WHERE status = 'active' AND item_id IS NULL
+     )
+       AND status = 'active';
+    GET DIAGNOSTICS v_refunded_count = ROW_COUNT;
+
+    UPDATE wallet.listing
+       SET status              = 'cancelled',
+           settled_at          = COALESCE(settled_at, now()),
+           current_bid         = NULL,
+           current_bid_account = NULL,
+           current_bid_id      = NULL
+     WHERE status = 'active'
+       AND item_id IS NULL;
+    GET DIAGNOSTICS v_cancelled_count = ROW_COUNT;
+
+    IF v_cancelled_count > 0 OR v_refunded_count > 0 THEN
+        INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+        VALUES (
+            'marketplace.legacy_cleanup',
+            'migration',
+            '20260520114243_wallet_inventory_listing_wire',
+            jsonb_build_object(
+                'cancelled_listings', v_cancelled_count,
+                'refunded_bids',      v_refunded_count,
+                'reason',             'pre-inventory-ledger active listings cleared'
+            )
+        );
+    END IF;
+END
+$$;
+
+-- VALID CHECK: every active listing MUST now carry item_id. Legacy
+-- service_create_listing(UUID, JSONB, ...) callers fail loudly on
+-- INSERT — that's intentional and forces the 6.1b axum/Astro switch
+-- to the *_with_item variants. Pre-existing non-active rows
+-- (cancelled / expired / sold) keep item_id NULL untouched.
+ALTER TABLE wallet.listing
+    ADD CONSTRAINT wallet_listing_active_item_id_chk
+        CHECK (status <> 'active' OR item_id IS NOT NULL);
+
+CREATE UNIQUE INDEX wallet_listing_active_item_uq
+    ON wallet.listing (item_id)
+    WHERE status = 'active' AND item_id IS NOT NULL;
+
+COMMENT ON COLUMN wallet.listing.item_id IS
+    'inventory.item.id of the listed row. NULL only allowed on legacy non-active listings; new active listings MUST reference an inventory.item. Active-listing uniqueness ensures one open listing per item.';
+
+-- ---------------------------------------------------------------------------
+-- 3. wallet.service_create_listing_with_item
+--    New authoritative listing creator. Takes (p_src_item_id, p_qty).
+--    p_qty NULL or = src.qty: lock the whole source row.
+--    p_qty < src.qty:        split via service_split_for_listing.
+--    Stores back-compat item_ref JSONB derived from the inventory row.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION wallet.service_create_listing_with_item(
+    p_seller_account  UUID,
+    p_src_item_id     UUID,
+    p_qty             BIGINT,
+    p_currency        wallet.currency_kind,
+    p_buy_now_price   BIGINT,
+    p_min_bid         BIGINT,
+    p_expires_at      TIMESTAMPTZ,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+    v_src         inventory.item%ROWTYPE;
+    v_currency    wallet.currency_kind := COALESCE(p_currency, 'khash'::wallet.currency_kind);
+    v_now         TIMESTAMPTZ := transaction_timestamp();
+    v_existing_id BIGINT;
+    v_listing_id  BIGINT;
+    v_listing_qty BIGINT;
+    v_listed_id   UUID;
+    v_was_split   BOOLEAN := false;
+    v_item_ref    JSONB;
+BEGIN
+    IF p_seller_account IS NULL OR p_src_item_id IS NULL OR p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'seller_account, src_item_id, idempotency_key are required'
+            USING ERRCODE = '22004';
+    END IF;
+
+    PERFORM wallet.assert_user_account(p_seller_account);
+
+    IF v_currency <> 'khash'::wallet.currency_kind THEN
+        RAISE EXCEPTION 'marketplace v1 only supports khash' USING ERRCODE = 'P1010';
+    END IF;
+    IF p_buy_now_price IS NULL AND p_min_bid IS NULL THEN
+        RAISE EXCEPTION 'listing requires buy_now_price or min_bid' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NOT NULL AND p_buy_now_price <= 0 THEN
+        RAISE EXCEPTION 'buy_now_price must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_min_bid IS NOT NULL AND p_min_bid <= 0 THEN
+        RAISE EXCEPTION 'min_bid must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NOT NULL AND p_min_bid IS NOT NULL
+       AND p_min_bid > p_buy_now_price THEN
+        RAISE EXCEPTION 'min_bid cannot exceed buy_now_price' USING ERRCODE = '22023';
+    END IF;
+    IF p_expires_at IS NULL OR p_expires_at <= v_now THEN
+        RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
+    END IF;
+    IF p_qty IS NOT NULL AND p_qty <= 0 THEN
+        RAISE EXCEPTION 'qty must be positive' USING ERRCODE = '22023';
+    END IF;
+
+    -- Replay shortcut.
+    SELECT id INTO v_existing_id
+      FROM wallet.listing
+     WHERE seller_account = p_seller_account
+       AND idempotency_key = p_idempotency_key;
+    IF v_existing_id IS NOT NULL THEN
+        RETURN v_existing_id;
+    END IF;
+
+    -- Lock + validate the source row. We hold the row lock through
+    -- both the optional split and the listing INSERT so a concurrent
+    -- caller can't race the same source.
+    SELECT * INTO v_src
+      FROM inventory.item
+     WHERE id = p_src_item_id
+     FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'item % not found', p_src_item_id USING ERRCODE = 'INV10';
+    END IF;
+    IF v_src.owner_account <> p_seller_account THEN
+        RAISE EXCEPTION 'item % not owned by seller', p_src_item_id USING ERRCODE = 'INV11';
+    END IF;
+    IF v_src.state <> 'held' THEN
+        RAISE EXCEPTION 'item % not in held state (state=%)',
+            p_src_item_id, v_src.state USING ERRCODE = 'INV12';
+    END IF;
+
+    -- Decide whole-row vs split. NULL qty or qty matching source =
+    -- whole row. Otherwise must split (and src must be stackable +
+    -- have strictly more qty than requested).
+    IF p_qty IS NULL OR p_qty = v_src.qty THEN
+        v_listing_qty := v_src.qty;
+        v_listed_id   := v_src.id;
+    ELSIF p_qty < v_src.qty THEN
+        IF NOT v_src.is_stackable THEN
+            RAISE EXCEPTION 'item % is instanced; partial listing not supported',
+                p_src_item_id USING ERRCODE = 'INV15';
+        END IF;
+        v_listed_id := inventory.service_split_for_listing(
+            p_seller_account, p_src_item_id, p_qty
+        );
+        v_listing_qty := p_qty;
+        v_was_split := true;
+    ELSE
+        RAISE EXCEPTION 'qty % exceeds source qty %', p_qty, v_src.qty
+            USING ERRCODE = 'INV13';
+    END IF;
+
+    -- Back-compat item_ref derived from the listed row.
+    v_item_ref := jsonb_build_object(
+        'kind',        v_src.kind,
+        'id',          v_src.ref,
+        'qty',         v_listing_qty,
+        'instance_id', v_listed_id::text,
+        'nbt',         v_src.nbt
+    );
+
+    INSERT INTO wallet.listing (
+        seller_account, item_id, item_ref, currency,
+        buy_now_price, min_bid, expires_at, idempotency_key
+    ) VALUES (
+        p_seller_account, v_listed_id, v_item_ref, v_currency,
+        p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
+    ) RETURNING id INTO v_listing_id;
+
+    -- Whole-row path needs the explicit lock RPC. The split path
+    -- already flipped the new row to listing_escrow.
+    IF NOT v_was_split THEN
+        PERFORM inventory.service_listing_lock(p_seller_account, v_listed_id, v_listing_id);
+    END IF;
+
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+    VALUES (
+        'marketplace.listing_create', 'listing', v_listing_id::TEXT,
+        jsonb_build_object(
+            'seller_account', p_seller_account,
+            'src_item_id',    p_src_item_id,
+            'item_id',        v_listed_id,
+            'qty',            v_listing_qty,
+            'was_split',      v_was_split,
+            'buy_now_price',  p_buy_now_price,
+            'min_bid',        p_min_bid,
+            'expires_at',     p_expires_at
+        )
+    );
+
+    RETURN v_listing_id;
+END;
+$$;
+
+ALTER FUNCTION wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO service_role;
+COMMENT ON FUNCTION wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
+    'SERVICE marketplace RPC. New authoritative listing creator. Takes (src_item_id, qty); qty NULL or = src.qty locks the whole row, qty < src.qty splits via inventory.service_split_for_listing. Successor to service_create_listing(UUID, JSONB, ...); legacy variant stays for axum/Astro back-compat until Phase 6.1c.';
+
+-- ---------------------------------------------------------------------------
+-- 4. public.proxy_market_create_listing_with_item
+--    Authenticated wrapper. Enforces inventory.is_2fa_required_for_listing
+--    aal2 gate + the high_value_khash_threshold check before calling
+--    the wallet service.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.proxy_market_create_listing_with_item(
+    p_src_item_id     UUID,
+    p_qty             BIGINT,
+    p_buy_now_price   BIGINT,
+    p_min_bid         BIGINT,
+    p_expires_at      TIMESTAMPTZ,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+    v_seller    UUID := private.proxy_market_caller_account();
+    v_aal       TEXT := inventory.caller_jwt_aal();
+    v_threshold BIGINT;
+    v_max_price BIGINT;
+BEGIN
+    IF p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'idempotency_key is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_src_item_id IS NULL THEN
+        RAISE EXCEPTION 'src_item_id is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_buy_now_price IS NULL AND p_min_bid IS NULL THEN
+        RAISE EXCEPTION 'listing requires buy_now_price or min_bid' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NOT NULL AND p_buy_now_price <= 0 THEN
+        RAISE EXCEPTION 'buy_now_price must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_min_bid IS NOT NULL AND p_min_bid <= 0 THEN
+        RAISE EXCEPTION 'min_bid must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_expires_at IS NULL OR p_expires_at <= statement_timestamp() THEN
+        RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
+    END IF;
+
+    -- 2FA gate: if the account opted into require_2fa_for_listing,
+    -- the JWT must carry aal=aal2.
+    IF inventory.is_2fa_required_for_listing(v_seller)
+       AND v_aal IS DISTINCT FROM 'aal2' THEN
+        RAISE EXCEPTION 'mfa_required for listing on account %', v_seller
+            USING ERRCODE = 'INV30';
+    END IF;
+
+    -- High-value gate. Compare max(buy_now_price, min_bid) against
+    -- the configured threshold. threshold = 0 means "not configured".
+    SELECT high_value_khash_threshold INTO v_threshold
+      FROM inventory.account_security
+     WHERE account = v_seller;
+    v_threshold := COALESCE(v_threshold, 0);
+
+    IF v_threshold > 0 THEN
+        v_max_price := GREATEST(
+            COALESCE(p_buy_now_price, 0),
+            COALESCE(p_min_bid, 0)
+        );
+        IF v_max_price >= v_threshold
+           AND v_aal IS DISTINCT FROM 'aal2' THEN
+            RAISE EXCEPTION 'mfa_required for high-value listing (price=%, threshold=%) on account %',
+                v_max_price, v_threshold, v_seller USING ERRCODE = 'INV30';
+        END IF;
+    END IF;
+
+    RETURN wallet.service_create_listing_with_item(
+        v_seller, p_src_item_id, p_qty, 'khash'::wallet.currency_kind,
+        p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
+    );
+END;
+$$;
+ALTER FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
+    'PUBLIC marketplace proxy. Authenticated wrapper for wallet.service_create_listing_with_item. Enforces inventory.is_2fa_required_for_listing aal2 gate and the high_value_khash_threshold gate. p_qty NULL = list whole row; p_qty < src.qty = split-and-list.';
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID);
+DROP FUNCTION IF EXISTS wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID);
+
+DROP INDEX IF EXISTS wallet.wallet_listing_active_item_uq;
+ALTER TABLE wallet.listing DROP CONSTRAINT IF EXISTS wallet_listing_active_item_id_chk;
+ALTER TABLE wallet.listing DROP COLUMN IF EXISTS item_id;
+
+DROP FUNCTION IF EXISTS inventory.service_split_for_listing(UUID, UUID, BIGINT);
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
+++ b/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
@@ -90,11 +90,15 @@ BEGIN
        SET qty = qty - p_qty, updated_at = now()
      WHERE id = p_src_item_id;
 
+    -- Preserve v_src.nbt rather than hardcoding '{}'::jsonb. Today the
+    -- is_stackable CHECK above guarantees v_src.nbt = '{}', so the two
+    -- are equivalent — but mirroring the source row keeps this RPC
+    -- correct if the stackable invariant is ever loosened.
     INSERT INTO inventory.item (
         owner_account, kind, ref, qty, nbt, state, source, source_ref
     ) VALUES (
         v_src.owner_account, v_src.kind, v_src.ref, p_qty,
-        '{}'::jsonb, 'listing_escrow', v_src.source,
+        v_src.nbt, 'listing_escrow', v_src.source,
         jsonb_build_object(
             'split_from',        v_src.id::text,
             'parent_source_ref', v_src.source_ref
@@ -136,30 +140,37 @@ ALTER TABLE wallet.listing
     ADD COLUMN item_id UUID
         REFERENCES inventory.item(id) ON DELETE NO ACTION;
 
+-- Hard preflight: refuse the cleanup if any pre-existing active legacy
+-- listing has an active bid. Active bids mean real escrowed khash —
+-- silently flipping bid status to 'refunded' without a ledger reversal
+-- would strand the bidder's khash. The 6.1a foundation deliberately
+-- skips ledger work; if a real bid exists, the migration aborts and
+-- requires manual reconciliation before re-running.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+          FROM wallet.listing l
+          JOIN wallet.bid     b ON b.listing_id = l.id
+         WHERE l.status = 'active'
+           AND l.item_id IS NULL
+           AND b.status = 'active'
+    ) THEN
+        RAISE EXCEPTION
+            'legacy active listings with active bids exist; reconcile escrow manually before re-running 20260520114243';
+    END IF;
+END
+$$;
+
 -- Hard cut. Cancel every pre-existing ACTIVE listing — none of them
 -- have item_id (column was just added), and going forward every
 -- listing MUST flow through the inventory ledger via the
--- *_with_item path. Production has no listings yet; this handles
--- dev / test fixtures so the CHECK below can be plain VALID.
+-- *_with_item path. The preflight above guarantees no active bids,
+-- so no ledger work is needed; this is pure schema hygiene.
 DO $$
 DECLARE
     v_cancelled_count INT;
-    v_refunded_count  INT;
 BEGIN
-    -- Refund any active bids on the about-to-be-cancelled listings.
-    -- No ledger work here — legacy market never went live so there
-    -- shouldn't be real escrowed khash. If there is, the audit_log
-    -- row makes it visible for manual reconciliation.
-    UPDATE wallet.bid
-       SET status     = 'refunded',
-           settled_at = COALESCE(settled_at, now())
-     WHERE listing_id IN (
-         SELECT id FROM wallet.listing
-          WHERE status = 'active' AND item_id IS NULL
-     )
-       AND status = 'active';
-    GET DIAGNOSTICS v_refunded_count = ROW_COUNT;
-
     UPDATE wallet.listing
        SET status              = 'cancelled',
            settled_at          = COALESCE(settled_at, now()),
@@ -170,7 +181,7 @@ BEGIN
        AND item_id IS NULL;
     GET DIAGNOSTICS v_cancelled_count = ROW_COUNT;
 
-    IF v_cancelled_count > 0 OR v_refunded_count > 0 THEN
+    IF v_cancelled_count > 0 THEN
         INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
         VALUES (
             'marketplace.legacy_cleanup',
@@ -178,7 +189,6 @@ BEGIN
             '20260520114243_wallet_inventory_listing_wire',
             jsonb_build_object(
                 'cancelled_listings', v_cancelled_count,
-                'refunded_bids',      v_refunded_count,
                 'reason',             'pre-inventory-ledger active listings cleared'
             )
         );
@@ -198,6 +208,17 @@ ALTER TABLE wallet.listing
 CREATE UNIQUE INDEX wallet_listing_active_item_uq
     ON wallet.listing (item_id)
     WHERE status = 'active' AND item_id IS NOT NULL;
+
+-- Expiry sweep support. service_expire_listings scans
+-- (status='active' AND currency='khash' AND expires_at <= now())
+-- ORDER BY expires_at, id. The existing wallet_listing_active_expires_idx
+-- covers status='active' on expires_at, but a tighter partial index
+-- with the id tiebreaker + currency predicate keeps the sweep cheap
+-- as marketplace volume grows.
+CREATE INDEX IF NOT EXISTS wallet_listing_active_khash_expiry_idx
+    ON wallet.listing (expires_at, id)
+    WHERE status = 'active'
+      AND currency = 'khash'::wallet.currency_kind;
 
 COMMENT ON COLUMN wallet.listing.item_id IS
     'inventory.item.id of the listed row. NULL only allowed on legacy non-active listings; new active listings MUST reference an inventory.item. Active-listing uniqueness ensures one open listing per item.';
@@ -330,9 +351,21 @@ BEGIN
     ) RETURNING id INTO v_listing_id;
 
     -- Whole-row path needs the explicit lock RPC. The split path
-    -- already flipped the new row to listing_escrow.
+    -- already flipped the new row to listing_escrow; backfill the
+    -- listing_id into source_ref so reconciliation tooling can
+    -- traverse split-row escrow → owning listing without a separate
+    -- join through wallet.listing.item_id.
     IF NOT v_was_split THEN
         PERFORM inventory.service_listing_lock(p_seller_account, v_listed_id, v_listing_id);
+    ELSE
+        UPDATE inventory.item
+           SET source_ref = source_ref
+                            || jsonb_build_object(
+                                   'listing_id',         v_listing_id,
+                                   'listing_created_at', v_now
+                               ),
+               updated_at  = now()
+         WHERE id = v_listed_id;
     END IF;
 
     INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
@@ -404,11 +437,12 @@ BEGIN
     END IF;
 
     -- 2FA gate: if the account opted into require_2fa_for_listing,
-    -- the JWT must carry aal=aal2.
+    -- the JWT must carry aal=aal2. Don't leak the account UUID into
+    -- the error message — caller already knows it's theirs, and the
+    -- audit_log row carries the details for support.
     IF inventory.is_2fa_required_for_listing(v_seller)
        AND v_aal IS DISTINCT FROM 'aal2' THEN
-        RAISE EXCEPTION 'mfa_required for listing on account %', v_seller
-            USING ERRCODE = 'INV30';
+        RAISE EXCEPTION 'mfa_required for listing' USING ERRCODE = 'INV30';
     END IF;
 
     -- High-value gate. Compare max(buy_now_price, min_bid) against
@@ -425,8 +459,8 @@ BEGIN
         );
         IF v_max_price >= v_threshold
            AND v_aal IS DISTINCT FROM 'aal2' THEN
-            RAISE EXCEPTION 'mfa_required for high-value listing (price=%, threshold=%) on account %',
-                v_max_price, v_threshold, v_seller USING ERRCODE = 'INV30';
+            RAISE EXCEPTION 'mfa_required for high-value listing'
+                USING ERRCODE = 'INV30';
         END IF;
     END IF;
 
@@ -442,13 +476,60 @@ GRANT  EXECUTE ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BI
 COMMENT ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
     'PUBLIC marketplace proxy. Authenticated wrapper for wallet.service_create_listing_with_item. Enforces inventory.is_2fa_required_for_listing aal2 gate and the high_value_khash_threshold gate. p_qty NULL = list whole row; p_qty < src.qty = split-and-list.';
 
+-- ---------------------------------------------------------------------------
+-- Legacy proxy_market_create_listing(JSONB, ...) deprecation
+--   The legacy proxy from migration 20260516015242 still exists for
+--   axum / Astro compile-time. With the new wallet_listing_active_item_id_chk
+--   in place, the legacy INSERT would fail with a raw check_violation.
+--   Replace the legacy proxy body with a clean P1011 error so callers
+--   see "use the *_with_item path" instead of a constraint trip.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.proxy_market_create_listing(
+    p_item_ref        JSONB,
+    p_buy_now_price   BIGINT,
+    p_min_bid         BIGINT,
+    p_expires_at      TIMESTAMPTZ,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+BEGIN
+    RAISE EXCEPTION 'legacy listing RPC disabled; use proxy_market_create_listing_with_item'
+        USING ERRCODE = 'P1011';
+END;
+$$;
+
+COMMENT ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
+    'DEPRECATED. Phase 6.1a stubbed this proxy to raise P1011 so axum/Astro see a clean migration error during the 6.1b cutover. Dropped entirely in Phase 6.1c.';
+
 NOTIFY pgrst, 'reload schema';
 
 -- migrate:down
+-- ============================================================================
+-- ⚠ OPERATIONAL WARNING ⚠
+-- Rolling back this migration RE-INTRODUCES the stuck-escrow + legacy
+-- listing path, removes wallet.listing.item_id, and resurrects the
+-- raw check_violation behaviour of the legacy proxy. Hard-gated on
+-- the GUC app.allow_marketplace_unsafe_down='on' so a stray dbmate
+-- rollback against prod aborts before touching anything. Local test
+-- harness opts in via PGOPTIONS — see test-migration.sh.
+-- ============================================================================
+DO $$
+BEGIN
+    IF current_setting('app.allow_marketplace_unsafe_down', true)
+       IS DISTINCT FROM 'on' THEN
+        RAISE EXCEPTION
+            'refusing destructive marketplace rollback: set app.allow_marketplace_unsafe_down=on to proceed';
+    END IF;
+END
+$$;
 
 DROP FUNCTION IF EXISTS public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID);
 DROP FUNCTION IF EXISTS wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID);
 
+DROP INDEX IF EXISTS wallet.wallet_listing_active_khash_expiry_idx;
 DROP INDEX IF EXISTS wallet.wallet_listing_active_item_uq;
 ALTER TABLE wallet.listing DROP CONSTRAINT IF EXISTS wallet_listing_active_item_id_chk;
 ALTER TABLE wallet.listing DROP COLUMN IF EXISTS item_id;

--- a/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
+++ b/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
@@ -28,6 +28,23 @@
 --
 -- Settle / cancel / expire / buy_now hooks land in the sibling
 -- migration 20260520114244_wallet_listing_settle_inventory.sql.
+--
+-- LOCK-ORDER INVARIANT (cross-schema):
+--   wallet marketplace functions lock wallet.listing FIRST, then call
+--   inventory.service_listing_* which locks inventory.item second.
+--   inventory.service_listing_* MUST NOT lock wallet.listing in any
+--   path — that would invert the order and create a deadlock surface.
+--   Any future reconciliation tooling that wants to traverse
+--   inventory → listing MUST read wallet.listing without acquiring a
+--   row lock (no FOR UPDATE / FOR SHARE).
+--
+-- OPERATIONAL NOTE (DDL locking):
+--   This migration builds non-CONCURRENT indexes + adds an ALTER
+--   COLUMN + CHECK inside dbmate's single transaction. Tables are
+--   empty at first deploy so locking is moot, but if a future
+--   re-application happens against a populated marketplace, run
+--   during a write pause — CONCURRENTLY isn't available in a
+--   transactional migration block.
 -- ============================================================================
 
 -- Preflight: fail fast if the 6.0 inventory hooks + JWT helpers the
@@ -382,22 +399,32 @@ BEGIN
             RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (price/expiry differs)',
                 p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
         END IF;
-        -- Source-item identity. Direct match for whole-row OR
-        -- source_ref split_from match for partial.
-        IF v_existing_item_id IS DISTINCT FROM p_src_item_id
-           AND NOT EXISTS (
-               SELECT 1 FROM inventory.item
-                WHERE id = v_existing_item_id
-                  AND source_ref ->> 'split_from' = p_src_item_id::text
-           ) THEN
-            RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (src_item_id differs)',
-                p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
-        END IF;
-        -- Qty check. NULL p_qty (whole-row request) must match the
-        -- listed item's full qty as recorded in item_ref.
-        IF p_qty IS NOT NULL AND v_existing_qty IS DISTINCT FROM p_qty THEN
-            RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (qty differs)',
-                p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
+        -- Qty + source-item identity check.
+        -- NULL p_qty means "list the whole src row" — replay must point
+        -- at the exact source (split-derived rows DON'T satisfy NULL
+        -- replay because the original wasn't whole-row).
+        -- Non-NULL p_qty (partial split) accepts either direct
+        -- src_item_id OR a split-derived row tracing back via
+        -- source_ref->>'split_from'.
+        IF p_qty IS NULL THEN
+            IF v_existing_item_id IS DISTINCT FROM p_src_item_id THEN
+                RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (whole-row replay against split listing)',
+                    p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
+            END IF;
+        ELSE
+            IF v_existing_item_id IS DISTINCT FROM p_src_item_id
+               AND NOT EXISTS (
+                   SELECT 1 FROM inventory.item
+                    WHERE id = v_existing_item_id
+                      AND source_ref ->> 'split_from' = p_src_item_id::text
+               ) THEN
+                RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (src_item_id differs)',
+                    p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
+            END IF;
+            IF v_existing_qty IS DISTINCT FROM p_qty THEN
+                RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (qty differs)',
+                    p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
+            END IF;
         END IF;
         RETURN v_existing_id;
     END IF;
@@ -645,6 +672,25 @@ BEGIN
        IS DISTINCT FROM 'on' THEN
         RAISE EXCEPTION
             'refusing destructive marketplace rollback: set app.allow_marketplace_unsafe_down=on to proceed';
+    END IF;
+END
+$$;
+
+-- Hard data guard: never drop item_id while active item-backed
+-- listings still exist. Dropping the column would orphan the
+-- inventory escrow rows without releasing them. The GUC above
+-- gates the rollback; this preflight covers the case where the
+-- operator opts in but data isn't ready.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM wallet.listing
+         WHERE status = 'active' AND item_id IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION
+            'refusing to drop wallet.listing.item_id: % active item-backed listings still exist; cancel or settle them before rolling back',
+            (SELECT count(*) FROM wallet.listing
+              WHERE status = 'active' AND item_id IS NOT NULL);
     END IF;
 END
 $$;

--- a/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
+++ b/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
@@ -236,6 +236,29 @@ BEGIN
         RAISE EXCEPTION
             'legacy active listings with stale current_bid_id pointers exist; manual reconciliation required';
     END IF;
+
+    -- Catch denormalized cache drift: current_bid_id points at an
+    -- active bid row, but the cached current_bid / current_bid_account
+    -- disagree with that bid's amount / bidder. Settle in the new
+    -- code path refuses this drift; surface it before the cleanup
+    -- below clears the cache and deletes the evidence.
+    IF EXISTS (
+        SELECT 1
+          FROM wallet.listing l
+          JOIN wallet.bid b
+            ON b.id = l.current_bid_id
+           AND b.listing_id = l.id
+           AND b.status = 'active'
+         WHERE l.status = 'active'
+           AND l.item_id IS NULL
+           AND (
+                l.current_bid IS DISTINCT FROM b.amount
+                OR l.current_bid_account IS DISTINCT FROM b.bidder_account
+           )
+    ) THEN
+        RAISE EXCEPTION
+            'legacy active listings with current_bid cache mismatch exist; manual reconciliation required';
+    END IF;
 END
 $$;
 
@@ -280,6 +303,26 @@ FROM cancelled;
 ALTER TABLE wallet.listing
     ADD CONSTRAINT wallet_listing_active_item_id_chk
         CHECK (status <> 'active' OR item_id IS NOT NULL);
+
+-- Defensive: duplicate-detection preflight before the unique index
+-- build. Impossible on first deploy (item_id was just added), but
+-- protects re-applications against dev/staging drift and surfaces a
+-- clean error instead of a raw unique_violation during CREATE INDEX.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+          FROM wallet.listing
+         WHERE status = 'active'
+           AND item_id IS NOT NULL
+         GROUP BY item_id
+        HAVING count(*) > 1
+    ) THEN
+        RAISE EXCEPTION
+            'duplicate active item-backed listings exist; manual reconciliation required before creating wallet_listing_active_item_uq';
+    END IF;
+END
+$$;
 
 CREATE UNIQUE INDEX wallet_listing_active_item_uq
     ON wallet.listing (item_id)

--- a/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
+++ b/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
@@ -47,6 +47,40 @@
 --   transactional migration block.
 -- ============================================================================
 
+-- Enum preflight: each label the new RPCs hardcode must already
+-- exist on its parent type. Protects against partial dev/staging
+-- rebuilds where an earlier migration's enum drifted.
+DO $$
+DECLARE
+    v_label TEXT;
+BEGIN
+    FOR v_label IN
+        SELECT req.label FROM (VALUES
+            ('inventory.item_state:held'),
+            ('inventory.item_state:listing_escrow'),
+            ('wallet.listing_status:active'),
+            ('wallet.listing_status:sold'),
+            ('wallet.listing_status:cancelled'),
+            ('wallet.listing_status:expired'),
+            ('wallet.bid_status:active'),
+            ('wallet.bid_status:won'),
+            ('wallet.currency_kind:khash')
+        ) AS req(label)
+         WHERE NOT EXISTS (
+            SELECT 1
+              FROM pg_type t
+              JOIN pg_namespace n ON n.oid = t.typnamespace
+              JOIN pg_enum e ON e.enumtypid = t.oid
+             WHERE n.nspname = split_part(split_part(req.label, ':', 1), '.', 1)
+               AND t.typname = split_part(split_part(req.label, ':', 1), '.', 2)
+               AND e.enumlabel = split_part(req.label, ':', 2)
+         )
+    LOOP
+        RAISE EXCEPTION 'enum preflight: missing required label %', v_label;
+    END LOOP;
+END
+$$;
+
 -- Preflight: fail fast if the 6.0 inventory hooks + JWT helpers the
 -- new wallet RPCs depend on are missing. Without these, the
 -- migration would technically succeed and only fail at runtime.

--- a/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
+++ b/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
@@ -134,6 +134,15 @@ BEGIN
             USING ERRCODE = 'P1009';
     END IF;
 
+    -- Defensive: bidding already refuses seller self-bids, but settle
+    -- is the final authority. A corrupted bid row pointing at the
+    -- seller would otherwise transfer the item to the seller's own
+    -- inventory with no money movement.
+    IF v_bidder = v_seller THEN
+        RAISE EXCEPTION 'seller cannot settle listing % to self', p_listing_id
+            USING ERRCODE = 'P1013';
+    END IF;
+
     DECLARE
         v_updated_bid_id BIGINT;
     BEGIN
@@ -245,20 +254,35 @@ BEGIN
     IF v_listing_row.status <> 'active' THEN
         IF v_listing_row.status = 'cancelled' THEN
             -- Idempotent re-cancel. If a prior call cancelled the
-            -- listing but failed to release the inventory row (e.g.
-            -- pre-6.1a bug, partial migration), try the unlock again.
-            -- inventory.service_listing_unlock is idempotent against
-            -- already-held rows (raises INV21 if state isn't
-            -- listing_escrow); catch that so repair stays a no-op.
+            -- listing but failed to release the inventory row, try
+            -- the unlock again ONLY when the item is provably in a
+            -- safe repair state: state='listing_escrow' OR ('held'
+            -- already owned by this seller). Any other state means
+            -- the item was transferred, consumed, or is mid-transit
+            -- — repair must surface that loudly, not swallow it.
             IF v_listing_row.item_id IS NOT NULL THEN
+                DECLARE
+                    v_item_state inventory.item_state;
+                    v_item_owner UUID;
                 BEGIN
-                    PERFORM inventory.service_listing_unlock(
-                        p_seller_account, v_listing_row.item_id, p_listing_id,
-                        COALESCE(p_reason, 'listing_cancelled_repair')
-                    );
-                EXCEPTION WHEN SQLSTATE 'INV21' THEN
-                    -- Already unlocked. Repair was a no-op; that's fine.
-                    NULL;
+                    SELECT state, owner_account
+                      INTO v_item_state, v_item_owner
+                      FROM inventory.item
+                     WHERE id = v_listing_row.item_id;
+                    IF v_item_state = 'listing_escrow' THEN
+                        PERFORM inventory.service_listing_unlock(
+                            p_seller_account, v_listing_row.item_id, p_listing_id,
+                            COALESCE(p_reason, 'listing_cancelled_repair')
+                        );
+                    ELSIF v_item_state = 'held' AND v_item_owner = p_seller_account THEN
+                        -- Already released to seller. Repair no-op.
+                        NULL;
+                    ELSE
+                        RAISE EXCEPTION
+                            'cancel repair refused: item % in unsafe state (state=%, owner=%)',
+                            v_listing_row.item_id, v_item_state, v_item_owner
+                            USING ERRCODE = 'P1002';
+                    END IF;
                 END;
             END IF;
             RETURN;
@@ -573,6 +597,12 @@ BEGIN
         p_reason);
 END;
 $$;
+-- Restate privilege contract on rollback for consistency. CREATE OR
+-- REPLACE preserves grants but the explicit ALTER + REVOKE + GRANT
+-- below makes the security-definer posture visible in the down path.
+ALTER FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) TO service_role;
 
 CREATE OR REPLACE FUNCTION wallet.service_cancel_listing(
     p_listing_id      BIGINT,
@@ -620,6 +650,9 @@ BEGIN
         COALESCE(p_reason, 'seller cancelled listing'));
 END;
 $$;
+ALTER FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) TO service_role;
 
 CREATE OR REPLACE FUNCTION wallet.service_expire_listings(
     p_limit INTEGER DEFAULT 100
@@ -675,5 +708,8 @@ BEGIN
     RETURN NEXT;
 END;
 $$;
+ALTER FUNCTION wallet.service_expire_listings(INTEGER) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_expire_listings(INTEGER) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION wallet.service_expire_listings(INTEGER) TO service_role;
 
 NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
+++ b/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
@@ -667,6 +667,7 @@ BEGIN
     );
     UPDATE wallet.listing
        SET status = 'cancelled', settled_at = v_now,
+           buyer_account = NULL,
            current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
      WHERE id = p_listing_id;
     INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
@@ -717,6 +718,7 @@ BEGIN
         ELSE
             UPDATE wallet.listing
                SET status = 'expired', settled_at = v_now,
+                   buyer_account = NULL,
                    current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
              WHERE id = v_listing_id;
             v_expired := v_expired + 1;

--- a/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
+++ b/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
@@ -469,8 +469,19 @@ NOTIFY pgrst, 'reload schema';
 --      foundation rollback alongside.
 --   3. Or roll back the foundation migration 20260520114243 in the
 --      same window so wallet.listing.item_id is gone entirely.
--- This down path is meant for dev / test, not live triage.
+-- This down path is meant for dev / test, not live triage. Hard-gated
+-- on app.allow_marketplace_unsafe_down='on' to mirror the foundation
+-- migration's guard.
 -- ============================================================================
+DO $$
+BEGIN
+    IF current_setting('app.allow_marketplace_unsafe_down', true)
+       IS DISTINCT FROM 'on' THEN
+        RAISE EXCEPTION
+            'refusing destructive marketplace rollback: set app.allow_marketplace_unsafe_down=on to proceed';
+    END IF;
+END
+$$;
 
 DROP INDEX IF EXISTS wallet.wallet_bid_one_won_per_listing_uq;
 

--- a/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
+++ b/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
@@ -608,10 +608,20 @@ BEGIN
     SELECT d.fee, d.net, d.seller_ledger_id, d.fee_ledger_id
       INTO v_fee, v_net, v_seller_ledger_id, v_fee_ledger_id
       FROM wallet.distribute_settlement(p_listing_id, v_seller, v_amount, v_bid_id) d;
-    UPDATE wallet.listing
-       SET status = 'sold', settled_at = v_now, buyer_account = v_bidder,
-           current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
-     WHERE id = p_listing_id;
+    DECLARE
+        v_updated_listing_id BIGINT;
+    BEGIN
+        UPDATE wallet.listing
+           SET status = 'sold', settled_at = v_now, buyer_account = v_bidder,
+               current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
+         WHERE id = p_listing_id
+           AND status = 'active'
+        RETURNING id INTO v_updated_listing_id;
+        IF v_updated_listing_id IS NULL THEN
+            RAISE EXCEPTION 'listing % no longer active at rollback settle update', p_listing_id
+                USING ERRCODE = 'P1002';
+        END IF;
+    END;
     INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
     VALUES ('marketplace.listing_settle', 'listing', p_listing_id::TEXT,
         jsonb_build_object('winning_bid_id', v_bid_id, 'buyer_account', v_bidder,
@@ -665,11 +675,21 @@ BEGIN
     v_refund_id := wallet.refund_active_bid(
         p_listing_id, 'refunded', COALESCE(p_reason, 'seller cancelled listing')
     );
-    UPDATE wallet.listing
-       SET status = 'cancelled', settled_at = v_now,
-           buyer_account = NULL,
-           current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
-     WHERE id = p_listing_id;
+    DECLARE
+        v_updated_listing_id BIGINT;
+    BEGIN
+        UPDATE wallet.listing
+           SET status = 'cancelled', settled_at = v_now,
+               buyer_account = NULL,
+               current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
+         WHERE id = p_listing_id
+           AND status = 'active'
+        RETURNING id INTO v_updated_listing_id;
+        IF v_updated_listing_id IS NULL THEN
+            RAISE EXCEPTION 'listing % no longer active at rollback cancel update', p_listing_id
+                USING ERRCODE = 'P1002';
+        END IF;
+    END;
     INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
     VALUES ('marketplace.listing_cancel', 'listing', p_listing_id::TEXT,
         jsonb_build_object('seller_account', p_seller_account, 'refunded_bid_id', v_refund_id),
@@ -716,11 +736,21 @@ BEGIN
             );
             v_settled := v_settled + 1;
         ELSE
-            UPDATE wallet.listing
-               SET status = 'expired', settled_at = v_now,
-                   buyer_account = NULL,
-                   current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
-             WHERE id = v_listing_id;
+            DECLARE
+                v_updated_listing_id BIGINT;
+            BEGIN
+                UPDATE wallet.listing
+                   SET status = 'expired', settled_at = v_now,
+                       buyer_account = NULL,
+                       current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
+                 WHERE id = v_listing_id
+                   AND status = 'active'
+                RETURNING id INTO v_updated_listing_id;
+                IF v_updated_listing_id IS NULL THEN
+                    RAISE EXCEPTION 'listing % no longer active at rollback expire update', v_listing_id
+                        USING ERRCODE = 'P1002';
+                END IF;
+            END;
             v_expired := v_expired + 1;
         END IF;
         v_total := v_total + 1;

--- a/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
+++ b/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
@@ -28,8 +28,44 @@
 -- Legacy listings with item_id IS NULL skip the inventory hook entirely.
 -- ============================================================================
 
+-- Preflight: fail fast if the inventory hooks this migration depends on
+-- are missing. Belt-and-suspenders against running on a database where
+-- the 6.0 foundation never landed.
+DO $$
+BEGIN
+    IF to_regprocedure('inventory.service_listing_settle(uuid, uuid, bigint, uuid)') IS NULL THEN
+        RAISE EXCEPTION 'missing inventory.service_listing_settle(uuid, uuid, bigint, uuid) — apply 6.0 foundation first';
+    END IF;
+    IF to_regprocedure('inventory.service_listing_unlock(uuid, uuid, bigint, text)') IS NULL THEN
+        RAISE EXCEPTION 'missing inventory.service_listing_unlock(uuid, uuid, bigint, text) — apply 6.0 foundation first';
+    END IF;
+END
+$$;
+
+-- One won bid per listing — enforced at the table level so future code
+-- paths cannot accidentally create two winning bids for one listing.
+-- Procedural EXISTS check inside service_settle_listing stays as a
+-- second line of defense with a clean P1002 error code.
+CREATE UNIQUE INDEX IF NOT EXISTS wallet_bid_one_won_per_listing_uq
+    ON wallet.bid (listing_id)
+    WHERE status = 'won';
+
 -- ---------------------------------------------------------------------------
 -- wallet.service_settle_listing — settle + transfer item to buyer
+--
+-- Sequence (one transaction, rolls back together):
+--   1. lock listing FOR UPDATE
+--   2. lock winning bid FOR UPDATE
+--   3. flip bid status to 'won'
+--   4. distribute_settlement (seller credit + treasury fee)
+--   5. inventory.service_listing_settle transfers escrowed item to buyer
+--   6. flip listing status to 'sold' (status-guarded UPDATE)
+--   7. audit_log
+--
+-- Inventory hook fires BEFORE the listing flips to 'sold' so the
+-- domain sequence reads "active escrow → transfer → sold" rather than
+-- "sold → then transfer". Mostly hygiene; one transaction so a
+-- failure anywhere rolls everything back.
 -- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION wallet.service_settle_listing(
@@ -76,7 +112,7 @@ BEGIN
 
     IF v_listing_row.current_bid_id IS NULL THEN
         RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
-            USING ERRCODE = '23503';
+            USING ERRCODE = 'P1009';
     END IF;
     IF p_winning_bid_id IS NOT NULL
        AND p_winning_bid_id <> v_listing_row.current_bid_id THEN
@@ -95,7 +131,7 @@ BEGIN
 
     IF v_bid_id IS NULL THEN
         RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
-            USING ERRCODE = '23503';
+            USING ERRCODE = 'P1009';
     END IF;
 
     DECLARE
@@ -116,21 +152,36 @@ BEGIN
       INTO v_fee, v_net, v_seller_ledger_id, v_fee_ledger_id
       FROM wallet.distribute_settlement(p_listing_id, v_seller, v_amount, v_bid_id) d;
 
-    UPDATE wallet.listing
-       SET status = 'sold',
-           settled_at = v_now,
-           buyer_account = v_bidder,
-           current_bid = NULL,
-           current_bid_account = NULL,
-           current_bid_id = NULL
-     WHERE id = p_listing_id;
-
-    -- Phase 6.1a: hand the escrowed inventory row to the buyer.
+    -- Phase 6.1a: hand the escrowed inventory row to the buyer BEFORE
+    -- the listing flips to 'sold' so the domain sequence stays
+    -- "active escrow → transfer → sold".
     IF v_listing_row.item_id IS NOT NULL THEN
         v_buyer_item_id := inventory.service_listing_settle(
             v_seller, v_listing_row.item_id, p_listing_id, v_bidder
         );
     END IF;
+
+    -- Status-guarded final flip. RETURNING asserts the row was still
+    -- 'active'; concurrent settle on the same listing would have
+    -- failed the FOR UPDATE chain above, so this is defensive.
+    DECLARE
+        v_updated_listing_id BIGINT;
+    BEGIN
+        UPDATE wallet.listing
+           SET status = 'sold',
+               settled_at = v_now,
+               buyer_account = v_bidder,
+               current_bid = NULL,
+               current_bid_account = NULL,
+               current_bid_id = NULL
+         WHERE id = p_listing_id
+           AND status = 'active'
+        RETURNING id INTO v_updated_listing_id;
+        IF v_updated_listing_id IS NULL THEN
+            RAISE EXCEPTION 'listing % no longer active at final settle update', p_listing_id
+                USING ERRCODE = 'P1002';
+        END IF;
+    END;
 
     INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
     VALUES (
@@ -153,8 +204,11 @@ BEGIN
 END;
 $$;
 
+ALTER FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) TO service_role;
 COMMENT ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) IS
-    'INTERNAL marketplace helper. Invoked by place_bid, buy_now, and expire_listings. Self-locks the listing row. Validates listing status=active+currency=khash+no won bid+matching current_bid_id, flips winning bid to won, distributes funds, and (Phase 6.1a) calls inventory.service_listing_settle to transfer the escrowed item to the buyer when listing.item_id IS NOT NULL.';
+    'INTERNAL marketplace helper. Invoked by place_bid, buy_now, and expire_listings. Self-locks the listing row. Validates listing status=active+currency=khash+no won bid+matching current_bid_id, flips winning bid to won, distributes funds, calls inventory.service_listing_settle to transfer the escrowed item to the buyer (Phase 6.1a; only when listing.item_id IS NOT NULL), then flips listing to sold under a status-guarded update.';
 
 -- ---------------------------------------------------------------------------
 -- wallet.service_cancel_listing — refund + release item to seller
@@ -190,6 +244,23 @@ BEGIN
     END IF;
     IF v_listing_row.status <> 'active' THEN
         IF v_listing_row.status = 'cancelled' THEN
+            -- Idempotent re-cancel. If a prior call cancelled the
+            -- listing but failed to release the inventory row (e.g.
+            -- pre-6.1a bug, partial migration), try the unlock again.
+            -- inventory.service_listing_unlock is idempotent against
+            -- already-held rows (raises INV21 if state isn't
+            -- listing_escrow); catch that so repair stays a no-op.
+            IF v_listing_row.item_id IS NOT NULL THEN
+                BEGIN
+                    PERFORM inventory.service_listing_unlock(
+                        p_seller_account, v_listing_row.item_id, p_listing_id,
+                        COALESCE(p_reason, 'listing_cancelled_repair')
+                    );
+                EXCEPTION WHEN SQLSTATE 'INV21' THEN
+                    -- Already unlocked. Repair was a no-op; that's fine.
+                    NULL;
+                END;
+            END IF;
             RETURN;
         END IF;
         RAISE EXCEPTION 'listing % not active (status=%)',
@@ -204,21 +275,36 @@ BEGIN
         p_listing_id, 'refunded', COALESCE(p_reason, 'seller cancelled listing')
     );
 
-    UPDATE wallet.listing
-       SET status = 'cancelled',
-           settled_at = v_now,
-           current_bid = NULL,
-           current_bid_account = NULL,
-           current_bid_id = NULL
-     WHERE id = p_listing_id;
-
-    -- Phase 6.1a: release the escrowed inventory row back to seller.
+    -- Phase 6.1a: release the escrowed inventory row back to seller
+    -- BEFORE the listing flips to 'cancelled' so the domain sequence
+    -- stays "active escrow → release → cancelled".
     IF v_listing_row.item_id IS NOT NULL THEN
         PERFORM inventory.service_listing_unlock(
             p_seller_account, v_listing_row.item_id, p_listing_id,
             COALESCE(p_reason, 'listing_cancelled')
         );
     END IF;
+
+    -- Status-guarded UPDATE. buyer_account explicitly cleared (cancel
+    -- can never leave a buyer association).
+    DECLARE
+        v_updated_listing_id BIGINT;
+    BEGIN
+        UPDATE wallet.listing
+           SET status = 'cancelled',
+               settled_at = v_now,
+               buyer_account = NULL,
+               current_bid = NULL,
+               current_bid_account = NULL,
+               current_bid_id = NULL
+         WHERE id = p_listing_id
+           AND status = 'active'
+        RETURNING id INTO v_updated_listing_id;
+        IF v_updated_listing_id IS NULL THEN
+            RAISE EXCEPTION 'listing % no longer active at final cancel update', p_listing_id
+                USING ERRCODE = 'P1002';
+        END IF;
+    END;
 
     INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
     VALUES (
@@ -233,8 +319,11 @@ BEGIN
 END;
 $$;
 
+ALTER FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) TO service_role;
 COMMENT ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) IS
-    'SERVICE marketplace RPC. Seller-driven cancel. Refunds the active bid (if any) and flips status to cancelled. Idempotent on already-cancelled. Phase 6.1a: also calls inventory.service_listing_unlock when listing.item_id IS NOT NULL.';
+    'SERVICE marketplace RPC. Seller-driven cancel. Refunds the active bid (if any) and flips status to cancelled. Idempotent on already-cancelled — re-cancel attempts an inventory unlock repair when item_id IS NOT NULL (no-op if already unlocked, INV21 swallowed). Phase 6.1a: calls inventory.service_listing_unlock when listing.item_id IS NOT NULL.';
 
 -- ---------------------------------------------------------------------------
 -- wallet.service_expire_listings — sweep + release items on no-bid expiry
@@ -254,11 +343,19 @@ DECLARE
     v_total           BIGINT := 0;
     v_settled         BIGINT := 0;
     v_expired         BIGINT := 0;
+    -- p_limit caps TRANSACTION SIZE, not just perf. Each settled
+    -- listing touches bids, ledger, balance, inventory.item +
+    -- inventory.transition, plus audit_log. Defaults to 100 to keep
+    -- one cron tick well under typical statement_timeout.
     v_limit           INTEGER := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 1000);
 BEGIN
     PERFORM set_config('lock_timeout', '2s', true);
     PERFORM set_config('statement_timeout', '30s', true);
 
+    -- Singleton sweeper: pg_try_advisory_xact_lock serializes parallel
+    -- cron runs. The FOR UPDATE SKIP LOCKED in the cursor below is
+    -- therefore DEFENSIVE-ONLY against any non-cron caller that holds
+    -- a listing row lock (place_bid, buy_now, cancel, settle).
     IF NOT pg_try_advisory_xact_lock(
         hashtextextended('wallet.service_expire_listings', 0)
     ) THEN
@@ -286,46 +383,44 @@ BEGIN
             );
             v_settled := v_settled + 1;
         ELSE
-            UPDATE wallet.listing
-               SET status = 'expired',
-                   settled_at = v_now,
-                   current_bid = NULL,
-                   current_bid_account = NULL,
-                   current_bid_id = NULL
-             WHERE id = v_listing_id;
-
+            -- Inventory unlock BEFORE the status flip — "active escrow
+            -- → release → expired" sequence. buyer_account also
+            -- cleared defensively (no-bid expiry has no buyer).
             IF v_item_id IS NOT NULL THEN
                 PERFORM inventory.service_listing_unlock(
                     v_seller, v_item_id, v_listing_id, 'listing_expired_no_bids'
                 );
             END IF;
 
+            DECLARE
+                v_updated_listing_id BIGINT;
+            BEGIN
+                UPDATE wallet.listing
+                   SET status = 'expired',
+                       settled_at = v_now,
+                       buyer_account = NULL,
+                       current_bid = NULL,
+                       current_bid_account = NULL,
+                       current_bid_id = NULL
+                 WHERE id = v_listing_id
+                   AND status = 'active'
+                RETURNING id INTO v_updated_listing_id;
+                IF v_updated_listing_id IS NULL THEN
+                    RAISE EXCEPTION 'listing % no longer active at expire update', v_listing_id
+                        USING ERRCODE = 'P1002';
+                END IF;
+            END;
+
             v_expired := v_expired + 1;
         END IF;
         v_total := v_total + 1;
     END LOOP;
 
-    DECLARE
-        v_skipped_non_khash BIGINT;
-    BEGIN
-        SELECT COUNT(*) INTO v_skipped_non_khash
-          FROM wallet.listing
-         WHERE status = 'active'
-           AND currency <> 'khash'::wallet.currency_kind
-           AND expires_at <= v_now;
-
-        IF v_skipped_non_khash > 0 THEN
-            INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
-            VALUES (
-                'marketplace.expire_sweep_unsupported_currency',
-                'listing', 'batch',
-                jsonb_build_object(
-                    'skipped_non_khash', v_skipped_non_khash,
-                    'cutoff_at', v_now
-                )
-            );
-        END IF;
-    END;
+    -- Per-sweep unsupported-currency count + audit insert removed
+    -- (Phase 6.1a). v1 is khash-only; non-khash actives would only
+    -- exist via direct DB edit and would spam audit_log on every
+    -- cron tick. Use an offline operational view if observability
+    -- becomes necessary again.
 
     IF v_total > 0 THEN
         INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
@@ -348,8 +443,11 @@ BEGIN
 END;
 $$;
 
+ALTER FUNCTION wallet.service_expire_listings(INTEGER) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_expire_listings(INTEGER) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION wallet.service_expire_listings(INTEGER) TO service_role;
 COMMENT ON FUNCTION wallet.service_expire_listings(INTEGER) IS
-    'SERVICE marketplace RPC. pg_cron-driven sweep of active KHASH listings past expires_at. Bid-bearing rows settle through service_settle_listing (inventory hand-off included). No-bid rows flip to expired and (Phase 6.1a) call inventory.service_listing_unlock to release the item back to the seller. Bounded to p_limit (default 100, clamped [1, 1000]).';
+    'SERVICE marketplace RPC. pg_cron-driven sweep of active KHASH listings past expires_at. Bid-bearing rows settle through service_settle_listing (inventory hand-off included). No-bid rows flip to expired and (Phase 6.1a) call inventory.service_listing_unlock to release the item back to the seller. Bounded to p_limit (default 100, clamped [1, 1000]) — p_limit caps TRANSACTION SIZE not just perf, because each settled listing touches bids + ledger + balance + inventory.item + audit_log.';
 
 NOTIFY pgrst, 'reload schema';
 
@@ -358,7 +456,23 @@ NOTIFY pgrst, 'reload schema';
 -- Revert the three functions to their pre-6.1a behaviour (no inventory
 -- hooks). Inline so dbmate rollback leaves a working market layer even
 -- if the foundation migration also rolls back.
+--
+-- ⚠ OPERATIONAL WARNING ⚠
+-- Rolling back this migration RE-INTRODUCES the stuck-escrow bug: any
+-- listing that settles, cancels, or expires under the reverted bodies
+-- will NOT release its inventory.item from listing_escrow. Before
+-- running migrate:down in production:
+--   1. Pause all marketplace writes (axum + cron).
+--   2. Drain or repair any wallet.listing rows where status='active'
+--      AND item_id IS NOT NULL — either cancel them through the
+--      6.1a-version of service_cancel_listing or apply the
+--      foundation rollback alongside.
+--   3. Or roll back the foundation migration 20260520114243 in the
+--      same window so wallet.listing.item_id is gone entirely.
+-- This down path is meant for dev / test, not live triage.
 -- ============================================================================
+
+DROP INDEX IF EXISTS wallet.wallet_bid_one_won_per_listing_uq;
 
 CREATE OR REPLACE FUNCTION wallet.service_settle_listing(
     p_listing_id     BIGINT,

--- a/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
+++ b/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
@@ -142,6 +142,23 @@ BEGIN
         RAISE EXCEPTION 'seller cannot settle listing % to self', p_listing_id
             USING ERRCODE = 'P1013';
     END IF;
+    -- Bidder must be a real user account. Place_bid already enforces
+    -- this; revalidating at settle defends against a corrupted bid row
+    -- pointing at a non-user account (treasury, escrow, system).
+    PERFORM wallet.assert_user_account(v_bidder);
+    -- Denormalized cache consistency. listing.(current_bid,
+    -- current_bid_account, current_bid_id) must agree with the active
+    -- bid row we just locked. A drift here means a previous code path
+    -- updated one side but not the other; refuse to settle on stale
+    -- cache.
+    IF v_listing_row.current_bid IS DISTINCT FROM v_amount
+       OR v_listing_row.current_bid_account IS DISTINCT FROM v_bidder THEN
+        RAISE EXCEPTION 'listing % current bid cache mismatch (cache=%/%, bid=%/%)',
+            p_listing_id,
+            v_listing_row.current_bid, v_listing_row.current_bid_account,
+            v_amount, v_bidder
+            USING ERRCODE = 'P1002';
+    END IF;
 
     DECLARE
         v_updated_bid_id BIGINT;
@@ -347,7 +364,7 @@ ALTER FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) OWNER TO servic
 REVOKE ALL ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) TO service_role;
 COMMENT ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) IS
-    'SERVICE marketplace RPC. Seller-driven cancel. Refunds the active bid (if any) and flips status to cancelled. Idempotent on already-cancelled — re-cancel attempts an inventory unlock repair when item_id IS NOT NULL (no-op if already unlocked, INV21 swallowed). Phase 6.1a: calls inventory.service_listing_unlock when listing.item_id IS NOT NULL.';
+    'SERVICE marketplace RPC. Seller-driven cancel. Refunds the active bid (if any) and flips status to cancelled. Idempotent on already-cancelled — re-cancel attempts an inventory unlock repair when item_id IS NOT NULL. Repair branch inspects the item state explicitly: listing_escrow triggers a real unlock, held+owned-by-seller is a no-op, anything else raises P1002. No blind error-swallowing. Phase 6.1a: calls inventory.service_listing_unlock when listing.item_id IS NOT NULL.';
 
 -- ---------------------------------------------------------------------------
 -- wallet.service_expire_listings — sweep + release items on no-bid expiry
@@ -380,6 +397,14 @@ BEGIN
     -- cron runs. The FOR UPDATE SKIP LOCKED in the cursor below is
     -- therefore DEFENSIVE-ONLY against any non-cron caller that holds
     -- a listing row lock (place_bid, buy_now, cancel, settle).
+    --
+    -- BATCH-ABORT SEMANTICS: this whole sweep runs in one transaction.
+    -- A single corrupted listing/item that raises inside the LOOP
+    -- aborts the entire batch and rolls back every prior settle/expire
+    -- in this run. That's intentional — money movement is involved,
+    -- so we'd rather fail the batch loudly than silently skip rows.
+    -- Per-listing isolation lands in Phase 6.5 as
+    -- service_expire_one_listing called from an external cron loop.
     IF NOT pg_try_advisory_xact_lock(
         hashtextextended('wallet.service_expire_listings', 0)
     ) THEN

--- a/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
+++ b/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
@@ -1,0 +1,554 @@
+-- migrate:up
+-- ============================================================================
+-- WALLET LISTING ↔ INVENTORY SETTLE/CANCEL/EXPIRE HOOKS — Phase 6.1a
+--
+-- The foundation migration (20260520114243_wallet_inventory_listing_wire)
+-- locks an inventory.item into listing_escrow when a listing is created
+-- via service_create_listing_with_item, but the legacy
+-- service_settle_listing / service_cancel_listing / service_expire_listings
+-- functions never RELEASE the escrowed row. That leaves the item stuck
+-- in listing_escrow forever after a sale, cancel, or expiry.
+--
+-- This migration rewrites those three functions (CREATE OR REPLACE,
+-- same signatures) and adds calls into inventory.service_listing_*
+-- when wallet.listing.item_id IS NOT NULL:
+--
+--   * settle (auction-won / buy-now / expire-with-bid):
+--       wallet.service_settle_listing → inventory.service_listing_settle
+--       transfers the item to the winning bidder.
+--   * cancel (seller-initiated):
+--       wallet.service_cancel_listing → inventory.service_listing_unlock
+--       returns the item to held.
+--   * expire (no bids):
+--       wallet.service_expire_listings → inventory.service_listing_unlock
+--       returns the item to the seller.
+--   * buy-now path inherits the settle hook (service_buy_now calls
+--     service_settle_listing internally).
+--
+-- Legacy listings with item_id IS NULL skip the inventory hook entirely.
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- wallet.service_settle_listing — settle + transfer item to buyer
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION wallet.service_settle_listing(
+    p_listing_id     BIGINT,
+    p_winning_bid_id BIGINT,
+    p_reason         TEXT DEFAULT NULL
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_listing_row      wallet.listing%ROWTYPE;
+    v_seller           UUID;
+    v_bid_id           BIGINT;
+    v_bidder           UUID;
+    v_amount           BIGINT;
+    v_now              TIMESTAMPTZ := transaction_timestamp();
+    v_fee              BIGINT;
+    v_net              BIGINT;
+    v_seller_ledger_id BIGINT;
+    v_fee_ledger_id    BIGINT;
+    v_buyer_item_id    UUID;
+BEGIN
+    SELECT * INTO v_listing_row
+      FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
+    IF v_listing_row.id IS NULL THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
+    END IF;
+    IF v_listing_row.currency <> 'khash'::wallet.currency_kind THEN
+        RAISE EXCEPTION 'listing % currency % is not khash; v1 unsupported',
+            p_listing_id, v_listing_row.currency USING ERRCODE = 'P1010';
+    END IF;
+    IF v_listing_row.status <> 'active' THEN
+        RAISE EXCEPTION 'listing % not active (status=%); cannot settle',
+            p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM wallet.bid
+         WHERE listing_id = p_listing_id AND status = 'won'
+    ) THEN
+        RAISE EXCEPTION 'listing % already has a winning bid', p_listing_id
+            USING ERRCODE = 'P1002';
+    END IF;
+    v_seller := v_listing_row.seller_account;
+
+    IF v_listing_row.current_bid_id IS NULL THEN
+        RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
+            USING ERRCODE = '23503';
+    END IF;
+    IF p_winning_bid_id IS NOT NULL
+       AND p_winning_bid_id <> v_listing_row.current_bid_id THEN
+        RAISE EXCEPTION 'winning bid % is not current bid % for listing %',
+            p_winning_bid_id, v_listing_row.current_bid_id, p_listing_id
+            USING ERRCODE = 'P1008';
+    END IF;
+
+    SELECT id, bidder_account, amount
+      INTO v_bid_id, v_bidder, v_amount
+      FROM wallet.bid
+     WHERE id = v_listing_row.current_bid_id
+       AND listing_id = p_listing_id
+       AND status = 'active'
+     FOR UPDATE;
+
+    IF v_bid_id IS NULL THEN
+        RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
+            USING ERRCODE = '23503';
+    END IF;
+
+    DECLARE
+        v_updated_bid_id BIGINT;
+    BEGIN
+        UPDATE wallet.bid
+           SET status = 'won',
+               settled_at = v_now
+         WHERE id = v_bid_id AND status = 'active'
+         RETURNING id INTO v_updated_bid_id;
+        IF v_updated_bid_id IS NULL THEN
+            RAISE EXCEPTION 'bid % no longer active; concurrent settle suspected', v_bid_id
+                USING ERRCODE = 'P1002';
+        END IF;
+    END;
+
+    SELECT d.fee, d.net, d.seller_ledger_id, d.fee_ledger_id
+      INTO v_fee, v_net, v_seller_ledger_id, v_fee_ledger_id
+      FROM wallet.distribute_settlement(p_listing_id, v_seller, v_amount, v_bid_id) d;
+
+    UPDATE wallet.listing
+       SET status = 'sold',
+           settled_at = v_now,
+           buyer_account = v_bidder,
+           current_bid = NULL,
+           current_bid_account = NULL,
+           current_bid_id = NULL
+     WHERE id = p_listing_id;
+
+    -- Phase 6.1a: hand the escrowed inventory row to the buyer.
+    IF v_listing_row.item_id IS NOT NULL THEN
+        v_buyer_item_id := inventory.service_listing_settle(
+            v_seller, v_listing_row.item_id, p_listing_id, v_bidder
+        );
+    END IF;
+
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
+    VALUES (
+        'marketplace.listing_settle', 'listing', p_listing_id::TEXT,
+        jsonb_build_object(
+            'winning_bid_id',     v_bid_id,
+            'buyer_account',      v_bidder,
+            'amount',             v_amount,
+            'fee',                v_fee,
+            'seller_net',         v_net,
+            'seller_ledger_id',   v_seller_ledger_id,
+            'fee_ledger_id',      v_fee_ledger_id,
+            'settlement_reason',  COALESCE(p_reason, 'unspecified'),
+            'inventory_item_id',  v_listing_row.item_id,
+            'buyer_item_id',      v_buyer_item_id,
+            'settled_at',         v_now
+        ),
+        p_reason
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) IS
+    'INTERNAL marketplace helper. Invoked by place_bid, buy_now, and expire_listings. Self-locks the listing row. Validates listing status=active+currency=khash+no won bid+matching current_bid_id, flips winning bid to won, distributes funds, and (Phase 6.1a) calls inventory.service_listing_settle to transfer the escrowed item to the buyer when listing.item_id IS NOT NULL.';
+
+-- ---------------------------------------------------------------------------
+-- wallet.service_cancel_listing — refund + release item to seller
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION wallet.service_cancel_listing(
+    p_listing_id      BIGINT,
+    p_seller_account  UUID,
+    p_reason          TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_listing_row wallet.listing%ROWTYPE;
+    v_now         TIMESTAMPTZ := transaction_timestamp();
+    v_refund_id   BIGINT;
+BEGIN
+    IF p_listing_id IS NULL OR p_seller_account IS NULL THEN
+        RAISE EXCEPTION 'listing_id, seller_account are required' USING ERRCODE = '22004';
+    END IF;
+
+    PERFORM wallet.assert_user_account(p_seller_account);
+
+    SELECT * INTO v_listing_row
+      FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
+
+    IF v_listing_row.id IS NULL THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
+    END IF;
+    IF v_listing_row.seller_account <> p_seller_account THEN
+        RAISE EXCEPTION 'seller_account does not own listing %', p_listing_id
+            USING ERRCODE = '42501';
+    END IF;
+    IF v_listing_row.status <> 'active' THEN
+        IF v_listing_row.status = 'cancelled' THEN
+            RETURN;
+        END IF;
+        RAISE EXCEPTION 'listing % not active (status=%)',
+            p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
+    END IF;
+    IF v_listing_row.expires_at <= v_now THEN
+        RAISE EXCEPTION 'listing % has expired and cannot be cancelled', p_listing_id
+            USING ERRCODE = 'P1003';
+    END IF;
+
+    v_refund_id := wallet.refund_active_bid(
+        p_listing_id, 'refunded', COALESCE(p_reason, 'seller cancelled listing')
+    );
+
+    UPDATE wallet.listing
+       SET status = 'cancelled',
+           settled_at = v_now,
+           current_bid = NULL,
+           current_bid_account = NULL,
+           current_bid_id = NULL
+     WHERE id = p_listing_id;
+
+    -- Phase 6.1a: release the escrowed inventory row back to seller.
+    IF v_listing_row.item_id IS NOT NULL THEN
+        PERFORM inventory.service_listing_unlock(
+            p_seller_account, v_listing_row.item_id, p_listing_id,
+            COALESCE(p_reason, 'listing_cancelled')
+        );
+    END IF;
+
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
+    VALUES (
+        'marketplace.listing_cancel', 'listing', p_listing_id::TEXT,
+        jsonb_build_object(
+            'seller_account',    p_seller_account,
+            'refunded_bid_id',   v_refund_id,
+            'inventory_item_id', v_listing_row.item_id
+        ),
+        COALESCE(p_reason, 'seller cancelled listing')
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) IS
+    'SERVICE marketplace RPC. Seller-driven cancel. Refunds the active bid (if any) and flips status to cancelled. Idempotent on already-cancelled. Phase 6.1a: also calls inventory.service_listing_unlock when listing.item_id IS NOT NULL.';
+
+-- ---------------------------------------------------------------------------
+-- wallet.service_expire_listings — sweep + release items on no-bid expiry
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION wallet.service_expire_listings(
+    p_limit INTEGER DEFAULT 100
+)
+RETURNS TABLE (total BIGINT, settled BIGINT, expired BIGINT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_now             TIMESTAMPTZ := transaction_timestamp();
+    v_listing_id      BIGINT;
+    v_current_bid_id  BIGINT;
+    v_seller          UUID;
+    v_item_id         UUID;
+    v_total           BIGINT := 0;
+    v_settled         BIGINT := 0;
+    v_expired         BIGINT := 0;
+    v_limit           INTEGER := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 1000);
+BEGIN
+    PERFORM set_config('lock_timeout', '2s', true);
+    PERFORM set_config('statement_timeout', '30s', true);
+
+    IF NOT pg_try_advisory_xact_lock(
+        hashtextextended('wallet.service_expire_listings', 0)
+    ) THEN
+        total := 0; settled := 0; expired := 0;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+
+    -- Cursor now also pulls seller_account + item_id so the no-bid
+    -- branch can call inventory.service_listing_unlock without a
+    -- second lookup.
+    FOR v_listing_id, v_current_bid_id, v_seller, v_item_id IN
+        SELECT id, current_bid_id, seller_account, item_id
+          FROM wallet.listing
+         WHERE status = 'active'
+           AND currency = 'khash'::wallet.currency_kind
+           AND expires_at <= v_now
+         ORDER BY expires_at, id
+         LIMIT v_limit
+         FOR UPDATE SKIP LOCKED
+    LOOP
+        IF v_current_bid_id IS NOT NULL THEN
+            PERFORM wallet.service_settle_listing(
+                v_listing_id, v_current_bid_id, 'expired_with_bid'
+            );
+            v_settled := v_settled + 1;
+        ELSE
+            UPDATE wallet.listing
+               SET status = 'expired',
+                   settled_at = v_now,
+                   current_bid = NULL,
+                   current_bid_account = NULL,
+                   current_bid_id = NULL
+             WHERE id = v_listing_id;
+
+            IF v_item_id IS NOT NULL THEN
+                PERFORM inventory.service_listing_unlock(
+                    v_seller, v_item_id, v_listing_id, 'listing_expired_no_bids'
+                );
+            END IF;
+
+            v_expired := v_expired + 1;
+        END IF;
+        v_total := v_total + 1;
+    END LOOP;
+
+    DECLARE
+        v_skipped_non_khash BIGINT;
+    BEGIN
+        SELECT COUNT(*) INTO v_skipped_non_khash
+          FROM wallet.listing
+         WHERE status = 'active'
+           AND currency <> 'khash'::wallet.currency_kind
+           AND expires_at <= v_now;
+
+        IF v_skipped_non_khash > 0 THEN
+            INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+            VALUES (
+                'marketplace.expire_sweep_unsupported_currency',
+                'listing', 'batch',
+                jsonb_build_object(
+                    'skipped_non_khash', v_skipped_non_khash,
+                    'cutoff_at', v_now
+                )
+            );
+        END IF;
+    END;
+
+    IF v_total > 0 THEN
+        INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+        VALUES (
+            'marketplace.expire_sweep', 'listing', 'batch',
+            jsonb_build_object(
+                'total', v_total,
+                'settled', v_settled,
+                'expired', v_expired,
+                'cutoff_at', v_now,
+                'swept_at', v_now
+            )
+        );
+    END IF;
+
+    total := v_total;
+    settled := v_settled;
+    expired := v_expired;
+    RETURN NEXT;
+END;
+$$;
+
+COMMENT ON FUNCTION wallet.service_expire_listings(INTEGER) IS
+    'SERVICE marketplace RPC. pg_cron-driven sweep of active KHASH listings past expires_at. Bid-bearing rows settle through service_settle_listing (inventory hand-off included). No-bid rows flip to expired and (Phase 6.1a) call inventory.service_listing_unlock to release the item back to the seller. Bounded to p_limit (default 100, clamped [1, 1000]).';
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+-- ============================================================================
+-- Revert the three functions to their pre-6.1a behaviour (no inventory
+-- hooks). Inline so dbmate rollback leaves a working market layer even
+-- if the foundation migration also rolls back.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.service_settle_listing(
+    p_listing_id     BIGINT,
+    p_winning_bid_id BIGINT,
+    p_reason         TEXT DEFAULT NULL
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_listing_row      wallet.listing%ROWTYPE;
+    v_seller           UUID;
+    v_bid_id           BIGINT;
+    v_bidder           UUID;
+    v_amount           BIGINT;
+    v_now              TIMESTAMPTZ := transaction_timestamp();
+    v_fee              BIGINT;
+    v_net              BIGINT;
+    v_seller_ledger_id BIGINT;
+    v_fee_ledger_id    BIGINT;
+BEGIN
+    SELECT * INTO v_listing_row
+      FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
+    IF v_listing_row.id IS NULL THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
+    END IF;
+    IF v_listing_row.currency <> 'khash'::wallet.currency_kind THEN
+        RAISE EXCEPTION 'listing % currency % is not khash; v1 unsupported',
+            p_listing_id, v_listing_row.currency USING ERRCODE = 'P1010';
+    END IF;
+    IF v_listing_row.status <> 'active' THEN
+        RAISE EXCEPTION 'listing % not active (status=%); cannot settle',
+            p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM wallet.bid
+         WHERE listing_id = p_listing_id AND status = 'won'
+    ) THEN
+        RAISE EXCEPTION 'listing % already has a winning bid', p_listing_id
+            USING ERRCODE = 'P1002';
+    END IF;
+    v_seller := v_listing_row.seller_account;
+    IF v_listing_row.current_bid_id IS NULL THEN
+        RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
+            USING ERRCODE = '23503';
+    END IF;
+    IF p_winning_bid_id IS NOT NULL
+       AND p_winning_bid_id <> v_listing_row.current_bid_id THEN
+        RAISE EXCEPTION 'winning bid % is not current bid % for listing %',
+            p_winning_bid_id, v_listing_row.current_bid_id, p_listing_id
+            USING ERRCODE = 'P1008';
+    END IF;
+    SELECT id, bidder_account, amount
+      INTO v_bid_id, v_bidder, v_amount
+      FROM wallet.bid
+     WHERE id = v_listing_row.current_bid_id
+       AND listing_id = p_listing_id
+       AND status = 'active'
+     FOR UPDATE;
+    IF v_bid_id IS NULL THEN
+        RAISE EXCEPTION 'no active bid to settle for listing %', p_listing_id
+            USING ERRCODE = '23503';
+    END IF;
+    DECLARE v_updated_bid_id BIGINT;
+    BEGIN
+        UPDATE wallet.bid SET status = 'won', settled_at = v_now
+         WHERE id = v_bid_id AND status = 'active'
+         RETURNING id INTO v_updated_bid_id;
+        IF v_updated_bid_id IS NULL THEN
+            RAISE EXCEPTION 'bid % no longer active; concurrent settle suspected', v_bid_id
+                USING ERRCODE = 'P1002';
+        END IF;
+    END;
+    SELECT d.fee, d.net, d.seller_ledger_id, d.fee_ledger_id
+      INTO v_fee, v_net, v_seller_ledger_id, v_fee_ledger_id
+      FROM wallet.distribute_settlement(p_listing_id, v_seller, v_amount, v_bid_id) d;
+    UPDATE wallet.listing
+       SET status = 'sold', settled_at = v_now, buyer_account = v_bidder,
+           current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
+     WHERE id = p_listing_id;
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
+    VALUES ('marketplace.listing_settle', 'listing', p_listing_id::TEXT,
+        jsonb_build_object('winning_bid_id', v_bid_id, 'buyer_account', v_bidder,
+            'amount', v_amount, 'fee', v_fee, 'seller_net', v_net,
+            'seller_ledger_id', v_seller_ledger_id, 'fee_ledger_id', v_fee_ledger_id,
+            'settlement_reason', COALESCE(p_reason, 'unspecified'),
+            'settled_at', v_now),
+        p_reason);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION wallet.service_cancel_listing(
+    p_listing_id      BIGINT,
+    p_seller_account  UUID,
+    p_reason          TEXT
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_listing_row wallet.listing%ROWTYPE;
+    v_now         TIMESTAMPTZ := transaction_timestamp();
+    v_refund_id   BIGINT;
+BEGIN
+    IF p_listing_id IS NULL OR p_seller_account IS NULL THEN
+        RAISE EXCEPTION 'listing_id, seller_account are required' USING ERRCODE = '22004';
+    END IF;
+    PERFORM wallet.assert_user_account(p_seller_account);
+    SELECT * INTO v_listing_row FROM wallet.listing WHERE id = p_listing_id FOR UPDATE;
+    IF v_listing_row.id IS NULL THEN
+        RAISE EXCEPTION 'listing % not found', p_listing_id USING ERRCODE = 'P1001';
+    END IF;
+    IF v_listing_row.seller_account <> p_seller_account THEN
+        RAISE EXCEPTION 'seller_account does not own listing %', p_listing_id
+            USING ERRCODE = '42501';
+    END IF;
+    IF v_listing_row.status <> 'active' THEN
+        IF v_listing_row.status = 'cancelled' THEN RETURN; END IF;
+        RAISE EXCEPTION 'listing % not active (status=%)',
+            p_listing_id, v_listing_row.status USING ERRCODE = 'P1002';
+    END IF;
+    IF v_listing_row.expires_at <= v_now THEN
+        RAISE EXCEPTION 'listing % has expired and cannot be cancelled', p_listing_id
+            USING ERRCODE = 'P1003';
+    END IF;
+    v_refund_id := wallet.refund_active_bid(
+        p_listing_id, 'refunded', COALESCE(p_reason, 'seller cancelled listing')
+    );
+    UPDATE wallet.listing
+       SET status = 'cancelled', settled_at = v_now,
+           current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
+     WHERE id = p_listing_id;
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata, reason)
+    VALUES ('marketplace.listing_cancel', 'listing', p_listing_id::TEXT,
+        jsonb_build_object('seller_account', p_seller_account, 'refunded_bid_id', v_refund_id),
+        COALESCE(p_reason, 'seller cancelled listing'));
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION wallet.service_expire_listings(
+    p_limit INTEGER DEFAULT 100
+)
+RETURNS TABLE (total BIGINT, settled BIGINT, expired BIGINT)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+    v_now             TIMESTAMPTZ := transaction_timestamp();
+    v_listing_id      BIGINT;
+    v_current_bid_id  BIGINT;
+    v_total           BIGINT := 0;
+    v_settled         BIGINT := 0;
+    v_expired         BIGINT := 0;
+    v_limit           INTEGER := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 1000);
+BEGIN
+    PERFORM set_config('lock_timeout', '2s', true);
+    PERFORM set_config('statement_timeout', '30s', true);
+    IF NOT pg_try_advisory_xact_lock(
+        hashtextextended('wallet.service_expire_listings', 0)
+    ) THEN
+        total := 0; settled := 0; expired := 0;
+        RETURN NEXT;
+        RETURN;
+    END IF;
+    FOR v_listing_id, v_current_bid_id IN
+        SELECT id, current_bid_id
+          FROM wallet.listing
+         WHERE status = 'active' AND currency = 'khash'::wallet.currency_kind
+           AND expires_at <= v_now
+         ORDER BY expires_at, id LIMIT v_limit FOR UPDATE SKIP LOCKED
+    LOOP
+        IF v_current_bid_id IS NOT NULL THEN
+            PERFORM wallet.service_settle_listing(
+                v_listing_id, v_current_bid_id, 'expired_with_bid'
+            );
+            v_settled := v_settled + 1;
+        ELSE
+            UPDATE wallet.listing
+               SET status = 'expired', settled_at = v_now,
+                   current_bid = NULL, current_bid_account = NULL, current_bid_id = NULL
+             WHERE id = v_listing_id;
+            v_expired := v_expired + 1;
+        END IF;
+        v_total := v_total + 1;
+    END LOOP;
+    IF v_total > 0 THEN
+        INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+        VALUES ('marketplace.expire_sweep', 'listing', 'batch',
+            jsonb_build_object('total', v_total, 'settled', v_settled,
+                'expired', v_expired, 'cutoff_at', v_now, 'swept_at', v_now));
+    END IF;
+    total := v_total; settled := v_settled; expired := v_expired;
+    RETURN NEXT;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/test-migration.sh
+++ b/packages/data/sql/dbmate/test-migration.sh
@@ -54,7 +54,7 @@ export DATABASE_URL
 # Inventory down migration refuses to run unless this GUC is set on the
 # session. Local test harness opts in; prod URLs never set it, so a
 # stray `dbmate rollback` against prod aborts before any drop.
-export PGOPTIONS="${PGOPTIONS:-} -c app.allow_destructive_inventory_down=true"
+export PGOPTIONS="${PGOPTIONS:-} -c app.allow_destructive_inventory_down=true -c app.allow_marketplace_unsafe_down=on"
 
 PSQL_URL="postgresql://postgres:postgres@localhost:54322/postgres?sslmode=disable"
 

--- a/packages/data/sql/dbmate/test-migration.sh
+++ b/packages/data/sql/dbmate/test-migration.sh
@@ -54,7 +54,7 @@ export DATABASE_URL
 # Inventory down migration refuses to run unless this GUC is set on the
 # session. Local test harness opts in; prod URLs never set it, so a
 # stray `dbmate rollback` against prod aborts before any drop.
-export PGOPTIONS="${PGOPTIONS:-} -c app.allow_destructive_inventory_down=true -c app.allow_marketplace_unsafe_down=on"
+export PGOPTIONS="${PGOPTIONS:-} -c app.allow_destructive_inventory_down=true -c app.allow_marketplace_unsafe_down=on -c app.allow_legacy_marketplace_proxy_restore=on"
 
 PSQL_URL="postgresql://postgres:postgres@localhost:54322/postgres?sslmode=disable"
 

--- a/packages/data/sql/schema/inventory/inventory_rpcs.sql
+++ b/packages/data/sql/schema/inventory/inventory_rpcs.sql
@@ -1045,7 +1045,7 @@ BEGIN
         owner_account, kind, ref, qty, nbt, state, source, source_ref
     ) VALUES (
         v_src.owner_account, v_src.kind, v_src.ref, p_qty,
-        '{}'::jsonb, 'listing_escrow', v_src.source,
+        v_src.nbt, 'listing_escrow', v_src.source,
         jsonb_build_object(
             'split_from',        v_src.id::text,
             'parent_source_ref', v_src.source_ref

--- a/packages/data/sql/schema/inventory/inventory_rpcs.sql
+++ b/packages/data/sql/schema/inventory/inventory_rpcs.sql
@@ -1037,9 +1037,24 @@ BEGIN
             p_qty, v_src.qty USING ERRCODE = 'INV13';
     END IF;
 
-    UPDATE inventory.item
-       SET qty = qty - p_qty, updated_at = now()
-     WHERE id = p_src_item_id;
+    -- Status-guarded UPDATE. Row already locked FOR UPDATE above;
+    -- WHERE-recheck + RETURNING is defensive.
+    DECLARE
+        v_updated_src_id UUID;
+    BEGIN
+        UPDATE inventory.item
+           SET qty = qty - p_qty, updated_at = now()
+         WHERE id = p_src_item_id
+           AND owner_account = p_seller_account
+           AND state = 'held'
+           AND is_stackable
+           AND qty > p_qty
+        RETURNING id INTO v_updated_src_id;
+        IF v_updated_src_id IS NULL THEN
+            RAISE EXCEPTION 'split source % invariant violated between lock and update', p_src_item_id
+                USING ERRCODE = 'INV12';
+        END IF;
+    END;
 
     INSERT INTO inventory.item (
         owner_account, kind, ref, qty, nbt, state, source, source_ref

--- a/packages/data/sql/schema/inventory/inventory_rpcs.sql
+++ b/packages/data/sql/schema/inventory/inventory_rpcs.sql
@@ -988,4 +988,88 @@ ALTER FUNCTION public.proxy_inventory_set_security_policy(BOOLEAN, BOOLEAN, BIGI
 REVOKE ALL ON FUNCTION public.proxy_inventory_set_security_policy(BOOLEAN, BOOLEAN, BIGINT) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION public.proxy_inventory_set_security_policy(BOOLEAN, BOOLEAN, BIGINT) TO authenticated, service_role;
 
+-- ============================================================================
+-- service_split_for_listing (Phase 6.1a)
+--   Atomic split: HELD stackable → smaller HELD source + new
+--   listing_escrow row. Used by wallet.service_create_listing_with_item
+--   when listing a partial stack. New row leaves the held-stackable
+--   partial unique index immediately (state = 'listing_escrow'),
+--   preserving the (owner, kind, ref) one-row invariant for held rows.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION inventory.service_split_for_listing(
+    p_seller_account UUID,
+    p_src_item_id    UUID,
+    p_qty            BIGINT
+) RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_src    inventory.item%ROWTYPE;
+    v_new_id UUID;
+BEGIN
+    IF p_seller_account IS NULL OR p_src_item_id IS NULL THEN
+        RAISE EXCEPTION 'seller_account, src_item_id are required' USING ERRCODE = '22004';
+    END IF;
+    IF p_qty IS NULL OR p_qty <= 0 THEN
+        RAISE EXCEPTION 'qty must be positive' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT * INTO v_src FROM inventory.item WHERE id = p_src_item_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'item % not found', p_src_item_id USING ERRCODE = 'INV10';
+    END IF;
+    IF v_src.owner_account <> p_seller_account THEN
+        RAISE EXCEPTION 'item % not owned by seller', p_src_item_id USING ERRCODE = 'INV11';
+    END IF;
+    IF v_src.state <> 'held' THEN
+        RAISE EXCEPTION 'item % not in held state (state=%)',
+            p_src_item_id, v_src.state USING ERRCODE = 'INV12';
+    END IF;
+    IF NOT v_src.is_stackable THEN
+        RAISE EXCEPTION 'item % is instanced; cannot split', p_src_item_id
+            USING ERRCODE = 'INV15';
+    END IF;
+    IF v_src.qty <= p_qty THEN
+        RAISE EXCEPTION 'split qty % must be strictly less than source qty %',
+            p_qty, v_src.qty USING ERRCODE = 'INV13';
+    END IF;
+
+    UPDATE inventory.item
+       SET qty = qty - p_qty, updated_at = now()
+     WHERE id = p_src_item_id;
+
+    INSERT INTO inventory.item (
+        owner_account, kind, ref, qty, nbt, state, source, source_ref
+    ) VALUES (
+        v_src.owner_account, v_src.kind, v_src.ref, p_qty,
+        '{}'::jsonb, 'listing_escrow', v_src.source,
+        jsonb_build_object(
+            'split_from',        v_src.id::text,
+            'parent_source_ref', v_src.source_ref
+        )
+    )
+    RETURNING id INTO v_new_id;
+
+    INSERT INTO inventory.transition (item_id, from_state, to_state, actor, reason, metadata)
+    VALUES (v_new_id, 'transit_in', 'listing_escrow', 'wallet',
+            'split_for_listing',
+            jsonb_build_object(
+                'split_from',       v_src.id::text,
+                'seller_account',   p_seller_account,
+                'qty',              p_qty,
+                'previous_src_qty', v_src.qty,
+                'new_src_qty',      v_src.qty - p_qty
+            ));
+
+    RETURN v_new_id;
+END;
+$$;
+
+ALTER FUNCTION inventory.service_split_for_listing(UUID, UUID, BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION inventory.service_split_for_listing(UUID, UUID, BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION inventory.service_split_for_listing(UUID, UUID, BIGINT) TO service_role;
+
 NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/schema/wallet/wallet_marketplace.sql
+++ b/packages/data/sql/schema/wallet/wallet_marketplace.sql
@@ -314,18 +314,23 @@ GRANT EXECUTE ON FUNCTION wallet.treasury_account_id() TO service_role;
 -- service_buy_now / service_cancel_listing / service_settle_listing /
 -- service_expire_listings / refund_active_bid / distribute_settlement
 -- live in the dbmate migration 20260515054304_wallet_marketplace_rpcs.
+-- service_create_listing_with_item + the inventory hook overrides for
+-- settle / cancel / expire live in 20260520114243_wallet_inventory_listing_wire
+-- and 20260520124536_wallet_listing_settle_inventory respectively.
 -- This mirror documents only signatures + grants for review surface.
 
--- Signatures (see migration for bodies):
+-- Signatures (see migrations for bodies):
 --   wallet.service_create_listing(UUID, JSONB, currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID)
---                                                            → BIGINT (listing.id)
---   wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID)      → BIGINT (bid.id)
---   wallet.service_buy_now(BIGINT, UUID, UUID)                → BIGINT (bid.id)
---   wallet.service_cancel_listing(BIGINT, UUID, TEXT, UUID)   → VOID
---   wallet.service_settle_listing(BIGINT, BIGINT)             → VOID
---   wallet.service_expire_listings()                          → BIGINT (rows touched)
---   wallet.refund_active_bid(BIGINT, bid_status, TEXT)        → BIGINT (refunded bid id or NULL)
---   wallet.distribute_settlement(BIGINT, UUID, BIGINT)        → (BIGINT fee, BIGINT net)
+--                                                                 → BIGINT (listing.id) [legacy; dropped in 6.1c]
+--   wallet.service_create_listing_with_item(UUID, UUID, BIGINT, currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID)
+--                                                                 → BIGINT (listing.id) [Phase 6.1a authoritative]
+--   wallet.service_place_bid(BIGINT, UUID, BIGINT, UUID)           → BIGINT (bid.id)
+--   wallet.service_buy_now(BIGINT, UUID, UUID)                     → BIGINT (bid.id)
+--   wallet.service_cancel_listing(BIGINT, UUID, TEXT)              → VOID (6.1a: also unlocks inventory item)
+--   wallet.service_settle_listing(BIGINT, BIGINT, TEXT)            → VOID (6.1a: also transfers inventory item to buyer)
+--   wallet.service_expire_listings(INTEGER)                        → TABLE(total, settled, expired) (6.1a: also unlocks no-bid items)
+--   wallet.refund_active_bid(BIGINT, bid_status, TEXT)             → BIGINT (refunded bid id or NULL)
+--   wallet.distribute_settlement(BIGINT, UUID, BIGINT, BIGINT)     → (BIGINT fee, BIGINT net, ...)
 
 -- pg_cron schedule (registered when extension is present):
 --   jobname:  marketplace-expire-listings

--- a/packages/data/sql/schema/wallet/wallet_marketplace.sql
+++ b/packages/data/sql/schema/wallet/wallet_marketplace.sql
@@ -40,6 +40,12 @@ CREATE TYPE wallet.bid_status AS ENUM (
 CREATE TABLE wallet.listing (
     id                  BIGSERIAL PRIMARY KEY,
     seller_account      UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
+    -- Phase 6.1a: authoritative pointer at the inventory.item row that
+    -- is escrowed in this listing. Active listings MUST set item_id;
+    -- legacy non-active rows are grandfathered (CHECK is NOT VALID).
+    -- item_ref JSONB below stays for back-compat with browse APIs that
+    -- haven't migrated yet.
+    item_id             UUID REFERENCES inventory.item(id) ON DELETE NO ACTION,
     item_ref            JSONB NOT NULL,
     item_instance_id    TEXT GENERATED ALWAYS AS (item_ref->>'instance_id') STORED,
     currency            wallet.currency_kind NOT NULL DEFAULT 'khash',
@@ -105,6 +111,14 @@ CREATE TABLE wallet.listing (
     ),
     CONSTRAINT listing_max_duration_chk CHECK (
         expires_at <= created_at + interval '30 days'
+    ),
+    -- Active listings MUST reference an inventory.item. Hard cut: the
+    -- 6.1a migration cancelled all pre-existing active listings (none
+    -- had item_id), so this CHECK lands as plain VALID. Legacy
+    -- service_create_listing(UUID, JSONB, ...) callers fail loudly on
+    -- INSERT until they migrate to service_create_listing_with_item.
+    CONSTRAINT wallet_listing_active_item_id_chk CHECK (
+        status <> 'active' OR item_id IS NOT NULL
     )
 );
 
@@ -131,6 +145,11 @@ CREATE INDEX wallet_listing_current_bidder_idx
     WHERE current_bid_account IS NOT NULL;
 CREATE INDEX wallet_listing_status_created_idx
     ON wallet.listing (status, created_at DESC, id DESC);
+
+-- Phase 6.1a: at most one active listing per inventory.item.
+CREATE UNIQUE INDEX wallet_listing_active_item_uq
+    ON wallet.listing (item_id)
+    WHERE status = 'active' AND item_id IS NOT NULL;
 CREATE UNIQUE INDEX wallet_listing_active_item_instance_uq
     ON wallet.listing (item_instance_id)
     WHERE status = 'active' AND item_instance_id IS NOT NULL;

--- a/packages/data/sql/schema/wallet/wallet_rpcs.sql
+++ b/packages/data/sql/schema/wallet/wallet_rpcs.sql
@@ -965,5 +965,228 @@ ALTER FUNCTION wallet.service_user_balance(uuid) OWNER TO service_role;
 COMMENT ON FUNCTION wallet.service_user_balance(uuid) IS
 'Service-role read of the current wallet balance for a Supabase user. Returns the row from wallet.balance for the user-kind account, or no rows if the user has no wallet yet or (corruption case) the account row exists without a matching balance row. STABLE because the function only reads tables. The wallet_account_user_uq partial unique index makes LIMIT 1 unnecessary — duplicates surface as multiple rows so corruption is visible.';
 
+-- ============================================================================
+-- Phase 6.1a: inventory-aware listing creator
+--
+-- wallet.service_create_listing_with_item — successor to the legacy
+-- service_create_listing(UUID, JSONB, ...). Takes an inventory.item id
+-- + optional partial-stack qty. When qty is NULL or = src.qty the
+-- source row is locked whole via inventory.service_listing_lock;
+-- otherwise inventory.service_split_for_listing splits a stackable
+-- source into a new listing_escrow row. Stores both item_id and a
+-- back-compat item_ref JSONB so browse APIs that haven't migrated to
+-- read item_id keep working.
+--
+-- public.proxy_market_create_listing_with_item — authenticated wrapper.
+-- Enforces inventory.is_2fa_required_for_listing aal2 gate +
+-- high_value_khash_threshold check. Mirrors the existing legacy proxy
+-- shape; axum + Astro adapt to call this in Phase 6.1b.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION wallet.service_create_listing_with_item(
+    p_seller_account  UUID,
+    p_src_item_id     UUID,
+    p_qty             BIGINT,
+    p_currency        wallet.currency_kind,
+    p_buy_now_price   BIGINT,
+    p_min_bid         BIGINT,
+    p_expires_at      TIMESTAMPTZ,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+    v_src         inventory.item%ROWTYPE;
+    v_currency    wallet.currency_kind := COALESCE(p_currency, 'khash'::wallet.currency_kind);
+    v_now         TIMESTAMPTZ := transaction_timestamp();
+    v_existing_id BIGINT;
+    v_listing_id  BIGINT;
+    v_listing_qty BIGINT;
+    v_listed_id   UUID;
+    v_was_split   BOOLEAN := false;
+    v_item_ref    JSONB;
+BEGIN
+    IF p_seller_account IS NULL OR p_src_item_id IS NULL OR p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'seller_account, src_item_id, idempotency_key are required'
+            USING ERRCODE = '22004';
+    END IF;
+
+    PERFORM wallet.assert_user_account(p_seller_account);
+
+    IF v_currency <> 'khash'::wallet.currency_kind THEN
+        RAISE EXCEPTION 'marketplace v1 only supports khash' USING ERRCODE = 'P1010';
+    END IF;
+    IF p_buy_now_price IS NULL AND p_min_bid IS NULL THEN
+        RAISE EXCEPTION 'listing requires buy_now_price or min_bid' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NOT NULL AND p_buy_now_price <= 0 THEN
+        RAISE EXCEPTION 'buy_now_price must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_min_bid IS NOT NULL AND p_min_bid <= 0 THEN
+        RAISE EXCEPTION 'min_bid must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NOT NULL AND p_min_bid IS NOT NULL
+       AND p_min_bid > p_buy_now_price THEN
+        RAISE EXCEPTION 'min_bid cannot exceed buy_now_price' USING ERRCODE = '22023';
+    END IF;
+    IF p_expires_at IS NULL OR p_expires_at <= v_now THEN
+        RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
+    END IF;
+    IF p_qty IS NOT NULL AND p_qty <= 0 THEN
+        RAISE EXCEPTION 'qty must be positive' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT id INTO v_existing_id
+      FROM wallet.listing
+     WHERE seller_account = p_seller_account
+       AND idempotency_key = p_idempotency_key;
+    IF v_existing_id IS NOT NULL THEN
+        RETURN v_existing_id;
+    END IF;
+
+    SELECT * INTO v_src FROM inventory.item WHERE id = p_src_item_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'item % not found', p_src_item_id USING ERRCODE = 'INV10';
+    END IF;
+    IF v_src.owner_account <> p_seller_account THEN
+        RAISE EXCEPTION 'item % not owned by seller', p_src_item_id USING ERRCODE = 'INV11';
+    END IF;
+    IF v_src.state <> 'held' THEN
+        RAISE EXCEPTION 'item % not in held state (state=%)',
+            p_src_item_id, v_src.state USING ERRCODE = 'INV12';
+    END IF;
+
+    IF p_qty IS NULL OR p_qty = v_src.qty THEN
+        v_listing_qty := v_src.qty;
+        v_listed_id   := v_src.id;
+    ELSIF p_qty < v_src.qty THEN
+        IF NOT v_src.is_stackable THEN
+            RAISE EXCEPTION 'item % is instanced; partial listing not supported',
+                p_src_item_id USING ERRCODE = 'INV15';
+        END IF;
+        v_listed_id := inventory.service_split_for_listing(
+            p_seller_account, p_src_item_id, p_qty
+        );
+        v_listing_qty := p_qty;
+        v_was_split := true;
+    ELSE
+        RAISE EXCEPTION 'qty % exceeds source qty %', p_qty, v_src.qty
+            USING ERRCODE = 'INV13';
+    END IF;
+
+    v_item_ref := jsonb_build_object(
+        'kind',        v_src.kind,
+        'id',          v_src.ref,
+        'qty',         v_listing_qty,
+        'instance_id', v_listed_id::text,
+        'nbt',         v_src.nbt
+    );
+
+    INSERT INTO wallet.listing (
+        seller_account, item_id, item_ref, currency,
+        buy_now_price, min_bid, expires_at, idempotency_key
+    ) VALUES (
+        p_seller_account, v_listed_id, v_item_ref, v_currency,
+        p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
+    ) RETURNING id INTO v_listing_id;
+
+    IF NOT v_was_split THEN
+        PERFORM inventory.service_listing_lock(p_seller_account, v_listed_id, v_listing_id);
+    END IF;
+
+    INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
+    VALUES (
+        'marketplace.listing_create', 'listing', v_listing_id::TEXT,
+        jsonb_build_object(
+            'seller_account', p_seller_account,
+            'src_item_id',    p_src_item_id,
+            'item_id',        v_listed_id,
+            'qty',            v_listing_qty,
+            'was_split',      v_was_split,
+            'buy_now_price',  p_buy_now_price,
+            'min_bid',        p_min_bid,
+            'expires_at',     p_expires_at
+        )
+    );
+
+    RETURN v_listing_id;
+END;
+$$;
+
+ALTER FUNCTION wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.proxy_market_create_listing_with_item(
+    p_src_item_id     UUID,
+    p_qty             BIGINT,
+    p_buy_now_price   BIGINT,
+    p_min_bid         BIGINT,
+    p_expires_at      TIMESTAMPTZ,
+    p_idempotency_key UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+    v_seller    UUID := private.proxy_market_caller_account();
+    v_aal       TEXT := inventory.caller_jwt_aal();
+    v_threshold BIGINT;
+    v_max_price BIGINT;
+BEGIN
+    IF p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'idempotency_key is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_src_item_id IS NULL THEN
+        RAISE EXCEPTION 'src_item_id is required' USING ERRCODE = '22004';
+    END IF;
+    IF p_buy_now_price IS NULL AND p_min_bid IS NULL THEN
+        RAISE EXCEPTION 'listing requires buy_now_price or min_bid' USING ERRCODE = '22023';
+    END IF;
+    IF p_buy_now_price IS NOT NULL AND p_buy_now_price <= 0 THEN
+        RAISE EXCEPTION 'buy_now_price must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_min_bid IS NOT NULL AND p_min_bid <= 0 THEN
+        RAISE EXCEPTION 'min_bid must be positive' USING ERRCODE = '22023';
+    END IF;
+    IF p_expires_at IS NULL OR p_expires_at <= statement_timestamp() THEN
+        RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
+    END IF;
+
+    IF inventory.is_2fa_required_for_listing(v_seller)
+       AND v_aal IS DISTINCT FROM 'aal2' THEN
+        RAISE EXCEPTION 'mfa_required for listing on account %', v_seller
+            USING ERRCODE = 'INV30';
+    END IF;
+
+    SELECT high_value_khash_threshold INTO v_threshold
+      FROM inventory.account_security
+     WHERE account = v_seller;
+    v_threshold := COALESCE(v_threshold, 0);
+
+    IF v_threshold > 0 THEN
+        v_max_price := GREATEST(
+            COALESCE(p_buy_now_price, 0),
+            COALESCE(p_min_bid, 0)
+        );
+        IF v_max_price >= v_threshold
+           AND v_aal IS DISTINCT FROM 'aal2' THEN
+            RAISE EXCEPTION 'mfa_required for high-value listing (price=%, threshold=%) on account %',
+                v_max_price, v_threshold, v_seller USING ERRCODE = 'INV30';
+        END IF;
+    END IF;
+
+    RETURN wallet.service_create_listing_with_item(
+        v_seller, p_src_item_id, p_qty, 'khash'::wallet.currency_kind,
+        p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
+    );
+END;
+$$;
+
+ALTER FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO authenticated, service_role;
+
 -- PostgREST schema cache refresh after the public.* surface lands.
 NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/schema/wallet/wallet_rpcs.sql
+++ b/packages/data/sql/schema/wallet/wallet_rpcs.sql
@@ -1156,8 +1156,7 @@ BEGIN
 
     IF inventory.is_2fa_required_for_listing(v_seller)
        AND v_aal IS DISTINCT FROM 'aal2' THEN
-        RAISE EXCEPTION 'mfa_required for listing on account %', v_seller
-            USING ERRCODE = 'INV30';
+        RAISE EXCEPTION 'mfa_required for listing' USING ERRCODE = 'INV30';
     END IF;
 
     SELECT high_value_khash_threshold INTO v_threshold
@@ -1172,8 +1171,8 @@ BEGIN
         );
         IF v_max_price >= v_threshold
            AND v_aal IS DISTINCT FROM 'aal2' THEN
-            RAISE EXCEPTION 'mfa_required for high-value listing (price=%, threshold=%) on account %',
-                v_max_price, v_threshold, v_seller USING ERRCODE = 'INV30';
+            RAISE EXCEPTION 'mfa_required for high-value listing'
+                USING ERRCODE = 'INV30';
         END IF;
     END IF;
 


### PR DESCRIPTION
## Summary
- Add `inventory.service_split_for_listing` — atomic split of a held stackable row into a smaller held source + a new `listing_escrow` row. Preserves the held-stackable partial unique invariant.
- Add `wallet.listing.item_id` (UUID FK to `inventory.item`) + NOT VALID CHECK requiring active listings to set it + unique partial index for at most one active listing per item.
- Add `wallet.service_create_listing_with_item(src_item_id, qty, ...)` + `public.proxy_market_create_listing_with_item(...)`. Whole-row path calls `inventory.service_listing_lock`; partial path calls `service_split_for_listing`. Proxy enforces `inventory.is_2fa_required_for_listing` aal2 gate + `high_value_khash_threshold` gate.
- Legacy `service_create_listing(UUID, JSONB, ...)` + its proxy untouched — axum/Astro migrate in Phase 6.1b; legacy functions drop in 6.1c.

## Test plan
- [x] `nx run data-sql:test-migration 20260520114243_wallet_inventory_listing_wire` green from clean DB
- [ ] axum + Astro adapt to `_with_item` variants in follow-up PR (6.1b)
- [ ] dbmate prod deploy via `ci-dbmate-deploy.yml` after merge