### PR TITLE
fix(mc_auth): public.proxy_service_user_balance bridge for PostgREST

### DIFF
--- a/apps/mc/mc_auth/src/supabase.rs
+++ b/apps/mc/mc_auth/src/supabase.rs
@@ -212,7 +212,7 @@ impl SupabaseClient {
             .ok_or_else(|| "auth disabled (no supabase env)".to_string())?;
         let params = json!({ "p_user_id": user_id });
         let resp = client
-            .rpc_schema("service_user_balance", params, "wallet")
+            .rpc("proxy_service_user_balance", params)
             .await
             .map_err(|e| format!("supa: {e}"))?;
         if !resp.status().is_success() {

--- a/packages/data/sql/dbmate/migrations/20260520132957_wallet_service_user_balance_public_proxy.sql
+++ b/packages/data/sql/dbmate/migrations/20260520132957_wallet_service_user_balance_public_proxy.sql
@@ -1,0 +1,59 @@
+-- migrate:up
+
+-- Public-schema PostgREST bridge for wallet.service_user_balance.
+--
+-- Why this exists:
+--   PostgREST only exposes configured schemas. Backend bridges such as
+--   mc_auth call RPCs through the public schema, so calls directly against
+--   wallet.service_user_balance are not visible unless the wallet schema is
+--   exposed. This wrapper keeps wallet private while exposing a narrow,
+--   service-role-only read path.
+--
+-- Authority:
+--   service_role only. anon/authenticated/PUBLIC are explicitly revoked.
+--
+-- Safety:
+--   SECURITY DEFINER with search_path='' prevents search-path hijacking.
+--   The inner function is schema-qualified.
+--
+-- Planner:
+--   STABLE is valid because this wrapper performs a read-only balance lookup.
+--   The inner function should also remain read-only.
+
+CREATE OR REPLACE FUNCTION public.proxy_service_user_balance(p_user_id uuid)
+RETURNS TABLE (
+    account_id uuid,
+    credits    bigint,
+    khash      bigint,
+    updated_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT
+        b.account_id,
+        b.credits,
+        b.khash,
+        b.updated_at
+    FROM wallet.service_user_balance(p_user_id) AS b;
+$$;
+
+ALTER FUNCTION public.proxy_service_user_balance(uuid) OWNER TO service_role;
+
+REVOKE ALL ON FUNCTION public.proxy_service_user_balance(uuid)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.proxy_service_user_balance(uuid)
+TO service_role;
+
+COMMENT ON FUNCTION public.proxy_service_user_balance(uuid) IS
+'Public-schema PostgREST bridge to wallet.service_user_balance(uuid). Exposes a narrow service-role-only read path for backend bridges such as mc_auth while keeping the wallet schema private. SECURITY DEFINER with empty search_path; inner RPC is schema-qualified and read-only.';
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS public.proxy_service_user_balance(uuid);
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/schema/wallet/wallet_rpcs.sql
+++ b/packages/data/sql/schema/wallet/wallet_rpcs.sql
@@ -1187,5 +1187,58 @@ ALTER FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT
 REVOKE ALL ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon;
 GRANT  EXECUTE ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO authenticated, service_role;
 
+-- ============================================================================
+-- public.proxy_service_user_balance — PostgREST bridge for backend bridges
+--
+-- Why this exists:
+--   PostgREST only exposes configured schemas. Backend bridges such as
+--   mc_auth call RPCs through the public schema, so calls directly against
+--   wallet.service_user_balance are not visible unless the wallet schema is
+--   exposed. This wrapper keeps wallet private while exposing a narrow,
+--   service-role-only read path.
+--
+-- Authority:
+--   service_role only. anon/authenticated/PUBLIC are explicitly revoked.
+--
+-- Safety:
+--   SECURITY DEFINER with search_path='' prevents search-path hijacking.
+--   The inner function is schema-qualified.
+--
+-- Planner:
+--   STABLE is valid because this wrapper performs a read-only balance lookup.
+--   The inner function should also remain read-only.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.proxy_service_user_balance(p_user_id uuid)
+RETURNS TABLE (
+    account_id uuid,
+    credits    bigint,
+    khash      bigint,
+    updated_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT
+        b.account_id,
+        b.credits,
+        b.khash,
+        b.updated_at
+    FROM wallet.service_user_balance(p_user_id) AS b;
+$$;
+
+ALTER FUNCTION public.proxy_service_user_balance(uuid) OWNER TO service_role;
+
+REVOKE ALL ON FUNCTION public.proxy_service_user_balance(uuid)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.proxy_service_user_balance(uuid)
+TO service_role;
+
+COMMENT ON FUNCTION public.proxy_service_user_balance(uuid) IS
+'Public-schema PostgREST bridge to wallet.service_user_balance(uuid). Exposes a narrow service-role-only read path for backend bridges such as mc_auth while keeping the wallet schema private. SECURITY DEFINER with empty search_path; inner RPC is schema-qualified and read-only.';
+
 -- PostgREST schema cache refresh after the public.* surface lands.
 NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
After #11199 + the dbmate deploy, mc_auth still rendered `0 / 0` because the call to `wallet.service_user_balance` never reaches the DB. Direct `curl` from inside the cluster confirmed PostgREST rejects the call:

\`\`\`
HTTP 406
{
  "code":"PGRST106",
  "message":"The schema must be one of the following: public, storage, graphql_public, tracker, profile, rentearth, meme, discordsh, forum, mc"
}
\`\`\`

`wallet` is intentionally **not** in `db-schemas` — it stays private to the SQL-side wallet machinery and PostgREST only exposes `public.*` plus a selected list of business schemas (`mc`, `forum`, `tracker`, etc.). Every `WalletBalance` fetch was 406-ing → error branch → `(0, 0)`.

## Fix
Bridge the wallet RPC through a `public.*` proxy and call that instead. Same pattern other wallet RPCs already use (`public.proxy_wallet_get_balance`, `public.proxy_wallet_list_coupons_readonly`, etc.).

- [`packages/data/sql/dbmate/migrations/20260520132957_wallet_service_user_balance_public_proxy.sql`](packages/data/sql/dbmate/migrations/20260520132957_wallet_service_user_balance_public_proxy.sql) — creates `public.proxy_service_user_balance(p_user_id uuid)` that returns `SELECT * FROM wallet.service_user_balance(p_user_id)`. `STABLE`, `SECURITY DEFINER`, empty `search_path`, `service_role` only. Includes `NOTIFY pgrst, 'reload schema'` so PostgREST picks it up immediately.
- [`packages/data/sql/schema/wallet/wallet_rpcs.sql`](packages/data/sql/schema/wallet/wallet_rpcs.sql) — same definition in the canonical schema file so a fresh DB regen stays in lockstep.
- [`apps/mc/mc_auth/src/supabase.rs`](apps/mc/mc_auth/src/supabase.rs) — swap `rpc_schema("service_user_balance", params, "wallet")` for `rpc("proxy_service_user_balance", params)` so PostgREST routes through the default `public` schema.

## Sibling issue (not in this PR)
User also reports the spawn admin claim still shows as a strip on Xaero map. Pod log shows it claimed correctly:
\`\`\`
[spawn-autoclaim] dimension=minecraft:overworld chunks=(-13,-13)..(12,12) claimed=650 skipped=26 failed=0
\`\`\`
Server-side 676/676 chunks are admin-claimed. The "strip" is Xaero's tile cache — flying the cube perimeter once forces a redraw; `/openpac claim-info` inside the cube confirms owner = `Server`. Not a code bug.

## Test plan
- [ ] `cargo check -p mc_auth` clean (verified locally).
- [ ] Migration applies via `ci-dbmate-deploy.yml` against `kilobase-prod` with manual approval.
- [ ] After mc image rebuild + rollout: `/wallet` for a linked user with non-zero balance shows real numbers; pod logs show no more `lazy balance fetch failed` warns.
- [ ] User without a wallet account row still gets `0 / 0` (the inner RPC returns no rows → `Ok(None)` → zeros).