### PR TITLE
fix(ci-bevy): retry rustup nightly install on checksum mismatch (#11291)

### DIFF
--- a/.github/workflows/ci-bevy.yml
+++ b/.github/workflows/ci-bevy.yml
@@ -68,10 +68,40 @@ jobs:
                   fetch-depth: 0
 
             - name: Setup Rust nightly (wasm32 + rust-src for -Z build-std atomics)
-              uses: dtolnay/rust-toolchain@nightly
-              with:
-                  targets: wasm32-unknown-unknown
-                  components: rust-src
+              # `dtolnay/rust-toolchain@nightly` fails fast when
+              # `static.rust-lang.org` is mid-rollout and the channel
+              # manifest checksum mismatches (rustup #3390). Wrap the
+              # install in a retry loop so transient release-server
+              # hiccups don't permanently break the build (#11291).
+              run: |
+                  set -euo pipefail
+                  if ! command -v rustup >/dev/null; then
+                      curl --proto '=https' --tlsv1.2 --retry 10 \
+                          --retry-connrefused --location --silent \
+                          --show-error --fail https://sh.rustup.rs \
+                          | sh -s -- --default-toolchain none -y
+                      echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+                      export PATH="$HOME/.cargo/bin:$PATH"
+                  fi
+                  attempt=1
+                  max_attempts=5
+                  while (( attempt <= max_attempts )); do
+                      if rustup toolchain install nightly \
+                          --target wasm32-unknown-unknown \
+                          --component rust-src \
+                          --profile minimal \
+                          --allow-downgrade \
+                          --no-self-update; then
+                          break
+                      fi
+                      if (( attempt == max_attempts )); then
+                          echo "rustup install failed after ${max_attempts} attempts" >&2
+                          exit 1
+                      fi
+                      sleep $(( attempt * 15 ))
+                      attempt=$(( attempt + 1 ))
+                  done
+                  rustup default nightly
 
             - name: Rust Cache
               uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Closes #11291.

## Context
`build_wasm` failed at 2026-05-23T01:46:55Z (run 26320185336) with:

\`\`\`
warn: checksum failed for 'https://static.rust-lang.org/dist/channel-rust-nightly.toml'
info: this is likely due to an ongoing update of the official release server, please try again later
error: toolchain 'nightly-x86_64-unknown-linux-gnu' is not installable
\`\`\`

`dtolnay/rust-toolchain@nightly` calls `rustup toolchain install` directly and exits 1 the moment the channel manifest checksum doesn't line up — rustup#3390. No retry, no recovery.

## Fix
Replace the action with an inline step that:
- bootstraps rustup if missing (same logic the action used),
- runs `rustup toolchain install nightly --target wasm32-unknown-unknown --component rust-src --profile minimal --allow-downgrade --no-self-update` in a retry loop,
- backs off 15s × attempt up to 5 attempts, then hard fails,
- defaults to nightly on success.

Transient release-server outages now self-recover instead of repeatedly firing the failure tracker.

## Test plan
- [ ] Re-run the failed build; expect green (no retry needed when servers are healthy).
- [ ] If the manifest mismatch reappears, expect logs to show the retry attempts before either passing or hard-failing.