### PR TITLE
fix(astro-irc): chat.js auto-discover misses every host (kbve.com/chat, landing live preview)

### DIFF
--- a/apps/irc/astro-irc/src/components/home/HomeChatEmbed.astro
+++ b/apps/irc/astro-irc/src/components/home/HomeChatEmbed.astro
@@ -15,7 +15,8 @@ const { channel = '#general', height = '420px', theme = 'dark' } = Astro.props;
 <div class="home-chat-embed not-content">
 	<div class="home-chat-embed__frame">
 		<div
-			id="kbve-home-chat"
+			id="kbve-chat-home"
+			data-kbve-chat
 			data-channel={channel}
 			data-theme={theme}
 			data-height={height}>

--- a/apps/irc/astro-irc/src/embed/index.tsx
+++ b/apps/irc/astro-irc/src/embed/index.tsx
@@ -114,13 +114,16 @@ export function unmount(el: HTMLElement | string): void {
 
 // ---------------------------------------------------------------------------
 // Auto-discover: scan the page on script load for elements tagged with
-//   <div id="kbve-chat" data-channel="..." data-ws="..." data-theme="..." />
-// and mount them. Hosts that prefer programmatic control can ignore this
+//   <div data-kbve-chat data-channel="..." data-ws="..." data-theme="..." />
+// or any id beginning with "kbve-chat" (kbve-chat, kbve-chat-home,
+// kbve-chat-embed, ...). The id prefix is forgiving because host pages
+// often need multiple mounts on the same page and bare `id="kbve-chat"`
+// can't repeat. Hosts that prefer programmatic control can ignore this
 // and call window.KbveChat.mount({...}) themselves.
 // ---------------------------------------------------------------------------
 function autoMount(): void {
 	const targets = document.querySelectorAll<HTMLElement>(
-		'[data-kbve-chat], #kbve-chat',
+		'[data-kbve-chat], [id^="kbve-chat"]',
 	);
 	for (const el of Array.from(targets)) {
 		if (instances.has(el)) continue;

--- a/apps/kbve/astro-kbve/src/components/kbve/KbveChatEmbed.astro
+++ b/apps/kbve/astro-kbve/src/components/kbve/KbveChatEmbed.astro
@@ -11,6 +11,7 @@ const { channel = '#general', height = '70vh', theme = 'auto' } = Astro.props;
 <div class="kbve-chat-embed-wrapper not-content">
 	<div
 		id="kbve-chat-embed"
+		data-kbve-chat
 		data-channel={channel}
 		data-ws="wss://chat.kbve.com/ws"
 		data-height={height}


### PR DESCRIPTION
## Root cause

The embed bundle's autoMount selector was \`'[data-kbve-chat], #kbve-chat'\` — but no wrapper component actually used the bare id \`kbve-chat\`:

| Wrapper | id used | Matched? |
|---|---|---|
| KbveChatEmbed (kbve.com/chat) | \`kbve-chat-embed\` | ❌ |
| HomeChatEmbed (chat.kbve.com landing live preview) | \`kbve-home-chat\` | ❌ |

So every server-rendered host div was silently ignored. Only programmatic \`window.KbveChat.mount({el})\` calls and \`/embed/example.html\` (which uses literal \`id=\"kbve-chat\"\`) ever worked.

## Fix

- **Embed selector** widened to \`'[data-kbve-chat], [id^=\"kbve-chat\"]'\`. Catches any id starting with \`kbve-chat\` so multi-mount pages can use suffixed ids (\`kbve-chat-embed\`, \`kbve-chat-home\`) without colliding.
- **Both wrapper components** gain explicit \`data-kbve-chat\` attribute for belt-and-suspenders matching independent of the id naming choice.
- Renamed HomeChatEmbed id \`kbve-home-chat\` → \`kbve-chat-home\` so it follows the same prefix scheme.

## Test plan

- [ ] Visit kbve.com/chat post-deploy — chat surface mounts and connects
- [ ] Visit chat.kbve.com (landing) — live preview section mounts
- [ ] /embed/example.html still shows all four panels (existing programmatic + auto-discover paths)