### PR TITLE
feat(q,nexus-defense): per-slot FieldDelta — each player gets own wave + buildings

### DIFF
--- a/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8601d21a86a5b1e219a0883223f429154d8f69645eeffda34c2dbea6ccd45a8
-size 9194920
+oid sha256:c371af69fa1f35ff66ba8703a5766c492a82e4c7f0c6a267fd413e7ddfb44c98
+size 6890584

--- a/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78002f79d6544651b1c88d23780855fe7d971c1bdd0bcbc648c05ba0a4078424
+oid sha256:aa6860b9bbf8ea47bd214e36cc66d53454b4f098e9d6b1633356d96b695ba9f7
 size 4200128

--- a/apps/godot/nexus-defense/tests/components/test_tower_sprite.gd
+++ b/apps/godot/nexus-defense/tests/components/test_tower_sprite.gd
@@ -1,0 +1,68 @@
+extends GdUnitTestSuite
+
+const TowerSprite := preload("res://ui/components/tower_sprite.gd")
+
+var _sprite: Node2D
+
+func before_test() -> void:
+	_sprite = auto_free(TowerSprite.new())
+	add_child(_sprite)
+	await await_idle_frame()
+
+func test_builds_color_rect_with_shader_material() -> void:
+	var rect: ColorRect = _sprite.get("_rect")
+	var mat: ShaderMaterial = _sprite.get("_mat")
+	assert_object(rect).is_not_null()
+	assert_object(mat).is_not_null()
+	assert_object(rect.material).is_same(mat)
+
+func test_sprite_centered_on_parent_origin() -> void:
+	var rect: ColorRect = _sprite.get("_rect")
+	var sz: Vector2 = _sprite.get("sprite_size")
+	assert_that(rect.position).is_equal(-sz * 0.5)
+
+func test_apply_id_maps_arrow_to_type_zero() -> void:
+	_sprite.call("apply_id", "arrow")
+	assert_int(int(_sprite.get("tower_type"))).is_equal(TowerSprite.TYPE_ARROW)
+	assert_that(_sprite.get("accent_color")).is_equal(TowerSprite.ACCENT_FROM_ID["arrow"])
+
+func test_apply_id_maps_cannon_frost_magic() -> void:
+	_sprite.call("apply_id", "cannon")
+	assert_int(int(_sprite.get("tower_type"))).is_equal(TowerSprite.TYPE_CANNON)
+	_sprite.call("apply_id", "frost")
+	assert_int(int(_sprite.get("tower_type"))).is_equal(TowerSprite.TYPE_FROST)
+	_sprite.call("apply_id", "magic")
+	assert_int(int(_sprite.get("tower_type"))).is_equal(TowerSprite.TYPE_MAGIC)
+
+func test_apply_id_unknown_defaults_to_arrow() -> void:
+	_sprite.call("apply_id", "no_such_tower")
+	assert_int(int(_sprite.get("tower_type"))).is_equal(TowerSprite.TYPE_ARROW)
+
+func test_setter_pushes_to_shader_uniform() -> void:
+	_sprite.set("tower_type", TowerSprite.TYPE_FROST)
+	var mat: ShaderMaterial = _sprite.get("_mat")
+	assert_int(int(mat.get_shader_parameter("tower_type"))).is_equal(TowerSprite.TYPE_FROST)
+
+func test_accent_setter_pushes_to_shader() -> void:
+	var col := Color(0.2, 0.6, 0.4, 1.0)
+	_sprite.set("accent_color", col)
+	var mat: ShaderMaterial = _sprite.get("_mat")
+	assert_that(mat.get_shader_parameter("accent_color")).is_equal(col)
+
+func test_level_clamps_to_valid_range() -> void:
+	_sprite.set("level", 10.0)
+	assert_float(float(_sprite.get("level"))).is_equal_approx(3.0, 0.001)
+	_sprite.set("level", 0.1)
+	assert_float(float(_sprite.get("level"))).is_equal_approx(0.5, 0.001)
+
+func test_apply_dict_routes_to_helpers() -> void:
+	_sprite.call("apply", {"id": "magic", "level": 2.0, "size": Vector2(64, 64)})
+	assert_int(int(_sprite.get("tower_type"))).is_equal(TowerSprite.TYPE_MAGIC)
+	assert_float(float(_sprite.get("level"))).is_equal_approx(2.0, 0.001)
+	assert_that(_sprite.get("sprite_size")).is_equal(Vector2(64, 64))
+
+func test_sprite_size_setter_resizes_rect() -> void:
+	_sprite.set("sprite_size", Vector2(80, 80))
+	var rect: ColorRect = _sprite.get("_rect")
+	assert_that(rect.size).is_equal(Vector2(80, 80))
+	assert_that(rect.position).is_equal(Vector2(-40, -40))

