### PR TITLE
feat(discordsh,supabase): /gh claim + gh.issue L2 cache (P0+P1 of #11262)

### DIFF
--- a/apps/discordsh/discordsh-bot/src/discord/commands/gh.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/gh.rs
@@ -1,15 +1,40 @@
-//! Top-level `/gh <number>` shortcut command.
-//!
-//! Uses the default repo from `AppState` and delegates to the shared
-//! issue/PR viewer logic.
+use jedi::entity::github::GitHubClient;
+use kbve::CachedIssue;
+use poise::serenity_prelude as serenity;
+use tracing::{info, warn};
 
 use crate::discord::bot::{Context, Error};
+use crate::discord::branding;
 use crate::discord::commands::github_board::view_issue_impl;
+use crate::discord::github::resolve_github_token;
 use crate::discord::github_permissions::{CommandTier, check_tier, github_permission_check};
 
-/// Quick issue/PR lookup using the default repository.
-#[poise::command(slash_command, check = "github_permission_check")]
-pub async fn gh(
+enum IssuePrecheck {
+    Cached {
+        title: String,
+        html_url: String,
+        assignee_count: usize,
+        already_assigned: bool,
+    },
+    Reject(String),
+    NeedsRest,
+}
+
+const COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+const DEFAULT_PROFILE_URL_BASE: &str = "https://kbve.com/@";
+const DEFAULT_CLAIM_MAX_ASSIGNEES: usize = 2;
+
+#[poise::command(
+    slash_command,
+    check = "github_permission_check",
+    subcommands("view", "claim")
+)]
+pub async fn gh(_ctx: Context<'_>) -> Result<(), Error> {
+    Ok(())
+}
+
+#[poise::command(slash_command)]
+async fn view(
     ctx: Context<'_>,
     #[description = "Issue or PR number"] number: u64,
 ) -> Result<(), Error> {
@@ -19,4 +44,276 @@ pub async fn gh(
 
     let (owner, repo_name) = ctx.data().app.default_repo.clone();
     view_issue_impl(ctx, &owner, &repo_name, number).await
+}
+
+#[poise::command(slash_command)]
+async fn claim(
+    ctx: Context<'_>,
+    #[description = "Issue number to claim"] number: u64,
+    #[description = "Repository (owner/repo, default from env)"] repo: Option<String>,
+) -> Result<(), Error> {
+    if !check_tier(ctx, CommandTier::Read).await? {
+        return Ok(());
+    }
+    ctx.defer().await?;
+
+    let (owner, repo_name) = parse_repo(&repo, &ctx.data().app.default_repo);
+    let full_name = format!("{owner}/{repo_name}");
+
+    if !ctx
+        .data()
+        .app
+        .github_repo_policy
+        .is_allowed(&owner, &repo_name)
+    {
+        return send_ephemeral(
+            ctx,
+            &format!("Repository `{full_name}` is not on the claim allowlist."),
+        )
+        .await;
+    }
+
+    let discord_id = ctx.author().id.get();
+    let identity = match ctx
+        .data()
+        .app
+        .members
+        .lookup_claim_identity(discord_id)
+        .await
+    {
+        Some(i) => i,
+        None => {
+            return send_ephemeral(
+                ctx,
+                "No KBVE account linked to your Discord. Sign in at <https://kbve.com/account/> first.",
+            )
+            .await;
+        }
+    };
+
+    let Some(github_login) = identity.github_login.clone().filter(|s| !s.is_empty()) else {
+        return send_ephemeral(
+            ctx,
+            "Your KBVE account is missing a linked GitHub identity. Link one at <https://kbve.com/account/>.",
+        )
+        .await;
+    };
+
+    let token_guild = ctx.guild_id().map(|g| g.get());
+    let token = match resolve_github_token(token_guild).await {
+        Some(t) => t,
+        None => {
+            return send_ephemeral(
+                ctx,
+                "No GitHub token configured for this server. A server admin can store one at <https://kbve.com>.",
+            )
+            .await;
+        }
+    };
+
+    let policy = ctx.data().app.github_repo_policy.clone();
+    let mut gh = GitHubClient::new(&token).with_policy(policy);
+    if let Ok(base) = std::env::var("GITHUB_API_BASE_URL")
+        && !base.is_empty()
+    {
+        gh = gh.with_base_url(&base);
+    }
+
+    let max_assignees = claim_max_assignees();
+
+    let precheck = precheck_from_store(ctx, &owner, &repo_name, number, &github_login).await;
+
+    let outcome = tokio::time::timeout(COMMAND_TIMEOUT, async {
+        let (title, html_url, assignee_count, already_assigned) = match precheck {
+            IssuePrecheck::Cached {
+                title,
+                html_url,
+                assignee_count,
+                already_assigned,
+            } => (title, html_url, assignee_count, already_assigned),
+            IssuePrecheck::Reject(msg) => return Err(msg),
+            IssuePrecheck::NeedsRest => {
+                let issue = gh
+                    .get_issue(&owner, &repo_name, number)
+                    .await
+                    .map_err(|e| format!("Failed to load #{number} from `{full_name}`: {e}"))?;
+
+                if issue.pull_request.is_some() {
+                    return Err(format!(
+                        "#{number} is a pull request, not an issue — request a review instead of claiming."
+                    ));
+                }
+                if issue.state != "open" {
+                    return Err(format!("#{number} is not open (state: `{}`).", issue.state));
+                }
+                let already_assigned = issue
+                    .assignees
+                    .iter()
+                    .any(|a| a.login.eq_ignore_ascii_case(&github_login));
+                (
+                    issue.title,
+                    issue.html_url,
+                    issue.assignees.len(),
+                    already_assigned,
+                )
+            }
+        };
+
+        if already_assigned {
+            return Err(format!("You already have #{number} assigned on GitHub."));
+        }
+        if assignee_count >= max_assignees {
+            return Err(format!(
+                "#{number} already has {assignee_count} assignee(s). Coordinate with them before claiming."
+            ));
+        }
+
+        gh.add_assignees(&owner, &repo_name, number, &[github_login.as_str()])
+            .await
+            .map_err(|e| format!("Failed to assign you to #{number}: {e}"))?;
+
+        Ok((title, html_url))
+    })
+    .await;
+
+    let (issue_title, issue_url) = match outcome {
+        Ok(Ok(pair)) => pair,
+        Ok(Err(msg)) => return send_ephemeral(ctx, &msg).await,
+        Err(_) => return send_ephemeral(ctx, "The request timed out — please try again.").await,
+    };
+
+    ctx.data()
+        .app
+        .github_cache
+        .invalidate_issue(&owner, &repo_name, number);
+    ctx.data()
+        .app
+        .github_store
+        .invalidate(&owner, &repo_name, number as u32);
+
+    info!(
+        discord_id,
+        user_id = %identity.user_id,
+        kbve_username = ?identity.kbve_username,
+        github_login = %github_login,
+        repo = %full_name,
+        issue = number,
+        "Issue claimed via /gh claim"
+    );
+
+    let profile_link = identity.kbve_username().map(|u| {
+        let base = profile_url_base();
+        format!("[@{u}]({base}{u})")
+    });
+
+    let assignee_line = match profile_link {
+        Some(link) => format!("{link} · `{github_login}`"),
+        None => format!("`{github_login}`"),
+    };
+
+    let title = format!("Claimed #{number} — {issue_title}");
+    let description = format!("Repository: `{full_name}`\nAssignee: {assignee_line}");
+
+    let embed = serenity::CreateEmbed::new()
+        .title(title)
+        .description(description)
+        .url(&issue_url)
+        .color(branding::GH_BLUE)
+        .author(branding::embed_author())
+        .footer(branding::embed_footer(None));
+
+    ctx.send(poise::CreateReply::default().embed(embed))
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "Failed to send claim confirmation");
+            e
+        })?;
+
+    Ok(())
+}
+
+async fn precheck_from_store(
+    ctx: Context<'_>,
+    owner: &str,
+    repo: &str,
+    number: u64,
+    github_login: &str,
+) -> IssuePrecheck {
+    let store = &ctx.data().app.github_store;
+    if !store.is_enabled() {
+        return IssuePrecheck::NeedsRest;
+    }
+
+    let cached = match store.get_issue(owner, repo, number as u32).await {
+        Ok(Some(issue)) => issue,
+        Ok(None) => return IssuePrecheck::NeedsRest,
+        Err(e) => {
+            warn!(error = %e, owner, repo, number, "github_store lookup failed; falling back to REST");
+            return IssuePrecheck::NeedsRest;
+        }
+    };
+
+    if cached.is_pull_request {
+        return IssuePrecheck::Reject(format!(
+            "#{number} is a pull request, not an issue — request a review instead of claiming."
+        ));
+    }
+
+    if cached.state != "open" {
+        return IssuePrecheck::Reject(format!(
+            "#{number} is not open (state: `{}`).",
+            cached.state
+        ));
+    }
+
+    if cached.is_stale(store.stale_after()) {
+        return IssuePrecheck::NeedsRest;
+    }
+
+    let assignee_count = cached.assignee_count();
+    let already_assigned = cached
+        .assignee_logins()
+        .iter()
+        .any(|l| l.eq_ignore_ascii_case(github_login));
+
+    let CachedIssue {
+        title, html_url, ..
+    } = cached;
+    IssuePrecheck::Cached {
+        title,
+        html_url,
+        assignee_count,
+        already_assigned,
+    }
+}
+
+fn parse_repo(repo: &Option<String>, default: &(String, String)) -> (String, String) {
+    match repo.as_deref().filter(|r| r.contains('/')) {
+        Some(r) => {
+            let (owner, name) = r.split_once('/').unwrap();
+            (owner.to_owned(), name.to_owned())
+        }
+        None => default.clone(),
+    }
+}
+
+async fn send_ephemeral(ctx: Context<'_>, msg: &str) -> Result<(), Error> {
+    ctx.send(poise::CreateReply::default().content(msg).ephemeral(true))
+        .await?;
+    Ok(())
+}
+
+fn profile_url_base() -> String {
+    std::env::var("KBVE_PROFILE_URL_BASE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_PROFILE_URL_BASE.to_owned())
+}
+
+fn claim_max_assignees() -> usize {
+    std::env::var("GITHUB_CLAIM_MAX_ASSIGNEES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_CLAIM_MAX_ASSIGNEES)
 }

--- a/apps/discordsh/discordsh-bot/src/state.rs
+++ b/apps/discordsh/discordsh-bot/src/state.rs
@@ -7,7 +7,7 @@ use poise::serenity_prelude as serenity;
 use tokio::sync::{Notify, RwLock};
 
 use bevy_db::NativeStore;
-use kbve::{FontDb, MemberCache};
+use kbve::{FontDb, GithubStore, MemberCache};
 
 use bevy_chat::ChatClient;
 
@@ -95,6 +95,10 @@ pub struct AppState {
 
     /// Cached GitHub labels and issues for reduced API calls.
     pub github_cache: GitHubCache,
+
+    /// L2 read-through cache backed by Supabase `gh.issue`. `is_enabled()` is
+    /// false when `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` are missing.
+    pub github_store: Arc<GithubStore>,
 
     /// Optional IRC client for cross-platform chat and world events.
     /// `None` if IRC is unavailable or not configured.
@@ -231,6 +235,7 @@ impl AppState {
             github_repo_policy: jedi::entity::github::RepoPolicy::from_env(),
             github_guard: GitHubCommandGuard::from_env(),
             github_cache: GitHubCache::new(),
+            github_store: Arc::new(GithubStore::from_env()),
             irc,
             relay,
             local_db,

--- a/apps/kbve/edge/functions/gh-backfill/index.ts
+++ b/apps/kbve/edge/functions/gh-backfill/index.ts
@@ -1,0 +1,188 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+import {
+  createServiceClient,
+  extractToken,
+  jsonResponse,
+  parseJwt,
+  requireServiceRole,
+} from "../_shared/supabase.ts";
+import {
+  enforceBodySizeLimit,
+  requireJsonContentType,
+} from "../_shared/validators.ts";
+
+interface BackfillRequest {
+  owner: string;
+  repo: string;
+  state?: "open" | "closed" | "all";
+  per_page?: number;
+  max_pages?: number;
+}
+
+interface GitHubIssueResp {
+  number: number;
+  title: string;
+  state: string;
+  body?: string | null;
+  html_url: string;
+  node_id?: string;
+  labels?: Array<{ name?: string; color?: string }>;
+  assignees?: Array<{ login?: string }>;
+  user?: { login?: string };
+  pull_request?: unknown;
+  created_at: string;
+  updated_at: string;
+  closed_at?: string | null;
+}
+
+const REPO_RE = /^[A-Za-z0-9._-]{1,100}$/;
+const DEFAULT_PER_PAGE = 100;
+const DEFAULT_MAX_PAGES = 10;
+
+function isValidSegment(s: unknown): s is string {
+  return typeof s === "string" && REPO_RE.test(s);
+}
+
+async function fetchPage(
+  token: string,
+  owner: string,
+  repo: string,
+  state: string,
+  perPage: number,
+  page: number,
+): Promise<{ rows: GitHubIssueResp[]; rateLimitRemaining: number | null }> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/issues?state=${state}&per_page=${perPage}&page=${page}`;
+  const resp = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "kbve-gh-backfill",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`GitHub API ${resp.status}: ${await resp.text()}`);
+  }
+  const rows = await resp.json() as GitHubIssueResp[];
+  const remaining = resp.headers.get("x-ratelimit-remaining");
+  return {
+    rows,
+    rateLimitRemaining: remaining ? parseInt(remaining, 10) : null,
+  };
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+  }
+
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+  const sizeErr = enforceBodySizeLimit(req);
+  if (sizeErr) return sizeErr;
+
+  let token = "";
+  try {
+    token = extractToken(req);
+  } catch {
+    return jsonResponse({ error: "authorization required" }, 401);
+  }
+  const claims = await parseJwt(token).catch(() => ({}));
+  const denied = requireServiceRole(claims);
+  if (denied) return denied;
+
+  let body: BackfillRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "invalid JSON" }, 400);
+  }
+
+  if (!isValidSegment(body.owner) || !isValidSegment(body.repo)) {
+    return jsonResponse({ error: "owner and repo are required and must match [A-Za-z0-9._-]" }, 400);
+  }
+
+  const state = body.state ?? "all";
+  if (!["open", "closed", "all"].includes(state)) {
+    return jsonResponse({ error: "state must be open|closed|all" }, 400);
+  }
+
+  const perPage = Math.min(Math.max(body.per_page ?? DEFAULT_PER_PAGE, 1), 100);
+  const maxPages = Math.min(Math.max(body.max_pages ?? DEFAULT_MAX_PAGES, 1), 50);
+
+  const githubToken = Deno.env.get("GITHUB_TOKEN") ?? Deno.env.get("GITHUB_TOKEN_PAT");
+  if (!githubToken) {
+    console.error("gh-backfill: GITHUB_TOKEN not configured");
+    return jsonResponse({ error: "Server not configured" }, 500);
+  }
+
+  const sb = createServiceClient();
+
+  let upserted = 0;
+  let page = 1;
+  let lastRateLimitRemaining: number | null = null;
+
+  while (page <= maxPages) {
+    let result: Awaited<ReturnType<typeof fetchPage>>;
+    try {
+      result = await fetchPage(githubToken, body.owner, body.repo, state, perPage, page);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error("gh-backfill fetch error:", msg);
+      return jsonResponse({ error: "GitHub fetch failed", detail: msg }, 502);
+    }
+
+    lastRateLimitRemaining = result.rateLimitRemaining;
+
+    if (result.rows.length === 0) break;
+
+    for (const issue of result.rows) {
+      const labels = (issue.labels ?? []).map((l) => ({ name: l.name, color: l.color }));
+      const assignees = (issue.assignees ?? []).map((a) => ({ login: a.login }));
+      const { error } = await sb.schema("gh").rpc("upsert_issue", {
+        p_owner: body.owner,
+        p_repo: body.repo,
+        p_number: issue.number,
+        p_title: issue.title,
+        p_state: issue.state,
+        p_body: issue.body ?? null,
+        p_labels: labels,
+        p_assignees: assignees,
+        p_author: issue.user?.login ?? null,
+        p_html_url: issue.html_url,
+        p_is_pull_request: !!issue.pull_request,
+        p_github_node_id: issue.node_id ?? null,
+        p_github_created_at: issue.created_at,
+        p_github_updated_at: issue.updated_at,
+        p_closed_at: issue.closed_at ?? null,
+      });
+      if (error) {
+        console.error(
+          `gh.upsert_issue failed for ${body.owner}/${body.repo}#${issue.number}: ${error.message}`,
+        );
+        continue;
+      }
+      upserted++;
+    }
+
+    if (result.rows.length < perPage) break;
+    page++;
+  }
+
+  return jsonResponse(
+    {
+      ok: true,
+      owner: body.owner,
+      repo: body.repo,
+      state,
+      pages_walked: page,
+      upserted,
+      rate_limit_remaining: lastRateLimitRemaining,
+    },
+    200,
+  );
+});

