### PR TITLE
test(agones-factorio): Phase 0.6 e2e — boot + UDP + RCON smoke

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,13 +3,14 @@
 		{
 			"key": "agones_factorio",
 			"app_name": "agones-factorio",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"version_toml": "apps/agones/factorio/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx",
 			"source_path": "apps/agones/factorio",
 			"runner": "ubuntu-latest",
 			"image": "kbve/agones-factorio",
-			"has_test": false
+			"e2e_name": "agones-factorio",
+			"has_test": true
 		},
 		{
 			"key": "astro_kbve",
@@ -317,7 +318,7 @@
 		{
 			"key": "nd_server",
 			"app_name": "nd-server",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"version_toml": "apps/godot/nexus-defense/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/nd-server.mdx",
 			"version_target": "apps/godot/nexus-defense/server/Cargo.toml",

--- a/apps/agones/factorio/e2e/boot.spec.ts
+++ b/apps/agones/factorio/e2e/boot.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { dockerLogs, dockerRunning } from './helpers/docker';
+
+describe('agones-factorio boot smoke', () => {
+	it('container is still running after scenario load', () => {
+		expect(dockerRunning()).toBe(true);
+	});
+
+	it('logs the Factorio server-ready marker', () => {
+		const logs = dockerLogs();
+		expect(logs).toMatch(/Hosting game/);
+	});
+
+	it('loaded the kbve scenario, not the default', () => {
+		const logs = dockerLogs();
+		expect(logs).toMatch(/scenarios\/kbve|scenario.*kbve/i);
+	});
+});

--- a/apps/agones/factorio/e2e/helpers/docker.ts
+++ b/apps/agones/factorio/e2e/helpers/docker.ts
@@ -1,0 +1,24 @@
+import { execSync } from 'child_process';
+
+const CONTAINER = process.env.FACTORIO_CONTAINER ?? 'agones-factorio-e2e';
+
+export function dockerLogs(container = CONTAINER): string {
+	return execSync(`docker logs ${container} 2>&1`, {
+		encoding: 'utf8',
+		maxBuffer: 32 * 1024 * 1024,
+	});
+}
+
+export function dockerRunning(container = CONTAINER): boolean {
+	try {
+		const out = execSync(
+			`docker inspect -f '{{.State.Running}}' ${container}`,
+			{
+				encoding: 'utf8',
+			},
+		).trim();
+		return out === 'true';
+	} catch {
+		return false;
+	}
+}

--- a/apps/agones/factorio/e2e/helpers/rcon.ts
+++ b/apps/agones/factorio/e2e/helpers/rcon.ts
@@ -1,0 +1,124 @@
+import { Socket } from 'net';
+
+const HOST = process.env.FACTORIO_HOST ?? '127.0.0.1';
+const PORT = parseInt(process.env.FACTORIO_RCON ?? '27015', 10);
+const PASSWORD = process.env.FACTORIO_RCON_PASSWORD ?? '';
+
+const SERVERDATA_AUTH = 3;
+const SERVERDATA_EXECCOMMAND = 2;
+const SERVERDATA_AUTH_RESPONSE = 2;
+const SERVERDATA_RESPONSE_VALUE = 0;
+
+export function getRconConfig() {
+	return { host: HOST, port: PORT, password: PASSWORD };
+}
+
+export class RconClient {
+	private socket: Socket;
+	private buffer: Buffer = Buffer.alloc(0);
+	private nextId = 1;
+	private pending = new Map<
+		number,
+		{ resolve: (body: string) => void; reject: (err: Error) => void }
+	>();
+
+	private constructor(socket: Socket) {
+		this.socket = socket;
+		socket.on('data', (chunk) => this.onData(chunk));
+		socket.on('error', (err) => this.failAll(err));
+		socket.on('close', () => this.failAll(new Error('RCON socket closed')));
+	}
+
+	static async connect(
+		host = HOST,
+		port = PORT,
+		timeoutMs = 5_000,
+	): Promise<RconClient> {
+		return new Promise((resolve, reject) => {
+			const socket = new Socket();
+			const timer = setTimeout(() => {
+				socket.destroy();
+				reject(new Error(`RCON connect to ${host}:${port} timed out`));
+			}, timeoutMs);
+			socket.once('error', (err) => {
+				clearTimeout(timer);
+				reject(err);
+			});
+			socket.connect(port, host, () => {
+				clearTimeout(timer);
+				resolve(new RconClient(socket));
+			});
+		});
+	}
+
+	async authenticate(password = PASSWORD): Promise<void> {
+		const id = this.send(SERVERDATA_AUTH, password);
+		await this.waitFor(id, SERVERDATA_AUTH_RESPONSE);
+	}
+
+	async exec(command: string): Promise<string> {
+		const id = this.send(SERVERDATA_EXECCOMMAND, command);
+		return this.waitFor(id, SERVERDATA_RESPONSE_VALUE);
+	}
+
+	close(): void {
+		this.socket.end();
+	}
+
+	private send(type: number, body: string): number {
+		const id = this.nextId++;
+		const bodyBuf = Buffer.from(body, 'utf8');
+		const packet = Buffer.alloc(14 + bodyBuf.length);
+		packet.writeInt32LE(10 + bodyBuf.length, 0);
+		packet.writeInt32LE(id, 4);
+		packet.writeInt32LE(type, 8);
+		bodyBuf.copy(packet, 12);
+		this.socket.write(packet);
+		return id;
+	}
+
+	private waitFor(id: number, expectedType: number): Promise<string> {
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(new Error(`RCON request ${id} timed out`));
+			}, 10_000);
+			this.pending.set(id, {
+				resolve: (body) => {
+					clearTimeout(timer);
+					resolve(body);
+				},
+				reject: (err) => {
+					clearTimeout(timer);
+					reject(err);
+				},
+			});
+			void expectedType;
+		});
+	}
+
+	private onData(chunk: Buffer): void {
+		this.buffer = Buffer.concat([this.buffer, chunk]);
+		while (this.buffer.length >= 12) {
+			const size = this.buffer.readInt32LE(0);
+			if (this.buffer.length < size + 4) return;
+			const id = this.buffer.readInt32LE(4);
+			const body = this.buffer.slice(12, 4 + size - 2).toString('utf8');
+			this.buffer = this.buffer.slice(4 + size);
+			const pending = this.pending.get(id);
+			if (pending) {
+				this.pending.delete(id);
+				pending.resolve(body);
+			} else if (id === -1) {
+				this.failAll(new Error('RCON auth rejected'));
+			}
+		}
+	}
+
+	private failAll(err: Error): void {
+		for (const [, p] of this.pending) {
+			p.reject(err);
+		}
+		this.pending.clear();
+	}
+}

