### PR TITLE
chore(ci): regen ci-dispatch-manifest with nd_server entry

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -304,6 +304,18 @@
 			"has_test": true
 		},
 		{
+			"key": "nd_server",
+			"app_name": "nd-server",
+			"version": "0.0.1",
+			"version_toml": "apps/godot/nexus-defense/server/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/nd-server.mdx",
+			"version_target": "apps/godot/nexus-defense/server/Cargo.toml",
+			"source_path": "apps/godot/nexus-defense/server",
+			"runner": "arc-runner-set",
+			"image": "kbve/nd-server",
+			"has_test": false
+		},
+		{
 			"key": "rareicon",
 			"app_name": "axum-rareicon",
 			"version": "0.1.3",
@@ -695,7 +707,7 @@
 	"unreal_game": [],
 	"bevy_game": [],
 	"summary": {
-		"docker": 25,
+		"docker": 26,
 		"npm": 4,
 		"crates": 24,
 		"python": 2,
@@ -705,6 +717,6 @@
 		"godot": 0,
 		"unreal_game": 0,
 		"bevy_game": 0,
-		"total": 64
+		"total": 65
 	}
 }


### PR DESCRIPTION
## Summary
- Regenerates \`.github/ci-dispatch-manifest.json\` so the new \`nd_server\` docker entry (shipped in 65b1e057e) actually lands in the manifest the dispatch workflow reads.
- Fixes the Manifest Guard failure on #11356 ([run 26418738194](https://github.com/KBVE/kbve/actions/runs/26418738194/job/77769175193)).

## Why
65b1e057e added the MDX page + \`packages/npm/devops/src/lib/ci/registry.ts\` entry for the relocated \`nd-server\` game-server crate but didn't regenerate the dispatch manifest (local \`astro-kbve:build\` was hitting a stale rollup cache). The Manifest Guard CI step rebuilds the manifest on a fresh checkout and diffs it against the committed copy, which surfaced the drift.

This PR runs \`nx run astro-kbve:build && nx run astro-kbve:sync:ci-manifest\` in a clean worktree and commits the regenerated file. No source changes — only the manifest JSON.

## Test plan
- [x] \`nx run astro-kbve:build\` — clean (7671 pages built)
- [x] \`nx run astro-kbve:sync:ci-manifest\` — wrote new manifest
- [x] \`jq '.docker[] | select(.app_name==\"nd-server\")'\` — entry present with version_toml + source_path + image + runner populated
- [ ] Manifest Guard re-runs green on this PR