### PR TITLE
harden(ci-dashboard): move alert fetch into versioned python script

### DIFF
--- a/.github/workflows/ci-dashboard.yml
+++ b/.github/workflows/ci-dashboard.yml
@@ -177,38 +177,17 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  set -euo pipefail
-                  # gh api --paginate emits one JSON array per page back-to-back,
-                  # which json.load() cannot parse ("Extra data" at start of page 2).
-                  # Slurp pages with `jq -s` and concatenate before writing.
-                  if ! gh api repos/${{ github.repository }}/code-scanning/alerts --paginate 2>/dev/null \
-                       | jq -s 'add // [] | map(select(.state == "open"))' \
-                       > /tmp/codeql-alerts.json; then
-                    echo '[]' > /tmp/codeql-alerts.json
-                  fi
-                  if ! python3 -c "import json; json.load(open('/tmp/codeql-alerts.json'))" 2>/dev/null; then
-                    echo '[]' > /tmp/codeql-alerts.json
-                  fi
-
-                  COUNT=$(python3 -c "import json; print(len(json.load(open('/tmp/codeql-alerts.json'))))" 2>/dev/null || echo 0)
-                  echo "CodeQL open alerts: $COUNT"
+                  python3 scripts/fetch-github-alerts.py \
+                    --endpoint code-scanning \
+                    --out /tmp/codeql-alerts.json
 
             - name: Fetch Dependabot alerts
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  set -euo pipefail
-                  if ! gh api repos/${{ github.repository }}/dependabot/alerts --paginate 2>/dev/null \
-                       | jq -s 'add // [] | map(select(.state == "open"))' \
-                       > /tmp/dependabot-alerts.json; then
-                    echo '[]' > /tmp/dependabot-alerts.json
-                  fi
-                  if ! python3 -c "import json; json.load(open('/tmp/dependabot-alerts.json'))" 2>/dev/null; then
-                    echo '[]' > /tmp/dependabot-alerts.json
-                  fi
-
-                  COUNT=$(python3 -c "import json; print(len(json.load(open('/tmp/dependabot-alerts.json'))))" 2>/dev/null || echo 0)
-                  echo "Dependabot open alerts: $COUNT"
+                  python3 scripts/fetch-github-alerts.py \
+                    --endpoint dependabot \
+                    --out /tmp/dependabot-alerts.json
 
             - name: Aggregate security data
               run: |
@@ -279,6 +258,22 @@ jobs:
                   path: |
                       apps/kbve/astro-kbve/src/content/docs/dashboard/security.mdx
                       apps/kbve/astro-kbve/public/data/nx/nx-security.json
+
+            - name: Upload raw audit payloads on failure
+              if: failure()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: dashboard-security-debug
+                  retention-days: 3
+                  if-no-files-found: ignore
+                  path: |
+                      /tmp/pnpm-audit.json
+                      /tmp/cargo-audit.json
+                      /tmp/pip-audit.json
+                      /tmp/pip-audit-partial.json
+                      /tmp/codeql-alerts.json
+                      /tmp/dependabot-alerts.json
+                      /tmp/nx-security-raw.json
 
             - name: Cleanup
               if: always()

