### PR TITLE
feat(q,td-server): bevy headless sim + broadcast snapshot fanout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12834,6 +12834,7 @@ name = "q"
 version = "0.1.1"
 dependencies = [
  "axum 0.7.9",
+ "bevy",
  "bincode",
  "bitflags 2.11.0",
  "crossbeam-channel",

--- a/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:842d912de65f479afa8ef9d85fa0e1eaebb8395d0596ee2290ec35a11d6846c4
-size 9306792
+oid sha256:44d572aa4e78a351135e64da27176ba05f2af6aa330d9d72c787833496b68968
+size 9307448

--- a/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24cfd265e12f28fe4e5d31cfaf81a5c2ab02e7ed376f943b64a8379c2a0c4388
+oid sha256:a5755a9fb74a8b783308ff88dd9691466b5e4a02cd6badb5afc548f5216d440b
 size 4133920

--- a/apps/td-server/src/main.rs
+++ b/apps/td-server/src/main.rs
@@ -1,12 +1,15 @@
 //! Nexus Defense game server entry point.
 //!
-//! Hosts the axum WS router from `q::net::server`. The bevy/rapier2d
-//! authoritative sim + Agones lifecycle land in follow-up commits per the
-//! phase plan in KBVE/kbve#11294.
+//! Boots the bevy headless sim, wires its snapshot broadcast into the axum
+//! WS router (`q::net::server`), and serves both from the same tokio
+//! runtime. Agones lifecycle + JWT verify land in follow-up commits per
+//! the phase plan in KBVE/kbve#11294.
 
 use std::net::SocketAddr;
 
+use q::nexus_defense_server::{SNAPSHOT_BROADCAST_CAPACITY, build_app, run_sim_loop};
 use tokio::net::TcpListener;
+use tokio::sync::broadcast;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -21,13 +24,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|_| "0.0.0.0:7878".into())
         .parse()?;
 
-    let app = q::net::server::router();
-    tracing::info!(%addr, "td-server listening");
+    let seed: u64 = std::env::var("TD_SERVER_SEED")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0xC0FFEE);
+
+    // Broadcast bus: bevy sim -> every WS session.
+    let (snap_tx, _) = broadcast::channel(SNAPSHOT_BROADCAST_CAPACITY);
+
+    // Bevy headless app — runs on a dedicated blocking thread so the App
+    // (which holds non-Send schedule state) never crosses task boundaries.
+    let sim_tx = snap_tx.clone();
+    let sim_handle = tokio::task::spawn_blocking(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("sim runtime");
+        let app = build_app(sim_tx, seed);
+        rt.block_on(run_sim_loop(app));
+    });
+
+    let state = q::net::server::ServerState::new(snap_tx, seed);
+    let router = q::net::server::router(state);
+
+    tracing::info!(%addr, %seed, "td-server listening");
 
     let listener = TcpListener::bind(addr).await?;
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    let serve = axum::serve(listener, router).with_graceful_shutdown(shutdown_signal());
+
+    if let Err(e) = serve.await {
+        tracing::error!("serve error: {e}");
+    }
+
+    // The sim task lives on a current-thread runtime inside spawn_blocking;
+    // letting main return drops the JoinHandle and the process exits.
+    drop(sim_handle);
     Ok(())
 }
 

--- a/packages/rust/q/Cargo.toml
+++ b/packages/rust/q/Cargo.toml
@@ -39,12 +39,16 @@ rapier2d-client = ["client", "dep:rapier2d"]
 rapier2d-server = ["server", "dep:rapier2d"]
 
 # Networking — WS client for the Godot extension, axum for the server.
-net-client = ["client", "dep:tokio-tungstenite", "dep:futures-util"]
-net-server = ["server", "dep:axum", "dep:tokio-tungstenite"]
+# Both sides require proto-* for wire framing.
+net-client = ["client", "proto-client", "dep:tokio-tungstenite", "dep:futures-util"]
+net-server = ["server", "proto-server", "dep:axum", "dep:tokio-tungstenite", "dep:futures-util"]
+
+# Bevy ECS app for server flavors. Server-only — clients use their host engine.
+bevy-server = ["server", "dep:bevy"]
 
 # Game bundles — convenience rollups consumed by build pipelines / sync scripts.
 nexus-defense = ["client", "proto-client", "rapier2d-client", "net-client"]