--- a/apps/agones/factorio/e2e/helpers/udp.ts
+++ b/apps/agones/factorio/e2e/helpers/udp.ts
@@ -1,0 +1,43 @@
+import { createSocket } from 'dgram';
+
+const HOST = process.env.FACTORIO_HOST ?? '127.0.0.1';
+const PORT = parseInt(process.env.FACTORIO_UDP ?? '34197', 10);
+
+export function getFactorioUdpAddress() {
+	return { host: HOST, port: PORT };
+}
+
+export async function udpProbe(
+	host = HOST,
+	port = PORT,
+	timeoutMs = 5_000,
+): Promise<Buffer> {
+	return new Promise((resolve, reject) => {
+		const socket = createSocket('udp4');
+		const timer = setTimeout(() => {
+			socket.close();
+			reject(new Error(`UDP probe to ${host}:${port} timed out`));
+		}, timeoutMs);
+
+		socket.once('error', (err) => {
+			clearTimeout(timer);
+			socket.close();
+			reject(err);
+		});
+
+		socket.once('message', (msg) => {
+			clearTimeout(timer);
+			socket.close();
+			resolve(msg);
+		});
+
+		const probe = Buffer.from([0x00]);
+		socket.send(probe, port, host, (err) => {
+			if (err) {
+				clearTimeout(timer);
+				socket.close();
+				reject(err);
+			}
+		});
+	});
+}

--- a/apps/agones/factorio/e2e/rcon.spec.ts
+++ b/apps/agones/factorio/e2e/rcon.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { RconClient, getRconConfig } from './helpers/rcon';
+
+const { password } = getRconConfig();
+const skip = password === '';
+
+describe.skipIf(skip)('agones-factorio RCON', () => {
+	let client: RconClient;
+
+	afterAll(() => {
+		client?.close();
+	});
+
+	it('authenticates with the configured password', async () => {
+		client = await RconClient.connect();
+		await expect(client.authenticate(password)).resolves.toBeUndefined();
+	});
+
+	it('executes /players online and returns a response', async () => {
+		const out = await client.exec('/players online');
+		expect(out).toMatch(/Online players|player|\(0\)/i);
+	});
+});

--- a/apps/agones/factorio/e2e/udp.spec.ts
+++ b/apps/agones/factorio/e2e/udp.spec.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { getFactorioUdpAddress, udpProbe } from './helpers/udp';
+
+describe('agones-factorio UDP listener', () => {
+	it('binds the game port and replies to a malformed datagram', async () => {
+		const { host, port } = getFactorioUdpAddress();
+		const reply = await udpProbe(host, port);
+		expect(reply.length).toBeGreaterThan(0);
+	});
+});

--- a/apps/agones/factorio/project.json
+++ b/apps/agones/factorio/project.json
@@ -34,6 +34,30 @@
 					]
 				}
 			}
