### PR TITLE
ci(pnpm): standardize --frozen-lockfile, opt-in playwright install

### DIFF
--- a/.github/workflows/ci-bevy.yml
+++ b/.github/workflows/ci-bevy.yml
@@ -136,7 +136,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Install project-local npm dependencies
               working-directory: apps/kbve/isometric

--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -89,7 +89,7 @@ jobs:
                   run_install: false
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Setup Python
               uses: actions/setup-python@v6
@@ -323,7 +323,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Setup Nx Cache
               uses: actions/cache@v5
@@ -1052,7 +1052,7 @@ jobs:
                   run_install: false
 
             - name: Install dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Regenerate all proto schemas
               run: npx tsx packages/data/codegen/gen-all.mjs

--- a/.github/workflows/ci-mc-gradle-cache.yml
+++ b/.github/workflows/ci-mc-gradle-cache.yml
@@ -95,7 +95,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
               env:
                   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 

--- a/.github/workflows/ci-mc-mods-cache.yml
+++ b/.github/workflows/ci-mc-mods-cache.yml
@@ -88,7 +88,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
               env:
                   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 

--- a/.github/workflows/ci-mc-smoke.yml
+++ b/.github/workflows/ci-mc-smoke.yml
@@ -145,7 +145,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
               env:
                   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -117,7 +117,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Setup Python + uv
               uses: astral-sh/setup-uv@v7

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -117,7 +117,10 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install --frozen-lockfile
+              timeout-minutes: 10
+              env:
+                  UV_THREADPOOL_SIZE: '16'
+              run: pnpm install --frozen-lockfile --prefer-offline
 
             - name: Setup Python + uv
               uses: astral-sh/setup-uv@v7
@@ -126,6 +129,9 @@ jobs:
 
             - name: Install Playwright Browsers
               if: ${{ inputs.install_playwright }}
+              timeout-minutes: 15
+              env:
+                  UV_THREADPOOL_SIZE: '16'
               run: pnpm exec playwright install --with-deps chromium
 
             # VALKEY_PASSWORD is injected into the runner container's

--- a/.github/workflows/npm-test-package.yml
+++ b/.github/workflows/npm-test-package.yml
@@ -46,7 +46,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Nx e2e ${{ inputs.project }}
               run: pnpm nx e2e ${{ inputs.project }} --no-cloud

--- a/.github/workflows/python-test-package.yml
+++ b/.github/workflows/python-test-package.yml
@@ -44,7 +44,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Setup Python
               uses: actions/setup-python@v6

--- a/.github/workflows/rust-test-crate.yml
+++ b/.github/workflows/rust-test-crate.yml
@@ -61,7 +61,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Nx e2e ${{ inputs.package }}
               run: pnpm nx e2e ${{ inputs.package }} --no-cloud

--- a/.github/workflows/utils-astro-deployment.yml
+++ b/.github/workflows/utils-astro-deployment.yml
@@ -77,7 +77,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Build Project
               shell: bash

--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -85,7 +85,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Setup Python
               uses: actions/setup-python@v6

--- a/.github/workflows/utils-npm-publish.yml
+++ b/.github/workflows/utils-npm-publish.yml
@@ -64,7 +64,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Sync version from source to package.json
               if: ${{ inputs.version_source != '' && inputs.version_target != '' }}

--- a/.github/workflows/utils-nx-kbve-shell.yml
+++ b/.github/workflows/utils-nx-kbve-shell.yml
@@ -73,7 +73,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Run NX Command
               shell: bash

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -162,7 +162,7 @@ jobs:
 
             - name: Install pnpm Dependencies
               if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
               env:
                   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
 

--- a/.github/workflows/utils-python-publish.yml
+++ b/.github/workflows/utils-python-publish.yml
@@ -66,7 +66,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Setup Python
               uses: actions/setup-python@v6

--- a/.github/workflows/utils-self-hosted-job.yml
+++ b/.github/workflows/utils-self-hosted-job.yml
@@ -186,7 +186,7 @@ jobs:
 
             - name: Install pnpm Dependencies
               if: inputs.setup_node
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Setup Nx Cache
               if: inputs.setup_node

