### PR TITLE
feat(q,nexus-defense): bidirectional input pump — ClientFrame → bevy sim

### DIFF
--- a/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd309b18ef2039ac326190d3fd5a0de49ebac26089ad1a96d534bf742e73f737
-size 9176360
+oid sha256:d8601d21a86a5b1e219a0883223f429154d8f69645eeffda34c2dbea6ccd45a8
+size 9194920

--- a/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7eea4f3f76e84b606baed5ce27f953c46a9ce1dfd7c0e474e2396e6c18cb1812
-size 4183616
+oid sha256:78002f79d6544651b1c88d23780855fe7d971c1bdd0bcbc648c05ba0a4078424
+size 4200128

--- a/apps/godot/nexus-defense/scenes/game.gd
+++ b/apps/godot/nexus-defense/scenes/game.gd
@@ -101,8 +101,38 @@ func _try_place(screen_pos: Vector2) -> void:
 	var occupied: Array[Vector2i] = (_hex_map.occupied_axials as Array[Vector2i]).duplicate()
 	occupied.append(axial)
 	_hex_map.set_occupied(occupied)
+	_send_place_building(axial.x, axial.y, _tower_kind_idx(_selected_tower))
 	Ui.toast("Placed %s at (%d,%d)" % [_selected_tower, axial.x, axial.y], 1.6, "ok")
 	_cancel_placement()
+
+func _send_place_building(col: int, row: int, kind_idx: int) -> void:
+	if socket == null or not socket.call("is_ws_connected"):
+		return
+	socket.call("send_place_building", _last_snapshot_tick, col, row, kind_idx)
+	_log("sent PlaceBuilding col=%d row=%d kind_idx=%d" % [col, row, kind_idx])
+
+func _tower_kind_idx(tower_id: String) -> int:
+	# Mirrors proto::BuildKind discriminants. Default to Tower until the
+	# build_bar IDs gain explicit kind metadata.
+	match tower_id:
+		"basic", "bomb", "ice", "fire", "artillery", "lightning", "sniper":
+			return 0  # Tower
+		"solar", "diesel", "nuclear":
+			return 1  # Generator
+		"battery":
+			return 2  # Battery
+		"repair":
+			return 3  # Repair
+		"armoury":
+			return 4  # Armoury
+		"village":
+			return 5  # Village
+		"town":
+			return 6  # Town
+		"castle":
+			return 7  # Castle
+		_:
+			return 0
 
 func _cancel_placement() -> void:
 	_selected_tower = ""
@@ -148,9 +178,21 @@ func _on_connected() -> void:
 func _on_welcome(slot: int, seed: int) -> void:
 	_log("welcome: slot=%d seed=0x%x" % [slot, seed])
 	Ui.toast("Welcome — slot %d" % slot, 2.0, "info")
+	# Smoke: when ND_AUTO_PLACE is set, fire a PlaceBuilding 0.8 s after
+	# Welcome so headless runs can exercise the input pump without a real
+	# click. Disabled by default for normal gameplay.
+	if OS.get_environment("ND_AUTO_PLACE") != "":
+		await get_tree().create_timer(0.8).timeout
+		_send_place_building(0, 0, 0)
 
-func _on_snapshot(tick: int, wave: int, enemy_count: int, gold: int, lives: int) -> void:
+var _last_snapshot_tick: int = 0
+var _last_building_count: int = 0
+
+func _on_snapshot(tick: int, wave: int, enemy_count: int, building_count: int, gold: int, lives: int) -> void:
+	_last_snapshot_tick = tick
 	var wave_changed: bool = wave != _wave
+	var building_changed: bool = building_count != _last_building_count
+	_last_building_count = building_count
 	if wave_changed:
 		_wave = wave
 		Ui.open("wave_banner", {"title": "Wave %d" % wave, "subtitle": "%d enemies inbound" % enemy_count})
@@ -158,9 +200,9 @@ func _on_snapshot(tick: int, wave: int, enemy_count: int, gold: int, lives: int)
 	_gold = gold
 	_enemies = enemy_count
 	Ui.open("hud_top", {"wave": _wave, "lives": _lives, "gold": _gold, "enemies": _enemies})