--- a/apps/godot/nexus-defense/tests/components/test_tower_sprite.gd.uid
+++ b/apps/godot/nexus-defense/tests/components/test_tower_sprite.gd.uid
@@ -1,0 +1,1 @@
+uid://bas0bd3r1abib

--- a/apps/godot/nexus-defense/ui/components/tower_sprite.gd
+++ b/apps/godot/nexus-defense/ui/components/tower_sprite.gd
@@ -1,0 +1,92 @@
+extends Node2D
+
+const TOWER_SHADER := preload("res://ui/shaders/tower.gdshader")
+
+const TYPE_ARROW := 0
+const TYPE_CANNON := 1
+const TYPE_FROST := 2
+const TYPE_MAGIC := 3
+
+const TYPE_FROM_ID := {
+	"arrow": TYPE_ARROW,
+	"cannon": TYPE_CANNON,
+	"frost": TYPE_FROST,
+	"magic": TYPE_MAGIC,
+}
+
+const ACCENT_FROM_ID := {
+	"arrow": Color(0.34, 0.85, 0.45, 1.0),
+	"cannon": Color(0.95, 0.55, 0.32, 1.0),
+	"frost": Color(0.5, 0.78, 0.95, 1.0),
+	"magic": Color(0.8, 0.5, 0.95, 1.0),
+}
+
+@export var sprite_size: Vector2 = Vector2(48, 48):
+	set(value):
+		sprite_size = value
+		if _rect:
+			_rect.size = value
+			_rect.position = -value * 0.5
+			_push_uniforms()
+@export var tower_type: int = TYPE_ARROW:
+	set(value):
+		tower_type = clamp(value, 0, 3)
+		_push_uniforms()
+@export var base_color: Color = Color(0.32, 0.36, 0.46, 1.0):
+	set(value):
+		base_color = value
+		_push_uniforms()
+@export var accent_color: Color = Color(0.32, 0.78, 0.95, 1.0):
+	set(value):
+		accent_color = value
+		_push_uniforms()
+@export var level: float = 1.0:
+	set(value):
+		level = clamp(value, 0.5, 3.0)
+		_push_uniforms()
+
+var _rect: ColorRect = null
+var _mat: ShaderMaterial = null
+
+func _ready() -> void:
+	_build()
+
+func _build() -> void:
+	_mat = ShaderMaterial.new()
+	_mat.shader = TOWER_SHADER
+	_rect = ColorRect.new()
+	_rect.size = sprite_size
+	_rect.position = -sprite_size * 0.5
+	_rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_rect.material = _mat
+	add_child(_rect)
+	_push_uniforms()
+
+func _push_uniforms() -> void:
+	if _mat == null:
+		return
+	_mat.set_shader_parameter("tower_type", tower_type)
+	_mat.set_shader_parameter("base_color", base_color)
+	_mat.set_shader_parameter("accent_color", accent_color)
+	_mat.set_shader_parameter("level", level)
+	_mat.set_shader_parameter("rect_size", sprite_size)
+
+func apply_id(tower_id: String) -> void:
+	tower_type = int(TYPE_FROM_ID.get(tower_id, TYPE_ARROW))
+	accent_color = ACCENT_FROM_ID.get(tower_id, accent_color)
+
+func apply(data: Variant) -> void:
+	if typeof(data) != TYPE_DICTIONARY:
+		return
+	if data.has("id"):
+		apply_id(String(data["id"]))
+	if data.has("tower_type"):
+		tower_type = int(data["tower_type"])
+	if data.has("accent_color"):
+		accent_color = data["accent_color"]
+	if data.has("base_color"):
+		base_color = data["base_color"]
+	if data.has("level"):
+		level = float(data["level"])
+	if data.has("size"):
+		sprite_size = data["size"]

