### PR TITLE
feat(nexus-defense): responsive component-based UI system

### DIFF
--- a/apps/godot/nexus-defense/project.godot
+++ b/apps/godot/nexus-defense/project.godot
@@ -19,6 +19,8 @@ config/icon="res://icon.svg"
 [autoload]
 
 ECS="*uid://dfqwl5njvdnmq"
+Bp="*res://ui/lib/breakpoint.gd"
+Ui="*res://ui/lib/ui_manager.gd"
 
 [display]
 

--- a/apps/godot/nexus-defense/scenes/main.gd
+++ b/apps/godot/nexus-defense/scenes/main.gd
@@ -2,48 +2,91 @@ extends Node2D
 
 const SERVER_URL := "ws://127.0.0.1:7878/ws"
 
-@onready var title_label: Label = $UI/Title
-@onready var status_label: Label = $UI/Status
+var _wave: int = 1
+var _lives: int = 20
+var _gold: int = 150
+var _enemies: int = 12
 
-var socket: MatchSocket
-var status_lines: Array[String] = []
+var socket: Node = null
 
 func _ready() -> void:
-	title_label.text = "Nexus Defense"
-	_append("Godot %s · gecs + q" % Engine.get_version_info()["string"])
+	var msg: String = "pong"
+	if ClassDB.class_exists("NdPing"):
+		var ping: Object = ClassDB.instantiate("NdPing")
+		if ping and ping.has_method("pong"):
+			msg = String(ping.call("pong"))
+		if ping and ping.has_method("queue_free"):
+			ping.call("queue_free")
+	print("[nexus-defense] main scene ready — q::nexus_defense pong: %s" % msg)
 
-	var ping := NdPing.new()
-	_append("ping: %s · 2+3=%d" % [ping.pong(), ping.add(2, 3)])
-	ping.queue_free()
+	Ui.open("boot", {"title": "Nexus Defense", "subtitle": "Dialing %s…" % SERVER_URL})
 
-	socket = MatchSocket.new()
-	add_child(socket)
-	socket.connected.connect(_on_connected)
-	socket.welcome.connect(_on_welcome)
-	socket.snapshot.connect(_on_snapshot)
-	socket.disconnected.connect(_on_disconnected)
-	socket.decode_error.connect(_on_decode_error)
-	_append("dialing %s" % SERVER_URL)
-	socket.connect_to(SERVER_URL)
+	if ClassDB.class_exists("MatchSocket"):
+		socket = ClassDB.instantiate("MatchSocket")
+		add_child(socket)
+		socket.connect("connected", _on_connected)
+		socket.connect("welcome", _on_welcome)
+		socket.connect("snapshot", _on_snapshot)
+		socket.connect("disconnected", _on_disconnected)
+		socket.connect("decode_error", _on_decode_error)
+		_log("dialing %s" % SERVER_URL)
+		socket.call("connect_to", SERVER_URL)
+	else:
+		_log("MatchSocket class unavailable — running offline")
+
+	await get_tree().create_timer(0.6).timeout
+	Ui.close("boot")
+
+	Ui.open("hud_top", {"wave": _wave, "lives": _lives, "gold": _gold, "enemies": _enemies})
+	var build_bar: Control = Ui.open("build_bar", {"gold": _gold})
+	if build_bar:
+		build_bar.tower_selected.connect(_on_tower_selected)
+		build_bar.tower_canceled.connect(_on_tower_canceled)
+
+	Ui.open("wave_banner", {"title": "Wave %d" % _wave, "subtitle": "%d enemies inbound" % _enemies})
+	Ui.toast("Godot %s · gecs + q · %s" % [Engine.get_version_info()["string"], msg], 3.0, "info")
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("pause"):
+		Ui.toggle("pause")
+	elif event.is_action_pressed("skip_wave"):
+		_advance_wave()
+
+func _advance_wave() -> void:
+	_wave += 1
+	_enemies = 10 + _wave * 3
+	_gold += 50
+	Ui.open("hud_top", {"wave": _wave, "lives": _lives, "gold": _gold, "enemies": _enemies})
+	var bar := Ui.get_panel("build_bar")
+	if bar:
+		bar.apply({"gold": _gold})
+	Ui.open("wave_banner", {"title": "Wave %d" % _wave, "subtitle": "%d enemies inbound" % _enemies})
+	Ui.toast("+50 gold reward", 1.6, "ok")
+
+func _on_tower_selected(id: String) -> void:
+	Ui.toast("Selected tower: %s" % id, 1.2, "info")
+
+func _on_tower_canceled() -> void:
+	Ui.toast("Build canceled", 1.0, "warn")
 
 func _on_connected() -> void:
-	_append("ws connected")
+	_log("ws connected")
+	Ui.toast("Connected to server", 1.6, "ok")
 
 func _on_welcome(slot: int, seed: int) -> void:
-	_append("welcome: slot=%d seed=0x%x" % [slot, seed])
+	_log("welcome: slot=%d seed=0x%x" % [slot, seed])
+	Ui.toast("Welcome — slot %d" % slot, 2.0, "info")
 
 func _on_snapshot(tick: int) -> void:
-	_append("snapshot tick=%d" % tick)
+	_log("snapshot tick=%d" % tick)
 
 func _on_disconnected(reason: String) -> void:
-	_append("disconnected: %s" % reason)
+	_log("disconnected: %s" % reason)
+	Ui.toast("Disconnected: %s" % reason, 2.4, "danger")
 
 func _on_decode_error(detail: String) -> void:
-	_append("decode error: %s" % detail)
+	_log("decode error: %s" % detail)
+	Ui.toast("Decode error: %s" % detail, 2.4, "warn")
 
-func _append(line: String) -> void:
-	status_lines.append(line)
-	if status_lines.size() > 6:
-		status_lines = status_lines.slice(status_lines.size() - 6)
-	status_label.text = "\n".join(status_lines)
+func _log(line: String) -> void:
 	print("[nexus-defense] %s" % line)

--- a/apps/godot/nexus-defense/scenes/main.tscn
+++ b/apps/godot/nexus-defense/scenes/main.tscn
@@ -5,41 +5,14 @@
 [node name="Main" type="Node2D" unique_id=1433128508]
 script = ExtResource("1_main")
 
-[node name="UI" type="CanvasLayer" parent="." unique_id=1922253551]
+[node name="BackgroundLayer" type="CanvasLayer" parent="." unique_id=1922253551]
+layer = -10
 
