### PR TITLE
feat(nexus-defense): HUD chip animations on value change

### DIFF
--- a/apps/godot/nexus-defense/tests/components/test_hud_top.gd
+++ b/apps/godot/nexus-defense/tests/components/test_hud_top.gd
@@ -34,3 +34,74 @@ func test_apply_with_non_dict_is_noop() -> void:
 	_hud.call("apply", "not a dict")
 	await await_idle_frame()
 	assert_int(int(_hud.get("gold"))).is_equal(before_gold)
+
+func test_chip_boxes_registered_for_all_tags() -> void:
+	var boxes: Dictionary = _hud.get("_chip_boxes")
+	for tag in ["wave", "lives", "gold", "enemies"]:
+		assert_bool(boxes.has(tag)).is_true()
+		assert_object(boxes[tag]).is_instanceof(PanelContainer)
+
+func test_gold_increase_kicks_off_punch_and_flash_tweens() -> void:
+	_hud.call("apply", {"gold": 100})
+	await await_idle_frame()
+	_hud.call("apply", {"gold": 250})
+	var tweens: Dictionary = _hud.get("_active_tweens")
+	assert_bool(tweens.has("gold")).is_true()
+	assert_bool(tweens.has("punch_gold")).is_true()
+	assert_bool(tweens.has("flash_gold")).is_true()
+
+func test_gold_decrease_skips_flash_and_punch() -> void:
+	_hud.call("apply", {"gold": 300})
+	await await_idle_frame()
+	var tweens: Dictionary = _hud.get("_active_tweens")
+	tweens.clear()
+	_hud.call("apply", {"gold": 100})
+	tweens = _hud.get("_active_tweens")
+	assert_bool(tweens.has("gold")).is_true()
+	assert_bool(tweens.has("punch_gold")).is_false()
+	assert_bool(tweens.has("flash_gold")).is_false()
+
+func test_lives_decrease_triggers_flash_and_punch() -> void:
+	_hud.call("apply", {"lives": 20})
+	await await_idle_frame()
+	_hud.call("apply", {"lives": 18})
+	var tweens: Dictionary = _hud.get("_active_tweens")
+	assert_bool(tweens.has("flash_lives")).is_true()
+	assert_bool(tweens.has("punch_lives")).is_true()
+
+func test_lives_increase_skips_flash_and_punch() -> void:
+	_hud.call("apply", {"lives": 10})
+	await await_idle_frame()
+	var tweens: Dictionary = _hud.get("_active_tweens")
+	tweens.clear()
+	_hud.call("apply", {"lives": 15})
+	tweens = _hud.get("_active_tweens")
+	assert_bool(tweens.has("flash_lives")).is_false()
+	assert_bool(tweens.has("punch_lives")).is_false()
+
+func test_wave_change_triggers_punch_and_flash() -> void:
+	_hud.call("apply", {"wave": 1})
+	await await_idle_frame()
+	_hud.call("apply", {"wave": 2})
+	var tweens: Dictionary = _hud.get("_active_tweens")
+	assert_bool(tweens.has("punch_wave")).is_true()
+	assert_bool(tweens.has("flash_wave")).is_true()
+
+func test_unchanged_value_does_not_animate() -> void:
+	_hud.call("apply", {"gold": 150})
+	await await_idle_frame()
+	# Drain any tweens from initial state
+	var tweens: Dictionary = _hud.get("_active_tweens")
+	tweens.clear()
+	_hud.call("apply", {"gold": 150})
+	tweens = _hud.get("_active_tweens")
+	assert_bool(tweens.has("punch_gold")).is_false()
+	assert_bool(tweens.has("flash_gold")).is_false()
+
+func test_int_tween_writes_label_text_eventually() -> void:
+	_hud.call("apply", {"gold": 50})
+	await await_idle_frame()
+	_hud.call("apply", {"gold": 100})
+	await get_tree().create_timer(0.5).timeout
+	var gold_label: Label = _hud.get("_gold_value")
+	assert_str(gold_label.text).is_equal("100")

--- a/apps/godot/nexus-defense/ui/components/hud_top.gd
+++ b/apps/godot/nexus-defense/ui/components/hud_top.gd
@@ -1,5 +1,11 @@
 extends "res://ui/components/panel_base.gd"
 
+const NUMBER_TWEEN_DURATION := 0.32
+const FLASH_DURATION := 0.12
+const FLASH_FADE_DURATION := 0.28
+const PUNCH_SCALE := 1.18
+const PUNCH_DURATION := 0.22
+
 var wave: int = 1
 var lives: int = 20
 var gold: int = 150
@@ -11,6 +17,8 @@ var _gold_value: Label
 var _enemies_value: Label
 var _pause_btn: Button
 var _root_margin: MarginContainer
+var _chip_boxes: Dictionary = {}
+var _active_tweens: Dictionary = {}
 
 func _build() -> void:
 	set_anchors_preset(Control.PRESET_FULL_RECT)
@@ -58,6 +66,7 @@ func _chip(caption: String, value: String, accent: Color, tag: String) -> Contro
 	vb.add_child(cap)
 	var val := make_label(value, Tokens.FONT_H2, Tokens.COLOR_TEXT)
 	vb.add_child(val)
+	_chip_boxes[tag] = box
 	match tag:
 		"wave": _wave_value = val
 		"lives": _lives_value = val
