### PR TITLE
feat(q,nexus-defense): bevy wave spawner + enemy mover

### DIFF
--- a/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16eb88b16e0948d31de6bf6b854752445fa99e1e5cb0a429fc79da50bf5fc570
-size 9170600
+oid sha256:9eb9993b1e56f999afeb2b7fbcd32098e7af33b5cc74c6b30a3057e63f3df3b3
+size 9173080

--- a/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ddc0f32b6628ead8aa8f8a238617d2e69c7e472cc75d6fec9a66c9e09581c2e
+oid sha256:2c6fc48d3d7a61a777c9323b8271f79fe8c1e72b34624d8d0677df90c6e25c38
 size 4183600

--- a/apps/godot/nexus-defense/scenes/main.gd
+++ b/apps/godot/nexus-defense/scenes/main.gd
@@ -77,8 +77,21 @@ func _on_welcome(slot: int, seed: int) -> void:
 	_log("welcome: slot=%d seed=0x%x" % [slot, seed])
 	Ui.toast("Welcome — slot %d" % slot, 2.0, "info")
 
-func _on_snapshot(tick: int) -> void:
-	_log("snapshot tick=%d" % tick)
+var _last_snapshot_log_tick: int = -1
+
+func _on_snapshot(tick: int, wave: int, enemy_count: int, gold: int, lives: int) -> void:
+	# Throttle log spam — only print once per second (10 snapshots) and on wave change.
+	var wave_changed: bool = wave != _wave
+	if wave_changed:
+		_wave = wave
+		Ui.open("wave_banner", {"title": "Wave %d" % wave, "subtitle": "%d enemies inbound" % enemy_count})
+	_lives = lives
+	_gold = gold
+	_enemies = enemy_count
+	Ui.open("hud_top", {"wave": _wave, "lives": _lives, "gold": _gold, "enemies": _enemies})
+	if _last_snapshot_log_tick < 0 or tick - _last_snapshot_log_tick >= 10 or wave_changed:
+		_last_snapshot_log_tick = tick
+		_log("snapshot tick=%d wave=%d enemies=%d gold=%d lives=%d" % [tick, wave, enemy_count, gold, lives])
 
 func _on_disconnected(reason: String) -> void:
 	_log("disconnected: %s" % reason)

--- a/packages/rust/q/src/nexus_defense/match_socket.rs
+++ b/packages/rust/q/src/nexus_defense/match_socket.rs
@@ -21,10 +21,23 @@ enum Outbound {
 
 enum Inbound {
     Connected,
-    Welcome { slot: u8, seed: u64 },
-    Snapshot { tick: u32 },
-    Disconnected { reason: String },
-    DecodeError { detail: String },
+    Welcome {
+        slot: u8,
+        seed: u64,
+    },
+    Snapshot {
+        tick: u32,
+        wave: u16,
+        enemy_count: u32,
+        gold: i32,
+        lives: i32,
+    },
+    Disconnected {
+        reason: String,
+    },
+    DecodeError {
+        detail: String,
+    },
 }
 
 #[derive(GodotClass)]
@@ -66,9 +79,23 @@ impl INode for MatchSocket {
                         &[(slot as i64).to_variant(), (seed as i64).to_variant()],
                     );
                 }
