### PR TITLE
feat(mc): lot/schematic schema for digital real-estate (phase 0)

### DIFF
--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -225,12 +225,13 @@ CREATE INDEX idx_mc_lot_vacant_world_chunk_cursor
              price_credits, price_khash)
     WHERE state = 0;
 -- "My lots" page is dominated by owned + built rows; vacant/under-build
--- are rare. INCLUDE the columns the dashboard renders so the index can
--- answer index-only.
+-- are rare. INCLUDE the columns the dashboard renders (including
+-- prices, which surface as "sell-for" hints on owned-but-not-built
+-- rows) so the index can answer index-only.
 CREATE INDEX idx_mc_lot_owner_active_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
-             chunk_area, anchor_y)
+             chunk_area, anchor_y, price_credits, price_khash)
     WHERE owner_user_id IS NOT NULL AND state IN (1, 2);
 
 ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
@@ -517,18 +518,27 @@ AS $$
     WHERE (p_world         IS NULL OR l.world = p_world)
       AND (p_state         IS NULL OR l.state = p_state)
       AND (p_owner_user_id IS NULL OR l.owner_user_id = p_owner_user_id)
+      -- Cursor all-or-none. Tuple comparison against any NULL would
+      -- silently return no rows; require the full cursor or none.
       AND (
           p_after_lot_id IS NULL
-          OR (l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id)
-             > (p_after_world, p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
+          OR (
+              p_after_world   IS NOT NULL
+              AND p_after_chunk_x IS NOT NULL
+              AND p_after_chunk_z IS NOT NULL
+              AND (l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id)
+                  > (p_after_world, p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
+          )
       )
     ORDER BY l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id
     LIMIT GREATEST(0, LEAST(p_limit, 1024))
-    -- OFFSET is preserved only for the non-cursor path; cursor callers
-    -- should pass 0. Plain OFFSET is fine for small admin scans and
-    -- gives a backwards-compat lever for the dashboard until it flips
-    -- to keyset.
-    OFFSET CASE WHEN p_after_lot_id IS NULL THEN GREATEST(0, p_offset) ELSE 0 END;
+    -- OFFSET preserved only for the non-cursor path; cursor callers
+    -- should pass 0. Capped at 100000 so a pathological admin call
+    -- can't request a multi-million-row deep scan.
+    OFFSET CASE
+        WHEN p_after_lot_id IS NULL THEN LEAST(GREATEST(0, p_offset), 100000)
+        ELSE 0
+    END;
 $$;
 
 ALTER FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER,
@@ -1313,12 +1323,20 @@ AS $$
       AND (NOT p_only_mine OR (me.uid IS NOT NULL AND l.owner_user_id = me.uid))
       AND (
           p_after_lot_id IS NULL
-          OR (l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id)
-             > (p_after_world, p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
+          OR (
+              p_after_world   IS NOT NULL
+              AND p_after_chunk_x IS NOT NULL
+              AND p_after_chunk_z IS NOT NULL
+              AND (l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id)
+                  > (p_after_world, p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
+          )
       )
     ORDER BY l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id
     LIMIT GREATEST(0, LEAST(p_limit, 1024))
-    OFFSET CASE WHEN p_after_lot_id IS NULL THEN GREATEST(0, p_offset) ELSE 0 END;
+    OFFSET CASE
+        WHEN p_after_lot_id IS NULL THEN LEAST(GREATEST(0, p_offset), 100000)
+        ELSE 0
+    END;
 $$;
 
 ALTER FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
@@ -1699,6 +1717,137 @@ COMMENT ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER, INTEGER) 
     'Service-role-only PostgREST bridge for janitor recovery of orphaned worker claims older than p_older_than_seconds. Batched + SKIP LOCKED with p_limit (max 512). Returns the count of jobs requeued in this call.';
 
 
+-- ===========================================================================
+-- HOT-PATH LIST RPCs — dedicated wrappers for the two most common reads
+-- ===========================================================================
+-- The generic list_lots() uses optional OR predicates, which can make the
+-- planner pick the broad cursor index instead of the narrower partial
+-- indexes (idx_mc_lot_vacant_*, idx_mc_lot_owner_active_*). These two
+-- wrappers hard-code the state predicate so the partial indexes are the
+-- only viable plan. Same cursor convention (chunk_x, chunk_z, lot_id),
+-- but world is fixed by p_world so it isn't part of the cursor tuple.
+
+CREATE OR REPLACE FUNCTION public.proxy_list_vacant_lots(
+    p_world TEXT,
+    p_limit INTEGER DEFAULT 256,
+    p_after_chunk_x INTEGER DEFAULT NULL,
+    p_after_chunk_z INTEGER DEFAULT NULL,
+    p_after_lot_id TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    lot_id          TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    chunk_area      INTEGER,
+    anchor_y        SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 256
+AS $$
+    SELECT l.lot_id,
+           l.chunk_x_min, l.chunk_x_max,
+           l.chunk_z_min, l.chunk_z_max,
+           l.chunk_area,
+           l.anchor_y,
+           l.price_credits,
+           l.price_khash
+    FROM mc.lot l
+    WHERE l.state = 0
+      AND l.world = p_world
+      AND (
+          p_after_lot_id IS NULL
+          OR (
+              p_after_chunk_x IS NOT NULL
+              AND p_after_chunk_z IS NOT NULL
+              AND (l.chunk_x_min, l.chunk_z_min, l.lot_id)
+                  > (p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
+          )
+      )
+    ORDER BY l.chunk_x_min, l.chunk_z_min, l.lot_id
+    LIMIT GREATEST(0, LEAST(p_limit, 1024));
+$$;
+
+ALTER FUNCTION public.proxy_list_vacant_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)
+    OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_list_vacant_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_list_vacant_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)
+    TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_list_vacant_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT) IS
+    'Hot-path: vacant lots in a world for the marketplace map. Hard-codes state=0 so idx_mc_lot_vacant_world_chunk_cursor is the only viable plan. Cursor pagination via (chunk_x, chunk_z, lot_id) of the last row from the prior page.';
+
+
+CREATE OR REPLACE FUNCTION public.proxy_list_my_active_lots(
+    p_world TEXT,
+    p_limit INTEGER DEFAULT 256,
+    p_after_chunk_x INTEGER DEFAULT NULL,
+    p_after_chunk_z INTEGER DEFAULT NULL,
+    p_after_lot_id TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    lot_id          TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    chunk_area      INTEGER,
+    anchor_y        SMALLINT,
+    state           SMALLINT,
+    current_schematic_id TEXT,
+    price_credits   BIGINT,
+    price_khash     BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 256
+AS $$
+    WITH me AS (SELECT auth.uid() AS uid)
+    SELECT l.lot_id,
+           l.chunk_x_min, l.chunk_x_max,
+           l.chunk_z_min, l.chunk_z_max,
+           l.chunk_area,
+           l.anchor_y,
+           l.state,
+           l.current_schematic_id,
+           l.price_credits,
+           l.price_khash
+    FROM mc.lot l, me
+    WHERE me.uid IS NOT NULL
+      AND l.owner_user_id = me.uid
+      AND l.state IN (1, 2)
+      AND l.world = p_world
+      AND (
+          p_after_lot_id IS NULL
+          OR (
+              p_after_chunk_x IS NOT NULL
+              AND p_after_chunk_z IS NOT NULL
+              AND (l.chunk_x_min, l.chunk_z_min, l.lot_id)
+                  > (p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
+          )
+      )
+    ORDER BY l.chunk_x_min, l.chunk_z_min, l.lot_id
+    LIMIT GREATEST(0, LEAST(p_limit, 1024));
+$$;
+
+ALTER FUNCTION public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)
+    OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)
+    TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT) IS
+    'Hot-path: caller-owned active lots (state IN (1, 2)) in a world. Hard-codes owner = auth.uid() and the state set so idx_mc_lot_owner_active_world_chunk_cursor is the only viable plan.';
+
+
 NOTIFY pgrst, 'reload schema';
 
 
@@ -1729,6 +1878,8 @@ DROP FUNCTION IF EXISTS mc.proxy_purchase_lot(TEXT);
 DROP FUNCTION IF EXISTS public.proxy_queue_demolish_lot(TEXT, UUID);
 DROP FUNCTION IF EXISTS public.proxy_queue_build_on_lot(TEXT, TEXT, UUID);
 DROP FUNCTION IF EXISTS public.proxy_purchase_lot(TEXT, UUID);
+DROP FUNCTION IF EXISTS public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT);
+DROP FUNCTION IF EXISTS public.proxy_list_vacant_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_list_schematics(TEXT);
 DROP FUNCTION IF EXISTS public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER);
 DROP FUNCTION IF EXISTS public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -68,8 +68,10 @@ SET search_path = ''
 AS $$
     -- pgcrypto lives in the extensions schema on Supabase/kilobase; the
     -- mc_pgcrypto_qualify migration already established this convention
-    -- and granted USAGE on extensions to service_role.
-    SELECT substr(encode(extensions.digest(p_key::text || ':' || p_tag, 'md5'), 'hex'), 1, 32)::uuid;
+    -- and granted USAGE on extensions to service_role. SHA-256 truncated
+    -- to 128 bits gives a UUID-sized digest with no realistic collision
+    -- surface even though the use is non-adversarial.
+    SELECT substr(encode(extensions.digest(p_key::text || ':' || p_tag, 'sha256'), 'hex'), 1, 32)::uuid;
 $$;
 
 ALTER FUNCTION mc._derive_idem_key(UUID, TEXT) OWNER TO postgres;
@@ -97,6 +99,8 @@ CREATE TABLE mc.schematic (
     CONSTRAINT mc_schematic_dims_chk   CHECK (dims_x > 0 AND dims_y > 0 AND dims_z > 0),
     CONSTRAINT mc_schematic_dims_y_chk CHECK (dims_y <= 384),
     CONSTRAINT mc_schematic_price_chk  CHECK (price_credits >= 0 AND price_khash >= 0),
+    CONSTRAINT mc_schematic_id_chk
+        CHECK (schematic_id ~ '^[A-Za-z0-9:_/-]{3,128}$'),
     CONSTRAINT mc_schematic_category_chk
         CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument')),
     -- Reject path-traversal + force schematics into the mod jar's
@@ -148,6 +152,7 @@ CREATE TABLE mc.lot (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
+    CONSTRAINT mc_lot_id_chk         CHECK (lot_id ~ '^[A-Za-z0-9:_-]{3,96}$'),
     CONSTRAINT mc_lot_state_chk      CHECK (state BETWEEN 0 AND 4),
     CONSTRAINT mc_lot_anchor_y_chk   CHECK (anchor_y BETWEEN -64 AND 319),
     CONSTRAINT mc_lot_price_chk      CHECK (price_credits >= 0 AND price_khash >= 0),
@@ -157,6 +162,13 @@ CREATE TABLE mc.lot (
     CONSTRAINT mc_lot_z_range_chk    CHECK (NOT isempty(chunk_z_range)
                                              AND lower_inc(chunk_z_range)
                                              AND NOT upper_inc(chunk_z_range)),
+    -- Explicit finite-bounds guard so the generated chunk_area columns
+    -- and the GIST EXCLUDE never see unbounded ranges. Belt-and-suspenders
+    -- with the isempty + bound-inclusion checks above.
+    CONSTRAINT mc_lot_x_range_finite_chk
+        CHECK (lower(chunk_x_range) IS NOT NULL AND upper(chunk_x_range) IS NOT NULL),
+    CONSTRAINT mc_lot_z_range_finite_chk
+        CHECK (lower(chunk_z_range) IS NOT NULL AND upper(chunk_z_range) IS NOT NULL),
     -- Vanilla dim ids look like 'minecraft:overworld' or
     -- 'kbve:survival_ext'. Enforce the namespaced format to keep typos and
     -- arbitrary text from sneaking into the world column.
@@ -171,7 +183,7 @@ CREATE TABLE mc.lot (
         OR state <> 2
     ),
 
-    EXCLUDE USING gist (
+    CONSTRAINT mc_lot_no_overlap_excl EXCLUDE USING gist (
         world WITH =,
         chunk_x_range WITH &&,
         chunk_z_range WITH &&
@@ -187,19 +199,26 @@ CREATE INDEX idx_mc_lot_world_chunk_order
 -- skip irrelevant rows entirely.
 CREATE INDEX idx_mc_lot_world_state_chunk_order
     ON mc.lot (world, state, lower(chunk_x_range), lower(chunk_z_range));
+-- proxy_list_lots(p_only_mine = true) filters by owner first then sorts
+-- by world/chunk. This partial index covers that path so "my lots" never
+-- falls back to a sort.
+CREATE INDEX idx_mc_lot_owner_world_chunk_order
+    ON mc.lot (owner_user_id, world, lower(chunk_x_range), lower(chunk_z_range))
+    WHERE owner_user_id IS NOT NULL;
 
 ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot FORCE ROW LEVEL SECURITY;
 
 -- Trigger touches updated_at only when something other than updated_at
 -- itself changed; cuts write amplification on no-op UPDATEs.
+-- clock_timestamp() captures real statement time even in long transactions.
 CREATE OR REPLACE FUNCTION mc.trg_lot_updated_at()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
 BEGIN
     IF NEW IS DISTINCT FROM OLD THEN
-        NEW.updated_at := NOW();
+        NEW.updated_at := clock_timestamp();
     END IF;
     RETURN NEW;
 END;
@@ -284,9 +303,15 @@ CREATE TABLE mc.lot_build_log (
             OR (action_kind = 1)),
     CONSTRAINT mc_lot_build_log_apply_error_len_chk
         CHECK (apply_error IS NULL OR length(apply_error) <= 2048),
+    CONSTRAINT mc_lot_build_log_claimed_by_len_chk
+        CHECK (claimed_by IS NULL OR length(claimed_by) <= 128),
+    -- Claimed state must carry full worker identity; non-claimed states
+    -- must not.
     CONSTRAINT mc_lot_build_log_claimed_consistency_chk
-        CHECK ((apply_state = 3 AND claimed_at IS NOT NULL)
-            OR (apply_state <> 3)),
+        CHECK (
+            (apply_state = 3 AND claimed_at IS NOT NULL AND claimed_by IS NOT NULL)
+            OR (apply_state <> 3 AND claimed_at IS NULL AND claimed_by IS NULL)
+        ),
     CONSTRAINT mc_lot_build_log_idem_uq UNIQUE (idempotency_key)
 );
 
@@ -460,25 +485,42 @@ RETURNS TABLE (
     schematic_id    TEXT,
     queued_at       TIMESTAMPTZ
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 ROWS 32
 AS $$
-    UPDATE mc.lot_build_log b
-       SET apply_state = 3,
-           claimed_at  = clock_timestamp(),
-           claimed_by  = p_worker_id
-     WHERE b.build_id IN (
-        SELECT inner_b.build_id
-          FROM mc.lot_build_log inner_b
-         WHERE inner_b.apply_state = 0
-         ORDER BY inner_b.queued_at
-         FOR UPDATE SKIP LOCKED
-         LIMIT GREATEST(1, LEAST(p_limit, 256))
-     )
-    RETURNING b.build_id, b.lot_id, b.actor_user_id,
-              b.action_kind, b.schematic_id, b.queued_at;
+BEGIN
+    IF p_worker_id IS NULL OR btrim(p_worker_id) = '' THEN
+        RAISE EXCEPTION 'worker_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF length(p_worker_id) > 128 THEN
+        RAISE EXCEPTION 'worker_id too long (max 128)' USING ERRCODE = '22001';
+    END IF;
+
+    -- UPDATE ... RETURNING has no ordering guarantee. Wrap in a CTE and
+    -- sort the final SELECT so workers process the batch in queued order.
+    RETURN QUERY
+    WITH claimed AS (
+        UPDATE mc.lot_build_log b
+           SET apply_state = 3,
+               claimed_at  = clock_timestamp(),
+               claimed_by  = p_worker_id
+         WHERE b.build_id IN (
+            SELECT inner_b.build_id
+              FROM mc.lot_build_log inner_b
+             WHERE inner_b.apply_state = 0
+             ORDER BY inner_b.queued_at
+             FOR UPDATE SKIP LOCKED
+             LIMIT GREATEST(1, LEAST(p_limit, 256))
+         )
+        RETURNING b.build_id, b.lot_id, b.actor_user_id,
+                  b.action_kind, b.schematic_id, b.queued_at
+    )
+    SELECT *
+      FROM claimed
+     ORDER BY queued_at, build_id;
+END;
 $$;
 
 ALTER FUNCTION mc.service_claim_pending_builds(TEXT, INTEGER) OWNER TO postgres;
@@ -522,7 +564,10 @@ GRANT EXECUTE ON FUNCTION mc.service_requeue_stale_claims(INTEGER)
 -- ===========================================================================
 -- mc.service_mark_build_applied — MC mod ACK on success
 -- ===========================================================================
-CREATE OR REPLACE FUNCTION mc.service_mark_build_applied(p_build_id TEXT)
+CREATE OR REPLACE FUNCTION mc.service_mark_build_applied(
+    p_build_id  TEXT,
+    p_worker_id TEXT
+)
 RETURNS BOOLEAN
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -535,13 +580,20 @@ DECLARE
     v_schematic_id  TEXT;
     v_rowcount      INTEGER;
 BEGIN
+    IF p_worker_id IS NULL OR btrim(p_worker_id) = '' THEN
+        RAISE EXCEPTION 'worker_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+
+    -- Only the worker that holds the claim may ACK it. Prevents a stale
+    -- or wrong worker from finalizing another worker's job.
     UPDATE mc.lot_build_log
        SET apply_state = 1,
            applied_at = clock_timestamp(),
            claimed_at = NULL,
            claimed_by = NULL
      WHERE build_id = p_build_id
-       AND apply_state IN (0, 3)
+       AND apply_state = 3
+       AND claimed_by = p_worker_id
     RETURNING lot_id, action_kind, schematic_id
         INTO v_lot_id, v_action_kind, v_schematic_id;
 
@@ -577,10 +629,10 @@ BEGIN
 END;
 $$;
 
-ALTER FUNCTION mc.service_mark_build_applied(TEXT) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.service_mark_build_applied(TEXT)
+ALTER FUNCTION mc.service_mark_build_applied(TEXT, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_mark_build_applied(TEXT, TEXT)
     FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION mc.service_mark_build_applied(TEXT)
+GRANT EXECUTE ON FUNCTION mc.service_mark_build_applied(TEXT, TEXT)
     TO service_role;
 
 
@@ -588,8 +640,9 @@ GRANT EXECUTE ON FUNCTION mc.service_mark_build_applied(TEXT)
 -- mc.service_mark_build_failed — MC mod ACK on failure
 -- ===========================================================================
 CREATE OR REPLACE FUNCTION mc.service_mark_build_failed(
-    p_build_id TEXT,
-    p_error TEXT
+    p_build_id  TEXT,
+    p_worker_id TEXT,
+    p_error     TEXT
 )
 RETURNS BOOLEAN
 LANGUAGE plpgsql
@@ -598,8 +651,13 @@ SET search_path = ''
 COST 100
 AS $$
 DECLARE
-    v_lot_id TEXT;
+    v_lot_id   TEXT;
+    v_rowcount INTEGER;
 BEGIN
+    IF p_worker_id IS NULL OR btrim(p_worker_id) = '' THEN
+        RAISE EXCEPTION 'worker_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+
     UPDATE mc.lot_build_log
        SET apply_state = 2,
            apply_error = left(p_error, 2048),
@@ -607,7 +665,8 @@ BEGIN
            claimed_at = NULL,
            claimed_by = NULL
      WHERE build_id = p_build_id
-       AND apply_state IN (0, 3)
+       AND apply_state = 3
+       AND claimed_by = p_worker_id
     RETURNING lot_id INTO v_lot_id;
 
     IF NOT FOUND THEN
@@ -618,15 +677,20 @@ BEGIN
        SET state = CASE WHEN current_schematic_id IS NULL THEN 1 ELSE 2 END
      WHERE lot_id = v_lot_id
        AND state IN (3, 4);
+    GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+    IF v_rowcount <> 1 THEN
+        RAISE EXCEPTION 'lot % not in active build/demolish state at failure ACK time', v_lot_id
+            USING ERRCODE = '22023';
+    END IF;
 
     RETURN TRUE;
 END;
 $$;
 
-ALTER FUNCTION mc.service_mark_build_failed(TEXT, TEXT) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.service_mark_build_failed(TEXT, TEXT)
+ALTER FUNCTION mc.service_mark_build_failed(TEXT, TEXT, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_mark_build_failed(TEXT, TEXT, TEXT)
     FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION mc.service_mark_build_failed(TEXT, TEXT)
+GRANT EXECUTE ON FUNCTION mc.service_mark_build_failed(TEXT, TEXT, TEXT)
     TO service_role;
 
 
@@ -656,6 +720,13 @@ DECLARE
     v_khash_ledger_id      BIGINT;
     v_purchase_id          TEXT;
 BEGIN
+    -- Serialize concurrent retries on the same idempotency_key. Without
+    -- the lock two identical requests can both miss the existing-key
+    -- check, then one inserts cleanly and the other tries the lot-state
+    -- path and surfaces a confusing "lot not vacant" error instead of
+    -- collapsing to the original purchase row.
+    PERFORM pg_advisory_xact_lock(hashtextextended(p_idempotency_key::text, 0));
+
     -- Idempotent replay: existing key must match the original parameters,
     -- otherwise the caller is reusing a key for a different request.
     SELECT purchase_id, lot_id, buyer_user_id
@@ -778,6 +849,10 @@ DECLARE
     v_khash_ledger_id      BIGINT;
     v_build_id             TEXT;
 BEGIN
+    -- Serialize concurrent retries on the same idempotency_key. See the
+    -- matching note in service_purchase_lot.
+    PERFORM pg_advisory_xact_lock(hashtextextended(p_idempotency_key::text, 0));
+
     SELECT build_id, lot_id, schematic_id, actor_user_id
       INTO v_existing_build_id, v_existing_lot, v_existing_schematic, v_existing_actor
       FROM mc.lot_build_log
@@ -928,6 +1003,8 @@ DECLARE
     v_lot_state            SMALLINT;
     v_build_id             TEXT;
 BEGIN
+    PERFORM pg_advisory_xact_lock(hashtextextended(p_idempotency_key::text, 0));
+
     SELECT build_id, lot_id, actor_user_id, action_kind
       INTO v_existing_build_id, v_existing_lot, v_existing_actor, v_existing_action
       FROM mc.lot_build_log
@@ -1288,10 +1365,107 @@ REVOKE ALL ON FUNCTION public.proxy_queue_demolish_lot(TEXT) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.proxy_queue_demolish_lot(TEXT) TO authenticated, service_role;
 
 
+-- ===========================================================================
+-- PUBLIC WORKER WRAPPERS — service_role only, for MC mod through PostgREST
+-- ===========================================================================
+-- The MC mod authenticates with the Supabase service-role JWT and reaches
+-- the DB through PostgREST. PostgREST only sees the public schema, so the
+-- mc.service_* worker RPCs need a public-side bridge. authenticated callers
+-- are excluded so dashboard clients can't drive the worker queue.
+
+CREATE OR REPLACE FUNCTION public.proxy_service_claim_pending_builds(
+    p_worker_id TEXT,
+    p_limit INTEGER DEFAULT 32
+)
+RETURNS TABLE (
+    build_id        TEXT,
+    lot_id          TEXT,
+    actor_user_id   UUID,
+    action_kind     SMALLINT,
+    schematic_id    TEXT,
+    queued_at       TIMESTAMPTZ
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+ROWS 32
+AS $$
+    SELECT * FROM mc.service_claim_pending_builds(p_worker_id, p_limit);
+$$;
+
+ALTER FUNCTION public.proxy_service_claim_pending_builds(TEXT, INTEGER) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_claim_pending_builds(TEXT, INTEGER)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_claim_pending_builds(TEXT, INTEGER)
+    TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_service_mark_build_applied(
+    p_build_id  TEXT,
+    p_worker_id TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT mc.service_mark_build_applied(p_build_id, p_worker_id);
+$$;
+
+ALTER FUNCTION public.proxy_service_mark_build_applied(TEXT, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_mark_build_applied(TEXT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_mark_build_applied(TEXT, TEXT)
+    TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_service_mark_build_failed(
+    p_build_id  TEXT,
+    p_worker_id TEXT,
+    p_error     TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT mc.service_mark_build_failed(p_build_id, p_worker_id, p_error);
+$$;
+
+ALTER FUNCTION public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT)
+    TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_service_requeue_stale_claims(
+    p_older_than_seconds INTEGER DEFAULT 300
+)
+RETURNS INTEGER
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT mc.service_requeue_stale_claims(p_older_than_seconds);
+$$;
+
+ALTER FUNCTION public.proxy_service_requeue_stale_claims(INTEGER) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER)
+    TO service_role;
+
+
 NOTIFY pgrst, 'reload schema';
 
 
 -- migrate:down
+
+DROP FUNCTION IF EXISTS public.proxy_service_requeue_stale_claims(INTEGER);
+DROP FUNCTION IF EXISTS public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT);
+DROP FUNCTION IF EXISTS public.proxy_service_mark_build_applied(TEXT, TEXT);
+DROP FUNCTION IF EXISTS public.proxy_service_claim_pending_builds(TEXT, INTEGER);
 
 DROP FUNCTION IF EXISTS public.proxy_queue_demolish_lot(TEXT);
 DROP FUNCTION IF EXISTS public.proxy_queue_build_on_lot(TEXT, TEXT);
@@ -1308,8 +1482,8 @@ DROP FUNCTION IF EXISTS mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INT
 DROP FUNCTION IF EXISTS mc.service_queue_demolish_lot(TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_queue_build_on_lot(TEXT, TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_purchase_lot(TEXT, UUID, UUID);
-DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT);
-DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT);
+DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT, TEXT);
+DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT, TEXT);
 DROP FUNCTION IF EXISTS mc.service_requeue_stale_claims(INTEGER);
 DROP FUNCTION IF EXISTS mc.service_claim_pending_builds(TEXT, INTEGER);
 DROP FUNCTION IF EXISTS mc.service_list_schematics(TEXT, BOOLEAN);

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -21,12 +21,20 @@ REVOKE ALL ON SCHEMA mc FROM PUBLIC, anon, authenticated;
 
 -- State domains: centralize enum bounds so RPCs/CHECKs don't drift
 -- from each other when ranges expand. Storage stays SMALLINT.
-CREATE DOMAIN mc.lot_state AS SMALLINT
-    CHECK (VALUE BETWEEN 0 AND 4);
-CREATE DOMAIN mc.build_action_kind AS SMALLINT
-    CHECK (VALUE IN (0, 1));
-CREATE DOMAIN mc.build_apply_state AS SMALLINT
-    CHECK (VALUE BETWEEN 0 AND 3);
+-- DO-block guards make local-dev partial replays safe.
+DO $$ BEGIN
+    CREATE DOMAIN mc.lot_state AS SMALLINT CHECK (VALUE BETWEEN 0 AND 4);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+    CREATE DOMAIN mc.build_action_kind AS SMALLINT CHECK (VALUE IN (0, 1));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+    -- 0 queued, 1 applied, 2 failed, 3 claimed, 4 cancelled
+    CREATE DOMAIN mc.build_apply_state AS SMALLINT CHECK (VALUE BETWEEN 0 AND 4);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 ALTER DOMAIN mc.lot_state OWNER TO postgres;
 ALTER DOMAIN mc.build_action_kind OWNER TO postgres;
 ALTER DOMAIN mc.build_apply_state OWNER TO postgres;
@@ -327,7 +335,7 @@ CREATE TABLE mc.lot_build_log (
     wallet_credits_ledger_id BIGINT,
     wallet_khash_ledger_id   BIGINT,
     idempotency_key UUID NOT NULL,
-    -- 0 = queued, 1 = applied, 2 = failed, 3 = claimed (worker holding it)
+    -- 0=queued, 1=applied, 2=failed, 3=claimed, 4=cancelled
     apply_state     mc.build_apply_state NOT NULL DEFAULT 0,
     apply_error     TEXT,
     claimed_at      TIMESTAMPTZ,
@@ -370,11 +378,26 @@ CREATE TABLE mc.lot_build_log (
     CONSTRAINT mc_lot_build_log_snapshot_state_chk CHECK (
         lot_state_before IS NULL OR lot_state_before IN (1, 2)
     ),
+    -- Built snapshot (state=2) must carry the schematic; otherwise
+    -- failure recovery would try to restore state=2 with NULL schematic
+    -- and trip mc_lot_built_has_schematic_chk on mc.lot.
+    CONSTRAINT mc_lot_build_log_snapshot_built_schematic_chk CHECK (
+        lot_state_before IS NULL
+        OR lot_state_before <> 2
+        OR schematic_id_before IS NOT NULL
+    ),
     -- Demolish snapshots must be built (or legacy NULL).
     CONSTRAINT mc_lot_build_log_demolish_snapshot_chk CHECK (
         action_kind <> 1
         OR lot_state_before IS NULL
         OR lot_state_before = 2
+    ),
+    -- Demolish targets a built lot, so the snapshot schematic is
+    -- required (mirror of the snapshot_built_schematic invariant).
+    CONSTRAINT mc_lot_build_log_demolish_snapshot_schematic_chk CHECK (
+        action_kind <> 1
+        OR lot_state_before IS NULL
+        OR schematic_id_before IS NOT NULL
     ),
     -- Claimed state must carry full worker identity; non-claimed states
     -- must not.
@@ -445,6 +468,12 @@ ALTER TABLE mc.lot SET (
 );
 
 -- Extended stats for correlated columns (state distribution skewed).
+-- Inert until ANALYZE runs. Seed/import migrations should follow up
+-- with:
+--   ANALYZE mc.lot;
+--   ANALYZE mc.lot_build_log;
+--   ANALYZE mc.schematic;
+-- so the planner sees the new column dependencies before traffic hits.
 CREATE STATISTICS st_mc_lot_world_state
     ON world, state
     FROM mc.lot;
@@ -543,7 +572,7 @@ AS $$
            l.anchor_y,
            l.owner_user_id,
            l.current_schematic_id,
-           l.state,
+           l.state::SMALLINT,
            l.price_credits,
            l.price_khash,
            l.created_at,
@@ -626,7 +655,7 @@ AS $$
            l.block_z_min, l.block_z_max,
            l.chunk_area, l.anchor_y,
            l.owner_user_id, l.current_schematic_id,
-           l.state, l.price_credits, l.price_khash,
+           l.state::SMALLINT, l.price_credits, l.price_khash,
            l.created_at, l.updated_at
     FROM mc.lot l
     WHERE l.lot_id = p_lot_id;
@@ -754,7 +783,7 @@ BEGIN
                   b.action_kind, b.schematic_id, b.queued_at
     )
     -- Denormalize lot + schematic so workers skip follow-up reads.
-    SELECT c.build_id, c.lot_id, c.actor_user_id, c.action_kind,
+    SELECT c.build_id, c.lot_id, c.actor_user_id, c.action_kind::SMALLINT,
            c.schematic_id, c.queued_at,
            l.world, l.chunk_x_min, l.chunk_x_max,
            l.chunk_z_min, l.chunk_z_max,
@@ -1541,7 +1570,7 @@ AS $$
            l.owner_user_id,
            (l.owner_user_id IS NOT NULL AND l.owner_user_id = me.uid) AS is_owned_by_me,
            l.current_schematic_id,
-           l.state,
+           l.state::SMALLINT,
            l.price_credits,
            l.price_khash
     FROM mc.lot l, me
@@ -2026,6 +2055,9 @@ BEGIN
         RAISE EXCEPTION 'build_id cannot be empty' USING ERRCODE = '22004';
     END IF;
 
+    -- apply_state = 2 (failed) only — cancelled (4) is terminal by
+    -- admin action and cannot be retried without re-queueing through
+    -- the normal RPC.
     SELECT lot_id, action_kind, schematic_id, schematic_id_before
       INTO v_lot_id, v_action_kind, v_schematic_id, v_schematic_id_before
       FROM mc.lot_build_log
@@ -2145,7 +2177,7 @@ SECURITY DEFINER
 SET search_path = ''
 ROWS 100
 AS $$
-    SELECT b.build_id, b.lot_id, b.actor_user_id, b.action_kind,
+    SELECT b.build_id, b.lot_id, b.actor_user_id, b.action_kind::SMALLINT,
            b.schematic_id, b.apply_error, b.failed_at, b.attempt_count
     FROM mc.lot_build_log b
     WHERE b.apply_state = 2
@@ -2237,22 +2269,30 @@ BEGIN
         RAISE EXCEPTION 'user_id cannot be null' USING ERRCODE = '22004';
     END IF;
 
+    -- Job-driven guard: drifted system could have apply_state IN (0,3)
+    -- rows even when no lot is in state (3,4). Check the build_log
+    -- side directly so the guard is the source of truth.
     IF NOT p_force AND EXISTS (
-        SELECT 1 FROM mc.lot
-         WHERE owner_user_id = p_user_id AND state IN (3, 4)
+        SELECT 1
+          FROM mc.lot l
+          JOIN mc.lot_build_log b ON b.lot_id = l.lot_id
+         WHERE l.owner_user_id = p_user_id
+           AND b.apply_state IN (0, 3)
     ) THEN
-        RAISE EXCEPTION 'user % has lots with active jobs; pass p_force = TRUE to override',
+        RAISE EXCEPTION 'user % has active build jobs; pass p_force = TRUE to override',
             p_user_id USING ERRCODE = '22023';
     END IF;
 
     -- p_force: cancel any active build/demolish jobs first so worker
     -- ACKs against the now-vacant lots can't violate
-    -- mc_lot_owner_state_chk or leave stuck claimed rows.
+    -- mc_lot_owner_state_chk or leave stuck claimed rows. Cancelled
+    -- (4) is distinct from failed (2) so retry/listing/dashboards can
+    -- tell the difference.
     IF p_force THEN
         UPDATE mc.lot_build_log b
-           SET apply_state = 2,
+           SET apply_state = 4,
                apply_error = 'cancelled by forced user lot release',
-               failed_at = clock_timestamp(),
+               failed_at = NULL,
                claimed_at = NULL,
                claimed_by = NULL
           FROM mc.lot l
@@ -2626,7 +2666,7 @@ BEGIN
            l.block_z_min, l.block_z_max,
            l.chunk_area,
            l.anchor_y,
-           l.state,
+           l.state::SMALLINT,
            l.current_schematic_id,
            l.price_credits,
            l.price_khash
@@ -2718,7 +2758,7 @@ BEGIN
            l.block_x_min, l.block_x_max,
            l.block_z_min, l.block_z_max,
            l.chunk_area, l.anchor_y,
-           l.state, l.current_schematic_id,
+           l.state::SMALLINT, l.current_schematic_id,
            l.price_credits, l.price_khash
     FROM mc.lot l
     WHERE l.owner_user_id = v_uid
@@ -2911,7 +2951,7 @@ BEGIN
            l.chunk_area, l.anchor_y,
            (l.owner_user_id IS NOT NULL) AS is_owned,
            (l.owner_user_id IS NOT NULL AND l.owner_user_id = v_uid) AS is_owned_by_me,
-           l.current_schematic_id, l.state,
+           l.current_schematic_id, l.state::SMALLINT,
            l.price_credits, l.price_khash
     FROM mc.lot l
     WHERE l.world = p_world

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -511,10 +511,17 @@ CREATE INDEX idx_mc_lot_current_schematic
     ON mc.lot (current_schematic_id)
     WHERE current_schematic_id IS NOT NULL;
 
--- Queue table sees state-update churn (queued -> claimed -> applied);
--- HOT updates rely on free space inside the page. fillfactor 80 leaves
--- room for in-page row replacement so we avoid index bloat from page
--- splits. The audit/append-mostly tables stay at the default 100.
+-- Queue table sees state-update churn (queued -> claimed -> applied).
+-- apply_state and attempt_count both participate in partial indexes
+-- (pending_claim WHERE apply_state=0 AND attempt_count<5, claimed_stale
+-- WHERE apply_state=3, failed_recent WHERE apply_state=2,
+-- one_active_per_lot WHERE apply_state IN (0,3)) so most state
+-- transitions still require index maintenance and are NOT HOT-eligible.
+-- fillfactor 80 still pays off: it leaves room on heap pages and reduces
+-- page-split pressure under churn even when HOT can't be used. The
+-- proper long-term fix for high build traffic is splitting the queue
+-- state into a dedicated mc.lot_build_queue table (phase 3).
+-- Audit/append-mostly tables stay at the default 100.
 ALTER TABLE mc.lot_build_log SET (
     fillfactor = 80,
     autovacuum_vacuum_scale_factor = 0.02,
@@ -884,21 +891,25 @@ CREATE OR REPLACE FUNCTION mc.service_requeue_stale_claims(
     p_older_than_seconds INTEGER DEFAULT 300,
     p_limit INTEGER DEFAULT 128
 )
-RETURNS INTEGER
+RETURNS TABLE (
+    requeued_count  INTEGER,
+    exhausted_count INTEGER
+)
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-    -- Batch + SKIP LOCKED so a janitor run never blocks on rows another
-    -- requeue is touching, and the write surface stays bounded per call.
+    -- Two-bucket recovery so a stale claim with attempt_count >= 5 can't
+    -- become an invisible blocker (it would be queued but excluded by
+    -- the partial pending-claim index, and still occupy the partial
+    -- one-active-per-lot unique slot). Under-cap rows go back to
+    -- queued; at-cap rows transition to failed and the lot is released
+    -- to its prior settled state (built or owned).
     WITH picked AS (
-        SELECT build_id
+        SELECT build_id, lot_id, action_kind, attempt_count
           FROM mc.lot_build_log
          WHERE apply_state = 3
            AND claimed_at IS NOT NULL
-           -- Clamp to [1s, 1d] so an accidental huge input can't push the
-           -- threshold so far back it matches nothing (or wraps planner
-           -- estimates).
            AND claimed_at < clock_timestamp()
                           - make_interval(secs =>
                               LEAST(GREATEST(1, COALESCE(p_older_than_seconds, 300)), 86400))
@@ -906,16 +917,46 @@ AS $$
          LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 128), 512))
          FOR UPDATE SKIP LOCKED
     ),
-    stale AS (
+    requeued AS (
         UPDATE mc.lot_build_log b
            SET apply_state = 0,
                claimed_at = NULL,
                claimed_by = NULL
-          FROM picked
-         WHERE b.build_id = picked.build_id
+          FROM picked p
+         WHERE b.build_id = p.build_id
+           AND p.attempt_count < 5
+        RETURNING 1
+    ),
+    exhausted AS (
+        UPDATE mc.lot_build_log b
+           SET apply_state = 2,
+               apply_error = 'retry budget exhausted after stale claim recovery',
+               failed_at = clock_timestamp(),
+               claimed_at = NULL,
+               claimed_by = NULL
+          FROM picked p
+         WHERE b.build_id = p.build_id
+           AND p.attempt_count >= 5
+        RETURNING b.lot_id, b.action_kind
+    ),
+    -- Release the lot back to its settled state so a new build can
+    -- queue. We don't know the exact prior state, so the same
+    -- heuristic the failure ACK uses applies: schematic_id present
+    -- => built (2), else owned (1).
+    released AS (
+        UPDATE mc.lot l
+           SET state = CASE
+                  WHEN l.current_schematic_id IS NULL THEN 1
+                  ELSE 2
+               END
+          FROM exhausted e
+         WHERE l.lot_id = e.lot_id
+           AND l.state IN (3, 4)
         RETURNING 1
     )
-    SELECT COUNT(*)::INTEGER FROM stale;
+    SELECT
+        (SELECT COUNT(*)::INTEGER FROM requeued),
+        (SELECT COUNT(*)::INTEGER FROM exhausted);
 $$;
 
 ALTER FUNCTION mc.service_requeue_stale_claims(INTEGER, INTEGER) OWNER TO postgres;
@@ -1807,12 +1848,15 @@ $$;
 
 ALTER FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
                                       TEXT, INTEGER, INTEGER, TEXT) OWNER TO service_role;
+-- service_role only. The raw shape exposes owner_user_id; authenticated
+-- callers must use public.proxy_list_lots_public (no raw UUIDs) or one
+-- of the hot-path partial RPCs.
 REVOKE ALL ON FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
                                               TEXT, INTEGER, INTEGER, TEXT)
-    FROM PUBLIC, anon;
+    FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
                                                  TEXT, INTEGER, INTEGER, TEXT)
-    TO authenticated, service_role;
+    TO service_role;
 
 
 CREATE OR REPLACE FUNCTION public.proxy_list_schematics(p_category TEXT DEFAULT NULL)
@@ -2025,13 +2069,16 @@ CREATE OR REPLACE FUNCTION public.proxy_service_requeue_stale_claims(
     p_older_than_seconds INTEGER DEFAULT 300,
     p_limit INTEGER DEFAULT 128
 )
-RETURNS INTEGER
+RETURNS TABLE (
+    requeued_count  INTEGER,
+    exhausted_count INTEGER
+)
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 COST 100
 AS $$
-    SELECT mc.service_requeue_stale_claims(p_older_than_seconds, p_limit);
+    SELECT * FROM mc.service_requeue_stale_claims(p_older_than_seconds, p_limit);
 $$;
 
 ALTER FUNCTION public.proxy_service_requeue_stale_claims(INTEGER, INTEGER) OWNER TO service_role;
@@ -2059,9 +2106,45 @@ LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
+DECLARE
+    v_lot_id TEXT;
+    v_action_kind SMALLINT;
+    v_rowcount INTEGER;
 BEGIN
     IF p_build_id IS NULL OR btrim(p_build_id) = '' THEN
         RAISE EXCEPTION 'build_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+
+    -- Failure ACK already flipped the lot back to its settled state, so
+    -- the retried job's ACK path (which expects state = 3 for builds /
+    -- state = 4 for demolishes) would fail. Pre-flight the lot here.
+    SELECT lot_id, action_kind
+      INTO v_lot_id, v_action_kind
+      FROM mc.lot_build_log
+     WHERE build_id = p_build_id
+       AND apply_state = 2
+     FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+
+    IF v_action_kind = 0 THEN
+        UPDATE mc.lot
+           SET state = 3
+         WHERE lot_id = v_lot_id
+           AND state IN (1, 2);
+    ELSE
+        UPDATE mc.lot
+           SET state = 4
+         WHERE lot_id = v_lot_id
+           AND state = 2;
+    END IF;
+
+    GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+    IF v_rowcount <> 1 THEN
+        RAISE EXCEPTION 'lot % is not in a retryable state for build %', v_lot_id, p_build_id
+            USING ERRCODE = '22023';
     END IF;
 
     UPDATE mc.lot_build_log
@@ -2077,7 +2160,7 @@ BEGIN
      WHERE build_id = p_build_id
        AND apply_state = 2;
 
-    RETURN FOUND;
+    RETURN TRUE;
 END;
 $$;
 
@@ -2139,8 +2222,11 @@ AS $$
     WHERE b.apply_state = 2
       AND (
           p_after_build_id IS NULL
-          OR (b.failed_at, b.build_id)
-             < (p_after_failed_at, p_after_build_id)
+          OR (
+              p_after_failed_at IS NOT NULL
+              AND (b.failed_at, b.build_id)
+                  < (p_after_failed_at, p_after_build_id)
+          )
       )
     ORDER BY b.failed_at DESC, b.build_id DESC
     LIMIT LEAST(GREATEST(COALESCE(p_limit, 100), 1), 500);
@@ -2168,13 +2254,25 @@ RETURNS TABLE (
     failed_at       TIMESTAMPTZ,
     attempt_count   INTEGER
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 ROWS 100
 AS $$
+BEGIN
+    IF p_after_build_id IS NOT NULL AND p_after_failed_at IS NULL THEN
+        RAISE EXCEPTION 'cursor must include after_failed_at and after_build_id together'
+            USING ERRCODE = '22023';
+    END IF;
+    IF p_after_build_id IS NULL AND p_after_failed_at IS NOT NULL THEN
+        RAISE EXCEPTION 'cursor must include after_failed_at and after_build_id together'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RETURN QUERY
     SELECT * FROM mc.service_list_failed_builds(p_limit, p_after_failed_at, p_after_build_id);
+END;
 $$;
 
 ALTER FUNCTION public.proxy_service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT) OWNER TO service_role;
@@ -2243,6 +2341,10 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     chunk_area      INTEGER,
     anchor_y        SMALLINT,
     price_credits   BIGINT,
@@ -2261,9 +2363,6 @@ BEGIN
     IF p_world !~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$' THEN
         RAISE EXCEPTION 'invalid world format' USING ERRCODE = '22023';
     END IF;
-    -- Cursor all-or-none. Split into two directional checks so the
-    -- 'lot_id NULL + one coord set' case (and its mirror) can't slip
-    -- through a clever boolean.
     IF p_after_lot_id IS NOT NULL
        AND (p_after_chunk_x IS NULL OR p_after_chunk_z IS NULL) THEN
         RAISE EXCEPTION 'cursor must include after_chunk_x, after_chunk_z, and after_lot_id together'
@@ -2279,6 +2378,8 @@ BEGIN
     SELECT l.lot_id,
            l.chunk_x_min, l.chunk_x_max,
            l.chunk_z_min, l.chunk_z_max,
+           l.block_x_min, l.block_x_max,
+           l.block_z_min, l.block_z_max,
            l.chunk_area,
            l.anchor_y,
            l.price_credits,
@@ -2319,6 +2420,10 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     chunk_area      INTEGER,
     anchor_y        SMALLINT,
     state           SMALLINT,
@@ -2359,6 +2464,8 @@ BEGIN
     SELECT l.lot_id,
            l.chunk_x_min, l.chunk_x_max,
            l.chunk_z_min, l.chunk_z_max,
+           l.block_x_min, l.block_x_max,
+           l.block_z_min, l.block_z_max,
            l.chunk_area,
            l.anchor_y,
            l.state,
@@ -2387,6 +2494,96 @@ GRANT EXECUTE ON FUNCTION public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGE
     TO authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT) IS
     'Hot-path: caller-owned active lots (state IN (1, 2)) in a world. Hard-codes owner = auth.uid() and the state set so idx_mc_lot_owner_active_world_chunk_cursor is the only viable plan.';
+
+
+-- Companion to proxy_list_my_active_lots for in-progress views the
+-- dashboard polls while waiting for worker ACK. Hard-codes the
+-- transitional state set so the planner pins to
+-- idx_mc_lot_owner_transitional_world_chunk_cursor.
+CREATE OR REPLACE FUNCTION public.proxy_list_my_transitional_lots(
+    p_world TEXT,
+    p_limit INTEGER DEFAULT 256,
+    p_after_chunk_x INTEGER DEFAULT NULL,
+    p_after_chunk_z INTEGER DEFAULT NULL,
+    p_after_lot_id TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    lot_id          TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
+    chunk_area      INTEGER,
+    anchor_y        SMALLINT,
+    state           SMALLINT,
+    current_schematic_id TEXT,
+    price_credits   BIGINT,
+    price_khash     BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 256
+AS $$
+DECLARE
+    v_uid UUID := auth.uid();
+BEGIN
+    IF v_uid IS NULL THEN
+        RAISE EXCEPTION 'not authenticated' USING ERRCODE = '42501';
+    END IF;
+    IF p_world IS NULL OR btrim(p_world) = '' THEN
+        RAISE EXCEPTION 'world cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF p_world !~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$' THEN
+        RAISE EXCEPTION 'invalid world format' USING ERRCODE = '22023';
+    END IF;
+    IF p_after_lot_id IS NOT NULL
+       AND (p_after_chunk_x IS NULL OR p_after_chunk_z IS NULL) THEN
+        RAISE EXCEPTION 'cursor must include after_chunk_x, after_chunk_z, and after_lot_id together'
+            USING ERRCODE = '22023';
+    END IF;
+    IF p_after_lot_id IS NULL
+       AND (p_after_chunk_x IS NOT NULL OR p_after_chunk_z IS NOT NULL) THEN
+        RAISE EXCEPTION 'cursor must include after_chunk_x, after_chunk_z, and after_lot_id together'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RETURN QUERY
+    SELECT l.lot_id,
+           l.chunk_x_min, l.chunk_x_max,
+           l.chunk_z_min, l.chunk_z_max,
+           l.block_x_min, l.block_x_max,
+           l.block_z_min, l.block_z_max,
+           l.chunk_area, l.anchor_y,
+           l.state, l.current_schematic_id,
+           l.price_credits, l.price_khash
+    FROM mc.lot l
+    WHERE l.owner_user_id = v_uid
+      AND l.state IN (3, 4)
+      AND l.world = p_world
+      AND (
+          p_after_lot_id IS NULL
+          OR (l.chunk_x_min, l.chunk_z_min, l.lot_id)
+             > (p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
+      )
+    ORDER BY l.chunk_x_min, l.chunk_z_min, l.lot_id
+    LIMIT LEAST(GREATEST(COALESCE(p_limit, 256), 1), 1024);
+END;
+$$;
+
+ALTER FUNCTION public.proxy_list_my_transitional_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)
+    OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_list_my_transitional_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_list_my_transitional_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)
+    TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_list_my_transitional_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT) IS
+    'Hot-path companion to proxy_list_my_active_lots for the in-progress dashboard view (state IN (3, 4)). Pins to idx_mc_lot_owner_transitional_world_chunk_cursor. Surfaces block-space bounds for direct map rendering.';
 
 
 -- ===========================================================================
@@ -2495,6 +2692,10 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     chunk_area      INTEGER,
     anchor_y        SMALLINT,
     is_owned        BOOLEAN,
@@ -2519,11 +2720,20 @@ BEGIN
     IF p_world !~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$' THEN
         RAISE EXCEPTION 'invalid world format' USING ERRCODE = '22023';
     END IF;
+    IF p_min_chunk_x IS NULL OR p_max_chunk_x IS NULL
+       OR p_min_chunk_z IS NULL OR p_max_chunk_z IS NULL THEN
+        RAISE EXCEPTION 'viewport bounds cannot be null' USING ERRCODE = '22004';
+    END IF;
     IF p_max_chunk_x < p_min_chunk_x OR p_max_chunk_z < p_min_chunk_z THEN
         RAISE EXCEPTION 'viewport max must be >= min' USING ERRCODE = '22023';
     END IF;
-    IF (p_max_chunk_x - p_min_chunk_x + 1) > 4096
-       OR (p_max_chunk_z - p_min_chunk_z + 1) > 4096 THEN
+    -- Guard against int4 overflow on (p_max_chunk_* + 1) when building
+    -- the int4range below. INT32_MAX = 2147483647.
+    IF p_max_chunk_x >= 2147483647 OR p_max_chunk_z >= 2147483647 THEN
+        RAISE EXCEPTION 'viewport max is too large' USING ERRCODE = '22023';
+    END IF;
+    IF (p_max_chunk_x::bigint - p_min_chunk_x::bigint + 1) > 4096
+       OR (p_max_chunk_z::bigint - p_min_chunk_z::bigint + 1) > 4096 THEN
         RAISE EXCEPTION 'viewport too large (max 4096 chunks per axis)'
             USING ERRCODE = '22023';
     END IF;
@@ -2532,6 +2742,8 @@ BEGIN
     SELECT l.lot_id,
            l.chunk_x_min, l.chunk_x_max,
            l.chunk_z_min, l.chunk_z_max,
+           l.block_x_min, l.block_x_max,
+           l.block_z_min, l.block_z_max,
            l.chunk_area, l.anchor_y,
            (l.owner_user_id IS NOT NULL) AS is_owned,
            (l.owner_user_id IS NOT NULL AND l.owner_user_id = v_uid) AS is_owned_by_me,
@@ -2543,7 +2755,10 @@ BEGIN
       AND l.chunk_z_range && int4range(p_min_chunk_z, p_max_chunk_z + 1, '[)')
       AND (p_state IS NULL OR l.state = p_state)
     ORDER BY l.chunk_x_min, l.chunk_z_min, l.lot_id
-    LIMIT LEAST(GREATEST(COALESCE(p_limit, 1000), 1), 4096);
+    -- Cap at 2000: SQL handles more, but PostgREST JSON serialization
+    -- and frontend rendering become the actual bottleneck past ~2k rows.
+    -- Bulk exports run as service_role through service_list_lots.
+    LIMIT LEAST(GREATEST(COALESCE(p_limit, 1000), 1), 2000);
 END;
 $$;
 
@@ -2596,6 +2811,7 @@ DROP FUNCTION IF EXISTS public.proxy_list_lots_in_viewport(TEXT, INTEGER, INTEGE
                                                             SMALLINT, INTEGER);
 DROP FUNCTION IF EXISTS public.proxy_list_lots_public(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
                                                       TEXT, INTEGER, INTEGER, TEXT);
+DROP FUNCTION IF EXISTS public.proxy_list_my_transitional_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_list_vacant_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_list_schematics(TEXT);

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -339,6 +339,9 @@ ALTER TABLE mc.lot_build_log FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.lot_build_log IS
     'Append-only audit of build/demolish events and concurrent work queue. action_kind: 0=build, 1=demolish. apply_state: 0=queued, 1=applied, 2=failed, 3=claimed.';
+COMMENT ON COLUMN mc.lot_build_log.action_kind IS '0=build, 1=demolish';
+COMMENT ON COLUMN mc.lot_build_log.apply_state IS
+    '0=queued, 1=applied, 2=failed, 3=claimed (worker holding the row)';
 
 
 -- ===========================================================================
@@ -517,7 +520,8 @@ BEGIN
              WHERE inner_b.apply_state = 0
              ORDER BY inner_b.queued_at, inner_b.build_id
              FOR UPDATE SKIP LOCKED
-             LIMIT GREATEST(1, LEAST(p_limit, 256))
+             -- 0 is a legitimate value (dry-poll / disabled worker).
+             LIMIT GREATEST(0, LEAST(p_limit, 256))
          )
         RETURNING b.build_id, b.lot_id, b.actor_user_id,
                   b.action_kind, b.schematic_id, b.queued_at
@@ -737,6 +741,19 @@ DECLARE
     v_khash_ledger_id      BIGINT;
     v_purchase_id          TEXT;
 BEGIN
+    -- service_role callers can hit this directly; mirror the cheap
+    -- public-wrapper guards inline so a bad arg surfaces a clear error
+    -- before the advisory lock or the lot-row FOR UPDATE.
+    IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
+        RAISE EXCEPTION 'lot_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id cannot be null' USING ERRCODE = '22004';
+    END IF;
+    IF p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'idempotency_key cannot be null' USING ERRCODE = '22004';
+    END IF;
+
     -- Serialize concurrent retries on the same idempotency_key. Without
     -- the lock two identical requests can both miss the existing-key
     -- check, then one inserts cleanly and the other tries the lot-state
@@ -866,6 +883,19 @@ DECLARE
     v_khash_ledger_id      BIGINT;
     v_build_id             TEXT;
 BEGIN
+    IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
+        RAISE EXCEPTION 'lot_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF p_schematic_id IS NULL OR btrim(p_schematic_id) = '' THEN
+        RAISE EXCEPTION 'schematic_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id cannot be null' USING ERRCODE = '22004';
+    END IF;
+    IF p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'idempotency_key cannot be null' USING ERRCODE = '22004';
+    END IF;
+
     -- Serialize concurrent retries on the same idempotency_key. See the
     -- matching note in service_purchase_lot.
     PERFORM pg_advisory_xact_lock(hashtextextended(p_idempotency_key::text, 0));
@@ -1020,6 +1050,16 @@ DECLARE
     v_lot_state            SMALLINT;
     v_build_id             TEXT;
 BEGIN
+    IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
+        RAISE EXCEPTION 'lot_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id cannot be null' USING ERRCODE = '22004';
+    END IF;
+    IF p_idempotency_key IS NULL THEN
+        RAISE EXCEPTION 'idempotency_key cannot be null' USING ERRCODE = '22004';
+    END IF;
+
     PERFORM pg_advisory_xact_lock(hashtextextended(p_idempotency_key::text, 0));
 
     SELECT build_id, lot_id, actor_user_id, action_kind
@@ -1177,31 +1217,9 @@ REVOKE ALL ON FUNCTION mc.proxy_list_schematics(TEXT)
 GRANT EXECUTE ON FUNCTION mc.proxy_list_schematics(TEXT) TO service_role;
 
 
-CREATE OR REPLACE FUNCTION mc.proxy_purchase_lot(p_lot_id TEXT)
-RETURNS TEXT
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = ''
-COST 100
-AS $$
-DECLARE
-    v_uid UUID := auth.uid();
-BEGIN
-    IF v_uid IS NULL THEN
-        RAISE EXCEPTION 'not authenticated' USING ERRCODE = '42501';
-    END IF;
-    RETURN mc.service_purchase_lot(p_lot_id, v_uid, gen_random_uuid());
-END;
-$$;
-
-ALTER FUNCTION mc.proxy_purchase_lot(TEXT) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.proxy_purchase_lot(TEXT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION mc.proxy_purchase_lot(TEXT) TO service_role;
-
-
-CREATE OR REPLACE FUNCTION mc.proxy_queue_build_on_lot(
+CREATE OR REPLACE FUNCTION mc.proxy_purchase_lot(
     p_lot_id TEXT,
-    p_schematic_id TEXT
+    p_idempotency_key UUID DEFAULT gen_random_uuid()
 )
 RETURNS TEXT
 LANGUAGE plpgsql
@@ -1215,17 +1233,20 @@ BEGIN
     IF v_uid IS NULL THEN
         RAISE EXCEPTION 'not authenticated' USING ERRCODE = '42501';
     END IF;
-    RETURN mc.service_queue_build_on_lot(p_lot_id, p_schematic_id, v_uid, gen_random_uuid());
+    RETURN mc.service_purchase_lot(p_lot_id, v_uid, p_idempotency_key);
 END;
 $$;
 
-ALTER FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT)
-    FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT) TO service_role;
+ALTER FUNCTION mc.proxy_purchase_lot(TEXT, UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.proxy_purchase_lot(TEXT, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.proxy_purchase_lot(TEXT, UUID) TO service_role;
 
 
-CREATE OR REPLACE FUNCTION mc.proxy_queue_demolish_lot(p_lot_id TEXT)
+CREATE OR REPLACE FUNCTION mc.proxy_queue_build_on_lot(
+    p_lot_id TEXT,
+    p_schematic_id TEXT,
+    p_idempotency_key UUID DEFAULT gen_random_uuid()
+)
 RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -1238,14 +1259,40 @@ BEGIN
     IF v_uid IS NULL THEN
         RAISE EXCEPTION 'not authenticated' USING ERRCODE = '42501';
     END IF;
-    RETURN mc.service_queue_demolish_lot(p_lot_id, v_uid, gen_random_uuid());
+    RETURN mc.service_queue_build_on_lot(p_lot_id, p_schematic_id, v_uid, p_idempotency_key);
 END;
 $$;
 
-ALTER FUNCTION mc.proxy_queue_demolish_lot(TEXT) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.proxy_queue_demolish_lot(TEXT)
+ALTER FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT, UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT, UUID)
     FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION mc.proxy_queue_demolish_lot(TEXT) TO service_role;
+GRANT EXECUTE ON FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT, UUID) TO service_role;
+
+
+CREATE OR REPLACE FUNCTION mc.proxy_queue_demolish_lot(
+    p_lot_id TEXT,
+    p_idempotency_key UUID DEFAULT gen_random_uuid()
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+COST 100
+AS $$
+DECLARE
+    v_uid UUID := auth.uid();
+BEGIN
+    IF v_uid IS NULL THEN
+        RAISE EXCEPTION 'not authenticated' USING ERRCODE = '42501';
+    END IF;
+    RETURN mc.service_queue_demolish_lot(p_lot_id, v_uid, p_idempotency_key);
+END;
+$$;
+
+ALTER FUNCTION mc.proxy_queue_demolish_lot(TEXT, UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.proxy_queue_demolish_lot(TEXT, UUID)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.proxy_queue_demolish_lot(TEXT, UUID) TO service_role;
 
 
 -- ===========================================================================
@@ -1316,7 +1363,13 @@ REVOKE ALL ON FUNCTION public.proxy_list_schematics(TEXT) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.proxy_list_schematics(TEXT) TO authenticated, service_role;
 
 
-CREATE OR REPLACE FUNCTION public.proxy_purchase_lot(p_lot_id TEXT)
+-- p_idempotency_key is optional. Clients that retry on network failure
+-- should pass a stable key so the repeat call collapses to the original
+-- purchase row instead of racing into a "lot not vacant" error.
+CREATE OR REPLACE FUNCTION public.proxy_purchase_lot(
+    p_lot_id TEXT,
+    p_idempotency_key UUID DEFAULT gen_random_uuid()
+)
 RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -1327,18 +1380,19 @@ BEGIN
     IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
         RAISE EXCEPTION 'lot_id cannot be empty' USING ERRCODE = '22004';
     END IF;
-    RETURN mc.proxy_purchase_lot(p_lot_id);
+    RETURN mc.proxy_purchase_lot(p_lot_id, p_idempotency_key);
 END;
 $$;
 
-ALTER FUNCTION public.proxy_purchase_lot(TEXT) OWNER TO service_role;
-REVOKE ALL ON FUNCTION public.proxy_purchase_lot(TEXT) FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION public.proxy_purchase_lot(TEXT) TO authenticated, service_role;
+ALTER FUNCTION public.proxy_purchase_lot(TEXT, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_purchase_lot(TEXT, UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_purchase_lot(TEXT, UUID) TO authenticated, service_role;
 
 
 CREATE OR REPLACE FUNCTION public.proxy_queue_build_on_lot(
     p_lot_id TEXT,
-    p_schematic_id TEXT
+    p_schematic_id TEXT,
+    p_idempotency_key UUID DEFAULT gen_random_uuid()
 )
 RETURNS TEXT
 LANGUAGE plpgsql
@@ -1353,16 +1407,19 @@ BEGIN
     IF p_schematic_id IS NULL OR btrim(p_schematic_id) = '' THEN
         RAISE EXCEPTION 'schematic_id cannot be empty' USING ERRCODE = '22004';
     END IF;
-    RETURN mc.proxy_queue_build_on_lot(p_lot_id, p_schematic_id);
+    RETURN mc.proxy_queue_build_on_lot(p_lot_id, p_schematic_id, p_idempotency_key);
 END;
 $$;
 
-ALTER FUNCTION public.proxy_queue_build_on_lot(TEXT, TEXT) OWNER TO service_role;
-REVOKE ALL ON FUNCTION public.proxy_queue_build_on_lot(TEXT, TEXT) FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION public.proxy_queue_build_on_lot(TEXT, TEXT) TO authenticated, service_role;
+ALTER FUNCTION public.proxy_queue_build_on_lot(TEXT, TEXT, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_queue_build_on_lot(TEXT, TEXT, UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_queue_build_on_lot(TEXT, TEXT, UUID) TO authenticated, service_role;
 
 
-CREATE OR REPLACE FUNCTION public.proxy_queue_demolish_lot(p_lot_id TEXT)
+CREATE OR REPLACE FUNCTION public.proxy_queue_demolish_lot(
+    p_lot_id TEXT,
+    p_idempotency_key UUID DEFAULT gen_random_uuid()
+)
 RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -1373,13 +1430,13 @@ BEGIN
     IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
         RAISE EXCEPTION 'lot_id cannot be empty' USING ERRCODE = '22004';
     END IF;
-    RETURN mc.proxy_queue_demolish_lot(p_lot_id);
+    RETURN mc.proxy_queue_demolish_lot(p_lot_id, p_idempotency_key);
 END;
 $$;
 
-ALTER FUNCTION public.proxy_queue_demolish_lot(TEXT) OWNER TO service_role;
-REVOKE ALL ON FUNCTION public.proxy_queue_demolish_lot(TEXT) FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION public.proxy_queue_demolish_lot(TEXT) TO authenticated, service_role;
+ALTER FUNCTION public.proxy_queue_demolish_lot(TEXT, UUID) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_queue_demolish_lot(TEXT, UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_queue_demolish_lot(TEXT, UUID) TO authenticated, service_role;
 
 
 -- ===========================================================================
@@ -1427,6 +1484,7 @@ RETURNS BOOLEAN
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
     SELECT mc.service_mark_build_applied(p_build_id, p_worker_id);
 $$;
@@ -1449,6 +1507,7 @@ RETURNS BOOLEAN
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
     SELECT mc.service_mark_build_failed(p_build_id, p_worker_id, p_error);
 $$;
@@ -1469,6 +1528,7 @@ RETURNS INTEGER
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
     SELECT mc.service_requeue_stale_claims(p_older_than_seconds);
 $$;
@@ -1499,15 +1559,24 @@ DROP FUNCTION IF EXISTS public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT)
 DROP FUNCTION IF EXISTS public.proxy_service_mark_build_applied(TEXT, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_service_claim_pending_builds(TEXT, INTEGER);
 
+-- Pre-idempotency-key signatures (covered for dev DBs that briefly held
+-- the older single-arg shapes).
 DROP FUNCTION IF EXISTS public.proxy_queue_demolish_lot(TEXT);
 DROP FUNCTION IF EXISTS public.proxy_queue_build_on_lot(TEXT, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_purchase_lot(TEXT);
-DROP FUNCTION IF EXISTS public.proxy_list_schematics(TEXT);
-DROP FUNCTION IF EXISTS public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER);
-
 DROP FUNCTION IF EXISTS mc.proxy_queue_demolish_lot(TEXT);
 DROP FUNCTION IF EXISTS mc.proxy_queue_build_on_lot(TEXT, TEXT);
 DROP FUNCTION IF EXISTS mc.proxy_purchase_lot(TEXT);
+
+DROP FUNCTION IF EXISTS public.proxy_queue_demolish_lot(TEXT, UUID);
+DROP FUNCTION IF EXISTS public.proxy_queue_build_on_lot(TEXT, TEXT, UUID);
+DROP FUNCTION IF EXISTS public.proxy_purchase_lot(TEXT, UUID);
+DROP FUNCTION IF EXISTS public.proxy_list_schematics(TEXT);
+DROP FUNCTION IF EXISTS public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER);
+
+DROP FUNCTION IF EXISTS mc.proxy_queue_demolish_lot(TEXT, UUID);
+DROP FUNCTION IF EXISTS mc.proxy_queue_build_on_lot(TEXT, TEXT, UUID);
+DROP FUNCTION IF EXISTS mc.proxy_purchase_lot(TEXT, UUID);
 DROP FUNCTION IF EXISTS mc.proxy_list_schematics(TEXT);
 DROP FUNCTION IF EXISTS mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER);
 

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -157,7 +157,14 @@ CREATE TABLE mc.lot (
         ((upper(chunk_x_range) - lower(chunk_x_range))
        * (upper(chunk_z_range) - lower(chunk_z_range))) STORED,
     anchor_y        SMALLINT NOT NULL,
-    owner_user_id   UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    -- ON DELETE RESTRICT, not SET NULL: the owner_state_chk requires
+    -- state > 0 to carry a non-null owner. SET NULL would let a user
+    -- deletion drop the owner column on a built/owned/under_build lot
+    -- and surface the CHECK violation at the wrong layer. Forcing a
+    -- restriction means user deletion has to flow through an explicit
+    -- 'release my lots' RPC that resets state, owner, and schematic
+    -- together.
+    owner_user_id   UUID REFERENCES auth.users(id) ON DELETE RESTRICT,
     current_schematic_id TEXT REFERENCES mc.schematic(schematic_id),
     -- 0 = vacant, 1 = owned, 2 = built, 3 = under_build, 4 = demolishing
     state           SMALLINT NOT NULL DEFAULT 0,
@@ -228,7 +235,9 @@ CREATE TABLE mc.lot (
 -- pick the index directly without rewriting the predicate. The trailing
 -- lot_id makes every ordering deterministic and unlocks keyset
 -- pagination in a later migration without touching these indexes.
-CREATE INDEX idx_mc_lot_owner ON mc.lot (owner_user_id) WHERE owner_user_id IS NOT NULL;
+-- Bare 'WHERE owner_user_id = $1' lookups are covered by the leading
+-- column of idx_mc_lot_owner_world_chunk_cursor; no separate non-cursor
+-- owner index needed.
 CREATE INDEX idx_mc_lot_world_chunk_cursor
     ON mc.lot (world, chunk_x_min, chunk_z_min, lot_id);
 CREATE INDEX idx_mc_lot_world_state_chunk_cursor
@@ -1197,7 +1206,9 @@ BEGIN
 
     -- The partial uq_mc_lot_build_log_one_active_per_lot index turns a
     -- concurrent second queue attempt into a unique_violation. Translate
-    -- to a clearer domain error.
+    -- ONLY that constraint into the domain error; an idempotency-key
+    -- collision (different mc_lot_build_log_idem_uq constraint) must
+    -- re-raise so the caller sees a distinct error.
     BEGIN
         INSERT INTO mc.lot_build_log (
             lot_id, actor_user_id, action_kind, schematic_id,
@@ -1212,8 +1223,16 @@ BEGIN
         )
         RETURNING build_id INTO v_build_id;
     EXCEPTION WHEN unique_violation THEN
-        RAISE EXCEPTION 'lot % already has an active queued/claimed job', p_lot_id
-            USING ERRCODE = '23505';
+        DECLARE
+            v_constraint TEXT;
+        BEGIN
+            GET STACKED DIAGNOSTICS v_constraint = CONSTRAINT_NAME;
+            IF v_constraint = 'uq_mc_lot_build_log_one_active_per_lot' THEN
+                RAISE EXCEPTION 'lot % already has an active queued/claimed job', p_lot_id
+                    USING ERRCODE = '23505';
+            END IF;
+            RAISE;
+        END;
     END;
 
     UPDATE mc.lot SET state = 3 WHERE lot_id = p_lot_id;
@@ -1303,8 +1322,16 @@ BEGIN
         )
         RETURNING build_id INTO v_build_id;
     EXCEPTION WHEN unique_violation THEN
-        RAISE EXCEPTION 'lot % already has an active queued/claimed job', p_lot_id
-            USING ERRCODE = '23505';
+        DECLARE
+            v_constraint TEXT;
+        BEGIN
+            GET STACKED DIAGNOSTICS v_constraint = CONSTRAINT_NAME;
+            IF v_constraint = 'uq_mc_lot_build_log_one_active_per_lot' THEN
+                RAISE EXCEPTION 'lot % already has an active queued/claimed job', p_lot_id
+                    USING ERRCODE = '23505';
+            END IF;
+            RAISE;
+        END;
     END;
 
     UPDATE mc.lot SET state = 4 WHERE lot_id = p_lot_id;
@@ -1550,15 +1577,36 @@ RETURNS TABLE (
     price_credits   BIGINT,
     price_khash     BIGINT
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 ROWS 256
 AS $$
-    SELECT * FROM mc.proxy_list_lots(
+BEGIN
+    -- Generic list has a four-field cursor (world + chunk_x + chunk_z +
+    -- lot_id). All-or-none, otherwise a malformed client cursor would
+    -- silently return zero rows from the SQL-level guard inside
+    -- mc.proxy_list_lots and hide the bug.
+    IF p_after_lot_id IS NOT NULL
+       AND (p_after_world IS NULL
+            OR p_after_chunk_x IS NULL
+            OR p_after_chunk_z IS NULL) THEN
+        RAISE EXCEPTION 'cursor must include after_world, after_chunk_x, after_chunk_z, and after_lot_id together'
+            USING ERRCODE = '22023';
+    END IF;
+    IF p_after_lot_id IS NULL
+       AND (p_after_world IS NOT NULL
+            OR p_after_chunk_x IS NOT NULL
+            OR p_after_chunk_z IS NOT NULL) THEN
+        RAISE EXCEPTION 'cursor must include after_world, after_chunk_x, after_chunk_z, and after_lot_id together'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RETURN QUERY SELECT * FROM mc.proxy_list_lots(
         p_world, p_state, p_only_mine, p_limit, p_offset,
         p_after_world, p_after_chunk_x, p_after_chunk_z, p_after_lot_id);
+END;
 $$;
 
 ALTER FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
@@ -1818,12 +1866,16 @@ BEGIN
     IF p_world !~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$' THEN
         RAISE EXCEPTION 'invalid world format' USING ERRCODE = '22023';
     END IF;
-    -- Cursor all-or-none. world is already pinned via p_world so it
-    -- doesn't enter the cursor tuple; the three remaining cursor args
-    -- must agree on null-ness.
-    IF (p_after_lot_id IS NULL) <> (p_after_chunk_x IS NULL OR p_after_chunk_z IS NULL)
-       OR (p_after_lot_id IS NOT NULL
-           AND (p_after_chunk_x IS NULL OR p_after_chunk_z IS NULL)) THEN
+    -- Cursor all-or-none. Split into two directional checks so the
+    -- 'lot_id NULL + one coord set' case (and its mirror) can't slip
+    -- through a clever boolean.
+    IF p_after_lot_id IS NOT NULL
+       AND (p_after_chunk_x IS NULL OR p_after_chunk_z IS NULL) THEN
+        RAISE EXCEPTION 'cursor must include after_chunk_x, after_chunk_z, and after_lot_id together'
+            USING ERRCODE = '22023';
+    END IF;
+    IF p_after_lot_id IS NULL
+       AND (p_after_chunk_x IS NOT NULL OR p_after_chunk_z IS NOT NULL) THEN
         RAISE EXCEPTION 'cursor must include after_chunk_x, after_chunk_z, and after_lot_id together'
             USING ERRCODE = '22023';
     END IF;

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -116,12 +116,14 @@ CREATE TABLE mc.schematic (
                resource_path ~ '^schematics/[A-Za-z0-9_./-]+\.(nbt|schem)$')
 );
 
--- Partial index lines up with proxy_list_schematics' WHERE enabled + ORDER
--- BY category, tier, name path. Unfiltered rows are extremely cold.
-CREATE INDEX idx_mc_schematic_enabled_category_tier_name
-    ON mc.schematic (category, tier, name)
+-- Partial index lines up with proxy_list_schematics' WHERE enabled +
+-- ORDER BY category, tier, name path. INCLUDE columns let the planner
+-- satisfy the catalog listing without touching the heap once the
+-- visibility map is warm.
+CREATE INDEX idx_mc_schematic_enabled_category_tier_name_cover
+    ON mc.schematic (category, tier, name, schematic_id)
+    INCLUDE (dims_x, dims_y, dims_z, price_credits, price_khash)
     WHERE enabled;
-CREATE INDEX idx_mc_schematic_tier ON mc.schematic (tier);
 
 ALTER TABLE mc.schematic ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.schematic FORCE ROW LEVEL SECURITY;
@@ -138,8 +140,15 @@ CREATE TABLE mc.lot (
     world           TEXT NOT NULL DEFAULT 'minecraft:overworld',
     chunk_x_range   int4range NOT NULL,
     chunk_z_range   int4range NOT NULL,
-    -- Stored generated columns so chunk-count guards in RPCs (and any
-    -- future "lots ordered by size" queries) don't recompute on every read.
+    -- Stored generated columns so chunk-count guards in RPCs, listing
+    -- sort orders, and dashboard map queries don't recompute on every
+    -- read. *_min / *_max are inclusive (i.e. -1 from the half-open
+    -- upper bound) so indexes and queries are in the same coordinate
+    -- system the dashboard renders in.
+    chunk_x_min     INTEGER GENERATED ALWAYS AS (lower(chunk_x_range)) STORED,
+    chunk_x_max     INTEGER GENERATED ALWAYS AS (upper(chunk_x_range) - 1) STORED,
+    chunk_z_min     INTEGER GENERATED ALWAYS AS (lower(chunk_z_range)) STORED,
+    chunk_z_max     INTEGER GENERATED ALWAYS AS (upper(chunk_z_range) - 1) STORED,
     chunk_width     INTEGER GENERATED ALWAYS AS
         (upper(chunk_x_range) - lower(chunk_x_range)) STORED,
     chunk_depth     INTEGER GENERATED ALWAYS AS
@@ -195,35 +204,35 @@ CREATE TABLE mc.lot (
     )
 );
 
+-- Now that we have stored chunk_x_min / chunk_z_min generated columns,
+-- prefer them over expression indexes on lower(chunk_*_range) so plans
+-- pick the index directly without rewriting the predicate. The trailing
+-- lot_id makes every ordering deterministic and unlocks keyset
+-- pagination in a later migration without touching these indexes.
 CREATE INDEX idx_mc_lot_owner ON mc.lot (owner_user_id) WHERE owner_user_id IS NOT NULL;
--- Covering order for service_list_lots / proxy_list_lots:
--- ORDER BY world, lower(chunk_x_range), lower(chunk_z_range).
-CREATE INDEX idx_mc_lot_world_chunk_order
-    ON mc.lot (world, lower(chunk_x_range), lower(chunk_z_range));
--- Same order with state in the leading position so state-filtered listings
--- skip irrelevant rows entirely.
-CREATE INDEX idx_mc_lot_world_state_chunk_order
-    ON mc.lot (world, state, lower(chunk_x_range), lower(chunk_z_range));
--- proxy_list_lots(p_only_mine = true) filters by owner first then sorts
--- by world/chunk. This partial index covers that path so "my lots" never
--- falls back to a sort.
-CREATE INDEX idx_mc_lot_owner_world_chunk_order
-    ON mc.lot (owner_user_id, world, lower(chunk_x_range), lower(chunk_z_range))
+CREATE INDEX idx_mc_lot_world_chunk_cursor
+    ON mc.lot (world, chunk_x_min, chunk_z_min, lot_id);
+CREATE INDEX idx_mc_lot_world_state_chunk_cursor
+    ON mc.lot (world, state, chunk_x_min, chunk_z_min, lot_id);
+CREATE INDEX idx_mc_lot_owner_world_chunk_cursor
+    ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     WHERE owner_user_id IS NOT NULL;
 
 ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot FORCE ROW LEVEL SECURITY;
 
 -- Trigger touches updated_at only when something other than updated_at
--- itself changed; cuts write amplification on no-op UPDATEs.
--- clock_timestamp() captures real statement time even in long transactions.
+-- itself changed; cuts write amplification on no-op UPDATEs. NOW() is
+-- transaction-stable, which is what we want for an audit-style column
+-- (callers expect rows updated in the same transaction to share a
+-- timestamp), and it skips the per-row clock read.
 CREATE OR REPLACE FUNCTION mc.trg_lot_updated_at()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
 BEGIN
     IF NEW IS DISTINCT FROM OLD THEN
-        NEW.updated_at := clock_timestamp();
+        NEW.updated_at := NOW();
     END IF;
     RETURN NEW;
 END;
@@ -257,11 +266,25 @@ CREATE TABLE mc.lot_purchase (
 
     CONSTRAINT mc_lot_purchase_price_chk
         CHECK (price_credits >= 0 AND price_khash >= 0),
+    -- Per-currency ledger reference must be present iff that currency
+    -- was actually charged. Prevents dirty audit rows that would force
+    -- defensive null-checking downstream.
+    CONSTRAINT mc_lot_purchase_credits_ledger_chk CHECK (
+        (price_credits = 0 AND wallet_credits_ledger_id IS NULL)
+        OR (price_credits > 0 AND wallet_credits_ledger_id IS NOT NULL)
+    ),
+    CONSTRAINT mc_lot_purchase_khash_ledger_chk CHECK (
+        (price_khash = 0 AND wallet_khash_ledger_id IS NULL)
+        OR (price_khash > 0 AND wallet_khash_ledger_id IS NOT NULL)
+    ),
     CONSTRAINT mc_lot_purchase_idem_uq UNIQUE (idempotency_key)
 );
 
 CREATE INDEX idx_mc_lot_purchase_lot   ON mc.lot_purchase (lot_id);
-CREATE INDEX idx_mc_lot_purchase_buyer ON mc.lot_purchase (buyer_user_id);
+-- Dashboard "my purchase history" sorts newest first; composite avoids
+-- a sort step.
+CREATE INDEX idx_mc_lot_purchase_buyer_created
+    ON mc.lot_purchase (buyer_user_id, created_at DESC, purchase_id DESC);
 
 -- Phase-0 invariant: each lot can be bought exactly once. Resale comes
 -- with an explicit ownership-epoch column in a follow-up migration.
@@ -310,6 +333,14 @@ CREATE TABLE mc.lot_build_log (
         CHECK (apply_error IS NULL OR length(apply_error) <= 2048),
     CONSTRAINT mc_lot_build_log_claimed_by_len_chk
         CHECK (claimed_by IS NULL OR length(claimed_by) <= 128),
+    CONSTRAINT mc_lot_build_log_credits_ledger_chk CHECK (
+        (price_credits = 0 AND wallet_credits_ledger_id IS NULL)
+        OR (price_credits > 0 AND wallet_credits_ledger_id IS NOT NULL)
+    ),
+    CONSTRAINT mc_lot_build_log_khash_ledger_chk CHECK (
+        (price_khash = 0 AND wallet_khash_ledger_id IS NULL)
+        OR (price_khash > 0 AND wallet_khash_ledger_id IS NOT NULL)
+    ),
     -- Claimed state must carry full worker identity; non-claimed states
     -- must not.
     CONSTRAINT mc_lot_build_log_claimed_consistency_chk
@@ -321,18 +352,46 @@ CREATE TABLE mc.lot_build_log (
 );
 
 CREATE INDEX idx_mc_lot_build_log_lot     ON mc.lot_build_log (lot_id);
-CREATE INDEX idx_mc_lot_build_log_actor   ON mc.lot_build_log (actor_user_id);
-CREATE INDEX idx_mc_lot_build_log_pending ON mc.lot_build_log (queued_at) WHERE apply_state = 0;
--- Stuck-job reclaim: find rows whose worker died after claiming.
+-- User history: newest-first composite drops the sort step.
+CREATE INDEX idx_mc_lot_build_log_actor_queued
+    ON mc.lot_build_log (actor_user_id, queued_at DESC, build_id DESC);
+-- Queue + worker claim path: include build_id so the claim ORDER BY
+-- (queued_at, build_id) is satisfied by index walk alone.
+CREATE INDEX idx_mc_lot_build_log_pending_claim
+    ON mc.lot_build_log (queued_at, build_id)
+    WHERE apply_state = 0;
+-- Stuck-job reclaim. build_id keeps janitor scans deterministic and
+-- supports a LIMIT-batched requeue.
 CREATE INDEX idx_mc_lot_build_log_claimed_stale
-    ON mc.lot_build_log (claimed_at)
+    ON mc.lot_build_log (claimed_at, build_id)
     WHERE apply_state = 3;
+-- Reverse FK lookup: "which build jobs referenced schematic X?"
+CREATE INDEX idx_mc_lot_build_log_schematic
+    ON mc.lot_build_log (schematic_id)
+    WHERE schematic_id IS NOT NULL;
 
 -- At most one outstanding job (queued OR claimed) per lot. Stronger than
 -- the lot.state guard because it survives RPC bugs / direct admin writes.
 CREATE UNIQUE INDEX uq_mc_lot_build_log_one_active_per_lot
     ON mc.lot_build_log (lot_id)
     WHERE apply_state IN (0, 3);
+
+-- Reverse FK lookup for mc.lot.current_schematic_id.
+CREATE INDEX idx_mc_lot_current_schematic
+    ON mc.lot (current_schematic_id)
+    WHERE current_schematic_id IS NOT NULL;
+
+-- Queue table sees state-update churn (queued -> claimed -> applied);
+-- HOT updates rely on free space inside the page. fillfactor 80 leaves
+-- room for in-page row replacement so we avoid index bloat from page
+-- splits. The audit/append-mostly tables stay at the default 100.
+ALTER TABLE mc.lot_build_log SET (
+    fillfactor = 80,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_vacuum_threshold = 1000,
+    autovacuum_analyze_threshold = 500
+);
 
 ALTER TABLE mc.lot_build_log ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot_build_log FORCE ROW LEVEL SECURITY;
@@ -354,10 +413,13 @@ STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $$
+    -- wallet.account has a partial unique index (kind='user', user_id)
+    -- so at most one row matches; LIMIT 1 was previously defensive but
+    -- masked corruption. Plain scalar subquery surfaces duplicates as a
+    -- "more than one row" runtime error instead.
     SELECT a.id
     FROM wallet.account a
-    WHERE a.kind = 'user' AND a.user_id = p_user_id
-    LIMIT 1;
+    WHERE a.kind = 'user' AND a.user_id = p_user_id;
 $$;
 
 ALTER FUNCTION mc._user_account_id(UUID) OWNER TO postgres;
@@ -399,10 +461,10 @@ ROWS 256
 AS $$
     SELECT l.lot_id,
            l.world,
-           lower(l.chunk_x_range)     AS chunk_x_min,
-           upper(l.chunk_x_range) - 1 AS chunk_x_max,
-           lower(l.chunk_z_range)     AS chunk_z_min,
-           upper(l.chunk_z_range) - 1 AS chunk_z_max,
+           l.chunk_x_min,
+           l.chunk_x_max,
+           l.chunk_z_min,
+           l.chunk_z_max,
            l.chunk_area,
            l.anchor_y,
            l.owner_user_id,
@@ -416,7 +478,7 @@ AS $$
     WHERE (p_world         IS NULL OR l.world = p_world)
       AND (p_state         IS NULL OR l.state = p_state)
       AND (p_owner_user_id IS NULL OR l.owner_user_id = p_owner_user_id)
-    ORDER BY l.world, lower(l.chunk_x_range), lower(l.chunk_z_range)
+    ORDER BY l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id
     LIMIT GREATEST(0, LEAST(p_limit, 1024))
     OFFSET GREATEST(0, p_offset);
 $$;
@@ -543,30 +605,43 @@ GRANT EXECUTE ON FUNCTION mc.service_claim_pending_builds(TEXT, INTEGER)
 -- mc.service_requeue_stale_claims — recover orphaned worker claims
 -- ===========================================================================
 CREATE OR REPLACE FUNCTION mc.service_requeue_stale_claims(
-    p_older_than_seconds INTEGER DEFAULT 300
+    p_older_than_seconds INTEGER DEFAULT 300,
+    p_limit INTEGER DEFAULT 128
 )
 RETURNS INTEGER
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-    WITH stale AS (
-        UPDATE mc.lot_build_log
+    -- Batch + SKIP LOCKED so a janitor run never blocks on rows another
+    -- requeue is touching, and the write surface stays bounded per call.
+    WITH picked AS (
+        SELECT build_id
+          FROM mc.lot_build_log
+         WHERE apply_state = 3
+           AND claimed_at IS NOT NULL
+           AND claimed_at < clock_timestamp()
+                          - make_interval(secs => GREATEST(1, p_older_than_seconds))
+         ORDER BY claimed_at, build_id
+         LIMIT GREATEST(0, LEAST(p_limit, 512))
+         FOR UPDATE SKIP LOCKED
+    ),
+    stale AS (
+        UPDATE mc.lot_build_log b
            SET apply_state = 0,
                claimed_at = NULL,
                claimed_by = NULL
-         WHERE apply_state = 3
-           AND claimed_at IS NOT NULL
-           AND claimed_at < clock_timestamp() - make_interval(secs => GREATEST(1, p_older_than_seconds))
+          FROM picked
+         WHERE b.build_id = picked.build_id
         RETURNING 1
     )
     SELECT COUNT(*)::INTEGER FROM stale;
 $$;
 
-ALTER FUNCTION mc.service_requeue_stale_claims(INTEGER) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.service_requeue_stale_claims(INTEGER)
+ALTER FUNCTION mc.service_requeue_stale_claims(INTEGER, INTEGER) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_requeue_stale_claims(INTEGER, INTEGER)
     FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION mc.service_requeue_stale_claims(INTEGER)
+GRANT EXECUTE ON FUNCTION mc.service_requeue_stale_claims(INTEGER, INTEGER)
     TO service_role;
 
 
@@ -1139,38 +1214,37 @@ RETURNS TABLE (
     price_credits   BIGINT,
     price_khash     BIGINT
 )
-LANGUAGE plpgsql
+LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 ROWS 256
 AS $$
-DECLARE
-    v_uid UUID := auth.uid();
-BEGIN
-    RETURN QUERY
+    -- LANGUAGE sql so the planner sees the body directly instead of going
+    -- through a plpgsql RETURN QUERY layer. auth.uid() is called once via
+    -- the CROSS JOIN so the equality survives function inlining cleanly.
+    WITH me AS (SELECT auth.uid() AS uid)
     SELECT l.lot_id,
            l.world,
-           lower(l.chunk_x_range)     AS chunk_x_min,
-           upper(l.chunk_x_range) - 1 AS chunk_x_max,
-           lower(l.chunk_z_range)     AS chunk_z_min,
-           upper(l.chunk_z_range) - 1 AS chunk_z_max,
+           l.chunk_x_min,
+           l.chunk_x_max,
+           l.chunk_z_min,
+           l.chunk_z_max,
            l.chunk_area,
            l.anchor_y,
            l.owner_user_id,
-           (l.owner_user_id IS NOT NULL AND l.owner_user_id = v_uid) AS is_owned_by_me,
+           (l.owner_user_id IS NOT NULL AND l.owner_user_id = me.uid) AS is_owned_by_me,
            l.current_schematic_id,
            l.state,
            l.price_credits,
            l.price_khash
-    FROM mc.lot l
+    FROM mc.lot l, me
     WHERE (p_world IS NULL OR l.world = p_world)
       AND (p_state IS NULL OR l.state = p_state)
-      AND (NOT p_only_mine OR (v_uid IS NOT NULL AND l.owner_user_id = v_uid))
-    ORDER BY l.world, lower(l.chunk_x_range), lower(l.chunk_z_range)
+      AND (NOT p_only_mine OR (me.uid IS NOT NULL AND l.owner_user_id = me.uid))
+    ORDER BY l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id
     LIMIT GREATEST(0, LEAST(p_limit, 1024))
     OFFSET GREATEST(0, p_offset);
-END;
 $$;
 
 ALTER FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER) OWNER TO postgres;
@@ -1225,7 +1299,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
-COST 100
+COST 10
 AS $$
 DECLARE
     v_uid UUID := auth.uid();
@@ -1251,7 +1325,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
-COST 100
+COST 10
 AS $$
 DECLARE
     v_uid UUID := auth.uid();
@@ -1277,7 +1351,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
-COST 100
+COST 10
 AS $$
 DECLARE
     v_uid UUID := auth.uid();
@@ -1374,7 +1448,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
-COST 100
+COST 10
 AS $$
 BEGIN
     IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
@@ -1398,7 +1472,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
-COST 100
+COST 10
 AS $$
 BEGIN
     IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
@@ -1424,7 +1498,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
-COST 100
+COST 10
 AS $$
 BEGIN
     IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
@@ -1522,7 +1596,8 @@ COMMENT ON FUNCTION public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT) IS
 
 
 CREATE OR REPLACE FUNCTION public.proxy_service_requeue_stale_claims(
-    p_older_than_seconds INTEGER DEFAULT 300
+    p_older_than_seconds INTEGER DEFAULT 300,
+    p_limit INTEGER DEFAULT 128
 )
 RETURNS INTEGER
 LANGUAGE sql
@@ -1530,16 +1605,16 @@ SECURITY DEFINER
 SET search_path = ''
 COST 100
 AS $$
-    SELECT mc.service_requeue_stale_claims(p_older_than_seconds);
+    SELECT mc.service_requeue_stale_claims(p_older_than_seconds, p_limit);
 $$;
 
-ALTER FUNCTION public.proxy_service_requeue_stale_claims(INTEGER) OWNER TO service_role;
-REVOKE ALL ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER)
+ALTER FUNCTION public.proxy_service_requeue_stale_claims(INTEGER, INTEGER) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER, INTEGER)
     FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER)
+GRANT EXECUTE ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER, INTEGER)
     TO service_role;
-COMMENT ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER) IS
-    'Service-role-only PostgREST bridge for janitor recovery of orphaned worker claims older than p_older_than_seconds. Returns the count of jobs requeued.';
+COMMENT ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER, INTEGER) IS
+    'Service-role-only PostgREST bridge for janitor recovery of orphaned worker claims older than p_older_than_seconds. Batched + SKIP LOCKED with p_limit (max 512). Returns the count of jobs requeued in this call.';
 
 
 NOTIFY pgrst, 'reload schema';
@@ -1554,6 +1629,7 @@ DROP FUNCTION IF EXISTS public.proxy_service_mark_build_applied(TEXT);
 DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT);
 DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT);
 
+DROP FUNCTION IF EXISTS public.proxy_service_requeue_stale_claims(INTEGER, INTEGER);
 DROP FUNCTION IF EXISTS public.proxy_service_requeue_stale_claims(INTEGER);
 DROP FUNCTION IF EXISTS public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_service_mark_build_applied(TEXT, TEXT);
@@ -1585,6 +1661,7 @@ DROP FUNCTION IF EXISTS mc.service_queue_build_on_lot(TEXT, TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_purchase_lot(TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT, TEXT);
 DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT, TEXT);
+DROP FUNCTION IF EXISTS mc.service_requeue_stale_claims(INTEGER, INTEGER);
 DROP FUNCTION IF EXISTS mc.service_requeue_stale_claims(INTEGER);
 DROP FUNCTION IF EXISTS mc.service_claim_pending_builds(TEXT, INTEGER);
 DROP FUNCTION IF EXISTS mc.service_list_schematics(TEXT, BOOLEAN);

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -236,6 +236,7 @@ BEGIN
     IF NEW.owner_user_id        IS DISTINCT FROM OLD.owner_user_id
        OR NEW.current_schematic_id IS DISTINCT FROM OLD.current_schematic_id
        OR NEW.state                IS DISTINCT FROM OLD.state
+       OR NEW.flags                IS DISTINCT FROM OLD.flags
        OR NEW.price_credits        IS DISTINCT FROM OLD.price_credits
        OR NEW.price_khash          IS DISTINCT FROM OLD.price_khash
        OR NEW.world                IS DISTINCT FROM OLD.world
@@ -364,6 +365,16 @@ CREATE TABLE mc.lot_build_log (
             AND price_khash = 0
             AND wallet_credits_ledger_id IS NULL
             AND wallet_khash_ledger_id IS NULL)
+    ),
+    -- Queueable jobs only start from owned (1) or built (2).
+    CONSTRAINT mc_lot_build_log_snapshot_state_chk CHECK (
+        lot_state_before IS NULL OR lot_state_before IN (1, 2)
+    ),
+    -- Demolish snapshots must be built (or legacy NULL).
+    CONSTRAINT mc_lot_build_log_demolish_snapshot_chk CHECK (
+        action_kind <> 1
+        OR lot_state_before IS NULL
+        OR lot_state_before = 2
     ),
     -- Claimed state must carry full worker identity; non-claimed states
     -- must not.
@@ -783,7 +794,8 @@ AS $$
     -- release the lot — prevents poisoned rows from blocking via
     -- the partial one-active-per-lot unique slot.
     WITH picked AS (
-        SELECT build_id, lot_id, action_kind, attempt_count, lot_state_before
+        SELECT build_id, lot_id, action_kind, attempt_count,
+               lot_state_before, schematic_id_before
           FROM mc.lot_build_log
          WHERE apply_state = 3
            AND claimed_at IS NOT NULL
@@ -814,10 +826,10 @@ AS $$
           FROM picked p
          WHERE b.build_id = p.build_id
            AND p.attempt_count >= 5
-        RETURNING b.lot_id, b.action_kind, b.lot_state_before
+        RETURNING b.lot_id, b.action_kind, b.lot_state_before, b.schematic_id_before
     ),
-    -- Release lot: snapshot wins; else demolish → built (2), build
-    -- uses schematic heuristic.
+    -- Snapshot-based release: restore state AND schematic together
+    -- when the snapshot exists; else fall back to the legacy heuristic.
     released AS (
         UPDATE mc.lot l
            SET state = CASE
@@ -825,6 +837,12 @@ AS $$
                   WHEN e.action_kind = 1 THEN 2
                   WHEN l.current_schematic_id IS NULL THEN 1
                   ELSE 2
+               END,
+               current_schematic_id = CASE
+                  WHEN e.lot_state_before IS NULL THEN l.current_schematic_id
+                  WHEN e.lot_state_before IN (0, 1) THEN NULL
+                  WHEN e.lot_state_before IN (2, 4) THEN e.schematic_id_before
+                  ELSE l.current_schematic_id
                END
           FROM exhausted e
          WHERE l.lot_id = e.lot_id
@@ -938,10 +956,11 @@ SET search_path = ''
 COST 100
 AS $$
 DECLARE
-    v_lot_id            TEXT;
-    v_action_kind       SMALLINT;
-    v_lot_state_before  SMALLINT;
-    v_rowcount          INTEGER;
+    v_lot_id               TEXT;
+    v_action_kind          SMALLINT;
+    v_lot_state_before     SMALLINT;
+    v_schematic_id_before  TEXT;
+    v_rowcount             INTEGER;
 BEGIN
     IF p_build_id IS NULL OR btrim(p_build_id) = '' THEN
         RAISE EXCEPTION 'build_id cannot be empty' USING ERRCODE = '22004';
@@ -965,22 +984,28 @@ BEGIN
      WHERE build_id = p_build_id
        AND apply_state = 3
        AND claimed_by = p_worker_id
-    RETURNING lot_id, action_kind, lot_state_before
-        INTO v_lot_id, v_action_kind, v_lot_state_before;
+    RETURNING lot_id, action_kind, lot_state_before, schematic_id_before
+        INTO v_lot_id, v_action_kind, v_lot_state_before, v_schematic_id_before;
 
     IF NOT FOUND THEN
         RETURN FALSE;
     END IF;
 
-    -- Restore to the snapshot if it was preserved; else fall back to
-    -- the schematic heuristic (rows queued before lot_state_before
-    -- existed).
+    -- Restore from snapshot when present (state AND schematic). Fall
+    -- back to the legacy schematic heuristic for rows queued before
+    -- snapshot columns existed.
     UPDATE mc.lot
        SET state = CASE
               WHEN v_lot_state_before IS NOT NULL THEN v_lot_state_before
               WHEN v_action_kind = 1 THEN 2
               WHEN current_schematic_id IS NULL THEN 1
               ELSE 2
+           END,
+           current_schematic_id = CASE
+              WHEN v_lot_state_before IS NULL THEN current_schematic_id
+              WHEN v_lot_state_before IN (0, 1) THEN NULL
+              WHEN v_lot_state_before IN (2, 4) THEN v_schematic_id_before
+              ELSE current_schematic_id
            END
      WHERE lot_id = v_lot_id
        AND state IN (3, 4);
@@ -2022,16 +2047,15 @@ BEGIN
             USING ERRCODE = '22023';
     END IF;
 
-    -- Block retry if the lot's current schematic drifted from the
-    -- snapshot taken at queue time. Prevents cross-build interference
-    -- when an intermediate successful build changed the lot.
-    IF v_schematic_id_before IS NOT NULL THEN
-        SELECT current_schematic_id INTO v_lot_current_schem
-          FROM mc.lot WHERE lot_id = v_lot_id;
-        IF v_lot_current_schem IS DISTINCT FROM v_schematic_id_before THEN
-            RAISE EXCEPTION 'lot % current_schematic changed since job % queued; cannot retry',
-                v_lot_id, p_build_id USING ERRCODE = '22023';
-        END IF;
+    -- Schematic-drift check covers both directions: NULL → set, set →
+    -- NULL, and set → different. Skipping the NULL case let an
+    -- intermediate successful build between queue and retry slip
+    -- through (snapshot=NULL, current_schematic=set).
+    SELECT current_schematic_id INTO v_lot_current_schem
+      FROM mc.lot WHERE lot_id = v_lot_id;
+    IF v_lot_current_schem IS DISTINCT FROM v_schematic_id_before THEN
+        RAISE EXCEPTION 'lot % current_schematic changed since job % queued; cannot retry',
+            v_lot_id, p_build_id USING ERRCODE = '22023';
     END IF;
 
     IF v_action_kind = 0 THEN
@@ -2201,7 +2225,7 @@ CREATE OR REPLACE FUNCTION mc.service_release_user_lots(
     p_force   BOOLEAN DEFAULT FALSE
 )
 RETURNS TABLE (
-    lot_id   TEXT,
+    lot_id      TEXT,
     prior_state SMALLINT
 )
 LANGUAGE plpgsql
@@ -2221,16 +2245,40 @@ BEGIN
             p_user_id USING ERRCODE = '22023';
     END IF;
 
+    -- p_force: cancel any active build/demolish jobs first so worker
+    -- ACKs against the now-vacant lots can't violate
+    -- mc_lot_owner_state_chk or leave stuck claimed rows.
+    IF p_force THEN
+        UPDATE mc.lot_build_log b
+           SET apply_state = 2,
+               apply_error = 'cancelled by forced user lot release',
+               failed_at = clock_timestamp(),
+               claimed_at = NULL,
+               claimed_by = NULL
+          FROM mc.lot l
+         WHERE b.lot_id = l.lot_id
+           AND l.owner_user_id = p_user_id
+           AND b.apply_state IN (0, 3);
+    END IF;
+
+    -- candidates CTE pins the prior state before the UPDATE so
+    -- RETURNING can surface it (UPDATE...RETURNING reads NEW).
     RETURN QUERY
-    WITH cleared AS (
-        UPDATE mc.lot
+    WITH candidates AS (
+        SELECT l.lot_id, l.state::SMALLINT AS prior_state
+          FROM mc.lot l
+         WHERE l.owner_user_id = p_user_id
+    ),
+    cleared AS (
+        UPDATE mc.lot l
            SET state = 0,
                owner_user_id = NULL,
                current_schematic_id = NULL
-         WHERE owner_user_id = p_user_id
-        RETURNING lot_id, state
+          FROM candidates c
+         WHERE l.lot_id = c.lot_id
+        RETURNING l.lot_id, c.prior_state
     )
-    SELECT cleared.lot_id, cleared.state FROM cleared;
+    SELECT cleared.lot_id, cleared.prior_state FROM cleared;
 END;
 $$;
 
@@ -2273,47 +2321,88 @@ CREATE OR REPLACE FUNCTION mc.service_repair_orphan_transitional(
     p_dry_run BOOLEAN DEFAULT TRUE
 )
 RETURNS TABLE (
-    lot_id      TEXT,
-    prior_state SMALLINT,
-    new_state   SMALLINT
+    lot_id              TEXT,
+    prior_state         SMALLINT,
+    new_state           SMALLINT,
+    latest_build_id     TEXT,
+    latest_apply_state  SMALLINT,
+    latest_failed_at    TIMESTAMPTZ,
+    latest_apply_error  TEXT
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
 BEGIN
+    -- Candidates first; UPDATE RETURNING sees NEW only, so prior_state
+    -- needs to be captured before the write.
     IF p_dry_run THEN
         RETURN QUERY
-        SELECT l.lot_id,
-               l.state::SMALLINT,
-               (CASE WHEN l.current_schematic_id IS NULL THEN 1 ELSE 2 END)::SMALLINT
-          FROM mc.lot l
-          LEFT JOIN mc.lot_build_log b
-            ON b.lot_id = l.lot_id
-           AND b.apply_state IN (0, 3)
-         WHERE l.state IN (3, 4)
-           AND b.build_id IS NULL;
+        SELECT c.lot_id,
+               c.prior_state,
+               c.new_state,
+               c.latest_build_id,
+               c.latest_apply_state,
+               c.latest_failed_at,
+               c.latest_apply_error
+          FROM (
+            SELECT l.lot_id,
+                   l.state::SMALLINT AS prior_state,
+                   (CASE WHEN l.current_schematic_id IS NULL THEN 1 ELSE 2 END)::SMALLINT AS new_state,
+                   latest.build_id        AS latest_build_id,
+                   latest.apply_state::SMALLINT AS latest_apply_state,
+                   latest.failed_at       AS latest_failed_at,
+                   latest.apply_error     AS latest_apply_error
+              FROM mc.lot l
+              LEFT JOIN mc.lot_build_log b
+                ON b.lot_id = l.lot_id
+               AND b.apply_state IN (0, 3)
+              LEFT JOIN LATERAL (
+                SELECT build_id, apply_state, failed_at, apply_error
+                  FROM mc.lot_build_log
+                 WHERE lot_id = l.lot_id
+                 ORDER BY queued_at DESC, build_id DESC
+                 LIMIT 1
+              ) latest ON TRUE
+             WHERE l.state IN (3, 4)
+               AND b.build_id IS NULL
+          ) c;
     ELSE
         RETURN QUERY
-        UPDATE mc.lot l
-           SET state = CASE WHEN l.current_schematic_id IS NULL THEN 1 ELSE 2 END
-         WHERE l.lot_id IN (
-            SELECT l2.lot_id
-              FROM mc.lot l2
+        WITH candidates AS (
+            SELECT l.lot_id,
+                   l.state::SMALLINT AS prior_state,
+                   (CASE WHEN l.current_schematic_id IS NULL THEN 1 ELSE 2 END)::SMALLINT AS new_state,
+                   latest.build_id        AS latest_build_id,
+                   latest.apply_state::SMALLINT AS latest_apply_state,
+                   latest.failed_at       AS latest_failed_at,
+                   latest.apply_error     AS latest_apply_error
+              FROM mc.lot l
               LEFT JOIN mc.lot_build_log b
-                ON b.lot_id = l2.lot_id
+                ON b.lot_id = l.lot_id
                AND b.apply_state IN (0, 3)
-             WHERE l2.state IN (3, 4)
+              LEFT JOIN LATERAL (
+                SELECT build_id, apply_state, failed_at, apply_error
+                  FROM mc.lot_build_log
+                 WHERE lot_id = l.lot_id
+                 ORDER BY queued_at DESC, build_id DESC
+                 LIMIT 1
+              ) latest ON TRUE
+             WHERE l.state IN (3, 4)
                AND b.build_id IS NULL
-         )
-        RETURNING l.lot_id,
-                  -- prior_state captured pre-update via OLD; UPDATE
-                  -- RETURNING doesn't expose OLD, so fall back to a
-                  -- placeholder: 3 or 4 was the source state but we
-                  -- can't distinguish per row here. Use the new state
-                  -- inverse as a proxy.
-                  (CASE WHEN l.state = 1 THEN 3 ELSE 4 END)::SMALLINT,
-                  l.state::SMALLINT;
+        ),
+        updated AS (
+            UPDATE mc.lot l
+               SET state = c.new_state
+              FROM candidates c
+             WHERE l.lot_id = c.lot_id
+            RETURNING l.lot_id
+        )
+        SELECT c.lot_id, c.prior_state, c.new_state,
+               c.latest_build_id, c.latest_apply_state,
+               c.latest_failed_at, c.latest_apply_error
+          FROM candidates c
+          JOIN updated u ON u.lot_id = c.lot_id;
     END IF;
 END;
 $$;
@@ -2328,7 +2417,15 @@ GRANT EXECUTE ON FUNCTION mc.service_repair_orphan_transitional(BOOLEAN)
 CREATE OR REPLACE FUNCTION public.proxy_service_repair_orphan_transitional(
     p_dry_run BOOLEAN DEFAULT TRUE
 )
-RETURNS TABLE (lot_id TEXT, prior_state SMALLINT, new_state SMALLINT)
+RETURNS TABLE (
+    lot_id              TEXT,
+    prior_state         SMALLINT,
+    new_state           SMALLINT,
+    latest_build_id     TEXT,
+    latest_apply_state  SMALLINT,
+    latest_failed_at    TIMESTAMPTZ,
+    latest_apply_error  TEXT
+)
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -157,6 +157,13 @@ CREATE TABLE mc.lot (
     chunk_area      INTEGER GENERATED ALWAYS AS
         ((upper(chunk_x_range) - lower(chunk_x_range))
        * (upper(chunk_z_range) - lower(chunk_z_range))) STORED,
+    -- Block-space mirrors of the chunk bounds. The dashboard map and
+    -- the MC mod both render in block space; storing these once avoids
+    -- per-client recompute and keeps the math DB-side.
+    block_x_min     INTEGER GENERATED ALWAYS AS (lower(chunk_x_range) * 16) STORED,
+    block_x_max     INTEGER GENERATED ALWAYS AS (upper(chunk_x_range) * 16 - 1) STORED,
+    block_z_min     INTEGER GENERATED ALWAYS AS (lower(chunk_z_range) * 16) STORED,
+    block_z_max     INTEGER GENERATED ALWAYS AS (upper(chunk_z_range) * 16 - 1) STORED,
     anchor_y        SMALLINT NOT NULL,
     -- ON DELETE RESTRICT, not SET NULL: the owner_state_chk requires
     -- state > 0 to carry a non-null owner. SET NULL would let a user
@@ -191,6 +198,18 @@ CREATE TABLE mc.lot (
         CHECK (lower(chunk_x_range) IS NOT NULL AND upper(chunk_x_range) IS NOT NULL),
     CONSTRAINT mc_lot_z_range_finite_chk
         CHECK (lower(chunk_z_range) IS NOT NULL AND upper(chunk_z_range) IS NOT NULL),
+    -- Hard ceiling on parcel size. 512 chunks = 8192 blocks per axis;
+    -- 262144 total chunks = 4 km × 4 km. Anything bigger is almost
+    -- certainly an admin tooling bug and would corrode map/exclusion
+    -- index behavior. Phase-0 RPC cap is 64 chunks; this is the table
+    -- floor that even direct admin INSERTs must obey.
+    CONSTRAINT mc_lot_chunk_width_max_chk
+        CHECK ((upper(chunk_x_range) - lower(chunk_x_range)) <= 512),
+    CONSTRAINT mc_lot_chunk_depth_max_chk
+        CHECK ((upper(chunk_z_range) - lower(chunk_z_range)) <= 512),
+    CONSTRAINT mc_lot_chunk_area_max_chk
+        CHECK ((upper(chunk_x_range) - lower(chunk_x_range))
+             * (upper(chunk_z_range) - lower(chunk_z_range)) <= 262144),
     -- Vanilla dim ids look like 'minecraft:overworld' or
     -- 'kbve:survival_ext'. Enforce the namespaced format to keep typos and
     -- arbitrary text from sneaking into the world column.
@@ -262,6 +281,15 @@ CREATE INDEX idx_mc_lot_owner_active_world_chunk_cursor
     INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
              chunk_area, anchor_y, price_credits, price_khash)
     WHERE owner_user_id IS NOT NULL AND state IN (1, 2);
+-- "Under build / demolishing" view of my lots. Smaller partial set,
+-- but lots in transitional states get re-rendered every few seconds
+-- by the dashboard waiting for the worker ACK, so a dedicated index
+-- earns its keep there.
+CREATE INDEX idx_mc_lot_owner_transitional_world_chunk_cursor
+    ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
+    INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
+             chunk_area, anchor_y, price_credits, price_khash)
+    WHERE owner_user_id IS NOT NULL AND state IN (3, 4);
 
 ALTER TABLE mc.lot OWNER TO postgres;
 ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
@@ -342,9 +370,12 @@ CREATE TABLE mc.lot_purchase (
 );
 
 -- Dashboard "my purchase history" sorts newest first; composite avoids
--- a sort step.
+-- a sort step. INCLUDE'd columns make the history list index-only.
+-- Ledger ids intentionally omitted — the dashboard doesn't render
+-- them, and adding them inflates the index without payoff.
 CREATE INDEX idx_mc_lot_purchase_buyer_created
-    ON mc.lot_purchase (buyer_user_id, created_at DESC, purchase_id DESC);
+    ON mc.lot_purchase (buyer_user_id, created_at DESC, purchase_id DESC)
+    INCLUDE (lot_id, price_credits, price_khash);
 
 -- Phase-0 invariant: each lot can be bought exactly once. Resale comes
 -- with an explicit ownership-epoch column in a follow-up migration.
@@ -388,8 +419,10 @@ CREATE TABLE mc.lot_build_log (
     failed_at       TIMESTAMPTZ,
     -- Retry budget. Incremented on every claim; rows that hit the cap
     -- are excluded from the SKIP LOCKED scan so a poisoned job cannot
-    -- cycle through claim -> stale-requeue -> claim forever.
-    attempt_count   SMALLINT NOT NULL DEFAULT 0,
+    -- cycle through claim -> stale-requeue -> claim forever. INTEGER
+    -- (not SMALLINT) so future schemas can reuse the column without
+    -- a type widening migration.
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
     last_attempt_at TIMESTAMPTZ,
 
     CONSTRAINT mc_lot_build_log_action_chk
@@ -434,20 +467,34 @@ CREATE TABLE mc.lot_build_log (
     CONSTRAINT mc_lot_build_log_idem_uq UNIQUE (idempotency_key)
 );
 
-CREATE INDEX idx_mc_lot_build_log_lot     ON mc.lot_build_log (lot_id);
--- User history: newest-first composite drops the sort step.
+-- Per-lot history: newest-first composite drops the sort for
+-- "show me every build event for this lot".
+CREATE INDEX idx_mc_lot_build_log_lot_queued
+    ON mc.lot_build_log (lot_id, queued_at DESC, build_id DESC);
+-- User history: INCLUDE the columns the 'my build history' page
+-- renders so the dashboard read goes index-only.
 CREATE INDEX idx_mc_lot_build_log_actor_queued
-    ON mc.lot_build_log (actor_user_id, queued_at DESC, build_id DESC);
+    ON mc.lot_build_log (actor_user_id, queued_at DESC, build_id DESC)
+    INCLUDE (lot_id, action_kind, schematic_id, apply_state,
+             failed_at, applied_at, attempt_count);
 -- Queue + worker claim path: include build_id so the claim ORDER BY
--- (queued_at, build_id) is satisfied by index walk alone.
+-- (queued_at, build_id) is satisfied by index walk alone. attempt_count
+-- predicate mirrors the claim WHERE so poisoned rows drop out of the
+-- partial index instead of getting scanned-and-skipped forever.
 CREATE INDEX idx_mc_lot_build_log_pending_claim
     ON mc.lot_build_log (queued_at, build_id)
-    WHERE apply_state = 0;
+    WHERE apply_state = 0 AND attempt_count < 5;
 -- Stuck-job reclaim. build_id keeps janitor scans deterministic and
--- supports a LIMIT-batched requeue.
+-- supports a LIMIT-batched requeue. claimed_at IS NOT NULL is
+-- redundant with the claimed-consistency CHECK today but makes the
+-- partial index self-documenting and survives future constraint edits.
 CREATE INDEX idx_mc_lot_build_log_claimed_stale
     ON mc.lot_build_log (claimed_at, build_id)
-    WHERE apply_state = 3;
+    WHERE apply_state = 3 AND claimed_at IS NOT NULL;
+-- Failed-job admin/janitor listing (#3, #10).
+CREATE INDEX idx_mc_lot_build_log_failed_recent
+    ON mc.lot_build_log (failed_at DESC, build_id DESC)
+    WHERE apply_state = 2;
 -- Reverse FK lookup: "which build jobs referenced schematic X?"
 CREATE INDEX idx_mc_lot_build_log_schematic
     ON mc.lot_build_log (schematic_id)
@@ -486,6 +533,22 @@ ALTER TABLE mc.lot SET (
     autovacuum_vacuum_threshold = 500,
     autovacuum_analyze_threshold = 250
 );
+
+-- Extended statistics for correlated column pairs. The planner
+-- otherwise treats (world, state) and (owner_user_id, state) as
+-- independent, which under-estimates selectivity on the hot list
+-- queries because state distribution is skewed (most rows owned or
+-- built, very few transitional). Same idea on the queue: pending +
+-- attempt_count are tightly correlated (most rows are 0/applied).
+CREATE STATISTICS st_mc_lot_world_state
+    ON world, state
+    FROM mc.lot;
+CREATE STATISTICS st_mc_lot_owner_state
+    ON owner_user_id, state
+    FROM mc.lot;
+CREATE STATISTICS st_mc_build_log_state_attempt
+    ON apply_state, attempt_count
+    FROM mc.lot_build_log;
 
 ALTER TABLE mc.lot_build_log OWNER TO postgres;
 ALTER TABLE mc.lot_build_log ENABLE ROW LEVEL SECURITY;
@@ -724,7 +787,20 @@ RETURNS TABLE (
     actor_user_id   UUID,
     action_kind     SMALLINT,
     schematic_id    TEXT,
-    queued_at       TIMESTAMPTZ
+    queued_at       TIMESTAMPTZ,
+    -- Denormalized lot + schematic columns so the worker can start
+    -- applying without follow-up queries. resource_path / dims_* are
+    -- NULL for demolish jobs (LEFT JOIN to mc.schematic).
+    world           TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    anchor_y        SMALLINT,
+    resource_path   TEXT,
+    dims_x          SMALLINT,
+    dims_y          SMALLINT,
+    dims_z          SMALLINT
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -761,21 +837,36 @@ BEGIN
          LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 32), 256))
          FOR UPDATE SKIP LOCKED
     ),
+    nowish AS (
+        -- One clock_timestamp() reading shared by claimed_at and
+        -- last_attempt_at; avoids the multi-microsecond drift the
+        -- old shape introduced.
+        SELECT clock_timestamp() AS ts
+    ),
     claimed AS (
         UPDATE mc.lot_build_log b
-           SET apply_state    = 3,
-               claimed_at     = clock_timestamp(),
-               claimed_by     = p_worker_id,
-               attempt_count  = b.attempt_count + 1,
-               last_attempt_at = clock_timestamp()
-          FROM picked
+           SET apply_state     = 3,
+               claimed_at      = nowish.ts,
+               claimed_by      = p_worker_id,
+               attempt_count   = b.attempt_count + 1,
+               last_attempt_at = nowish.ts
+          FROM picked, nowish
          WHERE b.build_id = picked.build_id
         RETURNING b.build_id, b.lot_id, b.actor_user_id,
                   b.action_kind, b.schematic_id, b.queued_at
     )
-    SELECT *
-      FROM claimed
-     ORDER BY queued_at, build_id;
+    -- Denormalize the claim with lot + schematic data so workers don't
+    -- need follow-up queries to start applying. schematic_id is NULL
+    -- on demolish jobs, so the schematic join is LEFT.
+    SELECT c.build_id, c.lot_id, c.actor_user_id, c.action_kind,
+           c.schematic_id, c.queued_at,
+           l.world, l.chunk_x_min, l.chunk_x_max,
+           l.chunk_z_min, l.chunk_z_max, l.anchor_y,
+           s.resource_path, s.dims_x, s.dims_y, s.dims_z
+      FROM claimed c
+      JOIN mc.lot l ON l.lot_id = c.lot_id
+      LEFT JOIN mc.schematic s ON s.schematic_id = c.schematic_id
+     ORDER BY c.queued_at, c.build_id;
 END;
 $$;
 
@@ -1856,7 +1947,17 @@ RETURNS TABLE (
     actor_user_id   UUID,
     action_kind     SMALLINT,
     schematic_id    TEXT,
-    queued_at       TIMESTAMPTZ
+    queued_at       TIMESTAMPTZ,
+    world           TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    anchor_y        SMALLINT,
+    resource_path   TEXT,
+    dims_x          SMALLINT,
+    dims_y          SMALLINT,
+    dims_z          SMALLINT
 )
 LANGUAGE sql
 SECURITY DEFINER
@@ -1940,6 +2041,149 @@ GRANT EXECUTE ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER, INT
     TO service_role;
 COMMENT ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER, INTEGER) IS
     'Service-role-only PostgREST bridge for janitor recovery of orphaned worker claims older than p_older_than_seconds. Batched + SKIP LOCKED with p_limit (max 512). Returns the count of jobs requeued in this call.';
+
+
+-- ===========================================================================
+-- mc.service_retry_failed_build — admin/janitor retry of a failed job
+-- ===========================================================================
+-- Moves a row from apply_state=2 (failed) back to 0 (queued). Optionally
+-- resets attempt_count so a poisoned build can re-enter the claim
+-- pipeline; default keeps the counter (and the row will stay dormant
+-- if the cap is already exhausted).
+CREATE OR REPLACE FUNCTION mc.service_retry_failed_build(
+    p_build_id TEXT,
+    p_reset_attempts BOOLEAN DEFAULT FALSE
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF p_build_id IS NULL OR btrim(p_build_id) = '' THEN
+        RAISE EXCEPTION 'build_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+
+    UPDATE mc.lot_build_log
+       SET apply_state     = 0,
+           apply_error     = NULL,
+           failed_at       = NULL,
+           applied_at      = NULL,
+           claimed_at      = NULL,
+           claimed_by      = NULL,
+           attempt_count   = CASE WHEN p_reset_attempts THEN 0
+                                   ELSE attempt_count END,
+           last_attempt_at = NULL
+     WHERE build_id = p_build_id
+       AND apply_state = 2;
+
+    RETURN FOUND;
+END;
+$$;
+
+ALTER FUNCTION mc.service_retry_failed_build(TEXT, BOOLEAN) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_retry_failed_build(TEXT, BOOLEAN)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_retry_failed_build(TEXT, BOOLEAN)
+    TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_service_retry_failed_build(
+    p_build_id TEXT,
+    p_reset_attempts BOOLEAN DEFAULT FALSE
+)
+RETURNS BOOLEAN
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT mc.service_retry_failed_build(p_build_id, p_reset_attempts);
+$$;
+
+ALTER FUNCTION public.proxy_service_retry_failed_build(TEXT, BOOLEAN) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_retry_failed_build(TEXT, BOOLEAN)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_retry_failed_build(TEXT, BOOLEAN)
+    TO service_role;
+COMMENT ON FUNCTION public.proxy_service_retry_failed_build(TEXT, BOOLEAN) IS
+    'Service-role-only PostgREST bridge: re-queue a failed build. p_reset_attempts=true clears the retry counter (use for transient infrastructure failures); default keeps it so persistent poison stays excluded.';
+
+
+-- ===========================================================================
+-- mc.service_list_failed_builds — admin/ops listing for failed jobs
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_list_failed_builds(
+    p_limit INTEGER DEFAULT 100,
+    p_after_failed_at TIMESTAMPTZ DEFAULT NULL,
+    p_after_build_id TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    build_id        TEXT,
+    lot_id          TEXT,
+    actor_user_id   UUID,
+    action_kind     SMALLINT,
+    schematic_id    TEXT,
+    apply_error     TEXT,
+    failed_at       TIMESTAMPTZ,
+    attempt_count   INTEGER
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 100
+AS $$
+    SELECT b.build_id, b.lot_id, b.actor_user_id, b.action_kind,
+           b.schematic_id, b.apply_error, b.failed_at, b.attempt_count
+    FROM mc.lot_build_log b
+    WHERE b.apply_state = 2
+      AND (
+          p_after_build_id IS NULL
+          OR (b.failed_at, b.build_id)
+             < (p_after_failed_at, p_after_build_id)
+      )
+    ORDER BY b.failed_at DESC, b.build_id DESC
+    LIMIT LEAST(GREATEST(COALESCE(p_limit, 100), 1), 500);
+$$;
+
+ALTER FUNCTION mc.service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT)
+    TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_service_list_failed_builds(
+    p_limit INTEGER DEFAULT 100,
+    p_after_failed_at TIMESTAMPTZ DEFAULT NULL,
+    p_after_build_id TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    build_id        TEXT,
+    lot_id          TEXT,
+    actor_user_id   UUID,
+    action_kind     SMALLINT,
+    schematic_id    TEXT,
+    apply_error     TEXT,
+    failed_at       TIMESTAMPTZ,
+    attempt_count   INTEGER
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 100
+AS $$
+    SELECT * FROM mc.service_list_failed_builds(p_limit, p_after_failed_at, p_after_build_id);
+$$;
+
+ALTER FUNCTION public.proxy_service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT)
+    TO service_role;
+COMMENT ON FUNCTION public.proxy_service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT) IS
+    'Service-role-only PostgREST bridge: keyset-paginated list of failed builds for ops dashboards. Uses idx_mc_lot_build_log_failed_recent.';
 
 
 CREATE OR REPLACE FUNCTION public.proxy_service_get_lot(p_lot_id TEXT)
@@ -2145,6 +2389,177 @@ COMMENT ON FUNCTION public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGER, INT
     'Hot-path: caller-owned active lots (state IN (1, 2)) in a world. Hard-codes owner = auth.uid() and the state set so idx_mc_lot_owner_active_world_chunk_cursor is the only viable plan.';
 
 
+-- ===========================================================================
+-- public.proxy_list_lots_public — generic listing without raw owner UUIDs
+-- ===========================================================================
+-- Same shape as proxy_list_lots but strips owner_user_id from the
+-- output. Use this for authenticated dashboard reads that need a mixed
+-- world/state list; the raw UUID column lives in the admin-only generic
+-- proxy_list_lots wrapper.
+CREATE OR REPLACE FUNCTION public.proxy_list_lots_public(
+    p_world TEXT DEFAULT NULL,
+    p_state SMALLINT DEFAULT NULL,
+    p_only_mine BOOLEAN DEFAULT FALSE,
+    p_limit INTEGER DEFAULT 256,
+    p_offset INTEGER DEFAULT 0,
+    p_after_world TEXT DEFAULT NULL,
+    p_after_chunk_x INTEGER DEFAULT NULL,
+    p_after_chunk_z INTEGER DEFAULT NULL,
+    p_after_lot_id TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    lot_id          TEXT,
+    world           TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    chunk_area      INTEGER,
+    anchor_y        SMALLINT,
+    is_owned        BOOLEAN,
+    is_owned_by_me  BOOLEAN,
+    current_schematic_id TEXT,
+    state           SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 256
+AS $$
+BEGIN
+    IF p_after_lot_id IS NOT NULL
+       AND (p_after_world IS NULL
+            OR p_after_chunk_x IS NULL
+            OR p_after_chunk_z IS NULL) THEN
+        RAISE EXCEPTION 'cursor must include after_world, after_chunk_x, after_chunk_z, and after_lot_id together'
+            USING ERRCODE = '22023';
+    END IF;
+    IF p_after_lot_id IS NULL
+       AND (p_after_world IS NOT NULL
+            OR p_after_chunk_x IS NOT NULL
+            OR p_after_chunk_z IS NOT NULL) THEN
+        RAISE EXCEPTION 'cursor must include after_world, after_chunk_x, after_chunk_z, and after_lot_id together'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RETURN QUERY
+    SELECT r.lot_id, r.world,
+           r.chunk_x_min, r.chunk_x_max,
+           r.chunk_z_min, r.chunk_z_max,
+           r.chunk_area, r.anchor_y,
+           (r.owner_user_id IS NOT NULL) AS is_owned,
+           r.is_owned_by_me,
+           r.current_schematic_id, r.state,
+           r.price_credits, r.price_khash
+    FROM mc.proxy_list_lots(
+        p_world, p_state, p_only_mine, p_limit, p_offset,
+        p_after_world, p_after_chunk_x, p_after_chunk_z, p_after_lot_id) r;
+END;
+$$;
+
+ALTER FUNCTION public.proxy_list_lots_public(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                             TEXT, INTEGER, INTEGER, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_list_lots_public(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                                     TEXT, INTEGER, INTEGER, TEXT)
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_list_lots_public(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                                        TEXT, INTEGER, INTEGER, TEXT)
+    TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_list_lots_public(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                                  TEXT, INTEGER, INTEGER, TEXT) IS
+    'Public-safe generic lot listing. Mirrors proxy_list_lots but replaces owner_user_id with is_owned + is_owned_by_me so the dashboard does not leak ownership UUIDs of other players. Use the dedicated hot-path wrappers (proxy_list_vacant_lots / proxy_list_my_active_lots) when possible — they hit narrower partial indexes.';
+
+
+-- ===========================================================================
+-- public.proxy_list_lots_in_viewport — bounding-box map RPC
+-- ===========================================================================
+-- Dashboard map panning/zooming asks for lots whose chunk range
+-- intersects the visible viewport. The EXCLUDE GiST index on
+-- (world, chunk_x_range, chunk_z_range) already indexes the right
+-- columns for the && (overlap) operator, so this query is index-fed.
+CREATE OR REPLACE FUNCTION public.proxy_list_lots_in_viewport(
+    p_world TEXT,
+    p_min_chunk_x INTEGER,
+    p_max_chunk_x INTEGER,
+    p_min_chunk_z INTEGER,
+    p_max_chunk_z INTEGER,
+    p_state SMALLINT DEFAULT NULL,
+    p_limit INTEGER DEFAULT 1000
+)
+RETURNS TABLE (
+    lot_id          TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    chunk_area      INTEGER,
+    anchor_y        SMALLINT,
+    is_owned        BOOLEAN,
+    is_owned_by_me  BOOLEAN,
+    current_schematic_id TEXT,
+    state           SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 1000
+AS $$
+DECLARE
+    v_uid UUID := auth.uid();
+BEGIN
+    IF p_world IS NULL OR btrim(p_world) = '' THEN
+        RAISE EXCEPTION 'world cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF p_world !~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$' THEN
+        RAISE EXCEPTION 'invalid world format' USING ERRCODE = '22023';
+    END IF;
+    IF p_max_chunk_x < p_min_chunk_x OR p_max_chunk_z < p_min_chunk_z THEN
+        RAISE EXCEPTION 'viewport max must be >= min' USING ERRCODE = '22023';
+    END IF;
+    IF (p_max_chunk_x - p_min_chunk_x + 1) > 4096
+       OR (p_max_chunk_z - p_min_chunk_z + 1) > 4096 THEN
+        RAISE EXCEPTION 'viewport too large (max 4096 chunks per axis)'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RETURN QUERY
+    SELECT l.lot_id,
+           l.chunk_x_min, l.chunk_x_max,
+           l.chunk_z_min, l.chunk_z_max,
+           l.chunk_area, l.anchor_y,
+           (l.owner_user_id IS NOT NULL) AS is_owned,
+           (l.owner_user_id IS NOT NULL AND l.owner_user_id = v_uid) AS is_owned_by_me,
+           l.current_schematic_id, l.state,
+           l.price_credits, l.price_khash
+    FROM mc.lot l
+    WHERE l.world = p_world
+      AND l.chunk_x_range && int4range(p_min_chunk_x, p_max_chunk_x + 1, '[)')
+      AND l.chunk_z_range && int4range(p_min_chunk_z, p_max_chunk_z + 1, '[)')
+      AND (p_state IS NULL OR l.state = p_state)
+    ORDER BY l.chunk_x_min, l.chunk_z_min, l.lot_id
+    LIMIT LEAST(GREATEST(COALESCE(p_limit, 1000), 1), 4096);
+END;
+$$;
+
+ALTER FUNCTION public.proxy_list_lots_in_viewport(TEXT, INTEGER, INTEGER, INTEGER, INTEGER,
+                                                  SMALLINT, INTEGER) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_list_lots_in_viewport(TEXT, INTEGER, INTEGER, INTEGER, INTEGER,
+                                                          SMALLINT, INTEGER)
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_list_lots_in_viewport(TEXT, INTEGER, INTEGER, INTEGER, INTEGER,
+                                                             SMALLINT, INTEGER)
+    TO authenticated, service_role;
+COMMENT ON FUNCTION public.proxy_list_lots_in_viewport(TEXT, INTEGER, INTEGER, INTEGER, INTEGER,
+                                                       SMALLINT, INTEGER) IS
+    'Viewport-bounded lot list for the dashboard map. Returns lots whose chunk range overlaps the (p_min_chunk_x..p_max_chunk_x, p_min_chunk_z..p_max_chunk_z) bbox in p_world. Fed by the GIST EXCLUDE index already created on (world, chunk_x_range, chunk_z_range). Owner UUIDs replaced with is_owned + is_owned_by_me.';
+
+
 NOTIFY pgrst, 'reload schema';
 
 
@@ -2157,6 +2572,8 @@ DROP FUNCTION IF EXISTS public.proxy_service_mark_build_applied(TEXT);
 DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT);
 DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT);
 
+DROP FUNCTION IF EXISTS public.proxy_service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT);
+DROP FUNCTION IF EXISTS public.proxy_service_retry_failed_build(TEXT, BOOLEAN);
 DROP FUNCTION IF EXISTS public.proxy_service_requeue_stale_claims(INTEGER, INTEGER);
 DROP FUNCTION IF EXISTS public.proxy_service_requeue_stale_claims(INTEGER);
 DROP FUNCTION IF EXISTS public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT);
@@ -2175,6 +2592,10 @@ DROP FUNCTION IF EXISTS mc.proxy_purchase_lot(TEXT);
 DROP FUNCTION IF EXISTS public.proxy_queue_demolish_lot(TEXT, UUID);
 DROP FUNCTION IF EXISTS public.proxy_queue_build_on_lot(TEXT, TEXT, UUID);
 DROP FUNCTION IF EXISTS public.proxy_purchase_lot(TEXT, UUID);
+DROP FUNCTION IF EXISTS public.proxy_list_lots_in_viewport(TEXT, INTEGER, INTEGER, INTEGER, INTEGER,
+                                                            SMALLINT, INTEGER);
+DROP FUNCTION IF EXISTS public.proxy_list_lots_public(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                                      TEXT, INTEGER, INTEGER, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_list_vacant_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_list_schematics(TEXT);
@@ -2195,6 +2616,8 @@ DROP FUNCTION IF EXISTS mc.service_queue_build_on_lot(TEXT, TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_purchase_lot(TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT, TEXT);
 DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT, TEXT);
+DROP FUNCTION IF EXISTS mc.service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT);
+DROP FUNCTION IF EXISTS mc.service_retry_failed_build(TEXT, BOOLEAN);
 DROP FUNCTION IF EXISTS mc.service_requeue_stale_claims(INTEGER, INTEGER);
 DROP FUNCTION IF EXISTS mc.service_requeue_stale_claims(INTEGER);
 DROP FUNCTION IF EXISTS mc.service_claim_pending_builds(TEXT, INTEGER);

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -35,7 +35,9 @@
 -- ============================================================================
 
 CREATE EXTENSION IF NOT EXISTS btree_gist;
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
+-- pgcrypto is already installed via the earlier mc_schema_init migration
+-- under the `extensions` schema; mc._derive_idem_key calls extensions.digest
+-- directly.
 
 -- Re-affirm schema + grants so this migration is independently runnable
 -- against a fresh database. mc was already created in mc_schema_init but
@@ -64,7 +66,10 @@ IMMUTABLE
 PARALLEL SAFE
 SET search_path = ''
 AS $$
-    SELECT substr(encode(public.digest(p_key::text || ':' || p_tag, 'md5'), 'hex'), 1, 32)::uuid;
+    -- pgcrypto lives in the extensions schema on Supabase/kilobase; the
+    -- mc_pgcrypto_qualify migration already established this convention
+    -- and granted USAGE on extensions to service_role.
+    SELECT substr(encode(extensions.digest(p_key::text || ':' || p_tag, 'md5'), 'hex'), 1, 32)::uuid;
 $$;
 
 ALTER FUNCTION mc._derive_idem_key(UUID, TEXT) OWNER TO postgres;

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -34,10 +34,14 @@
 -- route through the proxies. Pattern matches mc_public_proxies.sql.
 -- ============================================================================
 
+-- btree_gist supplies the gist_text_ops opclass needed by the
+-- (world WITH =) leg of the EXCLUDE constraint on mc.lot. Left in the
+-- default schema (rather than `extensions`) because EXCLUDE opclass
+-- resolution uses the live search_path at CREATE TABLE time, and pinning
+-- the extension to `extensions` would force every consumer to extend its
+-- search_path. pgcrypto sits in extensions because it's only called via
+-- explicit extensions.digest(...) — different concern.
 CREATE EXTENSION IF NOT EXISTS btree_gist;
--- pgcrypto is already installed via the earlier mc_schema_init migration
--- under the `extensions` schema; mc._derive_idem_key calls extensions.digest
--- directly.
 
 -- Re-affirm schema + grants so this migration is independently runnable
 -- against a fresh database. mc was already created in mc_schema_init but
@@ -63,6 +67,7 @@ CREATE OR REPLACE FUNCTION mc._derive_idem_key(p_key UUID, p_tag TEXT)
 RETURNS UUID
 LANGUAGE sql
 IMMUTABLE
+STRICT
 PARALLEL SAFE
 SET search_path = ''
 AS $$
@@ -510,7 +515,7 @@ BEGIN
             SELECT inner_b.build_id
               FROM mc.lot_build_log inner_b
              WHERE inner_b.apply_state = 0
-             ORDER BY inner_b.queued_at
+             ORDER BY inner_b.queued_at, inner_b.build_id
              FOR UPDATE SKIP LOCKED
              LIMIT GREATEST(1, LEAST(p_limit, 256))
          )
@@ -580,8 +585,14 @@ DECLARE
     v_schematic_id  TEXT;
     v_rowcount      INTEGER;
 BEGIN
+    IF p_build_id IS NULL OR btrim(p_build_id) = '' THEN
+        RAISE EXCEPTION 'build_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
     IF p_worker_id IS NULL OR btrim(p_worker_id) = '' THEN
         RAISE EXCEPTION 'worker_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF length(p_worker_id) > 128 THEN
+        RAISE EXCEPTION 'worker_id too long (max 128)' USING ERRCODE = '22001';
     END IF;
 
     -- Only the worker that holds the claim may ACK it. Prevents a stale
@@ -654,8 +665,14 @@ DECLARE
     v_lot_id   TEXT;
     v_rowcount INTEGER;
 BEGIN
+    IF p_build_id IS NULL OR btrim(p_build_id) = '' THEN
+        RAISE EXCEPTION 'build_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
     IF p_worker_id IS NULL OR btrim(p_worker_id) = '' THEN
         RAISE EXCEPTION 'worker_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF length(p_worker_id) > 128 THEN
+        RAISE EXCEPTION 'worker_id too long (max 128)' USING ERRCODE = '22001';
     END IF;
 
     UPDATE mc.lot_build_log
@@ -1398,6 +1415,8 @@ REVOKE ALL ON FUNCTION public.proxy_service_claim_pending_builds(TEXT, INTEGER)
     FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.proxy_service_claim_pending_builds(TEXT, INTEGER)
     TO service_role;
+COMMENT ON FUNCTION public.proxy_service_claim_pending_builds(TEXT, INTEGER) IS
+    'Service-role-only PostgREST bridge for MC worker job claiming. Returns up to p_limit queued build/demolish jobs and marks them apply_state=3 (claimed) atomically via SKIP LOCKED.';
 
 
 CREATE OR REPLACE FUNCTION public.proxy_service_mark_build_applied(
@@ -1417,6 +1436,8 @@ REVOKE ALL ON FUNCTION public.proxy_service_mark_build_applied(TEXT, TEXT)
     FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.proxy_service_mark_build_applied(TEXT, TEXT)
     TO service_role;
+COMMENT ON FUNCTION public.proxy_service_mark_build_applied(TEXT, TEXT) IS
+    'Service-role-only PostgREST bridge for MC worker success ACK. Only the worker that holds the claim (claimed_by match) may finalize the job.';
 
 
 CREATE OR REPLACE FUNCTION public.proxy_service_mark_build_failed(
@@ -1437,6 +1458,8 @@ REVOKE ALL ON FUNCTION public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT)
     FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT)
     TO service_role;
+COMMENT ON FUNCTION public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT) IS
+    'Service-role-only PostgREST bridge for MC worker failure ACK. Same claim-binding as the success path; apply_error is capped at 2048 chars.';
 
 
 CREATE OR REPLACE FUNCTION public.proxy_service_requeue_stale_claims(
@@ -1455,12 +1478,21 @@ REVOKE ALL ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER)
     FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER)
     TO service_role;
+COMMENT ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER) IS
+    'Service-role-only PostgREST bridge for janitor recovery of orphaned worker claims older than p_older_than_seconds. Returns the count of jobs requeued.';
 
 
 NOTIFY pgrst, 'reload schema';
 
 
 -- migrate:down
+
+-- Compatibility drops for any earlier in-flight signature on a dev DB
+-- where the first published migration shipped without p_worker_id.
+DROP FUNCTION IF EXISTS public.proxy_service_mark_build_failed(TEXT, TEXT);
+DROP FUNCTION IF EXISTS public.proxy_service_mark_build_applied(TEXT);
+DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT);
+DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT);
 
 DROP FUNCTION IF EXISTS public.proxy_service_requeue_stale_claims(INTEGER);
 DROP FUNCTION IF EXISTS public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT);

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -1,0 +1,1051 @@
+-- migrate:up
+
+-- ============================================================================
+-- MC LOT SYSTEM — digital real estate for the survival backend
+--
+-- Phase 0 schema: parcel registry, schematic catalog, ownership ledger, and
+-- build-event audit log. Players buy lots in the dashboard, then pick
+-- structures from the schematic catalog to place on owned lots. The MC mod
+-- side picks up purchase + build events and applies them to the world.
+--
+-- Lot bounds are stored as int4range pairs (chunk_x_range, chunk_z_range)
+-- with a GIST EXCLUDE constraint that forbids any two lots in the same
+-- world from overlapping at the chunk grid level. The schema supports
+-- 1x1 lots from day one and arbitrarily large lots (200x100 castles, etc)
+-- with no further migration — the operational ceiling lives in RPC guards,
+-- not table definitions.
+--
+-- Money flow rides on wallet.service_debit against the user-kind account.
+-- mc.lot_purchase and mc.lot_build_log keep their own append-only audit
+-- rows so we can reconstruct ownership / build history without joining
+-- through wallet.ledger.
+--
+-- Schema exposure: every public-callable RPC is fronted by a
+-- public.proxy_* wrapper because PostgREST only sees the public schema.
+-- The mc schema stays private; service_role and authenticated callers
+-- route through the proxies. Pattern matches mc_public_proxies.sql.
+-- ============================================================================
+
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+
+-- ===========================================================================
+-- mc.schematic — build catalog
+-- ===========================================================================
+CREATE TABLE mc.schematic (
+    schematic_id    TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    category        TEXT NOT NULL,
+    tier            SMALLINT NOT NULL DEFAULT 1,
+    dims_x          SMALLINT NOT NULL,
+    dims_y          SMALLINT NOT NULL,
+    dims_z          SMALLINT NOT NULL,
+    price_credits   BIGINT NOT NULL DEFAULT 0,
+    price_khash     BIGINT NOT NULL DEFAULT 0,
+    resource_path   TEXT NOT NULL,
+    enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT mc_schematic_tier_chk   CHECK (tier BETWEEN 1 AND 10),
+    CONSTRAINT mc_schematic_dims_chk   CHECK (dims_x > 0 AND dims_y > 0 AND dims_z > 0),
+    CONSTRAINT mc_schematic_dims_y_chk CHECK (dims_y <= 384),
+    CONSTRAINT mc_schematic_price_chk  CHECK (price_credits >= 0 AND price_khash >= 0),
+    CONSTRAINT mc_schematic_category_chk
+        CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument'))
+);
+
+CREATE INDEX idx_mc_schematic_category_enabled ON mc.schematic (category, enabled);
+CREATE INDEX idx_mc_schematic_tier ON mc.schematic (tier);
+
+ALTER TABLE mc.schematic ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE mc.schematic IS
+    'Build catalog. Dashboard reads enabled rows via proxy_list_schematics. Each row references a serialized structure blob in the Fabric mod jar by resource_path.';
+COMMENT ON COLUMN mc.schematic.dims_x IS 'Width in blocks (X axis).';
+COMMENT ON COLUMN mc.schematic.dims_y IS 'Height in blocks. Hard-capped at 384 (world build height).';
+COMMENT ON COLUMN mc.schematic.dims_z IS 'Depth in blocks (Z axis).';
+COMMENT ON COLUMN mc.schematic.resource_path IS 'Path inside the mod jar, e.g. ''schematics/house_small.nbt''. No leading slash.';
+
+
+-- ===========================================================================
+-- mc.lot — parcel registry
+-- ===========================================================================
+CREATE TABLE mc.lot (
+    lot_id          TEXT PRIMARY KEY,
+    world           TEXT NOT NULL DEFAULT 'minecraft:overworld',
+    chunk_x_range   int4range NOT NULL,
+    chunk_z_range   int4range NOT NULL,
+    anchor_y        SMALLINT NOT NULL,
+    owner_user_id   UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    current_schematic_id TEXT REFERENCES mc.schematic(schematic_id),
+    state           SMALLINT NOT NULL DEFAULT 0,
+    price_credits   BIGINT NOT NULL DEFAULT 0,
+    price_khash     BIGINT NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT mc_lot_state_chk      CHECK (state BETWEEN 0 AND 4),
+    CONSTRAINT mc_lot_anchor_y_chk   CHECK (anchor_y BETWEEN -64 AND 319),
+    CONSTRAINT mc_lot_price_chk      CHECK (price_credits >= 0 AND price_khash >= 0),
+    CONSTRAINT mc_lot_x_range_chk    CHECK (NOT isempty(chunk_x_range)
+                                             AND lower_inc(chunk_x_range)
+                                             AND NOT upper_inc(chunk_x_range)),
+    CONSTRAINT mc_lot_z_range_chk    CHECK (NOT isempty(chunk_z_range)
+                                             AND lower_inc(chunk_z_range)
+                                             AND NOT upper_inc(chunk_z_range)),
+    CONSTRAINT mc_lot_owner_state_chk CHECK (
+        (state = 0 AND owner_user_id IS NULL)
+        OR (state > 0 AND owner_user_id IS NOT NULL)
+    ),
+    CONSTRAINT mc_lot_built_has_schematic_chk CHECK (
+        (state = 2 AND current_schematic_id IS NOT NULL)
+        OR state <> 2
+    ),
+
+    EXCLUDE USING gist (
+        world WITH =,
+        chunk_x_range WITH &&,
+        chunk_z_range WITH &&
+    )
+);
+
+CREATE INDEX idx_mc_lot_owner ON mc.lot (owner_user_id) WHERE owner_user_id IS NOT NULL;
+CREATE INDEX idx_mc_lot_state ON mc.lot (state);
+CREATE INDEX idx_mc_lot_world_state ON mc.lot (world, state);
+
+ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION mc.trg_lot_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at := NOW();
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_mc_lot_updated_at
+    BEFORE UPDATE ON mc.lot
+    FOR EACH ROW
+    EXECUTE FUNCTION mc.trg_lot_updated_at();
+
+COMMENT ON TABLE mc.lot IS
+    'Parcel registry. Chunk-aligned rectangular regions guarded by a GIST EXCLUDE constraint that forbids overlap within a world.';
+COMMENT ON COLUMN mc.lot.chunk_x_range IS 'Half-open [min_chunk_x, max_chunk_x). 1x1 lot at chunk 5 = [5,6).';
+COMMENT ON COLUMN mc.lot.anchor_y IS 'Foundation Y in blocks. Schematics paste with their Y=0 layer at this absolute Y.';
+COMMENT ON COLUMN mc.lot.state IS '0=vacant, 1=owned, 2=built, 3=under_build, 4=demolishing';
+
+
+-- ===========================================================================
+-- mc.lot_purchase — ownership ledger (append-only)
+-- ===========================================================================
+CREATE TABLE mc.lot_purchase (
+    purchase_id     TEXT PRIMARY KEY DEFAULT public.gen_ulid(),
+    lot_id          TEXT NOT NULL REFERENCES mc.lot(lot_id) ON DELETE CASCADE,
+    buyer_user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    price_credits   BIGINT NOT NULL DEFAULT 0,
+    price_khash     BIGINT NOT NULL DEFAULT 0,
+    wallet_ledger_id BIGINT,
+    idempotency_key UUID NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT mc_lot_purchase_price_chk
+        CHECK (price_credits >= 0 AND price_khash >= 0),
+    CONSTRAINT mc_lot_purchase_idem_uq UNIQUE (idempotency_key)
+);
+
+CREATE INDEX idx_mc_lot_purchase_lot   ON mc.lot_purchase (lot_id);
+CREATE INDEX idx_mc_lot_purchase_buyer ON mc.lot_purchase (buyer_user_id);
+
+ALTER TABLE mc.lot_purchase ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE mc.lot_purchase IS
+    'Append-only ownership ledger. wallet_ledger_id back-references wallet.ledger so the purchase can be tied to its debit row.';
+
+
+-- ===========================================================================
+-- mc.lot_build_log — build/demolish audit (append-only)
+-- ===========================================================================
+CREATE TABLE mc.lot_build_log (
+    build_id        TEXT PRIMARY KEY DEFAULT public.gen_ulid(),
+    lot_id          TEXT NOT NULL REFERENCES mc.lot(lot_id) ON DELETE CASCADE,
+    actor_user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    action_kind     SMALLINT NOT NULL,
+    schematic_id    TEXT REFERENCES mc.schematic(schematic_id),
+    price_credits   BIGINT NOT NULL DEFAULT 0,
+    price_khash     BIGINT NOT NULL DEFAULT 0,
+    wallet_ledger_id BIGINT,
+    idempotency_key UUID NOT NULL,
+    apply_state     SMALLINT NOT NULL DEFAULT 0,
+    apply_error     TEXT,
+    queued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    applied_at      TIMESTAMPTZ,
+
+    CONSTRAINT mc_lot_build_log_action_chk
+        CHECK (action_kind IN (0, 1)),
+    CONSTRAINT mc_lot_build_log_apply_state_chk
+        CHECK (apply_state BETWEEN 0 AND 2),
+    CONSTRAINT mc_lot_build_log_build_has_schematic_chk
+        CHECK ((action_kind = 0 AND schematic_id IS NOT NULL)
+            OR (action_kind = 1)),
+    CONSTRAINT mc_lot_build_log_idem_uq UNIQUE (idempotency_key)
+);
+
+CREATE INDEX idx_mc_lot_build_log_lot     ON mc.lot_build_log (lot_id);
+CREATE INDEX idx_mc_lot_build_log_actor   ON mc.lot_build_log (actor_user_id);
+CREATE INDEX idx_mc_lot_build_log_pending ON mc.lot_build_log (queued_at) WHERE apply_state = 0;
+
+ALTER TABLE mc.lot_build_log ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE mc.lot_build_log IS
+    'Append-only audit of build/demolish events. action_kind: 0=build, 1=demolish. apply_state: 0=queued, 1=applied, 2=failed.';
+
+
+-- ===========================================================================
+-- mc._user_account_id — user → wallet user-kind account_id
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc._user_account_id(p_user_id UUID)
+RETURNS UUID
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT a.id
+    FROM wallet.account a
+    WHERE a.kind = 'user' AND a.user_id = p_user_id
+    LIMIT 1;
+$$;
+
+ALTER FUNCTION mc._user_account_id(UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc._user_account_id(UUID) FROM PUBLIC, anon, authenticated;
+
+
+-- ===========================================================================
+-- mc.service_list_lots
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_list_lots(
+    p_world TEXT DEFAULT NULL,
+    p_state SMALLINT DEFAULT NULL,
+    p_owner_user_id UUID DEFAULT NULL,
+    p_limit INTEGER DEFAULT 256,
+    p_offset INTEGER DEFAULT 0
+)
+RETURNS TABLE (
+    lot_id          TEXT,
+    world           TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    anchor_y        SMALLINT,
+    owner_user_id   UUID,
+    current_schematic_id TEXT,
+    state           SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT,
+    created_at      TIMESTAMPTZ,
+    updated_at      TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT l.lot_id,
+           l.world,
+           lower(l.chunk_x_range)     AS chunk_x_min,
+           upper(l.chunk_x_range) - 1 AS chunk_x_max,
+           lower(l.chunk_z_range)     AS chunk_z_min,
+           upper(l.chunk_z_range) - 1 AS chunk_z_max,
+           l.anchor_y,
+           l.owner_user_id,
+           l.current_schematic_id,
+           l.state,
+           l.price_credits,
+           l.price_khash,
+           l.created_at,
+           l.updated_at
+    FROM mc.lot l
+    WHERE (p_world         IS NULL OR l.world = p_world)
+      AND (p_state         IS NULL OR l.state = p_state)
+      AND (p_owner_user_id IS NULL OR l.owner_user_id = p_owner_user_id)
+    ORDER BY l.world, lower(l.chunk_x_range), lower(l.chunk_z_range)
+    LIMIT GREATEST(0, LEAST(p_limit, 1024))
+    OFFSET GREATEST(0, p_offset);
+$$;
+
+ALTER FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER)
+    TO service_role;
+
+
+-- ===========================================================================
+-- mc.service_list_schematics
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_list_schematics(
+    p_category TEXT DEFAULT NULL,
+    p_only_enabled BOOLEAN DEFAULT TRUE
+)
+RETURNS TABLE (
+    schematic_id    TEXT,
+    name            TEXT,
+    category        TEXT,
+    tier            SMALLINT,
+    dims_x          SMALLINT,
+    dims_y          SMALLINT,
+    dims_z          SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT,
+    resource_path   TEXT,
+    enabled         BOOLEAN,
+    created_at      TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT s.schematic_id, s.name, s.category, s.tier,
+           s.dims_x, s.dims_y, s.dims_z,
+           s.price_credits, s.price_khash,
+           s.resource_path, s.enabled, s.created_at
+    FROM mc.schematic s
+    WHERE (p_category IS NULL OR s.category = p_category)
+      AND (NOT p_only_enabled OR s.enabled)
+    ORDER BY s.category, s.tier, s.name;
+$$;
+
+ALTER FUNCTION mc.service_list_schematics(TEXT, BOOLEAN) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_list_schematics(TEXT, BOOLEAN)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_list_schematics(TEXT, BOOLEAN)
+    TO service_role;
+
+
+-- ===========================================================================
+-- mc.service_pending_builds — MC mod work queue
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_pending_builds(p_limit INTEGER DEFAULT 32)
+RETURNS TABLE (
+    build_id        TEXT,
+    lot_id          TEXT,
+    actor_user_id   UUID,
+    action_kind     SMALLINT,
+    schematic_id    TEXT,
+    queued_at       TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT b.build_id, b.lot_id, b.actor_user_id,
+           b.action_kind, b.schematic_id, b.queued_at
+    FROM mc.lot_build_log b
+    WHERE b.apply_state = 0
+    ORDER BY b.queued_at
+    LIMIT GREATEST(1, LEAST(p_limit, 256));
+$$;
+
+ALTER FUNCTION mc.service_pending_builds(INTEGER) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_pending_builds(INTEGER)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_pending_builds(INTEGER)
+    TO service_role;
+
+
+-- ===========================================================================
+-- mc.service_mark_build_applied — MC mod ACK on success
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_mark_build_applied(p_build_id TEXT)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_lot_id        TEXT;
+    v_action_kind   SMALLINT;
+    v_schematic_id  TEXT;
+BEGIN
+    UPDATE mc.lot_build_log
+       SET apply_state = 1,
+           applied_at = NOW()
+     WHERE build_id = p_build_id
+       AND apply_state = 0
+    RETURNING lot_id, action_kind, schematic_id
+        INTO v_lot_id, v_action_kind, v_schematic_id;
+
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+
+    IF v_action_kind = 0 THEN
+        UPDATE mc.lot
+           SET state = 2,
+               current_schematic_id = v_schematic_id
+         WHERE lot_id = v_lot_id;
+    ELSIF v_action_kind = 1 THEN
+        UPDATE mc.lot
+           SET state = 1,
+               current_schematic_id = NULL
+         WHERE lot_id = v_lot_id;
+    END IF;
+
+    RETURN TRUE;
+END;
+$$;
+
+ALTER FUNCTION mc.service_mark_build_applied(TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_mark_build_applied(TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_mark_build_applied(TEXT)
+    TO service_role;
+
+
+-- ===========================================================================
+-- mc.service_mark_build_failed — MC mod ACK on failure
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_mark_build_failed(
+    p_build_id TEXT,
+    p_error TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_lot_id TEXT;
+BEGIN
+    UPDATE mc.lot_build_log
+       SET apply_state = 2,
+           apply_error = p_error,
+           applied_at = NOW()
+     WHERE build_id = p_build_id
+       AND apply_state = 0
+    RETURNING lot_id INTO v_lot_id;
+
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+
+    UPDATE mc.lot
+       SET state = CASE WHEN current_schematic_id IS NULL THEN 1 ELSE 2 END
+     WHERE lot_id = v_lot_id;
+
+    RETURN TRUE;
+END;
+$$;
+
+ALTER FUNCTION mc.service_mark_build_failed(TEXT, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_mark_build_failed(TEXT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_mark_build_failed(TEXT, TEXT)
+    TO service_role;
+
+
+-- ===========================================================================
+-- mc.service_purchase_lot — atomic buy
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_purchase_lot(
+    p_lot_id TEXT,
+    p_user_id UUID,
+    p_idempotency_key UUID DEFAULT gen_random_uuid()
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_lot           mc.lot%ROWTYPE;
+    v_account_id    UUID;
+    v_ledger_id     BIGINT;
+    v_purchase_id   TEXT;
+BEGIN
+    SELECT purchase_id INTO v_purchase_id
+    FROM mc.lot_purchase
+    WHERE idempotency_key = p_idempotency_key;
+    IF FOUND THEN
+        RETURN v_purchase_id;
+    END IF;
+
+    SELECT * INTO v_lot FROM mc.lot WHERE lot_id = p_lot_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'lot % does not exist', p_lot_id USING ERRCODE = 'P0002';
+    END IF;
+    IF v_lot.state <> 0 THEN
+        RAISE EXCEPTION 'lot % is not vacant (state=%)', p_lot_id, v_lot.state
+            USING ERRCODE = '22023';
+    END IF;
+
+    v_account_id := mc._user_account_id(p_user_id);
+    IF v_account_id IS NULL THEN
+        RAISE EXCEPTION 'user % has no wallet account', p_user_id
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    IF v_lot.price_credits > 0 THEN
+        v_ledger_id := wallet.service_debit(
+            v_account_id,
+            'credits'::wallet.currency_kind,
+            v_lot.price_credits,
+            'purchase'::wallet.source_kind,
+            'mc.lot.purchase:' || p_lot_id,
+            'mc.lot',
+            NULL,
+            p_idempotency_key
+        );
+    END IF;
+    IF v_lot.price_khash > 0 THEN
+        v_ledger_id := wallet.service_debit(
+            v_account_id,
+            'khash'::wallet.currency_kind,
+            v_lot.price_khash,
+            'purchase'::wallet.source_kind,
+            'mc.lot.purchase:' || p_lot_id,
+            'mc.lot',
+            NULL,
+            p_idempotency_key
+        );
+    END IF;
+
+    INSERT INTO mc.lot_purchase (
+        lot_id, buyer_user_id, price_credits, price_khash,
+        wallet_ledger_id, idempotency_key
+    ) VALUES (
+        p_lot_id, p_user_id, v_lot.price_credits, v_lot.price_khash,
+        v_ledger_id, p_idempotency_key
+    )
+    RETURNING purchase_id INTO v_purchase_id;
+
+    UPDATE mc.lot
+       SET state = 1,
+           owner_user_id = p_user_id
+     WHERE lot_id = p_lot_id;
+
+    RETURN v_purchase_id;
+END;
+$$;
+
+ALTER FUNCTION mc.service_purchase_lot(TEXT, UUID, UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_purchase_lot(TEXT, UUID, UUID)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_purchase_lot(TEXT, UUID, UUID)
+    TO service_role;
+
+
+-- ===========================================================================
+-- mc.service_queue_build_on_lot — charge + queue build
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_queue_build_on_lot(
+    p_lot_id TEXT,
+    p_schematic_id TEXT,
+    p_user_id UUID,
+    p_idempotency_key UUID DEFAULT gen_random_uuid()
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_lot               mc.lot%ROWTYPE;
+    v_schematic         mc.schematic%ROWTYPE;
+    v_account_id        UUID;
+    v_ledger_id         BIGINT;
+    v_build_id          TEXT;
+    v_chunks            INTEGER;
+    v_lot_dx_blocks     INTEGER;
+    v_lot_dz_blocks     INTEGER;
+BEGIN
+    SELECT build_id INTO v_build_id
+    FROM mc.lot_build_log
+    WHERE idempotency_key = p_idempotency_key;
+    IF FOUND THEN
+        RETURN v_build_id;
+    END IF;
+
+    SELECT * INTO v_lot FROM mc.lot WHERE lot_id = p_lot_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'lot % does not exist', p_lot_id USING ERRCODE = 'P0002';
+    END IF;
+    IF v_lot.owner_user_id IS NULL OR v_lot.owner_user_id <> p_user_id THEN
+        RAISE EXCEPTION 'user % does not own lot %', p_user_id, p_lot_id
+            USING ERRCODE = '42501';
+    END IF;
+    IF v_lot.state NOT IN (1, 2) THEN
+        RAISE EXCEPTION 'lot % is not in a buildable state (state=%)',
+            p_lot_id, v_lot.state USING ERRCODE = '22023';
+    END IF;
+
+    SELECT * INTO v_schematic FROM mc.schematic WHERE schematic_id = p_schematic_id;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'schematic % does not exist', p_schematic_id
+            USING ERRCODE = 'P0002';
+    END IF;
+    IF NOT v_schematic.enabled THEN
+        RAISE EXCEPTION 'schematic % is disabled', p_schematic_id
+            USING ERRCODE = '22023';
+    END IF;
+
+    v_lot_dx_blocks := (upper(v_lot.chunk_x_range) - lower(v_lot.chunk_x_range)) * 16;
+    v_lot_dz_blocks := (upper(v_lot.chunk_z_range) - lower(v_lot.chunk_z_range)) * 16;
+    IF v_schematic.dims_x > v_lot_dx_blocks OR v_schematic.dims_z > v_lot_dz_blocks THEN
+        RAISE EXCEPTION 'schematic % (%x%) does not fit lot % (%x%)',
+            p_schematic_id, v_schematic.dims_x, v_schematic.dims_z,
+            p_lot_id, v_lot_dx_blocks, v_lot_dz_blocks
+            USING ERRCODE = '22023';
+    END IF;
+    IF v_lot.anchor_y + v_schematic.dims_y > 319 THEN
+        RAISE EXCEPTION 'schematic % at anchor_y=% exceeds world height',
+            p_schematic_id, v_lot.anchor_y USING ERRCODE = '22023';
+    END IF;
+
+    -- Phase-0 chunk-count guard. Lifted in a follow-up migration once the
+    -- tick-chunked paste pipeline is proven stable.
+    v_chunks := (upper(v_lot.chunk_x_range) - lower(v_lot.chunk_x_range))
+              * (upper(v_lot.chunk_z_range) - lower(v_lot.chunk_z_range));
+    IF v_chunks > 64 THEN
+        RAISE EXCEPTION 'lot % exceeds phase-0 build cap (chunks=%, max=64)',
+            p_lot_id, v_chunks USING ERRCODE = '22023';
+    END IF;
+
+    v_account_id := mc._user_account_id(p_user_id);
+    IF v_account_id IS NULL THEN
+        RAISE EXCEPTION 'user % has no wallet account', p_user_id
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    IF v_schematic.price_credits > 0 THEN
+        v_ledger_id := wallet.service_debit(
+            v_account_id,
+            'credits'::wallet.currency_kind,
+            v_schematic.price_credits,
+            'purchase'::wallet.source_kind,
+            'mc.lot.build:' || p_lot_id || ':' || p_schematic_id,
+            'mc.lot_build_log',
+            NULL,
+            p_idempotency_key
+        );
+    END IF;
+    IF v_schematic.price_khash > 0 THEN
+        v_ledger_id := wallet.service_debit(
+            v_account_id,
+            'khash'::wallet.currency_kind,
+            v_schematic.price_khash,
+            'purchase'::wallet.source_kind,
+            'mc.lot.build:' || p_lot_id || ':' || p_schematic_id,
+            'mc.lot_build_log',
+            NULL,
+            p_idempotency_key
+        );
+    END IF;
+
+    INSERT INTO mc.lot_build_log (
+        lot_id, actor_user_id, action_kind, schematic_id,
+        price_credits, price_khash, wallet_ledger_id, idempotency_key
+    ) VALUES (
+        p_lot_id, p_user_id, 0, p_schematic_id,
+        v_schematic.price_credits, v_schematic.price_khash,
+        v_ledger_id, p_idempotency_key
+    )
+    RETURNING build_id INTO v_build_id;
+
+    UPDATE mc.lot SET state = 3 WHERE lot_id = p_lot_id;
+
+    RETURN v_build_id;
+END;
+$$;
+
+ALTER FUNCTION mc.service_queue_build_on_lot(TEXT, TEXT, UUID, UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_queue_build_on_lot(TEXT, TEXT, UUID, UUID)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_queue_build_on_lot(TEXT, TEXT, UUID, UUID)
+    TO service_role;
+
+
+-- ===========================================================================
+-- mc.service_queue_demolish_lot — queue a clear job
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_queue_demolish_lot(
+    p_lot_id TEXT,
+    p_user_id UUID,
+    p_idempotency_key UUID DEFAULT gen_random_uuid()
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_lot       mc.lot%ROWTYPE;
+    v_build_id  TEXT;
+BEGIN
+    SELECT build_id INTO v_build_id
+    FROM mc.lot_build_log
+    WHERE idempotency_key = p_idempotency_key;
+    IF FOUND THEN
+        RETURN v_build_id;
+    END IF;
+
+    SELECT * INTO v_lot FROM mc.lot WHERE lot_id = p_lot_id FOR UPDATE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'lot % does not exist', p_lot_id USING ERRCODE = 'P0002';
+    END IF;
+    IF v_lot.owner_user_id IS NULL OR v_lot.owner_user_id <> p_user_id THEN
+        RAISE EXCEPTION 'user % does not own lot %', p_user_id, p_lot_id
+            USING ERRCODE = '42501';
+    END IF;
+    IF v_lot.state <> 2 THEN
+        RAISE EXCEPTION 'lot % has nothing to demolish (state=%)',
+            p_lot_id, v_lot.state USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO mc.lot_build_log (
+        lot_id, actor_user_id, action_kind, schematic_id, idempotency_key
+    ) VALUES (
+        p_lot_id, p_user_id, 1, NULL, p_idempotency_key
+    )
+    RETURNING build_id INTO v_build_id;
+
+    UPDATE mc.lot SET state = 4 WHERE lot_id = p_lot_id;
+
+    RETURN v_build_id;
+END;
+$$;
+
+ALTER FUNCTION mc.service_queue_demolish_lot(TEXT, UUID, UUID) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_queue_demolish_lot(TEXT, UUID, UUID)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_queue_demolish_lot(TEXT, UUID, UUID)
+    TO service_role;
+
+
+-- ===========================================================================
+-- mc.proxy_* RPCs (caller is auth.uid())
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.proxy_list_lots(
+    p_world TEXT DEFAULT NULL,
+    p_state SMALLINT DEFAULT NULL,
+    p_only_mine BOOLEAN DEFAULT FALSE,
+    p_limit INTEGER DEFAULT 256,
+    p_offset INTEGER DEFAULT 0
+)
+RETURNS TABLE (
+    lot_id          TEXT,
+    world           TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    anchor_y        SMALLINT,
+    owner_user_id   UUID,
+    is_owned_by_me  BOOLEAN,
+    current_schematic_id TEXT,
+    state           SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_uid UUID := auth.uid();
+BEGIN
+    RETURN QUERY
+    SELECT l.lot_id,
+           l.world,
+           lower(l.chunk_x_range)     AS chunk_x_min,
+           upper(l.chunk_x_range) - 1 AS chunk_x_max,
+           lower(l.chunk_z_range)     AS chunk_z_min,
+           upper(l.chunk_z_range) - 1 AS chunk_z_max,
+           l.anchor_y,
+           l.owner_user_id,
+           (l.owner_user_id IS NOT NULL AND l.owner_user_id = v_uid) AS is_owned_by_me,
+           l.current_schematic_id,
+           l.state,
+           l.price_credits,
+           l.price_khash
+    FROM mc.lot l
+    WHERE (p_world IS NULL OR l.world = p_world)
+      AND (p_state IS NULL OR l.state = p_state)
+      AND (NOT p_only_mine OR (v_uid IS NOT NULL AND l.owner_user_id = v_uid))
+    ORDER BY l.world, lower(l.chunk_x_range), lower(l.chunk_z_range)
+    LIMIT GREATEST(0, LEAST(p_limit, 1024))
+    OFFSET GREATEST(0, p_offset);
+END;
+$$;
+
+ALTER FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER)
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER)
+    TO authenticated, service_role;
+
+
+CREATE OR REPLACE FUNCTION mc.proxy_list_schematics(p_category TEXT DEFAULT NULL)
+RETURNS TABLE (
+    schematic_id    TEXT,
+    name            TEXT,
+    category        TEXT,
+    tier            SMALLINT,
+    dims_x          SMALLINT,
+    dims_y          SMALLINT,
+    dims_z          SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT s.schematic_id, s.name, s.category, s.tier,
+           s.dims_x, s.dims_y, s.dims_z,
+           s.price_credits, s.price_khash
+    FROM mc.schematic s
+    WHERE (p_category IS NULL OR s.category = p_category)
+      AND s.enabled
+    ORDER BY s.category, s.tier, s.name;
+$$;
+
+ALTER FUNCTION mc.proxy_list_schematics(TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.proxy_list_schematics(TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION mc.proxy_list_schematics(TEXT) TO authenticated, service_role;
+
+
+CREATE OR REPLACE FUNCTION mc.proxy_purchase_lot(p_lot_id TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_uid UUID := auth.uid();
+BEGIN
+    IF v_uid IS NULL THEN
+        RAISE EXCEPTION 'not authenticated' USING ERRCODE = '42501';
+    END IF;
+    RETURN mc.service_purchase_lot(p_lot_id, v_uid, gen_random_uuid());
+END;
+$$;
+
+ALTER FUNCTION mc.proxy_purchase_lot(TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.proxy_purchase_lot(TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION mc.proxy_purchase_lot(TEXT) TO authenticated, service_role;
+
+
+CREATE OR REPLACE FUNCTION mc.proxy_queue_build_on_lot(
+    p_lot_id TEXT,
+    p_schematic_id TEXT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_uid UUID := auth.uid();
+BEGIN
+    IF v_uid IS NULL THEN
+        RAISE EXCEPTION 'not authenticated' USING ERRCODE = '42501';
+    END IF;
+    RETURN mc.service_queue_build_on_lot(p_lot_id, p_schematic_id, v_uid, gen_random_uuid());
+END;
+$$;
+
+ALTER FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT) TO authenticated, service_role;
+
+
+CREATE OR REPLACE FUNCTION mc.proxy_queue_demolish_lot(p_lot_id TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_uid UUID := auth.uid();
+BEGIN
+    IF v_uid IS NULL THEN
+        RAISE EXCEPTION 'not authenticated' USING ERRCODE = '42501';
+    END IF;
+    RETURN mc.service_queue_demolish_lot(p_lot_id, v_uid, gen_random_uuid());
+END;
+$$;
+
+ALTER FUNCTION mc.proxy_queue_demolish_lot(TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.proxy_queue_demolish_lot(TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION mc.proxy_queue_demolish_lot(TEXT) TO authenticated, service_role;
+
+
+-- ===========================================================================
+-- PUBLIC PROXY WRAPPERS — PostgREST sees these
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION public.proxy_list_lots(
+    p_world TEXT DEFAULT NULL,
+    p_state SMALLINT DEFAULT NULL,
+    p_only_mine BOOLEAN DEFAULT FALSE,
+    p_limit INTEGER DEFAULT 256,
+    p_offset INTEGER DEFAULT 0
+)
+RETURNS TABLE (
+    lot_id          TEXT,
+    world           TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    anchor_y        SMALLINT,
+    owner_user_id   UUID,
+    is_owned_by_me  BOOLEAN,
+    current_schematic_id TEXT,
+    state           SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT * FROM mc.proxy_list_lots(p_world, p_state, p_only_mine, p_limit, p_offset);
+$$;
+
+ALTER FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER)
+    FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER)
+    TO authenticated, service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_list_schematics(p_category TEXT DEFAULT NULL)
+RETURNS TABLE (
+    schematic_id    TEXT,
+    name            TEXT,
+    category        TEXT,
+    tier            SMALLINT,
+    dims_x          SMALLINT,
+    dims_y          SMALLINT,
+    dims_z          SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT * FROM mc.proxy_list_schematics(p_category);
+$$;
+
+ALTER FUNCTION public.proxy_list_schematics(TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_list_schematics(TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_list_schematics(TEXT) TO authenticated, service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_purchase_lot(p_lot_id TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
+        RAISE EXCEPTION 'lot_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    RETURN mc.proxy_purchase_lot(p_lot_id);
+END;
+$$;
+
+ALTER FUNCTION public.proxy_purchase_lot(TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_purchase_lot(TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_purchase_lot(TEXT) TO authenticated, service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_queue_build_on_lot(
+    p_lot_id TEXT,
+    p_schematic_id TEXT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
+        RAISE EXCEPTION 'lot_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF p_schematic_id IS NULL OR btrim(p_schematic_id) = '' THEN
+        RAISE EXCEPTION 'schematic_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    RETURN mc.proxy_queue_build_on_lot(p_lot_id, p_schematic_id);
+END;
+$$;
+
+ALTER FUNCTION public.proxy_queue_build_on_lot(TEXT, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_queue_build_on_lot(TEXT, TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_queue_build_on_lot(TEXT, TEXT) TO authenticated, service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_queue_demolish_lot(p_lot_id TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
+        RAISE EXCEPTION 'lot_id cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    RETURN mc.proxy_queue_demolish_lot(p_lot_id);
+END;
+$$;
+
+ALTER FUNCTION public.proxy_queue_demolish_lot(TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_queue_demolish_lot(TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.proxy_queue_demolish_lot(TEXT) TO authenticated, service_role;
+
+
+NOTIFY pgrst, 'reload schema';
+
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS public.proxy_queue_demolish_lot(TEXT);
+DROP FUNCTION IF EXISTS public.proxy_queue_build_on_lot(TEXT, TEXT);
+DROP FUNCTION IF EXISTS public.proxy_purchase_lot(TEXT);
+DROP FUNCTION IF EXISTS public.proxy_list_schematics(TEXT);
+DROP FUNCTION IF EXISTS public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER);
+
+DROP FUNCTION IF EXISTS mc.proxy_queue_demolish_lot(TEXT);
+DROP FUNCTION IF EXISTS mc.proxy_queue_build_on_lot(TEXT, TEXT);
+DROP FUNCTION IF EXISTS mc.proxy_purchase_lot(TEXT);
+DROP FUNCTION IF EXISTS mc.proxy_list_schematics(TEXT);
+DROP FUNCTION IF EXISTS mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER);
+
+DROP FUNCTION IF EXISTS mc.service_queue_demolish_lot(TEXT, UUID, UUID);
+DROP FUNCTION IF EXISTS mc.service_queue_build_on_lot(TEXT, TEXT, UUID, UUID);
+DROP FUNCTION IF EXISTS mc.service_purchase_lot(TEXT, UUID, UUID);
+DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT);
+DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT);
+DROP FUNCTION IF EXISTS mc.service_pending_builds(INTEGER);
+DROP FUNCTION IF EXISTS mc.service_list_schematics(TEXT, BOOLEAN);
+DROP FUNCTION IF EXISTS mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER);
+DROP FUNCTION IF EXISTS mc._user_account_id(UUID);
+
+DROP TABLE IF EXISTS mc.lot_build_log;
+DROP TABLE IF EXISTS mc.lot_purchase;
+DROP TABLE IF EXISTS mc.lot;
+DROP FUNCTION IF EXISTS mc.trg_lot_updated_at();
+DROP TABLE IF EXISTS mc.schematic;
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -1,68 +1,27 @@
 -- migrate:up
 
--- ============================================================================
--- MC LOT SYSTEM — digital real estate for the survival backend
---
--- Phase 0 schema: parcel registry, schematic catalog, ownership ledger, and
--- build-event audit log. Players buy lots in the dashboard, then pick
--- structures from the schematic catalog to place on owned lots. The MC mod
--- side picks up purchase + build events and applies them to the world.
---
--- Lot bounds are stored as int4range pairs (chunk_x_range, chunk_z_range)
--- with a GIST EXCLUDE constraint that forbids any two lots in the same
--- world from overlapping at the chunk grid level. The schema supports
--- 1x1 lots from day one and arbitrarily large lots (200x100 castles, etc)
--- with no further migration — the operational ceiling lives in RPC guards,
--- not table definitions.
---
--- Money flow rides on wallet.service_debit against the user-kind account.
--- mc.lot_purchase and mc.lot_build_log keep their own append-only audit
--- rows so we can reconstruct ownership / build history without joining
--- through wallet.ledger. Both ledgers carry a per-currency ledger reference
--- pair (wallet_credits_ledger_id, wallet_khash_ledger_id) because a single
--- charge can debit BOTH currencies; storing one column would discard the
--- second debit on a dual-currency purchase.
---
--- Idempotency is enforced both at the mc layer (UNIQUE(idempotency_key))
--- AND at the wallet layer (per-currency-derived UUID via
--- mc._derive_idem_key) so retrying a dual-currency charge cannot collide
--- on the wallet side.
---
--- Schema exposure: every public-callable RPC is fronted by a
--- public.proxy_* wrapper because PostgREST only sees the public schema.
--- The mc schema stays private; service_role and authenticated callers
--- route through the proxies. Pattern matches mc_public_proxies.sql.
--- ============================================================================
+-- mc lot system — digital real estate for the survival backend.
+-- Tables: mc.schematic (catalog), mc.lot (parcels, GIST EXCLUDE on
+-- (world, chunk_x_range, chunk_z_range) prevents overlap),
+-- mc.lot_purchase (ownership ledger), mc.lot_build_log (build audit
+-- + concurrent work queue).
+-- Money flows through wallet.service_debit; dual-currency charges
+-- use mc._derive_idem_key to avoid wallet-side idempotency collision.
+-- RPC layering: mc.service_* (service_role), mc.proxy_* (auth.uid()),
+-- public.proxy_* (PostgREST surface).
 
--- btree_gist supplies the gist_text_ops opclass needed by the
--- (world WITH =) leg of the EXCLUDE constraint on mc.lot. Left in the
--- default schema (rather than `extensions`) because EXCLUDE opclass
--- resolution uses the live search_path at CREATE TABLE time, and pinning
--- the extension to `extensions` would force every consumer to extend its
--- search_path. pgcrypto sits in extensions because it's only called via
--- explicit extensions.digest(...) — different concern.
+-- btree_gist supplies gist_text_ops for the EXCLUDE constraint. Kept
+-- in default schema; pinning to `extensions` breaks opclass resolution
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 
--- Re-affirm schema + grants so this migration is independently runnable
--- against a fresh database. mc was already created in mc_schema_init but
--- IF NOT EXISTS keeps the statement safe to replay.
 CREATE SCHEMA IF NOT EXISTS mc;
 GRANT USAGE ON SCHEMA mc TO service_role;
 REVOKE ALL ON SCHEMA mc FROM PUBLIC, anon, authenticated;
 
 
--- ===========================================================================
--- mc._derive_idem_key — deterministic per-currency idempotency key
--- ===========================================================================
---
--- wallet.service_debit treats (account, idempotency_key) as the uniqueness
--- scope for replay collapsing. A single mc.lot purchase or build can debit
--- BOTH credits AND khash; reusing the same key for both calls would either
--- silently no-op the second debit or surface a fingerprint mismatch
--- depending on how wallet handles it. Derive a stable per-currency UUID
--- from the caller-supplied key so retry semantics still work, but each
--- currency has its own slot.
--- ===========================================================================
+-- mc._derive_idem_key — wallet.service_debit treats (account,
+-- idempotency_key) as the uniqueness scope; dual-currency charges
+-- need a stable per-currency UUID so credits + khash don't collide.
 CREATE OR REPLACE FUNCTION mc._derive_idem_key(p_key UUID, p_tag TEXT)
 RETURNS UUID
 LANGUAGE sql
@@ -71,11 +30,8 @@ STRICT
 PARALLEL SAFE
 SET search_path = ''
 AS $$
-    -- pgcrypto lives in the extensions schema on Supabase/kilobase; the
-    -- mc_pgcrypto_qualify migration already established this convention
-    -- and granted USAGE on extensions to service_role. SHA-256 truncated
-    -- to 128 bits gives a UUID-sized digest with no realistic collision
-    -- surface even though the use is non-adversarial.
+    -- pgcrypto lives in extensions schema on Supabase. SHA-256 truncated
+    -- to 128 bits = UUID-sized digest.
     SELECT substr(encode(extensions.digest(p_key::text || ':' || p_tag, 'sha256'), 'hex'), 1, 32)::uuid;
 $$;
 
@@ -108,18 +64,14 @@ CREATE TABLE mc.schematic (
         CHECK (schematic_id ~ '^[A-Za-z0-9:_/-]{3,128}$'),
     CONSTRAINT mc_schematic_category_chk
         CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument')),
-    -- Reject path-traversal + force schematics into the mod jar's
-    -- schematics/ dir. Loader on the Java side concats this onto a class
-    -- loader resource path, so anything escaping the dir is a footgun.
+    -- Reject path traversal; lock to schematics/ dir in mod jar.
     CONSTRAINT mc_schematic_resource_path_chk
         CHECK (resource_path !~ '(^/|\.\.)' AND
                resource_path ~ '^schematics/[A-Za-z0-9_./-]+\.(nbt|schem)$')
 );
 
--- Partial index lines up with proxy_list_schematics' WHERE enabled +
--- ORDER BY category, tier, name path. INCLUDE columns let the planner
--- satisfy the catalog listing without touching the heap once the
--- visibility map is warm.
+-- Index-only path for proxy_list_schematics: WHERE enabled ORDER BY
+-- category, tier, name.
 CREATE INDEX idx_mc_schematic_enabled_category_tier_name_cover
     ON mc.schematic (category, tier, name, schematic_id)
     INCLUDE (dims_x, dims_y, dims_z, price_credits, price_khash)
@@ -130,7 +82,7 @@ ALTER TABLE mc.schematic ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.schematic FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.schematic IS
-    'Build catalog. RPC-only: RLS is enabled + forced with NO policies; direct table access is denied even to service_role. All reads/writes flow through SECURITY DEFINER RPCs.';
+    'Build catalog. RPC-only — RLS forced with no policies; all access via SECURITY DEFINER RPCs.';
 
 
 -- ===========================================================================
@@ -141,11 +93,8 @@ CREATE TABLE mc.lot (
     world           TEXT NOT NULL DEFAULT 'minecraft:overworld',
     chunk_x_range   int4range NOT NULL,
     chunk_z_range   int4range NOT NULL,
-    -- Stored generated columns so chunk-count guards in RPCs, listing
-    -- sort orders, and dashboard map queries don't recompute on every
-    -- read. *_min / *_max are inclusive (i.e. -1 from the half-open
-    -- upper bound) so indexes and queries are in the same coordinate
-    -- system the dashboard renders in.
+    -- Stored generated columns for chunk-count guards, index ORDER BY,
+    -- and map queries. *_min / *_max are inclusive (upper-1).
     chunk_x_min     INTEGER GENERATED ALWAYS AS (lower(chunk_x_range)) STORED,
     chunk_x_max     INTEGER GENERATED ALWAYS AS (upper(chunk_x_range) - 1) STORED,
     chunk_z_min     INTEGER GENERATED ALWAYS AS (lower(chunk_z_range)) STORED,
@@ -157,21 +106,14 @@ CREATE TABLE mc.lot (
     chunk_area      INTEGER GENERATED ALWAYS AS
         ((upper(chunk_x_range) - lower(chunk_x_range))
        * (upper(chunk_z_range) - lower(chunk_z_range))) STORED,
-    -- Block-space mirrors of the chunk bounds. The dashboard map and
-    -- the MC mod both render in block space; storing these once avoids
-    -- per-client recompute and keeps the math DB-side.
+    -- Block-space mirrors so map/worker reads skip chunk*16 client-side.
     block_x_min     INTEGER GENERATED ALWAYS AS (lower(chunk_x_range) * 16) STORED,
     block_x_max     INTEGER GENERATED ALWAYS AS (upper(chunk_x_range) * 16 - 1) STORED,
     block_z_min     INTEGER GENERATED ALWAYS AS (lower(chunk_z_range) * 16) STORED,
     block_z_max     INTEGER GENERATED ALWAYS AS (upper(chunk_z_range) * 16 - 1) STORED,
     anchor_y        SMALLINT NOT NULL,
-    -- ON DELETE RESTRICT, not SET NULL: the owner_state_chk requires
-    -- state > 0 to carry a non-null owner. SET NULL would let a user
-    -- deletion drop the owner column on a built/owned/under_build lot
-    -- and surface the CHECK violation at the wrong layer. Forcing a
-    -- restriction means user deletion has to flow through an explicit
-    -- 'release my lots' RPC that resets state, owner, and schematic
-    -- together.
+    -- RESTRICT not SET NULL: owner_state_chk requires owner with
+    -- state>0; user-delete must flow through a release-lots RPC.
     owner_user_id   UUID REFERENCES auth.users(id) ON DELETE RESTRICT,
     current_schematic_id TEXT REFERENCES mc.schematic(schematic_id),
     -- 0 = vacant, 1 = owned, 2 = built, 3 = under_build, 4 = demolishing
@@ -191,18 +133,12 @@ CREATE TABLE mc.lot (
     CONSTRAINT mc_lot_z_range_chk    CHECK (NOT isempty(chunk_z_range)
                                              AND lower_inc(chunk_z_range)
                                              AND NOT upper_inc(chunk_z_range)),
-    -- Explicit finite-bounds guard so the generated chunk_area columns
-    -- and the GIST EXCLUDE never see unbounded ranges. Belt-and-suspenders
-    -- with the isempty + bound-inclusion checks above.
     CONSTRAINT mc_lot_x_range_finite_chk
         CHECK (lower(chunk_x_range) IS NOT NULL AND upper(chunk_x_range) IS NOT NULL),
     CONSTRAINT mc_lot_z_range_finite_chk
         CHECK (lower(chunk_z_range) IS NOT NULL AND upper(chunk_z_range) IS NOT NULL),
-    -- Hard ceiling on parcel size. 512 chunks = 8192 blocks per axis;
-    -- 262144 total chunks = 4 km × 4 km. Anything bigger is almost
-    -- certainly an admin tooling bug and would corrode map/exclusion
-    -- index behavior. Phase-0 RPC cap is 64 chunks; this is the table
-    -- floor that even direct admin INSERTs must obey.
+    -- 512 chunks = 8192 blocks per axis; 262144 area = 4km^2. Table
+    -- floor; phase-0 RPC cap is 64 chunks.
     CONSTRAINT mc_lot_chunk_width_max_chk
         CHECK ((upper(chunk_x_range) - lower(chunk_x_range)) <= 512),
     CONSTRAINT mc_lot_chunk_depth_max_chk
@@ -210,22 +146,14 @@ CREATE TABLE mc.lot (
     CONSTRAINT mc_lot_chunk_area_max_chk
         CHECK ((upper(chunk_x_range) - lower(chunk_x_range))
              * (upper(chunk_z_range) - lower(chunk_z_range)) <= 262144),
-    -- Vanilla dim ids look like 'minecraft:overworld' or
-    -- 'kbve:survival_ext'. Enforce the namespaced format to keep typos and
-    -- arbitrary text from sneaking into the world column.
+    -- Vanilla namespaced dim id: 'minecraft:overworld' etc.
     CONSTRAINT mc_lot_world_chk
         CHECK (world ~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$'),
     CONSTRAINT mc_lot_owner_state_chk CHECK (
         (state = 0 AND owner_user_id IS NULL)
         OR (state > 0 AND owner_user_id IS NOT NULL)
     ),
-    -- Schematic presence per state:
-    --   0 vacant       — no schematic (and no owner; see vacant_clean_chk).
-    --   1 owned        — no schematic (clean lot, no build yet).
-    --   2 built        — schematic NOT NULL.
-    --   3 under_build  — schematic free (rebuild flow may carry the
-    --                    prior schematic; first build starts NULL).
-    --   4 demolishing  — schematic NOT NULL (target row of the clear).
+    -- 0/1: no schematic. 2/4: schematic NOT NULL. 3: free (rebuild).
     CONSTRAINT mc_lot_built_has_schematic_chk CHECK (
         CASE state
             WHEN 0 THEN current_schematic_id IS NULL
@@ -235,9 +163,7 @@ CREATE TABLE mc.lot (
             ELSE TRUE  -- state=3 unconstrained
         END
     ),
-    -- Vacant lots have no owner. state=0 + owner combos slipped through
-    -- the broader owner_state_chk because that check allowed state>0
-    -- with non-null owner; this is the stricter inverse for state=0.
+    -- state=0 inverse of owner_state_chk: no owner, no schematic.
     CONSTRAINT mc_lot_vacant_clean_chk CHECK (
         state <> 0
         OR (owner_user_id IS NULL AND current_schematic_id IS NULL)
@@ -250,11 +176,7 @@ CREATE TABLE mc.lot (
     )
 );
 
--- Now that we have stored chunk_x_min / chunk_z_min generated columns,
--- prefer them over expression indexes on lower(chunk_*_range) so plans
--- pick the index directly without rewriting the predicate. The trailing
--- lot_id makes every ordering deterministic and unlocks keyset
--- pagination in a later migration without touching these indexes.
+-- Generated chunk_min columns + trailing lot_id for keyset pagination.
 -- Bare 'WHERE owner_user_id = $1' lookups are covered by the leading
 -- column of idx_mc_lot_owner_world_chunk_cursor; no separate non-cursor
 -- owner index needed.
@@ -265,26 +187,19 @@ CREATE INDEX idx_mc_lot_world_state_chunk_cursor
 CREATE INDEX idx_mc_lot_owner_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     WHERE owner_user_id IS NOT NULL;
--- Hottest dashboard read path: "what vacant lots can I buy in <world>?"
--- Partial + INCLUDE so the marketplace map renders without heap hops.
+-- Marketplace map: vacant lots, index-only via INCLUDE.
 CREATE INDEX idx_mc_lot_vacant_world_chunk_cursor
     ON mc.lot (world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (chunk_x_max, chunk_z_max, chunk_area, anchor_y,
              price_credits, price_khash)
     WHERE state = 0;
--- "My lots" page is dominated by owned + built rows; vacant/under-build
--- are rare. INCLUDE the columns the dashboard renders (including
--- prices, which surface as "sell-for" hints on owned-but-not-built
--- rows) so the index can answer index-only.
+-- "My lots" (state IN (1,2)), index-only.
 CREATE INDEX idx_mc_lot_owner_active_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
              chunk_area, anchor_y, price_credits, price_khash)
     WHERE owner_user_id IS NOT NULL AND state IN (1, 2);
--- "Under build / demolishing" view of my lots. Smaller partial set,
--- but lots in transitional states get re-rendered every few seconds
--- by the dashboard waiting for the worker ACK, so a dedicated index
--- earns its keep there.
+-- Transitional poll view (state IN (3,4)).
 CREATE INDEX idx_mc_lot_owner_transitional_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
@@ -295,11 +210,7 @@ ALTER TABLE mc.lot OWNER TO postgres;
 ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot FORCE ROW LEVEL SECURITY;
 
--- Trigger touches updated_at only when one of the mutable business
--- columns changed; cuts write amplification on no-op UPDATEs and avoids
--- a whole-row IS DISTINCT FROM comparison that would touch every
--- generated chunk_* column too. NOW() (transaction-stable) is the right
--- clock for an audit-style column.
+-- Per-column DISTINCT check skips generated cols; NOW() for txn-stable.
 CREATE OR REPLACE FUNCTION mc.trg_lot_updated_at()
 RETURNS TRIGGER
 LANGUAGE plpgsql
@@ -327,7 +238,7 @@ CREATE TRIGGER trg_mc_lot_updated_at
     EXECUTE FUNCTION mc.trg_lot_updated_at();
 
 COMMENT ON TABLE mc.lot IS
-    'Parcel registry. Chunk-aligned rectangular regions guarded by a GIST EXCLUDE constraint that forbids overlap within a world. RPC-only: RLS is enabled + forced with NO policies; all reads/writes flow through SECURITY DEFINER RPCs.';
+    'Parcel registry. Chunk-aligned regions; GIST EXCLUDE forbids overlap. RPC-only — RLS forced with no policies.';
 COMMENT ON COLUMN mc.lot.state IS '0=vacant, 1=owned, 2=built, 3=under_build, 4=demolishing';
 
 
@@ -340,14 +251,8 @@ CREATE TABLE mc.lot_purchase (
     buyer_user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
-    -- One ledger id per currency. A dual-currency purchase fills both;
-    -- single-currency purchases leave the other NULL.
-    -- NOTE: deliberately NOT declared as a FOREIGN KEY to wallet.ledger.
-    -- mc and wallet are owned by different teams' migration timelines
-    -- and wallet.ledger uses ON DELETE NO ACTION semantics that would
-    -- block valid retention/archival flows over there. The reverse
-    -- direction (wallet.ledger.ref_type = 'mc.lot' / .ref_id) is how the
-    -- audit trail is reconstructed; back-reference here is informational.
+    -- Per-currency back-ref. NOT a FK to wallet.ledger; that path's NO
+    -- ACTION semantics would block wallet retention/archival.
     wallet_credits_ledger_id BIGINT,
     wallet_khash_ledger_id   BIGINT,
     idempotency_key UUID NOT NULL,
@@ -355,9 +260,7 @@ CREATE TABLE mc.lot_purchase (
 
     CONSTRAINT mc_lot_purchase_price_chk
         CHECK (price_credits >= 0 AND price_khash >= 0),
-    -- Per-currency ledger reference must be present iff that currency
-    -- was actually charged. Prevents dirty audit rows that would force
-    -- defensive null-checking downstream.
+    -- Ledger ref NOT NULL iff that currency was charged.
     CONSTRAINT mc_lot_purchase_credits_ledger_chk CHECK (
         (price_credits = 0 AND wallet_credits_ledger_id IS NULL)
         OR (price_credits > 0 AND wallet_credits_ledger_id IS NOT NULL)
@@ -369,19 +272,12 @@ CREATE TABLE mc.lot_purchase (
     CONSTRAINT mc_lot_purchase_idem_uq UNIQUE (idempotency_key)
 );
 
--- Dashboard "my purchase history" sorts newest first; composite avoids
--- a sort step. INCLUDE'd columns make the history list index-only.
--- Ledger ids intentionally omitted — the dashboard doesn't render
--- them, and adding them inflates the index without payoff.
+-- "My purchases" newest-first, index-only (ledger ids omitted on purpose).
 CREATE INDEX idx_mc_lot_purchase_buyer_created
     ON mc.lot_purchase (buyer_user_id, created_at DESC, purchase_id DESC)
     INCLUDE (lot_id, price_credits, price_khash);
 
--- Phase-0 invariant: each lot can be bought exactly once. Resale comes
--- with an explicit ownership-epoch column in a follow-up migration.
--- This unique index also covers the lookup-by-lot path; no separate
--- non-unique idx_mc_lot_purchase_lot needed (would just be write
--- amplification).
+-- Phase-0 invariant: one purchase per lot. Doubles as lookup index.
 CREATE UNIQUE INDEX uq_mc_lot_purchase_one_per_lot
     ON mc.lot_purchase (lot_id);
 
@@ -390,7 +286,7 @@ ALTER TABLE mc.lot_purchase ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot_purchase FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.lot_purchase IS
-    'Append-only ownership ledger. Per-currency wallet_*_ledger_id columns back-reference wallet.ledger so dual-currency purchases retain both debit references. RPC-only: RLS enabled + forced, no policies.';
+    'Append-only ownership ledger. Per-currency back-refs to wallet.ledger. RPC-only — RLS forced with no policies.';
 
 
 -- ===========================================================================
@@ -405,7 +301,6 @@ CREATE TABLE mc.lot_build_log (
     schematic_id    TEXT REFERENCES mc.schematic(schematic_id),
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
-    -- One ledger id per currency. Mirrors mc.lot_purchase.
     wallet_credits_ledger_id BIGINT,
     wallet_khash_ledger_id   BIGINT,
     idempotency_key UUID NOT NULL,
@@ -417,11 +312,7 @@ CREATE TABLE mc.lot_build_log (
     queued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     applied_at      TIMESTAMPTZ,
     failed_at       TIMESTAMPTZ,
-    -- Retry budget. Incremented on every claim; rows that hit the cap
-    -- are excluded from the SKIP LOCKED scan so a poisoned job cannot
-    -- cycle through claim -> stale-requeue -> claim forever. INTEGER
-    -- (not SMALLINT) so future schemas can reuse the column without
-    -- a type widening migration.
+    -- Incremented on claim; cap excludes poison from SKIP LOCKED scan.
     attempt_count   INTEGER NOT NULL DEFAULT 0,
     last_attempt_at TIMESTAMPTZ,
 
@@ -446,9 +337,8 @@ CREATE TABLE mc.lot_build_log (
         (price_khash = 0 AND wallet_khash_ledger_id IS NULL)
         OR (price_khash > 0 AND wallet_khash_ledger_id IS NOT NULL)
     ),
-    -- Demolish is always free in phase 0: action_kind=1 cannot carry a
-    -- schematic, price, or ledger ref. Locking this in at the table
-    -- level so a future RPC change can't silently break the invariant.
+    -- Demolish is free in phase 0 — table-level lock so future RPC
+    -- changes can't silently start charging.
     CONSTRAINT mc_lot_build_log_demolish_free_chk CHECK (
         action_kind <> 1
         OR (schematic_id IS NULL
@@ -467,31 +357,24 @@ CREATE TABLE mc.lot_build_log (
     CONSTRAINT mc_lot_build_log_idem_uq UNIQUE (idempotency_key)
 );
 
--- Per-lot history: newest-first composite drops the sort for
--- "show me every build event for this lot".
+-- Per-lot history.
 CREATE INDEX idx_mc_lot_build_log_lot_queued
     ON mc.lot_build_log (lot_id, queued_at DESC, build_id DESC);
--- User history: INCLUDE the columns the 'my build history' page
--- renders so the dashboard read goes index-only.
+-- "My build history" — index-only via INCLUDE.
 CREATE INDEX idx_mc_lot_build_log_actor_queued
     ON mc.lot_build_log (actor_user_id, queued_at DESC, build_id DESC)
     INCLUDE (lot_id, action_kind, schematic_id, apply_state,
              failed_at, applied_at, attempt_count);
--- Queue + worker claim path: include build_id so the claim ORDER BY
--- (queued_at, build_id) is satisfied by index walk alone. attempt_count
--- predicate mirrors the claim WHERE so poisoned rows drop out of the
--- partial index instead of getting scanned-and-skipped forever.
+-- Worker claim path. attempt_count predicate mirrors claim WHERE so
+-- exhausted rows drop out of the index.
 CREATE INDEX idx_mc_lot_build_log_pending_claim
     ON mc.lot_build_log (queued_at, build_id)
     WHERE apply_state = 0 AND attempt_count < 5;
--- Stuck-job reclaim. build_id keeps janitor scans deterministic and
--- supports a LIMIT-batched requeue. claimed_at IS NOT NULL is
--- redundant with the claimed-consistency CHECK today but makes the
--- partial index self-documenting and survives future constraint edits.
+-- Stale-claim janitor scan.
 CREATE INDEX idx_mc_lot_build_log_claimed_stale
     ON mc.lot_build_log (claimed_at, build_id)
     WHERE apply_state = 3 AND claimed_at IS NOT NULL;
--- Failed-job admin/janitor listing (#3, #10).
+-- Failed-job admin listing.
 CREATE INDEX idx_mc_lot_build_log_failed_recent
     ON mc.lot_build_log (failed_at DESC, build_id DESC)
     WHERE apply_state = 2;
@@ -500,8 +383,7 @@ CREATE INDEX idx_mc_lot_build_log_schematic
     ON mc.lot_build_log (schematic_id)
     WHERE schematic_id IS NOT NULL;
 
--- At most one outstanding job (queued OR claimed) per lot. Stronger than
--- the lot.state guard because it survives RPC bugs / direct admin writes.
+-- One outstanding job per lot. Survives RPC bugs / direct writes.
 CREATE UNIQUE INDEX uq_mc_lot_build_log_one_active_per_lot
     ON mc.lot_build_log (lot_id)
     WHERE apply_state IN (0, 3);
@@ -511,17 +393,9 @@ CREATE INDEX idx_mc_lot_current_schematic
     ON mc.lot (current_schematic_id)
     WHERE current_schematic_id IS NOT NULL;
 
--- Queue table sees state-update churn (queued -> claimed -> applied).
--- apply_state and attempt_count both participate in partial indexes
--- (pending_claim WHERE apply_state=0 AND attempt_count<5, claimed_stale
--- WHERE apply_state=3, failed_recent WHERE apply_state=2,
--- one_active_per_lot WHERE apply_state IN (0,3)) so most state
--- transitions still require index maintenance and are NOT HOT-eligible.
--- fillfactor 80 still pays off: it leaves room on heap pages and reduces
--- page-split pressure under churn even when HOT can't be used. The
--- proper long-term fix for high build traffic is splitting the queue
--- state into a dedicated mc.lot_build_queue table (phase 3).
--- Audit/append-mostly tables stay at the default 100.
+-- apply_state + attempt_count participate in partial indexes so most
+-- transitions aren't HOT-eligible. fillfactor still cuts page splits;
+-- phase-3 queue/audit split is the real high-throughput fix.
 ALTER TABLE mc.lot_build_log SET (
     fillfactor = 80,
     autovacuum_vacuum_scale_factor = 0.02,
@@ -530,9 +404,7 @@ ALTER TABLE mc.lot_build_log SET (
     autovacuum_analyze_threshold = 500
 );
 
--- mc.lot churns too: state cycles 0 -> 1 -> 3 -> 2 -> 4 -> 1, and the
--- updated_at trigger writes on every meaningful column change. Less
--- aggressive than lot_build_log but tighter than the catalog default.
+-- mc.lot state cycles 0->1->3->2->4->1; tighter than catalog default.
 ALTER TABLE mc.lot SET (
     fillfactor = 90,
     autovacuum_vacuum_scale_factor = 0.05,
@@ -541,12 +413,7 @@ ALTER TABLE mc.lot SET (
     autovacuum_analyze_threshold = 250
 );
 
--- Extended statistics for correlated column pairs. The planner
--- otherwise treats (world, state) and (owner_user_id, state) as
--- independent, which under-estimates selectivity on the hot list
--- queries because state distribution is skewed (most rows owned or
--- built, very few transitional). Same idea on the queue: pending +
--- attempt_count are tightly correlated (most rows are 0/applied).
+-- Extended stats for correlated columns (state distribution skewed).
 CREATE STATISTICS st_mc_lot_world_state
     ON world, state
     FROM mc.lot;
@@ -562,7 +429,7 @@ ALTER TABLE mc.lot_build_log ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot_build_log FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.lot_build_log IS
-    'Append-only audit of build/demolish events and concurrent work queue. action_kind: 0=build, 1=demolish. apply_state: 0=queued, 1=applied, 2=failed, 3=claimed. RPC-only: RLS enabled + forced, no policies.';
+    'Audit + work queue. action_kind: 0=build, 1=demolish. apply_state: 0=queued, 1=applied, 2=failed, 3=claimed. RPC-only — RLS forced.';
 COMMENT ON COLUMN mc.lot_build_log.action_kind IS '0=build, 1=demolish';
 COMMENT ON COLUMN mc.lot_build_log.apply_state IS
     '0=queued, 1=applied, 2=failed, 3=claimed (worker holding the row)';
@@ -578,10 +445,8 @@ STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-    -- wallet.account has a partial unique index (kind='user', user_id)
-    -- so at most one row matches; LIMIT 1 was previously defensive but
-    -- masked corruption. Plain scalar subquery surfaces duplicates as a
-    -- "more than one row" runtime error instead.
+    -- wallet.account partial unique (kind='user', user_id) enforces
+    -- single match; no LIMIT 1 so duplicates raise instead of hide.
     SELECT a.id
     FROM wallet.account a
     WHERE a.kind = 'user' AND a.user_id = p_user_id;
@@ -594,11 +459,7 @@ REVOKE ALL ON FUNCTION mc._user_account_id(UUID) FROM PUBLIC, anon, authenticate
 -- ===========================================================================
 -- mc.service_list_lots
 -- ===========================================================================
--- Cursor pagination via four trailing p_after_* args. Default-NULL keeps
--- the legacy LIMIT/OFFSET shape for callers that don't pass a cursor;
--- callers that DO pass (world, chunk_x_min, chunk_z_min, lot_id) of the
--- last row from the prior page get a clean index walk via
--- idx_mc_lot_world_chunk_cursor.
+-- Cursor pagination via trailing p_after_* args; NULL = legacy LIMIT/OFFSET.
 CREATE OR REPLACE FUNCTION mc.service_list_lots(
     p_world TEXT DEFAULT NULL,
     p_state SMALLINT DEFAULT NULL,
@@ -617,6 +478,10 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     chunk_area      INTEGER,
     anchor_y        SMALLINT,
     owner_user_id   UUID,
@@ -639,6 +504,10 @@ AS $$
            l.chunk_x_max,
            l.chunk_z_min,
            l.chunk_z_max,
+           l.block_x_min,
+           l.block_x_max,
+           l.block_z_min,
+           l.block_z_max,
            l.chunk_area,
            l.anchor_y,
            l.owner_user_id,
@@ -699,6 +568,10 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     chunk_area      INTEGER,
     anchor_y        SMALLINT,
     owner_user_id   UUID,
@@ -718,6 +591,8 @@ AS $$
     SELECT l.lot_id, l.world,
            l.chunk_x_min, l.chunk_x_max,
            l.chunk_z_min, l.chunk_z_max,
+           l.block_x_min, l.block_x_max,
+           l.block_z_min, l.block_z_max,
            l.chunk_area, l.anchor_y,
            l.owner_user_id, l.current_schematic_id,
            l.state, l.price_credits, l.price_khash,
@@ -779,10 +654,8 @@ GRANT EXECUTE ON FUNCTION mc.service_list_schematics(TEXT, BOOLEAN)
 -- mc.service_claim_pending_builds — concurrency-safe work claim
 -- ===========================================================================
 --
--- Replaces a plain SELECT of queued rows. Uses FOR UPDATE SKIP LOCKED so
--- multiple MC workers polling at the same time each get a distinct slice,
--- and flips apply_state from 0 → 3 (claimed) in the same statement so a
--- worker death leaves a recoverable claim instead of a lost job.
+-- SKIP LOCKED claim; flips 0 → 3 atomically so worker death leaves a
+-- recoverable claim, not a lost job.
 -- ===========================================================================
 CREATE OR REPLACE FUNCTION mc.service_claim_pending_builds(
     p_worker_id TEXT,
@@ -795,14 +668,15 @@ RETURNS TABLE (
     action_kind     SMALLINT,
     schematic_id    TEXT,
     queued_at       TIMESTAMPTZ,
-    -- Denormalized lot + schematic columns so the worker can start
-    -- applying without follow-up queries. resource_path / dims_* are
-    -- NULL for demolish jobs (LEFT JOIN to mc.schematic).
     world           TEXT,
     chunk_x_min     INTEGER,
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     anchor_y        SMALLINT,
     resource_path   TEXT,
     dims_x          SMALLINT,
@@ -822,34 +696,20 @@ BEGIN
         RAISE EXCEPTION 'worker_id too long (max 128)' USING ERRCODE = '22001';
     END IF;
 
-    -- Pick + claim split into two CTEs:
-    --   picked  — SKIP LOCKED scan of queued rows ordered for fairness;
-    --             cap p_limit at [0, 256] so the dry-poll case (p_limit=0)
-    --             is legitimate.
-    --   claimed — UPDATE ... FROM picked is the more index-friendly
-    --             shape than the older WHERE build_id IN (...) form.
-    -- UPDATE ... RETURNING has no ordering guarantee, so the final SELECT
-    -- re-sorts the batch so workers process in queued order.
+    -- Final ORDER BY because UPDATE...RETURNING is unordered; workers
+    -- process the batch in queued order. p_limit=0 is dry-poll.
     RETURN QUERY
     WITH picked AS (
         SELECT build_id
           FROM mc.lot_build_log
          WHERE apply_state = 0
-           -- Retry budget: skip poison jobs that have already exhausted
-           -- their attempts. The stale-claim janitor never resurrects
-           -- past this cap either, so the row stays queued but dormant
-           -- until an admin retries via service_retry_failed_build.
+           -- Exhausted jobs stay dormant; admin unsticks via retry RPC.
            AND attempt_count < 5
          ORDER BY queued_at, build_id
          LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 32), 256))
          FOR UPDATE SKIP LOCKED
     ),
-    nowish AS (
-        -- One clock_timestamp() reading shared by claimed_at and
-        -- last_attempt_at; avoids the multi-microsecond drift the
-        -- old shape introduced.
-        SELECT clock_timestamp() AS ts
-    ),
+    nowish AS (SELECT clock_timestamp() AS ts),
     claimed AS (
         UPDATE mc.lot_build_log b
            SET apply_state     = 3,
@@ -862,13 +722,13 @@ BEGIN
         RETURNING b.build_id, b.lot_id, b.actor_user_id,
                   b.action_kind, b.schematic_id, b.queued_at
     )
-    -- Denormalize the claim with lot + schematic data so workers don't
-    -- need follow-up queries to start applying. schematic_id is NULL
-    -- on demolish jobs, so the schematic join is LEFT.
+    -- Denormalize lot + schematic so workers skip follow-up reads.
     SELECT c.build_id, c.lot_id, c.actor_user_id, c.action_kind,
            c.schematic_id, c.queued_at,
            l.world, l.chunk_x_min, l.chunk_x_max,
-           l.chunk_z_min, l.chunk_z_max, l.anchor_y,
+           l.chunk_z_min, l.chunk_z_max,
+           l.block_x_min, l.block_x_max,
+           l.block_z_min, l.block_z_max, l.anchor_y,
            s.resource_path, s.dims_x, s.dims_y, s.dims_z
       FROM claimed c
       JOIN mc.lot l ON l.lot_id = c.lot_id
@@ -899,12 +759,9 @@ LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-    -- Two-bucket recovery so a stale claim with attempt_count >= 5 can't
-    -- become an invisible blocker (it would be queued but excluded by
-    -- the partial pending-claim index, and still occupy the partial
-    -- one-active-per-lot unique slot). Under-cap rows go back to
-    -- queued; at-cap rows transition to failed and the lot is released
-    -- to its prior settled state (built or owned).
+    -- Under-cap stale claims requeue; at-cap stale claims fail and
+    -- release the lot — prevents poisoned rows from blocking via
+    -- the partial one-active-per-lot unique slot.
     WITH picked AS (
         SELECT build_id, lot_id, action_kind, attempt_count
           FROM mc.lot_build_log
@@ -939,13 +796,12 @@ AS $$
            AND p.attempt_count >= 5
         RETURNING b.lot_id, b.action_kind
     ),
-    -- Release the lot back to its settled state so a new build can
-    -- queue. We don't know the exact prior state, so the same
-    -- heuristic the failure ACK uses applies: schematic_id present
-    -- => built (2), else owned (1).
+    -- Release lot: demolish failures → built (2); build failures use
+    -- schematic heuristic.
     released AS (
         UPDATE mc.lot l
            SET state = CASE
+                  WHEN e.action_kind = 1 THEN 2
                   WHEN l.current_schematic_id IS NULL THEN 1
                   ELSE 2
                END
@@ -995,8 +851,7 @@ BEGIN
         RAISE EXCEPTION 'worker_id too long (max 128)' USING ERRCODE = '22001';
     END IF;
 
-    -- Only the worker that holds the claim may ACK it. Prevents a stale
-    -- or wrong worker from finalizing another worker's job.
+    -- Worker-bound ACK: claimed_by must match.
     UPDATE mc.lot_build_log
        SET apply_state = 1,
            applied_at = clock_timestamp(),
@@ -1062,8 +917,9 @@ SET search_path = ''
 COST 100
 AS $$
 DECLARE
-    v_lot_id   TEXT;
-    v_rowcount INTEGER;
+    v_lot_id      TEXT;
+    v_action_kind SMALLINT;
+    v_rowcount    INTEGER;
 BEGIN
     IF p_build_id IS NULL OR btrim(p_build_id) = '' THEN
         RAISE EXCEPTION 'build_id cannot be empty' USING ERRCODE = '22004';
@@ -1077,13 +933,9 @@ BEGIN
 
     UPDATE mc.lot_build_log
        SET apply_state = 2,
-           -- Always carry SOME diagnostic string so operators reading
-           -- the row aren't left guessing on null/blank input.
            apply_error = left(
                COALESCE(NULLIF(btrim(p_error), ''), 'worker reported failure'),
                2048),
-           -- Distinct timestamp from applied_at so dashboards can tell
-           -- 'finished cleanly' from 'gave up' without inspecting state.
            failed_at = clock_timestamp(),
            applied_at = NULL,
            claimed_at = NULL,
@@ -1091,14 +943,18 @@ BEGIN
      WHERE build_id = p_build_id
        AND apply_state = 3
        AND claimed_by = p_worker_id
-    RETURNING lot_id INTO v_lot_id;
+    RETURNING lot_id, action_kind INTO v_lot_id, v_action_kind;
 
     IF NOT FOUND THEN
         RETURN FALSE;
     END IF;
 
     UPDATE mc.lot
-       SET state = CASE WHEN current_schematic_id IS NULL THEN 1 ELSE 2 END
+       SET state = CASE
+              WHEN v_action_kind = 1 THEN 2
+              WHEN current_schematic_id IS NULL THEN 1
+              ELSE 2
+           END
      WHERE lot_id = v_lot_id
        AND state IN (3, 4);
     GET DIAGNOSTICS v_rowcount = ROW_COUNT;
@@ -1157,17 +1013,10 @@ BEGIN
         RAISE EXCEPTION 'idempotency_key cannot be null' USING ERRCODE = '22004';
     END IF;
 
-    -- Serialize concurrent retries on the same idempotency_key. Without
-    -- the lock two identical requests can both miss the existing-key
-    -- check, then one inserts cleanly and the other tries the lot-state
-    -- path and surfaces a confusing "lot not vacant" error instead of
-    -- collapsing to the original purchase row. Namespace the lock key
-    -- so a caller that reuses the same idempotency_key across purchase,
-    -- build, and demolish doesn't accidentally cross-block.
+    -- Advisory lock: serialize same-key retries before the existing-row
+    -- check; namespace by op so cross-op key reuse doesn't deadlock.
     PERFORM pg_advisory_xact_lock(hashtextextended('mc.purchase:' || p_idempotency_key::text, 0));
 
-    -- Idempotent replay: existing key must match the original parameters,
-    -- otherwise the caller is reusing a key for a different request.
     SELECT purchase_id, lot_id, buyer_user_id
       INTO v_existing_purchase_id, v_existing_lot, v_existing_buyer
       FROM mc.lot_purchase
@@ -1310,8 +1159,6 @@ BEGIN
         RAISE EXCEPTION 'idempotency_key cannot be null' USING ERRCODE = '22004';
     END IF;
 
-    -- Serialize concurrent retries on the same idempotency_key. See the
-    -- matching note in service_purchase_lot.
     PERFORM pg_advisory_xact_lock(hashtextextended('mc.build:' || p_idempotency_key::text, 0));
 
     SELECT build_id, lot_id, schematic_id, actor_user_id
@@ -1330,8 +1177,8 @@ BEGIN
 
     SELECT owner_user_id, state, anchor_y,
            chunk_area,
-           chunk_width * 16,
-           chunk_depth * 16
+           block_x_max - block_x_min + 1,
+           block_z_max - block_z_min + 1
       INTO v_lot_owner, v_lot_state, v_lot_anchor_y,
            v_lot_chunk_area,
            v_lot_dx_blocks,
@@ -1377,8 +1224,7 @@ BEGIN
             p_schematic_id, v_lot_anchor_y USING ERRCODE = '22023';
     END IF;
 
-    -- Phase-0 chunk-count guard. Lifted in a follow-up migration once the
-    -- tick-chunked paste pipeline is proven stable.
+    -- Phase-0 cap; lifted once tick-chunked paste pipeline is stable.
     IF v_lot_chunk_area > 64 THEN
         RAISE EXCEPTION 'lot % exceeds phase-0 build cap (chunks=%, max=64)',
             p_lot_id, v_lot_chunk_area USING ERRCODE = '22023';
@@ -1415,11 +1261,8 @@ BEGIN
         );
     END IF;
 
-    -- The partial uq_mc_lot_build_log_one_active_per_lot index turns a
-    -- concurrent second queue attempt into a unique_violation. Translate
-    -- ONLY that constraint into the domain error; an idempotency-key
-    -- collision (different mc_lot_build_log_idem_uq constraint) must
-    -- re-raise so the caller sees a distinct error.
+    -- Concurrent second queue surfaces as unique_violation on the
+    -- partial active-per-lot index; map only that, re-raise others.
     BEGIN
         INSERT INTO mc.lot_build_log (
             lot_id, actor_user_id, action_kind, schematic_id,
@@ -1446,8 +1289,6 @@ BEGIN
         END;
     END;
 
-    -- Self-validating transition: defense-in-depth in case a future
-    -- refactor weakens the earlier FOR UPDATE + state guard.
     DECLARE v_rowcount INTEGER;
     BEGIN
         UPDATE mc.lot
@@ -1605,6 +1446,10 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     chunk_area      INTEGER,
     anchor_y        SMALLINT,
     owner_user_id   UUID,
@@ -1620,12 +1465,6 @@ SECURITY DEFINER
 SET search_path = ''
 ROWS 256
 AS $$
-    -- LANGUAGE sql so the planner sees the body directly instead of going
-    -- through a plpgsql RETURN QUERY layer. auth.uid() is called once via
-    -- the CROSS JOIN so the equality survives function inlining cleanly.
-    -- Keyset pagination via trailing p_after_* args: when supplied, the
-    -- (world, chunk_x_min, chunk_z_min, lot_id) tuple comparison walks
-    -- idx_mc_lot_world_chunk_cursor directly.
     WITH me AS (SELECT auth.uid() AS uid)
     SELECT l.lot_id,
            l.world,
@@ -1633,6 +1472,10 @@ AS $$
            l.chunk_x_max,
            l.chunk_z_min,
            l.chunk_z_max,
+           l.block_x_min,
+           l.block_x_max,
+           l.block_z_min,
+           l.block_z_max,
            l.chunk_area,
            l.anchor_y,
            l.owner_user_id,
@@ -1805,6 +1648,10 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     chunk_area      INTEGER,
     anchor_y        SMALLINT,
     owner_user_id   UUID,
@@ -1821,10 +1668,7 @@ SET search_path = ''
 ROWS 256
 AS $$
 BEGIN
-    -- Generic list has a four-field cursor (world + chunk_x + chunk_z +
-    -- lot_id). All-or-none, otherwise a malformed client cursor would
-    -- silently return zero rows from the SQL-level guard inside
-    -- mc.proxy_list_lots and hide the bug.
+    -- Four-field cursor all-or-none; partial cursor would silent-empty.
     IF p_after_lot_id IS NOT NULL
        AND (p_after_world IS NULL
             OR p_after_chunk_x IS NULL
@@ -1997,6 +1841,10 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     anchor_y        SMALLINT,
     resource_path   TEXT,
     dims_x          SMALLINT,
@@ -2115,9 +1963,7 @@ BEGIN
         RAISE EXCEPTION 'build_id cannot be empty' USING ERRCODE = '22004';
     END IF;
 
-    -- Failure ACK already flipped the lot back to its settled state, so
-    -- the retried job's ACK path (which expects state = 3 for builds /
-    -- state = 4 for demolishes) would fail. Pre-flight the lot here.
+    -- Restore lot to 3/4 so the next worker ACK can proceed.
     SELECT lot_id, action_kind
       INTO v_lot_id, v_action_kind
       FROM mc.lot_build_log
@@ -2292,6 +2138,10 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     chunk_area      INTEGER,
     anchor_y        SMALLINT,
     owner_user_id   UUID,
@@ -2321,12 +2171,8 @@ COMMENT ON FUNCTION public.proxy_service_get_lot(TEXT) IS
 -- ===========================================================================
 -- HOT-PATH LIST RPCs — dedicated wrappers for the two most common reads
 -- ===========================================================================
--- The generic list_lots() uses optional OR predicates, which can make the
--- planner pick the broad cursor index instead of the narrower partial
--- indexes (idx_mc_lot_vacant_*, idx_mc_lot_owner_active_*). These two
--- wrappers hard-code the state predicate so the partial indexes are the
--- only viable plan. Same cursor convention (chunk_x, chunk_z, lot_id),
--- but world is fixed by p_world so it isn't part of the cursor tuple.
+-- Hard-coded state predicates so partial indexes are the only plan.
+-- world fixed by p_world; cursor only carries (chunk_x, chunk_z, lot_id).
 
 CREATE OR REPLACE FUNCTION public.proxy_list_vacant_lots(
     p_world TEXT,
@@ -2611,6 +2457,10 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    block_x_min     INTEGER,
+    block_x_max     INTEGER,
+    block_z_min     INTEGER,
+    block_z_max     INTEGER,
     chunk_area      INTEGER,
     anchor_y        SMALLINT,
     is_owned        BOOLEAN,
@@ -2646,6 +2496,8 @@ BEGIN
     SELECT r.lot_id, r.world,
            r.chunk_x_min, r.chunk_x_max,
            r.chunk_z_min, r.chunk_z_max,
+           r.block_x_min, r.block_x_max,
+           r.block_z_min, r.block_z_max,
            r.chunk_area, r.anchor_y,
            (r.owner_user_id IS NOT NULL) AS is_owned,
            r.is_owned_by_me,

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -192,9 +192,28 @@ CREATE TABLE mc.lot (
         (state = 0 AND owner_user_id IS NULL)
         OR (state > 0 AND owner_user_id IS NOT NULL)
     ),
+    -- Schematic presence per state:
+    --   0 vacant       — no schematic (and no owner; see vacant_clean_chk).
+    --   1 owned        — no schematic (clean lot, no build yet).
+    --   2 built        — schematic NOT NULL.
+    --   3 under_build  — schematic free (rebuild flow may carry the
+    --                    prior schematic; first build starts NULL).
+    --   4 demolishing  — schematic NOT NULL (target row of the clear).
     CONSTRAINT mc_lot_built_has_schematic_chk CHECK (
-        (state = 2 AND current_schematic_id IS NOT NULL)
-        OR state <> 2
+        CASE state
+            WHEN 0 THEN current_schematic_id IS NULL
+            WHEN 1 THEN current_schematic_id IS NULL
+            WHEN 2 THEN current_schematic_id IS NOT NULL
+            WHEN 4 THEN current_schematic_id IS NOT NULL
+            ELSE TRUE  -- state=3 unconstrained
+        END
+    ),
+    -- Vacant lots have no owner. state=0 + owner combos slipped through
+    -- the broader owner_state_chk because that check allowed state>0
+    -- with non-null owner; this is the stricter inverse for state=0.
+    CONSTRAINT mc_lot_vacant_clean_chk CHECK (
+        state <> 0
+        OR (owner_user_id IS NULL AND current_schematic_id IS NULL)
     ),
 
     CONSTRAINT mc_lot_no_overlap_excl EXCLUDE USING gist (
@@ -311,7 +330,6 @@ CREATE TABLE mc.lot_purchase (
     CONSTRAINT mc_lot_purchase_idem_uq UNIQUE (idempotency_key)
 );
 
-CREATE INDEX idx_mc_lot_purchase_lot   ON mc.lot_purchase (lot_id);
 -- Dashboard "my purchase history" sorts newest first; composite avoids
 -- a sort step.
 CREATE INDEX idx_mc_lot_purchase_buyer_created
@@ -319,6 +337,9 @@ CREATE INDEX idx_mc_lot_purchase_buyer_created
 
 -- Phase-0 invariant: each lot can be bought exactly once. Resale comes
 -- with an explicit ownership-epoch column in a follow-up migration.
+-- This unique index also covers the lookup-by-lot path; no separate
+-- non-unique idx_mc_lot_purchase_lot needed (would just be write
+-- amplification).
 CREATE UNIQUE INDEX uq_mc_lot_purchase_one_per_lot
     ON mc.lot_purchase (lot_id);
 
@@ -372,6 +393,17 @@ CREATE TABLE mc.lot_build_log (
         (price_khash = 0 AND wallet_khash_ledger_id IS NULL)
         OR (price_khash > 0 AND wallet_khash_ledger_id IS NOT NULL)
     ),
+    -- Demolish is always free in phase 0: action_kind=1 cannot carry a
+    -- schematic, price, or ledger ref. Locking this in at the table
+    -- level so a future RPC change can't silently break the invariant.
+    CONSTRAINT mc_lot_build_log_demolish_free_chk CHECK (
+        action_kind <> 1
+        OR (schematic_id IS NULL
+            AND price_credits = 0
+            AND price_khash = 0
+            AND wallet_credits_ledger_id IS NULL
+            AND wallet_khash_ledger_id IS NULL)
+    ),
     -- Claimed state must carry full worker identity; non-claimed states
     -- must not.
     CONSTRAINT mc_lot_build_log_claimed_consistency_chk
@@ -422,6 +454,17 @@ ALTER TABLE mc.lot_build_log SET (
     autovacuum_analyze_scale_factor = 0.01,
     autovacuum_vacuum_threshold = 1000,
     autovacuum_analyze_threshold = 500
+);
+
+-- mc.lot churns too: state cycles 0 -> 1 -> 3 -> 2 -> 4 -> 1, and the
+-- updated_at trigger writes on every meaningful column change. Less
+-- aggressive than lot_build_log but tighter than the catalog default.
+ALTER TABLE mc.lot SET (
+    fillfactor = 90,
+    autovacuum_vacuum_scale_factor = 0.05,
+    autovacuum_analyze_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 500,
+    autovacuum_analyze_threshold = 250
 );
 
 ALTER TABLE mc.lot_build_log ENABLE ROW LEVEL SECURITY;
@@ -531,12 +574,12 @@ AS $$
           )
       )
     ORDER BY l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id
-    LIMIT GREATEST(0, LEAST(p_limit, 1024))
+    LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 256), 1024))
     -- OFFSET preserved only for the non-cursor path; cursor callers
     -- should pass 0. Capped at 100000 so a pathological admin call
     -- can't request a multi-million-row deep scan.
     OFFSET CASE
-        WHEN p_after_lot_id IS NULL THEN LEAST(GREATEST(0, p_offset), 100000)
+        WHEN p_after_lot_id IS NULL THEN LEAST(GREATEST(0, COALESCE(p_offset, 0)), 100000)
         ELSE 0
     END;
 $$;
@@ -643,7 +686,7 @@ BEGIN
           FROM mc.lot_build_log
          WHERE apply_state = 0
          ORDER BY queued_at, build_id
-         LIMIT GREATEST(0, LEAST(p_limit, 256))
+         LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 32), 256))
          FOR UPDATE SKIP LOCKED
     ),
     claimed AS (
@@ -693,9 +736,9 @@ AS $$
            -- estimates).
            AND claimed_at < clock_timestamp()
                           - make_interval(secs =>
-                              LEAST(GREATEST(1, p_older_than_seconds), 86400))
+                              LEAST(GREATEST(1, COALESCE(p_older_than_seconds, 300)), 86400))
          ORDER BY claimed_at, build_id
-         LIMIT GREATEST(0, LEAST(p_limit, 512))
+         LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 128), 512))
          FOR UPDATE SKIP LOCKED
     ),
     stale AS (
@@ -828,7 +871,11 @@ BEGIN
 
     UPDATE mc.lot_build_log
        SET apply_state = 2,
-           apply_error = left(p_error, 2048),
+           -- Always carry SOME diagnostic string so operators reading
+           -- the row aren't left guessing on null/blank input.
+           apply_error = left(
+               COALESCE(NULLIF(btrim(p_error), ''), 'worker reported failure'),
+               2048),
            applied_at = clock_timestamp(),
            claimed_at = NULL,
            claimed_by = NULL
@@ -1148,18 +1195,26 @@ BEGIN
         );
     END IF;
 
-    INSERT INTO mc.lot_build_log (
-        lot_id, actor_user_id, action_kind, schematic_id,
-        price_credits, price_khash,
-        wallet_credits_ledger_id, wallet_khash_ledger_id,
-        idempotency_key
-    ) VALUES (
-        p_lot_id, p_user_id, 0, p_schematic_id,
-        v_sch_price_credits, v_sch_price_khash,
-        v_credits_ledger_id, v_khash_ledger_id,
-        p_idempotency_key
-    )
-    RETURNING build_id INTO v_build_id;
+    -- The partial uq_mc_lot_build_log_one_active_per_lot index turns a
+    -- concurrent second queue attempt into a unique_violation. Translate
+    -- to a clearer domain error.
+    BEGIN
+        INSERT INTO mc.lot_build_log (
+            lot_id, actor_user_id, action_kind, schematic_id,
+            price_credits, price_khash,
+            wallet_credits_ledger_id, wallet_khash_ledger_id,
+            idempotency_key
+        ) VALUES (
+            p_lot_id, p_user_id, 0, p_schematic_id,
+            v_sch_price_credits, v_sch_price_khash,
+            v_credits_ledger_id, v_khash_ledger_id,
+            p_idempotency_key
+        )
+        RETURNING build_id INTO v_build_id;
+    EXCEPTION WHEN unique_violation THEN
+        RAISE EXCEPTION 'lot % already has an active queued/claimed job', p_lot_id
+            USING ERRCODE = '23505';
+    END;
 
     UPDATE mc.lot SET state = 3 WHERE lot_id = p_lot_id;
 
@@ -1240,12 +1295,17 @@ BEGIN
             p_lot_id, v_lot_state USING ERRCODE = '22023';
     END IF;
 
-    INSERT INTO mc.lot_build_log (
-        lot_id, actor_user_id, action_kind, schematic_id, idempotency_key
-    ) VALUES (
-        p_lot_id, p_user_id, 1, NULL, p_idempotency_key
-    )
-    RETURNING build_id INTO v_build_id;
+    BEGIN
+        INSERT INTO mc.lot_build_log (
+            lot_id, actor_user_id, action_kind, schematic_id, idempotency_key
+        ) VALUES (
+            p_lot_id, p_user_id, 1, NULL, p_idempotency_key
+        )
+        RETURNING build_id INTO v_build_id;
+    EXCEPTION WHEN unique_violation THEN
+        RAISE EXCEPTION 'lot % already has an active queued/claimed job', p_lot_id
+            USING ERRCODE = '23505';
+    END;
 
     UPDATE mc.lot SET state = 4 WHERE lot_id = p_lot_id;
 
@@ -1332,9 +1392,9 @@ AS $$
           )
       )
     ORDER BY l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id
-    LIMIT GREATEST(0, LEAST(p_limit, 1024))
+    LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 256), 1024))
     OFFSET CASE
-        WHEN p_after_lot_id IS NULL THEN LEAST(GREATEST(0, p_offset), 100000)
+        WHEN p_after_lot_id IS NULL THEN LEAST(GREATEST(0, COALESCE(p_offset, 0)), 100000)
         ELSE 0
     END;
 $$;
@@ -1745,12 +1805,30 @@ RETURNS TABLE (
     price_credits   BIGINT,
     price_khash     BIGINT
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 ROWS 256
 AS $$
+BEGIN
+    IF p_world IS NULL OR btrim(p_world) = '' THEN
+        RAISE EXCEPTION 'world cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF p_world !~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$' THEN
+        RAISE EXCEPTION 'invalid world format' USING ERRCODE = '22023';
+    END IF;
+    -- Cursor all-or-none. world is already pinned via p_world so it
+    -- doesn't enter the cursor tuple; the three remaining cursor args
+    -- must agree on null-ness.
+    IF (p_after_lot_id IS NULL) <> (p_after_chunk_x IS NULL OR p_after_chunk_z IS NULL)
+       OR (p_after_lot_id IS NOT NULL
+           AND (p_after_chunk_x IS NULL OR p_after_chunk_z IS NULL)) THEN
+        RAISE EXCEPTION 'cursor must include after_chunk_x, after_chunk_z, and after_lot_id together'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RETURN QUERY
     SELECT l.lot_id,
            l.chunk_x_min, l.chunk_x_max,
            l.chunk_z_min, l.chunk_z_max,
@@ -1763,15 +1841,12 @@ AS $$
       AND l.world = p_world
       AND (
           p_after_lot_id IS NULL
-          OR (
-              p_after_chunk_x IS NOT NULL
-              AND p_after_chunk_z IS NOT NULL
-              AND (l.chunk_x_min, l.chunk_z_min, l.lot_id)
-                  > (p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
-          )
+          OR (l.chunk_x_min, l.chunk_z_min, l.lot_id)
+             > (p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
       )
     ORDER BY l.chunk_x_min, l.chunk_z_min, l.lot_id
-    LIMIT GREATEST(0, LEAST(p_limit, 1024));
+    LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 256), 1024));
+END;
 $$;
 
 ALTER FUNCTION public.proxy_list_vacant_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)
@@ -1804,13 +1879,36 @@ RETURNS TABLE (
     price_credits   BIGINT,
     price_khash     BIGINT
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 ROWS 256
 AS $$
-    WITH me AS (SELECT auth.uid() AS uid)
+DECLARE
+    v_uid UUID := auth.uid();
+BEGIN
+    IF v_uid IS NULL THEN
+        RAISE EXCEPTION 'not authenticated' USING ERRCODE = '42501';
+    END IF;
+    IF p_world IS NULL OR btrim(p_world) = '' THEN
+        RAISE EXCEPTION 'world cannot be empty' USING ERRCODE = '22004';
+    END IF;
+    IF p_world !~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$' THEN
+        RAISE EXCEPTION 'invalid world format' USING ERRCODE = '22023';
+    END IF;
+    IF p_after_lot_id IS NOT NULL
+       AND (p_after_chunk_x IS NULL OR p_after_chunk_z IS NULL) THEN
+        RAISE EXCEPTION 'cursor must include after_chunk_x, after_chunk_z, and after_lot_id together'
+            USING ERRCODE = '22023';
+    END IF;
+    IF p_after_lot_id IS NULL
+       AND (p_after_chunk_x IS NOT NULL OR p_after_chunk_z IS NOT NULL) THEN
+        RAISE EXCEPTION 'cursor must include after_chunk_x, after_chunk_z, and after_lot_id together'
+            USING ERRCODE = '22023';
+    END IF;
+
+    RETURN QUERY
     SELECT l.lot_id,
            l.chunk_x_min, l.chunk_x_max,
            l.chunk_z_min, l.chunk_z_max,
@@ -1820,22 +1918,18 @@ AS $$
            l.current_schematic_id,
            l.price_credits,
            l.price_khash
-    FROM mc.lot l, me
-    WHERE me.uid IS NOT NULL
-      AND l.owner_user_id = me.uid
+    FROM mc.lot l
+    WHERE l.owner_user_id = v_uid
       AND l.state IN (1, 2)
       AND l.world = p_world
       AND (
           p_after_lot_id IS NULL
-          OR (
-              p_after_chunk_x IS NOT NULL
-              AND p_after_chunk_z IS NOT NULL
-              AND (l.chunk_x_min, l.chunk_z_min, l.lot_id)
-                  > (p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
-          )
+          OR (l.chunk_x_min, l.chunk_z_min, l.lot_id)
+             > (p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
       )
     ORDER BY l.chunk_x_min, l.chunk_z_min, l.lot_id
-    LIMIT GREATEST(0, LEAST(p_limit, 1024));
+    LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 256), 1024));
+END;
 $$;
 
 ALTER FUNCTION public.proxy_list_my_active_lots(TEXT, INTEGER, INTEGER, INTEGER, TEXT)

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -19,6 +19,19 @@ GRANT USAGE ON SCHEMA mc TO service_role;
 REVOKE ALL ON SCHEMA mc FROM PUBLIC, anon, authenticated;
 
 
+-- State domains: centralize enum bounds so RPCs/CHECKs don't drift
+-- from each other when ranges expand. Storage stays SMALLINT.
+CREATE DOMAIN mc.lot_state AS SMALLINT
+    CHECK (VALUE BETWEEN 0 AND 4);
+CREATE DOMAIN mc.build_action_kind AS SMALLINT
+    CHECK (VALUE IN (0, 1));
+CREATE DOMAIN mc.build_apply_state AS SMALLINT
+    CHECK (VALUE BETWEEN 0 AND 3);
+ALTER DOMAIN mc.lot_state OWNER TO postgres;
+ALTER DOMAIN mc.build_action_kind OWNER TO postgres;
+ALTER DOMAIN mc.build_apply_state OWNER TO postgres;
+
+
 -- mc._derive_idem_key — wallet.service_debit treats (account,
 -- idempotency_key) as the uniqueness scope; dual-currency charges
 -- need a stable per-currency UUID so credits + khash don't collide.
@@ -117,14 +130,18 @@ CREATE TABLE mc.lot (
     owner_user_id   UUID REFERENCES auth.users(id) ON DELETE RESTRICT,
     current_schematic_id TEXT REFERENCES mc.schematic(schematic_id),
     -- 0 = vacant, 1 = owned, 2 = built, 3 = under_build, 4 = demolishing
-    state           SMALLINT NOT NULL DEFAULT 0,
+    state           mc.lot_state NOT NULL DEFAULT 0,
+    -- Bitfield for non-lifecycle attributes (admin_reserved, featured,
+    -- no_demolish, no_transfer, market_visible…). Phase-0 leaves bits
+    -- undefined; flags=0 = normal lot.
+    flags           INTEGER NOT NULL DEFAULT 0,
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT mc_lot_id_chk         CHECK (lot_id ~ '^[A-Za-z0-9:_-]{3,96}$'),
-    CONSTRAINT mc_lot_state_chk      CHECK (state BETWEEN 0 AND 4),
+    CONSTRAINT mc_lot_flags_chk      CHECK (flags >= 0),
     CONSTRAINT mc_lot_anchor_y_chk   CHECK (anchor_y BETWEEN -64 AND 319),
     CONSTRAINT mc_lot_price_chk      CHECK (price_credits >= 0 AND price_khash >= 0),
     CONSTRAINT mc_lot_x_range_chk    CHECK (NOT isempty(chunk_x_range)
@@ -297,15 +314,20 @@ CREATE TABLE mc.lot_build_log (
     lot_id          TEXT NOT NULL REFERENCES mc.lot(lot_id) ON DELETE CASCADE,
     actor_user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     -- 0 = build, 1 = demolish
-    action_kind     SMALLINT NOT NULL,
+    action_kind     mc.build_action_kind NOT NULL,
     schematic_id    TEXT REFERENCES mc.schematic(schematic_id),
+    -- Pre-queue snapshot of the lot. failure recovery / retry uses
+    -- these instead of the current_schematic_id heuristic so concurrent
+    -- successful builds in between don't get rolled back accidentally.
+    lot_state_before    mc.lot_state,
+    schematic_id_before TEXT REFERENCES mc.schematic(schematic_id),
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
     wallet_credits_ledger_id BIGINT,
     wallet_khash_ledger_id   BIGINT,
     idempotency_key UUID NOT NULL,
     -- 0 = queued, 1 = applied, 2 = failed, 3 = claimed (worker holding it)
-    apply_state     SMALLINT NOT NULL DEFAULT 0,
+    apply_state     mc.build_apply_state NOT NULL DEFAULT 0,
     apply_error     TEXT,
     claimed_at      TIMESTAMPTZ,
     claimed_by      TEXT,
@@ -316,10 +338,6 @@ CREATE TABLE mc.lot_build_log (
     attempt_count   INTEGER NOT NULL DEFAULT 0,
     last_attempt_at TIMESTAMPTZ,
 
-    CONSTRAINT mc_lot_build_log_action_chk
-        CHECK (action_kind IN (0, 1)),
-    CONSTRAINT mc_lot_build_log_apply_state_chk
-        CHECK (apply_state BETWEEN 0 AND 3),
     CONSTRAINT mc_lot_build_log_build_has_schematic_chk
         CHECK ((action_kind = 0 AND schematic_id IS NOT NULL)
             OR (action_kind = 1)),
@@ -366,9 +384,11 @@ CREATE INDEX idx_mc_lot_build_log_actor_queued
     INCLUDE (lot_id, action_kind, schematic_id, apply_state,
              failed_at, applied_at, attempt_count);
 -- Worker claim path. attempt_count predicate mirrors claim WHERE so
--- exhausted rows drop out of the index.
+-- exhausted rows drop out of the index. INCLUDE'd columns cut heap
+-- fetches for the picked/claimed pipeline.
 CREATE INDEX idx_mc_lot_build_log_pending_claim
     ON mc.lot_build_log (queued_at, build_id)
+    INCLUDE (lot_id, actor_user_id, action_kind, schematic_id)
     WHERE apply_state = 0 AND attempt_count < 5;
 -- Stale-claim janitor scan.
 CREATE INDEX idx_mc_lot_build_log_claimed_stale
@@ -763,7 +783,7 @@ AS $$
     -- release the lot — prevents poisoned rows from blocking via
     -- the partial one-active-per-lot unique slot.
     WITH picked AS (
-        SELECT build_id, lot_id, action_kind, attempt_count
+        SELECT build_id, lot_id, action_kind, attempt_count, lot_state_before
           FROM mc.lot_build_log
          WHERE apply_state = 3
            AND claimed_at IS NOT NULL
@@ -794,13 +814,14 @@ AS $$
           FROM picked p
          WHERE b.build_id = p.build_id
            AND p.attempt_count >= 5
-        RETURNING b.lot_id, b.action_kind
+        RETURNING b.lot_id, b.action_kind, b.lot_state_before
     ),
-    -- Release lot: demolish failures → built (2); build failures use
-    -- schematic heuristic.
+    -- Release lot: snapshot wins; else demolish → built (2), build
+    -- uses schematic heuristic.
     released AS (
         UPDATE mc.lot l
            SET state = CASE
+                  WHEN e.lot_state_before IS NOT NULL THEN e.lot_state_before
                   WHEN e.action_kind = 1 THEN 2
                   WHEN l.current_schematic_id IS NULL THEN 1
                   ELSE 2
@@ -917,9 +938,10 @@ SET search_path = ''
 COST 100
 AS $$
 DECLARE
-    v_lot_id      TEXT;
-    v_action_kind SMALLINT;
-    v_rowcount    INTEGER;
+    v_lot_id            TEXT;
+    v_action_kind       SMALLINT;
+    v_lot_state_before  SMALLINT;
+    v_rowcount          INTEGER;
 BEGIN
     IF p_build_id IS NULL OR btrim(p_build_id) = '' THEN
         RAISE EXCEPTION 'build_id cannot be empty' USING ERRCODE = '22004';
@@ -943,14 +965,19 @@ BEGIN
      WHERE build_id = p_build_id
        AND apply_state = 3
        AND claimed_by = p_worker_id
-    RETURNING lot_id, action_kind INTO v_lot_id, v_action_kind;
+    RETURNING lot_id, action_kind, lot_state_before
+        INTO v_lot_id, v_action_kind, v_lot_state_before;
 
     IF NOT FOUND THEN
         RETURN FALSE;
     END IF;
 
+    -- Restore to the snapshot if it was preserved; else fall back to
+    -- the schematic heuristic (rows queued before lot_state_before
+    -- existed).
     UPDATE mc.lot
        SET state = CASE
+              WHEN v_lot_state_before IS NOT NULL THEN v_lot_state_before
               WHEN v_action_kind = 1 THEN 2
               WHEN current_schematic_id IS NULL THEN 1
               ELSE 2
@@ -1131,6 +1158,7 @@ DECLARE
     v_existing_actor       UUID;
     v_lot_owner            UUID;
     v_lot_state            SMALLINT;
+    v_lot_schematic_before TEXT;
     v_lot_anchor_y         SMALLINT;
     v_lot_chunk_area       INTEGER;
     v_lot_dx_blocks        INTEGER;
@@ -1175,11 +1203,11 @@ BEGIN
         RETURN v_existing_build_id;
     END IF;
 
-    SELECT owner_user_id, state, anchor_y,
+    SELECT owner_user_id, state, current_schematic_id, anchor_y,
            chunk_area,
            block_x_max - block_x_min + 1,
            block_z_max - block_z_min + 1
-      INTO v_lot_owner, v_lot_state, v_lot_anchor_y,
+      INTO v_lot_owner, v_lot_state, v_lot_schematic_before, v_lot_anchor_y,
            v_lot_chunk_area,
            v_lot_dx_blocks,
            v_lot_dz_blocks
@@ -1266,11 +1294,13 @@ BEGIN
     BEGIN
         INSERT INTO mc.lot_build_log (
             lot_id, actor_user_id, action_kind, schematic_id,
+            lot_state_before, schematic_id_before,
             price_credits, price_khash,
             wallet_credits_ledger_id, wallet_khash_ledger_id,
             idempotency_key
         ) VALUES (
             p_lot_id, p_user_id, 0, p_schematic_id,
+            v_lot_state, v_lot_schematic_before,
             v_sch_price_credits, v_sch_price_khash,
             v_credits_ledger_id, v_khash_ledger_id,
             p_idempotency_key
@@ -1335,6 +1365,7 @@ DECLARE
     v_existing_action      SMALLINT;
     v_lot_owner            UUID;
     v_lot_state            SMALLINT;
+    v_lot_schematic_before TEXT;
     v_build_id             TEXT;
 BEGIN
     IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
@@ -1363,8 +1394,8 @@ BEGIN
         RETURN v_existing_build_id;
     END IF;
 
-    SELECT owner_user_id, state
-      INTO v_lot_owner, v_lot_state
+    SELECT owner_user_id, state, current_schematic_id
+      INTO v_lot_owner, v_lot_state, v_lot_schematic_before
       FROM mc.lot
      WHERE lot_id = p_lot_id
      FOR UPDATE;
@@ -1382,9 +1413,13 @@ BEGIN
 
     BEGIN
         INSERT INTO mc.lot_build_log (
-            lot_id, actor_user_id, action_kind, schematic_id, idempotency_key
+            lot_id, actor_user_id, action_kind, schematic_id,
+            lot_state_before, schematic_id_before,
+            idempotency_key
         ) VALUES (
-            p_lot_id, p_user_id, 1, NULL, p_idempotency_key
+            p_lot_id, p_user_id, 1, NULL,
+            v_lot_state, v_lot_schematic_before,
+            p_idempotency_key
         )
         RETURNING build_id INTO v_build_id;
     EXCEPTION WHEN unique_violation THEN
@@ -1955,17 +1990,19 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-    v_lot_id TEXT;
-    v_action_kind SMALLINT;
-    v_rowcount INTEGER;
+    v_lot_id              TEXT;
+    v_action_kind         SMALLINT;
+    v_schematic_id        TEXT;
+    v_schematic_id_before TEXT;
+    v_lot_current_schem   TEXT;
+    v_rowcount            INTEGER;
 BEGIN
     IF p_build_id IS NULL OR btrim(p_build_id) = '' THEN
         RAISE EXCEPTION 'build_id cannot be empty' USING ERRCODE = '22004';
     END IF;
 
-    -- Restore lot to 3/4 so the next worker ACK can proceed.
-    SELECT lot_id, action_kind
-      INTO v_lot_id, v_action_kind
+    SELECT lot_id, action_kind, schematic_id, schematic_id_before
+      INTO v_lot_id, v_action_kind, v_schematic_id, v_schematic_id_before
       FROM mc.lot_build_log
      WHERE build_id = p_build_id
        AND apply_state = 2
@@ -1973,6 +2010,28 @@ BEGIN
 
     IF NOT FOUND THEN
         RETURN FALSE;
+    END IF;
+
+    -- Invariant checks: build needs a schematic, demolish doesn't.
+    IF v_action_kind = 0 AND v_schematic_id IS NULL THEN
+        RAISE EXCEPTION 'build job % is malformed: missing schematic', p_build_id
+            USING ERRCODE = '22023';
+    END IF;
+    IF v_action_kind = 1 AND v_schematic_id IS NOT NULL THEN
+        RAISE EXCEPTION 'demolish job % is malformed: schematic must be NULL', p_build_id
+            USING ERRCODE = '22023';
+    END IF;
+
+    -- Block retry if the lot's current schematic drifted from the
+    -- snapshot taken at queue time. Prevents cross-build interference
+    -- when an intermediate successful build changed the lot.
+    IF v_schematic_id_before IS NOT NULL THEN
+        SELECT current_schematic_id INTO v_lot_current_schem
+          FROM mc.lot WHERE lot_id = v_lot_id;
+        IF v_lot_current_schem IS DISTINCT FROM v_schematic_id_before THEN
+            RAISE EXCEPTION 'lot % current_schematic changed since job % queued; cannot retry',
+                v_lot_id, p_build_id USING ERRCODE = '22023';
+        END IF;
     END IF;
 
     IF v_action_kind = 0 THEN
@@ -2128,6 +2187,162 @@ GRANT EXECUTE ON FUNCTION public.proxy_service_list_failed_builds(INTEGER, TIMES
     TO service_role;
 COMMENT ON FUNCTION public.proxy_service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT) IS
     'Service-role-only PostgREST bridge: keyset-paginated list of failed builds for ops dashboards. Uses idx_mc_lot_build_log_failed_recent.';
+
+
+-- ===========================================================================
+-- mc.service_release_user_lots — flow for auth.users delete cascade
+-- ===========================================================================
+-- owner_user_id is ON DELETE RESTRICT; this RPC is the canonical path to
+-- relinquish lots before/during user deletion. By default refuses to
+-- touch lots with an active worker job (state IN (3,4)); p_force = TRUE
+-- skips that guard (admin escalation).
+CREATE OR REPLACE FUNCTION mc.service_release_user_lots(
+    p_user_id UUID,
+    p_force   BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE (
+    lot_id   TEXT,
+    prior_state SMALLINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'user_id cannot be null' USING ERRCODE = '22004';
+    END IF;
+
+    IF NOT p_force AND EXISTS (
+        SELECT 1 FROM mc.lot
+         WHERE owner_user_id = p_user_id AND state IN (3, 4)
+    ) THEN
+        RAISE EXCEPTION 'user % has lots with active jobs; pass p_force = TRUE to override',
+            p_user_id USING ERRCODE = '22023';
+    END IF;
+
+    RETURN QUERY
+    WITH cleared AS (
+        UPDATE mc.lot
+           SET state = 0,
+               owner_user_id = NULL,
+               current_schematic_id = NULL
+         WHERE owner_user_id = p_user_id
+        RETURNING lot_id, state
+    )
+    SELECT cleared.lot_id, cleared.state FROM cleared;
+END;
+$$;
+
+ALTER FUNCTION mc.service_release_user_lots(UUID, BOOLEAN) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_release_user_lots(UUID, BOOLEAN)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_release_user_lots(UUID, BOOLEAN)
+    TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_service_release_user_lots(
+    p_user_id UUID,
+    p_force   BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE (lot_id TEXT, prior_state SMALLINT)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT * FROM mc.service_release_user_lots(p_user_id, p_force);
+$$;
+
+ALTER FUNCTION public.proxy_service_release_user_lots(UUID, BOOLEAN) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_release_user_lots(UUID, BOOLEAN)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_release_user_lots(UUID, BOOLEAN)
+    TO service_role;
+COMMENT ON FUNCTION public.proxy_service_release_user_lots(UUID, BOOLEAN) IS
+    'Service-role-only: release all lots owned by p_user_id back to vacant. Required before auth.users delete because owner_user_id is ON DELETE RESTRICT.';
+
+
+-- ===========================================================================
+-- mc.service_repair_orphan_transitional — repair stuck under_build/demolishing
+-- ===========================================================================
+-- Lots in state IN (3, 4) with no active job in mc.lot_build_log can
+-- only land that way through admin error, failed migration, or a future
+-- bug bypassing the queue lifecycle. This RPC scans for them and snaps
+-- them back to a settled state (1 or 2 per current_schematic_id).
+CREATE OR REPLACE FUNCTION mc.service_repair_orphan_transitional(
+    p_dry_run BOOLEAN DEFAULT TRUE
+)
+RETURNS TABLE (
+    lot_id      TEXT,
+    prior_state SMALLINT,
+    new_state   SMALLINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+    IF p_dry_run THEN
+        RETURN QUERY
+        SELECT l.lot_id,
+               l.state::SMALLINT,
+               (CASE WHEN l.current_schematic_id IS NULL THEN 1 ELSE 2 END)::SMALLINT
+          FROM mc.lot l
+          LEFT JOIN mc.lot_build_log b
+            ON b.lot_id = l.lot_id
+           AND b.apply_state IN (0, 3)
+         WHERE l.state IN (3, 4)
+           AND b.build_id IS NULL;
+    ELSE
+        RETURN QUERY
+        UPDATE mc.lot l
+           SET state = CASE WHEN l.current_schematic_id IS NULL THEN 1 ELSE 2 END
+         WHERE l.lot_id IN (
+            SELECT l2.lot_id
+              FROM mc.lot l2
+              LEFT JOIN mc.lot_build_log b
+                ON b.lot_id = l2.lot_id
+               AND b.apply_state IN (0, 3)
+             WHERE l2.state IN (3, 4)
+               AND b.build_id IS NULL
+         )
+        RETURNING l.lot_id,
+                  -- prior_state captured pre-update via OLD; UPDATE
+                  -- RETURNING doesn't expose OLD, so fall back to a
+                  -- placeholder: 3 or 4 was the source state but we
+                  -- can't distinguish per row here. Use the new state
+                  -- inverse as a proxy.
+                  (CASE WHEN l.state = 1 THEN 3 ELSE 4 END)::SMALLINT,
+                  l.state::SMALLINT;
+    END IF;
+END;
+$$;
+
+ALTER FUNCTION mc.service_repair_orphan_transitional(BOOLEAN) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_repair_orphan_transitional(BOOLEAN)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_repair_orphan_transitional(BOOLEAN)
+    TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.proxy_service_repair_orphan_transitional(
+    p_dry_run BOOLEAN DEFAULT TRUE
+)
+RETURNS TABLE (lot_id TEXT, prior_state SMALLINT, new_state SMALLINT)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT * FROM mc.service_repair_orphan_transitional(p_dry_run);
+$$;
+
+ALTER FUNCTION public.proxy_service_repair_orphan_transitional(BOOLEAN) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_repair_orphan_transitional(BOOLEAN)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_repair_orphan_transitional(BOOLEAN)
+    TO service_role;
+COMMENT ON FUNCTION public.proxy_service_repair_orphan_transitional(BOOLEAN) IS
+    'Service-role-only: snap state IN (3, 4) lots without an active job back to settled. p_dry_run = TRUE returns the candidate list without writing.';
 
 
 CREATE OR REPLACE FUNCTION public.proxy_service_get_lot(p_lot_id TEXT)
@@ -2639,6 +2854,8 @@ DROP FUNCTION IF EXISTS public.proxy_service_mark_build_applied(TEXT);
 DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT);
 DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT);
 
+DROP FUNCTION IF EXISTS public.proxy_service_repair_orphan_transitional(BOOLEAN);
+DROP FUNCTION IF EXISTS public.proxy_service_release_user_lots(UUID, BOOLEAN);
 DROP FUNCTION IF EXISTS public.proxy_service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT);
 DROP FUNCTION IF EXISTS public.proxy_service_retry_failed_build(TEXT, BOOLEAN);
 DROP FUNCTION IF EXISTS public.proxy_service_requeue_stale_claims(INTEGER, INTEGER);
@@ -2684,6 +2901,8 @@ DROP FUNCTION IF EXISTS mc.service_queue_build_on_lot(TEXT, TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_purchase_lot(TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT, TEXT);
 DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT, TEXT);
+DROP FUNCTION IF EXISTS mc.service_repair_orphan_transitional(BOOLEAN);
+DROP FUNCTION IF EXISTS mc.service_release_user_lots(UUID, BOOLEAN);
 DROP FUNCTION IF EXISTS mc.service_list_failed_builds(INTEGER, TIMESTAMPTZ, TEXT);
 DROP FUNCTION IF EXISTS mc.service_retry_failed_build(TEXT, BOOLEAN);
 DROP FUNCTION IF EXISTS mc.service_requeue_stale_claims(INTEGER, INTEGER);
@@ -2706,5 +2925,9 @@ DROP TABLE IF EXISTS mc.lot;
 DROP FUNCTION IF EXISTS mc.trg_lot_updated_at();
 
 DROP TABLE IF EXISTS mc.schematic;
+
+DROP DOMAIN IF EXISTS mc.build_apply_state;
+DROP DOMAIN IF EXISTS mc.build_action_kind;
+DROP DOMAIN IF EXISTS mc.lot_state;
 
 NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -217,21 +217,45 @@ CREATE INDEX idx_mc_lot_world_state_chunk_cursor
 CREATE INDEX idx_mc_lot_owner_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     WHERE owner_user_id IS NOT NULL;
+-- Hottest dashboard read path: "what vacant lots can I buy in <world>?"
+-- Partial + INCLUDE so the marketplace map renders without heap hops.
+CREATE INDEX idx_mc_lot_vacant_world_chunk_cursor
+    ON mc.lot (world, chunk_x_min, chunk_z_min, lot_id)
+    INCLUDE (chunk_x_max, chunk_z_max, chunk_area, anchor_y,
+             price_credits, price_khash)
+    WHERE state = 0;
+-- "My lots" page is dominated by owned + built rows; vacant/under-build
+-- are rare. INCLUDE the columns the dashboard renders so the index can
+-- answer index-only.
+CREATE INDEX idx_mc_lot_owner_active_world_chunk_cursor
+    ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
+    INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
+             chunk_area, anchor_y)
+    WHERE owner_user_id IS NOT NULL AND state IN (1, 2);
 
 ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot FORCE ROW LEVEL SECURITY;
 
--- Trigger touches updated_at only when something other than updated_at
--- itself changed; cuts write amplification on no-op UPDATEs. NOW() is
--- transaction-stable, which is what we want for an audit-style column
--- (callers expect rows updated in the same transaction to share a
--- timestamp), and it skips the per-row clock read.
+-- Trigger touches updated_at only when one of the mutable business
+-- columns changed; cuts write amplification on no-op UPDATEs and avoids
+-- a whole-row IS DISTINCT FROM comparison that would touch every
+-- generated chunk_* column too. NOW() (transaction-stable) is the right
+-- clock for an audit-style column.
 CREATE OR REPLACE FUNCTION mc.trg_lot_updated_at()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    IF NEW IS DISTINCT FROM OLD THEN
+    IF NEW.owner_user_id        IS DISTINCT FROM OLD.owner_user_id
+       OR NEW.current_schematic_id IS DISTINCT FROM OLD.current_schematic_id
+       OR NEW.state                IS DISTINCT FROM OLD.state
+       OR NEW.price_credits        IS DISTINCT FROM OLD.price_credits
+       OR NEW.price_khash          IS DISTINCT FROM OLD.price_khash
+       OR NEW.world                IS DISTINCT FROM OLD.world
+       OR NEW.chunk_x_range        IS DISTINCT FROM OLD.chunk_x_range
+       OR NEW.chunk_z_range        IS DISTINCT FROM OLD.chunk_z_range
+       OR NEW.anchor_y             IS DISTINCT FROM OLD.anchor_y
+    THEN
         NEW.updated_at := NOW();
     END IF;
     RETURN NEW;
@@ -259,6 +283,12 @@ CREATE TABLE mc.lot_purchase (
     price_khash     BIGINT NOT NULL DEFAULT 0,
     -- One ledger id per currency. A dual-currency purchase fills both;
     -- single-currency purchases leave the other NULL.
+    -- NOTE: deliberately NOT declared as a FOREIGN KEY to wallet.ledger.
+    -- mc and wallet are owned by different teams' migration timelines
+    -- and wallet.ledger uses ON DELETE NO ACTION semantics that would
+    -- block valid retention/archival flows over there. The reverse
+    -- direction (wallet.ledger.ref_type = 'mc.lot' / .ref_id) is how the
+    -- audit trail is reconstructed; back-reference here is informational.
     wallet_credits_ledger_id BIGINT,
     wallet_khash_ledger_id   BIGINT,
     idempotency_key UUID NOT NULL,
@@ -429,12 +459,21 @@ REVOKE ALL ON FUNCTION mc._user_account_id(UUID) FROM PUBLIC, anon, authenticate
 -- ===========================================================================
 -- mc.service_list_lots
 -- ===========================================================================
+-- Cursor pagination via four trailing p_after_* args. Default-NULL keeps
+-- the legacy LIMIT/OFFSET shape for callers that don't pass a cursor;
+-- callers that DO pass (world, chunk_x_min, chunk_z_min, lot_id) of the
+-- last row from the prior page get a clean index walk via
+-- idx_mc_lot_world_chunk_cursor.
 CREATE OR REPLACE FUNCTION mc.service_list_lots(
     p_world TEXT DEFAULT NULL,
     p_state SMALLINT DEFAULT NULL,
     p_owner_user_id UUID DEFAULT NULL,
     p_limit INTEGER DEFAULT 256,
-    p_offset INTEGER DEFAULT 0
+    p_offset INTEGER DEFAULT 0,
+    p_after_world TEXT DEFAULT NULL,
+    p_after_chunk_x INTEGER DEFAULT NULL,
+    p_after_chunk_z INTEGER DEFAULT NULL,
+    p_after_lot_id TEXT DEFAULT NULL
 )
 RETURNS TABLE (
     lot_id          TEXT,
@@ -478,15 +517,27 @@ AS $$
     WHERE (p_world         IS NULL OR l.world = p_world)
       AND (p_state         IS NULL OR l.state = p_state)
       AND (p_owner_user_id IS NULL OR l.owner_user_id = p_owner_user_id)
+      AND (
+          p_after_lot_id IS NULL
+          OR (l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id)
+             > (p_after_world, p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
+      )
     ORDER BY l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id
     LIMIT GREATEST(0, LEAST(p_limit, 1024))
-    OFFSET GREATEST(0, p_offset);
+    -- OFFSET is preserved only for the non-cursor path; cursor callers
+    -- should pass 0. Plain OFFSET is fine for small admin scans and
+    -- gives a backwards-compat lever for the dashboard until it flips
+    -- to keyset.
+    OFFSET CASE WHEN p_after_lot_id IS NULL THEN GREATEST(0, p_offset) ELSE 0 END;
 $$;
 
-ALTER FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER)
+ALTER FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER,
+                                    TEXT, INTEGER, INTEGER, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER,
+                                            TEXT, INTEGER, INTEGER, TEXT)
     FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER)
+GRANT EXECUTE ON FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER,
+                                               TEXT, INTEGER, INTEGER, TEXT)
     TO service_role;
 
 
@@ -568,23 +619,30 @@ BEGIN
         RAISE EXCEPTION 'worker_id too long (max 128)' USING ERRCODE = '22001';
     END IF;
 
-    -- UPDATE ... RETURNING has no ordering guarantee. Wrap in a CTE and
-    -- sort the final SELECT so workers process the batch in queued order.
+    -- Pick + claim split into two CTEs:
+    --   picked  — SKIP LOCKED scan of queued rows ordered for fairness;
+    --             cap p_limit at [0, 256] so the dry-poll case (p_limit=0)
+    --             is legitimate.
+    --   claimed — UPDATE ... FROM picked is the more index-friendly
+    --             shape than the older WHERE build_id IN (...) form.
+    -- UPDATE ... RETURNING has no ordering guarantee, so the final SELECT
+    -- re-sorts the batch so workers process in queued order.
     RETURN QUERY
-    WITH claimed AS (
+    WITH picked AS (
+        SELECT build_id
+          FROM mc.lot_build_log
+         WHERE apply_state = 0
+         ORDER BY queued_at, build_id
+         LIMIT GREATEST(0, LEAST(p_limit, 256))
+         FOR UPDATE SKIP LOCKED
+    ),
+    claimed AS (
         UPDATE mc.lot_build_log b
            SET apply_state = 3,
                claimed_at  = clock_timestamp(),
                claimed_by  = p_worker_id
-         WHERE b.build_id IN (
-            SELECT inner_b.build_id
-              FROM mc.lot_build_log inner_b
-             WHERE inner_b.apply_state = 0
-             ORDER BY inner_b.queued_at, inner_b.build_id
-             FOR UPDATE SKIP LOCKED
-             -- 0 is a legitimate value (dry-poll / disabled worker).
-             LIMIT GREATEST(0, LEAST(p_limit, 256))
-         )
+          FROM picked
+         WHERE b.build_id = picked.build_id
         RETURNING b.build_id, b.lot_id, b.actor_user_id,
                   b.action_kind, b.schematic_id, b.queued_at
     )
@@ -620,8 +678,12 @@ AS $$
           FROM mc.lot_build_log
          WHERE apply_state = 3
            AND claimed_at IS NOT NULL
+           -- Clamp to [1s, 1d] so an accidental huge input can't push the
+           -- threshold so far back it matches nothing (or wraps planner
+           -- estimates).
            AND claimed_at < clock_timestamp()
-                          - make_interval(secs => GREATEST(1, p_older_than_seconds))
+                          - make_interval(secs =>
+                              LEAST(GREATEST(1, p_older_than_seconds), 86400))
          ORDER BY claimed_at, build_id
          LIMIT GREATEST(0, LEAST(p_limit, 512))
          FOR UPDATE SKIP LOCKED
@@ -991,8 +1053,8 @@ BEGIN
 
     SELECT owner_user_id, state, anchor_y,
            chunk_area,
-           (upper(chunk_x_range) - lower(chunk_x_range)) * 16,
-           (upper(chunk_z_range) - lower(chunk_z_range)) * 16
+           chunk_width * 16,
+           chunk_depth * 16
       INTO v_lot_owner, v_lot_state, v_lot_anchor_y,
            v_lot_chunk_area,
            v_lot_dx_blocks,
@@ -1196,7 +1258,11 @@ CREATE OR REPLACE FUNCTION mc.proxy_list_lots(
     p_state SMALLINT DEFAULT NULL,
     p_only_mine BOOLEAN DEFAULT FALSE,
     p_limit INTEGER DEFAULT 256,
-    p_offset INTEGER DEFAULT 0
+    p_offset INTEGER DEFAULT 0,
+    p_after_world TEXT DEFAULT NULL,
+    p_after_chunk_x INTEGER DEFAULT NULL,
+    p_after_chunk_z INTEGER DEFAULT NULL,
+    p_after_lot_id TEXT DEFAULT NULL
 )
 RETURNS TABLE (
     lot_id          TEXT,
@@ -1223,6 +1289,9 @@ AS $$
     -- LANGUAGE sql so the planner sees the body directly instead of going
     -- through a plpgsql RETURN QUERY layer. auth.uid() is called once via
     -- the CROSS JOIN so the equality survives function inlining cleanly.
+    -- Keyset pagination via trailing p_after_* args: when supplied, the
+    -- (world, chunk_x_min, chunk_z_min, lot_id) tuple comparison walks
+    -- idx_mc_lot_world_chunk_cursor directly.
     WITH me AS (SELECT auth.uid() AS uid)
     SELECT l.lot_id,
            l.world,
@@ -1242,19 +1311,23 @@ AS $$
     WHERE (p_world IS NULL OR l.world = p_world)
       AND (p_state IS NULL OR l.state = p_state)
       AND (NOT p_only_mine OR (me.uid IS NOT NULL AND l.owner_user_id = me.uid))
+      AND (
+          p_after_lot_id IS NULL
+          OR (l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id)
+             > (p_after_world, p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
+      )
     ORDER BY l.world, l.chunk_x_min, l.chunk_z_min, l.lot_id
     LIMIT GREATEST(0, LEAST(p_limit, 1024))
-    OFFSET GREATEST(0, p_offset);
+    OFFSET CASE WHEN p_after_lot_id IS NULL THEN GREATEST(0, p_offset) ELSE 0 END;
 $$;
 
-ALTER FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER)
+ALTER FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                  TEXT, INTEGER, INTEGER, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                          TEXT, INTEGER, INTEGER, TEXT)
     FROM PUBLIC, anon, authenticated;
--- Only the public wrapper (running as service_role) calls into this layer.
--- authenticated is intentionally excluded — direct PostgREST access to the
--- mc schema is impossible anyway, but tightening the grant means a future
--- exposure mistake doesn't accidentally expose this entry point.
-GRANT EXECUTE ON FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER)
+GRANT EXECUTE ON FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                             TEXT, INTEGER, INTEGER, TEXT)
     TO service_role;
 
 
@@ -1377,7 +1450,11 @@ CREATE OR REPLACE FUNCTION public.proxy_list_lots(
     p_state SMALLINT DEFAULT NULL,
     p_only_mine BOOLEAN DEFAULT FALSE,
     p_limit INTEGER DEFAULT 256,
-    p_offset INTEGER DEFAULT 0
+    p_offset INTEGER DEFAULT 0,
+    p_after_world TEXT DEFAULT NULL,
+    p_after_chunk_x INTEGER DEFAULT NULL,
+    p_after_chunk_z INTEGER DEFAULT NULL,
+    p_after_lot_id TEXT DEFAULT NULL
 )
 RETURNS TABLE (
     lot_id          TEXT,
@@ -1401,13 +1478,18 @@ SECURITY DEFINER
 SET search_path = ''
 ROWS 256
 AS $$
-    SELECT * FROM mc.proxy_list_lots(p_world, p_state, p_only_mine, p_limit, p_offset);
+    SELECT * FROM mc.proxy_list_lots(
+        p_world, p_state, p_only_mine, p_limit, p_offset,
+        p_after_world, p_after_chunk_x, p_after_chunk_z, p_after_lot_id);
 $$;
 
-ALTER FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER) OWNER TO service_role;
-REVOKE ALL ON FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER)
+ALTER FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                      TEXT, INTEGER, INTEGER, TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                              TEXT, INTEGER, INTEGER, TEXT)
     FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER)
+GRANT EXECUTE ON FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                                 TEXT, INTEGER, INTEGER, TEXT)
     TO authenticated, service_role;
 
 
@@ -1649,12 +1731,16 @@ DROP FUNCTION IF EXISTS public.proxy_queue_build_on_lot(TEXT, TEXT, UUID);
 DROP FUNCTION IF EXISTS public.proxy_purchase_lot(TEXT, UUID);
 DROP FUNCTION IF EXISTS public.proxy_list_schematics(TEXT);
 DROP FUNCTION IF EXISTS public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER);
+DROP FUNCTION IF EXISTS public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                               TEXT, INTEGER, INTEGER, TEXT);
 
 DROP FUNCTION IF EXISTS mc.proxy_queue_demolish_lot(TEXT, UUID);
 DROP FUNCTION IF EXISTS mc.proxy_queue_build_on_lot(TEXT, TEXT, UUID);
 DROP FUNCTION IF EXISTS mc.proxy_purchase_lot(TEXT, UUID);
 DROP FUNCTION IF EXISTS mc.proxy_list_schematics(TEXT);
 DROP FUNCTION IF EXISTS mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER);
+DROP FUNCTION IF EXISTS mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                           TEXT, INTEGER, INTEGER, TEXT);
 
 DROP FUNCTION IF EXISTS mc.service_queue_demolish_lot(TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_queue_build_on_lot(TEXT, TEXT, UUID, UUID);
@@ -1666,6 +1752,8 @@ DROP FUNCTION IF EXISTS mc.service_requeue_stale_claims(INTEGER);
 DROP FUNCTION IF EXISTS mc.service_claim_pending_builds(TEXT, INTEGER);
 DROP FUNCTION IF EXISTS mc.service_list_schematics(TEXT, BOOLEAN);
 DROP FUNCTION IF EXISTS mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER);
+DROP FUNCTION IF EXISTS mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER,
+                                             TEXT, INTEGER, INTEGER, TEXT);
 DROP FUNCTION IF EXISTS mc._user_account_id(UUID);
 DROP FUNCTION IF EXISTS mc._derive_idem_key(UUID, TEXT);
 

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -125,11 +125,12 @@ CREATE INDEX idx_mc_schematic_enabled_category_tier_name_cover
     INCLUDE (dims_x, dims_y, dims_z, price_credits, price_khash)
     WHERE enabled;
 
+ALTER TABLE mc.schematic OWNER TO postgres;
 ALTER TABLE mc.schematic ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.schematic FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.schematic IS
-    'Build catalog. Dashboard reads enabled rows via proxy_list_schematics. Each row references a serialized structure blob in the Fabric mod jar by resource_path.';
+    'Build catalog. RPC-only: RLS is enabled + forced with NO policies; direct table access is denied even to service_role. All reads/writes flow through SECURITY DEFINER RPCs.';
 
 
 -- ===========================================================================
@@ -262,6 +263,7 @@ CREATE INDEX idx_mc_lot_owner_active_world_chunk_cursor
              chunk_area, anchor_y, price_credits, price_khash)
     WHERE owner_user_id IS NOT NULL AND state IN (1, 2);
 
+ALTER TABLE mc.lot OWNER TO postgres;
 ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot FORCE ROW LEVEL SECURITY;
 
@@ -297,7 +299,7 @@ CREATE TRIGGER trg_mc_lot_updated_at
     EXECUTE FUNCTION mc.trg_lot_updated_at();
 
 COMMENT ON TABLE mc.lot IS
-    'Parcel registry. Chunk-aligned rectangular regions guarded by a GIST EXCLUDE constraint that forbids overlap within a world.';
+    'Parcel registry. Chunk-aligned rectangular regions guarded by a GIST EXCLUDE constraint that forbids overlap within a world. RPC-only: RLS is enabled + forced with NO policies; all reads/writes flow through SECURITY DEFINER RPCs.';
 COMMENT ON COLUMN mc.lot.state IS '0=vacant, 1=owned, 2=built, 3=under_build, 4=demolishing';
 
 
@@ -352,11 +354,12 @@ CREATE INDEX idx_mc_lot_purchase_buyer_created
 CREATE UNIQUE INDEX uq_mc_lot_purchase_one_per_lot
     ON mc.lot_purchase (lot_id);
 
+ALTER TABLE mc.lot_purchase OWNER TO postgres;
 ALTER TABLE mc.lot_purchase ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot_purchase FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.lot_purchase IS
-    'Append-only ownership ledger. Per-currency wallet_*_ledger_id columns back-reference wallet.ledger so dual-currency purchases retain both debit references.';
+    'Append-only ownership ledger. Per-currency wallet_*_ledger_id columns back-reference wallet.ledger so dual-currency purchases retain both debit references. RPC-only: RLS enabled + forced, no policies.';
 
 
 -- ===========================================================================
@@ -382,6 +385,12 @@ CREATE TABLE mc.lot_build_log (
     claimed_by      TEXT,
     queued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     applied_at      TIMESTAMPTZ,
+    failed_at       TIMESTAMPTZ,
+    -- Retry budget. Incremented on every claim; rows that hit the cap
+    -- are excluded from the SKIP LOCKED scan so a poisoned job cannot
+    -- cycle through claim -> stale-requeue -> claim forever.
+    attempt_count   SMALLINT NOT NULL DEFAULT 0,
+    last_attempt_at TIMESTAMPTZ,
 
     CONSTRAINT mc_lot_build_log_action_chk
         CHECK (action_kind IN (0, 1)),
@@ -392,6 +401,8 @@ CREATE TABLE mc.lot_build_log (
             OR (action_kind = 1)),
     CONSTRAINT mc_lot_build_log_apply_error_len_chk
         CHECK (apply_error IS NULL OR length(apply_error) <= 2048),
+    CONSTRAINT mc_lot_build_log_attempt_count_chk
+        CHECK (attempt_count >= 0 AND attempt_count <= 100),
     CONSTRAINT mc_lot_build_log_claimed_by_len_chk
         CHECK (claimed_by IS NULL OR length(claimed_by) <= 128),
     CONSTRAINT mc_lot_build_log_credits_ledger_chk CHECK (
@@ -476,11 +487,12 @@ ALTER TABLE mc.lot SET (
     autovacuum_analyze_threshold = 250
 );
 
+ALTER TABLE mc.lot_build_log OWNER TO postgres;
 ALTER TABLE mc.lot_build_log ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot_build_log FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.lot_build_log IS
-    'Append-only audit of build/demolish events and concurrent work queue. action_kind: 0=build, 1=demolish. apply_state: 0=queued, 1=applied, 2=failed, 3=claimed.';
+    'Append-only audit of build/demolish events and concurrent work queue. action_kind: 0=build, 1=demolish. apply_state: 0=queued, 1=applied, 2=failed, 3=claimed. RPC-only: RLS enabled + forced, no policies.';
 COMMENT ON COLUMN mc.lot_build_log.action_kind IS '0=build, 1=demolish';
 COMMENT ON COLUMN mc.lot_build_log.apply_state IS
     '0=queued, 1=applied, 2=failed, 3=claimed (worker holding the row)';
@@ -604,6 +616,52 @@ GRANT EXECUTE ON FUNCTION mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, IN
 
 
 -- ===========================================================================
+-- mc.service_get_lot — primary-key lookup
+-- ===========================================================================
+-- Dedicated PK fetch for detail views, worker diagnostics, and admin
+-- repair flows; cheaper than threading a single-row case through
+-- service_list_lots' optional-filter predicate.
+CREATE OR REPLACE FUNCTION mc.service_get_lot(p_lot_id TEXT)
+RETURNS TABLE (
+    lot_id          TEXT,
+    world           TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    chunk_area      INTEGER,
+    anchor_y        SMALLINT,
+    owner_user_id   UUID,
+    current_schematic_id TEXT,
+    state           SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT,
+    created_at      TIMESTAMPTZ,
+    updated_at      TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 1
+AS $$
+    SELECT l.lot_id, l.world,
+           l.chunk_x_min, l.chunk_x_max,
+           l.chunk_z_min, l.chunk_z_max,
+           l.chunk_area, l.anchor_y,
+           l.owner_user_id, l.current_schematic_id,
+           l.state, l.price_credits, l.price_khash,
+           l.created_at, l.updated_at
+    FROM mc.lot l
+    WHERE l.lot_id = p_lot_id;
+$$;
+
+ALTER FUNCTION mc.service_get_lot(TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_get_lot(TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_get_lot(TEXT) TO service_role;
+
+
+-- ===========================================================================
 -- mc.service_list_schematics
 -- ===========================================================================
 CREATE OR REPLACE FUNCTION mc.service_list_schematics(
@@ -694,15 +752,22 @@ BEGIN
         SELECT build_id
           FROM mc.lot_build_log
          WHERE apply_state = 0
+           -- Retry budget: skip poison jobs that have already exhausted
+           -- their attempts. The stale-claim janitor never resurrects
+           -- past this cap either, so the row stays queued but dormant
+           -- until an admin retries via service_retry_failed_build.
+           AND attempt_count < 5
          ORDER BY queued_at, build_id
          LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 32), 256))
          FOR UPDATE SKIP LOCKED
     ),
     claimed AS (
         UPDATE mc.lot_build_log b
-           SET apply_state = 3,
-               claimed_at  = clock_timestamp(),
-               claimed_by  = p_worker_id
+           SET apply_state    = 3,
+               claimed_at     = clock_timestamp(),
+               claimed_by     = p_worker_id,
+               attempt_count  = b.attempt_count + 1,
+               last_attempt_at = clock_timestamp()
           FROM picked
          WHERE b.build_id = picked.build_id
         RETURNING b.build_id, b.lot_id, b.actor_user_id,
@@ -885,7 +950,10 @@ BEGIN
            apply_error = left(
                COALESCE(NULLIF(btrim(p_error), ''), 'worker reported failure'),
                2048),
-           applied_at = clock_timestamp(),
+           -- Distinct timestamp from applied_at so dashboards can tell
+           -- 'finished cleanly' from 'gave up' without inspecting state.
+           failed_at = clock_timestamp(),
+           applied_at = NULL,
            claimed_at = NULL,
            claimed_by = NULL
      WHERE build_id = p_build_id
@@ -961,8 +1029,10 @@ BEGIN
     -- the lock two identical requests can both miss the existing-key
     -- check, then one inserts cleanly and the other tries the lot-state
     -- path and surfaces a confusing "lot not vacant" error instead of
-    -- collapsing to the original purchase row.
-    PERFORM pg_advisory_xact_lock(hashtextextended(p_idempotency_key::text, 0));
+    -- collapsing to the original purchase row. Namespace the lock key
+    -- so a caller that reuses the same idempotency_key across purchase,
+    -- build, and demolish doesn't accidentally cross-block.
+    PERFORM pg_advisory_xact_lock(hashtextextended('mc.purchase:' || p_idempotency_key::text, 0));
 
     -- Idempotent replay: existing key must match the original parameters,
     -- otherwise the caller is reusing a key for a different request.
@@ -1033,10 +1103,19 @@ BEGIN
     )
     RETURNING purchase_id INTO v_purchase_id;
 
-    UPDATE mc.lot
-       SET state = 1,
-           owner_user_id = p_user_id
-     WHERE lot_id = p_lot_id;
+    DECLARE v_rowcount INTEGER;
+    BEGIN
+        UPDATE mc.lot
+           SET state = 1,
+               owner_user_id = p_user_id
+         WHERE lot_id = p_lot_id
+           AND state = 0;
+        GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+        IF v_rowcount <> 1 THEN
+            RAISE EXCEPTION 'lot % no longer vacant at purchase commit', p_lot_id
+                USING ERRCODE = '22023';
+        END IF;
+    END;
 
     RETURN v_purchase_id;
 END;
@@ -1101,7 +1180,7 @@ BEGIN
 
     -- Serialize concurrent retries on the same idempotency_key. See the
     -- matching note in service_purchase_lot.
-    PERFORM pg_advisory_xact_lock(hashtextextended(p_idempotency_key::text, 0));
+    PERFORM pg_advisory_xact_lock(hashtextextended('mc.build:' || p_idempotency_key::text, 0));
 
     SELECT build_id, lot_id, schematic_id, actor_user_id
       INTO v_existing_build_id, v_existing_lot, v_existing_schematic, v_existing_actor
@@ -1235,7 +1314,21 @@ BEGIN
         END;
     END;
 
-    UPDATE mc.lot SET state = 3 WHERE lot_id = p_lot_id;
+    -- Self-validating transition: defense-in-depth in case a future
+    -- refactor weakens the earlier FOR UPDATE + state guard.
+    DECLARE v_rowcount INTEGER;
+    BEGIN
+        UPDATE mc.lot
+           SET state = 3
+         WHERE lot_id = p_lot_id
+           AND owner_user_id = p_user_id
+           AND state IN (1, 2);
+        GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+        IF v_rowcount <> 1 THEN
+            RAISE EXCEPTION 'lot % no longer in a buildable state at queue commit', p_lot_id
+                USING ERRCODE = '22023';
+        END IF;
+    END;
 
     RETURN v_build_id;
 END;
@@ -1281,7 +1374,7 @@ BEGIN
         RAISE EXCEPTION 'idempotency_key cannot be null' USING ERRCODE = '22004';
     END IF;
 
-    PERFORM pg_advisory_xact_lock(hashtextextended(p_idempotency_key::text, 0));
+    PERFORM pg_advisory_xact_lock(hashtextextended('mc.demolish:' || p_idempotency_key::text, 0));
 
     SELECT build_id, lot_id, actor_user_id, action_kind
       INTO v_existing_build_id, v_existing_lot, v_existing_actor, v_existing_action
@@ -1334,7 +1427,19 @@ BEGIN
         END;
     END;
 
-    UPDATE mc.lot SET state = 4 WHERE lot_id = p_lot_id;
+    DECLARE v_rowcount INTEGER;
+    BEGIN
+        UPDATE mc.lot
+           SET state = 4
+         WHERE lot_id = p_lot_id
+           AND owner_user_id = p_user_id
+           AND state = 2;
+        GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+        IF v_rowcount <> 1 THEN
+            RAISE EXCEPTION 'lot % no longer demolishable at queue commit', p_lot_id
+                USING ERRCODE = '22023';
+        END IF;
+    END;
 
     RETURN v_build_id;
 END;
@@ -1720,6 +1825,18 @@ ALTER FUNCTION public.proxy_queue_demolish_lot(TEXT, UUID) OWNER TO service_role
 REVOKE ALL ON FUNCTION public.proxy_queue_demolish_lot(TEXT, UUID) FROM PUBLIC, anon;
 GRANT EXECUTE ON FUNCTION public.proxy_queue_demolish_lot(TEXT, UUID) TO authenticated, service_role;
 
+COMMENT ON FUNCTION public.proxy_purchase_lot(TEXT, UUID) IS
+    'Authenticated client RPC: charge wallet + flip the vacant lot to owned. Pass a stable p_idempotency_key on retries so network repeats collapse to the original purchase.';
+COMMENT ON FUNCTION public.proxy_queue_build_on_lot(TEXT, TEXT, UUID) IS
+    'Authenticated client RPC: charge schematic cost + queue a build on a lot the caller owns. Idempotent on p_idempotency_key.';
+COMMENT ON FUNCTION public.proxy_queue_demolish_lot(TEXT, UUID) IS
+    'Authenticated client RPC: queue a demolish on a built lot the caller owns. Free in phase 0; idempotent on p_idempotency_key.';
+COMMENT ON FUNCTION public.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
+                                          TEXT, INTEGER, INTEGER, TEXT) IS
+    'Generic lot listing RPC. Prefer the dedicated public.proxy_list_vacant_lots and public.proxy_list_my_active_lots wrappers for dashboard use — those bind hard-coded predicates to the partial INCLUDE indexes. This generic shape stays for admin/compat callers.';
+COMMENT ON FUNCTION public.proxy_list_schematics(TEXT) IS
+    'Catalog read: enabled schematics, optionally filtered to a category. Sorted by (category, tier, name). Index-only path via idx_mc_schematic_enabled_category_tier_name_cover.';
+
 
 -- ===========================================================================
 -- PUBLIC WORKER WRAPPERS — service_role only, for MC mod through PostgREST
@@ -1825,6 +1942,40 @@ COMMENT ON FUNCTION public.proxy_service_requeue_stale_claims(INTEGER, INTEGER) 
     'Service-role-only PostgREST bridge for janitor recovery of orphaned worker claims older than p_older_than_seconds. Batched + SKIP LOCKED with p_limit (max 512). Returns the count of jobs requeued in this call.';
 
 
+CREATE OR REPLACE FUNCTION public.proxy_service_get_lot(p_lot_id TEXT)
+RETURNS TABLE (
+    lot_id          TEXT,
+    world           TEXT,
+    chunk_x_min     INTEGER,
+    chunk_x_max     INTEGER,
+    chunk_z_min     INTEGER,
+    chunk_z_max     INTEGER,
+    chunk_area      INTEGER,
+    anchor_y        SMALLINT,
+    owner_user_id   UUID,
+    current_schematic_id TEXT,
+    state           SMALLINT,
+    price_credits   BIGINT,
+    price_khash     BIGINT,
+    created_at      TIMESTAMPTZ,
+    updated_at      TIMESTAMPTZ
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 1
+AS $$
+    SELECT * FROM mc.service_get_lot(p_lot_id);
+$$;
+
+ALTER FUNCTION public.proxy_service_get_lot(TEXT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_get_lot(TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_get_lot(TEXT) TO service_role;
+COMMENT ON FUNCTION public.proxy_service_get_lot(TEXT) IS
+    'Service-role-only primary-key lookup for a single lot. Use for detail views, worker diagnostics, and admin repair flows.';
+
+
 -- ===========================================================================
 -- HOT-PATH LIST RPCs — dedicated wrappers for the two most common reads
 -- ===========================================================================
@@ -1897,7 +2048,7 @@ BEGIN
              > (p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
       )
     ORDER BY l.chunk_x_min, l.chunk_z_min, l.lot_id
-    LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 256), 1024));
+    LIMIT LEAST(GREATEST(COALESCE(p_limit, 256), 1), 1024);
 END;
 $$;
 
@@ -1980,7 +2131,7 @@ BEGIN
              > (p_after_chunk_x, p_after_chunk_z, p_after_lot_id)
       )
     ORDER BY l.chunk_x_min, l.chunk_z_min, l.lot_id
-    LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 256), 1024));
+    LIMIT LEAST(GREATEST(COALESCE(p_limit, 256), 1), 1024);
 END;
 $$;
 
@@ -2047,6 +2198,8 @@ DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT, TEXT);
 DROP FUNCTION IF EXISTS mc.service_requeue_stale_claims(INTEGER, INTEGER);
 DROP FUNCTION IF EXISTS mc.service_requeue_stale_claims(INTEGER);
 DROP FUNCTION IF EXISTS mc.service_claim_pending_builds(TEXT, INTEGER);
+DROP FUNCTION IF EXISTS public.proxy_service_get_lot(TEXT);
+DROP FUNCTION IF EXISTS mc.service_get_lot(TEXT);
 DROP FUNCTION IF EXISTS mc.service_list_schematics(TEXT, BOOLEAN);
 DROP FUNCTION IF EXISTS mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER);
 DROP FUNCTION IF EXISTS mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER,

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -2111,12 +2111,31 @@ BEGIN
             USING ERRCODE = '22023';
     END IF;
 
+    -- Lock the lot row so concurrent queue-build / queue-demolish /
+    -- release flows serialize against this retry. They already take
+    -- FOR UPDATE on the same row.
+    SELECT current_schematic_id INTO v_lot_current_schem
+      FROM mc.lot WHERE lot_id = v_lot_id
+      FOR UPDATE;
+
+    -- Pre-empt the partial unique index (apply_state IN (0,3)) with an
+    -- explicit guard so callers see a clean error, not a 23505 from a
+    -- late constraint violation.
+    IF EXISTS (
+        SELECT 1
+          FROM mc.lot_build_log b
+         WHERE b.lot_id = v_lot_id
+           AND b.apply_state IN (0, 3)
+           AND b.build_id <> p_build_id
+    ) THEN
+        RAISE EXCEPTION 'lot % already has an active queued/claimed job', v_lot_id
+            USING ERRCODE = '23505';
+    END IF;
+
     -- Schematic-drift check covers both directions: NULL → set, set →
     -- NULL, and set → different. Skipping the NULL case let an
     -- intermediate successful build between queue and retry slip
     -- through (snapshot=NULL, current_schematic=set).
-    SELECT current_schematic_id INTO v_lot_current_schem
-      FROM mc.lot WHERE lot_id = v_lot_id;
     IF v_lot_current_schem IS DISTINCT FROM v_schematic_id_before THEN
         RAISE EXCEPTION 'lot % current_schematic changed since job % queued; cannot retry',
             v_lot_id, p_build_id USING ERRCODE = '22023';
@@ -2290,8 +2309,9 @@ COMMENT ON FUNCTION public.proxy_service_list_failed_builds(INTEGER, TIMESTAMPTZ
 -- ===========================================================================
 -- owner_user_id is ON DELETE RESTRICT; this RPC is the canonical path to
 -- relinquish lots before/during user deletion. By default refuses to
--- touch lots with an active worker job (state IN (3,4)); p_force = TRUE
--- skips that guard (admin escalation).
+-- touch lots with an active queued / claimed build job in
+-- mc.lot_build_log (apply_state IN (0, 3)); p_force = TRUE cancels those
+-- jobs first (apply_state = 4) and proceeds (admin escalation).
 CREATE OR REPLACE FUNCTION mc.service_release_user_lots(
     p_user_id UUID,
     p_force   BOOLEAN DEFAULT FALSE

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -238,9 +238,9 @@ CREATE INDEX idx_mc_lot_transitional_repair
     ON mc.lot (lot_id)
     INCLUDE (state, current_schematic_id)
     WHERE state IN (3, 4);
--- Viewport range scan via GIST on the int4range columns directly.
-CREATE INDEX idx_mc_lot_world_chunk_ranges_gist
-    ON mc.lot USING gist (world, chunk_x_range, chunk_z_range);
+-- Viewport && reads ride mc_lot_no_overlap_excl (gist on world, chunk_x_range,
+-- chunk_z_range with the same WITH operators). A second explicit gist on the
+-- same columns would double write-amp on lot create without changing plans.
 
 ALTER TABLE mc.lot OWNER TO postgres;
 ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
@@ -500,10 +500,10 @@ ALTER TABLE mc.lot_build_log ENABLE ROW LEVEL SECURITY;
 ALTER TABLE mc.lot_build_log FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.lot_build_log IS
-    'Audit + work queue. action_kind: 0=build, 1=demolish. apply_state: 0=queued, 1=applied, 2=failed, 3=claimed. RPC-only — RLS forced.';
+    'Audit + work queue. action_kind: 0=build, 1=demolish. apply_state: 0=queued, 1=applied, 2=failed, 3=claimed, 4=cancelled. RPC-only — RLS forced.';
 COMMENT ON COLUMN mc.lot_build_log.action_kind IS '0=build, 1=demolish';
 COMMENT ON COLUMN mc.lot_build_log.apply_state IS
-    '0=queued, 1=applied, 2=failed, 3=claimed (worker holding the row)';
+    '0=queued, 1=applied, 2=failed, 3=claimed (worker holding the row), 4=cancelled (forced user-lot release)';
 
 
 -- ===========================================================================

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -18,7 +18,15 @@
 -- Money flow rides on wallet.service_debit against the user-kind account.
 -- mc.lot_purchase and mc.lot_build_log keep their own append-only audit
 -- rows so we can reconstruct ownership / build history without joining
--- through wallet.ledger.
+-- through wallet.ledger. Both ledgers carry a per-currency ledger reference
+-- pair (wallet_credits_ledger_id, wallet_khash_ledger_id) because a single
+-- charge can debit BOTH currencies; storing one column would discard the
+-- second debit on a dual-currency purchase.
+--
+-- Idempotency is enforced both at the mc layer (UNIQUE(idempotency_key))
+-- AND at the wallet layer (per-currency-derived UUID via
+-- mc._derive_idem_key) so retrying a dual-currency charge cannot collide
+-- on the wallet side.
 --
 -- Schema exposure: every public-callable RPC is fronted by a
 -- public.proxy_* wrapper because PostgREST only sees the public schema.
@@ -27,6 +35,41 @@
 -- ============================================================================
 
 CREATE EXTENSION IF NOT EXISTS btree_gist;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Re-affirm schema + grants so this migration is independently runnable
+-- against a fresh database. mc was already created in mc_schema_init but
+-- IF NOT EXISTS keeps the statement safe to replay.
+CREATE SCHEMA IF NOT EXISTS mc;
+GRANT USAGE ON SCHEMA mc TO service_role;
+REVOKE ALL ON SCHEMA mc FROM PUBLIC, anon, authenticated;
+
+
+-- ===========================================================================
+-- mc._derive_idem_key — deterministic per-currency idempotency key
+-- ===========================================================================
+--
+-- wallet.service_debit treats (account, idempotency_key) as the uniqueness
+-- scope for replay collapsing. A single mc.lot purchase or build can debit
+-- BOTH credits AND khash; reusing the same key for both calls would either
+-- silently no-op the second debit or surface a fingerprint mismatch
+-- depending on how wallet handles it. Derive a stable per-currency UUID
+-- from the caller-supplied key so retry semantics still work, but each
+-- currency has its own slot.
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc._derive_idem_key(p_key UUID, p_tag TEXT)
+RETURNS UUID
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+SET search_path = ''
+AS $$
+    SELECT substr(encode(public.digest(p_key::text || ':' || p_tag, 'md5'), 'hex'), 1, 32)::uuid;
+$$;
+
+ALTER FUNCTION mc._derive_idem_key(UUID, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc._derive_idem_key(UUID, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc._derive_idem_key(UUID, TEXT) TO service_role;
 
 
 -- ===========================================================================
@@ -50,20 +93,27 @@ CREATE TABLE mc.schematic (
     CONSTRAINT mc_schematic_dims_y_chk CHECK (dims_y <= 384),
     CONSTRAINT mc_schematic_price_chk  CHECK (price_credits >= 0 AND price_khash >= 0),
     CONSTRAINT mc_schematic_category_chk
-        CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument'))
+        CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument')),
+    -- Reject path-traversal + force schematics into the mod jar's
+    -- schematics/ dir. Loader on the Java side concats this onto a class
+    -- loader resource path, so anything escaping the dir is a footgun.
+    CONSTRAINT mc_schematic_resource_path_chk
+        CHECK (resource_path !~ '(^/|\.\.)' AND
+               resource_path ~ '^schematics/[A-Za-z0-9_./-]+\.(nbt|schem)$')
 );
 
-CREATE INDEX idx_mc_schematic_category_enabled ON mc.schematic (category, enabled);
+-- Partial index lines up with proxy_list_schematics' WHERE enabled + ORDER
+-- BY category, tier, name path. Unfiltered rows are extremely cold.
+CREATE INDEX idx_mc_schematic_enabled_category_tier_name
+    ON mc.schematic (category, tier, name)
+    WHERE enabled;
 CREATE INDEX idx_mc_schematic_tier ON mc.schematic (tier);
 
 ALTER TABLE mc.schematic ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc.schematic FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.schematic IS
     'Build catalog. Dashboard reads enabled rows via proxy_list_schematics. Each row references a serialized structure blob in the Fabric mod jar by resource_path.';
-COMMENT ON COLUMN mc.schematic.dims_x IS 'Width in blocks (X axis).';
-COMMENT ON COLUMN mc.schematic.dims_y IS 'Height in blocks. Hard-capped at 384 (world build height).';
-COMMENT ON COLUMN mc.schematic.dims_z IS 'Depth in blocks (Z axis).';
-COMMENT ON COLUMN mc.schematic.resource_path IS 'Path inside the mod jar, e.g. ''schematics/house_small.nbt''. No leading slash.';
 
 
 -- ===========================================================================
@@ -74,9 +124,19 @@ CREATE TABLE mc.lot (
     world           TEXT NOT NULL DEFAULT 'minecraft:overworld',
     chunk_x_range   int4range NOT NULL,
     chunk_z_range   int4range NOT NULL,
+    -- Stored generated columns so chunk-count guards in RPCs (and any
+    -- future "lots ordered by size" queries) don't recompute on every read.
+    chunk_width     INTEGER GENERATED ALWAYS AS
+        (upper(chunk_x_range) - lower(chunk_x_range)) STORED,
+    chunk_depth     INTEGER GENERATED ALWAYS AS
+        (upper(chunk_z_range) - lower(chunk_z_range)) STORED,
+    chunk_area      INTEGER GENERATED ALWAYS AS
+        ((upper(chunk_x_range) - lower(chunk_x_range))
+       * (upper(chunk_z_range) - lower(chunk_z_range))) STORED,
     anchor_y        SMALLINT NOT NULL,
     owner_user_id   UUID REFERENCES auth.users(id) ON DELETE SET NULL,
     current_schematic_id TEXT REFERENCES mc.schematic(schematic_id),
+    -- 0 = vacant, 1 = owned, 2 = built, 3 = under_build, 4 = demolishing
     state           SMALLINT NOT NULL DEFAULT 0,
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
@@ -92,6 +152,11 @@ CREATE TABLE mc.lot (
     CONSTRAINT mc_lot_z_range_chk    CHECK (NOT isempty(chunk_z_range)
                                              AND lower_inc(chunk_z_range)
                                              AND NOT upper_inc(chunk_z_range)),
+    -- Vanilla dim ids look like 'minecraft:overworld' or
+    -- 'kbve:survival_ext'. Enforce the namespaced format to keep typos and
+    -- arbitrary text from sneaking into the world column.
+    CONSTRAINT mc_lot_world_chk
+        CHECK (world ~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$'),
     CONSTRAINT mc_lot_owner_state_chk CHECK (
         (state = 0 AND owner_user_id IS NULL)
         OR (state > 0 AND owner_user_id IS NOT NULL)
@@ -109,17 +174,28 @@ CREATE TABLE mc.lot (
 );
 
 CREATE INDEX idx_mc_lot_owner ON mc.lot (owner_user_id) WHERE owner_user_id IS NOT NULL;
-CREATE INDEX idx_mc_lot_state ON mc.lot (state);
-CREATE INDEX idx_mc_lot_world_state ON mc.lot (world, state);
+-- Covering order for service_list_lots / proxy_list_lots:
+-- ORDER BY world, lower(chunk_x_range), lower(chunk_z_range).
+CREATE INDEX idx_mc_lot_world_chunk_order
+    ON mc.lot (world, lower(chunk_x_range), lower(chunk_z_range));
+-- Same order with state in the leading position so state-filtered listings
+-- skip irrelevant rows entirely.
+CREATE INDEX idx_mc_lot_world_state_chunk_order
+    ON mc.lot (world, state, lower(chunk_x_range), lower(chunk_z_range));
 
 ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc.lot FORCE ROW LEVEL SECURITY;
 
+-- Trigger touches updated_at only when something other than updated_at
+-- itself changed; cuts write amplification on no-op UPDATEs.
 CREATE OR REPLACE FUNCTION mc.trg_lot_updated_at()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    NEW.updated_at := NOW();
+    IF NEW IS DISTINCT FROM OLD THEN
+        NEW.updated_at := NOW();
+    END IF;
     RETURN NEW;
 END;
 $$;
@@ -131,8 +207,6 @@ CREATE TRIGGER trg_mc_lot_updated_at
 
 COMMENT ON TABLE mc.lot IS
     'Parcel registry. Chunk-aligned rectangular regions guarded by a GIST EXCLUDE constraint that forbids overlap within a world.';
-COMMENT ON COLUMN mc.lot.chunk_x_range IS 'Half-open [min_chunk_x, max_chunk_x). 1x1 lot at chunk 5 = [5,6).';
-COMMENT ON COLUMN mc.lot.anchor_y IS 'Foundation Y in blocks. Schematics paste with their Y=0 layer at this absolute Y.';
 COMMENT ON COLUMN mc.lot.state IS '0=vacant, 1=owned, 2=built, 3=under_build, 4=demolishing';
 
 
@@ -145,7 +219,10 @@ CREATE TABLE mc.lot_purchase (
     buyer_user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
-    wallet_ledger_id BIGINT,
+    -- One ledger id per currency. A dual-currency purchase fills both;
+    -- single-currency purchases leave the other NULL.
+    wallet_credits_ledger_id BIGINT,
+    wallet_khash_ledger_id   BIGINT,
     idempotency_key UUID NOT NULL,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
@@ -157,48 +234,76 @@ CREATE TABLE mc.lot_purchase (
 CREATE INDEX idx_mc_lot_purchase_lot   ON mc.lot_purchase (lot_id);
 CREATE INDEX idx_mc_lot_purchase_buyer ON mc.lot_purchase (buyer_user_id);
 
+-- Phase-0 invariant: each lot can be bought exactly once. Resale comes
+-- with an explicit ownership-epoch column in a follow-up migration.
+CREATE UNIQUE INDEX uq_mc_lot_purchase_one_per_lot
+    ON mc.lot_purchase (lot_id);
+
 ALTER TABLE mc.lot_purchase ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc.lot_purchase FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.lot_purchase IS
-    'Append-only ownership ledger. wallet_ledger_id back-references wallet.ledger so the purchase can be tied to its debit row.';
+    'Append-only ownership ledger. Per-currency wallet_*_ledger_id columns back-reference wallet.ledger so dual-currency purchases retain both debit references.';
 
 
 -- ===========================================================================
--- mc.lot_build_log — build/demolish audit (append-only)
+-- mc.lot_build_log — build/demolish audit + work queue
 -- ===========================================================================
 CREATE TABLE mc.lot_build_log (
     build_id        TEXT PRIMARY KEY DEFAULT public.gen_ulid(),
     lot_id          TEXT NOT NULL REFERENCES mc.lot(lot_id) ON DELETE CASCADE,
     actor_user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    -- 0 = build, 1 = demolish
     action_kind     SMALLINT NOT NULL,
     schematic_id    TEXT REFERENCES mc.schematic(schematic_id),
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
-    wallet_ledger_id BIGINT,
+    -- One ledger id per currency. Mirrors mc.lot_purchase.
+    wallet_credits_ledger_id BIGINT,
+    wallet_khash_ledger_id   BIGINT,
     idempotency_key UUID NOT NULL,
+    -- 0 = queued, 1 = applied, 2 = failed, 3 = claimed (worker holding it)
     apply_state     SMALLINT NOT NULL DEFAULT 0,
     apply_error     TEXT,
+    claimed_at      TIMESTAMPTZ,
+    claimed_by      TEXT,
     queued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     applied_at      TIMESTAMPTZ,
 
     CONSTRAINT mc_lot_build_log_action_chk
         CHECK (action_kind IN (0, 1)),
     CONSTRAINT mc_lot_build_log_apply_state_chk
-        CHECK (apply_state BETWEEN 0 AND 2),
+        CHECK (apply_state BETWEEN 0 AND 3),
     CONSTRAINT mc_lot_build_log_build_has_schematic_chk
         CHECK ((action_kind = 0 AND schematic_id IS NOT NULL)
             OR (action_kind = 1)),
+    CONSTRAINT mc_lot_build_log_apply_error_len_chk
+        CHECK (apply_error IS NULL OR length(apply_error) <= 2048),
+    CONSTRAINT mc_lot_build_log_claimed_consistency_chk
+        CHECK ((apply_state = 3 AND claimed_at IS NOT NULL)
+            OR (apply_state <> 3)),
     CONSTRAINT mc_lot_build_log_idem_uq UNIQUE (idempotency_key)
 );
 
 CREATE INDEX idx_mc_lot_build_log_lot     ON mc.lot_build_log (lot_id);
 CREATE INDEX idx_mc_lot_build_log_actor   ON mc.lot_build_log (actor_user_id);
 CREATE INDEX idx_mc_lot_build_log_pending ON mc.lot_build_log (queued_at) WHERE apply_state = 0;
+-- Stuck-job reclaim: find rows whose worker died after claiming.
+CREATE INDEX idx_mc_lot_build_log_claimed_stale
+    ON mc.lot_build_log (claimed_at)
+    WHERE apply_state = 3;
+
+-- At most one outstanding job (queued OR claimed) per lot. Stronger than
+-- the lot.state guard because it survives RPC bugs / direct admin writes.
+CREATE UNIQUE INDEX uq_mc_lot_build_log_one_active_per_lot
+    ON mc.lot_build_log (lot_id)
+    WHERE apply_state IN (0, 3);
 
 ALTER TABLE mc.lot_build_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE mc.lot_build_log FORCE ROW LEVEL SECURITY;
 
 COMMENT ON TABLE mc.lot_build_log IS
-    'Append-only audit of build/demolish events. action_kind: 0=build, 1=demolish. apply_state: 0=queued, 1=applied, 2=failed.';
+    'Append-only audit of build/demolish events and concurrent work queue. action_kind: 0=build, 1=demolish. apply_state: 0=queued, 1=applied, 2=failed, 3=claimed.';
 
 
 -- ===========================================================================
@@ -238,6 +343,7 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    chunk_area      INTEGER,
     anchor_y        SMALLINT,
     owner_user_id   UUID,
     current_schematic_id TEXT,
@@ -251,6 +357,7 @@ LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+ROWS 256
 AS $$
     SELECT l.lot_id,
            l.world,
@@ -258,6 +365,7 @@ AS $$
            upper(l.chunk_x_range) - 1 AS chunk_x_max,
            lower(l.chunk_z_range)     AS chunk_z_min,
            upper(l.chunk_z_range) - 1 AS chunk_z_max,
+           l.chunk_area,
            l.anchor_y,
            l.owner_user_id,
            l.current_schematic_id,
@@ -307,6 +415,7 @@ LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+ROWS 64
 AS $$
     SELECT s.schematic_id, s.name, s.category, s.tier,
            s.dims_x, s.dims_y, s.dims_z,
@@ -326,9 +435,18 @@ GRANT EXECUTE ON FUNCTION mc.service_list_schematics(TEXT, BOOLEAN)
 
 
 -- ===========================================================================
--- mc.service_pending_builds — MC mod work queue
+-- mc.service_claim_pending_builds — concurrency-safe work claim
 -- ===========================================================================
-CREATE OR REPLACE FUNCTION mc.service_pending_builds(p_limit INTEGER DEFAULT 32)
+--
+-- Replaces a plain SELECT of queued rows. Uses FOR UPDATE SKIP LOCKED so
+-- multiple MC workers polling at the same time each get a distinct slice,
+-- and flips apply_state from 0 → 3 (claimed) in the same statement so a
+-- worker death leaves a recoverable claim instead of a lost job.
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_claim_pending_builds(
+    p_worker_id TEXT,
+    p_limit INTEGER DEFAULT 32
+)
 RETURNS TABLE (
     build_id        TEXT,
     lot_id          TEXT,
@@ -338,22 +456,61 @@ RETURNS TABLE (
     queued_at       TIMESTAMPTZ
 )
 LANGUAGE sql
-STABLE
+SECURITY DEFINER
+SET search_path = ''
+ROWS 32
+AS $$
+    UPDATE mc.lot_build_log b
+       SET apply_state = 3,
+           claimed_at  = clock_timestamp(),
+           claimed_by  = p_worker_id
+     WHERE b.build_id IN (
+        SELECT inner_b.build_id
+          FROM mc.lot_build_log inner_b
+         WHERE inner_b.apply_state = 0
+         ORDER BY inner_b.queued_at
+         FOR UPDATE SKIP LOCKED
+         LIMIT GREATEST(1, LEAST(p_limit, 256))
+     )
+    RETURNING b.build_id, b.lot_id, b.actor_user_id,
+              b.action_kind, b.schematic_id, b.queued_at;
+$$;
+
+ALTER FUNCTION mc.service_claim_pending_builds(TEXT, INTEGER) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_claim_pending_builds(TEXT, INTEGER)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.service_claim_pending_builds(TEXT, INTEGER)
+    TO service_role;
+
+
+-- ===========================================================================
+-- mc.service_requeue_stale_claims — recover orphaned worker claims
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION mc.service_requeue_stale_claims(
+    p_older_than_seconds INTEGER DEFAULT 300
+)
+RETURNS INTEGER
+LANGUAGE sql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-    SELECT b.build_id, b.lot_id, b.actor_user_id,
-           b.action_kind, b.schematic_id, b.queued_at
-    FROM mc.lot_build_log b
-    WHERE b.apply_state = 0
-    ORDER BY b.queued_at
-    LIMIT GREATEST(1, LEAST(p_limit, 256));
+    WITH stale AS (
+        UPDATE mc.lot_build_log
+           SET apply_state = 0,
+               claimed_at = NULL,
+               claimed_by = NULL
+         WHERE apply_state = 3
+           AND claimed_at IS NOT NULL
+           AND claimed_at < clock_timestamp() - make_interval(secs => GREATEST(1, p_older_than_seconds))
+        RETURNING 1
+    )
+    SELECT COUNT(*)::INTEGER FROM stale;
 $$;
 
-ALTER FUNCTION mc.service_pending_builds(INTEGER) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.service_pending_builds(INTEGER)
+ALTER FUNCTION mc.service_requeue_stale_claims(INTEGER) OWNER TO postgres;
+REVOKE ALL ON FUNCTION mc.service_requeue_stale_claims(INTEGER)
     FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION mc.service_pending_builds(INTEGER)
+GRANT EXECUTE ON FUNCTION mc.service_requeue_stale_claims(INTEGER)
     TO service_role;
 
 
@@ -365,17 +522,21 @@ RETURNS BOOLEAN
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 DECLARE
     v_lot_id        TEXT;
     v_action_kind   SMALLINT;
     v_schematic_id  TEXT;
+    v_rowcount      INTEGER;
 BEGIN
     UPDATE mc.lot_build_log
        SET apply_state = 1,
-           applied_at = NOW()
+           applied_at = clock_timestamp(),
+           claimed_at = NULL,
+           claimed_by = NULL
      WHERE build_id = p_build_id
-       AND apply_state = 0
+       AND apply_state IN (0, 3)
     RETURNING lot_id, action_kind, schematic_id
         INTO v_lot_id, v_action_kind, v_schematic_id;
 
@@ -387,12 +548,24 @@ BEGIN
         UPDATE mc.lot
            SET state = 2,
                current_schematic_id = v_schematic_id
-         WHERE lot_id = v_lot_id;
+         WHERE lot_id = v_lot_id
+           AND state = 3;
+        GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+        IF v_rowcount <> 1 THEN
+            RAISE EXCEPTION 'lot % not in under_build state at ACK time', v_lot_id
+                USING ERRCODE = '22023';
+        END IF;
     ELSIF v_action_kind = 1 THEN
         UPDATE mc.lot
            SET state = 1,
                current_schematic_id = NULL
-         WHERE lot_id = v_lot_id;
+         WHERE lot_id = v_lot_id
+           AND state = 4;
+        GET DIAGNOSTICS v_rowcount = ROW_COUNT;
+        IF v_rowcount <> 1 THEN
+            RAISE EXCEPTION 'lot % not in demolishing state at ACK time', v_lot_id
+                USING ERRCODE = '22023';
+        END IF;
     END IF;
 
     RETURN TRUE;
@@ -417,16 +590,19 @@ RETURNS BOOLEAN
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 DECLARE
     v_lot_id TEXT;
 BEGIN
     UPDATE mc.lot_build_log
        SET apply_state = 2,
-           apply_error = p_error,
-           applied_at = NOW()
+           apply_error = left(p_error, 2048),
+           applied_at = clock_timestamp(),
+           claimed_at = NULL,
+           claimed_by = NULL
      WHERE build_id = p_build_id
-       AND apply_state = 0
+       AND apply_state IN (0, 3)
     RETURNING lot_id INTO v_lot_id;
 
     IF NOT FOUND THEN
@@ -435,7 +611,8 @@ BEGIN
 
     UPDATE mc.lot
        SET state = CASE WHEN current_schematic_id IS NULL THEN 1 ELSE 2 END
-     WHERE lot_id = v_lot_id;
+     WHERE lot_id = v_lot_id
+       AND state IN (3, 4);
 
     RETURN TRUE;
 END;
@@ -460,26 +637,44 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 DECLARE
-    v_lot           mc.lot%ROWTYPE;
-    v_account_id    UUID;
-    v_ledger_id     BIGINT;
-    v_purchase_id   TEXT;
+    v_existing_purchase_id TEXT;
+    v_existing_lot         TEXT;
+    v_existing_buyer       UUID;
+    v_lot_state            SMALLINT;
+    v_price_credits        BIGINT;
+    v_price_khash          BIGINT;
+    v_account_id           UUID;
+    v_credits_ledger_id    BIGINT;
+    v_khash_ledger_id      BIGINT;
+    v_purchase_id          TEXT;
 BEGIN
-    SELECT purchase_id INTO v_purchase_id
-    FROM mc.lot_purchase
-    WHERE idempotency_key = p_idempotency_key;
+    -- Idempotent replay: existing key must match the original parameters,
+    -- otherwise the caller is reusing a key for a different request.
+    SELECT purchase_id, lot_id, buyer_user_id
+      INTO v_existing_purchase_id, v_existing_lot, v_existing_buyer
+      FROM mc.lot_purchase
+     WHERE idempotency_key = p_idempotency_key;
     IF FOUND THEN
-        RETURN v_purchase_id;
+        IF v_existing_lot <> p_lot_id OR v_existing_buyer <> p_user_id THEN
+            RAISE EXCEPTION 'idempotency_key % already used for a different lot/buyer',
+                p_idempotency_key USING ERRCODE = '22023';
+        END IF;
+        RETURN v_existing_purchase_id;
     END IF;
 
-    SELECT * INTO v_lot FROM mc.lot WHERE lot_id = p_lot_id FOR UPDATE;
+    SELECT state, price_credits, price_khash
+      INTO v_lot_state, v_price_credits, v_price_khash
+      FROM mc.lot
+     WHERE lot_id = p_lot_id
+     FOR UPDATE;
     IF NOT FOUND THEN
         RAISE EXCEPTION 'lot % does not exist', p_lot_id USING ERRCODE = 'P0002';
     END IF;
-    IF v_lot.state <> 0 THEN
-        RAISE EXCEPTION 'lot % is not vacant (state=%)', p_lot_id, v_lot.state
+    IF v_lot_state <> 0 THEN
+        RAISE EXCEPTION 'lot % is not vacant (state=%)', p_lot_id, v_lot_state
             USING ERRCODE = '22023';
     END IF;
 
@@ -489,37 +684,39 @@ BEGIN
             USING ERRCODE = 'P0002';
     END IF;
 
-    IF v_lot.price_credits > 0 THEN
-        v_ledger_id := wallet.service_debit(
+    IF v_price_credits > 0 THEN
+        v_credits_ledger_id := wallet.service_debit(
             v_account_id,
             'credits'::wallet.currency_kind,
-            v_lot.price_credits,
+            v_price_credits,
             'purchase'::wallet.source_kind,
             'mc.lot.purchase:' || p_lot_id,
             'mc.lot',
             NULL,
-            p_idempotency_key
+            mc._derive_idem_key(p_idempotency_key, 'credits')
         );
     END IF;
-    IF v_lot.price_khash > 0 THEN
-        v_ledger_id := wallet.service_debit(
+    IF v_price_khash > 0 THEN
+        v_khash_ledger_id := wallet.service_debit(
             v_account_id,
             'khash'::wallet.currency_kind,
-            v_lot.price_khash,
+            v_price_khash,
             'purchase'::wallet.source_kind,
             'mc.lot.purchase:' || p_lot_id,
             'mc.lot',
             NULL,
-            p_idempotency_key
+            mc._derive_idem_key(p_idempotency_key, 'khash')
         );
     END IF;
 
     INSERT INTO mc.lot_purchase (
         lot_id, buyer_user_id, price_credits, price_khash,
-        wallet_ledger_id, idempotency_key
+        wallet_credits_ledger_id, wallet_khash_ledger_id,
+        idempotency_key
     ) VALUES (
-        p_lot_id, p_user_id, v_lot.price_credits, v_lot.price_khash,
-        v_ledger_id, p_idempotency_key
+        p_lot_id, p_user_id, v_price_credits, v_price_khash,
+        v_credits_ledger_id, v_khash_ledger_id,
+        p_idempotency_key
     )
     RETURNING purchase_id INTO v_purchase_id;
 
@@ -552,67 +749,98 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 DECLARE
-    v_lot               mc.lot%ROWTYPE;
-    v_schematic         mc.schematic%ROWTYPE;
-    v_account_id        UUID;
-    v_ledger_id         BIGINT;
-    v_build_id          TEXT;
-    v_chunks            INTEGER;
-    v_lot_dx_blocks     INTEGER;
-    v_lot_dz_blocks     INTEGER;
+    v_existing_build_id    TEXT;
+    v_existing_lot         TEXT;
+    v_existing_schematic   TEXT;
+    v_existing_actor       UUID;
+    v_lot_owner            UUID;
+    v_lot_state            SMALLINT;
+    v_lot_anchor_y         SMALLINT;
+    v_lot_chunk_area       INTEGER;
+    v_lot_dx_blocks        INTEGER;
+    v_lot_dz_blocks        INTEGER;
+    v_sch_dims_x           SMALLINT;
+    v_sch_dims_y           SMALLINT;
+    v_sch_dims_z           SMALLINT;
+    v_sch_price_credits    BIGINT;
+    v_sch_price_khash      BIGINT;
+    v_sch_enabled          BOOLEAN;
+    v_account_id           UUID;
+    v_credits_ledger_id    BIGINT;
+    v_khash_ledger_id      BIGINT;
+    v_build_id             TEXT;
 BEGIN
-    SELECT build_id INTO v_build_id
-    FROM mc.lot_build_log
-    WHERE idempotency_key = p_idempotency_key;
+    SELECT build_id, lot_id, schematic_id, actor_user_id
+      INTO v_existing_build_id, v_existing_lot, v_existing_schematic, v_existing_actor
+      FROM mc.lot_build_log
+     WHERE idempotency_key = p_idempotency_key;
     IF FOUND THEN
-        RETURN v_build_id;
+        IF v_existing_lot <> p_lot_id
+           OR v_existing_schematic IS DISTINCT FROM p_schematic_id
+           OR v_existing_actor <> p_user_id THEN
+            RAISE EXCEPTION 'idempotency_key % already used for a different build request',
+                p_idempotency_key USING ERRCODE = '22023';
+        END IF;
+        RETURN v_existing_build_id;
     END IF;
 
-    SELECT * INTO v_lot FROM mc.lot WHERE lot_id = p_lot_id FOR UPDATE;
+    SELECT owner_user_id, state, anchor_y,
+           chunk_area,
+           (upper(chunk_x_range) - lower(chunk_x_range)) * 16,
+           (upper(chunk_z_range) - lower(chunk_z_range)) * 16
+      INTO v_lot_owner, v_lot_state, v_lot_anchor_y,
+           v_lot_chunk_area,
+           v_lot_dx_blocks,
+           v_lot_dz_blocks
+      FROM mc.lot
+     WHERE lot_id = p_lot_id
+     FOR UPDATE;
     IF NOT FOUND THEN
         RAISE EXCEPTION 'lot % does not exist', p_lot_id USING ERRCODE = 'P0002';
     END IF;
-    IF v_lot.owner_user_id IS NULL OR v_lot.owner_user_id <> p_user_id THEN
+    IF v_lot_owner IS NULL OR v_lot_owner <> p_user_id THEN
         RAISE EXCEPTION 'user % does not own lot %', p_user_id, p_lot_id
             USING ERRCODE = '42501';
     END IF;
-    IF v_lot.state NOT IN (1, 2) THEN
+    IF v_lot_state NOT IN (1, 2) THEN
         RAISE EXCEPTION 'lot % is not in a buildable state (state=%)',
-            p_lot_id, v_lot.state USING ERRCODE = '22023';
+            p_lot_id, v_lot_state USING ERRCODE = '22023';
     END IF;
 
-    SELECT * INTO v_schematic FROM mc.schematic WHERE schematic_id = p_schematic_id;
+    SELECT dims_x, dims_y, dims_z,
+           price_credits, price_khash, enabled
+      INTO v_sch_dims_x, v_sch_dims_y, v_sch_dims_z,
+           v_sch_price_credits, v_sch_price_khash, v_sch_enabled
+      FROM mc.schematic
+     WHERE schematic_id = p_schematic_id;
     IF NOT FOUND THEN
         RAISE EXCEPTION 'schematic % does not exist', p_schematic_id
             USING ERRCODE = 'P0002';
     END IF;
-    IF NOT v_schematic.enabled THEN
+    IF NOT v_sch_enabled THEN
         RAISE EXCEPTION 'schematic % is disabled', p_schematic_id
             USING ERRCODE = '22023';
     END IF;
 
-    v_lot_dx_blocks := (upper(v_lot.chunk_x_range) - lower(v_lot.chunk_x_range)) * 16;
-    v_lot_dz_blocks := (upper(v_lot.chunk_z_range) - lower(v_lot.chunk_z_range)) * 16;
-    IF v_schematic.dims_x > v_lot_dx_blocks OR v_schematic.dims_z > v_lot_dz_blocks THEN
+    IF v_sch_dims_x > v_lot_dx_blocks OR v_sch_dims_z > v_lot_dz_blocks THEN
         RAISE EXCEPTION 'schematic % (%x%) does not fit lot % (%x%)',
-            p_schematic_id, v_schematic.dims_x, v_schematic.dims_z,
+            p_schematic_id, v_sch_dims_x, v_sch_dims_z,
             p_lot_id, v_lot_dx_blocks, v_lot_dz_blocks
             USING ERRCODE = '22023';
     END IF;
-    IF v_lot.anchor_y + v_schematic.dims_y > 319 THEN
+    IF v_lot_anchor_y + v_sch_dims_y > 319 THEN
         RAISE EXCEPTION 'schematic % at anchor_y=% exceeds world height',
-            p_schematic_id, v_lot.anchor_y USING ERRCODE = '22023';
+            p_schematic_id, v_lot_anchor_y USING ERRCODE = '22023';
     END IF;
 
     -- Phase-0 chunk-count guard. Lifted in a follow-up migration once the
     -- tick-chunked paste pipeline is proven stable.
-    v_chunks := (upper(v_lot.chunk_x_range) - lower(v_lot.chunk_x_range))
-              * (upper(v_lot.chunk_z_range) - lower(v_lot.chunk_z_range));
-    IF v_chunks > 64 THEN
+    IF v_lot_chunk_area > 64 THEN
         RAISE EXCEPTION 'lot % exceeds phase-0 build cap (chunks=%, max=64)',
-            p_lot_id, v_chunks USING ERRCODE = '22023';
+            p_lot_id, v_lot_chunk_area USING ERRCODE = '22023';
     END IF;
 
     v_account_id := mc._user_account_id(p_user_id);
@@ -621,38 +849,41 @@ BEGIN
             USING ERRCODE = 'P0002';
     END IF;
 
-    IF v_schematic.price_credits > 0 THEN
-        v_ledger_id := wallet.service_debit(
+    IF v_sch_price_credits > 0 THEN
+        v_credits_ledger_id := wallet.service_debit(
             v_account_id,
             'credits'::wallet.currency_kind,
-            v_schematic.price_credits,
+            v_sch_price_credits,
             'purchase'::wallet.source_kind,
             'mc.lot.build:' || p_lot_id || ':' || p_schematic_id,
             'mc.lot_build_log',
             NULL,
-            p_idempotency_key
+            mc._derive_idem_key(p_idempotency_key, 'credits')
         );
     END IF;
-    IF v_schematic.price_khash > 0 THEN
-        v_ledger_id := wallet.service_debit(
+    IF v_sch_price_khash > 0 THEN
+        v_khash_ledger_id := wallet.service_debit(
             v_account_id,
             'khash'::wallet.currency_kind,
-            v_schematic.price_khash,
+            v_sch_price_khash,
             'purchase'::wallet.source_kind,
             'mc.lot.build:' || p_lot_id || ':' || p_schematic_id,
             'mc.lot_build_log',
             NULL,
-            p_idempotency_key
+            mc._derive_idem_key(p_idempotency_key, 'khash')
         );
     END IF;
 
     INSERT INTO mc.lot_build_log (
         lot_id, actor_user_id, action_kind, schematic_id,
-        price_credits, price_khash, wallet_ledger_id, idempotency_key
+        price_credits, price_khash,
+        wallet_credits_ledger_id, wallet_khash_ledger_id,
+        idempotency_key
     ) VALUES (
         p_lot_id, p_user_id, 0, p_schematic_id,
-        v_schematic.price_credits, v_schematic.price_khash,
-        v_ledger_id, p_idempotency_key
+        v_sch_price_credits, v_sch_price_khash,
+        v_credits_ledger_id, v_khash_ledger_id,
+        p_idempotency_key
     )
     RETURNING build_id INTO v_build_id;
 
@@ -681,29 +912,46 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 DECLARE
-    v_lot       mc.lot%ROWTYPE;
-    v_build_id  TEXT;
+    v_existing_build_id    TEXT;
+    v_existing_lot         TEXT;
+    v_existing_actor       UUID;
+    v_existing_action      SMALLINT;
+    v_lot_owner            UUID;
+    v_lot_state            SMALLINT;
+    v_build_id             TEXT;
 BEGIN
-    SELECT build_id INTO v_build_id
-    FROM mc.lot_build_log
-    WHERE idempotency_key = p_idempotency_key;
+    SELECT build_id, lot_id, actor_user_id, action_kind
+      INTO v_existing_build_id, v_existing_lot, v_existing_actor, v_existing_action
+      FROM mc.lot_build_log
+     WHERE idempotency_key = p_idempotency_key;
     IF FOUND THEN
-        RETURN v_build_id;
+        IF v_existing_lot <> p_lot_id
+           OR v_existing_actor <> p_user_id
+           OR v_existing_action <> 1 THEN
+            RAISE EXCEPTION 'idempotency_key % already used for a different request',
+                p_idempotency_key USING ERRCODE = '22023';
+        END IF;
+        RETURN v_existing_build_id;
     END IF;
 
-    SELECT * INTO v_lot FROM mc.lot WHERE lot_id = p_lot_id FOR UPDATE;
+    SELECT owner_user_id, state
+      INTO v_lot_owner, v_lot_state
+      FROM mc.lot
+     WHERE lot_id = p_lot_id
+     FOR UPDATE;
     IF NOT FOUND THEN
         RAISE EXCEPTION 'lot % does not exist', p_lot_id USING ERRCODE = 'P0002';
     END IF;
-    IF v_lot.owner_user_id IS NULL OR v_lot.owner_user_id <> p_user_id THEN
+    IF v_lot_owner IS NULL OR v_lot_owner <> p_user_id THEN
         RAISE EXCEPTION 'user % does not own lot %', p_user_id, p_lot_id
             USING ERRCODE = '42501';
     END IF;
-    IF v_lot.state <> 2 THEN
+    IF v_lot_state <> 2 THEN
         RAISE EXCEPTION 'lot % has nothing to demolish (state=%)',
-            p_lot_id, v_lot.state USING ERRCODE = '22023';
+            p_lot_id, v_lot_state USING ERRCODE = '22023';
     END IF;
 
     INSERT INTO mc.lot_build_log (
@@ -727,7 +975,7 @@ GRANT EXECUTE ON FUNCTION mc.service_queue_demolish_lot(TEXT, UUID, UUID)
 
 
 -- ===========================================================================
--- mc.proxy_* RPCs (caller is auth.uid())
+-- mc.proxy_* RPCs (auth.uid()-bound; called by the public.proxy_* layer)
 -- ===========================================================================
 CREATE OR REPLACE FUNCTION mc.proxy_list_lots(
     p_world TEXT DEFAULT NULL,
@@ -743,6 +991,7 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    chunk_area      INTEGER,
     anchor_y        SMALLINT,
     owner_user_id   UUID,
     is_owned_by_me  BOOLEAN,
@@ -755,6 +1004,7 @@ LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+ROWS 256
 AS $$
 DECLARE
     v_uid UUID := auth.uid();
@@ -766,6 +1016,7 @@ BEGIN
            upper(l.chunk_x_range) - 1 AS chunk_x_max,
            lower(l.chunk_z_range)     AS chunk_z_min,
            upper(l.chunk_z_range) - 1 AS chunk_z_max,
+           l.chunk_area,
            l.anchor_y,
            l.owner_user_id,
            (l.owner_user_id IS NOT NULL AND l.owner_user_id = v_uid) AS is_owned_by_me,
@@ -785,9 +1036,13 @@ $$;
 
 ALTER FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER) OWNER TO postgres;
 REVOKE ALL ON FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER)
-    FROM PUBLIC, anon;
+    FROM PUBLIC, anon, authenticated;
+-- Only the public wrapper (running as service_role) calls into this layer.
+-- authenticated is intentionally excluded — direct PostgREST access to the
+-- mc schema is impossible anyway, but tightening the grant means a future
+-- exposure mistake doesn't accidentally expose this entry point.
 GRANT EXECUTE ON FUNCTION mc.proxy_list_lots(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER)
-    TO authenticated, service_role;
+    TO service_role;
 
 
 CREATE OR REPLACE FUNCTION mc.proxy_list_schematics(p_category TEXT DEFAULT NULL)
@@ -806,6 +1061,7 @@ LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+ROWS 64
 AS $$
     SELECT s.schematic_id, s.name, s.category, s.tier,
            s.dims_x, s.dims_y, s.dims_z,
@@ -817,8 +1073,9 @@ AS $$
 $$;
 
 ALTER FUNCTION mc.proxy_list_schematics(TEXT) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.proxy_list_schematics(TEXT) FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION mc.proxy_list_schematics(TEXT) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION mc.proxy_list_schematics(TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.proxy_list_schematics(TEXT) TO service_role;
 
 
 CREATE OR REPLACE FUNCTION mc.proxy_purchase_lot(p_lot_id TEXT)
@@ -826,6 +1083,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 DECLARE
     v_uid UUID := auth.uid();
@@ -838,8 +1096,8 @@ END;
 $$;
 
 ALTER FUNCTION mc.proxy_purchase_lot(TEXT) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.proxy_purchase_lot(TEXT) FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION mc.proxy_purchase_lot(TEXT) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION mc.proxy_purchase_lot(TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.proxy_purchase_lot(TEXT) TO service_role;
 
 
 CREATE OR REPLACE FUNCTION mc.proxy_queue_build_on_lot(
@@ -850,6 +1108,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 DECLARE
     v_uid UUID := auth.uid();
@@ -862,8 +1121,9 @@ END;
 $$;
 
 ALTER FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT) FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.proxy_queue_build_on_lot(TEXT, TEXT) TO service_role;
 
 
 CREATE OR REPLACE FUNCTION mc.proxy_queue_demolish_lot(p_lot_id TEXT)
@@ -871,6 +1131,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 DECLARE
     v_uid UUID := auth.uid();
@@ -883,8 +1144,9 @@ END;
 $$;
 
 ALTER FUNCTION mc.proxy_queue_demolish_lot(TEXT) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc.proxy_queue_demolish_lot(TEXT) FROM PUBLIC, anon;
-GRANT EXECUTE ON FUNCTION mc.proxy_queue_demolish_lot(TEXT) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION mc.proxy_queue_demolish_lot(TEXT)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION mc.proxy_queue_demolish_lot(TEXT) TO service_role;
 
 
 -- ===========================================================================
@@ -904,6 +1166,7 @@ RETURNS TABLE (
     chunk_x_max     INTEGER,
     chunk_z_min     INTEGER,
     chunk_z_max     INTEGER,
+    chunk_area      INTEGER,
     anchor_y        SMALLINT,
     owner_user_id   UUID,
     is_owned_by_me  BOOLEAN,
@@ -916,6 +1179,7 @@ LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+ROWS 256
 AS $$
     SELECT * FROM mc.proxy_list_lots(p_world, p_state, p_only_mine, p_limit, p_offset);
 $$;
@@ -943,6 +1207,7 @@ LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+ROWS 64
 AS $$
     SELECT * FROM mc.proxy_list_schematics(p_category);
 $$;
@@ -957,6 +1222,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 BEGIN
     IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
@@ -979,6 +1245,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 BEGIN
     IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
@@ -1001,6 +1268,7 @@ RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
+COST 100
 AS $$
 BEGIN
     IF p_lot_id IS NULL OR btrim(p_lot_id) = '' THEN
@@ -1037,15 +1305,20 @@ DROP FUNCTION IF EXISTS mc.service_queue_build_on_lot(TEXT, TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_purchase_lot(TEXT, UUID, UUID);
 DROP FUNCTION IF EXISTS mc.service_mark_build_failed(TEXT, TEXT);
 DROP FUNCTION IF EXISTS mc.service_mark_build_applied(TEXT);
-DROP FUNCTION IF EXISTS mc.service_pending_builds(INTEGER);
+DROP FUNCTION IF EXISTS mc.service_requeue_stale_claims(INTEGER);
+DROP FUNCTION IF EXISTS mc.service_claim_pending_builds(TEXT, INTEGER);
 DROP FUNCTION IF EXISTS mc.service_list_schematics(TEXT, BOOLEAN);
 DROP FUNCTION IF EXISTS mc.service_list_lots(TEXT, SMALLINT, UUID, INTEGER, INTEGER);
 DROP FUNCTION IF EXISTS mc._user_account_id(UUID);
+DROP FUNCTION IF EXISTS mc._derive_idem_key(UUID, TEXT);
 
 DROP TABLE IF EXISTS mc.lot_build_log;
 DROP TABLE IF EXISTS mc.lot_purchase;
+
+DROP TRIGGER IF EXISTS trg_mc_lot_updated_at ON mc.lot;
 DROP TABLE IF EXISTS mc.lot;
 DROP FUNCTION IF EXISTS mc.trg_lot_updated_at();
+
 DROP TABLE IF EXISTS mc.schematic;
 
 NOTIFY pgrst, 'reload schema';

--- a/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
+++ b/packages/data/sql/dbmate/migrations/20260526223407_mc_lot_system.sql
@@ -57,8 +57,7 @@ AS $$
 $$;
 
 ALTER FUNCTION mc._derive_idem_key(UUID, TEXT) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc._derive_idem_key(UUID, TEXT) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION mc._derive_idem_key(UUID, TEXT) TO service_role;
+REVOKE ALL ON FUNCTION mc._derive_idem_key(UUID, TEXT) FROM PUBLIC, anon, authenticated, service_role;
 
 
 -- ===========================================================================
@@ -87,7 +86,7 @@ CREATE TABLE mc.schematic (
         CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument')),
     -- Reject path traversal; lock to schematics/ dir in mod jar.
     CONSTRAINT mc_schematic_resource_path_chk
-        CHECK (resource_path !~ '(^/|\.\.)' AND
+        CHECK (resource_path !~ '(^/|\.\.|//|\\)' AND
                resource_path ~ '^schematics/[A-Za-z0-9_./-]+\.(nbt|schem)$')
 );
 
@@ -150,6 +149,8 @@ CREATE TABLE mc.lot (
 
     CONSTRAINT mc_lot_id_chk         CHECK (lot_id ~ '^[A-Za-z0-9:_-]{3,96}$'),
     CONSTRAINT mc_lot_flags_chk      CHECK (flags >= 0),
+    -- Phase-0 reserves the low 16 bits; reject undefined upper-half writes.
+    CONSTRAINT mc_lot_flags_mask_chk CHECK ((flags & ~65535) = 0),
     CONSTRAINT mc_lot_anchor_y_chk   CHECK (anchor_y BETWEEN -64 AND 319),
     CONSTRAINT mc_lot_price_chk      CHECK (price_credits >= 0 AND price_khash >= 0),
     CONSTRAINT mc_lot_x_range_chk    CHECK (NOT isempty(chunk_x_range)
@@ -212,24 +213,34 @@ CREATE INDEX idx_mc_lot_world_state_chunk_cursor
 CREATE INDEX idx_mc_lot_owner_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     WHERE owner_user_id IS NOT NULL;
--- Marketplace map: vacant lots, index-only via INCLUDE.
 CREATE INDEX idx_mc_lot_vacant_world_chunk_cursor
     ON mc.lot (world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (chunk_x_max, chunk_z_max, chunk_area, anchor_y,
+             block_x_min, block_x_max, block_z_min, block_z_max,
              price_credits, price_khash)
     WHERE state = 0;
--- "My lots" (state IN (1,2)), index-only.
 CREATE INDEX idx_mc_lot_owner_active_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
-             chunk_area, anchor_y, price_credits, price_khash)
+             chunk_area, anchor_y,
+             block_x_min, block_x_max, block_z_min, block_z_max,
+             price_credits, price_khash)
     WHERE owner_user_id IS NOT NULL AND state IN (1, 2);
--- Transitional poll view (state IN (3,4)).
 CREATE INDEX idx_mc_lot_owner_transitional_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
-             chunk_area, anchor_y, price_credits, price_khash)
+             chunk_area, anchor_y,
+             block_x_min, block_x_max, block_z_min, block_z_max,
+             price_credits, price_khash)
     WHERE owner_user_id IS NOT NULL AND state IN (3, 4);
+-- Global transitional scan: repair / admin sweep across all worlds + owners.
+CREATE INDEX idx_mc_lot_transitional_repair
+    ON mc.lot (lot_id)
+    INCLUDE (state, current_schematic_id)
+    WHERE state IN (3, 4);
+-- Viewport range scan via GIST on the int4range columns directly.
+CREATE INDEX idx_mc_lot_world_chunk_ranges_gist
+    ON mc.lot USING gist (world, chunk_x_range, chunk_z_range);
 
 ALTER TABLE mc.lot OWNER TO postgres;
 ALTER TABLE mc.lot ENABLE ROW LEVEL SECURITY;
@@ -513,7 +524,7 @@ AS $$
 $$;
 
 ALTER FUNCTION mc._user_account_id(UUID) OWNER TO postgres;
-REVOKE ALL ON FUNCTION mc._user_account_id(UUID) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION mc._user_account_id(UUID) FROM PUBLIC, anon, authenticated, service_role;
 
 
 -- ===========================================================================
@@ -763,11 +774,10 @@ BEGIN
         SELECT build_id
           FROM mc.lot_build_log
          WHERE apply_state = 0
-           -- Exhausted jobs stay dormant; admin unsticks via retry RPC.
            AND attempt_count < 5
          ORDER BY queued_at, build_id
          LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 32), 256))
-         FOR UPDATE SKIP LOCKED
+         FOR NO KEY UPDATE SKIP LOCKED
     ),
     nowish AS (SELECT clock_timestamp() AS ts),
     claimed AS (
@@ -833,7 +843,7 @@ AS $$
                               LEAST(GREATEST(1, COALESCE(p_older_than_seconds, 300)), 86400))
          ORDER BY claimed_at, build_id
          LIMIT GREATEST(0, LEAST(COALESCE(p_limit, 128), 512))
-         FOR UPDATE SKIP LOCKED
+         FOR NO KEY UPDATE SKIP LOCKED
     ),
     requeued AS (
         UPDATE mc.lot_build_log b
@@ -1757,7 +1767,9 @@ SET search_path = ''
 ROWS 256
 AS $$
 BEGIN
-    -- Four-field cursor all-or-none; partial cursor would silent-empty.
+    IF auth.role() <> 'service_role' THEN
+        RAISE EXCEPTION 'service_role required' USING ERRCODE = '42501';
+    END IF;
     IF p_after_lot_id IS NOT NULL
        AND (p_after_world IS NULL
             OR p_after_chunk_x IS NULL
@@ -1940,12 +1952,17 @@ RETURNS TABLE (
     dims_y          SMALLINT,
     dims_z          SMALLINT
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 ROWS 32
 AS $$
-    SELECT * FROM mc.service_claim_pending_builds(p_worker_id, p_limit);
+BEGIN
+    IF auth.role() <> 'service_role' THEN
+        RAISE EXCEPTION 'service_role required' USING ERRCODE = '42501';
+    END IF;
+    RETURN QUERY SELECT * FROM mc.service_claim_pending_builds(p_worker_id, p_limit);
+END;
 $$;
 
 ALTER FUNCTION public.proxy_service_claim_pending_builds(TEXT, INTEGER) OWNER TO service_role;
@@ -1962,12 +1979,17 @@ CREATE OR REPLACE FUNCTION public.proxy_service_mark_build_applied(
     p_worker_id TEXT
 )
 RETURNS BOOLEAN
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 COST 100
 AS $$
-    SELECT mc.service_mark_build_applied(p_build_id, p_worker_id);
+BEGIN
+    IF auth.role() <> 'service_role' THEN
+        RAISE EXCEPTION 'service_role required' USING ERRCODE = '42501';
+    END IF;
+    RETURN mc.service_mark_build_applied(p_build_id, p_worker_id);
+END;
 $$;
 
 ALTER FUNCTION public.proxy_service_mark_build_applied(TEXT, TEXT) OWNER TO service_role;
@@ -1985,12 +2007,17 @@ CREATE OR REPLACE FUNCTION public.proxy_service_mark_build_failed(
     p_error     TEXT
 )
 RETURNS BOOLEAN
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 COST 100
 AS $$
-    SELECT mc.service_mark_build_failed(p_build_id, p_worker_id, p_error);
+BEGIN
+    IF auth.role() <> 'service_role' THEN
+        RAISE EXCEPTION 'service_role required' USING ERRCODE = '42501';
+    END IF;
+    RETURN mc.service_mark_build_failed(p_build_id, p_worker_id, p_error);
+END;
 $$;
 
 ALTER FUNCTION public.proxy_service_mark_build_failed(TEXT, TEXT, TEXT) OWNER TO service_role;
@@ -2010,12 +2037,17 @@ RETURNS TABLE (
     requeued_count  INTEGER,
     exhausted_count INTEGER
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 COST 100
 AS $$
-    SELECT * FROM mc.service_requeue_stale_claims(p_older_than_seconds, p_limit);
+BEGIN
+    IF auth.role() <> 'service_role' THEN
+        RAISE EXCEPTION 'service_role required' USING ERRCODE = '42501';
+    END IF;
+    RETURN QUERY SELECT * FROM mc.service_requeue_stale_claims(p_older_than_seconds, p_limit);
+END;
 $$;
 
 ALTER FUNCTION public.proxy_service_requeue_stale_claims(INTEGER, INTEGER) OWNER TO service_role;
@@ -2137,11 +2169,16 @@ CREATE OR REPLACE FUNCTION public.proxy_service_retry_failed_build(
     p_reset_attempts BOOLEAN DEFAULT FALSE
 )
 RETURNS BOOLEAN
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-    SELECT mc.service_retry_failed_build(p_build_id, p_reset_attempts);
+BEGIN
+    IF auth.role() <> 'service_role' THEN
+        RAISE EXCEPTION 'service_role required' USING ERRCODE = '42501';
+    END IF;
+    RETURN mc.service_retry_failed_build(p_build_id, p_reset_attempts);
+END;
 $$;
 
 ALTER FUNCTION public.proxy_service_retry_failed_build(TEXT, BOOLEAN) OWNER TO service_role;
@@ -2222,6 +2259,9 @@ SET search_path = ''
 ROWS 100
 AS $$
 BEGIN
+    IF auth.role() <> 'service_role' THEN
+        RAISE EXCEPTION 'service_role required' USING ERRCODE = '42501';
+    END IF;
     IF p_after_build_id IS NOT NULL AND p_after_failed_at IS NULL THEN
         RAISE EXCEPTION 'cursor must include after_failed_at and after_build_id together'
             USING ERRCODE = '22023';
@@ -2334,11 +2374,16 @@ CREATE OR REPLACE FUNCTION public.proxy_service_release_user_lots(
     p_force   BOOLEAN DEFAULT FALSE
 )
 RETURNS TABLE (lot_id TEXT, prior_state SMALLINT)
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-    SELECT * FROM mc.service_release_user_lots(p_user_id, p_force);
+BEGIN
+    IF auth.role() <> 'service_role' THEN
+        RAISE EXCEPTION 'service_role required' USING ERRCODE = '42501';
+    END IF;
+    RETURN QUERY SELECT * FROM mc.service_release_user_lots(p_user_id, p_force);
+END;
 $$;
 
 ALTER FUNCTION public.proxy_service_release_user_lots(UUID, BOOLEAN) OWNER TO service_role;
@@ -2466,11 +2511,16 @@ RETURNS TABLE (
     latest_failed_at    TIMESTAMPTZ,
     latest_apply_error  TEXT
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
 AS $$
-    SELECT * FROM mc.service_repair_orphan_transitional(p_dry_run);
+BEGIN
+    IF auth.role() <> 'service_role' THEN
+        RAISE EXCEPTION 'service_role required' USING ERRCODE = '42501';
+    END IF;
+    RETURN QUERY SELECT * FROM mc.service_repair_orphan_transitional(p_dry_run);
+END;
 $$;
 
 ALTER FUNCTION public.proxy_service_repair_orphan_transitional(BOOLEAN) OWNER TO service_role;
@@ -2504,13 +2554,18 @@ RETURNS TABLE (
     created_at      TIMESTAMPTZ,
     updated_at      TIMESTAMPTZ
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
 ROWS 1
 AS $$
-    SELECT * FROM mc.service_get_lot(p_lot_id);
+BEGIN
+    IF auth.role() <> 'service_role' THEN
+        RAISE EXCEPTION 'service_role required' USING ERRCODE = '42501';
+    END IF;
+    RETURN QUERY SELECT * FROM mc.service_get_lot(p_lot_id);
+END;
 $$;
 
 ALTER FUNCTION public.proxy_service_get_lot(TEXT) OWNER TO service_role;
@@ -2871,7 +2926,7 @@ GRANT EXECUTE ON FUNCTION public.proxy_list_lots_public(TEXT, SMALLINT, BOOLEAN,
     TO authenticated, service_role;
 COMMENT ON FUNCTION public.proxy_list_lots_public(TEXT, SMALLINT, BOOLEAN, INTEGER, INTEGER,
                                                   TEXT, INTEGER, INTEGER, TEXT) IS
-    'Public-safe generic lot listing. Mirrors proxy_list_lots but replaces owner_user_id with is_owned + is_owned_by_me so the dashboard does not leak ownership UUIDs of other players. Use the dedicated hot-path wrappers (proxy_list_vacant_lots / proxy_list_my_active_lots) when possible — they hit narrower partial indexes.';
+    'Admin/debug/compat-only. Generic lot listing fallback that does not pin a partial INCLUDE index, so heap fetches dominate on hot paths. Prefer the dedicated hot-path wrappers (proxy_list_vacant_lots / proxy_list_my_active_lots / proxy_list_my_transitional_lots) in app code. Replaces owner_user_id with is_owned + is_owned_by_me so it never leaks third-party UUIDs.';
 
 
 -- ===========================================================================

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -77,9 +77,10 @@ CREATE TABLE IF NOT EXISTS mc.schematic (
                resource_path ~ '^schematics/[A-Za-z0-9_./-]+\.(nbt|schem)$')
 );
 
-CREATE INDEX IF NOT EXISTS idx_mc_schematic_enabled_category_tier_name
-    ON mc.schematic (category, tier, name) WHERE enabled;
-CREATE INDEX IF NOT EXISTS idx_mc_schematic_tier ON mc.schematic (tier);
+CREATE INDEX IF NOT EXISTS idx_mc_schematic_enabled_category_tier_name_cover
+    ON mc.schematic (category, tier, name, schematic_id)
+    INCLUDE (dims_x, dims_y, dims_z, price_credits, price_khash)
+    WHERE enabled;
 
 
 -- ========== TABLE: mc.lot ==========
@@ -89,6 +90,10 @@ CREATE TABLE IF NOT EXISTS mc.lot (
     world           TEXT NOT NULL DEFAULT 'minecraft:overworld',
     chunk_x_range   int4range NOT NULL,
     chunk_z_range   int4range NOT NULL,
+    chunk_x_min     INTEGER GENERATED ALWAYS AS (lower(chunk_x_range)) STORED,
+    chunk_x_max     INTEGER GENERATED ALWAYS AS (upper(chunk_x_range) - 1) STORED,
+    chunk_z_min     INTEGER GENERATED ALWAYS AS (lower(chunk_z_range)) STORED,
+    chunk_z_max     INTEGER GENERATED ALWAYS AS (upper(chunk_z_range) - 1) STORED,
     chunk_width     INTEGER GENERATED ALWAYS AS
         (upper(chunk_x_range) - lower(chunk_x_range)) STORED,
     chunk_depth     INTEGER GENERATED ALWAYS AS
@@ -139,13 +144,15 @@ CREATE TABLE IF NOT EXISTS mc.lot (
 
 CREATE INDEX IF NOT EXISTS idx_mc_lot_owner
     ON mc.lot (owner_user_id) WHERE owner_user_id IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_mc_lot_world_chunk_order
-    ON mc.lot (world, lower(chunk_x_range), lower(chunk_z_range));
-CREATE INDEX IF NOT EXISTS idx_mc_lot_world_state_chunk_order
-    ON mc.lot (world, state, lower(chunk_x_range), lower(chunk_z_range));
-CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_world_chunk_order
-    ON mc.lot (owner_user_id, world, lower(chunk_x_range), lower(chunk_z_range))
+CREATE INDEX IF NOT EXISTS idx_mc_lot_world_chunk_cursor
+    ON mc.lot (world, chunk_x_min, chunk_z_min, lot_id);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_world_state_chunk_cursor
+    ON mc.lot (world, state, chunk_x_min, chunk_z_min, lot_id);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_world_chunk_cursor
+    ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     WHERE owner_user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mc_lot_current_schematic
+    ON mc.lot (current_schematic_id) WHERE current_schematic_id IS NOT NULL;
 
 
 -- ========== TABLE: mc.lot_purchase ==========
@@ -163,11 +170,20 @@ CREATE TABLE IF NOT EXISTS mc.lot_purchase (
 
     CONSTRAINT mc_lot_purchase_price_chk
         CHECK (price_credits >= 0 AND price_khash >= 0),
+    CONSTRAINT mc_lot_purchase_credits_ledger_chk CHECK (
+        (price_credits = 0 AND wallet_credits_ledger_id IS NULL)
+        OR (price_credits > 0 AND wallet_credits_ledger_id IS NOT NULL)
+    ),
+    CONSTRAINT mc_lot_purchase_khash_ledger_chk CHECK (
+        (price_khash = 0 AND wallet_khash_ledger_id IS NULL)
+        OR (price_khash > 0 AND wallet_khash_ledger_id IS NOT NULL)
+    ),
     CONSTRAINT mc_lot_purchase_idem_uq UNIQUE (idempotency_key)
 );
 
-CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_lot   ON mc.lot_purchase (lot_id);
-CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_buyer ON mc.lot_purchase (buyer_user_id);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_lot ON mc.lot_purchase (lot_id);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_buyer_created
+    ON mc.lot_purchase (buyer_user_id, created_at DESC, purchase_id DESC);
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mc_lot_purchase_one_per_lot
     ON mc.lot_purchase (lot_id);
 
@@ -203,6 +219,14 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
         CHECK (apply_error IS NULL OR length(apply_error) <= 2048),
     CONSTRAINT mc_lot_build_log_claimed_by_len_chk
         CHECK (claimed_by IS NULL OR length(claimed_by) <= 128),
+    CONSTRAINT mc_lot_build_log_credits_ledger_chk CHECK (
+        (price_credits = 0 AND wallet_credits_ledger_id IS NULL)
+        OR (price_credits > 0 AND wallet_credits_ledger_id IS NOT NULL)
+    ),
+    CONSTRAINT mc_lot_build_log_khash_ledger_chk CHECK (
+        (price_khash = 0 AND wallet_khash_ledger_id IS NULL)
+        OR (price_khash > 0 AND wallet_khash_ledger_id IS NOT NULL)
+    ),
     CONSTRAINT mc_lot_build_log_claimed_consistency_chk
         CHECK (
             (apply_state = 3 AND claimed_at IS NOT NULL AND claimed_by IS NOT NULL)
@@ -213,14 +237,24 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
 
 CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_lot
     ON mc.lot_build_log (lot_id);
-CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_actor
-    ON mc.lot_build_log (actor_user_id);
-CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_pending
-    ON mc.lot_build_log (queued_at) WHERE apply_state = 0;
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_actor_queued
+    ON mc.lot_build_log (actor_user_id, queued_at DESC, build_id DESC);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_pending_claim
+    ON mc.lot_build_log (queued_at, build_id) WHERE apply_state = 0;
 CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_claimed_stale
-    ON mc.lot_build_log (claimed_at) WHERE apply_state = 3;
+    ON mc.lot_build_log (claimed_at, build_id) WHERE apply_state = 3;
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_schematic
+    ON mc.lot_build_log (schematic_id) WHERE schematic_id IS NOT NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mc_lot_build_log_one_active_per_lot
     ON mc.lot_build_log (lot_id) WHERE apply_state IN (0, 3);
+
+ALTER TABLE mc.lot_build_log SET (
+    fillfactor = 80,
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_analyze_scale_factor = 0.01,
+    autovacuum_vacuum_threshold = 1000,
+    autovacuum_analyze_threshold = 500
+);
 
 
 COMMENT ON COLUMN mc.lot_build_log.action_kind IS '0=build, 1=demolish';

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -42,7 +42,8 @@
 -- ============================================================
 
 CREATE EXTENSION IF NOT EXISTS btree_gist;
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
+-- pgcrypto is installed under the `extensions` schema by mc_schema_init.
+-- mc._derive_idem_key calls extensions.digest directly.
 
 
 -- ========== TABLE: mc.schematic ==========

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -1,0 +1,169 @@
+-- ============================================================
+-- MC LOT SYSTEM — Digital real-estate for the survival backend.
+--
+-- This file mirrors the contents of the dbmate migration
+-- 20260526223407_mc_lot_system.sql and exists as the canonical
+-- source of truth for the lot/schematic schema. Update both when
+-- changing the schema.
+--
+-- Tables:
+--   mc.schematic        — build catalog (id, dims, price, resource path)
+--   mc.lot              — parcel registry (chunk_x_range, chunk_z_range,
+--                         owner, current_schematic_id, state, price)
+--   mc.lot_purchase     — append-only ownership ledger
+--   mc.lot_build_log    — append-only build/demolish audit
+--
+-- Constraints worth highlighting:
+--   - mc.lot uses a GIST EXCLUDE constraint on
+--     (world =, chunk_x_range &&, chunk_z_range &&) so two lots in the
+--     same world cannot occupy any overlapping chunk.
+--   - chunk_x_range / chunk_z_range are stored as half-open int4range
+--     pairs so a 1x1 lot at chunk 5 is [5, 6), and a 13x7 castle
+--     bounding box is [20, 33) x [-10, -3).
+--   - lot.state is a smallint enum:
+--         0 = vacant, 1 = owned, 2 = built,
+--         3 = under_build, 4 = demolishing
+--
+-- RPC layering:
+--   mc.service_*  — service_role only, used by MC mod + admin tooling.
+--   mc.proxy_*    — authenticated callers; uses auth.uid() for ownership.
+--   public.proxy_*— PostgREST wrapper because the mc schema is private.
+--
+-- Money flow rides on wallet.service_debit against the user-kind
+-- account; mc.lot_purchase and mc.lot_build_log keep their own audit
+-- rows so we can reconstruct ownership / build history without
+-- joining through wallet.ledger.
+-- ============================================================
+
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+
+-- ========== TABLE: mc.schematic ==========
+
+CREATE TABLE IF NOT EXISTS mc.schematic (
+    schematic_id    TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    category        TEXT NOT NULL,
+    tier            SMALLINT NOT NULL DEFAULT 1,
+    dims_x          SMALLINT NOT NULL,
+    dims_y          SMALLINT NOT NULL,
+    dims_z          SMALLINT NOT NULL,
+    price_credits   BIGINT NOT NULL DEFAULT 0,
+    price_khash     BIGINT NOT NULL DEFAULT 0,
+    resource_path   TEXT NOT NULL,
+    enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT mc_schematic_tier_chk   CHECK (tier BETWEEN 1 AND 10),
+    CONSTRAINT mc_schematic_dims_chk   CHECK (dims_x > 0 AND dims_y > 0 AND dims_z > 0),
+    CONSTRAINT mc_schematic_dims_y_chk CHECK (dims_y <= 384),
+    CONSTRAINT mc_schematic_price_chk  CHECK (price_credits >= 0 AND price_khash >= 0),
+    CONSTRAINT mc_schematic_category_chk
+        CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_schematic_category_enabled ON mc.schematic (category, enabled);
+CREATE INDEX IF NOT EXISTS idx_mc_schematic_tier ON mc.schematic (tier);
+
+
+-- ========== TABLE: mc.lot ==========
+
+CREATE TABLE IF NOT EXISTS mc.lot (
+    lot_id          TEXT PRIMARY KEY,
+    world           TEXT NOT NULL DEFAULT 'minecraft:overworld',
+    chunk_x_range   int4range NOT NULL,
+    chunk_z_range   int4range NOT NULL,
+    anchor_y        SMALLINT NOT NULL,
+    owner_user_id   UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    current_schematic_id TEXT REFERENCES mc.schematic(schematic_id),
+    state           SMALLINT NOT NULL DEFAULT 0,
+    price_credits   BIGINT NOT NULL DEFAULT 0,
+    price_khash     BIGINT NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT mc_lot_state_chk      CHECK (state BETWEEN 0 AND 4),
+    CONSTRAINT mc_lot_anchor_y_chk   CHECK (anchor_y BETWEEN -64 AND 319),
+    CONSTRAINT mc_lot_price_chk      CHECK (price_credits >= 0 AND price_khash >= 0),
+    CONSTRAINT mc_lot_x_range_chk    CHECK (NOT isempty(chunk_x_range)
+                                             AND lower_inc(chunk_x_range)
+                                             AND NOT upper_inc(chunk_x_range)),
+    CONSTRAINT mc_lot_z_range_chk    CHECK (NOT isempty(chunk_z_range)
+                                             AND lower_inc(chunk_z_range)
+                                             AND NOT upper_inc(chunk_z_range)),
+    CONSTRAINT mc_lot_owner_state_chk CHECK (
+        (state = 0 AND owner_user_id IS NULL)
+        OR (state > 0 AND owner_user_id IS NOT NULL)
+    ),
+    CONSTRAINT mc_lot_built_has_schematic_chk CHECK (
+        (state = 2 AND current_schematic_id IS NOT NULL)
+        OR state <> 2
+    ),
+
+    EXCLUDE USING gist (
+        world WITH =,
+        chunk_x_range WITH &&,
+        chunk_z_range WITH &&
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_lot_owner ON mc.lot (owner_user_id) WHERE owner_user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mc_lot_state ON mc.lot (state);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_world_state ON mc.lot (world, state);
+
+
+-- ========== TABLE: mc.lot_purchase ==========
+
+CREATE TABLE IF NOT EXISTS mc.lot_purchase (
+    purchase_id     TEXT PRIMARY KEY DEFAULT public.gen_ulid(),
+    lot_id          TEXT NOT NULL REFERENCES mc.lot(lot_id) ON DELETE CASCADE,
+    buyer_user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    price_credits   BIGINT NOT NULL DEFAULT 0,
+    price_khash     BIGINT NOT NULL DEFAULT 0,
+    wallet_ledger_id BIGINT,
+    idempotency_key UUID NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT mc_lot_purchase_price_chk
+        CHECK (price_credits >= 0 AND price_khash >= 0),
+    CONSTRAINT mc_lot_purchase_idem_uq UNIQUE (idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_lot   ON mc.lot_purchase (lot_id);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_buyer ON mc.lot_purchase (buyer_user_id);
+
+
+-- ========== TABLE: mc.lot_build_log ==========
+
+CREATE TABLE IF NOT EXISTS mc.lot_build_log (
+    build_id        TEXT PRIMARY KEY DEFAULT public.gen_ulid(),
+    lot_id          TEXT NOT NULL REFERENCES mc.lot(lot_id) ON DELETE CASCADE,
+    actor_user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    action_kind     SMALLINT NOT NULL,
+    schematic_id    TEXT REFERENCES mc.schematic(schematic_id),
+    price_credits   BIGINT NOT NULL DEFAULT 0,
+    price_khash     BIGINT NOT NULL DEFAULT 0,
+    wallet_ledger_id BIGINT,
+    idempotency_key UUID NOT NULL,
+    apply_state     SMALLINT NOT NULL DEFAULT 0,
+    apply_error     TEXT,
+    queued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    applied_at      TIMESTAMPTZ,
+
+    CONSTRAINT mc_lot_build_log_action_chk
+        CHECK (action_kind IN (0, 1)),
+    CONSTRAINT mc_lot_build_log_apply_state_chk
+        CHECK (apply_state BETWEEN 0 AND 2),
+    CONSTRAINT mc_lot_build_log_build_has_schematic_chk
+        CHECK ((action_kind = 0 AND schematic_id IS NOT NULL)
+            OR (action_kind = 1)),
+    CONSTRAINT mc_lot_build_log_idem_uq UNIQUE (idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_lot     ON mc.lot_build_log (lot_id);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_actor   ON mc.lot_build_log (actor_user_id);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_pending ON mc.lot_build_log (queued_at) WHERE apply_state = 0;
+
+
+-- RPC bodies live in the migration file (20260526223407_mc_lot_system.sql).
+-- This file documents the table layer; the functions are deployed via the
+-- migration since they reference wallet.service_debit and auth.uid().

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -41,9 +41,12 @@
 -- credits and khash legs each have their own wallet idempotency slot.
 -- ============================================================
 
+-- btree_gist supplies the gist_text_ops opclass needed by the EXCLUDE
+-- constraint on mc.lot. Left in the default schema; EXCLUDE opclass
+-- lookup runs at CREATE TABLE time and uses live search_path.
+-- pgcrypto sits in `extensions` (mc_schema_init); mc._derive_idem_key
+-- calls extensions.digest explicitly.
 CREATE EXTENSION IF NOT EXISTS btree_gist;
--- pgcrypto is installed under the `extensions` schema by mc_schema_init.
--- mc._derive_idem_key calls extensions.digest directly.
 
 
 -- ========== TABLE: mc.schematic ==========

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -48,6 +48,19 @@
 -- calls extensions.digest explicitly.
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 
+DO $$ BEGIN
+    CREATE DOMAIN mc.lot_state AS SMALLINT CHECK (VALUE BETWEEN 0 AND 4);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+    CREATE DOMAIN mc.build_action_kind AS SMALLINT CHECK (VALUE IN (0, 1));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+    CREATE DOMAIN mc.build_apply_state AS SMALLINT CHECK (VALUE BETWEEN 0 AND 3);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
 
 -- ========== TABLE: mc.schematic ==========
 
@@ -112,14 +125,15 @@ CREATE TABLE IF NOT EXISTS mc.lot (
     -- RPC that resets state, owner, and schematic together.
     owner_user_id   UUID REFERENCES auth.users(id) ON DELETE RESTRICT,
     current_schematic_id TEXT REFERENCES mc.schematic(schematic_id),
-    state           SMALLINT NOT NULL DEFAULT 0,
+    state           mc.lot_state NOT NULL DEFAULT 0,
+    flags           INTEGER NOT NULL DEFAULT 0,
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
     CONSTRAINT mc_lot_id_chk         CHECK (lot_id ~ '^[A-Za-z0-9:_-]{3,96}$'),
-    CONSTRAINT mc_lot_state_chk      CHECK (state BETWEEN 0 AND 4),
+    CONSTRAINT mc_lot_flags_chk      CHECK (flags >= 0),
     CONSTRAINT mc_lot_anchor_y_chk   CHECK (anchor_y BETWEEN -64 AND 319),
     CONSTRAINT mc_lot_price_chk      CHECK (price_credits >= 0 AND price_khash >= 0),
     CONSTRAINT mc_lot_x_range_chk    CHECK (NOT isempty(chunk_x_range)
@@ -233,14 +247,16 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
     build_id        TEXT PRIMARY KEY DEFAULT public.gen_ulid(),
     lot_id          TEXT NOT NULL REFERENCES mc.lot(lot_id) ON DELETE CASCADE,
     actor_user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-    action_kind     SMALLINT NOT NULL,
+    action_kind     mc.build_action_kind NOT NULL,
     schematic_id    TEXT REFERENCES mc.schematic(schematic_id),
+    lot_state_before    mc.lot_state,
+    schematic_id_before TEXT REFERENCES mc.schematic(schematic_id),
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
     wallet_credits_ledger_id BIGINT,
     wallet_khash_ledger_id   BIGINT,
     idempotency_key UUID NOT NULL,
-    apply_state     SMALLINT NOT NULL DEFAULT 0,
+    apply_state     mc.build_apply_state NOT NULL DEFAULT 0,
     apply_error     TEXT,
     claimed_at      TIMESTAMPTZ,
     claimed_by      TEXT,
@@ -252,10 +268,6 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
     -- NOTE: 'failed_at' replaces the prior use of applied_at for failure
     -- timestamps; mark_build_failed writes failed_at and NULLs applied_at.
 
-    CONSTRAINT mc_lot_build_log_action_chk
-        CHECK (action_kind IN (0, 1)),
-    CONSTRAINT mc_lot_build_log_apply_state_chk
-        CHECK (apply_state BETWEEN 0 AND 3),
     CONSTRAINT mc_lot_build_log_build_has_schematic_chk
         CHECK ((action_kind = 0 AND schematic_id IS NOT NULL)
             OR (action_kind = 1)),
@@ -297,6 +309,7 @@ CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_actor_queued
              failed_at, applied_at, attempt_count);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_pending_claim
     ON mc.lot_build_log (queued_at, build_id)
+    INCLUDE (lot_id, actor_user_id, action_kind, schematic_id)
     WHERE apply_state = 0 AND attempt_count < 5;
 CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_claimed_stale
     ON mc.lot_build_log (claimed_at, build_id)

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -57,7 +57,8 @@ DO $$ BEGIN
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 DO $$ BEGIN
-    CREATE DOMAIN mc.build_apply_state AS SMALLINT CHECK (VALUE BETWEEN 0 AND 3);
+    -- 0 queued, 1 applied, 2 failed, 3 claimed, 4 cancelled
+    CREATE DOMAIN mc.build_apply_state AS SMALLINT CHECK (VALUE BETWEEN 0 AND 4);
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 
@@ -296,10 +297,20 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
     CONSTRAINT mc_lot_build_log_snapshot_state_chk CHECK (
         lot_state_before IS NULL OR lot_state_before IN (1, 2)
     ),
+    CONSTRAINT mc_lot_build_log_snapshot_built_schematic_chk CHECK (
+        lot_state_before IS NULL
+        OR lot_state_before <> 2
+        OR schematic_id_before IS NOT NULL
+    ),
     CONSTRAINT mc_lot_build_log_demolish_snapshot_chk CHECK (
         action_kind <> 1
         OR lot_state_before IS NULL
         OR lot_state_before = 2
+    ),
+    CONSTRAINT mc_lot_build_log_demolish_snapshot_schematic_chk CHECK (
+        action_kind <> 1
+        OR lot_state_before IS NULL
+        OR schematic_id_before IS NOT NULL
     ),
     CONSTRAINT mc_lot_build_log_claimed_consistency_chk
         CHECK (

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS mc.schematic (
     CONSTRAINT mc_schematic_category_chk
         CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument')),
     CONSTRAINT mc_schematic_resource_path_chk
-        CHECK (resource_path !~ '(^/|\.\.)' AND
+        CHECK (resource_path !~ '(^/|\.\.|//|\\)' AND
                resource_path ~ '^schematics/[A-Za-z0-9_./-]+\.(nbt|schem)$')
 );
 
@@ -135,6 +135,7 @@ CREATE TABLE IF NOT EXISTS mc.lot (
 
     CONSTRAINT mc_lot_id_chk         CHECK (lot_id ~ '^[A-Za-z0-9:_-]{3,96}$'),
     CONSTRAINT mc_lot_flags_chk      CHECK (flags >= 0),
+    CONSTRAINT mc_lot_flags_mask_chk CHECK ((flags & ~65535) = 0),
     CONSTRAINT mc_lot_anchor_y_chk   CHECK (anchor_y BETWEEN -64 AND 319),
     CONSTRAINT mc_lot_price_chk      CHECK (price_credits >= 0 AND price_khash >= 0),
     CONSTRAINT mc_lot_x_range_chk    CHECK (NOT isempty(chunk_x_range)
@@ -191,18 +192,29 @@ CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_world_chunk_cursor
 CREATE INDEX IF NOT EXISTS idx_mc_lot_vacant_world_chunk_cursor
     ON mc.lot (world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (chunk_x_max, chunk_z_max, chunk_area, anchor_y,
+             block_x_min, block_x_max, block_z_min, block_z_max,
              price_credits, price_khash)
     WHERE state = 0;
 CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_active_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
-             chunk_area, anchor_y, price_credits, price_khash)
+             chunk_area, anchor_y,
+             block_x_min, block_x_max, block_z_min, block_z_max,
+             price_credits, price_khash)
     WHERE owner_user_id IS NOT NULL AND state IN (1, 2);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_transitional_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
-             chunk_area, anchor_y, price_credits, price_khash)
+             chunk_area, anchor_y,
+             block_x_min, block_x_max, block_z_min, block_z_max,
+             price_credits, price_khash)
     WHERE owner_user_id IS NOT NULL AND state IN (3, 4);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_transitional_repair
+    ON mc.lot (lot_id)
+    INCLUDE (state, current_schematic_id)
+    WHERE state IN (3, 4);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_world_chunk_ranges_gist
+    ON mc.lot USING gist (world, chunk_x_range, chunk_z_range);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_current_schematic
     ON mc.lot (current_schematic_id) WHERE current_schematic_id IS NOT NULL;
 

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -159,7 +159,7 @@ CREATE INDEX IF NOT EXISTS idx_mc_lot_vacant_world_chunk_cursor
 CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_active_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
-             chunk_area, anchor_y)
+             chunk_area, anchor_y, price_credits, price_khash)
     WHERE owner_user_id IS NOT NULL AND state IN (1, 2);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_current_schematic
     ON mc.lot (current_schematic_id) WHERE current_schematic_id IS NOT NULL;

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -65,6 +65,8 @@ CREATE TABLE IF NOT EXISTS mc.schematic (
     CONSTRAINT mc_schematic_dims_chk   CHECK (dims_x > 0 AND dims_y > 0 AND dims_z > 0),
     CONSTRAINT mc_schematic_dims_y_chk CHECK (dims_y <= 384),
     CONSTRAINT mc_schematic_price_chk  CHECK (price_credits >= 0 AND price_khash >= 0),
+    CONSTRAINT mc_schematic_id_chk
+        CHECK (schematic_id ~ '^[A-Za-z0-9:_/-]{3,128}$'),
     CONSTRAINT mc_schematic_category_chk
         CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument')),
     CONSTRAINT mc_schematic_resource_path_chk
@@ -100,6 +102,7 @@ CREATE TABLE IF NOT EXISTS mc.lot (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
+    CONSTRAINT mc_lot_id_chk         CHECK (lot_id ~ '^[A-Za-z0-9:_-]{3,96}$'),
     CONSTRAINT mc_lot_state_chk      CHECK (state BETWEEN 0 AND 4),
     CONSTRAINT mc_lot_anchor_y_chk   CHECK (anchor_y BETWEEN -64 AND 319),
     CONSTRAINT mc_lot_price_chk      CHECK (price_credits >= 0 AND price_khash >= 0),
@@ -109,6 +112,10 @@ CREATE TABLE IF NOT EXISTS mc.lot (
     CONSTRAINT mc_lot_z_range_chk    CHECK (NOT isempty(chunk_z_range)
                                              AND lower_inc(chunk_z_range)
                                              AND NOT upper_inc(chunk_z_range)),
+    CONSTRAINT mc_lot_x_range_finite_chk
+        CHECK (lower(chunk_x_range) IS NOT NULL AND upper(chunk_x_range) IS NOT NULL),
+    CONSTRAINT mc_lot_z_range_finite_chk
+        CHECK (lower(chunk_z_range) IS NOT NULL AND upper(chunk_z_range) IS NOT NULL),
     CONSTRAINT mc_lot_world_chk
         CHECK (world ~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$'),
     CONSTRAINT mc_lot_owner_state_chk CHECK (
@@ -120,7 +127,7 @@ CREATE TABLE IF NOT EXISTS mc.lot (
         OR state <> 2
     ),
 
-    EXCLUDE USING gist (
+    CONSTRAINT mc_lot_no_overlap_excl EXCLUDE USING gist (
         world WITH =,
         chunk_x_range WITH &&,
         chunk_z_range WITH &&
@@ -133,6 +140,9 @@ CREATE INDEX IF NOT EXISTS idx_mc_lot_world_chunk_order
     ON mc.lot (world, lower(chunk_x_range), lower(chunk_z_range));
 CREATE INDEX IF NOT EXISTS idx_mc_lot_world_state_chunk_order
     ON mc.lot (world, state, lower(chunk_x_range), lower(chunk_z_range));
+CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_world_chunk_order
+    ON mc.lot (owner_user_id, world, lower(chunk_x_range), lower(chunk_z_range))
+    WHERE owner_user_id IS NOT NULL;
 
 
 -- ========== TABLE: mc.lot_purchase ==========
@@ -188,9 +198,13 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
             OR (action_kind = 1)),
     CONSTRAINT mc_lot_build_log_apply_error_len_chk
         CHECK (apply_error IS NULL OR length(apply_error) <= 2048),
+    CONSTRAINT mc_lot_build_log_claimed_by_len_chk
+        CHECK (claimed_by IS NULL OR length(claimed_by) <= 128),
     CONSTRAINT mc_lot_build_log_claimed_consistency_chk
-        CHECK ((apply_state = 3 AND claimed_at IS NOT NULL)
-            OR (apply_state <> 3)),
+        CHECK (
+            (apply_state = 3 AND claimed_at IS NOT NULL AND claimed_by IS NOT NULL)
+            OR (apply_state <> 3 AND claimed_at IS NULL AND claimed_by IS NULL)
+        ),
     CONSTRAINT mc_lot_build_log_idem_uq UNIQUE (idempotency_key)
 );
 

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -151,6 +151,16 @@ CREATE INDEX IF NOT EXISTS idx_mc_lot_world_state_chunk_cursor
 CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_world_chunk_cursor
     ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
     WHERE owner_user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mc_lot_vacant_world_chunk_cursor
+    ON mc.lot (world, chunk_x_min, chunk_z_min, lot_id)
+    INCLUDE (chunk_x_max, chunk_z_max, chunk_area, anchor_y,
+             price_credits, price_khash)
+    WHERE state = 0;
+CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_active_world_chunk_cursor
+    ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
+    INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
+             chunk_area, anchor_y)
+    WHERE owner_user_id IS NOT NULL AND state IN (1, 2);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_current_schematic
     ON mc.lot (current_schematic_id) WHERE current_schematic_id IS NOT NULL;
 

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -223,6 +223,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_mc_lot_build_log_one_active_per_lot
     ON mc.lot_build_log (lot_id) WHERE apply_state IN (0, 3);
 
 
+COMMENT ON COLUMN mc.lot_build_log.action_kind IS '0=build, 1=demolish';
+COMMENT ON COLUMN mc.lot_build_log.apply_state IS
+    '0=queued, 1=applied, 2=failed, 3=claimed (worker holding the row)';
+
+
 -- RPC bodies live in the migration file (20260526223407_mc_lot_system.sql).
 -- This file documents the table layer; the functions are deployed via the
 -- migration since they reference wallet.service_debit and auth.uid().

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -229,6 +229,9 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
     claimed_by      TEXT,
     queued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     applied_at      TIMESTAMPTZ,
+    failed_at       TIMESTAMPTZ,
+    attempt_count   SMALLINT NOT NULL DEFAULT 0,
+    last_attempt_at TIMESTAMPTZ,
 
     CONSTRAINT mc_lot_build_log_action_chk
         CHECK (action_kind IN (0, 1)),
@@ -239,6 +242,8 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
             OR (action_kind = 1)),
     CONSTRAINT mc_lot_build_log_apply_error_len_chk
         CHECK (apply_error IS NULL OR length(apply_error) <= 2048),
+    CONSTRAINT mc_lot_build_log_attempt_count_chk
+        CHECK (attempt_count >= 0 AND attempt_count <= 100),
     CONSTRAINT mc_lot_build_log_claimed_by_len_chk
         CHECK (claimed_by IS NULL OR length(claimed_by) <= 128),
     CONSTRAINT mc_lot_build_log_credits_ledger_chk CHECK (

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -131,8 +131,17 @@ CREATE TABLE IF NOT EXISTS mc.lot (
         OR (state > 0 AND owner_user_id IS NOT NULL)
     ),
     CONSTRAINT mc_lot_built_has_schematic_chk CHECK (
-        (state = 2 AND current_schematic_id IS NOT NULL)
-        OR state <> 2
+        CASE state
+            WHEN 0 THEN current_schematic_id IS NULL
+            WHEN 1 THEN current_schematic_id IS NULL
+            WHEN 2 THEN current_schematic_id IS NOT NULL
+            WHEN 4 THEN current_schematic_id IS NOT NULL
+            ELSE TRUE
+        END
+    ),
+    CONSTRAINT mc_lot_vacant_clean_chk CHECK (
+        state <> 0
+        OR (owner_user_id IS NULL AND current_schematic_id IS NULL)
     ),
 
     CONSTRAINT mc_lot_no_overlap_excl EXCLUDE USING gist (
@@ -191,9 +200,10 @@ CREATE TABLE IF NOT EXISTS mc.lot_purchase (
     CONSTRAINT mc_lot_purchase_idem_uq UNIQUE (idempotency_key)
 );
 
-CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_lot ON mc.lot_purchase (lot_id);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_buyer_created
     ON mc.lot_purchase (buyer_user_id, created_at DESC, purchase_id DESC);
+-- Unique on (lot_id) covers both the phase-0 'one purchase per lot'
+-- invariant and the lookup-by-lot path; no separate non-unique index.
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mc_lot_purchase_one_per_lot
     ON mc.lot_purchase (lot_id);
 
@@ -237,6 +247,14 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
         (price_khash = 0 AND wallet_khash_ledger_id IS NULL)
         OR (price_khash > 0 AND wallet_khash_ledger_id IS NOT NULL)
     ),
+    CONSTRAINT mc_lot_build_log_demolish_free_chk CHECK (
+        action_kind <> 1
+        OR (schematic_id IS NULL
+            AND price_credits = 0
+            AND price_khash = 0
+            AND wallet_credits_ledger_id IS NULL
+            AND wallet_khash_ledger_id IS NULL)
+    ),
     CONSTRAINT mc_lot_build_log_claimed_consistency_chk
         CHECK (
             (apply_state = 3 AND claimed_at IS NOT NULL AND claimed_by IS NOT NULL)
@@ -264,6 +282,14 @@ ALTER TABLE mc.lot_build_log SET (
     autovacuum_analyze_scale_factor = 0.01,
     autovacuum_vacuum_threshold = 1000,
     autovacuum_analyze_threshold = 500
+);
+
+ALTER TABLE mc.lot SET (
+    fillfactor = 90,
+    autovacuum_vacuum_scale_factor = 0.05,
+    autovacuum_analyze_scale_factor = 0.02,
+    autovacuum_vacuum_threshold = 500,
+    autovacuum_analyze_threshold = 250
 );
 
 

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -249,6 +249,8 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
     failed_at       TIMESTAMPTZ,
     attempt_count   INTEGER NOT NULL DEFAULT 0,
     last_attempt_at TIMESTAMPTZ,
+    -- NOTE: 'failed_at' replaces the prior use of applied_at for failure
+    -- timestamps; mark_build_failed writes failed_at and NULLs applied_at.
 
     CONSTRAINT mc_lot_build_log_action_chk
         CHECK (action_kind IN (0, 1)),

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -101,6 +101,10 @@ CREATE TABLE IF NOT EXISTS mc.lot (
     chunk_area      INTEGER GENERATED ALWAYS AS
         ((upper(chunk_x_range) - lower(chunk_x_range))
        * (upper(chunk_z_range) - lower(chunk_z_range))) STORED,
+    block_x_min     INTEGER GENERATED ALWAYS AS (lower(chunk_x_range) * 16) STORED,
+    block_x_max     INTEGER GENERATED ALWAYS AS (upper(chunk_x_range) * 16 - 1) STORED,
+    block_z_min     INTEGER GENERATED ALWAYS AS (lower(chunk_z_range) * 16) STORED,
+    block_z_max     INTEGER GENERATED ALWAYS AS (upper(chunk_z_range) * 16 - 1) STORED,
     anchor_y        SMALLINT NOT NULL,
     -- ON DELETE RESTRICT: owner_state_chk requires state>0 to carry a
     -- non-null owner, so SET NULL would induce CHECK violations on user
@@ -128,6 +132,13 @@ CREATE TABLE IF NOT EXISTS mc.lot (
         CHECK (lower(chunk_x_range) IS NOT NULL AND upper(chunk_x_range) IS NOT NULL),
     CONSTRAINT mc_lot_z_range_finite_chk
         CHECK (lower(chunk_z_range) IS NOT NULL AND upper(chunk_z_range) IS NOT NULL),
+    CONSTRAINT mc_lot_chunk_width_max_chk
+        CHECK ((upper(chunk_x_range) - lower(chunk_x_range)) <= 512),
+    CONSTRAINT mc_lot_chunk_depth_max_chk
+        CHECK ((upper(chunk_z_range) - lower(chunk_z_range)) <= 512),
+    CONSTRAINT mc_lot_chunk_area_max_chk
+        CHECK ((upper(chunk_x_range) - lower(chunk_x_range))
+             * (upper(chunk_z_range) - lower(chunk_z_range)) <= 262144),
     CONSTRAINT mc_lot_world_chk
         CHECK (world ~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$'),
     CONSTRAINT mc_lot_owner_state_chk CHECK (
@@ -172,6 +183,11 @@ CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_active_world_chunk_cursor
     INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
              chunk_area, anchor_y, price_credits, price_khash)
     WHERE owner_user_id IS NOT NULL AND state IN (1, 2);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_owner_transitional_world_chunk_cursor
+    ON mc.lot (owner_user_id, world, chunk_x_min, chunk_z_min, lot_id)
+    INCLUDE (state, current_schematic_id, chunk_x_max, chunk_z_max,
+             chunk_area, anchor_y, price_credits, price_khash)
+    WHERE owner_user_id IS NOT NULL AND state IN (3, 4);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_current_schematic
     ON mc.lot (current_schematic_id) WHERE current_schematic_id IS NOT NULL;
 
@@ -203,7 +219,8 @@ CREATE TABLE IF NOT EXISTS mc.lot_purchase (
 );
 
 CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_buyer_created
-    ON mc.lot_purchase (buyer_user_id, created_at DESC, purchase_id DESC);
+    ON mc.lot_purchase (buyer_user_id, created_at DESC, purchase_id DESC)
+    INCLUDE (lot_id, price_credits, price_khash);
 -- Unique on (lot_id) covers both the phase-0 'one purchase per lot'
 -- invariant and the lookup-by-lot path; no separate non-unique index.
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mc_lot_purchase_one_per_lot
@@ -230,7 +247,7 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
     queued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     applied_at      TIMESTAMPTZ,
     failed_at       TIMESTAMPTZ,
-    attempt_count   SMALLINT NOT NULL DEFAULT 0,
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
     last_attempt_at TIMESTAMPTZ,
 
     CONSTRAINT mc_lot_build_log_action_chk
@@ -270,14 +287,21 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
     CONSTRAINT mc_lot_build_log_idem_uq UNIQUE (idempotency_key)
 );
 
-CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_lot
-    ON mc.lot_build_log (lot_id);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_lot_queued
+    ON mc.lot_build_log (lot_id, queued_at DESC, build_id DESC);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_actor_queued
-    ON mc.lot_build_log (actor_user_id, queued_at DESC, build_id DESC);
+    ON mc.lot_build_log (actor_user_id, queued_at DESC, build_id DESC)
+    INCLUDE (lot_id, action_kind, schematic_id, apply_state,
+             failed_at, applied_at, attempt_count);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_pending_claim
-    ON mc.lot_build_log (queued_at, build_id) WHERE apply_state = 0;
+    ON mc.lot_build_log (queued_at, build_id)
+    WHERE apply_state = 0 AND attempt_count < 5;
 CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_claimed_stale
-    ON mc.lot_build_log (claimed_at, build_id) WHERE apply_state = 3;
+    ON mc.lot_build_log (claimed_at, build_id)
+    WHERE apply_state = 3 AND claimed_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_failed_recent
+    ON mc.lot_build_log (failed_at DESC, build_id DESC)
+    WHERE apply_state = 2;
 CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_schematic
     ON mc.lot_build_log (schematic_id) WHERE schematic_id IS NOT NULL;
 CREATE UNIQUE INDEX IF NOT EXISTS uq_mc_lot_build_log_one_active_per_lot
@@ -298,6 +322,16 @@ ALTER TABLE mc.lot SET (
     autovacuum_vacuum_threshold = 500,
     autovacuum_analyze_threshold = 250
 );
+
+CREATE STATISTICS IF NOT EXISTS st_mc_lot_world_state
+    ON world, state
+    FROM mc.lot;
+CREATE STATISTICS IF NOT EXISTS st_mc_lot_owner_state
+    ON owner_user_id, state
+    FROM mc.lot;
+CREATE STATISTICS IF NOT EXISTS st_mc_build_log_state_attempt
+    ON apply_state, attempt_count
+    FROM mc.lot_build_log;
 
 
 COMMENT ON COLUMN mc.lot_build_log.action_kind IS '0=build, 1=demolish';

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -1,7 +1,7 @@
 -- ============================================================
 -- MC LOT SYSTEM — Digital real-estate for the survival backend.
 --
--- This file mirrors the contents of the dbmate migration
+-- This file mirrors the dbmate migration
 -- 20260526223407_mc_lot_system.sql and exists as the canonical
 -- source of truth for the lot/schematic schema. Update both when
 -- changing the schema.
@@ -9,33 +9,40 @@
 -- Tables:
 --   mc.schematic        — build catalog (id, dims, price, resource path)
 --   mc.lot              — parcel registry (chunk_x_range, chunk_z_range,
---                         owner, current_schematic_id, state, price)
---   mc.lot_purchase     — append-only ownership ledger
---   mc.lot_build_log    — append-only build/demolish audit
+--                         owner, current_schematic_id, state, price,
+--                         generated chunk_width/depth/area)
+--   mc.lot_purchase     — append-only ownership ledger (per-currency
+--                         wallet ledger references; one-purchase-per-lot
+--                         unique index)
+--   mc.lot_build_log    — append-only build/demolish audit + concurrent
+--                         work queue (apply_state 0/1/2/3 + claimed_at/by)
+--
+-- Concurrency:
+--   - mc.service_claim_pending_builds uses FOR UPDATE SKIP LOCKED so
+--     multiple MC workers can poll without taking the same job.
+--   - uq_mc_lot_build_log_one_active_per_lot WHERE apply_state IN (0,3)
+--     enforces "at most one outstanding job per lot" at the DB level.
 --
 -- Constraints worth highlighting:
---   - mc.lot uses a GIST EXCLUDE constraint on
---     (world =, chunk_x_range &&, chunk_z_range &&) so two lots in the
---     same world cannot occupy any overlapping chunk.
---   - chunk_x_range / chunk_z_range are stored as half-open int4range
---     pairs so a 1x1 lot at chunk 5 is [5, 6), and a 13x7 castle
---     bounding box is [20, 33) x [-10, -3).
---   - lot.state is a smallint enum:
---         0 = vacant, 1 = owned, 2 = built,
---         3 = under_build, 4 = demolishing
+--   - mc.lot has a GIST EXCLUDE on (world =, chunk_x_range &&,
+--     chunk_z_range &&) so two lots in the same world cannot share
+--     a chunk.
+--   - resource_path is namespaced and path-traversal-safe.
+--   - world ids must match '^[a-z0-9_.-]+:[a-z0-9_/.-]+$'.
 --
 -- RPC layering:
---   mc.service_*  — service_role only, used by MC mod + admin tooling.
---   mc.proxy_*    — authenticated callers; uses auth.uid() for ownership.
---   public.proxy_*— PostgREST wrapper because the mc schema is private.
+--   mc.service_*   — service_role only. MC mod + admin tooling.
+--   mc.proxy_*     — internal layer called from the public wrappers.
+--   public.proxy_* — PostgREST surface. authenticated callers.
 --
 -- Money flow rides on wallet.service_debit against the user-kind
--- account; mc.lot_purchase and mc.lot_build_log keep their own audit
--- rows so we can reconstruct ownership / build history without
--- joining through wallet.ledger.
+-- account; mc.lot_purchase / mc.lot_build_log keep their own audit
+-- rows. Dual-currency charges go through mc._derive_idem_key so the
+-- credits and khash legs each have their own wallet idempotency slot.
 -- ============================================================
 
 CREATE EXTENSION IF NOT EXISTS btree_gist;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 
 -- ========== TABLE: mc.schematic ==========
@@ -58,10 +65,14 @@ CREATE TABLE IF NOT EXISTS mc.schematic (
     CONSTRAINT mc_schematic_dims_y_chk CHECK (dims_y <= 384),
     CONSTRAINT mc_schematic_price_chk  CHECK (price_credits >= 0 AND price_khash >= 0),
     CONSTRAINT mc_schematic_category_chk
-        CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument'))
+        CHECK (category IN ('house', 'castle', 'tower', 'farm', 'shop', 'utility', 'monument')),
+    CONSTRAINT mc_schematic_resource_path_chk
+        CHECK (resource_path !~ '(^/|\.\.)' AND
+               resource_path ~ '^schematics/[A-Za-z0-9_./-]+\.(nbt|schem)$')
 );
 
-CREATE INDEX IF NOT EXISTS idx_mc_schematic_category_enabled ON mc.schematic (category, enabled);
+CREATE INDEX IF NOT EXISTS idx_mc_schematic_enabled_category_tier_name
+    ON mc.schematic (category, tier, name) WHERE enabled;
 CREATE INDEX IF NOT EXISTS idx_mc_schematic_tier ON mc.schematic (tier);
 
 
@@ -72,6 +83,13 @@ CREATE TABLE IF NOT EXISTS mc.lot (
     world           TEXT NOT NULL DEFAULT 'minecraft:overworld',
     chunk_x_range   int4range NOT NULL,
     chunk_z_range   int4range NOT NULL,
+    chunk_width     INTEGER GENERATED ALWAYS AS
+        (upper(chunk_x_range) - lower(chunk_x_range)) STORED,
+    chunk_depth     INTEGER GENERATED ALWAYS AS
+        (upper(chunk_z_range) - lower(chunk_z_range)) STORED,
+    chunk_area      INTEGER GENERATED ALWAYS AS
+        ((upper(chunk_x_range) - lower(chunk_x_range))
+       * (upper(chunk_z_range) - lower(chunk_z_range))) STORED,
     anchor_y        SMALLINT NOT NULL,
     owner_user_id   UUID REFERENCES auth.users(id) ON DELETE SET NULL,
     current_schematic_id TEXT REFERENCES mc.schematic(schematic_id),
@@ -90,6 +108,8 @@ CREATE TABLE IF NOT EXISTS mc.lot (
     CONSTRAINT mc_lot_z_range_chk    CHECK (NOT isempty(chunk_z_range)
                                              AND lower_inc(chunk_z_range)
                                              AND NOT upper_inc(chunk_z_range)),
+    CONSTRAINT mc_lot_world_chk
+        CHECK (world ~ '^[a-z0-9_.-]+:[a-z0-9_/.-]+$'),
     CONSTRAINT mc_lot_owner_state_chk CHECK (
         (state = 0 AND owner_user_id IS NULL)
         OR (state > 0 AND owner_user_id IS NOT NULL)
@@ -106,9 +126,12 @@ CREATE TABLE IF NOT EXISTS mc.lot (
     )
 );
 
-CREATE INDEX IF NOT EXISTS idx_mc_lot_owner ON mc.lot (owner_user_id) WHERE owner_user_id IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_mc_lot_state ON mc.lot (state);
-CREATE INDEX IF NOT EXISTS idx_mc_lot_world_state ON mc.lot (world, state);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_owner
+    ON mc.lot (owner_user_id) WHERE owner_user_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_mc_lot_world_chunk_order
+    ON mc.lot (world, lower(chunk_x_range), lower(chunk_z_range));
+CREATE INDEX IF NOT EXISTS idx_mc_lot_world_state_chunk_order
+    ON mc.lot (world, state, lower(chunk_x_range), lower(chunk_z_range));
 
 
 -- ========== TABLE: mc.lot_purchase ==========
@@ -119,7 +142,8 @@ CREATE TABLE IF NOT EXISTS mc.lot_purchase (
     buyer_user_id   UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
-    wallet_ledger_id BIGINT,
+    wallet_credits_ledger_id BIGINT,
+    wallet_khash_ledger_id   BIGINT,
     idempotency_key UUID NOT NULL,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
 
@@ -130,6 +154,8 @@ CREATE TABLE IF NOT EXISTS mc.lot_purchase (
 
 CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_lot   ON mc.lot_purchase (lot_id);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_purchase_buyer ON mc.lot_purchase (buyer_user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_mc_lot_purchase_one_per_lot
+    ON mc.lot_purchase (lot_id);
 
 
 -- ========== TABLE: mc.lot_build_log ==========
@@ -142,26 +168,41 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
     schematic_id    TEXT REFERENCES mc.schematic(schematic_id),
     price_credits   BIGINT NOT NULL DEFAULT 0,
     price_khash     BIGINT NOT NULL DEFAULT 0,
-    wallet_ledger_id BIGINT,
+    wallet_credits_ledger_id BIGINT,
+    wallet_khash_ledger_id   BIGINT,
     idempotency_key UUID NOT NULL,
     apply_state     SMALLINT NOT NULL DEFAULT 0,
     apply_error     TEXT,
+    claimed_at      TIMESTAMPTZ,
+    claimed_by      TEXT,
     queued_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     applied_at      TIMESTAMPTZ,
 
     CONSTRAINT mc_lot_build_log_action_chk
         CHECK (action_kind IN (0, 1)),
     CONSTRAINT mc_lot_build_log_apply_state_chk
-        CHECK (apply_state BETWEEN 0 AND 2),
+        CHECK (apply_state BETWEEN 0 AND 3),
     CONSTRAINT mc_lot_build_log_build_has_schematic_chk
         CHECK ((action_kind = 0 AND schematic_id IS NOT NULL)
             OR (action_kind = 1)),
+    CONSTRAINT mc_lot_build_log_apply_error_len_chk
+        CHECK (apply_error IS NULL OR length(apply_error) <= 2048),
+    CONSTRAINT mc_lot_build_log_claimed_consistency_chk
+        CHECK ((apply_state = 3 AND claimed_at IS NOT NULL)
+            OR (apply_state <> 3)),
     CONSTRAINT mc_lot_build_log_idem_uq UNIQUE (idempotency_key)
 );
 
-CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_lot     ON mc.lot_build_log (lot_id);
-CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_actor   ON mc.lot_build_log (actor_user_id);
-CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_pending ON mc.lot_build_log (queued_at) WHERE apply_state = 0;
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_lot
+    ON mc.lot_build_log (lot_id);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_actor
+    ON mc.lot_build_log (actor_user_id);
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_pending
+    ON mc.lot_build_log (queued_at) WHERE apply_state = 0;
+CREATE INDEX IF NOT EXISTS idx_mc_lot_build_log_claimed_stale
+    ON mc.lot_build_log (claimed_at) WHERE apply_state = 3;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_mc_lot_build_log_one_active_per_lot
+    ON mc.lot_build_log (lot_id) WHERE apply_state IN (0, 3);
 
 
 -- RPC bodies live in the migration file (20260526223407_mc_lot_system.sql).

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -213,8 +213,6 @@ CREATE INDEX IF NOT EXISTS idx_mc_lot_transitional_repair
     ON mc.lot (lot_id)
     INCLUDE (state, current_schematic_id)
     WHERE state IN (3, 4);
-CREATE INDEX IF NOT EXISTS idx_mc_lot_world_chunk_ranges_gist
-    ON mc.lot USING gist (world, chunk_x_range, chunk_z_range);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_current_schematic
     ON mc.lot (current_schematic_id) WHERE current_schematic_id IS NOT NULL;
 

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -102,7 +102,11 @@ CREATE TABLE IF NOT EXISTS mc.lot (
         ((upper(chunk_x_range) - lower(chunk_x_range))
        * (upper(chunk_z_range) - lower(chunk_z_range))) STORED,
     anchor_y        SMALLINT NOT NULL,
-    owner_user_id   UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    -- ON DELETE RESTRICT: owner_state_chk requires state>0 to carry a
+    -- non-null owner, so SET NULL would induce CHECK violations on user
+    -- deletion. Force the deletion path through an explicit release-lots
+    -- RPC that resets state, owner, and schematic together.
+    owner_user_id   UUID REFERENCES auth.users(id) ON DELETE RESTRICT,
     current_schematic_id TEXT REFERENCES mc.schematic(schematic_id),
     state           SMALLINT NOT NULL DEFAULT 0,
     price_credits   BIGINT NOT NULL DEFAULT 0,
@@ -151,8 +155,6 @@ CREATE TABLE IF NOT EXISTS mc.lot (
     )
 );
 
-CREATE INDEX IF NOT EXISTS idx_mc_lot_owner
-    ON mc.lot (owner_user_id) WHERE owner_user_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_mc_lot_world_chunk_cursor
     ON mc.lot (world, chunk_x_min, chunk_z_min, lot_id);
 CREATE INDEX IF NOT EXISTS idx_mc_lot_world_state_chunk_cursor

--- a/packages/data/sql/schema/mc/mc_lot.sql
+++ b/packages/data/sql/schema/mc/mc_lot.sql
@@ -293,6 +293,14 @@ CREATE TABLE IF NOT EXISTS mc.lot_build_log (
             AND wallet_credits_ledger_id IS NULL
             AND wallet_khash_ledger_id IS NULL)
     ),
+    CONSTRAINT mc_lot_build_log_snapshot_state_chk CHECK (
+        lot_state_before IS NULL OR lot_state_before IN (1, 2)
+    ),
+    CONSTRAINT mc_lot_build_log_demolish_snapshot_chk CHECK (
+        action_kind <> 1
+        OR lot_state_before IS NULL
+        OR lot_state_before = 2
+    ),
     CONSTRAINT mc_lot_build_log_claimed_consistency_chk
         CHECK (
             (apply_state = 3 AND claimed_at IS NOT NULL AND claimed_by IS NOT NULL)


### PR DESCRIPTION
## Summary

Single dbmate migration adds the mc-side real-estate primitives. Players will buy lots via the kbve.com/mc dashboard then pick structures from the schematic catalog to place on owned lots. The MC mod side picks up purchase + build events and applies them in-world.

### Tables

| Table | Purpose |
|------|---------|
| \`mc.schematic\` | Build catalog (id, dims in blocks, category, tier, price, resource_path) |
| \`mc.lot\` | Parcel registry (chunk_x_range/z_range as half-open int4range, anchor_y, owner, current_schematic_id, state, price) |
| \`mc.lot_purchase\` | Append-only ownership ledger keyed by idempotency_key + back-reference to \`wallet.ledger\` |
| \`mc.lot_build_log\` | Append-only build/demolish audit. \`apply_state\`: 0 queued → 1 applied / 2 failed. Used as the MC-mod work queue. |

### No-overlap guarantee

GIST \`EXCLUDE\` constraint on \`mc.lot\` (\`world =, chunk_x_range &&, chunk_z_range &&\`) blocks any two lots in the same world from sharing a chunk. Atomic at insert time — no race window.

### Variable lot size

\`int4range\` columns + EXCLUDE support 1×1 through 13×7 (200×100 block) castle lots **with no further schema work**. A phase-0 RPC guard caps queued builds at 64 chunks per job; lifted in a follow-up once the MC tick-chunked paste pipeline is proven stable.

### RPC layering

Matches the existing \`mc_public_proxies\` pattern:

| Layer | Caller | Functions |
|------|--------|-----------|
| \`mc.service_*\` | service_role (MC mod + admin tooling) | \`service_list_lots\`, \`service_list_schematics\`, \`service_pending_builds\`, \`service_mark_build_applied/failed\`, \`service_purchase_lot\`, \`service_queue_build_on_lot\`, \`service_queue_demolish_lot\` |
| \`mc.proxy_*\` | authenticated, bound by \`auth.uid()\` | \`proxy_list_lots\`, \`proxy_list_schematics\`, \`proxy_purchase_lot\`, \`proxy_queue_build_on_lot\`, \`proxy_queue_demolish_lot\` |
| \`public.proxy_*\` | PostgREST surface | Wrappers around the \`mc.proxy_*\` set (mc schema stays private from PostgREST) |

### Money flow

Lot purchase + build cost both call \`wallet.service_debit\` against the user's user-kind account (lookup via internal \`mc._user_account_id\` helper). Idempotency keys propagate end-to-end so retry never double-charges.

### Validation in \`service_queue_build_on_lot\`

- Ownership: \`v_lot.owner_user_id = p_user_id\`.
- Lot state is buildable (\`1\` owned or \`2\` already built).
- Schematic exists and is enabled.
- \`schematic.dims_x ≤ lot_block_width\` and \`schematic.dims_z ≤ lot_block_depth\` (chunk count × 16).
- \`anchor_y + schematic.dims_y ≤ 319\` (world build height).
- Phase-0 cap: lot chunk count ≤ 64.

## Test plan

- [ ] \`dbmate migrate --no-dump-schema\` against the dev database. Confirm tables + indexes + functions land.
- [ ] Insert two overlapping lots, expect \`exclusion_violation\` (SQLSTATE \`23P01\`).
- [ ] Seed one schematic + one vacant lot. Call \`public.proxy_purchase_lot(lot_id)\` as an authenticated user. Confirm \`mc.lot.state\` flips to 1 and \`wallet.balance\` debits.
- [ ] Call \`public.proxy_queue_build_on_lot(lot_id, schematic_id)\`. Confirm a row lands in \`mc.lot_build_log\` with \`apply_state = 0\`.
- [ ] Service-role: \`mc.service_pending_builds(32)\` returns the queued row. \`mc.service_mark_build_applied(build_id)\` flips it to 1 and updates \`mc.lot.state\` to 2.

## Follow-ups

- MC mod side: pending-build polling/listener + schematic loader + tick-chunked paste pipeline.
- Lot seeding: a separate migration / admin tool generates the initial spawn-ring lot grid once geometry is locked.
- Phase 3: free-form claims (player draws bounding box in dashboard; same EXCLUDE constraint guards overlap).