### PR TITLE
ch: add migrations dir + logs_raw MergeTree→ReplicatedMergeTree delta

### DIFF
--- a/packages/data/ch/README.md
+++ b/packages/data/ch/README.md
@@ -15,6 +15,7 @@ ClickHouse DDL for the KBVE observability stack. Two flavors live side by side:
 | `traces.sql`             | Logflare OTEL trace templates.                                                                                                    |
 | `observability.sql`      | `observability.logs_raw` (replicated) + `logs_distributed` — direct Vector → ClickHouse log pipeline. Day-partitioned, 8-day TTL. |
 | `firecracker.sql`        | `firecracker.vm_events` — microVM lifecycle telemetry from `firecracker-ctl`. 90-day TTL for capacity planning.                   |
+| `migrations/`            | One-shot deltas to align an existing cluster with `schemas/*.sql`. See `migrations/README.md` for the naming + apply convention.  |
 | `dev-docker-compose.yml` | Single-node ClickHouse for local DDL validation (no Logflare, no Postgres). Mounted on `tmpfs` for cheap teardown.                |
 
 ## Engines and retention

--- a/packages/data/ch/migrations/20260520_logs_raw_to_replicated.sql
+++ b/packages/data/ch/migrations/20260520_logs_raw_to_replicated.sql
@@ -1,0 +1,102 @@
+-- 20260520_logs_raw_to_replicated.sql
+--
+-- Convert observability.logs_raw from plain MergeTree (per-node, no
+-- replication) to ReplicatedMergeTree across the 2 shard × 2 replica
+-- cluster, matching the engine declared in
+-- packages/data/ch/schemas/observability.sql.
+--
+-- Background: every node currently has `observability.logs_raw` as plain
+-- `MergeTree`. The Distributed engine `Distributed('cluster', ..., rand())`
+-- writes each row to a single replica per shard, so reads that load-balance
+-- across replicas see a different slice each time — and short-window
+-- dashboard queries return 0 when they land on the replica that did not
+-- receive the recent batch.
+--
+-- This migration creates a new ReplicatedMergeTree under a `_new` name,
+-- moves every partition into it per-node (since the data lives only on the
+-- replica that the Distributed engine happened to write to), then atomically
+-- swaps the two tables on the cluster.
+--
+-- DO NOT execute this file end-to-end with --multiquery. The
+-- `ATTACH PARTITION` step is per-node and is described in
+-- 20260520_logs_raw_to_replicated_runbook.md.
+--
+-- ---------------------------------------------------------------------------
+-- STEP 1 — Create the replicated shadow table on every node.
+-- ---------------------------------------------------------------------------
+-- Same column shape as the legacy table. Engine matches schemas/observability.sql.
+-- TTL is 8 DAY per the canonical schema; the legacy table drifted to 90 DAY
+-- at some point. Operators who want to preserve the 90 DAY retention should
+-- patch this DDL before applying.
+
+CREATE TABLE IF NOT EXISTS observability.logs_raw_new ON CLUSTER 'cluster'
+(
+    timestamp       DateTime64(3, 'UTC'),
+    service         LowCardinality(String),
+    level           LowCardinality(String),
+    message         String,
+    metadata        String DEFAULT '{}',
+    pod_name        String DEFAULT '',
+    pod_namespace   LowCardinality(String) DEFAULT '',
+    ingested_at     DateTime64(3, 'UTC') DEFAULT now64(3)
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/observability/logs_raw', '{replica}')
+ORDER BY (service, timestamp)
+PARTITION BY toYYYYMMDD(timestamp)
+TTL toDateTime(timestamp) + INTERVAL 8 DAY;
+
+-- ---------------------------------------------------------------------------
+-- STEP 2 — Per-node ATTACH PARTITION (NOT executed by this file).
+-- ---------------------------------------------------------------------------
+-- Each replica holds a disjoint slice of the legacy data, so the ATTACH must
+-- run on every node — `ON CLUSTER` distributes the DDL but does not move the
+-- data across nodes. Generate and run the per-partition statements on each
+-- pod individually; see the runbook for the loop.
+--
+-- Shape:
+--   ALTER TABLE observability.logs_raw_new
+--     ATTACH PARTITION ID '<YYYYMMDD>' FROM observability.logs_raw;
+
+-- ---------------------------------------------------------------------------
+-- STEP 3 — Atomic swap. After every partition has been attached on every
+-- node, swap the two tables in one cluster-wide DDL. Inserts that race the
+-- swap will land in whichever table is named `logs_raw` at the moment the
+-- Distributed engine resolves the target — both halves of the swap contain
+-- the same data after step 2.
+-- ---------------------------------------------------------------------------
+
+EXCHANGE TABLES observability.logs_raw AND observability.logs_raw_new ON CLUSTER 'cluster';
+
+-- ---------------------------------------------------------------------------
+-- STEP 4 — Drop the now-legacy MergeTree (formerly `logs_raw_new`, which
+-- held a copy of the live table at the moment of the swap; after EXCHANGE,
+-- the legacy MergeTree data lives under `logs_raw_new`).
+-- ---------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS observability.logs_raw_new ON CLUSTER 'cluster' SYNC;
+
+-- ---------------------------------------------------------------------------
+-- STEP 5 — Verification (read-only).
+-- ---------------------------------------------------------------------------
+
+-- Every node should now report ReplicatedMergeTree:
+--   SELECT hostName(), engine
+--     FROM clusterAllReplicas('cluster', system.tables)
+--    WHERE database = 'observability' AND name = 'logs_raw';
+
+-- Replica delay should be 0 (or trending to 0):
+--   SELECT hostName(), absolute_delay, queue_size
+--     FROM clusterAllReplicas('cluster', system.replicas)
+--    WHERE database = 'observability' AND table = 'logs_raw';
+
+-- Recent ingest should be visible from any node and any replica:
+--   SELECT max(timestamp), max(ingested_at), count() FILTER (WHERE
+--     ingested_at > now() - INTERVAL 5 MINUTE)
+--   FROM observability.logs_distributed;
+
+-- ---------------------------------------------------------------------------
+-- STEP 6 — Record the migration as applied.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO observability.schema_migrations (name, applied_by)
+VALUES ('20260520_logs_raw_to_replicated', '<operator-handle>');

--- a/packages/data/ch/migrations/20260520_logs_raw_to_replicated_runbook.md
+++ b/packages/data/ch/migrations/20260520_logs_raw_to_replicated_runbook.md
@@ -1,0 +1,229 @@
+# Runbook — `20260520_logs_raw_to_replicated`
+
+Convert `observability.logs_raw` from per-node `MergeTree` to cluster-wide
+`ReplicatedMergeTree`. Run during a planned window; Vector ingest is paused
+for the duration (~5–15 minutes depending on partition count).
+
+## Pre-flight
+
+Confirm the drift is still present:
+
+```bash
+for pod in chi-clickhouse-cluster-cluster-{0,1}-{0,1}-0; do
+  echo "=== $pod ==="
+  kubectl -n clickhouse exec "$pod" -c clickhouse -- clickhouse-client \
+    --query "SELECT name, engine FROM system.tables
+             WHERE database='observability' AND name='logs_raw'
+             FORMAT TabSeparated"
+done
+```
+
+Expected output: `logs_raw  MergeTree` on every node. If any node already
+reports `ReplicatedMergeTree`, stop and re-plan — partial state is not handled
+by this runbook.
+
+Ensure the migrations ledger exists (one-time, idempotent):
+
+```sql
+CREATE TABLE IF NOT EXISTS observability.schema_migrations ON CLUSTER 'cluster'
+(
+    name         String,
+    applied_at   DateTime64(3, 'UTC') DEFAULT now64(3),
+    applied_by   String
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/observability/schema_migrations', '{replica}')
+ORDER BY (name, applied_at);
+```
+
+## Step 1 — Pause Vector
+
+Scale the daemonset to zero so no new writes land in the table being moved:
+
+```bash
+kubectl -n vector scale daemonset supabase-vector --replicas=0
+kubectl -n vector wait --for=delete pod -l app.kubernetes.io/name=vector --timeout=120s || true
+```
+
+Confirm no insert traffic:
+
+```sql
+SELECT count() FROM system.query_log
+ WHERE event_time > now() - INTERVAL 1 MINUTE
+   AND query_kind = 'Insert'
+   AND query LIKE '%observability.logs%';
+-- expect 0
+```
+
+## Step 2 — Create the replicated shadow
+
+Run from any pod:
+
+```bash
+kubectl -n clickhouse exec -i chi-clickhouse-cluster-cluster-0-0-0 -c clickhouse -- \
+  clickhouse-client --multiquery < packages/data/ch/migrations/20260520_logs_raw_to_replicated.sql
+```
+
+…but **stop at the EXCHANGE TABLES line** (the DDL file is intentionally
+ordered to fail-stop here if you pipe the whole thing in, because step 3 has
+not run yet). The safe form is to copy only the `CREATE TABLE IF NOT EXISTS
+observability.logs_raw_new ...` block and execute that:
+
+```bash
+kubectl -n clickhouse exec chi-clickhouse-cluster-cluster-0-0-0 -c clickhouse -- \
+  clickhouse-client --query "$(sed -n '/^CREATE TABLE IF NOT EXISTS observability.logs_raw_new/,/^TTL toDateTime/p' \
+    packages/data/ch/migrations/20260520_logs_raw_to_replicated.sql)"
+```
+
+Verify all four pods now show both tables:
+
+```bash
+for pod in chi-clickhouse-cluster-cluster-{0,1}-{0,1}-0; do
+  kubectl -n clickhouse exec "$pod" -c clickhouse -- clickhouse-client \
+    --query "SELECT name, engine FROM system.tables
+             WHERE database='observability' AND name IN ('logs_raw','logs_raw_new')
+             FORMAT TabSeparated"
+done
+```
+
+## Step 3 — Per-node ATTACH PARTITION
+
+For each pod, enumerate active partitions on the legacy MergeTree and attach
+them into the replicated shadow:
+
+```bash
+for pod in chi-clickhouse-cluster-cluster-{0,1}-{0,1}-0; do
+  echo "=== $pod ==="
+  partitions=$(kubectl -n clickhouse exec "$pod" -c clickhouse -- clickhouse-client \
+    --query "SELECT DISTINCT partition_id FROM system.parts
+             WHERE database='observability' AND table='logs_raw' AND active
+             ORDER BY partition_id FORMAT TabSeparated")
+  for pid in $partitions; do
+    kubectl -n clickhouse exec "$pod" -c clickhouse -- clickhouse-client \
+      --query "ALTER TABLE observability.logs_raw_new
+                 ATTACH PARTITION ID '$pid' FROM observability.logs_raw"
+  done
+done
+```
+
+`ATTACH PARTITION` is a metadata-only operation on the same node, then the
+replicated engine registers the parts with Keeper, which fans them out to the
+in-shard replica. Watch the queue drain:
+
+```sql
+SELECT hostName(), absolute_delay, queue_size
+  FROM clusterAllReplicas('cluster', system.replicas)
+ WHERE database = 'observability' AND table = 'logs_raw_new'
+ ORDER BY hostName();
+```
+
+Wait until every row reports `queue_size = 0` and `absolute_delay` is
+trending to 0 (or flatlined; merges may temporarily inflate it). Cross-check
+that both replicas of each shard now hold the same row count:
+
+```sql
+SELECT hostName(), sum(rows)
+  FROM clusterAllReplicas('cluster', system.parts)
+ WHERE database = 'observability' AND table = 'logs_raw_new' AND active
+ GROUP BY hostName()
+ ORDER BY hostName();
+```
+
+Within a shard, both replicas should now report the same total.
+
+## Step 4 — Atomic swap
+
+```bash
+kubectl -n clickhouse exec chi-clickhouse-cluster-cluster-0-0-0 -c clickhouse -- \
+  clickhouse-client --query "EXCHANGE TABLES observability.logs_raw AND
+                              observability.logs_raw_new ON CLUSTER 'cluster'"
+```
+
+Confirm:
+
+```bash
+for pod in chi-clickhouse-cluster-cluster-{0,1}-{0,1}-0; do
+  kubectl -n clickhouse exec "$pod" -c clickhouse -- clickhouse-client \
+    --query "SELECT name, engine FROM system.tables
+             WHERE database='observability' AND name IN ('logs_raw','logs_raw_new')
+             FORMAT TabSeparated"
+done
+```
+
+Expected: `logs_raw  ReplicatedMergeTree` and `logs_raw_new  MergeTree` on
+every node.
+
+## Step 5 — Drop the legacy MergeTree
+
+```bash
+kubectl -n clickhouse exec chi-clickhouse-cluster-cluster-0-0-0 -c clickhouse -- \
+  clickhouse-client --query "DROP TABLE IF EXISTS observability.logs_raw_new
+                              ON CLUSTER 'cluster' SYNC"
+```
+
+## Step 6 — Resume Vector
+
+```bash
+kubectl -n vector scale daemonset supabase-vector --replicas=1
+kubectl -n vector rollout status daemonset/supabase-vector --timeout=120s
+```
+
+Verify ingest:
+
+```sql
+SELECT now() AS now_utc,
+       max(timestamp) AS max_ts,
+       max(ingested_at) AS max_ingested,
+       count() FILTER (WHERE ingested_at > now() - INTERVAL 1 MINUTE) AS rows_1m
+  FROM observability.logs_distributed;
+```
+
+`max_ingested` should be within ~10 seconds of `now_utc`, and `rows_1m`
+non-zero.
+
+Run the freshness probe against each replica to confirm the fix:
+
+```bash
+for pod in chi-clickhouse-cluster-cluster-{0,1}-{0,1}-0; do
+  echo "=== $pod ==="
+  kubectl -n clickhouse exec "$pod" -c clickhouse -- clickhouse-client \
+    --query "SELECT max(timestamp), max(ingested_at)
+             FROM observability.logs_raw
+             FORMAT TabSeparated"
+done
+```
+
+All four pods should report the same recent `max(ingested_at)`.
+
+## Step 7 — Record the migration
+
+```sql
+INSERT INTO observability.schema_migrations (name, applied_by)
+VALUES ('20260520_logs_raw_to_replicated', '<operator-handle>');
+```
+
+## Rollback
+
+Before step 4 (`EXCHANGE TABLES`):
+
+```sql
+DROP TABLE observability.logs_raw_new ON CLUSTER 'cluster' SYNC;
+```
+
+…and resume Vector. No data is lost; the legacy MergeTree is untouched.
+
+After step 4 but before step 5: re-run `EXCHANGE TABLES` to swap back.
+
+After step 5: the legacy MergeTree is gone. Restoring from backup (or
+re-creating as MergeTree and waiting for new ingest) is the only option. Do
+not attempt to roll back past this point without a fresh snapshot.
+
+## Why per-node `ATTACH`?
+
+`ON CLUSTER` distributes a DDL statement to every node, but
+`ATTACH PARTITION FROM` only moves data files that already exist **locally**
+on the node executing the DDL. Because the legacy table was plain
+`MergeTree`, each replica holds a different (disjoint) slice of rows — the
+slice the Distributed engine happened to write to that replica via `rand()`.
+Running the ATTACH on every node ensures every disjoint slice is captured,
+and the new ReplicatedMergeTree then fans the resulting parts out to the
+in-shard replica via Keeper.

--- a/packages/data/ch/migrations/README.md
+++ b/packages/data/ch/migrations/README.md
@@ -1,0 +1,54 @@
+# `packages/data/ch/migrations` — ClickHouse schema migrations
+
+One-shot DDL migrations against the production observability cluster. Files in
+`packages/data/ch/schemas/` are the canonical desired state for **new**
+installs; this directory holds the deltas required to bring the **existing**
+prod cluster from a known historical state into alignment.
+
+## Naming
+
+```
+YYYYMMDD_<short_slug>.sql
+YYYYMMDD_<short_slug>_runbook.md   (optional, when the DDL needs out-of-band steps)
+```
+
+The date is the day the migration is authored, not the day it ships. Slugs are
+short and descriptive (`logs_raw_to_replicated`, `alerts_raw_add_severity`).
+
+## What goes here
+
+- DDL whose effect cannot be expressed by re-running `schemas/*.sql` against an
+  existing cluster (e.g. engine swaps, partition moves, distributed-table
+  rebinds).
+- DDL that requires per-shard or per-replica steps that `ON CLUSTER` cannot
+  express (e.g. `ATTACH PARTITION FROM` between engines).
+
+If the migration is just additive (`ALTER TABLE ... ADD COLUMN`), prefer
+editing the canonical schema file in `schemas/` and applying it via
+`CREATE TABLE IF NOT EXISTS ... ON CLUSTER` semantics; do not add a migration.
+
+## Applying
+
+Migrations are applied manually by an operator during a planned window. Each
+migration's runbook (when present) lists prerequisites, the per-pod commands,
+and verification queries. There is no auto-runner.
+
+Track applied migrations on the cluster itself:
+
+```sql
+CREATE TABLE IF NOT EXISTS observability.schema_migrations ON CLUSTER 'cluster'
+(
+    name         String,
+    applied_at   DateTime64(3, 'UTC') DEFAULT now64(3),
+    applied_by   String
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/observability/schema_migrations', '{replica}')
+ORDER BY (name, applied_at);
+```
+
+After a successful migration:
+
+```sql
+INSERT INTO observability.schema_migrations (name, applied_by)
+VALUES ('20260520_logs_raw_to_replicated', '<operator-handle>');
+```


### PR DESCRIPTION
## Summary
- `packages/data/ch/schemas/observability.sql` declares `ReplicatedMergeTree` for `observability.logs_raw`, but every node in the production 2×2 cluster currently holds it as plain `MergeTree`. With no replication and `Distributed(..., rand())` sharding, each row only lives on whichever replica the Distributed engine wrote to. Reads load-balance across replicas, so short-window dashboard queries hit the empty replica and report 0 rows even though the in-shard partner has the data.
- Add a new `packages/data/ch/migrations/` directory with a generic `README.md` (naming convention + `observability.schema_migrations` ledger DDL), the engine-swap DDL (`20260520_logs_raw_to_replicated.sql`), and the full prod runbook (`20260520_logs_raw_to_replicated_runbook.md`).
- Link the new directory from `packages/data/ch/README.md` so it's discoverable.

## Diagnostic snapshot (taken at 2026-05-20 12:30 UTC)
```
chi-clickhouse-cluster-cluster-0-0-0: logs_raw MergeTree (recent partitions present)
chi-clickhouse-cluster-cluster-0-1-0: logs_raw MergeTree (stale, last write 2026-05-01)
chi-clickhouse-cluster-cluster-1-0-0: logs_raw MergeTree (recent partitions present)
chi-clickhouse-cluster-cluster-1-1-0: logs_raw MergeTree (stale, last write 2026-04-11)
```
`alerts_raw`, `*_distributed`, and the schemas/ DDL are all correct — scope is limited to `logs_raw`.

## What ships from this PR
**Artifacts only.** No DDL runs against prod from this commit. The runbook is the canonical apply path.

The migration uses an atomic `EXCHANGE TABLES` to swap a freshly-created replicated shadow with the legacy table; the per-node `ATTACH PARTITION` step is documented in the runbook because `ON CLUSTER` cannot move per-node disjoint data (each replica holds a different slice of legacy rows).

The shadow table sets TTL to `8 DAY`, matching the canonical schema. The live table drifted to `90 DAY` at some point; operators who want to preserve the longer retention can patch the DDL block before applying. Either way the dashboard's `7d` window remains the longest reachable from the UI.

## Test plan
- [ ] Reviewer reads `migrations/README.md` and confirms the naming convention + ledger DDL are agreeable.
- [ ] Reviewer walks the runbook against the diagnostic snapshot and confirms each step is sequenced safely.
- [ ] Apply on prod in a planned window per the runbook; verify `clusterAllReplicas('cluster', system.tables)` reports `ReplicatedMergeTree` on every node and that `max(ingested_at)` per replica converges within ~10 s.
- [ ] After apply, the `/dashboard/clickhouse/` 15m/1h/6h/24h windows return non-zero data consistently across refreshes (no replica-routing flakiness).