-[node name="Background" type="ColorRect" parent="UI" unique_id=716727939]
+[node name="Background" type="ColorRect" parent="BackgroundLayer" unique_id=716727939]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-color = Color(0.105882, 0.12549, 0.172549, 1)
+color = Color(0.07, 0.08, 0.11, 1)
+mouse_filter = 2
 
-[node name="Title" type="Label" parent="UI" unique_id=1272313858]
-anchors_preset = -1
-anchor_left = 0.5
-anchor_top = 0.4
-anchor_right = 0.5
-anchor_bottom = 0.4
-offset_left = -240.0
-offset_top = -32.0
-offset_right = 240.0
-offset_bottom = 32.0
-theme_override_font_sizes/font_size = 56
-text = "Nexus Defense"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Status" type="Label" parent="UI" unique_id=1829364366]
-anchors_preset = -1
-anchor_left = 0.5
-anchor_top = 0.55
-anchor_right = 0.5
-anchor_bottom = 0.55
-offset_left = -480.0
-offset_top = -90.0
-offset_right = 480.0
-offset_bottom = 90.0
-theme_override_font_sizes/font_size = 16
-text = "loading…"
-horizontal_alignment = 1
-vertical_alignment = 0
-autowrap_mode = 2
+[node name="World" type="Node2D" parent="."]

--- a/apps/godot/nexus-defense/ui/components/boot_screen.gd
+++ b/apps/godot/nexus-defense/ui/components/boot_screen.gd
@@ -1,0 +1,64 @@
+extends "res://ui/components/panel_base.gd"
+
+var title_text: String = "Nexus Defense"
+var subtitle_text: String = "Booting systems…"
+
+var _title: Label
+var _subtitle: Label
+var _spinner: Control
+var _spinner_angle: float = 0.0
+
+func _build() -> void:
+	set_anchors_preset(Control.PRESET_FULL_RECT)
+	mouse_filter = Control.MOUSE_FILTER_STOP
+
+	var bg := ColorRect.new()
+	bg.set_anchors_preset(Control.PRESET_FULL_RECT)
+	bg.color = Tokens.COLOR_BG
+	add_child(bg)
+
+	var center := CenterContainer.new()
+	center.set_anchors_preset(Control.PRESET_FULL_RECT)
+	add_child(center)
+
+	var vb := VBoxContainer.new()
+	vb.alignment = BoxContainer.ALIGNMENT_CENTER
+	vb.add_theme_constant_override("separation", Tokens.SPACE_LG)
+	center.add_child(vb)
+
+	_title = make_label(title_text, Tokens.FONT_DISPLAY, Tokens.COLOR_ACCENT)
+	_title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vb.add_child(_title)
+
+	_subtitle = make_label(subtitle_text, Tokens.FONT_H2, Tokens.COLOR_TEXT_MUTED)
+	_subtitle.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vb.add_child(_subtitle)
+
+	_spinner = Control.new()
+	_spinner.custom_minimum_size = Vector2(48, 48)
+	_spinner.draw.connect(_draw_spinner)
+	vb.add_child(_spinner)
+
+	set_process(true)
+
+func _process(delta: float) -> void:
+	_spinner_angle = fposmod(_spinner_angle + delta * TAU * 1.2, TAU)
+	_spinner.queue_redraw()
+
+func _draw_spinner() -> void:
+	var center := _spinner.size / 2
+	var radius := minf(center.x, center.y) - 4
+	var arc_color := Tokens.COLOR_ACCENT
+	var track_color := Tokens.COLOR_OUTLINE
+	_spinner.draw_arc(center, radius, 0.0, TAU, 48, track_color, 4, true)
+	_spinner.draw_arc(center, radius, _spinner_angle, _spinner_angle + TAU * 0.35, 32, arc_color, 4, true)
+
+func apply(data: Variant) -> void:
+	if typeof(data) != TYPE_DICTIONARY:
+		return
+	if data.has("title"):
+		title_text = String(data["title"])
+		if _title: _title.text = title_text
+	if data.has("subtitle"):
+		subtitle_text = String(data["subtitle"])
+		if _subtitle: _subtitle.text = subtitle_text

