### PR TITLE
fix(mc-behavior): cull AI mobs that drift into spawn claim

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
@@ -55,14 +55,6 @@ public class AiCreatureManager {
      */
     private static final String AI_MARKER_TAG = "kbve_ai_creature";
 
-    private static final int SPAWN_PROTECT_BUFFER = 64;
-    private static final int SPAWN_PROTECT_MIN_X = -200 - SPAWN_PROTECT_BUFFER;
-    private static final int SPAWN_PROTECT_MIN_Y = -200 - SPAWN_PROTECT_BUFFER;
-    private static final int SPAWN_PROTECT_MIN_Z = -200 - SPAWN_PROTECT_BUFFER;
-    private static final int SPAWN_PROTECT_MAX_X = 200 + SPAWN_PROTECT_BUFFER;
-    private static final int SPAWN_PROTECT_MAX_Y = 200 + SPAWN_PROTECT_BUFFER;
-    private static final int SPAWN_PROTECT_MAX_Z = 200 + SPAWN_PROTECT_BUFFER;
-
     /** Tracked creatures keyed by Minecraft entity ID. */
     private final ConcurrentHashMap<Integer, CreatureSlot> creatures = new ConcurrentHashMap<>();
 
@@ -137,6 +129,33 @@ public class AiCreatureManager {
     }
 
     /**
+     * Despawn tracked, unowned AI creatures that wandered into the
+     * server-claim cube after spawning legitimately outside it. Spawn-time
+     * rejection in {@link #spawnNear} only fires when the picked surface
+     * is inside the claim; a hostile spawned at the edge can still walk in.
+     * Pets ({@code ownerEntityId != 0}) are exempt because they have to
+     * follow their owner across the claim boundary.
+     */
+    private void sweepCreaturesInsideSpawnProtection(ServerWorld world) {
+        int removed = 0;
+        var it = creatures.entrySet().iterator();
+        while (it.hasNext()) {
+            var entry = it.next();
+            var slot = entry.getValue();
+            if (slot.ownerEntityId != 0) continue;
+            var entity = world.getEntityById(entry.getKey());
+            if (!(entity instanceof MobEntity mob) || !mob.isAlive()) continue;
+            if (!SpawnRegion.containsBlock(mob.getBlockPos())) continue;
+            entity.discard();
+            it.remove();
+            removed++;
+        }
+        if (removed > 0) {
+            LOGGER.info("[AI] Culled {} AI creature(s) that drifted into spawn claim", removed);
+        }
+    }
+
+    /**
      * Build an observation for each tracked creature and submit it to Rust.
      * Called at throttled intervals by {@link NpcTickHandler}, not every tick.
      */
@@ -147,6 +166,7 @@ public class AiCreatureManager {
         // Run the orphan sweep first so any stale creatures from a previous
         // session are gone before we submit observations for the current set.
         sweepOrphanedAiCreatures(overworld);
+        sweepCreaturesInsideSpawnProtection(overworld);
 
         long currentTick = overworld.getTime();
 
@@ -348,15 +368,7 @@ public class AiCreatureManager {
     }
 
     private static boolean isInsideSpawnProtection(BlockPos pos) {
-        int x = pos.getX();
-        int y = pos.getY();
-        int z = pos.getZ();
-        return x >= SPAWN_PROTECT_MIN_X
-                && x <= SPAWN_PROTECT_MAX_X
-                && y >= SPAWN_PROTECT_MIN_Y
-                && y <= SPAWN_PROTECT_MAX_Y
-                && z >= SPAWN_PROTECT_MIN_Z
-                && z <= SPAWN_PROTECT_MAX_Z;
+        return SpawnRegion.containsBlock(pos);
     }
 
     private boolean hasCreatureOwnedBy(CreatureKind kind, int ownerEntityId) {

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/SpawnAutoClaim.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/SpawnAutoClaim.java
@@ -20,10 +20,10 @@ public final class SpawnAutoClaim {
     private static final String OPAC_MOD_ID = "openpartiesandclaims";
     private static final UUID SERVER_CLAIM_UUID = new UUID(0L, 0L);
 
-    private static final int FROM_CHUNK_X = -13;
-    private static final int FROM_CHUNK_Z = -13;
-    private static final int TO_CHUNK_X = 12;
-    private static final int TO_CHUNK_Z = 12;
+    private static final int FROM_CHUNK_X = SpawnRegion.FROM_CHUNK_X;
+    private static final int FROM_CHUNK_Z = SpawnRegion.FROM_CHUNK_Z;
+    private static final int TO_CHUNK_X = SpawnRegion.TO_CHUNK_X;
+    private static final int TO_CHUNK_Z = SpawnRegion.TO_CHUNK_Z;
 
     private static final RegistryKey<World>[] DIMENSIONS = arr(World.OVERWORLD);
 

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/SpawnRegion.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/SpawnRegion.java
@@ -1,0 +1,36 @@
+package com.kbve.statetree;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+
+public final class SpawnRegion {
+
+    public static final int FROM_CHUNK_X = -13;
+    public static final int FROM_CHUNK_Z = -13;
+    public static final int TO_CHUNK_X = 12;
+    public static final int TO_CHUNK_Z = 12;
+
+    public static final int MIN_X = FROM_CHUNK_X << 4;
+    public static final int MIN_Z = FROM_CHUNK_Z << 4;
+    public static final int MAX_X = ((TO_CHUNK_X + 1) << 4) - 1;
+    public static final int MAX_Z = ((TO_CHUNK_Z + 1) << 4) - 1;
+
+    private SpawnRegion() {}
+
+    public static boolean containsBlock(int x, int z) {
+        return x >= MIN_X && x <= MAX_X && z >= MIN_Z && z <= MAX_Z;
+    }
+
+    public static boolean containsBlock(BlockPos pos) {
+        return containsBlock(pos.getX(), pos.getZ());
+    }
+
+    public static boolean containsChunk(int cx, int cz) {
+        return cx >= FROM_CHUNK_X && cx <= TO_CHUNK_X
+                && cz >= FROM_CHUNK_Z && cz <= TO_CHUNK_Z;
+    }
+
+    public static boolean containsChunk(ChunkPos cp) {
+        return containsChunk(cp.x, cp.z);
+    }
+}


### PR DESCRIPTION
## Summary

AI skeletons get rejected at spawn-time if their picked surface is inside the OPAC server-claim cube (\`AiCreatureManager.spawnNear\` → \`isInsideSpawnProtection\`). But a hostile spawned just outside the claim can still walk in and harass players in the safe zone.

Fixed two things:

### 1. Single source of truth for the spawn cube

\`AiCreatureManager\` had hand-tuned bounds (±264 box, full Y range) that drifted from the actual OPAC claim (\`-13..12\` chunks = \`[-208, 207]\` blocks x/z, full Y column).

New \`SpawnRegion\` holder exposes \`FROM_CHUNK_X..TO_CHUNK_Z\` plus derived block bounds + \`containsBlock\` / \`containsChunk\` helpers. \`SpawnAutoClaim\` and \`AiCreatureManager\` both pull from it now — the claim region and the protection region can't disagree again.

### 2. Drift culling

New \`sweepCreaturesInsideSpawnProtection\` runs on the same throttled cadence as observation submission (in \`submitObservations\`, alongside the existing \`sweepOrphanedAiCreatures\`). Walks the tracked-creature map, discards any unowned \`MobEntity\` whose current \`BlockPos\` is inside the claim cube. Pets (\`ownerEntityId != 0\`) are exempt — they have to follow the player across the boundary.

## Test plan

- [ ] Boot the mc fleet, walk to the edge of the spawn claim, watch logs for \`[AI] Culled N AI creature(s) that drifted into spawn claim\` when a skeleton wanders in
- [ ] Verify pet wolves still follow you into the claim without being culled
- [ ] Verify spawn-time rejection still works (no new AI skeletons inside the cube at all — should never see a freshly-spawned one inside)