-                Inbound::Snapshot { tick } => {
-                    self.base_mut()
-                        .emit_signal(&StringName::from("snapshot"), &[(tick as i64).to_variant()]);
+                Inbound::Snapshot {
+                    tick,
+                    wave,
+                    enemy_count,
+                    gold,
+                    lives,
+                } => {
+                    self.base_mut().emit_signal(
+                        &StringName::from("snapshot"),
+                        &[
+                            (tick as i64).to_variant(),
+                            (wave as i64).to_variant(),
+                            (enemy_count as i64).to_variant(),
+                            (gold as i64).to_variant(),
+                            (lives as i64).to_variant(),
+                        ],
+                    );
                 }
                 Inbound::Disconnected { reason } => {
                     self.connected = false;
@@ -94,10 +121,11 @@ impl MatchSocket {
     #[signal]
     fn welcome(slot: i64, seed: i64);
 
-    /// Snapshot landed; consumer can pull additional detail from a buffer
-    /// later. For now only the tick is plumbed through.
+    /// Snapshot landed — summary surface for the HUD. Per-entity detail can
+    /// be pulled from a future ring buffer; for now we plumb the headline
+    /// numbers so GDScript can render a wave/enemies/gold display.
     #[signal]
-    fn snapshot(tick: i64);
+    fn snapshot(tick: i64, wave: i64, enemy_count: i64, gold: i64, lives: i64);
 
     #[signal]
     fn disconnected(reason: GString);
@@ -231,7 +259,18 @@ async fn run_socket(url: String, tx: Sender<Inbound>, rx: Receiver<Outbound>) {
                     });
                 }
                 Ok(ServerEvent::Snapshot(snap)) => {
-                    let _ = tx.send(Inbound::Snapshot { tick: snap.tick });
+                    let field = snap.fields.first();
+                    let enemy_count = field.map(|f| f.enemies.len() as u32).unwrap_or(0);
+                    let wave = field.map(|f| f.wave).unwrap_or(0);
+                    let gold = field.map(|f| f.gold).unwrap_or(0);
+                    let lives = field.map(|f| f.lives).unwrap_or(0);
+                    let _ = tx.send(Inbound::Snapshot {
+                        tick: snap.tick,
+                        wave,
+                        enemy_count,
+                        gold,
+                        lives,
+                    });
                 }
                 Ok(ServerEvent::Reject { reason }) => {
                     let _ = tx.send(Inbound::Disconnected { reason });

--- a/packages/rust/q/src/nexus_defense_server/mod.rs
+++ b/packages/rust/q/src/nexus_defense_server/mod.rs
@@ -5,14 +5,16 @@
 //! [`build_app`] and driven by [`run_sim_loop`] from a tokio task — no winit,
 //! no rendering, just a fixed-cadence scheduler that calls `App::update`.
 //!
-//! Snapshots produced by the [`emit_snapshot`] system are fanned out via a
+//! Snapshots produced by [`emit_snapshot`] are fanned out via a
 //! `tokio::sync::broadcast::Sender<ServerEvent>` so the axum WS layer can
 //! subscribe a `Receiver` per connection.
 
 use std::time::Duration;
 
 use bevy::app::App;
-use bevy::prelude::{IntoScheduleConfigs, Res, ResMut, Resource, Update};
+use bevy::ecs::entity::Entity;
+use bevy::ecs::system::Commands;
+use bevy::prelude::{Component, IntoScheduleConfigs, Query, Res, ResMut, Resource, Update};
 use tokio::sync::broadcast;
 use tokio::time;
 
@@ -21,12 +23,27 @@ use crate::proto::{self, ServerEvent};
 /// Server sim tick rate. 20 Hz matches the design budget in #11294.
 pub const SIM_TICK_HZ: u32 = 20;
 
+/// Seconds per tick.
+const TICK_DT: f32 = 1.0 / SIM_TICK_HZ as f32;
+
 /// Send a snapshot every `SNAPSHOT_EVERY_N_TICKS` sim ticks (10 Hz at 20 Hz sim).
 pub const SNAPSHOT_EVERY_N_TICKS: u32 = 2;
 
 /// Capacity for the broadcast channel — enough headroom for late subscribers
 /// to catch up without lagging the producer.
 pub const SNAPSHOT_BROADCAST_CAPACITY: usize = 256;
+
+/// Map dimensions used by the placeholder spawner.
+const PLAYFIELD_WIDTH: f32 = 800.0;
+const SPAWN_X: f32 = 0.0;
+const SPAWN_Y: f32 = 240.0;
+const ENEMY_SPEED: f32 = 60.0;
+const ENEMY_HP: f32 = 50.0;
+const ENEMIES_PER_WAVE: u32 = 10;
+/// Ticks between consecutive enemy spawns inside a wave (0.5 s at 20 Hz).
+const SPAWN_INTERVAL_TICKS: u32 = 10;
+/// Ticks between waves (5 s at 20 Hz).
+const WAVE_INTERVAL_TICKS: u32 = SIM_TICK_HZ * 5;
 
 #[derive(Resource, Default)]
 pub struct SimClock {
@@ -42,6 +59,31 @@ pub struct SnapshotBroadcast {
 #[derive(Resource, Clone, Copy)]
 pub struct SimSeed(pub u64);
 
+#[derive(Resource, Default)]
+pub struct WaveState {
+    pub wave: u16,
+    pub spawned_in_wave: u32,
+    pub next_spawn_tick: u32,
+    pub next_wave_tick: u32,
+}
+
+#[derive(Component)]
+pub struct Position(pub f32, pub f32);
+
+#[derive(Component)]
+pub struct Velocity(pub f32, pub f32);
+
+#[derive(Component)]
+pub struct Health {
+    pub hp: f32,
+    pub max_hp: f32,
+}
+
+#[derive(Component)]
+pub struct EnemyTag {
+    pub kind: proto::EnemyKind,
+}
+
 /// Build a headless bevy `App` wired to broadcast snapshots over `tx`.
 ///
 /// Caller owns the broadcast `Sender`; clone a `Receiver` per WS connection.
@@ -50,7 +92,18 @@ pub fn build_app(tx: broadcast::Sender<ServerEvent>, seed: u64) -> App {
     app.insert_resource(SimClock::default())
         .insert_resource(SimSeed(seed))
         .insert_resource(SnapshotBroadcast { tx })
-        .add_systems(Update, (tick_sim, emit_snapshot).chain());
+        .insert_resource(WaveState::default())
+        .add_systems(
+            Update,
+            (
+                tick_sim,
+                spawn_wave_enemies,
+                move_enemies,
+                despawn_offscreen,
+                emit_snapshot,
+            )
+                .chain(),
+        );
     app
 }
 
@@ -59,16 +112,96 @@ fn tick_sim(mut clock: ResMut<SimClock>) {
     clock.elapsed_ms = clock.elapsed_ms.wrapping_add(1000 / SIM_TICK_HZ);
 }
 
-fn emit_snapshot(clock: Res<SimClock>, bcast: Res<SnapshotBroadcast>) {
+fn spawn_wave_enemies(clock: Res<SimClock>, mut wave: ResMut<WaveState>, mut commands: Commands) {
+    if clock.tick >= wave.next_wave_tick && wave.spawned_in_wave >= ENEMIES_PER_WAVE {
+        wave.wave = wave.wave.wrapping_add(1);
+        wave.spawned_in_wave = 0;
+        wave.next_spawn_tick = clock.tick;
+        wave.next_wave_tick = clock.tick + WAVE_INTERVAL_TICKS;
+    }
+
+    if wave.spawned_in_wave >= ENEMIES_PER_WAVE {
+        return;
+    }
+    if clock.tick < wave.next_spawn_tick {
+        return;
+    }
+
+    let kind = match wave.spawned_in_wave % 4 {
+        0 => proto::EnemyKind::Runner,
+        1 => proto::EnemyKind::Scout,
+        2 => proto::EnemyKind::Brute,
+        _ => proto::EnemyKind::Shielded,
+    };
+
+    commands.spawn((
+        EnemyTag { kind },
+        Position(SPAWN_X, SPAWN_Y + (wave.spawned_in_wave as f32 * 4.0)),
+        Velocity(ENEMY_SPEED, 0.0),
+        Health {
+            hp: ENEMY_HP,
+            max_hp: ENEMY_HP,
+        },
+    ));
+
+    wave.spawned_in_wave += 1;
+    wave.next_spawn_tick = clock.tick + SPAWN_INTERVAL_TICKS;
+}
+
+fn move_enemies(mut q: Query<(&Velocity, &mut Position)>) {
+    for (vel, mut pos) in q.iter_mut() {
+        pos.0 += vel.0 * TICK_DT;
+        pos.1 += vel.1 * TICK_DT;
+    }
+}
+
+fn despawn_offscreen(mut commands: Commands, q: Query<(Entity, &Position)>) {
+    for (entity, pos) in q.iter() {
+        if pos.0 > PLAYFIELD_WIDTH {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+fn emit_snapshot(
+    clock: Res<SimClock>,
+    wave: Res<WaveState>,
+    bcast: Res<SnapshotBroadcast>,
+    enemies: Query<(Entity, &EnemyTag, &Position, &Health)>,
+) {
     if clock.tick % SNAPSHOT_EVERY_N_TICKS != 0 {
         return;
     }
+
+    let mut enemy_deltas = Vec::with_capacity(enemies.iter().len());
+    for (entity, tag, pos, hp) in enemies.iter() {
+        enemy_deltas.push(proto::EnemyDelta {
+            eid: proto::EntityId(entity.index_u32()),
+            kind: tag.kind,
+            pos: proto::Vec2 { x: pos.0, y: pos.1 },
+            hp: hp.hp,
+            max_hp: hp.max_hp,
+            status_bits: 0,
+            destroyed: false,
+        });
+    }
+
+    let field = proto::FieldDelta {
+        owner: proto::PlayerSlot(0),
+        buildings: Vec::new(),
+        enemies: enemy_deltas,
+        projectiles: Vec::new(),
+        gold: 150,
+        lives: 20,
+        wave: wave.wave,
+    };
+
     let snap = proto::Snapshot {
         tick: clock.tick,
         server_time_ms: clock.elapsed_ms,
         input_ack: 0,
         players: Vec::new(),
-        fields: Vec::new(),
+        fields: vec![field],
         keyframe: clock.tick % (SIM_TICK_HZ * 5) == 0,
     };
     let _ = bcast.tx.send(ServerEvent::Snapshot(snap));


### PR DESCRIPTION
## Summary
Server sim is no longer empty — bevy spawns waves of enemies, ticks them across the field, and serializes the live entity set into each Snapshot. Client sees real \`wave\`, \`enemies\`, \`gold\`, \`lives\` numbers and updates the HUD on every frame.

## Server (\`q::nexus_defense_server\`)
- New components: \`Position\`, \`Velocity\`, \`Health\`, \`EnemyTag { kind }\`.
- New resource: \`WaveState\` (wave counter + spawn cadence).
- New systems chained on \`Update\`:
  - \`spawn_wave_enemies\` — drops 10 enemies per wave, one every 0.5 s, cycling through Runner / Scout / Brute / Shielded kinds.
  - \`move_enemies\` — applies velocity at \`TICK_DT = 1/20\` s.
  - \`despawn_offscreen\` — removes entities past \`x = 800\`.
  - \`emit_snapshot\` — now queries the enemy set and builds a \`proto::EnemyDelta\` per entity using \`Entity::index_u32()\` as the wire id.
- New wave starts 5 s after the previous one finishes.

## Client (\`q::nexus_defense::match_socket\`)
- \`Inbound::Snapshot\` carries \`tick\`, \`wave\`, \`enemy_count\`, \`gold\`, \`lives\`.
- \`snapshot\` GDScript signal signature extended; the WS decode pulls the first \`FieldDelta\` and forwards the headline numbers.

## main.gd
- \`_on_snapshot\` updates \`hud_top\` every snapshot, fires the \`wave_banner\` panel on wave change, and throttles the log to ~1 line/sec + wave transitions.

## Smoke (mac arm64, Godot 4.6.3)
\`\`\`
Initialize godot-rust (API v4.6.stable.official, runtime v4.6.3.stable.official, safeguards strict)
[nexus-defense] ws connected
[nexus-defense] welcome: slot=0 seed=0xc0ffee
[nexus-defense] snapshot tick=104 wave=1 enemies=12 gold=150 lives=20
\`\`\`

## Test plan
- [ ] \`git pull && git lfs pull\`
- [ ] Terminal A: \`cargo run -p td-server\`
- [ ] Terminal B: F5 in Godot — HUD shows \`enemies\` counter climbing as a wave spawns, then dropping as enemies pass the right edge; wave_banner fires when wave counter increments.

## Next
- Input pump: route \`ClientFrame::PlaceBuilding\` etc. into a bevy mpsc resource so the client can build towers.
- Client-side snapshot ring buffer + render of enemy positions (Phase 2 in #11294).

## Related
- #11294 — multiplayer TD tracker
- #11322 — bevy headless sim + broadcast fanout
- #11325 — godot-rust 0.5.3 migration