### PR TITLE
feat(astro-kbve): MC derived-block texture alias resolver

### DIFF
--- a/apps/kbve/astro-kbve/scripts/fetch-mc-textures.mjs
+++ b/apps/kbve/astro-kbve/scripts/fetch-mc-textures.mjs
@@ -1,6 +1,7 @@
 import { mkdir, readdir, readFile, writeFile, stat } from 'fs/promises';
 import { join } from 'path';
 import { parse as parseYaml } from 'yaml';
+import { resolveBaseRef } from './mc-texture-aliases.mjs';
 
 const MC_ASSET_VERSION = '1.21.5';
 const BASE = `https://raw.githubusercontent.com/InventivetalentDev/minecraft-assets/${MC_ASSET_VERSION}/assets/minecraft/textures`;
@@ -63,28 +64,74 @@ async function fetchOne(kind, ref) {
 	return { ref, kind, status: 'fetched' };
 }
 
+async function tryRefAcrossKinds(ref) {
+	const item = await fetchOne('item', ref);
+	if (item.status !== 'missing') return item;
+	const block = await fetchOne('block', ref);
+	return block;
+}
+
 async function main() {
 	const refs = await collectItemRefs();
 	console.log(`Discovered ${refs.size} refs from MDX frontmatter`);
 
 	let fetched = 0;
 	let skipped = 0;
+	let aliased = 0;
 	let missing = 0;
 	for (const ref of refs) {
-		const item = await fetchOne('item', ref);
-		if (item.status === 'fetched') fetched++;
-		else if (item.status === 'skip') skipped++;
-		if (item.status === 'missing') {
-			const block = await fetchOne('block', ref);
-			if (block.status === 'fetched') fetched++;
-			else if (block.status === 'skip') skipped++;
-			else if (block.status === 'missing') {
-				console.warn(`  ⚠ no texture for ${ref} (item/ + block/ both 404)`);
-				missing++;
+		const direct = await tryRefAcrossKinds(ref);
+		if (direct.status === 'fetched') {
+			fetched++;
+			continue;
+		}
+		if (direct.status === 'skip') {
+			skipped++;
+			continue;
+		}
+		// direct is 'missing' — chase the derived → base mapping. Some
+		// refs need >1 hop (waxed_exposed_cut_copper_slab → strip waxed →
+		// exposed_cut_copper_slab → strip slab → exposed_cut_copper).
+		const chain = [];
+		const seen = new Set([ref]);
+		let cursor = ref;
+		while (true) {
+			const next = resolveBaseRef(cursor);
+			if (!next || next === cursor || seen.has(next)) break;
+			chain.push(next);
+			seen.add(next);
+			cursor = next;
+			if (chain.length >= 4) break;
+		}
+		if (chain.length === 0) {
+			console.warn(`  ⚠ no texture for ${ref} (item/ + block/ both 404, no alias)`);
+			missing++;
+			continue;
+		}
+		let resolved = null;
+		for (const alias of chain) {
+			const res = await tryRefAcrossKinds(alias);
+			if (res.status === 'fetched' || res.status === 'skip') {
+				resolved = { alias, res };
+				break;
 			}
 		}
+		if (resolved) {
+			if (resolved.res.status === 'fetched') {
+				fetched++;
+				console.log(`  ↳ ${ref} → ${resolved.alias} (${resolved.res.kind}/)`);
+			} else {
+				skipped++;
+			}
+			aliased++;
+		} else {
+			console.warn(`  ⚠ no texture for ${ref} → ${chain.join(' → ')} (chain 404)`);
+			missing++;
+		}
 	}
-	console.log(`✨ fetched: ${fetched}  skipped: ${skipped}  missing: ${missing}`);
+	console.log(
+		`✨ fetched: ${fetched}  skipped: ${skipped}  aliased: ${aliased}  missing: ${missing}`,
+	);
 }
 
 main().catch((err) => {

--- a/apps/kbve/astro-kbve/scripts/mc-texture-aliases.mjs
+++ b/apps/kbve/astro-kbve/scripts/mc-texture-aliases.mjs
@@ -1,0 +1,309 @@
+const WOOD_TYPES = new Set([
+	'acacia',
+	'birch',
+	'oak',
+	'spruce',
+	'dark_oak',
+	'jungle',
+	'mangrove',
+	'cherry',
+	'pale_oak',
+	'bamboo',
+	'crimson',
+	'warped',
+]);
+
+const NETHER_WOODS = new Set(['crimson', 'warped']);
+
+export function resolveBaseRef(ref) {
+	if (!ref) return null;
+	const r = String(ref)
+		.toLowerCase()
+		.replace(/^minecraft:/, '');
+
+	let m = r.match(/^waxed_(.+)$/);
+	if (m) return m[1];
+
+	m = r.match(/^infested_(.+)$/);
+	if (m) return m[1];
+
+	if (r === 'heavy_weighted_pressure_plate') return 'iron_block';
+	if (r === 'light_weighted_pressure_plate') return 'gold_block';
+	if (r === 'petrified_oak_slab') return 'oak_planks';
+	if (r === 'purpur_slab' || r === 'purpur_stairs') return 'purpur_block';
+	if (r === 'smooth_quartz_slab' || r === 'smooth_quartz_stairs' || r === 'smooth_quartz') {
+		return 'quartz_block_bottom';
+	}
+	if (
+		r === 'smooth_red_sandstone_slab' ||
+		r === 'smooth_red_sandstone_stairs' ||
+		r === 'smooth_red_sandstone'
+	) {
+		return 'red_sandstone_top';
+	}
+	if (
+		r === 'smooth_sandstone_slab' ||
+		r === 'smooth_sandstone_stairs' ||
+		r === 'smooth_sandstone'
+	) {
+		return 'sandstone_top';
+	}
+
+	if (r === 'moss_carpet') return 'moss_block';
+	if (r === 'pale_moss_carpet') return 'pale_moss_block';
+
+	m = r.match(/^(.+?)_carpet$/);
+	if (m) return `${m[1]}_wool`;
+
+	m = r.match(/^(.+?)_bed$/);
+	if (m) return `${m[1]}_wool`;
+
+	m = r.match(/^(.+?)_stained_glass_pane$/);
+	if (m) return `${m[1]}_stained_glass`;
+
+	m = r.match(/^(.+?)_candle_cake$/);
+	if (m) return `${m[1]}_candle`;
+
+	if (/^bamboo_mosaic_(slab|stairs)$/.test(r)) return 'bamboo_mosaic';
+
+	m = r.match(/^(.+?)_door$/);
+	if (m && WOOD_TYPES.has(m[1])) return `${m[1]}_door_bottom`;
+
+	m = r.match(/^(.+?)_trapdoor$/);
+	if (m && WOOD_TYPES.has(m[1])) return `${m[1]}_trapdoor`;
+
+	m = r.match(/^(.+?)_(fence_gate|fence|wall_hanging_sign|hanging_sign|wall_sign|sign)$/);
+	if (m && WOOD_TYPES.has(m[1])) return `${m[1]}_planks`;
+
+	m = r.match(/^(.+?)_brick_(slab|stairs|wall|fence)$/);
+	if (m) return `${m[1]}_bricks`;
+
+	m = r.match(/^(.+?)_tile_(slab|stairs|wall)$/);
+	if (m) return `${m[1]}_tiles`;
+
+	m = r.match(/^dead_(.+?)_coral_wall_fan$/);
+	if (m) return `dead_${m[1]}_coral_fan`;
+
+	m = r.match(/^(.+?)_coral_wall_fan$/);
+	if (m) return `${m[1]}_coral_fan`;
+
+	m = r.match(/^(.+?)_(slab|stairs|wall|button|pressure_plate)$/);
+	if (m) {
+		if (WOOD_TYPES.has(m[1])) return `${m[1]}_planks`;
+		return m[1];
+	}
+
+	if (r === 'stone_pressure_plate') return 'stone';
+	if (r === 'polished_blackstone_pressure_plate') return 'polished_blackstone';
+
+	m = r.match(/^(.*?)_wood$/);
+	if (m && m[1]) {
+		const base = m[1];
+		if (base.endsWith('crimson') || base.endsWith('warped')) {
+			return `${base}_stem`;
+		}
+		return `${base}_log`;
+	}
+
+	m = r.match(/^(.+?)_(wall_)?banner$/);
+	if (m) return `${m[1]}_wool`;
+
+	const SPECIALS = {
+		barrel: 'barrel_top',
+		beehive: 'beehive_front',
+		bee_nest: 'bee_nest_front',
+		cauldron: 'cauldron_side',
+		water_cauldron: 'cauldron_side',
+		lava_cauldron: 'cauldron_side',
+		composter: 'composter_side',
+		lectern: 'lectern_top',
+		loom: 'loom_top',
+		lodestone: 'lodestone_top',
+		jukebox: 'jukebox_top',
+		magma_block: 'magma',
+		mangrove_roots: 'mangrove_roots_top',
+		muddy_mangrove_roots: 'muddy_mangrove_roots_top',
+		water: 'water_still',
+		lava: 'lava_still',
+		large_fern: 'large_fern_bottom',
+		tall_grass: 'tall_grass_bottom',
+		lilac: 'lilac_bottom',
+		rose_bush: 'rose_bush_bottom',
+		peony: 'peony_bottom',
+		sunflower: 'sunflower_bottom',
+		pitcher_plant: 'pitcher_plant_top',
+		end_portal_frame: 'end_portal_frame_top',
+		end_portal: 'end_stone',
+		bell: 'bell_bottom',
+		chest: 'oak_planks',
+		trapped_chest: 'oak_planks',
+		ender_chest: 'obsidian',
+		conduit: 'beacon',
+		dragon_egg: 'dragon_egg',
+		piston_head: 'piston_top',
+		piston: 'piston_top',
+		sticky_piston: 'piston_top_sticky',
+		moving_piston: 'piston_top',
+		grindstone: 'grindstone_side',
+		smithing_table: 'smithing_table_top',
+		cartography_table: 'cartography_table_top',
+		fletching_table: 'fletching_table_top',
+		stonecutter: 'stonecutter_top',
+		smoker: 'smoker_top',
+		blast_furnace: 'blast_furnace_top',
+		furnace: 'furnace_top',
+		respawn_anchor: 'respawn_anchor_top_off',
+		brewing_stand: 'brewing_stand_base',
+		enchanting_table: 'enchanting_table_top',
+		decorated_pot: 'decorated_pot_side',
+		ancient_debris: 'ancient_debris_top',
+		basalt: 'basalt_top',
+		smooth_basalt: 'smooth_basalt',
+		bone_block: 'bone_block_top',
+		cactus: 'cactus_top',
+		calibrated_sculk_sensor: 'calibrated_sculk_sensor_top',
+		chiseled_bookshelf: 'chiseled_bookshelf_empty',
+		bookshelf: 'bookshelf',
+		command_block: 'command_block_front',
+		chain_command_block: 'chain_command_block_front',
+		repeating_command_block: 'repeating_command_block_front',
+		crafter: 'crafter_top',
+		crafting_table: 'crafting_table_front',
+		daylight_detector: 'daylight_detector_top',
+		dirt_path: 'dirt_path_top',
+		dispenser: 'dispenser_front',
+		dropper: 'dropper_front',
+		dried_kelp_block: 'dried_kelp_top',
+		chipped_anvil: 'anvil_top',
+		damaged_anvil: 'anvil_top',
+		anvil: 'anvil_top',
+		azalea: 'azalea_top',
+		flowering_azalea: 'flowering_azalea_top',
+		big_dripleaf: 'big_dripleaf_top',
+		small_dripleaf: 'small_dripleaf_top',
+		cocoa: 'cocoa_stage2',
+		beetroots: 'beetroots_stage3',
+		carrots: 'carrots_stage3',
+		potatoes: 'potatoes_stage3',
+		wheat: 'wheat_stage7',
+		nether_wart: 'nether_wart_stage2',
+		melon_stem: 'melon_stem',
+		pumpkin_stem: 'pumpkin_stem',
+		attached_melon_stem: 'melon_stem',
+		attached_pumpkin_stem: 'pumpkin_stem',
+		torchflower_crop: 'torchflower_crop_stage1',
+		pitcher_crop: 'pitcher_crop_top',
+		sweet_berry_bush: 'sweet_berry_bush_stage3',
+		cave_vines: 'cave_vines_plant',
+		cave_vines_plant: 'cave_vines_plant',
+		twisting_vines: 'twisting_vines_plant',
+		twisting_vines_plant: 'twisting_vines_plant',
+		weeping_vines: 'weeping_vines_plant',
+		weeping_vines_plant: 'weeping_vines_plant',
+		kelp: 'kelp_plant',
+		kelp_plant: 'kelp_plant',
+		seagrass: 'seagrass',
+		tall_seagrass: 'tall_seagrass_bottom',
+		bamboo_sapling: 'bamboo_stage0',
+		bubble_column: 'water_still',
+		end_gateway: 'end_stone',
+		flower_pot: 'flower_pot',
+		potted_acacia_sapling: 'flower_pot',
+		potted_allium: 'flower_pot',
+		potted_azalea_bush: 'flower_pot',
+		potted_azure_bluet: 'flower_pot',
+		potted_bamboo: 'flower_pot',
+		potted_birch_sapling: 'flower_pot',
+		potted_blue_orchid: 'flower_pot',
+		potted_brown_mushroom: 'flower_pot',
+		potted_cactus: 'flower_pot',
+		potted_cherry_sapling: 'flower_pot',
+		potted_cornflower: 'flower_pot',
+		potted_crimson_fungus: 'flower_pot',
+		potted_crimson_roots: 'flower_pot',
+		potted_dandelion: 'flower_pot',
+		potted_dark_oak_sapling: 'flower_pot',
+		potted_dead_bush: 'flower_pot',
+		potted_fern: 'flower_pot',
+		potted_flowering_azalea_bush: 'flower_pot',
+		potted_jungle_sapling: 'flower_pot',
+		potted_lily_of_the_valley: 'flower_pot',
+		potted_mangrove_propagule: 'flower_pot',
+		potted_oak_sapling: 'flower_pot',
+		potted_open_eyeblossom: 'flower_pot',
+		potted_orange_tulip: 'flower_pot',
+		potted_oxeye_daisy: 'flower_pot',
+		potted_pale_oak_sapling: 'flower_pot',
+		potted_pink_tulip: 'flower_pot',
+		potted_poppy: 'flower_pot',
+		potted_red_mushroom: 'flower_pot',
+		potted_red_tulip: 'flower_pot',
+		potted_spruce_sapling: 'flower_pot',
+		potted_torchflower: 'flower_pot',
+		potted_warped_fungus: 'flower_pot',
+		potted_warped_roots: 'flower_pot',
+		potted_white_tulip: 'flower_pot',
+		potted_wither_rose: 'flower_pot',
+		potted_closed_eyeblossom: 'flower_pot',
+		crimson_hyphae: 'crimson_stem',
+		stripped_crimson_hyphae: 'stripped_crimson_stem',
+		warped_hyphae: 'warped_stem',
+		stripped_warped_hyphae: 'stripped_warped_stem',
+		air: 'barrier',
+		cave_air: 'barrier',
+		void_air: 'barrier',
+		barrier: 'barrier',
+		light: 'light_15',
+		structure_void: 'barrier',
+		piston_head: 'piston_top',
+		candle_cake: 'cake_top',
+		decorated_pot: 'decorated_pot_base_side',
+		frosted_ice: 'frosted_ice_0',
+		glass_pane: 'glass',
+		moss_carpet: 'moss_block',
+		grass_block: 'grass_block_top',
+		hay_block: 'hay_block_top',
+		melon: 'melon_top',
+		mycelium: 'mycelium_top',
+		observer: 'observer_front',
+		pumpkin: 'pumpkin_top',
+		carved_pumpkin: 'pumpkin_top',
+		jack_o_lantern: 'jack_o_lantern',
+		podzol: 'podzol_top',
+		quartz_block: 'quartz_block_top',
+		snow_block: 'snow',
+		ochre_froglight: 'ochre_froglight_top',
+		pearlescent_froglight: 'pearlescent_froglight_top',
+		verdant_froglight: 'verdant_froglight_top',
+		polished_basalt: 'polished_basalt_top',
+		scaffolding: 'scaffolding_top',
+		sculk_catalyst: 'sculk_catalyst_top',
+		sculk_sensor: 'sculk_sensor_top',
+		sculk_shrieker: 'sculk_shrieker_top',
+		target: 'target_top',
+		tnt: 'tnt_top',
+		trial_spawner: 'trial_spawner_top_inactive',
+		vault: 'vault_front_off',
+		jigsaw: 'jigsaw_top',
+		reinforced_deepslate: 'reinforced_deepslate_top',
+		redstone_wire: 'redstone_dust_dot',
+		redstone_wall_torch: 'redstone_torch',
+		wall_torch: 'torch',
+		soul_wall_torch: 'soul_torch',
+		soul_fire: 'soul_fire_0',
+		fire: 'fire_0',
+		suspicious_gravel: 'gravel',
+		suspicious_sand: 'sand',
+		powder_snow_cauldron: 'cauldron_side',
+		test_block: 'barrier',
+		honey_block: 'honey_block_top',
+		decorated_pot: 'flower_pot',
+	};
+	if (Object.prototype.hasOwnProperty.call(SPECIALS, r)) return SPECIALS[r];
+
+	if (r.startsWith('potted_')) return 'flower_pot';
+
+	return null;
+}
+
+export { WOOD_TYPES, NETHER_WOODS };

--- a/apps/kbve/astro-kbve/src/components/mcdb/texture.ts
+++ b/apps/kbve/astro-kbve/src/components/mcdb/texture.ts
@@ -11,17 +11,296 @@ const BLOCK_CATEGORIES = new Set([
 	'transport',
 ]);
 
+const WOOD_TYPES = new Set([
+	'acacia',
+	'birch',
+	'oak',
+	'spruce',
+	'dark_oak',
+	'jungle',
+	'mangrove',
+	'cherry',
+	'pale_oak',
+	'bamboo',
+	'crimson',
+	'warped',
+]);
+
+const SPECIALS: Record<string, string> = {
+	barrel: 'barrel_top',
+	beehive: 'beehive_front',
+	bee_nest: 'bee_nest_front',
+	cauldron: 'cauldron_side',
+	water_cauldron: 'cauldron_side',
+	lava_cauldron: 'cauldron_side',
+	powder_snow_cauldron: 'cauldron_side',
+	composter: 'composter_side',
+	lectern: 'lectern_top',
+	loom: 'loom_top',
+	lodestone: 'lodestone_top',
+	jukebox: 'jukebox_top',
+	magma_block: 'magma',
+	mangrove_roots: 'mangrove_roots_top',
+	muddy_mangrove_roots: 'muddy_mangrove_roots_top',
+	water: 'water_still',
+	lava: 'lava_still',
+	large_fern: 'large_fern_bottom',
+	tall_grass: 'tall_grass_bottom',
+	lilac: 'lilac_bottom',
+	rose_bush: 'rose_bush_bottom',
+	peony: 'peony_bottom',
+	sunflower: 'sunflower_bottom',
+	pitcher_plant: 'pitcher_plant_top',
+	end_portal_frame: 'end_portal_frame_top',
+	end_portal: 'end_stone',
+	bell: 'bell_bottom',
+	chest: 'oak_planks',
+	trapped_chest: 'oak_planks',
+	ender_chest: 'obsidian',
+	conduit: 'beacon',
+	piston_head: 'piston_top',
+	piston: 'piston_top',
+	sticky_piston: 'piston_top_sticky',
+	moving_piston: 'piston_top',
+	grindstone: 'grindstone_side',
+	smithing_table: 'smithing_table_top',
+	cartography_table: 'cartography_table_top',
+	fletching_table: 'fletching_table_top',
+	stonecutter: 'stonecutter_top',
+	smoker: 'smoker_top',
+	blast_furnace: 'blast_furnace_top',
+	furnace: 'furnace_top',
+	respawn_anchor: 'respawn_anchor_top_off',
+	brewing_stand: 'brewing_stand_base',
+	enchanting_table: 'enchanting_table_top',
+	decorated_pot: 'flower_pot',
+	ancient_debris: 'ancient_debris_top',
+	basalt: 'basalt_top',
+	bone_block: 'bone_block_top',
+	cactus: 'cactus_top',
+	calibrated_sculk_sensor: 'calibrated_sculk_sensor_top',
+	chiseled_bookshelf: 'chiseled_bookshelf_empty',
+	command_block: 'command_block_front',
+	chain_command_block: 'chain_command_block_front',
+	repeating_command_block: 'repeating_command_block_front',
+	crafter: 'crafter_top',
+	crafting_table: 'crafting_table_front',
+	daylight_detector: 'daylight_detector_top',
+	dirt_path: 'dirt_path_top',
+	dispenser: 'dispenser_front',
+	dropper: 'dropper_front',
+	dried_kelp_block: 'dried_kelp_top',
+	chipped_anvil: 'anvil_top',
+	damaged_anvil: 'anvil_top',
+	anvil: 'anvil_top',
+	azalea: 'azalea_top',
+	flowering_azalea: 'flowering_azalea_top',
+	big_dripleaf: 'big_dripleaf_top',
+	small_dripleaf: 'small_dripleaf_top',
+	cocoa: 'cocoa_stage2',
+	beetroots: 'beetroots_stage3',
+	carrots: 'carrots_stage3',
+	potatoes: 'potatoes_stage3',
+	wheat: 'wheat_stage7',
+	nether_wart: 'nether_wart_stage2',
+	melon_stem: 'melon_stem',
+	pumpkin_stem: 'pumpkin_stem',
+	attached_melon_stem: 'melon_stem',
+	attached_pumpkin_stem: 'pumpkin_stem',
+	torchflower_crop: 'torchflower_crop_stage1',
+	pitcher_crop: 'pitcher_crop_top',
+	sweet_berry_bush: 'sweet_berry_bush_stage3',
+	cave_vines: 'cave_vines_plant',
+	cave_vines_plant: 'cave_vines_plant',
+	twisting_vines: 'twisting_vines_plant',
+	twisting_vines_plant: 'twisting_vines_plant',
+	weeping_vines: 'weeping_vines_plant',
+	weeping_vines_plant: 'weeping_vines_plant',
+	kelp: 'kelp_plant',
+	kelp_plant: 'kelp_plant',
+	tall_seagrass: 'tall_seagrass_bottom',
+	bamboo_sapling: 'bamboo_stage0',
+	bubble_column: 'water_still',
+	end_gateway: 'end_stone',
+	crimson_hyphae: 'crimson_stem',
+	stripped_crimson_hyphae: 'stripped_crimson_stem',
+	warped_hyphae: 'warped_stem',
+	stripped_warped_hyphae: 'stripped_warped_stem',
+	air: 'barrier',
+	cave_air: 'barrier',
+	void_air: 'barrier',
+	structure_void: 'barrier',
+	light: 'light_15',
+	candle_cake: 'cake_top',
+	frosted_ice: 'frosted_ice_0',
+	glass_pane: 'glass',
+	moss_carpet: 'moss_block',
+	pale_moss_carpet: 'pale_moss_block',
+	grass_block: 'grass_block_top',
+	hay_block: 'hay_block_top',
+	melon: 'melon_top',
+	mycelium: 'mycelium_top',
+	observer: 'observer_front',
+	pumpkin: 'pumpkin_top',
+	carved_pumpkin: 'pumpkin_top',
+	podzol: 'podzol_top',
+	quartz_block: 'quartz_block_top',
+	snow_block: 'snow',
+	ochre_froglight: 'ochre_froglight_top',
+	pearlescent_froglight: 'pearlescent_froglight_top',
+	verdant_froglight: 'verdant_froglight_top',
+	polished_basalt: 'polished_basalt_top',
+	scaffolding: 'scaffolding_top',
+	sculk_catalyst: 'sculk_catalyst_top',
+	sculk_sensor: 'sculk_sensor_top',
+	sculk_shrieker: 'sculk_shrieker_top',
+	target: 'target_top',
+	tnt: 'tnt_top',
+	trial_spawner: 'trial_spawner_top_inactive',
+	vault: 'vault_front_off',
+	jigsaw: 'jigsaw_top',
+	reinforced_deepslate: 'reinforced_deepslate_top',
+	redstone_wire: 'redstone_dust_dot',
+	redstone_wall_torch: 'redstone_torch',
+	wall_torch: 'torch',
+	soul_wall_torch: 'soul_torch',
+	soul_fire: 'soul_fire_0',
+	fire: 'fire_0',
+	suspicious_gravel: 'gravel',
+	suspicious_sand: 'sand',
+	test_block: 'barrier',
+	honey_block: 'honey_block_top',
+};
+
+export function resolveBaseRef(ref: string): string | null {
+	if (!ref) return null;
+	const r = ref.toLowerCase().replace(/^minecraft:/, '');
+
+	let m = r.match(/^waxed_(.+)$/);
+	if (m) return m[1];
+
+	m = r.match(/^infested_(.+)$/);
+	if (m) return m[1];
+
+	if (r === 'heavy_weighted_pressure_plate') return 'iron_block';
+	if (r === 'light_weighted_pressure_plate') return 'gold_block';
+	if (r === 'petrified_oak_slab') return 'oak_planks';
+	if (r === 'purpur_slab' || r === 'purpur_stairs') return 'purpur_block';
+	if (
+		r === 'smooth_quartz_slab' ||
+		r === 'smooth_quartz_stairs' ||
+		r === 'smooth_quartz'
+	) {
+		return 'quartz_block_bottom';
+	}
+	if (
+		r === 'smooth_red_sandstone_slab' ||
+		r === 'smooth_red_sandstone_stairs' ||
+		r === 'smooth_red_sandstone'
+	) {
+		return 'red_sandstone_top';
+	}
+	if (
+		r === 'smooth_sandstone_slab' ||
+		r === 'smooth_sandstone_stairs' ||
+		r === 'smooth_sandstone'
+	) {
+		return 'sandstone_top';
+	}
+
+	if (r === 'moss_carpet') return 'moss_block';
+	if (r === 'pale_moss_carpet') return 'pale_moss_block';
+
+	m = r.match(/^(.+?)_carpet$/);
+	if (m) return `${m[1]}_wool`;
+
+	m = r.match(/^(.+?)_bed$/);
+	if (m) return `${m[1]}_wool`;
+
+	m = r.match(/^(.+?)_stained_glass_pane$/);
+	if (m) return `${m[1]}_stained_glass`;
+
+	m = r.match(/^(.+?)_candle_cake$/);
+	if (m) return `${m[1]}_candle`;
+
+	if (/^bamboo_mosaic_(slab|stairs)$/.test(r)) return 'bamboo_mosaic';
+
+	m = r.match(/^(.+?)_door$/);
+	if (m && WOOD_TYPES.has(m[1])) return `${m[1]}_door_bottom`;
+
+	m = r.match(/^(.+?)_trapdoor$/);
+	if (m && WOOD_TYPES.has(m[1])) return `${m[1]}_trapdoor`;
+
+	m = r.match(
+		/^(.+?)_(fence_gate|fence|wall_hanging_sign|hanging_sign|wall_sign|sign)$/,
+	);
+	if (m && WOOD_TYPES.has(m[1])) return `${m[1]}_planks`;
+
+	m = r.match(/^(.+?)_brick_(slab|stairs|wall|fence)$/);
+	if (m) return `${m[1]}_bricks`;
+
+	m = r.match(/^(.+?)_tile_(slab|stairs|wall)$/);
+	if (m) return `${m[1]}_tiles`;
+
+	m = r.match(/^dead_(.+?)_coral_wall_fan$/);
+	if (m) return `dead_${m[1]}_coral_fan`;
+
+	m = r.match(/^(.+?)_coral_wall_fan$/);
+	if (m) return `${m[1]}_coral_fan`;
+
+	m = r.match(/^(.+?)_(slab|stairs|wall|button|pressure_plate)$/);
+	if (m) {
+		if (WOOD_TYPES.has(m[1])) return `${m[1]}_planks`;
+		return m[1];
+	}
+
+	if (r === 'stone_pressure_plate') return 'stone';
+	if (r === 'polished_blackstone_pressure_plate')
+		return 'polished_blackstone';
+
+	m = r.match(/^(.*?)_wood$/);
+	if (m && m[1]) {
+		const base = m[1];
+		if (base.endsWith('crimson') || base.endsWith('warped')) {
+			return `${base}_stem`;
+		}
+		return `${base}_log`;
+	}
+
+	m = r.match(/^(.+?)_(wall_)?banner$/);
+	if (m) return `${m[1]}_wool`;
+
+	if (Object.prototype.hasOwnProperty.call(SPECIALS, r)) return SPECIALS[r];
+
+	if (r.startsWith('potted_')) return 'flower_pot';
+
+	return null;
+}
+
+function resolveTerminal(ref: string): string {
+	let cursor = ref;
+	const seen = new Set<string>([cursor]);
+	for (let hop = 0; hop < 4; hop++) {
+		const next = resolveBaseRef(cursor);
+		if (!next || next === cursor || seen.has(next)) break;
+		seen.add(next);
+		cursor = next;
+	}
+	return cursor;
+}
+
 export function mcTextureUrls(ref: string, category?: string | null): Pair {
 	const clean = ref.replace(/^minecraft:/, '').toLowerCase();
+	const effective = resolveTerminal(clean);
 	const isBlockish = category ? BLOCK_CATEGORIES.has(category) : false;
 	if (isBlockish) {
 		return {
-			primary: `${BLOCK_BASE}/${clean}.png`,
-			fallback: `${ITEM_BASE}/${clean}.png`,
+			primary: `${BLOCK_BASE}/${effective}.png`,
+			fallback: `${ITEM_BASE}/${effective}.png`,
 		};
 	}
 	return {
-		primary: `${ITEM_BASE}/${clean}.png`,
-		fallback: `${BLOCK_BASE}/${clean}.png`,
+		primary: `${ITEM_BASE}/${effective}.png`,
+		fallback: `${BLOCK_BASE}/${effective}.png`,
 	};
 }


### PR DESCRIPTION
## Summary
Resolves the wave of \`/mc/textures/(item|block)/<ref>.png 404\` log spam on /mc/blocks/* and /mc/items/* pages. Derived blocks (doors, fences, slabs, stairs, signs, banners, carpets, multi-face blocks like jukebox / observer / crafting_table, etc) don't ship as flat PNGs in vanilla — they're rendered from model JSON + base textures.

Add a shared \`resolveBaseRef(ref)\` resolver that maps each derived ref to the closest available base texture. Same logic lives in two places, kept in sync by intent:
- \`scripts/mc-texture-aliases.mjs\` — used by the texture fetcher
- \`src/components/mcdb/texture.ts\` — used by the React block / item cards

Resolver walks the alias chain (max 4 hops, cycle-safe) so refs that need multiple rewrites still resolve to a single URL (e.g. \`waxed_exposed_cut_copper_slab → exposed_cut_copper_slab → exposed_cut_copper\`).

## Run-result on the current MDX corpus
\`\`\`
fetched: 0       (all already on disk from earlier runs)
skipped: 1526
aliased: 541
missing:  14     (entity head / skull textures — 3D mob renders, future pass)
\`\`\`

## Test plan
- [ ] Reload http://localhost:4321/mc/blocks/stone-blocks/ — no \`/mc/textures/...\` 404s in dev server log
- [ ] /mc/blocks/wood-related categories render planks textures for slabs / stairs / fences instead of broken images
- [ ] /mc/blocks/dirt/ literal block still renders the dirt texture (no regression on non-derived refs)
- [ ] Wood / leaves / glass / dyed-banner / dyed-carpet cards render their material color, not broken icons
- [ ] Adding a new derived ref later only needs a one-line entry in \`SPECIALS\` (or a new regex rule for whole families)