### PR TITLE
fix(mc/spawn-autoclaim): correct OPAC claim() arg order — restores full 26x26 cube

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/SpawnAutoClaim.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/SpawnAutoClaim.java
@@ -43,7 +43,7 @@ public final class SpawnAutoClaim {
         }
         Object claims;
         Method getMethod;
-        Method tryToClaimMethod;
+        Method claimMethod;
         try {
             Class<?> apiClass = Class.forName("xaero.pac.common.server.api.OpenPACServerAPI");
             Object api = apiClass.getMethod("get", MinecraftServer.class).invoke(null, server);
@@ -51,20 +51,18 @@ public final class SpawnAutoClaim {
             Class<?> claimsCls = claims.getClass();
 
             getMethod = findMethod(claimsCls, "get", Identifier.class, int.class, int.class);
-            tryToClaimMethod = findMethod(
+            claimMethod = findMethod(
                     claimsCls,
-                    "tryToClaim",
+                    "claim",
                     Identifier.class,
                     UUID.class,
                     int.class,
                     int.class,
                     int.class,
-                    int.class,
-                    int.class,
                     boolean.class);
-            if (getMethod == null || tryToClaimMethod == null) {
-                LOGGER.warn("[spawn-autoclaim] OPAC API signature mismatch — get={} tryToClaim={}",
-                        getMethod, tryToClaimMethod);
+            if (getMethod == null || claimMethod == null) {
+                LOGGER.warn("[spawn-autoclaim] OPAC API signature mismatch — get={} claim={}",
+                        getMethod, claimMethod);
                 return;
             }
         } catch (Throwable t) {
@@ -85,8 +83,8 @@ public final class SpawnAutoClaim {
                             skipped++;
                             continue;
                         }
-                        tryToClaimMethod.invoke(
-                                claims, dimId, SERVER_CLAIM_UUID, cx, cz, cx, cz, 0, true);
+                        claimMethod.invoke(
+                                claims, dimId, SERVER_CLAIM_UUID, -1, cx, cz, false);
                         claimed++;
                     } catch (Throwable t) {
                         failed++;


### PR DESCRIPTION
## Summary
Closes #11233. The strip-not-cube bug was an **arg-order regression** in our reflective `SpawnAutoClaim` call, not an OPAC throttle or persistence quirk.

## Confirmed via upstream API source
Fetched [`xaero/open-parties-and-claims` branch `1.21.11`](https://github.com/thexaero/open-parties-and-claims/blob/1.21.11/Common/src/main/java/xaero/pac/common/server/claims/api/IServerClaimsManagerAPI.java). Canonical signatures:

\`\`\`java
claim(Identifier dim, UUID id,
      int subConfigIndex,
      int x, int z,
      boolean forceload)

tryToClaim(Identifier dim, UUID playerId,
           int subConfigIndex,
           int fromX, int fromZ,
           int x, int z,
           boolean replace)
\`\`\`

**`subConfigIndex` is the FIRST int** in both methods. Our reflective call assumed `(fromX, fromZ, toX, toZ, color, replace)`, so every 26×26 iteration fed:

\`\`\`java
tryToClaim(dim, uuid,
           /*subConfigIndex=*/cx,
           /*fromX=*/cz,  /*fromZ=*/cx,
           /*x=*/cz,      /*z=*/0,
           /*replace=*/true)
\`\`\`

The literal `0` in the `z` slot is **exactly** why disk only ever had positions at `z=0, x ∈ {-13..12}` — the strip. Confirmed via `xxd` on the NBT file in issue #11233.

## Fix
Switch from `tryToClaim` (which adds quota / distance limit checks we don't want on the server-claim path) back to the raw `claim()` method. Upstream doc:

> "Directly replaces the current claim state of a chunk. It is usually a bad idea to give regular players unfiltered access to this method. Use tryToClaim or tryToForceload instead if you want different limitations to be considered."

For server-seeded admin claims we **explicitly want** to bypass those limits, so `claim()` is the right primitive. Args now passed in canonical order:

\`\`\`java
claim(dimId, SERVER_CLAIM_UUID, -1, cx, cz, false)
//    dim   owner               subId x   z   forceload
\`\`\`

Per-chunk try-catch + failure-count logging stay — a single OPAC hiccup still never aborts the dimension sweep.

## Belt-and-suspenders follow-up (separate worktree, separate PR)
Per discussion in #11233: also build a native region-protection layer in `behavior_statetree` sourced from a Supabase RPC (`mc.region_protection` table). Even with this PR fixing OPAC, having a non-OPAC backstop means future plugin updates / reflective drift can't strand the spawn cube.

That's tracked as Phase B in #11233 and not in this PR's scope.

## Test plan
- [ ] `gradle compileJava` clean (verified locally).
- [ ] After rollout to a fresh world: pod log shows `claimed=676 skipped=0 failed=0`.
- [ ] After rollout to existing world: pod log shows roughly `claimed=650 skipped=26 failed=0` (skips the 26 strip chunks from prior buggy runs that are now server-owned; claims the remaining 650).
- [ ] `xxd .../00000000-0000-0000-0000-000000000000.nbt` shows a `positions` array with 676 entries covering all (x, z) combos in [-13..12] × [-13..12].
- [ ] Xaero map after a relog shows the full square admin claim around `(0, 67, 0)`.