--- a/.github/workflows/utils-tauri-build.yml
+++ b/.github/workflows/utils-tauri-build.yml
@@ -146,7 +146,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Install project-local npm dependencies
               working-directory: ${{ inputs.project_path }}
@@ -248,7 +248,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Install project-local npm dependencies
               working-directory: ${{ inputs.project_path }}
@@ -346,7 +346,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Install project-local npm dependencies
               working-directory: ${{ inputs.project_path }}
@@ -435,7 +435,7 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install
+              run: pnpm install --frozen-lockfile
 
             - name: Install project-local npm dependencies
               working-directory: ${{ inputs.project_path }}

--- a/package.json
+++ b/package.json
@@ -221,8 +221,8 @@
 		"includedScripts": []
 	},
 	"scripts": {
-		"postinstall": "pnpm exec playwright install chromium",
-		"prepare": "husky"
+		"prepare": "husky",
+		"setup:e2e": "pnpm exec playwright install chromium"
 	},
 	"pnpm": {
 		"minimumReleaseAge": 720,


### PR DESCRIPTION
## Summary
Three structural CI fixes so the reusable `docker-test-app` workflow can't hang on `Install pnpm Dependencies` for hours like it did on the most recent `axum-kbve-e2e` run.

**Root cause (confirmed via live runner-pod inspection, not the original hypothesis):** the hang was *not* an egress drop to the playwright CDN. The chromium zip downloaded to 100% in ~6s. The hang happens *after* the download, inside Playwright's zip extraction:

- All 11 Node threads in the `oopDownloadBrowserMain.js` process were sleeping — main in `do_epoll_wait`, every worker in `__futex_wait`.
- FD pinned mid-write on `libwidevinecdm.so` inside `/root/.cache/ms-playwright/chromium-1217/...`.
- No active TCP sockets on the process.

That's a classic **libuv threadpool deadlock**: Playwright's `extract-zip` parallelizes file writes across libuv workers, the default `UV_THREADPOOL_SIZE=4` is too small under contention, and the main thread waits on a callback whose worker is itself blocked → deadlock for the full 180min job budget.

This was triggered by the root `postinstall` hook running `pnpm exec playwright install chromium` on every `pnpm install`, so jobs that never touch a browser still tripped the deadlock.

**Fixes:**
1. **Move chromium fetch out of always-on postinstall** (`package.json`):
   - `postinstall: pnpm exec playwright install chromium` → `setup:e2e: pnpm exec playwright install chromium`.
   - Opt-in for local devs (`pnpm setup:e2e`); jobs that need browsers already run dedicated `pnpm exec playwright install --with-deps chromium` steps.
2. **Standardize `--frozen-lockfile` across CI** (17 workflow files):
   - Locks resolution to the committed lockfile so a registry hiccup or stale manifest can't snowball into a multi-hour install.
   - Matches the pattern already used by `ci-e2e.yml`, `ci-manifest-guard.yml`, and `utils-update-version-toml.yml`.
3. **Step-level timeouts + `UV_THREADPOOL_SIZE=16`** on `docker-test-app.yml`:
   - `Install pnpm Dependencies` capped at 10min, `Install Playwright Browsers` capped at 15min — future deadlocks fail fast instead of burning the 180min job budget.
   - `UV_THREADPOOL_SIZE=16` gives libuv enough workers that the chromium extract can't starve itself.
   - `--prefer-offline` keeps pnpm on the warm cache instead of round-tripping the registry per package.

No runtime behavior change for applications. Local devs who need playwright browsers run `pnpm setup:e2e` once.

## Test plan
- [ ] Trigger `ci-docker.yml` (`axum-kbve-e2e`) and confirm `Install pnpm Dependencies` completes in <2 minutes with cache warm.
- [ ] `ci-e2e.yml`, `ci-dashboard.yml`, `utils-tauri-build.yml` runs succeed end-to-end.
- [ ] Spot-check a workflow that does need playwright (e.g. ci-e2e against astro-kbve) and confirm the dedicated `pnpm exec playwright install` step still resolves chromium under the new `UV_THREADPOOL_SIZE`.
- [ ] Local dev clone → `pnpm install` no longer pulls chromium; running `pnpm setup:e2e` does.