### PR TITLE
fix(astro-kbve): boot profile on main thread; SharedWorker as background fallback

### DIFF
--- a/apps/kbve/astro-kbve/src/components/user/profile-controller.ts
+++ b/apps/kbve/astro-kbve/src/components/user/profile-controller.ts
@@ -427,46 +427,72 @@ export async function bootProfile() {
 		}
 	}
 
-	// Init with timeout — never hang forever
-	try {
-		await Promise.race([
-			initSupa(),
-			new Promise<never>((_, reject) =>
-				setTimeout(
-					() => reject(new Error('Supabase init timed out')),
-					INIT_TIMEOUT_MS,
-				),
-			),
-		]);
-	} catch {
-		if (!painted) switchState('unauth');
-		return;
+	// Main-thread first: if localStorage already has a valid session,
+	// hand it directly to handleSession() and bypass the SharedWorker
+	// initSupa() round-trip entirely. SharedWorker can be slow or
+	// unresponsive (esp. on mobile / cold tab) and was the source of
+	// 12s profile-load timeouts. The worker is now a background nicety
+	// for cross-tab auth events, not a hard dependency for boot.
+	const storageSession = readSupabaseSessionFromStorage();
+	const haveStorageSession = !!(
+		storageSession?.user?.id && storageSession.access_token
+	);
+	if (haveStorageSession) {
+		await handleSession(storageSession as any, 'init');
 	}
 
-	const supa = getSupa();
+	// If neither the fast paint nor a localStorage session painted,
+	// flip to unauth immediately so the user doesn't stare at the
+	// loading spinner while the background SharedWorker path warms up.
+	if (!painted && !haveStorageSession) {
+		switchState('unauth');
+	}
 
-	// Background sync: refresh profile + staff caches on auth events,
-	// tab focus / visibility, and a 15-min fallback timer. Updates the
-	// persistent atoms plus the BroadcastChannel bus so other tabs and
-	// surfaces stay in sync without ever blocking the UI.
-	installProfileSync({
-		apiBase: window.location.origin,
-		supabaseUrl: SUPABASE_URL,
-		supabaseAnonKey: SUPABASE_ANON_KEY,
-		subscribeAuth: (handler) =>
-			supa.on('auth', (msg: unknown) => handler(msg as never)),
-	});
+	// Background: kick off SharedWorker init without blocking the UI.
+	// Once ready, subscribe to cross-tab auth events. If init fails or
+	// hangs we don't care — the main-thread fetch already painted.
+	void (async () => {
+		try {
+			await Promise.race([
+				initSupa(),
+				new Promise<never>((_, reject) =>
+					setTimeout(
+						() => reject(new Error('Supabase init timed out')),
+						INIT_TIMEOUT_MS,
+					),
+				),
+			]);
+		} catch {
+			return;
+		}
 
-	// Get current session
-	const s = await supa.getSession().catch(() => null);
-	const session = s?.session ?? null;
+		const supa = getSupa();
 
-	// Handle current state — refresh whatever the fast paint already showed.
-	await handleSession(session, 'init');
+		// Background sync: refresh profile + staff caches on auth events,
+		// tab focus / visibility, and a 15-min fallback timer. Updates the
+		// persistent atoms plus the BroadcastChannel bus so other tabs and
+		// surfaces stay in sync without ever blocking the UI.
+		installProfileSync({
+			apiBase: window.location.origin,
+			supabaseUrl: SUPABASE_URL,
+			supabaseAnonKey: SUPABASE_ANON_KEY,
+			subscribeAuth: (handler) =>
+				supa.on('auth', (msg: unknown) => handler(msg as never)),
+		});
 
-	// Listen for auth changes (sign-in / sign-out from other tabs or navbar)
-	supa.on('auth', async (msg: any) => {
-		const newSession = msg.session ?? null;
-		await handleSession(newSession, 'auth-event');
-	});
+		// If we never got a localStorage session above, ask the gateway
+		// for one as a fallback — covers fresh sign-ins that arrived
+		// after page load.
+		if (!haveStorageSession) {
+			const s = await supa.getSession().catch(() => null);
+			const session = s?.session ?? null;
+			if (session) await handleSession(session, 'init');
+		}
+
+		// Listen for cross-tab sign-in / sign-out.
+		supa.on('auth', async (msg: any) => {
+			const newSession = msg.session ?? null;
+			await handleSession(newSession, 'auth-event');
+		});
+	})();
 }


### PR DESCRIPTION
## Summary
\`/profile\` (and any surface that boots through \`profile-controller.ts\`) sometimes hangs on "Loading…" for up to 12s before timing out. The hang sits inside \`initSupa()\` — the SharedWorker round-trip used to resolve the Supabase session. On mobile, cold tabs, or any state where the worker is slow / blocked / unresponsive, boot stalls there before the main-thread profile fetch ever runs.

The session already lives in \`localStorage\` (\`sb-auth-token\`), and the \`/api/v1/profile/me\` call is plain main-thread fetch. There's no reason to gate either on the worker.

## What changes
\`bootProfile()\` now:
1. **Fast paint** cached profile from \`localStorage\` (unchanged).
2. **Reads the session from \`localStorage\` directly** and calls \`handleSession()\` on the main thread — bypasses SharedWorker entirely for the common path.
3. **Flips to \`unauth\` immediately** if neither the fast paint nor the localStorage session painted anything. No more 12-second loading spinner for signed-out visitors.
4. **Kicks \`initSupa()\` off in the background** (no \`await\` on the boot path). Once it resolves it installs \`installProfileSync\` and subscribes to cross-tab auth events. If it never resolves the page still works — we just don't get cross-tab pushes.
5. **Falls back to \`supa.getSession()\`** only if localStorage was empty (fresh sign-in arriving after page load).

## Test plan
- [ ] Signed-in cold load → profile card renders in < 1s, no loading spinner stall.
- [ ] Signed-out cold load → \`unauth\` state shows immediately, no 12s wait.
- [ ] Sign in from navbar → cross-tab event still propagates (background \`installProfileSync\` handles it).
- [ ] Hard-disabled SharedWorker (DevTools → Sources → Service workers / blocked) → /profile still works.
- [ ] Mobile cold tab (Safari) → no timeout.