### PR TITLE
ci(docker): skip playwright install for vitest-only Docker app tests

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -214,6 +214,7 @@ jobs:
             project: ${{ needs.config.outputs.e2e_name }}
             runner: ${{ needs.config.outputs.runner }}
             image: ${{ needs.config.outputs.image }}
+            install_playwright: false
             version_source: ${{ needs.config.outputs.version_source }}
             version_target: ${{ needs.config.outputs.version_target }}
 


### PR DESCRIPTION
## Summary
Follow-up to #11304. The manifest-dispatched Docker app tests under \`ci-docker.yml\` are vitest endpoint tests against the running container — they never touch a browser. \`docker-test-app.yml\` defaulted \`install_playwright: true\`, so \`axum-kbve-e2e\` still spent the entire CI run inside Playwright's chromium extract, which is where the libuv-threadpool deadlock lives.

Live runner-pod inspection after #11304 merged confirmed the same exact deadlock signature:
- All Node threads sleeping (main in \`do_epoll_wait\`, all 20 workers in \`__futex_wait\` with \`UV_THREADPOOL_SIZE=16\`).
- FD pinned mid-write on \`/root/.cache/ms-playwright/chromium-1217/chrome-linux64/WidevineCdm/.../libwidevinecdm.so\` (same file every run).
- \`UV_THREADPOOL_SIZE=16\` was not enough — the deadlock is deeper than threadpool starvation.

## Fix
Pass \`install_playwright: false\` from \`ci-docker.yml\` to \`docker-test-app.yml\`. \`ci-e2e.yml\` already opts in per-project via \`matrix.playwright\`, so callers that actually need a browser stay unchanged.

## Test plan
- [ ] Trigger \`ci-docker.yml\` (\`axum-kbve-e2e\`) and confirm step 13 \`Install Playwright Browsers\` is skipped, e2e completes in normal time.
- [ ] Spot-check a workflow that does need playwright (e.g. \`ci-e2e.yml\` against \`astro-kbve\`) and confirm \`pnpm exec playwright install\` still runs.