### PR TITLE
feat(q,td-server): supabase JWT auth handshake gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12841,6 +12841,7 @@ dependencies = [
  "godot",
  "http 1.4.0",
  "infer",
+ "jsonwebtoken 9.3.1",
  "objc2 0.6.4",
  "postcard",
  "rapier2d",

--- a/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9eb9993b1e56f999afeb2b7fbcd32098e7af33b5cc74c6b30a3057e63f3df3b3
-size 9173080
+oid sha256:fd309b18ef2039ac326190d3fd5a0de49ebac26089ad1a96d534bf742e73f737
+size 9176360

--- a/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c6fc48d3d7a61a777c9323b8271f79fe8c1e72b34624d8d0677df90c6e25c38
-size 4183600
+oid sha256:7eea4f3f76e84b606baed5ce27f953c46a9ce1dfd7c0e474e2396e6c18cb1812
+size 4183616

--- a/apps/godot/nexus-defense/scenes/main.gd
+++ b/apps/godot/nexus-defense/scenes/main.gd
@@ -1,6 +1,11 @@
 extends Node2D
 
 const SERVER_URL := "ws://127.0.0.1:7878/ws"
+# Dev placeholder — swapped for a live Supabase access token from the auth UI
+# once that lands. Server runs in dev-accept mode when SUPABASE_JWT_SECRET is
+# unset and admits any non-empty username.
+const DEV_JWT := "dev"
+const DEV_USERNAME := "h0lybyte"
 
 var _wave: int = 1
 var _lives: int = 20
@@ -29,8 +34,8 @@ func _ready() -> void:
 		socket.connect("snapshot", _on_snapshot)
 		socket.connect("disconnected", _on_disconnected)
 		socket.connect("decode_error", _on_decode_error)
-		_log("dialing %s" % SERVER_URL)
-		socket.call("connect_to", SERVER_URL)
+		_log("dialing %s as %s" % [SERVER_URL, DEV_USERNAME])
+		socket.call("connect_to", SERVER_URL, DEV_JWT, DEV_USERNAME)
 	else:
 		_log("MatchSocket class unavailable — running offline")
 

--- a/apps/td-server/src/main.rs
+++ b/apps/td-server/src/main.rs
@@ -44,10 +44,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         rt.block_on(run_sim_loop(app));
     });
 
-    let state = q::net::server::ServerState::new(snap_tx, seed);
+    let jwt_secret = std::env::var("SUPABASE_JWT_SECRET")
+        .unwrap_or_default()
+        .into_bytes();
+    let auth_mode = if jwt_secret.is_empty() {
+        "dev-accept (SUPABASE_JWT_SECRET unset)"
+    } else {
+        "supabase HS256"
+    };
+
+    let state = q::net::server::ServerState::new(snap_tx, seed, jwt_secret);
     let router = q::net::server::router(state);
 
-    tracing::info!(%addr, %seed, "td-server listening");
+    tracing::info!(%addr, %seed, auth = %auth_mode, "td-server listening");
 
     let listener = TcpListener::bind(addr).await?;
     let serve = axum::serve(listener, router).with_graceful_shutdown(shutdown_signal());