--- a/apps/godot/nexus-defense/ui/components/tower_sprite.gd.uid
+++ b/apps/godot/nexus-defense/ui/components/tower_sprite.gd.uid
@@ -1,0 +1,1 @@
+uid://wuk3i7ir15at

--- a/apps/godot/nexus-defense/ui/shaders/tower.gdshader
+++ b/apps/godot/nexus-defense/ui/shaders/tower.gdshader
@@ -1,0 +1,96 @@
+shader_type canvas_item;
+
+uniform int tower_type : hint_range(0, 3) = 0;
+uniform vec4 base_color : source_color = vec4(0.32, 0.36, 0.46, 1.0);
+uniform vec4 accent_color : source_color = vec4(0.32, 0.78, 0.95, 1.0);
+uniform vec4 outline_color : source_color = vec4(0.04, 0.06, 0.10, 1.0);
+uniform float level : hint_range(0.5, 3.0) = 1.0;
+uniform float outline_width : hint_range(0.0, 4.0) = 1.5;
+uniform vec2 rect_size = vec2(48.0, 48.0);
+
+float sdf_rect(vec2 p, vec2 b) {
+	vec2 d = abs(p) - b;
+	return length(max(d, vec2(0.0))) + min(max(d.x, d.y), 0.0);
+}
+
+float sdf_circle(vec2 p, float r) {
+	return length(p) - r;
+}
+
+float sdf_triangle_iso(vec2 p, float halfw, float h) {
+	p.x = abs(p.x);
+	float k = halfw / max(h, 0.001);
+	float d1 = p.x * h / sqrt(h * h + halfw * halfw) + p.y * halfw / sqrt(h * h + halfw * halfw) - halfw * h / sqrt(h * h + halfw * halfw);
+	float d2 = -p.y - h * 0.5;
+	return max(d1, d2);
+}
+
+float sdf_hex(vec2 p, float s) {
+	const vec3 k = vec3(-0.866025404, 0.5, 0.577350269);
+	p = abs(p);
+	p -= 2.0 * min(dot(k.xy, p), 0.0) * k.xy;
+	p -= vec2(clamp(p.x, -k.z * s, k.z * s), s);
+	return length(p) * sign(p.y);
+}
+
+float sdf_diamond(vec2 p, vec2 b) {
+	p = abs(p);
+	return (p.x * b.y + p.y * b.x - b.x * b.y) / length(b);
+}
+
+float merge(float a, float b) { return min(a, b); }
+
+float arrow_sdf(vec2 p, float s) {
+	float base = sdf_rect(p - vec2(0.0, s * 0.42), vec2(s * 0.32, s * 0.32));
+	float spire = sdf_triangle_iso(p - vec2(0.0, -s * 0.15), s * 0.36, s * 0.65);
+	return merge(base, spire);
+}
+
+float cannon_sdf(vec2 p, float s) {
+	float base = sdf_rect(p - vec2(0.0, s * 0.25), vec2(s * 0.48, s * 0.42));
+	float barrel = sdf_circle(p - vec2(0.0, -s * 0.18), s * 0.32);
+	return merge(base, barrel);
+}
+
+float frost_sdf(vec2 p, float s) {
+	float outer = sdf_hex(p, s * 0.62);
+	return outer;
+}
+
+float magic_sdf(vec2 p, float s) {
+	float orb = sdf_circle(p, s * 0.46);
+	return orb;
+}
+
+float silhouette(vec2 p, int t, float s) {
+	if (t == 0) return arrow_sdf(p, s);
+	if (t == 1) return cannon_sdf(p, s);
+	if (t == 2) return frost_sdf(p, s);
+	return magic_sdf(p, s);
+}
+
+float accent_mask(vec2 p, int t, float s) {
+	if (t == 0) return sdf_triangle_iso(p - vec2(0.0, -s * 0.30), s * 0.20, s * 0.34);
+	if (t == 1) return sdf_circle(p - vec2(0.0, -s * 0.18), s * 0.16);
+	if (t == 2) return sdf_hex(p, s * 0.28);
+	return abs(sdf_circle(p, s * 0.30)) - s * 0.05;
+}
+
+void fragment() {
+	vec2 px = (UV - vec2(0.5)) * rect_size;
+	float s = min(rect_size.x, rect_size.y) * 0.5 * clamp(level, 0.5, 3.0);
+
+	float body = silhouette(px, tower_type, s);
+	float acc = accent_mask(px, tower_type, s);
+
+	float body_alpha = 1.0 - smoothstep(-1.0, 1.0, body);
+	float outline = smoothstep(-outline_width, 0.0, body) - smoothstep(0.0, 1.0, body);
+	float acc_alpha = (1.0 - smoothstep(-1.0, 1.0, acc)) * body_alpha;
+
+	vec4 col = base_color;
+	col.rgb = mix(col.rgb, accent_color.rgb, acc_alpha);
+	col.rgb = mix(col.rgb, outline_color.rgb, outline);
+	col.a *= max(body_alpha, outline);
+
+	COLOR = col;
+}

