### PR TITLE
feat(q,nexus-defense): multi-slot roster + supabase refresh token persistence

### DIFF
--- a/apps/godot/nexus-defense/net/supabase_client.gd
+++ b/apps/godot/nexus-defense/net/supabase_client.gd
@@ -2,17 +2,20 @@ extends Node
 
 # Supabase GoTrue client (KBVE: supabase.kbve.com).
 #
-# Anon key + URL are public — same values the Astro auth bridge embeds. The
-# only secret here is the user's email/password, pulled from OS env so we
-# never commit credentials to the repo.
+# Anon key + URL are public — same values the Astro auth bridge embeds.
+# Credentials come from OS env; refresh tokens persist to user_data_dir so
+# reconnects can skip the password round-trip (and the captcha gate).
 
 const SUPABASE_URL := "https://supabase.kbve.com"
 const SUPABASE_ANON_KEY := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiaWF0IjoxNzU1NDAzMjAwLCJleHAiOjE5MTMxNjk2MDB9.oietJI22ZytbghFywvdYMSJp7rcsBdBYbcciJxeGWrg"
+const SESSION_FILENAME := "session.json"
+const ACCESS_EXP_SKEW_SEC := 30
 
-signal sign_in_succeeded(access_token: String, kbve_username: String)
-signal sign_in_failed(reason: String)
+signal session_ready(access_token: String, kbve_username: String)
+signal session_failed(reason: String)
 
 var _http: HTTPRequest = null
+var _pending_kind: String = ""
 var _pending_username: String = ""
 
 func _ready() -> void:
@@ -21,54 +24,120 @@ func _ready() -> void:
 	add_child(_http)
 	_http.request_completed.connect(_on_request_completed)
 
+# -----------------------------------------------------------------------------
+# Public API
+# -----------------------------------------------------------------------------
+
+## Try cached -> refresh -> sign_in. Always emits one of session_ready /
+## session_failed so callers can chain a single connect().
+func resume_or_sign_in(email: String, password: String, username_hint: String = "", captcha_token: String = "") -> void:
+	var cached: Dictionary = _load_session()
+	if not cached.is_empty():
+		var now: int = int(Time.get_unix_time_from_system())
+		var exp: int = int(cached.get("expires_at", 0))
+		if exp - ACCESS_EXP_SKEW_SEC > now:
+			print("[supabase] reusing cached access_token (exp in %d s)" % (exp - now))
+			var token: String = String(cached.get("access_token", ""))
+			var uname: String = String(cached.get("kbve_username", username_hint))
+			session_ready.emit(token, uname)
+			return
+		var refresh: String = String(cached.get("refresh_token", ""))
+		if not refresh.is_empty():
+			print("[supabase] cached token expired; refreshing")
+			refresh_session(refresh, username_hint)
+			return
+	if not email.is_empty() and not password.is_empty():
+		sign_in_with_password(email, password, username_hint, captcha_token)
+	else:
+		session_failed.emit("no cached session and no credentials provided")
+
 func sign_in_with_password(email: String, password: String, username_hint: String = "", captcha_token: String = "") -> void:
 	if email.is_empty() or password.is_empty():
-		sign_in_failed.emit("missing credentials")
+		session_failed.emit("missing credentials")
 		return
+	if _pending_kind != "":
+		session_failed.emit("auth call already in flight")
+		return
+	_pending_kind = "sign_in"
 	_pending_username = username_hint
 	var url := "%s/auth/v1/token?grant_type=password" % SUPABASE_URL
-	var headers := PackedStringArray([
-		"apikey: %s" % SUPABASE_ANON_KEY,
-		"Authorization: Bearer %s" % SUPABASE_ANON_KEY,
-		"Content-Type: application/json",
-	])
 	# KBVE GoTrue enforces hcaptcha — pass a token via `captcha_token` once
 	# the in-game captcha flow lands. Bot/headless callers will get
 	# HTTP 500 "captcha verification process failed" without one.
 	var payload: Dictionary = {"email": email, "password": password}
 	if not captcha_token.is_empty():
 		payload["gotrue_meta_security"] = {"captcha_token": captcha_token}
