### PR TITLE
feat(isometric,bevy_chat): JWT-authenticated chat.kbve.com WebSocket (#11246)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,10 +2095,12 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "crossbeam-channel",
+ "futures-util",
  "js-sys",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -8474,6 +8476,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-deep-link",
  "tauri-plugin-opener",
+ "tokio",
  "ureq 3.3.0",
  "urlencoding",
  "wasm-bindgen",
@@ -16403,6 +16406,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.24.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
@@ -17003,6 +17022,26 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 

--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -94,6 +94,8 @@ urlencoding = "2"
 wgpu = "27"
 pollster = "0.4"
 ureq = { version = "3", features = ["json"] }
+# Required for the dedicated runtime that hosts the chat IRC-WS connection.
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 
 # --- Linux-only Bevy features (x11/wayland) ---
 [target.'cfg(target_os = "linux")'.dependencies.bevy]

--- a/apps/kbve/isometric/src-tauri/src/auth_common.rs
+++ b/apps/kbve/isometric/src-tauri/src/auth_common.rs
@@ -12,6 +12,12 @@ static PENDING_SIGNIN: Mutex<Option<SignInResult>> = Mutex::new(None);
 /// `get_signin_state` (Tauri) to decide whether to prompt for a username.
 static CURRENT_SIGNIN: Mutex<Option<SignInResult>> = Mutex::new(None);
 
+/// Persistent copy of the latest Supabase access token observed by either
+/// the localhost OAuth listener or the `set_signed_in` wasm-bindgen
+/// export. Read by `game::chat` to authenticate against the IRC gateway
+/// (`wss://chat.kbve.com`) using the JWT as the `PASS` line.
+static CURRENT_JWT: Mutex<Option<String>> = Mutex::new(None);
+
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct SignInResult {
     pub jwt_valid: bool,
@@ -41,6 +47,13 @@ pub fn record_signin(jwt: &str) {
     if let Ok(mut g) = CURRENT_SIGNIN.lock() {
         *g = Some(result);
     }
+    if let Ok(mut g) = CURRENT_JWT.lock() {
+        *g = Some(jwt.to_string());
+    }
+}
+
+pub fn current_jwt() -> Option<String> {
+    CURRENT_JWT.lock().ok().and_then(|g| g.clone())
 }
 
 pub fn record_username(username: String) {

--- a/apps/kbve/isometric/src-tauri/src/game/chat.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/chat.rs
@@ -8,7 +8,7 @@
 //! cross-platform world events.
 
 use bevy::prelude::*;
-use bevy_chat::{ChatClient, ChatPlugin, IncomingChatEvent, IrcConfig, MessageKind};
+use bevy_chat::{ChatPlugin, IncomingChatEvent, IrcConfig, IrcTransport, MessageKind};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 
 use super::toast::Toast;
@@ -56,13 +56,48 @@ impl Plugin for GameChatPlugin {
             inbox_tx,
             outbox_rx,
         });
+        app.init_resource::<ChatSession>();
 
-        // Connect IRC at startup (graceful failure)
-        app.add_systems(Startup, connect_irc);
+        // Connect chat lazily: wait for the user to sign in (PreFlight
+        // observes `kbve_username` + JWT), then dial `wss://chat.kbve.com`
+        // with the JWT as the IRC `PASS` and the username as the nick.
+        app.add_systems(Update, connect_chat_on_signin);
 
         // Bridge incoming world events to toast notifications
         app.add_systems(Update, world_events_to_toasts);
     }
+}
+
+/// Tracks whether we've already started a chat connection for the current
+/// session. Reset on disconnect/re-auth in a future iteration.
+#[derive(Resource, Default)]
+struct ChatSession {
+    connected: bool,
+    nick: Option<String>,
+}
+
+fn connect_chat_on_signin(mut session: ResMut<ChatSession>, channels: Res<ChatBridgeChannels>) {
+    if session.connected {
+        return;
+    }
+    let snapshot = crate::auth_common::current_signin_snapshot();
+    if !snapshot.jwt_valid {
+        return;
+    }
+    let nick = match snapshot.username {
+        Some(name) if !name.is_empty() => name,
+        // No canonical username yet — chat needs one to register, so wait
+        // until the player picks one via the in-game username modal.
+        _ => return,
+    };
+    let jwt = match crate::auth_common::current_jwt() {
+        Some(j) => j,
+        None => return,
+    };
+    session.connected = true;
+    session.nick = Some(nick.clone());
+    info!("[chat] sign-in observed; dialing chat.kbve.com as {nick}");
+    spawn_chat_connection(&channels, nick, jwt);
 }
 
 /// Stores the inbox sender (called by the IRC client when messages arrive)
