### PR TITLE
refactor(astro-kbve): hoist GitHub to /agents/github (provider-centric) + shared guild picker

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -193,8 +193,8 @@ export default defineConfig({
 							collapsed: true,
 							items: [
 								{ label: 'Overview', link: '/dashboard/agents/', attrs: { 'data-auth-visibility': 'auth' } },
+								{ label: 'GitHub', link: '/dashboard/agents/github/', attrs: { 'data-auth-visibility': 'auth' } },
 								{ label: 'discordsh', link: '/dashboard/agents/discordsh/', attrs: { 'data-auth-visibility': 'auth' } },
-								{ label: 'discordsh · GitHub', link: '/dashboard/agents/discordsh/github/', attrs: { 'data-auth-visibility': 'auth' } },
 							],
 						},
 						{ label: 'Marketplace', link: '/dashboard/market/', attrs: { 'data-auth-visibility': 'auth' } },

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
@@ -19,11 +19,13 @@ import ReactAgentDiscordsh from './ReactAgentDiscordsh';
 			</p>
 			<p class="agent-lede" style="margin-top: 0.75rem;">
 				New to discordsh + GitHub? Run the
-				<a href="/dashboard/agents/discordsh/github/">
-					guided GitHub setup wizard
-				</a>
+				<a href="/dashboard/agents/github/">GitHub provider wizard</a>
 				— it generates the HMAC webhook secret, validates your PAT, and smoke-tests
-				the backfill in one flow.
+				the backfill end-to-end. The rows it provisions (<code>
+					github_webhook:&lt;guild&gt;
+				</code> +{' '}
+				<code>github:&lt;guild&gt;</code>) are shared across any agent
+				that consumes GitHub credentials.
 			</p>
 		</header>
 

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentsDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentsDashboard.astro
@@ -1,7 +1,10 @@
 ---
-interface BotIntegration {
+type CardKind = 'bot' | 'provider';
+
+interface AgentCard {
 	key: string;
 	name: string;
+	kind: CardKind;
 	tagline: string;
 	description: string;
 	docs_url: string;
@@ -10,22 +13,37 @@ interface BotIntegration {
 	status: 'available' | 'coming_soon';
 }
 
-const BOTS: BotIntegration[] = [
+const CARDS: AgentCard[] = [
+	{
+		key: 'github',
+		name: 'GitHub',
+		kind: 'provider',
+		tagline:
+			'Per-guild GitHub integration — webhook HMAC, PAT, repo allowlist (future).',
+		description:
+			'Provider page. Stores github_webhook:<guild> + github:<guild> (PAT) rows in Supabase Vault. Any agent consuming GitHub credentials (discordsh today, future bots later) reads the same rows. Run the guided wizard to provision everything end-to-end + smoke-test the webhook + backfill path.',
+		docs_url: '/project/discordsh-bot/',
+		manage_url: '/dashboard/agents/github/',
+		services: ['github', 'github_webhook', 'github_repos'],
+		status: 'available',
+	},
 	{
 		key: 'discordsh',
 		name: 'discordsh',
+		kind: 'bot',
 		tagline:
 			'Discord gateway bot — slash commands, GitHub bridge, dungeon game.',
 		description:
-			'Embed dungeon, /gh claim self-assign, /github board reads, GitHub issue → Discord forum thread sync (Phase 2). Per-guild PAT + webhook secret resolved from Supabase Vault.',
+			'Embed dungeon, /gh claim self-assign, /github board reads, GitHub issue → Discord forum thread sync (Phase 2). Reads its per-guild GitHub PAT + webhook secret from the rows you provision under the GitHub provider page.',
 		docs_url: '/project/discordsh-bot/',
 		manage_url: '/dashboard/agents/discordsh/',
-		services: ['github', 'github_webhook', 'github_repos'],
+		services: ['github', 'github_webhook'],
 		status: 'available',
 	},
 	{
 		key: 'irc_gateway',
 		name: 'irc-gateway',
+		kind: 'bot',
 		tagline: 'JWT-authenticated IRC bridge for chat services.',
 		description:
 			'Bridges KBVE chat traffic to IRC backends. Per-guild routing not yet wired through the agents surface.',
@@ -36,8 +54,12 @@ const BOTS: BotIntegration[] = [
 	},
 ];
 
-const statusLabel = (s: BotIntegration['status']) =>
+const BOTS = CARDS;
+
+const statusLabel = (s: AgentCard['status']) =>
 	s === 'available' ? 'Available' : 'Coming soon';
+
+const kindLabel = (k: CardKind) => (k === 'provider' ? 'Provider' : 'Bot');
 ---
 
 <section
@@ -63,10 +85,16 @@ const statusLabel = (s: BotIntegration['status']) =>
 						data-agent={bot.key}>
 						<div class="agent-card__head">
 							<h2 class="agent-card__name">{bot.name}</h2>
-							<span
-								class={`agent-card__status agent-card__status--${bot.status}`}>
-								{statusLabel(bot.status)}
-							</span>
+							<div class="agent-card__badges">
+								<span
+									class={`agent-card__kind agent-card__kind--${bot.kind}`}>
+									{kindLabel(bot.kind)}
+								</span>
+								<span
+									class={`agent-card__status agent-card__status--${bot.status}`}>
+									{statusLabel(bot.status)}
+								</span>
+							</div>
 						</div>
 						<p class="agent-card__tagline">{bot.tagline}</p>
 						<p class="agent-card__description">{bot.description}</p>
@@ -190,11 +218,18 @@ const statusLabel = (s: BotIntegration['status']) =>
 		font-family: var(--sl-font-mono, ui-monospace, monospace);
 	}
 
-	.agent-card__status {
-		font-size: 0.75rem;
+	.agent-card__badges {
+		display: flex;
+		gap: 0.35rem;
+		align-items: center;
+	}
+
+	.agent-card__status,
+	.agent-card__kind {
+		font-size: 0.7rem;
 		font-weight: 600;
 		text-transform: uppercase;
-		padding: 0.2rem 0.55rem;
+		padding: 0.2rem 0.5rem;
 		border-radius: 999px;
 		letter-spacing: 0.04em;
 	}
@@ -207,6 +242,16 @@ const statusLabel = (s: BotIntegration['status']) =>
 	.agent-card__status--coming_soon {
 		background: rgba(148, 163, 184, 0.15);
 		color: #94a3b8;
+	}
+
+	.agent-card__kind--provider {
+		background: rgba(168, 139, 250, 0.15);
+		color: #a78bfa;
+	}
+
+	.agent-card__kind--bot {
+		background: rgba(88, 166, 255, 0.15);
+		color: #58a6ff;
 	}
 
 	.agent-card__tagline {

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentDiscordsh.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentDiscordsh.tsx
@@ -5,7 +5,6 @@ import {
 	LogIn,
 	RefreshCw,
 	AlertTriangle,
-	Users,
 	KeyRound,
 	Plus,
 	Trash2,
@@ -18,23 +17,7 @@ import {
 } from './agentsService';
 import { styles } from './dashboard-ui';
 import { AddTokenModal, DeleteTokenModal } from './ReactAgentTokenModals';
-
-const DISCORD_CDN = 'https://cdn.discordapp.com';
-
-function guildIconUrl(guild: DiscordGuild): string | null {
-	if (!guild.icon) return null;
-	return `${DISCORD_CDN}/icons/${guild.id}/${guild.icon}.png?size=64`;
-}
-
-function initials(name: string): string {
-	return name
-		.split(/\s+/)
-		.map((s) => s[0])
-		.filter(Boolean)
-		.slice(0, 2)
-		.join('')
-		.toUpperCase();
-}
+import ReactAgentGuildPicker from './ReactAgentGuildPicker';
 
 function formatDate(iso: string): string {
 	try {
@@ -57,8 +40,6 @@ function maskService(svc: string): { label: string; color: string } {
 export default function ReactAgentDiscordsh() {
 	const authState = useStore(agentsService.$authState);
 	const guilds = useStore(agentsService.$guilds);
-	const guildsLoading = useStore(agentsService.$guildsLoading);
-	const guildsError = useStore(agentsService.$guildsError);
 	const selectedGuildId = useStore(agentsService.$selectedGuildId);
 	const tokens = useStore(agentsService.$tokens);
 	const tokensLoading = useStore(agentsService.$tokensLoading);
@@ -169,13 +150,20 @@ export default function ReactAgentDiscordsh() {
 		<div
 			className="not-content"
 			style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
-			<GuildPicker
-				guilds={guilds}
-				loading={guildsLoading}
-				error={guildsError}
-				selectedGuildId={selectedGuildId}
-				onSelect={(id) => agentsService.selectGuild(id)}
-			/>
+			<ReactAgentGuildPicker />
+
+			{guilds.length > 1 && selectedGuild && (
+				<p
+					style={{
+						margin: 0,
+						fontSize: '0.78rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					This guild is shared across the agents surface — visit{' '}
+					<a href="/dashboard/agents/github/">GitHub</a> to configure
+					the webhook + PAT for the same guild.
+				</p>
+			)}
 
 			{selectedGuild ? (
 				<TokenList
@@ -189,158 +177,6 @@ export default function ReactAgentDiscordsh() {
 				<EmptyGuildPrompt guildCount={guilds.length} />
 			)}
 		</div>
-	);
-}
-
-interface GuildPickerProps {
-	guilds: DiscordGuild[];
-	loading: boolean;
-	error: string | null;
-	selectedGuildId: string | null;
-	onSelect: (id: string) => void;
-}
-
-function GuildPicker({
-	guilds,
-	loading,
-	error,
-	selectedGuildId,
-	onSelect,
-}: GuildPickerProps) {
-	return (
-		<section style={styles.sectionBorder}>
-			<header
-				style={{
-					padding: '0.85rem 1rem',
-					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
-					display: 'flex',
-					alignItems: 'center',
-					gap: '0.5rem',
-				}}>
-				<Users size={18} color="#58a6ff" />
-				<strong>Discord guilds you own</strong>
-				{loading && (
-					<Loader2
-						size={14}
-						style={{
-							animation: 'spin 1s linear infinite',
-							marginLeft: '0.5rem',
-						}}
-					/>
-				)}
-			</header>
-
-			<div style={{ padding: '0.85rem 1rem' }}>
-				{error && (
-					<p
-						style={{
-							color: '#f87171',
-							fontSize: '0.85rem',
-							margin: 0,
-						}}>
-						{error}
-					</p>
-				)}
-				{!error && !loading && guilds.length === 0 && (
-					<p
-						style={{
-							color: 'var(--sl-color-gray-3, #9ca0aa)',
-							fontSize: '0.9rem',
-							margin: 0,
-						}}>
-						You don't own any Discord guilds. Only guild owners can
-						manage bot integration tokens.
-					</p>
-				)}
-				{guilds.length > 0 && (
-					<div
-						style={{
-							display: 'grid',
-							gridTemplateColumns:
-								'repeat(auto-fill, minmax(220px, 1fr))',
-							gap: '0.6rem',
-						}}>
-						{guilds.map((g) => {
-							const iconUrl = guildIconUrl(g);
-							const active = selectedGuildId === g.id;
-							return (
-								<button
-									key={g.id}
-									type="button"
-									onClick={() => onSelect(g.id)}
-									style={{
-										display: 'flex',
-										alignItems: 'center',
-										gap: '0.65rem',
-										padding: '0.6rem 0.75rem',
-										borderRadius: 10,
-										border: `1px solid ${active ? '#58a6ff' : 'var(--sl-color-gray-5, #2d2f36)'}`,
-										background: active
-											? 'rgba(88,166,255,0.08)'
-											: 'transparent',
-										color: 'var(--sl-color-white, #fff)',
-										cursor: 'pointer',
-										textAlign: 'left',
-										transition:
-											'border-color 0.15s ease, background 0.15s ease',
-									}}>
-									{iconUrl ? (
-										<img
-											src={iconUrl}
-											alt=""
-											width={36}
-											height={36}
-											style={{
-												borderRadius: 8,
-												flexShrink: 0,
-											}}
-										/>
-									) : (
-										<div
-											aria-hidden
-											style={{
-												width: 36,
-												height: 36,
-												borderRadius: 8,
-												background: '#374151',
-												color: '#e5e7eb',
-												display: 'flex',
-												alignItems: 'center',
-												justifyContent: 'center',
-												fontWeight: 700,
-												fontSize: '0.8rem',
-												flexShrink: 0,
-											}}>
-											{initials(g.name)}
-										</div>
-									)}
-									<div style={{ minWidth: 0 }}>
-										<div
-											style={{
-												fontWeight: 600,
-												overflow: 'hidden',
-												textOverflow: 'ellipsis',
-												whiteSpace: 'nowrap',
-											}}>
-											{g.name}
-										</div>
-										<div
-											style={{
-												fontSize: '0.7rem',
-												color: 'var(--sl-color-gray-3, #9ca0aa)',
-												fontFamily:
-													'var(--sl-font-mono, ui-monospace, monospace)',
-											}}>
-											{g.id}
-										</div>
-									</div>
-								</button>
-							);
-						})}
-					</div>
-				)}
-			</div>
-		</section>
 	);
 }
 

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
@@ -19,6 +19,7 @@ import {
 	type DiscordGuild,
 } from './agentsService';
 import { styles } from './dashboard-ui';
+import ReactAgentGuildPicker from './ReactAgentGuildPicker';
 
 const GITHUB_OWNER_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}$/;
 const GITHUB_REPO_RE = /^[A-Za-z0-9._-]{1,100}$/;
@@ -103,25 +104,39 @@ export default function ReactAgentGithubWizard() {
 
 	if (!selectedGuild) {
 		return (
-			<section style={styles.sectionBorder}>
-				<div style={{ padding: '1rem' }}>
-					<p
-						style={{
-							margin: 0,
-							color: 'var(--sl-color-gray-3, #9ca0aa)',
-						}}>
-						Pick a guild on the{' '}
-						<a href="/dashboard/agents/discordsh/">
-							discordsh page
-						</a>{' '}
-						first. The wizard provisions Vault rows for that guild.
-					</p>
-				</div>
-			</section>
+			<div
+				className="not-content"
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '1rem',
+				}}>
+				<ReactAgentGuildPicker title="Pick a guild to configure GitHub for" />
+				<p
+					style={{
+						margin: 0,
+						fontSize: '0.85rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					The wizard provisions Vault rows scoped to the picked guild
+					(<code>github_pat:&lt;guild&gt;</code> +{' '}
+					<code>github_webhook:&lt;guild&gt;</code>). The selection is
+					shared with{' '}
+					<a href="/dashboard/agents/discordsh/">discordsh</a> and any
+					other agent that consumes GitHub credentials.
+				</p>
+			</div>
 		);
 	}
 
-	return <WizardBody guild={selectedGuild} tokens={tokens} />;
+	return (
+		<div
+			className="not-content"
+			style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+			<ReactAgentGuildPicker title="Configuring GitHub for" />
+			<WizardBody guild={selectedGuild} tokens={tokens} />
+		</div>
+	);
 }
 
 interface WizardBodyProps {

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGuildPicker.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGuildPicker.tsx
@@ -1,0 +1,172 @@
+import { useStore } from '@nanostores/react';
+import { Loader2, Users } from 'lucide-react';
+import { agentsService, type DiscordGuild } from './agentsService';
+import { styles } from './dashboard-ui';
+
+const DISCORD_CDN = 'https://cdn.discordapp.com';
+
+function guildIconUrl(guild: DiscordGuild): string | null {
+	if (!guild.icon) return null;
+	return `${DISCORD_CDN}/icons/${guild.id}/${guild.icon}.png?size=64`;
+}
+
+function initials(name: string): string {
+	return name
+		.split(/\s+/)
+		.map((s) => s[0])
+		.filter(Boolean)
+		.slice(0, 2)
+		.join('')
+		.toUpperCase();
+}
+
+interface GuildPickerProps {
+	title?: string;
+}
+
+export default function ReactAgentGuildPicker({
+	title = 'Discord guilds you own',
+}: GuildPickerProps) {
+	const guilds = useStore(agentsService.$guilds);
+	const loading = useStore(agentsService.$guildsLoading);
+	const error = useStore(agentsService.$guildsError);
+	const selectedGuildId = useStore(agentsService.$selectedGuildId);
+
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<Users size={18} color="#58a6ff" />
+				<strong>{title}</strong>
+				{loading && (
+					<Loader2
+						size={14}
+						style={{
+							animation: 'spin 1s linear infinite',
+							marginLeft: '0.5rem',
+						}}
+					/>
+				)}
+			</header>
+
+			<div style={{ padding: '0.85rem 1rem' }}>
+				{error && (
+					<p
+						style={{
+							color: '#f87171',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						{error}
+					</p>
+				)}
+				{!error && !loading && guilds.length === 0 && (
+					<p
+						style={{
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+							margin: 0,
+						}}>
+						You don't own any Discord guilds. Only guild owners can
+						manage bot integration tokens.
+					</p>
+				)}
+				{guilds.length > 0 && (
+					<div
+						style={{
+							display: 'grid',
+							gridTemplateColumns:
+								'repeat(auto-fill, minmax(220px, 1fr))',
+							gap: '0.6rem',
+						}}>
+						{guilds.map((g) => {
+							const iconUrl = guildIconUrl(g);
+							const active = selectedGuildId === g.id;
+							return (
+								<button
+									key={g.id}
+									type="button"
+									onClick={() =>
+										agentsService.selectGuild(g.id)
+									}
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: '0.65rem',
+										padding: '0.6rem 0.75rem',
+										borderRadius: 10,
+										border: `1px solid ${active ? '#58a6ff' : 'var(--sl-color-gray-5, #2d2f36)'}`,
+										background: active
+											? 'rgba(88,166,255,0.08)'
+											: 'transparent',
+										color: 'var(--sl-color-white, #fff)',
+										cursor: 'pointer',
+										textAlign: 'left',
+										transition:
+											'border-color 0.15s ease, background 0.15s ease',
+									}}>
+									{iconUrl ? (
+										<img
+											src={iconUrl}
+											alt=""
+											width={36}
+											height={36}
+											style={{
+												borderRadius: 8,
+												flexShrink: 0,
+											}}
+										/>
+									) : (
+										<div
+											aria-hidden
+											style={{
+												width: 36,
+												height: 36,
+												borderRadius: 8,
+												background: '#374151',
+												color: '#e5e7eb',
+												display: 'flex',
+												alignItems: 'center',
+												justifyContent: 'center',
+												fontWeight: 700,
+												fontSize: '0.8rem',
+												flexShrink: 0,
+											}}>
+											{initials(g.name)}
+										</div>
+									)}
+									<div style={{ minWidth: 0 }}>
+										<div
+											style={{
+												fontWeight: 600,
+												overflow: 'hidden',
+												textOverflow: 'ellipsis',
+												whiteSpace: 'nowrap',
+											}}>
+											{g.name}
+										</div>
+										<div
+											style={{
+												fontSize: '0.7rem',
+												color: 'var(--sl-color-gray-3, #9ca0aa)',
+												fontFamily:
+													'var(--sl-font-mono, ui-monospace, monospace)',
+											}}>
+											{g.id}
+										</div>
+									</div>
+								</button>
+							);
+						})}
+					</div>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/agents/github/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/agents/github/index.mdx
@@ -1,19 +1,19 @@
 ---
-title: discordsh · GitHub setup
-description: Guided wizard — generate HMAC webhook secret, register GitHub PAT, configure webhook, smoke-test backfill.
+title: GitHub provider
+description: Per-guild GitHub integration — HMAC webhook secret, PAT, webhook configuration, smoke-test backfill. Shared by every KBVE agent that consumes the GitHub Vault rows.
 tableOfContents: false
 graph:
     visible: false
 sidebar:
-    label: GitHub setup
+    label: GitHub
     order: 2
 unsplash: 1558494949-ef010cbdcc31
 img: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75
 tags:
     - dashboard
     - agents
-    - discordsh
     - github
+    - integrations
 ---
 
 import AstroAgentGithubWizard from '@/components/dashboard/AstroAgentGithubWizard.astro';


### PR DESCRIPTION
Re-orgs the agents surface from bot-centric to provider-centric per the discussion on #11362. GitHub is a cross-cutting provider (any agent can consume \`github_pat:<guild>\` + \`github_webhook:<guild>\`), so nesting it under \`/agents/discordsh/github/\` was misleading.

## What changes

| Before | After |
|---|---|
| \`/dashboard/agents/discordsh/github/\` | \`/dashboard/agents/github/\` |
| Inline guild picker in \`ReactAgentDiscordsh\` | Shared \`ReactAgentGuildPicker\` component |
| Wizard's "Pick a guild on the discordsh page first" CTA | Wizard surfaces the same shared picker inline |
| Sidebar: \`Agents → Overview · discordsh · discordsh · GitHub\` | Sidebar: \`Agents → Overview · GitHub · discordsh\` |
| Catalog: 2 cards (discordsh, irc-gateway) | Catalog: 3 cards w/ Provider/Bot kind badges (GitHub provider + discordsh bot + irc-gateway placeholder) |

The wizard route is renamed via \`git mv\`; old route deleted.

## Files

- \`src/components/dashboard/ReactAgentGuildPicker.tsx\` (new) — shared picker. Reads/writes \`agentsService\` nanostores so a guild pick on either page persists to the other.
- \`src/components/dashboard/ReactAgentDiscordsh.tsx\` — drops inline picker + helpers (\`guildIconUrl\`, \`initials\`, \`DISCORD_CDN\` — all moved into the shared component). Adds an inline cross-link to the GitHub provider page when a guild is selected.
- \`src/components/dashboard/ReactAgentGithubWizard.tsx\` — replaces the \"go to discordsh page first\" empty state with the shared picker; the picker is also shown above the four steps so users can re-pick without bouncing.
- \`src/components/dashboard/AstroAgentsDashboard.astro\` — new \`CardKind\` (\`'bot' | 'provider'\`); new GitHub provider card; kind badge alongside the existing status badge.
- \`src/components/dashboard/AstroAgentDiscordsh.astro\` — cross-link URL updated.
- \`src/content/docs/dashboard/agents/github/index.mdx\` — new route.
- \`src/content/docs/dashboard/agents/discordsh/github/index.mdx\` — deleted (git detected the rename).
- \`astro.config.mjs\` — sidebar reshuffle.

## Why now

After P0–P3 landed it became clear the URL shape was hardcoding a bot/integration coupling that doesn't exist. The Vault rows are per-guild and any bot can consume them — discordsh is just the first. Refactoring before users are deeply linked to \`/agents/discordsh/github/\` is cheap; later it would mean redirects.

## No version bump

\`axum-kbve\` v1.0.171 from the P0 PR has not yet published. P1 (#11368), P2 (#11372), P3 (#11385), and this refactor all ride the same image tag.

## Next slices (still under #11362)

- **P4** — per-guild repo allowlist (\`github_repos:<guild>\` Vault row + UI editor under \`/agents/github/\`) + \`gh-webhook\` refactor to read it.
- **P5** — \`gh.event_queue_stats\` widget under \`/agents/github/\`.
- **P6** — bot install wizard.
- Token list hoist — move CRUD off the discordsh page to a shared \`/agents/tokens/\` so deleting a GitHub row provisioned via the GitHub page doesn't feel like it lives in the wrong spot.

## Verification

- \`./kbve.sh -nx astro-kbve:build\` ✓
- No new dependencies