### PR TITLE
feat(nexus-defense): supabase.kbve.com sign-in via GoTrue REST

### DIFF
--- a/apps/godot/nexus-defense/net/supabase_client.gd
+++ b/apps/godot/nexus-defense/net/supabase_client.gd
@@ -1,0 +1,87 @@
+extends Node
+
+# Supabase GoTrue client (KBVE: supabase.kbve.com).
+#
+# Anon key + URL are public — same values the Astro auth bridge embeds. The
+# only secret here is the user's email/password, pulled from OS env so we
+# never commit credentials to the repo.
+
+const SUPABASE_URL := "https://supabase.kbve.com"
+const SUPABASE_ANON_KEY := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiaWF0IjoxNzU1NDAzMjAwLCJleHAiOjE5MTMxNjk2MDB9.oietJI22ZytbghFywvdYMSJp7rcsBdBYbcciJxeGWrg"
+
+signal sign_in_succeeded(access_token: String, kbve_username: String)
+signal sign_in_failed(reason: String)
+
+var _http: HTTPRequest = null
+var _pending_username: String = ""
+
+func _ready() -> void:
+	_http = HTTPRequest.new()
+	_http.timeout = 15.0
+	add_child(_http)
+	_http.request_completed.connect(_on_request_completed)
+
+func sign_in_with_password(email: String, password: String, username_hint: String = "", captcha_token: String = "") -> void:
+	if email.is_empty() or password.is_empty():
+		sign_in_failed.emit("missing credentials")
+		return
+	_pending_username = username_hint
+	var url := "%s/auth/v1/token?grant_type=password" % SUPABASE_URL
+	var headers := PackedStringArray([
+		"apikey: %s" % SUPABASE_ANON_KEY,
+		"Authorization: Bearer %s" % SUPABASE_ANON_KEY,
+		"Content-Type: application/json",
+	])
+	# KBVE GoTrue enforces hcaptcha — pass a token via `captcha_token` once
+	# the in-game captcha flow lands. Bot/headless callers will get
+	# HTTP 500 "captcha verification process failed" without one.
+	var payload: Dictionary = {"email": email, "password": password}
+	if not captcha_token.is_empty():
+		payload["gotrue_meta_security"] = {"captcha_token": captcha_token}
+	var body := JSON.stringify(payload)
+	print("[supabase] POST %s" % url)
+	var err: int = _http.request(url, headers, HTTPClient.METHOD_POST, body)
+	if err != OK:
+		sign_in_failed.emit("HTTPRequest.request error code %d" % err)
+
+func _on_request_completed(result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray) -> void:
+	print("[supabase] response result=%d http=%d bytes=%d" % [result, response_code, body.size()])
+	if result != HTTPRequest.RESULT_SUCCESS:
+		sign_in_failed.emit("transport result=%d" % result)
+		return
+	var text: String = body.get_string_from_utf8()
+	var parsed: Variant = JSON.parse_string(text)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		sign_in_failed.emit("non-JSON response (HTTP %d)" % response_code)
+		return
+	var dict: Dictionary = parsed
+	if response_code != 200:
+		var msg: String = String(dict.get("error_description", dict.get("msg", "HTTP %d" % response_code)))
+		sign_in_failed.emit(msg)
+		return
+	var access_token: String = String(dict.get("access_token", ""))
+	if access_token.is_empty():
+		sign_in_failed.emit("response missing access_token")
+		return
+	# Prefer the kbve_username injected by the GoTrue Custom Access Token hook;
+	# fall back to the hint (or empty, letting the server decide).
+	var username: String = _decode_kbve_username(access_token)
+	if username.is_empty():
+		username = _pending_username
+	sign_in_succeeded.emit(access_token, username)
+
+func _decode_kbve_username(jwt: String) -> String:
+	var parts: PackedStringArray = jwt.split(".")
+	if parts.size() < 2:
+		return ""
+	var payload_b64: String = parts[1]
+	# JWT uses base64url without padding — convert + pad.
+	payload_b64 = payload_b64.replace("-", "+").replace("_", "/")
+	var pad: int = (4 - payload_b64.length() % 4) % 4
+	for _i in range(pad):
+		payload_b64 += "="
+	var raw: PackedByteArray = Marshalls.base64_to_raw(payload_b64)
+	var json: Variant = JSON.parse_string(raw.get_string_from_utf8())
+	if typeof(json) != TYPE_DICTIONARY:
+		return ""
+	return String(json.get("kbve_username", ""))

