### PR TITLE
feat(isometric): in-game chat overlay + input (#11246 part B)

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/commands.rs
+++ b/apps/kbve/isometric/src-tauri/src/commands.rs
@@ -178,6 +178,12 @@ pub fn set_username(username: String) {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[tauri::command]
+pub fn send_chat(text: String) -> bool {
+    crate::game::chat::queue_outgoing_chat(&text)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tauri::command]
 pub fn open_oauth_url(app: tauri::AppHandle, provider: String) -> Result<(), String> {
     use tauri_plugin_opener::OpenerExt;
     let redirect = crate::auth::build_redirect_url();
@@ -270,6 +276,12 @@ pub fn set_signed_in(jwt: &str) {
 #[wasm_bindgen]
 pub fn set_username(username: &str) {
     crate::game::net::request_set_username(username);
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn send_chat(text: &str) -> bool {
+    crate::game::chat::queue_outgoing_chat(text)
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/apps/kbve/isometric/src-tauri/src/game/chat.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/chat.rs
@@ -8,10 +8,36 @@
 //! cross-platform world events.
 
 use bevy::prelude::*;
-use bevy_chat::{ChatPlugin, IncomingChatEvent, IrcConfig, IrcTransport, MessageKind};
+use bevy_chat::{ChatMessage, ChatPlugin, IncomingChatEvent, IrcConfig, IrcTransport, MessageKind};
 use crossbeam_channel::{Receiver, Sender, unbounded};
+use std::sync::OnceLock;
 
 use super::toast::Toast;
+
+/// Default channel new messages from the React input box land on.
+pub const DEFAULT_SEND_CHANNEL: &str = "#global";
+
+/// Outbox sender exposed for the `send_chat` Tauri command + wasm-bindgen
+/// export. Set once when the chat plugin builds; readers must tolerate a
+/// `None` value before that happens.
+static OUTBOX_TX: OnceLock<Sender<ChatMessage>> = OnceLock::new();
+
+/// Build and queue a `ChatMessage` from raw user input. Returns `false` if
+/// chat hasn't initialized yet or the user is not signed in (no nick).
+pub fn queue_outgoing_chat(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let Some(tx) = OUTBOX_TX.get() else {
+        return false;
+    };
+    let nick = crate::auth_common::current_signin_snapshot()
+        .username
+        .unwrap_or_else(|| "guest".to_owned());
+    let msg = ChatMessage::chat(&nick, "isometric", DEFAULT_SEND_CHANNEL, trimmed);
+    tx.send(msg).is_ok()
+}
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -57,6 +83,7 @@ impl Plugin for GameChatPlugin {
             outbox_rx,
         });
         app.init_resource::<ChatSession>();
+        let _ = OUTBOX_TX.set(outbox_tx);
 
         // Connect chat lazily: wait for the user to sign in (PreFlight
         // observes `kbve_username` + JWT), then dial `wss://chat.kbve.com`
@@ -97,7 +124,12 @@ fn connect_chat_on_signin(mut session: ResMut<ChatSession>, channels: Res<ChatBr
     session.connected = true;
     session.nick = Some(nick.clone());
     info!("[chat] sign-in observed; dialing chat.kbve.com as {nick}");
-    spawn_chat_connection(&channels, nick, jwt);
+    spawn_chat_connection(
+        channels.inbox_tx.clone(),
+        channels.outbox_rx.clone(),
+        nick,
+        jwt,
+    );
 }
 
 /// Stores the inbox sender (called by the IRC client when messages arrive)
@@ -127,7 +159,12 @@ fn chat_config(nick: String, jwt: String) -> IrcConfig {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn spawn_chat_connection(channels: &ChatBridgeChannels, nick: String, jwt: String) {
+fn spawn_chat_connection(
+    inbox_tx: Sender<ChatMessage>,
+    outbox_rx: Receiver<ChatMessage>,
+    nick: String,
+    jwt: String,
+) {
     use bevy_chat::ChatClient;
     use wasm_bindgen::JsCast;
 
@@ -142,11 +179,19 @@ fn spawn_chat_connection(channels: &ChatBridgeChannels, nick: String, jwt: Strin
         return;
     }
 
-    let inbox_tx = channels.inbox_tx.clone();
+    // Inbound: drain WASM client buffer into ECS crossbeam inbox each tick.
+    // Outbound: pull queued ChatMessages and ship via the WebSocket. Both
+    // run inside the same setInterval so we don't leak two timers.
     let client_for_poll = client.clone();
     let closure = wasm_bindgen::prelude::Closure::wrap(Box::new(move || {
         for msg in client_for_poll.drain_incoming() {
             let _ = inbox_tx.send(msg);
+        }
+        while let Ok(out) = outbox_rx.try_recv() {
+            if let Err(e) = client_for_poll.send(&out) {
+                warn!("[chat] outbound send failed: {e}");
+                break;
+            }
         }
     }) as Box<dyn FnMut()>);
     if let Some(window) = web_sys::window() {
@@ -160,12 +205,16 @@ fn spawn_chat_connection(channels: &ChatBridgeChannels, nick: String, jwt: Strin
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn spawn_chat_connection(channels: &ChatBridgeChannels, nick: String, jwt: String) {
+fn spawn_chat_connection(
+    inbox_tx: Sender<ChatMessage>,
+    outbox_rx: Receiver<ChatMessage>,
+    nick: String,
+    jwt: String,
+) {
     use bevy_chat::ChatClient;
 
     let config = chat_config(nick, jwt);
     let host = config.host.clone();
-    let inbox_tx = channels.inbox_tx.clone();
     info!(
         "[chat] connecting to IRC gateway at {} (nick={})",
         host, config.nick
@@ -173,9 +222,9 @@ fn spawn_chat_connection(channels: &ChatBridgeChannels, nick: String, jwt: Strin
 
     // Bevy runs sync — drive the async connect on a dedicated tokio
     // runtime spawned on a worker thread. The runtime lives for the
-    // process lifetime; broadcast receiver shuffles each `ChatMessage`
-    // into the crossbeam inbox so `ChatPlugin::receive_inbox` can read
-    // it on the main ECS thread.
+    // process lifetime; one task forwards incoming messages into the
+    // crossbeam inbox, another drains the outbox channel and pushes each
+    // queued ChatMessage onto the WebSocket.
     std::thread::Builder::new()
         .name("chat-irc-ws".to_string())
         .spawn(move || {
@@ -197,6 +246,31 @@ fn spawn_chat_connection(channels: &ChatBridgeChannels, nick: String, jwt: Strin
                     return;
                 }
                 info!("[chat] native IRC-WS bridge active");
+
+                // Outbound: spawn a task that pulls from the crossbeam
+                // outbox in a blocking loop on a tokio blocking thread,
+                // forwarding each message via the async send. Using
+                // spawn_blocking keeps the synchronous Receiver::recv
+                // call off the async executor.
+                let client_send = client.clone();
+                tokio::spawn(async move {
+                    loop {
+                        let outbox = outbox_rx.clone();
+                        let next = tokio::task::spawn_blocking(move || outbox.recv())
+                            .await
+                            .ok()
+                            .and_then(|r| r.ok());
+                        let Some(msg) = next else {
+                            break;
+                        };
+                        if let Err(e) = client_send.send(&msg).await {
+                            warn!("[chat] outbound send failed: {e}");
+                            break;
+                        }
+                    }
+                    warn!("[chat] native outbound pump ended");
+                });
+
                 while let Ok(msg) = subscriber.recv().await {
                     if inbox_tx.send(msg).is_err() {
                         break;
@@ -211,9 +285,6 @@ fn spawn_chat_connection(channels: &ChatBridgeChannels, nick: String, jwt: Strin
 // ---------------------------------------------------------------------------
 // Event bridge: IncomingChatEvent → Toast
 // ---------------------------------------------------------------------------
-
-#[allow(unused_imports)]
-use bevy_chat::ChatMessage;
 
 fn world_events_to_toasts(mut events: MessageReader<IncomingChatEvent>, mut commands: Commands) {
     for IncomingChatEvent(msg) in events.read() {

--- a/apps/kbve/isometric/src-tauri/src/game/chat_ui.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/chat_ui.rs
@@ -1,0 +1,177 @@
+//! Bottom-left chat log overlay.
+//!
+//! Renders the last `CHAT_HISTORY_MAX` incoming chat messages as a
+//! semi-transparent glass panel anchored above the joystick. The React
+//! `ChatInput.tsx` component handles the actual text entry — it submits
+//! through the `send_chat` Tauri command / wasm-bindgen export which
+//! enqueues a `ChatMessage` on the chat outbox.
+
+use bevy::picking::Pickable;
+use bevy::prelude::*;
+use bevy::ui::FocusPolicy;
+use bevy_chat::{IncomingChatEvent, MessageKind};
+
+use super::phase::GamePhase;
+use super::ui_color;
+
+const CHAT_HISTORY_MAX: usize = 30;
+const PANEL_WIDTH: f32 = 320.0;
+const PANEL_MAX_HEIGHT: f32 = 200.0;
+
+#[derive(Resource, Default)]
+struct ChatLog {
+    /// Ring buffer of recent lines: (display label, body).
+    entries: Vec<ChatLogEntry>,
+}
+
+#[derive(Clone)]
+struct ChatLogEntry {
+    sender: String,
+    content: String,
+    color: Color,
+}
+
+#[derive(Component)]
+struct ChatOverlayRoot;
+
+#[derive(Component)]
+struct ChatLogList;
+
+pub struct ChatUiPlugin;
+
+impl Plugin for ChatUiPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ChatLog>();
+        app.add_systems(OnEnter(GamePhase::Playing), spawn_chat_overlay);
+        app.add_systems(
+            Update,
+            (ingest_incoming, render_log).run_if(in_state(GamePhase::Playing)),
+        );
+    }
+}
+
+fn spawn_chat_overlay(mut commands: Commands) {
+    commands
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(16.0),
+                bottom: Val::Px(212.0),
+                width: Val::Px(PANEL_WIDTH),
+                max_height: Val::Px(PANEL_MAX_HEIGHT),
+                flex_direction: FlexDirection::Column,
+                padding: UiRect::all(Val::Px(8.0)),
+                row_gap: Val::Px(2.0),
+                border_radius: BorderRadius::all(Val::Px(6.0)),
+                overflow: Overflow::clip(),
+                ..default()
+            },
+            BackgroundColor(Color::srgba(0.05, 0.05, 0.08, 0.75)),
+            GlobalZIndex(55),
+            FocusPolicy::Pass,
+            Pickable::IGNORE,
+            DespawnOnExit(GamePhase::Playing),
+            ChatOverlayRoot,
+        ))
+        .with_child((
+            Node {
+                width: Val::Percent(100.0),
+                flex_direction: FlexDirection::Column,
+                row_gap: Val::Px(2.0),
+                ..default()
+            },
+            FocusPolicy::Pass,
+            Pickable::IGNORE,
+            ChatLogList,
+        ));
+}
+
+fn ingest_incoming(mut events: MessageReader<IncomingChatEvent>, mut log: ResMut<ChatLog>) {
+    for IncomingChatEvent(msg) in events.read() {
+        // Skip world-events; those already toast.
+        if msg.channel == "#world-events" {
+            continue;
+        }
+        let color = color_for_kind(&msg.kind);
+        log.entries.push(ChatLogEntry {
+            sender: msg.sender.clone(),
+            content: msg.content.clone(),
+            color,
+        });
+        if log.entries.len() > CHAT_HISTORY_MAX {
+            let excess = log.entries.len() - CHAT_HISTORY_MAX;
+            log.entries.drain(0..excess);
+        }
+    }
+}
+
+fn color_for_kind(kind: &MessageKind) -> Color {
+    match kind {
+        MessageKind::Chat => ui_color::TEXT_PRIMARY,
+        MessageKind::System => ui_color::TEXT_SECONDARY,
+        _ => ui_color::TEXT_ACCENT,
+    }
+}
+
+fn render_log(
+    mut commands: Commands,
+    log: Res<ChatLog>,
+    list_q: Query<Entity, With<ChatLogList>>,
+    existing: Query<Entity, (With<ChatLogLine>, Without<ChatLogList>)>,
+) {
+    if !log.is_changed() {
+        return;
+    }
+    for e in &existing {
+        commands.entity(e).despawn();
+    }
+    let Ok(list) = list_q.single() else {
+        return;
+    };
+    let visible = log
+        .entries
+        .iter()
+        .rev()
+        .take(CHAT_HISTORY_MAX)
+        .collect::<Vec<_>>();
+    commands.entity(list).with_children(|list_children| {
+        for entry in visible.iter().rev() {
+            list_children
+                .spawn((
+                    Node {
+                        flex_direction: FlexDirection::Row,
+                        column_gap: Val::Px(4.0),
+                        ..default()
+                    },
+                    FocusPolicy::Pass,
+                    Pickable::IGNORE,
+                    ChatLogLine,
+                ))
+                .with_children(|line| {
+                    line.spawn((
+                        Text::new(format!("{}:", entry.sender)),
+                        TextFont {
+                            font_size: 11.0,
+                            ..default()
+                        },
+                        TextColor(entry.color),
+                        FocusPolicy::Pass,
+                        Pickable::IGNORE,
+                    ));
+                    line.spawn((
+                        Text::new(entry.content.clone()),
+                        TextFont {
+                            font_size: 11.0,
+                            ..default()
+                        },
+                        TextColor(ui_color::TEXT_PRIMARY),
+                        FocusPolicy::Pass,
+                        Pickable::IGNORE,
+                    ));
+                });
+        }
+    });
+}
+
+#[derive(Component)]
+struct ChatLogLine;

--- a/apps/kbve/isometric/src-tauri/src/game/mod.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/mod.rs
@@ -3,6 +3,7 @@ pub mod camera;
 pub mod campfire;
 pub mod candle;
 pub mod chat;
+pub mod chat_ui;
 pub mod client_profile;
 pub mod crafting_ui;
 pub mod creatures;
@@ -187,6 +188,7 @@ impl PluginGroup for GamePluginGroup {
             .add(PixelatePlugin)
             .add(toast::ToastPlugin)
             .add(chat::GameChatPlugin)
+            .add(chat_ui::ChatUiPlugin)
             .add(InteractionUiPlugin)
             .add(InventoryUiPlugin)
             .add(EquipmentUiPlugin)

--- a/apps/kbve/isometric/src-tauri/src/game/pause_menu.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/pause_menu.rs
@@ -24,6 +24,7 @@ pub enum UiOverlay {
     Equipment,
     Crafting,
     Deploy,
+    Chat,
 }
 
 impl UiOverlay {

--- a/apps/kbve/isometric/src-tauri/src/main.rs
+++ b/apps/kbve/isometric/src-tauri/src/main.rs
@@ -62,6 +62,7 @@ fn main() {
                     isometric_game::commands::open_oauth_url,
                     isometric_game::commands::get_signin_state,
                     isometric_game::commands::set_username,
+                    isometric_game::commands::send_chat,
                 ])
                 .setup(|app| {
                     use tauri_plugin_deep_link::DeepLinkExt;

--- a/apps/kbve/isometric/src/App.tsx
+++ b/apps/kbve/isometric/src/App.tsx
@@ -1,3 +1,4 @@
+import { ChatInput } from './components/ChatInput';
 import { HUD } from './components/HUD';
 import { FPSCounter } from './components/FPSCounter';
 import { ObjectLabel } from './components/ObjectLabel';
@@ -13,6 +14,7 @@ function App() {
 			<HUD />
 			<ObjectLabel />
 			<UsernameModal />
+			<ChatInput />
 		</div>
 	);
 }

--- a/apps/kbve/isometric/src/components/ChatInput.tsx
+++ b/apps/kbve/isometric/src/components/ChatInput.tsx
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { GlassPanel } from '../ui/shared/GlassPanel';
+
+function detectTauri(): boolean {
+	return !!(
+		(window as typeof window & { __TAURI_INTERNALS__?: unknown })
+			.__TAURI_INTERNALS__ ||
+		(window as typeof window & { __TAURI__?: unknown }).__TAURI__
+	);
+}
+
+async function sendChat(text: string): Promise<boolean> {
+	if (!text.trim()) return false;
+	if (detectTauri()) {
+		try {
+			return await invoke<boolean>('send_chat', { text });
+		} catch (err) {
+			console.warn('[chat] send_chat (tauri) threw', err);
+			return false;
+		}
+	}
+	try {
+		const mod = await import('../../wasm-pkg/isometric_game.js');
+		const fn = (mod as unknown as { send_chat?: (s: string) => boolean })
+			.send_chat;
+		if (typeof fn !== 'function') return false;
+		return fn(text);
+	} catch (err) {
+		console.warn('[chat] send_chat (wasm) threw', err);
+		return false;
+	}
+}
+
+/**
+ * Chat input — focused via `T`, sent via Enter, cancelled via Esc.
+ *
+ * The Bevy side renders the log overlay; this component owns the text-entry
+ * UI because Bevy has no native input widget. The input only renders while
+ * focused so the rest of the game keeps keyboard control.
+ */
+export function ChatInput() {
+	const [open, setOpen] = useState(false);
+	const [value, setValue] = useState('');
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			// Ignore keystrokes while already typing into another input.
+			const target = e.target as HTMLElement | null;
+			if (target && target.tagName === 'INPUT') {
+				if (target === inputRef.current && e.key === 'Escape') {
+					setOpen(false);
+					setValue('');
+				}
+				return;
+			}
+			if (e.key === 'T' || e.key === 't') {
+				if (!e.metaKey && !e.ctrlKey && !e.altKey) {
+					e.preventDefault();
+					setOpen(true);
+				}
+			} else if (e.key === 'Escape' && open) {
+				setOpen(false);
+				setValue('');
+			}
+		};
+		window.addEventListener('keydown', onKeyDown, true);
+		return () => window.removeEventListener('keydown', onKeyDown, true);
+	}, [open]);
+
+	useEffect(() => {
+		if (open) {
+			inputRef.current?.focus();
+		}
+	}, [open]);
+
+	const submit = useCallback(async () => {
+		const text = value.trim();
+		if (!text) {
+			setOpen(false);
+			return;
+		}
+		const ok = await sendChat(text);
+		if (!ok) {
+			console.warn('[chat] send failed (not connected or rejected)');
+		}
+		setValue('');
+		setOpen(false);
+	}, [value]);
+
+	if (!open) return null;
+
+	return (
+		<div className="fixed left-4 bottom-[180px] z-[80] pointer-events-auto w-[320px]">
+			<GlassPanel className="px-3 py-2">
+				<input
+					ref={inputRef}
+					type="text"
+					maxLength={300}
+					value={value}
+					onChange={(e) => setValue(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter') {
+							e.preventDefault();
+							void submit();
+						}
+					}}
+					placeholder="Say something to #global..."
+					className="w-full bg-transparent outline-none text-sm text-text placeholder:text-text-muted"
+				/>
+			</GlassPanel>
+		</div>
+	);
+}


### PR DESCRIPTION
Follow-up to #11275 which wired authenticated chat.kbve.com WebSocket. This PR adds the user-facing surface and the outbound plumbing.

## Bevy
- `game::chat_ui::ChatUiPlugin` renders a bottom-left log pane during `GamePhase::Playing`. 30-line ring buffer of incoming chat, rerenders only on change. World-events still go to toast.
- `game::chat` exposes a static `OUTBOX_TX` + `queue_outgoing_chat(text)` so React / Tauri can enqueue messages without grabbing an ECS handle. Connection task drains the outbox and forwards through `ChatClient::send` (native via `spawn_blocking`, WASM via the same `setInterval` that drains incoming).
- `UiOverlay::Chat` added for future input-blocking gating.

## React
- `ChatInput.tsx` mounted from `App.tsx`. `T` focuses, `Enter` submits, `Esc` cancels. Submit dispatches to the new `send_chat` Tauri command (native) or `send_chat` wasm-bindgen export.
- Only renders while focused; the rest of the game keeps keyboard control until the player opens chat.

## Out of scope (follow-up)
- Cooldown / spam guard on outbound sends.
- Channel switcher / DMs.
- Emoji autocomplete.

## Test plan
- [ ] `cargo build --bin isometric-game` + `BUILD_TARGET=tauri pnpm exec vite build` clean (verified locally).
- [ ] Sign in → land in Playing → log pane visible bottom-left above the joystick.
- [ ] Press T → input appears focused → type → Enter → message round-trips through `wss://chat.kbve.com` and shows up in the log.
- [ ] Press Esc with input open → input dismissed, no send.
- [ ] WASM arcade page: same flow via `send_chat` wasm export.