### PR TITLE
test(mc-e2e): cover plugin load + SpawnAutoClaim regressions

### DIFF
--- a/apps/mc/e2e/helpers/docker.ts
+++ b/apps/mc/e2e/helpers/docker.ts
@@ -1,0 +1,10 @@
+import { execSync } from 'child_process';
+
+const CONTAINER = process.env.MC_CONTAINER ?? 'mc-e2e';
+
+export function dockerLogs(container = CONTAINER): string {
+	return execSync(`docker logs ${container} 2>&1`, {
+		encoding: 'utf8',
+		maxBuffer: 32 * 1024 * 1024,
+	});
+}

--- a/apps/mc/e2e/spawn-claim.spec.ts
+++ b/apps/mc/e2e/spawn-claim.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { waitForRcon } from './helpers/rcon';
+import { dockerLogs } from './helpers/docker';
+
+const SPAWN_CLAIM_LOG =
+	/\[spawn-autoclaim\] dimension=minecraft:overworld chunks=\(-13,-13\)\.\.\(12,12\) claimed=(\d+) skipped=(\d+) failed=(\d+)/;
+
+const EXPECTED_TOTAL = 26 * 26;
+
+async function waitForClaimLog(
+	timeoutMs = 60_000,
+	intervalMs = 1_000,
+): Promise<RegExpMatchArray> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const match = dockerLogs().match(SPAWN_CLAIM_LOG);
+		if (match) return match;
+		await new Promise((r) => setTimeout(r, intervalMs));
+	}
+	throw new Error(
+		`spawn-autoclaim summary log not seen within ${timeoutMs}ms`,
+	);
+}
+
+describe('SpawnAutoClaim boot regression', () => {
+	let match: RegExpMatchArray;
+
+	beforeAll(async () => {
+		await waitForRcon();
+		match = await waitForClaimLog();
+	});
+
+	it('OPAC mod is loaded', () => {
+		const logs = dockerLogs();
+		expect(logs).not.toMatch(/\[spawn-autoclaim\] OPAC not loaded/);
+	});
+
+	it('OPAC API reflection bound cleanly', () => {
+		const logs = dockerLogs();
+		expect(logs).not.toMatch(
+			/\[spawn-autoclaim\] OPAC API signature mismatch|\[spawn-autoclaim\] OPAC bootstrap failed/,
+		);
+	});
+
+	it('claims the full 26x26 chunk square at spawn', () => {
+		const claimed = parseInt(match[1], 10);
+		const skipped = parseInt(match[2], 10);
+		const failed = parseInt(match[3], 10);
+		expect(failed).toBe(0);
+		expect(claimed + skipped).toBe(EXPECTED_TOTAL);
+	});
+
+	it('first-boot claim covers the cube without skips', () => {
+		const claimed = parseInt(match[1], 10);
+		expect(claimed).toBe(EXPECTED_TOTAL);
+	});
+});

--- a/apps/mc/lobby/e2e/helpers/docker.ts
+++ b/apps/mc/lobby/e2e/helpers/docker.ts
@@ -1,0 +1,20 @@
+import { execSync } from 'child_process';
+
+const CONTAINER = process.env.LOBBY_CONTAINER ?? 'mc-lobby-e2e';
+
+export function dockerLogs(container = CONTAINER): string {
+	return execSync(`docker logs ${container} 2>&1`, {
+		encoding: 'utf8',
+		maxBuffer: 32 * 1024 * 1024,
+	});
+}
+
+export function dockerExec(cmd: string, container = CONTAINER): string {
+	return execSync(
+		`docker exec ${container} sh -c '${cmd.replace(/'/g, "'\\''")}' 2>&1`,
+		{
+			encoding: 'utf8',
+			maxBuffer: 8 * 1024 * 1024,
+		},
+	);
+}