--- a/apps/godot/nexus-defense/net/supabase_client.gd.uid
+++ b/apps/godot/nexus-defense/net/supabase_client.gd.uid
@@ -1,0 +1,1 @@
+uid://k3btcimxf656

--- a/apps/godot/nexus-defense/project.godot
+++ b/apps/godot/nexus-defense/project.godot
@@ -21,6 +21,7 @@ config/icon="res://icon.svg"
 ECS="*uid://dfqwl5njvdnmq"
 Bp="*res://ui/lib/breakpoint.gd"
 Ui="*res://ui/lib/ui_manager.gd"
+Supabase="*res://net/supabase_client.gd"
 
 [display]
 

--- a/apps/godot/nexus-defense/scenes/main.gd
+++ b/apps/godot/nexus-defense/scenes/main.gd
@@ -1,11 +1,14 @@
 extends Node2D
 
 const SERVER_URL := "ws://127.0.0.1:7878/ws"
-# Dev placeholder — swapped for a live Supabase access token from the auth UI
-# once that lands. Server runs in dev-accept mode when SUPABASE_JWT_SECRET is
-# unset and admits any non-empty username.
+# When the OS env vars below are unset, we fall back to dev-accept mode:
+# the server admits any non-empty username when SUPABASE_JWT_SECRET is also
+# unset. Setting them runs a real GoTrue sign-in against supabase.kbve.com.
 const DEV_JWT := "dev"
 const DEV_USERNAME := "h0lybyte"
+const ENV_EMAIL := "ND_SUPABASE_EMAIL"
+const ENV_PASSWORD := "ND_SUPABASE_PASSWORD"
+const ENV_USERNAME := "ND_SUPABASE_USERNAME"
 
 var _wave: int = 1
 var _lives: int = 20
@@ -24,9 +27,11 @@ func _ready() -> void:
 			ping.call("queue_free")
 	print("[nexus-defense] main scene ready — q::nexus_defense pong: %s" % msg)
 
-	Ui.open("boot", {"title": "Nexus Defense", "subtitle": "Dialing %s…" % SERVER_URL})
+	Ui.open("boot", {"title": "Nexus Defense", "subtitle": "Authenticating…"})
 
-	if ClassDB.class_exists("MatchSocket"):
+	if not ClassDB.class_exists("MatchSocket"):
+		_log("MatchSocket class unavailable — running offline")
+	else:
 		socket = ClassDB.instantiate("MatchSocket")
 		add_child(socket)
 		socket.connect("connected", _on_connected)
@@ -34,10 +39,7 @@ func _ready() -> void:
 		socket.connect("snapshot", _on_snapshot)
 		socket.connect("disconnected", _on_disconnected)
 		socket.connect("decode_error", _on_decode_error)
-		_log("dialing %s as %s" % [SERVER_URL, DEV_USERNAME])
-		socket.call("connect_to", SERVER_URL, DEV_JWT, DEV_USERNAME)
-	else:
-		_log("MatchSocket class unavailable — running offline")
+		await _begin_session()
 
 	await get_tree().create_timer(0.6).timeout
 	Ui.close("boot")
@@ -108,3 +110,34 @@ func _on_decode_error(detail: String) -> void:
 
 func _log(line: String) -> void:
 	print("[nexus-defense] %s" % line)
