### PR TITLE
feat(edge,discordsh-bot): publish v0.1.32 / v0.1.15 to ship /gh claim

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.169",
+			"version": "1.0.170",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -97,7 +97,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.14",
+			"version": "0.1.15",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
@@ -111,7 +111,7 @@
 		{
 			"key": "edge",
 			"app_name": "edge",
-			"version": "0.1.31",
+			"version": "0.1.32",
 			"version_toml": "apps/kbve/edge/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
 			"version_target": "apps/kbve/edge/deno.json",
@@ -246,7 +246,7 @@
 		{
 			"key": "mc",
 			"app_name": "mc",
-			"version": "1.0.57",
+			"version": "1.0.58",
 			"version_toml": "apps/mc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc.mdx",
 			"source_path": "apps/mc",
@@ -266,7 +266,7 @@
 		{
 			"key": "mc_lobby",
 			"app_name": "mc-lobby",
-			"version": "1.0.9",
+			"version": "1.0.10",
 			"version_toml": "apps/mc/lobby/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc-lobby.mdx",
 			"source_path": "apps/mc/lobby",
@@ -279,7 +279,7 @@
 		{
 			"key": "mc_velocity",
 			"app_name": "mc-velocity",
-			"version": "1.1.9",
+			"version": "1.1.10",
 			"version_toml": "apps/mc/velocity/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/mc-velocity.mdx",
 			"source_path": "apps/mc/velocity",

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.14"
+version: "0.1.15"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.31"
+version: "0.1.32"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json

--- a/apps/kbve/edge/functions/main/index.ts
+++ b/apps/kbve/edge/functions/main/index.ts
@@ -8,7 +8,7 @@ const JWT_SECRET = Deno.env.get("JWT_SECRET");
 const VERIFY_JWT = Deno.env.get("VERIFY_JWT") === "true";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
-const PUBLIC_ROUTES = new Set(["health"]);
+const PUBLIC_ROUTES = new Set(["health", "gh-webhook"]);
 const STAFF_ROUTES = new Set(["argo"]);
 
 const SB_ACCESS_TOKEN_COOKIE = "sb-access-token";

--- a/apps/kbve/edge/version.toml
+++ b/apps/kbve/edge/version.toml
@@ -55,3 +55,13 @@ description = "OWS admin operations (unstuck, maintenance, status)"
 name = "irc"
 label = "IRC"
 description = "IRC admin operations (channels, messages, server status)"
+
+[[functions]]
+name = "gh-webhook"
+label = "GH Webhook"
+description = "GitHub webhook ingest — HMAC-verifies deliveries and upserts gh.issue + gh.issue_event"
+
+[[functions]]
+name = "gh-backfill"
+label = "GH Backfill"
+description = "One-time paginated REST walk that populates gh.issue for an allowlisted repo"


### PR DESCRIPTION
Triggers the actual prod rollout of #11310. PR #11310 merged with the bot subcommand + edge functions on disk but did not bump the version sources, so the version gate skipped publish for both \`edge\` and \`discordsh-bot\`. The production images today still predate \`/gh claim\`.

## Changes

- \`apps/kbve/astro-kbve/src/content/docs/project/edge.mdx\` → \`version: "0.1.32"\` (source of truth per the \"version comes from MDX, not version.toml\" convention)
- \`apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx\` → \`version: "0.1.15"\`
- \`apps/kbve/edge/version.toml\` — register \`gh-webhook\` + \`gh-backfill\` in the \`[[functions]]\` registry so the public function list + edge docs page surface them next to the existing functions
- \`apps/kbve/edge/functions/main/index.ts\` — add \`gh-webhook\` to \`PUBLIC_ROUTES\`. GitHub deliveries authenticate via \`X-Hub-Signature-256\` HMAC verified inside the handler; the router's Supabase-JWT gate would 401 every webhook otherwise. \`gh-backfill\` stays gated (requires service_role).
- \`.github/ci-dispatch-manifest.json\` — full regen per the established convention. Picks up the in-flight \`axum-kbve\`/\`mc\`/\`mc-lobby\`/\`mc-velocity\` post-publish syncs incidentally.

## What this unblocks

Once merged, \`ci-main.yml\` runs on push to dev → main, dispatches \`ci-docker.yml\` for both apps, publish jobs run (version gate now sees a diff), ArgoCD picks up the new image tags.

## Ops follow-up (separate from this PR)

1. Set Supabase edge env on the prod functions deployment: \`GITHUB_WEBHOOK_SECRET\`, \`GITHUB_TOKEN\`, \`GH_WEBHOOK_ALLOWED_REPOS=KBVE/kbve\`.
2. Configure GitHub webhook on \`KBVE/kbve\` repo: URL \`https://<edge-host>/functions/v1/gh-webhook\`, content type \`application/json\`, secret matching \`GITHUB_WEBHOOK_SECRET\`, events: Issues + Issue comments + Pull requests + Pull request reviews + Pull request review comments.
3. Run \`gh-backfill\` once to populate \`gh.issue\` for \`KBVE/kbve\`:
   \`\`\`bash
   curl -X POST 'https://<edge-host>/functions/v1/gh-backfill' \\
     -H "Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>" \\
     -H 'Content-Type: application/json' \\
     -d '{"owner":"KBVE","repo":"kbve","state":"all"}'
   \`\`\`
4. Try \`/gh claim <issue#>\` in Discord (server with the bot present + linked GitHub identity on your KBVE account).

## Verification

- \`./kbve.sh -nx astro-kbve:build\` → \`./kbve.sh -nx astro-kbve:sync:ci-manifest\` → \`64 tracked items\` ✓
- Manifest diff matches expected (edge 0.1.31→0.1.32, discordsh-bot 0.1.14→0.1.15, plus incidental sync).