### PR TITLE
chore(dbmate): slim 6.0/6.1a migration comments to fit ConfigMap limit

### DIFF
--- a/packages/data/sql/dbmate/migrations/20260518091000_inventory_schema_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260518091000_inventory_schema_init.sql
@@ -1,64 +1,14 @@
 -- migrate:up
 
--- Phase 6.0 of the marketplace bootstrap: KBVE inventory layer.
---
--- The KBVE inventory is the canonical ledger of items owned by a
--- wallet account. Once an item is in the inventory, it is NOT in the
--- source game; the game's runtime inventory and the KBVE inventory are
--- mutually exclusive. Games are bridges; the ledger is authoritative.
---
--- Anti-dupe design
---   Every deposit / withdraw flows through a two-phase coordinator
---   (inventory.bridge_request). The game bridge MUST present a signed
---   HMAC receipt referencing a unique game_tx_hash; the receipt is
---   inserted into inventory.bridge_receipt with the hash as primary key
---   so the same physical game-side transaction can never settle twice.
---   The settlement RPC is idempotent against the (game_tx_hash, secret)
---   pair: re-presenting the same receipt returns the same item_id.
---
--- Stackable vs instanced
---   nbt = '{}' rows merge on (owner_account, kind, ref) via a partial
---   unique index. Enchanted / damaged / named items carry a non-empty
---   nbt and always stay one-row-per-item.
---
--- Withdraw timeout
---   Withdraw rows park in state = 'transit_out' until the bridge
---   settles. There is NO auto-rollback — that would risk a dup if the
---   game finished delivery before the bridge could ack. Reconciliation
---   cron (Phase 6.5) flags stuck rows for admin review.
---
--- Listing integration
---   wallet.service_create_listing will (in a follow-up migration) call
---   inventory.service_listing_lock to flip the item to listing_escrow.
---   Cancel / expire call _unlock; sale settlement calls _settle which
---   transfers ownership atomically. The wallet.listing.item_ref JSONB
---   becomes a denormalised projection of the inventory row; the
---   inventory row is the source of truth.
-
--- ============================================================================
--- SCHEMA + GRANTS
--- ============================================================================
-
 CREATE SCHEMA IF NOT EXISTS inventory;
 GRANT USAGE ON SCHEMA inventory TO service_role;
 
--- pgcrypto is already enabled in production for gen_random_uuid() and
--- hmac(); we list it here so local dev stacks pick it up via the init
--- scripts if they haven't already.
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
-
--- ============================================================================
--- ENUMS
--- ============================================================================
 
 CREATE TYPE inventory.item_state AS ENUM (
     'held',             -- in KBVE inventory, available to the owner
     'listing_escrow',   -- locked by an active marketplace listing
     'transit_in',       -- VIRTUAL: used only as the from_state in
-                        -- inventory.transition rows when a new item
-                        -- row is minted (deposit_settle, listing_settle
-                        -- buyer-side). No inventory.item row is ever
-                        -- stored with this state.
     'transit_out',      -- mid-withdraw; deducted from owner, awaiting bridge ack
     'consumed'          -- terminal: sold to buyer, burned, or withdrawn out
 );
@@ -68,91 +18,10 @@ CREATE TYPE inventory.bridge_direction AS ENUM ('deposit', 'withdraw');
 CREATE TYPE inventory.bridge_status AS ENUM (
     'pending',     -- created, awaiting bridge action
     'in_progress', -- bridge acknowledged (reserved for Phase 6.5 worker;
-                   -- no current RPC transitions to this value)
     'settled',     -- completed successfully
     'failed',      -- bridge or verification rejected; terminal
     'cancelled'    -- user / admin abandoned; terminal
 );
