### PR TITLE
fix(mc/lobby): bake AdvancedPortals enableProxySupport=true

### DIFF
--- a/apps/mc/lobby/Dockerfile
+++ b/apps/mc/lobby/Dockerfile
@@ -109,6 +109,14 @@ ENV JVM_XX_OPTS="-XX:+UseZGC -XX:+ZGenerational -XX:+AlwaysPreTouch -XX:+Disable
 # section is still present at /config/paper-global.yml on first boot.
 COPY apps/mc/lobby/config/ /config/
 
+# AdvancedPortals ships with enableProxySupport: false by default, which
+# silently breaks every portal that uses a `bungee: - <server>` arg —
+# the portal triggers but the proxy-side server switch never fires.
+# Seed the patched copy directly into /plugins/AdvancedPortals/ so first
+# boot copies it in instead of generating the default.
+COPY apps/mc/lobby/config/plugins/AdvancedPortals/config.yaml \
+    /plugins/AdvancedPortals/config.yaml
+
 # Source-built kbve-mc-uplink plugin — forwards death/advancement events
 # to the Velocity-side discord relay over the kbve:relay-events channel.
 COPY --from=plugin-builder /build/build/libs/kbve-mc-uplink-*.jar \

--- a/apps/mc/lobby/config/plugins/AdvancedPortals/config.yaml
+++ b/apps/mc/lobby/config/plugins/AdvancedPortals/config.yaml
@@ -1,0 +1,29 @@
+blockSpectatorMode: true
+commandPortals:
+    console: true
+    enabled: true
+    op: true
+    permsWildcard: true
+    proxy: true
+defaultTriggerBlock: NETHER_PORTAL
+disableGatewayBeam: true
+disablePhysicsEvents: true
+enableProxySupport: true
+joinCooldown: 5
+maxPortalVisualisationSize: 1000
+maxSelectionVisualisationSize: 9000
+playFailSound: true
+portalProtection: true
+portalProtectionRadius: 5
+selectorMaterial: IRON_AXE
+showVisibleRange: 50
+stopWaterFlow: true
+throwbackStrength: 0.7
+translationFile: en_GB
+useOnlySpecialAxe: true
+warpEffect:
+    enabled: true
+    soundEffect: ender
+    visualEffect: ender
+warpMessageInChat: false
+warpMessageOnActionBar: true


### PR DESCRIPTION
## Summary
The survival portal at world `(5, -54..-57, -1..1)` had `bungee: -mc` set, but walking through it did nothing. Pulled the live PVC copy:

\`\`\`
$ kubectl exec mc-lobby-... -- cat /data/plugins/AdvancedPortals/config.yaml
...
enableProxySupport: false
...
\`\`\`

AdvancedPortals ships its default config with proxy support **off**. Any portal with a `bungee:` arg fires the portalEvent locally but never sends the proxy-side server-switch packet — player just stands on the portal block.

## Fix
- New [`apps/mc/lobby/config/plugins/AdvancedPortals/config.yaml`](apps/mc/lobby/config/plugins/AdvancedPortals/config.yaml) with `enableProxySupport: true`. All other AdvancedPortals defaults preserved unchanged.
- [`apps/mc/lobby/Dockerfile`](apps/mc/lobby/Dockerfile) copies it into `/plugins/AdvancedPortals/config.yaml` during image build so first-boot PVC seeding picks it up instead of generating the broken default.

## Already hotfixed on running pod
- `kubectl exec mc-lobby-... -- sed -i 's/false/true/' /data/plugins/AdvancedPortals/config.yaml`
- `kubectl rollout restart deployment/mc-lobby`
- New pod (`mc-lobby-77f8b8977f-wtznf`) came up with proxy support enabled. Survival portal works again.

This PR is for the **persistent** fix so a fresh PVC (wipe / migration / cluster rebuild) doesn't regress.

## Test plan
- [ ] Walk through the survival portal in the lobby → Velocity moves you to the mc-fabric backend.
- [ ] First boot on a fresh PVC: `cat /data/plugins/AdvancedPortals/config.yaml` shows `enableProxySupport: true`.
- [ ] All other AdvancedPortals defaults remain intact (compare to v2.6.1 reference).