--- a/apps/kbve/edge/functions/gh-webhook/index.ts
+++ b/apps/kbve/edge/functions/gh-webhook/index.ts
@@ -1,0 +1,256 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+import { createServiceClient, jsonResponse } from "../_shared/supabase.ts";
+import { enforceBodySizeLimit } from "../_shared/validators.ts";
+
+const ALLOWED_EVENTS = new Set([
+  "issues",
+  "issue_comment",
+  "pull_request",
+  "pull_request_review",
+  "pull_request_review_comment",
+  "ping",
+]);
+
+const ALLOWED_REPOS = parseAllowlist(Deno.env.get("GH_WEBHOOK_ALLOWED_REPOS"));
+
+interface GithubLabel {
+  name?: string;
+  color?: string;
+}
+interface GithubUserLite {
+  login?: string;
+}
+
+interface GithubIssueLite {
+  number: number;
+  title: string;
+  state: string;
+  body?: string | null;
+  html_url: string;
+  node_id?: string;
+  labels?: GithubLabel[];
+  assignees?: GithubUserLite[];
+  user?: GithubUserLite;
+  pull_request?: unknown;
+  created_at: string;
+  updated_at: string;
+  closed_at?: string | null;
+}
+
+interface GithubPullLite extends GithubIssueLite {
+  draft?: boolean;
+  merged?: boolean;
+}
+
+interface GithubRepoLite {
+  owner?: { login?: string };
+  name?: string;
+  full_name?: string;
+}
+
+interface GithubPayload {
+  action?: string;
+  issue?: GithubIssueLite;
+  pull_request?: GithubPullLite;
+  repository?: GithubRepoLite;
+  comment?: { user?: GithubUserLite; body?: string };
+  sender?: GithubUserLite;
+}
+
+function parseAllowlist(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .filter((s) => s.includes("/")),
+  );
+}
+
+async function verifySignature(
+  secret: string,
+  signatureHeader: string | null,
+  body: string,
+): Promise<boolean> {
+  if (!signatureHeader || !signatureHeader.startsWith("sha256=")) {
+    return false;
+  }
+  const expected = signatureHeader.slice("sha256=".length).toLowerCase();
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sigBuf = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(body),
+  );
+  const actual = Array.from(new Uint8Array(sigBuf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  return timingSafeEqual(expected, actual);
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function repoFromPayload(p: GithubPayload): { owner: string; repo: string } | null {
+  const r = p.repository;
+  if (!r) return null;
+  const owner = r.owner?.login ?? "";
+  const repo = r.name ?? (r.full_name?.split("/")[1] ?? "");
+  if (!owner || !repo) return null;
+  return { owner, repo };
+}
+
+function issueFromPayload(p: GithubPayload): GithubIssueLite | null {
+  if (p.issue) return p.issue;
+  if (p.pull_request) return p.pull_request;
+  return null;
+}
+
+function mapEventType(githubEvent: string, action: string | undefined): string {
+  if (githubEvent === "issue_comment") {
+    return action === "created" ? "commented" : `comment_${action ?? "unknown"}`;
+  }
+  if (githubEvent === "pull_request_review") {
+    return action === "submitted" ? "reviewed" : `review_${action ?? "unknown"}`;
+  }
+  if (githubEvent === "pull_request_review_comment") {
+    return action === "created" ? "commented" : `review_comment_${action ?? "unknown"}`;
+  }
+  return action ?? githubEvent;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST method is allowed" }, 405);
+  }
+
+  const sizeErr = enforceBodySizeLimit(req);
+  if (sizeErr) return sizeErr;
+
+  const githubEvent = req.headers.get("x-github-event") ?? "";
+  const deliveryId = req.headers.get("x-github-delivery") ?? null;
+  const signature = req.headers.get("x-hub-signature-256");
+
+  if (!ALLOWED_EVENTS.has(githubEvent)) {
+    return jsonResponse({ ok: true, skipped: githubEvent }, 200);
+  }
+
+  const secret = Deno.env.get("GITHUB_WEBHOOK_SECRET");
+  if (!secret) {
+    console.error("gh-webhook: GITHUB_WEBHOOK_SECRET not configured");
+    return jsonResponse({ error: "Server not configured" }, 500);
+  }
+
+  const rawBody = await req.text();
+
+  if (!(await verifySignature(secret, signature, rawBody))) {
+    console.warn("gh-webhook: signature verification failed", {
+      delivery: deliveryId,
+      event: githubEvent,
+    });
+    return jsonResponse({ error: "invalid signature" }, 401);
+  }
+
+  if (githubEvent === "ping") {
+    return jsonResponse({ ok: true, pong: true }, 200);
+  }
+
+  let payload: GithubPayload;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return jsonResponse({ error: "invalid JSON" }, 400);
+  }
+
+  const repoInfo = repoFromPayload(payload);
+  if (!repoInfo) {
+    return jsonResponse({ ok: true, skipped: "no repo in payload" }, 200);
+  }
+
+  const fullName = `${repoInfo.owner}/${repoInfo.repo}`.toLowerCase();
+  if (ALLOWED_REPOS.size > 0 && !ALLOWED_REPOS.has(fullName)) {
+    return jsonResponse({ ok: true, skipped: `repo not allowlisted: ${fullName}` }, 200);
+  }
+
+  const issue = issueFromPayload(payload);
+  if (!issue) {
+    return jsonResponse({ ok: true, skipped: "no issue in payload" }, 200);
+  }
+
+  const sb = createServiceClient();
+
+  const labels = (issue.labels ?? []).map((l) => ({
+    name: l.name,
+    color: l.color,
+  }));
+  const assignees = (issue.assignees ?? []).map((a) => ({ login: a.login }));
+
+  const upsertParams = {
+    p_owner: repoInfo.owner,
+    p_repo: repoInfo.repo,
+    p_number: issue.number,
+    p_title: issue.title,
+    p_state: issue.state,
+    p_body: issue.body ?? null,
+    p_labels: labels,
+    p_assignees: assignees,
+    p_author: issue.user?.login ?? null,
+    p_html_url: issue.html_url,
+    p_is_pull_request: !!payload.pull_request || !!issue.pull_request,
+    p_github_node_id: issue.node_id ?? null,
+    p_github_created_at: issue.created_at,
+    p_github_updated_at: issue.updated_at,
+    p_closed_at: issue.closed_at ?? null,
+  };
+
+  const { error: upsertErr } = await sb
+    .schema("gh")
+    .rpc("upsert_issue", upsertParams);
+  if (upsertErr) {
+    console.error("gh.upsert_issue failed:", upsertErr.message);
+    return jsonResponse({ error: "upsert failed" }, 500);
+  }
+
+  const eventActor = payload.sender?.login ?? payload.comment?.user?.login ?? null;
+  const { error: eventErr } = await sb.schema("gh").rpc("record_event", {
+    p_owner: repoInfo.owner,
+    p_repo: repoInfo.repo,
+    p_number: issue.number,
+    p_event_type: mapEventType(githubEvent, payload.action),
+    p_actor: eventActor,
+    p_payload: payload,
+    p_github_delivery_id: deliveryId,
+  });
+  if (eventErr) {
+    console.error("gh.record_event failed:", eventErr.message);
+  }
+
+  return jsonResponse(
+    {
+      ok: true,
+      event: githubEvent,
+      action: payload.action,
+      delivery: deliveryId,
+      issue: `${fullName}#${issue.number}`,
+    },
+    200,
+  );
+});

--- a/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
@@ -15,20 +15,35 @@ LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+ROWS 1
 AS $$
 BEGIN
+    IF p_discord_id IS NULL OR p_discord_id !~ '^[0-9]{15,25}$' THEN
+        RETURN;
+    END IF;
+
     RETURN QUERY
     SELECT
         d.user_id,
-        (g.identity_data->>'user_name')::TEXT AS github_login,
-        g.provider_id::TEXT                   AS github_id,
-        p.username::TEXT                      AS kbve_username
+        g.github_login,
+        g.github_id,
+        p.username::TEXT AS kbve_username
     FROM auth.identities d
-    LEFT JOIN auth.identities g
-      ON g.user_id = d.user_id AND g.provider = 'github'
+    LEFT JOIN LATERAL (
+        SELECT
+            (gi.identity_data->>'user_name')::TEXT AS github_login,
+            gi.provider_id::TEXT                   AS github_id
+        FROM auth.identities gi
+        WHERE gi.user_id = d.user_id
+          AND gi.provider = 'github'
+        ORDER BY gi.created_at DESC NULLS LAST
+        LIMIT 1
+    ) g ON TRUE
     LEFT JOIN profile.username p
       ON p.user_id = d.user_id
-    WHERE d.provider = 'discord' AND d.provider_id = p_discord_id
+    WHERE d.provider = 'discord'
+      AND d.provider_id = p_discord_id
+    ORDER BY d.created_at DESC NULLS LAST
     LIMIT 1;
 END;
 $$;
@@ -42,7 +57,7 @@ GRANT EXECUTE ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT)
 TO service_role;
 
 COMMENT ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT) IS
-'Resolves a Discord user_id (auth.identities.provider_id where provider=discord) into the linked GitHub login + KBVE profile username in one round-trip. LEFT JOIN so callers can distinguish "no KBVE account" (empty result) from "no GitHub link" (github_login NULL) and "no profile username" (kbve_username NULL). Used by discordsh /gh claim. SECURITY DEFINER with empty search_path; auth.identities and profile.username are schema-qualified.';
+'Resolves a Discord snowflake to KBVE user_id + (optional) linked GitHub login/id + (optional) profile.username in one round-trip. Empty result = no auth.identities row for the snowflake (or invalid input shape). NULL github_login = KBVE account exists but no GitHub identity linked. NULL kbve_username = no profile.username row yet. LATERAL join on github keeps results stable when a user has multiple github links (picks latest). Input is validated against ^[0-9]{15,25}$ to reject probes for non-snowflake provider_ids. SECURITY DEFINER with empty search_path; every reference is schema-qualified. Used by discordsh /gh claim.';
 
 NOTIFY pgrst, 'reload schema';
 

--- a/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
@@ -1,0 +1,50 @@
+-- migrate:up
+
+CREATE OR REPLACE FUNCTION tracker.find_claim_identity_by_discord_id(
+    p_discord_id TEXT
+)
+RETURNS TABLE (
+    user_id        UUID,
+    github_login   TEXT,
+    github_id      TEXT,
+    kbve_username  TEXT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        d.user_id,
+        (g.identity_data->>'user_name')::TEXT AS github_login,
+        g.provider_id::TEXT                   AS github_id,
+        p.username::TEXT                      AS kbve_username
+    FROM auth.identities d
+    LEFT JOIN auth.identities g
+      ON g.user_id = d.user_id AND g.provider = 'github'
+    LEFT JOIN profile.username p
+      ON p.user_id = d.user_id
+    WHERE d.provider = 'discord' AND d.provider_id = p_discord_id
+    LIMIT 1;
+END;
+$$;
+
+ALTER FUNCTION tracker.find_claim_identity_by_discord_id(TEXT) OWNER TO service_role;
+
+REVOKE ALL ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT)
+TO service_role;
+
+COMMENT ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT) IS
+'Resolves a Discord user_id (auth.identities.provider_id where provider=discord) into the linked GitHub login + KBVE profile username in one round-trip. LEFT JOIN so callers can distinguish "no KBVE account" (empty result) from "no GitHub link" (github_login NULL) and "no profile username" (kbve_username NULL). Used by discordsh /gh claim. SECURITY DEFINER with empty search_path; auth.identities and profile.username are schema-qualified.';
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS tracker.find_claim_identity_by_discord_id(TEXT);
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
@@ -1,5 +1,7 @@
 -- migrate:up
 
+CREATE SCHEMA IF NOT EXISTS tracker;
+
 CREATE OR REPLACE FUNCTION tracker.find_claim_identity_by_discord_id(
     p_discord_id TEXT
 )

--- a/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
@@ -44,14 +44,14 @@ BEGIN
         FROM auth.identities gi
         WHERE gi.user_id = d.user_id
           AND gi.provider = 'github'
-        ORDER BY gi.created_at DESC NULLS LAST
+        ORDER BY gi.created_at DESC NULLS LAST, gi.id DESC
         LIMIT 1
     ) g ON TRUE
     LEFT JOIN profile.username p
       ON p.user_id = d.user_id
     WHERE d.provider = 'discord'
       AND d.provider_id = p_discord_id
-    ORDER BY d.created_at DESC NULLS LAST
+    ORDER BY d.created_at DESC NULLS LAST, d.id DESC
     LIMIT 1;
 END;
 $$;
@@ -65,7 +65,7 @@ GRANT EXECUTE ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT)
 TO service_role;
 
 COMMENT ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT) IS
-'Resolves a Discord snowflake to KBVE user_id + (optional) linked GitHub login/id + (optional) profile.username in one round-trip. Empty result = no auth.identities row for the snowflake (or invalid input shape). NULL github_login = KBVE account exists but no GitHub identity linked. NULL kbve_username = no profile.username row yet. LATERAL join on github keeps results stable when a user has multiple github links (picks latest by created_at). github_login extracted via COALESCE(user_name, preferred_username, login) since the claim name differs across GitHub OAuth scopes (user:email/openid/some SDKs). Input is gated by ^[0-9]{15,25}$ in a PL/pgSQL early-return guard before any auth.identities lookup, so non-snowflake probes short-circuit to an empty result without touching the table. SECURITY DEFINER with empty search_path; every reference schema-qualified. Used by discordsh /gh claim.';
+'Backend/service_role only; intentionally not exposed to anon/authenticated clients because it surfaces linked identity metadata from auth.identities. Resolves a Discord snowflake to KBVE user_id + (optional) linked GitHub login/id + (optional) profile.username in one round-trip. Empty result = no auth.identities row for the snowflake (or invalid input shape). NULL github_login = KBVE account exists but no GitHub identity linked. NULL kbve_username = no profile.username row yet. LATERAL join on github picks the latest GitHub identity by (created_at DESC NULLS LAST, id DESC) so the tie-breaker is fully deterministic even when timestamps collide. Same tie-breaker applied on the outer discord lookup. github_login extracted via COALESCE(user_name, preferred_username, login) since the claim name differs across GitHub OAuth scopes. Input is gated by ^[0-9]{15,25}$ in a PL/pgSQL early-return guard before any auth.identities lookup, so non-snowflake probes short-circuit to an empty result without touching the table. SECURITY DEFINER with empty search_path; every reference schema-qualified.';
 
 NOTIFY pgrst, 'reload schema';
 

--- a/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
@@ -19,6 +19,7 @@ STABLE
 SECURITY DEFINER
 SET search_path = ''
 ROWS 1
+COST 50
 AS $$
 BEGIN
     IF p_discord_id IS NULL OR p_discord_id !~ '^[0-9]{15,25}$' THEN