@@ -81,18 +90,85 @@ func _refresh_fonts() -> void:
 		if label:
 			label.add_theme_font_size_override("font_size", font_size(Tokens.FONT_H2))
 
+func _stop_tween(key: String) -> void:
+	var tw: Variant = _active_tweens.get(key)
+	if tw != null and tw is Tween and (tw as Tween).is_valid():
+		(tw as Tween).kill()
+	_active_tweens.erase(key)
+
+func _register_tween(key: String, tw: Tween) -> void:
+	_active_tweens[key] = tw
+	tw.finished.connect(func() -> void:
+		if _active_tweens.get(key) == tw:
+			_active_tweens.erase(key)
+	)
+
+func _tween_int(label: Label, from_val: int, to_val: int, key: String) -> void:
+	if label == null or from_val == to_val:
+		if label != null:
+			label.text = str(to_val)
+		return
+	_stop_tween(key)
+	label.text = str(from_val)
+	var tw := create_tween()
+	tw.tween_method(func(v: float) -> void:
+		if is_instance_valid(label):
+			label.text = str(int(round(v)))
+	, float(from_val), float(to_val), NUMBER_TWEEN_DURATION).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
+	tw.tween_callback(func() -> void:
+		if is_instance_valid(label):
+			label.text = str(to_val)
+	)
+	_register_tween(key, tw)
+
+func _punch_chip(tag: String) -> void:
+	var box: Control = _chip_boxes.get(tag)
+	if box == null:
+		return
+	var key := "punch_" + tag
+	_stop_tween(key)
+	box.pivot_offset = box.size / 2.0
+	box.scale = Vector2(PUNCH_SCALE, PUNCH_SCALE)
+	var tw := create_tween()
+	tw.tween_property(box, "scale", Vector2.ONE, PUNCH_DURATION).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+	_register_tween(key, tw)
+
+func _flash_chip(tag: String, flash_color: Color) -> void:
+	var box: Control = _chip_boxes.get(tag)
+	if box == null:
+		return
+	var key := "flash_" + tag
+	_stop_tween(key)
+	var tw := create_tween()
+	tw.tween_property(box, "modulate", flash_color, FLASH_DURATION).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+	tw.tween_property(box, "modulate", Color.WHITE, FLASH_FADE_DURATION).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
+	_register_tween(key, tw)
+
 func apply(data: Variant) -> void:
 	if typeof(data) != TYPE_DICTIONARY:
 		return
 	if data.has("wave"):
+		var prev: int = wave
 		wave = int(data["wave"])
-		if _wave_value: _wave_value.text = str(wave)
+		_tween_int(_wave_value, prev, wave, "wave")
+		if wave != prev:
+			_punch_chip("wave")
+			_flash_chip("wave", Color(Tokens.COLOR_ACCENT.r, Tokens.COLOR_ACCENT.g, Tokens.COLOR_ACCENT.b, 1.0).lightened(0.2))
 	if data.has("lives"):
+		var prev_lives: int = lives
 		lives = int(data["lives"])
-		if _lives_value: _lives_value.text = str(lives)
+		_tween_int(_lives_value, prev_lives, lives, "lives")
+		if lives < prev_lives:
+			_flash_chip("lives", Tokens.COLOR_DANGER)
+			_punch_chip("lives")
 	if data.has("gold"):
+		var prev_gold: int = gold
 		gold = int(data["gold"])
-		if _gold_value: _gold_value.text = str(gold)
+		_tween_int(_gold_value, prev_gold, gold, "gold")
+		if gold > prev_gold:
+			_flash_chip("gold", Tokens.COLOR_WARN.lightened(0.2))
+			_punch_chip("gold")
 	if data.has("enemies"):
+		var prev_enemies: int = enemies_left
 		enemies_left = int(data["enemies"])
-		if _enemies_value: _enemies_value.text = str(enemies_left)
+		_tween_int(_enemies_value, prev_enemies, enemies_left, "enemies")


### PR DESCRIPTION
## Summary
Adds three small polish layers to \`ui/components/hud_top.gd\` so HUD updates read as state changes instead of silent text replacements:

- **Number tween** — values lerp from previous to new over 0.32 s with a cubic ease-out, replacing the snap-to-new-string behavior.
- **Punch scale** — chip PanelContainer pops to 1.18x and springs back (Tween.TRANS_BACK / EASE_OUT) on wave change (any direction), lives decrease, gold increase.
- **Flash modulate** — chip flashes 120 ms then fades back over 280 ms; cyan-tinted on wave change, \`COLOR_DANGER\` red on lives decrease, \`COLOR_WARN\` gold on gold increase.

Gold loss / lives gain / wave unchanged → no flash + no punch; the number still tweens so the player still sees the delta animate.

Active tweens are tracked in \`_active_tweens\` keyed by tag and auto-remove themselves on \`Tween.finished\`. Repeated applies kill the prior tween for the same key first, so a fast cascade of snapshot updates doesn't double-tween a single chip.

## Test plan
- [x] \`scripts/test.sh\` — 121/121 (8 new \`test_hud_top.gd\` cases: registry populated, punch/flash gating per direction, unchanged values don't animate, final label text correct after tween)
- [x] \`scripts/test-e2e.sh\` — 130/130 (incl. live td-server smoke)
- [ ] Eyes on it in the editor: open the game scene, hit Space (skip_wave) and watch the wave/gold chips pop + the lives stay calm