### PR TITLE
fix(agones-factorio): rootless UID, RCON arg conflict, e2e RCON bind

### DIFF
--- a/apps/agones/factorio/Dockerfile
+++ b/apps/agones/factorio/Dockerfile
@@ -3,13 +3,15 @@ FROM factoriotools/factorio:${FACTORIO_VERSION}-rootless
 
 USER root
 
-COPY --chown=factorio:factorio apps/agones/factorio/scenarios/kbve /factorio/scenarios/kbve
-COPY --chown=factorio:factorio apps/agones/factorio/config /opt/factorio/config-defaults
+COPY --chown=1000:1000 apps/agones/factorio/scenarios/kbve /factorio/scenarios/kbve
+COPY --chown=1000:1000 apps/agones/factorio/config /opt/factorio/config-defaults
 COPY apps/agones/factorio/shim/agones-shim.sh /usr/local/bin/agones-shim
 
-RUN chmod +x /usr/local/bin/agones-shim
+RUN chmod +x /usr/local/bin/agones-shim && \
+    mkdir -p /shared/log /factorio/config && \
+    chown -R 1000:1000 /shared/log /factorio/config
 
-USER factorio
+USER 1000:1000
 
 ENV FACTORIO_BIN=/opt/factorio/bin/x64/factorio \
     FACTORIO_SCENARIO=kbve \

--- a/apps/agones/factorio/project.json
+++ b/apps/agones/factorio/project.json
@@ -48,7 +48,7 @@
 			"options": {
 				"commands": [
 					"docker rm -f agones-factorio-e2e 2>/dev/null || true",
-					"docker run -d --name agones-factorio-e2e -p 34197:34197/udp -p 27015:27015/tcp -e FACTORIO_RCON_PASSWORD=e2e-test kbve/agones-factorio:latest",
+					"docker run -d --name agones-factorio-e2e -p 34197:34197/udp -p 27015:27015/tcp -e FACTORIO_RCON_PASSWORD=e2e-test -e FACTORIO_RCON_BIND=0.0.0.0 kbve/agones-factorio:latest",
 					"echo 'Waiting for Factorio to come up...' && for i in $(seq 1 240); do if docker logs agones-factorio-e2e 2>&1 | grep -q 'Hosting game'; then echo 'Factorio ready after '\"$i\"'s'; break; fi; if [ $i -eq 240 ]; then echo 'Factorio did not start in 240s'; docker logs agones-factorio-e2e 2>&1 | tail -120; docker rm -f agones-factorio-e2e 2>/dev/null || true; exit 1; fi; sleep 1; done",
 					"FACTORIO_HOST=127.0.0.1 FACTORIO_UDP=34197 FACTORIO_RCON=27015 FACTORIO_RCON_PASSWORD=e2e-test FACTORIO_CONTAINER=agones-factorio-e2e npx vitest run; EC=$?; echo '--- container logs ---'; docker logs agones-factorio-e2e 2>&1 | tail -120; docker rm -f agones-factorio-e2e 2>/dev/null || true; exit $EC"
 				],

--- a/apps/agones/factorio/shim/agones-shim.sh
+++ b/apps/agones/factorio/shim/agones-shim.sh
@@ -25,7 +25,7 @@ done
 
 RCON_ARGS=""
 if [ -n "$FACTORIO_RCON_PASSWORD" ]; then
-    RCON_ARGS="--rcon-port ${FACTORIO_RCON_PORT} --rcon-bind ${FACTORIO_RCON_BIND}:${FACTORIO_RCON_PORT} --rcon-password ${FACTORIO_RCON_PASSWORD}"
+    RCON_ARGS="--rcon-bind ${FACTORIO_RCON_BIND}:${FACTORIO_RCON_PORT} --rcon-password ${FACTORIO_RCON_PASSWORD}"
 fi
 
 sdk_post() {


### PR DESCRIPTION
## Summary

Resolves the `CI - Docker / agones-factorio` failure from #11386 (also closes the bot-filed CI issue once this lands and the next publish succeeds). Three distinct bugs were stacked in the prior PRs; validated locally on `linux/amd64` (built via `docker buildx --platform linux/amd64`, ran the image, watched it reach `Hosting game`, and confirmed both ports answer from the host).

### Bug 1 — rootless user name lookup

`factoriotools/factorio:2.0.76-rootless` uses `USER 1000:1000` numeric and **does not** define a `factorio` entry in `/etc/passwd`. Our Dockerfile said `USER factorio`, so docker's runtime name resolution failed:

```
docker: Error response from daemon: unable to find user factorio: no matching entries in passwd file
```

Every `docker run` aborted before any layer of the image executed, which is why the e2e step exited 1 immediately. Switched `USER` and `COPY --chown` to numeric `1000:1000`.

### Bug 2 — Factorio refuses `--rcon-port` + `--rcon-bind` together

Hit during local validation:

```
Error Main.cpp:539: --rcon-port cannot be used with --rcon-bind
```

`--rcon-bind ${HOST}:${PORT}` already encodes the port, so drop `--rcon-port` and keep the bind form. Loopback-by-default behavior is unchanged.

### Bug 3 — e2e couldn't reach RCON

The shim still binds RCON to `127.0.0.1` by default (correct for production — RCON should never leak past pod loopback). But the e2e harness reaches the container via `docker run -p 27015:27015`, which forwards to the container's `0.0.0.0` interface, not its loopback — so the RCON spec would have hung indefinitely. Pass `-e FACTORIO_RCON_BIND=0.0.0.0` in the e2e `docker run` only. Production defaults stay loopback-only.

### Misc

Pre-create `/shared/log` and `/factorio/config` with `1000:1000` ownership in the image so the shim doesn't have to `mkdir` at runtime under the unprivileged UID.

Refs: #11138, #11386

## Test plan

- [x] Local: `docker buildx build --platform linux/amd64 -f apps/agones/factorio/Dockerfile -t kbve/agones-factorio:amd64-test --load .` succeeds.
- [x] Local: `docker run --platform linux/amd64 -d -p 34197:34197/udp -p 27015:27015/tcp -e FACTORIO_RCON_PASSWORD=local-test -e FACTORIO_RCON_BIND=0.0.0.0 kbve/agones-factorio:amd64-test` reaches `Hosting game` + `RCON interface at IP ADDR:({0.0.0.0:27015})` and stays up.
- [x] Local: `nc -z 127.0.0.1 27015` + `nc -zu 127.0.0.1 34197` both succeed.
- [ ] CI: `CI - Docker / agones-factorio` passes through the e2e step on this branch.
- [ ] CI: after merge + next `ci-main` dispatch, `ghcr.io/kbve/agones-factorio:0.0.2` is published.