### PR TITLE
feat(arc-runner): bake node+pnpm+playwright chromium into runner image

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.157",
+			"version": "1.0.169",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -24,7 +24,8 @@
 			"runner": "ubuntu-latest",
 			"image": "kbve/arc-runner",
 			"deployment_yamls": [
-				"apps/kube/github/runners/manifests/values-kbve.yaml"
+				"apps/kube/github/runners/manifests/values-kbve.yaml",
+				"apps/kube/github/runners/manifests/values.yaml"
 			],
 			"has_test": false
 		},
@@ -124,7 +125,7 @@
 		{
 			"key": "firecracker_ctl",
 			"app_name": "firecracker-ctl",
-			"version": "0.1.36",
+			"version": "0.1.41",
 			"version_toml": "apps/vm/firecracker-ctl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/firecracker-ctl.mdx",
 			"version_target": "apps/vm/firecracker-ctl/Cargo.toml",
@@ -208,7 +209,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.16",
+			"version": "0.1.18",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",
@@ -245,7 +246,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.50",
+			"version": "1.0.57",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",
@@ -265,7 +266,7 @@
 		{
 			"key": "mc_lobby",
 			"app_name": "mc-lobby",
-			"version": "1.0.7",
+			"version": "1.0.9",
 			"version_toml": "apps/mc/lobby/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc-lobby.mdx",
 			"source_path": "apps/mc/lobby",
@@ -278,7 +279,7 @@
 		{
 			"key": "mc_velocity",
 			"app_name": "mc-velocity",
-			"version": "1.1.8",
+			"version": "1.1.9",
 			"version_toml": "apps/mc/velocity/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc-velocity.mdx",
 			"source_path": "apps/mc/velocity",
@@ -319,7 +320,7 @@
 		{
 			"key": "rows",
 			"app_name": "rows",
-			"version": "0.1.23",
+			"version": "0.1.24",
 			"version_toml": "apps/rows/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/rows.mdx",
 			"version_target": "apps/rows/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
@@ -19,6 +19,7 @@ runner: ubuntu-latest
 image: kbve/arc-runner
 deployment_yamls:
     - apps/kube/github/runners/manifests/values-kbve.yaml
+    - apps/kube/github/runners/manifests/values.yaml
 has_test: false
 author: h0lybyte
 license: KBVE

--- a/apps/kube/github/runners/manifests/values.yaml
+++ b/apps/kube/github/runners/manifests/values.yaml
@@ -36,7 +36,7 @@ template:
         # Init container to copy externals for DinD
         initContainers:
             - name: init-dind-externals
-              image: ghcr.io/actions/actions-runner:2.334.0
+              image: ghcr.io/kbve/arc-runner:0.1.3
               command:
                   [
                       'cp',
@@ -50,7 +50,7 @@ template:
                     mountPath: /home/runner/tmpDir
         containers:
             - name: runner
-              image: ghcr.io/actions/actions-runner:2.334.0
+              image: ghcr.io/kbve/arc-runner:0.1.3
               # Fix sudoers for root before starting runner (Unity builder uses sudo)
               command:
                   [

--- a/packages/docker/arc-runner/Dockerfile
+++ b/packages/docker/arc-runner/Dockerfile
@@ -19,11 +19,14 @@
 ARG ACTIONS_RUNNER_VERSION=2.334.0
 ARG KUBECTL_VERSION=1.31.0
 ARG DBMATE_VERSION=2.28.0
+ARG NODE_VERSION=24.16.0
+ARG PNPM_VERSION=10.33.0
+ARG PLAYWRIGHT_VERSION=1.59.1
 
 FROM --platform=linux/amd64 ghcr.io/actions/actions-runner:${ACTIONS_RUNNER_VERSION} AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/kbve/kbve"
-LABEL org.opencontainers.image.description="KBVE arc-runner-set image — actions-runner + git-lfs/unzip/jq/xz/gh + kubectl/dbmate/envsubst/postgresql-client."
+LABEL org.opencontainers.image.description="KBVE arc-runner-set image — actions-runner + git-lfs/unzip/jq/xz/gh + kubectl/dbmate/envsubst/postgresql-client + node/pnpm/playwright-chromium."
 LABEL org.opencontainers.image.licenses="MIT"
 
 USER root
@@ -90,5 +93,39 @@ RUN set -eux; \
     psql --version >/dev/null; \
     envsubst --version >/dev/null; \
     protoc --version >/dev/null
+
+# node + pnpm + playwright chromium
+#
+# Baked at image-build time so per-job `pnpm exec playwright install` is a
+# no-op cache hit at PLAYWRIGHT_BROWSERS_PATH. Avoids the libuv-threadpool
+# deadlock observed on arc-runner-set when playwright extracts chromium's
+# libwidevinecdm.so onto the pod's overlayfs at runtime.
+#
+# Keep NODE_VERSION/PNPM_VERSION/PLAYWRIGHT_VERSION in lockstep with
+# package.json + .github/workflows/* (actions/setup-node, pnpm/action-setup,
+# @playwright/test). Mismatch falls back to per-job install and re-opens
+# the deadlock.
+ARG NODE_VERSION
+ARG PNPM_VERSION
+ARG PLAYWRIGHT_VERSION
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+RUN set -eux; \
+    curl -fsSL -o /tmp/node.tar.xz \
+        "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz"; \
+    curl -fsSL -o /tmp/node.shasums \
+        "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt"; \
+    grep "node-v${NODE_VERSION}-linux-x64.tar.xz" /tmp/node.shasums | sha256sum -c -; \
+    tar -xJf /tmp/node.tar.xz -C /opt; \
+    ln -s "/opt/node-v${NODE_VERSION}-linux-x64/bin/node" /usr/local/bin/node; \
+    ln -s "/opt/node-v${NODE_VERSION}-linux-x64/bin/npm" /usr/local/bin/npm; \
+    ln -s "/opt/node-v${NODE_VERSION}-linux-x64/bin/npx" /usr/local/bin/npx; \
+    rm /tmp/node.tar.xz /tmp/node.shasums; \
+    npm install -g "pnpm@${PNPM_VERSION}"; \
+    mkdir -p "${PLAYWRIGHT_BROWSERS_PATH}"; \
+    npx --yes "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium; \
+    chmod -R a+rX "${PLAYWRIGHT_BROWSERS_PATH}"; \
+    node --version >/dev/null; \
+    pnpm --version >/dev/null; \
+    test -d "${PLAYWRIGHT_BROWSERS_PATH}/chromium-"*/chrome-linux*
 
 USER runner


### PR DESCRIPTION
## Summary
Permanent fix for the libuv-threadpool deadlock that wedged \`axum-kbve-e2e\` for hours on \`arc-runner-set\`. Bake node + pnpm + playwright chromium into the custom \`ghcr.io/kbve/arc-runner\` image so per-job \`pnpm exec playwright install\` is a no-op cache hit at \`PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright\` and the runtime extract path (which deadlocks on \`libwidevinecdm.so\` even with \`UV_THREADPOOL_SIZE=16\`) is never exercised.

Live debug from the failing runs:
- All Node threads in \`oopDownloadBrowserMain.js\` sleeping (main in \`do_epoll_wait\`, all 20 workers in \`__futex_wait\` with \`UV_THREADPOOL_SIZE=16\`).
- FD pinned mid-write on \`/root/.cache/ms-playwright/chromium-1217/chrome-linux64/WidevineCdm/.../libwidevinecdm.so\` — same file every reproduction.
- No active TCP sockets — fully off-network, pure userspace deadlock.

## Changes
1. **\`packages/docker/arc-runner/Dockerfile\`** — adds Node 24.16.0 + pnpm 10.33.0, runs \`npx playwright@1.59.1 install --with-deps chromium\` at image-build time, pins \`PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright\` as image ENV so workflows pick it up without explicit wiring.
2. **\`apps/kube/github/runners/manifests/values.yaml\`** — flips \`arc-runner-set\` init + runner containers from \`ghcr.io/actions/actions-runner:2.334.0\` to \`ghcr.io/kbve/arc-runner:0.1.3\`. The custom image already existed (git-lfs/jq/gh/kubectl/dbmate baked) and is currently used by \`arc-runner-set-kbve\` via \`values-kbve.yaml\` — \`arc-runner-set\` was the only set still on upstream. First publish of the bake-extended image runs on the existing \`0.1.3\` tag of the upstream runner; post-publish sync bumps both YAMLs to \`0.1.4\` once the new image lands in GHCR.
3. **\`apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx\`** — appends \`values.yaml\` to \`deployment_yamls\` so every future image bump syncs both runner-set manifests.
4. **\`.github/ci-dispatch-manifest.json\`** — full regen (per repo convention) picks up the new \`deployment_yamls\` entry plus drift from other recent merges.

## Tradeoffs
- Image grows ~500MB → ~1.5GB (chromium 170MB extracted + headless-shell + ffmpeg + Node 24 runtime).
- First runner-pod pull per node is ~30s slower; subsequent pods on the same node reuse the layer.
- \`NODE_VERSION\` / \`PNPM_VERSION\` / \`PLAYWRIGHT_VERSION\` Dockerfile ARGs must stay in lockstep with \`actions/setup-node\` / \`pnpm/action-setup\` / \`@playwright/test\` in workspace. Mismatch falls back to per-job install and re-opens the deadlock.

## Test plan
- [ ] Merge → ci-docker builds \`ghcr.io/kbve/arc-runner:0.1.4\`, post-publish sync updates both YAMLs.
- [ ] Argo rolls runner pods (\`kbve.com/restart-trigger\` annotation forces reroll).
- [ ] Trigger an \`axum-kbve-e2e\` run on \`arc-runner-set\` and confirm step 13 \`Install Playwright Browsers\` (if re-enabled) returns in <1s — see \`PLAYWRIGHT_BROWSERS_PATH\` pre-populated.
- [ ] Confirm \`Install pnpm Dependencies\` finishes in <30s (pnpm cache + frozen lockfile + warm node modules path).

## Follow-up
Once this rolls out and stabilizes, revert #11311 (\`install_playwright: false\` in ci-docker.yml) so any Docker-tested project that *does* need a browser can opt in without the deadlock risk.