### PR TITLE
fix(arc-runner): sha256sum -c needs filename in cwd

### DIFF
--- a/packages/docker/arc-runner/Dockerfile
+++ b/packages/docker/arc-runner/Dockerfile
@@ -110,16 +110,15 @@ ARG PNPM_VERSION
 ARG PLAYWRIGHT_VERSION
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 RUN set -eux; \
-    curl -fsSL -o /tmp/node.tar.xz \
-        "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz"; \
-    curl -fsSL -o /tmp/node.shasums \
-        "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt"; \
-    grep "node-v${NODE_VERSION}-linux-x64.tar.xz" /tmp/node.shasums | sha256sum -c -; \
-    tar -xJf /tmp/node.tar.xz -C /opt; \
+    cd /tmp; \
+    curl -fsSL -O "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz"; \
+    curl -fsSL -O "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt"; \
+    grep "node-v${NODE_VERSION}-linux-x64.tar.xz" SHASUMS256.txt | sha256sum -c -; \
+    tar -xJf "node-v${NODE_VERSION}-linux-x64.tar.xz" -C /opt; \
     ln -s "/opt/node-v${NODE_VERSION}-linux-x64/bin/node" /usr/local/bin/node; \
     ln -s "/opt/node-v${NODE_VERSION}-linux-x64/bin/npm" /usr/local/bin/npm; \
     ln -s "/opt/node-v${NODE_VERSION}-linux-x64/bin/npx" /usr/local/bin/npx; \
-    rm /tmp/node.tar.xz /tmp/node.shasums; \
+    rm "node-v${NODE_VERSION}-linux-x64.tar.xz" SHASUMS256.txt; \
     npm install -g "pnpm@${PNPM_VERSION}"; \
     mkdir -p "${PLAYWRIGHT_BROWSERS_PATH}"; \
     npx --yes "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium; \


### PR DESCRIPTION
## Summary
Hotfix for #11319. The Node tarball verify step in the runner image fails because \`sha256sum -c\` reads filenames from the SHASUMS manifest as-is and tries to open them relative to cwd. \`curl -o /tmp/node.tar.xz\` writes a renamed file, so \`sha256sum -c\` looks for \`node-v24.16.0-linux-x64.tar.xz\` in cwd and exits 1.

\`\`\`
+ sha256sum -c -
sha256sum: node-v24.16.0-linux-x64.tar.xz: No such file or directory
\`\`\`

Fix: cd /tmp and \`curl -O\` so both the tarball and SHASUMS256.txt land under the canonical filenames the manifest references.

## Test plan
- [ ] Trigger ci-docker for arc-runner and confirm the [3/3] RUN step completes through the playwright install.