### PR TITLE
fix(jedi/alerts): rewrite firing SQL to avoid argMax alias shadow

### DIFF
--- a/packages/rust/jedi/src/entity/pipe_clickhouse/alerts.rs
+++ b/packages/rust/jedi/src/entity/pipe_clickhouse/alerts.rs
@@ -64,21 +64,34 @@ pub fn build_alerts_firing_sql(params: &AlertsFiringParams) -> String {
     let minutes = clamped_minutes(params.minutes);
     format!(
         "SELECT \
-            argMax(timestamp, timestamp) AS timestamp, \
-            argMax(status, timestamp) AS status, \
-            argMax(alertname, timestamp) AS alertname, \
-            argMax(severity, timestamp) AS severity, \
-            argMax(namespace, timestamp) AS namespace, \
-            argMax(pod, timestamp) AS pod, \
-            argMax(service, timestamp) AS service, \
-            argMax(summary, timestamp) AS summary, \
-            argMax(starts_at, timestamp) AS starts_at, \
+            last_seen AS timestamp, \
+            last_status AS status, \
+            last_alertname AS alertname, \
+            last_severity AS severity, \
+            last_namespace AS namespace, \
+            last_pod AS pod, \
+            last_service AS service, \
+            last_summary AS summary, \
+            last_starts_at AS starts_at, \
             fingerprint \
-         FROM alerts_distributed \
-         WHERE timestamp > now() - INTERVAL {minutes} MINUTE \
-         GROUP BY fingerprint \
-         HAVING status = 'firing' \
-         ORDER BY starts_at DESC"
+         FROM ( \
+            SELECT \
+                fingerprint, \
+                argMax(timestamp, timestamp) AS last_seen, \
+                argMax(status, timestamp) AS last_status, \
+                argMax(alertname, timestamp) AS last_alertname, \
+                argMax(severity, timestamp) AS last_severity, \
+                argMax(namespace, timestamp) AS last_namespace, \
+                argMax(pod, timestamp) AS last_pod, \
+                argMax(service, timestamp) AS last_service, \
+                argMax(summary, timestamp) AS last_summary, \
+                argMax(starts_at, timestamp) AS last_starts_at \
+             FROM alerts_distributed \
+             WHERE timestamp > now() - INTERVAL {minutes} MINUTE \
+             GROUP BY fingerprint \
+         ) \
+         WHERE last_status = 'firing' \
+         ORDER BY last_starts_at DESC"
     )
 }
 
@@ -196,9 +209,12 @@ mod tests {
     #[test]
     fn firing_sql_uses_argmax_dedupe() {
         let sql = build_alerts_firing_sql(&AlertsFiringParams { minutes: Some(60) });
-        assert!(sql.contains("argMax(status, timestamp)"));
+        assert!(sql.contains("INTERVAL 60 MINUTE"));
+        assert!(sql.contains("argMax(status, timestamp) AS last_status"));
         assert!(sql.contains("GROUP BY fingerprint"));
-        assert!(sql.contains("HAVING status = 'firing'"));
+        assert!(sql.contains("WHERE last_status = 'firing'"));
+        assert!(sql.contains("ORDER BY last_starts_at DESC"));
+        assert!(sql.contains("last_seen AS timestamp"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `/dashboard/grafana/` "Currently firing" panel shows "Failed to load" because the ClickHouse 25.x new analyzer rejects `build_alerts_firing_sql` with `Code: 184. DB::Exception: Aggregate function argMax(timestamp, timestamp) AS timestamp is found in WHERE in query. (ILLEGAL_AGGREGATION)`. Same query also produces "Aggregate function ... is found inside another aggregate function" when WHERE is pushed into a sibling subquery — bare `timestamp` references resolve to the SELECT alias (itself an aggregate) instead of the column.
- Rewrite as a subquery using non-shadowing alias names (`last_seen`, `last_status`, ...) for the `argMax(..., timestamp)` aggregates, then project them back to the wire-level column names (`timestamp`, `status`, ...) at the outer SELECT. `WHERE last_status = 'firing'` and `ORDER BY last_starts_at DESC` move to the outer query so they operate on already-aggregated rows.
- Same row shape on the wire — `AlertFiringRow` consumers in `alertsService.ts` / `ReactAlerts.tsx` need no change.

## Verification
- Live run against `chi-clickhouse-cluster-cluster-0-0-0` (ClickHouse 25.8.4) returns rows:
  ```
  timestamp:   2026-05-24 16:35:04.801
  status:      firing
  alertname:   KubeJobFailed
  severity:    warning
  ...
  ```
- `firing_sql_uses_argmax_dedupe` updated to assert the new subquery shape.
- All 6 `alerts::tests` pass: `cargo test -p jedi --lib --features clickhouse alerts::tests` → `test result: ok. 6 passed; 0 failed`.

## Test plan
- [ ] Merge + wait for axum-kbve roll.
- [ ] Refresh `/dashboard/grafana/` and confirm "Currently firing" populates with the same rows the other three alert panels already show.
- [ ] Switch between the 15m/1h/6h/24h/7d range buttons and confirm the count flexes correctly.