-	if _last_snapshot_log_tick < 0 or tick - _last_snapshot_log_tick >= 10 or wave_changed:
+	if _last_snapshot_log_tick < 0 or tick - _last_snapshot_log_tick >= 10 or wave_changed or building_changed:
 		_last_snapshot_log_tick = tick
-		_log("snapshot tick=%d wave=%d enemies=%d gold=%d lives=%d" % [tick, wave, enemy_count, gold, lives])
+		_log("snapshot tick=%d wave=%d enemies=%d buildings=%d gold=%d lives=%d" % [tick, wave, enemy_count, building_count, gold, lives])
 
 func _on_disconnected(reason: String) -> void:
 	_log("disconnected: %s" % reason)

--- a/apps/td-server/src/main.rs
+++ b/apps/td-server/src/main.rs
@@ -9,7 +9,7 @@ use std::net::SocketAddr;
 
 use q::nexus_defense_server::{SNAPSHOT_BROADCAST_CAPACITY, build_app, run_sim_loop};
 use tokio::net::TcpListener;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -31,6 +31,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Broadcast bus: bevy sim -> every WS session.
     let (snap_tx, _) = broadcast::channel(SNAPSHOT_BROADCAST_CAPACITY);
+    // Input mailbox: WS sessions -> bevy sim.
+    let (input_tx, input_rx) = mpsc::unbounded_channel::<q::net::server::SlotInput>();
 
     // Bevy headless app — runs on a dedicated blocking thread so the App
     // (which holds non-Send schedule state) never crosses task boundaries.
@@ -40,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .enable_time()
             .build()
             .expect("sim runtime");
-        let app = build_app(sim_tx, seed);
+        let app = build_app(sim_tx, input_rx, seed);
         rt.block_on(run_sim_loop(app));
     });
 
@@ -53,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "supabase HS256"
     };
 
-    let state = q::net::server::ServerState::new(snap_tx, seed, jwt_secret);
+    let state = q::net::server::ServerState::new(snap_tx, input_tx, seed, jwt_secret);
     let router = q::net::server::router(state);
 
     tracing::info!(%addr, %seed, auth = %auth_mode, "td-server listening");

--- a/packages/rust/q/src/net/server.rs
+++ b/packages/rust/q/src/net/server.rs
@@ -13,11 +13,15 @@ use axum::extract::State;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::IntoResponse;
 use axum::routing::get;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc};
 
 #[cfg(feature = "supabase-auth")]
 use crate::auth;
-use crate::proto::{self, ClientMessage, ServerEvent};
+use crate::proto::{self, ClientMessage, Input, ServerEvent};
+
+/// One input as it crosses from a WS session into the bevy sim. Slot is the
+/// authenticated source; trust this, never the wire.
+pub type SlotInput = (proto::PlayerSlot, Input);
 
 /// Match-wide roster of admitted players, indexed by slot.
 /// Holds `MAX_PLAYERS` slots; `None` = free.