--- a/apps/godot/nexus-defense/ui/components/build_bar.gd
+++ b/apps/godot/nexus-defense/ui/components/build_bar.gd
@@ -1,0 +1,157 @@
+extends "res://ui/components/panel_base.gd"
+
+const DEFAULT_TOWERS := [
+	{"id": "arrow", "label": "Arrow", "icon": "🏹", "cost": 50, "accent": Color(0.34, 0.85, 0.45)},
+	{"id": "cannon", "label": "Cannon", "icon": "💥", "cost": 120, "accent": Color(0.95, 0.55, 0.32)},
+	{"id": "frost", "label": "Frost", "icon": "❄", "cost": 90, "accent": Color(0.5, 0.78, 0.95)},
+	{"id": "magic", "label": "Magic", "icon": "✨", "cost": 200, "accent": Color(0.8, 0.5, 0.95)},
+]
+
+var towers: Array = DEFAULT_TOWERS.duplicate(true)
+var selected_id: String = ""
+var gold: int = 150
+
+var _root_margin: MarginContainer
+var _scroll: ScrollContainer
+var _row: HBoxContainer
+var _buttons: Dictionary = {}
+
+signal tower_selected(tower_id: String)
+signal tower_canceled()
+
+func _build() -> void:
+	set_anchors_preset(Control.PRESET_BOTTOM_WIDE)
+
+	_root_margin = make_margin(safe_margin(), 0, safe_margin(), safe_margin())
+	_root_margin.set_anchors_preset(Control.PRESET_BOTTOM_WIDE)
+	add_child(_root_margin)
+
+	var panel := PanelContainer.new()
+	panel.theme_type_variation = "PanelContainerHud"
+	panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_root_margin.add_child(panel)
+
+	var vbox := VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", Tokens.SPACE_SM)
+	panel.add_child(vbox)
+
+	var header := HBoxContainer.new()
+	header.add_theme_constant_override("separation", Tokens.SPACE_MD)
+	vbox.add_child(header)
+	header.add_child(make_label("BUILD", Tokens.FONT_SMALL, Tokens.COLOR_TEXT_MUTED))
+	header.add_child(make_spacer())
+	var cancel_btn := make_button("Cancel", "Ghost")
+	cancel_btn.custom_minimum_size = Vector2(96, 36)
+	cancel_btn.pressed.connect(_on_cancel)
+	header.add_child(cancel_btn)
+
+	_scroll = ScrollContainer.new()
+	_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO
+	_scroll.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_scroll.custom_minimum_size.y = _bar_height()
+	vbox.add_child(_scroll)
+
+	_row = HBoxContainer.new()
+	_row.add_theme_constant_override("separation", Tokens.SPACE_SM)
+	_scroll.add_child(_row)
+
+	_rebuild_buttons()
+
+func _bar_height() -> int:
+	var bp := get_node_or_null("/root/Bp")
+	if bp:
+		return int(bp.pick(Tokens.BUILD_BAR_HEIGHT, 112))
+	return 112
+
+func _rebuild_buttons() -> void:
+	for child in _row.get_children():
+		child.queue_free()
+	_buttons.clear()
+	for t in towers:
+		_row.add_child(_tower_button(t))
+
+func _tower_button(t: Dictionary) -> Control:
+	var card := Button.new()
+	card.theme_type_variation = "ButtonIcon"
+	card.toggle_mode = true
+	card.focus_mode = Control.FOCUS_ALL
+	card.custom_minimum_size = Vector2(_bar_height() - 16, _bar_height() - 16)
+	card.tooltip_text = "%s · %d gold" % [t["label"], int(t["cost"])]
+	card.pressed.connect(_on_tower_pressed.bind(String(t["id"])))
+
+	var vb := VBoxContainer.new()
+	vb.set_anchors_preset(Control.PRESET_FULL_RECT)
+	vb.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	vb.alignment = BoxContainer.ALIGNMENT_CENTER
+	vb.add_theme_constant_override("separation", 2)
+	card.add_child(vb)
+
+	var icon := make_label(String(t["icon"]), Tokens.FONT_H1, t["accent"])
+	icon.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	icon.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	vb.add_child(icon)
+
+	var label := make_label(String(t["label"]), Tokens.FONT_SMALL, Tokens.COLOR_TEXT)
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	vb.add_child(label)
+
+	var cost := make_label("%d⛁" % int(t["cost"]), Tokens.FONT_SMALL, Tokens.COLOR_WARN)
+	cost.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	cost.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	vb.add_child(cost)
+
+	_buttons[String(t["id"])] = {"button": card, "cost": int(t["cost"]), "icon": icon, "label": label, "cost_label": cost}
+	_refresh_affordability_for(String(t["id"]))
+	return card
+
+func _refresh_affordability() -> void:
+	for id in _buttons.keys():
+		_refresh_affordability_for(id)
+
+func _refresh_affordability_for(id: String) -> void:
+	var entry: Dictionary = _buttons[id]
+	var afford: bool = gold >= entry["cost"]
+	entry["button"].disabled = not afford
+	entry["cost_label"].modulate.a = 1.0 if afford else 0.5
+
+func _on_tower_pressed(id: String) -> void:
+	if selected_id == id:
+		selected_id = ""
+		_buttons[id]["button"].button_pressed = false
+		tower_canceled.emit()
+		panel_event.emit("tower_canceled", null)
+		return
+	if selected_id != "" and _buttons.has(selected_id):
+		_buttons[selected_id]["button"].button_pressed = false
+	selected_id = id
+	tower_selected.emit(id)
+	panel_event.emit("tower_selected", id)
+
+func _on_cancel() -> void:
+	if selected_id == "" or not _buttons.has(selected_id):
+		return
+	_buttons[selected_id]["button"].button_pressed = false
+	selected_id = ""
+	tower_canceled.emit()
+	panel_event.emit("tower_canceled", null)
+
+func _on_breakpoint(_klass: int) -> void:
+	if _root_margin:
+		_root_margin.add_theme_constant_override("margin_left", safe_margin())
+		_root_margin.add_theme_constant_override("margin_right", safe_margin())
+		_root_margin.add_theme_constant_override("margin_bottom", safe_margin())
+	if _scroll:
+		_scroll.custom_minimum_size.y = _bar_height()
+	_rebuild_buttons()
+
+func apply(data: Variant) -> void:
+	if typeof(data) != TYPE_DICTIONARY:
+		return
+	if data.has("towers"):
+		towers = data["towers"]
+		_rebuild_buttons()
+	if data.has("gold"):
+		gold = int(data["gold"])
+		_refresh_affordability()

--- a/apps/godot/nexus-defense/ui/components/hud_top.gd
+++ b/apps/godot/nexus-defense/ui/components/hud_top.gd
@@ -1,0 +1,93 @@
+extends "res://ui/components/panel_base.gd"
+
+var wave: int = 1
+var lives: int = 20
+var gold: int = 150
+var enemies_left: int = 0
+
+var _wave_value: Label
+var _lives_value: Label
+var _gold_value: Label
+var _enemies_value: Label
+var _pause_btn: Button
+var _root_margin: MarginContainer
+
+func _build() -> void:
+	set_anchors_preset(Control.PRESET_TOP_WIDE)
+	custom_minimum_size.y = 0
+	mouse_filter = Control.MOUSE_FILTER_PASS
+
+	_root_margin = make_margin(safe_margin(), safe_margin() / 2, safe_margin(), 0)
+	_root_margin.set_anchors_preset(Control.PRESET_TOP_WIDE)
+	add_child(_root_margin)
+
+	var panel := PanelContainer.new()
+	panel.theme_type_variation = "PanelContainerHud"
+	panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_root_margin.add_child(panel)
+
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", Tokens.SPACE_MD)
+	panel.add_child(row)
+
+	row.add_child(_chip("WAVE", str(wave), Tokens.COLOR_ACCENT, "wave"))
+	row.add_child(_chip("ENEMIES", str(enemies_left), Tokens.COLOR_TEXT_MUTED, "enemies"))
+	row.add_child(make_spacer())
+	row.add_child(_chip("LIVES", str(lives), Tokens.COLOR_DANGER, "lives"))
+	row.add_child(_chip("GOLD", str(gold), Tokens.COLOR_WARN, "gold"))
+
+	_pause_btn = make_button("II", "Icon")
+	_pause_btn.custom_minimum_size = Vector2(44, 44)
+	_pause_btn.tooltip_text = "Pause (Esc)"
+	_pause_btn.pressed.connect(_on_pause)
+	row.add_child(_pause_btn)
+
+func _chip(caption: String, value: String, accent: Color, tag: String) -> Control:
+	var box := PanelContainer.new()
+	box.theme_type_variation = "PanelContainerGlass"
+	var vb := VBoxContainer.new()
+	vb.add_theme_constant_override("separation", 0)
+	box.add_child(vb)
+	var cap := make_label(caption, Tokens.FONT_SMALL, accent)
+	cap.add_theme_constant_override("outline_size", 0)
+	vb.add_child(cap)
+	var val := make_label(value, Tokens.FONT_H2, Tokens.COLOR_TEXT)
+	vb.add_child(val)
+	match tag:
+		"wave": _wave_value = val
+		"lives": _lives_value = val
+		"gold": _gold_value = val
+		"enemies": _enemies_value = val
+	return box
+
+func _on_pause() -> void:
+	var ui := get_node_or_null("/root/Ui")
+	if ui:
+		ui.toggle("pause")
+
+func _on_breakpoint(_klass: int) -> void:
+	if _root_margin:
+		_root_margin.add_theme_constant_override("margin_left", safe_margin())
+		_root_margin.add_theme_constant_override("margin_right", safe_margin())
+	_refresh_fonts()
+
+func _refresh_fonts() -> void:
+	for label in [_wave_value, _lives_value, _gold_value, _enemies_value]:
+		if label:
+			label.add_theme_font_size_override("font_size", font_size(Tokens.FONT_H2))
+
+func apply(data: Variant) -> void:
+	if typeof(data) != TYPE_DICTIONARY:
+		return
+	if data.has("wave"):
+		wave = int(data["wave"])
+		if _wave_value: _wave_value.text = str(wave)
+	if data.has("lives"):
+		lives = int(data["lives"])
+		if _lives_value: _lives_value.text = str(lives)
+	if data.has("gold"):
+		gold = int(data["gold"])
+		if _gold_value: _gold_value.text = str(gold)
+	if data.has("enemies"):
+		enemies_left = int(data["enemies"])
+		if _enemies_value: _enemies_value.text = str(enemies_left)