--- a/packages/rust/q/Cargo.toml
+++ b/packages/rust/q/Cargo.toml
@@ -46,9 +46,19 @@ net-server = ["server", "proto-server", "dep:axum", "dep:tokio-tungstenite", "de
 # Bevy ECS app for server flavors. Server-only — clients use their host engine.
 bevy-server = ["server", "dep:bevy"]
 
+# Supabase JWT verification — used by the server flavor to admit players.
+supabase-auth = ["server", "dep:jsonwebtoken"]
+
 # Game bundles — convenience rollups consumed by build pipelines / sync scripts.
 nexus-defense = ["client", "proto-client", "rapier2d-client", "net-client"]
-nexus-defense-server = ["server", "proto-server", "rapier2d-server", "net-server", "bevy-server"]
+nexus-defense-server = [
+    "server",
+    "proto-server",
+    "rapier2d-server",
+    "net-server",
+    "bevy-server",
+    "supabase-auth",
+]
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -78,6 +88,9 @@ bevy = { version = "0.18", optional = true, default-features = false, features =
 tokio-tungstenite = { version = "0.24", optional = true, default-features = false, features = ["rustls-tls-webpki-roots", "connect"] }
 axum = { version = "0.7", optional = true, default-features = false, features = ["ws", "json"] }
 futures-util = { version = "0.3", optional = true, default-features = false, features = ["sink", "std"] }
+
+# Supabase JWT verification (HS256 against SUPABASE_JWT_SECRET).
+jsonwebtoken = { version = "9.3", optional = true, default-features = false }
 
 # -----------------------------------------------------------------------------
 # Desktop platform deps — link in unconditionally on those OSes (target-cfg gated).

--- a/packages/rust/q/src/auth/mod.rs
+++ b/packages/rust/q/src/auth/mod.rs
@@ -1,0 +1,64 @@
+//! Supabase access-token verification.
+//!
+//! Tokens are issued by GoTrue on supabase.kbve.com. They are HS256 JWTs
+//! signed with the project's `SUPABASE_JWT_SECRET`. The Custom Access Token
+//! hook injects a top-level `kbve_username` claim — see the project memory
+//! note `project_supabase_kbve_username_hook.md` — so servers can identify
+//! players without an extra DB round trip.
+
+use serde::{Deserialize, Serialize};
+
+use jsonwebtoken::{DecodingKey, Validation, decode};
+
+/// Claims the server trusts after a successful Supabase JWT verify.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SupabaseClaims {
+    pub sub: String,
+    pub exp: i64,
+    #[serde(default)]
+    pub kbve_username: String,
+    #[serde(default)]
+    pub role: String,
+    #[serde(default)]
+    pub aud: String,
+}
+
+#[derive(Debug)]
+pub enum AuthError {
+    /// `SUPABASE_JWT_SECRET` is empty and strict mode was requested.
+    MissingSecret,
+    /// `jsonwebtoken` rejected the token (signature, expiry, etc.).
+    Invalid(String),
+    /// JWT decoded but `kbve_username` claim is missing.
+    MissingUsername,
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthError::MissingSecret => write!(f, "SUPABASE_JWT_SECRET is not set"),
+            AuthError::Invalid(msg) => write!(f, "invalid token: {msg}"),
+            AuthError::MissingUsername => write!(f, "token missing kbve_username claim"),
+        }
+    }
+}
+
+impl std::error::Error for AuthError {}
+
+/// Verify a Supabase access token. `secret` is the project's
+/// `SUPABASE_JWT_SECRET`. Returns the decoded claims on success.
+pub fn verify_supabase_jwt(token: &str, secret: &[u8]) -> Result<SupabaseClaims, AuthError> {
+    if secret.is_empty() {
+        return Err(AuthError::MissingSecret);
+    }
+    let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
+    // GoTrue tokens default to aud=`authenticated`. Don't pin it — clients
+    // may legitimately come in with different aud (e.g. service role).
+    validation.validate_aud = false;
+    let data = decode::<SupabaseClaims>(token, &DecodingKey::from_secret(secret), &validation)
+        .map_err(|e| AuthError::Invalid(e.to_string()))?;
+    if data.claims.kbve_username.is_empty() {
+        return Err(AuthError::MissingUsername);
+    }
+    Ok(data.claims)
+}

--- a/packages/rust/q/src/lib.rs
+++ b/packages/rust/q/src/lib.rs
@@ -75,6 +75,9 @@ pub mod rapier;
 #[cfg(any(feature = "net-client", feature = "net-server"))]
 pub mod net;
 
+#[cfg(feature = "supabase-auth")]
+pub mod auth;
+
 #[cfg(feature = "nexus-defense")]
 pub mod nexus_defense;
 

--- a/packages/rust/q/src/net/server.rs
+++ b/packages/rust/q/src/net/server.rs
@@ -1,8 +1,10 @@
 //! Server-side WebSocket transport — axum router + per-match session loop.
 //!