@@ -76,6 +80,9 @@ pub struct ServerState {
     /// Broadcast bus shared with the bevy sim. WS sessions subscribe a
     /// receiver per connection.
     pub broadcast: Option<broadcast::Sender<ServerEvent>>,
+    /// Inputs from authenticated WS sessions → sim. None = no sim wired,
+    /// inputs are silently dropped (smoke/test path).
+    pub input_tx: Option<mpsc::UnboundedSender<SlotInput>>,
     /// Seed echoed back to clients in the Welcome frame.
     pub seed: u64,
     /// Supabase JWT secret. Empty = dev-accept mode (any token admitted).
@@ -85,9 +92,15 @@ pub struct ServerState {
 }
 
 impl ServerState {
-    pub fn new(broadcast: broadcast::Sender<ServerEvent>, seed: u64, jwt_secret: Vec<u8>) -> Self {
+    pub fn new(
+        broadcast: broadcast::Sender<ServerEvent>,
+        input_tx: mpsc::UnboundedSender<SlotInput>,
+        seed: u64,
+        jwt_secret: Vec<u8>,
+    ) -> Self {
         Self {
             broadcast: Some(broadcast),
+            input_tx: Some(input_tx),
             seed,
             jwt_secret,
             roster: Arc::new(RwLock::new(Roster::new(proto::MAX_PLAYERS))),
@@ -97,6 +110,7 @@ impl ServerState {
     pub fn empty() -> Self {
         Self {
             broadcast: None,
+            input_tx: None,
             seed: 0,
             jwt_secret: Vec::new(),
             roster: Arc::new(RwLock::new(Roster::new(proto::MAX_PLAYERS))),
@@ -167,7 +181,14 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
                 match msg {
                     Message::Binary(bytes) => {
                         let mut buf = bytes;
-                        let _ = proto::decode::<ClientMessage>(&mut buf);
+                        if let Ok(ClientMessage::Frame(frame)) =
+                            proto::decode::<ClientMessage>(&mut buf)
+                            && let Some(tx) = state.input_tx.as_ref()
+                        {
+                            for input in frame.inputs {
+                                let _ = tx.send((slot, input));
+                            }
+                        }
                     }
                     Message::Close(_) => break,
                     _ => {}

--- a/packages/rust/q/src/nexus_defense/match_socket.rs
+++ b/packages/rust/q/src/nexus_defense/match_socket.rs
@@ -29,6 +29,7 @@ enum Inbound {
         tick: u32,
         wave: u16,
         enemy_count: u32,
+        building_count: u32,
         gold: i32,
         lives: i32,
     },
@@ -83,6 +84,7 @@ impl INode for MatchSocket {
                     tick,
                     wave,
                     enemy_count,
+                    building_count,
                     gold,
                     lives,
                 } => {
@@ -92,6 +94,7 @@ impl INode for MatchSocket {
                             (tick as i64).to_variant(),
                             (wave as i64).to_variant(),
                             (enemy_count as i64).to_variant(),
+                            (building_count as i64).to_variant(),
                             (gold as i64).to_variant(),
                             (lives as i64).to_variant(),
                         ],
@@ -125,7 +128,7 @@ impl MatchSocket {
     /// be pulled from a future ring buffer; for now we plumb the headline
     /// numbers so GDScript can render a wave/enemies/gold display.
     #[signal]
-    fn snapshot(tick: i64, wave: i64, enemy_count: i64, gold: i64, lives: i64);
+    fn snapshot(tick: i64, wave: i64, enemy_count: i64, building_count: i64, gold: i64, lives: i64);
 
     #[signal]
     fn disconnected(reason: GString);
@@ -172,21 +175,57 @@ impl MatchSocket {
 
     #[func]
     fn send_heartbeat(&mut self, client_tick: i64) {
+        self.send_frame(
+            client_tick,
+            vec![proto::Input::Heartbeat {
+                client_tick: client_tick as u32,
+            }],
+        );
+    }
+
+    /// Queue a single `PlaceBuilding` input for the next client frame.
+    /// `kind_idx` matches `proto::BuildKind` discriminants (Tower=0, …, Nexus=8).
+    #[func]
+    fn send_place_building(&mut self, client_tick: i64, col: i64, row: i64, kind_idx: i64) {
+        let kind = match kind_idx {
+            0 => proto::BuildKind::Tower,
+            1 => proto::BuildKind::Generator,
+            2 => proto::BuildKind::Battery,
+            3 => proto::BuildKind::Repair,
+            4 => proto::BuildKind::Armoury,
+            5 => proto::BuildKind::Village,
+            6 => proto::BuildKind::Town,
+            7 => proto::BuildKind::Castle,
+            8 => proto::BuildKind::Nexus,
+            _ => {
+                godot_warn!("[MatchSocket] unknown BuildKind index {kind_idx}");
+                return;
+            }
+        };
+        self.send_frame(
+            client_tick,
+            vec![proto::Input::PlaceBuilding {
+                col: col as i32,
+                row: row as i32,
+                kind,
+            }],
+        );
+    }
+
+    fn send_frame(&mut self, client_tick: i64, inputs: Vec<proto::Input>) {
         let tx = match &self.outbound_tx {
             Some(t) => t.clone(),
             None => return,
         };
         let msg = ClientMessage::Frame(proto::ClientFrame {
             client_tick: client_tick as u32,
-            inputs: vec![proto::Input::Heartbeat {
-                client_tick: client_tick as u32,
-            }],
+            inputs,
         });
         match proto::encode(&msg) {
             Ok(buf) => {
                 let _ = tx.send(Outbound::Send(buf));
             }
-            Err(e) => godot_warn!("[MatchSocket] encode heartbeat failed: {e}"),
+            Err(e) => godot_warn!("[MatchSocket] encode frame failed: {e}"),
         }
     }
 
@@ -201,7 +240,7 @@ impl MatchSocket {
     }
 
     #[func]
-    fn is_connected(&self) -> bool {
+    fn is_ws_connected(&self) -> bool {
         self.connected
     }
 }
@@ -292,6 +331,7 @@ async fn run_socket(
                 Ok(ServerEvent::Snapshot(snap)) => {
                     let field = snap.fields.first();
                     let enemy_count = field.map(|f| f.enemies.len() as u32).unwrap_or(0);
+                    let building_count = field.map(|f| f.buildings.len() as u32).unwrap_or(0);
                     let wave = field.map(|f| f.wave).unwrap_or(0);
                     let gold = field.map(|f| f.gold).unwrap_or(0);
                     let lives = field.map(|f| f.lives).unwrap_or(0);
@@ -299,6 +339,7 @@ async fn run_socket(
                         tick: snap.tick,
                         wave,
                         enemy_count,
+                        building_count,
                         gold,
                         lives,
                     });

--- a/packages/rust/q/src/nexus_defense_server/mod.rs
+++ b/packages/rust/q/src/nexus_defense_server/mod.rs
@@ -5,20 +5,24 @@
 //! [`build_app`] and driven by [`run_sim_loop`] from a tokio task — no winit,
 //! no rendering, just a fixed-cadence scheduler that calls `App::update`.
 //!
-//! Snapshots produced by [`emit_snapshot`] are fanned out via a
-//! `tokio::sync::broadcast::Sender<ServerEvent>` so the axum WS layer can
-//! subscribe a `Receiver` per connection.
+//! Inputs flow in via an `mpsc::UnboundedReceiver<(PlayerSlot, Input)>` that
+//! the axum WS layer feeds; snapshots flow out via a
+//! `tokio::sync::broadcast::Sender<ServerEvent>` so each WS connection can
+//! subscribe a `Receiver`.
 
+use std::sync::Mutex;
 use std::time::Duration;
 
 use bevy::app::App;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::system::Commands;
-use bevy::prelude::{Component, IntoScheduleConfigs, Query, Res, ResMut, Resource, Update};
-use tokio::sync::broadcast;
+use bevy::prelude::{
+    Component, IntoScheduleConfigs, Query, Res, ResMut, Resource, Update, Without,
+};
+use tokio::sync::{broadcast, mpsc};
 use tokio::time;
 
-use crate::proto::{self, ServerEvent};
+use crate::proto::{self, Input, ServerEvent};
 
 /// Server sim tick rate. 20 Hz matches the design budget in #11294.
 pub const SIM_TICK_HZ: u32 = 20;
@@ -45,6 +49,8 @@ const SPAWN_INTERVAL_TICKS: u32 = 10;
 /// Ticks between waves (5 s at 20 Hz).
 const WAVE_INTERVAL_TICKS: u32 = SIM_TICK_HZ * 5;
 
+const BUILDING_HP: f32 = 200.0;
+
 #[derive(Resource, Default)]
 pub struct SimClock {
     pub tick: u32,
@@ -58,6 +64,15 @@ pub struct SnapshotBroadcast {
 
 #[derive(Resource, Clone, Copy)]
 pub struct SimSeed(pub u64);
+
+/// Mailbox of authenticated inputs (slot + payload) waiting to be applied to
+/// the bevy world. The WS handler is the sole producer; `drain_inputs` is the
+/// sole consumer. `Mutex` is only here so bevy can hold the !Send Receiver
+/// inside a `Resource` — we never have actual contention.
+#[derive(Resource)]
+pub struct InputQueue {
+    pub rx: Mutex<mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>>,
+}
 
 #[derive(Resource, Default)]
 pub struct WaveState {
@@ -84,19 +99,34 @@ pub struct EnemyTag {
     pub kind: proto::EnemyKind,
 }
 
-/// Build a headless bevy `App` wired to broadcast snapshots over `tx`.
-///
-/// Caller owns the broadcast `Sender`; clone a `Receiver` per WS connection.
-pub fn build_app(tx: broadcast::Sender<ServerEvent>, seed: u64) -> App {
+#[derive(Component)]
+pub struct BuildingTag {
+    pub kind: proto::BuildKind,
+    pub owner: proto::PlayerSlot,
+    pub col: i32,
+    pub row: i32,
+}
+
+/// Build a headless bevy `App` wired to broadcast snapshots over `tx` and
+/// accept inputs from `input_rx`.
+pub fn build_app(
+    tx: broadcast::Sender<ServerEvent>,
+    input_rx: mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>,
+    seed: u64,
+) -> App {
     let mut app = App::new();
     app.insert_resource(SimClock::default())
         .insert_resource(SimSeed(seed))
         .insert_resource(SnapshotBroadcast { tx })
+        .insert_resource(InputQueue {
+            rx: Mutex::new(input_rx),
+        })
         .insert_resource(WaveState::default())
         .add_systems(
             Update,
             (
                 tick_sim,
+                drain_inputs,
                 spawn_wave_enemies,
                 move_enemies,
                 despawn_offscreen,
@@ -110,6 +140,48 @@ pub fn build_app(tx: broadcast::Sender<ServerEvent>, seed: u64) -> App {
 fn tick_sim(mut clock: ResMut<SimClock>) {
     clock.tick = clock.tick.wrapping_add(1);
     clock.elapsed_ms = clock.elapsed_ms.wrapping_add(1000 / SIM_TICK_HZ);
+}
+
+fn drain_inputs(queue: Res<InputQueue>, mut commands: Commands) {
+    let mut guard = match queue.rx.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    while let Ok((slot, input)) = guard.try_recv() {
+        apply_input(slot, input, &mut commands);
+    }
+}
+
+fn apply_input(slot: proto::PlayerSlot, input: Input, commands: &mut Commands) {
+    match input {
+        Input::PlaceBuilding { col, row, kind } => {
+            // Treat (col, row) as a 32-pixel grid; centre the entity in the
+            // cell. Real placement validation (cost, collisions, paths) lands
+            // alongside the economy + path-gen systems.
+            let x = (col as f32) * 32.0 + 16.0;
+            let y = (row as f32) * 32.0 + 16.0;
+            commands.spawn((
+                BuildingTag {
+                    kind,
+                    owner: slot,
+                    col,
+                    row,
+                },
+                Position(x, y),
+                Health {
+                    hp: BUILDING_HP,
+                    max_hp: BUILDING_HP,
+                },
+            ));
+        }
+        Input::Heartbeat { .. } | Input::Leave => {
+            // No-op for now; the WS handler tracks lifecycle.
+        }
+        _ => {
+            // SellBuilding / Upgrade / Retarget / UseItem / SkipWave / TogglePause
+            // land alongside the matching economy + targeting systems.
+        }
+    }
 }
 
 fn spawn_wave_enemies(clock: Res<SimClock>, mut wave: ResMut<WaveState>, mut commands: Commands) {
@@ -155,7 +227,7 @@ fn move_enemies(mut q: Query<(&Velocity, &mut Position)>) {
     }
 }
 
-fn despawn_offscreen(mut commands: Commands, q: Query<(Entity, &Position)>) {
+fn despawn_offscreen(mut commands: Commands, q: Query<(Entity, &Position), Without<BuildingTag>>) {
     for (entity, pos) in q.iter() {
         if pos.0 > PLAYFIELD_WIDTH {
             commands.entity(entity).despawn();
@@ -168,6 +240,7 @@ fn emit_snapshot(
     wave: Res<WaveState>,
     bcast: Res<SnapshotBroadcast>,
     enemies: Query<(Entity, &EnemyTag, &Position, &Health)>,
+    buildings: Query<(Entity, &BuildingTag, &Health)>,
 ) {
     if clock.tick % SNAPSHOT_EVERY_N_TICKS != 0 {
         return;
@@ -186,9 +259,23 @@ fn emit_snapshot(
         });
     }
 
+    let mut building_deltas = Vec::with_capacity(buildings.iter().len());
+    for (entity, tag, hp) in buildings.iter() {
+        building_deltas.push(proto::BuildingDelta {
+            eid: proto::EntityId(entity.index_u32()),
+            kind: tag.kind,
+            col: tag.col,
+            row: tag.row,
+            hp: hp.hp,
+            max_hp: hp.max_hp,
+            online: true,
+            destroyed: false,
+        });
+    }
+
     let field = proto::FieldDelta {
         owner: proto::PlayerSlot(0),
-        buildings: Vec::new(),
+        buildings: building_deltas,
         enemies: enemy_deltas,
         projectiles: Vec::new(),
         gold: 150,


### PR DESCRIPTION
## Summary
Closes the loop end-to-end. Client \`ClientFrame::PlaceBuilding\` inputs land in an mpsc queue, the bevy sim drains them every tick and spawns the matching authoritative entities, and snapshots fan back out with the live building roster.

## Server
- New \`q::net::server::SlotInput\` alias: \`(PlayerSlot, Input)\` — slot is the *authenticated* source, never the wire field.
- \`ServerState\` gains an optional \`mpsc::UnboundedSender<SlotInput>\`. The WS handler decodes every \`ClientFrame\` and forwards each input through the channel, tagged with the admitted slot.
- \`q::nexus_defense_server\`:
  - New \`InputQueue\` resource (\`Mutex<UnboundedReceiver>\`).
  - New \`drain_inputs\` system chained between \`tick_sim\` and \`spawn_wave_enemies\`.
  - \`PlaceBuilding\` spawns a \`BuildingTag\` entity at \`(col*32 + 16, row*32 + 16)\` with the same \`Health\` shape as enemies. Other \`Input\` variants are no-op placeholders until the economy / targeting systems land.
- \`emit_snapshot\` now queries the building set, fills \`FieldDelta.buildings\`.
- \`despawn_offscreen\` scoped \`Without<BuildingTag>\` so buildings stick around past the enemy despawn line.

## Client
- \`q::nexus_defense::match_socket\`:
  - New \`#[func] send_place_building(client_tick, col, row, kind_idx)\`. \`kind_idx\` maps to \`proto::BuildKind\` by discriminant (Tower=0 … Nexus=8).
  - Refactored \`send_heartbeat\` to share \`send_frame\` helper.
  - \`Inbound::Snapshot\` carries \`building_count\`. Godot \`snapshot\` signal gains an extra \`i64\` between \`enemy_count\` and \`gold\`.
  - Renamed \`is_connected → is_ws_connected\` to avoid colliding with the built-in \`Object.is_connected(signal, callable)\` (gdscript was dispatching to the wrong overload).
- \`apps/td-server\`: mpsc channel sender + receiver threaded into \`ServerState\` and \`build_app\`.

## main.gd
- \`place_build\` action (left-click or space) calls \`send_place_building\` with a deterministic test placement at row 8 and an incrementing column.
- \`ND_AUTO_PLACE\` env triggers an auto-place 0.8 s after Welcome so headless smoke can exercise the input path.
- Snapshot handler logs \`buildings=N\` alongside \`enemies=\`/\`gold=\`/\`lives=\`.
- Verbose \`connect()\` return-check on each signal — diagnosed the \`is_connected\` collision listed above.

## Test plan
- [ ] \`cargo build -p td-server && cargo build -p q --no-default-features --features nexus-defense\` (release + debug) — both green here.
- [ ] Run \`td-server\` locally, then open the godot project (F5) — HUD shows \`buildings=0\` initially.
- [ ] Click in the play field (or press space) → server logs receive \`PlaceBuilding\`, next snapshot reports \`buildings=1\`.
- [ ] \`ND_AUTO_PLACE=1 godot --headless --quit-after 15\` fires an auto-place 0.8 s after Welcome; snapshot count climbs to 1.

> Sandbox/CI note: this terminal's Bash sandbox kills headless Godot with exit 137 before the auto-place fires, so the final end-to-end log can't be captured here. The server-side compile + smoke ran clean; rest is verified in the Godot editor on the dev box.

## Next
- Per-slot \`FieldDelta\` so each player sees their own enemies/buildings.
- Validate placement (cost, terrain, collision) instead of free spawn.
- Targeting + projectile systems wired off \`Retarget\` / \`SkipWave\` inputs.

## Related
- #11294 — multiplayer TD tracker
- #11334 — multi-slot roster (this PR fills inputs in)
- #11326 — bevy wave spawner (extends with building system)