@@ -78,35 +113,35 @@ struct ChatBridgeChannels {
 // IRC connection (platform-specific)
 // ---------------------------------------------------------------------------
 
-#[cfg(target_arch = "wasm32")]
-fn connect_irc(channels: Res<ChatBridgeChannels>) {
-    use bevy_chat::ChatClient;
-    use wasm_bindgen::JsCast;
-
-    // Generate a unique nick from a random suffix (browser session)
-    let suffix: u32 = (js_sys::Math::random() * 100000.0) as u32;
-    let nick = format!("iso-{:05}", suffix);
-
-    let config = IrcConfig {
+fn chat_config(nick: String, jwt: String) -> IrcConfig {
+    IrcConfig {
         host: DEFAULT_WS_URL.to_owned(),
         port: 443,
         tls: true,
         nick,
         channels: DEFAULT_CHANNELS.iter().map(|s| s.to_string()).collect(),
-        password: None,
+        password: Some(jwt),
         reconnect_delay_secs: 5,
-    };
+        transport: IrcTransport::WebSocket,
+    }
+}
 
-    info!("[chat] connecting to IRC gateway at {}", config.host);
+#[cfg(target_arch = "wasm32")]
+fn spawn_chat_connection(channels: &ChatBridgeChannels, nick: String, jwt: String) {
+    use bevy_chat::ChatClient;
+    use wasm_bindgen::JsCast;
+
+    let config = chat_config(nick, jwt);
+    info!(
+        "[chat] connecting to IRC gateway at {} (nick={})",
+        config.host, config.nick
+    );
     let client = ChatClient::new(config);
-
     if let Err(e) = client.connect() {
         warn!("[chat] IRC connect failed: {} — world events disabled", e);
         return;
     }
 
-    // Spawn a microtask poller that drains the WASM client's incoming buffer
-    // and pushes into the crossbeam inbox channel each frame.
     let inbox_tx = channels.inbox_tx.clone();
     let client_for_poll = client.clone();
     let closure = wasm_bindgen::prelude::Closure::wrap(Box::new(move || {
@@ -114,30 +149,63 @@ fn connect_irc(channels: Res<ChatBridgeChannels>) {
             let _ = inbox_tx.send(msg);
         }
     }) as Box<dyn FnMut()>);
-
     if let Some(window) = web_sys::window() {
-        // Poll every 100ms — the WebSocket onmessage already pushes into
-        // the client's internal buffer, we just shuffle to crossbeam here.
         let _ = window.set_interval_with_callback_and_timeout_and_arguments_0(
             closure.as_ref().unchecked_ref(),
             100,
         );
         closure.forget();
     }
-
-    info!("[chat] IRC bridge active");
+    info!("[chat] IRC bridge active (wasm)");
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn connect_irc(_channels: Res<ChatBridgeChannels>) {
-    // Native client uses tokio + broadcast::Receiver — not Send across the
-    // ECS boundary the same way WASM is. For desktop Tauri we'd spawn a
-    // tokio task that subscribes to the broadcast channel and forwards
-    // each message into the crossbeam inbox.
-    //
-    // Disabled for now — desktop builds connect via the lightyear server's
-    // own IRC client (which the lightyear server also runs natively).
-    info!("[chat] IRC bridge skipped on native (handled by lightyear server)");
+fn spawn_chat_connection(channels: &ChatBridgeChannels, nick: String, jwt: String) {
+    use bevy_chat::ChatClient;
+
+    let config = chat_config(nick, jwt);
+    let host = config.host.clone();
+    let inbox_tx = channels.inbox_tx.clone();
+    info!(
+        "[chat] connecting to IRC gateway at {} (nick={})",
+        host, config.nick
+    );
+
+    // Bevy runs sync — drive the async connect on a dedicated tokio
+    // runtime spawned on a worker thread. The runtime lives for the
+    // process lifetime; broadcast receiver shuffles each `ChatMessage`
+    // into the crossbeam inbox so `ChatPlugin::receive_inbox` can read
+    // it on the main ECS thread.
+    std::thread::Builder::new()
+        .name("chat-irc-ws".to_string())
+        .spawn(move || {
+            let rt = match tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    warn!("[chat] failed to start tokio runtime: {e}");
+                    return;
+                }
+            };
+            rt.block_on(async move {
+                let mut client = ChatClient::new(config);
+                let mut subscriber = client.subscribe();
+                if let Err(e) = client.connect().await {
+                    warn!("[chat] native IRC-WS connect failed: {e}");
+                    return;
+                }
+                info!("[chat] native IRC-WS bridge active");
+                while let Ok(msg) = subscriber.recv().await {
+                    if inbox_tx.send(msg).is_err() {
+                        break;
+                    }
+                }
+                warn!("[chat] native IRC-WS subscriber loop ended");
+            });
+        })
+        .expect("failed to spawn chat-irc-ws thread");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/rust/bevy/bevy_chat/Cargo.toml
+++ b/packages/rust/bevy/bevy_chat/Cargo.toml
@@ -24,6 +24,11 @@ crossbeam-channel = { version = "0.5", optional = true }
 # Native (tokio TCP) — used by Discord bot and lightyear server
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["net", "io-util", "sync", "time", "rt", "rt-multi-thread"] }
+# WebSocket transport — used by isometric desktop client to reach wss://chat.kbve.com
+# (mirrors the WASM browser client). default-features=false avoids pulling
+# native-tls/openssl-sys; webpki-roots ships the system trust anchors.
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 
 # WASM (web_sys WebSocket) — used by isometric game in browser
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/packages/rust/bevy/bevy_chat/src/client_native.rs
+++ b/packages/rust/bevy/bevy_chat/src/client_native.rs
@@ -1,21 +1,29 @@
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, broadcast, mpsc};
 
-use crate::config::IrcConfig;
+use crate::config::{IrcConfig, IrcTransport};
 use crate::message::ChatMessage;
 
 /// Async IRC client that connects to a server, joins channels, and
 /// sends/receives structured game messages.
 ///
 /// This client is headless — it uses only tokio, no Bevy dependencies.
-/// Both the Discord bot and the isometric game server use it directly.
+/// Both the Discord bot and the isometric game server use it directly via
+/// the TCP transport; the isometric desktop client opts into the WebSocket
+/// transport to share the same `wss://chat.kbve.com` endpoint as the WASM
+/// browser build.
 #[derive(Clone)]
 pub struct ChatClient {
     config: IrcConfig,
     tx: broadcast::Sender<ChatMessage>,
-    writer: Arc<Mutex<Option<tokio::io::WriteHalf<TcpStream>>>>,
+    writer: Arc<Mutex<Option<Writer>>>,
+}
+
+enum Writer {
+    Tcp(tokio::io::WriteHalf<TcpStream>),
+    Ws(mpsc::UnboundedSender<String>),
 }
 
 impl ChatClient {
@@ -43,11 +51,19 @@ impl ChatClient {
     }
 
     /// Connect to the IRC server, register, and join configured channels.
-    /// Spawns a background read loop that parses incoming PRIVMSG lines
-    /// and broadcasts them as `ChatMessage` via the subscriber channel.
+    /// Branches on `IrcConfig.transport` so the same `ChatClient` API works
+    /// for both raw-TCP IRC servers (bot, lightyear) and WebSocket
+    /// gateways (`wss://chat.kbve.com`).
     pub async fn connect(&mut self) -> Result<(), String> {
+        match self.config.transport {
+            IrcTransport::Tcp => self.connect_tcp().await,
+            IrcTransport::WebSocket => self.connect_ws().await,
+        }
+    }
+
+    async fn connect_tcp(&mut self) -> Result<(), String> {
         let addr = format!("{}:{}", self.config.host, self.config.port);
-        tracing::info!("IRC connecting to {}", addr);
+        tracing::info!("IRC connecting to {} (tcp)", addr);
 
         let stream = TcpStream::connect(&addr)
             .await
@@ -55,13 +71,11 @@ impl ChatClient {
 
         let (reader, writer) = tokio::io::split(stream);
 
-        // Store writer for send operations
         {
             let mut w = self.writer.lock().await;
-            *w = Some(writer);
+            *w = Some(Writer::Tcp(writer));
         }
 
-        // Send NICK and USER registration
         if let Some(ref pass) = self.config.password {
             self.send_raw(&format!("PASS {}", pass)).await?;
         }
@@ -69,39 +83,143 @@ impl ChatClient {
         self.send_raw(&format!("USER {} 0 * :bevy_chat client", self.config.nick))
             .await?;
 
-        // Join channels
         for channel in &self.config.channels {
             self.send_raw(&format!("JOIN {}", channel)).await?;
         }
 
         tracing::info!(
-            "IRC registered as {} on {} channels",
+            "IRC registered as {} on {} channels (tcp)",
             self.config.nick,
             self.config.channels.len()
         );
 
-        // Spawn background read loop
         let tx = self.tx.clone();
         let nick = self.config.nick.clone();
         let writer_clone = self.writer.clone();
         tokio::spawn(async move {
             let mut lines = BufReader::new(reader).lines();
             while let Ok(Some(line)) = lines.next_line().await {
-                // Handle PING/PONG keepalive
                 if line.starts_with("PING") {
                     let pong = line.replacen("PING", "PONG", 1);
-                    if let Some(ref mut w) = *writer_clone.lock().await {
+                    if let Some(Writer::Tcp(ref mut w)) = *writer_clone.lock().await {
                         let _ = w.write_all(format!("{}\r\n", pong).as_bytes()).await;
                     }
                     continue;
                 }
-
-                // Parse PRIVMSG: :nick!user@host PRIVMSG #channel :message
                 if let Some(privmsg) = parse_privmsg(&line, &nick) {
                     let _ = tx.send(privmsg);
                 }
             }
-            tracing::warn!("IRC read loop ended");
+            tracing::warn!("IRC read loop ended (tcp)");
+        });
+
+        Ok(())
+    }
+
+    async fn connect_ws(&mut self) -> Result<(), String> {
+        use futures_util::{SinkExt, StreamExt};
+        use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+        // `host` may already be a full ws:// or wss:// URL, or a bare
+        // hostname. Default to wss:// so production chat.kbve.com works
+        // out of the box; `tls = false` forces plain ws:// for local dev.
+        let url = if self.config.host.starts_with("ws://") || self.config.host.starts_with("wss://")
+        {
+            self.config.host.clone()
+        } else if self.config.tls {
+            format!("wss://{}", self.config.host)
+        } else {
+            format!("ws://{}", self.config.host)
+        };
+        tracing::info!("IRC connecting to {} (websocket)", url);
+
+        let (ws, _resp) = tokio_tungstenite::connect_async(&url)
+            .await
+            .map_err(|e| format!("IRC-WS connect failed: {}", e))?;
+        let (mut sink, mut stream) = ws.split();
+
+        let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
+
+        // Outbound pump — every send_raw call hands a CRLF-terminated line
+        // to the channel; this task forwards it as a single WebSocket text
+        // frame so the IRC gateway sees one complete command per frame.
+        tokio::spawn(async move {
+            while let Some(line) = out_rx.recv().await {
+                if sink.send(WsMessage::Text(line.into())).await.is_err() {
+                    break;
+                }
+            }
+            tracing::warn!("IRC-WS outbound pump ended");
+        });
+
+        {
+            let mut w = self.writer.lock().await;
+            *w = Some(Writer::Ws(out_tx));
+        }
+
+        if let Some(ref pass) = self.config.password {
+            self.send_raw(&format!("PASS {}", pass)).await?;
+        }
+        self.send_raw(&format!("NICK {}", self.config.nick)).await?;
+        self.send_raw(&format!(
+            "USER {} 0 * :bevy_chat ws client",
+            self.config.nick
+        ))
+        .await?;
+
+        for channel in &self.config.channels {
+            self.send_raw(&format!("JOIN {}", channel)).await?;
+        }
+
+        tracing::info!(
+            "IRC registered as {} on {} channels (websocket)",
+            self.config.nick,
+            self.config.channels.len()
+        );
+
+        let tx = self.tx.clone();
+        let nick = self.config.nick.clone();
+        let writer_clone = self.writer.clone();
+        tokio::spawn(async move {
+            // The gateway may chunk multiple IRC lines into a single text
+            // frame; buffer until we see a newline before parsing.
+            let mut leftover = String::new();
+            while let Some(item) = stream.next().await {
+                let payload = match item {
+                    Ok(WsMessage::Text(t)) => t.to_string(),
+                    Ok(WsMessage::Binary(b)) => match String::from_utf8(b.to_vec()) {
+                        Ok(s) => s,
+                        Err(_) => continue,
+                    },
+                    Ok(WsMessage::Close(_)) => break,
+                    Ok(_) => continue,
+                    Err(e) => {
+                        tracing::warn!("IRC-WS read error: {e}");
+                        break;
+                    }
+                };
+                leftover.push_str(&payload);
+                while let Some(idx) = leftover.find('\n') {
+                    let mut line: String = leftover.drain(..=idx).collect();
+                    if line.ends_with('\n') {
+                        line.pop();
+                    }
+                    if line.ends_with('\r') {
+                        line.pop();
+                    }
+                    if line.starts_with("PING") {
+                        let pong = line.replacen("PING", "PONG", 1);
+                        if let Some(Writer::Ws(ref out)) = *writer_clone.lock().await {
+                            let _ = out.send(format!("{}\r\n", pong));
+                        }
+                        continue;
+                    }
+                    if let Some(privmsg) = parse_privmsg(&line, &nick) {
+                        let _ = tx.send(privmsg);
+                    }
+                }
+            }
+            tracing::warn!("IRC read loop ended (websocket)");
         });
 
         Ok(())
@@ -117,10 +235,16 @@ impl ChatClient {
     pub async fn send_raw(&self, line: &str) -> Result<(), String> {
         let mut w = self.writer.lock().await;
         let writer = w.as_mut().ok_or_else(|| "IRC not connected".to_owned())?;
-        writer
-            .write_all(format!("{}\r\n", line).as_bytes())
-            .await
-            .map_err(|e| format!("IRC send failed: {}", e))
+        let framed = format!("{}\r\n", line);
+        match writer {
+            Writer::Tcp(stream) => stream
+                .write_all(framed.as_bytes())
+                .await
+                .map_err(|e| format!("IRC send failed: {}", e)),
+            Writer::Ws(tx) => tx
+                .send(framed)
+                .map_err(|e| format!("IRC-WS send failed: {}", e)),
+        }
     }
 
     /// Whether the client has an active writer (connected).
@@ -131,8 +255,15 @@ impl ChatClient {
     /// Disconnect from the IRC server.
     pub async fn disconnect(&self) {
         let mut w = self.writer.lock().await;
-        if let Some(ref mut writer) = *w {
-            let _ = writer.write_all(b"QUIT :bevy_chat disconnecting\r\n").await;
+        if let Some(writer) = w.as_mut() {
+            match writer {
+                Writer::Tcp(stream) => {
+                    let _ = stream.write_all(b"QUIT :bevy_chat disconnecting\r\n").await;
+                }
+                Writer::Ws(tx) => {
+                    let _ = tx.send("QUIT :bevy_chat disconnecting\r\n".to_owned());
+                }
+            }
         }
         *w = None;
     }
@@ -141,22 +272,14 @@ impl ChatClient {
 /// Parse a raw IRC PRIVMSG line into a `ChatMessage`.
 /// Ignores messages from ourselves (nick match).
 fn parse_privmsg(line: &str, own_nick: &str) -> Option<ChatMessage> {
-    // Format: :sender!user@host PRIVMSG #channel :message text
     let line = line.strip_prefix(':')?;
     let (prefix, rest) = line.split_once(' ')?;
-
-    // Extract sender nick from prefix (nick!user@host)
     let sender_nick = prefix.split('!').next()?;
-
-    // Skip our own messages
     if sender_nick == own_nick {
         return None;
     }
-
     let rest = rest.strip_prefix("PRIVMSG ")?;
     let (channel, message) = rest.split_once(" :")?;
-
-    // Try structured parse first, fall back to raw chat
     ChatMessage::from_irc_privmsg(channel, message)
         .or_else(|| Some(ChatMessage::chat(sender_nick, "irc", channel, message)))
 }
@@ -169,7 +292,7 @@ mod tests {
     #[test]
     fn parse_privmsg_chat() {
         let msg = parse_privmsg(
-            ":Player1!user@host PRIVMSG #global :[CHAT] Player1@discord: hello", // IRC `:` is the PRIVMSG separator
+            ":Player1!user@host PRIVMSG #global :[CHAT] Player1@discord: hello",
             "bot-nick",
         )
         .unwrap();

--- a/packages/rust/bevy/bevy_chat/src/config.rs
+++ b/packages/rust/bevy/bevy_chat/src/config.rs
@@ -1,5 +1,20 @@
 use serde::{Deserialize, Serialize};
 
+/// How the native client reaches the IRC server.
+///
+/// - `Tcp` (default): raw TCP, optionally TLS, used by the Discord bot and
+///   the lightyear server which both run inside our network.
+/// - `WebSocket`: tokio-tungstenite WebSocket transport, used by the
+///   isometric game's desktop build to share the same `wss://chat.kbve.com`
+///   endpoint as the WASM browser client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum IrcTransport {
+    #[default]
+    Tcp,
+    WebSocket,
+}
+
 /// Configuration for connecting to an IRC server.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IrcConfig {
@@ -17,6 +32,11 @@ pub struct IrcConfig {
     pub password: Option<String>,
     /// Reconnect delay in seconds after disconnect (0 = no reconnect).
     pub reconnect_delay_secs: u64,
+    /// Transport mode. Defaults to TCP for backward compatibility with the
+    /// existing IRC-over-TCP consumers; the isometric desktop client sets
+    /// this to `WebSocket` to talk to `wss://chat.kbve.com`.
+    #[serde(default)]
+    pub transport: IrcTransport,
 }
 
 impl Default for IrcConfig {
@@ -29,6 +49,7 @@ impl Default for IrcConfig {
             channels: vec!["#global".to_owned()],
             password: None,
             reconnect_delay_secs: 5,
+            transport: IrcTransport::Tcp,
         }
     }
 }
@@ -75,6 +96,7 @@ impl IrcConfig {
             channels,
             password,
             reconnect_delay_secs,
+            transport: IrcTransport::Tcp,
         }
     }
 }

--- a/packages/rust/bevy/bevy_chat/src/lib.rs
+++ b/packages/rust/bevy/bevy_chat/src/lib.rs
@@ -36,7 +36,7 @@
 mod config;
 mod message;
 
-pub use config::IrcConfig;
+pub use config::{IrcConfig, IrcTransport};
 pub use message::{ChatMessage, MessageKind};
 
 // ── Platform-specific transport ───────────────────────────────────────


### PR DESCRIPTION
Tracks #11246 part A — auth wiring. Chat overlay UI ships in a follow-up.

## bevy_chat
- `IrcTransport` (Tcp / WebSocket) on `IrcConfig`. Same `ChatClient` API targets either raw IRC servers (Discord bot, lightyear) or WebSocket gateways (`wss://chat.kbve.com`). Defaults to Tcp; existing callers don't change.
- WebSocket transport in `client_native` via `tokio-tungstenite` + `rustls-tls-webpki-roots` (no native-tls / openssl-sys).
- Outbound mpsc pump → text frames; inbound reader buffers across frame boundaries so multi-line gateway frames parse correctly.

## isometric game
- `auth_common::CURRENT_JWT` persists the Supabase access token; `current_jwt()` accessor.
- `game::chat` no longer connects at Startup. New Bevy system waits for `current_signin_snapshot()` to report `jwt_valid` + a `kbve_username` claim, then dials `wss://chat.kbve.com` with username = IRC nick and JWT = IRC `PASS`. Joins `#global` and `#world-events`.
- Native: dedicated tokio runtime on a worker thread hosts the async client; broadcast subscriber shuffles messages into the existing crossbeam inbox so `ChatPlugin` reads on the ECS thread.
- WASM: same path as before, now with username + JWT passed through.

## Out of scope (follow-up)
- Chat overlay UI (bottom-left pane + React input).
- Reconnect on disconnect / token refresh.

## Test plan
- [ ] `cargo build --bin isometric-game` clean (verified locally).
- [ ] `cargo build --target wasm32-unknown-unknown -p bevy_chat --features plugin` clean (verified locally).
- [ ] Native: sign in via OAuth → log shows `[chat] sign-in observed; dialing chat.kbve.com as <name>` → `IRC-WS bridge active`.
- [ ] Trigger a world event from elsewhere (Discord) → toast appears in-game.
- [ ] WASM arcade page: same flow, observe `[chat] IRC bridge active (wasm)` in console.