### PR TITLE
feat(astro-kbve): agents token CRUD modals (P2 of #11362)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -304,6 +304,18 @@
 			"has_test": true
 		},
 		{
+			"key": "nd_server",
+			"app_name": "nd-server",
+			"version": "0.0.1",
+			"version_toml": "apps/godot/nexus-defense/server/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/nd-server.mdx",
+			"version_target": "apps/godot/nexus-defense/server/Cargo.toml",
+			"source_path": "apps/godot/nexus-defense/server",
+			"runner": "arc-runner-set",
+			"image": "kbve/nd-server",
+			"has_test": false
+		},
+		{
 			"key": "rareicon",
 			"app_name": "axum-rareicon",
 			"version": "0.1.3",
@@ -695,7 +707,7 @@
 	"unreal_game": [],
 	"bevy_game": [],
 	"summary": {
-		"docker": 25,
+		"docker": 26,
 		"npm": 4,
 		"crates": 24,
 		"python": 2,
@@ -705,6 +717,6 @@
 		"godot": 0,
 		"unreal_game": 0,
 		"bevy_game": 0,
-		"total": 64
+		"total": 65
 	}
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentDiscordsh.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentDiscordsh.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	Loader2,
@@ -7,6 +7,9 @@ import {
 	AlertTriangle,
 	Users,
 	KeyRound,
+	Plus,
+	Trash2,
+	Power,
 } from 'lucide-react';
 import {
 	agentsService,
@@ -14,6 +17,7 @@ import {
 	type DiscordGuild,
 } from './agentsService';
 import { styles } from './dashboard-ui';
+import { AddTokenModal, DeleteTokenModal } from './ReactAgentTokenModals';
 
 const DISCORD_CDN = 'https://cdn.discordapp.com';
 
@@ -355,6 +359,18 @@ function TokenList({
 	error,
 	onRefresh,
 }: TokenListProps) {
+	const [addOpen, setAddOpen] = useState(false);
+	const [pendingDelete, setPendingDelete] = useState<AgentTokenRow | null>(
+		null,
+	);
+	const [togglingId, setTogglingId] = useState<string | null>(null);
+
+	async function handleToggle(t: AgentTokenRow) {
+		setTogglingId(t.token_id);
+		await agentsService.toggleToken(t.token_id, !t.is_active);
+		setTogglingId(null);
+	}
+
 	return (
 		<section style={styles.sectionBorder}>
 			<header
@@ -379,10 +395,30 @@ function TokenList({
 				</span>
 				<button
 					type="button"
+					onClick={() => setAddOpen(true)}
+					style={{
+						marginLeft: 'auto',
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.35rem',
+						padding: '0.3rem 0.7rem',
+						borderRadius: 6,
+						border: 'none',
+						background: '#58a6ff',
+						color: '#0d1117',
+						cursor: 'pointer',
+						fontSize: '0.8rem',
+						fontWeight: 600,
+					}}
+					aria-label="Add token">
+					<Plus size={14} />
+					Add token
+				</button>
+				<button
+					type="button"
 					onClick={onRefresh}
 					disabled={loading}
 					style={{
-						marginLeft: 'auto',
 						display: 'inline-flex',
 						alignItems: 'center',
 						gap: '0.35rem',
@@ -467,6 +503,13 @@ function TokenList({
 									<th style={{ padding: '0.4rem 0.5rem' }}>
 										Created
 									</th>
+									<th
+										style={{
+											padding: '0.4rem 0.5rem',
+											textAlign: 'right',
+										}}>
+										Actions
+									</th>
 								</tr>
 							</thead>
 							<tbody>
@@ -535,6 +578,93 @@ function TokenList({
 												}}>
 												{formatDate(t.created_at)}
 											</td>
+											<td
+												style={{
+													padding: '0.5rem',
+													textAlign: 'right',
+													whiteSpace: 'nowrap',
+												}}>
+												<button
+													type="button"
+													onClick={() =>
+														handleToggle(t)
+													}
+													disabled={
+														togglingId ===
+														t.token_id
+													}
+													aria-label={
+														t.is_active
+															? 'Disable token'
+															: 'Enable token'
+													}
+													title={
+														t.is_active
+															? 'Disable token'
+															: 'Enable token'
+													}
+													style={{
+														display: 'inline-flex',
+														alignItems: 'center',
+														gap: '0.25rem',
+														padding:
+															'0.25rem 0.5rem',
+														borderRadius: 6,
+														border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+														background:
+															'transparent',
+														color: t.is_active
+															? '#fbbf24'
+															: '#4ade80',
+														cursor:
+															togglingId ===
+															t.token_id
+																? 'wait'
+																: 'pointer',
+														fontSize: '0.75rem',
+														marginRight: '0.35rem',
+													}}>
+													{togglingId ===
+													t.token_id ? (
+														<Loader2
+															size={12}
+															style={{
+																animation:
+																	'spin 1s linear infinite',
+															}}
+														/>
+													) : (
+														<Power size={12} />
+													)}
+													{t.is_active
+														? 'Disable'
+														: 'Enable'}
+												</button>
+												<button
+													type="button"
+													onClick={() =>
+														setPendingDelete(t)
+													}
+													aria-label="Delete token"
+													title="Delete token"
+													style={{
+														display: 'inline-flex',
+														alignItems: 'center',
+														gap: '0.25rem',
+														padding:
+															'0.25rem 0.5rem',
+														borderRadius: 6,
+														border: '1px solid rgba(239,68,68,0.4)',
+														background:
+															'transparent',
+														color: '#f87171',
+														cursor: 'pointer',
+														fontSize: '0.75rem',
+													}}>
+													<Trash2 size={12} />
+													Delete
+												</button>
+											</td>
 										</tr>
 									);
 								})}
@@ -548,10 +678,19 @@ function TokenList({
 						fontSize: '0.78rem',
 						color: 'var(--sl-color-gray-3, #9ca0aa)',
 					}}>
-					Token values are never returned by the dashboard. Add /
-					rotate / delete operations will land in the P2 update.
+					Token values are written to Supabase Vault encrypted and
+					never returned by the dashboard. Use Disable to
+					soft-deactivate a token without removing it.
 				</p>
 			</div>
+
+			{addOpen && <AddTokenModal onClose={() => setAddOpen(false)} />}
+			{pendingDelete && (
+				<DeleteTokenModal
+					token={pendingDelete}
+					onClose={() => setPendingDelete(null)}
+				/>
+			)}
 		</section>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentTokenModals.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentTokenModals.tsx
@@ -1,0 +1,531 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Loader2, RefreshCw, Shuffle, X } from 'lucide-react';
+import { agentsService, type AgentTokenRow } from './agentsService';
+
+const TOKEN_NAME_RE = /^[a-z0-9_-]{3,64}$/;
+const SERVICE_RE = /^[a-z0-9_]{2,32}$/;
+
+const SERVICE_PRESETS: Array<{
+	value: string;
+	label: string;
+	hint?: string;
+}> = [
+	{
+		value: 'github',
+		label: 'github — PAT',
+		hint: 'GitHub personal access token. Used by /github board commands + /gh claim + gh-backfill.',
+	},
+	{
+		value: 'github_webhook',
+		label: 'github_webhook — HMAC',
+		hint: 'HMAC secret for the GitHub webhook delivery. Set the same value in your repo Settings → Webhooks → Secret.',
+	},
+	{
+		value: 'github_repos',
+		label: 'github_repos — repo allowlist (future)',
+		hint: 'Comma-separated owner/repo list for this guild. Used by P4 of the agents rollout.',
+	},
+	{
+		value: 'irc',
+		label: 'irc — bridge token',
+		hint: 'IRC gateway credential for this guild.',
+	},
+];
+
+interface BaseModalProps {
+	onClose: () => void;
+}
+
+function ModalShell({
+	children,
+	onClose,
+	title,
+}: BaseModalProps & { children: React.ReactNode; title: string }) {
+	const dialogRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		function onKey(e: KeyboardEvent) {
+			if (e.key === 'Escape') onClose();
+		}
+		document.addEventListener('keydown', onKey);
+		return () => document.removeEventListener('keydown', onKey);
+	}, [onClose]);
+
+	return (
+		<div
+			role="dialog"
+			aria-modal="true"
+			aria-label={title}
+			style={{
+				position: 'fixed',
+				inset: 0,
+				background: 'rgba(0,0,0,0.55)',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				zIndex: 9999,
+				padding: '1rem',
+			}}
+			onClick={(e) => {
+				if (e.target === e.currentTarget) onClose();
+			}}>
+			<div
+				ref={dialogRef}
+				style={{
+					background: 'var(--sl-color-bg-nav, #0d1117)',
+					border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+					borderRadius: 12,
+					maxWidth: 560,
+					width: '100%',
+					maxHeight: '90vh',
+					overflowY: 'auto',
+					display: 'flex',
+					flexDirection: 'column',
+				}}>
+				<header
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'space-between',
+						padding: '0.85rem 1.1rem',
+						borderBottom:
+							'1px solid var(--sl-color-gray-5, #2d2f36)',
+					}}>
+					<h2 style={{ margin: 0, fontSize: '1rem' }}>{title}</h2>
+					<button
+						type="button"
+						onClick={onClose}
+						aria-label="Close"
+						style={{
+							background: 'transparent',
+							border: 'none',
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							cursor: 'pointer',
+							padding: 4,
+						}}>
+						<X size={18} />
+					</button>
+				</header>
+				{children}
+			</div>
+		</div>
+	);
+}
+
+function genSecret(bytes = 32): string {
+	const arr = new Uint8Array(bytes);
+	crypto.getRandomValues(arr);
+	return Array.from(arr)
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+export function AddTokenModal({ onClose }: BaseModalProps) {
+	const [tokenName, setTokenName] = useState('');
+	const [service, setService] = useState('github_webhook');
+	const [tokenValue, setTokenValue] = useState('');
+	const [description, setDescription] = useState('');
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const preset = useMemo(
+		() => SERVICE_PRESETS.find((p) => p.value === service),
+		[service],
+	);
+
+	const nameOk = TOKEN_NAME_RE.test(tokenName);
+	const serviceOk = SERVICE_RE.test(service);
+	const valueOk = tokenValue.length >= 10 && tokenValue.length <= 8000;
+	const formValid = nameOk && serviceOk && valueOk && !busy;
+
+	async function submit(e: React.FormEvent) {
+		e.preventDefault();
+		if (!formValid) return;
+		setBusy(true);
+		setError(null);
+		const r = await agentsService.addToken({
+			tokenName,
+			service,
+			tokenValue,
+			description: description.trim() || null,
+		});
+		setBusy(false);
+		if (!r.ok) {
+			setError(r.error);
+			return;
+		}
+		onClose();
+	}
+
+	return (
+		<ModalShell title="Add token" onClose={onClose}>
+			<form
+				onSubmit={submit}
+				style={{
+					padding: '1rem 1.1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.85rem',
+				}}>
+				<Field
+					label="Service"
+					hint={preset?.hint}
+					control={
+						<select
+							value={service}
+							onChange={(e) => setService(e.target.value)}
+							style={inputStyle}>
+							{SERVICE_PRESETS.map((p) => (
+								<option key={p.value} value={p.value}>
+									{p.label}
+								</option>
+							))}
+						</select>
+					}
+				/>
+
+				<Field
+					label="Token name"
+					hint="Friendly label for this row. 3–64 chars, lowercase a–z, 0–9, _ -"
+					error={
+						tokenName.length > 0 && !nameOk
+							? 'Must match ^[a-z0-9_-]{3,64}$'
+							: null
+					}
+					control={
+						<input
+							type="text"
+							value={tokenName}
+							placeholder={
+								service === 'github_webhook'
+									? 'github-webhook-hmac'
+									: 'github-pat'
+							}
+							onChange={(e) =>
+								setTokenName(e.target.value.toLowerCase())
+							}
+							style={inputStyle}
+							autoComplete="off"
+							spellCheck={false}
+						/>
+					}
+				/>
+
+				<Field
+					label="Token value"
+					hint="Stored encrypted in Supabase Vault. Never returned to the dashboard after submission."
+					error={
+						tokenValue.length > 0 && !valueOk
+							? 'Must be 10–8000 chars'
+							: null
+					}
+					control={
+						<div
+							style={{
+								display: 'flex',
+								flexDirection: 'column',
+								gap: '0.4rem',
+							}}>
+							<textarea
+								value={tokenValue}
+								onChange={(e) => setTokenValue(e.target.value)}
+								rows={3}
+								spellCheck={false}
+								autoComplete="off"
+								style={{
+									...inputStyle,
+									fontFamily:
+										'var(--sl-font-mono, ui-monospace, monospace)',
+									resize: 'vertical',
+								}}
+							/>
+							{service === 'github_webhook' && (
+								<button
+									type="button"
+									onClick={() => setTokenValue(genSecret(32))}
+									style={smallButton}>
+									<Shuffle
+										size={14}
+										style={{ marginRight: 6 }}
+									/>
+									Generate random 32-byte hex
+								</button>
+							)}
+						</div>
+					}
+				/>
+
+				<Field
+					label="Description (optional)"
+					control={
+						<input
+							type="text"
+							value={description}
+							maxLength={256}
+							placeholder={
+								service === 'github_webhook'
+									? 'HMAC secret for KBVE/kbve webhook'
+									: ''
+							}
+							onChange={(e) => setDescription(e.target.value)}
+							style={inputStyle}
+						/>
+					}
+				/>
+
+				{error && (
+					<p
+						style={{
+							color: '#f87171',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						{error}
+					</p>
+				)}
+
+				<div
+					style={{
+						display: 'flex',
+						justifyContent: 'flex-end',
+						gap: '0.5rem',
+					}}>
+					<button
+						type="button"
+						onClick={onClose}
+						style={secondaryButton}>
+						Cancel
+					</button>
+					<button
+						type="submit"
+						disabled={!formValid}
+						style={primaryButton(formValid)}>
+						{busy ? (
+							<Loader2
+								size={14}
+								style={{ animation: 'spin 1s linear infinite' }}
+							/>
+						) : null}
+						{busy ? 'Saving…' : 'Save token'}
+					</button>
+				</div>
+			</form>
+		</ModalShell>
+	);
+}
+
+interface DeleteTokenModalProps extends BaseModalProps {
+	token: AgentTokenRow;
+}
+
+export function DeleteTokenModal({ token, onClose }: DeleteTokenModalProps) {
+	const [confirmText, setConfirmText] = useState('');
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const match = confirmText === token.token_name;
+
+	async function submit() {
+		if (!match || busy) return;
+		setBusy(true);
+		setError(null);
+		const r = await agentsService.deleteToken(token.token_id);
+		setBusy(false);
+		if (!r.ok) {
+			setError(r.error);
+			return;
+		}
+		onClose();
+	}
+
+	return (
+		<ModalShell title="Delete token" onClose={onClose}>
+			<div
+				style={{
+					padding: '1rem 1.1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.85rem',
+				}}>
+				<p
+					style={{
+						margin: 0,
+						fontSize: '0.9rem',
+						color: 'var(--sl-color-gray-2, #c2c5cc)',
+					}}>
+					This permanently removes the Vault row. The encrypted value
+					is destroyed and any service consuming this row stops
+					working immediately.
+				</p>
+				<p
+					style={{
+						margin: 0,
+						fontSize: '0.85rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					Type{' '}
+					<code
+						style={{
+							background: 'rgba(255,255,255,0.08)',
+							padding: '0 0.3rem',
+							borderRadius: 4,
+						}}>
+						{token.token_name}
+					</code>{' '}
+					to confirm.
+				</p>
+				<input
+					type="text"
+					value={confirmText}
+					onChange={(e) => setConfirmText(e.target.value)}
+					style={inputStyle}
+					autoComplete="off"
+					spellCheck={false}
+				/>
+				{error && (
+					<p
+						style={{
+							color: '#f87171',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						{error}
+					</p>
+				)}
+				<div
+					style={{
+						display: 'flex',
+						justifyContent: 'flex-end',
+						gap: '0.5rem',
+					}}>
+					<button
+						type="button"
+						onClick={onClose}
+						style={secondaryButton}>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={submit}
+						disabled={!match || busy}
+						style={dangerButton(match && !busy)}>
+						{busy ? (
+							<Loader2
+								size={14}
+								style={{ animation: 'spin 1s linear infinite' }}
+							/>
+						) : null}
+						{busy ? 'Deleting…' : 'Delete token'}
+					</button>
+				</div>
+			</div>
+		</ModalShell>
+	);
+}
+
+function Field({
+	label,
+	hint,
+	error,
+	control,
+}: {
+	label: string;
+	hint?: string;
+	error?: string | null;
+	control: React.ReactNode;
+}) {
+	return (
+		<label
+			style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+			<span
+				style={{
+					fontSize: '0.8rem',
+					fontWeight: 600,
+					color: 'var(--sl-color-white, #fff)',
+				}}>
+				{label}
+			</span>
+			{control}
+			{hint && !error && (
+				<span
+					style={{
+						fontSize: '0.75rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					{hint}
+				</span>
+			)}
+			{error && (
+				<span style={{ fontSize: '0.75rem', color: '#f87171' }}>
+					{error}
+				</span>
+			)}
+		</label>
+	);
+}
+
+const inputStyle: React.CSSProperties = {
+	background: 'rgba(255,255,255,0.04)',
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	borderRadius: 6,
+	color: 'var(--sl-color-white, #fff)',
+	padding: '0.5rem 0.65rem',
+	fontSize: '0.9rem',
+	width: '100%',
+	boxSizing: 'border-box',
+};
+
+const smallButton: React.CSSProperties = {
+	alignSelf: 'flex-start',
+	display: 'inline-flex',
+	alignItems: 'center',
+	padding: '0.3rem 0.6rem',
+	borderRadius: 6,
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	background: 'transparent',
+	color: 'var(--sl-color-white, #fff)',
+	cursor: 'pointer',
+	fontSize: '0.78rem',
+};
+
+const secondaryButton: React.CSSProperties = {
+	padding: '0.5rem 1rem',
+	borderRadius: 8,
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	background: 'transparent',
+	color: 'var(--sl-color-white, #fff)',
+	cursor: 'pointer',
+	fontSize: '0.9rem',
+};
+
+function primaryButton(enabled: boolean): React.CSSProperties {
+	return {
+		padding: '0.5rem 1rem',
+		borderRadius: 8,
+		border: 'none',
+		background: enabled ? '#58a6ff' : 'rgba(88,166,255,0.4)',
+		color: '#0d1117',
+		fontWeight: 600,
+		cursor: enabled ? 'pointer' : 'not-allowed',
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+	};
+}
+
+function dangerButton(enabled: boolean): React.CSSProperties {
+	return {
+		padding: '0.5rem 1rem',
+		borderRadius: 8,
+		border: 'none',
+		background: enabled ? '#ef4444' : 'rgba(239,68,68,0.4)',
+		color: '#fff',
+		fontWeight: 600,
+		cursor: enabled ? 'pointer' : 'not-allowed',
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+	};
+}
+
+export const _refreshIcon = RefreshCw;

--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -187,6 +187,142 @@ class AgentsService {
 		if (guildId) await this.loadTokens(guildId);
 	}
 
+	public async addToken(input: {
+		tokenName: string;
+		service: string;
+		tokenValue: string;
+		description?: string | null;
+	}): Promise<{ ok: true; tokenId: string } | { ok: false; error: string }> {
+		const guildId = this.$selectedGuildId.get();
+		const accessToken = this.$accessToken.get();
+		const providerToken = this.$providerToken.get();
+		if (!guildId || !accessToken || !providerToken) {
+			return { ok: false, error: 'No guild selected or session missing' };
+		}
+
+		const resp = await this.callGuildVault(
+			'tokens.set_token',
+			accessToken,
+			{
+				server_id: guildId,
+				provider_token: providerToken,
+				token_name: input.tokenName,
+				service: input.service,
+				token_value: input.tokenValue,
+				description: input.description ?? null,
+			},
+		);
+
+		if (!resp.ok) return { ok: false, error: resp.error };
+		const tokenId =
+			(resp.body as { token_id?: string } | null)?.token_id ?? '';
+		await this.refreshSelectedGuild();
+		addToast({
+			id: `token-add-${Date.now()}`,
+			message: `Token "${input.tokenName}" registered.`,
+			severity: 'success',
+			duration: 3500,
+		});
+		return { ok: true, tokenId };
+	}
+
+	public async deleteToken(
+		tokenId: string,
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		const guildId = this.$selectedGuildId.get();
+		const accessToken = this.$accessToken.get();
+		const providerToken = this.$providerToken.get();
+		if (!guildId || !accessToken || !providerToken) {
+			return { ok: false, error: 'No guild selected or session missing' };
+		}
+
+		const resp = await this.callGuildVault(
+			'tokens.delete_token',
+			accessToken,
+			{
+				server_id: guildId,
+				provider_token: providerToken,
+				token_id: tokenId,
+			},
+		);
+
+		if (!resp.ok) return { ok: false, error: resp.error };
+		await this.refreshSelectedGuild();
+		addToast({
+			id: `token-del-${Date.now()}`,
+			message: 'Token deleted.',
+			severity: 'success',
+			duration: 3500,
+		});
+		return { ok: true };
+	}
+
+	public async toggleToken(
+		tokenId: string,
+		isActive: boolean,
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		const guildId = this.$selectedGuildId.get();
+		const accessToken = this.$accessToken.get();
+		const providerToken = this.$providerToken.get();
+		if (!guildId || !accessToken || !providerToken) {
+			return { ok: false, error: 'No guild selected or session missing' };
+		}
+
+		const resp = await this.callGuildVault(
+			'tokens.toggle_token',
+			accessToken,
+			{
+				server_id: guildId,
+				provider_token: providerToken,
+				token_id: tokenId,
+				is_active: isActive,
+			},
+		);
+
+		if (!resp.ok) return { ok: false, error: resp.error };
+		await this.refreshSelectedGuild();
+		return { ok: true };
+	}
+
+	private async callGuildVault(
+		command: string,
+		accessToken: string,
+		extra: Record<string, unknown>,
+	): Promise<{ ok: true; body: unknown } | { ok: false; error: string }> {
+		try {
+			const resp = await fetch(GUILD_VAULT_URL, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${accessToken}`,
+				},
+				body: JSON.stringify({ command, ...extra }),
+			});
+			const text = await resp.text();
+			let body: unknown;
+			try {
+				body = JSON.parse(text);
+			} catch {
+				return {
+					ok: false,
+					error: `HTTP ${resp.status}: ${text.slice(0, 200)}`,
+				};
+			}
+			if (!resp.ok) {
+				const errMsg =
+					(body as { error?: string } | null)?.error ??
+					`HTTP ${resp.status}`;
+				return { ok: false, error: errMsg };
+			}
+			return { ok: true, body };
+		} catch (e) {
+			return {
+				ok: false,
+				error: e instanceof Error ? e.message : 'Network error',
+			};
+		}
+	}
+
 	public async signInWithDiscord(): Promise<void> {
 		try {
 			const { authBridge } = await import('@/components/auth/AuthBridge');


### PR DESCRIPTION
Third slice of #11362. Brings the /dashboard/agents/discordsh surface to feature-parity with the curl path: guild owners can now add, disable/enable, and delete Vault rows from the UI. After this lands, the dogfood path becomes:

1. Sign in (Discord OAuth).
2. Pick guild.
3. **Add token** → service preset + value + optional description.
4. Per-row Disable / Enable / Delete actions.

No more curl to provision \`github_webhook:<guild>\`, \`github_pat:<guild>\`, etc.

## Files

- \`src/components/dashboard/agentsService.ts\`
  - \`addToken({tokenName, service, tokenValue, description})\` → \`tokens.set_token\`
  - \`deleteToken(tokenId)\` → \`tokens.delete_token\`
  - \`toggleToken(tokenId, isActive)\` → \`tokens.toggle_token\`
  - Private \`callGuildVault(command, accessToken, extra)\` collapses the shared HTTP / JSON-parse / error-shape boilerplate so each CRUD method stays short.
  - Auto-refresh selected guild's token list after each successful op + toast.

- \`src/components/dashboard/ReactAgentTokenModals.tsx\` (new)
  - **ModalShell** — backdrop click / ESC close, autofocus-friendly container.
  - **AddTokenModal** — service preset dropdown with inline hints (\`github\`, \`github_webhook\`, \`github_repos\`, \`irc\`). \"Generate random 32-byte hex\" shortcut on \`github_webhook\` via \`crypto.getRandomValues\`. Client-side validation mirrors \`apps/kbve/edge/functions/guild-vault/_shared.ts\` (\`^[a-z0-9_-]{3,64}$\` name, \`^[a-z0-9_]{2,32}$\` service, 10–8000 char value) so we fail fast before the round-trip.
  - **DeleteTokenModal** — type-the-token-name confirmation pattern, error passthrough.

- \`src/components/dashboard/ReactAgentDiscordsh.tsx\`
  - Token table picks up an Actions column with row-level Disable/Enable + Delete.
  - Header \"Add token\" CTA next to Refresh.
  - Lifecycle state in \`TokenList\` (\`addOpen\`, \`pendingDelete\`, \`togglingId\`).
  - Stale P1 placeholder note replaced with usage hint.

## Security shape

- Token value field lives only in the React form state for the lifetime of the modal — never localStorage / IDB.
- service_role never touched in the browser. guild-vault auth is the user's Supabase JWT + Discord provider_token; both already in memory from P1.
- DeleteTokenModal requires an exact \`token_name\` match before the RPC call so a stray click cannot wipe a row.

## No version bump

axum-kbve v1.0.171 (from #11364 P0) is still pre-publish. P1 (#11368) and now P2 ride the same image tag — when ci-docker eventually fires, all three slices ship together.

## Out of scope (continues #11362)

- **P3** GitHub guided wizard — uses these CRUD primitives for one-click webhook secret + PAT setup.
- **P4** per-guild repo allowlist (env → Vault).
- **P5** queue stats widget.
- **P6** bot install wizard.

## Verification

- \`./kbve.sh -nx astro-kbve:build\` ✓
- Manifest regen (incidental nd_server addition from in-flight work; full regen per convention)
- No new dependencies