### PR TITLE
feat(gh-backfill): resolve GitHub PAT via Supabase Vault (per-guild)

### DIFF
--- a/apps/kbve/edge/functions/gh-backfill/index.ts
+++ b/apps/kbve/edge/functions/gh-backfill/index.ts
@@ -15,10 +15,14 @@ import {
 interface BackfillRequest {
   owner: string;
   repo: string;
+  guild_id?: string;
   state?: "open" | "closed" | "all";
   per_page?: number;
   max_pages?: number;
 }
+
+const SNOWFLAKE_RE = /^[0-9]{17,20}$/;
+const VAULT_GITHUB_SERVICE = "github";
 
 interface GitHubIssueResp {
   number: number;
@@ -114,13 +118,35 @@ serve(async (req) => {
   const perPage = Math.min(Math.max(body.per_page ?? DEFAULT_PER_PAGE, 1), 100);
   const maxPages = Math.min(Math.max(body.max_pages ?? DEFAULT_MAX_PAGES, 1), 50);
 
-  const githubToken = Deno.env.get("GITHUB_TOKEN") ?? Deno.env.get("GITHUB_TOKEN_PAT");
-  if (!githubToken) {
-    console.error("gh-backfill: GITHUB_TOKEN not configured");
-    return jsonResponse({ error: "Server not configured" }, 500);
+  const guildId = (body.guild_id ?? Deno.env.get("GH_BACKFILL_DEFAULT_GUILD_ID") ?? "").trim();
+  if (!SNOWFLAKE_RE.test(guildId)) {
+    return jsonResponse(
+      {
+        error:
+          "guild_id is required and must be a Discord snowflake (17–20 digits). Pass in body or set GH_BACKFILL_DEFAULT_GUILD_ID on the edge deployment.",
+      },
+      400,
+    );
   }
 
   const sb = createServiceClient();
+
+  const { data: githubToken, error: tokenErr } = await sb.rpc(
+    "bot_get_guild_token",
+    { p_server_id: guildId, p_service: VAULT_GITHUB_SERVICE },
+  );
+  if (tokenErr) {
+    console.error("gh-backfill: vault lookup failed:", tokenErr.message);
+    return jsonResponse({ error: "Failed to resolve GitHub token from vault" }, 500);
+  }
+  if (!githubToken || typeof githubToken !== "string") {
+    return jsonResponse(
+      {
+        error: `No GitHub PAT found in vault for guild ${guildId} (service=${VAULT_GITHUB_SERVICE}).`,
+      },
+      404,
+    );
+  }
 
   let upserted = 0;
   let page = 1;


### PR DESCRIPTION
Follow-up to #11349 (still pending dev → main → publish). Refactors gh-backfill to resolve its GitHub PAT from the existing guild-vault row instead of an inline \`GITHUB_TOKEN\` env var on the edge deployment.

## Why

The bot already stores per-guild GitHub PATs in Supabase Vault under tag \`github_pat:<server_id>\` (lookup via \`public.bot_get_guild_token\`). Adding a duplicate env-var copy on the edge deployment would split the source of truth and block per-guild scaling. This change reuses the row the bot already has for \`/github\` commands — zero new secret material on the edge side.

## Changes

\`apps/kbve/edge/functions/gh-backfill/index.ts\`:
- Accept optional \`guild_id\` in request body; default \`GH_BACKFILL_DEFAULT_GUILD_ID\` env.
- Validate Discord snowflake shape (\`^[0-9]{17,20}$\`) before calling the RPC.
- Call \`supabase.rpc("bot_get_guild_token", { p_server_id, p_service: "github" })\` to fetch the PAT.
- Distinguish 404 (vault row missing for guild) from 500 (RPC error).
- Drops the old \`Deno.env.get("GITHUB_TOKEN")\` fallback.

## Same publish cycle

#11349 bumped \`edge.mdx\` to v0.1.32; ci-docker has not yet built/published that version. This PR lands the refactor before the publish fires, so v0.1.32 ships the Vault-aware code.

## Ops impact

Once merged + published:
1. **One k8s env** to add on \`functions-deployment.yaml\`: \`GH_BACKFILL_DEFAULT_GUILD_ID=<kbve_guild_id>\` (optional — can pass \`guild_id\` per request instead).
2. **No PAT secret to add** — bot's existing Vault row is reused.
3. Webhook secret (\`GITHUB_WEBHOOK_SECRET\`) + repo allowlist (\`GH_WEBHOOK_ALLOWED_REPOS\`) still need to be set on edge env (separate from PAT path; gh-webhook is hot-path and can't Vault per delivery).