+	_post_token(url, payload)
+
+func refresh_session(refresh_token: String, username_hint: String = "") -> void:
+	if refresh_token.is_empty():
+		session_failed.emit("missing refresh_token")
+		return
+	if _pending_kind != "":
+		session_failed.emit("auth call already in flight")
+		return
+	_pending_kind = "refresh"
+	_pending_username = username_hint
+	var url := "%s/auth/v1/token?grant_type=refresh_token" % SUPABASE_URL
+	_post_token(url, {"refresh_token": refresh_token})
+
+func clear_session() -> void:
+	var path: String = _session_path()
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(path)
+
+# -----------------------------------------------------------------------------
+# Internals
+# -----------------------------------------------------------------------------
+
+func _post_token(url: String, payload: Dictionary) -> void:
+	var headers := PackedStringArray([
+		"apikey: %s" % SUPABASE_ANON_KEY,
+		"Authorization: Bearer %s" % SUPABASE_ANON_KEY,
+		"Content-Type: application/json",
+	])
 	var body := JSON.stringify(payload)
-	print("[supabase] POST %s" % url)
+	print("[supabase] POST %s (%s)" % [url, _pending_kind])
 	var err: int = _http.request(url, headers, HTTPClient.METHOD_POST, body)
 	if err != OK:
-		sign_in_failed.emit("HTTPRequest.request error code %d" % err)
+		var k := _pending_kind
+		_pending_kind = ""
+		session_failed.emit("HTTPRequest.request error code %d (%s)" % [err, k])
 
 func _on_request_completed(result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray) -> void:
-	print("[supabase] response result=%d http=%d bytes=%d" % [result, response_code, body.size()])
+	var kind: String = _pending_kind
+	_pending_kind = ""
+	print("[supabase] response kind=%s result=%d http=%d bytes=%d" % [kind, result, response_code, body.size()])
 	if result != HTTPRequest.RESULT_SUCCESS:
-		sign_in_failed.emit("transport result=%d" % result)
+		session_failed.emit("transport result=%d" % result)
 		return
 	var text: String = body.get_string_from_utf8()
 	var parsed: Variant = JSON.parse_string(text)
 	if typeof(parsed) != TYPE_DICTIONARY:
-		sign_in_failed.emit("non-JSON response (HTTP %d)" % response_code)
+		session_failed.emit("non-JSON response (HTTP %d)" % response_code)
 		return
 	var dict: Dictionary = parsed
 	if response_code != 200:
 		var msg: String = String(dict.get("error_description", dict.get("msg", "HTTP %d" % response_code)))
-		sign_in_failed.emit(msg)
+		# Refresh failure usually means token revoked — clear cache so the
+		# next boot falls through to password sign-in.
+		if kind == "refresh":
+			clear_session()
+		session_failed.emit(msg)
 		return
 	var access_token: String = String(dict.get("access_token", ""))
 	if access_token.is_empty():
-		sign_in_failed.emit("response missing access_token")
+		session_failed.emit("response missing access_token")
 		return
+	var refresh_token: String = String(dict.get("refresh_token", ""))
+	var expires_in: int = int(dict.get("expires_in", 3600))
 	# Prefer the kbve_username injected by the GoTrue Custom Access Token hook;
-	# fall back to the hint (or empty, letting the server decide).
+	# fall back to the hint (or 'guest', so the server doesn't see empty).
 	var username: String = _decode_kbve_username(access_token)
 	if username.is_empty():
 		username = _pending_username
-	sign_in_succeeded.emit(access_token, username)
+	_save_session(access_token, refresh_token, username, expires_in)
+	session_ready.emit(access_token, username)
 
 func _decode_kbve_username(jwt: String) -> String:
 	var parts: PackedStringArray = jwt.split(".")
@@ -85,3 +154,38 @@ func _decode_kbve_username(jwt: String) -> String:
 	if typeof(json) != TYPE_DICTIONARY:
 		return ""
 	return String(json.get("kbve_username", ""))
