### PR TITLE
feat(isometric): inventory slot click → Use/Equip/Inspect menu (#11249)

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/inventory_ui.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/inventory_ui.rs
@@ -2,11 +2,13 @@
 //!
 //! Reads `Inventory<ItemKind>` resource directly (no JSON polling).
 //! Toggled via KeyCode::KeyI. Displays a 4x4 grid with item icons
-//! and quantities.
+//! and quantities. Clicking a populated slot opens a context menu with
+//! Use / Equip / Inspect actions keyed off the item's proto flags.
 
 use bevy::prelude::*;
 
 use super::inventory::ItemKind;
+use super::net::{EquipRequestEvent, UseItemRequestEvent};
 use super::pause_menu::UiOverlay;
 use super::phase::GamePhase;
 use super::ui_color;
@@ -58,6 +60,23 @@ struct ToggleBtnLabel;
 #[derive(Resource, Default)]
 struct InventoryUiState {
     open: bool,
+    /// Currently selected slot index (for context menu).
+    selected_slot: Option<usize>,
+}
+
+#[derive(Component)]
+struct SlotContextMenu;
+
+#[derive(Component)]
+struct InspectModal;
+
+#[derive(Component, Clone, Copy)]
+enum SlotAction {
+    Use { slot: u32 },
+    Equip { slot: u32 },
+    Inspect { slot: u32 },
+    Close,
+    CloseInspect,
 }
 
 pub struct InventoryUiPlugin;
@@ -68,7 +87,14 @@ impl Plugin for InventoryUiPlugin {
         app.add_systems(OnEnter(GamePhase::Playing), spawn_inventory_ui);
         app.add_systems(
             Update,
-            (toggle_inventory, update_inventory_slots).run_if(in_state(GamePhase::Playing)),
+            (
+                toggle_inventory,
+                update_inventory_slots,
+                handle_slot_clicks,
+                handle_slot_actions,
+                close_menu_on_inventory_close,
+            )
+                .run_if(in_state(GamePhase::Playing)),
         );
     }
 }
@@ -180,6 +206,8 @@ fn spawn_inventory_ui(mut commands: Commands) {
                                     ..default()
                                 },
                                 BackgroundColor(SLOT_BG),
+                                Interaction::default(),
+                                bevy::ui::FocusPolicy::Block,
                                 InventorySlot { index: i },
                             ))
                             .with_children(|slot| {
@@ -190,6 +218,8 @@ fn spawn_inventory_ui(mut commands: Commands) {
                                         ..default()
                                     },
                                     TextColor(ui_color::TEXT_PRIMARY),
+                                    bevy::ui::FocusPolicy::Pass,
+                                    bevy::picking::Pickable::IGNORE,
                                     SlotIcon { index: i },
                                 ));
                                 slot.spawn((
@@ -199,6 +229,8 @@ fn spawn_inventory_ui(mut commands: Commands) {
                                         ..default()
                                     },
                                     TextColor(ui_color::TEXT_SECONDARY),
+                                    bevy::ui::FocusPolicy::Pass,
+                                    bevy::picking::Pickable::IGNORE,
                                     SlotName { index: i },
                                 ));
                                 slot.spawn((
@@ -208,6 +240,8 @@ fn spawn_inventory_ui(mut commands: Commands) {
                                         ..default()
                                     },
                                     TextColor(GOLD_TEXT),
+                                    bevy::ui::FocusPolicy::Pass,
+                                    bevy::picking::Pickable::IGNORE,
                                     SlotQty { index: i },
                                 ));
                             });
