### PR TITLE
feat(astro-kbve): wire kbve.com/chat to live chat.js embed

### DIFF
--- a/apps/kbve/astro-kbve/src/components/kbve/KbveChatEmbed.astro
+++ b/apps/kbve/astro-kbve/src/components/kbve/KbveChatEmbed.astro
@@ -1,0 +1,61 @@
+---
+interface Props {
+	channel?: string;
+	height?: string;
+	theme?: 'dark' | 'light' | 'auto';
+}
+
+const { channel = '#general', height = '70vh', theme = 'auto' } = Astro.props;
+---
+
+<div class="kbve-chat-embed-wrapper not-content">
+	<div
+		id="kbve-chat-embed"
+		data-channel={channel}
+		data-ws="wss://chat.kbve.com/ws"
+		data-height={height}
+		data-theme={theme === 'auto' ? undefined : theme}>
+	</div>
+	<p class="kbve-chat-embed-wrapper__hint">
+		Powered by <a
+			href="https://chat.kbve.com"
+			target="_blank"
+			rel="noopener noreferrer">
+			chat.kbve.com
+		</a>. Same identity, same channels.
+	</p>
+</div>
+
+<script is:inline src="https://chat.kbve.com/embed/chat.js" defer></script>
+
+<style>
+	.kbve-chat-embed-wrapper {
+		margin: 1.5rem auto;
+		max-width: 1100px;
+	}
+
+	.kbve-chat-embed-wrapper #kbve-chat-embed {
+		border-radius: 14px;
+		overflow: hidden;
+		box-shadow:
+			0 24px 64px -20px
+				color-mix(in srgb, var(--sl-color-accent) 30%, transparent),
+			0 0 0 1px var(--sl-color-border);
+	}
+
+	.kbve-chat-embed-wrapper__hint {
+		text-align: center;
+		font-size: 0.8rem;
+		color: var(--sl-color-gray-3);
+		margin-top: 0.75rem;
+	}
+
+	.kbve-chat-embed-wrapper__hint a {
+		color: var(--sl-color-text-accent);
+		text-decoration: none;
+	}
+
+	.kbve-chat-embed-wrapper__hint a:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/content/docs/chat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/chat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chat
-description: Connect with the KBVE community through our IRC chat interface.
+description: Real-time IRC chat for the KBVE community, embedded live.
 template: splash
 sidebar:
   label: Chat
@@ -10,17 +10,13 @@ lastUpdated: false
 tableOfContents: false
 ---
 
-# Community Chat
+import KbveChatEmbed from '../../components/kbve/KbveChatEmbed.astro';
 
-Join the conversation in our IRC chat room.
+<KbveChatEmbed channel="#general" height="70vh" />
 
-## About
+## Tips
 
-Connect with the KBVE community in real-time through our web-based IRC interface. Share ideas, get help, and collaborate with other members.
-
-## Quick Tips
-
-- Be respectful and follow community guidelines
+- Sign in (top right of the chat) to send messages — read-only mode without auth
 - Use `/help` to see available commands
 - Messages are public and visible to all users
-- Stay on topic and keep conversations constructive
+- Need the full experience? Open [chat.kbve.com](https://chat.kbve.com/chat/)


### PR DESCRIPTION
## Summary

kbve.com/chat was a static MDX placeholder. Now it serves the live chat.js bundle from chat.kbve.com — same identity, same channels, no logout/login between sites.

## Implementation

- New \`KbveChatEmbed.astro\` component in \`src/components/kbve/\` — mounts \`<div id=\"kbve-chat-embed\" data-channel data-ws data-height>\` and loads \`<script src=\"https://chat.kbve.com/embed/chat.js\" defer>\`
- \`chat.mdx\` rewritten to import the component, with trimmed tips list and a link out to chat.kbve.com for the full experience
- Wrapper carries \`not-content\` so Starlight prose styles don't fight the layout
- Theme inheritance is free: the embed bundle's CSS var fallback chain (#11140) reads kbve.com's \`--sl-color-*\` through the shadow boundary — no \`data-theme\` prop needed unless you want to force light/dark

## Test plan

- [ ] Visit kbve.com/chat after deploy — embed renders inside Starlight splash layout, picks up site theme
- [ ] Toggle dark/light on kbve.com — embed colors follow
- [ ] Same Supabase session works (\`kbve_session\` cookie is \`*.kbve.com\` scoped)
- [ ] Sign in / send / leave channel — all work cross-origin