--- a/apps/godot/nexus-defense/ui/components/panel_base.gd
+++ b/apps/godot/nexus-defense/ui/components/panel_base.gd
@@ -1,0 +1,82 @@
+extends Control
+
+const Tokens := preload("res://ui/lib/tokens.gd")
+
+signal panel_event(event_name: String, payload: Variant)
+
+var _built: bool = false
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_PASS
+	if not _built:
+		_built = true
+		_build()
+	var bp := get_node_or_null("/root/Bp")
+	if bp and bp.has_signal("changed") and not bp.changed.is_connected(_on_breakpoint):
+		bp.changed.connect(_on_breakpoint)
+
+func _build() -> void:
+	pass
+
+func _on_breakpoint(_klass: int) -> void:
+	pass
+
+func apply(_data: Variant) -> void:
+	pass
+
+func open_anim() -> void:
+	modulate.a = 0.0
+	var tw := create_tween()
+	tw.tween_property(self, "modulate:a", 1.0, Tokens.ANIM_MED)
+
+func close_anim() -> void:
+	var tw := create_tween()
+	tw.tween_property(self, "modulate:a", 0.0, Tokens.ANIM_FAST)
+	await tw.finished
+
+func safe_margin() -> int:
+	var bp := get_node_or_null("/root/Bp")
+	if bp:
+		return int(bp.pick(Tokens.SAFE_MARGIN, 16))
+	return 16
+
+func font_size(table: Dictionary) -> int:
+	var bp := get_node_or_null("/root/Bp")
+	if bp:
+		return int(bp.font(table))
+	return int(table.get("desktop", 16))
+
+func is_touch() -> bool:
+	var bp := get_node_or_null("/root/Bp")
+	return bp != null and bp.is_touch()
+
+func make_label(txt: String, table: Dictionary = Tokens.FONT_BODY, color: Color = Tokens.COLOR_TEXT) -> Label:
+	var l := Label.new()
+	l.text = txt
+	l.add_theme_font_size_override("font_size", font_size(table))
+	l.add_theme_color_override("font_color", color)
+	l.add_theme_color_override("font_outline_color", Color(0, 0, 0, 0.6))
+	l.add_theme_constant_override("outline_size", 4)
+	return l
+
+func make_button(txt: String, variant: String = "") -> Button:
+	var b := Button.new()
+	b.text = txt
+	if variant != "":
+		b.theme_type_variation = "Button" + variant
+	b.custom_minimum_size = Vector2(0, 44)
+	b.focus_mode = Control.FOCUS_ALL
+	return b
+
+func make_spacer() -> Control:
+	var c := Control.new()
+	c.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	return c
+
+func make_margin(left: int, top: int, right: int, bottom: int) -> MarginContainer:
+	var m := MarginContainer.new()
+	m.add_theme_constant_override("margin_left", left)
+	m.add_theme_constant_override("margin_right", right)
+	m.add_theme_constant_override("margin_top", top)
+	m.add_theme_constant_override("margin_bottom", bottom)
+	return m

