### PR TITLE
feat(q,td-server): postcard wire schemas + axum game server skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16155,6 +16155,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "td-server"
+version = "0.1.0"
+dependencies = [
+ "axum 0.7.9",
+ "q",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 	'packages/rust/jedi',
 	'apps/kbve/kilobase',
 	'packages/rust/q',
+	'apps/td-server',
 'apps/herbmail/axum-herbmail',
 	'apps/memes/axum-memes',
 	'apps/irc/irc-gateway',

--- a/apps/td-server/Cargo.toml
+++ b/apps/td-server/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "td-server"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Nexus Defense game server — axum + tokio host for the bevy/rapier2d authoritative sim (KBVE/kbve#11294)."
+
+[[bin]]
+name = "td-server"
+path = "src/main.rs"
+
+[dependencies]
+q = { path = "../../packages/rust/q", default-features = false, features = ["nexus-defense-server"] }
+axum = { version = "0.7", default-features = false, features = ["ws", "json", "http1", "tokio"] }
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/apps/td-server/src/main.rs
+++ b/apps/td-server/src/main.rs
@@ -1,0 +1,56 @@
+//! Nexus Defense game server entry point.
+//!
+//! Hosts the axum WS router from `q::net::server`. The bevy/rapier2d
+//! authoritative sim + Agones lifecycle land in follow-up commits per the
+//! phase plan in KBVE/kbve#11294.
+
+use std::net::SocketAddr;
+
+use tokio::net::TcpListener;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| "info,td_server=debug".into()),
+        )
+        .init();
+
+    let addr: SocketAddr = std::env::var("TD_SERVER_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:7878".into())
+        .parse()?;
+
+    let app = q::net::server::router();
+    tracing::info!(%addr, "td-server listening");
+
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        if let Ok(mut s) = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        {
+            s.recv().await;
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+
+    tracing::info!("shutdown signal received");
+}

--- a/packages/rust/q/src/net/client.rs
+++ b/packages/rust/q/src/net/client.rs
@@ -1,4 +1,19 @@
 //! Client-side WebSocket transport — tokio-tungstenite over rustls.
-//! Stub. MatchSocket + SnapshotBuffer land here next.
+//!
+//! The actual `MatchSocket` will land as a `#[derive(GodotClass)]` under
+//! `q::nexus_defense::match_socket` once the protocol round-trips in tests.
+//! For now this module only exposes encode/decode shims so consumers can
+//! prove parity with the server side.
 
-pub fn placeholder() {}
+#[cfg(feature = "proto-shared")]
+use crate::proto;
+
+#[cfg(feature = "proto-shared")]
+pub fn encode_client_frame(frame: &proto::ClientFrame) -> Result<Vec<u8>, postcard::Error> {
+    proto::encode(frame)
+}
+
+#[cfg(feature = "proto-shared")]
+pub fn decode_server_event(buf: &mut [u8]) -> Result<proto::ServerEvent, postcard::Error> {
+    proto::decode(buf)
+}

--- a/packages/rust/q/src/net/server.rs
+++ b/packages/rust/q/src/net/server.rs
@@ -1,4 +1,58 @@
-//! Server-side WebSocket transport — axum router + agones lifecycle.
-//! Stub.
+//! Server-side WebSocket transport — axum router + per-match session loop.
+//!
+//! Real session state (Agones lifecycle, snapshot fanout, JWT verify) lands
+//! after `apps/td-server/` boots end-to-end. For now this module only ships
+//! a router factory + an echo handler that the binary can mount as a smoke
+//! test.
 
-pub fn placeholder() {}
+use axum::Router;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use axum::routing::get;
+
+#[cfg(feature = "proto-shared")]
+use crate::proto;
+
+/// Build the axum router. Mount under any base path in the host binary.
+pub fn router() -> Router {
+    Router::new()
+        .route("/healthz", get(|| async { "ok" }))
+        .route("/ws", get(ws_upgrade))
+}
+
+async fn ws_upgrade(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(handle_socket)
+}
+
+async fn handle_socket(mut socket: WebSocket) {
+    // Send a Welcome immediately so the client side can prove the round-trip
+    // before the sim is wired up. Slot + seed are placeholder values.
+    #[cfg(feature = "proto-shared")]
+    {
+        let evt = proto::ServerEvent::Welcome {
+            protocol: proto::PROTOCOL_VERSION,
+            your_slot: proto::PlayerSlot(0),
+            seed: 0,
+        };
+        if let Ok(buf) = proto::encode(&evt) {
+            let _ = socket.send(Message::Binary(buf)).await;
+        }
+    }
+
+    while let Some(Ok(msg)) = socket.recv().await {
+        match msg {
+            Message::Binary(bytes) => {
+                // Echo any ClientFrame the client sends. Real handler will
+                // route inputs into the bevy sim.
+                #[cfg(feature = "proto-shared")]
+                {
+                    let mut buf = bytes.clone();
+                    let _ = proto::decode::<proto::ClientFrame>(&mut buf);
+                }
+                let _ = socket.send(Message::Binary(bytes)).await;
+            }
+            Message::Close(_) => break,
+            _ => {}
+        }
+    }
+}