@@ -260,6 +294,308 @@ fn toggle_inventory(
     }
     for mut txt in &mut label_q {
         **txt = if state.open { "Close" } else { "Bag" }.to_string();
+    }
+}
+
+fn handle_slot_clicks(
+    mut commands: Commands,
+    mut state: ResMut<InventoryUiState>,
+    inventory: Res<bevy_inventory::Inventory<ItemKind>>,
+    existing_menu: Query<Entity, With<SlotContextMenu>>,
+    slot_q: Query<(&Interaction, &InventorySlot), Changed<Interaction>>,
+) {
+    for (interaction, slot) in &slot_q {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+        let Some(stack) = inventory.items.get(slot.index) else {
+            continue;
+        };
+        if stack.kind.item().is_none() {
+            continue;
+        }
+        // Toggle: clicking the same slot a second time closes the menu.
+        if state.selected_slot == Some(slot.index) {
+            state.selected_slot = None;
+            for e in &existing_menu {
+                commands.entity(e).despawn();
+            }
+            continue;
+        }
+        state.selected_slot = Some(slot.index);
+        for e in &existing_menu {
+            commands.entity(e).despawn();
+        }
+        spawn_slot_context_menu(&mut commands, slot.index, &inventory);
+    }
+}
+
+fn spawn_slot_context_menu(
+    commands: &mut Commands,
+    slot_index: usize,
+    inventory: &bevy_inventory::Inventory<ItemKind>,
+) {
+    let stack = match inventory.items.get(slot_index) {
+        Some(s) => s,
+        None => return,
+    };
+    let item = match stack.kind.item() {
+        Some(i) => i,
+        None => return,
+    };
+    let is_consumable = item.consumable.unwrap_or(false);
+    let is_equipment = item.equipment.is_some();
+    let item_name = item.name.clone();
+    let slot32 = slot_index as u32;
+
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(160.0),
+                right: Val::Px(220.0),
+                flex_direction: FlexDirection::Column,
+                padding: UiRect::all(Val::Px(8.0)),
+                row_gap: Val::Px(4.0),
+                border_radius: BorderRadius::all(Val::Px(4.0)),
+                min_width: Val::Px(120.0),
+                ..default()
+            },
+            BackgroundColor(ui_color::PANEL),
+            GlobalZIndex(120),
+            bevy::ui::FocusPolicy::Block,
+            SlotContextMenu,
+        ))
+        .with_children(|menu| {
+            menu.spawn((
+                Text::new(item_name),
+                TextFont {
+                    font_size: 12.0,
+                    ..default()
+                },
+                TextColor(GOLD_TEXT),
+                bevy::ui::FocusPolicy::Pass,
+                bevy::picking::Pickable::IGNORE,
+            ));
+
+            if is_consumable {
+                spawn_action_button(menu, "Use", SlotAction::Use { slot: slot32 });
+            }
+            if is_equipment {
+                spawn_action_button(menu, "Equip", SlotAction::Equip { slot: slot32 });
+            }
+            spawn_action_button(menu, "Inspect", SlotAction::Inspect { slot: slot32 });
+            spawn_action_button(menu, "Close", SlotAction::Close);
+        });
+}
+
+fn spawn_action_button(parent: &mut ChildSpawnerCommands, label: &str, action: SlotAction) {
+    parent
+        .spawn((
+            Node {
+                width: Val::Percent(100.0),
+                height: Val::Px(24.0),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                border_radius: BorderRadius::all(Val::Px(3.0)),
+                ..default()
+            },
+            BackgroundColor(SLOT_BG),
+            Interaction::default(),
+            bevy::ui::FocusPolicy::Block,
+            action,
+        ))
+        .with_child((
+            Text::new(label.to_string()),
+            TextFont {
+                font_size: 11.0,
+                ..default()
+            },
+            TextColor(ui_color::TEXT_PRIMARY),
+            bevy::ui::FocusPolicy::Pass,
+            bevy::picking::Pickable::IGNORE,
+        ));
+}
+
+fn handle_slot_actions(
+    mut commands: Commands,
+    mut state: ResMut<InventoryUiState>,
+    inventory: Res<bevy_inventory::Inventory<ItemKind>>,
+    mut use_writer: MessageWriter<UseItemRequestEvent>,
+    mut equip_writer: MessageWriter<EquipRequestEvent>,
+    existing_menu: Query<Entity, With<SlotContextMenu>>,
+    existing_inspect: Query<Entity, With<InspectModal>>,
+    btn_q: Query<(&Interaction, &SlotAction), Changed<Interaction>>,
+) {
+    for (interaction, action) in &btn_q {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+        match *action {
+            SlotAction::Use { slot } => {
+                use_writer.write(UseItemRequestEvent {
+                    inventory_slot: slot,
+                });
+                state.selected_slot = None;
+                for e in &existing_menu {
+                    commands.entity(e).despawn();
+                }
+            }
+            SlotAction::Equip { slot } => {
+                equip_writer.write(EquipRequestEvent {
+                    inventory_slot: slot,
+                });
+                state.selected_slot = None;
+                for e in &existing_menu {
+                    commands.entity(e).despawn();
+                }
+            }
+            SlotAction::Inspect { slot } => {
+                for e in &existing_inspect {
+                    commands.entity(e).despawn();
+                }
+                spawn_inspect_modal(&mut commands, slot as usize, &inventory);
+            }
+            SlotAction::Close => {
+                state.selected_slot = None;
+                for e in &existing_menu {
+                    commands.entity(e).despawn();
+                }
+            }
+            SlotAction::CloseInspect => {
+                for e in &existing_inspect {
+                    commands.entity(e).despawn();
+                }
+            }
+        }
+    }
+}
+
+fn spawn_inspect_modal(
+    commands: &mut Commands,
+    slot_index: usize,
+    inventory: &bevy_inventory::Inventory<ItemKind>,
+) {
+    let stack = match inventory.items.get(slot_index) {
+        Some(s) => s,
+        None => return,
+    };
+    let item = match stack.kind.item() {
+        Some(i) => i,
+        None => return,
+    };
+    let name = item.name.clone();
+    let description = item.description.clone().unwrap_or_default();
+    let lore = item.lore.clone().unwrap_or_default();
+    let emoji = item.emoji.clone().unwrap_or_default();
+
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                top: Val::Px(0.0),
+                left: Val::Px(0.0),
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                ..default()
+            },
+            BackgroundColor(Color::srgba(0.0, 0.0, 0.0, 0.6)),
+            GlobalZIndex(140),
+            InspectModal,
+        ))
+        .with_children(|root| {
+            root.spawn((
+                Node {
+                    width: Val::Px(320.0),
+                    flex_direction: FlexDirection::Column,
+                    padding: UiRect::all(Val::Px(14.0)),
+                    row_gap: Val::Px(8.0),
+                    border_radius: BorderRadius::all(Val::Px(6.0)),
+                    ..default()
+                },
+                BackgroundColor(ui_color::PANEL),
+                bevy::ui::FocusPolicy::Block,
+            ))
+            .with_children(|panel| {
+                panel
+                    .spawn(Node {
+                        flex_direction: FlexDirection::Row,
+                        column_gap: Val::Px(8.0),
+                        align_items: AlignItems::Center,
+                        ..default()
+                    })
+                    .with_children(|header| {
+                        if !emoji.is_empty() {
+                            header.spawn((
+                                Text::new(emoji),
+                                TextFont {
+                                    font_size: 22.0,
+                                    ..default()
+                                },
+                                TextColor(ui_color::TEXT_PRIMARY),
+                                bevy::ui::FocusPolicy::Pass,
+                                bevy::picking::Pickable::IGNORE,
+                            ));
+                        }
+                        header.spawn((
+                            Text::new(name),
+                            TextFont {
+                                font_size: 16.0,
+                                ..default()
+                            },
+                            TextColor(GOLD_TEXT),
+                            bevy::ui::FocusPolicy::Pass,
+                            bevy::picking::Pickable::IGNORE,
+                        ));
+                    });
+                if !description.is_empty() {
+                    panel.spawn((
+                        Text::new(description),
+                        TextFont {
+                            font_size: 12.0,
+                            ..default()
+                        },
+                        TextColor(ui_color::TEXT_PRIMARY),
+                        bevy::ui::FocusPolicy::Pass,
+                        bevy::picking::Pickable::IGNORE,
+                    ));
+                }
+                if !lore.is_empty() {
+                    panel.spawn((
+                        Text::new(lore),
+                        TextFont {
+                            font_size: 11.0,
+                            ..default()
+                        },
+                        TextColor(ui_color::TEXT_SECONDARY),
+                        bevy::ui::FocusPolicy::Pass,
+                        bevy::picking::Pickable::IGNORE,
+                    ));
+                }
+                spawn_action_button(panel, "Close", SlotAction::CloseInspect);
+            });
+        });
+}
+
+fn close_menu_on_inventory_close(
+    mut commands: Commands,
+    mut state: ResMut<InventoryUiState>,
+    existing_menu: Query<Entity, With<SlotContextMenu>>,
+    existing_inspect: Query<Entity, With<InspectModal>>,
+) {
+    if state.open {
+        return;
+    }
+    if state.selected_slot.is_some() {
+        state.selected_slot = None;
+    }
+    for e in &existing_menu {
+        commands.entity(e).despawn();
+    }
+    for e in &existing_inspect {
+        commands.entity(e).despawn();
     }
 }
 


