### PR TITLE
fix(kbve-gateway): split HTTPS listener per hostname for SNI cert selection

### DIFF
--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -20,18 +20,56 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
-        # HTTPS listener — Cloudflare terminates public TLS on the edge.
-        # This listener handles origin TLS for Full/Strict SSL modes.
-        # chuckrpg.com and api.chuckrpg.com certs are issued by cert-manager
-        # in the chuckrpg namespace; Cloudflare proxies handle the public edge.
-        # game.chuckrpg.com uses Agones UDP (not HTTPS) — no cert needed here.
-        - name: https
+        # HTTPS listeners — one per cert/hostname so Envoy can route TLS
+        # by SNI to the matching certificate. Cilium gateway does NOT
+        # perform SNI-based selection across multiple certificateRefs on
+        # a single listener (it uses only the first ref), so each cert
+        # gets its own listener with an explicit hostname filter.
+        # Cloudflare terminates public TLS at the edge; origin certs must
+        # match the SNI CF sends for Full/Strict SSL modes.
+        - name: https-kbve
           protocol: HTTPS
           port: 443
+          hostname: '*.kbve.com'
           tls:
               mode: Terminate
               certificateRefs:
                   - name: kbve-wt-tls
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-kbve-root
+          protocol: HTTPS
+          port: 443
+          hostname: kbve.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - name: kbve-wt-tls
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-memes
+          protocol: HTTPS
+          port: 443
+          hostname: meme.sh
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: memes-tls
+                    namespace: memes
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-memes-www
+          protocol: HTTPS
+          port: 443
+          hostname: www.meme.sh
+          tls:
+              mode: Terminate
+              certificateRefs:
                   - kind: Secret
                     group: ''
                     name: memes-tls


### PR DESCRIPTION
## Problem

After #11229 merged, `https://meme.sh` is still 404. Direct probe shows Envoy presents the WRONG cert for the SNI:

```
$ openssl s_client -connect 142.132.206.71:443 -servername meme.sh
subject=/CN=kbve.com         ← should be CN=meme.sh
```

Even though Gateway has both `kbve-wt-tls` + `memes-tls` in `certificateRefs` and ReferenceGrant resolves, Cilium gateway uses only the **first** ref for all incoming SNIs. CF rejects the cert mismatch → returns 404 without ever reaching Envoy's HTTPRoute layer.

This is a Cilium gateway implementation detail (per spec the gateway SHOULD do SNI-based selection across multiple refs, but Cilium currently does not).

## Fix

Split the single HTTPS listener into per-hostname listeners. Each listener has its own `hostname` filter + own `certificateRefs`. Envoy routes by SNI to the listener whose hostname matches, then serves that listener's cert.

| Listener | hostname | cert |
|---|---|---|
| `https-kbve` | `*.kbve.com` | `kbve-wt-tls` |
| `https-kbve-root` | `kbve.com` | `kbve-wt-tls` |
| `https-memes` | `meme.sh` | `memes-tls` (cross-ns) |
| `https-memes-www` | `www.meme.sh` | `memes-tls` (cross-ns) |

## Reusable pattern

Every upcoming non-kbve.com cutover (`discord.sh`, `herbmail.com`, `cryptothrone.com`, `chuckrpg.com`, `rareicon.com`) adds one listener entry with its own cert + ReferenceGrant.

## Test plan

- [ ] ArgoCD syncs `kbve` app clean (gateway has 4 HTTPS listeners + 1 HTTP)
- [ ] `kubectl describe gateway -n kbve kbve-gateway` → all listeners Programmed + Accepted
- [ ] `openssl s_client -connect 142.132.206.71:443 -servername meme.sh` → CN includes meme.sh
- [ ] `openssl s_client -connect 142.132.206.71:443 -servername kbve.com` → CN=kbve.com
- [ ] `curl -sI https://meme.sh` → 200 via CF, envoy origin
- [ ] HTTPRoute for meme.sh attaches to the new listener (status accepted)