### PR TITLE
fix(memes): wire meme.sh TLS through Cilium gateway

### DIFF
--- a/apps/kube/cert-manager/manifests/cluster-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/cluster-issuer.yaml
@@ -46,16 +46,18 @@ spec:
                                   cert-manager.io/http01-ingress-path-type: 'Prefix'
 
             # --- Solver 4: MEME.SH domains ---
+            # Migrated to Cilium Gateway HTTPRoute solver post-Phase-2 cutover.
+            # meme.sh CNAME -> gateway.kbve.com (.71); nginx no longer serves it.
             - selector:
                   dnsZones:
                       - meme.sh
               http01:
-                  ingress:
-                      ingressClassName: nginx
-                      ingressTemplate:
-                          metadata:
-                              annotations:
-                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
+                  gatewayHTTPRoute:
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
+                            group: gateway.networking.k8s.io
 
             # --- Solver 5: CRYPTOTHRONE.COM domains ---
             - selector:

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -32,6 +32,10 @@ spec:
               mode: Terminate
               certificateRefs:
                   - name: kbve-wt-tls
+                  - kind: Secret
+                    group: ''
+                    name: memes-tls
+                    namespace: memes
           allowedRoutes:
               namespaces:
                   from: All

--- a/apps/kube/memes/manifest/kustomization.yaml
+++ b/apps/kube/memes/manifest/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
     - memes-externalsecret.yaml
     - memes-deployment.yaml
     - httproute.yaml
+    - memes-cert.yaml
+    - memes-refgrant.yaml

--- a/apps/kube/memes/manifest/memes-cert.yaml
+++ b/apps/kube/memes/manifest/memes-cert.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: memes-cert
+    namespace: memes
+spec:
+    secretName: memes-tls
+    issuerRef:
+        name: letsencrypt-http
+        kind: ClusterIssuer
+    dnsNames:
+        - meme.sh
+        - www.meme.sh
+    privateKey:
+        algorithm: ECDSA
+        size: 256
+    duration: 2160h
+    renewBefore: 720h

--- a/apps/kube/memes/manifest/memes-refgrant.yaml
+++ b/apps/kube/memes/manifest/memes-refgrant.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+    name: memes-tls-from-kbve-gateway
+    namespace: memes
+spec:
+    from:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          namespace: kbve
+    to:
+        - group: ''
+          kind: Secret
+          name: memes-tls


### PR DESCRIPTION
## Problem

Post-cutover (#11215), `https://meme.sh` returns Cloudflare 404 because the gateway's `kbve-wt-tls` cert only has SANs `*.kbve.com` + `kbve.com` — no `meme.sh`. CF rejects origin TLS, never reaches Envoy.

Origin actually works:
```
curl -sI -k --resolve meme.sh:443:142.132.206.71 https://meme.sh → 200 envoy (31KB)
```

So the path is TLS — CF can't get a valid handshake for `meme.sh` SNI.

## Fix

1. **[cluster-issuer.yaml](apps/kube/cert-manager/manifests/cluster-issuer.yaml)** — switch meme.sh solver from nginx Ingress HTTP-01 to **gatewayHTTPRoute** (parentRef `kbve-gateway`). nginx no longer serves meme.sh, so the old solver couldn't complete challenges. `.71` is reachable from Let's Encrypt now that the Hetzner vMAC binding is removed (per Phase 2 unblock).

2. **[memes-cert.yaml](apps/kube/memes/manifest/memes-cert.yaml)** (new) — Certificate CR. Was previously implicit from the deleted nginx Ingress's `cert-manager.io/cluster-issuer` annotation. Reuses existing `memes-tls` secret in `memes` ns. SANs: `meme.sh`, `www.meme.sh`.

3. **[memes-refgrant.yaml](apps/kube/memes/manifest/memes-refgrant.yaml)** (new) — ReferenceGrant allowing `kbve-gateway` (kbve ns) to read `memes-tls` Secret (memes ns).

4. **[kbve-gateway.yaml](apps/kube/kbve/manifest/kbve-gateway.yaml)** — add `memes-tls` as second `certificateRefs` entry on the https listener. Envoy serves by SNI (kbve.com → `kbve-wt-tls`; meme.sh → `memes-tls`).

5. **[memes/manifest/kustomization.yaml](apps/kube/memes/manifest/kustomization.yaml)** — wire in the new resources.

## Reusable pattern

Every cutover for a non-kbve.com hostname (discord.sh, herbmail.com, cryptothrone.com, chuckrpg.com, rareicon.com) hits the same TLS SAN problem. This PR establishes the pattern: per-domain Certificate + ReferenceGrant + gateway certRef addition + cluster-issuer solver switch.

## Test plan

- [ ] ArgoCD syncs cert-manager + memes apps clean
- [ ] `kubectl get certificate -n memes memes-cert` → Ready=True (renewal succeeds via gateway solver)
- [ ] `kubectl get referencegrant -n memes` → present
- [ ] `kubectl describe gateway -n kbve kbve-gateway` → both cert refs accepted
- [ ] `curl -sI https://meme.sh` → 200 (real CF path, envoy origin)
- [ ] `curl -sI https://www.meme.sh` → 200
- [ ] Cert renewal in ~60 days completes via HTTPRoute challenge