-
--- ============================================================================
--- ERROR CODE MAP (custom SQLSTATEs)
--- ============================================================================
--- INV01  bridge_request not found
--- INV02  bridge_request direction mismatch
--- INV03  game_tx_hash collision (different bridge_request)
--- INV04  bridge_request already terminal
--- INV05  bridge_request expired
--- INV06  HMAC verification failed
--- INV07  payload_sha256 mismatch
--- INV08  idempotency_key replay parameter mismatch
--- INV10  inventory.item not found
--- INV11  inventory.item not owned by caller
--- INV12  inventory.item not in held state
--- INV13  inventory.item qty insufficient for withdraw
--- INV14  inventory.item not in transit_out at settle
--- INV15  instanced (non-empty nbt) item must be withdrawn whole
--- INV16  qty overflow on stackable merge (qty + delta > BIGINT max)
--- INV20  listing_lock: item not in held state
--- INV21  listing_unlock: item not in listing_escrow state
--- INV22  listing_settle: item not in listing_escrow state
--- INV23  listing_lock/settle: seller account mismatch
--- INV30  mfa_required (aal2 missing for gated transition)
--- ============================================================================
---
--- LOCK ORDER CONTRACT
---   To keep wallet ↔ inventory integration deadlock-free, when a single
---   transaction needs to row-lock rows in MORE THAN ONE category below,
---   it must lock them in this order, top first:
---
---     1. wallet.listing            (the marketplace coordinator row)
---     2. wallet.account (seller)
---     3. wallet.account (buyer)
---     4. inventory.bridge_request  (the bridge coordinator row)
---     5. inventory.bridge_receipt  (FK target only; never row-locked)
---     6. inventory.item            (held / escrow / transit rows)
---     7. inventory.account_security
---
---   A function that touches only ONE category may lock that category
---   directly without first acquiring any higher-numbered category. For
---   example service_listing_lock locks only inventory.item — that is
---   fine and does NOT violate the order. The order only matters for
---   cross-category transactions like wallet checkout flows that will
---   land in Phase 6.1.
---
--- UPDATED_AT POLICY
---   inventory.* updated_at columns are maintained by the service RPCs in
---   this migration, NOT by a trigger. Every UPDATE path in this file
---   sets updated_at = now() explicitly. If a new mutation path is added
---   later, either: (a) set updated_at in the UPDATE, or (b) replace this
---   policy with a BEFORE UPDATE trigger on each table. Mixing the two
---   silently leaves stale updated_at values; pick one and stick with it.
---
--- ROADMAP (deferred to later phases — explicit so reviewers can track):
---   Phase 6.1 (wallet listing rewire):
---     * service_split_item_for_listing — dedicated partial-row split RPC
---       so callers don't have to misuse withdraw_begin's split path.
---     * Listing ownership FK / validation — prove p_listing_id still
---       belongs to (p_seller_account, p_item_id) at lock/settle time.
---     * high_value_khash_threshold wiring on listing creation (aal2 gate).
---   Phase 6.5 (bridge worker + reconciliation):
---     * Versioned bridge secrets (kid + active_from/retired_at) so
---       rotation does not invalidate in-flight signed receipts.
---     * service_bridge_request_fail / _cancel RPCs (sets status,
---       completed_at; for withdraws also returns item to held).
---     * service_bridge_claim_pending(p_game_id, p_direction, p_limit)
---       using FOR UPDATE SKIP LOCKED, plus attempt_count / last_error /
---       claimed_at / claimed_by / next_attempt_at columns.
---     * Move HMAC verification fully into axum (constant-time);
---       inventory.verify_hmac stays as defense in depth only.
--- ============================================================================
-
--- ============================================================================
--- TABLE: inventory.bridge_secret
---   Per-game HMAC secret used to verify bridge receipts. Insert via the
---   register RPC; the SHA-256 of the secret is stored, never the secret
---   itself. Bridges sign payloads with the raw secret out-of-band; the
---   axum bridge endpoint compares H(secret) on each request.
--- ============================================================================
 
 CREATE TABLE inventory.bridge_secret (
     game_id      TEXT PRIMARY KEY CHECK (length(game_id) BETWEEN 1 AND 64),
@@ -165,10 +34,6 @@ CREATE TABLE inventory.bridge_secret (
 COMMENT ON TABLE inventory.bridge_secret IS
     'Per-game HMAC verification material. secret_hash is sha256(raw_secret); the raw secret never enters the database.';
 
--- ============================================================================
--- TABLE: inventory.bridge_request
--- ============================================================================
-
 CREATE TABLE inventory.bridge_request (
     id            BIGSERIAL PRIMARY KEY,
     account       UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
@@ -176,8 +41,6 @@ CREATE TABLE inventory.bridge_request (
     game_id       TEXT NOT NULL REFERENCES inventory.bridge_secret(game_id) ON DELETE NO ACTION,
     kind          TEXT NOT NULL CHECK (length(kind) BETWEEN 1 AND 64),
     ref           TEXT NOT NULL CHECK (length(ref) BETWEEN 1 AND 128),
-    -- Same operational cap as inventory.item.qty; refuse bridge requests
-    -- that would lead to over-cap rows on settle.
     qty           BIGINT NOT NULL CHECK (qty > 0 AND qty <= 9223372036854775000),
     nbt           JSONB NOT NULL DEFAULT '{}'::jsonb
                   CHECK (jsonb_typeof(nbt) = 'object'),
@@ -189,17 +52,8 @@ CREATE TABLE inventory.bridge_request (
     receipt_tx_hash  TEXT,
     expires_at       TIMESTAMPTZ NOT NULL,
     created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
-    -- settled_at: when the bridge produced a valid receipt. Only ever
-    --   set for status='settled'. Never set for failed/cancelled.
-    -- completed_at: when the request reached ANY terminal status (settled,
-    --   failed, or cancelled). Lets reconciliation jobs reason about
-    --   "how long did this take" without overloading settled_at.
     settled_at       TIMESTAMPTZ,
     completed_at     TIMESTAMPTZ,
-    -- Populated by future service_bridge_request_fail / _cancel RPCs.
-    -- Free-form short label ("expired", "game_offline", "user_cancel"
-    -- etc.) plus structured metadata for whatever the failure path
-    -- needs to carry forward. NULL while pending/in_progress.
     terminal_reason     TEXT
                         CHECK (terminal_reason IS NULL
                                OR (length(terminal_reason) BETWEEN 1 AND 64)),
@@ -211,10 +65,6 @@ CREATE TABLE inventory.bridge_request (
         CHECK (expires_at > created_at
                AND expires_at <= created_at + interval '24 hours'),
 
-    -- Manual or admin terminal updates (when service_bridge_request_fail
-    -- / _cancel land in Phase 6.5) MUST set terminal_reason — otherwise
-    -- reconciliation tooling has no signal to triage on. Direct
-    -- `UPDATE bridge_request SET status='failed'` is rejected.
     CONSTRAINT bridge_request_terminal_consistency_chk CHECK (
         (status = 'settled'
             AND settled_at IS NOT NULL
@@ -239,11 +89,6 @@ CREATE TABLE inventory.bridge_request (
     CONSTRAINT bridge_request_id_game_uq UNIQUE (id, game_id)
 );
 
--- Idempotency lookup: every retry of *_begin walks this index, then
--- compares identity fields (direction/game/kind/ref/qty/item). INCLUDE
--- the hot identity columns so the replay path is an index-only scan
--- and skips a heap fetch. nbt is intentionally left off; it's not in
--- the identity tuple often enough to justify the index bloat.
 CREATE UNIQUE INDEX inventory_bridge_request_account_key_uq
     ON inventory.bridge_request (account, idempotency_key)
     INCLUDE (id, direction, game_id, kind, ref, qty, item_id, status);
@@ -255,30 +100,18 @@ CREATE INDEX inventory_bridge_request_stuck_idx
     ON inventory.bridge_request (status, expires_at)
     WHERE status IN ('pending', 'in_progress');
 
--- User-facing "my pending transfers" feed. proxy_inventory_list_pending
--- filters by account + status IN (pending, in_progress) and orders by
--- (created_at DESC, id DESC). Partial index moves the status predicate
--- out of the key columns so the planner gets a clean ordered walk.
 CREATE INDEX inventory_bridge_request_account_pending_idx
     ON inventory.bridge_request (account, created_at DESC, id DESC)
     WHERE status IN ('pending', 'in_progress');
 
--- Admin/reconciliation: "what bridge_request touched this item?"
--- Sparse — item_id is NULL until the begin RPC fills it — so partial
--- index avoids indexing NULL entries.
 CREATE INDEX inventory_bridge_request_item_idx
     ON inventory.bridge_request (item_id)
     WHERE item_id IS NOT NULL;
 
--- Bridge-worker pickup. Game plugins poll for pending work scoped to
--- their game_id; partial-index on status=pending keeps this cheap as
--- the table grows.
 CREATE INDEX inventory_bridge_request_pickup_idx
     ON inventory.bridge_request (game_id, direction, created_at)
     WHERE status = 'pending';
 
--- Per-game stuck/expired scan for the Phase 6.5 reconciliation cron.
--- Filtered to the same non-terminal statuses bridge workers care about.
 CREATE INDEX inventory_bridge_request_game_stuck_idx
     ON inventory.bridge_request (game_id, status, expires_at)
     WHERE status IN ('pending', 'in_progress');
@@ -288,42 +121,20 @@ COMMENT ON TABLE inventory.bridge_request IS
 COMMENT ON COLUMN inventory.bridge_request.item_id IS
     'Resulting inventory row affected by settlement. For deposits this may be a pre-existing row that was bumped via stackable merge; for withdraws it is the (possibly split) transit_out row that was created in begin.';
 
--- ============================================================================
--- TABLE: inventory.bridge_receipt
---   The anti-dupe primary primitive. game_tx_hash is the bridge-supplied
---   stable id for the game-side transaction (e.g. mc server tick + slot +
---   player UUID + nonce, hashed). Inserting a row with a duplicate hash
---   raises a unique-violation, which we surface as a 409 conflict from
---   axum. The HMAC verify must succeed BEFORE the row is inserted; we
---   keep the signature alongside the hash so audits can re-verify later.
--- ============================================================================
-
 CREATE TABLE inventory.bridge_receipt (
-    -- SHA-256 hex of the bridge-side transaction identity. The bridge
-    -- worker picks the hash inputs (e.g. mc tick + slot + player UUID +
-    -- nonce) and ships the hex digest; we enforce the digest shape so
-    -- "opaque string" cannot be smuggled past anti-dupe later.
     game_tx_hash       TEXT PRIMARY KEY CHECK (game_tx_hash ~ '^[0-9a-f]{64}$'),
     bridge_request_id  BIGINT NOT NULL,
     game_id            TEXT NOT NULL REFERENCES inventory.bridge_secret(game_id) ON DELETE NO ACTION,
-    -- SHA-256 HMAC, hex encoded. If a future bridge needs base64, add
-    -- an explicit encoding column and relax this check.
     hmac_signature     TEXT NOT NULL CHECK (hmac_signature ~ '^[0-9a-f]{64}$'),
     payload_sha256     TEXT NOT NULL CHECK (payload_sha256 ~ '^[0-9a-f]{64}$'),
     verified_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
 
-    -- Composite FK: a receipt's (request_id, game_id) MUST match the
-    -- linked bridge_request row. Prevents admin tools / future migrations
-    -- from inserting a receipt whose game_id drifts from the request's.
     CONSTRAINT bridge_receipt_request_game_fk
         FOREIGN KEY (bridge_request_id, game_id)
         REFERENCES inventory.bridge_request(id, game_id)
         ON DELETE NO ACTION
 );
 
--- One bridge_request settles at most once. The unique constraint
--- encodes the invariant for future tooling; the FOR UPDATE lock on
--- bridge_request + status check already enforce it at runtime.
 CREATE UNIQUE INDEX inventory_bridge_receipt_request_uq
     ON inventory.bridge_receipt (bridge_request_id);
 
@@ -332,34 +143,20 @@ COMMENT ON TABLE inventory.bridge_receipt IS
 COMMENT ON COLUMN inventory.bridge_receipt.game_id IS
     'Denormalized copy of bridge_request.game_id; the composite FK bridge_receipt_request_game_fk guarantees it cannot drift from the linked request.';
 
--- Tie bridge_request.receipt_tx_hash back to the receipt row that
--- settled it. Both tables must exist before we can declare this FK.
 ALTER TABLE inventory.bridge_request
     ADD CONSTRAINT bridge_request_receipt_tx_hash_fk
         FOREIGN KEY (receipt_tx_hash)
         REFERENCES inventory.bridge_receipt(game_tx_hash)
         ON DELETE NO ACTION;
 
--- ============================================================================
--- TABLE: inventory.item
--- ============================================================================
-
 CREATE TABLE inventory.item (
     id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     owner_account UUID NOT NULL REFERENCES wallet.account(id) ON DELETE NO ACTION,
     kind          TEXT NOT NULL CHECK (length(kind) BETWEEN 1 AND 64),
     ref           TEXT NOT NULL CHECK (length(ref) BETWEEN 1 AND 128),
-    -- Upper bound matches inventory.max_stack_qty() so a fresh row can
-    -- never be inserted above the ceiling the merge guards enforce.
-    -- Keep literal in sync with inventory.max_stack_qty().
     qty           BIGINT NOT NULL CHECK (qty > 0 AND qty <= 9223372036854775000),
     nbt           JSONB NOT NULL DEFAULT '{}'::jsonb
                   CHECK (jsonb_typeof(nbt) = 'object'),
-    -- Stored generated column: true iff this row participates in
-    -- stack-merge identity. Lets the partial unique index, ON CONFLICT
-    -- predicates, and RPC checks read a single named flag instead of
-    -- repeating `nbt = '{}'::jsonb` in five places. The expression is
-    -- IMMUTABLE w.r.t. nbt, so STORED is safe.
     is_stackable  BOOLEAN GENERATED ALWAYS AS (nbt = '{}'::jsonb) STORED,
     state         inventory.item_state NOT NULL DEFAULT 'held',
     source        TEXT NOT NULL CHECK (length(source) BETWEEN 1 AND 64),
@@ -369,41 +166,23 @@ CREATE TABLE inventory.item (
     updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- Stackable merge: at most one held row per (owner, kind, ref) when nbt
--- is the empty object. Non-empty nbt always stays one-row-per-instance.
 CREATE UNIQUE INDEX inventory_item_stackable_merge_uq
     ON inventory.item (owner_account, kind, ref)
     WHERE is_stackable AND state = 'held';
 
--- Hot lookup: "all items the caller can act on" = held + listing_escrow,
--- ordered by created_at DESC, id DESC for keyset pagination.
--- state lives in the partial-index predicate (not in the column list),
--- so a multi-state query (held + listing_escrow together) walks the
--- index in true global order without re-sort.
 CREATE INDEX inventory_item_owner_created_active_idx
     ON inventory.item (owner_account, created_at DESC, id DESC)
     WHERE state IN ('held', 'listing_escrow');
 
--- Tail of active items by kind/ref for marketplace cross-references
 CREATE INDEX inventory_item_kind_ref_state_idx
     ON inventory.item (kind, ref, state);
 
--- Reconciliation scan: "items currently in flight to or from the game"
--- (transit_out) and "items locked into an open listing" (listing_escrow).
--- updated_at lets cron flag rows that have been stuck in the state for
--- longer than the configured threshold.
 CREATE INDEX inventory_item_inflight_updated_idx
     ON inventory.item (state, updated_at)
     WHERE state IN ('transit_out', 'listing_escrow');
 
 COMMENT ON TABLE inventory.item IS
     'Canonical KBVE inventory. Items in this table are NOT in the source game. Stackable rows merge via the partial unique index when nbt is empty.';
-
--- ============================================================================
--- TABLE: inventory.transition
---   Append-only audit log. Every state change writes a row. Useful for
---   anti-dupe audits, support tickets, and admin tooling.
--- ============================================================================
 
 CREATE TABLE inventory.transition (
     id          BIGSERIAL PRIMARY KEY,
@@ -422,20 +201,14 @@ CREATE TABLE inventory.transition (
 CREATE INDEX inventory_transition_item_created_idx
     ON inventory.transition (item_id, created_at DESC);
 
--- Admin/audit feed: "last N transitions across the whole ledger".
 CREATE INDEX inventory_transition_created_idx
     ON inventory.transition (created_at DESC);
 
 COMMENT ON TABLE inventory.transition IS
     'Append-only audit log of every inventory state change. Never modified after insert.';
 
--- Block UPDATE/DELETE on the audit log; service RPCs only INSERT.
 REVOKE UPDATE, DELETE ON inventory.transition FROM PUBLIC, anon, authenticated, service_role;
 
--- Defense in depth: even table owners get refused by the trigger. Grants
--- alone won't stop the owning role from issuing an UPDATE/DELETE in a
--- one-off ad-hoc session; this trigger makes the audit log immutable
--- regardless of caller.
 CREATE OR REPLACE FUNCTION inventory.transition_block_mutation()
 RETURNS TRIGGER
 LANGUAGE plpgsql
@@ -455,30 +228,10 @@ BEFORE UPDATE OR DELETE ON inventory.transition
 FOR EACH ROW
 EXECUTE FUNCTION inventory.transition_block_mutation();
 
--- ============================================================================
--- TABLE: inventory.account_security
---   Per-account 2FA policy. The SQL layer owns the *policy* (which
---   accounts require 2FA, at what value threshold); the *verification*
---   happens at the JWT layer — Supabase issues JWTs with an `aal` claim
---   (aal1 = single-factor, aal2 = MFA-verified). The user-facing proxy
---   RPCs read request.jwt.claims and refuse the transition when policy
---   requires aal2 but the session is only aal1.
---
---   Anti-theft note: changing the policy ALSO requires aal2 once any
---   field on a row is true. Prevents an attacker on a stolen aal1
---   session from disabling 2FA before draining the inventory.
--- ============================================================================
-
 CREATE TABLE inventory.account_security (
     account                      UUID PRIMARY KEY REFERENCES wallet.account(id) ON DELETE NO ACTION,
     require_2fa_for_withdraw     BOOLEAN NOT NULL DEFAULT false,
     require_2fa_for_listing      BOOLEAN NOT NULL DEFAULT false,
-    -- Reserved for Phase 6.1 listing wiring. The column is settable now
-    -- so axum + UI can persist the user preference, but no inventory
-    -- proxy currently consults it. Once wallet.service_create_listing
-    -- is rewired to take an item_id, that proxy will compare the
-    -- listing's buy_now_price / item market value against this
-    -- threshold and require aal2 when exceeded.
     high_value_khash_threshold   BIGINT  NOT NULL DEFAULT 0 CHECK (high_value_khash_threshold >= 0),
     created_at                   TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at                   TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -486,15 +239,6 @@ CREATE TABLE inventory.account_security (
 
 COMMENT ON TABLE inventory.account_security IS
     '2FA policy per wallet account. Verification (JWT aal claim) lives in Supabase; this table only holds the gate rules and is read by the inventory proxies before any transition.';
-
--- ============================================================================
--- ACCESS CONTROL
---   Direct table access is service_role only. authenticated callers go
---   through public.proxy_inventory_* SECURITY DEFINER wrappers which
---   apply auth.uid() -> wallet.account scoping. RLS is intentionally
---   not enabled — no role other than service_role gets any privilege on
---   these tables, so policies on top of zero grants would be noise.
--- ============================================================================
 
 REVOKE ALL ON ALL TABLES    IN SCHEMA inventory FROM PUBLIC, anon, authenticated;
 REVOKE ALL ON ALL SEQUENCES IN SCHEMA inventory FROM PUBLIC, anon, authenticated;
@@ -506,14 +250,6 @@ GRANT  SELECT, INSERT         ON inventory.transition       TO service_role;
 GRANT  SELECT, INSERT, UPDATE ON inventory.account_security TO service_role;
 GRANT  USAGE ON ALL SEQUENCES IN SCHEMA inventory TO service_role;
 
--- ============================================================================
--- STACK QUANTITY CEILING
---   Centralized cap so RPCs and the table CHECK stay in sync. Two
---   transactions worth of merges can still add without overflowing
---   BIGINT (9_223_372_036_854_775_807). Mark IMMUTABLE so it can sit
---   inside CHECK predicates and ON CONFLICT WHERE clauses.
--- ============================================================================
-
 CREATE OR REPLACE FUNCTION inventory.max_stack_qty()
 RETURNS BIGINT
 LANGUAGE sql
@@ -524,22 +260,6 @@ AS $$ SELECT 9223372036854775000::bigint $$;
 ALTER FUNCTION inventory.max_stack_qty() OWNER TO service_role;
 REVOKE ALL ON FUNCTION inventory.max_stack_qty() FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION inventory.max_stack_qty() TO service_role;
-
--- ============================================================================
--- HMAC VERIFY HELPER
---   Takes the raw secret (the bridge knows it; the table only stores a
---   sha256). The caller is expected to be service_role / the axum bridge
---   endpoint that holds the secret in its env.
---
---   Trust model: SQL-side verification is DEFENSE IN DEPTH, not the
---   primary security boundary. The axum bridge endpoint MUST do its own
---   constant-time HMAC + payload_sha256 + secret-hash compare BEFORE
---   calling service_*_settle. The reason: PL/pgSQL '=' on TEXT is not
---   constant-time and would leak signature bytes under a timing oracle.
---   The SQL check exists so a misconfigured bridge or a service_role
---   call that skips the axum path still cannot smuggle an unsigned
---   receipt in.
--- ============================================================================
 
 CREATE OR REPLACE FUNCTION inventory.verify_hmac(
     p_game_id      TEXT,
@@ -563,8 +283,6 @@ BEGIN
         RETURN false;
     END IF;
 
-    -- Always hash UTF-8 bytes so the SQL side matches the bridge's
-    -- behaviour regardless of Postgres' bytea-encoding setting.
     IF v_stored_hash <> encode(extensions.digest(convert_to(p_raw_secret, 'UTF8'), 'sha256'), 'hex') THEN
         RETURN false;
     END IF;
@@ -588,11 +306,6 @@ GRANT  EXECUTE ON FUNCTION inventory.verify_hmac(TEXT, TEXT, TEXT, TEXT) TO serv
 COMMENT ON FUNCTION inventory.verify_hmac(TEXT, TEXT, TEXT, TEXT) IS
     'HMAC verify against the stored sha256(secret). service_role only — bridge endpoint passes the raw secret from env. NOTE: the final = compare is not constant-time; for stricter timing-attack resistance the bridge endpoint should verify in axum using a CT compare crate before calling this RPC.';
 
--- ============================================================================
--- SERVICE RPCs
--- ============================================================================
-
--- Register / rotate a per-game bridge secret. Idempotent on game_id.
 CREATE OR REPLACE FUNCTION inventory.service_register_bridge_secret(
     p_game_id      TEXT,
     p_raw_secret   TEXT,
@@ -603,11 +316,6 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 BEGIN
-    -- Rotation is immediate and invalidates any in-flight receipts
-    -- signed with the old secret. For non-breaking rotation, future
-    -- work will add versioned secrets (kid, active_from, retired_at)
-    -- and require the bridge payload to declare which version it
-    -- signed with.
     IF length(COALESCE(p_game_id, '')) < 1 OR length(p_game_id) > 64 THEN
         RAISE EXCEPTION 'game_id length must be 1..64' USING ERRCODE = '22023';
     END IF;
@@ -633,9 +341,6 @@ ALTER FUNCTION inventory.service_register_bridge_secret(TEXT, TEXT, TEXT) OWNER 
 REVOKE ALL ON FUNCTION inventory.service_register_bridge_secret(TEXT, TEXT, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION inventory.service_register_bridge_secret(TEXT, TEXT, TEXT) TO service_role;
 
--- ---------------------------------------------------------------------
--- 2FA policy helpers
--- ---------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION inventory.is_2fa_required_for_withdraw(p_account UUID)
 RETURNS BOOLEAN
 LANGUAGE sql
@@ -714,12 +419,6 @@ ALTER FUNCTION inventory.service_set_security_policy(UUID, BOOLEAN, BOOLEAN, BIG
 REVOKE ALL ON FUNCTION inventory.service_set_security_policy(UUID, BOOLEAN, BOOLEAN, BIGINT) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION inventory.service_set_security_policy(UUID, BOOLEAN, BOOLEAN, BIGINT) TO service_role;
 
--- ---------------------------------------------------------------------
--- service_deposit_begin
---   Opens a deposit bridge_request and returns its id. The game plugin
---   then atomically removes the item from the player and calls
---   service_deposit_settle with the signed receipt.
--- ---------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION inventory.service_deposit_begin(
     p_account          UUID,
     p_kind             TEXT,
@@ -766,18 +465,6 @@ BEGIN
         RAISE EXCEPTION 'game_ref must be a JSON object' USING ERRCODE = '22023';
     END IF;
 
-    -- Idempotent replay returns the original row id — but only if the
-    -- replay carries identical parameters. Reusing the same key with a
-    -- different ref / qty / game / direction is a caller bug and we
-    -- refuse it loudly rather than silently aliasing.
-    --
-    -- game_ref is intentionally NOT part of the identity tuple: it is
-    -- non-authoritative source-side metadata (e.g. mc world+pos) that the
-    -- bridge may refine between attempts. The authoritative bridge
-    -- identity is (account, direction, game_id, kind, ref, qty, nbt) +
-    -- the idempotency_key uniqueness. p_ttl is creation-only and is
-    -- intentionally ignored on replay — retries must not fail because
-    -- the caller chose a different ttl the second time.
     SELECT * INTO v_existing
       FROM inventory.bridge_request
      WHERE account = p_account
@@ -815,12 +502,6 @@ ALTER FUNCTION inventory.service_deposit_begin(UUID, TEXT, TEXT, BIGINT, JSONB, 
 REVOKE ALL ON FUNCTION inventory.service_deposit_begin(UUID, TEXT, TEXT, BIGINT, JSONB, TEXT, JSONB, UUID, INTERVAL) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION inventory.service_deposit_begin(UUID, TEXT, TEXT, BIGINT, JSONB, TEXT, JSONB, UUID, INTERVAL) TO service_role;
 
--- ---------------------------------------------------------------------
--- service_deposit_settle
---   Verifies HMAC, inserts the receipt insert-once, then inserts the
---   inventory.item row (merging on stackable). Idempotent against
---   game_tx_hash: replaying the same receipt returns the same item_id.
--- ---------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION inventory.service_deposit_settle(
     p_bridge_request_id BIGINT,
     p_game_tx_hash      TEXT,
@@ -841,7 +522,6 @@ DECLARE
     v_merge_existing_id  UUID;
     v_merge_existing_qty BIGINT;
 BEGIN
-    -- Required input validation.
     IF p_bridge_request_id IS NULL
        OR coalesce(length(p_game_tx_hash), 0) = 0
        OR coalesce(length(p_raw_secret), 0) = 0
@@ -850,9 +530,6 @@ BEGIN
        OR coalesce(length(p_payload), 0) = 0 THEN
         RAISE EXCEPTION 'all settle inputs are required' USING ERRCODE = '22004';
     END IF;
-    -- Cheap format gates before doing crypto work: same shape the
-    -- bridge_receipt CHECKs enforce, surfaced as a clean 22023 instead
-    -- of a raw constraint violation deep in the INSERT.
     IF p_game_tx_hash !~ '^[0-9a-f]{64}$' THEN
         RAISE EXCEPTION 'game_tx_hash must be 64 lowercase hex chars' USING ERRCODE = '22023';
     END IF;
@@ -863,7 +540,6 @@ BEGIN
         RAISE EXCEPTION 'hmac_signature must be 64 lowercase hex chars' USING ERRCODE = '22023';
     END IF;
 
-    -- Lock the bridge_request row so concurrent settles can't race.
     SELECT * INTO v_req
       FROM inventory.bridge_request
      WHERE id = p_bridge_request_id
@@ -875,8 +551,6 @@ BEGIN
         RAISE EXCEPTION 'bridge_request % is not a deposit', p_bridge_request_id USING ERRCODE = 'INV02';
     END IF;
 
-    -- Idempotent replay: pull the item_id via the receipt -> bridge_request
-    -- chain so we don't rely on the stale local v_req snapshot.
     SELECT r.bridge_request_id, br.item_id
       INTO v_existing, v_existing_item
       FROM inventory.bridge_receipt r
@@ -906,10 +580,6 @@ BEGIN
         RAISE EXCEPTION 'hmac verification failed for bridge_request %', v_req.id USING ERRCODE = 'INV06';
     END IF;
 
-    -- Hard anti-dupe gate: write the receipt FIRST. A duplicate
-    -- game_tx_hash trips the unique violation before any inventory
-    -- mutation runs, so two concurrent settles for the same physical
-    -- game transaction can never both move items.
     INSERT INTO inventory.bridge_receipt (
         game_tx_hash, bridge_request_id, game_id,
         hmac_signature, payload_sha256
@@ -918,15 +588,7 @@ BEGIN
         p_hmac_signature, p_payload_sha256
     );
 
-    -- Stackable merge via the partial unique index. Atomic insert-or-bump
-    -- so concurrent deposits for the same (owner, kind, ref) stack never
-    -- race-insert two rows. Non-empty nbt rows fall through to a plain
-    -- INSERT — the partial index excludes them so they never collide.
     IF v_req.nbt = '{}'::jsonb THEN
-        -- Best-effort audit pre-read (NOT a safety guard — a concurrent
-        -- inserter may sneak a row in between this SELECT and the
-        -- INSERT, and the real overflow protection lives in the
-        -- ON CONFLICT WHERE clause below).
         SELECT id, qty INTO v_merge_existing_id, v_merge_existing_qty
           FROM inventory.item
          WHERE owner_account = v_req.account
@@ -935,12 +597,6 @@ BEGIN
            AND is_stackable
            AND state = 'held';
 
-        -- Race-safe upsert. The WHERE on DO UPDATE refuses to bump qty
-        -- past the ceiling — if the existing row already sits at or
-        -- above max - delta, the UPDATE is skipped, RETURNING produces
-        -- no row, and we raise INV16. Same predicate catches the
-        -- "fresh-insert-then-second-tx-conflict" race the pre-read
-        -- cannot see.
         INSERT INTO inventory.item (
             owner_account, kind, ref, qty, nbt, state, source, source_ref
         ) VALUES (
@@ -969,9 +625,6 @@ BEGIN
         RETURNING id INTO v_item_id;
     END IF;
 
-    -- Audit metadata: capture whether this was a fresh row or a merge
-    -- into an existing stack so reconciliation tooling can tell qty
-    -- bumps apart from genuine new-row inserts.
     INSERT INTO inventory.transition (item_id, from_state, to_state, actor, reason, metadata)
     VALUES (v_item_id, 'transit_in', 'held',
             v_req.game_id || '_bridge',
@@ -999,13 +652,6 @@ ALTER FUNCTION inventory.service_deposit_settle(BIGINT, TEXT, TEXT, TEXT, TEXT, 
 REVOKE ALL ON FUNCTION inventory.service_deposit_settle(BIGINT, TEXT, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION inventory.service_deposit_settle(BIGINT, TEXT, TEXT, TEXT, TEXT, TEXT) TO service_role;
 
--- ---------------------------------------------------------------------
--- service_withdraw_begin
---   Initiates a withdraw: validates ownership, transitions item to
---   transit_out, creates bridge_request. Caller (bridge) then delivers
---   in-game and calls service_withdraw_settle to flip to consumed.
---   Splits stackable rows when qty < current row qty.
--- ---------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION inventory.service_withdraw_begin(
     p_account          UUID,
     p_item_id          UUID,
@@ -1042,21 +688,11 @@ BEGIN
         RAISE EXCEPTION 'game_ref must be a JSON object' USING ERRCODE = '22023';
     END IF;
 
-    -- Idempotent replay returns the original row id — but only if the
-    -- replay carries identical parameters. Reusing a key for a different
-    -- item/qty/game is a caller bug; surface INV08 loudly. p_ttl and
-    -- p_game_ref are creation-only and intentionally ignored on replay.
     SELECT * INTO v_existing
       FROM inventory.bridge_request
      WHERE account = p_account
        AND idempotency_key = p_idempotency_key;
     IF FOUND THEN
-        -- Replay proof: if the existing request used the same item_id
-        -- directly, trivially match. Otherwise prove the linked item is
-        -- the exact split row that withdraw_begin would have produced
-        -- for THIS caller: same owner, kind/ref/nbt cloned from parent,
-        -- qty equal to the request, still in transit_out, and source_ref
-        -- carries the parent split_from pointer.
         IF v_existing.direction <> 'withdraw'
            OR v_existing.game_id <> p_game_id
            OR v_existing.qty <> p_qty
@@ -1093,16 +729,12 @@ BEGIN
     IF v_item.qty < p_qty THEN
         RAISE EXCEPTION 'item % has qty %, cannot withdraw %', p_item_id, v_item.qty, p_qty USING ERRCODE = 'INV13';
     END IF;
-    -- Non-empty nbt = instanced (enchant / damage / custom name). The
-    -- item is one logical unit even if qty > 1; partial withdraw would
-    -- silently duplicate the metadata across rows. Refuse it.
     IF NOT v_item.is_stackable AND p_qty <> v_item.qty THEN
         RAISE EXCEPTION 'instanced item % must be withdrawn whole (qty=%, requested=%)',
             p_item_id, v_item.qty, p_qty USING ERRCODE = 'INV15';
     END IF;
 
     IF v_item.qty = p_qty THEN
-        -- Whole row moves to transit_out.
         UPDATE inventory.item
            SET state = 'transit_out',
                updated_at = now()
@@ -1114,18 +746,11 @@ BEGIN
                 'withdraw_begin',
                 jsonb_build_object('qty', p_qty));
     ELSE
-        -- Partial withdraw: split. Reduce held qty, create a new
-        -- transit_out row with the withdrawn qty. New row carries the
-        -- same nbt + source for traceability.
         UPDATE inventory.item
            SET qty = qty - p_qty,
                updated_at = now()
          WHERE id = p_item_id;
 
-        -- Wrap the parent's source_ref instead of merging keys: a
-        -- repeated split/merge cycle would otherwise overwrite an
-        -- existing `split_from` and lose lineage. parent_source_ref
-        -- preserves the chain for support / audit traversal.
         INSERT INTO inventory.item (
             owner_account, kind, ref, qty, nbt, state, source, source_ref
         ) VALUES (
@@ -1163,11 +788,6 @@ ALTER FUNCTION inventory.service_withdraw_begin(UUID, UUID, BIGINT, TEXT, JSONB,
 REVOKE ALL ON FUNCTION inventory.service_withdraw_begin(UUID, UUID, BIGINT, TEXT, JSONB, UUID, INTERVAL) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION inventory.service_withdraw_begin(UUID, UUID, BIGINT, TEXT, JSONB, UUID, INTERVAL) TO service_role;
 
--- ---------------------------------------------------------------------
--- service_withdraw_settle
---   Bridge confirms delivery, item -> consumed (terminal). HMAC verified
---   and game_tx_hash insert-once-locked.
--- ---------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION inventory.service_withdraw_settle(
     p_bridge_request_id BIGINT,
     p_game_tx_hash      TEXT,
@@ -1224,11 +844,6 @@ BEGIN
     IF v_req.status IN ('settled', 'failed', 'cancelled') THEN
         RAISE EXCEPTION 'bridge_request % already terminal (status=%)', v_req.id, v_req.status USING ERRCODE = 'INV04';
     END IF;
-    -- Expiry is INTENTIONALLY NOT enforced on withdraw_settle. The
-    -- source game may have already delivered the item by the time the
-    -- bridge ack arrives; refusing the settle would leave the item
-    -- duped (in-game + in transit_out). Stuck/expired withdraws are
-    -- surfaced by the Phase 6.5 reconciliation cron for admin review.
     IF p_payload_sha256 <> encode(extensions.digest(convert_to(p_payload, 'UTF8'), 'sha256'), 'hex') THEN
         RAISE EXCEPTION 'payload_sha256 mismatch for bridge_request %', v_req.id USING ERRCODE = 'INV07';
     END IF;
@@ -1236,8 +851,6 @@ BEGIN
         RAISE EXCEPTION 'hmac verification failed for bridge_request %', v_req.id USING ERRCODE = 'INV06';
     END IF;
 
-    -- Anti-dupe primitive first: a duplicate game_tx_hash fails before
-    -- we flip the item to consumed.
     INSERT INTO inventory.bridge_receipt (
         game_tx_hash, bridge_request_id, game_id,
         hmac_signature, payload_sha256
@@ -1275,16 +888,6 @@ ALTER FUNCTION inventory.service_withdraw_settle(BIGINT, TEXT, TEXT, TEXT, TEXT,
 REVOKE ALL ON FUNCTION inventory.service_withdraw_settle(BIGINT, TEXT, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION inventory.service_withdraw_settle(BIGINT, TEXT, TEXT, TEXT, TEXT, TEXT) TO service_role;
 
--- ---------------------------------------------------------------------
--- Listing integration RPCs
--- ---------------------------------------------------------------------
--- service_listing_lock contract: WHOLE-ROW lock.
---   The entire inventory.item row's qty is escrowed; there is no
---   partial-qty listing path here. Callers that want to list a subset of
---   a stackable row (e.g. 16 of 64 iron ingots) must split the row first
---   via a dedicated RPC and pass the new row's id. This keeps the lock
---   path race-free and avoids a split-on-lock branch that would
---   complicate cancel/refund accounting.
 CREATE OR REPLACE FUNCTION inventory.service_listing_lock(
     p_seller_account UUID,
     p_item_id        UUID,
@@ -1341,10 +944,6 @@ DECLARE
     v_merge_into  UUID;
     v_merge_qty   BIGINT;
 BEGIN
-    -- Reason is optional (we default it below) but if the caller bothered
-    -- to pass one, enforce the same 1..128 bound the transition table
-    -- has so we fail with a clean 22023 instead of a raw constraint
-    -- violation deep inside the audit INSERT.
     IF p_reason IS NOT NULL
        AND (length(p_reason) < 1 OR length(p_reason) > 128) THEN
         RAISE EXCEPTION 'reason length must be 1..128' USING ERRCODE = '22023';
@@ -1362,11 +961,6 @@ BEGIN
             p_item_id USING ERRCODE = 'INV21';
     END IF;
 
-    -- Stackable unlock must respect the partial unique index. If the
-    -- seller already holds another empty-nbt row for (kind, ref), flip
-    -- the escrow row to 'consumed' and bump qty on the existing held
-    -- row instead of returning to 'held' (which would violate the
-    -- partial unique constraint).
     IF v_item.is_stackable THEN
         SELECT id, qty INTO v_merge_into, v_merge_qty
           FROM inventory.item
@@ -1453,7 +1047,6 @@ BEGIN
         RAISE EXCEPTION 'item % not in listing_escrow (state=%)', p_item_id, v_item.state USING ERRCODE = 'INV22';
     END IF;
 
-    -- Seller's row becomes consumed (terminal).
     UPDATE inventory.item
        SET state = 'consumed',
            updated_at = now()
@@ -1465,12 +1058,7 @@ BEGIN
             jsonb_build_object('listing_id', p_listing_id,
                                'buyer_account', p_buyer_account));
 
-    -- Buyer-side: atomic insert-or-bump via the partial unique index so
-    -- concurrent settlements + deposits on the same stackable row don't
-    -- race-insert duplicates.
     IF v_item.is_stackable THEN
-        -- Best-effort audit pre-read; real race-safe overflow guard is
-        -- the WHERE on DO UPDATE below.
         SELECT id, qty INTO v_buyer_merge_id, v_buyer_merge_qty
           FROM inventory.item
          WHERE owner_account = p_buyer_account
@@ -1531,13 +1119,6 @@ ALTER FUNCTION inventory.service_listing_settle(UUID, UUID, BIGINT, UUID) OWNER 
 REVOKE ALL ON FUNCTION inventory.service_listing_settle(UUID, UUID, BIGINT, UUID) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION inventory.service_listing_settle(UUID, UUID, BIGINT, UUID) TO service_role;
 
--- ============================================================================
--- PUBLIC PROXIES (auth.uid()-scoped reads + user-initiated requests)
--- ============================================================================
-
--- Internal helper — lives in the inventory schema so the public.* namespace
--- only contains true user-facing RPCs. Called from each public proxy via
--- SECURITY DEFINER chain; never exposed to authenticated directly.
 CREATE OR REPLACE FUNCTION inventory.caller_account()
 RETURNS UUID
 LANGUAGE plpgsql
@@ -1566,12 +1147,6 @@ ALTER FUNCTION inventory.caller_account() OWNER TO service_role;
 REVOKE ALL ON FUNCTION inventory.caller_account() FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION inventory.caller_account() TO service_role;
 
--- Caller's held + listing_escrow inventory. Returns one row per item.
--- Keyset pagination. p_limit caps page size (default 50, max 200);
--- p_before_created_at + p_before_id are the (created_at, id) tuple of
--- the LAST row from the previous page. Pass NULLs for the first page.
--- Index inventory_item_owner_created_active_idx ((owner, created_at DESC, id DESC) WHERE state IN (...))
--- supports the ordering directly across both states.
 CREATE OR REPLACE FUNCTION public.proxy_inventory_list_held(
     p_limit              INT         DEFAULT 50,
     p_before_created_at  TIMESTAMPTZ DEFAULT NULL,
@@ -1595,9 +1170,6 @@ DECLARE
     v_account UUID := inventory.caller_account();
     v_limit   INT  := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 200);
 BEGIN
-    -- Keyset cursor must be all-NULL (first page) or fully populated;
-    -- a partially supplied cursor row-compares against NULL and silently
-    -- returns no rows.
     IF (p_before_created_at IS NULL) IS DISTINCT FROM (p_before_id IS NULL) THEN
         RAISE EXCEPTION 'pagination cursor requires both created_at and id, or neither'
             USING ERRCODE = '22023';
@@ -1622,7 +1194,6 @@ GRANT  EXECUTE ON FUNCTION public.proxy_inventory_list_held(INT, TIMESTAMPTZ, UU
 COMMENT ON FUNCTION public.proxy_inventory_list_held(INT, TIMESTAMPTZ, UUID) IS
     'Authenticated RPC. Returns the caller''s actionable inventory rows (state = held or listing_escrow), newest first. Keyset paginated: pass p_before_created_at + p_before_id from the last row of the previous page (NULL for first page). p_limit clamps to 1..200.';
 
--- Caller's pending bridge requests (deposits + withdraws in flight).
 CREATE OR REPLACE FUNCTION public.proxy_inventory_list_pending(
     p_limit              INT         DEFAULT 50,
     p_before_created_at  TIMESTAMPTZ DEFAULT NULL,
@@ -1673,11 +1244,6 @@ GRANT  EXECUTE ON FUNCTION public.proxy_inventory_list_pending(INT, TIMESTAMPTZ,
 COMMENT ON FUNCTION public.proxy_inventory_list_pending(INT, TIMESTAMPTZ, BIGINT) IS
     'Authenticated RPC. Returns the caller''s in-flight bridge requests (status in pending, in_progress) ordered newest first. Keyset paginated via (created_at, id) cursor. p_limit clamps to 1..200.';
 
--- Read the caller's Supabase JWT AAL claim. aal2 == MFA-verified
--- session, aal1 == single-factor. NULL when no JWT is present (e.g.
--- direct service_role call). plpgsql wrapper catches invalid_text
--- on a malformed setting so a corrupt request.jwt.claims surfaces as
--- "no aal" (deny by default) instead of bubbling a 22P02 to the caller.
 CREATE OR REPLACE FUNCTION inventory.caller_jwt_aal()
 RETURNS TEXT
 LANGUAGE plpgsql
@@ -1703,14 +1269,6 @@ ALTER FUNCTION inventory.caller_jwt_aal() OWNER TO service_role;
 REVOKE ALL ON FUNCTION inventory.caller_jwt_aal() FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION inventory.caller_jwt_aal() TO service_role;
 
--- Caller-initiated withdraw request. The user signals intent here; the
--- game bridge picks up the bridge_request, delivers the item in-game,
--- and calls service_withdraw_settle with a signed receipt.
--- 2FA gate: if inventory.account_security.require_2fa_for_withdraw is
--- true for this account, the caller's JWT must carry aal=aal2. The
--- supabase auth layer issues aal2 only after a successful MFA challenge
--- within the session, so the bar is "verified TOTP / passkey in this
--- browser session".
 CREATE OR REPLACE FUNCTION public.proxy_inventory_request_withdraw(
     p_item_id          UUID,
     p_qty              BIGINT,
@@ -1750,9 +1308,6 @@ BEGIN
         p_idempotency_key
     );
 
-    -- Return the full pending row so the UI can render the "transfer
-    -- in progress" card without a follow-up proxy_inventory_list_pending
-    -- round trip.
     RETURN QUERY
         SELECT br.id, br.direction::text, br.game_id, br.kind, br.ref,
                br.qty, br.status::text, br.expires_at, br.created_at
@@ -1767,11 +1322,6 @@ GRANT  EXECUTE ON FUNCTION public.proxy_inventory_request_withdraw(UUID, BIGINT,
 COMMENT ON FUNCTION public.proxy_inventory_request_withdraw(UUID, BIGINT, TEXT, UUID) IS
     'Authenticated RPC. Opens a withdraw bridge_request for the caller''s held item. Raises INV30 mfa_required when account_security.require_2fa_for_withdraw is true and the JWT lacks aal=aal2. Returns the new bridge_request row (id + status + ttl + identity) so the UI can render the pending transfer immediately.';
 
--- 2FA policy management. Reading the current policy is always allowed
--- (aal1 OK). Writing the policy requires aal2 when ANY 2FA flag is
--- currently enabled or being set to true — this prevents an attacker on
--- a stolen aal1 session from disabling the 2FA gate before draining
--- the inventory.
 CREATE OR REPLACE FUNCTION public.proxy_inventory_get_security_policy()
 RETURNS TABLE (
     require_2fa_for_withdraw     BOOLEAN,
@@ -1786,9 +1336,6 @@ AS $$
 DECLARE
     v_account UUID := inventory.caller_account();
 BEGIN
-    -- LEFT JOIN against a 1-row VALUES seed: guarantees exactly one row
-    -- back even when no account_security row exists, and uses the
-    -- account_security primary key index for the matched case.
     RETURN QUERY
         SELECT COALESCE(s.require_2fa_for_withdraw, false),
                COALESCE(s.require_2fa_for_listing,  false),
@@ -1850,17 +1397,6 @@ COMMENT ON FUNCTION public.proxy_inventory_set_security_policy(BOOLEAN, BOOLEAN,
 NOTIFY pgrst, 'reload schema';
 
 -- migrate:down
--- This rollback is intentionally destructive — DROP SCHEMA CASCADE at
--- the end wipes any rows in inventory.* including the audit log. Only
--- run this in dev / test, never against a populated prod database.
--- For prod, write a forward-fix migration instead.
---
--- Hard gate: the connection running this rollback MUST set the GUC
--- app.allow_destructive_inventory_down = 'true' (e.g. via PGOPTIONS or
--- a session-level SET) before invoking dbmate rollback. Without it we
--- refuse, so a `dbmate rollback` against prod with the standard URL
--- aborts before touching anything. The local test harness sets this
--- via PGOPTIONS — see packages/data/sql/dbmate/test-migration.sh.
 DO $$
 BEGIN
     IF current_setting('app.allow_destructive_inventory_down', true)
@@ -1899,8 +1435,6 @@ DROP TABLE IF EXISTS inventory.bridge_receipt   CASCADE;
 DROP TABLE IF EXISTS inventory.bridge_request   CASCADE;
 DROP TABLE IF EXISTS inventory.bridge_secret    CASCADE;
 
--- Trigger function: dropped AFTER the table so the trigger is gone
--- first; otherwise we hit "other objects depend on it".
 DROP FUNCTION IF EXISTS inventory.transition_block_mutation();
 
 DROP TYPE IF EXISTS inventory.bridge_status;
@@ -1909,6 +1443,4 @@ DROP TYPE IF EXISTS inventory.item_state;
 
 DROP SCHEMA IF EXISTS inventory CASCADE;
 
--- Tell PostgREST the public API surface shrunk so /rest/v1/* stops
--- advertising the dropped proxy_inventory_* RPCs.
 NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
+++ b/packages/data/sql/dbmate/migrations/20260520114243_wallet_inventory_listing_wire.sql
@@ -1,55 +1,5 @@
 -- migrate:up
--- ============================================================================
--- WALLET ↔ INVENTORY LISTING WIRE — foundation (Phase 6.1a)
---
--- Lands:
---   1. inventory.service_split_for_listing — split a HELD stackable row
---      directly into a NEW listing_escrow row + a smaller held source.
---      Combines "split + lock" so the partial-unique invariant on
---      held-stackable rows is never violated (the new row leaves the
---      partial index immediately because it's in listing_escrow).
---   2. wallet.listing.item_id column + active-uniqueness + CHECK so
---      active listings MUST reference an inventory.item row. Existing
---      legacy non-active rows keep working because the CHECK only
---      fires for status='active'.
---   3. wallet.service_create_listing_with_item — new authoritative
---      listing creator that takes (p_item_id, p_qty). When p_qty is
---      NULL or equals the source row qty, the whole row is locked via
---      inventory.service_listing_lock. Otherwise it splits via
---      inventory.service_split_for_listing.
---   4. public.proxy_market_create_listing_with_item — authenticated
---      wrapper. Enforces inventory.is_2fa_required_for_listing aal2
---      gate + the high_value_khash_threshold gate.
---
--- The legacy wallet.service_create_listing(UUID, JSONB, ...) +
--- proxy_market_create_listing(JSONB, ...) STAY in place. axum + Astro
--- migrate to the *_with_item variants in Phase 6.1b. The legacy
--- functions get dropped in 6.1c once all callers move over.
---
--- Settle / cancel / expire / buy_now hooks land in the sibling
--- migration 20260520114244_wallet_listing_settle_inventory.sql.
---
--- LOCK-ORDER INVARIANT (cross-schema):
---   wallet marketplace functions lock wallet.listing FIRST, then call
---   inventory.service_listing_* which locks inventory.item second.
---   inventory.service_listing_* MUST NOT lock wallet.listing in any
---   path — that would invert the order and create a deadlock surface.
---   Any future reconciliation tooling that wants to traverse
---   inventory → listing MUST read wallet.listing without acquiring a
---   row lock (no FOR UPDATE / FOR SHARE).
---
--- OPERATIONAL NOTE (DDL locking):
---   This migration builds non-CONCURRENT indexes + adds an ALTER
---   COLUMN + CHECK inside dbmate's single transaction. Tables are
---   empty at first deploy so locking is moot, but if a future
---   re-application happens against a populated marketplace, run
---   during a write pause — CONCURRENTLY isn't available in a
---   transactional migration block.
--- ============================================================================
 
--- Enum preflight: each label the new RPCs hardcode must already
--- exist on its parent type. Protects against partial dev/staging
--- rebuilds where an earlier migration's enum drifted.
 DO $$
 DECLARE
     v_label TEXT;
@@ -81,9 +31,6 @@ BEGIN
 END
 $$;
 
--- Preflight: fail fast if the 6.0 inventory hooks + JWT helpers the
--- new wallet RPCs depend on are missing. Without these, the
--- migration would technically succeed and only fail at runtime.
 DO $$
 BEGIN
     IF to_regprocedure('inventory.service_listing_lock(uuid, uuid, bigint)') IS NULL THEN
@@ -100,19 +47,6 @@ BEGIN
     END IF;
 END
 $$;
-
--- ---------------------------------------------------------------------------
--- 1. inventory.service_split_for_listing
---    Atomically: src.qty -= p_qty, INSERT new row in 'listing_escrow'
---    with the same kind/ref/source as src. src stays 'held' and
---    inside the partial unique index; the new row sits in
---    listing_escrow so it never collides with the held-stackable
---    invariant. Caller (wallet) then INSERTs wallet.listing with
---    item_id = returned new id.
---
---    p_qty MUST be strictly less than src.qty — a whole-row "split"
---    is a no-op the caller should handle via service_listing_lock.
--- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION inventory.service_split_for_listing(
     p_seller_account UUID,
@@ -157,11 +91,6 @@ BEGIN
             p_qty, v_src.qty USING ERRCODE = 'INV13';
     END IF;
 
-    -- Status-guarded UPDATE. Row is already locked FOR UPDATE above,
-    -- so the WHERE-recheck + RETURNING is purely defensive against
-    -- future refactors that might weaken the lock chain. If the
-    -- preconditions changed between the lock and the update, the
-    -- RETURNING is empty and we raise.
     DECLARE
         v_updated_src_id UUID;
     BEGIN
@@ -179,10 +108,6 @@ BEGIN
         END IF;
     END;
 
-    -- Preserve v_src.nbt rather than hardcoding '{}'::jsonb. Today the
-    -- is_stackable CHECK above guarantees v_src.nbt = '{}', so the two
-    -- are equivalent — but mirroring the source row keeps this RPC
-    -- correct if the stackable invariant is ever loosened.
     INSERT INTO inventory.item (
         owner_account, kind, ref, qty, nbt, state, source, source_ref
     ) VALUES (
@@ -195,9 +120,6 @@ BEGIN
     )
     RETURNING id INTO v_new_id;
 
-    -- New row was minted directly into listing_escrow via a "virtual"
-    -- transit_in -> listing_escrow transition. Carries split metadata
-    -- so the audit stream can reconcile both halves.
     INSERT INTO inventory.transition (item_id, from_state, to_state, actor, reason, metadata)
     VALUES (v_new_id, 'transit_in', 'listing_escrow', 'wallet',
             'split_for_listing',
@@ -219,22 +141,10 @@ GRANT  EXECUTE ON FUNCTION inventory.service_split_for_listing(UUID, UUID, BIGIN
 COMMENT ON FUNCTION inventory.service_split_for_listing(UUID, UUID, BIGINT) IS
     'Atomic split-for-listing helper. Splits a HELD stackable row, producing a new row directly in listing_escrow state (never held). Used by wallet.service_create_listing_with_item when a partial-stack listing is requested. Returns the new row id, which the caller must INSERT into wallet.listing.item_id. Refuses instanced rows and refuses whole-row splits (caller should service_listing_lock the source directly in that case).';
 
--- ---------------------------------------------------------------------------
--- 2. wallet.listing.item_id column + active-uniqueness + CHECK
---    Active listings MUST carry item_id. Legacy non-active rows keep
---    item_id NULL.
--- ---------------------------------------------------------------------------
-
 ALTER TABLE wallet.listing
     ADD COLUMN item_id UUID
         REFERENCES inventory.item(id) ON DELETE NO ACTION;
 
--- Hard preflight: refuse the cleanup if any pre-existing active legacy
--- listing has an active bid. Active bids mean real escrowed khash —
--- silently flipping bid status to 'refunded' without a ledger reversal
--- would strand the bidder's khash. The 6.1a foundation deliberately
--- skips ledger work; if a real bid exists, the migration aborts and
--- requires manual reconciliation before re-running.
 DO $$
 BEGIN
     IF EXISTS (
@@ -249,10 +159,6 @@ BEGIN
             'legacy active listings with active bids exist; reconcile escrow manually before re-running 20260520114243';
     END IF;
 
-    -- Catch corrupted current_bid_id pointers (listing claims a
-    -- current bid but no matching active wallet.bid row exists).
-    -- The cleanup below would silently null these out; surface them
-    -- as a hard failure so they get manual review first.
     IF EXISTS (
         SELECT 1
           FROM wallet.listing l
@@ -271,11 +177,6 @@ BEGIN
             'legacy active listings with stale current_bid_id pointers exist; manual reconciliation required';
     END IF;
 
-    -- Catch denormalized cache drift: current_bid_id points at an
-    -- active bid row, but the cached current_bid / current_bid_account
-    -- disagree with that bid's amount / bidder. Settle in the new
-    -- code path refuses this drift; surface it before the cleanup
-    -- below clears the cache and deletes the evidence.
     IF EXISTS (
         SELECT 1
           FROM wallet.listing l
@@ -296,15 +197,6 @@ BEGIN
 END
 $$;
 
--- Hard cut. Cancel every pre-existing ACTIVE listing — none of them
--- have item_id (column was just added), and going forward every
--- listing MUST flow through the inventory ledger via the
--- *_with_item path. The preflight above guarantees no active bids,
--- so no ledger work is needed; this is pure schema hygiene.
---
--- One audit row PER cancelled listing so reconciliation can replay
--- the exact set of legacy ids without a snapshot. CTE pipes the
--- RETURNING set into the audit_log INSERT.
 WITH cancelled AS (
     UPDATE wallet.listing
        SET status              = 'cancelled',
@@ -329,19 +221,10 @@ SELECT
     )
 FROM cancelled;
 
--- VALID CHECK: every active listing MUST now carry item_id. Legacy
--- service_create_listing(UUID, JSONB, ...) callers fail loudly on
--- INSERT — that's intentional and forces the 6.1b axum/Astro switch
--- to the *_with_item variants. Pre-existing non-active rows
--- (cancelled / expired / sold) keep item_id NULL untouched.
 ALTER TABLE wallet.listing
     ADD CONSTRAINT wallet_listing_active_item_id_chk
         CHECK (status <> 'active' OR item_id IS NOT NULL);
 
--- Defensive: duplicate-detection preflight before the unique index
--- build. Impossible on first deploy (item_id was just added), but
--- protects re-applications against dev/staging drift and surfaces a
--- clean error instead of a raw unique_violation during CREATE INDEX.
 DO $$
 BEGIN
     IF EXISTS (
@@ -362,12 +245,6 @@ CREATE UNIQUE INDEX wallet_listing_active_item_uq
     ON wallet.listing (item_id)
     WHERE status = 'active' AND item_id IS NOT NULL;
 
--- Expiry sweep support. service_expire_listings scans
--- (status='active' AND currency='khash' AND expires_at <= now())
--- ORDER BY expires_at, id. The existing wallet_listing_active_expires_idx
--- covers status='active' on expires_at, but a tighter partial index
--- with the id tiebreaker + currency predicate keeps the sweep cheap
--- as marketplace volume grows.
 CREATE INDEX IF NOT EXISTS wallet_listing_active_khash_expiry_idx
     ON wallet.listing (expires_at, id)
     WHERE status = 'active'
@@ -375,14 +252,6 @@ CREATE INDEX IF NOT EXISTS wallet_listing_active_khash_expiry_idx
 
 COMMENT ON COLUMN wallet.listing.item_id IS
     'inventory.item.id of the listed row. NULL only allowed on legacy non-active listings; new active listings MUST reference an inventory.item. Active-listing uniqueness ensures one open listing per item.';
-
--- ---------------------------------------------------------------------------
--- 3. wallet.service_create_listing_with_item
---    New authoritative listing creator. Takes (p_src_item_id, p_qty).
---    p_qty NULL or = src.qty: lock the whole source row.
---    p_qty < src.qty:        split via service_split_for_listing.
---    Stores back-compat item_ref JSONB derived from the inventory row.
--- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION wallet.service_create_listing_with_item(
     p_seller_account  UUID,
@@ -439,9 +308,6 @@ BEGIN
     IF p_expires_at IS NULL OR p_expires_at <= v_now THEN
         RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
     END IF;
-    -- Upfront max-duration check. Table-level listing_max_duration_chk
-    -- enforces the same cap via created_at + 30d, but raising here
-    -- surfaces a clean 22023 instead of a raw check_violation.
     IF p_expires_at > v_now + interval '30 days' THEN
         RAISE EXCEPTION 'expires_at exceeds 30-day maximum listing duration'
             USING ERRCODE = '22023';
@@ -450,18 +316,6 @@ BEGIN
         RAISE EXCEPTION 'qty must be positive' USING ERRCODE = '22023';
     END IF;
 
-    -- Replay with full payload validation. Reusing the same
-    -- idempotency_key against different parameters is a caller bug;
-    -- surface as P1012 instead of silently aliasing the original row.
-    -- wallet_listing_seller_idempotency_uq (lives in the original
-    -- 20260514113538_wallet_marketplace_schema migration) serializes
-    -- concurrent same-key inserts at the table level.
-    --
-    -- Source-item check: the listing's item_id is either p_src_item_id
-    -- itself (whole-row path) or a split-derived row whose source_ref
-    -- ->>'split_from' points back at p_src_item_id (partial path).
-    -- Both replay variants must resolve to the originally requested
-    -- source.
     SELECT l.id, l.item_id, l.buy_now_price, l.min_bid, l.expires_at,
            COALESCE((l.item_ref ->> 'qty')::BIGINT, 0)
       INTO v_existing_id, v_existing_item_id, v_existing_buy_now,
@@ -476,13 +330,6 @@ BEGIN
             RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (price/expiry differs)',
                 p_idempotency_key, v_existing_id USING ERRCODE = 'P1012';
         END IF;
-        -- Qty + source-item identity check.
-        -- NULL p_qty means "list the whole src row" — replay must point
-        -- at the exact source (split-derived rows DON'T satisfy NULL
-        -- replay because the original wasn't whole-row).
-        -- Non-NULL p_qty (partial split) accepts either direct
-        -- src_item_id OR a split-derived row tracing back via
-        -- source_ref->>'split_from'.
         IF p_qty IS NULL THEN
             IF v_existing_item_id IS DISTINCT FROM p_src_item_id THEN
                 RAISE EXCEPTION 'idempotency_key % replay parameter mismatch on listing % (whole-row replay against split listing)',
@@ -506,9 +353,6 @@ BEGIN
         RETURN v_existing_id;
     END IF;
 
-    -- Lock + validate the source row. We hold the row lock through
-    -- both the optional split and the listing INSERT so a concurrent
-    -- caller can't race the same source.
     SELECT * INTO v_src
       FROM inventory.item
      WHERE id = p_src_item_id
@@ -524,9 +368,6 @@ BEGIN
             p_src_item_id, v_src.state USING ERRCODE = 'INV12';
     END IF;
 
-    -- Decide whole-row vs split. NULL qty or qty matching source =
-    -- whole row. Otherwise must split (and src must be stackable +
-    -- have strictly more qty than requested).
     IF p_qty IS NULL OR p_qty = v_src.qty THEN
         v_listing_qty := v_src.qty;
         v_listed_id   := v_src.id;
@@ -545,7 +386,6 @@ BEGIN
             USING ERRCODE = 'INV13';
     END IF;
 
-    -- Back-compat item_ref derived from the listed row.
     v_item_ref := jsonb_build_object(
         'kind',        v_src.kind,
         'id',          v_src.ref,
@@ -562,17 +402,9 @@ BEGIN
         p_buy_now_price, p_min_bid, p_expires_at, p_idempotency_key
     ) RETURNING id INTO v_listing_id;
 
-    -- Whole-row path needs the explicit lock RPC. The split path
-    -- already flipped the new row to listing_escrow; backfill the
-    -- listing_id into source_ref so reconciliation tooling can
-    -- traverse split-row escrow → owning listing without a separate
-    -- join through wallet.listing.item_id.
     IF NOT v_was_split THEN
         PERFORM inventory.service_listing_lock(p_seller_account, v_listed_id, v_listing_id);
     ELSE
-        -- COALESCE in case a future schema relaxation makes
-        -- source_ref nullable; today the column is NOT NULL DEFAULT
-        -- '{}'::jsonb so the COALESCE is defensive.
         UPDATE inventory.item
            SET source_ref = COALESCE(source_ref, '{}'::jsonb)
                             || jsonb_build_object(
@@ -607,13 +439,6 @@ REVOKE ALL ON FUNCTION wallet.service_create_listing_with_item(UUID, UUID, BIGIN
 GRANT  EXECUTE ON FUNCTION wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO service_role;
 COMMENT ON FUNCTION wallet.service_create_listing_with_item(UUID, UUID, BIGINT, wallet.currency_kind, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
     'SERVICE marketplace RPC. New authoritative listing creator. Takes (src_item_id, qty); qty NULL or = src.qty locks the whole row, qty < src.qty splits via inventory.service_split_for_listing. Successor to service_create_listing(UUID, JSONB, ...); legacy variant stays for axum/Astro back-compat until Phase 6.1c.';
-
--- ---------------------------------------------------------------------------
--- 4. public.proxy_market_create_listing_with_item
---    Authenticated wrapper. Enforces inventory.is_2fa_required_for_listing
---    aal2 gate + the high_value_khash_threshold check before calling
---    the wallet service.
--- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION public.proxy_market_create_listing_with_item(
     p_src_item_id     UUID,
@@ -650,24 +475,16 @@ BEGIN
     IF p_expires_at IS NULL OR p_expires_at <= statement_timestamp() THEN
         RAISE EXCEPTION 'expires_at must be in the future' USING ERRCODE = '22023';
     END IF;
-    -- Mirror the service-side 30-day cap so the proxy boundary
-    -- surfaces a clean error before any service work runs.
     IF p_expires_at > statement_timestamp() + interval '30 days' THEN
         RAISE EXCEPTION 'expires_at exceeds 30-day maximum listing duration'
             USING ERRCODE = '22023';
     END IF;
 
-    -- 2FA gate: if the account opted into require_2fa_for_listing,
-    -- the JWT must carry aal=aal2. Don't leak the account UUID into
-    -- the error message — caller already knows it's theirs, and the
-    -- audit_log row carries the details for support.
     IF inventory.is_2fa_required_for_listing(v_seller)
        AND v_aal IS DISTINCT FROM 'aal2' THEN
         RAISE EXCEPTION 'mfa_required for listing' USING ERRCODE = 'INV30';
     END IF;
 
-    -- High-value gate. Compare max(buy_now_price, min_bid) against
-    -- the configured threshold. threshold = 0 means "not configured".
     SELECT high_value_khash_threshold INTO v_threshold
       FROM inventory.account_security
      WHERE account = v_seller;
@@ -697,15 +514,6 @@ GRANT  EXECUTE ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BI
 COMMENT ON FUNCTION public.proxy_market_create_listing_with_item(UUID, BIGINT, BIGINT, BIGINT, TIMESTAMPTZ, UUID) IS
     'PUBLIC marketplace proxy. Authenticated wrapper for wallet.service_create_listing_with_item. Enforces inventory.is_2fa_required_for_listing aal2 gate and the high_value_khash_threshold gate. p_qty NULL = list whole row; p_qty < src.qty = split-and-list.';
 
--- ---------------------------------------------------------------------------
--- Legacy proxy_market_create_listing(JSONB, ...) deprecation
---   The legacy proxy from migration 20260516015242 still exists for
---   axum / Astro compile-time. With the new wallet_listing_active_item_id_chk
---   in place, the legacy INSERT would fail with a raw check_violation.
---   Replace the legacy proxy body with a clean P1011 error so callers
---   see "use the *_with_item path" instead of a constraint trip.
--- ---------------------------------------------------------------------------
-
 CREATE OR REPLACE FUNCTION public.proxy_market_create_listing(
     p_item_ref        JSONB,
     p_buy_now_price   BIGINT,
@@ -722,9 +530,6 @@ BEGIN
 END;
 $$;
 
--- Restate the privilege contract explicitly. CREATE OR REPLACE
--- preserves grants/owner, but for a security-definer public RPC the
--- intent should be visible in this migration.
 ALTER FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) OWNER TO service_role;
 REVOKE ALL ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) FROM PUBLIC, anon;
 GRANT  EXECUTE ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TIMESTAMPTZ, UUID) TO authenticated, service_role;
@@ -734,15 +539,6 @@ COMMENT ON FUNCTION public.proxy_market_create_listing(JSONB, BIGINT, BIGINT, TI
 NOTIFY pgrst, 'reload schema';
 
 -- migrate:down
--- ============================================================================
--- ⚠ OPERATIONAL WARNING ⚠
--- Rolling back this migration RE-INTRODUCES the stuck-escrow + legacy
--- listing path, removes wallet.listing.item_id, and resurrects the
--- raw check_violation behaviour of the legacy proxy. Hard-gated on
--- the GUC app.allow_marketplace_unsafe_down='on' so a stray dbmate
--- rollback against prod aborts before touching anything. Local test
--- harness opts in via PGOPTIONS — see test-migration.sh.
--- ============================================================================
 DO $$
 BEGIN
     IF current_setting('app.allow_marketplace_unsafe_down', true)
@@ -753,11 +549,6 @@ BEGIN
 END
 $$;
 
--- Hard data guard: never drop item_id while active item-backed
--- listings still exist. Dropping the column would orphan the
--- inventory escrow rows without releasing them. The GUC above
--- gates the rollback; this preflight covers the case where the
--- operator opts in but data isn't ready.
 DO $$
 BEGIN
     IF EXISTS (
@@ -782,14 +573,6 @@ ALTER TABLE wallet.listing DROP COLUMN IF EXISTS item_id;
 
 DROP FUNCTION IF EXISTS inventory.service_split_for_listing(UUID, UUID, BIGINT);
 
--- Belt-and-suspenders: restoring the legacy JSONB listing proxy
--- reopens the non-inventory-backed listing path on the PostgREST
--- surface. Even though the outer app.allow_marketplace_unsafe_down
--- gate must already be 'on' to reach here, the legacy proxy
--- restoration carries its own GUC so an operator running a partial
--- rollback (e.g. dropping only the sibling) doesn't accidentally
--- resurrect public JSONB-only listing creation. Dev/test sets both
--- via PGOPTIONS — see test-migration.sh.
 DO $$
 BEGIN
     IF current_setting('app.allow_legacy_marketplace_proxy_restore', true)
@@ -800,9 +583,6 @@ BEGIN
 END
 $$;
 
--- Restore the pre-6.1a legacy proxy body so rollback leaves the
--- original public listing path functional rather than stuck at the
--- P1011 stub. Body lifted from 20260516015242_wallet_marketplace_proxies.sql.
 CREATE OR REPLACE FUNCTION public.proxy_market_create_listing(
     p_item_ref        JSONB,
     p_buy_now_price   BIGINT,

--- a/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
+++ b/packages/data/sql/dbmate/migrations/20260520124536_wallet_listing_settle_inventory.sql
@@ -1,36 +1,5 @@
 -- migrate:up
--- ============================================================================
--- WALLET LISTING ↔ INVENTORY SETTLE/CANCEL/EXPIRE HOOKS — Phase 6.1a
---
--- The foundation migration (20260520114243_wallet_inventory_listing_wire)
--- locks an inventory.item into listing_escrow when a listing is created
--- via service_create_listing_with_item, but the legacy
--- service_settle_listing / service_cancel_listing / service_expire_listings
--- functions never RELEASE the escrowed row. That leaves the item stuck
--- in listing_escrow forever after a sale, cancel, or expiry.
---
--- This migration rewrites those three functions (CREATE OR REPLACE,
--- same signatures) and adds calls into inventory.service_listing_*
--- when wallet.listing.item_id IS NOT NULL:
---
---   * settle (auction-won / buy-now / expire-with-bid):
---       wallet.service_settle_listing → inventory.service_listing_settle
---       transfers the item to the winning bidder.
---   * cancel (seller-initiated):
---       wallet.service_cancel_listing → inventory.service_listing_unlock
---       returns the item to held.
---   * expire (no bids):
---       wallet.service_expire_listings → inventory.service_listing_unlock
---       returns the item to the seller.
---   * buy-now path inherits the settle hook (service_buy_now calls
---     service_settle_listing internally).
---
--- Legacy listings with item_id IS NULL skip the inventory hook entirely.
--- ============================================================================
 
--- Preflight: fail fast if the inventory hooks this migration depends on
--- are missing. Belt-and-suspenders against running on a database where
--- the 6.0 foundation never landed.
 DO $$
 BEGIN
     IF to_regprocedure('inventory.service_listing_settle(uuid, uuid, bigint, uuid)') IS NULL THEN
@@ -42,31 +11,9 @@ BEGIN
 END
 $$;
 
--- One won bid per listing — enforced at the table level so future code
--- paths cannot accidentally create two winning bids for one listing.
--- Procedural EXISTS check inside service_settle_listing stays as a
--- second line of defense with a clean P1002 error code.
 CREATE UNIQUE INDEX IF NOT EXISTS wallet_bid_one_won_per_listing_uq
     ON wallet.bid (listing_id)
     WHERE status = 'won';
-
--- ---------------------------------------------------------------------------
--- wallet.service_settle_listing — settle + transfer item to buyer
---
--- Sequence (one transaction, rolls back together):
---   1. lock listing FOR UPDATE
---   2. lock winning bid FOR UPDATE
---   3. flip bid status to 'won'
---   4. distribute_settlement (seller credit + treasury fee)
---   5. inventory.service_listing_settle transfers escrowed item to buyer
---   6. flip listing status to 'sold' (status-guarded UPDATE)
---   7. audit_log
---
--- Inventory hook fires BEFORE the listing flips to 'sold' so the
--- domain sequence reads "active escrow → transfer → sold" rather than
--- "sold → then transfer". Mostly hygiene; one transaction so a
--- failure anywhere rolls everything back.
--- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION wallet.service_settle_listing(
     p_listing_id     BIGINT,
@@ -134,23 +81,11 @@ BEGIN
             USING ERRCODE = 'P1009';
     END IF;
 
-    -- Defensive: bidding already refuses seller self-bids, but settle
-    -- is the final authority. A corrupted bid row pointing at the
-    -- seller would otherwise transfer the item to the seller's own
-    -- inventory with no money movement.
     IF v_bidder = v_seller THEN
         RAISE EXCEPTION 'seller cannot settle listing % to self', p_listing_id
             USING ERRCODE = 'P1013';
     END IF;
-    -- Bidder must be a real user account. Place_bid already enforces
-    -- this; revalidating at settle defends against a corrupted bid row
-    -- pointing at a non-user account (treasury, escrow, system).
     PERFORM wallet.assert_user_account(v_bidder);
-    -- Denormalized cache consistency. listing.(current_bid,
-    -- current_bid_account, current_bid_id) must agree with the active
-    -- bid row we just locked. A drift here means a previous code path
-    -- updated one side but not the other; refuse to settle on stale
-    -- cache.
     IF v_listing_row.current_bid IS DISTINCT FROM v_amount
        OR v_listing_row.current_bid_account IS DISTINCT FROM v_bidder THEN
         RAISE EXCEPTION 'listing % current bid cache mismatch (cache=%/%, bid=%/%)',
@@ -178,18 +113,12 @@ BEGIN
       INTO v_fee, v_net, v_seller_ledger_id, v_fee_ledger_id
       FROM wallet.distribute_settlement(p_listing_id, v_seller, v_amount, v_bid_id) d;
 
-    -- Phase 6.1a: hand the escrowed inventory row to the buyer BEFORE
-    -- the listing flips to 'sold' so the domain sequence stays
-    -- "active escrow → transfer → sold".
     IF v_listing_row.item_id IS NOT NULL THEN
         v_buyer_item_id := inventory.service_listing_settle(
             v_seller, v_listing_row.item_id, p_listing_id, v_bidder
         );
     END IF;
 
-    -- Status-guarded final flip. RETURNING asserts the row was still
-    -- 'active'; concurrent settle on the same listing would have
-    -- failed the FOR UPDATE chain above, so this is defensive.
     DECLARE
         v_updated_listing_id BIGINT;
     BEGIN
@@ -236,10 +165,6 @@ GRANT  EXECUTE ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) T
 COMMENT ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) IS
     'INTERNAL marketplace helper. Invoked by place_bid, buy_now, and expire_listings. Self-locks the listing row. Validates listing status=active+currency=khash+no won bid+matching current_bid_id, flips winning bid to won, distributes funds, calls inventory.service_listing_settle to transfer the escrowed item to the buyer (Phase 6.1a; only when listing.item_id IS NOT NULL), then flips listing to sold under a status-guarded update.';
 
--- ---------------------------------------------------------------------------
--- wallet.service_cancel_listing — refund + release item to seller
--- ---------------------------------------------------------------------------
-
 CREATE OR REPLACE FUNCTION wallet.service_cancel_listing(
     p_listing_id      BIGINT,
     p_seller_account  UUID,
@@ -270,13 +195,6 @@ BEGIN
     END IF;
     IF v_listing_row.status <> 'active' THEN
         IF v_listing_row.status = 'cancelled' THEN
-            -- Idempotent re-cancel. If a prior call cancelled the
-            -- listing but failed to release the inventory row, try
-            -- the unlock again ONLY when the item is provably in a
-            -- safe repair state: state='listing_escrow' OR ('held'
-            -- already owned by this seller). Any other state means
-            -- the item was transferred, consumed, or is mid-transit
-            -- — repair must surface that loudly, not swallow it.
             IF v_listing_row.item_id IS NOT NULL THEN
                 DECLARE
                     v_item_state inventory.item_state;
@@ -292,7 +210,6 @@ BEGIN
                             COALESCE(p_reason, 'listing_cancelled_repair')
                         );
                     ELSIF v_item_state = 'held' AND v_item_owner = p_seller_account THEN
-                        -- Already released to seller. Repair no-op.
                         NULL;
                     ELSE
                         RAISE EXCEPTION
@@ -316,9 +233,6 @@ BEGIN
         p_listing_id, 'refunded', COALESCE(p_reason, 'seller cancelled listing')
     );
 
-    -- Phase 6.1a: release the escrowed inventory row back to seller
-    -- BEFORE the listing flips to 'cancelled' so the domain sequence
-    -- stays "active escrow → release → cancelled".
     IF v_listing_row.item_id IS NOT NULL THEN
         PERFORM inventory.service_listing_unlock(
             p_seller_account, v_listing_row.item_id, p_listing_id,
@@ -326,8 +240,6 @@ BEGIN
         );
     END IF;
 
-    -- Status-guarded UPDATE. buyer_account explicitly cleared (cancel
-    -- can never leave a buyer association).
     DECLARE
         v_updated_listing_id BIGINT;
     BEGIN
@@ -366,10 +278,6 @@ GRANT  EXECUTE ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) TO 
 COMMENT ON FUNCTION wallet.service_cancel_listing(BIGINT, UUID, TEXT) IS
     'SERVICE marketplace RPC. Seller-driven cancel. Refunds the active bid (if any) and flips status to cancelled. Idempotent on already-cancelled — re-cancel attempts an inventory unlock repair when item_id IS NOT NULL. Repair branch inspects the item state explicitly: listing_escrow triggers a real unlock, held+owned-by-seller is a no-op, anything else raises P1002. No blind error-swallowing. Phase 6.1a: calls inventory.service_listing_unlock when listing.item_id IS NOT NULL.';
 
--- ---------------------------------------------------------------------------
--- wallet.service_expire_listings — sweep + release items on no-bid expiry
--- ---------------------------------------------------------------------------
-
 CREATE OR REPLACE FUNCTION wallet.service_expire_listings(
     p_limit INTEGER DEFAULT 100
 )
@@ -384,27 +292,11 @@ DECLARE
     v_total           BIGINT := 0;
     v_settled         BIGINT := 0;
     v_expired         BIGINT := 0;
-    -- p_limit caps TRANSACTION SIZE, not just perf. Each settled
-    -- listing touches bids, ledger, balance, inventory.item +
-    -- inventory.transition, plus audit_log. Defaults to 100 to keep
-    -- one cron tick well under typical statement_timeout.
     v_limit           INTEGER := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 1000);
 BEGIN
     PERFORM set_config('lock_timeout', '2s', true);
     PERFORM set_config('statement_timeout', '30s', true);
 
-    -- Singleton sweeper: pg_try_advisory_xact_lock serializes parallel
-    -- cron runs. The FOR UPDATE SKIP LOCKED in the cursor below is
-    -- therefore DEFENSIVE-ONLY against any non-cron caller that holds
-    -- a listing row lock (place_bid, buy_now, cancel, settle).
-    --
-    -- BATCH-ABORT SEMANTICS: this whole sweep runs in one transaction.
-    -- A single corrupted listing/item that raises inside the LOOP
-    -- aborts the entire batch and rolls back every prior settle/expire
-    -- in this run. That's intentional — money movement is involved,
-    -- so we'd rather fail the batch loudly than silently skip rows.
-    -- Per-listing isolation lands in Phase 6.5 as
-    -- service_expire_one_listing called from an external cron loop.
     IF NOT pg_try_advisory_xact_lock(
         hashtextextended('wallet.service_expire_listings', 0)
     ) THEN
@@ -413,9 +305,6 @@ BEGIN
         RETURN;
     END IF;
 
-    -- Cursor now also pulls seller_account + item_id so the no-bid
-    -- branch can call inventory.service_listing_unlock without a
-    -- second lookup.
     FOR v_listing_id, v_current_bid_id, v_seller, v_item_id IN
         SELECT id, current_bid_id, seller_account, item_id
           FROM wallet.listing
@@ -432,9 +321,6 @@ BEGIN
             );
             v_settled := v_settled + 1;
         ELSE
-            -- Inventory unlock BEFORE the status flip — "active escrow
-            -- → release → expired" sequence. buyer_account also
-            -- cleared defensively (no-bid expiry has no buyer).
             IF v_item_id IS NOT NULL THEN
                 PERFORM inventory.service_listing_unlock(
                     v_seller, v_item_id, v_listing_id, 'listing_expired_no_bids'
@@ -464,12 +350,6 @@ BEGIN
         END IF;
         v_total := v_total + 1;
     END LOOP;
-
-    -- Per-sweep unsupported-currency count + audit insert removed
-    -- (Phase 6.1a). v1 is khash-only; non-khash actives would only
-    -- exist via direct DB edit and would spam audit_log on every
-    -- cron tick. Use an offline operational view if observability
-    -- becomes necessary again.
 
     IF v_total > 0 THEN
         INSERT INTO wallet.audit_log (action, target_type, target_id, metadata)
@@ -501,27 +381,6 @@ COMMENT ON FUNCTION wallet.service_expire_listings(INTEGER) IS
 NOTIFY pgrst, 'reload schema';
 
 -- migrate:down
--- ============================================================================
--- Revert the three functions to their pre-6.1a behaviour (no inventory
--- hooks). Inline so dbmate rollback leaves a working market layer even
--- if the foundation migration also rolls back.
---
--- ⚠ OPERATIONAL WARNING ⚠
--- Rolling back this migration RE-INTRODUCES the stuck-escrow bug: any
--- listing that settles, cancels, or expires under the reverted bodies
--- will NOT release its inventory.item from listing_escrow. Before
--- running migrate:down in production:
---   1. Pause all marketplace writes (axum + cron).
---   2. Drain or repair any wallet.listing rows where status='active'
---      AND item_id IS NOT NULL — either cancel them through the
---      6.1a-version of service_cancel_listing or apply the
---      foundation rollback alongside.
---   3. Or roll back the foundation migration 20260520114243 in the
---      same window so wallet.listing.item_id is gone entirely.
--- This down path is meant for dev / test, not live triage. Hard-gated
--- on app.allow_marketplace_unsafe_down='on' to mirror the foundation
--- migration's guard.
--- ============================================================================
 DO $$
 BEGIN
     IF current_setting('app.allow_marketplace_unsafe_down', true)
@@ -632,9 +491,6 @@ BEGIN
         p_reason);
 END;
 $$;
--- Restate privilege contract on rollback for consistency. CREATE OR
--- REPLACE preserves grants but the explicit ALTER + REVOKE + GRANT
--- below makes the security-definer posture visible in the down path.
 ALTER FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION wallet.service_settle_listing(BIGINT, BIGINT, TEXT) TO service_role;


### PR DESCRIPTION
## Summary
- ci-dbmate-deploy ships migrations as a kubectl ConfigMap (1 MiB cap). Adding 6.1a's foundation + sibling pushed the migrations dir to 1.1 MiB; the prod dispatch failed at the ConfigMap create step.
- Strip non-load-bearing comments + ASCII dividers from the three 6.0/6.1a migrations. Functional SQL untouched. Heavy docs live in [packages/data/sql/schema/inventory/](../../tree/dev/packages/data/sql/schema/inventory) and [packages/data/sql/schema/wallet/](../../tree/dev/packages/data/sql/schema/wallet) mirrors.
- Migrations dir now at ~1.00 MiB with ~48 KiB headroom.

## Verification
- [x] Full-stack \`dbmate rollback\` (sibling + foundation) + \`dbmate up\` clean
- [ ] Re-dispatch ci-dbmate-deploy against main after merge

## Follow-up
Switch ci-dbmate-deploy delivery to a gzipped Secret so future migrations stop hitting the ConfigMap cap.