### PR TITLE
feat(gh-webhook): per-guild HMAC secret via Supabase Vault

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -111,7 +111,7 @@
 		{
 			"key": "edge",
 			"app_name": "edge",
-			"version": "0.1.32",
+			"version": "0.1.33",
 			"version_toml": "apps/kbve/edge/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
 			"version_target": "apps/kbve/edge/deno.json",
@@ -209,7 +209,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.18",
+			"version": "0.1.19",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.32"
+version: "0.1.33"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json

--- a/apps/kbve/edge/functions/gh-webhook/index.ts
+++ b/apps/kbve/edge/functions/gh-webhook/index.ts
@@ -13,6 +13,8 @@ const ALLOWED_EVENTS = new Set([
 ]);
 
 const ALLOWED_REPOS = parseAllowlist(Deno.env.get("GH_WEBHOOK_ALLOWED_REPOS"));
+const SNOWFLAKE_RE = /^[0-9]{17,20}$/;
+const VAULT_WEBHOOK_SERVICE = "github_webhook";
 
 interface GithubLabel {
   name?: string;
@@ -145,18 +147,46 @@ serve(async (req) => {
   const sizeErr = enforceBodySizeLimit(req);
   if (sizeErr) return sizeErr;
 
+  const url = new URL(req.url);
+  const segments = url.pathname.split("/").filter((s) => s.length > 0);
+  const guildId = segments[segments.length - 1] ?? "";
+  if (!SNOWFLAKE_RE.test(guildId)) {
+    return jsonResponse(
+      {
+        error:
+          "missing guild_id path segment. Use /functions/v1/gh-webhook/<discord_guild_snowflake>",
+      },
+      400,
+    );
+  }
+
   const githubEvent = req.headers.get("x-github-event") ?? "";
   const deliveryId = req.headers.get("x-github-delivery") ?? null;
   const signature = req.headers.get("x-hub-signature-256");
 
   if (!ALLOWED_EVENTS.has(githubEvent)) {
-    return jsonResponse({ ok: true, skipped: githubEvent }, 200);
+    return jsonResponse({ ok: true, skipped: githubEvent, guild: guildId }, 200);
   }
 
-  const secret = Deno.env.get("GITHUB_WEBHOOK_SECRET");
-  if (!secret) {
-    console.error("gh-webhook: GITHUB_WEBHOOK_SECRET not configured");
-    return jsonResponse({ error: "Server not configured" }, 500);
+  const sb = createServiceClient();
+
+  const { data: secret, error: secretErr } = await sb.rpc(
+    "bot_get_guild_token",
+    { p_server_id: guildId, p_service: VAULT_WEBHOOK_SERVICE },
+  );
+  if (secretErr) {
+    console.error(
+      "gh-webhook: vault lookup failed",
+      { guild: guildId, error: secretErr.message },
+    );
+    return jsonResponse({ error: "Failed to resolve webhook secret" }, 500);
+  }
+  if (!secret || typeof secret !== "string") {
+    console.warn(
+      "gh-webhook: no webhook secret registered for guild",
+      { guild: guildId },
+    );
+    return jsonResponse({ error: "webhook not configured for guild" }, 404);
   }
 
   const rawBody = await req.text();
@@ -165,12 +195,13 @@ serve(async (req) => {
     console.warn("gh-webhook: signature verification failed", {
       delivery: deliveryId,
       event: githubEvent,
+      guild: guildId,
     });
     return jsonResponse({ error: "invalid signature" }, 401);
   }
 
   if (githubEvent === "ping") {
-    return jsonResponse({ ok: true, pong: true }, 200);
+    return jsonResponse({ ok: true, pong: true, guild: guildId }, 200);
   }
 
   let payload: GithubPayload;
@@ -182,20 +213,21 @@ serve(async (req) => {
 
   const repoInfo = repoFromPayload(payload);
   if (!repoInfo) {
-    return jsonResponse({ ok: true, skipped: "no repo in payload" }, 200);
+    return jsonResponse({ ok: true, skipped: "no repo in payload", guild: guildId }, 200);
   }
 
   const fullName = `${repoInfo.owner}/${repoInfo.repo}`.toLowerCase();
   if (ALLOWED_REPOS.size > 0 && !ALLOWED_REPOS.has(fullName)) {
-    return jsonResponse({ ok: true, skipped: `repo not allowlisted: ${fullName}` }, 200);
+    return jsonResponse(
+      { ok: true, skipped: `repo not allowlisted: ${fullName}`, guild: guildId },
+      200,
+    );
   }
 
   const issue = issueFromPayload(payload);
   if (!issue) {
-    return jsonResponse({ ok: true, skipped: "no issue in payload" }, 200);
+    return jsonResponse({ ok: true, skipped: "no issue in payload", guild: guildId }, 200);
   }
-
-  const sb = createServiceClient();
 
   const labels = (issue.labels ?? []).map((l) => ({
     name: l.name,
@@ -250,6 +282,7 @@ serve(async (req) => {
       action: payload.action,
       delivery: deliveryId,
       issue: `${fullName}#${issue.number}`,
+      guild: guildId,
     },
     200,
   );


### PR DESCRIPTION
Follow-up to #11349 + #11354. The previous webhook implementation used a single global \`GITHUB_WEBHOOK_SECRET\` env var on the edge deployment, which would have forced every guild to share one HMAC secret. This rewires gh-webhook to fetch a per-guild secret from Supabase Vault using the same pattern \`gh-backfill\` uses for PATs.

## URL shape

Each guild registers their GitHub webhook at:

\`\`\`
POST /functions/v1/gh-webhook/<discord_guild_snowflake>
\`\`\`

## Function flow

1. Parse \`guild_id\` from the last path segment.
2. Validate Discord snowflake shape \`^[0-9]{17,20}$\` — reject malformed before doing any IO.
3. \`public.bot_get_guild_token(p_server_id=guild_id, p_service='github_webhook')\` resolves this guild's HMAC secret from the existing guild-vault storage.
4. HMAC-verify \`X-Hub-Signature-256\` against that secret.
5. Continue with the existing upsert + record_event flow. Every response now carries \`guild\` for observability.

Chicken-and-egg avoided: we resolve the secret *before* trusting the request body, using only the path segment (which the verifier authenticates against per-guild).

## Operator flow (per guild)

1. Bot guild owner generates a random ≥32-char string.
2. Stores it via the bot's existing guild-vault SET RPC with service \`github_webhook\` for their guild.
3. Configures the GitHub webhook on their repo:
   - URL: \`https://<edge>/functions/v1/gh-webhook/<their_guild_id>\`
   - Secret: same string
   - Events: Issues + Issue comments + Pull requests + PR reviews + PR review comments

No new k8s env or shared secret on the edge deployment.

## Repo allowlist still global

\`GH_WEBHOOK_ALLOWED_REPOS\` env stays as-is — global gate on which repos may write to \`gh.issue\`. Per-guild repo scoping is a future concern; for now any guild whose snowflake has a valid \`github_webhook\` vault row can post events for any allowlisted repo.

## Version

Bumps \`apps/kbve/astro-kbve/src/content/docs/project/edge.mdx\` → \`0.1.33\`. \`v0.1.32\` already shipped with the now-superseded global-env wiring and will need to be replaced before the webhook can serve traffic.

## Manifest

Regenerated \`.github/ci-dispatch-manifest.json\` per the established \"full regen, never surgical\" convention.