@@ -36,7 +37,8 @@ BEGIN
         SELECT
             COALESCE(
                 gi.identity_data->>'user_name',
-                gi.identity_data->>'preferred_username'
+                gi.identity_data->>'preferred_username',
+                gi.identity_data->>'login'
             )::TEXT                 AS github_login,
             gi.provider_id::TEXT    AS github_id
         FROM auth.identities gi
@@ -63,7 +65,7 @@ GRANT EXECUTE ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT)
 TO service_role;
 
 COMMENT ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT) IS
-'Resolves a Discord snowflake to KBVE user_id + (optional) linked GitHub login/id + (optional) profile.username in one round-trip. Empty result = no auth.identities row for the snowflake (or invalid input shape). NULL github_login = KBVE account exists but no GitHub identity linked. NULL kbve_username = no profile.username row yet. LATERAL join on github keeps results stable when a user has multiple github links (picks latest by created_at). github_login extracted via COALESCE(user_name, preferred_username) since the claim name differs across GitHub OAuth scopes. Input is gated by ^[0-9]{15,25}$ in WHERE so non-snowflake probes short-circuit to empty result. SECURITY DEFINER with empty search_path; every reference schema-qualified. Used by discordsh /gh claim.';
+'Resolves a Discord snowflake to KBVE user_id + (optional) linked GitHub login/id + (optional) profile.username in one round-trip. Empty result = no auth.identities row for the snowflake (or invalid input shape). NULL github_login = KBVE account exists but no GitHub identity linked. NULL kbve_username = no profile.username row yet. LATERAL join on github keeps results stable when a user has multiple github links (picks latest by created_at). github_login extracted via COALESCE(user_name, preferred_username, login) since the claim name differs across GitHub OAuth scopes (user:email/openid/some SDKs). Input is gated by ^[0-9]{15,25}$ in a PL/pgSQL early-return guard before any auth.identities lookup, so non-snowflake probes short-circuit to an empty result without touching the table. SECURITY DEFINER with empty search_path; every reference schema-qualified. Used by discordsh /gh claim.';
 
 NOTIFY pgrst, 'reload schema';
 

--- a/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033932_tracker_find_claim_identity_by_discord_id.sql
@@ -2,6 +2,9 @@
 
 CREATE SCHEMA IF NOT EXISTS tracker;
 
+REVOKE ALL ON SCHEMA tracker FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA tracker TO service_role;
+
 CREATE OR REPLACE FUNCTION tracker.find_claim_identity_by_discord_id(
     p_discord_id TEXT
 )
@@ -31,8 +34,11 @@ BEGIN
     FROM auth.identities d
     LEFT JOIN LATERAL (
         SELECT
-            (gi.identity_data->>'user_name')::TEXT AS github_login,
-            gi.provider_id::TEXT                   AS github_id
+            COALESCE(
+                gi.identity_data->>'user_name',
+                gi.identity_data->>'preferred_username'
+            )::TEXT                 AS github_login,
+            gi.provider_id::TEXT    AS github_id
         FROM auth.identities gi
         WHERE gi.user_id = d.user_id
           AND gi.provider = 'github'
@@ -57,7 +63,7 @@ GRANT EXECUTE ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT)
 TO service_role;
 
 COMMENT ON FUNCTION tracker.find_claim_identity_by_discord_id(TEXT) IS
-'Resolves a Discord snowflake to KBVE user_id + (optional) linked GitHub login/id + (optional) profile.username in one round-trip. Empty result = no auth.identities row for the snowflake (or invalid input shape). NULL github_login = KBVE account exists but no GitHub identity linked. NULL kbve_username = no profile.username row yet. LATERAL join on github keeps results stable when a user has multiple github links (picks latest). Input is validated against ^[0-9]{15,25}$ to reject probes for non-snowflake provider_ids. SECURITY DEFINER with empty search_path; every reference is schema-qualified. Used by discordsh /gh claim.';
+'Resolves a Discord snowflake to KBVE user_id + (optional) linked GitHub login/id + (optional) profile.username in one round-trip. Empty result = no auth.identities row for the snowflake (or invalid input shape). NULL github_login = KBVE account exists but no GitHub identity linked. NULL kbve_username = no profile.username row yet. LATERAL join on github keeps results stable when a user has multiple github links (picks latest by created_at). github_login extracted via COALESCE(user_name, preferred_username) since the claim name differs across GitHub OAuth scopes. Input is gated by ^[0-9]{15,25}$ in WHERE so non-snowflake probes short-circuit to empty result. SECURITY DEFINER with empty search_path; every reference schema-qualified. Used by discordsh /gh claim.';
 
 NOTIFY pgrst, 'reload schema';
 

--- a/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
@@ -29,7 +29,28 @@ CREATE TABLE IF NOT EXISTS gh.issue (
     CONSTRAINT gh_issue_owner_shape_chk  CHECK (owner ~ '^[A-Za-z0-9_.-]{1,100}$'),
     CONSTRAINT gh_issue_repo_shape_chk   CHECK (repo  ~ '^[A-Za-z0-9_.-]{1,100}$'),
     CONSTRAINT gh_issue_number_pos_chk   CHECK (number > 0),
-    CONSTRAINT gh_issue_state_chk        CHECK (state IN ('open', 'closed'))
+    CONSTRAINT gh_issue_state_chk        CHECK (state IN ('open', 'closed')),
+    CONSTRAINT gh_issue_labels_array_chk    CHECK (jsonb_typeof(labels)    = 'array'),
+    CONSTRAINT gh_issue_assignees_array_chk CHECK (jsonb_typeof(assignees) = 'array'),
+    CONSTRAINT gh_issue_discord_guild_pos_chk
+        CHECK (discord_guild_id   IS NULL OR discord_guild_id   > 0),
+    CONSTRAINT gh_issue_discord_channel_pos_chk
+        CHECK (discord_channel_id IS NULL OR discord_channel_id > 0),
+    CONSTRAINT gh_issue_discord_thread_pos_chk
+        CHECK (discord_thread_id  IS NULL OR discord_thread_id  > 0),
+    CONSTRAINT gh_issue_discord_mapping_all_or_none_chk CHECK (
+        (
+            discord_guild_id   IS NULL
+            AND discord_channel_id IS NULL
+            AND discord_thread_id  IS NULL
+        )
+        OR
+        (
+            discord_guild_id   IS NOT NULL
+            AND discord_channel_id IS NOT NULL
+            AND discord_thread_id  IS NOT NULL
+        )
+    )
 );
 
 CREATE INDEX IF NOT EXISTS gh_issue_open_by_repo_updated_idx
@@ -67,15 +88,21 @@ CREATE TABLE IF NOT EXISTS gh.issue_event (
     CONSTRAINT gh_issue_event_attempts_chk
         CHECK (delivery_attempts >= 0),
     CONSTRAINT gh_issue_event_state_chk
-        CHECK (delivery_state IN (0, 1, 2, 3))
+        CHECK (delivery_state IN (0, 1, 2, 3)),
+    CONSTRAINT gh_issue_event_payload_object_chk
+        CHECK (jsonb_typeof(payload) = 'object')
 );
 
 COMMENT ON COLUMN gh.issue_event.delivery_state IS
 '0=pending (claimable), 1=claimed (in-flight, lease expires at claimed_at + p_lease_secs), 2=delivered (terminal success), 3=dead_letter (terminal failure, retries exhausted).';
 
-CREATE INDEX IF NOT EXISTS gh_issue_event_claimable_idx
-    ON gh.issue_event (created_at, claimed_at)
-    WHERE delivery_state < 2;
+CREATE INDEX IF NOT EXISTS gh_issue_event_pending_claim_idx
+    ON gh.issue_event (created_at, id)
+    WHERE delivery_state = 0;
+
+CREATE INDEX IF NOT EXISTS gh_issue_event_expired_claim_idx
+    ON gh.issue_event (claimed_at, created_at, id)
+    WHERE delivery_state = 1;
 
 CREATE INDEX IF NOT EXISTS gh_issue_event_lookup_idx
     ON gh.issue_event (owner, repo, number, created_at DESC);
@@ -143,8 +170,9 @@ BEGIN
                                      THEN EXCLUDED.is_pull_request ELSE gh.issue.is_pull_request END,
             closed_at         = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
                                      THEN EXCLUDED.closed_at ELSE gh.issue.closed_at END,
-            github_node_id    = COALESCE(EXCLUDED.github_node_id, gh.issue.github_node_id),
-            github_created_at = EXCLUDED.github_created_at,
+            github_node_id    = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
+                                     THEN COALESCE(EXCLUDED.github_node_id, gh.issue.github_node_id)
+                                     ELSE gh.issue.github_node_id END,
             github_updated_at = GREATEST(gh.issue.github_updated_at, EXCLUDED.github_updated_at),
             synced_at         = now()
     RETURNING * INTO v_row;
@@ -290,6 +318,8 @@ LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+ROWS 100
+COST 50
 AS $$
     SELECT *
     FROM gh.issue
