### PR TITLE
observability: fix alerts-poll JSONEachRow timestamps + add vector PrometheusRule

### DIFF
--- a/apps/kube/vector/manifests/alerts-poll-cronjob.yaml
+++ b/apps/kube/vector/manifests/alerts-poll-cronjob.yaml
@@ -45,7 +45,11 @@ data:
             print("Nothing to insert.")
             sys.exit(0)
 
-        now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="milliseconds")
+        now_iso = (
+            datetime.datetime.now(datetime.timezone.utc)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z")
+        )
         lines = []
         for a in alerts:
             labels = a.get("labels", {}) or {}
@@ -66,7 +70,7 @@ data:
                 "labels": json.dumps(labels, sort_keys=True),
                 "annotations": json.dumps(anno, sort_keys=True),
                 "fingerprint": fp,
-                "starts_at": a.get("activeAt") or now_iso,
+                "starts_at": (a.get("activeAt") or now_iso).replace("+00:00", "Z"),
                 "ends_at": None,
                 "generator_url": anno.get("runbook_url", ""),
                 "source": SOURCE_LABEL,
@@ -77,6 +81,7 @@ data:
         q = urllib.parse.urlencode({
             "user": CH_USER,
             "password": CH_PASSWORD,
+            "date_time_input_format": "best_effort",
             "query": "INSERT INTO observability.alerts_distributed FORMAT JSONEachRow",
         })
         insert_url = f"{CH_ENDPOINT}/?{q}"
@@ -88,7 +93,11 @@ data:
                     print(f"ERROR: ClickHouse insert returned {r.status}", file=sys.stderr)
                     sys.exit(1)
         except urllib.error.HTTPError as e:
-            print(f"ERROR: ClickHouse insert failed: {e.code} {e.reason}", file=sys.stderr)
+            try:
+                detail = e.read().decode("utf-8", errors="replace")[:500]
+            except Exception:
+                detail = ""
+            print(f"ERROR: ClickHouse insert failed: {e.code} {e.reason} :: {detail}", file=sys.stderr)
             sys.exit(1)
         except (urllib.error.URLError, TimeoutError) as e:
             print(f"ERROR: ClickHouse unreachable: {e}", file=sys.stderr)

--- a/apps/kube/vector/manifests/vector-alerts.yaml
+++ b/apps/kube/vector/manifests/vector-alerts.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+    name: vector-pipeline
+    namespace: vector
+    labels:
+        release: monitoring
+        prometheus: kube-prometheus
+        role: alert-rules
+spec:
+    groups:
+        - name: vector.daemonset
+          rules:
+              - alert: VectorDaemonSetUnavailable
+                annotations:
+                    summary: 'Vector DaemonSet `supabase-vector` has no Ready pods'
+                    description: |
+                        The `supabase-vector` DaemonSet in the `vector` namespace
+                        reports 0 ready pods. Log ingestion to
+                        `observability.logs_distributed` is stopped — the
+                        ClickHouse dashboard and downstream alert poll will both
+                        go silent within minutes.
+
+                        Check `kubectl -n vector get pods` for the failing pod
+                        and `kubectl -n vector logs <pod>` for a Lua/VRL config
+                        parse error or a sink connection failure.
+                expr: |
+                    kube_daemonset_status_number_ready{namespace="vector", daemonset="supabase-vector"} == 0
+                for: 5m
+                labels:
+                    severity: critical
+                    service: vector
+
+              - alert: VectorDaemonSetMissingNodes
+                annotations:
+                    summary: 'Vector DaemonSet `supabase-vector` is short {{ $value }} pod(s)'
+                    description: |
+                        `supabase-vector` should run one pod per schedulable
+                        node, but has fewer ready pods than the desired number.
+                        Some nodes are not shipping logs into ClickHouse.
+                expr: |
+                    kube_daemonset_status_desired_number_scheduled{namespace="vector", daemonset="supabase-vector"}
+                      - kube_daemonset_status_number_ready{namespace="vector", daemonset="supabase-vector"} > 0
+                for: 15m
+                labels:
+                    severity: warning
+                    service: vector
+
+        - name: vector.alerts_poll
+          rules:
+              - alert: AlertsPollCronJobStale
+                annotations:
+                    summary: '`alerts-poll` has not had a successful run in >15m'
+                    description: |
+                        The `alerts-poll` CronJob in the `vector` namespace
+                        has not had a successful run for over 15 minutes (or
+                        never has). The Alerts dashboard (Alertmanager →
+                        ClickHouse poll) will stop showing fresh firing
+                        alerts. Check
+                        `kubectl -n vector get jobs --sort-by=.metadata.creationTimestamp`
+                        and inspect the latest pod's stderr for the
+                        ClickHouse response body.
+                expr: |
+                    (
+                      time() - max(kube_cronjob_status_last_successful_time{namespace="vector", cronjob="alerts-poll"}) > 900
+                    )
+                    or on() (
+                      absent(kube_cronjob_status_last_successful_time{namespace="vector", cronjob="alerts-poll"}) == 1
+                      and on() (count(kube_cronjob_info{namespace="vector", cronjob="alerts-poll"}) > 0)
+                    )
+                for: 5m
+                labels:
+                    severity: warning
+                    service: vector