--- a/apps/godot/nexus-defense/ui/components/pause_modal.gd
+++ b/apps/godot/nexus-defense/ui/components/pause_modal.gd
@@ -1,0 +1,94 @@
+extends "res://ui/components/panel_base.gd"
+
+var _backdrop: ColorRect
+var _panel: PanelContainer
+
+signal action(verb: String)
+
+func _build() -> void:
+	set_anchors_preset(Control.PRESET_FULL_RECT)
+	mouse_filter = Control.MOUSE_FILTER_STOP
+
+	_backdrop = ColorRect.new()
+	_backdrop.set_anchors_preset(Control.PRESET_FULL_RECT)
+	_backdrop.color = Tokens.COLOR_OVERLAY
+	_backdrop.mouse_filter = Control.MOUSE_FILTER_STOP
+	_backdrop.gui_input.connect(_on_backdrop_input)
+	add_child(_backdrop)
+
+	var center := CenterContainer.new()
+	center.set_anchors_preset(Control.PRESET_FULL_RECT)
+	add_child(center)
+
+	_panel = PanelContainer.new()
+	_panel.theme_type_variation = "PanelContainerModal"
+	_panel.custom_minimum_size = Vector2(_min_width(), 0)
+	center.add_child(_panel)
+
+	var vb := VBoxContainer.new()
+	vb.add_theme_constant_override("separation", Tokens.SPACE_MD)
+	_panel.add_child(vb)
+
+	var title := make_label("Paused", Tokens.FONT_H1, Tokens.COLOR_TEXT)
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vb.add_child(title)
+
+	var subtitle := make_label("Catch your breath, commander.", Tokens.FONT_BODY, Tokens.COLOR_TEXT_MUTED)
+	subtitle.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vb.add_child(subtitle)
+
+	vb.add_child(_divider())
+
+	vb.add_child(_action_btn("Resume", "Primary", "resume"))
+	vb.add_child(_action_btn("Settings", "", "settings"))
+	vb.add_child(_action_btn("Quit to Menu", "Danger", "quit"))
+
+	get_tree().paused = true
+	process_mode = Node.PROCESS_MODE_ALWAYS
+
+func _min_width() -> int:
+	var bp := get_node_or_null("/root/Bp")
+	if bp and bp.is_mobile():
+		return 280
+	return 360
+
+func _action_btn(label: String, variant: String, verb: String) -> Button:
+	var b := make_button(label, variant)
+	b.custom_minimum_size = Vector2(0, 52)
+	b.pressed.connect(_on_action.bind(verb))
+	return b
+
+func _divider() -> Control:
+	var c := ColorRect.new()
+	c.custom_minimum_size = Vector2(0, 1)
+	c.color = Tokens.COLOR_OUTLINE
+	return c
+
+func _on_action(verb: String) -> void:
+	action.emit(verb)
+	panel_event.emit("action", verb)
+	match verb:
+		"resume":
+			_close()
+		"quit":
+			_close()
+			get_tree().quit()
+
+func _on_backdrop_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		_close()
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("pause") or event.is_action_pressed("ui_cancel"):
+		_close()
+		get_viewport().set_input_as_handled()
+
+func _close() -> void:
+	get_tree().paused = false
+	var ui := get_node_or_null("/root/Ui")
+	if ui:
+		ui.close("pause")
+
+func close_anim() -> void:
+	get_tree().paused = false
+	await super.close_anim()

--- a/apps/godot/nexus-defense/ui/components/toast.gd
+++ b/apps/godot/nexus-defense/ui/components/toast.gd
@@ -1,0 +1,90 @@
+extends "res://ui/components/panel_base.gd"
+
+var _label: Label
+var _panel: PanelContainer
+var _kind: String = "info"
+var _stack_index: int = 0
+
+const TOAST_W := 320
+const TOAST_H := 56
+const STACK_GAP := 8
+
+func _build() -> void:
+	custom_minimum_size = Vector2(TOAST_W, TOAST_H)
+	size = Vector2(TOAST_W, TOAST_H)
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+	_panel = PanelContainer.new()
+	_panel.theme_type_variation = "PanelContainerToast"
+	_panel.set_anchors_preset(Control.PRESET_FULL_RECT)
+	add_child(_panel)
+
+	var hb := HBoxContainer.new()
+	hb.add_theme_constant_override("separation", Tokens.SPACE_MD)
+	_panel.add_child(hb)
+
+	var dot := ColorRect.new()
+	dot.custom_minimum_size = Vector2(6, 0)
+	dot.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	dot.color = Tokens.COLOR_ACCENT
+	hb.add_child(dot)
+
+	_label = make_label("", Tokens.FONT_BODY, Tokens.COLOR_TEXT)
+	_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	hb.add_child(_label)
+
+func show_toast(message: String, duration: float, kind: String) -> void:
+	_label.text = message
+	_kind = kind
+	var dot: ColorRect = _panel.get_child(0).get_child(0)
+	dot.color = _kind_color(kind)
+	open_anim()
+	await get_tree().create_timer(duration).timeout
+	await close_anim()
+	queue_free()
+
+func _kind_color(kind: String) -> Color:
+	match kind:
+		"ok": return Tokens.COLOR_OK
+		"warn": return Tokens.COLOR_WARN
+		"danger": return Tokens.COLOR_DANGER
+		_: return Tokens.COLOR_ACCENT
+
+func position_in_stack(idx: int) -> void:
+	_stack_index = idx
+	_layout()
+
+func open_anim() -> void:
+	modulate.a = 0.0
+	var start_x := position.x + 24
+	var target_x := position.x
+	position.x = start_x
+	var tw := create_tween().set_parallel(true)
+	tw.tween_property(self, "modulate:a", 1.0, Tokens.ANIM_MED)
+	tw.tween_property(self, "position:x", target_x, Tokens.ANIM_MED).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
+
+func close_anim() -> void:
+	var tw := create_tween().set_parallel(true)
+	tw.tween_property(self, "modulate:a", 0.0, Tokens.ANIM_FAST)
+	tw.tween_property(self, "position:x", position.x + 24, Tokens.ANIM_FAST)
+	await tw.finished
+
+func _layout() -> void:
+	var viewport := get_viewport().get_visible_rect().size
+	var margin := safe_margin()
+	var bp := get_node_or_null("/root/Bp")
+	var top_anchor: float = margin
+	if bp and bp.is_mobile():
+		position.x = (viewport.x - TOAST_W) / 2
+		position.y = top_anchor + (TOAST_H + STACK_GAP) * _stack_index
+	else:
+		position.x = viewport.x - TOAST_W - margin
+		position.y = top_anchor + (TOAST_H + STACK_GAP) * _stack_index
+
+func _on_breakpoint(_klass: int) -> void:
+	_layout()
+
+func _ready() -> void:
+	super._ready()
+	_layout()