+
+func _session_path() -> String:
+	return OS.get_user_data_dir() + "/" + SESSION_FILENAME
+
+func _save_session(access_token: String, refresh_token: String, username: String, expires_in: int) -> void:
+	var now: int = int(Time.get_unix_time_from_system())
+	var payload: Dictionary = {
+		"access_token": access_token,
+		"refresh_token": refresh_token,
+		"kbve_username": username,
+		"expires_at": now + expires_in,
+		"saved_at": now,
+	}
+	var path: String = _session_path()
+	var f: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	if f == null:
+		push_warning("[supabase] cannot write session to %s" % path)
+		return
+	f.store_string(JSON.stringify(payload))
+	f.close()
+	print("[supabase] session persisted to %s" % path)
+
+func _load_session() -> Dictionary:
+	var path: String = _session_path()
+	if not FileAccess.file_exists(path):
+		return {}
+	var f: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return {}
+	var text: String = f.get_as_text()
+	f.close()
+	var parsed: Variant = JSON.parse_string(text)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return {}
+	return parsed

--- a/apps/godot/nexus-defense/scenes/main.gd
+++ b/apps/godot/nexus-defense/scenes/main.gd
@@ -115,27 +115,30 @@ func _begin_session() -> void:
 	var email: String = OS.get_environment(ENV_EMAIL)
 	var password: String = OS.get_environment(ENV_PASSWORD)
 	var hint: String = OS.get_environment(ENV_USERNAME)
-	if email.is_empty() or password.is_empty():
-		_log("no %s/%s set — using dev-accept JWT" % [ENV_EMAIL, ENV_PASSWORD])
+	if email.is_empty() and password.is_empty() and not _has_cached_session():
+		_log("no %s/%s set and no cached session — using dev-accept JWT" % [ENV_EMAIL, ENV_PASSWORD])
 		_dial(DEV_JWT, DEV_USERNAME)
 		return
-	_log("signing in to %s as %s" % [Supabase.SUPABASE_URL, email])
-	Supabase.sign_in_succeeded.connect(_on_supabase_signed_in, CONNECT_ONE_SHOT)
-	Supabase.sign_in_failed.connect(_on_supabase_failed, CONNECT_ONE_SHOT)
-	Supabase.sign_in_with_password(email, password, hint)
+	_log("supabase session bootstrap (cached -> refresh -> sign_in chain)")
+	Supabase.session_ready.connect(_on_supabase_ready, CONNECT_ONE_SHOT)
+	Supabase.session_failed.connect(_on_supabase_failed, CONNECT_ONE_SHOT)
+	Supabase.resume_or_sign_in(email, password, hint)
 
-func _on_supabase_signed_in(access_token: String, kbve_username: String) -> void:
+func _has_cached_session() -> bool:
+	return FileAccess.file_exists(Supabase._session_path())
+
+func _on_supabase_ready(access_token: String, kbve_username: String) -> void:
 	var resolved: String = kbve_username
 	if resolved.is_empty():
 		resolved = OS.get_environment(ENV_USERNAME)
 	if resolved.is_empty():
 		resolved = "guest"
-	_log("supabase sign-in ok — kbve_username=%s" % resolved)
+	_log("supabase session ready — kbve_username=%s" % resolved)
 	_dial(access_token, resolved)
 
 func _on_supabase_failed(reason: String) -> void:
-	_log("supabase sign-in failed: %s — falling back to dev JWT" % reason)
-	Ui.toast("Supabase sign-in failed: %s" % reason, 3.0, "warn")
+	_log("supabase session failed: %s — falling back to dev JWT" % reason)
+	Ui.toast("Supabase auth failed: %s" % reason, 3.0, "warn")
 	_dial(DEV_JWT, DEV_USERNAME)
 
 func _dial(jwt: String, kbve_username: String) -> void:

--- a/packages/rust/q/src/net/server.rs
+++ b/packages/rust/q/src/net/server.rs
@@ -1,12 +1,12 @@
 //! Server-side WebSocket transport — axum router + per-match session loop.
 //!
