### PR TITLE
feat(mc-behavior): Capital Guards garrison the spawn claim (phase 1)

### DIFF
--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/AiCreatureManager.java
@@ -55,8 +55,19 @@ public class AiCreatureManager {
      */
     private static final String AI_MARKER_TAG = "kbve_ai_creature";
 
+    /**
+     * World-tick of first time a tracked cullable mob was observed inside
+     * the spawn claim. Used to grant a grace window for capital guards to
+     * engage the drifter before the cull sweep kicks in. Cleared when the
+     * mob leaves the claim or is despawned.
+     */
+    private static final long CLAIM_CULL_GRACE_TICKS = 600L;
+
     /** Tracked creatures keyed by Minecraft entity ID. */
     private final ConcurrentHashMap<Integer, CreatureSlot> creatures = new ConcurrentHashMap<>();
+
+    /** When each tracked entity first drifted into the claim (world ticks). */
+    private final ConcurrentHashMap<Integer, Long> firstSeenInClaim = new ConcurrentHashMap<>();
 
     // -----------------------------------------------------------------------
     // Per-creature bookkeeping slot
@@ -137,16 +148,29 @@ public class AiCreatureManager {
      * follow their owner across the claim boundary.
      */
     private void sweepCreaturesInsideSpawnProtection(ServerWorld world) {
+        long now = world.getTime();
         int removed = 0;
         var it = creatures.entrySet().iterator();
         while (it.hasNext()) {
             var entry = it.next();
+            int entityId = entry.getKey();
             var slot = entry.getValue();
             if (slot.ownerEntityId != 0) continue;
-            var entity = world.getEntityById(entry.getKey());
-            if (!(entity instanceof MobEntity mob) || !mob.isAlive()) continue;
-            if (!SpawnRegion.containsBlock(mob.getBlockPos())) continue;
+            if (!slot.kind.cullableInsideClaim()) continue;
+            var entity = world.getEntityById(entityId);
+            if (!(entity instanceof MobEntity mob) || !mob.isAlive()) {
+                firstSeenInClaim.remove(entityId);
+                continue;
+            }
+            if (!SpawnRegion.containsBlock(mob.getBlockPos())) {
+                firstSeenInClaim.remove(entityId);
+                continue;
+            }
+            Long firstTick = firstSeenInClaim.putIfAbsent(entityId, now);
+            long enteredAt = firstTick != null ? firstTick : now;
+            if (now - enteredAt < CLAIM_CULL_GRACE_TICKS) continue;
             entity.discard();
+            firstSeenInClaim.remove(entityId);
             it.remove();
             removed++;
         }
@@ -172,6 +196,7 @@ public class AiCreatureManager {
 
         for (var entry : creatures.entrySet()) {
             var slot = entry.getValue();
+            if (!slot.kind.submitsObservations()) continue;
             var entity = overworld.getEntityById(entry.getKey());
             if (!(entity instanceof MobEntity mob) || !mob.isAlive()) continue;
 
@@ -301,6 +326,70 @@ public class AiCreatureManager {
             entity.discard();
         }
         creatures.remove(entityId);
+    }
+
+    /**
+     * Spawn one instance of {@code kind} at an absolute world surface near
+     * {@code anchor}. Bypasses the spawn-protection rejection — used by the
+     * Capital Guard boot spawner to place guards inside the claim. The
+     * caller is responsible for choosing a sane anchor and for limiting how
+     * many of {@code kind} are alive at any time.
+     *
+     * @return true if a creature was spawned
+     */
+    public boolean spawnAtAnchor(ServerWorld world, CreatureKind kind, BlockPos anchor) {
+        BlockPos surface = world.getTopPosition(
+                Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
+                anchor
+        );
+        MobEntity mob = kind.create(world, surface, null);
+        if (mob == null) return false;
+
+        mob.addCommandTag(AI_MARKER_TAG);
+
+        if (!world.spawnEntity(mob)) {
+            return false;
+        }
+
+        creatures.put(mob.getId(), new CreatureSlot(kind, 0));
+        LOGGER.info("[AI] Spawned {} at [{}, {}, {}] (id={}) at-anchor",
+                kind.tag(),
+                surface.getX(), surface.getY(), surface.getZ(),
+                mob.getId());
+        return true;
+    }
+
+    /**
+     * Re-claim persisted entities matching {@code commandTag} back into the
+     * tracking map under {@code kind}. Used at server start so creatures
+     * with {@code setPersistent(true)} (capital guards) survive restarts —
+     * without this, the next {@link #sweepOrphanedAiCreatures} would
+     * discard them as orphans because the in-memory map starts empty.
+     *
+     * @return number of entities re-claimed
+     */
+    public int reclaimPersistedKind(ServerWorld world, CreatureKind kind, String commandTag) {
+        int reclaimed = 0;
+        for (Entity entity : world.iterateEntities()) {
+            if (!(entity instanceof MobEntity)) continue;
+            if (!entity.isAlive()) continue;
+            if (!entity.getCommandTags().contains(commandTag)) continue;
+            if (creatures.containsKey(entity.getId())) continue;
+            creatures.put(entity.getId(), new CreatureSlot(kind, 0));
+            reclaimed++;
+        }
+        return reclaimed;
+    }
+
+    /** Count tracked, alive creatures of a given kind. */
+    public int aliveCount(ServerWorld world, CreatureKind kind) {
+        int n = 0;
+        for (var entry : creatures.entrySet()) {
+            if (entry.getValue().kind != kind) continue;
+            var entity = world.getEntityById(entry.getKey());
+            if (entity != null && entity.isAlive()) n++;
+        }
+        return n;
     }
 
     // -----------------------------------------------------------------------

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/BehaviorStateTreeMod.java
@@ -87,6 +87,11 @@ public class BehaviorStateTreeMod implements ModInitializer {
         tickHandler.setShipManager(shipManager);
         ServerTickEvents.END_SERVER_TICK.register(tickHandler);
 
+        // Capital Guards: top up the IronGolem garrison inside the spawn
+        // claim on every boot. Vanilla AI handles patrol + aggro; this
+        // mod only owns the population count.
+        CapitalGuardSpawner.register(tickHandler.getCreatureManager());
+
         // Shutdown runtime on server stop
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> {
             LOGGER.info("[{}] Shutting down NPC AI runtime", MOD_ID);

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CapitalGuardKind.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CapitalGuardKind.java
@@ -1,0 +1,97 @@
+package com.kbve.statetree;
+
+import com.google.gson.JsonArray;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeInstance;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.passive.IronGolemEntity;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Capital Guard archetype: vanilla iron golem with boosted stats, anchored
+ * to the spawn-protection cube. Uses the golem's built-in hostile-mob
+ * targeting so no Rust-side behavior tree is required — we just spawn a
+ * very tough guard and let vanilla do the rest.
+ *
+ * <p>This kind opts out of both observation submission (vanilla AI only)
+ * and the claim-drift cull (guards are meant to live inside the claim).
+ */
+final class CapitalGuardKind implements CreatureKind {
+
+    static final double MAX_HEALTH = 500.0;
+    static final double ATTACK_DAMAGE = 30.0;
+    static final double KNOCKBACK_RESISTANCE = 1.0;
+    static final double MOVEMENT_SPEED = 0.30;
+    static final double FOLLOW_RANGE = 64.0;
+
+    /** Scoreboard tag so the boot-time spawner can count surviving guards. */
+    static final String GUARD_TAG = "kbve_capital_guard";
+
+    @Override
+    public String tag() {
+        return "guard";
+    }
+
+    @Override
+    public boolean submitsObservations() {
+        return false;
+    }
+
+    @Override
+    public boolean cullableInsideClaim() {
+        return false;
+    }
+
+    @Override
+    public @Nullable MobEntity create(ServerWorld world, BlockPos pos, @Nullable Entity owner) {
+        IronGolemEntity golem = EntityType.IRON_GOLEM.create(world, SpawnReason.COMMAND);
+        if (golem == null) return null;
+
+        golem.refreshPositionAndAngles(
+                pos.getX() + 0.5,
+                pos.getY(),
+                pos.getZ() + 0.5,
+                world.getRandom().nextFloat() * 360,
+                0
+        );
+        setAttribute(golem, EntityAttributes.MAX_HEALTH, MAX_HEALTH);
+        setAttribute(golem, EntityAttributes.ATTACK_DAMAGE, ATTACK_DAMAGE);
+        setAttribute(golem, EntityAttributes.KNOCKBACK_RESISTANCE, KNOCKBACK_RESISTANCE);
+        setAttribute(golem, EntityAttributes.MOVEMENT_SPEED, MOVEMENT_SPEED);
+        setAttribute(golem, EntityAttributes.FOLLOW_RANGE, FOLLOW_RANGE);
+        golem.setHealth((float) MAX_HEALTH);
+        golem.setPlayerCreated(true);
+        golem.setPersistent();
+        golem.addCommandTag(GUARD_TAG);
+        golem.setCustomName(Text.of("§6Capital Guard"));
+        golem.setCustomNameVisible(true);
+        return golem;
+    }
+
+    @Override
+    public void gatherNearbyEntities(
+            ServerWorld world,
+            MobEntity self,
+            @Nullable Entity owner,
+            JsonArray out) {
+        // No observations published; vanilla AI handles targeting.
+    }
+
+    private static void setAttribute(
+            MobEntity mob,
+            RegistryEntry<EntityAttribute> attribute,
+            double value) {
+        EntityAttributeInstance inst = mob.getAttributeInstance(attribute);
+        if (inst != null) {
+            inst.setBaseValue(value);
+        }
+    }
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CapitalGuardSpawner.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CapitalGuardSpawner.java
@@ -45,12 +45,11 @@ public final class CapitalGuardSpawner {
         if (deficit == 0) return;
 
         Random rand = new Random();
-        BlockPos spawn = overworld.getSpawnPos();
         int spawned = 0;
         for (int i = 0; i < deficit; i++) {
             int ox = rand.nextInt(ANCHOR_RADIUS * 2 + 1) - ANCHOR_RADIUS;
             int oz = rand.nextInt(ANCHOR_RADIUS * 2 + 1) - ANCHOR_RADIUS;
-            BlockPos anchor = spawn.add(ox, 0, oz);
+            BlockPos anchor = new BlockPos(ox, 0, oz);
             if (!SpawnRegion.containsBlock(anchor)) continue;
             if (manager.spawnAtAnchor(overworld, CreatureKinds.CAPITAL_GUARD, anchor)) {
                 spawned++;

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CapitalGuardSpawner.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CapitalGuardSpawner.java
@@ -1,0 +1,62 @@
+package com.kbve.statetree;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Random;
+
+/**
+ * Tops up the Capital Guard population to {@link #TARGET_COUNT} at server
+ * start. Counts surviving guards by scoreboard tag so previously spawned
+ * guards loaded from disk are honored; only the deficit is spawned fresh.
+ *
+ * <p>Anchors are scattered around world spawn ({@code 0, 0}) so guards
+ * don't pile up on one block. Vanilla IronGolem AI then takes over —
+ * they patrol within wander radius and aggro any hostile that comes
+ * inside their target-detection range.
+ */
+public final class CapitalGuardSpawner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BehaviorStateTreeMod.MOD_ID);
+
+    static final int TARGET_COUNT = 4;
+    private static final int ANCHOR_RADIUS = 24;
+
+    private CapitalGuardSpawner() {}
+
+    public static void register(AiCreatureManager manager) {
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> populate(server, manager));
+    }
+
+    private static void populate(MinecraftServer server, AiCreatureManager manager) {
+        ServerWorld overworld = server.getOverworld();
+        if (overworld == null) return;
+
+        int reclaimed = manager.reclaimPersistedKind(
+                overworld, CreatureKinds.CAPITAL_GUARD, CapitalGuardKind.GUARD_TAG);
+        int existing = manager.aliveCount(overworld, CreatureKinds.CAPITAL_GUARD);
+        int deficit = Math.max(0, TARGET_COUNT - existing);
+        LOGGER.info("[capital-guard] reclaimed={} existing={} target={} spawning={}",
+                reclaimed, existing, TARGET_COUNT, deficit);
+        if (deficit == 0) return;
+
+        Random rand = new Random();
+        BlockPos spawn = overworld.getSpawnPos();
+        int spawned = 0;
+        for (int i = 0; i < deficit; i++) {
+            int ox = rand.nextInt(ANCHOR_RADIUS * 2 + 1) - ANCHOR_RADIUS;
+            int oz = rand.nextInt(ANCHOR_RADIUS * 2 + 1) - ANCHOR_RADIUS;
+            BlockPos anchor = spawn.add(ox, 0, oz);
+            if (!SpawnRegion.containsBlock(anchor)) continue;
+            if (manager.spawnAtAnchor(overworld, CreatureKinds.CAPITAL_GUARD, anchor)) {
+                spawned++;
+            }
+        }
+        LOGGER.info("[capital-guard] spawned {} new guard(s)", spawned);
+    }
+
+}

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKind.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKind.java
@@ -35,6 +35,27 @@ public interface CreatureKind {
     String tag();
 
     /**
+     * Whether this kind should be observed and ticked by the Rust ECS.
+     * Defaults to true. Kinds whose behavior runs entirely on vanilla
+     * AI (e.g. capital guards using IronGolem auto-aggro) can return
+     * false to skip the per-tick observation marshaling.
+     */
+    default boolean submitsObservations() {
+        return true;
+    }
+
+    /**
+     * Whether the claim-drift cull sweep in {@link AiCreatureManager} may
+     * despawn this kind if it ends up inside the spawn-protection cube.
+     * Defaults to true (hostile spawns that drift in get culled). Kinds
+     * that are meant to live inside the claim (capital guards) return
+     * false.
+     */
+    default boolean cullableInsideClaim() {
+        return true;
+    }
+
+    /**
      * Build and configure a ready-to-spawn mob at {@code pos}. Return
      * {@code null} if this kind can't spawn right now (e.g. an owned
      * creature whose owner vanished between the command and the actuator

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKinds.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/CreatureKinds.java
@@ -17,6 +17,7 @@ public final class CreatureKinds {
     public static final CreatureKind SKELETON_HORSEMAN = new HorsemanSkeletonKind();
     public static final CreatureKind PET_DOG = new PetDogCreatureKind();
     public static final CreatureKind PET_PARROT = new PetParrotCreatureKind();
+    public static final CreatureKind CAPITAL_GUARD = new CapitalGuardKind();
 
     private CreatureKinds() {}
 }

--- a/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
+++ b/apps/mc/behavior_statetree/java/src/main/java/com/kbve/statetree/NpcTickHandler.java
@@ -69,6 +69,10 @@ public class NpcTickHandler implements ServerTickEvents.EndTick {
                 creatureManager, metrics);
     }
 
+    public AiCreatureManager getCreatureManager() {
+        return creatureManager;
+    }
+
     /** Inject the ship manager (called once during mod init). */
     public void setShipManager(com.kbve.statetree.ship.ShipManager manager) {
         this.shipManager = manager;


### PR DESCRIPTION
## Summary

Replace the despawn-only claim-drift policy from #11344 with a guards-first one: boosted iron golems patrol the spawn cube and engage hostile drifters via vanilla AI. The cull sweep stays on as a 30s-grace backstop for anything the guards can't reach (terrain-stuck mobs, mid-air spawns).

### New \`CapitalGuardKind\`

- Vanilla \`IronGolem\` entity. Max HP 500, attack 30, KB-resist 1.0, movement 0.30, follow range 64.
- \`setPersistent(true)\` + scoreboard tag \`kbve_capital_guard\` so guards survive restarts and can be counted by tag.
- \`setPlayerCreated(true)\` so the vanilla GolemTargetGoal hostile-mob targeting pathway is correct.
- Opts out of \`submitsObservations()\` (no Rust ECS round-trip — vanilla AI is enough) and \`cullableInsideClaim()\` (guards LIVE inside the claim; the cull sweep must not despawn them).

### \`CreatureKind\` extension points

Two new \`default\` methods:
- \`submitsObservations()\` — default true; false for kinds running on pure vanilla AI.
- \`cullableInsideClaim()\` — default true; false for kinds anchored to the claim.

Wired through \`AiCreatureManager.submitObservations\` and \`sweepCreaturesInsideSpawnProtection\`.

### \`AiCreatureManager\` APIs

- \`spawnAtAnchor(world, kind, BlockPos)\` — absolute-coord spawn that bypasses claim rejection. The existing \`spawnNear\` rejects unowned spawns inside the claim; guards need exactly the opposite.
- \`reclaimPersistedKind(world, kind, tag)\` — re-claim alive entities bearing a tag into the tracking map on boot so the orphan sweep doesn't discard persistent guards from a previous session.
- \`aliveCount(world, kind)\` — population probe used by the spawner to compute the deficit each boot.

### \`CapitalGuardSpawner\`

Registered on \`SERVER_STARTED\`. Reclaims persisted guards, counts the alive population, tops up to \`TARGET_COUNT = 4\` by scattering anchors within \`ANCHOR_RADIUS = 24\` of world spawn.

### Cull-sweep grace

\`sweepCreaturesInsideSpawnProtection\` no longer despawns on first sight. Tracks \`firstSeenInClaim\` per entity ID and skips the discard until 600 ticks (~30s) have elapsed inside the claim. Gives guards time to engage. Entry/exit clears the timestamp so a mob that walks out and back in gets a fresh grace window.

## Test plan

- [ ] Boot the mc fleet, watch for \`[capital-guard] reclaimed=0 existing=0 target=4 spawning=4\` then 4× \`[AI] Spawned guard at [...] at-anchor\` on first boot.
- [ ] Restart the server. Watch for \`reclaimed=N\` matching the alive count from the previous session — no double-spawn.
- [ ] Walk a zombie into the claim. Within 30s a guard engages it and kills it; if not, the cull sweep logs \`[AI] Culled 1 AI creature(s) ...\` after the grace.
- [ ] Pet wolves and pet parrots still follow players across the claim boundary (cull sweep already exempts \`ownerEntityId != 0\`).
- [ ] Kill a guard with /kill: next \`SERVER_STARTED\` (restart) tops the population back up to 4.

## Follow-ups

- Phase 2: \"Capital Barracks\" structure at spawn that visually anchors the guards + spawns reinforcements on player-damage events.
- Phase 3: Captain / Magistrate ranks.