--- a/apps/godot/nexus-defense/ui/components/wave_banner.gd
+++ b/apps/godot/nexus-defense/ui/components/wave_banner.gd
@@ -1,0 +1,68 @@
+extends "res://ui/components/panel_base.gd"
+
+var title_text: String = "Wave 1"
+var subtitle_text: String = "12 enemies incoming"
+var duration: float = 2.4
+
+var _title: Label
+var _subtitle: Label
+var _panel: PanelContainer
+
+func _build() -> void:
+	set_anchors_preset(Control.PRESET_FULL_RECT)
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+	var center := CenterContainer.new()
+	center.set_anchors_preset(Control.PRESET_FULL_RECT)
+	center.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(center)
+
+	_panel = PanelContainer.new()
+	_panel.theme_type_variation = "PanelContainerGlass"
+	_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	center.add_child(_panel)
+
+	var vb := VBoxContainer.new()
+	vb.alignment = BoxContainer.ALIGNMENT_CENTER
+	vb.add_theme_constant_override("separation", Tokens.SPACE_SM)
+	_panel.add_child(vb)
+
+	_title = make_label(title_text, Tokens.FONT_DISPLAY, Tokens.COLOR_ACCENT)
+	_title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_title.add_theme_constant_override("outline_size", 6)
+	vb.add_child(_title)
+
+	_subtitle = make_label(subtitle_text, Tokens.FONT_H2, Tokens.COLOR_TEXT_MUTED)
+	_subtitle.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vb.add_child(_subtitle)
+
+func open_anim() -> void:
+	modulate.a = 0.0
+	scale = Vector2(0.92, 0.92)
+	pivot_offset = size / 2
+	var tw := create_tween().set_parallel(true)
+	tw.tween_property(self, "modulate:a", 1.0, Tokens.ANIM_MED)
+	tw.tween_property(self, "scale", Vector2.ONE, Tokens.ANIM_MED).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+	await tw.finished
+	await get_tree().create_timer(duration).timeout
+	var ui := get_node_or_null("/root/Ui")
+	if ui:
+		ui.close("wave_banner")
+
+func close_anim() -> void:
+	var tw := create_tween().set_parallel(true)
+	tw.tween_property(self, "modulate:a", 0.0, Tokens.ANIM_FAST)
+	tw.tween_property(self, "scale", Vector2(0.96, 0.96), Tokens.ANIM_FAST)
+	await tw.finished
+
+func apply(data: Variant) -> void:
+	if typeof(data) != TYPE_DICTIONARY:
+		return
+	if data.has("title"):
+		title_text = String(data["title"])
+		if _title: _title.text = title_text
+	if data.has("subtitle"):
+		subtitle_text = String(data["subtitle"])
+		if _subtitle: _subtitle.text = subtitle_text
+	if data.has("duration"):
+		duration = float(data["duration"])

--- a/apps/godot/nexus-defense/ui/lib/breakpoint.gd
+++ b/apps/godot/nexus-defense/ui/lib/breakpoint.gd
@@ -1,0 +1,49 @@
+extends Node
+
+enum Klass { MOBILE, TABLET, DESKTOP }
+
+const MOBILE_MAX := 720
+const TABLET_MAX := 1180
+
+signal changed(klass: int)
+
+var current: int = Klass.DESKTOP
+
+func _ready() -> void:
+	get_viewport().size_changed.connect(_recompute)
+	_recompute()
+
+func _recompute() -> void:
+	var w: float = get_viewport().get_visible_rect().size.x
+	var k := Klass.DESKTOP
+	if w <= MOBILE_MAX:
+		k = Klass.MOBILE
+	elif w <= TABLET_MAX:
+		k = Klass.TABLET
+	if k != current:
+		current = k
+		changed.emit(k)
+
+func name_of(k: int = -1) -> String:
+	if k == -1:
+		k = current
+	match k:
+		Klass.MOBILE: return "mobile"
+		Klass.TABLET: return "tablet"
+		_: return "desktop"
+
+func pick(table: Dictionary, fallback: Variant = null) -> Variant:
+	var key := name_of()
+	if table.has(key):
+		return table[key]
+	if table.has("desktop"):
+		return table["desktop"]
+	return fallback
+
+func font(table: Dictionary) -> int:
+	return int(pick(table, 16))
+
+func is_mobile() -> bool: return current == Klass.MOBILE
+func is_tablet() -> bool: return current == Klass.TABLET
+func is_desktop() -> bool: return current == Klass.DESKTOP
+func is_touch() -> bool: return current != Klass.DESKTOP

--- a/apps/godot/nexus-defense/ui/lib/tokens.gd
+++ b/apps/godot/nexus-defense/ui/lib/tokens.gd
@@ -1,0 +1,40 @@
+class_name UiTokens
+extends RefCounted
+
+const COLOR_BG := Color(0.07, 0.08, 0.11)
+const COLOR_SURFACE := Color(0.12, 0.14, 0.19)
+const COLOR_SURFACE_ALT := Color(0.16, 0.18, 0.24)
+const COLOR_ACCENT := Color(0.32, 0.78, 0.95)
+const COLOR_ACCENT_HOVER := Color(0.45, 0.86, 1.0)
+const COLOR_DANGER := Color(0.95, 0.32, 0.36)
+const COLOR_OK := Color(0.34, 0.85, 0.45)
+const COLOR_WARN := Color(0.98, 0.78, 0.32)
+const COLOR_TEXT := Color(0.92, 0.94, 0.98)
+const COLOR_TEXT_MUTED := Color(0.62, 0.66, 0.74)
+const COLOR_OUTLINE := Color(0.22, 0.26, 0.34)
+const COLOR_OVERLAY := Color(0.0, 0.0, 0.0, 0.55)
+
+const RADIUS_SM := 4
+const RADIUS_MD := 8
+const RADIUS_LG := 14
+const RADIUS_PILL := 999
+
+const SPACE_XS := 4
+const SPACE_SM := 8
+const SPACE_MD := 14
+const SPACE_LG := 22
+const SPACE_XL := 32
+
+const FONT_DISPLAY := {"mobile": 36, "tablet": 48, "desktop": 56}
+const FONT_H1 := {"mobile": 22, "tablet": 28, "desktop": 32}
+const FONT_H2 := {"mobile": 18, "tablet": 20, "desktop": 22}
+const FONT_BODY := {"mobile": 14, "tablet": 15, "desktop": 16}
+const FONT_SMALL := {"mobile": 11, "tablet": 12, "desktop": 13}
+
+const ANIM_FAST := 0.12
+const ANIM_MED := 0.24
+const ANIM_SLOW := 0.4
+
+const HUD_BAR_HEIGHT := {"mobile": 56, "tablet": 64, "desktop": 72}
+const BUILD_BAR_HEIGHT := {"mobile": 96, "tablet": 112, "desktop": 128}
+const SAFE_MARGIN := {"mobile": 10, "tablet": 18, "desktop": 28}

