### PR TITLE
fix(q): clippy 1.94 — is_multiple_of + needless_range_loop in nd_server

### DIFF
--- a/packages/rust/q/src/nexus_defense_server/mod.rs
+++ b/packages/rust/q/src/nexus_defense_server/mod.rs
@@ -282,8 +282,8 @@ fn sync_per_slot_state(
             over.fired[idx] = false;
         }
     }
-    for idx in 0..proto::MAX_PLAYERS {
-        if !active_mask[idx] {
+    for (idx, &is_active) in active_mask.iter().enumerate().take(proto::MAX_PLAYERS) {
+        if !is_active {
             wave.slots[idx] = None;
             economy.slots[idx] = None;
             over.fired[idx] = false;
@@ -553,6 +553,7 @@ fn check_game_over(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn emit_snapshot(
     clock: Res<SimClock>,
     wave: Res<WaveState>,
@@ -563,7 +564,7 @@ fn emit_snapshot(
     buildings: Query<(Entity, &BuildingTag, &Health)>,
     projectiles: Query<(Entity, &Position, &Velocity, &ProjectileTag)>,
 ) {
-    if clock.tick % SNAPSHOT_EVERY_N_TICKS != 0 {
+    if !clock.tick.is_multiple_of(SNAPSHOT_EVERY_N_TICKS) {
         return;
     }
 
@@ -654,7 +655,7 @@ fn emit_snapshot(
         input_ack: 0,
         players: Vec::new(),
         fields,
-        keyframe: clock.tick % (SIM_TICK_HZ * 5) == 0,
+        keyframe: clock.tick.is_multiple_of(SIM_TICK_HZ * 5),
     };
     let _ = bcast.tx.send(ServerEvent::Snapshot(snap));
 }


### PR DESCRIPTION
## Summary
Fixes the \`nd-server:lint\` failure on #11356 ([run 26473073804](https://github.com/KBVE/kbve/actions/runs/26473073804/job/77769175193)) caused by Rust 1.94 promoting three lints to hard errors against \`q::nexus_defense_server\`:

- \`needless_range_loop\` — rewrite \`for idx in 0..MAX_PLAYERS\` over \`active_mask\` as \`iter().enumerate().take(MAX_PLAYERS)\` so the destructure carries both index and payload.
- \`manual_is_multiple_of\` (2 sites) — \`tick % N\` → \`tick.is_multiple_of(N)\`.
- \`too_many_arguments\` on \`emit_snapshot\` — bevy ECS systems get their dependency graph through the parameter list, so the count is intrinsic. \`#[allow(clippy::too_many_arguments)]\` on the fn.

## Test plan
- [x] \`cargo clippy -p nd-server --all-targets -- -D warnings\` — clean
- [x] \`cargo clippy -p q --all-targets -- -D warnings\` — clean
- [x] \`cargo build -p nd-server\` — clean
- [ ] CI \`Validate Dev→Main PR\` lint sweep on this branch