### PR TITLE
fix(ci-dashboard): slurp paginated gh api output before json.load

### DIFF
--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -178,10 +178,17 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   set -euo pipefail
-                  gh api repos/${{ github.repository }}/code-scanning/alerts \
-                    --paginate \
-                    -q '[.[] | select(.state == "open")]' \
-                    > /tmp/codeql-alerts.json 2>/dev/null || echo '[]' > /tmp/codeql-alerts.json
+                  # gh api --paginate emits one JSON array per page back-to-back,
+                  # which json.load() cannot parse ("Extra data" at start of page 2).
+                  # Slurp pages with `jq -s` and concatenate before writing.
+                  if ! gh api repos/${{ github.repository }}/code-scanning/alerts --paginate 2>/dev/null \
+                       | jq -s 'add // [] | map(select(.state == "open"))' \
+                       > /tmp/codeql-alerts.json; then
+                    echo '[]' > /tmp/codeql-alerts.json
+                  fi
+                  if ! python3 -c "import json; json.load(open('/tmp/codeql-alerts.json'))" 2>/dev/null; then
+                    echo '[]' > /tmp/codeql-alerts.json
+                  fi
 
                   COUNT=$(python3 -c "import json; print(len(json.load(open('/tmp/codeql-alerts.json'))))" 2>/dev/null || echo 0)
                   echo "CodeQL open alerts: $COUNT"
@@ -191,10 +198,14 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   set -euo pipefail
-                  gh api repos/${{ github.repository }}/dependabot/alerts \
-                    --paginate \
-                    -q '[.[] | select(.state == "open")]' \
-                    > /tmp/dependabot-alerts.json 2>/dev/null || echo '[]' > /tmp/dependabot-alerts.json
+                  if ! gh api repos/${{ github.repository }}/dependabot/alerts --paginate 2>/dev/null \
+                       | jq -s 'add // [] | map(select(.state == "open"))' \
+                       > /tmp/dependabot-alerts.json; then
+                    echo '[]' > /tmp/dependabot-alerts.json
+                  fi
+                  if ! python3 -c "import json; json.load(open('/tmp/dependabot-alerts.json'))" 2>/dev/null; then
+                    echo '[]' > /tmp/dependabot-alerts.json
+                  fi
 
                   COUNT=$(python3 -c "import json; print(len(json.load(open('/tmp/dependabot-alerts.json'))))" 2>/dev/null || echo 0)
                   echo "Dependabot open alerts: $COUNT"


### PR DESCRIPTION
Closes #11351

## Root cause

Security Audit's "Aggregate security data" step crashed:
\`\`\`
json.decoder.JSONDecodeError: Extra data: line 2 column 1 (char 35729)
\`\`\`

The fetch steps used:
\`\`\`
gh api repos/.../alerts --paginate -q '[.[] | select(.state == \"open\")]' > /tmp/codeql-alerts.json
\`\`\`

\`--paginate\` runs the \`-q\` jq filter **per page** and concatenates each page's JSON output. With multiple pages the result file is:
\`\`\`
[ ... ]
[ ... ]
[ ... ]
\`\`\`
Valid JSON per page, **invalid** as a single document. \`json.load()\` succeeds on page 1 then trips on the second \`[\` at char 35729.

Both CodeQL and Dependabot fetches had the same pattern. The \`echo 0\` fallback in the count step silently swallowed the failure, so it only surfaced at the aggregate step.

## Fix

Drop per-page \`-q\` and slurp the paginated stream in one final jq pass:
\`\`\`
gh api repos/.../alerts --paginate \\
  | jq -s 'add // [] | map(select(.state == \"open\"))' \\
  > /tmp/codeql-alerts.json
\`\`\`

- \`-s\` slurps every page's array into one outer array
- \`add // []\` concatenates pages (fallback to \`[]\` when zero alerts)
- filter runs once over the merged list

Added a defensive \`python3 json.load\` validation after write — if anything in the pipeline produces non-JSON, replace with \`[]\` instead of crashing the aggregate step downstream.

Applied to both \`Fetch CodeQL alerts\` and \`Fetch Dependabot alerts\`.

## Test plan

- [ ] Manual dispatch \`CI - Daily Dashboard\` → Security Audit job succeeds
- [ ] CodeQL alert count + Dependabot alert count log correctly (non-zero when present)
- [ ] Aggregate step writes \`/tmp/nx-security-raw.json\` without JSON error
- [ ] Next scheduled run (daily) green