--- a/apps/mc/lobby/e2e/plugins.spec.ts
+++ b/apps/mc/lobby/e2e/plugins.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { RconClient, waitForRcon } from './helpers/rcon';
+import { dockerExec, dockerLogs } from './helpers/docker';
+
+describe('MC lobby plugin load', () => {
+	let rcon: RconClient;
+
+	beforeAll(async () => {
+		await waitForRcon();
+		rcon = new RconClient();
+		await rcon.connect();
+		await rcon.authenticate();
+	});
+
+	afterAll(() => {
+		rcon?.disconnect();
+	});
+
+	it('reports AdvancedPortals in /plugins', async () => {
+		const response = await rcon.command('plugins');
+		expect(response).toMatch(/AdvancedPortals/);
+	});
+
+	it('reports EssentialsX + EssentialsXSpawn in /plugins', async () => {
+		const response = await rcon.command('plugins');
+		expect(response).toMatch(/EssentialsX(?!\w)/);
+		expect(response).toMatch(/EssentialsXSpawn/);
+	});
+
+	it('reports LuckPerms in /plugins', async () => {
+		const response = await rcon.command('plugins');
+		expect(response).toMatch(/LuckPerms/);
+	});
+
+	it('reports kbve-mc-uplink in /plugins', async () => {
+		const response = await rcon.command('plugins');
+		expect(response).toMatch(/kbve-mc-uplink|uplink/i);
+	});
+
+	it('baked AdvancedPortals config enables proxy support', () => {
+		const config = dockerExec(
+			'cat /data/plugins/AdvancedPortals/config.yaml',
+		);
+		expect(config).toMatch(/enableProxySupport:\s*true/);
+	});
+
+	it('logs no plugin load failures', () => {
+		const logs = dockerLogs();
+		expect(logs).not.toMatch(
+			/Could not load .*plugin|ClassNotFoundException.*Plugin|Could not load 'plugins/i,
+		);
+	});
+});

--- a/apps/mc/velocity/e2e/helpers/docker.ts
+++ b/apps/mc/velocity/e2e/helpers/docker.ts
@@ -1,0 +1,10 @@
+import { execSync } from 'child_process';
+
+const CONTAINER = process.env.VELOCITY_CONTAINER ?? 'mc-velocity-e2e';
+
+export function dockerLogs(container = CONTAINER): string {
+	return execSync(`docker logs ${container} 2>&1`, {
+		encoding: 'utf8',
+		maxBuffer: 32 * 1024 * 1024,
+	});
+}

--- a/apps/mc/velocity/e2e/plugins.spec.ts
+++ b/apps/mc/velocity/e2e/plugins.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { dockerLogs } from './helpers/docker';
+
+describe('MC velocity proxy plugins', () => {
+	it('loads kbve-velocity-commands', () => {
+		const logs = dockerLogs();
+		expect(logs).toMatch(/KBVE Velocity Commands/);
+	});
+
+	it('loads LuckPerms-Velocity', () => {
+		const logs = dockerLogs();
+		expect(logs).toMatch(/LuckPerms v\d/);
+	});
+
+	it('loads AdvancedPortals proxy plugin', () => {
+		const logs = dockerLogs();
+		expect(logs).toMatch(/advancedportals|AdvancedPortals/);
+	});
+
+	it('logs no plugin discovery errors', () => {
+		const logs = dockerLogs();
+		expect(logs).not.toMatch(
+			/Couldn't load plugin|ClassNotFoundException.*Plugin|Failed to load plugin/i,
+		);
+	});
+});

