### PR TITLE
fix(irc-gateway): skip redundant dev e2e in CI to prevent 180min hang

### DIFF
--- a/apps/irc/project.json
+++ b/apps/irc/project.json
@@ -1,30 +1,40 @@
 {
-  "name": "irc",
-  "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "projectType": "application",
-  "sourceRoot": "apps/irc",
-  "targets": {
-    "e2e": {
-      "executor": "nx:run-commands",
-      "cache": false,
-      "options": {
-        "commands": [
-          "nx test irc-gateway --no-cloud",
-          "nx e2e irc-e2e --no-cloud",
-          "docker rm -f irc-e2e-test 2>/dev/null || true",
-          "nx container irc-gateway --configuration=local --no-cloud",
-          "nx e2e:docker irc-e2e --no-cloud; EC=$?; docker rm -f irc-e2e-test 2>/dev/null || true; exit $EC"
-        ],
-        "parallel": false
-      }
-    },
-    "container": {
-      "executor": "nx:run-commands",
-      "options": {
-        "commands": ["nx container irc-gateway"],
-        "parallel": false
-      }
-    }
-  },
-  "tags": []
+	"name": "irc",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/irc",
+	"targets": {
+		"e2e": {
+			"executor": "nx:run-commands",
+			"cache": false,
+			"options": {
+				"commands": [
+					"nx test irc-gateway --no-cloud",
+					"nx e2e irc-e2e --no-cloud",
+					"docker rm -f irc-e2e-test 2>/dev/null || true",
+					"nx container irc-gateway --configuration=local --no-cloud",
+					"nx e2e:docker irc-e2e --no-cloud; EC=$?; docker rm -f irc-e2e-test 2>/dev/null || true; exit $EC"
+				],
+				"parallel": false
+			},
+			"configurations": {
+				"ci": {
+					"commands": [
+						"nx test irc-gateway --no-cloud",
+						"docker rm -f irc-e2e-test 2>/dev/null || true",
+						"nx container irc-gateway --configuration=local --no-cloud",
+						"nx e2e:docker irc-e2e --no-cloud; EC=$?; docker rm -f irc-e2e-test 2>/dev/null || true; exit $EC"
+					]
+				}
+			}
+		},
+		"container": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["nx container irc-gateway"],
+				"parallel": false
+			}
+		}
+	},
+	"tags": []
 }


### PR DESCRIPTION
## Summary

- CI run [26476562931](https://github.com/KBVE/kbve/actions/runs/26476562931/job/77963559826) hit the 180min job timeout because `nx e2e irc` runs five sequential phases, including a dev-mode playwright e2e that's redundant with the docker e2e that follows.
- Add a `ci` configuration on the `e2e` target in `apps/irc/project.json` that drops the dev-mode phase. CI workflow already passes `--configuration=ci` ([docker-test-app.yml:148](https://github.com/KBVE/kbve/blob/main/.github/workflows/docker-test-app.yml#L148)).

## Root cause

`nx e2e irc` chains:

1. `nx test irc-gateway` — cargo test (cold compile ~5min)
2. `nx e2e irc-e2e` — dev mode pw → `./kbve.sh -nx irc-gateway:dev` → astro build + cold `cargo run -p irc-gateway` (debug)
3. `docker rm`
4. `nx container irc-gateway --configuration=local` — docker build (cold release compile)
5. `nx e2e:docker irc-e2e` — pw against container

Phase 2 is redundant — Dockerfile builds astro + Rust standalone, so docker mode (phase 5) tests the same surface. Worse, `./kbve.sh -nx ...` runs `pnpm nx run ...` without `exec`, so playwright's SIGTERM to the webServer doesn't reach the cargo subprocess tree. After phase 2 logs went silent for 3hr post-chromium-download, the runner hit `timeout-minutes: 180`.

## Fix

Drop phase 2 in the CI configuration. Local `nx e2e irc` (no `--configuration=ci`) keeps the full chain for dev iteration.

## Test plan

- [ ] CI - Docker (irc-gateway) workflow_dispatch finishes well under 180min
- [ ] Phase 2 (`nx e2e irc-e2e`) no longer appears in CI logs
- [ ] Phases 1, 3, 4, 5 still run and pass
- [ ] Local `nx e2e irc` (no `--configuration=ci`) still runs all 5 phases