### PR TITLE
feat(astro-kbve): /dashboard/agents catalog page (P0 of #11362)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.170",
+			"version": "1.0.171",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",

--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -188,6 +188,7 @@ export default defineConfig({
 						{ label: 'Overview', link: '/dashboard/', attrs: { 'data-auth-visibility': 'auth' } },
 						{ label: 'Profile', link: '/dashboard/profile/', attrs: { 'data-auth-visibility': 'auth' } },
 						{ label: 'Account', link: '/dashboard/account/', attrs: { 'data-auth-visibility': 'auth' } },
+						{ label: 'Agents', link: '/dashboard/agents/', attrs: { 'data-auth-visibility': 'auth' } },
 						{ label: 'Marketplace', link: '/dashboard/market/', attrs: { 'data-auth-visibility': 'auth' } },
 						{ label: 'API', link: '/dashboard/api/' },
 						{ label: 'Kanban', link: '/dashboard/kanban/', attrs: { 'data-auth-visibility': 'auth' } },

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentsDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentsDashboard.astro
@@ -1,0 +1,282 @@
+---
+interface BotIntegration {
+	key: string;
+	name: string;
+	tagline: string;
+	description: string;
+	docs_url: string;
+	manage_url: string | null;
+	services: string[];
+	status: 'available' | 'coming_soon';
+}
+
+const BOTS: BotIntegration[] = [
+	{
+		key: 'discordsh',
+		name: 'discordsh',
+		tagline:
+			'Discord gateway bot — slash commands, GitHub bridge, dungeon game.',
+		description:
+			'Embed dungeon, /gh claim self-assign, /github board reads, GitHub issue → Discord forum thread sync (Phase 2). Per-guild PAT + webhook secret resolved from Supabase Vault.',
+		docs_url: '/project/discordsh-bot/',
+		manage_url: '/dashboard/agents/discordsh/',
+		services: ['github', 'github_webhook', 'github_repos'],
+		status: 'available',
+	},
+	{
+		key: 'irc_gateway',
+		name: 'irc-gateway',
+		tagline: 'JWT-authenticated IRC bridge for chat services.',
+		description:
+			'Bridges KBVE chat traffic to IRC backends. Per-guild routing not yet wired through the agents surface.',
+		docs_url: '/project/irc-gateway/',
+		manage_url: null,
+		services: ['irc'],
+		status: 'coming_soon',
+	},
+];
+
+const statusLabel = (s: BotIntegration['status']) =>
+	s === 'available' ? 'Available' : 'Coming soon';
+---
+
+<section
+	id="agents-dashboard-wrapper"
+	class="agents-dashboard-wrapper kbve-dashboard-page"
+	aria-label="Agents — KBVE bot integration catalog">
+	<div class="dashboard-content">
+		<header class="agents-header not-content">
+			<h1 class="agents-title">Agents</h1>
+			<p class="agents-lede">
+				Self-service registration for KBVE bot integrations. Each bot
+				reads its per-guild secrets (PATs, webhook HMACs, repo
+				allowlists) from Supabase Vault, scoped by your Discord guild
+				ID. Pick a bot to manage its tokens for guilds you own.
+			</p>
+		</header>
+
+		<div class="not-content agents-grid">
+			{
+				BOTS.map((bot) => (
+					<article
+						class={`agent-card agent-card--${bot.status}`}
+						data-agent={bot.key}>
+						<div class="agent-card__head">
+							<h2 class="agent-card__name">{bot.name}</h2>
+							<span
+								class={`agent-card__status agent-card__status--${bot.status}`}>
+								{statusLabel(bot.status)}
+							</span>
+						</div>
+						<p class="agent-card__tagline">{bot.tagline}</p>
+						<p class="agent-card__description">{bot.description}</p>
+
+						<div class="agent-card__services">
+							{bot.services.map((svc) => (
+								<code class="agent-card__service">{svc}</code>
+							))}
+						</div>
+
+						<div class="agent-card__actions">
+							<a
+								class="agent-card__cta agent-card__cta--secondary"
+								href={bot.docs_url}>
+								Docs
+							</a>
+							{bot.manage_url ? (
+								<a
+									class="agent-card__cta agent-card__cta--primary"
+									href={bot.manage_url}>
+									Manage
+								</a>
+							) : (
+								<span
+									class="agent-card__cta agent-card__cta--disabled"
+									aria-disabled="true">
+									Manage
+								</span>
+							)}
+						</div>
+					</article>
+				))
+			}
+		</div>
+	</div>
+</section>
+
+<style>
+	.agents-dashboard-wrapper {
+		background: transparent;
+		min-height: 100vh;
+		position: relative;
+		width: 100%;
+	}
+
+	.dashboard-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 2rem 1rem;
+	}
+
+	@media (min-width: 768px) {
+		.dashboard-content {
+			padding: 2rem 1.5rem;
+		}
+	}
+
+	.agents-header {
+		margin-bottom: 2rem;
+	}
+
+	.agents-title {
+		font-size: clamp(1.75rem, 2.5vw, 2.25rem);
+		font-weight: 700;
+		margin: 0 0 0.5rem;
+		color: var(--sl-color-white, #fff);
+	}
+
+	.agents-lede {
+		font-size: 0.95rem;
+		line-height: 1.6;
+		color: var(--sl-color-gray-2, #c2c5cc);
+		margin: 0;
+		max-width: 56ch;
+	}
+
+	.agents-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 1.25rem;
+	}
+
+	@media (min-width: 720px) {
+		.agents-grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+
+	.agent-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		padding: 1.25rem;
+		border-radius: 12px;
+		border: 1px solid var(--sl-color-gray-5, #2d2f36);
+		background: var(--sl-color-bg-nav, rgba(255, 255, 255, 0.02));
+		transition:
+			border-color 0.15s ease,
+			transform 0.15s ease;
+	}
+
+	.agent-card:hover {
+		border-color: var(--sl-color-accent, #58a6ff);
+	}
+
+	.agent-card--coming_soon {
+		opacity: 0.7;
+	}
+
+	.agent-card__head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+	}
+
+	.agent-card__name {
+		margin: 0;
+		font-size: 1.15rem;
+		font-weight: 600;
+		font-family: var(--sl-font-mono, ui-monospace, monospace);
+	}
+
+	.agent-card__status {
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		padding: 0.2rem 0.55rem;
+		border-radius: 999px;
+		letter-spacing: 0.04em;
+	}
+
+	.agent-card__status--available {
+		background: rgba(34, 197, 94, 0.15);
+		color: #4ade80;
+	}
+
+	.agent-card__status--coming_soon {
+		background: rgba(148, 163, 184, 0.15);
+		color: #94a3b8;
+	}
+
+	.agent-card__tagline {
+		margin: 0;
+		font-size: 0.9rem;
+		color: var(--sl-color-gray-2, #c2c5cc);
+		line-height: 1.45;
+	}
+
+	.agent-card__description {
+		margin: 0;
+		font-size: 0.85rem;
+		color: var(--sl-color-gray-3, #9ca0aa);
+		line-height: 1.55;
+	}
+
+	.agent-card__services {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+	}
+
+	.agent-card__service {
+		font-size: 0.75rem;
+		padding: 0.15rem 0.5rem;
+		border-radius: 6px;
+		background: rgba(88, 166, 255, 0.12);
+		color: #58a6ff;
+		font-family: var(--sl-font-mono, ui-monospace, monospace);
+	}
+
+	.agent-card__actions {
+		display: flex;
+		gap: 0.5rem;
+		margin-top: auto;
+		padding-top: 0.5rem;
+	}
+
+	.agent-card__cta {
+		font-size: 0.85rem;
+		font-weight: 500;
+		padding: 0.45rem 0.9rem;
+		border-radius: 8px;
+		text-decoration: none;
+		transition: background 0.15s ease;
+	}
+
+	.agent-card__cta--primary {
+		background: var(--sl-color-accent, #58a6ff);
+		color: var(--sl-color-text-invert, #0d1117);
+	}
+
+	.agent-card__cta--primary:hover {
+		background: var(--sl-color-accent-high, #79b8ff);
+	}
+
+	.agent-card__cta--secondary {
+		background: rgba(255, 255, 255, 0.05);
+		color: var(--sl-color-white, #fff);
+		border: 1px solid var(--sl-color-gray-5, #2d2f36);
+	}
+
+	.agent-card__cta--secondary:hover {
+		background: rgba(255, 255, 255, 0.08);
+	}
+
+	.agent-card__cta--disabled {
+		background: rgba(255, 255, 255, 0.03);
+		color: var(--sl-color-gray-4, #6b7280);
+		border: 1px solid var(--sl-color-gray-5, #2d2f36);
+		cursor: not-allowed;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/agents/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/agents/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Agents
+description: Self-service management for KBVE bot integrations — Discord, GitHub, IRC, and more.
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: Agents
+    order: 14
+unsplash: 1558494949-ef010cbdcc31
+img: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - agents
+    - bots
+---
+
+import AstroAgentsDashboard from '@/components/dashboard/AstroAgentsDashboard.astro';
+
+<AstroAgentsDashboard />

--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -12,7 +12,7 @@ tags:
 key: astro_kbve
 pipeline: docker
 app_name: axum-kbve
-version: "1.0.170"
+version: "1.0.171"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
 version_target: apps/kbve/axum-kbve/Cargo.toml


### PR DESCRIPTION
First slice of #11362 — the agents self-service surface. Ships P0 (catalog) only; later phases land separately.

## What

\`/dashboard/agents/\` renders a discovery catalog of KBVE bot integrations. Static cards, no auth code, no IO. Same MDX + Astro shell + sidebar pattern as the existing dashboard surfaces (edge, clickhouse, grafana, vm, argo, forgejo).

## Files

- \`apps/kbve/astro-kbve/src/content/docs/dashboard/agents/index.mdx\` — Starlight route with the established frontmatter.
- \`apps/kbve/astro-kbve/src/components/dashboard/AstroAgentsDashboard.astro\` — catalog shell. Header + lede + responsive card grid. Each card: bot name, tagline, description, Vault services it consumes (\`github\` / \`github_webhook\` / \`github_repos\` for discordsh; \`irc\` for irc-gateway), Docs CTA, Manage CTA.
- \`astro.config.mjs\` — new \"Agents\" sidebar entry under Dashboard, \`data-auth-visibility=\"auth\"\` so it only appears for signed-in users (P1+ uses the picker behind that gate).
- \`apps/kbve/astro-kbve/src/content/docs/project/api.mdx\` v1.0.170 → v1.0.171 to retrigger \`axum-kbve\` republish.
- \`.github/ci-dispatch-manifest.json\` regenerated per convention.

## Bot cards in this PR

| Bot | Status | Services | Manage |
|---|---|---|---|
| discordsh | Available | \`github\`, \`github_webhook\`, \`github_repos\` | /dashboard/agents/discordsh/ (404 until P1) |
| irc-gateway | Coming soon | \`irc\` | disabled |

## What this does NOT do

- No auth code yet — P1 wires the Discord guild picker + token list.
- No CRUD — P2 ships the modal flow.
- No GitHub wizard — P3.
- \`/dashboard/agents/discordsh/\` will 404 until P1 lands; the \"Manage\" CTA on the discordsh card is deliberate forward-link.

## Verification

- \`./kbve.sh -nx astro-kbve:build\` ✓
- Manifest regen ✓
- No new dependencies; pure content + UI.