### PR TITLE
fix(mc-lobby-e2e): match Bukkit plugin names not JAR names

### DIFF
--- a/apps/mc/lobby/e2e/plugins.spec.ts
+++ b/apps/mc/lobby/e2e/plugins.spec.ts
@@ -21,10 +21,11 @@ describe('MC lobby plugin load', () => {
 		expect(response).toMatch(/AdvancedPortals/);
 	});
 
-	it('reports EssentialsX + EssentialsXSpawn in /plugins', async () => {
+	it('reports Essentials + EssentialsSpawn + EssentialsAntiBuild in /plugins', async () => {
 		const response = await rcon.command('plugins');
-		expect(response).toMatch(/EssentialsX(?!\w)/);
-		expect(response).toMatch(/EssentialsXSpawn/);
+		expect(response).toMatch(/Essentials(?!\w)/);
+		expect(response).toMatch(/EssentialsSpawn/);
+		expect(response).toMatch(/EssentialsAntiBuild/);
 	});
 
 	it('reports LuckPerms in /plugins', async () => {


### PR DESCRIPTION
## Summary

Lobby e2e regressed against the actual RCON \`/plugins\` output:

\`\`\`
Bukkit Plugins (6):
 - AdvancedPortals, Essentials, EssentialsAntiBuild, EssentialsSpawn, LuckPerms, WorldEdit
\`\`\`

The EssentialsX project ships JARs as \`EssentialsX-*.jar\` but \`plugin.yml\` registers under \`Essentials\` / \`EssentialsAntiBuild\` / \`EssentialsSpawn\`. RCON reports the registered Bukkit name, so the regex \`/EssentialsX(?!\\w)/\` never matched on production output.

Switched to the registered names and expanded coverage to \`EssentialsAntiBuild\` for parity with the lobby image.

CI evidence: https://github.com/KBVE/kbve/actions/runs/26335991751/job/77529687434

## Test plan

- [ ] \`nx run mc-lobby:e2e\` — \`plugins.spec.ts\` passes (Essentials base + Spawn + AntiBuild all reported)