+
+func _begin_session() -> void:
+	var email: String = OS.get_environment(ENV_EMAIL)
+	var password: String = OS.get_environment(ENV_PASSWORD)
+	var hint: String = OS.get_environment(ENV_USERNAME)
+	if email.is_empty() or password.is_empty():
+		_log("no %s/%s set — using dev-accept JWT" % [ENV_EMAIL, ENV_PASSWORD])
+		_dial(DEV_JWT, DEV_USERNAME)
+		return
+	_log("signing in to %s as %s" % [Supabase.SUPABASE_URL, email])
+	Supabase.sign_in_succeeded.connect(_on_supabase_signed_in, CONNECT_ONE_SHOT)
+	Supabase.sign_in_failed.connect(_on_supabase_failed, CONNECT_ONE_SHOT)
+	Supabase.sign_in_with_password(email, password, hint)
+
+func _on_supabase_signed_in(access_token: String, kbve_username: String) -> void:
+	var resolved: String = kbve_username
+	if resolved.is_empty():
+		resolved = OS.get_environment(ENV_USERNAME)
+	if resolved.is_empty():
+		resolved = "guest"
+	_log("supabase sign-in ok — kbve_username=%s" % resolved)
+	_dial(access_token, resolved)
+
+func _on_supabase_failed(reason: String) -> void:
+	_log("supabase sign-in failed: %s — falling back to dev JWT" % reason)
+	Ui.toast("Supabase sign-in failed: %s" % reason, 3.0, "warn")
+	_dial(DEV_JWT, DEV_USERNAME)
+
+func _dial(jwt: String, kbve_username: String) -> void:
+	_log("dialing %s as %s" % [SERVER_URL, kbve_username])
+	socket.call("connect_to", SERVER_URL, jwt, kbve_username)


### PR DESCRIPTION
## Summary
- New \`apps/godot/nexus-defense/net/supabase_client.gd\` autoload (\`Supabase\`) that posts to \`{SUPABASE_URL}/auth/v1/token?grant_type=password\` and surfaces \`access_token\` + \`kbve_username\` via signals.
- \`main.gd\` reads \`ND_SUPABASE_EMAIL\` / \`ND_SUPABASE_PASSWORD\` / \`ND_SUPABASE_USERNAME\` from OS env; signs in if present, falls back to the dev JWT path otherwise. On success the real access token + resolved \`kbve_username\` flow into \`MatchSocket.connect_to(...)\`.
- \`kbve_username\` is decoded from the JWT payload itself (GoTrue Custom Access Token hook claim), with the env hint / \`guest\` as fallback.
- Anon key + URL embedded as constants — same public values the Astro auth bridge ships.

## Files
- \`apps/godot/nexus-defense/net/supabase_client.gd\` (new)
- \`apps/godot/nexus-defense/project.godot\` (\`Supabase\` autoload registered)
- \`apps/godot/nexus-defense/scenes/main.gd\` (env-driven session boot)

## Captcha gate
KBVE GoTrue enforces hcaptcha. A direct \`curl\` confirms:
\`\`\`
$ curl -sS -X POST '...auth/v1/token?grant_type=password' \\
    -H 'apikey: <anon>' -H 'Content-Type: application/json' \\
    -d '{"email":"bogus@example.com","password":"wrong"}'
HTTP 500 {"code":500,"error_code":"unexpected_failure","msg":"captcha verification process failed"}
\`\`\`
\`sign_in_with_password\` already accepts an optional \`captcha_token\` param — wire it up once the in-game hcaptcha flow lands. Headless / bot callers will continue to be blocked, by design. Failures surface a toast and the client falls back to the dev JWT so local dev never breaks.

## Smoke (mac arm64, headless)
\`\`\`
[nexus-defense] main scene ready — q::nexus_defense pong: q::nexus_defense online
[nexus-defense] no ND_SUPABASE_EMAIL/ND_SUPABASE_PASSWORD set — using dev-accept JWT
[nexus-defense] dialing ws://127.0.0.1:7878/ws as h0lybyte
[nexus-defense] ws connected
[nexus-defense] welcome: slot=0 seed=0xc0ffee
\`\`\`

## Test plan
- [ ] Open in Godot 4.6 editor (no env) → boots in dev-accept, dials td-server with placeholder JWT.
- [ ] Run with \`ND_SUPABASE_EMAIL=...\` + \`ND_SUPABASE_PASSWORD=...\` plus a valid hcaptcha token wired into the client — server logs the verified \`kbve_username\`.
- [ ] td-server with \`SUPABASE_JWT_SECRET=<project secret>\` should accept the real JWT and reject the dev placeholder.

## Next
- Capture an hcaptcha token in-game (webview or godot plugin) and pass through \`Supabase.sign_in_with_password(..., captcha_token)\`.
- Persist refresh tokens via \`OS.get_user_data_dir()\` so reconnects skip the GoTrue round-trip.
- Multi-slot roster on the server side now that real usernames flow.

## Related
- #11294 — multiplayer TD tracker
- #11327 — server-side JWT verify (this lands the client half)
- \`project_supabase_kbve_username_hook.md\` — JWT carries \`kbve_username\` via GoTrue hook