--- a/apps/godot/nexus-defense/ui/shaders/tower.gdshader.uid
+++ b/apps/godot/nexus-defense/ui/shaders/tower.gdshader.uid
@@ -1,0 +1,1 @@
+uid://dx0217bm5qft7

--- a/apps/td-server/src/main.rs
+++ b/apps/td-server/src/main.rs
@@ -34,18 +34,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Input mailbox: WS sessions -> bevy sim.
     let (input_tx, input_rx) = mpsc::unbounded_channel::<q::net::server::SlotInput>();
 
-    // Bevy headless app — runs on a dedicated blocking thread so the App
-    // (which holds non-Send schedule state) never crosses task boundaries.
-    let sim_tx = snap_tx.clone();
-    let sim_handle = tokio::task::spawn_blocking(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
-            .build()
-            .expect("sim runtime");
-        let app = build_app(sim_tx, input_rx, seed);
-        rt.block_on(run_sim_loop(app));
-    });
-
     let jwt_secret = std::env::var("SUPABASE_JWT_SECRET")
         .unwrap_or_default()
         .into_bytes();
@@ -55,7 +43,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "supabase HS256"
     };
 
-    let state = q::net::server::ServerState::new(snap_tx, input_tx, seed, jwt_secret);
+    // Build ServerState first so the sim + WS layer share the same roster.
+    let state = q::net::server::ServerState::new(snap_tx.clone(), input_tx, seed, jwt_secret);
+    let roster = state.roster.clone();
+
+    // Bevy headless app — runs on a dedicated blocking thread so the App
+    // (which holds non-Send schedule state) never crosses task boundaries.
+    let sim_handle = tokio::task::spawn_blocking(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("sim runtime");
+        let app = build_app(snap_tx, input_rx, roster, seed);
+        rt.block_on(run_sim_loop(app));
+    });
+
     let router = q::net::server::router(state);
 
     tracing::info!(%addr, %seed, auth = %auth_mode, "td-server listening");

--- a/packages/rust/q/src/net/server.rs
+++ b/packages/rust/q/src/net/server.rs
@@ -73,6 +73,16 @@ impl Roster {
             })
             .collect()
     }
+
+    /// Enumerate every claimed slot. Used by the sim to size per-player
+    /// fields (`Snapshot.fields[]`) and per-player wave spawners.
+    pub fn active_slots(&self) -> Vec<proto::PlayerSlot> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| s.as_ref().map(|_| proto::PlayerSlot(i as u8)))
+            .collect()
+    }
 }
 
 #[derive(Clone)]

--- a/packages/rust/q/src/nexus_defense/match_socket.rs
+++ b/packages/rust/q/src/nexus_defense/match_socket.rs
@@ -315,6 +315,9 @@ async fn run_socket(
     });
 
     // Inbound pump — drain ws messages, decode postcard, push to channel.
