### PR TITLE
ci: fix bot-PR auto-merge dispatch (use REST + harden)

### DIFF
--- a/.github/actions/dispatch-auto-merge/action.yml
+++ b/.github/actions/dispatch-auto-merge/action.yml
@@ -1,0 +1,69 @@
+name: Dispatch auto-merge
+description: Trigger ci-auto-merge-bot-prs.yml via REST dispatch with PR number validation, retries, and run-creation check.
+
+inputs:
+    pr_number:
+        description: PR number to dispatch auto-merge for
+        required: true
+    workflow_file:
+        description: Auto-merge workflow filename
+        required: false
+        default: ci-auto-merge-bot-prs.yml
+    ref:
+        description: Ref to dispatch the workflow against
+        required: false
+        default: main
+    github_token:
+        description: Token with actions write permission on the target repo
+        required: true
+
+runs:
+    using: composite
+    steps:
+        - name: Dispatch
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github_token }}
+              PR_NUM: ${{ inputs.pr_number }}
+              WF: ${{ inputs.workflow_file }}
+              REF: ${{ inputs.ref }}
+              REPO: ${{ github.repository }}
+          run: |
+              set -uo pipefail
+
+              if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+                  echo "::error::Invalid pr_number '$PR_NUM' (must be digits)"
+                  exit 1
+              fi
+
+              dispatched=false
+              for attempt in 1 2 3; do
+                  if gh api \
+                      --method POST \
+                      "repos/${REPO}/actions/workflows/${WF}/dispatches" \
+                      -f "ref=${REF}" \
+                      -f "inputs[pr_number]=${PR_NUM}"; then
+                      dispatched=true
+                      echo "Dispatched ${WF} for PR #${PR_NUM} on attempt ${attempt}"
+                      break
+                  fi
+                  echo "::warning::Dispatch attempt ${attempt} failed for PR #${PR_NUM}"
+                  sleep $((attempt * 5))
+              done
+
+              if [[ "$dispatched" != "true" ]]; then
+                  echo "::error::Failed to dispatch ${WF} for PR #${PR_NUM} after 3 attempts"
+                  exit 1
+              fi
+
+              # Eventually-consistent run list; warn (not fail) if nothing shows.
+              for _ in 1 2 3; do
+                  sleep 5
+                  count=$(gh api "repos/${REPO}/actions/workflows/${WF}/runs?event=workflow_dispatch&per_page=5" \
+                      --jq "[.workflow_runs[] | select(.created_at > (now - 60 | todate))] | length")
+                  if [[ "${count:-0}" -ge 1 ]]; then
+                      echo "Confirmed ${WF} run scheduled (${count} recent dispatch run(s))"
+                      exit 0
+                  fi
+              done
+              echo "::warning::Dispatch succeeded but no recent run visible yet — auto-merge may still fire async"

--- a/.github/workflows/ci-bevy.yml
+++ b/.github/workflows/ci-bevy.yml
@@ -223,6 +223,7 @@ jobs:
                   fi
 
             - name: Create deploy branch and PR
+              id: pr
               if: steps.diff.outputs.changed == 'true'
               env:
                   GH_TOKEN: ${{ github.token }}
@@ -244,8 +245,15 @@ jobs:
                     --label "auto-pr"
 
                   PR_NUM=$(gh pr view "$BRANCH" --json number --jq '.number')
-                  echo "Created PR #${PR_NUM} — triggering auto-merge"
-                  gh workflow run ci-auto-merge-bot-prs.yml --field pr_number="${PR_NUM}" || true
+                  echo "Created PR #${PR_NUM}"
+                  echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
+
+            - name: Dispatch auto-merge
+              if: steps.pr.outputs.pr_number != ''
+              uses: ./.github/actions/dispatch-auto-merge
+              with:
+                  pr_number: ${{ steps.pr.outputs.pr_number }}
+                  github_token: ${{ github.token }}
 
     # ---------------------------------------------------------------------------
     # Failure tracker — surfaces build failures as GitHub issues (#8186).

--- a/.github/workflows/utils-post-publish.yml
+++ b/.github/workflows/utils-post-publish.yml
@@ -363,8 +363,10 @@ jobs:
                   echo "pushed=true" >> "$GITHUB_OUTPUT"
                   echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
