### PR TITLE
feat(ci-dbmate-deploy): gzip-tarball migrations + untar initContainer

### DIFF
--- a/.github/workflows/ci-dbmate-deploy.yml
+++ b/.github/workflows/ci-dbmate-deploy.yml
@@ -72,17 +72,24 @@ jobs:
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends gettext-base
 
-            - name: Build migrations ConfigMap (replace existing)
+            - name: Build migrations ConfigMap (gzipped tarball)
               run: |
-                  # delete-then-create avoids the
-                  # `kubectl.kubernetes.io/last-applied-configuration`
-                  # annotation that `kubectl apply` would inline (the
-                  # migrations dump pushes it over the 262144 byte
-                  # annotation limit).
+                  # Pack the migrations dir as a single gzip tarball
+                  # before pushing into the ConfigMap. Raw files hit
+                  # the 1 MiB ConfigMap cap once the tree grows past
+                  # ~50 migrations; gzip drops 1.1 MiB of SQL to ~200
+                  # KiB. The dbmate-runner Job's busybox initContainer
+                  # extracts the tarball at startup. See follow-up
+                  # issue #11250 for an OCI-image delivery that
+                  # removes the cap entirely.
+                  tar -czf migrations.tar.gz \
+                      -C packages/data/sql/dbmate \
+                      migrations/
+                  ls -lh migrations.tar.gz
                   kubectl -n kilobase delete configmap dbmate-migrations \
                     --ignore-not-found
                   kubectl -n kilobase create configmap dbmate-migrations \
-                    --from-file=packages/data/sql/dbmate/migrations/
+                    --from-file=migrations.tar.gz=migrations.tar.gz
 
             - name: Render + run a status Job
               env:

--- a/apps/kube/kilobase/manifests/dbmate-runner-kyverno-policy.yaml
+++ b/apps/kube/kilobase/manifests/dbmate-runner-kyverno-policy.yaml
@@ -70,6 +70,19 @@ spec:
                                         capabilities:
                                             drop:
                                                 - 'ALL'
+                              # initContainers (added when migrations
+                              # ship as a gzipped tarball — the untar
+                              # step extracts into an emptyDir) must
+                              # match the same hardening contract.
+                              =(initContainers):
+                                  - name: '*'
+                                    securityContext:
+                                        runAsNonRoot: true
+                                        readOnlyRootFilesystem: true
+                                        allowPrivilegeEscalation: false
+                                        capabilities:
+                                            drop:
+                                                - 'ALL'
         - name: kilobase-job-volume-allowlist
           match:
               any:
@@ -89,17 +102,21 @@ spec:
                                   operator: Exists
           validate:
               message: >-
-                  Job volumes must reference only `dbmate-migrations`
-                  (ConfigMap) or `dbmate-creds` (Secret). hostPath /
-                  emptyDir / arbitrary PVC mounts are blocked.
+                  Job volumes must use only the dbmate-runner contract:
+                  `migrations-cm` (ConfigMap dbmate-migrations, gzip
+                  tarball), `dbmate-creds` (Secret), or `migrations-work`
+                  (emptyDir untar scratch). hostPath / PVC / arbitrary
+                  mounts blocked. Source kinds are pinned to the Job
+                  template; container hardening (readOnlyRootFilesystem +
+                  drop ALL caps) prevents lateral abuse of an emptyDir.
               foreach:
                   - list: 'request.object.spec.template.spec.volumes'
                     deny:
                         conditions:
                             all:
-                                - key: "{{ element.configMap.name || element.secret.secretName || '_' }}"
+                                - key: '{{ element.name }}'
                                   operator: NotIn
                                   value:
-                                      - 'dbmate-migrations'
+                                      - 'migrations-cm'
+                                      - 'migrations-work'
                                       - 'dbmate-creds'
-                                      - '_'

--- a/apps/kube/kilobase/templates/dbmate-runner-job.yaml
+++ b/apps/kube/kilobase/templates/dbmate-runner-job.yaml
@@ -41,6 +41,44 @@ spec:
             securityContext:
                 seccompProfile:
                     type: RuntimeDefault
