### PR TITLE
fix(nd-native): ship macOS dylibs via Forgejo LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,10 @@ apps/rareicon/**/Plugins/**/*.framework/** filter=lfs diff=lfs merge=lfs -text
 # XCFramework binary slices — Info.plist + headers stay text, the
 # library payload (.a per arch slice) is matched by the *.a rule above.
 # Explicit rule for any future *.framework wrapped libraries too.
+
+# Godot GDExtension prebuilt binaries (gdext rust crates under apps/godot/<game>/addons/<name>/bin/)
+# Same storage strategy: pointer files here, blobs on Forgejo.
+apps/godot/**/addons/**/bin/**/*.dylib filter=lfs diff=lfs merge=lfs -text
+apps/godot/**/addons/**/bin/**/*.dll   filter=lfs diff=lfs merge=lfs -text
+apps/godot/**/addons/**/bin/**/*.so    filter=lfs diff=lfs merge=lfs -text
+apps/godot/**/addons/**/bin/**/*.wasm  filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,10 @@ vitest.config.*.timestamp*
 **/bin/Debug/
 **/bin/Release/
 **/obj/
+# Godot gdext native binaries live under bin/debug/ + bin/release/ (lowercase);
+# macOS is case-insensitive so the .NET rules above would swallow them.
+!apps/godot/**/addons/**/bin/
+!apps/godot/**/addons/**/bin/**
 /artifacts/
 *.user
 *.suo

--- a/apps/godot/nexus-defense/.gitignore
+++ b/apps/godot/nexus-defense/.gitignore
@@ -2,9 +2,3 @@
 .import/
 export_presets.cfg
 *.translation
-
-# nd-native build outputs — built locally via packages/rust/nd-native/sync.sh
-addons/nd_native/bin/**/*.dylib
-addons/nd_native/bin/**/*.so
-addons/nd_native/bin/**/*.dll
-addons/nd_native/bin/**/*.wasm

--- a/apps/godot/nexus-defense/addons/nd_native/bin/debug/libnd_native.dylib
+++ b/apps/godot/nexus-defense/addons/nd_native/bin/debug/libnd_native.dylib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd283e703d27a1ec53d665c8e9079e36934b8f3179bbc47ccb0099cb1eb688c1
+size 3383984

--- a/apps/godot/nexus-defense/addons/nd_native/bin/release/libnd_native.dylib
+++ b/apps/godot/nexus-defense/addons/nd_native/bin/release/libnd_native.dylib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c962863f8d2f38713d2894da39c540cbc5a43f8723751df3b0a7590461a4caa3
+size 2614896


### PR DESCRIPTION
## Summary
- Tracks Godot gdext binaries (\`apps/godot/**/addons/**/bin/**/*.{dylib,dll,so,wasm}\`) through Git LFS, matching the existing Rareicon Unity-plugin pattern.
- Pointer files land in this GitHub repo (~150 bytes each); real \`.dylib\`/\`.so\`/\`.dll\`/\`.wasm\` blobs live on the self-hosted Forgejo at \`git.kbve.com\`.
- Adds the mac arm64 \`libnd_native.dylib\` (debug + release) so opening the Godot project after a fresh clone resolves the GDExtension without anyone needing to run \`cargo build\` first.
- Negates the .NET \`**/bin/{Debug,Release}/\` rules for \`apps/godot/**/addons/**/bin/\` — macOS is case-insensitive so those rules were silently hiding the lowercase \`bin/debug/\` + \`bin/release/\` dirs.

## Why LFS
The first revision of this PR committed the raw 5MB dylibs into git history. Every rebuild would re-bloat the repo. Forgejo LFS is what Rareicon already uses for the same shape of artifact — devs working on that path already have credentials cached.

## Test plan
- [ ] \`git pull && git lfs pull\` on main repo
- [ ] Open Godot 4.6 → no \`Can't open dynamic library\` errors
- [ ] F5 — status line reads \`gecs + nd-native · nd-native online · 2+3=5\`
- [ ] \`./packages/rust/nd-native/sync.sh -mac\` still rebuilds + overwrites the LFS-tracked dylibs
- [ ] \`git lfs ls-files | grep nd_native\` shows two entries

## Devs without Forgejo creds
\`GIT_LFS_SKIP_SMUDGE=1 git clone …\` lets devs who don't touch \`apps/godot/\` clone without ever hitting Forgejo (same as the Rareicon path).

## Related
- #11294 — multiplayer TD tracker
- #11297 — gdext scaffold (introduced the broken gitignore that necessitated this fix)