### PR TITLE
refactor(astro-kbve): client-router audit Phase 1 — DOMContentLoaded → view-transition-safe lifecycle

### DIFF
--- a/apps/kbve/astro-kbve/src/components/arcade/ArcadeHero.astro
+++ b/apps/kbve/astro-kbve/src/components/arcade/ArcadeHero.astro
@@ -92,7 +92,7 @@ const {
 	}
 </style>
 
-<script is:inline>
+<script is:inline data-astro-rerun>
 	(() => {
 		const reduceMotion =
 			typeof window !== 'undefined' &&
@@ -168,10 +168,10 @@ const {
 			});
 		}
 
-		if (document.readyState === 'loading') {
-			document.addEventListener('DOMContentLoaded', init);
-		} else {
-			init();
-		}
+		// `data-astro-rerun` on the script tag ensures this IIFE runs on
+		// every nav swap under ClientRouter, not just the initial hard
+		// load. At swap time the DOM is fully present, so no readyState
+		// check is needed.
+		init();
 	})();
 </script>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroKanbanDashboard.astro
@@ -783,14 +783,8 @@ const sectionNames = [
 		});
 	}
 
-	// Init on load + Astro page transitions
-	if (document.readyState === 'loading') {
-		document.addEventListener('DOMContentLoaded', initKanbanSections, {
-			once: true,
-		});
-	} else {
-		initKanbanSections();
-	}
+	// `astro:page-load` fires on both initial hard load and every
+	// ClientRouter swap, so no separate DOMContentLoaded path needed.
 	document.addEventListener('astro:page-load', initKanbanSections);
 </script>
 

--- a/apps/kbve/astro-kbve/src/components/kbve/DeferredAdsense.astro
+++ b/apps/kbve/astro-kbve/src/components/kbve/DeferredAdsense.astro
@@ -51,8 +51,8 @@ const AD_CLIENT = 'ca-pub-3698214103602019';
 	is:inline
 	async
 	src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${AD_CLIENT}`}
-	crossorigin="anonymous">
-</script>
+	crossorigin="anonymous"
+></script>
 
 <DeferredSection
 	id={id}
@@ -86,7 +86,7 @@ const AD_CLIENT = 'ca-pub-3698214103602019';
 	</aside>
 </DeferredSection>
 
-<script is:inline define:vars={{ sectionId: id }}>
+<script is:inline define:vars={{ sectionId: id }} data-astro-rerun>
 	(function () {
 		let mo = null;
 		const fire = () => {
@@ -130,10 +130,10 @@ const AD_CLIENT = 'ca-pub-3698214103602019';
 		document.addEventListener('astro:before-swap', cleanup, { once: true });
 		window.addEventListener('pagehide', cleanup, { once: true });
 
-		if (document.readyState === 'loading') {
-			document.addEventListener('DOMContentLoaded', fire, { once: true });
-		} else {
-			fire();
-		}
+		// `data-astro-rerun` re-runs this IIFE on every nav swap, so by
+		// the time we get here the DOM is fully parsed. `fire()` is
+		// idempotent (no-op when section already loaded) so safe to
+		// call directly without a readystate gate.
+		fire();
 	})();
 </script>

--- a/apps/kbve/astro-kbve/src/components/vn/VisualNovelPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/vn/VisualNovelPanel.astro
@@ -57,13 +57,19 @@ const initial = optionMap[defaultId] ?? options[0];
 		</div>
 	</div>
 
-	<script is:inline define:vars={{ options, defaultId, onChoice }}>
-		document.addEventListener('DOMContentLoaded', () => {
+	<script
+		is:inline
+		define:vars={{ options, defaultId, onChoice }}
+		data-astro-rerun
+	>
+		(() => {
 			const imageBox = document.getElementById('vn-image');
 			const messageBox = document.getElementById('vn-message');
 			const choiceBox = document.getElementById('vn-choices');
 			const titleBox = document.getElementById('vn-title');
 			const descBox = document.getElementById('vn-desc');
+			if (!imageBox || !messageBox || !choiceBox || !titleBox || !descBox)
+				return;
 
 			const optionMap = Object.fromEntries(
 				options.map((opt) => [opt.id, opt]),
@@ -128,6 +134,6 @@ const initial = optionMap[defaultId] ?? options[0];
 			};
 
 			renderNode(currentId);
-		});
+		})();
 	</script>
 </section>


### PR DESCRIPTION
## Summary
First of a multi-phase audit to make the astro-kbve site safe to re-enable Starlight's \`<ClientRouter />\` (View Transitions). Under view transitions, \`DOMContentLoaded\` fires only on the initial hard load — subsequent nav swaps skip it, so any init that relies on it silently stops running.

Phase 1 ports the 4 files that still use \`DOMContentLoaded\` or the dual-listener fallback pattern. ClientRouter is **not** activated in this PR — it ships in the final phase after the rest of the audit lands.

## Files
| File | Pattern |
|---|---|
| \`components/vn/VisualNovelPanel.astro\` | inline IIFE + \`data-astro-rerun\` + null guard |
| \`components/arcade/ArcadeHero.astro\` | inline IIFE + \`data-astro-rerun\` |
| \`components/kbve/DeferredAdsense.astro\` | inline IIFE + \`data-astro-rerun\` (keeps existing \`astro:before-swap\` MO cleanup) |
| \`components/dashboard/AstroKanbanDashboard.astro\` | single \`astro:page-load\` listener (drops the redundant \`DOMContentLoaded\` fallback) |

## Two patterns used
1. **Component-local inline scripts** that init their own DOM → add \`data-astro-rerun\` so the IIFE re-runs on each swap. Drop the \`document.readyState === 'loading'\` gate (DOM is fully parsed at swap time). Null-guard the queried elements so a non-matching swap exits cleanly.
2. **Globally-registered init handlers** → single \`astro:page-load\` listener (fires on initial load too, no fallback needed).

## What's next
- **Phase 2**: audit remaining ~30 inline \`<script>\` blocks that don't use lifecycle listeners but may still have first-load-only side effects.
- **Phase 3**: classify \`client:*\` islands. Most are stateless and remount fine; flag the few that need \`transition:persist\` (auth shell, future Yuki assistant).
- **Phase 4**: enable \`<ClientRouter />\` in the Starlight layout.

## Test plan
- [ ] \`pnpm exec astro sync\` clean (verified)
- [ ] \`/arcade/\` hero stat odometer still animates on hard load
- [ ] VN panel pages still init the message + choice loop
- [ ] AdSense slots still push on intersection
- [ ] Dashboard kanban sections still snap-scroll