### PR DESCRIPTION
## Summary
- The Alerts dashboard ("Alertmanager → ClickHouse poll") has been empty since the CronJob shipped because every run failed with `Code: 27. DB::Exception: Cannot parse input: expected '"' before: '+00:00", "status": "firing", "alertname": "TargetDown", ...'` — Python's `datetime.isoformat()` produced `2026-05-20T18:20:25.123+00:00` and CH's JSONEachRow parser into `DateTime64(3, 'UTC')` rejects the `+00:00` suffix.
- Fix `apps/kube/vector/manifests/alerts-poll-cronjob.yaml`: format both `timestamp` and `starts_at` with a `Z` suffix (replace `+00:00` → `Z`), and add `date_time_input_format=best_effort` to the insert URL as a defense in depth. Also surface the ClickHouse response body in the error path so future regressions don't require a manual debug pod to diagnose.
- Add `apps/kube/vector/manifests/vector-alerts.yaml` — a `PrometheusRule` (`release: monitoring`) so the next outage pages instead of going silent: `VectorDaemonSetUnavailable` (critical, 5m), `VectorDaemonSetMissingNodes` (warning, 15m), and `AlertsPollCronJobStale` (warning, 5m on stale OR `absent()` — the latter is exactly today's "never succeeded" state).

## Diagnostic snapshot
- `kubectl -n vector get cronjob`: `alerts-poll  */5 * * * *  False  0  4m  4d3h` (running on schedule, failing every run).
- `system.query_log` on `chi-...-1-0-0`: 30m of `Code: 27. DB::Exception: Cannot parse input: expected '"' before: '+00:00", ...'` errors.
- `kube_state_metrics`: `kube_cronjob_status_last_successful_time{namespace="vector", cronjob="alerts-poll"}` is absent → the `absent()` branch of the new rule covers this.

## Validation
- `kubectl apply --dry-run=server -f apps/kube/vector/manifests/vector-alerts.yaml` → `prometheusrule.monitoring.coreos.com/vector-pipeline created (server dry run)`.
- KSM exposes the metrics the rule depends on: confirmed `kube_daemonset_status_number_ready{namespace="vector", daemonset="supabase-vector"}` (=1 currently) and `kube_cronjob_status_last_successful_time` (gauge present in KSM 2.x).

## Test plan
- [ ] Merge + wait for ArgoCD sync.
- [ ] Trigger one manual cronjob run (`kubectl -n vector create job --from=cronjob/alerts-poll alerts-poll-manual-1`) and confirm the pod exits 0 with `Insert OK.` in stdout.
- [ ] `SELECT count() FROM observability.alerts_distributed WHERE ingested_at > now() - INTERVAL 10 MINUTE;` returns >0.
- [ ] `/dashboard/clickhouse/alerts/` "Currently firing" + "By severity" + "Top alertnames" + "Recent timeline" all populate.
- [ ] Scale `supabase-vector` to 0 for >5m in a test cluster and confirm `VectorDaemonSetUnavailable` fires (or wait for the next real outage; the alert flows back through this same poll into the dashboard).