--- a/scripts/fetch-github-alerts.py
+++ b/scripts/fetch-github-alerts.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Fetch GitHub security alerts (code-scanning or dependabot) for KBVE/kbve.
+
+Replaces inline shell in .github/workflows/ci-dashboard.yml so that:
+  * pagination is handled by the Python script (no `gh api --paginate`
+    quirks that emit one JSON array per page → invalid combined doc)
+  * no shell interpolation of intermediate paths (security boundary)
+  * schema validation lives next to the fetch logic
+  * the script is unit-testable and re-runnable outside CI
+
+Exit codes:
+  0  success — JSON array of open alerts written to --out
+  2  fetch failed (HTTP error, schema mismatch, etc.) — empty `[]`
+     written so downstream aggregate step still succeeds
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+OWNER = "KBVE"
+REPO = "kbve"
+API_BASE = "https://api.github.com"
+API_VERSION = "2022-11-28"
+USER_AGENT = "kbve-ci-dashboard-fetch/1.0"
+
+ENDPOINTS = {
+    "code-scanning": f"/repos/{OWNER}/{REPO}/code-scanning/alerts",
+    "dependabot": f"/repos/{OWNER}/{REPO}/dependabot/alerts",
+}
+
+
+def fetch_all(path: str, token: str, per_page: int, timeout: float) -> list[dict[str, Any]]:
+    """Page through a GitHub REST endpoint that returns arrays.
+
+    Uses the Link: rel=\"next\" header for pagination — the same contract
+    `gh api --paginate` follows, but stitched together client-side so we
+    end up with one JSON array instead of N concatenated payloads.
+    """
+    url = f"{API_BASE}{path}?per_page={per_page}&state=open"
+    out: list[dict[str, Any]] = []
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": API_VERSION,
+    }
+    while url:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.load(resp)
+            if not isinstance(payload, list):
+                raise ValueError(
+                    f"expected list, got {type(payload).__name__}")
+            out.extend(payload)
+            url = next_link(resp.headers.get("Link") or "")
+    return out
+
+
+def next_link(header: str) -> str | None:
+    """Parse Link: <url>; rel=\"next\", ..."""
+    for part in header.split(","):
+        segments = [s.strip() for s in part.split(";")]
+        if len(segments) < 2:
+            continue
+        if 'rel="next"' in segments[1:]:
+            url = segments[0].strip()
+            if url.startswith("<") and url.endswith(">"):
+                return url[1:-1]
+    return None
+
+
+def validate(alerts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop entries that don't look like alert objects.
+
+    GitHub's API has been stable on `state` since 2022, but the schema
+    check keeps the downstream aggregate step honest if shape ever
+    drifts. Bad entries are skipped, not failed — partial data beats
+    nothing.
+    """
+    clean: list[dict[str, Any]] = []
+    for a in alerts:
+        if isinstance(a, dict) and a.get("state") == "open":
+            clean.append(a)
+    return clean
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--endpoint",
+        required=True,
+        choices=sorted(ENDPOINTS),
+        help="Which security feed to fetch.",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Where to write the filtered JSON array.",
+    )
+    parser.add_argument(
+        "--per-page",
+        type=int,
+        default=100,
+        help="Pagination size (max 100 per GitHub).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Per-request timeout in seconds.",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        print("::error::GITHUB_TOKEN env not set", file=sys.stderr)
+        with open(args.out, "w") as f:
+            json.dump([], f)
+        return 2
+
+    path = ENDPOINTS[args.endpoint]
+    try:
+        raw = fetch_all(path, token, args.per_page, args.timeout)
+    except urllib.error.HTTPError as e:
+        if e.code in (403, 404):
+            print(
+                f"::notice::{args.endpoint} returned HTTP {e.code} — assuming zero alerts",
+                file=sys.stderr,
+            )
+            with open(args.out, "w") as f:
+                json.dump([], f)
+            return 0
+        print(
+            f"::error::{args.endpoint} HTTP {e.code}: {e.reason}", file=sys.stderr)
+        with open(args.out, "w") as f:
+            json.dump([], f)
+        return 2
+    except (urllib.error.URLError, ValueError, json.JSONDecodeError) as e:
+        print(f"::warning::{args.endpoint} fetch failed: {e}", file=sys.stderr)
+        with open(args.out, "w") as f:
+            json.dump([], f)
+        return 2
+
+    clean = validate(raw)
+    with open(args.out, "w") as f:
+        json.dump(clean, f, indent=2)
+    print(f"{args.endpoint}: {len(clean)} open alerts")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #11382. Replaces inline shell+gh+jq pipelines for the CodeQL and Dependabot fetch steps with a single review-able Python script at \`scripts/fetch-github-alerts.py\`. Workflow steps collapse to a 3-line \`python3\` invocation each.

## Why

Surfaced during review of #11382: the original fix worked, but kept ~70 lines of inline shell with \`\$VAR\` interpolation, multiple silent \`|| echo []\` fallbacks, and per-step duplication between codeql and dependabot. Hard to audit, easy to regress, no shared test surface.

## What

All five hardening items bundled in one place:

1. **Scope hardcoded** to \`KBVE/kbve\` in the script. No template interpolation, no other repos.
2. **API version pinned** (\`X-GitHub-Api-Version: 2022-11-28\`, \`Accept: application/vnd.github+json\`) so silent schema drift surfaces as a parse failure instead of bad downstream data.
3. **Schema sanity check** before write: top-level must be a list of dicts carrying \`state\`. Bad entries are dropped, not failed — partial data beats none.
4. **Real HTTP error handling.** 403/404 short-circuit to \`[]\` with a notice (alerting endpoint disabled = legit zero alerts). Other HTTP errors log and still write \`[]\` so the aggregate step keeps running. No more \`2>/dev/null || echo []\` masking real outages.
5. **Per-request 30s timeout** via urllib so a hung GitHub API can't burn the daily runner.

Plus:

6. **Pagination** handled via \`Link: rel=\"next\"\` inside the script. Eliminates the \`gh api --paginate\` quirk that emitted one JSON array per page (root cause of #11351).
7. **Diagnostic artifact** — new \`if: failure()\` step uploads raw \`/tmp/{codeql,dependabot,pnpm,cargo,pip,nx-security-raw}.json\` as \`dashboard-security-debug\`. Future regressions are grepable from the run page without a re-run.

## Security boundary

Original concern was that inline shell with \`\$OUT\` interpolation in workflow yaml was brittle and unauditable. Moving the logic out of yaml into a stdlib-only Python script under \`scripts/\` removes the surface entirely: the only workflow-level inputs are the literal \`--endpoint\` and \`--out\` args, both fixed at the call site.

Pure stdlib (\`urllib\` + \`json\` + \`argparse\`) — no new pip installs in CI. Runnable locally:

\`\`\`
GITHUB_TOKEN=\$(gh auth token) python3 scripts/fetch-github-alerts.py \\
  --endpoint code-scanning --out /tmp/x.json
\`\`\`

## Test plan

- [ ] Manual dispatch \`CI - Daily Dashboard\` → Security Audit job succeeds
- [ ] CodeQL + Dependabot counts log correctly (non-zero when present)
- [ ] Force a fetch failure (revoke token in fork) → script writes \`[]\`, aggregate keeps running
- [ ] Force schema-shape break (rename \`state\` → \`status\` in a mock) → entries filtered out, no crash
- [ ] Failure path uploads the \`dashboard-security-debug\` artifact