### PR TITLE
ci(deps): bump game-ci/unity-builder v4 -> v5

### DIFF
--- a/.github/workflows/ci-unity.yml
+++ b/.github/workflows/ci-unity.yml
@@ -283,7 +283,7 @@ jobs:
                   fi
 
             - name: Build with Unity
-              uses: game-ci/unity-builder@v4
+              uses: game-ci/unity-builder@v5
               env:
                   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
                   UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}

--- a/.github/workflows/utils-unity-azure-deployment.yml
+++ b/.github/workflows/utils-unity-azure-deployment.yml
@@ -110,7 +110,7 @@ jobs:
                       Library-${{ inputs.project_path }}-
 
             - name: Build with Unity
-              uses: game-ci/unity-builder@v4
+              uses: game-ci/unity-builder@v5
               env:
                   UNITY_LICENSE: ${{ secrets.unity_license }}
                   UNITY_EMAIL: ${{ secrets.unity_email }}


### PR DESCRIPTION
## Summary
- Bumps `game-ci/unity-builder` from `v4` to `v5` in [`ci-unity.yml`](.github/workflows/ci-unity.yml#L286) and [`utils-unity-azure-deployment.yml`](.github/workflows/utils-unity-azure-deployment.yml#L113). Closes #11160.

## Compatibility review
- **v5.0.0 breaking changes:**
  - Action runtime: Node.js 20 -> 24.
  - Cloud Runner -> Orchestrator (extracted to plugin loader).
  - `Cli` -> `PluginOptions` rename (Orchestrator/plugin internals only).
  - Legacy CLI removal.
- **Our usage** only touches the core build inputs - `projectPath`, `unityVersion`, `targetPlatform`, `buildName` - none of which changed in v5. We do not use Cloud Runner / Orchestrator / Cli at all.
- **Node 24 readiness:**
  - `ci-unity.yml` already sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` on the ARC self-hosted runner (line 291), so Node 24 is provisioned.
  - `utils-unity-azure-deployment.yml` runs on `ubuntu-latest`, which ships Node 24 natively.

## Test plan
- [ ] Trigger a Unity build via `ci-unity.yml` (any axum/bevy-adjacent Unity project) and confirm the `Build with Unity` step picks up v5 without input-shape errors.
- [ ] Confirm the Azure-deployment reusable workflow still resolves the action on `ubuntu-latest`.