### PR TITLE
feat(q,nexus-defense): combat loop — towers fire, kills pay bounty, lives drain, game-over

### DIFF
--- a/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/debug/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1065b2ab9d27ea61381bd552ac78a2ead94491336a8da95991d2a52d69481b53
-size 9200168
+oid sha256:6a1be7bdaf96cfd12d7ac3fce4010f7928366f9db1dc68327fff1527bf086c95
+size 9195560

--- a/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:895203e0742f262d826f38abbf607a0d59a51aeb52aedba2642d785d14ce207e
+oid sha256:3e2fb0856a59b50a65dfea7ffb579b449e196ba1f1226defe955d27b04b9e93d
 size 4200128

--- a/packages/rust/q/src/net/server.rs
+++ b/packages/rust/q/src/net/server.rs
@@ -312,6 +312,14 @@ async fn send_reject(socket: &mut WebSocket, reason: &str) {
     if let Ok(buf) = proto::encode(&evt) {
         let _ = socket.send(Message::Binary(buf)).await;
     }
+    // Issue a clean WS Close so the client tears down without surfacing a
+    // protocol-error disconnect on top of the Reject payload.
+    let _ = socket
+        .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+            code: 1000,
+            reason: reason.to_string().into(),
+        })))
+        .await;
 }
 
 /// Patches Snapshot frames so every connected slot shows up in `players[]`.

--- a/packages/rust/q/src/nexus_defense_server/mod.rs
+++ b/packages/rust/q/src/nexus_defense_server/mod.rs
@@ -5,15 +5,9 @@
 //! [`build_app`] and driven by [`run_sim_loop`] from a tokio task — no winit,
 //! no rendering, just a fixed-cadence scheduler that calls `App::update`.
 //!
-//! Inputs flow in via an `mpsc::UnboundedReceiver<(PlayerSlot, Input)>` that
-//! the axum WS layer feeds; snapshots flow out via a
-//! `tokio::sync::broadcast::Sender<ServerEvent>` so each WS connection can
-//! subscribe a `Receiver`.
-//!
-//! Each `Snapshot` carries one `FieldDelta` per active roster slot. Enemies
-//! and buildings are owned by a `PlayerSlot` and partitioned into the
-//! matching field on the way out — every player gets their own wave + their
-//! own placements, which is the parallel-race default per the design tracker.
+//! Each `Snapshot` carries one `FieldDelta` per active roster slot. Enemies,
+//! buildings, and projectiles are owned by a `PlayerSlot` and partitioned
+//! into the matching field on the way out.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
@@ -23,7 +17,7 @@ use bevy::app::App;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::system::Commands;
 use bevy::prelude::{
-    Component, IntoScheduleConfigs, Query, Res, ResMut, Resource, Update, Without,
+    Component, IntoScheduleConfigs, Query, Res, ResMut, Resource, Update, With, Without,
 };
 use tokio::sync::{broadcast, mpsc};
 use tokio::time;
@@ -64,15 +58,24 @@ const BUILDING_HP: f32 = 200.0;
 const STARTING_GOLD: i32 = 150;
 const STARTING_LIVES: i32 = 20;
 
-/// Hard cap on inputs accepted per slot per sim tick. Anything past this is
-/// dropped silently; abusive clients can't stall the sim or flood entity
-/// spawns. 8 / tick = 160 inputs / sec at SIM_TICK_HZ=20 — well above any
-/// realistic human cadence.
+/// Hard cap on inputs accepted per slot per sim tick.
 const INPUT_BUDGET_PER_TICK: u32 = 8;
 