-nexus-defense-server = ["server", "proto-server", "rapier2d-server", "net-server"]
+nexus-defense-server = ["server", "proto-server", "rapier2d-server", "net-server", "bevy-server"]
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -66,6 +70,9 @@ bincode = { version = "2.0", optional = true, features = ["serde"] }
 
 # Physics
 rapier2d = { version = "0.22", optional = true }
+
+# Bevy ECS — headless server. No render, no winit; we drive App::update from a tokio task.
+bevy = { version = "0.18", optional = true, default-features = false, features = ["bevy_state"] }
 
 # Networking
 tokio-tungstenite = { version = "0.24", optional = true, default-features = false, features = ["rustls-tls-webpki-roots", "connect"] }

--- a/packages/rust/q/src/net/server.rs
+++ b/packages/rust/q/src/net/server.rs
@@ -1,58 +1,103 @@
 //! Server-side WebSocket transport — axum router + per-match session loop.
 //!
-//! Real session state (Agones lifecycle, snapshot fanout, JWT verify) lands
-//! after `apps/td-server/` boots end-to-end. For now this module only ships
-//! a router factory + an echo handler that the binary can mount as a smoke
-//! test.
+//! The router accepts an optional broadcast `Sender<ServerEvent>` so the bevy
+//! sim can fan out snapshots to every connected client. When `None`, the
+//! handler still sends a Welcome on connect for smoke tests.
+
+use std::sync::Arc;
 
 use axum::Router;
+use axum::extract::State;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::IntoResponse;
 use axum::routing::get;
+use tokio::sync::broadcast;
 
-#[cfg(feature = "proto-shared")]
-use crate::proto;
+use crate::proto::{self, ServerEvent};
 