-//! Every connection must send a `ClientMessage::JoinMatch` first; the server
-//! verifies the Supabase JWT (HS256 against `SUPABASE_JWT_SECRET`) before it
-//! emits Welcome or subscribes to the snapshot broadcast. If the secret is
-//! unset the server runs in dev-accept mode and admits the username field
-//! at face value — handy for local smoke runs, never for production.
+//! Every connection sends a `ClientMessage::JoinMatch` first; the server
+//! verifies the Supabase JWT (HS256 against `SUPABASE_JWT_SECRET`) and then
+//! claims a free slot from the shared roster. When `SUPABASE_JWT_SECRET` is
+//! unset the server runs in dev-accept mode and trusts the username field at
+//! face value — handy for local smoke runs, never for production.
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use axum::Router;
 use axum::extract::State;
@@ -19,6 +19,58 @@ use tokio::sync::broadcast;
 use crate::auth;
 use crate::proto::{self, ClientMessage, ServerEvent};
 
+/// Match-wide roster of admitted players, indexed by slot.
+/// Holds `MAX_PLAYERS` slots; `None` = free.
+#[derive(Default)]
+pub struct Roster {
+    slots: Vec<Option<RosterEntry>>,
+}
+
+#[derive(Clone)]
+struct RosterEntry {
+    kbve_username: String,
+}
+
+impl Roster {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            slots: vec![None; capacity.max(1)],
+        }
+    }
+
+    /// Claim the lowest free slot. Returns `None` when full.
+    fn claim(&mut self, kbve_username: String) -> Option<proto::PlayerSlot> {
+        for (i, s) in self.slots.iter_mut().enumerate() {
+            if s.is_none() {
+                *s = Some(RosterEntry { kbve_username });
+                return Some(proto::PlayerSlot(i as u8));
+            }
+        }
+        None
+    }
+
+    fn release(&mut self, slot: proto::PlayerSlot) {
+        if let Some(s) = self.slots.get_mut(slot.0 as usize) {
+            *s = None;
+        }
+    }
+
+    /// Snapshot the roster as a `PlayerView` list for the wire.
+    fn snapshot(&self) -> Vec<proto::PlayerView> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| {
+                s.as_ref().map(|e| proto::PlayerView {
+                    slot: proto::PlayerSlot(i as u8),
+                    kbve_username: e.kbve_username.clone(),
+                    connected: true,
+                })
+            })
+            .collect()
+    }
+}
+
 #[derive(Clone)]
 pub struct ServerState {
     /// Broadcast bus shared with the bevy sim. WS sessions subscribe a
@@ -28,6 +80,8 @@ pub struct ServerState {
     pub seed: u64,
     /// Supabase JWT secret. Empty = dev-accept mode (any token admitted).
     pub jwt_secret: Vec<u8>,
+    /// Shared roster — multiple WS sessions race for free slots.
+    pub roster: Arc<RwLock<Roster>>,
 }
 
 impl ServerState {
@@ -36,6 +90,7 @@ impl ServerState {
             broadcast: Some(broadcast),
             seed,
             jwt_secret,
+            roster: Arc::new(RwLock::new(Roster::new(proto::MAX_PLAYERS))),
         }
     }
 
@@ -44,6 +99,7 @@ impl ServerState {
             broadcast: None,
             seed: 0,
             jwt_secret: Vec::new(),
+            roster: Arc::new(RwLock::new(Roster::new(proto::MAX_PLAYERS))),
         }
     }
 }
@@ -73,6 +129,8 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
         Some(a) => a,
         None => return,
     };
+    let slot = admitted.slot;
+    let roster_handle = state.roster.clone();
 
     let welcome = ServerEvent::Welcome {
         protocol: proto::PROTOCOL_VERSION,
@@ -82,6 +140,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
     if let Ok(buf) = proto::encode(&welcome)
         && socket.send(Message::Binary(buf)).await.is_err()
     {
+        release_slot(&roster_handle, slot);
         return;
     }
 
@@ -97,7 +156,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
                 }
             } => {
                 let Some(evt) = evt else { break };
-                let evt = inject_admitted_player(evt, &admitted);
+                let evt = inject_roster(evt, &state.roster);
                 let Ok(buf) = proto::encode(&evt) else { continue };
                 if socket.send(Message::Binary(buf)).await.is_err() {
                     break;
@@ -115,6 +174,14 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
                 }
             }
         }