+    // Track the slot Welcome assigned so we can pick the matching FieldDelta
+    // out of every Snapshot (server emits one per active player).
+    let mut own_slot: Option<u8> = None;
     while let Some(frame) = reader.next().await {
         match frame {
             Ok(Message::Binary(mut bytes)) => match proto::decode::<ServerEvent>(&mut bytes) {
@@ -323,13 +326,16 @@ async fn run_socket(
                     your_slot,
                     seed,
                 }) => {
+                    own_slot = Some(your_slot.0);
                     let _ = tx.send(Inbound::Welcome {
                         slot: your_slot.0,
                         seed,
                     });
                 }
                 Ok(ServerEvent::Snapshot(snap)) => {
-                    let field = snap.fields.first();
+                    let field = own_slot
+                        .and_then(|s| snap.fields.iter().find(|f| f.owner.0 == s))
+                        .or_else(|| snap.fields.first());
                     let enemy_count = field.map(|f| f.enemies.len() as u32).unwrap_or(0);
                     let building_count = field.map(|f| f.buildings.len() as u32).unwrap_or(0);
                     let wave = field.map(|f| f.wave).unwrap_or(0);

--- a/packages/rust/q/src/nexus_defense_server/mod.rs
+++ b/packages/rust/q/src/nexus_defense_server/mod.rs
@@ -9,8 +9,14 @@
 //! the axum WS layer feeds; snapshots flow out via a
 //! `tokio::sync::broadcast::Sender<ServerEvent>` so each WS connection can
 //! subscribe a `Receiver`.
+//!
+//! Each `Snapshot` carries one `FieldDelta` per active roster slot. Enemies
+//! and buildings are owned by a `PlayerSlot` and partitioned into the
+//! matching field on the way out — every player gets their own wave + their
+//! own placements, which is the parallel-race default per the design tracker.
 
-use std::sync::Mutex;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use bevy::app::App;
@@ -22,6 +28,7 @@ use bevy::prelude::{
 use tokio::sync::{broadcast, mpsc};
 use tokio::time;
 
+use crate::net::server::Roster;
 use crate::proto::{self, Input, ServerEvent};
 
 /// Server sim tick rate. 20 Hz matches the design budget in #11294.
@@ -40,7 +47,6 @@ pub const SNAPSHOT_BROADCAST_CAPACITY: usize = 256;
 /// Map dimensions used by the placeholder spawner.
 const PLAYFIELD_WIDTH: f32 = 800.0;
 const SPAWN_X: f32 = 0.0;
-const SPAWN_Y: f32 = 240.0;
 const ENEMY_SPEED: f32 = 60.0;
 const ENEMY_HP: f32 = 50.0;
 const ENEMIES_PER_WAVE: u32 = 10;
@@ -48,6 +54,9 @@ const ENEMIES_PER_WAVE: u32 = 10;
 const SPAWN_INTERVAL_TICKS: u32 = 10;
 /// Ticks between waves (5 s at 20 Hz).
 const WAVE_INTERVAL_TICKS: u32 = SIM_TICK_HZ * 5;
+/// Vertical stripe assigned to each slot — slot 0 at y=120, slot 1 at y=280, etc.
+const SLOT_STRIPE_BASE: f32 = 120.0;
+const SLOT_STRIPE_HEIGHT: f32 = 160.0;
 
 const BUILDING_HP: f32 = 200.0;
 
@@ -67,15 +76,26 @@ pub struct SimSeed(pub u64);
 
 /// Mailbox of authenticated inputs (slot + payload) waiting to be applied to
 /// the bevy world. The WS handler is the sole producer; `drain_inputs` is the
-/// sole consumer. `Mutex` is only here so bevy can hold the !Send Receiver
-/// inside a `Resource` — we never have actual contention.
+/// sole consumer.
 #[derive(Resource)]
 pub struct InputQueue {
     pub rx: Mutex<mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>>,
 }
 
+/// Shared roster handle from `q::net::server::ServerState`. The sim reads it
+/// each tick to drive per-player wave spawns + snapshot framing.
+#[derive(Resource, Clone)]
+pub struct RosterHandle(pub Arc<RwLock<Roster>>);
+
+/// Per-slot wave bookkeeping. One row per active slot; the sim drops rows
+/// when a slot vacates (handled in `spawn_wave_enemies`).
 #[derive(Resource, Default)]
 pub struct WaveState {
+    pub slots: HashMap<u8, SlotWave>,
+}
+
+#[derive(Default)]
+pub struct SlotWave {
     pub wave: u16,
     pub spawned_in_wave: u32,
     pub next_spawn_tick: u32,
@@ -97,6 +117,7 @@ pub struct Health {
 #[derive(Component)]
 pub struct EnemyTag {
     pub kind: proto::EnemyKind,
+    pub owner: proto::PlayerSlot,
 }
 
 #[derive(Component)]
@@ -107,11 +128,12 @@ pub struct BuildingTag {
     pub row: i32,
 }
 
-/// Build a headless bevy `App` wired to broadcast snapshots over `tx` and
-/// accept inputs from `input_rx`.
+/// Build a headless bevy `App` wired to broadcast snapshots over `tx`,
+/// accept inputs from `input_rx`, and read the shared roster from `roster`.
 pub fn build_app(
     tx: broadcast::Sender<ServerEvent>,
     input_rx: mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>,
+    roster: Arc<RwLock<Roster>>,
     seed: u64,
 ) -> App {
     let mut app = App::new();
@@ -121,6 +143,7 @@ pub fn build_app(
         .insert_resource(InputQueue {
             rx: Mutex::new(input_rx),
         })
+        .insert_resource(RosterHandle(roster))
         .insert_resource(WaveState::default())
         .add_systems(
             Update,
@@ -184,40 +207,62 @@ fn apply_input(slot: proto::PlayerSlot, input: Input, commands: &mut Commands) {
     }
 }
 
-fn spawn_wave_enemies(clock: Res<SimClock>, mut wave: ResMut<WaveState>, mut commands: Commands) {
-    if clock.tick >= wave.next_wave_tick && wave.spawned_in_wave >= ENEMIES_PER_WAVE {
-        wave.wave = wave.wave.wrapping_add(1);
-        wave.spawned_in_wave = 0;
-        wave.next_spawn_tick = clock.tick;
-        wave.next_wave_tick = clock.tick + WAVE_INTERVAL_TICKS;
-    }
-
-    if wave.spawned_in_wave >= ENEMIES_PER_WAVE {
-        return;
-    }
-    if clock.tick < wave.next_spawn_tick {
-        return;
-    }
-
-    let kind = match wave.spawned_in_wave % 4 {
-        0 => proto::EnemyKind::Runner,
-        1 => proto::EnemyKind::Scout,
-        2 => proto::EnemyKind::Brute,
-        _ => proto::EnemyKind::Shielded,
+fn spawn_wave_enemies(
+    clock: Res<SimClock>,
+    roster: Res<RosterHandle>,
+    mut wave: ResMut<WaveState>,
+    mut commands: Commands,
+) {
+    let active = match roster.0.read() {
+        Ok(r) => r.active_slots(),
+        Err(p) => p.into_inner().active_slots(),
     };
+    if active.is_empty() {
+        return;
+    }
 
-    commands.spawn((
-        EnemyTag { kind },
-        Position(SPAWN_X, SPAWN_Y + (wave.spawned_in_wave as f32 * 4.0)),
-        Velocity(ENEMY_SPEED, 0.0),
-        Health {
-            hp: ENEMY_HP,
-            max_hp: ENEMY_HP,
-        },
-    ));
+    // Drop bookkeeping for slots that vacated.
+    let active_set: std::collections::HashSet<u8> = active.iter().map(|s| s.0).collect();
+    wave.slots.retain(|k, _| active_set.contains(k));
 
-    wave.spawned_in_wave += 1;
-    wave.next_spawn_tick = clock.tick + SPAWN_INTERVAL_TICKS;
+    for slot in active {
+        let entry = wave.slots.entry(slot.0).or_default();
+
+        if clock.tick >= entry.next_wave_tick && entry.spawned_in_wave >= ENEMIES_PER_WAVE {
+            entry.wave = entry.wave.wrapping_add(1);
+            entry.spawned_in_wave = 0;
+            entry.next_spawn_tick = clock.tick;
+            entry.next_wave_tick = clock.tick + WAVE_INTERVAL_TICKS;
+        }
+
+        if entry.spawned_in_wave >= ENEMIES_PER_WAVE {
+            continue;
+        }
+        if clock.tick < entry.next_spawn_tick {
+            continue;
+        }
+
+        let kind = match entry.spawned_in_wave % 4 {
+            0 => proto::EnemyKind::Runner,
+            1 => proto::EnemyKind::Scout,
+            2 => proto::EnemyKind::Brute,
+            _ => proto::EnemyKind::Shielded,
+        };
+
+        let stripe_y = SLOT_STRIPE_BASE + (slot.0 as f32) * SLOT_STRIPE_HEIGHT;
+        commands.spawn((
+            EnemyTag { kind, owner: slot },
+            Position(SPAWN_X, stripe_y + (entry.spawned_in_wave as f32 * 4.0)),
+            Velocity(ENEMY_SPEED, 0.0),
+            Health {
+                hp: ENEMY_HP,
+                max_hp: ENEMY_HP,
+            },
+        ));
+
+        entry.spawned_in_wave += 1;
+        entry.next_spawn_tick = clock.tick + SPAWN_INTERVAL_TICKS;
+    }
 }
 
 fn move_enemies(mut q: Query<(&Velocity, &mut Position)>) {
@@ -239,6 +284,7 @@ fn emit_snapshot(
     clock: Res<SimClock>,
     wave: Res<WaveState>,
     bcast: Res<SnapshotBroadcast>,
+    roster: Res<RosterHandle>,
     enemies: Query<(Entity, &EnemyTag, &Position, &Health)>,
     buildings: Query<(Entity, &BuildingTag, &Health)>,
 ) {
@@ -246,49 +292,66 @@ fn emit_snapshot(
         return;
     }
 
-    let mut enemy_deltas = Vec::with_capacity(enemies.iter().len());
-    for (entity, tag, pos, hp) in enemies.iter() {
-        enemy_deltas.push(proto::EnemyDelta {
-            eid: proto::EntityId(entity.index_u32()),
-            kind: tag.kind,
-            pos: proto::Vec2 { x: pos.0, y: pos.1 },
-            hp: hp.hp,
-            max_hp: hp.max_hp,
-            status_bits: 0,
-            destroyed: false,
-        });
-    }
-
-    let mut building_deltas = Vec::with_capacity(buildings.iter().len());
-    for (entity, tag, hp) in buildings.iter() {
-        building_deltas.push(proto::BuildingDelta {
-            eid: proto::EntityId(entity.index_u32()),
-            kind: tag.kind,
-            col: tag.col,
-            row: tag.row,
-            hp: hp.hp,
-            max_hp: hp.max_hp,
-            online: true,
-            destroyed: false,
-        });
-    }
-
-    let field = proto::FieldDelta {
-        owner: proto::PlayerSlot(0),
-        buildings: building_deltas,
-        enemies: enemy_deltas,
-        projectiles: Vec::new(),
-        gold: 150,
-        lives: 20,
-        wave: wave.wave,
+    let active = match roster.0.read() {
+        Ok(r) => r.active_slots(),
+        Err(p) => p.into_inner().active_slots(),
     };
+
+    // Bin entities by owner slot so the per-field loop is one pass.
+    let mut enemy_bins: HashMap<u8, Vec<proto::EnemyDelta>> = HashMap::new();
+    for (entity, tag, pos, hp) in enemies.iter() {
+        enemy_bins
+            .entry(tag.owner.0)
+            .or_default()
+            .push(proto::EnemyDelta {
+                eid: proto::EntityId(entity.index_u32()),
+                kind: tag.kind,
+                pos: proto::Vec2 { x: pos.0, y: pos.1 },
+                hp: hp.hp,
+                max_hp: hp.max_hp,
+                status_bits: 0,
+                destroyed: false,
+            });
+    }
+    let mut building_bins: HashMap<u8, Vec<proto::BuildingDelta>> = HashMap::new();
+    for (entity, tag, hp) in buildings.iter() {
+        building_bins
+            .entry(tag.owner.0)
+            .or_default()
+            .push(proto::BuildingDelta {
+                eid: proto::EntityId(entity.index_u32()),
+                kind: tag.kind,
+                col: tag.col,
+                row: tag.row,
+                hp: hp.hp,
+                max_hp: hp.max_hp,
+                online: true,
+                destroyed: false,
+            });
+    }
+
+    let fields: Vec<proto::FieldDelta> = active
+        .iter()
+        .map(|slot| {
+            let slot_wave = wave.slots.get(&slot.0).map(|w| w.wave).unwrap_or(0);
+            proto::FieldDelta {
+                owner: *slot,
+                buildings: building_bins.remove(&slot.0).unwrap_or_default(),
+                enemies: enemy_bins.remove(&slot.0).unwrap_or_default(),
+                projectiles: Vec::new(),
+                gold: 150,
+                lives: 20,
+                wave: slot_wave,
+            }
+        })
+        .collect();
 
     let snap = proto::Snapshot {
         tick: clock.tick,
         server_time_ms: clock.elapsed_ms,
         input_ack: 0,
         players: Vec::new(),
-        fields: vec![field],
+        fields,
         keyframe: clock.tick % (SIM_TICK_HZ * 5) == 0,
     };
     let _ = bcast.tx.send(ServerEvent::Snapshot(snap));


### PR DESCRIPTION
## Summary
\`Snapshot.fields[]\` now carries one \`FieldDelta\` per active roster slot instead of lumping every player into slot 0. Enemies and buildings are partitioned by their \`owner: PlayerSlot\`; the client picks the field that matches the slot \`Welcome\` assigned it.

Parallel-race default per the tracker (#11294): every player runs their own wave with their own spawns + their own placements. PvP-send mode just needs to cross-route deltas later — the data shape is ready.

## Server (\`q::nexus_defense_server\`)
- New \`RosterHandle\` resource (\`Arc<RwLock<Roster>>\`) shared with \`q::net::server::ServerState\`. \`build_app\` takes it as a fourth arg.
- \`WaveState\` now keyed by slot (\`HashMap<u8, SlotWave>\`). \`spawn_wave_enemies\` iterates the roster's \`active_slots()\`, drives a per-slot wave clock, spawns enemies on the slot's vertical stripe (\`SLOT_STRIPE_BASE + slot * SLOT_STRIPE_HEIGHT\`). Bookkeeping for vacated slots gets trimmed each tick.
- \`EnemyTag\` gains \`owner: PlayerSlot\`; \`BuildingTag.owner\` was already there from the input pump.
- \`emit_snapshot\` bins entities by owner once, materializes one \`FieldDelta\` per active slot in a single pass.

## Net (\`q::net::server\`)
- \`Roster::active_slots()\` — new public API the sim uses to size the per-slot field list.
- \`ServerState.roster\` already public; \`td-server\` clones it into the sim builder.

## \`td-server\`
- Build \`ServerState\` first, clone the roster into the sim's \`spawn_blocking\` closure. Snapshot bus + input mailbox unchanged.

## Client (\`q::nexus_defense::match_socket\`)
- Reader stores \`own_slot\` from \`Welcome\`. On Snapshot, finds the \`FieldDelta\` with \`owner == own_slot\` (falls back to \`fields.first()\` if absent) so the HUD tracks the local player, not whichever slot happens to be at index 0.

## Build matrix
\`\`\`
cargo build -p q                                                          ok
cargo build -p q --no-default-features --features nexus-defense           ok
cargo build -p q --no-default-features --features nexus-defense-server    ok
cargo build -p td-server                                                  ok
cargo test  -p q --no-default-features --features proto-shared --lib proto  3/3 ok
\`\`\`

## Test plan
- [ ] \`cargo run -p td-server\` + two godot clients in parallel — each HUD shows \`enemies=\` rising independently (their own stripe).
- [ ] One client places a tower; the other's snapshot still shows \`buildings=0\` for their own field.
- [ ] Drop one client — the remaining player's snapshot keeps building waves; the vacated slot's bookkeeping drops on the next tick.

## Next
- Placement validation (cost / collision / path) keyed off per-slot economy.
- Per-slot lives / gold tracking (currently hard-coded 150 / 20 in every field).
- Targeting + projectile systems wired off \`Retarget\` inputs.

## Related
- #11294 — multiplayer TD tracker
- #11334 — multi-slot roster (this is the matching sim half)
- #11353 — bidirectional input pump (this extends the snapshot side)