-/// Cost lookup matching the catalog in the legacy phaser TD config. Wire-
-/// faithful for the placeholder buildings the sim spawns right now; real
-/// per-tier costs land alongside the upgrade/tier systems.
+// --- Combat tuning -------------------------------------------------------
+const TOWER_RANGE: f32 = 140.0;
+const TOWER_RANGE_SQ: f32 = TOWER_RANGE * TOWER_RANGE;
+const TOWER_DAMAGE: f32 = 18.0;
+/// Ticks between shots — 0.4 s.
+const TOWER_FIRE_INTERVAL_TICKS: u32 = 8;
+const PROJECTILE_SPEED: f32 = 320.0;
+const PROJECTILE_HIT_RADIUS: f32 = 12.0;
+const PROJECTILE_HIT_RADIUS_SQ: f32 = PROJECTILE_HIT_RADIUS * PROJECTILE_HIT_RADIUS;
+/// Distance a projectile can travel before self-despawn.
+const PROJECTILE_MAX_RANGE: f32 = 600.0;
+/// Gold awarded per enemy kill (uniform for v1; tier scaling later).
+const ENEMY_BOUNTY: i32 = 8;
+
+/// Cost lookup matching the catalog in the legacy phaser TD config.
 fn build_cost(kind: proto::BuildKind) -> i32 {
     match kind {
         proto::BuildKind::Tower => 60,
@@ -81,9 +84,13 @@ fn build_cost(kind: proto::BuildKind) -> i32 {
         proto::BuildKind::Repair => 90,
         proto::BuildKind::Armoury => 120,
         proto::BuildKind::Village => 70,
-        // Town/Castle/Nexus aren't placeable via the build bar in v1.
         proto::BuildKind::Town | proto::BuildKind::Castle | proto::BuildKind::Nexus => 0,
     }
+}
+
+/// True when the building kind actively targets + fires at enemies.
+fn building_is_offensive(kind: proto::BuildKind) -> bool {
+    matches!(kind, proto::BuildKind::Tower)
 }
 
 #[derive(Resource, Default)]
@@ -100,16 +107,12 @@ pub struct SnapshotBroadcast {
 #[derive(Resource, Clone, Copy)]
 pub struct SimSeed(pub u64);
 
-/// Mailbox of authenticated inputs (slot + payload) waiting to be applied to
-/// the bevy world. The WS handler is the sole producer; `drain_inputs` is the
-/// sole consumer.
+/// Mailbox of authenticated inputs (slot + payload).
 #[derive(Resource)]
 pub struct InputQueue {
     pub rx: Mutex<mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>>,
 }
 
-/// Shared roster handle from `q::net::server::ServerState`. The sim reads it
-/// each tick to drive per-player wave spawns + snapshot framing.
 #[derive(Resource, Clone)]
 pub struct RosterHandle(pub Arc<RwLock<Roster>>);
 
@@ -121,7 +124,6 @@ pub struct SlotWave {
     pub next_wave_tick: u32,
 }
 
-/// Stack-allocated per-slot wave bookkeeping. `None` = slot vacant.
 #[derive(Resource)]
 pub struct WaveState {
     pub slots: [Option<SlotWave>; proto::MAX_PLAYERS],
@@ -135,9 +137,6 @@ impl Default for WaveState {
     }
 }
 
-/// Per-slot resources (gold + lives + accumulated kills). Slot index is
-/// authoritative; clients never see anyone else's economy beyond what we
-/// stamp into the snapshot.
 #[derive(Default, Clone, Copy)]
 pub struct PlayerEconomyEntry {
     pub gold: i32,
@@ -158,10 +157,16 @@ impl Default for PlayerEconomy {
     }
 }
 
-/// Per-tick input counter, reset by `drain_inputs` each tick.
 #[derive(Resource, Default)]
 pub struct InputBudget {
     pub consumed: [u32; proto::MAX_PLAYERS],
+}
+
+/// Tracks which slots have already received a GameOver event so we don't
+/// flood the broadcast every tick once lives hit zero.
+#[derive(Resource, Default)]
+pub struct GameOverFlags {
+    pub fired: [bool; proto::MAX_PLAYERS],
 }
 
 #[derive(Component)]
@@ -190,8 +195,18 @@ pub struct BuildingTag {
     pub row: i32,
 }
 
-/// Build a headless bevy `App` wired to broadcast snapshots over `tx`,
-/// accept inputs from `input_rx`, and read the shared roster from `roster`.
+#[derive(Component)]
+pub struct TowerStats {
+    pub last_fire_tick: u32,
+}
+
+#[derive(Component)]
+pub struct ProjectileTag {
+    pub owner: proto::PlayerSlot,
+    pub damage: f32,
+    pub remaining_range: f32,
+}
+
 pub fn build_app(
     tx: broadcast::Sender<ServerEvent>,
     input_rx: mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>,
@@ -209,6 +224,7 @@ pub fn build_app(
         .insert_resource(WaveState::default())
         .insert_resource(PlayerEconomy::default())
         .insert_resource(InputBudget::default())
+        .insert_resource(GameOverFlags::default())
         .add_systems(
             Update,
             (
@@ -217,7 +233,11 @@ pub fn build_app(
                 drain_inputs,
                 spawn_wave_enemies,
                 move_enemies,
-                despawn_offscreen,
+                tower_fire,
+                move_projectiles,
+                projectile_hits,
+                enemies_reach_end,
+                check_game_over,
                 emit_snapshot,
             )
                 .chain(),
@@ -228,19 +248,16 @@ pub fn build_app(
 fn tick_sim(mut clock: ResMut<SimClock>, mut budget: ResMut<InputBudget>) {
     clock.tick = clock.tick.wrapping_add(1);
     clock.elapsed_ms = clock.elapsed_ms.wrapping_add(1000 / SIM_TICK_HZ);
-    // Reset every slot's per-tick input budget.
     for c in budget.consumed.iter_mut() {
         *c = 0;
     }
 }
 
-/// Materialize per-slot state for slots that just joined; tear down state
-/// for slots that vacated. One system covers WaveState + PlayerEconomy so
-/// they always agree on which slots are alive.
 fn sync_per_slot_state(
     roster: Res<RosterHandle>,
     mut wave: ResMut<WaveState>,
     mut economy: ResMut<PlayerEconomy>,
+    mut over: ResMut<GameOverFlags>,
 ) {
     let active = match roster.0.read() {
         Ok(r) => r.active_slots(),
@@ -262,12 +279,14 @@ fn sync_per_slot_state(
                 lives: STARTING_LIVES,
                 kills: 0,
             });
+            over.fired[idx] = false;
         }
     }
     for idx in 0..proto::MAX_PLAYERS {
         if !active_mask[idx] {
             wave.slots[idx] = None;
             economy.slots[idx] = None;
+            over.fired[idx] = false;
         }
     }
 }
@@ -276,6 +295,7 @@ fn drain_inputs(
     queue: Res<InputQueue>,
     mut budget: ResMut<InputBudget>,
     mut economy: ResMut<PlayerEconomy>,
+    clock: Res<SimClock>,
     mut commands: Commands,
 ) {
     let mut guard = match queue.rx.lock() {
@@ -288,11 +308,10 @@ fn drain_inputs(
             continue;
         }
         if budget.consumed[idx] >= INPUT_BUDGET_PER_TICK {
-            // Drop — slot already spent its budget this tick.
             continue;
         }
         budget.consumed[idx] += 1;
-        apply_input(slot, input, &mut economy, &mut commands);
+        apply_input(slot, input, &mut economy, clock.tick, &mut commands);
     }
 }
 
@@ -300,14 +319,13 @@ fn apply_input(
     slot: proto::PlayerSlot,
     input: Input,
     economy: &mut PlayerEconomy,
+    tick: u32,
     commands: &mut Commands,
 ) {
     let idx = slot.0 as usize;
     match input {
         Input::PlaceBuilding { col, row, kind } => {
             let cost = build_cost(kind);
-            // Reject silently if the slot has no economy entry (vacated mid-flight)
-            // or insufficient gold.
             let Some(entry) = economy.slots.get_mut(idx).and_then(|s| s.as_mut()) else {
                 return;
             };
@@ -315,12 +333,9 @@ fn apply_input(
                 return;
             }
             entry.gold -= cost;
-            // Treat (col, row) as a 32-pixel grid; centre the entity in the
-            // cell. Real collision / path validation lands alongside the
-            // path-gen system.
             let x = (col as f32) * 32.0 + 16.0;
             let y = (row as f32) * 32.0 + 16.0;
-            commands.spawn((
+            let mut spawn = commands.spawn((
                 BuildingTag {
                     kind,
                     owner: slot,
@@ -333,14 +348,14 @@ fn apply_input(
                     max_hp: BUILDING_HP,
                 },
             ));
+            if building_is_offensive(kind) {
+                spawn.insert(TowerStats {
+                    last_fire_tick: tick,
+                });
+            }
         }
-        Input::Heartbeat { .. } | Input::Leave => {
-            // No-op for now; the WS handler tracks lifecycle.
-        }
-        _ => {
-            // SellBuilding / Upgrade / Retarget / UseItem / SkipWave / TogglePause
-            // land alongside the matching economy + targeting systems.
-        }
+        Input::Heartbeat { .. } | Input::Leave => {}
+        _ => {}
     }
 }
 
@@ -388,17 +403,152 @@ fn spawn_wave_enemies(clock: Res<SimClock>, mut wave: ResMut<WaveState>, mut com
     }
 }
 
-fn move_enemies(mut q: Query<(&Velocity, &mut Position)>) {
+fn move_enemies(mut q: Query<(&Velocity, &mut Position), With<EnemyTag>>) {
     for (vel, mut pos) in q.iter_mut() {
         pos.0 += vel.0 * TICK_DT;
         pos.1 += vel.1 * TICK_DT;
     }
 }
 
-fn despawn_offscreen(mut commands: Commands, q: Query<(Entity, &Position), Without<BuildingTag>>) {
-    for (entity, pos) in q.iter() {
-        if pos.0 > PLAYFIELD_WIDTH {
+fn tower_fire(
+    clock: Res<SimClock>,
+    mut towers: Query<(&BuildingTag, &Position, &mut TowerStats)>,
+    enemies: Query<(Entity, &EnemyTag, &Position)>,
+    mut commands: Commands,
+) {
+    for (tag, tower_pos, mut stats) in towers.iter_mut() {
+        if !building_is_offensive(tag.kind) {
+            continue;
+        }
+        if clock.tick.wrapping_sub(stats.last_fire_tick) < TOWER_FIRE_INTERVAL_TICKS {
+            continue;
+        }
+
+        // Pick the closest enemy belonging to the same slot, within range.
+        let mut best: Option<(Entity, f32, f32, f32)> = None;
+        for (e_entity, e_tag, e_pos) in enemies.iter() {
+            if e_tag.owner.0 != tag.owner.0 {
+                continue;
+            }
+            let dx = e_pos.0 - tower_pos.0;
+            let dy = e_pos.1 - tower_pos.1;
+            let dist_sq = dx * dx + dy * dy;
+            if dist_sq > TOWER_RANGE_SQ {
+                continue;
+            }
+            if best.map(|(_, b, _, _)| dist_sq < b).unwrap_or(true) {
+                best = Some((e_entity, dist_sq, dx, dy));
+            }
+        }
+        let Some((_target_entity, dist_sq, dx, dy)) = best else {
+            continue;
+        };
+
+        let dist = dist_sq.sqrt().max(0.001);
+        let vx = dx / dist * PROJECTILE_SPEED;
+        let vy = dy / dist * PROJECTILE_SPEED;
+
+        commands.spawn((
+            ProjectileTag {
+                owner: tag.owner,
+                damage: TOWER_DAMAGE,
+                remaining_range: PROJECTILE_MAX_RANGE,
+            },
+            Position(tower_pos.0, tower_pos.1),
+            Velocity(vx, vy),
+        ));
+        stats.last_fire_tick = clock.tick;
+    }
+}
+
+fn move_projectiles(
+    mut commands: Commands,
+    mut q: Query<(Entity, &Velocity, &mut Position, &mut ProjectileTag)>,
+) {
+    for (entity, vel, mut pos, mut proj) in q.iter_mut() {
+        let step_dx = vel.0 * TICK_DT;
+        let step_dy = vel.1 * TICK_DT;
+        pos.0 += step_dx;
+        pos.1 += step_dy;
+        let travelled = (step_dx * step_dx + step_dy * step_dy).sqrt();
+        proj.remaining_range -= travelled;
+        if proj.remaining_range <= 0.0 {
             commands.entity(entity).despawn();
+        }
+    }
+}
+
+fn projectile_hits(
+    mut commands: Commands,
+    mut economy: ResMut<PlayerEconomy>,
+    projectiles: Query<(Entity, &Position, &ProjectileTag)>,
+    mut enemies: Query<(Entity, &EnemyTag, &Position, &mut Health), Without<ProjectileTag>>,
+) {
+    for (p_entity, p_pos, p_tag) in projectiles.iter() {
+        // Find first enemy of the same owner within hit radius.
+        let mut hit: Option<(Entity, bool)> = None;
+        for (e_entity, e_tag, e_pos, mut e_hp) in enemies.iter_mut() {
+            if e_tag.owner.0 != p_tag.owner.0 {
+                continue;
+            }
+            let dx = e_pos.0 - p_pos.0;
+            let dy = e_pos.1 - p_pos.1;
+            if dx * dx + dy * dy > PROJECTILE_HIT_RADIUS_SQ {
+                continue;
+            }
+            e_hp.hp -= p_tag.damage;
+            let killed = e_hp.hp <= 0.0;
+            hit = Some((e_entity, killed));
+            break;
+        }
+        if let Some((enemy_entity, killed)) = hit {
+            commands.entity(p_entity).despawn();
+            if killed {
+                commands.entity(enemy_entity).despawn();
+                let idx = p_tag.owner.0 as usize;
+                if let Some(entry) = economy.slots.get_mut(idx).and_then(|s| s.as_mut()) {
+                    entry.gold = entry.gold.saturating_add(ENEMY_BOUNTY);
+                    entry.kills = entry.kills.wrapping_add(1);
+                }
+            }
+        }
+    }
+}
+
+fn enemies_reach_end(
+    mut commands: Commands,
+    mut economy: ResMut<PlayerEconomy>,
+    q: Query<(Entity, &EnemyTag, &Position)>,
+) {
+    for (entity, tag, pos) in q.iter() {
+        if pos.0 <= PLAYFIELD_WIDTH {
+            continue;
+        }
+        commands.entity(entity).despawn();
+        let idx = tag.owner.0 as usize;
+        if let Some(entry) = economy.slots.get_mut(idx).and_then(|s| s.as_mut()) {
+            entry.lives = entry.lives.saturating_sub(1).max(0);
+        }
+    }
+}
+
+fn check_game_over(
+    economy: Res<PlayerEconomy>,
+    bcast: Res<SnapshotBroadcast>,
+    mut flags: ResMut<GameOverFlags>,
+) {
+    for idx in 0..proto::MAX_PLAYERS {
+        if flags.fired[idx] {
+            continue;
+        }
+        let Some(entry) = economy.slots.get(idx).and_then(|s| s.as_ref()) else {
+            continue;
+        };
+        if entry.lives <= 0 {
+            flags.fired[idx] = true;
+            let _ = bcast.tx.send(ServerEvent::GameOver {
+                winner: Some(proto::PlayerSlot(idx as u8)),
+            });
         }
     }
 }
@@ -411,6 +561,7 @@ fn emit_snapshot(
     roster: Res<RosterHandle>,
     enemies: Query<(Entity, &EnemyTag, &Position, &Health)>,
     buildings: Query<(Entity, &BuildingTag, &Health)>,
+    projectiles: Query<(Entity, &Position, &Velocity, &ProjectileTag)>,
 ) {
     if clock.tick % SNAPSHOT_EVERY_N_TICKS != 0 {
         return;
@@ -421,7 +572,6 @@ fn emit_snapshot(
         Err(p) => p.into_inner().active_slots(),
     };
 
-    // Bin entities by owner slot so the per-field loop is one pass.
     let mut enemy_bins: HashMap<u8, Vec<proto::EnemyDelta>> = HashMap::new();
     for (entity, tag, pos, hp) in enemies.iter() {
         enemy_bins
@@ -453,6 +603,18 @@ fn emit_snapshot(
                 destroyed: false,
             });
     }
+    let mut projectile_bins: HashMap<u8, Vec<proto::ProjectileDelta>> = HashMap::new();
+    for (entity, pos, vel, tag) in projectiles.iter() {
+        projectile_bins
+            .entry(tag.owner.0)
+            .or_default()
+            .push(proto::ProjectileDelta {
+                eid: proto::EntityId(entity.index_u32()),
+                pos: proto::Vec2 { x: pos.0, y: pos.1 },
+                vel: proto::Vec2 { x: vel.0, y: vel.1 },
+                destroyed: false,
+            });
+    }
 
     let fields: Vec<proto::FieldDelta> = active
         .iter()
@@ -478,7 +640,7 @@ fn emit_snapshot(
                 owner: *slot,
                 buildings: building_bins.remove(&slot.0).unwrap_or_default(),
                 enemies: enemy_bins.remove(&slot.0).unwrap_or_default(),
-                projectiles: Vec::new(),
+                projectiles: projectile_bins.remove(&slot.0).unwrap_or_default(),
                 gold: econ.gold,
                 lives: econ.lives,
                 wave: slot_wave,
@@ -497,8 +659,6 @@ fn emit_snapshot(
     let _ = bcast.tx.send(ServerEvent::Snapshot(snap));
 }
 
-/// Drive `App::update` on a tokio task at `SIM_TICK_HZ`. Loops until the
-/// surrounding task is aborted.
 pub async fn run_sim_loop(mut app: App) {
     let mut ticker = time::interval(Duration::from_millis(1000 / SIM_TICK_HZ as u64));
     ticker.set_missed_tick_behavior(time::MissedTickBehavior::Skip);


### PR DESCRIPTION
## Summary
Gameplay loop closes. Towers shoot, kills mint gold, leaked enemies bleed lives, hitting zero lives broadcasts a single \`ServerEvent::GameOver\`. Plus a small ergonomic fix on the reject path.

## Combat tuning
\`\`\`
TOWER_RANGE                = 140 u
TOWER_DAMAGE               = 18 hp
TOWER_FIRE_INTERVAL_TICKS  = 8 (0.4 s @ 20 Hz)
PROJECTILE_SPEED           = 320 u/s
PROJECTILE_HIT_RADIUS      = 12 u
PROJECTILE_MAX_RANGE       = 600 u
ENEMY_BOUNTY               = 8 gold
\`\`\`

## \`q::nexus_defense_server\`
- New components: \`TowerStats { last_fire_tick }\` (attached on \`PlaceBuilding\` when \`building_is_offensive(kind)\`); \`ProjectileTag { owner, damage, remaining_range }\`.
- New systems chained on Update:
  | system | does |
  |--------|------|
  | \`tower_fire\` | pick nearest same-owner enemy in range, spawn projectile, stamp \`last_fire_tick\` |
  | \`move_projectiles\` | advance position, decrement \`remaining_range\`, despawn at 0 |
  | \`projectile_hits\` | first same-owner enemy within hit radius takes damage; on kill, despawn + bounty + \`kills++\` |
  | \`enemies_reach_end\` | past \`PLAYFIELD_WIDTH\` → owner \`lives--\`, despawn |
  | \`check_game_over\` | \`lives <= 0\` → exactly one \`ServerEvent::GameOver\` per slot (latched via \`GameOverFlags\` so we don't flood every tick) |
- \`emit_snapshot\` bins projectiles by owner too; \`FieldDelta.projectiles\` carries pos + vel for client-side interpolation.
- \`move_enemies\` query tightened to \`With<EnemyTag>\` so projectiles use \`move_projectiles\`.

## \`q::net::server\`
- \`send_reject\` now follows the Reject payload with a clean WS \`Close\` frame (code 1000, reason carried in the close). Client surfaces a single \`Disconnected\` with the rejection reason instead of a tungstenite protocol error chained on top.

## Build matrix
\`\`\`
cargo build -p q                                                          ok
cargo build -p q --no-default-features --features nexus-defense           ok
cargo build -p q --no-default-features --features nexus-defense-server    ok
cargo build -p td-server                                                  ok
cargo test  -p q --no-default-features --features proto-shared --lib proto  3/3 ok
\`\`\`
Server boots clean; sim ticks. dylibs refreshed on Forgejo LFS.

## Test plan
- [ ] \`cargo run -p td-server\` + Godot client.
- [ ] Place a Tower along the wave stripe — projectile streaks toward an enemy, enemy HP drops and despawns; HUD gold ticks up by 8 per kill.
- [ ] Watch a wave pass un-towered — \`lives\` ticks down by 1 per leaked enemy.
- [ ] Let \`lives\` hit 0 — exactly one \`GameOver\` event surfaces (currently no client handler beyond decode_error). Future PR wires a UI to it.
- [ ] Send an invalid JoinMatch token — client surfaces \`Disconnected: …\` (single line, no \"protocol error\" chained).

## Next
- Client-side projectile + enemy hp rendering (currently HUD only sees counts; positions land via existing snapshot fields).
- GameOver UI panel + return-to-menu wiring.
- Tower kind variants beyond \`Tower\` (Bomb/Ice/Fire from the legacy catalog) once cost/stat tables move into proto.

## Related
- #11294 — multiplayer TD tracker
- #11365 — per-slot economy (this PR closes the spend→earn loop)