+    }
+
+    release_slot(&roster_handle, slot);
+}
+
+fn release_slot(roster: &Arc<RwLock<Roster>>, slot: proto::PlayerSlot) {
+    if let Ok(mut r) = roster.write() {
+        r.release(slot);
     }
 }
 
@@ -144,41 +211,67 @@ async fn await_join_match(
             .await;
             return None;
         }
-        return admit(state, jm).await;
+        return admit(state, socket, jm).await;
     }
 }
 
 #[cfg(feature = "supabase-auth")]
-async fn admit(state: &Arc<ServerState>, jm: proto::JoinMatch) -> Option<AdmittedPlayer> {
-    if state.jwt_secret.is_empty() {
-        return Some(AdmittedPlayer {
-            slot: proto::PlayerSlot(0),
-            kbve_username: if jm.kbve_username.is_empty() {
-                "guest".into()
-            } else {
-                jm.kbve_username
-            },
-        });
-    }
-    match auth::verify_supabase_jwt(&jm.jwt, &state.jwt_secret) {
-        Ok(claims) => Some(AdmittedPlayer {
-            slot: proto::PlayerSlot(0),
-            kbve_username: claims.kbve_username,
-        }),
-        Err(_) => None,
-    }
-}
-
-#[cfg(not(feature = "supabase-auth"))]
-async fn admit(_state: &Arc<ServerState>, jm: proto::JoinMatch) -> Option<AdmittedPlayer> {
-    Some(AdmittedPlayer {
-        slot: proto::PlayerSlot(0),
-        kbve_username: if jm.kbve_username.is_empty() {
+async fn admit(
+    state: &Arc<ServerState>,
+    socket: &mut WebSocket,
+    jm: proto::JoinMatch,
+) -> Option<AdmittedPlayer> {
+    let kbve_username = if state.jwt_secret.is_empty() {
+        if jm.kbve_username.is_empty() {
             "guest".into()
         } else {
             jm.kbve_username
-        },
-    })
+        }
+    } else {
+        match auth::verify_supabase_jwt(&jm.jwt, &state.jwt_secret) {
+            Ok(claims) => claims.kbve_username,
+            Err(e) => {
+                send_reject(socket, &format!("auth rejected: {e}")).await;
+                return None;
+            }
+        }
+    };
+    claim_slot(state, socket, kbve_username).await
+}
+
+#[cfg(not(feature = "supabase-auth"))]
+async fn admit(
+    state: &Arc<ServerState>,
+    socket: &mut WebSocket,
+    jm: proto::JoinMatch,
+) -> Option<AdmittedPlayer> {
+    let kbve_username = if jm.kbve_username.is_empty() {
+        "guest".into()
+    } else {
+        jm.kbve_username
+    };
+    claim_slot(state, socket, kbve_username).await
+}
+
+async fn claim_slot(
+    state: &Arc<ServerState>,
+    socket: &mut WebSocket,
+    kbve_username: String,
+) -> Option<AdmittedPlayer> {
+    let slot = match state.roster.write() {
+        Ok(mut r) => r.claim(kbve_username.clone()),
+        Err(_) => None,
+    };
+    match slot {
+        Some(slot) => Some(AdmittedPlayer {
+            slot,
+            kbve_username,
+        }),
+        None => {
+            send_reject(socket, "match full").await;
+            None
+        }
+    }
 }
 
 async fn send_reject(socket: &mut WebSocket, reason: &str) {
@@ -190,17 +283,14 @@ async fn send_reject(socket: &mut WebSocket, reason: &str) {
     }
 }
 
-/// Patches Snapshot frames so the admitted player shows up in `players[]`
-/// even before the sim builds its own roster.
-fn inject_admitted_player(evt: ServerEvent, admitted: &AdmittedPlayer) -> ServerEvent {
+/// Patches Snapshot frames so every connected slot shows up in `players[]`.
+fn inject_roster(evt: ServerEvent, roster: &Arc<RwLock<Roster>>) -> ServerEvent {
     match evt {
         ServerEvent::Snapshot(mut snap) => {
-            if snap.players.is_empty() {
-                snap.players.push(proto::PlayerView {
-                    slot: admitted.slot,
-                    kbve_username: admitted.kbve_username.clone(),
-                    connected: true,
-                });
+            if snap.players.is_empty()
+                && let Ok(r) = roster.read()
+            {
+                snap.players = r.snapshot();
             }
             ServerEvent::Snapshot(snap)
         }


### PR DESCRIPTION
## Summary
Two long-overdue plumbing pieces ahead of real gameplay:

1. **Server-side roster** — \`q::net::server\` now hands out distinct \`PlayerSlot\` values, mirrors the live roster into every \`Snapshot.players[]\`, and frees slots when a connection drops. \`proto::MAX_PLAYERS\` caps capacity.
2. **Client-side session persistence** — \`SupabaseClient\` saves \`access_token\` / \`refresh_token\` / \`kbve_username\` to \`OS.get_user_data_dir()/session.json\` and chains \`cached → refresh → sign_in\` on boot so reconnects skip the GoTrue password round-trip (and the hcaptcha gate).

## Server changes (\`q::net::server\`)
- New \`Roster\` struct (\`Vec<Option<RosterEntry>>\`) sized to \`proto::MAX_PLAYERS\`, wrapped in \`Arc<RwLock<>>\` on \`ServerState\`.
- \`claim_slot\` reserves the lowest free slot on admit; \`send_reject(\"match full\")\` once capacity is reached.
- \`handle_socket\` calls \`release_slot\` when the WS pump exits, so disconnects / drops / refused-writes all free the seat for the next client.
- \`inject_admitted_player\` → \`inject_roster\` — every outgoing \`Snapshot.players[]\` mirrors the live roster, not just the local player.

## Client changes (\`apps/godot/nexus-defense/net/supabase_client.gd\`)
- Persists \`{access_token, refresh_token, kbve_username, expires_at, saved_at}\` to \`session.json\` after every successful exchange.
- Renamed signals: \`sign_in_succeeded → session_ready\`, \`sign_in_failed → session_failed\` (cover both sign-in and refresh outcomes).
- New \`refresh_session(refresh_token, username_hint)\` hits \`/auth/v1/token?grant_type=refresh_token\`; on failure (revoked token) it clears the cache so the next boot falls through to password sign-in.
- New \`resume_or_sign_in(...)\` walks the \`cached → refresh → sign_in\` chain and always emits exactly one of \`session_ready\` / \`session_failed\`.

## \`main.gd\`
- \`_begin_session\` invokes \`resume_or_sign_in\` whenever env creds OR a cached session is present; otherwise stays on the dev-accept fast path.

## Smoke (two godot clients in parallel, fresh server)
\`\`\`
godot A: welcome: slot=1 seed=0xc0ffee
godot B: welcome: slot=0 seed=0xc0ffee
\`\`\`

## Test plan
- [ ] Single client: HUD shows \`welcome: slot=0\`; restart godot — second run reuses the cached token (look for \`reusing cached access_token\` in the log).
- [ ] Spawn two godot clients against the same server: each gets a distinct slot. \`Snapshot.players[]\` carries both rows.
- [ ] Connect 5 clients to a server with \`MAX_PLAYERS = 4\`: 5th gets \`ServerEvent::Reject { reason: \"match full\" }\`.
- [ ] Manually corrupt \`~/Library/Application Support/Godot/app_userdata/Nexus Defense/session.json\` → boot falls through to sign-in.

## Next
- In-game hcaptcha capture (still the only thing blocking real-creds smoke).
- Input pump: route \`ClientFrame::PlaceBuilding\` etc. into the bevy sim, keyed by \`PlayerSlot\`.
- Server bevy sim: per-slot \`FieldDelta\` instead of a single shared field.

## Related
- #11294 — multiplayer TD tracker
- #11327 — server-side JWT verify
- #11332 — supabase GDScript client