@@ -320,6 +350,8 @@ RETURNS TABLE (
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+ROWS 50
+COST 100
 AS $$
 DECLARE
     v_lease INTERVAL := make_interval(secs => GREATEST(p_lease_secs, 30));
@@ -370,7 +402,7 @@ BEGIN
             last_error     = NULL,
             updated_at     = now()
         WHERE id = p_id
-          AND delivery_state < 2;
+          AND delivery_state = 1;
 
     GET DIAGNOSTICS v_rows = ROW_COUNT;
     RETURN v_rows > 0;
@@ -403,7 +435,7 @@ BEGIN
             last_error     = LEFT(COALESCE(p_error, ''), 2000),
             updated_at     = now()
         WHERE id = p_id
-          AND delivery_state < 2
+          AND delivery_state = 1
         RETURNING delivery_state INTO v_new_state;
 
     RETURN v_new_state;
@@ -418,9 +450,6 @@ ALTER SCHEMA gh OWNER TO service_role;
 ALTER TABLE gh.issue OWNER TO service_role;
 ALTER TABLE gh.issue_event OWNER TO service_role;
 ALTER SEQUENCE gh.issue_event_id_seq OWNER TO service_role;
-
-ALTER DEFAULT PRIVILEGES IN SCHEMA gh
-    GRANT EXECUTE ON FUNCTIONS TO service_role;
 
 COMMENT ON SCHEMA gh IS
 'L2 cache for GitHub issue/PR metadata + append-only event queue feeding the discordsh thread sync. Mirror-only, RPC-only surface (no direct table grants), owned by service_role.';
@@ -439,7 +468,7 @@ COMMENT ON FUNCTION gh.claim_undelivered_events(INT, INT) IS
 COMMENT ON FUNCTION gh.mark_event_delivered(BIGINT) IS
 'Transitions delivery_state 0/1 → 2 once the bot reflects the event in the matching thread. Idempotent: returns false on rows already in state ≥ 2.';
 COMMENT ON FUNCTION gh.mark_event_failed(BIGINT, TEXT, INT) IS
-'Release the lease + record last_error. Transitions state 1 → 0 (retryable) when delivery_attempts < p_max_attempts, otherwise 1 → 3 (dead_letter). Returns the new delivery_state (NULL if the row was already terminal). last_error truncated to 2000 chars.';
+'Release the lease + record last_error. Caller must be in state=1 (claimed); rows already terminal (2/3) or never claimed (0) return NULL. Because delivery_attempts is incremented at claim time, a failure on the N-th claimed attempt dead-letters when delivery_attempts >= p_max_attempts at that point — i.e. p_max_attempts=1 dead-letters on the first failure, =25 on the 25th. Otherwise transitions 1 → 0 so the event becomes claimable again. last_error truncated to 2000 chars.';
 
 NOTIFY pgrst, 'reload schema';
 

--- a/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
@@ -2,6 +2,9 @@
 
 CREATE SCHEMA IF NOT EXISTS gh;
 
+REVOKE ALL ON SCHEMA gh FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA gh TO service_role;
+
 CREATE TABLE IF NOT EXISTS gh.issue (
     owner               TEXT        NOT NULL,
     repo                TEXT        NOT NULL,
@@ -22,7 +25,11 @@ CREATE TABLE IF NOT EXISTS gh.issue (
     discord_guild_id    BIGINT,
     discord_channel_id  BIGINT,
     discord_thread_id   BIGINT,
-    PRIMARY KEY (owner, repo, number)
+    PRIMARY KEY (owner, repo, number),
+    CONSTRAINT gh_issue_owner_shape_chk  CHECK (owner ~ '^[A-Za-z0-9_.-]{1,100}$'),
+    CONSTRAINT gh_issue_repo_shape_chk   CHECK (repo  ~ '^[A-Za-z0-9_.-]{1,100}$'),
+    CONSTRAINT gh_issue_number_pos_chk   CHECK (number > 0),
+    CONSTRAINT gh_issue_state_chk        CHECK (state IN ('open', 'closed'))
 );
 
 CREATE INDEX IF NOT EXISTS gh_issue_state_idx
@@ -31,7 +38,7 @@ CREATE INDEX IF NOT EXISTS gh_issue_state_idx
 CREATE INDEX IF NOT EXISTS gh_issue_updated_idx
     ON gh.issue (github_updated_at DESC);
 
-CREATE INDEX IF NOT EXISTS gh_issue_thread_idx
+CREATE UNIQUE INDEX IF NOT EXISTS gh_issue_discord_thread_unique
     ON gh.issue (discord_thread_id)
     WHERE discord_thread_id IS NOT NULL;
 
@@ -46,10 +53,18 @@ CREATE TABLE IF NOT EXISTS gh.issue_event (
     github_delivery_id   TEXT,
     delivered_to_discord BOOLEAN     NOT NULL DEFAULT FALSE,
     delivered_at         TIMESTAMPTZ,
+    claimed_at           TIMESTAMPTZ,
+    delivery_attempts    INT         NOT NULL DEFAULT 0,
+    last_error           TEXT,
     created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
     FOREIGN KEY (owner, repo, number)
         REFERENCES gh.issue (owner, repo, number)
-        ON DELETE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT gh_issue_event_type_shape_chk
+        CHECK (event_type ~ '^[A-Za-z0-9_.:-]{1,80}$'),
+    CONSTRAINT gh_issue_event_attempts_chk
+        CHECK (delivery_attempts >= 0)
 );
 
 CREATE INDEX IF NOT EXISTS gh_issue_event_undelivered_idx
@@ -96,24 +111,35 @@ BEGIN
     )
     VALUES (
         p_owner, p_repo, p_number,
-        p_title, p_state, p_body, COALESCE(p_labels, '[]'::jsonb), COALESCE(p_assignees, '[]'::jsonb),
+        p_title, p_state, p_body,
+        COALESCE(p_labels, '[]'::jsonb),
+        COALESCE(p_assignees, '[]'::jsonb),
         p_author, p_html_url,
         p_is_pull_request, p_github_node_id,
         p_github_created_at, p_github_updated_at, p_closed_at, now()
     )
     ON CONFLICT (owner, repo, number) DO UPDATE
-        SET title             = EXCLUDED.title,
-            state             = EXCLUDED.state,
-            body              = EXCLUDED.body,
-            labels            = EXCLUDED.labels,
-            assignees         = EXCLUDED.assignees,
-            author            = EXCLUDED.author,
-            html_url          = EXCLUDED.html_url,
-            is_pull_request   = EXCLUDED.is_pull_request,
+        SET title             = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
+                                     THEN EXCLUDED.title ELSE gh.issue.title END,
+            state             = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
+                                     THEN EXCLUDED.state ELSE gh.issue.state END,
+            body              = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
+                                     THEN EXCLUDED.body ELSE gh.issue.body END,
+            labels            = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
+                                     THEN EXCLUDED.labels ELSE gh.issue.labels END,
+            assignees         = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
+                                     THEN EXCLUDED.assignees ELSE gh.issue.assignees END,
+            author            = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
+                                     THEN EXCLUDED.author ELSE gh.issue.author END,
+            html_url          = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
+                                     THEN EXCLUDED.html_url ELSE gh.issue.html_url END,
+            is_pull_request   = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
+                                     THEN EXCLUDED.is_pull_request ELSE gh.issue.is_pull_request END,
+            closed_at         = CASE WHEN EXCLUDED.github_updated_at >= gh.issue.github_updated_at
+                                     THEN EXCLUDED.closed_at ELSE gh.issue.closed_at END,
             github_node_id    = COALESCE(EXCLUDED.github_node_id, gh.issue.github_node_id),
             github_created_at = EXCLUDED.github_created_at,
             github_updated_at = GREATEST(gh.issue.github_updated_at, EXCLUDED.github_updated_at),
-            closed_at         = EXCLUDED.closed_at,
             synced_at         = now()
     RETURNING * INTO v_row;
 
@@ -150,18 +176,30 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-    v_row gh.issue;
+    v_row     gh.issue;
+    v_current BIGINT;
 BEGIN
+    SELECT discord_thread_id INTO v_current
+    FROM gh.issue
+    WHERE owner = p_owner AND repo = p_repo AND number = p_number
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'gh.issue not found for %/%/#%', p_owner, p_repo, p_number;
+    END IF;
+
+    IF v_current IS NOT NULL AND v_current <> p_thread_id THEN
+        RAISE EXCEPTION 'gh.issue %/%/#% already mapped to thread %; refusing to remap to %',
+            p_owner, p_repo, p_number, v_current, p_thread_id
+            USING ERRCODE = 'unique_violation';
+    END IF;
+
     UPDATE gh.issue
         SET discord_guild_id   = p_guild_id,
             discord_channel_id = p_channel_id,
             discord_thread_id  = p_thread_id
         WHERE owner = p_owner AND repo = p_repo AND number = p_number
         RETURNING * INTO v_row;
-
-    IF NOT FOUND THEN
-        RAISE EXCEPTION 'gh.issue not found for %/%/#%', p_owner, p_repo, p_number;
-    END IF;
 
     RETURN v_row;
 END;
@@ -245,7 +283,7 @@ AS $$
     FROM gh.issue
     WHERE owner = p_owner AND repo = p_repo AND state = 'open'
     ORDER BY github_updated_at DESC
-    LIMIT GREATEST(p_limit, 1);
+    LIMIT LEAST(GREATEST(p_limit, 1), 500);
 $$;
 
 ALTER FUNCTION gh.list_open_issues(TEXT, TEXT, INT) OWNER TO service_role;
@@ -253,75 +291,139 @@ REVOKE ALL ON FUNCTION gh.list_open_issues(TEXT, TEXT, INT) FROM PUBLIC, anon, a
 GRANT EXECUTE ON FUNCTION gh.list_open_issues(TEXT, TEXT, INT) TO service_role;
 
 CREATE OR REPLACE FUNCTION gh.claim_undelivered_events(
-    p_limit INT DEFAULT 50
+    p_limit       INT      DEFAULT 50,
+    p_lease_secs  INT      DEFAULT 300
 )
 RETURNS TABLE (
-    id           BIGINT,
-    owner        TEXT,
-    repo         TEXT,
-    number       INT,
-    event_type   TEXT,
-    actor        TEXT,
-    payload      JSONB,
-    created_at   TIMESTAMPTZ
+    id                BIGINT,
+    owner             TEXT,
+    repo              TEXT,
+    number            INT,
+    event_type        TEXT,
+    actor             TEXT,
+    payload           JSONB,
+    created_at        TIMESTAMPTZ,
+    delivery_attempts INT
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
+DECLARE
+    v_lease INTERVAL := make_interval(secs => GREATEST(p_lease_secs, 30));
 BEGIN
     RETURN QUERY
     UPDATE gh.issue_event e
-        SET delivered_to_discord = TRUE,
-            delivered_at = now()
+        SET claimed_at        = now(),
+            delivery_attempts = e.delivery_attempts + 1,
+            updated_at        = now()
         WHERE e.id IN (
             SELECT inner_e.id
             FROM gh.issue_event inner_e
             WHERE inner_e.delivered_to_discord = FALSE
+              AND (inner_e.claimed_at IS NULL OR inner_e.claimed_at < now() - v_lease)
             ORDER BY inner_e.created_at ASC
-            LIMIT GREATEST(p_limit, 1)
+            LIMIT LEAST(GREATEST(p_limit, 1), 250)
             FOR UPDATE SKIP LOCKED
         )
         RETURNING
             e.id, e.owner, e.repo, e.number, e.event_type, e.actor,
-            e.payload, e.created_at;
+            e.payload, e.created_at, e.delivery_attempts;
 END;
 $$;
 
-ALTER FUNCTION gh.claim_undelivered_events(INT) OWNER TO service_role;
+ALTER FUNCTION gh.claim_undelivered_events(INT, INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.claim_undelivered_events(INT, INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.claim_undelivered_events(INT, INT) TO service_role;
 
-REVOKE ALL ON FUNCTION gh.claim_undelivered_events(INT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION gh.claim_undelivered_events(INT) TO service_role;
+CREATE OR REPLACE FUNCTION gh.mark_event_delivered(p_id BIGINT)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_rows INT;
+BEGIN
+    UPDATE gh.issue_event
+        SET delivered_to_discord = TRUE,
+            delivered_at         = now(),
+            claimed_at           = NULL,
+            last_error           = NULL,
+            updated_at           = now()
+        WHERE id = p_id
+          AND delivered_to_discord = FALSE;
 
-GRANT USAGE ON SCHEMA gh TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA gh TO service_role;
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA gh TO service_role;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    RETURN v_rows > 0;
+END;
+$$;
+
+ALTER FUNCTION gh.mark_event_delivered(BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.mark_event_delivered(BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.mark_event_delivered(BIGINT) TO service_role;
+
+CREATE OR REPLACE FUNCTION gh.mark_event_failed(p_id BIGINT, p_error TEXT)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_rows INT;
+BEGIN
+    UPDATE gh.issue_event
+        SET claimed_at = NULL,
+            last_error = LEFT(COALESCE(p_error, ''), 2000),
+            updated_at = now()
+        WHERE id = p_id
+          AND delivered_to_discord = FALSE;
+
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    RETURN v_rows > 0;
+END;
+$$;
+
+ALTER FUNCTION gh.mark_event_failed(BIGINT, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.mark_event_failed(BIGINT, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.mark_event_failed(BIGINT, TEXT) TO service_role;
+
+ALTER SCHEMA gh OWNER TO service_role;
+ALTER TABLE gh.issue OWNER TO service_role;
+ALTER TABLE gh.issue_event OWNER TO service_role;
+ALTER SEQUENCE gh.issue_event_id_seq OWNER TO service_role;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA gh
-    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO service_role;
-ALTER DEFAULT PRIVILEGES IN SCHEMA gh
-    GRANT USAGE, SELECT ON SEQUENCES TO service_role;
+    GRANT EXECUTE ON FUNCTIONS TO service_role;
 
 COMMENT ON SCHEMA gh IS
-'L2 cache for GitHub issue/PR metadata + append-only event queue feeding the discordsh thread sync. Mirror-only, owned by service_role.';
+'L2 cache for GitHub issue/PR metadata + append-only event queue feeding the discordsh thread sync. Mirror-only, RPC-only surface (no direct table grants), owned by service_role.';
 COMMENT ON TABLE gh.issue IS
-'Mirror of the latest GitHub issue/PR state for allowlisted repos. discord_thread_id is set once the bot creates a forum thread for the issue.';
+'Mirror of the latest GitHub issue/PR state for allowlisted repos. discord_thread_id is set once the bot creates a forum thread for the issue. Unique partial index on discord_thread_id prevents one thread mapping to multiple issues.';
 COMMENT ON TABLE gh.issue_event IS
-'Append-only stream of upstream GitHub events (opened/closed/labeled/assigned/commented). delivered_to_discord flips true once the bot has reflected the event in the matching thread.';
+'Append-only stream of upstream GitHub events (opened/closed/labeled/assigned/commented). Lease-based delivery: claim_undelivered_events sets claimed_at + bumps delivery_attempts; mark_event_delivered flips delivered_to_discord on Discord success; mark_event_failed records the error and releases the claim so it can be retried after the lease window.';
 COMMENT ON FUNCTION gh.upsert_issue(
     TEXT, TEXT, INT, TEXT, TEXT, TEXT, JSONB, JSONB, TEXT, TEXT, BOOLEAN, TEXT,
     TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ
-) IS 'Atomic upsert from the gh-webhook edge function. github_updated_at uses GREATEST to swallow out-of-order webhook deliveries.';
-COMMENT ON FUNCTION gh.claim_undelivered_events(INT) IS
-'Bot worker fetches the next batch of undelivered events with SKIP LOCKED + atomic mark-delivered. Safe to run concurrently across bot shards.';
+) IS 'Atomic upsert from the gh-webhook edge function. All mutable fields are gated on EXCLUDED.github_updated_at >= existing.github_updated_at so out-of-order or stale webhook deliveries cannot regress newer state. github_updated_at itself uses GREATEST.';
+COMMENT ON FUNCTION gh.set_discord_thread(TEXT, TEXT, INT, BIGINT, BIGINT, BIGINT) IS
+'Idempotent for the same thread_id; refuses to remap an issue already linked to a different thread (raises unique_violation). Locks the row FOR UPDATE.';
+COMMENT ON FUNCTION gh.claim_undelivered_events(INT, INT) IS
+'Lease-based claim. Returns events that are either unclaimed or whose claim has expired (claimed_at < now() - p_lease_secs). Sets claimed_at, increments delivery_attempts. Does NOT mark delivered — caller must invoke mark_event_delivered after the Discord side succeeds, or mark_event_failed on failure so the lease releases for retry.';
+COMMENT ON FUNCTION gh.mark_event_delivered(BIGINT) IS
+'Flips delivered_to_discord = true once the bot has reflected the event in the matching thread. Idempotent — returns false if already delivered.';
+COMMENT ON FUNCTION gh.mark_event_failed(BIGINT, TEXT) IS
+'Release the lease + record the last error so the event becomes claimable again. last_error is truncated to 2000 chars.';
 
 NOTIFY pgrst, 'reload schema';
 
 -- migrate:down
 
+DROP FUNCTION IF EXISTS gh.mark_event_failed(BIGINT, TEXT);
+DROP FUNCTION IF EXISTS gh.mark_event_delivered(BIGINT);
+DROP FUNCTION IF EXISTS gh.claim_undelivered_events(INT, INT);
 DROP FUNCTION IF EXISTS gh.list_open_issues(TEXT, TEXT, INT);
 DROP FUNCTION IF EXISTS gh.get_issue(TEXT, TEXT, INT);
-DROP FUNCTION IF EXISTS gh.claim_undelivered_events(INT);
 DROP FUNCTION IF EXISTS gh.record_event(TEXT, TEXT, INT, TEXT, TEXT, JSONB, TEXT);
 DROP FUNCTION IF EXISTS gh.set_discord_thread(TEXT, TEXT, INT, BIGINT, BIGINT, BIGINT);
 DROP FUNCTION IF EXISTS gh.upsert_issue(

--- a/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
@@ -32,8 +32,9 @@ CREATE TABLE IF NOT EXISTS gh.issue (
     CONSTRAINT gh_issue_state_chk        CHECK (state IN ('open', 'closed'))
 );
 
-CREATE INDEX IF NOT EXISTS gh_issue_state_idx
-    ON gh.issue (owner, repo, state);
+CREATE INDEX IF NOT EXISTS gh_issue_open_by_repo_updated_idx
+    ON gh.issue (owner, repo, github_updated_at DESC)
+    WHERE state = 'open';
 
 CREATE INDEX IF NOT EXISTS gh_issue_updated_idx
     ON gh.issue (github_updated_at DESC);
@@ -51,7 +52,7 @@ CREATE TABLE IF NOT EXISTS gh.issue_event (
     actor                TEXT,
     payload              JSONB       NOT NULL,
     github_delivery_id   TEXT,
-    delivered_to_discord BOOLEAN     NOT NULL DEFAULT FALSE,
+    delivery_state       SMALLINT    NOT NULL DEFAULT 0,
     delivered_at         TIMESTAMPTZ,
     claimed_at           TIMESTAMPTZ,
     delivery_attempts    INT         NOT NULL DEFAULT 0,
@@ -64,12 +65,17 @@ CREATE TABLE IF NOT EXISTS gh.issue_event (
     CONSTRAINT gh_issue_event_type_shape_chk
         CHECK (event_type ~ '^[A-Za-z0-9_.:-]{1,80}$'),
     CONSTRAINT gh_issue_event_attempts_chk
-        CHECK (delivery_attempts >= 0)
+        CHECK (delivery_attempts >= 0),
+    CONSTRAINT gh_issue_event_state_chk
+        CHECK (delivery_state IN (0, 1, 2, 3))
 );
 
-CREATE INDEX IF NOT EXISTS gh_issue_event_undelivered_idx
-    ON gh.issue_event (created_at)
-    WHERE delivered_to_discord = FALSE;
+COMMENT ON COLUMN gh.issue_event.delivery_state IS
+'0=pending (claimable), 1=claimed (in-flight, lease expires at claimed_at + p_lease_secs), 2=delivered (terminal success), 3=dead_letter (terminal failure, retries exhausted).';
+
+CREATE INDEX IF NOT EXISTS gh_issue_event_claimable_idx
+    ON gh.issue_event (created_at, claimed_at)
+    WHERE delivery_state < 2;
 
 CREATE INDEX IF NOT EXISTS gh_issue_event_lookup_idx
     ON gh.issue_event (owner, repo, number, created_at DESC);
@@ -236,6 +242,12 @@ BEGIN
         DO NOTHING
     RETURNING id INTO v_id;
 
+    IF v_id IS NULL AND p_github_delivery_id IS NOT NULL THEN
+        SELECT id INTO v_id
+        FROM gh.issue_event
+        WHERE github_delivery_id = p_github_delivery_id;
+    END IF;
+
     RETURN v_id;
 END;
 $$;
@@ -313,19 +325,25 @@ DECLARE
     v_lease INTERVAL := make_interval(secs => GREATEST(p_lease_secs, 30));
 BEGIN
     RETURN QUERY
+    WITH claimable AS (
+        SELECT inner_e.id
+        FROM gh.issue_event inner_e
+        WHERE inner_e.delivery_state = 0
+           OR (
+               inner_e.delivery_state = 1
+               AND inner_e.claimed_at < now() - v_lease
+           )
+        ORDER BY inner_e.created_at ASC
+        LIMIT LEAST(GREATEST(p_limit, 1), 250)
+        FOR UPDATE SKIP LOCKED
+    )
     UPDATE gh.issue_event e
-        SET claimed_at        = now(),
+        SET delivery_state    = 1,
+            claimed_at        = now(),
             delivery_attempts = e.delivery_attempts + 1,
             updated_at        = now()
-        WHERE e.id IN (
-            SELECT inner_e.id
-            FROM gh.issue_event inner_e
-            WHERE inner_e.delivered_to_discord = FALSE
-              AND (inner_e.claimed_at IS NULL OR inner_e.claimed_at < now() - v_lease)
-            ORDER BY inner_e.created_at ASC
-            LIMIT LEAST(GREATEST(p_limit, 1), 250)
-            FOR UPDATE SKIP LOCKED
-        )
+        FROM claimable c
+        WHERE e.id = c.id
         RETURNING
             e.id, e.owner, e.repo, e.number, e.event_type, e.actor,
             e.payload, e.created_at, e.delivery_attempts;
@@ -346,13 +364,13 @@ DECLARE
     v_rows INT;
 BEGIN
     UPDATE gh.issue_event
-        SET delivered_to_discord = TRUE,
-            delivered_at         = now(),
-            claimed_at           = NULL,
-            last_error           = NULL,
-            updated_at           = now()
+        SET delivery_state = 2,
+            delivered_at   = now(),
+            claimed_at     = NULL,
+            last_error     = NULL,
+            updated_at     = now()
         WHERE id = p_id
-          AND delivered_to_discord = FALSE;
+          AND delivery_state < 2;
 
     GET DIAGNOSTICS v_rows = ROW_COUNT;
     RETURN v_rows > 0;
@@ -363,30 +381,38 @@ ALTER FUNCTION gh.mark_event_delivered(BIGINT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION gh.mark_event_delivered(BIGINT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION gh.mark_event_delivered(BIGINT) TO service_role;
 
-CREATE OR REPLACE FUNCTION gh.mark_event_failed(p_id BIGINT, p_error TEXT)
-RETURNS BOOLEAN
+CREATE OR REPLACE FUNCTION gh.mark_event_failed(
+    p_id           BIGINT,
+    p_error        TEXT,
+    p_max_attempts INT DEFAULT 25
+)
+RETURNS SMALLINT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-    v_rows INT;
+    v_new_state SMALLINT;
 BEGIN
     UPDATE gh.issue_event
-        SET claimed_at = NULL,
-            last_error = LEFT(COALESCE(p_error, ''), 2000),
-            updated_at = now()
+        SET delivery_state = CASE
+                                WHEN delivery_attempts >= GREATEST(p_max_attempts, 1) THEN 3
+                                ELSE 0
+                             END,
+            claimed_at     = NULL,
+            last_error     = LEFT(COALESCE(p_error, ''), 2000),
+            updated_at     = now()
         WHERE id = p_id
-          AND delivered_to_discord = FALSE;
+          AND delivery_state < 2
+        RETURNING delivery_state INTO v_new_state;
 
-    GET DIAGNOSTICS v_rows = ROW_COUNT;
-    RETURN v_rows > 0;
+    RETURN v_new_state;
 END;
 $$;
 
-ALTER FUNCTION gh.mark_event_failed(BIGINT, TEXT) OWNER TO service_role;
-REVOKE ALL ON FUNCTION gh.mark_event_failed(BIGINT, TEXT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION gh.mark_event_failed(BIGINT, TEXT) TO service_role;
+ALTER FUNCTION gh.mark_event_failed(BIGINT, TEXT, INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.mark_event_failed(BIGINT, TEXT, INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.mark_event_failed(BIGINT, TEXT, INT) TO service_role;
 
 ALTER SCHEMA gh OWNER TO service_role;
 ALTER TABLE gh.issue OWNER TO service_role;
@@ -401,7 +427,7 @@ COMMENT ON SCHEMA gh IS
 COMMENT ON TABLE gh.issue IS
 'Mirror of the latest GitHub issue/PR state for allowlisted repos. discord_thread_id is set once the bot creates a forum thread for the issue. Unique partial index on discord_thread_id prevents one thread mapping to multiple issues.';
 COMMENT ON TABLE gh.issue_event IS
-'Append-only stream of upstream GitHub events (opened/closed/labeled/assigned/commented). Lease-based delivery: claim_undelivered_events sets claimed_at + bumps delivery_attempts; mark_event_delivered flips delivered_to_discord on Discord success; mark_event_failed records the error and releases the claim so it can be retried after the lease window.';
+'Event queue for upstream GitHub events (opened/closed/labeled/assigned/commented). Row facts (owner/repo/number/event_type/payload/...) are immutable after insert; delivery_state + claimed_at + delivered_at + delivery_attempts + last_error mutate as the worker processes the event. Lease-based: claim_undelivered_events transitions 0→1 + bumps attempts; mark_event_delivered transitions 1→2 on Discord success; mark_event_failed transitions 1→0 (retryable) or 1→3 (dead_letter after p_max_attempts).';
 COMMENT ON FUNCTION gh.upsert_issue(
     TEXT, TEXT, INT, TEXT, TEXT, TEXT, JSONB, JSONB, TEXT, TEXT, BOOLEAN, TEXT,
     TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ
@@ -411,15 +437,15 @@ COMMENT ON FUNCTION gh.set_discord_thread(TEXT, TEXT, INT, BIGINT, BIGINT, BIGIN
 COMMENT ON FUNCTION gh.claim_undelivered_events(INT, INT) IS
 'Lease-based claim. Returns events that are either unclaimed or whose claim has expired (claimed_at < now() - p_lease_secs). Sets claimed_at, increments delivery_attempts. Does NOT mark delivered — caller must invoke mark_event_delivered after the Discord side succeeds, or mark_event_failed on failure so the lease releases for retry.';
 COMMENT ON FUNCTION gh.mark_event_delivered(BIGINT) IS
-'Flips delivered_to_discord = true once the bot has reflected the event in the matching thread. Idempotent — returns false if already delivered.';
-COMMENT ON FUNCTION gh.mark_event_failed(BIGINT, TEXT) IS
-'Release the lease + record the last error so the event becomes claimable again. last_error is truncated to 2000 chars.';
+'Transitions delivery_state 0/1 → 2 once the bot reflects the event in the matching thread. Idempotent: returns false on rows already in state ≥ 2.';
+COMMENT ON FUNCTION gh.mark_event_failed(BIGINT, TEXT, INT) IS
+'Release the lease + record last_error. Transitions state 1 → 0 (retryable) when delivery_attempts < p_max_attempts, otherwise 1 → 3 (dead_letter). Returns the new delivery_state (NULL if the row was already terminal). last_error truncated to 2000 chars.';
 
 NOTIFY pgrst, 'reload schema';
 
 -- migrate:down
 
-DROP FUNCTION IF EXISTS gh.mark_event_failed(BIGINT, TEXT);
+DROP FUNCTION IF EXISTS gh.mark_event_failed(BIGINT, TEXT, INT);
 DROP FUNCTION IF EXISTS gh.mark_event_delivered(BIGINT);
 DROP FUNCTION IF EXISTS gh.claim_undelivered_events(INT, INT);
 DROP FUNCTION IF EXISTS gh.list_open_issues(TEXT, TEXT, INT);

--- a/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
@@ -103,7 +103,15 @@ CREATE TABLE IF NOT EXISTS gh.issue_event (
     CONSTRAINT gh_issue_event_delivered_after_created_chk
         CHECK (delivered_at IS NULL OR delivered_at >= created_at),
     CONSTRAINT gh_issue_event_claim_token_when_claimed_chk
-        CHECK (delivery_state <> 1 OR claim_token IS NOT NULL)
+        CHECK (delivery_state <> 1 OR claim_token IS NOT NULL),
+    CONSTRAINT gh_issue_event_claim_token_only_when_claimed_chk
+        CHECK (delivery_state = 1 OR claim_token IS NULL),
+    CONSTRAINT gh_issue_event_claimed_at_when_claimed_chk
+        CHECK (delivery_state <> 1 OR claimed_at IS NOT NULL),
+    CONSTRAINT gh_issue_event_claimed_at_only_when_claimed_chk
+        CHECK (delivery_state = 1 OR claimed_at IS NULL),
+    CONSTRAINT gh_issue_event_delivered_at_when_delivered_chk
+        CHECK (delivery_state <> 2 OR delivered_at IS NOT NULL)
 );
 
 COMMENT ON COLUMN gh.issue_event.delivery_state IS

--- a/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
@@ -50,7 +50,13 @@ CREATE TABLE IF NOT EXISTS gh.issue (
             AND discord_channel_id IS NOT NULL
             AND discord_thread_id  IS NOT NULL
         )
-    )
+    ),
+    CONSTRAINT gh_issue_updated_after_created_chk
+        CHECK (github_updated_at >= github_created_at),
+    CONSTRAINT gh_issue_closed_after_created_chk
+        CHECK (closed_at IS NULL OR closed_at >= github_created_at),
+    CONSTRAINT gh_issue_open_has_no_closed_at_chk
+        CHECK (state <> 'open' OR closed_at IS NULL)
 );
 
 CREATE INDEX IF NOT EXISTS gh_issue_open_by_repo_updated_idx
@@ -76,6 +82,7 @@ CREATE TABLE IF NOT EXISTS gh.issue_event (
     delivery_state       SMALLINT    NOT NULL DEFAULT 0,
     delivered_at         TIMESTAMPTZ,
     claimed_at           TIMESTAMPTZ,
+    claim_token          UUID,
     delivery_attempts    INT         NOT NULL DEFAULT 0,
     last_error           TEXT,
     created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -90,7 +97,13 @@ CREATE TABLE IF NOT EXISTS gh.issue_event (
     CONSTRAINT gh_issue_event_state_chk
         CHECK (delivery_state IN (0, 1, 2, 3)),
     CONSTRAINT gh_issue_event_payload_object_chk
-        CHECK (jsonb_typeof(payload) = 'object')
+        CHECK (jsonb_typeof(payload) = 'object'),
+    CONSTRAINT gh_issue_event_claimed_after_created_chk
+        CHECK (claimed_at IS NULL OR claimed_at >= created_at),
+    CONSTRAINT gh_issue_event_delivered_after_created_chk
+        CHECK (delivered_at IS NULL OR delivered_at >= created_at),
+    CONSTRAINT gh_issue_event_claim_token_when_claimed_chk
+        CHECK (delivery_state <> 1 OR claim_token IS NOT NULL)
 );
 
 COMMENT ON COLUMN gh.issue_event.delivery_state IS
@@ -103,6 +116,10 @@ CREATE INDEX IF NOT EXISTS gh_issue_event_pending_claim_idx
 CREATE INDEX IF NOT EXISTS gh_issue_event_expired_claim_idx
     ON gh.issue_event (claimed_at, created_at, id)
     WHERE delivery_state = 1;
+
+CREATE INDEX IF NOT EXISTS gh_issue_event_dead_letter_idx
+    ON gh.issue_event (updated_at DESC, id DESC)
+    WHERE delivery_state = 3;
 
 CREATE INDEX IF NOT EXISTS gh_issue_event_lookup_idx
     ON gh.issue_event (owner, repo, number, created_at DESC);
@@ -345,7 +362,8 @@ RETURNS TABLE (
     actor             TEXT,
     payload           JSONB,
     created_at        TIMESTAMPTZ,
-    delivery_attempts INT
+    delivery_attempts INT,
+    claim_token       UUID
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -372,13 +390,14 @@ BEGIN
     UPDATE gh.issue_event e
         SET delivery_state    = 1,
             claimed_at        = now(),
+            claim_token       = gen_random_uuid(),
             delivery_attempts = e.delivery_attempts + 1,
             updated_at        = now()
         FROM claimable c
         WHERE e.id = c.id
         RETURNING
             e.id, e.owner, e.repo, e.number, e.event_type, e.actor,
-            e.payload, e.created_at, e.delivery_attempts;
+            e.payload, e.created_at, e.delivery_attempts, e.claim_token;
 END;
 $$;
 
@@ -386,7 +405,10 @@ ALTER FUNCTION gh.claim_undelivered_events(INT, INT) OWNER TO service_role;
 REVOKE ALL ON FUNCTION gh.claim_undelivered_events(INT, INT) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION gh.claim_undelivered_events(INT, INT) TO service_role;
 
-CREATE OR REPLACE FUNCTION gh.mark_event_delivered(p_id BIGINT)
+CREATE OR REPLACE FUNCTION gh.mark_event_delivered(
+    p_id          BIGINT,
+    p_claim_token UUID
+)
 RETURNS BOOLEAN
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -399,22 +421,25 @@ BEGIN
         SET delivery_state = 2,
             delivered_at   = now(),
             claimed_at     = NULL,
+            claim_token    = NULL,
             last_error     = NULL,
             updated_at     = now()
         WHERE id = p_id
-          AND delivery_state = 1;
+          AND delivery_state = 1
+          AND claim_token = p_claim_token;
 
     GET DIAGNOSTICS v_rows = ROW_COUNT;
     RETURN v_rows > 0;
 END;
 $$;
 
-ALTER FUNCTION gh.mark_event_delivered(BIGINT) OWNER TO service_role;
-REVOKE ALL ON FUNCTION gh.mark_event_delivered(BIGINT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION gh.mark_event_delivered(BIGINT) TO service_role;
+ALTER FUNCTION gh.mark_event_delivered(BIGINT, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.mark_event_delivered(BIGINT, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.mark_event_delivered(BIGINT, UUID) TO service_role;
 
 CREATE OR REPLACE FUNCTION gh.mark_event_failed(
     p_id           BIGINT,
+    p_claim_token  UUID,
     p_error        TEXT,
     p_max_attempts INT DEFAULT 25
 )
@@ -432,19 +457,51 @@ BEGIN
                                 ELSE 0
                              END,
             claimed_at     = NULL,
+            claim_token    = NULL,
             last_error     = LEFT(COALESCE(p_error, ''), 2000),
             updated_at     = now()
         WHERE id = p_id
           AND delivery_state = 1
+          AND claim_token = p_claim_token
         RETURNING delivery_state INTO v_new_state;
 
     RETURN v_new_state;
 END;
 $$;
 
-ALTER FUNCTION gh.mark_event_failed(BIGINT, TEXT, INT) OWNER TO service_role;
-REVOKE ALL ON FUNCTION gh.mark_event_failed(BIGINT, TEXT, INT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION gh.mark_event_failed(BIGINT, TEXT, INT) TO service_role;
+ALTER FUNCTION gh.mark_event_failed(BIGINT, UUID, TEXT, INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.mark_event_failed(BIGINT, UUID, TEXT, INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.mark_event_failed(BIGINT, UUID, TEXT, INT) TO service_role;
+
+CREATE OR REPLACE FUNCTION gh.event_queue_stats()
+RETURNS TABLE (
+    pending           BIGINT,
+    claimed           BIGINT,
+    delivered         BIGINT,
+    dead_letter       BIGINT,
+    oldest_pending_at TIMESTAMPTZ,
+    oldest_claimed_at TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 1
+COST 50
+AS $$
+    SELECT
+        count(*) FILTER (WHERE delivery_state = 0) AS pending,
+        count(*) FILTER (WHERE delivery_state = 1) AS claimed,
+        count(*) FILTER (WHERE delivery_state = 2) AS delivered,
+        count(*) FILTER (WHERE delivery_state = 3) AS dead_letter,
+        min(created_at) FILTER (WHERE delivery_state = 0) AS oldest_pending_at,
+        min(claimed_at) FILTER (WHERE delivery_state = 1) AS oldest_claimed_at
+    FROM gh.issue_event;
+$$;
+
+ALTER FUNCTION gh.event_queue_stats() OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.event_queue_stats() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.event_queue_stats() TO service_role;
 
 ALTER SCHEMA gh OWNER TO service_role;
 ALTER TABLE gh.issue OWNER TO service_role;
@@ -464,18 +521,21 @@ COMMENT ON FUNCTION gh.upsert_issue(
 COMMENT ON FUNCTION gh.set_discord_thread(TEXT, TEXT, INT, BIGINT, BIGINT, BIGINT) IS
 'Idempotent for the same thread_id; refuses to remap an issue already linked to a different thread (raises unique_violation). Locks the row FOR UPDATE.';
 COMMENT ON FUNCTION gh.claim_undelivered_events(INT, INT) IS
-'Lease-based claim. Returns events that are either unclaimed or whose claim has expired (claimed_at < now() - p_lease_secs). Sets claimed_at, increments delivery_attempts. Does NOT mark delivered — caller must invoke mark_event_delivered after the Discord side succeeds, or mark_event_failed on failure so the lease releases for retry.';
-COMMENT ON FUNCTION gh.mark_event_delivered(BIGINT) IS
-'Transitions delivery_state 0/1 → 2 once the bot reflects the event in the matching thread. Idempotent: returns false on rows already in state ≥ 2.';
-COMMENT ON FUNCTION gh.mark_event_failed(BIGINT, TEXT, INT) IS
-'Release the lease + record last_error. Caller must be in state=1 (claimed); rows already terminal (2/3) or never claimed (0) return NULL. Because delivery_attempts is incremented at claim time, a failure on the N-th claimed attempt dead-letters when delivery_attempts >= p_max_attempts at that point — i.e. p_max_attempts=1 dead-letters on the first failure, =25 on the 25th. Otherwise transitions 1 → 0 so the event becomes claimable again. last_error truncated to 2000 chars.';
+'Lease-based claim. Returns events that are either unclaimed (state=0) or whose claim has expired (state=1 AND claimed_at < now() - p_lease_secs). Sets state=1, claimed_at=now(), generates a fresh claim_token (UUID), increments delivery_attempts. Does NOT mark delivered — caller must invoke mark_event_delivered with the returned claim_token after Discord succeeds, or mark_event_failed on failure. claim_token is required by the finalizers so a stalled worker cannot finalize a row that another worker has since reclaimed.';
+COMMENT ON FUNCTION gh.mark_event_delivered(BIGINT, UUID) IS
+'Transitions delivery_state 1 → 2 once the bot reflects the event in the matching thread. Requires p_claim_token match the current claim_token on the row, so a stalled worker that finishes after lease expiry + reclaim by another worker is rejected. Returns false on rows not currently claimed by this worker (state != 1 or token mismatch).';
+COMMENT ON FUNCTION gh.mark_event_failed(BIGINT, UUID, TEXT, INT) IS
+'Release the lease + record last_error. Caller must be in state=1 with a matching claim_token; rows already terminal (2/3), never claimed (0), or claimed by a different worker return NULL. Because delivery_attempts is incremented at claim time, a failure on the N-th claimed attempt dead-letters when delivery_attempts >= p_max_attempts at that point — i.e. p_max_attempts=1 dead-letters on the first failure, =25 on the 25th. Otherwise transitions 1 → 0 so the event becomes claimable again. last_error truncated to 2000 chars.';
+COMMENT ON FUNCTION gh.event_queue_stats() IS
+'Operational counter snapshot per delivery_state plus oldest pending and oldest still-claimed timestamps. Use to surface stuck workers, growing backlogs, or accumulating dead-letters. Cheap full-table aggregate, fine to poll at minute granularity.';
 
 NOTIFY pgrst, 'reload schema';
 
 -- migrate:down
 
-DROP FUNCTION IF EXISTS gh.mark_event_failed(BIGINT, TEXT, INT);
-DROP FUNCTION IF EXISTS gh.mark_event_delivered(BIGINT);
+DROP FUNCTION IF EXISTS gh.event_queue_stats();
+DROP FUNCTION IF EXISTS gh.mark_event_failed(BIGINT, UUID, TEXT, INT);
+DROP FUNCTION IF EXISTS gh.mark_event_delivered(BIGINT, UUID);
 DROP FUNCTION IF EXISTS gh.claim_undelivered_events(INT, INT);
 DROP FUNCTION IF EXISTS gh.list_open_issues(TEXT, TEXT, INT);
 DROP FUNCTION IF EXISTS gh.get_issue(TEXT, TEXT, INT);

--- a/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
@@ -1,0 +1,334 @@
+-- migrate:up
+
+CREATE SCHEMA IF NOT EXISTS gh;
+
+CREATE TABLE IF NOT EXISTS gh.issue (
+    owner               TEXT        NOT NULL,
+    repo                TEXT        NOT NULL,
+    number              INT         NOT NULL,
+    title               TEXT        NOT NULL,
+    state               TEXT        NOT NULL,
+    body                TEXT,
+    labels              JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    assignees           JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    author              TEXT,
+    html_url            TEXT        NOT NULL,
+    is_pull_request     BOOLEAN     NOT NULL DEFAULT FALSE,
+    github_node_id      TEXT,
+    github_created_at   TIMESTAMPTZ NOT NULL,
+    github_updated_at   TIMESTAMPTZ NOT NULL,
+    closed_at           TIMESTAMPTZ,
+    synced_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    discord_guild_id    BIGINT,
+    discord_channel_id  BIGINT,
+    discord_thread_id   BIGINT,
+    PRIMARY KEY (owner, repo, number)
+);
+
+CREATE INDEX IF NOT EXISTS gh_issue_state_idx
+    ON gh.issue (owner, repo, state);
+
+CREATE INDEX IF NOT EXISTS gh_issue_updated_idx
+    ON gh.issue (github_updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS gh_issue_thread_idx
+    ON gh.issue (discord_thread_id)
+    WHERE discord_thread_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS gh.issue_event (
+    id                   BIGSERIAL PRIMARY KEY,
+    owner                TEXT        NOT NULL,
+    repo                 TEXT        NOT NULL,
+    number               INT         NOT NULL,
+    event_type           TEXT        NOT NULL,
+    actor                TEXT,
+    payload              JSONB       NOT NULL,
+    github_delivery_id   TEXT,
+    delivered_to_discord BOOLEAN     NOT NULL DEFAULT FALSE,
+    delivered_at         TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    FOREIGN KEY (owner, repo, number)
+        REFERENCES gh.issue (owner, repo, number)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS gh_issue_event_undelivered_idx
+    ON gh.issue_event (created_at)
+    WHERE delivered_to_discord = FALSE;
+
+CREATE INDEX IF NOT EXISTS gh_issue_event_lookup_idx
+    ON gh.issue_event (owner, repo, number, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS gh_issue_event_delivery_unique
+    ON gh.issue_event (github_delivery_id)
+    WHERE github_delivery_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION gh.upsert_issue(
+    p_owner             TEXT,
+    p_repo              TEXT,
+    p_number            INT,
+    p_title             TEXT,
+    p_state             TEXT,
+    p_body              TEXT,
+    p_labels            JSONB,
+    p_assignees         JSONB,
+    p_author            TEXT,
+    p_html_url          TEXT,
+    p_is_pull_request   BOOLEAN,
+    p_github_node_id    TEXT,
+    p_github_created_at TIMESTAMPTZ,
+    p_github_updated_at TIMESTAMPTZ,
+    p_closed_at         TIMESTAMPTZ
+)
+RETURNS gh.issue
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_row gh.issue;
+BEGIN
+    INSERT INTO gh.issue (
+        owner, repo, number,
+        title, state, body, labels, assignees, author, html_url,
+        is_pull_request, github_node_id,
+        github_created_at, github_updated_at, closed_at, synced_at
+    )
+    VALUES (
+        p_owner, p_repo, p_number,
+        p_title, p_state, p_body, COALESCE(p_labels, '[]'::jsonb), COALESCE(p_assignees, '[]'::jsonb),
+        p_author, p_html_url,
+        p_is_pull_request, p_github_node_id,
+        p_github_created_at, p_github_updated_at, p_closed_at, now()
+    )
+    ON CONFLICT (owner, repo, number) DO UPDATE
+        SET title             = EXCLUDED.title,
+            state             = EXCLUDED.state,
+            body              = EXCLUDED.body,
+            labels            = EXCLUDED.labels,
+            assignees         = EXCLUDED.assignees,
+            author            = EXCLUDED.author,
+            html_url          = EXCLUDED.html_url,
+            is_pull_request   = EXCLUDED.is_pull_request,
+            github_node_id    = COALESCE(EXCLUDED.github_node_id, gh.issue.github_node_id),
+            github_created_at = EXCLUDED.github_created_at,
+            github_updated_at = GREATEST(gh.issue.github_updated_at, EXCLUDED.github_updated_at),
+            closed_at         = EXCLUDED.closed_at,
+            synced_at         = now()
+    RETURNING * INTO v_row;
+
+    RETURN v_row;
+END;
+$$;
+
+ALTER FUNCTION gh.upsert_issue(
+    TEXT, TEXT, INT, TEXT, TEXT, TEXT, JSONB, JSONB, TEXT, TEXT, BOOLEAN, TEXT,
+    TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ
+) OWNER TO service_role;
+
+REVOKE ALL ON FUNCTION gh.upsert_issue(
+    TEXT, TEXT, INT, TEXT, TEXT, TEXT, JSONB, JSONB, TEXT, TEXT, BOOLEAN, TEXT,
+    TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ
+) FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION gh.upsert_issue(
+    TEXT, TEXT, INT, TEXT, TEXT, TEXT, JSONB, JSONB, TEXT, TEXT, BOOLEAN, TEXT,
+    TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ
+) TO service_role;
+
+CREATE OR REPLACE FUNCTION gh.set_discord_thread(
+    p_owner       TEXT,
+    p_repo        TEXT,
+    p_number      INT,
+    p_guild_id    BIGINT,
+    p_channel_id  BIGINT,
+    p_thread_id   BIGINT
+)
+RETURNS gh.issue
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_row gh.issue;
+BEGIN
+    UPDATE gh.issue
+        SET discord_guild_id   = p_guild_id,
+            discord_channel_id = p_channel_id,
+            discord_thread_id  = p_thread_id
+        WHERE owner = p_owner AND repo = p_repo AND number = p_number
+        RETURNING * INTO v_row;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'gh.issue not found for %/%/#%', p_owner, p_repo, p_number;
+    END IF;
+
+    RETURN v_row;
+END;
+$$;
+
+ALTER FUNCTION gh.set_discord_thread(TEXT, TEXT, INT, BIGINT, BIGINT, BIGINT) OWNER TO service_role;
+
+REVOKE ALL ON FUNCTION gh.set_discord_thread(TEXT, TEXT, INT, BIGINT, BIGINT, BIGINT)
+    FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION gh.set_discord_thread(TEXT, TEXT, INT, BIGINT, BIGINT, BIGINT)
+    TO service_role;
+
+CREATE OR REPLACE FUNCTION gh.record_event(
+    p_owner              TEXT,
+    p_repo               TEXT,
+    p_number             INT,
+    p_event_type         TEXT,
+    p_actor              TEXT,
+    p_payload            JSONB,
+    p_github_delivery_id TEXT
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_id BIGINT;
+BEGIN
+    INSERT INTO gh.issue_event (owner, repo, number, event_type, actor, payload, github_delivery_id)
+    VALUES (p_owner, p_repo, p_number, p_event_type, p_actor, p_payload, p_github_delivery_id)
+    ON CONFLICT (github_delivery_id) WHERE github_delivery_id IS NOT NULL
+        DO NOTHING
+    RETURNING id INTO v_id;
+
+    RETURN v_id;
+END;
+$$;
+
+ALTER FUNCTION gh.record_event(TEXT, TEXT, INT, TEXT, TEXT, JSONB, TEXT) OWNER TO service_role;
+
+REVOKE ALL ON FUNCTION gh.record_event(TEXT, TEXT, INT, TEXT, TEXT, JSONB, TEXT)
+    FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION gh.record_event(TEXT, TEXT, INT, TEXT, TEXT, JSONB, TEXT)
+    TO service_role;
+
+CREATE OR REPLACE FUNCTION gh.get_issue(
+    p_owner  TEXT,
+    p_repo   TEXT,
+    p_number INT
+)
+RETURNS gh.issue
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT *
+    FROM gh.issue
+    WHERE owner = p_owner AND repo = p_repo AND number = p_number;
+$$;
+
+ALTER FUNCTION gh.get_issue(TEXT, TEXT, INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.get_issue(TEXT, TEXT, INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.get_issue(TEXT, TEXT, INT) TO service_role;
+
+CREATE OR REPLACE FUNCTION gh.list_open_issues(
+    p_owner TEXT,
+    p_repo  TEXT,
+    p_limit INT DEFAULT 100
+)
+RETURNS SETOF gh.issue
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT *
+    FROM gh.issue
+    WHERE owner = p_owner AND repo = p_repo AND state = 'open'
+    ORDER BY github_updated_at DESC
+    LIMIT GREATEST(p_limit, 1);
+$$;
+
+ALTER FUNCTION gh.list_open_issues(TEXT, TEXT, INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.list_open_issues(TEXT, TEXT, INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.list_open_issues(TEXT, TEXT, INT) TO service_role;
+
+CREATE OR REPLACE FUNCTION gh.claim_undelivered_events(
+    p_limit INT DEFAULT 50
+)
+RETURNS TABLE (
+    id           BIGINT,
+    owner        TEXT,
+    repo         TEXT,
+    number       INT,
+    event_type   TEXT,
+    actor        TEXT,
+    payload      JSONB,
+    created_at   TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    RETURN QUERY
+    UPDATE gh.issue_event e
+        SET delivered_to_discord = TRUE,
+            delivered_at = now()
+        WHERE e.id IN (
+            SELECT inner_e.id
+            FROM gh.issue_event inner_e
+            WHERE inner_e.delivered_to_discord = FALSE
+            ORDER BY inner_e.created_at ASC
+            LIMIT GREATEST(p_limit, 1)
+            FOR UPDATE SKIP LOCKED
+        )
+        RETURNING
+            e.id, e.owner, e.repo, e.number, e.event_type, e.actor,
+            e.payload, e.created_at;
+END;
+$$;
+
+ALTER FUNCTION gh.claim_undelivered_events(INT) OWNER TO service_role;
+
+REVOKE ALL ON FUNCTION gh.claim_undelivered_events(INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.claim_undelivered_events(INT) TO service_role;
+
+GRANT USAGE ON SCHEMA gh TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA gh TO service_role;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA gh TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA gh
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA gh
+    GRANT USAGE, SELECT ON SEQUENCES TO service_role;
+
+COMMENT ON SCHEMA gh IS
+'L2 cache for GitHub issue/PR metadata + append-only event queue feeding the discordsh thread sync. Mirror-only, owned by service_role.';
+COMMENT ON TABLE gh.issue IS
+'Mirror of the latest GitHub issue/PR state for allowlisted repos. discord_thread_id is set once the bot creates a forum thread for the issue.';
+COMMENT ON TABLE gh.issue_event IS
+'Append-only stream of upstream GitHub events (opened/closed/labeled/assigned/commented). delivered_to_discord flips true once the bot has reflected the event in the matching thread.';
+COMMENT ON FUNCTION gh.upsert_issue(
+    TEXT, TEXT, INT, TEXT, TEXT, TEXT, JSONB, JSONB, TEXT, TEXT, BOOLEAN, TEXT,
+    TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ
+) IS 'Atomic upsert from the gh-webhook edge function. github_updated_at uses GREATEST to swallow out-of-order webhook deliveries.';
+COMMENT ON FUNCTION gh.claim_undelivered_events(INT) IS
+'Bot worker fetches the next batch of undelivered events with SKIP LOCKED + atomic mark-delivered. Safe to run concurrently across bot shards.';
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS gh.list_open_issues(TEXT, TEXT, INT);
+DROP FUNCTION IF EXISTS gh.get_issue(TEXT, TEXT, INT);
+DROP FUNCTION IF EXISTS gh.claim_undelivered_events(INT);
+DROP FUNCTION IF EXISTS gh.record_event(TEXT, TEXT, INT, TEXT, TEXT, JSONB, TEXT);
+DROP FUNCTION IF EXISTS gh.set_discord_thread(TEXT, TEXT, INT, BIGINT, BIGINT, BIGINT);
+DROP FUNCTION IF EXISTS gh.upsert_issue(
+    TEXT, TEXT, INT, TEXT, TEXT, TEXT, JSONB, JSONB, TEXT, TEXT, BOOLEAN, TEXT,
+    TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ
+);
+DROP TABLE IF EXISTS gh.issue_event;
+DROP TABLE IF EXISTS gh.issue;
+DROP SCHEMA IF EXISTS gh;
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
+++ b/packages/data/sql/dbmate/migrations/20260523033933_gh_issue_cache_init.sql
@@ -466,6 +466,7 @@ BEGIN
                              END,
             claimed_at     = NULL,
             claim_token    = NULL,
+            delivered_at   = NULL,
             last_error     = LEFT(COALESCE(p_error, ''), 2000),
             updated_at     = now()
         WHERE id = p_id
@@ -521,7 +522,7 @@ COMMENT ON SCHEMA gh IS
 COMMENT ON TABLE gh.issue IS
 'Mirror of the latest GitHub issue/PR state for allowlisted repos. discord_thread_id is set once the bot creates a forum thread for the issue. Unique partial index on discord_thread_id prevents one thread mapping to multiple issues.';
 COMMENT ON TABLE gh.issue_event IS
-'Event queue for upstream GitHub events (opened/closed/labeled/assigned/commented). Row facts (owner/repo/number/event_type/payload/...) are immutable after insert; delivery_state + claimed_at + delivered_at + delivery_attempts + last_error mutate as the worker processes the event. Lease-based: claim_undelivered_events transitions 0→1 + bumps attempts; mark_event_delivered transitions 1→2 on Discord success; mark_event_failed transitions 1→0 (retryable) or 1→3 (dead_letter after p_max_attempts).';
+'Event queue for upstream GitHub events (opened/closed/labeled/assigned/commented). Row facts (owner/repo/number/event_type/payload/...) are treated as immutable by the RPC surface after insert — no trigger enforces this, but no role outside service_role can reach the table and the RPCs never update those columns. delivery_state + claimed_at + delivered_at + delivery_attempts + last_error + claim_token mutate as the worker processes the event. Lease-based: claim_undelivered_events transitions 0→1 + bumps attempts; mark_event_delivered transitions 1→2 on Discord success; mark_event_failed transitions 1→0 (retryable) or 1→3 (dead_letter after p_max_attempts).';
 COMMENT ON FUNCTION gh.upsert_issue(
     TEXT, TEXT, INT, TEXT, TEXT, TEXT, JSONB, JSONB, TEXT, TEXT, BOOLEAN, TEXT,
     TIMESTAMPTZ, TIMESTAMPTZ, TIMESTAMPTZ

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.78"
 
 [features]
 default = []
-supabase = ["dep:lru"]
+supabase = ["dep:lru", "dep:uuid"]
 image-gen = ["dep:resvg"]
 wallet = ["dep:uuid"]
 legacy-sync-db = ["diesel/postgres", "diesel/r2d2", "dep:r2d2"]

--- a/packages/rust/kbve/src/entity/client/github_store.rs
+++ b/packages/rust/kbve/src/entity/client/github_store.rs
@@ -328,23 +328,36 @@ impl GithubStore {
     }
 
     pub async fn mark_event_delivered(&self, id: i64) -> Result<bool, GithubStoreError> {
-        self.call_event_state("mark_event_delivered", serde_json::json!({ "p_id": id }))
-            .await
+        let resp_text = self
+            .call_event_state_raw("mark_event_delivered", serde_json::json!({ "p_id": id }))
+            .await?;
+        parse_bool_body(&resp_text)
     }
 
-    pub async fn mark_event_failed(&self, id: i64, error: &str) -> Result<bool, GithubStoreError> {
-        self.call_event_state(
-            "mark_event_failed",
-            serde_json::json!({ "p_id": id, "p_error": error }),
-        )
-        .await
+    pub async fn mark_event_failed(
+        &self,
+        id: i64,
+        error: &str,
+        max_attempts: u32,
+    ) -> Result<DeliveryState, GithubStoreError> {
+        let resp_text = self
+            .call_event_state_raw(
+                "mark_event_failed",
+                serde_json::json!({
+                    "p_id": id,
+                    "p_error": error,
+                    "p_max_attempts": max_attempts,
+                }),
+            )
+            .await?;
+        parse_delivery_state_body(&resp_text)
     }
 
-    async fn call_event_state(
+    async fn call_event_state_raw(
         &self,
         rpc: &str,
         params: serde_json::Value,
-    ) -> Result<bool, GithubStoreError> {
+    ) -> Result<String, GithubStoreError> {
         let Some(client) = self.client.as_ref() else {
             return Err(GithubStoreError::NotConfigured);
         };
@@ -358,15 +371,52 @@ impl GithubStore {
             return Err(GithubStoreError::Http { status, body: text });
         }
 
-        let trimmed = text.trim();
-        if trimmed == "true" {
-            Ok(true)
-        } else if trimmed == "false" {
-            Ok(false)
-        } else {
-            serde_json::from_str::<bool>(trimmed).map_err(GithubStoreError::Decode)
+        Ok(text)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryState {
+    Pending,
+    Claimed,
+    Delivered,
+    DeadLetter,
+}
+
+impl DeliveryState {
+    pub fn from_smallint(v: i16) -> Option<Self> {
+        match v {
+            0 => Some(Self::Pending),
+            1 => Some(Self::Claimed),
+            2 => Some(Self::Delivered),
+            3 => Some(Self::DeadLetter),
+            _ => None,
         }
     }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Delivered | Self::DeadLetter)
+    }
+}
+
+fn parse_bool_body(text: &str) -> Result<bool, GithubStoreError> {
+    let trimmed = text.trim();
+    if trimmed == "true" {
+        Ok(true)
+    } else if trimmed == "false" {
+        Ok(false)
+    } else {
+        serde_json::from_str::<bool>(trimmed).map_err(GithubStoreError::Decode)
+    }
+}
+
+fn parse_delivery_state_body(text: &str) -> Result<DeliveryState, GithubStoreError> {
+    let trimmed = text.trim();
+    let n: i16 = serde_json::from_str(trimmed)?;
+    DeliveryState::from_smallint(n).ok_or_else(|| GithubStoreError::Http {
+        status: reqwest::StatusCode::BAD_GATEWAY,
+        body: format!("unexpected delivery_state value: {n}"),
+    })
 }
 
 fn parse_optional_row<T>(text: &str) -> Result<Option<T>, GithubStoreError>
@@ -442,6 +492,42 @@ mod tests {
         assert!(none.is_none());
         let none: Option<CachedIssue> = parse_optional_row("null").unwrap();
         assert!(none.is_none());
+    }
+
+    #[test]
+    fn delivery_state_round_trip() {
+        for (n, st) in [
+            (0, DeliveryState::Pending),
+            (1, DeliveryState::Claimed),
+            (2, DeliveryState::Delivered),
+            (3, DeliveryState::DeadLetter),
+        ] {
+            assert_eq!(DeliveryState::from_smallint(n), Some(st));
+        }
+        assert_eq!(DeliveryState::from_smallint(99), None);
+        assert!(!DeliveryState::Pending.is_terminal());
+        assert!(!DeliveryState::Claimed.is_terminal());
+        assert!(DeliveryState::Delivered.is_terminal());
+        assert!(DeliveryState::DeadLetter.is_terminal());
+    }
+
+    #[test]
+    fn parse_delivery_state_body_accepts_smallint() {
+        assert_eq!(
+            parse_delivery_state_body("0").unwrap(),
+            DeliveryState::Pending
+        );
+        assert_eq!(
+            parse_delivery_state_body(" 3 ").unwrap(),
+            DeliveryState::DeadLetter
+        );
+        assert!(parse_delivery_state_body("99").is_err());
+    }
+
+    #[test]
+    fn parse_bool_body_accepts_true_false() {
+        assert!(parse_bool_body("true").unwrap());
+        assert!(!parse_bool_body("false").unwrap());
     }
 
     #[test]

--- a/packages/rust/kbve/src/entity/client/github_store.rs
+++ b/packages/rust/kbve/src/entity/client/github_store.rs
@@ -91,6 +91,8 @@ pub struct UndeliveredEvent {
     pub actor: Option<String>,
     pub payload: serde_json::Value,
     pub created_at: String,
+    #[serde(default)]
+    pub delivery_attempts: i32,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -297,12 +299,16 @@ impl GithubStore {
     pub async fn claim_undelivered(
         &self,
         limit: u32,
+        lease_secs: u32,
     ) -> Result<Vec<UndeliveredEvent>, GithubStoreError> {
         let Some(client) = self.client.as_ref() else {
             return Err(GithubStoreError::NotConfigured);
         };
 
-        let params = serde_json::json!({ "p_limit": limit });
+        let params = serde_json::json!({
+            "p_limit": limit,
+            "p_lease_secs": lease_secs,
+        });
         let resp = client
             .rpc_schema("claim_undelivered_events", params, SCHEMA)
             .await?;
@@ -319,6 +325,47 @@ impl GithubStore {
             info!(count = rows.len(), "claimed undelivered gh events");
         }
         Ok(rows)
+    }
+
+    pub async fn mark_event_delivered(&self, id: i64) -> Result<bool, GithubStoreError> {
+        self.call_event_state("mark_event_delivered", serde_json::json!({ "p_id": id }))
+            .await
+    }
+
+    pub async fn mark_event_failed(&self, id: i64, error: &str) -> Result<bool, GithubStoreError> {
+        self.call_event_state(
+            "mark_event_failed",
+            serde_json::json!({ "p_id": id, "p_error": error }),
+        )
+        .await
+    }
+
+    async fn call_event_state(
+        &self,
+        rpc: &str,
+        params: serde_json::Value,
+    ) -> Result<bool, GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let resp = client.rpc_schema(rpc, params, SCHEMA).await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, rpc, "gh event-state RPC HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        let trimmed = text.trim();
+        if trimmed == "true" {
+            Ok(true)
+        } else if trimmed == "false" {
+            Ok(false)
+        } else {
+            serde_json::from_str::<bool>(trimmed).map_err(GithubStoreError::Decode)
+        }
     }
 }
 

--- a/packages/rust/kbve/src/entity/client/github_store.rs
+++ b/packages/rust/kbve/src/entity/client/github_store.rs
@@ -1,0 +1,408 @@
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use lru::LruCache;
+use serde::Deserialize;
+use tracing::{info, warn};
+
+use super::supabase::SupabaseClient;
+
+const SCHEMA: &str = "gh";
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CachedIssue {
+    pub owner: String,
+    pub repo: String,
+    pub number: u32,
+    pub title: String,
+    pub state: String,
+    #[serde(default)]
+    pub body: Option<String>,
+    #[serde(default)]
+    pub labels: serde_json::Value,
+    #[serde(default)]
+    pub assignees: serde_json::Value,
+    #[serde(default)]
+    pub author: Option<String>,
+    pub html_url: String,
+    #[serde(default)]
+    pub is_pull_request: bool,
+    pub github_created_at: String,
+    pub github_updated_at: String,
+    #[serde(default)]
+    pub closed_at: Option<String>,
+    pub synced_at: String,
+    #[serde(default)]
+    pub discord_guild_id: Option<i64>,
+    #[serde(default)]
+    pub discord_channel_id: Option<i64>,
+    #[serde(default)]
+    pub discord_thread_id: Option<i64>,
+}
+
+impl CachedIssue {
+    pub fn assignee_logins(&self) -> Vec<String> {
+        self.assignees
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.get("login").and_then(|l| l.as_str()).map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn label_names(&self) -> Vec<String> {
+        self.labels
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.get("name").and_then(|n| n.as_str()).map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn assignee_count(&self) -> usize {
+        self.assignees.as_array().map(|arr| arr.len()).unwrap_or(0)
+    }
+
+    pub fn is_stale(&self, max_age: Duration) -> bool {
+        match chrono::DateTime::parse_from_rfc3339(&self.synced_at) {
+            Ok(synced) => {
+                let now = chrono::Utc::now();
+                let age = now.signed_duration_since(synced.with_timezone(&chrono::Utc));
+                age.to_std().map(|d| d > max_age).unwrap_or(false)
+            }
+            Err(_) => true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UndeliveredEvent {
+    pub id: i64,
+    pub owner: String,
+    pub repo: String,
+    pub number: u32,
+    pub event_type: String,
+    #[serde(default)]
+    pub actor: Option<String>,
+    pub payload: serde_json::Value,
+    pub created_at: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GithubStoreError {
+    #[error("supabase client not configured")]
+    NotConfigured,
+    #[error("supabase HTTP {status}: {body}")]
+    Http {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+    #[error("supabase transport: {0}")]
+    Transport(#[from] super::supabase::SupabaseError),
+    #[error("response decode: {0}")]
+    Decode(#[from] serde_json::Error),
+    #[error("response body: {0}")]
+    Body(#[from] reqwest::Error),
+}
+
+struct CachedEntry {
+    issue: Option<CachedIssue>,
+    expires_at: Instant,
+}
+
+pub struct GithubStore {
+    client: Option<SupabaseClient>,
+    cache: Mutex<LruCache<(String, String, u32), CachedEntry>>,
+    ttl: Duration,
+    stale_after: Duration,
+}
+
+impl GithubStore {
+    pub fn new(client: Option<SupabaseClient>, capacity: usize, ttl: Duration) -> Self {
+        let cap = NonZeroUsize::new(capacity).unwrap_or(NonZeroUsize::new(512).unwrap());
+        Self {
+            client,
+            cache: Mutex::new(LruCache::new(cap)),
+            ttl,
+            stale_after: Duration::from_secs(5 * 60),
+        }
+    }
+
+    pub fn from_env() -> Self {
+        let ttl_secs = std::env::var("GITHUB_STORE_TTL_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(30);
+        let stale_secs = std::env::var("GITHUB_STORE_STALE_AFTER_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(300);
+        let cap = std::env::var("GITHUB_STORE_CAPACITY")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(1024);
+
+        let mut store = Self::new(
+            SupabaseClient::from_env(),
+            cap,
+            Duration::from_secs(ttl_secs),
+        );
+        store.stale_after = Duration::from_secs(stale_secs);
+        store
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.client.is_some()
+    }
+
+    pub fn stale_after(&self) -> Duration {
+        self.stale_after
+    }
+
+    pub fn invalidate(&self, owner: &str, repo: &str, number: u32) {
+        let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
+        cache.pop(&(owner.to_owned(), repo.to_owned(), number));
+    }
+
+    pub async fn get_issue(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u32,
+    ) -> Result<Option<CachedIssue>, GithubStoreError> {
+        let key = (owner.to_owned(), repo.to_owned(), number);
+
+        {
+            let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(entry) = cache.get(&key) {
+                if Instant::now() < entry.expires_at {
+                    return Ok(entry.issue.clone());
+                }
+            }
+        }
+
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({
+            "p_owner": owner,
+            "p_repo": repo,
+            "p_number": number,
+        });
+
+        let resp = client.rpc_schema("get_issue", params, SCHEMA).await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, owner, repo, number, "gh.get_issue HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        let issue = parse_optional_row::<CachedIssue>(&text)?;
+
+        {
+            let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
+            cache.put(
+                key,
+                CachedEntry {
+                    issue: issue.clone(),
+                    expires_at: Instant::now() + self.ttl,
+                },
+            );
+        }
+
+        Ok(issue)
+    }
+
+    pub async fn list_open(
+        &self,
+        owner: &str,
+        repo: &str,
+        limit: u32,
+    ) -> Result<Vec<CachedIssue>, GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({
+            "p_owner": owner,
+            "p_repo": repo,
+            "p_limit": limit,
+        });
+
+        let resp = client
+            .rpc_schema("list_open_issues", params, SCHEMA)
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, owner, repo, "gh.list_open_issues HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        let rows: Vec<CachedIssue> = serde_json::from_str(&text)?;
+        info!(owner, repo, count = rows.len(), "gh.list_open_issues");
+        Ok(rows)
+    }
+
+    pub async fn set_discord_thread(
+        &self,
+        owner: &str,
+        repo: &str,
+        number: u32,
+        guild_id: i64,
+        channel_id: i64,
+        thread_id: i64,
+    ) -> Result<(), GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({
+            "p_owner": owner,
+            "p_repo": repo,
+            "p_number": number,
+            "p_guild_id": guild_id,
+            "p_channel_id": channel_id,
+            "p_thread_id": thread_id,
+        });
+
+        let resp = client
+            .rpc_schema("set_discord_thread", params, SCHEMA)
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, owner, repo, number, "gh.set_discord_thread HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        self.invalidate(owner, repo, number);
+        info!(
+            owner,
+            repo, number, thread_id, "Discord thread linked to gh.issue"
+        );
+        Ok(())
+    }
+
+    pub async fn claim_undelivered(
+        &self,
+        limit: u32,
+    ) -> Result<Vec<UndeliveredEvent>, GithubStoreError> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(GithubStoreError::NotConfigured);
+        };
+
+        let params = serde_json::json!({ "p_limit": limit });
+        let resp = client
+            .rpc_schema("claim_undelivered_events", params, SCHEMA)
+            .await?;
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        if !status.is_success() {
+            warn!(%status, body = %text, "gh.claim_undelivered_events HTTP error");
+            return Err(GithubStoreError::Http { status, body: text });
+        }
+
+        let rows: Vec<UndeliveredEvent> = serde_json::from_str(&text)?;
+        if !rows.is_empty() {
+            info!(count = rows.len(), "claimed undelivered gh events");
+        }
+        Ok(rows)
+    }
+}
+
+fn parse_optional_row<T>(text: &str) -> Result<Option<T>, GithubStoreError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let trimmed = text.trim();
+    if trimmed.is_empty() || trimmed == "null" {
+        return Ok(None);
+    }
+
+    if let Ok(row) = serde_json::from_str::<T>(trimmed) {
+        return Ok(Some(row));
+    }
+
+    let rows: Vec<T> = serde_json::from_str(trimmed)?;
+    Ok(rows.into_iter().next())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_issue_extracts_logins_and_labels() {
+        let raw = serde_json::json!({
+            "owner": "KBVE",
+            "repo": "kbve",
+            "number": 11262,
+            "title": "feat: /gh claim",
+            "state": "open",
+            "labels": [{"name": "enhancement"}, {"name": "discordsh"}],
+            "assignees": [{"login": "h0lybyte"}],
+            "author": "h0lybyte",
+            "html_url": "https://github.com/KBVE/kbve/issues/11262",
+            "is_pull_request": false,
+            "github_created_at": "2026-05-21T00:00:00Z",
+            "github_updated_at": "2026-05-22T00:00:00Z",
+            "synced_at": "2026-05-22T00:00:00Z"
+        });
+        let issue: CachedIssue = serde_json::from_value(raw).unwrap();
+        assert_eq!(issue.assignee_logins(), vec!["h0lybyte"]);
+        assert_eq!(issue.label_names(), vec!["enhancement", "discordsh"]);
+        assert_eq!(issue.assignee_count(), 1);
+    }
+
+    #[test]
+    fn cached_issue_stale_when_synced_old() {
+        let raw = serde_json::json!({
+            "owner": "KBVE",
+            "repo": "kbve",
+            "number": 1,
+            "title": "old",
+            "state": "open",
+            "labels": [],
+            "assignees": [],
+            "author": null,
+            "html_url": "https://example.com",
+            "is_pull_request": false,
+            "github_created_at": "2000-01-01T00:00:00Z",
+            "github_updated_at": "2000-01-01T00:00:00Z",
+            "synced_at": "2000-01-01T00:00:00Z"
+        });
+        let issue: CachedIssue = serde_json::from_value(raw).unwrap();
+        assert!(issue.is_stale(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn parse_optional_row_handles_empty() {
+        let none: Option<CachedIssue> = parse_optional_row("").unwrap();
+        assert!(none.is_none());
+        let none: Option<CachedIssue> = parse_optional_row("[]").unwrap();
+        assert!(none.is_none());
+        let none: Option<CachedIssue> = parse_optional_row("null").unwrap();
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn store_disabled_without_client_get() {
+        let store = GithubStore::new(None, 16, Duration::from_secs(60));
+        assert!(!store.is_enabled());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = rt.block_on(store.get_issue("KBVE", "kbve", 1));
+        assert!(matches!(err, Err(GithubStoreError::NotConfigured)));
+    }
+}

--- a/packages/rust/kbve/src/entity/client/github_store.rs
+++ b/packages/rust/kbve/src/entity/client/github_store.rs
@@ -93,6 +93,7 @@ pub struct UndeliveredEvent {
     pub created_at: String,
     #[serde(default)]
     pub delivery_attempts: i32,
+    pub claim_token: uuid::Uuid,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -327,9 +328,16 @@ impl GithubStore {
         Ok(rows)
     }
 
-    pub async fn mark_event_delivered(&self, id: i64) -> Result<bool, GithubStoreError> {
+    pub async fn mark_event_delivered(
+        &self,
+        id: i64,
+        claim_token: uuid::Uuid,
+    ) -> Result<bool, GithubStoreError> {
         let resp_text = self
-            .call_event_state_raw("mark_event_delivered", serde_json::json!({ "p_id": id }))
+            .call_event_state_raw(
+                "mark_event_delivered",
+                serde_json::json!({ "p_id": id, "p_claim_token": claim_token }),
+            )
             .await?;
         parse_bool_body(&resp_text)
     }
@@ -337,6 +345,7 @@ impl GithubStore {
     pub async fn mark_event_failed(
         &self,
         id: i64,
+        claim_token: uuid::Uuid,
         error: &str,
         max_attempts: u32,
     ) -> Result<DeliveryState, GithubStoreError> {
@@ -345,6 +354,7 @@ impl GithubStore {
                 "mark_event_failed",
                 serde_json::json!({
                     "p_id": id,
+                    "p_claim_token": claim_token,
                     "p_error": error,
                     "p_max_attempts": max_attempts,
                 }),

--- a/packages/rust/kbve/src/entity/client/member.rs
+++ b/packages/rust/kbve/src/entity/client/member.rs
@@ -28,6 +28,27 @@ pub struct UserProfile {
     pub last_sign_in: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClaimIdentity {
+    pub user_id: String,
+    #[serde(default)]
+    pub github_login: Option<String>,
+    #[serde(default)]
+    pub github_id: Option<String>,
+    #[serde(default)]
+    pub kbve_username: Option<String>,
+}
+
+impl ClaimIdentity {
+    pub fn has_github(&self) -> bool {
+        self.github_login.as_deref().is_some_and(|s| !s.is_empty())
+    }
+
+    pub fn kbve_username(&self) -> Option<&str> {
+        self.kbve_username.as_deref().filter(|s| !s.is_empty())
+    }
+}
+
 /// Whether a Discord user is a linked Member or an unlinked Guest.
 #[derive(Debug, Clone)]
 pub enum MemberStatus {
@@ -68,6 +89,11 @@ struct CachedEntry {
     expires_at: Instant,
 }
 
+struct CachedClaimEntry {
+    identity: Option<ClaimIdentity>,
+    expires_at: Instant,
+}
+
 /// Thread-safe LRU cache for Discord user membership lookups.
 ///
 /// Each entry has a TTL; expired entries trigger a re-lookup.
@@ -76,6 +102,7 @@ struct CachedEntry {
 pub struct MemberCache {
     client: Option<SupabaseClient>,
     cache: Mutex<LruCache<u64, CachedEntry>>,
+    claim_cache: Mutex<LruCache<u64, CachedClaimEntry>>,
     ttl: Duration,
 }
 
@@ -90,6 +117,7 @@ impl MemberCache {
         Self {
             client,
             cache: Mutex::new(LruCache::new(cap)),
+            claim_cache: Mutex::new(LruCache::new(cap)),
             ttl,
         }
     }
@@ -150,6 +178,91 @@ impl MemberCache {
     pub fn invalidate(&self, discord_id: u64) {
         let mut cache = self.cache.lock().unwrap_or_else(|e| e.into_inner());
         cache.pop(&discord_id);
+        let mut claim = self.claim_cache.lock().unwrap_or_else(|e| e.into_inner());
+        claim.pop(&discord_id);
+    }
+
+    pub async fn lookup_claim_identity(&self, discord_id: u64) -> Option<ClaimIdentity> {
+        {
+            let mut cache = self.claim_cache.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(entry) = cache.get(&discord_id) {
+                if Instant::now() < entry.expires_at {
+                    return entry.identity.clone();
+                }
+            }
+        }
+
+        match self.fetch_claim_identity_from_supabase(discord_id).await {
+            Ok(identity) => {
+                let mut cache = self.claim_cache.lock().unwrap_or_else(|e| e.into_inner());
+                cache.put(
+                    discord_id,
+                    CachedClaimEntry {
+                        identity: identity.clone(),
+                        expires_at: Instant::now() + self.ttl,
+                    },
+                );
+                identity
+            }
+            Err(()) => None,
+        }
+    }
+
+    async fn fetch_claim_identity_from_supabase(
+        &self,
+        discord_id: u64,
+    ) -> Result<Option<ClaimIdentity>, ()> {
+        let Some(client) = self.client.as_ref() else {
+            return Err(());
+        };
+
+        let params = serde_json::json!({
+            "p_discord_id": discord_id.to_string()
+        });
+
+        let resp = client
+            .rpc_schema("find_claim_identity_by_discord_id", params, "tracker")
+            .await
+            .map_err(|e| {
+                warn!(discord_id, error = %e, "Claim identity lookup failed");
+            })?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            warn!(discord_id, %status, %body, "Claim identity lookup HTTP error");
+            return Err(());
+        }
+
+        let text = resp.text().await.map_err(|e| {
+            warn!(discord_id, error = %e, "Failed to read claim identity response");
+        })?;
+
+        if let Ok(identity) = serde_json::from_str::<ClaimIdentity>(&text) {
+            info!(
+                discord_id,
+                user_id = %identity.user_id,
+                github_login = ?identity.github_login,
+                "Claim identity resolved"
+            );
+            return Ok(Some(identity));
+        }
+
+        if let Ok(mut rows) = serde_json::from_str::<Vec<ClaimIdentity>>(&text) {
+            if let Some(identity) = rows.pop() {
+                info!(
+                    discord_id,
+                    user_id = %identity.user_id,
+                    github_login = ?identity.github_login,
+                    "Claim identity resolved"
+                );
+                return Ok(Some(identity));
+            }
+            return Ok(None);
+        }
+
+        warn!(discord_id, body = %text, "Unparseable claim identity response");
+        Err(())
     }
 
     async fn fetch_from_supabase(&self, discord_id: u64) -> MemberStatus {
@@ -267,6 +380,43 @@ mod tests {
         };
         let status = MemberStatus::Member(profile);
         assert_eq!(status.display_name(), Some("TestUser"));
+    }
+
+    #[test]
+    fn claim_identity_lookup_none_without_client() {
+        let cache = MemberCache::new(None, 16, Duration::from_secs(60));
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let id = rt.block_on(cache.lookup_claim_identity(12345));
+        assert!(id.is_none());
+    }
+
+    #[test]
+    fn claim_identity_helpers() {
+        let with_github = ClaimIdentity {
+            user_id: "uuid".into(),
+            github_login: Some("h0lybyte".into()),
+            github_id: Some("12345".into()),
+            kbve_username: Some("h0lybyte".into()),
+        };
+        assert!(with_github.has_github());
+        assert_eq!(with_github.kbve_username(), Some("h0lybyte"));
+
+        let no_github = ClaimIdentity {
+            user_id: "uuid".into(),
+            github_login: None,
+            github_id: None,
+            kbve_username: Some("ghost".into()),
+        };
+        assert!(!no_github.has_github());
+        assert_eq!(no_github.kbve_username(), Some("ghost"));
+
+        let empty_username = ClaimIdentity {
+            user_id: "uuid".into(),
+            github_login: Some("dev".into()),
+            github_id: Some("1".into()),
+            kbve_username: Some(String::new()),
+        };
+        assert_eq!(empty_username.kbve_username(), None);
     }
 
     #[test]

--- a/packages/rust/kbve/src/entity/client/mod.rs
+++ b/packages/rust/kbve/src/entity/client/mod.rs
@@ -1,5 +1,7 @@
 pub mod ai;
 #[cfg(feature = "supabase")]
+pub mod github_store;
+#[cfg(feature = "supabase")]
 pub mod member;
 #[cfg(feature = "legacy-sync-db")]
 pub mod resend;
@@ -9,6 +11,8 @@ pub mod supabase;
 pub mod vault;
 
 pub use ai::*;
+#[cfg(feature = "supabase")]
+pub use github_store::*;
 #[cfg(feature = "supabase")]
 pub use member::*;
 #[cfg(feature = "legacy-sync-db")]


### PR DESCRIPTION
Closes #11262 P0 + P1.

## P0 — /gh claim

- `tracker.find_claim_identity_by_discord_id(p_discord_id)` RPC joins `auth.identities` (discord + github) and `profile.username` so one round-trip resolves: KBVE `user_id`, linked GitHub `login` + `id`, and the canonical `kbve_username`.
- `MemberCache::lookup_claim_identity` adds a second LRU+TTL cache alongside the existing membership cache. Only **authoritative** responses (HTTP 200) are cached — transport / HTTP errors are not negative-cached, so transient failures cannot lock a user out.
- `/gh` is now a parent command. Subs:
  - `/gh view <number>` (replaces the old `/gh <number>` shortcut)
  - `/gh claim <number> [repo]` — Read tier (still rate-limited via `GITHUB_CMD_RATE_LIMIT`), guards:
    - Repo allowlist (`GITHUB_ALLOWED_REPOS`)
    - Identity check: no KBVE row → sign-in prompt; KBVE row but no GitHub → link-GitHub prompt
    - PR rejection / `state == open` / self-already-assigned / max-assignees (`GITHUB_CLAIM_MAX_ASSIGNEES`, default 2)
  - Confirmation embed links `[@kbve_username](https://kbve.com/@kbve_username)` when present, falls back to `` `<github_login>` ``. Base configurable via `KBVE_PROFILE_URL_BASE`.

## P1 — Supabase L2 cache

- `gh` schema: `gh.issue` (PK `(owner, repo, number)`, JSONB labels/assignees, GitHub timestamps, optional `discord_{guild,channel,thread}_id`) + append-only `gh.issue_event` (FK to `gh.issue`, partial unique index on `github_delivery_id`, `delivered_to_discord` flag).
- Service-role-only RPCs: `gh.upsert_issue`, `gh.set_discord_thread`, `gh.record_event`, `gh.get_issue`, `gh.list_open_issues`, `gh.claim_undelivered_events` (uses `FOR UPDATE SKIP LOCKED` so multiple bot shards can drain safely).
- `kbve::GithubStore` Rust client: read-through L2 over the new RPCs with its own LRU + per-entry TTL + RFC3339 staleness check. Wired into bot `AppState`; `/gh claim` calls `precheck_from_store` first and only falls through to GitHub REST when the row is missing, stale, or the store is disabled.
- Edge functions:
  - `gh-webhook`: HMAC-SHA256 verify with `GITHUB_WEBHOOK_SECRET`, optional repo allowlist (`GH_WEBHOOK_ALLOWED_REPOS`), upserts on `issues`, `issue_comment`, `pull_request{,_review,_review_comment}`, records each delivery with its `X-GitHub-Delivery` ID for idempotency.
  - `gh-backfill`: service-role gated, paginated REST walk to populate `gh.issue` for an allowlisted repo on first install.

## Deploy notes

1. Apply migrations via `ci-dbmate-deploy.yml`:
   - `20260523033932_tracker_find_claim_identity_by_discord_id.sql`
   - `20260523033933_gh_issue_cache_init.sql`
2. Deploy `gh-webhook` + `gh-backfill` edge functions.
3. Set Supabase project envs: `GITHUB_WEBHOOK_SECRET`, `GITHUB_TOKEN` (for backfill), `GH_WEBHOOK_ALLOWED_REPOS=kbve/kbve`.
4. Configure GitHub webhook on `KBVE/kbve` → `<edge>/functions/v1/gh-webhook`, content type JSON, secret matching `GITHUB_WEBHOOK_SECRET`, events: Issues + Issue comments + Pull requests + PR reviews + PR review comments.
5. Run backfill once: `POST /functions/v1/gh-backfill { "owner": "KBVE", "repo": "kbve", "state": "all" }` with `Authorization: Bearer <service_role_key>`.
6. Bot picks up `GithubStore` automatically once `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` are in its env (already set in prod for the existing `MemberCache`).

## What's not in this PR (tracked in #11262)

- **P2** — forum-channel thread-per-issue (consumes `gh.issue_event` via realtime).
- **P3** — bi-directional thread → GitHub comment as the linked user.
- pgTAP tests for the new RPCs (manual verification covered by P1's edge function smoke test).

## Verification

- `cargo check -p kbve --features supabase` ✅
- `cargo check -p discordsh-bot` ✅
- `cargo test -p kbve --features supabase --lib client::member:: client::github_store::` → 12 passed