--- a/apps/godot/nexus-defense/ui/lib/ui_manager.gd
+++ b/apps/godot/nexus-defense/ui/lib/ui_manager.gd
@@ -1,0 +1,116 @@
+extends Node
+
+const LAYER_HUD := 10
+const LAYER_PANEL := 20
+const LAYER_TOAST := 30
+const LAYER_MODAL := 40
+
+const UiThemeBuilder := preload("res://ui/lib/ui_theme.gd")
+const PanelBase := preload("res://ui/components/panel_base.gd")
+const HudTop := preload("res://ui/components/hud_top.gd")
+const BuildBar := preload("res://ui/components/build_bar.gd")
+const WaveBanner := preload("res://ui/components/wave_banner.gd")
+const PauseModal := preload("res://ui/components/pause_modal.gd")
+const BootScreen := preload("res://ui/components/boot_screen.gd")
+const Toast := preload("res://ui/components/toast.gd")
+
+signal opened(panel_name: String)
+signal closed(panel_name: String)
+
+var theme_ref: Theme
+var _layers: Dictionary = {}
+var _registry: Dictionary = {}
+var _live: Dictionary = {}
+var _toast_stack: Array[Control] = []
+
+func _ready() -> void:
+	theme_ref = UiThemeBuilder.build()
+	_make_layer(LAYER_HUD, "HudLayer")
+	_make_layer(LAYER_PANEL, "PanelLayer")
+	_make_layer(LAYER_TOAST, "ToastLayer")
+	_make_layer(LAYER_MODAL, "ModalLayer")
+	_register_defaults()
+
+func _make_layer(idx: int, name: String) -> CanvasLayer:
+	var l := CanvasLayer.new()
+	l.name = name
+	l.layer = idx
+	add_child(l)
+	_layers[idx] = l
+	return l
+
+func _register_defaults() -> void:
+	register("hud_top", HudTop, LAYER_HUD)
+	register("build_bar", BuildBar, LAYER_HUD)
+	register("wave_banner", WaveBanner, LAYER_HUD)
+	register("pause", PauseModal, LAYER_MODAL)
+	register("boot", BootScreen, LAYER_MODAL)
+
+func register(panel_name: String, script: Script, layer_idx: int = LAYER_PANEL) -> void:
+	_registry[panel_name] = {"script": script, "layer": layer_idx}
+
+func open(panel_name: String, data: Variant = null) -> Control:
+	if _live.has(panel_name):
+		var existing: Control = _live[panel_name]
+		if data != null and existing.has_method("apply"):
+			existing.apply(data)
+		return existing
+	if not _registry.has(panel_name):
+		push_warning("UiManager: unknown panel '%s'" % panel_name)
+		return null
+	var entry: Dictionary = _registry[panel_name]
+	var inst: Control = entry["script"].new()
+	inst.theme = theme_ref
+	_layers[entry["layer"]].add_child(inst)
+	_live[panel_name] = inst
+	inst.tree_exiting.connect(_on_panel_exit.bind(panel_name))
+	if data != null and inst.has_method("apply"):
+		inst.apply(data)
+	if inst.has_method("open_anim"):
+		inst.open_anim()
+	opened.emit(panel_name)
+	return inst
+
+func close(panel_name: String) -> void:
+	if not _live.has(panel_name):
+		return
+	var inst: Control = _live[panel_name]
+	if inst.has_method("close_anim"):
+		await inst.close_anim()
+	if is_instance_valid(inst):
+		inst.queue_free()
+
+func toggle(panel_name: String, data: Variant = null) -> Control:
+	if _live.has(panel_name):
+		close(panel_name)
+		return null
+	return open(panel_name, data)
+
+func get_panel(panel_name: String) -> Control:
+	return _live.get(panel_name, null)
+
+func is_open(panel_name: String) -> bool:
+	return _live.has(panel_name)
+
+func toast(message: String, duration: float = 2.0, kind: String = "info") -> void:
+	var inst: Control = Toast.new()
+	inst.theme = theme_ref
+	_layers[LAYER_TOAST].add_child(inst)
+	_toast_stack.append(inst)
+	inst.tree_exiting.connect(func() -> void: _toast_stack.erase(inst))
+	inst.position_in_stack(_toast_stack.size() - 1)
+	inst.show_toast(message, duration, kind)
+	_reflow_toasts()
+
+func _reflow_toasts() -> void:
+	for i in _toast_stack.size():
+		var t: Control = _toast_stack[i]
+		if is_instance_valid(t) and t.has_method("position_in_stack"):
+			t.position_in_stack(i)
+
+func _on_panel_exit(panel_name: String) -> void:
+	if _live.get(panel_name) and not is_instance_valid(_live[panel_name]):
+		_live.erase(panel_name)
+	elif _live.has(panel_name):
+		_live.erase(panel_name)
+	closed.emit(panel_name)