+		},
+		"e2e": {
+			"executor": "nx:run-commands",
+			"dependsOn": [
+				{
+					"target": "container",
+					"projects": ["agones-factorio"],
+					"params": "forward"
+				}
+			],
+			"cache": false,
+			"options": {
+				"commands": [
+					"docker rm -f agones-factorio-e2e 2>/dev/null || true",
+					"docker run -d --name agones-factorio-e2e -p 34197:34197/udp -p 27015:27015/tcp -e FACTORIO_RCON_PASSWORD=e2e-test kbve/agones-factorio:latest",
+					"echo 'Waiting for Factorio to come up...' && for i in $(seq 1 240); do if docker logs agones-factorio-e2e 2>&1 | grep -q 'Hosting game'; then echo 'Factorio ready after '\"$i\"'s'; break; fi; if [ $i -eq 240 ]; then echo 'Factorio did not start in 240s'; docker logs agones-factorio-e2e 2>&1 | tail -120; docker rm -f agones-factorio-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
+					"FACTORIO_HOST=127.0.0.1 FACTORIO_UDP=34197 FACTORIO_RCON=27015 FACTORIO_RCON_PASSWORD=e2e-test FACTORIO_CONTAINER=agones-factorio-e2e npx vitest run; EC=$?; echo '--- container logs ---'; docker logs agones-factorio-e2e 2>&1 | tail -120; docker rm -f agones-factorio-e2e 2>/dev/null || true; exit $EC"
+				],
+				"parallel": false,
+				"cwd": "apps/agones/factorio"
+			},
+			"configurations": {
+				"ci": {}
+			}
 		}
 	},
 	"tags": ["scope:agones"]

--- a/apps/agones/factorio/tsconfig.e2e.json
+++ b/apps/agones/factorio/tsconfig.e2e.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true
+	},
+	"include": ["e2e/**/*.ts", "vitest.config.ts"]
+}

--- a/apps/agones/factorio/vitest.config.ts
+++ b/apps/agones/factorio/vitest.config.ts
@@ -1,0 +1,8 @@
+export default {
+	test: {
+		include: ['e2e/**/*.spec.ts'],
+		testTimeout: 30_000,
+		hookTimeout: 240_000,
+		fileParallelism: false,
+	},
+};

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
@@ -18,7 +18,9 @@ source_path: apps/agones/factorio
 version_toml: apps/agones/factorio/version.toml
 runner: ubuntu-latest
 image: kbve/agones-factorio
-has_test: false
+has_test: true
+e2e_name: agones-factorio
+test_framework: typescript
 author: h0lybyte
 license: KBVE
 status: active


### PR DESCRIPTION
## Summary

Phase 0.6 of issue #11138. Scaffolds the vitest e2e for `apps/agones/factorio/` so CI can verify the image actually boots, binds the game socket, and answers RCON before publishing to ghcr. Mirrors the `apps/mc/velocity` e2e shape so reviewers don't need to learn a new pattern.

### What's covered

- **Boot smoke** — container is still running after scenario load, Factorio `"Hosting game"` log marker is present, and the `kbve` scenario (not the default) was loaded.
- **UDP listener** — `dgram` ping to `FACTORIO_HOST:FACTORIO_UDP` returns a non-empty reply (Factorio rejects malformed datagrams with a length-prefixed response).
- **RCON round-trip** — hand-rolled Source-RCON client (~100 LOC) authenticates with `FACTORIO_RCON_PASSWORD` and confirms `/players online` echoes back something sensible. Auto-skips when no password is set so local `docker run` without RCON still passes.

### What changed

- `apps/agones/factorio/e2e/*` — specs + helpers (`docker.ts`, `udp.ts`, `rcon.ts`).
- `apps/agones/factorio/vitest.config.ts` + `tsconfig.e2e.json` — match the mc-velocity layout, `hookTimeout: 240_000` because Factorio scenario load is slow.
- `apps/agones/factorio/project.json` — adds the `e2e` target with the standard `container → docker run → poll-for-ready → vitest → cleanup` recipe; depends on `container`.
- `apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx` — `has_test: true`, `e2e_name: agones-factorio`, `test_framework: typescript` so `ci-docker.yml` fans out the e2e job.
- `.github/ci-dispatch-manifest.json` — full diff per repo policy (not a surgical edit).

Refs: #11138, follows #11373 + #11376.

## Test plan

- [ ] `./kbve.sh -nx agones-factorio:container` builds the image.
- [ ] `./kbve.sh -nx agones-factorio:e2e` boots the container, waits for `Hosting game`, runs the vitest suite (boot + UDP + RCON), cleans up.
- [ ] Manifest entry now reports `has_test: true` + `e2e_name: agones-factorio`.
- [ ] After merge, the next `ci-main` dispatch sees `is_newer(0.0.2, 0.0.1) = true`, ci-docker.yml runs, the e2e step passes, and `ghcr.io/kbve/agones-factorio:0.0.2` is published.