-/// Build the axum router. Mount under any base path in the host binary.
-pub fn router() -> Router {
-    Router::new()
-        .route("/healthz", get(|| async { "ok" }))
-        .route("/ws", get(ws_upgrade))
+#[derive(Clone)]
+pub struct ServerState {
+    /// Broadcast bus shared with the bevy sim. WS sessions subscribe a
+    /// receiver per connection.
+    pub broadcast: Option<broadcast::Sender<ServerEvent>>,
+    /// Seed echoed back to clients in the Welcome frame.
+    pub seed: u64,
 }
 
-async fn ws_upgrade(ws: WebSocketUpgrade) -> impl IntoResponse {
-    ws.on_upgrade(handle_socket)
-}
-
-async fn handle_socket(mut socket: WebSocket) {
-    // Send a Welcome immediately so the client side can prove the round-trip
-    // before the sim is wired up. Slot + seed are placeholder values.
-    #[cfg(feature = "proto-shared")]
-    {
-        let evt = proto::ServerEvent::Welcome {
-            protocol: proto::PROTOCOL_VERSION,
-            your_slot: proto::PlayerSlot(0),
-            seed: 0,
-        };
-        if let Ok(buf) = proto::encode(&evt) {
-            let _ = socket.send(Message::Binary(buf)).await;
+impl ServerState {
+    pub fn new(broadcast: broadcast::Sender<ServerEvent>, seed: u64) -> Self {
+        Self {
+            broadcast: Some(broadcast),
+            seed,
         }
     }
 
-    while let Some(Ok(msg)) = socket.recv().await {
-        match msg {
-            Message::Binary(bytes) => {
-                // Echo any ClientFrame the client sends. Real handler will
-                // route inputs into the bevy sim.
-                #[cfg(feature = "proto-shared")]
-                {
-                    let mut buf = bytes.clone();
-                    let _ = proto::decode::<proto::ClientFrame>(&mut buf);
+    pub fn empty() -> Self {
+        Self {
+            broadcast: None,
+            seed: 0,
+        }
+    }
+}
+
+/// Build the axum router with the supplied shared state.
+pub fn router(state: ServerState) -> Router {
+    Router::new()
+        .route("/healthz", get(|| async { "ok" }))
+        .route("/ws", get(ws_upgrade))
+        .with_state(Arc::new(state))
+}
+
+async fn ws_upgrade(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<ServerState>>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, state))
+}
+
+async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
+    let welcome = ServerEvent::Welcome {
+        protocol: proto::PROTOCOL_VERSION,
+        your_slot: proto::PlayerSlot(0),
+        seed: state.seed,
+    };
+    if let Ok(buf) = proto::encode(&welcome)
+        && socket.send(Message::Binary(buf)).await.is_err()
+    {
+        return;
+    }
+
+    let mut rx = state.broadcast.as_ref().map(|tx| tx.subscribe());
+
+    loop {
+        tokio::select! {
+            // Snapshot fanout → forward to client.
+            biased;
+            evt = async {
+                match &mut rx {
+                    Some(r) => r.recv().await.ok(),
+                    None => futures_util::future::pending::<Option<ServerEvent>>().await,
                 }
-                let _ = socket.send(Message::Binary(bytes)).await;
+            } => {
+                let Some(evt) = evt else { break };
+                let Ok(buf) = proto::encode(&evt) else { continue };
+                if socket.send(Message::Binary(buf)).await.is_err() {
+                    break;
+                }
             }
-            Message::Close(_) => break,
-            _ => {}
+            // Inbound client frames.
+            incoming = socket.recv() => {
+                let Some(Ok(msg)) = incoming else { break };
+                match msg {
+                    Message::Binary(bytes) => {
+                        let mut buf = bytes;
+                        let _ = proto::decode::<proto::ClientFrame>(&mut buf);
+                        // Inputs land in the bevy sim once that pump exists.
+                    }
+                    Message::Close(_) => break,
+                    _ => {}
+                }
+            }
         }
     }
 }

--- a/packages/rust/q/src/nexus_defense_server/mod.rs
+++ b/packages/rust/q/src/nexus_defense_server/mod.rs
@@ -1,4 +1,86 @@
 //! Nexus Defense server-side systems (bevy + rapier2d + axum side).
-//! Activated by `--features nexus-defense-server`. Stub.
+//! Activated by `--features nexus-defense-server`.
+//!
+//! Hosts the authoritative simulation. The bevy `App` is built by
+//! [`build_app`] and driven by [`run_sim_loop`] from a tokio task — no winit,
+//! no rendering, just a fixed-cadence scheduler that calls `App::update`.
+//!
+//! Snapshots produced by the [`emit_snapshot`] system are fanned out via a
+//! `tokio::sync::broadcast::Sender<ServerEvent>` so the axum WS layer can
+//! subscribe a `Receiver` per connection.
 
-pub fn placeholder() {}
+use std::time::Duration;
+
+use bevy::app::App;
+use bevy::prelude::{IntoScheduleConfigs, Res, ResMut, Resource, Update};
+use tokio::sync::broadcast;
+use tokio::time;
+
+use crate::proto::{self, ServerEvent};
+
+/// Server sim tick rate. 20 Hz matches the design budget in #11294.
+pub const SIM_TICK_HZ: u32 = 20;
+
+/// Send a snapshot every `SNAPSHOT_EVERY_N_TICKS` sim ticks (10 Hz at 20 Hz sim).
+pub const SNAPSHOT_EVERY_N_TICKS: u32 = 2;
+
+/// Capacity for the broadcast channel — enough headroom for late subscribers
+/// to catch up without lagging the producer.
+pub const SNAPSHOT_BROADCAST_CAPACITY: usize = 256;
+
+#[derive(Resource, Default)]
+pub struct SimClock {
+    pub tick: u32,
+    pub elapsed_ms: u32,
+}
+
+#[derive(Resource, Clone)]
+pub struct SnapshotBroadcast {
+    pub tx: broadcast::Sender<ServerEvent>,
+}
+
+#[derive(Resource, Clone, Copy)]
+pub struct SimSeed(pub u64);
+
+/// Build a headless bevy `App` wired to broadcast snapshots over `tx`.
+///
+/// Caller owns the broadcast `Sender`; clone a `Receiver` per WS connection.
+pub fn build_app(tx: broadcast::Sender<ServerEvent>, seed: u64) -> App {
+    let mut app = App::new();
+    app.insert_resource(SimClock::default())
+        .insert_resource(SimSeed(seed))
+        .insert_resource(SnapshotBroadcast { tx })
+        .add_systems(Update, (tick_sim, emit_snapshot).chain());
+    app
+}
+
+fn tick_sim(mut clock: ResMut<SimClock>) {
+    clock.tick = clock.tick.wrapping_add(1);
+    clock.elapsed_ms = clock.elapsed_ms.wrapping_add(1000 / SIM_TICK_HZ);
+}
+
+fn emit_snapshot(clock: Res<SimClock>, bcast: Res<SnapshotBroadcast>) {
+    if clock.tick % SNAPSHOT_EVERY_N_TICKS != 0 {
+        return;
+    }
+    let snap = proto::Snapshot {
+        tick: clock.tick,
+        server_time_ms: clock.elapsed_ms,
+        input_ack: 0,
+        players: Vec::new(),
+        fields: Vec::new(),
+        keyframe: clock.tick % (SIM_TICK_HZ * 5) == 0,
+    };
+    let _ = bcast.tx.send(ServerEvent::Snapshot(snap));
+}
+
+/// Drive `App::update` on a tokio task at `SIM_TICK_HZ`. Loops until the
+/// surrounding task is aborted.
+pub async fn run_sim_loop(mut app: App) {
+    let mut ticker = time::interval(Duration::from_millis(1000 / SIM_TICK_HZ as u64));
+    ticker.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+    loop {
+        ticker.tick().await;
+        app.update();
+    }
+}


### PR DESCRIPTION
## Summary
First end-to-end frame of authoritative gameplay: td-server boots a bevy \`App\` at 20 Hz, emits \`proto::Snapshot\` frames every 2 ticks (10 Hz) onto a \`tokio::sync::broadcast\` bus, and the axum WS layer fans them out to every connected \`MatchSocket\`.

## Architecture
\`\`\`
+-----------------------------+
| td-server (tokio runtime)   |
|                             |
|  +-----------------------+  |
|  | spawn_blocking thread |  |
|  |  bevy App @ 20 Hz     |  |
|  |  emit_snapshot system |  |  ServerEvent::Snapshot
|  +-----------+-----------+  |---->  broadcast::Sender
|              v              |          v
|     tokio::sync::broadcast  |          v
|              |              |          v
|              v              |        +-------------+
|     axum WS handler         |        | per-socket  |
|     (subscribes Receiver)   |--------|  Receiver   |
+-----------------------------+        +------+------+
                                              v
                                       tungstenite frame
                                              v
                                       godot MatchSocket
                                       (decode postcard,
                                        emit signal)
\`\`\`

## Changes
- **q::nexus_defense_server**: \`SimClock\`, \`SimSeed\`, \`SnapshotBroadcast\` resources; \`tick_sim\` + \`emit_snapshot\` systems chained on \`Update\`; \`build_app\` constructor + \`run_sim_loop\` async driver.
- **q::net::server**: \`router\` now takes \`ServerState { broadcast, seed }\`. WS handler subscribes a broadcast \`Receiver\` per session and \`tokio::select!\`s between fanout and inbound client frames. Welcome still sends on connect.
- **q Cargo**: new \`bevy-server\` feature pulling \`bevy 0.18\` (no default features, \`bevy_state\` only). \`net-client\` and \`net-server\` now imply their respective \`proto-*\` features. \`nexus-defense-server\` rolls up everything.
- **apps/td-server**: spawns the bevy App via \`tokio::task::spawn_blocking\` + a current-thread runtime so the non-\`Send\` App stays pinned. Reads \`TD_SERVER_SEED\` (default \`0xC0FFEE\`).

## Smoke
\`\`\`bash
# Terminal A
cargo run -p td-server

# Terminal B
godot --headless --quit-after 5 apps/godot/nexus-defense

# Output
[nexus-defense] dialing ws://127.0.0.1:7878/ws
[nexus-defense] ws connected
[nexus-defense] welcome: slot=0 seed=0xc0ffee
[nexus-defense] snapshot tick=2784
\`\`\`

## Test plan
- [ ] \`cargo build -p q\` (default = client) ✓ still
- [ ] \`cargo build -p q --no-default-features --features nexus-defense\` ✓
- [ ] \`cargo build -p td-server\` ✓
- [ ] \`git pull && git lfs pull\` then F5 in Godot — HUD logs rolling \`snapshot tick=…\` lines at ~10 Hz

## Next
- Real \`Snapshot.fields\` content (player views + entities) — wave spawner + minimal enemy mover in bevy
- Client-side snapshot ring buffer + interpolation
- Authoritative input ingestion (forward \`ClientFrame\` → bevy sim resource)

## Related
- #11294 — multiplayer TD tracker (this lands phase 1 of the server side)
- #11313 — q feature flag refactor
- #11314 — proto + td-server skeleton
- #11316 — MatchSocket godot class