-            # ── PR creation (GITHUB_TOKEN — author becomes github-actions[bot]) ──
-            - name: Create PR and trigger auto-merge
+            # GITHUB_TOKEN here — PR author must be github-actions[bot] for the
+            # auto-merge author gate.
+            - name: Create PR
+              id: pr
               if: steps.push.outputs.pushed == 'true'
               env:
                   GITHUB_TOKEN: ${{ github.token }}
@@ -394,4 +396,11 @@ jobs:
 
                   PR_NUM=$(gh pr view "$BRANCH" --json number --jq '.number')
                   echo "Created PR #${PR_NUM}"
-                  gh workflow run ci-auto-merge-bot-prs.yml --field pr_number="${PR_NUM}" --repo ${{ github.repository }} || true
+                  echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
+
+            - name: Dispatch auto-merge
+              if: steps.pr.outputs.pr_number != ''
+              uses: ./.github/actions/dispatch-auto-merge
+              with:
+                  pr_number: ${{ steps.pr.outputs.pr_number }}
+                  github_token: ${{ github.token }}

--- a/.github/workflows/utils-update-version-toml.yml
+++ b/.github/workflows/utils-update-version-toml.yml
@@ -152,6 +152,7 @@ jobs:
                   npx nx run astro-kbve:sync:ci-manifest
 
             - name: Create PR
+              id: pr
               env:
                   GH_TOKEN: ${{ github.token }}
               run: |
@@ -190,5 +191,12 @@ jobs:
                     --label "auto-pr")
 
                   PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
-                  echo "Created PR #${PR_NUM}, dispatching auto-merge..."
-                  gh workflow run ci-auto-merge-bot-prs.yml --field pr_number="${PR_NUM}" --repo ${{ github.repository }} || true
+                  echo "Created PR #${PR_NUM}"
+                  echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
+
+            - name: Dispatch auto-merge
+              if: steps.pr.outputs.pr_number != ''
+              uses: ./.github/actions/dispatch-auto-merge
+              with:
+                  pr_number: ${{ steps.pr.outputs.pr_number }}
+                  github_token: ${{ github.token }}


### PR DESCRIPTION
## Summary
Bot PRs created by `utils-post-publish.yml`, `utils-update-version-toml.yml`, and `ci-bevy.yml` (e.g. #11307) were never actually dispatching `ci-auto-merge-bot-prs.yml`. The shell step ran `gh workflow run` with a trailing `|| true`, but the call itself was returning:

```
unable to determine default branch for KBVE/kbve: HTTP 401: Bad credentials (https://api.github.com/graphql)
```

`gh workflow run` probes the default branch via GraphQL before posting, and `github.token` from a reusable workflow context lacks the right scope for that path. The job's `actions: write` permission was already in place; only the transport was wrong.

## Changes
- New composite action `.github/actions/dispatch-auto-merge` that:
  - Posts directly to `POST /repos/<owner>/<repo>/actions/workflows/<file>/dispatches` (no GraphQL probe)
  - Validates `pr_number` is digits
  - Retries the dispatch up to 3x with backoff on transient failures
  - Polls the workflow_runs list for ~15s to confirm the run was scheduled (warn-only if not yet visible, since the list is eventually consistent)
- All three callers (`utils-post-publish.yml`, `utils-update-version-toml.yml`, `ci-bevy.yml`) split the PR creation and the dispatch into two steps:
  - Create PR step uses `github.token` so the author stays `github-actions[bot]` (the auto-merge workflow gates on author)
  - Dispatch step `uses: ./.github/actions/dispatch-auto-merge` with the new action

## Test plan
- [ ] Next post-publish run (e.g. mc-lobby) creates the Atomic PR AND a corresponding `Auto-merge bot PRs` workflow_dispatch run appears within ~15s.
- [ ] PR auto-approves and squash-merges without manual intervention.
- [ ] Failure case (manually edit `pr_number` to non-numeric) surfaces the validation error cleanly.

Closes the auto-merge gap that left #11307 hanging until manual merge.