--- a/apps/mc/velocity/project.json
+++ b/apps/mc/velocity/project.json
@@ -48,10 +48,9 @@
 			"options": {
 				"commands": [
 					"docker rm -f mc-velocity-e2e 2>/dev/null || true",
-					"docker run -d --name mc-velocity-e2e -p 25578:25577 -e TYPE=VELOCITY -e MEMORY=512M kbve/mc-velocity:latest",
+					"docker run -d --name mc-velocity-e2e -p 25578:25577 -e TYPE=VELOCITY -e MEMORY=512M -e PLUGINS='https://cdn.modrinth.com/data/Vebnzrzj/versions/GZjsuCmU/LuckPerms-Velocity-5.5.17.jar,https://cdn.modrinth.com/data/axTqSWQA/versions/AXKMcS6i/Advanced-Portals-Spigot-2.7.1.jar' kbve/mc-velocity:latest",
 					"echo 'Waiting for Velocity to come up...' && for i in $(seq 1 300); do if docker logs mc-velocity-e2e 2>&1 | grep -q 'Done ('; then echo 'Velocity ready after '\"$i\"'s'; break; fi; if [ $i -eq 300 ]; then echo 'Velocity did not start in 300s'; docker logs mc-velocity-e2e 2>&1 | tail -80; docker rm -f mc-velocity-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
-					"docker logs mc-velocity-e2e 2>&1 | grep -q 'KBVE Velocity Commands' || { echo 'kbve-velocity-commands plugin did not load'; docker logs mc-velocity-e2e 2>&1 | tail -80; docker rm -f mc-velocity-e2e 2>/dev/null || true; exit 1; }",
-					"VELOCITY_HOST=127.0.0.1 VELOCITY_PORT=25578 npx vitest run; EC=$?; echo '--- container logs ---'; docker logs mc-velocity-e2e 2>&1 | tail -50; docker rm -f mc-velocity-e2e 2>/dev/null || true; exit $EC"
+					"VELOCITY_HOST=127.0.0.1 VELOCITY_PORT=25578 VELOCITY_CONTAINER=mc-velocity-e2e npx vitest run; EC=$?; echo '--- container logs ---'; docker logs mc-velocity-e2e 2>&1 | tail -80; docker rm -f mc-velocity-e2e 2>/dev/null || true; exit $EC"
 				],
 				"parallel": false,
 				"cwd": "apps/mc/velocity"


### PR DESCRIPTION
## Summary

Three regressions shipped to prod in the last week because the e2e suite never asserted them. This PR closes the gaps.

### 1. Velocity proxy missing AdvancedPortals plugin (#11286)
The proxy was launching without the AP proxy-side half, so the lobby's portal trigger fired but the cross-server switch silently no-oped. The velocity e2e was launching without ANY \`PLUGINS\` env set, so even LuckPerms-Velocity was absent during tests — the suite could never have caught the missing JAR.

- \`apps/mc/velocity/project.json\`: pass the same Modrinth-pinned \`PLUGINS\` env the Deployment uses.
- \`apps/mc/velocity/e2e/plugins.spec.ts\`: assert AdvancedPortals + LuckPerms-Velocity + kbve-velocity-commands all load and no plugin discovery errors appear.

### 2. Lobby \`enableProxySupport\` baked config drift (#11277)
AdvancedPortals defaults to \`enableProxySupport: false\`. We baked a patched \`config.yaml\` into the lobby image, but nothing verified the baked copy survived first boot or that the plugins list reported AP loaded.

- \`apps/mc/lobby/e2e/plugins.spec.ts\`: RCON \`/plugins\` assertions for AP/Essentials/LuckPerms/uplink, plus a \`docker exec\` check that \`/data/plugins/AdvancedPortals/config.yaml\` still has \`enableProxySupport: true\`.

### 3. SpawnAutoClaim strip-bug (#11264, follow-up to #11233)
\`behavior_statetree\`'s reflective call to OPAC's \`claim()\` had the wrong arg order, so the spawn cube was a 1-chunk-wide strip instead of 26×26. Burned through two PR cycles before being root-caused via NBT hexdump.

- \`apps/mc/e2e/spawn-claim.spec.ts\`: parse the \`[spawn-autoclaim] dimension=... claimed=N skipped=M failed=K\` summary log, assert \`claimed + skipped == 676\` and \`failed == 0\`, with an explicit first-boot test that pins \`claimed == 676\` so any future regression to a strip pattern fails loudly. Also asserts OPAC is actually loaded and the reflective API bind didn't fall back.

### Helpers
Each e2e suite gets a small \`helpers/docker.ts\` (\`dockerLogs\`, \`dockerExec\` for lobby). Nothing in spec-land shells out without going through it.

## Test plan

- [ ] \`nx run mc-velocity:e2e\` — plugins.spec.ts passes after the PLUGINS env loads both plugins
- [ ] \`nx run mc-lobby:e2e\` — plugins.spec.ts passes; baked config check succeeds
- [ ] \`nx run mc:e2e\` — spawn-claim.spec.ts sees the \`claimed=676\` summary on a clean boot
- [ ] Negative test: temporarily revert \`SpawnAutoClaim.java\` to the buggy arg-order and confirm \`first-boot claim covers the cube without skips\` fails