### PR DESCRIPTION
Closes #11249.

## Summary
- Inventory grid slots are now `Interaction`-enabled with the standard FocusPolicy/Pickable patches so clicks land on the slot itself, not the icon/name/qty text children.
- Clicking a populated slot opens an anchored context menu. Actions are gated on item flags from the baked itemdb proto:
  - **Use** when `item.consumable`
  - **Equip** when `item.equipment` is present
  - **Inspect** always
  - **Close** dismisses without action
- Use and Equip dispatch the existing `UseItemRequestEvent` / `EquipRequestEvent`, so server-side handling is unchanged.
- Inspect spawns a centered modal showing emoji, name, description, and lore.
- Closing the bag tears down any open menu / inspect modal so the next open starts clean.

## Out of scope (follow-ups)
- Drop (server has no `DropRequest` yet).
- Deploy from inventory (needs tile-pick mode).
- Right-click default action.
- Drag-drop reorder.

## Test plan
- [ ] `cargo build --bin isometric-game` + `BUILD_TARGET=tauri pnpm exec vite build` clean (verified locally).
- [ ] Native: open bag, click a chopped log slot → Use button dispatches.
- [ ] Open bag, click an equippable slot → Equip button dispatches, `EquipmentUpdate` arrives, slot empties.
- [ ] Click Inspect → modal shows item description / lore from itemdb.
- [ ] No FocusPolicy regression on the bag toggle or on title/pause menus.