### PR TITLE
chore(q): godot-rust 0.4.5 → 0.5.3 migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6640,9 +6640,9 @@ dependencies = [
 
 [[package]]
 name = "gdextension-api"
-version = "0.3.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5383f33a2772746bbc83e5b0480862dd1eedfd0518b976f37f3db11c81e71a6a"
+checksum = "58ad9a3d877c77834a2d1d92842ebd56928f61bd52e0fac4f04fc8b3731b0437"
 
 [[package]]
 name = "gdk"
@@ -7287,9 +7287,9 @@ dependencies = [
 
 [[package]]
 name = "godot"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5599d03afd17a511e11d0bf9e06c88d4095a9120f10cf00a74f50b300f53413e"
+checksum = "71af3920bb1d3e14eb2e71644b140d26035fe3edc6b662db4575c439778b7ee7"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -7297,40 +7297,39 @@ dependencies = [
 
 [[package]]
 name = "godot-bindings"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38b6e65306c05e3c3f0131ee8dbf7394691e53268d72019007ec20687f2280f"
+checksum = "d9347553a03444bbdc1e802f35ea58b7b52c01ece19b081d327c87991db5fd46"
 dependencies = [
  "gdextension-api",
 ]
 
 [[package]]
 name = "godot-cell"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738efef92fdcf1d92f0ed5a29c6f3cdce58e64029d08928c20e08771e1239c16"
+checksum = "bdee833f1fe0bc3208062ede0626f552559dfdcc824ff5e6208aa922a0f509d1"
 
 [[package]]
 name = "godot-codegen"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b9a59f603f354c54d83fb74071209203d0ebe396b2419acc731c90ebf94680"
+checksum = "4fac542f1dd9bdaeb7d537fa5ba499fb6d89b29e484061959930c45b509818af"
 dependencies = [
  "godot-bindings",
  "heck 0.5.0",
  "nanoserde",
  "proc-macro2",
  "quote",
- "regex",
 ]
 
 [[package]]
 name = "godot-core"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e80dfb58d2048ae0dca60bec32129dc1f96510f904b992ad170d84e950c33"
+checksum = "d92e2c8b7f1fe46b59c8ecec5ed1156e7ad973e30c9133444b009462f8b09e06"
 dependencies = [
- "glam 0.30.10",
+ "glam 0.32.1",
  "godot-bindings",
  "godot-cell",
  "godot-codegen",
@@ -7339,21 +7338,20 @@ dependencies = [
 
 [[package]]
 name = "godot-ffi"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6237b26c52c5baa6566705a73cd8804ea4ef83a666540939dd5a4e068c242666"
+checksum = "b0b34c2008795f645977bec2ebbc30a73b4f53ca2de54a0a93ff2cc2dffd10c9"
 dependencies = [
  "godot-bindings",
  "godot-codegen",
- "godot-macros",
  "libc",
 ]
 
 [[package]]
 name = "godot-macros"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d696b67ba99ff7d75e07546b04c3a711651d2c9e5851c9225dea3b64f8bb5af6"
+checksum = "1799cc35d0db5760a74f8f97de7d620e74542b76d5d41f38ea301fa2cb69882f"
 dependencies = [
  "godot-bindings",
  "proc-macro2",

--- a/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44d572aa4e78a351135e64da27176ba05f2af6aa330d9d72c787833496b68968
-size 9307448
+oid sha256:16eb88b16e0948d31de6bf6b854752445fa99e1e5cb0a429fc79da50bf5fc570
+size 9170600

--- a/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5755a9fb74a8b783308ff88dd9691466b5e4a02cd6badb5afc548f5216d440b
-size 4133920
+oid sha256:3ddc0f32b6628ead8aa8f8a238617d2e69c7e472cc75d6fec9a66c9e09581c2e
+size 4183600

--- a/packages/rust/q/Cargo.toml
+++ b/packages/rust/q/Cargo.toml
@@ -58,7 +58,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Client / shared infra (gated by features)
-godot = { version = "0.4.5", optional = true, features = ["experimental-wasm", "experimental-threads"] }
+godot = { version = "0.5.3", optional = true, features = ["experimental-wasm", "experimental-threads"] }
 dashmap = { version = "6.1.0", optional = true }
 crossbeam-channel = { version = "0.5.15", optional = true }
 bitflags = { version = "2.9.0", optional = true, features = ["serde"] }

--- a/packages/rust/q/src/extensions/ui_extension.rs
+++ b/packages/rust/q/src/extensions/ui_extension.rs
@@ -1,4 +1,5 @@
 use crate::impl_node_ext_common;
+use godot::builtin::Side;
 use godot::classes::control::LayoutPreset;
 use godot::classes::{Button, CanvasLayer, Control};
 use godot::prelude::*;

--- a/packages/rust/q/src/lib.rs
+++ b/packages/rust/q/src/lib.rs
@@ -37,18 +37,18 @@ struct Q;
 #[gdextension]
 unsafe impl ExtensionLibrary for Q {
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
-    fn on_level_init(level: InitLevel) {
+    fn on_stage_init(stage: godot::init::InitStage) {
         use crate::threads::runtime::RuntimeManager;
-        if level == InitLevel::Scene {
+        if stage == godot::init::InitStage::Scene {
             let mut engine = godot::classes::Engine::singleton();
             engine.register_singleton(RuntimeManager::SINGLETON, &RuntimeManager::new_alloc());
         }
     }
 
     #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
-    fn on_level_deinit(level: InitLevel) {
+    fn on_stage_deinit(stage: godot::init::InitStage) {
         use crate::threads::runtime::RuntimeManager;
-        if level == InitLevel::Scene {
+        if stage == godot::init::InitStage::Scene {
             let mut engine = godot::classes::Engine::singleton();
             if let Some(singleton) = engine.get_singleton(RuntimeManager::SINGLETON) {
                 engine.unregister_singleton(RuntimeManager::SINGLETON);
@@ -61,12 +61,6 @@ unsafe impl ExtensionLibrary for Q {
             }
         }
     }
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
-    fn on_level_init(_level: InitLevel) {}
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
-    fn on_level_deinit(_level: InitLevel) {}
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/rust/q/src/manager/browser_manager.rs
+++ b/packages/rust/q/src/manager/browser_manager.rs
@@ -63,7 +63,7 @@ impl ICanvasLayer for BrowserManager {
 
         {
             let base = self.base_mut();
-            if let Some(tree) = base.get_tree()
+            if let Some(tree) = base.get_tree_or_null()
                 && let Some(mut root) = tree.get_root()
             {
                 let callable = Callable::from_object_method(
@@ -71,7 +71,7 @@ impl ICanvasLayer for BrowserManager {
                     "on_window_resize",
                 );
 
-                let error = root.connect("size_changed", &callable);
+                let error: godot::global::Error = root.connect("size_changed", &callable);
                 if error != godot::global::Error::OK {
                     godot_error!(
                         "[BrowserManager] Failed to connect root size_changed: {:?}",

--- a/packages/rust/q/src/manager/game_manager.rs
+++ b/packages/rust/q/src/manager/game_manager.rs
@@ -182,7 +182,7 @@ impl GameManager {
     #[func]
     fn pause_game(&mut self) {
         self.base_mut().emit_signal("game_paused", &[]);
-        if let Some(mut scene_tree) = self.base().get_tree() {
+        if let Some(mut scene_tree) = self.base().get_tree_or_null() {
             scene_tree.set_pause(true);
         }
         debug_print!("[GameManager] Game Paused.");
@@ -191,7 +191,7 @@ impl GameManager {
     #[func]
     fn resume_game(&mut self) {
         self.base_mut().emit_signal("game_resumed", &[]);
-        if let Some(mut scene_tree) = self.base().get_tree() {
+        if let Some(mut scene_tree) = self.base().get_tree_or_null() {
             scene_tree.set_pause(false);
         }
         debug_print!("[GameManager] Game Resumed.");
@@ -202,7 +202,7 @@ impl GameManager {
         self.base_mut().emit_signal("game_exited", &[]);
         debug_print!("[GameManager] Exiting Game...");
 
-        if let Some(mut scene_tree) = self.base().get_tree() {
+        if let Some(mut scene_tree) = self.base().get_tree_or_null() {
             scene_tree.quit();
         }
     }

--- a/packages/rust/q/src/manager/gui_manager.rs
+++ b/packages/rust/q/src/manager/gui_manager.rs
@@ -41,7 +41,7 @@ impl GUIManagerExt for Gd<CanvasLayer> {
     }
 
     fn with_windowflag(&mut self, flag: WindowFlags, flag_boolean: bool) {
-        if let Some(root) = self.get_tree().and_then(|tree| tree.get_root()) {
+        if let Some(root) = self.get_tree_or_null().and_then(|tree| tree.get_root()) {
             if let Ok(mut root_window) = root.try_cast::<Window>() {
                 godot_print!(
                     "[Godot] Modifying window flag: {:?}, setting to: {}",

--- a/packages/rust/q/src/manager/music_manager.rs
+++ b/packages/rust/q/src/manager/music_manager.rs
@@ -70,16 +70,19 @@ impl INode for MusicManager {
 
             {
                 let base = self.base_mut();
-                let mut active_player = base.get_node_as::<AudioStreamPlayer>(active_name.arg());
+                let mut active_player =
+                    base.get_node_as::<AudioStreamPlayer>(&NodePath::from(&active_name));
                 active_player.set_volume_db(active_vol);
 
-                let mut idle_player = base.get_node_as::<AudioStreamPlayer>(idle_name.arg());
+                let mut idle_player =
+                    base.get_node_as::<AudioStreamPlayer>(&NodePath::from(&idle_name));
                 idle_player.set_volume_db(idle_vol);
             }
 
             if t >= 1.0 {
                 let base = self.base_mut();
-                let mut active_player = base.get_node_as::<AudioStreamPlayer>(active_name.arg());
+                let mut active_player =
+                    base.get_node_as::<AudioStreamPlayer>(&NodePath::from(&active_name));
                 active_player.stop();
                 true
             } else {
@@ -325,7 +328,7 @@ impl MusicManager {
 
         {
             let base = self.base_mut();
-            let idle_player = base.get_node_as::<AudioStreamPlayer>(idle_name.arg());
+            let idle_player = base.get_node_as::<AudioStreamPlayer>(&NodePath::from(&idle_name));
             if idle_player.is_instance_valid() {
                 let mut idle_player = idle_player;
                 idle_player.set_stream(&audio_stream);

--- a/packages/rust/q/src/platform/browser.rs
+++ b/packages/rust/q/src/platform/browser.rs
@@ -164,7 +164,7 @@ impl GodotBrowser {
             let rect = {
                 let viewport_size = self
                     .base()
-                    .get_tree()
+                    .get_tree_or_null()
                     .and_then(|tree| tree.get_root())
                     .map(|viewport| viewport.get_size())
                     .unwrap_or(Vector2i::new(800, 600));


### PR DESCRIPTION
## Summary
Bumps the godot-rust binding to 0.5.3 so q's API version matches the Godot 4.6 runtime. The prior 0.4.5 build only ran because the strict safeguard tolerated the minor diff, but the smoke log was warning:
\`\`\`
Initialize godot-rust (API v4.5.stable.official, runtime v4.6.3.stable.official, safeguards strict)
\`\`\`
After this PR:
\`\`\`
Initialize godot-rust (API v4.6.stable.official, runtime v4.6.3.stable.official, safeguards strict)
\`\`\`

## Breaking changes patched
- **\`ExtensionLibrary\` trait** — \`on_level_init\` / \`on_level_deinit\` renamed to \`on_stage_init\` / \`on_stage_deinit\`; \`InitLevel\` renamed to \`InitStage\`. \`lib.rs\` updated. The no-op stubs for non-desktop targets are no longer needed because the trait now provides empty defaults.
- **\`Side\` type** — moved out of the prelude into \`godot::builtin::Side\`. Explicit import added in \`extensions/ui_extension.rs\`.
- **\`Node::get_tree()\`** — now returns \`Gd<SceneTree>\` directly and panics if the node is detached. Defensive callers switched to \`get_tree_or_null()\` (returns \`Option<Gd<SceneTree>>\`) in \`browser_manager.rs\`, \`game_manager.rs\`, \`gui_manager.rs\`, and \`platform/browser.rs\`.
- **\`StringName::arg()\`** removed. \`music_manager.rs\` now converts each \`StringName\` to a \`NodePath\` via \`NodePath::from(&name)\` at the \`get_node_as\` call site, and passes by reference so the same name can be reused.
- **\`Object::connect\`** returns \`godot::global::Error\` directly instead of \`Result\`; \`browser_manager.rs\` annotated explicitly.

## Build matrix
\`\`\`bash
cargo build -p q                                                          # default (client)         ok
cargo build -p q --no-default-features --features nexus-defense           # client bundle            ok
cargo build -p q --no-default-features --features nexus-defense-server    # server bundle            ok
cargo build -p td-server                                                                             ok
\`\`\`

## Smoke (mac arm64, Godot 4.6.3, debug + release libq.dylib via Forgejo LFS)
\`\`\`
Initialize godot-rust (API v4.6.stable.official, runtime v4.6.3.stable.official, safeguards strict)
[nexus-defense] main scene ready — q::nexus_defense pong: q::nexus_defense online
[nexus-defense] dialing ws://127.0.0.1:7878/ws
[nexus-defense] ws connected
[nexus-defense] welcome: slot=0 seed=0xc0ffee
[nexus-defense] snapshot tick=46
\`\`\`

## Test plan
- [ ] \`git pull && git lfs pull\`
- [ ] \`cargo build -p q\` (default features) ✓
- [ ] Open \`apps/godot/nexus-defense\` in Godot 4.6 → output now logs \`API v4.6\` instead of \`API v4.5\`
- [ ] Rareicon's Unity Plugins build path unchanged (q's \`client\` feature is still default)

## Related
- #11294 — multiplayer TD tracker
- #11313 — q feature flag refactor
- #11322 — bevy headless sim