### PR TITLE
fix(mc-velocity): install AdvancedPortals plugin on Velocity proxy

### DIFF
--- a/apps/kube/agones/mc/manifests/velocity-deployment.yaml
+++ b/apps/kube/agones/mc/manifests/velocity-deployment.yaml
@@ -76,8 +76,19 @@ spec:
                       # 5.5.17 is the latest Velocity release; 5.5.x versions
                       # share a stable plugin-messaging wire format so the
                       # 4-patch gap to Fabric 5.5.21 is safe.
+                      # The Advanced-Portals-Spigot-2.7.1.jar is a universal
+                      # bundle — same JAR exposes a Paper plugin entrypoint on
+                      # the lobby AND a Velocity plugin entrypoint here
+                      # (velocity-plugin.json declares
+                      # AdvancedPortalsVelocityPlugin). Without the proxy-side
+                      # half installed, the lobby's portal trigger fires but
+                      # the cross-server switch silently no-ops because nothing
+                      # on Velocity is listening on the AdvancedPortals plugin
+                      # channel. Project axTqSWQA / version AXKMcS6i pins to
+                      # 2.7.1 to stay in lockstep with the Modrinth slug
+                      # `advanced-portals` pulled by the lobby image.
                       - name: PLUGINS
-                        value: 'https://cdn.modrinth.com/data/Vebnzrzj/versions/GZjsuCmU/LuckPerms-Velocity-5.5.17.jar'
+                        value: 'https://cdn.modrinth.com/data/Vebnzrzj/versions/GZjsuCmU/LuckPerms-Velocity-5.5.17.jar,https://cdn.modrinth.com/data/axTqSWQA/versions/AXKMcS6i/Advanced-Portals-Spigot-2.7.1.jar'
                       # Matches the LuckPerms env vars on the Fabric fleet pod.
                       # EnvironmentVariableConfigAdapter overrides the on-disk
                       # luckperms.conf without touching the PVC.


### PR DESCRIPTION
## Summary

Lobby ↔ survival nether portal fires the trigger (cooldown-protection warning is printed; `enableProxySupport: true`, `enableProxySupport` patch v1.0.8 in #11277), but the cross-server transfer silently no-ops.

Root cause: Velocity is missing the proxy-side half of AdvancedPortals.

Pulled `Advanced-Portals-Spigot-2.7.1.jar` from the running lobby pod and inspected the JAR — it contains `velocity-plugin.json`:

```json
{"id":"advancedportals","main":"com.sekwah.advancedportals.velocity.AdvancedPortalsVelocityPlugin"}
```

The same JAR is BOTH the Paper plugin AND the Velocity plugin. The Spigot side sends a plugin-message to switch servers; without `AdvancedPortalsVelocityPlugin` loaded on Velocity, nothing on the proxy is listening on that channel and the player stays on the lobby.

Fix: append the universal JAR to itzg's `PLUGINS` env var on the Velocity Deployment (same Modrinth-pinned URL pattern already used for LuckPerms-Velocity). Pinned to project `axTqSWQA` / version `AXKMcS6i` so the proxy half stays in lockstep with the `advanced-portals` slug the lobby pulls.

- AdvancedPortals 2.7.1 universal bundle baked into Velocity via `PLUGINS=...,Advanced-Portals-Spigot-2.7.1.jar`
- No code in `apps/mc/velocity/` touched — env-driven plugin load matches the existing LuckPerms-Velocity pattern.

## Test plan

- [ ] Velocity Deployment rolls out and pod logs `[advancedportals] AdvancedPortals Velocity loaded` (or similar) at boot
- [ ] In the lobby, walk into the survival nether portal — proxy switches the player to the `mc` backend without manual `/server mc`
- [ ] LuckPerms-Velocity still loads (sanity check that the PLUGINS comma-split didn't break the existing entry)