### PR TITLE
feat(astro-kbve): /dashboard/agents/discordsh — guild picker + token list (P1 of #11362)

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -188,7 +188,14 @@ export default defineConfig({
 						{ label: 'Overview', link: '/dashboard/', attrs: { 'data-auth-visibility': 'auth' } },
 						{ label: 'Profile', link: '/dashboard/profile/', attrs: { 'data-auth-visibility': 'auth' } },
 						{ label: 'Account', link: '/dashboard/account/', attrs: { 'data-auth-visibility': 'auth' } },
-						{ label: 'Agents', link: '/dashboard/agents/', attrs: { 'data-auth-visibility': 'auth' } },
+						{
+							label: 'Agents',
+							collapsed: true,
+							items: [
+								{ label: 'Overview', link: '/dashboard/agents/', attrs: { 'data-auth-visibility': 'auth' } },
+								{ label: 'discordsh', link: '/dashboard/agents/discordsh/', attrs: { 'data-auth-visibility': 'auth' } },
+							],
+						},
 						{ label: 'Marketplace', link: '/dashboard/market/', attrs: { 'data-auth-visibility': 'auth' } },
 						{ label: 'API', link: '/dashboard/api/' },
 						{ label: 'Kanban', link: '/dashboard/kanban/', attrs: { 'data-auth-visibility': 'auth' } },

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
@@ -1,0 +1,73 @@
+---
+import ReactAgentDiscordsh from './ReactAgentDiscordsh';
+---
+
+<section
+	id="agent-discordsh-wrapper"
+	class="agent-discordsh-wrapper kbve-dashboard-page"
+	aria-label="Discordsh agent — token management for owned Discord guilds">
+	<div class="dashboard-content">
+		<header class="agent-header not-content">
+			<h1 class="agent-title">discordsh</h1>
+			<p class="agent-lede">
+				Manage tokens for guilds you own. Each row in <code>
+					vault.secrets
+				</code>
+				is keyed by your Discord guild ID. Token values stay server-side —
+				the dashboard only renders metadata (service, description, active
+				flag, timestamps).
+			</p>
+		</header>
+
+		<ReactAgentDiscordsh client:only="react" />
+	</div>
+</section>
+
+<style>
+	.agent-discordsh-wrapper {
+		background: transparent;
+		min-height: 100vh;
+		position: relative;
+		width: 100%;
+	}
+
+	.dashboard-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 2rem 1rem;
+	}
+
+	@media (min-width: 768px) {
+		.dashboard-content {
+			padding: 2rem 1.5rem;
+		}
+	}
+
+	.agent-header {
+		margin-bottom: 1.5rem;
+	}
+
+	.agent-title {
+		font-size: clamp(1.75rem, 2.5vw, 2.25rem);
+		font-weight: 700;
+		margin: 0 0 0.4rem;
+		font-family: var(--sl-font-mono, ui-monospace, monospace);
+		color: var(--sl-color-white, #fff);
+	}
+
+	.agent-lede {
+		font-size: 0.95rem;
+		line-height: 1.55;
+		color: var(--sl-color-gray-2, #c2c5cc);
+		margin: 0;
+		max-width: 64ch;
+	}
+
+	.agent-lede code {
+		font-family: var(--sl-font-mono, ui-monospace, monospace);
+		background: rgba(255, 255, 255, 0.06);
+		padding: 0.05rem 0.35rem;
+		border-radius: 4px;
+		font-size: 0.85em;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentDiscordsh.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentDiscordsh.tsx
@@ -1,0 +1,574 @@
+import { useEffect, useMemo } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	Loader2,
+	LogIn,
+	RefreshCw,
+	AlertTriangle,
+	Users,
+	KeyRound,
+} from 'lucide-react';
+import {
+	agentsService,
+	type AgentTokenRow,
+	type DiscordGuild,
+} from './agentsService';
+import { styles } from './dashboard-ui';
+
+const DISCORD_CDN = 'https://cdn.discordapp.com';
+
+function guildIconUrl(guild: DiscordGuild): string | null {
+	if (!guild.icon) return null;
+	return `${DISCORD_CDN}/icons/${guild.id}/${guild.icon}.png?size=64`;
+}
+
+function initials(name: string): string {
+	return name
+		.split(/\s+/)
+		.map((s) => s[0])
+		.filter(Boolean)
+		.slice(0, 2)
+		.join('')
+		.toUpperCase();
+}
+
+function formatDate(iso: string): string {
+	try {
+		return new Date(iso).toLocaleString();
+	} catch {
+		return iso;
+	}
+}
+
+function maskService(svc: string): { label: string; color: string } {
+	if (svc === 'github') return { label: 'github · PAT', color: '#58a6ff' };
+	if (svc === 'github_webhook')
+		return { label: 'github · webhook', color: '#a78bfa' };
+	if (svc === 'github_repos')
+		return { label: 'github · repo list', color: '#34d399' };
+	if (svc === 'irc') return { label: 'irc', color: '#fb7185' };
+	return { label: svc, color: '#94a3b8' };
+}
+
+export default function ReactAgentDiscordsh() {
+	const authState = useStore(agentsService.$authState);
+	const guilds = useStore(agentsService.$guilds);
+	const guildsLoading = useStore(agentsService.$guildsLoading);
+	const guildsError = useStore(agentsService.$guildsError);
+	const selectedGuildId = useStore(agentsService.$selectedGuildId);
+	const tokens = useStore(agentsService.$tokens);
+	const tokensLoading = useStore(agentsService.$tokensLoading);
+	const tokensError = useStore(agentsService.$tokensError);
+
+	useEffect(() => {
+		void agentsService.initAuth();
+	}, []);
+
+	const selectedGuild = useMemo(
+		() => guilds.find((g) => g.id === selectedGuildId) ?? null,
+		[guilds, selectedGuildId],
+	);
+
+	if (authState === 'loading') {
+		return (
+			<div className="not-content" style={styles.fullCenter}>
+				<Loader2
+					size={28}
+					style={{
+						animation: 'spin 1s linear infinite',
+						color: 'var(--sl-color-accent, #58a6ff)',
+					}}
+				/>
+				<p
+					style={{
+						marginTop: '0.75rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					Loading session…
+				</p>
+			</div>
+		);
+	}
+
+	if (authState === 'unauthenticated') {
+		return (
+			<div className="not-content" style={styles.fullCenter}>
+				<div style={styles.iconBadge('#58a6ff')}>
+					<LogIn size={28} color="#58a6ff" />
+				</div>
+				<h2 style={{ margin: '0.5rem 0' }}>Sign in required</h2>
+				<p
+					style={{
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+						maxWidth: 480,
+					}}>
+					Manage your discordsh integration by signing in with
+					Discord. We use your Discord identity to verify which guilds
+					you own before showing or editing their stored tokens.
+				</p>
+				<button
+					type="button"
+					onClick={() => void agentsService.signInWithDiscord()}
+					style={{
+						marginTop: '1rem',
+						padding: '0.55rem 1.1rem',
+						borderRadius: 8,
+						border: 'none',
+						background: '#5865F2',
+						color: '#fff',
+						fontWeight: 600,
+						cursor: 'pointer',
+					}}>
+					Sign in with Discord
+				</button>
+			</div>
+		);
+	}
+
+	if (authState === 'discord_reauth_required') {
+		return (
+			<div className="not-content" style={styles.fullCenter}>
+				<div style={styles.iconBadge('#facc15')}>
+					<AlertTriangle size={28} color="#facc15" />
+				</div>
+				<h2 style={{ margin: '0.5rem 0' }}>Discord session expired</h2>
+				<p
+					style={{
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+						maxWidth: 480,
+					}}>
+					Your Discord access token has expired or was not captured by
+					the last sign-in. Re-sign-in to grant the agents dashboard a
+					fresh provider token (used only to verify guild ownership;
+					never stored).
+				</p>
+				<button
+					type="button"
+					onClick={() => void agentsService.signInWithDiscord()}
+					style={{
+						marginTop: '1rem',
+						padding: '0.55rem 1.1rem',
+						borderRadius: 8,
+						border: 'none',
+						background: '#5865F2',
+						color: '#fff',
+						fontWeight: 600,
+						cursor: 'pointer',
+					}}>
+					Re-sign-in with Discord
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className="not-content"
+			style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+			<GuildPicker
+				guilds={guilds}
+				loading={guildsLoading}
+				error={guildsError}
+				selectedGuildId={selectedGuildId}
+				onSelect={(id) => agentsService.selectGuild(id)}
+			/>
+
+			{selectedGuild ? (
+				<TokenList
+					guild={selectedGuild}
+					tokens={tokens}
+					loading={tokensLoading}
+					error={tokensError}
+					onRefresh={() => void agentsService.refreshSelectedGuild()}
+				/>
+			) : (
+				<EmptyGuildPrompt guildCount={guilds.length} />
+			)}
+		</div>
+	);
+}
+
+interface GuildPickerProps {
+	guilds: DiscordGuild[];
+	loading: boolean;
+	error: string | null;
+	selectedGuildId: string | null;
+	onSelect: (id: string) => void;
+}
+
+function GuildPicker({
+	guilds,
+	loading,
+	error,
+	selectedGuildId,
+	onSelect,
+}: GuildPickerProps) {
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<Users size={18} color="#58a6ff" />
+				<strong>Discord guilds you own</strong>
+				{loading && (
+					<Loader2
+						size={14}
+						style={{
+							animation: 'spin 1s linear infinite',
+							marginLeft: '0.5rem',
+						}}
+					/>
+				)}
+			</header>
+
+			<div style={{ padding: '0.85rem 1rem' }}>
+				{error && (
+					<p
+						style={{
+							color: '#f87171',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						{error}
+					</p>
+				)}
+				{!error && !loading && guilds.length === 0 && (
+					<p
+						style={{
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+							margin: 0,
+						}}>
+						You don't own any Discord guilds. Only guild owners can
+						manage bot integration tokens.
+					</p>
+				)}
+				{guilds.length > 0 && (
+					<div
+						style={{
+							display: 'grid',
+							gridTemplateColumns:
+								'repeat(auto-fill, minmax(220px, 1fr))',
+							gap: '0.6rem',
+						}}>
+						{guilds.map((g) => {
+							const iconUrl = guildIconUrl(g);
+							const active = selectedGuildId === g.id;
+							return (
+								<button
+									key={g.id}
+									type="button"
+									onClick={() => onSelect(g.id)}
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: '0.65rem',
+										padding: '0.6rem 0.75rem',
+										borderRadius: 10,
+										border: `1px solid ${active ? '#58a6ff' : 'var(--sl-color-gray-5, #2d2f36)'}`,
+										background: active
+											? 'rgba(88,166,255,0.08)'
+											: 'transparent',
+										color: 'var(--sl-color-white, #fff)',
+										cursor: 'pointer',
+										textAlign: 'left',
+										transition:
+											'border-color 0.15s ease, background 0.15s ease',
+									}}>
+									{iconUrl ? (
+										<img
+											src={iconUrl}
+											alt=""
+											width={36}
+											height={36}
+											style={{
+												borderRadius: 8,
+												flexShrink: 0,
+											}}
+										/>
+									) : (
+										<div
+											aria-hidden
+											style={{
+												width: 36,
+												height: 36,
+												borderRadius: 8,
+												background: '#374151',
+												color: '#e5e7eb',
+												display: 'flex',
+												alignItems: 'center',
+												justifyContent: 'center',
+												fontWeight: 700,
+												fontSize: '0.8rem',
+												flexShrink: 0,
+											}}>
+											{initials(g.name)}
+										</div>
+									)}
+									<div style={{ minWidth: 0 }}>
+										<div
+											style={{
+												fontWeight: 600,
+												overflow: 'hidden',
+												textOverflow: 'ellipsis',
+												whiteSpace: 'nowrap',
+											}}>
+											{g.name}
+										</div>
+										<div
+											style={{
+												fontSize: '0.7rem',
+												color: 'var(--sl-color-gray-3, #9ca0aa)',
+												fontFamily:
+													'var(--sl-font-mono, ui-monospace, monospace)',
+											}}>
+											{g.id}
+										</div>
+									</div>
+								</button>
+							);
+						})}
+					</div>
+				)}
+			</div>
+		</section>
+	);
+}
+
+interface TokenListProps {
+	guild: DiscordGuild;
+	tokens: AgentTokenRow[];
+	loading: boolean;
+	error: string | null;
+	onRefresh: () => void;
+}
+
+function TokenList({
+	guild,
+	tokens,
+	loading,
+	error,
+	onRefresh,
+}: TokenListProps) {
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<KeyRound size={18} color="#a78bfa" />
+				<strong>Tokens for {guild.name}</strong>
+				<span
+					style={{
+						marginLeft: '0.4rem',
+						fontSize: '0.75rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+						fontFamily:
+							'var(--sl-font-mono, ui-monospace, monospace)',
+					}}>
+					{guild.id}
+				</span>
+				<button
+					type="button"
+					onClick={onRefresh}
+					disabled={loading}
+					style={{
+						marginLeft: 'auto',
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.35rem',
+						padding: '0.3rem 0.6rem',
+						borderRadius: 6,
+						border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+						background: 'transparent',
+						color: 'var(--sl-color-white, #fff)',
+						cursor: loading ? 'wait' : 'pointer',
+						fontSize: '0.8rem',
+					}}
+					aria-label="Refresh tokens">
+					<RefreshCw
+						size={14}
+						style={
+							loading
+								? { animation: 'spin 1s linear infinite' }
+								: undefined
+						}
+					/>
+					Refresh
+				</button>
+			</header>
+
+			<div style={{ padding: '0.85rem 1rem' }}>
+				{error && (
+					<p
+						style={{
+							color: '#f87171',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						{error}
+					</p>
+				)}
+				{!error && loading && tokens.length === 0 && (
+					<p
+						style={{
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						Loading tokens…
+					</p>
+				)}
+				{!error && !loading && tokens.length === 0 && (
+					<p
+						style={{
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+							margin: 0,
+						}}>
+						No tokens registered for this guild yet.
+					</p>
+				)}
+				{tokens.length > 0 && (
+					<div style={{ overflowX: 'auto' }}>
+						<table
+							style={{
+								width: '100%',
+								borderCollapse: 'collapse',
+								fontSize: '0.85rem',
+							}}>
+							<thead>
+								<tr
+									style={{
+										textAlign: 'left',
+										color: 'var(--sl-color-gray-3, #9ca0aa)',
+									}}>
+									<th style={{ padding: '0.4rem 0.5rem' }}>
+										Name
+									</th>
+									<th style={{ padding: '0.4rem 0.5rem' }}>
+										Service
+									</th>
+									<th style={{ padding: '0.4rem 0.5rem' }}>
+										Description
+									</th>
+									<th style={{ padding: '0.4rem 0.5rem' }}>
+										Active
+									</th>
+									<th style={{ padding: '0.4rem 0.5rem' }}>
+										Created
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								{tokens.map((t) => {
+									const svc = maskService(t.service);
+									return (
+										<tr
+											key={t.token_id}
+											style={{
+												borderTop:
+													'1px solid var(--sl-color-gray-5, #262626)',
+											}}>
+											<td style={{ padding: '0.5rem' }}>
+												<code
+													style={{
+														fontFamily:
+															'var(--sl-font-mono, ui-monospace, monospace)',
+													}}>
+													{t.token_name}
+												</code>
+											</td>
+											<td style={{ padding: '0.5rem' }}>
+												<span
+													style={{
+														fontSize: '0.75rem',
+														padding:
+															'0.15rem 0.5rem',
+														borderRadius: 6,
+														background: `${svc.color}22`,
+														color: svc.color,
+													}}>
+													{svc.label}
+												</span>
+											</td>
+											<td
+												style={{
+													padding: '0.5rem',
+													color: 'var(--sl-color-gray-2, #c2c5cc)',
+												}}>
+												{t.description || '—'}
+											</td>
+											<td style={{ padding: '0.5rem' }}>
+												{t.is_active ? (
+													<span
+														style={{
+															color: '#4ade80',
+														}}>
+														● active
+													</span>
+												) : (
+													<span
+														style={{
+															color: '#94a3b8',
+														}}>
+														○ disabled
+													</span>
+												)}
+											</td>
+											<td
+												style={{
+													padding: '0.5rem',
+													color: 'var(--sl-color-gray-3, #9ca0aa)',
+													fontFamily:
+														'var(--sl-font-mono, ui-monospace, monospace)',
+													fontSize: '0.78rem',
+												}}>
+												{formatDate(t.created_at)}
+											</td>
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				)}
+				<p
+					style={{
+						marginTop: '0.85rem',
+						fontSize: '0.78rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					Token values are never returned by the dashboard. Add /
+					rotate / delete operations will land in the P2 update.
+				</p>
+			</div>
+		</section>
+	);
+}
+
+function EmptyGuildPrompt({ guildCount }: { guildCount: number }) {
+	if (guildCount === 0) return null;
+	return (
+		<section style={styles.sectionBorder}>
+			<div style={{ padding: '1rem' }}>
+				<p
+					style={{
+						margin: 0,
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					Pick a guild above to view its registered bot tokens.
+				</p>
+			</div>
+		</section>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -1,0 +1,206 @@
+import { atom } from 'nanostores';
+import { initSupa, getSupa, SUPABASE_URL } from '@/lib/supa';
+import { addToast } from '@kbve/droid';
+
+export type AuthState =
+	| 'loading'
+	| 'authenticated'
+	| 'unauthenticated'
+	| 'discord_reauth_required';
+
+export interface DiscordGuild {
+	id: string;
+	name: string;
+	icon: string | null;
+	owner: boolean;
+	permissions: string;
+}
+
+export interface AgentTokenRow {
+	token_id: string;
+	token_name: string;
+	service: string;
+	description: string | null;
+	is_active: boolean;
+	created_at: string;
+	updated_at: string | null;
+}
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10';
+const GUILD_VAULT_URL = `${SUPABASE_URL}/functions/v1/guild-vault`;
+
+class AgentsService {
+	public readonly $authState = atom<AuthState>('loading');
+	public readonly $accessToken = atom<string | null>(null);
+	public readonly $providerToken = atom<string | null>(null);
+
+	public readonly $guilds = atom<DiscordGuild[]>([]);
+	public readonly $guildsLoading = atom<boolean>(false);
+	public readonly $guildsError = atom<string | null>(null);
+
+	public readonly $selectedGuildId = atom<string | null>(null);
+
+	public readonly $tokens = atom<AgentTokenRow[]>([]);
+	public readonly $tokensLoading = atom<boolean>(false);
+	public readonly $tokensError = atom<string | null>(null);
+
+	public async initAuth(): Promise<void> {
+		try {
+			await initSupa();
+			const supa = getSupa();
+			const sessionResult = await supa.getSession().catch(() => null);
+			const session = sessionResult?.session ?? null;
+
+			if (!session?.access_token) {
+				this.$authState.set('unauthenticated');
+				return;
+			}
+
+			this.$accessToken.set(session.access_token as string);
+
+			const providerToken =
+				(session as { provider_token?: string | null } | null)
+					?.provider_token ?? null;
+			if (!providerToken) {
+				this.$authState.set('discord_reauth_required');
+				return;
+			}
+
+			this.$providerToken.set(providerToken);
+			this.$authState.set('authenticated');
+
+			await this.loadOwnedGuilds();
+		} catch {
+			this.$authState.set('unauthenticated');
+		}
+	}
+
+	public async loadOwnedGuilds(): Promise<void> {
+		const providerToken = this.$providerToken.get();
+		if (!providerToken) return;
+
+		this.$guildsLoading.set(true);
+		this.$guildsError.set(null);
+
+		try {
+			const resp = await fetch(`${DISCORD_API_BASE}/users/@me/guilds`, {
+				headers: { Authorization: `Bearer ${providerToken}` },
+			});
+
+			if (resp.status === 401) {
+				this.$authState.set('discord_reauth_required');
+				this.$providerToken.set(null);
+				this.$guildsError.set(
+					'Discord session expired. Re-sign-in required.',
+				);
+				return;
+			}
+
+			if (!resp.ok) {
+				const body = await resp.text();
+				this.$guildsError.set(
+					`Discord API ${resp.status}: ${body.slice(0, 200)}`,
+				);
+				return;
+			}
+
+			const allGuilds = (await resp.json()) as DiscordGuild[];
+			const owned = allGuilds.filter((g) => g.owner === true);
+			this.$guilds.set(owned);
+
+			if (owned.length === 1) {
+				this.selectGuild(owned[0].id);
+			}
+		} catch (e) {
+			this.$guildsError.set(
+				e instanceof Error
+					? e.message
+					: 'Failed to load Discord guilds',
+			);
+		} finally {
+			this.$guildsLoading.set(false);
+		}
+	}
+
+	public selectGuild(guildId: string): void {
+		const current = this.$selectedGuildId.get();
+		if (current === guildId) return;
+		this.$selectedGuildId.set(guildId);
+		void this.loadTokens(guildId);
+	}
+
+	public async loadTokens(guildId: string): Promise<void> {
+		const accessToken = this.$accessToken.get();
+		const providerToken = this.$providerToken.get();
+		if (!accessToken || !providerToken) return;
+
+		this.$tokensLoading.set(true);
+		this.$tokensError.set(null);
+
+		try {
+			const resp = await fetch(GUILD_VAULT_URL, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${accessToken}`,
+				},
+				body: JSON.stringify({
+					command: 'tokens.list_tokens',
+					server_id: guildId,
+					provider_token: providerToken,
+				}),
+			});
+
+			const text = await resp.text();
+			let body: unknown;
+			try {
+				body = JSON.parse(text);
+			} catch {
+				this.$tokensError.set(
+					`HTTP ${resp.status}: ${text.slice(0, 200)}`,
+				);
+				return;
+			}
+
+			if (!resp.ok) {
+				const errMsg =
+					(body as { error?: string } | null)?.error ??
+					`HTTP ${resp.status}`;
+				this.$tokensError.set(errMsg);
+				return;
+			}
+
+			const rows =
+				(body as { tokens?: AgentTokenRow[] } | null)?.tokens ?? [];
+			this.$tokens.set(rows);
+		} catch (e) {
+			this.$tokensError.set(
+				e instanceof Error ? e.message : 'Failed to load tokens',
+			);
+		} finally {
+			this.$tokensLoading.set(false);
+		}
+	}
+
+	public async refreshSelectedGuild(): Promise<void> {
+		const guildId = this.$selectedGuildId.get();
+		if (guildId) await this.loadTokens(guildId);
+	}
+
+	public async signInWithDiscord(): Promise<void> {
+		try {
+			const { authBridge } = await import('@/components/auth/AuthBridge');
+			await authBridge.signInWithOAuth('discord');
+		} catch (e) {
+			addToast({
+				id: `discord-signin-err-${Date.now()}`,
+				message:
+					e instanceof Error ? e.message : 'Discord sign-in failed',
+				severity: 'error',
+				duration: 5000,
+			});
+		}
+	}
+}
+
+export const agentsService = new AgentsService();

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/agents/discordsh/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/agents/discordsh/index.mdx
@@ -1,0 +1,20 @@
+---
+title: discordsh agent
+description: Manage discordsh bot integration tokens for guilds you own.
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: discordsh
+    order: 1
+unsplash: 1558494949-ef010cbdcc31
+img: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - agents
+    - discordsh
+---
+
+import AstroAgentDiscordsh from '@/components/dashboard/AstroAgentDiscordsh.astro';
+
+<AstroAgentDiscordsh />


### PR DESCRIPTION
Second slice of #11362 — read-only management surface for the discordsh agent. CRUD lands in P2.

## What

\`/dashboard/agents/discordsh/\` (linked from the P0 catalog's discordsh \"Manage\" CTA). Signed-in users see:

1. **Guilds you own** — fetched from Discord API \`/users/@me/guilds\` with the Supabase session's \`provider_token\`, filtered to \`owner: true\`. Auto-selects when there's exactly one.
2. **Tokens for the picked guild** — \`guild-vault tokens.list_tokens\` round-trip. Returns metadata only (name / service / description / active / timestamps); token values stay service-role-only and never reach the browser.

## Files

- \`apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts\` — singleton, mirrors the existing \`homeService\` pattern (nanostores: \`$authState\`, \`$accessToken\`, \`$providerToken\`, \`$guilds\`, \`$selectedGuildId\`, \`$tokens\`, etc.). Adds a new \`discord_reauth_required\` auth state: Supabase doesn't refresh OAuth provider tokens, so when the session lacks \`provider_token\` (or Discord returns 401), users are prompted to re-sign-in. Provider token stays in memory only.
- \`apps/kbve/astro-kbve/src/components/dashboard/ReactAgentDiscordsh.tsx\` — single React island handling all four auth states (loading / unauthenticated / discord_reauth_required / authenticated). Responsive guild picker grid + tokens table with masked service badges (\`github · PAT\`, \`github · webhook\`, etc.).
- \`apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro\` — SSG shell, \`client:only=\"react\"\` per the astro-kbve SSG convention.
- \`apps/kbve/astro-kbve/src/content/docs/dashboard/agents/discordsh/index.mdx\` — Starlight route.
- \`astro.config.mjs\` — promote the flat \`Agents\` sidebar entry to a collapsed group with Overview + discordsh children. Drops \`attrs\` from the group node (Starlight rejects it on groups); auth-visibility stays on the leaves.

## Auth model (per #11362 scoping decision: reuse Supabase Discord identity)

- \`session.provider_token\` from \`@supabase/supabase-js\` Discord OAuth gives the Discord access token for the lifetime of the session.
- For \`verifyGuildOwnership\` (server-side in \`guild-vault\`), the UI passes \`provider_token\` in the request body — matches the existing API contract of \`tokens.set_token\` / \`list_tokens\` / etc.
- 401 from Discord API → state flips to \`discord_reauth_required\`, surfaces a re-sign-in CTA. No silent failure.
- Provider token never written to localStorage / IndexedDB by this code; in-memory atom only.

## No version bump

axum-kbve v1.0.171 from PR #11364 (P0) has not yet published — no \`ci-docker\` run for it has fired on main. This change rides the same publish cycle.

## Out of scope (deferred to later phases of #11362)

- **P2** — token CRUD modals (set / delete / toggle).
- **P3** — GitHub guided wizard (generate webhook secret, store, display webhook URL, GitHub deep link, smoke-backfill).
- **P4** — per-guild repo allowlist migration from env to Vault.
- **P5** — \`gh.event_queue_stats\` per-guild widget.
- **P6** — bot install wizard.

## Verification

- \`./kbve.sh -nx astro-kbve:build\` ✓ (initial attempt failed because Starlight sidebar groups don't accept \`attrs\` — fixed by moving auth-visibility to the leaves; rebuild green)
- Manifest regen ✓ (no diff since no version change)
- No new dependencies