+            initContainers:
+                # The ConfigMap holds a single migrations.tar.gz (gzip
+                # tarball of the migrations dir). Raw files would hit
+                # the 1 MiB ConfigMap cap once the tree grows past
+                # ~50 migrations; gzip drops 1.1 MiB of SQL to ~200
+                # KiB. Untar into the shared emptyDir so the main
+                # dbmate container reads the original layout.
+                - name: untar
+                  image: busybox:1.37
+                  command:
+                      - sh
+                      - -c
+                      - >-
+                          set -e;
+                          tar -xzf /cm/migrations.tar.gz -C /work;
+                          echo "extracted $(ls /work/migrations | wc -l) migrations"
+                  volumeMounts:
+                      - name: migrations-cm
+                        mountPath: /cm
+                        readOnly: true
+                      - name: migrations-work
+                        mountPath: /work
+                  resources:
+                      requests:
+                          cpu: 10m
+                          memory: 16Mi
+                      limits:
+                          cpu: 100m
+                          memory: 64Mi
+                  securityContext:
+                      runAsNonRoot: true
+                      runAsUser: 65532
+                      readOnlyRootFilesystem: true
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop: ['ALL']
+                      seccompProfile:
+                          type: RuntimeDefault
             containers:
                 - name: dbmate
                   image: ghcr.io/amacneil/dbmate:2.28.0
@@ -48,7 +86,7 @@ spec:
                       - dbmate
                       - --no-dump-schema
                       - --migrations-dir
-                      - /m
+                      - /m/migrations
                       - up
                   env:
                       - name: DATABASE_URL
@@ -57,7 +95,7 @@ spec:
                                 name: dbmate-creds
                                 key: DATABASE_URL
                   volumeMounts:
-                      - name: migrations
+                      - name: migrations-work
                         mountPath: /m
                         readOnly: true
                   resources:
@@ -77,7 +115,10 @@ spec:
                       seccompProfile:
                           type: RuntimeDefault
             volumes:
-                - name: migrations
+                - name: migrations-cm
                   configMap:
                       name: dbmate-migrations
                       defaultMode: 0444
+                - name: migrations-work
+                  emptyDir:
+                      sizeLimit: 32Mi


### PR DESCRIPTION
## Summary
Permanent fix for the 1 MiB ConfigMap cap that blocked the 6.1a prod deploy (#11243 slimmed comments as the immediate unblock; this PR removes the recurring tax).

Pack the migrations dir as a single \`migrations.tar.gz\` before creating the ConfigMap. A busybox \`initContainer\` extracts the tarball into a shared emptyDir at Job startup; the main dbmate container reads \`/m/migrations\` from the emptyDir.

## Changes
- **\`.github/workflows/ci-dbmate-deploy.yml\`** — \`tar -czf migrations.tar.gz ...\`; ConfigMap created from the single tarball file (binaryData).
- **\`apps/kube/kilobase/templates/dbmate-runner-job.yaml\`** — new \`untar\` initContainer; two volumes (\`migrations-cm\` ConfigMap + \`migrations-work\` emptyDir 32 MiB); main container reads from emptyDir; preserves all existing hardening (readOnlyRootFilesystem, drop-ALL, non-root 65532).
- **\`apps/kube/kilobase/manifests/dbmate-runner-kyverno-policy.yaml\`** — allowlist new volume names; require initContainers to satisfy the same hardening as main containers.

## Size projection
- Current migrations dir (post-#11243 slim): ~1.00 MiB raw → 188 KiB gzip → ~258 KiB base64 in ConfigMap.
- Headroom: ~4-5× before next cap.

## Long-term
Issue #11250 tracks OCI-image delivery for cap-free migrations once headroom shrinks.

## Test plan
- [x] \`kubectl --dry-run=client apply\` clean for both Job + policy
- [x] envsubst render parses as valid YAML
- [x] Local tarball size sanity (188 KiB)
- [ ] Merge #11243 first; merge this; dispatch a status-only \`ci-dbmate-deploy\` to verify the new Job shape applies + extracts; then full apply