--- a/apps/godot/nexus-defense/ui/lib/ui_theme.gd
+++ b/apps/godot/nexus-defense/ui/lib/ui_theme.gd
@@ -1,0 +1,93 @@
+class_name UiTheme
+extends RefCounted
+
+const T := preload("res://ui/lib/tokens.gd")
+
+static func build() -> Theme:
+	var theme := Theme.new()
+	theme.default_font_size = 16
+
+	_apply_panel(theme)
+	_apply_label(theme)
+	_apply_button(theme, "", T.COLOR_SURFACE_ALT, T.COLOR_OUTLINE, T.COLOR_ACCENT, T.COLOR_TEXT)
+	_apply_button(theme, "Primary", T.COLOR_ACCENT, T.COLOR_ACCENT, T.COLOR_ACCENT_HOVER, T.COLOR_BG)
+	_apply_button(theme, "Danger", T.COLOR_DANGER, T.COLOR_DANGER, T.COLOR_DANGER.lightened(0.15), T.COLOR_TEXT)
+	_apply_button(theme, "Ghost", Color(0, 0, 0, 0), T.COLOR_OUTLINE, T.COLOR_ACCENT, T.COLOR_TEXT)
+	_apply_button(theme, "Icon", T.COLOR_SURFACE, T.COLOR_OUTLINE, T.COLOR_ACCENT, T.COLOR_TEXT)
+	_apply_progress(theme)
+	_apply_panel_variants(theme)
+	return theme
+
+static func stylebox(color: Color, radius: int = T.RADIUS_MD, border: int = 0, border_color: Color = T.COLOR_OUTLINE, pad: int = 12) -> StyleBoxFlat:
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = color
+	sb.corner_radius_top_left = radius
+	sb.corner_radius_top_right = radius
+	sb.corner_radius_bottom_left = radius
+	sb.corner_radius_bottom_right = radius
+	if border > 0:
+		sb.border_width_top = border
+		sb.border_width_bottom = border
+		sb.border_width_left = border
+		sb.border_width_right = border
+		sb.border_color = border_color
+	sb.content_margin_top = pad
+	sb.content_margin_bottom = pad
+	sb.content_margin_left = pad + 4
+	sb.content_margin_right = pad + 4
+	return sb
+
+static func _apply_panel(theme: Theme) -> void:
+	theme.set_stylebox("panel", "PanelContainer", stylebox(T.COLOR_SURFACE, T.RADIUS_MD, 1, T.COLOR_OUTLINE))
+	theme.set_stylebox("panel", "Panel", stylebox(T.COLOR_SURFACE, T.RADIUS_MD, 1, T.COLOR_OUTLINE))
+
+static func _apply_label(theme: Theme) -> void:
+	theme.set_color("font_color", "Label", T.COLOR_TEXT)
+	theme.set_color("font_outline_color", "Label", Color(0, 0, 0, 0.55))
+	theme.set_constant("outline_size", "Label", 0)
+
+static func _apply_button(theme: Theme, variant: String, bg: Color, border_color: Color, accent: Color, text: Color) -> void:
+	var node_class := "Button"
+	if variant != "":
+		node_class = "Button" + variant
+		theme.set_type_variation(node_class, "Button")
+	var border := 1 if variant == "Ghost" else 0
+	var pad := 10
+	var normal := stylebox(bg, T.RADIUS_MD, border, border_color, pad)
+	var hover := stylebox(accent, T.RADIUS_MD, 0, accent, pad)
+	var pressed := stylebox(bg.darkened(0.12), T.RADIUS_MD, 0, border_color, pad)
+	var focus := stylebox(bg, T.RADIUS_MD, 2, accent, pad)
+	var disabled := stylebox(bg.darkened(0.35), T.RADIUS_MD, 0, border_color, pad)
+	theme.set_stylebox("normal", node_class, normal)
+	theme.set_stylebox("hover", node_class, hover)
+	theme.set_stylebox("pressed", node_class, pressed)
+	theme.set_stylebox("focus", node_class, focus)
+	theme.set_stylebox("disabled", node_class, disabled)
+	theme.set_color("font_color", node_class, text)
+	theme.set_color("font_hover_color", node_class, T.COLOR_BG if variant == "Primary" else text)
+	theme.set_color("font_pressed_color", node_class, text)
+	theme.set_color("font_disabled_color", node_class, T.COLOR_TEXT_MUTED)
+
+static func _apply_progress(theme: Theme) -> void:
+	var bg := stylebox(T.COLOR_SURFACE_ALT, T.RADIUS_PILL, 0, T.COLOR_OUTLINE, 0)
+	bg.content_margin_top = 0
+	bg.content_margin_bottom = 0
+	bg.content_margin_left = 0
+	bg.content_margin_right = 0
+	var fill := stylebox(T.COLOR_ACCENT, T.RADIUS_PILL, 0, T.COLOR_ACCENT, 0)
+	fill.content_margin_top = 0
+	fill.content_margin_bottom = 0
+	fill.content_margin_left = 0
+	fill.content_margin_right = 0
+	theme.set_stylebox("background", "ProgressBar", bg)
+	theme.set_stylebox("fill", "ProgressBar", fill)
+	theme.set_color("font_color", "ProgressBar", T.COLOR_TEXT)
+
+static func _apply_panel_variants(theme: Theme) -> void:
+	for variant in ["Glass", "Toast", "Modal", "Hud"]:
+		var variant_name: String = "PanelContainer" + String(variant)
+		theme.set_type_variation(variant_name, "PanelContainer")
+	theme.set_stylebox("panel", "PanelContainerGlass", stylebox(Color(T.COLOR_SURFACE.r, T.COLOR_SURFACE.g, T.COLOR_SURFACE.b, 0.78), T.RADIUS_LG, 1, T.COLOR_OUTLINE))
+	theme.set_stylebox("panel", "PanelContainerToast", stylebox(T.COLOR_SURFACE_ALT, T.RADIUS_MD, 1, T.COLOR_ACCENT))
+	theme.set_stylebox("panel", "PanelContainerModal", stylebox(T.COLOR_SURFACE, T.RADIUS_LG, 1, T.COLOR_OUTLINE, 24))
+	theme.set_stylebox("panel", "PanelContainerHud", stylebox(Color(T.COLOR_BG.r, T.COLOR_BG.g, T.COLOR_BG.b, 0.65), T.RADIUS_MD, 1, T.COLOR_OUTLINE, 10))


### PR DESCRIPTION
## Summary
- Adds `Bp` + `Ui` autoloads driving a layered CanvasLayer registry (HUD / Panel / Toast / Modal) and a central programmatic `Theme` builder.
- Ships reusable Control components — `hud_top`, `build_bar`, `wave_banner`, `toast`, `pause_modal`, `boot_screen` — that subscribe to viewport-class changes (mobile ≤720, tablet ≤1180, desktop) and reflow margins / fonts / chrome.
- Rewrites `scenes/main.{gd,tscn}` to drive everything via `Ui.open / close / toggle / toast / apply`, so gameplay code touches the UI by name + data instead of node paths.

## API
```gdscript
Ui.open("hud_top", {"wave": 1, "lives": 20, "gold": 150})
Ui.open("build_bar", {"gold": 150}).tower_selected.connect(_on_pick)
Ui.toast("Wave cleared", 2.0, "ok")          # info | ok | warn | danger
Ui.toggle("pause")
Ui.register("inventory", MyScript, Ui.LAYER_PANEL)  # plug new component
```

## Adding a new component
1. New `ui/components/foo.gd` extending `panel_base.gd`; override `_build()` and (optional) `apply(data)` / `open_anim()` / `close_anim()`.
2. `register("foo", FooScript, LAYER_PANEL)` inside `ui_manager.gd::_register_defaults` (or from any other script at runtime).
3. Call `Ui.open("foo", {…})` from gameplay.

## Test plan
- [x] `godot --headless --quit-after 100 --path apps/godot/nexus-defense` boots clean (existing `ECS` autoload uid warning is pre-existing, unrelated).
- [ ] Run editor at desktop resolution, confirm HUD / build bar / wave banner / toast layouts.
- [ ] Resize window through 600 / 900 / 1400 widths, confirm font + margin + toast-anchor reflow on each breakpoint flip.
- [ ] Press `Esc` to open `pause_modal`, click backdrop or `Resume`, confirm `get_tree().paused` toggles correctly.
- [ ] Press `Space` (`skip_wave` action) to advance the wave and confirm `hud_top.apply` + new `wave_banner` + `+50 gold` toast fire.