--- a/packages/rust/q/src/proto/mod.rs
+++ b/packages/rust/q/src/proto/mod.rs
@@ -1,12 +1,253 @@
 //! Shared wire types between the Godot client and the bevy/axum server.
 //!
-//! Encoded with `postcard` (COBS-framed) for snapshots and inputs.
-//! Concrete message types land here as the protocol stabilizes; this stub
-//! exists so feature gating builds without errors.
+//! Encoded with `postcard` (COBS-framed) for snapshots and inputs. Keep this
+//! module pure — no Godot, no Bevy, no I/O — so both sides can reuse it.
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct ProtoHello {
-    pub version: u32,
+/// Bump on any breaking wire change. Server rejects mismatched clients.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Maximum players per match (parallel-race default per #11294).
+pub const MAX_PLAYERS: usize = 4;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct EntityId(pub u32);
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct PlayerSlot(pub u8);
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Vec2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum BuildKind {
+    Tower = 0,
+    Generator = 1,
+    Battery = 2,
+    Repair = 3,
+    Armoury = 4,
+    Village = 5,
+    Town = 6,
+    Castle = 7,
+    Nexus = 8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum EnemyKind {
+    Runner = 0,
+    Brute = 1,
+    Scout = 2,
+    Boss = 3,
+    Flying = 4,
+    Shielded = 5,
+    Regen = 6,
+}
+
+// -----------------------------------------------------------------------------
+// Client -> Server
+// -----------------------------------------------------------------------------
+
+/// First message client sends after WS upgrade. Server validates protocol +
+/// JWT then admits the player into a slot.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct JoinMatch {
+    pub protocol: u32,
+    pub match_token: String,
+    pub kbve_username: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Input {
+    PlaceBuilding {
+        col: i32,
+        row: i32,
+        kind: BuildKind,
+    },
+    UpgradeBuilding {
+        eid: EntityId,
+        kind_idx: u8,
+    },
+    SellBuilding {
+        eid: EntityId,
+    },
+    SkipWave,
+    TogglePause,
+    UseItem {
+        item_id: u32,
+        target_eid: Option<EntityId>,
+    },
+    Retarget {
+        eid: EntityId,
+        target: Option<Vec2>,
+    },
+    Leave,
+    /// Wall-clock round-trip echo. Server replies via `Snapshot.input_ack`.
+    Heartbeat {
+        client_tick: u32,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClientFrame {
+    pub client_tick: u32,
+    pub inputs: Vec<Input>,
+}
+
+// -----------------------------------------------------------------------------
+// Server -> Client
+// -----------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PlayerView {
+    pub slot: PlayerSlot,
+    pub kbve_username: String,
+    pub connected: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BuildingDelta {
+    pub eid: EntityId,
+    pub kind: BuildKind,
+    pub col: i32,
+    pub row: i32,
+    pub hp: f32,
+    pub max_hp: f32,
+    pub online: bool,
+    pub destroyed: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EnemyDelta {
+    pub eid: EntityId,
+    pub kind: EnemyKind,
+    pub pos: Vec2,
+    pub hp: f32,
+    pub max_hp: f32,
+    pub status_bits: u32,
+    pub destroyed: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ProjectileDelta {
+    pub eid: EntityId,
+    pub pos: Vec2,
+    pub vel: Vec2,
+    pub destroyed: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FieldDelta {
+    pub owner: PlayerSlot,
+    pub buildings: Vec<BuildingDelta>,
+    pub enemies: Vec<EnemyDelta>,
+    pub projectiles: Vec<ProjectileDelta>,
+    pub gold: i32,
+    pub lives: i32,
+    pub wave: u16,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Snapshot {
+    /// Sim tick on the server. Monotonic.
+    pub tick: u32,
+    /// Milliseconds since match start. Lets the client tune interpolation.
+    pub server_time_ms: u32,
+    /// Echo of the highest client_tick the server has consumed for this player.
+    pub input_ack: u32,
+    /// Roster + connection status, broadcast on every snapshot for simplicity.
+    pub players: Vec<PlayerView>,
+    /// One entry per player field; delta'd against the last ack'd snapshot.
+    pub fields: Vec<FieldDelta>,
+    /// `true` once every N seconds — drops the delta base and re-syncs.
+    pub keyframe: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ServerEvent {
+    /// Bidirectional handshake — server confirms the JoinMatch.
+    Welcome {
+        protocol: u32,
+        your_slot: PlayerSlot,
+        seed: u64,
+    },
+    Snapshot(Snapshot),
+    /// One-shot effects that shouldn't be replayed from a keyframe (sfx, splashes).
+    Ephemeral {
+        kind: u16,
+        payload: Vec<u8>,
+    },
+    GameOver {
+        winner: Option<PlayerSlot>,
+    },
+    Reject {
+        reason: String,
+    },
+}
+
+// -----------------------------------------------------------------------------
+// Codec helpers — postcard with COBS framing so each WS binary message is one
+// independent frame and partial reads can resynchronize.
+// -----------------------------------------------------------------------------
+
+#[cfg(feature = "proto-shared")]
+pub fn encode<T: Serialize>(value: &T) -> Result<Vec<u8>, postcard::Error> {
+    postcard::to_allocvec_cobs(value)
+}
+
+#[cfg(feature = "proto-shared")]
+pub fn decode<T: for<'de> Deserialize<'de>>(buf: &mut [u8]) -> Result<T, postcard::Error> {
+    postcard::from_bytes_cobs(buf)
+}
+
+#[cfg(all(test, feature = "proto-shared"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_round_trips() {
+        let frame = ClientFrame {
+            client_tick: 42,
+            inputs: vec![
+                Input::PlaceBuilding {
+                    col: 3,
+                    row: 4,
+                    kind: BuildKind::Tower,
+                },
+                Input::SkipWave,
+            ],
+        };
+        let mut buf = encode(&frame).expect("encode");
+        let back: ClientFrame = decode(&mut buf).expect("decode");
+        assert_eq!(back.client_tick, 42);
+        assert_eq!(back.inputs.len(), 2);
+    }
+
+    #[test]
+    fn server_event_round_trips() {
+        let evt = ServerEvent::Welcome {
+            protocol: PROTOCOL_VERSION,
+            your_slot: PlayerSlot(1),
+            seed: 0xDEADBEEFCAFEu64,
+        };
+        let mut buf = encode(&evt).expect("encode");
+        let back: ServerEvent = decode(&mut buf).expect("decode");
+        match back {
+            ServerEvent::Welcome {
+                protocol,
+                your_slot,
+                seed,
+            } => {
+                assert_eq!(protocol, PROTOCOL_VERSION);
+                assert_eq!(your_slot, PlayerSlot(1));
+                assert_eq!(seed, 0xDEADBEEFCAFEu64);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Fleshes out \`q::proto\` with the concrete wire types both sides will exchange — \`Input\`, \`ClientFrame\`, \`JoinMatch\`, \`ServerEvent\`, \`Snapshot\`, \`FieldDelta\`, \`BuildingDelta\`, \`EnemyDelta\`, \`ProjectileDelta\`, \`PlayerView\`. Encoded via \`postcard\` with COBS framing so each WS binary message is one self-contained frame.
- \`q::net::server\` now ships an axum router (\`/healthz\`, \`/ws\`) with a WS upgrade handler that sends \`ServerEvent::Welcome\` on connect and echoes \`ClientFrame\` payloads back. Real session state (Agones, JWT verify, snapshot fanout) lands in follow-ups.
- \`q::net::client\` exposes encode/decode shims so the Godot side can ship the same protocol surface ahead of the \`MatchSocket\` Godot class.
- New \`apps/td-server/\` binary — axum + tokio host, reads \`TD_SERVER_ADDR\`, wires \`tracing-subscriber\`, graceful SIGINT/SIGTERM shutdown. Tiny but proves the \`q\` \`nexus-defense-server\` feature path links and serves cleanly.

## Wire constants
- \`PROTOCOL_VERSION = 1\` — bump on any breaking change; server rejects mismatched clients.
- \`MAX_PLAYERS = 4\` (parallel-race default per #11294).

## Validation
\`\`\`bash
cargo build -p q                                                          # default (client) ✓
cargo build -p q --no-default-features --features nexus-defense           # client bundle    ✓
cargo build -p td-server                                                  # server bin       ✓
cargo test -p q --no-default-features --features proto-shared --lib proto # 2/2 round-trip   ✓

# Smoke
TD_SERVER_ADDR=127.0.0.1:7878 cargo run -p td-server
curl http://127.0.0.1:7878/healthz   # 'ok'
\`\`\`

## Test plan
- [ ] \`cargo test -p q --no-default-features --features proto-shared --lib proto\` — both round-trip tests pass
- [ ] \`cargo run -p td-server\` boots, \`/healthz\` returns \`ok\`, Ctrl-C exits cleanly
- [ ] A websocket client (e.g. \`websocat ws://127.0.0.1:7878/ws\`) immediately receives a binary frame on connect (\`ServerEvent::Welcome\` postcard)

## Related
- #11294 — multiplayer TD tracker (this is phase scaffolding for the server side)
- #11313 — q feature flag refactor (this lands on top)