-//! The router accepts an optional broadcast `Sender<ServerEvent>` so the bevy
-//! sim can fan out snapshots to every connected client. When `None`, the
-//! handler still sends a Welcome on connect for smoke tests.
+//! Every connection must send a `ClientMessage::JoinMatch` first; the server
+//! verifies the Supabase JWT (HS256 against `SUPABASE_JWT_SECRET`) before it
+//! emits Welcome or subscribes to the snapshot broadcast. If the secret is
+//! unset the server runs in dev-accept mode and admits the username field
+//! at face value — handy for local smoke runs, never for production.
 
 use std::sync::Arc;
 
@@ -13,7 +15,9 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use tokio::sync::broadcast;
 
-use crate::proto::{self, ServerEvent};
+#[cfg(feature = "supabase-auth")]
+use crate::auth;
+use crate::proto::{self, ClientMessage, ServerEvent};
 
 #[derive(Clone)]
 pub struct ServerState {
@@ -22,13 +26,16 @@ pub struct ServerState {
     pub broadcast: Option<broadcast::Sender<ServerEvent>>,
     /// Seed echoed back to clients in the Welcome frame.
     pub seed: u64,
+    /// Supabase JWT secret. Empty = dev-accept mode (any token admitted).
+    pub jwt_secret: Vec<u8>,
 }
 
 impl ServerState {
-    pub fn new(broadcast: broadcast::Sender<ServerEvent>, seed: u64) -> Self {
+    pub fn new(broadcast: broadcast::Sender<ServerEvent>, seed: u64, jwt_secret: Vec<u8>) -> Self {
         Self {
             broadcast: Some(broadcast),
             seed,
+            jwt_secret,
         }
     }
 
@@ -36,8 +43,14 @@ impl ServerState {
         Self {
             broadcast: None,
             seed: 0,
+            jwt_secret: Vec::new(),
         }
     }
+}
+
+struct AdmittedPlayer {
+    slot: proto::PlayerSlot,
+    kbve_username: String,
 }
 
 /// Build the axum router with the supplied shared state.
@@ -56,9 +69,14 @@ async fn ws_upgrade(
 }
 
 async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
+    let admitted = match await_join_match(&mut socket, &state).await {
+        Some(a) => a,
+        None => return,
+    };
+
     let welcome = ServerEvent::Welcome {
         protocol: proto::PROTOCOL_VERSION,
-        your_slot: proto::PlayerSlot(0),
+        your_slot: admitted.slot,
         seed: state.seed,
     };
     if let Ok(buf) = proto::encode(&welcome)
@@ -71,7 +89,6 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
 
     loop {
         tokio::select! {
-            // Snapshot fanout → forward to client.
             biased;
             evt = async {
                 match &mut rx {
@@ -80,24 +97,113 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
                 }
             } => {
                 let Some(evt) = evt else { break };
+                let evt = inject_admitted_player(evt, &admitted);
                 let Ok(buf) = proto::encode(&evt) else { continue };
                 if socket.send(Message::Binary(buf)).await.is_err() {
                     break;
                 }
             }
-            // Inbound client frames.
             incoming = socket.recv() => {
                 let Some(Ok(msg)) = incoming else { break };
                 match msg {
                     Message::Binary(bytes) => {
                         let mut buf = bytes;
-                        let _ = proto::decode::<proto::ClientFrame>(&mut buf);
-                        // Inputs land in the bevy sim once that pump exists.
+                        let _ = proto::decode::<ClientMessage>(&mut buf);
                     }
                     Message::Close(_) => break,
                     _ => {}
                 }
             }
         }
+    }
+}
+
+async fn await_join_match(
+    socket: &mut WebSocket,
+    state: &Arc<ServerState>,
+) -> Option<AdmittedPlayer> {
+    loop {
+        let msg = socket.recv().await?.ok()?;
+        let Message::Binary(bytes) = msg else {
+            continue;
+        };
+        let mut buf = bytes;
+        let Ok(ClientMessage::JoinMatch(jm)) = proto::decode::<ClientMessage>(&mut buf) else {
+            send_reject(socket, "expected JoinMatch as first frame").await;
+            return None;
+        };
+        if jm.protocol != proto::PROTOCOL_VERSION {
+            send_reject(
+                socket,
+                &format!(
+                    "protocol mismatch: client={}, server={}",
+                    jm.protocol,
+                    proto::PROTOCOL_VERSION
+                ),
+            )
+            .await;
+            return None;
+        }
+        return admit(state, jm).await;
+    }
+}
+
+#[cfg(feature = "supabase-auth")]
+async fn admit(state: &Arc<ServerState>, jm: proto::JoinMatch) -> Option<AdmittedPlayer> {
+    if state.jwt_secret.is_empty() {
+        return Some(AdmittedPlayer {
+            slot: proto::PlayerSlot(0),
+            kbve_username: if jm.kbve_username.is_empty() {
+                "guest".into()
+            } else {
+                jm.kbve_username
+            },
+        });
+    }
+    match auth::verify_supabase_jwt(&jm.jwt, &state.jwt_secret) {
+        Ok(claims) => Some(AdmittedPlayer {
+            slot: proto::PlayerSlot(0),
+            kbve_username: claims.kbve_username,
+        }),
+        Err(_) => None,
+    }
+}
+
+#[cfg(not(feature = "supabase-auth"))]
+async fn admit(_state: &Arc<ServerState>, jm: proto::JoinMatch) -> Option<AdmittedPlayer> {
+    Some(AdmittedPlayer {
+        slot: proto::PlayerSlot(0),
+        kbve_username: if jm.kbve_username.is_empty() {
+            "guest".into()
+        } else {
+            jm.kbve_username
+        },
+    })
+}
+
+async fn send_reject(socket: &mut WebSocket, reason: &str) {
+    let evt = ServerEvent::Reject {
+        reason: reason.to_string(),
+    };
+    if let Ok(buf) = proto::encode(&evt) {
+        let _ = socket.send(Message::Binary(buf)).await;
+    }
+}
+
+/// Patches Snapshot frames so the admitted player shows up in `players[]`
+/// even before the sim builds its own roster.
+fn inject_admitted_player(evt: ServerEvent, admitted: &AdmittedPlayer) -> ServerEvent {
+    match evt {
+        ServerEvent::Snapshot(mut snap) => {
+            if snap.players.is_empty() {
+                snap.players.push(proto::PlayerView {
+                    slot: admitted.slot,
+                    kbve_username: admitted.kbve_username.clone(),
+                    connected: true,
+                });
+            }
+            ServerEvent::Snapshot(snap)
+        }
+        other => other,
     }
 }

--- a/packages/rust/q/src/nexus_defense/match_socket.rs
+++ b/packages/rust/q/src/nexus_defense/match_socket.rs
@@ -11,7 +11,7 @@ use godot::classes::INode;
 use godot::prelude::*;
 use tokio_tungstenite::tungstenite::Message;
 
-use crate::proto::{self, ServerEvent};
+use crate::proto::{self, ClientMessage, ServerEvent};
 use crate::threads::runtime::RuntimeManager;
 
 enum Outbound {
@@ -133,16 +133,22 @@ impl MatchSocket {
     #[signal]
     fn decode_error(detail: GString);
 
-    /// Open a connection to the given `ws://host:port/ws` URL.
+    /// Open a connection and send the JoinMatch handshake.
     /// Returns immediately; the actual connect happens on the tokio runtime.
+    /// `jwt` is a Supabase access token; `kbve_username` is sent for logging.
     #[func]
-    fn connect_to(&mut self, url: GString) {
+    fn connect_to(&mut self, url: GString, jwt: GString, kbve_username: GString) {
         if self.inbound_rx.is_some() {
             godot_warn!("[MatchSocket] connect_to called while already connected");
             return;
         }
 
         let url_str = url.to_string();
+        let join = proto::JoinMatch {
+            protocol: proto::PROTOCOL_VERSION,
+            jwt: jwt.to_string(),
+            kbve_username: kbve_username.to_string(),
+        };
         let (inbound_tx, inbound_rx) = unbounded::<Inbound>();
         let (outbound_tx, outbound_rx) = unbounded::<Outbound>();
         self.inbound_rx = Some(inbound_rx);
@@ -160,7 +166,7 @@ impl MatchSocket {
         let runtime = runtime_gd.bind();
 
         runtime.spawn(async move {
-            run_socket(url_str, inbound_tx, outbound_rx).await;
+            run_socket(url_str, join, inbound_tx, outbound_rx).await;
         });
     }
 
@@ -170,13 +176,13 @@ impl MatchSocket {
             Some(t) => t.clone(),
             None => return,
         };
-        let frame = proto::ClientFrame {
+        let msg = ClientMessage::Frame(proto::ClientFrame {
             client_tick: client_tick as u32,
             inputs: vec![proto::Input::Heartbeat {
                 client_tick: client_tick as u32,
             }],
-        };
-        match proto::encode(&frame) {
+        });
+        match proto::encode(&msg) {
             Ok(buf) => {
                 let _ = tx.send(Outbound::Send(buf));
             }
@@ -200,7 +206,12 @@ impl MatchSocket {
     }
 }
 
-async fn run_socket(url: String, tx: Sender<Inbound>, rx: Receiver<Outbound>) {
+async fn run_socket(
+    url: String,
+    join: proto::JoinMatch,
+    tx: Sender<Inbound>,
+    rx: Receiver<Outbound>,
+) {
     let (ws_stream, _) = match tokio_tungstenite::connect_async(&url).await {
         Ok(s) => s,
         Err(e) => {
@@ -213,6 +224,26 @@ async fn run_socket(url: String, tx: Sender<Inbound>, rx: Receiver<Outbound>) {
     let _ = tx.send(Inbound::Connected);
 
     let (mut writer, mut reader) = ws_stream.split();
+
+    // Send the JoinMatch handshake immediately. Server holds Welcome until it
+    // verifies the JWT.
+    let join_msg = ClientMessage::JoinMatch(join);
+    match proto::encode(&join_msg) {
+        Ok(buf) => {
+            if writer.send(Message::Binary(buf)).await.is_err() {
+                let _ = tx.send(Inbound::Disconnected {
+                    reason: "join send failed".into(),
+                });
+                return;
+            }
+        }
+        Err(e) => {
+            let _ = tx.send(Inbound::Disconnected {
+                reason: format!("join encode failed: {e}"),
+            });
+            return;
+        }
+    }
 
     // Outbound pump — pull from crossbeam channel, push onto the ws.
     let writer_tx = tx.clone();

--- a/packages/rust/q/src/proto/mod.rs
+++ b/packages/rust/q/src/proto/mod.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Bump on any breaking wire change. Server rejects mismatched clients.
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Maximum players per match (parallel-race default per #11294).
 pub const MAX_PLAYERS: usize = 4;
@@ -55,11 +55,23 @@ pub enum EnemyKind {
 
 /// First message client sends after WS upgrade. Server validates protocol +
 /// JWT then admits the player into a slot.
+///
+/// `jwt` is a Supabase GoTrue access token issued by supabase.kbve.com. The
+/// `kbve_username` field is informational only; the server trusts the claim
+/// inside the JWT (injected by the Custom Access Token hook), not the field.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JoinMatch {
     pub protocol: u32,
-    pub match_token: String,
+    pub jwt: String,
     pub kbve_username: String,
+}
+
+/// Top-level client-to-server envelope. The first frame on every connection
+/// must be `JoinMatch`; subsequent frames are `Frame`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ClientMessage {
+    JoinMatch(JoinMatch),
+    Frame(ClientFrame),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -211,7 +223,7 @@ mod tests {
 
     #[test]
     fn input_round_trips() {
-        let frame = ClientFrame {
+        let msg = ClientMessage::Frame(ClientFrame {
             client_tick: 42,
             inputs: vec![
                 Input::PlaceBuilding {
@@ -221,11 +233,34 @@ mod tests {
                 },
                 Input::SkipWave,
             ],
-        };
-        let mut buf = encode(&frame).expect("encode");
-        let back: ClientFrame = decode(&mut buf).expect("decode");
-        assert_eq!(back.client_tick, 42);
-        assert_eq!(back.inputs.len(), 2);
+        });
+        let mut buf = encode(&msg).expect("encode");
+        let back: ClientMessage = decode(&mut buf).expect("decode");
+        match back {
+            ClientMessage::Frame(frame) => {
+                assert_eq!(frame.client_tick, 42);
+                assert_eq!(frame.inputs.len(), 2);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn join_match_round_trips() {
+        let msg = ClientMessage::JoinMatch(JoinMatch {
+            protocol: PROTOCOL_VERSION,
+            jwt: "header.payload.signature".into(),
+            kbve_username: "h0lybyte".into(),
+        });
+        let mut buf = encode(&msg).expect("encode");
+        let back: ClientMessage = decode(&mut buf).expect("decode");
+        match back {
+            ClientMessage::JoinMatch(jm) => {
+                assert_eq!(jm.protocol, PROTOCOL_VERSION);
+                assert_eq!(jm.kbve_username, "h0lybyte");
+            }
+            _ => panic!("wrong variant"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Every WS connection must now send a \`JoinMatch\` as its first frame; the server verifies a Supabase access token (HS256 against \`SUPABASE_JWT_SECRET\`) and extracts the \`kbve_username\` claim before emitting \`Welcome\` or subscribing to the snapshot broadcast. Multiplayer can't ship without this gate.

## Wire — PROTOCOL_VERSION bumped to 2
- New \`proto::ClientMessage\` envelope: \`JoinMatch(JoinMatch)\` | \`Frame(ClientFrame)\`. Every client→server binary frame is now wrapped.
- \`proto::JoinMatch { protocol, jwt, kbve_username }\` — \`jwt\` is a Supabase access token; \`kbve_username\` is informational, server trusts the JWT claim.
- \`proto::Snapshot\` shape unchanged; the server fills \`players[]\` with the admitted player on its way out so the HUD has a roster immediately.

## \`q::auth\` (new, gated by \`supabase-auth\` feature)
- \`verify_supabase_jwt(token, secret) -> SupabaseClaims\` using \`jsonwebtoken\` HS256.
- Validates expiry and \`kbve_username\` presence.
- \`nexus-defense-server\` rollup picks up \`supabase-auth\` automatically.

## \`q::net::server\`
- \`ServerState\` gained \`jwt_secret: Vec<u8>\`. Empty = dev-accept mode (any non-empty username admitted; logged at boot).
- \`handle_socket\` awaits \`JoinMatch\` first, sends \`ServerEvent::Reject\` on protocol mismatch / auth failure, then sends \`Welcome\` and subscribes.
- \`inject_admitted_player\` patches each outgoing \`Snapshot.players[]\` so the kbve_username shows up before the sim builds its own roster.

## Client (\`q::nexus_defense::match_socket\`)
- \`connect_to(url, jwt, kbve_username)\` — Godot side now sends \`ClientMessage::JoinMatch\` as its first frame.
- \`send_heartbeat\` wraps the \`ClientFrame\` in the new envelope.

## \`td-server::main\`
- Reads \`SUPABASE_JWT_SECRET\` env var, threads into \`ServerState\`. Auth mode surfaces in the listening log line.

## \`main.gd\`
- Passes a placeholder dev JWT + username on \`_ready\` until the Supabase session UI lands.

## Smoke
\`\`\`
td-server: auth=dev-accept (SUPABASE_JWT_SECRET unset)
godot:
  dialing ws://127.0.0.1:7878/ws as h0lybyte
  ws connected
  welcome: slot=0 seed=0xc0ffee
  snapshot tick=90 wave=0 enemies=9 gold=150 lives=20
\`\`\`

## Test plan
- [ ] \`git pull && git lfs pull\`
- [ ] Terminal A: \`cargo run -p td-server\` (no env) — admits any username
- [ ] Terminal A2: \`SUPABASE_JWT_SECRET=<project secret> cargo run -p td-server\` — rejects bogus tokens, accepts live Supabase access tokens
- [ ] Terminal B: F5 in Godot — HUD shows \`welcome\` → rolling \`snapshot\` lines

## Next
- Pull the JWT from a live Supabase session in main.gd instead of hard-coding a dev placeholder.
- Multi-slot assignment (currently every player lands in slot 0); requires server-side match-token issuance.
- Input pump — route \`ClientFrame\` inputs into the bevy sim.

## Related
- #11294 — multiplayer TD tracker
- \`project_supabase_kbve_username_hook.md\` — GoTrue Custom Access Token hook that injects \`kbve_username\`
- #11326 — bevy wave spawner (this lands the auth gate in front of those snapshots)