### PR TITLE
chore(deps): drop unused @swc/plugin-styled-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"@swc-node/register": "1.11.1",
 		"@swc/cli": "0.7.10",
 		"@swc/core": "1.15.21",
-		"@swc/plugin-styled-components": "^1.5.122",
 		"@tailwindcss/forms": "^0.5.9",
 		"@tailwindcss/postcss": "^4.1.3",
 		"@tailwindcss/typography": "^0.5.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,9 +386,6 @@ importers:
       '@swc/core':
         specifier: 1.15.21
         version: 1.15.21(@swc/helpers@0.5.21)
-      '@swc/plugin-styled-components':
-        specifier: ^1.5.122
-        version: 1.5.122
       '@tailwindcss/forms':
         specifier: ^0.5.9
         version: 0.5.10(tailwindcss@4.1.3)
@@ -5521,9 +5518,6 @@ packages:
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
-
-  '@swc/plugin-styled-components@1.5.122':
-    resolution: {integrity: sha512-FdYfM6/07lbFbti/Ve1PVZFpulWZEDDzTsC3WoU+s2BAG8VP6mZh+6Re1sSZD13RzUU7CbMFsQqEpcVkP75ZQw==}
 
   '@swc/types@0.1.25':
     resolution: {integrity: sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==}
@@ -23629,10 +23623,6 @@ snapshots:
   '@swc/helpers@0.5.21':
     dependencies:
       tslib: 2.8.1
-
-  '@swc/plugin-styled-components@1.5.122':
-    dependencies:
-      '@swc/counter': 0.1.3
 
   '@swc/types@0.1.25':
     dependencies:


### PR DESCRIPTION
## Summary
- Removes `@swc/plugin-styled-components` (`^1.5.122`) from root `devDependencies`. Nothing wires it: no `.swcrc`, no `jsc.experimental.plugins`, no `swcPlugins` field anywhere in the tree. The styled-components transform actually runs through `babel-plugin-styled-components` 2.1.4 in the Next/Babel pipeline.
- Closes #10812. Dependabot proposed bumping to `12.9.0`, which crosses the swc_core ABI break introduced at `12.x` (built against swc_core v53+). The repo pins `@swc/core` `1.15.21` (swc_core ~v33), so the bumped plugin would fail to load at runtime if anything tried to use it. Dropping the dead dep is the cleaner fix.

## Test plan
- [ ] `pnpm install` resolves without diff drift.
- [ ] Affected Next/Astro builds (`astro-kbve`, `astro-memes`, etc.) still produce styled-components output via the Babel transform.