### PR TITLE
refactor(astro-kbve): client-router audit Phase 2 — onMount on core component scripts

### DIFF
--- a/apps/kbve/astro-kbve/src/components/astropad/devcode/Devcode.astro
+++ b/apps/kbve/astro-kbve/src/components/astropad/devcode/Devcode.astro
@@ -36,7 +36,7 @@ const uniqueId = `devcode-${Math.random().toString(36).substring(2, 11)}`;
 	</div>
 </div>
 
-<script is:inline define:vars={{ uniqueId }}>
+<script is:inline define:vars={{ uniqueId }} data-astro-rerun>
 	const container = document.getElementById(uniqueId);
 	if (container) {
 		const btn = container.querySelector('.copy-btn');

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroApiDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroApiDashboard.astro
@@ -85,10 +85,19 @@ const configJson = JSON.stringify(configuration);
 </style>
 
 <script is:inline src={SCALAR_CDN}></script>
-<script is:inline define:vars={{ configJson }}>
+<script is:inline define:vars={{ configJson }} data-astro-rerun>
 	(function () {
+		// Skip when the host mount node isn't on the swap target (router
+		// can re-fire this script on any page; only run where the
+		// Scalar mount exists).
+		if (!document.getElementById('scalar-app')) return;
 		var cfg = JSON.parse(configJson);
 		window.__scalarBaseConfig = cfg;
+		if (!window.Scalar) return;
+		// Tear down any previous instance bound to the now-removed DOM.
+		try {
+			window.__scalarRef?.destroy?.();
+		} catch (e) {}
 		window.__scalarRef = window.Scalar.createApiReference(
 			'#scalar-app',
 			cfg,

--- a/apps/kbve/astro-kbve/src/components/hero/mainhero/AstroMainHero.astro
+++ b/apps/kbve/astro-kbve/src/components/hero/mainhero/AstroMainHero.astro
@@ -293,14 +293,11 @@ const verticalAlignmentClasses = {
 </style>
 
 <script>
-	/**
-	 * Client-side script
-	 * Handles preloading and optimizations
-	 */
+	import { onMount } from '@kbve/astro/utils/clientRouter';
 
-	// Preload background images for better performance
-	const heroWrapper = document.querySelector('.astro-main-hero-wrapper');
-	if (heroWrapper) {
+	onMount(() => {
+		const heroWrapper = document.querySelector('.astro-main-hero-wrapper');
+		if (!heroWrapper) return;
 		const skeleton = heroWrapper.querySelector(
 			'[data-x-kbve="main-hero-skeleton"]',
 		) as HTMLElement;
@@ -314,11 +311,10 @@ const verticalAlignmentClasses = {
 				}
 			}
 		}
-	}
 
-	// Log hero load time (development only)
-	if (import.meta.env.DEV) {
-		console.log('[MainHero] Component initialized');
-		performance.mark('main-hero-loaded');
-	}
+		if (import.meta.env.DEV) {
+			console.log('[MainHero] Component initialized');
+			performance.mark('main-hero-loaded');
+		}
+	});
 </script>

--- a/apps/kbve/astro-kbve/src/components/hero/subhero/AstroSubHero.astro
+++ b/apps/kbve/astro-kbve/src/components/hero/subhero/AstroSubHero.astro
@@ -288,14 +288,11 @@ const alignmentClasses = {
 </style>
 
 <script>
-	/**
-	 * Client-side script
-	 * Handles preloading and optimizations
-	 */
+	import { onMount } from '@kbve/astro/utils/clientRouter';
 
-	// Preload background images for better performance
-	const heroWrapper = document.querySelector('.astro-sub-hero-wrapper');
-	if (heroWrapper) {
+	onMount(() => {
+		const heroWrapper = document.querySelector('.astro-sub-hero-wrapper');
+		if (!heroWrapper) return;
 		const skeleton = heroWrapper.querySelector(
 			'[data-x-kbve="sub-hero-skeleton"]',
 		) as HTMLElement;
@@ -309,11 +306,10 @@ const alignmentClasses = {
 				}
 			}
 		}
-	}
 
-	// Log sub hero load time (development only)
-	if (import.meta.env.DEV) {
-		console.log('[SubHero] Component initialized');
-		performance.mark('sub-hero-loaded');
-	}
+		if (import.meta.env.DEV) {
+			console.log('[SubHero] Component initialized');
+			performance.mark('sub-hero-loaded');
+		}
+	});
 </script>

--- a/apps/kbve/astro-kbve/src/components/market/AstroMarketAccountSummary.astro
+++ b/apps/kbve/astro-kbve/src/components/market/AstroMarketAccountSummary.astro
@@ -37,11 +37,14 @@
 <script>
 	import { myBids, myListings, MarketApiError } from './api';
 	import { initSupa, getSupa } from '@/lib/supa';
+	import { onMount } from '@kbve/astro/utils/clientRouter';
 
-	const shell = document.querySelector<HTMLElement>(
-		'[data-kbve-market-shell]',
-	);
-	if (shell) {
+	onMount(() => {
+		const shell = document.querySelector<HTMLElement>(
+			'[data-kbve-market-shell]',
+		);
+		if (!shell) return;
+
 		const errorEl = shell.querySelector<HTMLElement>(
 			'[data-kbve-market-error]',
 		);
@@ -62,18 +65,20 @@
 			}
 		};
 
+		let cancelled = false;
 		(async () => {
 			try {
 				await initSupa();
 			} catch {
-				shell.dataset.kbveMarketState = 'signed-out';
+				if (!cancelled) shell.dataset.kbveMarketState = 'signed-out';
 				return;
 			}
+			if (cancelled) return;
 			const supa = getSupa();
 			const sessionResult = await supa.getSession().catch(() => null);
 			const token = sessionResult?.session?.access_token;
 			if (!token) {
-				shell.dataset.kbveMarketState = 'signed-out';
+				if (!cancelled) shell.dataset.kbveMarketState = 'signed-out';
 				return;
 			}
 
@@ -82,6 +87,7 @@
 					myListings({ limit: 100 }),
 					myBids({ limit: 100 }),
 				]);
+				if (cancelled) return;
 				setStat(
 					'active-listings',
 					ls.filter((l) => l.listing_status === 'active').length,
@@ -101,6 +107,7 @@
 				setError(null);
 				shell.dataset.kbveMarketState = 'ready';
 			} catch (e) {
+				if (cancelled) return;
 				setError(
 					e instanceof MarketApiError
 						? e.message
@@ -109,7 +116,11 @@
 				shell.dataset.kbveMarketState = 'error';
 			}
 		})();
-	}
+
+		return () => {
+			cancelled = true;
+		};
+	});
 </script>
 
 <style is:global>

--- a/apps/kbve/astro-kbve/src/components/providers/AskamaForumComposeProvider.astro
+++ b/apps/kbve/astro-kbve/src/components/providers/AskamaForumComposeProvider.astro
@@ -132,184 +132,193 @@ const spaces = await getForumSpaces();
 
 <script>
 	import { initSupa, getSupa } from '@/lib/supa';
+	import { onMount } from '@kbve/astro/utils/clientRouter';
 
-	// prettier-plugin-astro keeps reformatting <textarea ... /> into
-	// <textarea>...\n  </textarea>, leaving leading whitespace as the
-	// initial value. Force-clear on load.
-	for (const t of document.querySelectorAll<HTMLTextAreaElement>(
-		'.compose-form__field textarea',
-	)) {
-		if (!t.defaultValue || /^\s+$/.test(t.defaultValue)) {
-			t.value = '';
-			t.defaultValue = '';
-		}
-	}
-
-	const form = document.getElementById(
-		'compose-form',
-	) as HTMLFormElement | null;
-	const status = document.getElementById(
-		'compose-status',
-	) as HTMLOutputElement | null;
-
-	// Apply the askama-rendered default-space to the <select> on
-	// load. The option list is server-pre-rendered; we only set the
-	// active value here.
-	const spaceSelect = form?.querySelector<HTMLSelectElement>(
-		'select[name="space_slug"]',
-	);
-	const defaultSpace = spaceSelect?.dataset.defaultSpace?.trim();
-	if (spaceSelect && defaultSpace) {
-		const match = Array.from(spaceSelect.options).find(
-			(o) => o.value === defaultSpace,
-		);
-		if (match) spaceSelect.value = defaultSpace;
-	}
-
-	// Eligibility gate: hide the form for anon visitors and for
-	// signed-in users without a username. The submit RPC enforces
-	// the same rules server-side, but failing client-side avoids
-	// the "fill out a long body, hit post, get rejected" flow.
-	(async () => {
-		const gate = document.getElementById('compose-gate');
-		const gateLede = gate?.querySelector<HTMLElement>(
-			'.compose-gate__lede',
-		);
-		const signin = document.getElementById(
-			'compose-gate-signin',
-		) as HTMLAnchorElement | null;
-		if (!gate || !form) return;
-
-		const showGate = (mode: 'anon' | 'no-username' | 'init-error') => {
-			form.hidden = true;
-			gate.hidden = false;
-			if (gateLede) {
-				gateLede.textContent =
-					mode === 'anon'
-						? (gateLede.dataset.anonText ?? '')
-						: mode === 'no-username'
-							? (gateLede.dataset.noUsernameText ?? '')
-							: (gateLede.dataset.initErrorText ?? '');
+	onMount(() => {
+		// prettier-plugin-astro keeps reformatting <textarea ... /> into
+		// <textarea>...\n  </textarea>, leaving leading whitespace as the
+		// initial value. Force-clear on load.
+		for (const t of document.querySelectorAll<HTMLTextAreaElement>(
+			'.compose-form__field textarea',
+		)) {
+			if (!t.defaultValue || /^\s+$/.test(t.defaultValue)) {
+				t.value = '';
+				t.defaultValue = '';
 			}
-			if (signin) {
-				if (mode === 'init-error') {
-					signin.textContent = 'Refresh page';
-					signin.href = location.pathname + location.search;
-					signin.addEventListener(
-						'click',
-						(ev) => {
-							ev.preventDefault();
-							location.reload();
-						},
-						{ once: true },
-					);
-				} else {
-					signin.textContent =
-						mode === 'anon' ? 'Sign in' : 'Set username';
-					signin.href = '/dashboard/profile/';
+		}
+
+		const form = document.getElementById(
+			'compose-form',
+		) as HTMLFormElement | null;
+		if (!form) return;
+		const status = document.getElementById(
+			'compose-status',
+		) as HTMLOutputElement | null;
+
+		// Apply the askama-rendered default-space to the <select> on
+		// load. The option list is server-pre-rendered; we only set the
+		// active value here.
+		const spaceSelect = form?.querySelector<HTMLSelectElement>(
+			'select[name="space_slug"]',
+		);
+		const defaultSpace = spaceSelect?.dataset.defaultSpace?.trim();
+		if (spaceSelect && defaultSpace) {
+			const match = Array.from(spaceSelect.options).find(
+				(o) => o.value === defaultSpace,
+			);
+			if (match) spaceSelect.value = defaultSpace;
+		}
+
+		// Eligibility gate: hide the form for anon visitors and for
+		// signed-in users without a username. The submit RPC enforces
+		// the same rules server-side, but failing client-side avoids
+		// the "fill out a long body, hit post, get rejected" flow.
+		(async () => {
+			const gate = document.getElementById('compose-gate');
+			const gateLede = gate?.querySelector<HTMLElement>(
+				'.compose-gate__lede',
+			);
+			const signin = document.getElementById(
+				'compose-gate-signin',
+			) as HTMLAnchorElement | null;
+			if (!gate || !form) return;
+
+			const showGate = (mode: 'anon' | 'no-username' | 'init-error') => {
+				form.hidden = true;
+				gate.hidden = false;
+				if (gateLede) {
+					gateLede.textContent =
+						mode === 'anon'
+							? (gateLede.dataset.anonText ?? '')
+							: mode === 'no-username'
+								? (gateLede.dataset.noUsernameText ?? '')
+								: (gateLede.dataset.initErrorText ?? '');
 				}
-			}
-		};
-
-		try {
-			await initSupa();
-		} catch {
-			showGate('init-error');
-			return;
-		}
-		const supa = getSupa();
-		const sessionResult = await supa.getSession().catch(() => null);
-		const session = sessionResult?.session ?? null;
-		if (!session?.access_token) {
-			showGate('anon');
-			return;
-		}
-
-		try {
-			const res = await fetch('/api/v1/me', {
-				headers: { Authorization: `Bearer ${session.access_token}` },
-			});
-			if (!res.ok) throw new Error(`me ${res.status}`);
-			const data = (await res.json()) as { username?: string | null };
-			if (!data.username) {
-				showGate('no-username');
-				return;
-			}
-		} catch (err) {
-			console.warn('compose: /api/v1/me probe failed', err);
-		}
-	})();
-
-	function setStatus(kind: 'idle' | 'busy' | 'error' | 'ok', msg = '') {
-		if (!status) return;
-		status.dataset.kind = kind;
-		status.textContent = msg;
-	}
-
-	form?.addEventListener('submit', async (ev) => {
-		ev.preventDefault();
-		setStatus('busy', 'Posting…');
-
-		try {
-			await initSupa();
-		} catch {
-			setStatus(
-				'error',
-				'Could not initialize auth. Reload and try again.',
-			);
-			return;
-		}
-		const supa = getSupa();
-		// SupabaseGateway returns `{ session, ... }` — unwrap before
-		// reaching for access_token.
-		const sessionResult = await supa.getSession().catch(() => null);
-		const session = sessionResult?.session ?? null;
-		if (!session?.access_token) {
-			setStatus('error', 'Sign in first to post a thread.');
-			return;
-		}
-
-		const fd = new FormData(form);
-		const payload = {
-			space_slug: String(fd.get('space_slug') || '').trim(),
-			thread_type: String(fd.get('thread_type') || 'discussion'),
-			title: String(fd.get('title') || '').trim(),
-			body: String(fd.get('body') || ''),
-		};
-
-		try {
-			const res = await fetch('/api/v1/forum/threads', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					Authorization: `Bearer ${session.access_token}`,
-				},
-				body: JSON.stringify(payload),
-			});
-
-			if (!res.ok) {
-				const body = await res.text().catch(() => '');
-				setStatus('error', `${res.status}: ${body || res.statusText}`);
-				return;
-			}
-
-			const data = (await res.json()) as {
-				thread_id?: string;
-				slug?: string;
+				if (signin) {
+					if (mode === 'init-error') {
+						signin.textContent = 'Refresh page';
+						signin.href = location.pathname + location.search;
+						signin.addEventListener(
+							'click',
+							(ev) => {
+								ev.preventDefault();
+								location.reload();
+							},
+							{ once: true },
+						);
+					} else {
+						signin.textContent =
+							mode === 'anon' ? 'Sign in' : 'Set username';
+						signin.href = '/dashboard/profile/';
+					}
+				}
 			};
-			const target = data.slug || data.thread_id;
-			if (!target) {
-				setStatus('error', 'Posted but no id returned.');
+
+			try {
+				await initSupa();
+			} catch {
+				showGate('init-error');
 				return;
 			}
-			setStatus('ok', 'Posted! Redirecting…');
-			window.location.assign(`/forum/t/${target}`);
-		} catch (err) {
-			setStatus(
-				'error',
-				err instanceof Error ? err.message : 'Network error',
-			);
+			const supa = getSupa();
+			const sessionResult = await supa.getSession().catch(() => null);
+			const session = sessionResult?.session ?? null;
+			if (!session?.access_token) {
+				showGate('anon');
+				return;
+			}
+
+			try {
+				const res = await fetch('/api/v1/me', {
+					headers: {
+						Authorization: `Bearer ${session.access_token}`,
+					},
+				});
+				if (!res.ok) throw new Error(`me ${res.status}`);
+				const data = (await res.json()) as { username?: string | null };
+				if (!data.username) {
+					showGate('no-username');
+					return;
+				}
+			} catch (err) {
+				console.warn('compose: /api/v1/me probe failed', err);
+			}
+		})();
+
+		function setStatus(kind: 'idle' | 'busy' | 'error' | 'ok', msg = '') {
+			if (!status) return;
+			status.dataset.kind = kind;
+			status.textContent = msg;
 		}
+
+		form?.addEventListener('submit', async (ev) => {
+			ev.preventDefault();
+			setStatus('busy', 'Posting…');
+
+			try {
+				await initSupa();
+			} catch {
+				setStatus(
+					'error',
+					'Could not initialize auth. Reload and try again.',
+				);
+				return;
+			}
+			const supa = getSupa();
+			// SupabaseGateway returns `{ session, ... }` — unwrap before
+			// reaching for access_token.
+			const sessionResult = await supa.getSession().catch(() => null);
+			const session = sessionResult?.session ?? null;
+			if (!session?.access_token) {
+				setStatus('error', 'Sign in first to post a thread.');
+				return;
+			}
+
+			const fd = new FormData(form);
+			const payload = {
+				space_slug: String(fd.get('space_slug') || '').trim(),
+				thread_type: String(fd.get('thread_type') || 'discussion'),
+				title: String(fd.get('title') || '').trim(),
+				body: String(fd.get('body') || ''),
+			};
+
+			try {
+				const res = await fetch('/api/v1/forum/threads', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${session.access_token}`,
+					},
+					body: JSON.stringify(payload),
+				});
+
+				if (!res.ok) {
+					const body = await res.text().catch(() => '');
+					setStatus(
+						'error',
+						`${res.status}: ${body || res.statusText}`,
+					);
+					return;
+				}
+
+				const data = (await res.json()) as {
+					thread_id?: string;
+					slug?: string;
+				};
+				const target = data.slug || data.thread_id;
+				if (!target) {
+					setStatus('error', 'Posted but no id returned.');
+					return;
+				}
+				setStatus('ok', 'Posted! Redirecting…');
+				window.location.assign(`/forum/t/${target}`);
+			} catch (err) {
+				setStatus(
+					'error',
+					err instanceof Error ? err.message : 'Network error',
+				);
+			}
+		});
 	});
 </script>
 

--- a/apps/kbve/astro-kbve/src/components/providers/AskamaForumThreadProvider.astro
+++ b/apps/kbve/astro-kbve/src/components/providers/AskamaForumThreadProvider.astro
@@ -315,417 +315,431 @@
 <script>
 	import { initSupa, getSupa } from '@/lib/supa';
 	import { addToast } from '@kbve/droid';
+	import { onMount } from '@kbve/astro/utils/clientRouter';
 
-	// prettier-plugin-astro keeps reformatting <textarea ... /> back
-	// into <textarea>...\n  </textarea>, which means the textarea's
-	// initial value is leading whitespace and the cursor opens
-	// indented. Force-clear every textarea on load.
-	for (const t of document.querySelectorAll<HTMLTextAreaElement>(
-		'.thread-compose__textarea, .forum-mod-dialog__textarea',
-	)) {
-		if (!t.defaultValue || /^\s+$/.test(t.defaultValue)) {
-			t.value = '';
-			t.defaultValue = '';
+	onMount(() => {
+		// prettier-plugin-astro keeps reformatting <textarea ... /> back
+		// into <textarea>...\n  </textarea>, which means the textarea's
+		// initial value is leading whitespace and the cursor opens
+		// indented. Force-clear every textarea on load.
+		for (const t of document.querySelectorAll<HTMLTextAreaElement>(
+			'.thread-compose__textarea, .forum-mod-dialog__textarea',
+		)) {
+			if (!t.defaultValue || /^\s+$/.test(t.defaultValue)) {
+				t.value = '';
+				t.defaultValue = '';
+			}
 		}
-	}
 
-	// Initial-letter fallback for the author avatar slot. The askama
-	// template emits `data-avatar="<url-or-empty>"` and `data-letter="<username>"`.
-	// When the URL is non-empty we swap the letter for an `<img>`; otherwise
-	// the first character renders inside the rounded square.
-	for (const el of document.querySelectorAll<HTMLElement>(
-		'.thread-card__author-avatar',
-	)) {
-		const url = el.dataset.avatar?.trim();
-		const letter = el.dataset.letter?.trim().charAt(0).toUpperCase() || '?';
-		if (url) {
-			const img = document.createElement('img');
-			img.src = url;
-			img.alt = '';
-			img.width = 32;
-			img.height = 32;
-			el.appendChild(img);
-		} else {
-			el.textContent = letter;
+		// Initial-letter fallback for the author avatar slot. The askama
+		// template emits `data-avatar="<url-or-empty>"` and `data-letter="<username>"`.
+		// When the URL is non-empty we swap the letter for an `<img>`; otherwise
+		// the first character renders inside the rounded square.
+		for (const el of document.querySelectorAll<HTMLElement>(
+			'.thread-card__author-avatar',
+		)) {
+			const url = el.dataset.avatar?.trim();
+			const letter =
+				el.dataset.letter?.trim().charAt(0).toUpperCase() || '?';
+			if (url) {
+				const img = document.createElement('img');
+				img.src = url;
+				img.alt = '';
+				img.width = 32;
+				img.height = 32;
+				el.appendChild(img);
+			} else {
+				el.textContent = letter;
+			}
 		}
-	}
 
-	// Swap the Thread Actions hint based on auth state. The buttons
-	// stay disabled until bookmark/subscribe/report endpoints land —
-	// this just stops telling signed-in users to sign in.
-	(async () => {
-		const hint = document.querySelector<HTMLElement>(
-			'[data-thread-actions-hint]',
-		);
-		if (!hint) return;
-		try {
-			await initSupa();
-		} catch {
-			return;
-		}
-		const supa = getSupa();
-		const sessionResult = await supa.getSession().catch(() => null);
-		const isAuthed = !!sessionResult?.session?.access_token;
-		const next = isAuthed ? hint.dataset.authText : hint.dataset.anonText;
-		if (next) hint.textContent = next;
-	})();
-
-	// Comment compose: submit via fetch with the local Supabase access
-	// token. axum's POST /api/v1/forum/t/{slug}/comments runs the
-	// service_create_comment RPC and returns the new comment id.
-	const composeForm = document.getElementById(
-		'thread-compose-form',
-	) as HTMLFormElement | null;
-	const composeStatus = document.getElementById(
-		'thread-compose-status',
-	) as HTMLOutputElement | null;
-
-	function setComposeStatus(
-		kind: 'idle' | 'busy' | 'error' | 'ok',
-		msg = '',
-	) {
-		if (!composeStatus) return;
-		composeStatus.dataset.kind = kind;
-		composeStatus.textContent = msg;
-	}
-
-	composeForm?.addEventListener('submit', async (ev) => {
-		ev.preventDefault();
-		setComposeStatus('busy', 'Posting…');
-
-		try {
-			await initSupa();
-		} catch {
-			setComposeStatus(
-				'error',
-				'Could not initialize auth. Reload and try again.',
+		// Swap the Thread Actions hint based on auth state. The buttons
+		// stay disabled until bookmark/subscribe/report endpoints land —
+		// this just stops telling signed-in users to sign in.
+		(async () => {
+			const hint = document.querySelector<HTMLElement>(
+				'[data-thread-actions-hint]',
 			);
-			return;
-		}
-		const supa = getSupa();
-		// SupabaseGateway returns `{ session, ... }` — unwrap before
-		// reaching for access_token. Without this we read undefined and
-		// every signed-in user sees "Sign in first to comment."
-		const sessionResult = await supa.getSession().catch(() => null);
-		const session = sessionResult?.session ?? null;
-		if (!session?.access_token) {
-			setComposeStatus('error', 'Sign in first to comment.');
-			return;
+			if (!hint) return;
+			try {
+				await initSupa();
+			} catch {
+				return;
+			}
+			const supa = getSupa();
+			const sessionResult = await supa.getSession().catch(() => null);
+			const isAuthed = !!sessionResult?.session?.access_token;
+			const next = isAuthed
+				? hint.dataset.authText
+				: hint.dataset.anonText;
+			if (next) hint.textContent = next;
+		})();
+
+		// Comment compose: submit via fetch with the local Supabase access
+		// token. axum's POST /api/v1/forum/t/{slug}/comments runs the
+		// service_create_comment RPC and returns the new comment id.
+		const composeForm = document.getElementById(
+			'thread-compose-form',
+		) as HTMLFormElement | null;
+		const composeStatus = document.getElementById(
+			'thread-compose-status',
+		) as HTMLOutputElement | null;
+
+		function setComposeStatus(
+			kind: 'idle' | 'busy' | 'error' | 'ok',
+			msg = '',
+		) {
+			if (!composeStatus) return;
+			composeStatus.dataset.kind = kind;
+			composeStatus.textContent = msg;
 		}
 
-		const slug = composeForm.dataset.threadSlug || '';
-		const fd = new FormData(composeForm);
-		const payload = { body: String(fd.get('body') || '') };
+		composeForm?.addEventListener('submit', async (ev) => {
+			ev.preventDefault();
+			setComposeStatus('busy', 'Posting…');
 
-		try {
-			const res = await fetch(`/api/v1/forum/t/${slug}/comments`, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					Authorization: `Bearer ${session.access_token}`,
-				},
-				body: JSON.stringify(payload),
-			});
-			if (!res.ok) {
-				const body = await res.text().catch(() => '');
+			try {
+				await initSupa();
+			} catch {
 				setComposeStatus(
 					'error',
-					`${res.status}: ${body || res.statusText}`,
+					'Could not initialize auth. Reload and try again.',
 				);
 				return;
 			}
-			setComposeStatus('ok', 'Posted! Reloading…');
-			window.location.reload();
-		} catch (err) {
-			setComposeStatus(
-				'error',
-				err instanceof Error ? err.message : 'Network error',
-			);
-		}
-	});
-
-	// ── Comment row actions: edit-own / mod-edit / mod-remove ─────
-	(async () => {
-		const rows = Array.from(
-			document.querySelectorAll<HTMLElement>(
-				'.forum-comment[data-comment-id]',
-			),
-		);
-		if (rows.length === 0) return;
-
-		try {
-			await initSupa();
-		} catch {
-			return;
-		}
-		const supa = getSupa();
-		const sessionResult = await supa.getSession().catch(() => null);
-		const session = sessionResult?.session ?? null;
-		if (!session?.access_token) return;
-
-		const myId = String(session.user?.id ?? '');
-		let isStaff = false;
-		try {
-			const res = await fetch('/api/v1/me/staff', {
-				headers: { Authorization: `Bearer ${session.access_token}` },
-			});
-			if (res.ok) {
-				const data = (await res.json()) as { is_staff?: boolean };
-				isStaff = !!data.is_staff;
-			}
-		} catch {
-			/* swallow — we just hide the mod buttons */
-		}
-
-		for (const row of rows) {
-			const authorId = row.dataset.authorId || '';
-			const menuEl = row.querySelector<HTMLDetailsElement>(
-				'.forum-comment__menu',
-			);
-			if (!menuEl) continue;
-
-			const isOwn = myId && authorId === myId;
-			const editOwnBtn = menuEl.querySelector<HTMLButtonElement>(
-				'[data-action="edit-own"]',
-			);
-			const modEditBtn = menuEl.querySelector<HTMLButtonElement>(
-				'[data-action="mod-edit"]',
-			);
-			const modRemoveBtn = menuEl.querySelector<HTMLButtonElement>(
-				'[data-action="mod-remove"]',
-			);
-
-			if (editOwnBtn) editOwnBtn.hidden = !isOwn;
-			if (modEditBtn) modEditBtn.hidden = !isStaff;
-			if (modRemoveBtn) modRemoveBtn.hidden = !isStaff;
-
-			if (isOwn || isStaff) menuEl.hidden = false;
-		}
-
-		// One <dialog> shared by all rows; mode + currentBody are passed
-		// per-open. Using HTMLDialogElement keeps focus trapping + ESC
-		// cancel free, no library required. Submission is gated on the
-		// dialog's `close` event, so the form's `method="dialog"` natively
-		// closes with returnValue="confirm" on submit.
-		type ModMode = 'edit-own' | 'mod-edit' | 'mod-remove';
-		type ModResult = { body?: string; reason?: string } | null;
-
-		const modDialog = document.getElementById(
-			'forum-mod-dialog',
-		) as HTMLDialogElement | null;
-		const modDialogTitle =
-			modDialog?.querySelector<HTMLElement>('.forum-mod-dialog__title') ??
-			null;
-		const modDialogWarn =
-			modDialog?.querySelector<HTMLElement>(
-				'.forum-mod-dialog__warning',
-			) ?? null;
-		const modBodyField =
-			modDialog?.querySelector<HTMLElement>('[data-field="body"]') ??
-			null;
-		const modReasonField =
-			modDialog?.querySelector<HTMLElement>('[data-field="reason"]') ??
-			null;
-		const modBodyInput =
-			modDialog?.querySelector<HTMLTextAreaElement>(
-				'textarea[name="body"]',
-			) ?? null;
-		const modReasonInput =
-			modDialog?.querySelector<HTMLTextAreaElement>(
-				'textarea[name="reason"]',
-			) ?? null;
-		const modPrimaryBtn =
-			modDialog?.querySelector<HTMLButtonElement>(
-				'.forum-mod-dialog__btn--primary',
-			) ?? null;
-		const modCancelBtns = modDialog
-			? modDialog.querySelectorAll<HTMLButtonElement>(
-					'[data-action="cancel"]',
-				)
-			: null;
-
-		let pendingResolve: ((r: ModResult) => void) | null = null;
-		let pendingMode: ModMode | null = null;
-
-		modCancelBtns?.forEach((btn) =>
-			btn.addEventListener('click', () => modDialog?.close('cancel')),
-		);
-
-		modDialog?.addEventListener('close', () => {
-			if (!pendingResolve) return;
-			const action = modDialog.returnValue;
-			const mode = pendingMode;
-			const showBody = mode !== 'mod-remove';
-			const showReason = mode !== 'edit-own';
-			const resolver = pendingResolve;
-			pendingResolve = null;
-			pendingMode = null;
-			if (action !== 'confirm') {
-				resolver(null);
-				return;
-			}
-			resolver({
-				body: showBody ? (modBodyInput?.value ?? '') : undefined,
-				reason: showReason ? (modReasonInput?.value ?? '') : undefined,
-			});
-		});
-
-		function openModDialog(
-			mode: ModMode,
-			currentBody: string,
-		): Promise<ModResult> {
-			if (!modDialog) return Promise.resolve(null);
-			const isRemove = mode === 'mod-remove';
-			const isModEdit = mode === 'mod-edit';
-			pendingMode = mode;
-			if (modDialogTitle) {
-				modDialogTitle.textContent = isRemove
-					? 'Remove comment'
-					: isModEdit
-						? 'Mod-edit comment'
-						: 'Edit your comment';
-			}
-			if (modDialogWarn) {
-				if (isRemove) {
-					modDialogWarn.textContent =
-						"This decrements the thread's comment count and cannot be undone.";
-					modDialogWarn.hidden = false;
-				} else {
-					modDialogWarn.hidden = true;
-					modDialogWarn.textContent = '';
-				}
-			}
-			if (modBodyField) modBodyField.hidden = isRemove;
-			if (modReasonField) modReasonField.hidden = mode === 'edit-own';
-			if (modBodyInput) {
-				modBodyInput.value = isRemove ? '' : currentBody;
-				modBodyInput.required = !isRemove;
-			}
-			if (modReasonInput) modReasonInput.value = '';
-			if (modPrimaryBtn) {
-				modPrimaryBtn.textContent = isRemove ? 'Remove' : 'Save';
-				modPrimaryBtn.classList.toggle(
-					'forum-mod-dialog__btn--danger',
-					isRemove,
-				);
-			}
-			modDialog.showModal();
-			(isRemove ? modReasonInput : modBodyInput)?.focus();
-			return new Promise((resolve) => {
-				pendingResolve = resolve;
-			});
-		}
-
-		document.addEventListener('click', async (ev) => {
-			const target = ev.target as HTMLElement | null;
-			if (!target) return;
-			const btn = target.closest<HTMLButtonElement>(
-				'.forum-comment__action',
-			);
-			if (!btn) return;
-
-			const row = btn.closest<HTMLElement>(
-				'.forum-comment[data-comment-id]',
-			);
-			if (!row) return;
-			const commentId = row.dataset.commentId || '';
-			const action = btn.dataset.action as ModMode | undefined;
-			if (!commentId || !action) return;
-
-			ev.preventDefault();
-
-			// Close the kebab menu so the dialog has visual focus.
-			const menuEl = row.querySelector<HTMLDetailsElement>(
-				'.forum-comment__menu',
-			);
-			if (menuEl) menuEl.open = false;
-
-			const supa2 = getSupa();
-			const sr = await supa2.getSession().catch(() => null);
-			const sess = sr?.session ?? null;
-			if (!sess?.access_token) {
-				addToast({
-					id: `forum-mod-auth-${Date.now()}`,
-					message: 'Sign in first to moderate or edit.',
-					severity: 'warning',
-					duration: 4000,
-				});
+			const supa = getSupa();
+			// SupabaseGateway returns `{ session, ... }` — unwrap before
+			// reaching for access_token. Without this we read undefined and
+			// every signed-in user sees "Sign in first to comment."
+			const sessionResult = await supa.getSession().catch(() => null);
+			const session = sessionResult?.session ?? null;
+			if (!session?.access_token) {
+				setComposeStatus('error', 'Sign in first to comment.');
 				return;
 			}
 
-			const rawTpl = row.querySelector<HTMLTemplateElement>(
-				'.forum-comment__raw',
-			);
-			const currentBody = rawTpl?.innerHTML?.trim() ?? '';
+			const slug = composeForm.dataset.threadSlug || '';
+			const fd = new FormData(composeForm);
+			const payload = { body: String(fd.get('body') || '') };
 
-			const result = await openModDialog(action, currentBody);
-			if (!result) return;
-
-			let url = '';
-			let method = 'PATCH';
-			let body: Record<string, string> | null = null;
-
-			if (action === 'edit-own') {
-				const next = (result.body ?? '').trim();
-				if (!next || next === currentBody) return;
-				url = `/api/v1/forum/c/${commentId}`;
-				body = { body: next };
-			} else if (action === 'mod-edit') {
-				const next = (result.body ?? '').trim();
-				if (!next || next === currentBody) return;
-				url = `/api/v1/forum/c/${commentId}/moderate`;
-				body = { body: next, reason: result.reason ?? '' };
-			} else if (action === 'mod-remove') {
-				url = `/api/v1/forum/c/${commentId}`;
-				method = 'DELETE';
-				body = { body: '', reason: result.reason ?? '' };
-			} else {
-				return;
-			}
-
-			btn.disabled = true;
 			try {
-				const res = await fetch(url, {
-					method,
+				const res = await fetch(`/api/v1/forum/t/${slug}/comments`, {
+					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
-						Authorization: `Bearer ${sess.access_token}`,
+						Authorization: `Bearer ${session.access_token}`,
 					},
-					body: JSON.stringify(body),
+					body: JSON.stringify(payload),
 				});
 				if (!res.ok) {
-					const text = await res.text().catch(() => '');
+					const body = await res.text().catch(() => '');
+					setComposeStatus(
+						'error',
+						`${res.status}: ${body || res.statusText}`,
+					);
+					return;
+				}
+				setComposeStatus('ok', 'Posted! Reloading…');
+				window.location.reload();
+			} catch (err) {
+				setComposeStatus(
+					'error',
+					err instanceof Error ? err.message : 'Network error',
+				);
+			}
+		});
+
+		// ── Comment row actions: edit-own / mod-edit / mod-remove ─────
+		(async () => {
+			const rows = Array.from(
+				document.querySelectorAll<HTMLElement>(
+					'.forum-comment[data-comment-id]',
+				),
+			);
+			if (rows.length === 0) return;
+
+			try {
+				await initSupa();
+			} catch {
+				return;
+			}
+			const supa = getSupa();
+			const sessionResult = await supa.getSession().catch(() => null);
+			const session = sessionResult?.session ?? null;
+			if (!session?.access_token) return;
+
+			const myId = String(session.user?.id ?? '');
+			let isStaff = false;
+			try {
+				const res = await fetch('/api/v1/me/staff', {
+					headers: {
+						Authorization: `Bearer ${session.access_token}`,
+					},
+				});
+				if (res.ok) {
+					const data = (await res.json()) as { is_staff?: boolean };
+					isStaff = !!data.is_staff;
+				}
+			} catch {
+				/* swallow — we just hide the mod buttons */
+			}
+
+			for (const row of rows) {
+				const authorId = row.dataset.authorId || '';
+				const menuEl = row.querySelector<HTMLDetailsElement>(
+					'.forum-comment__menu',
+				);
+				if (!menuEl) continue;
+
+				const isOwn = myId && authorId === myId;
+				const editOwnBtn = menuEl.querySelector<HTMLButtonElement>(
+					'[data-action="edit-own"]',
+				);
+				const modEditBtn = menuEl.querySelector<HTMLButtonElement>(
+					'[data-action="mod-edit"]',
+				);
+				const modRemoveBtn = menuEl.querySelector<HTMLButtonElement>(
+					'[data-action="mod-remove"]',
+				);
+
+				if (editOwnBtn) editOwnBtn.hidden = !isOwn;
+				if (modEditBtn) modEditBtn.hidden = !isStaff;
+				if (modRemoveBtn) modRemoveBtn.hidden = !isStaff;
+
+				if (isOwn || isStaff) menuEl.hidden = false;
+			}
+
+			// One <dialog> shared by all rows; mode + currentBody are passed
+			// per-open. Using HTMLDialogElement keeps focus trapping + ESC
+			// cancel free, no library required. Submission is gated on the
+			// dialog's `close` event, so the form's `method="dialog"` natively
+			// closes with returnValue="confirm" on submit.
+			type ModMode = 'edit-own' | 'mod-edit' | 'mod-remove';
+			type ModResult = { body?: string; reason?: string } | null;
+
+			const modDialog = document.getElementById(
+				'forum-mod-dialog',
+			) as HTMLDialogElement | null;
+			const modDialogTitle =
+				modDialog?.querySelector<HTMLElement>(
+					'.forum-mod-dialog__title',
+				) ?? null;
+			const modDialogWarn =
+				modDialog?.querySelector<HTMLElement>(
+					'.forum-mod-dialog__warning',
+				) ?? null;
+			const modBodyField =
+				modDialog?.querySelector<HTMLElement>('[data-field="body"]') ??
+				null;
+			const modReasonField =
+				modDialog?.querySelector<HTMLElement>(
+					'[data-field="reason"]',
+				) ?? null;
+			const modBodyInput =
+				modDialog?.querySelector<HTMLTextAreaElement>(
+					'textarea[name="body"]',
+				) ?? null;
+			const modReasonInput =
+				modDialog?.querySelector<HTMLTextAreaElement>(
+					'textarea[name="reason"]',
+				) ?? null;
+			const modPrimaryBtn =
+				modDialog?.querySelector<HTMLButtonElement>(
+					'.forum-mod-dialog__btn--primary',
+				) ?? null;
+			const modCancelBtns = modDialog
+				? modDialog.querySelectorAll<HTMLButtonElement>(
+						'[data-action="cancel"]',
+					)
+				: null;
+
+			let pendingResolve: ((r: ModResult) => void) | null = null;
+			let pendingMode: ModMode | null = null;
+
+			modCancelBtns?.forEach((btn) =>
+				btn.addEventListener('click', () => modDialog?.close('cancel')),
+			);
+
+			modDialog?.addEventListener('close', () => {
+				if (!pendingResolve) return;
+				const action = modDialog.returnValue;
+				const mode = pendingMode;
+				const showBody = mode !== 'mod-remove';
+				const showReason = mode !== 'edit-own';
+				const resolver = pendingResolve;
+				pendingResolve = null;
+				pendingMode = null;
+				if (action !== 'confirm') {
+					resolver(null);
+					return;
+				}
+				resolver({
+					body: showBody ? (modBodyInput?.value ?? '') : undefined,
+					reason: showReason
+						? (modReasonInput?.value ?? '')
+						: undefined,
+				});
+			});
+
+			function openModDialog(
+				mode: ModMode,
+				currentBody: string,
+			): Promise<ModResult> {
+				if (!modDialog) return Promise.resolve(null);
+				const isRemove = mode === 'mod-remove';
+				const isModEdit = mode === 'mod-edit';
+				pendingMode = mode;
+				if (modDialogTitle) {
+					modDialogTitle.textContent = isRemove
+						? 'Remove comment'
+						: isModEdit
+							? 'Mod-edit comment'
+							: 'Edit your comment';
+				}
+				if (modDialogWarn) {
+					if (isRemove) {
+						modDialogWarn.textContent =
+							"This decrements the thread's comment count and cannot be undone.";
+						modDialogWarn.hidden = false;
+					} else {
+						modDialogWarn.hidden = true;
+						modDialogWarn.textContent = '';
+					}
+				}
+				if (modBodyField) modBodyField.hidden = isRemove;
+				if (modReasonField) modReasonField.hidden = mode === 'edit-own';
+				if (modBodyInput) {
+					modBodyInput.value = isRemove ? '' : currentBody;
+					modBodyInput.required = !isRemove;
+				}
+				if (modReasonInput) modReasonInput.value = '';
+				if (modPrimaryBtn) {
+					modPrimaryBtn.textContent = isRemove ? 'Remove' : 'Save';
+					modPrimaryBtn.classList.toggle(
+						'forum-mod-dialog__btn--danger',
+						isRemove,
+					);
+				}
+				modDialog.showModal();
+				(isRemove ? modReasonInput : modBodyInput)?.focus();
+				return new Promise((resolve) => {
+					pendingResolve = resolve;
+				});
+			}
+
+			document.addEventListener('click', async (ev) => {
+				const target = ev.target as HTMLElement | null;
+				if (!target) return;
+				const btn = target.closest<HTMLButtonElement>(
+					'.forum-comment__action',
+				);
+				if (!btn) return;
+
+				const row = btn.closest<HTMLElement>(
+					'.forum-comment[data-comment-id]',
+				);
+				if (!row) return;
+				const commentId = row.dataset.commentId || '';
+				const action = btn.dataset.action as ModMode | undefined;
+				if (!commentId || !action) return;
+
+				ev.preventDefault();
+
+				// Close the kebab menu so the dialog has visual focus.
+				const menuEl = row.querySelector<HTMLDetailsElement>(
+					'.forum-comment__menu',
+				);
+				if (menuEl) menuEl.open = false;
+
+				const supa2 = getSupa();
+				const sr = await supa2.getSession().catch(() => null);
+				const sess = sr?.session ?? null;
+				if (!sess?.access_token) {
 					addToast({
-						id: `forum-mod-err-${Date.now()}`,
-						message: `${res.status}: ${text || res.statusText}`,
+						id: `forum-mod-auth-${Date.now()}`,
+						message: 'Sign in first to moderate or edit.',
+						severity: 'warning',
+						duration: 4000,
+					});
+					return;
+				}
+
+				const rawTpl = row.querySelector<HTMLTemplateElement>(
+					'.forum-comment__raw',
+				);
+				const currentBody = rawTpl?.innerHTML?.trim() ?? '';
+
+				const result = await openModDialog(action, currentBody);
+				if (!result) return;
+
+				let url = '';
+				let method = 'PATCH';
+				let body: Record<string, string> | null = null;
+
+				if (action === 'edit-own') {
+					const next = (result.body ?? '').trim();
+					if (!next || next === currentBody) return;
+					url = `/api/v1/forum/c/${commentId}`;
+					body = { body: next };
+				} else if (action === 'mod-edit') {
+					const next = (result.body ?? '').trim();
+					if (!next || next === currentBody) return;
+					url = `/api/v1/forum/c/${commentId}/moderate`;
+					body = { body: next, reason: result.reason ?? '' };
+				} else if (action === 'mod-remove') {
+					url = `/api/v1/forum/c/${commentId}`;
+					method = 'DELETE';
+					body = { body: '', reason: result.reason ?? '' };
+				} else {
+					return;
+				}
+
+				btn.disabled = true;
+				try {
+					const res = await fetch(url, {
+						method,
+						headers: {
+							'Content-Type': 'application/json',
+							Authorization: `Bearer ${sess.access_token}`,
+						},
+						body: JSON.stringify(body),
+					});
+					if (!res.ok) {
+						const text = await res.text().catch(() => '');
+						addToast({
+							id: `forum-mod-err-${Date.now()}`,
+							message: `${res.status}: ${text || res.statusText}`,
+							severity: 'error',
+							duration: 6000,
+						});
+						btn.disabled = false;
+						return;
+					}
+					addToast({
+						id: `forum-mod-ok-${Date.now()}`,
+						message:
+							action === 'mod-remove'
+								? 'Comment removed.'
+								: 'Comment updated.',
+						severity: 'success',
+						duration: 3000,
+					});
+					window.location.reload();
+				} catch (err) {
+					addToast({
+						id: `forum-mod-net-${Date.now()}`,
+						message:
+							err instanceof Error
+								? err.message
+								: 'Network error',
 						severity: 'error',
 						duration: 6000,
 					});
 					btn.disabled = false;
-					return;
 				}
-				addToast({
-					id: `forum-mod-ok-${Date.now()}`,
-					message:
-						action === 'mod-remove'
-							? 'Comment removed.'
-							: 'Comment updated.',
-					severity: 'success',
-					duration: 3000,
-				});
-				window.location.reload();
-			} catch (err) {
-				addToast({
-					id: `forum-mod-net-${Date.now()}`,
-					message:
-						err instanceof Error ? err.message : 'Network error',
-					severity: 'error',
-					duration: 6000,
-				});
-				btn.disabled = false;
-			}
-		});
-	})();
+			});
+		})();
+	});
 </script>
 
 <style>

--- a/apps/kbve/astro-kbve/src/components/redirect/MetaRedirect.astro
+++ b/apps/kbve/astro-kbve/src/components/redirect/MetaRedirect.astro
@@ -13,7 +13,7 @@ const url = new URL(to, Astro.url).toString();
 		<meta charset="UTF-8" />
 		<title>Redirecting…</title>
 		<meta http-equiv="refresh" content="0; url={url}" />
-		<script is:inline define:vars={{ url }}>
+		<script is:inline define:vars={{ url }} data-astro-rerun>
 			window.location.replace(url);
 		</script>
 	</head>

--- a/apps/kbve/astro-kbve/src/components/referral/AstroReferralCard.astro
+++ b/apps/kbve/astro-kbve/src/components/referral/AstroReferralCard.astro
@@ -157,11 +157,13 @@
 <script>
 	import { initSupa, getSupa } from '@/lib/supa';
 	import { fetchAndCacheProfile, getProfileFromCache } from '@kbve/droid';
+	import { onMount } from '@kbve/astro/utils/clientRouter';
 
-	const shell = document.querySelector<HTMLElement>(
-		'[data-kbve-referral-shell]',
-	);
-	if (shell) {
+	onMount(() => {
+		const shell = document.querySelector<HTMLElement>(
+			'[data-kbve-referral-shell]',
+		);
+		if (!shell) return;
 		const handleEl = shell.querySelector<HTMLElement>(
 			'[data-kbve-referral-handle]',
 		);
@@ -532,7 +534,7 @@
 				}
 			});
 		})();
-	}
+	});
 </script>
 
 <style>

--- a/apps/kbve/astro-kbve/src/components/search/AstroKbveSearch.astro
+++ b/apps/kbve/astro-kbve/src/components/search/AstroKbveSearch.astro
@@ -272,14 +272,14 @@ import KbveSearchPalette from './KbveSearchPalette.tsx';
 </style>
 
 <script>
+	import { onMount } from '@kbve/astro/utils/clientRouter';
+
 	const isMac =
 		typeof navigator !== 'undefined' &&
 		/Mac|iPhone|iPad/.test(navigator.platform);
-	document
-		.querySelectorAll<HTMLElement>('[data-kbve-search-keycap]')
-		.forEach((el) => {
-			el.textContent = isMac ? '⌘K' : 'Ctrl+K';
-		});
+
+	// Event-delegated click — `document` survives router swaps so this
+	// listener attaches once at module init and keeps working forever.
 	document.addEventListener('click', (e) => {
 		const btn = (e.target as HTMLElement | null)?.closest?.(
 			'[data-kbve-search-trigger]',
@@ -288,5 +288,15 @@ import KbveSearchPalette from './KbveSearchPalette.tsx';
 			e.preventDefault();
 			window.dispatchEvent(new CustomEvent('kbve:search:open'));
 		}
+	});
+
+	// Keycap text writes into per-page DOM nodes, so re-run on every
+	// swap to update the freshly mounted markup.
+	onMount(() => {
+		document
+			.querySelectorAll<HTMLElement>('[data-kbve-search-keycap]')
+			.forEach((el) => {
+				el.textContent = isMac ? '⌘K' : 'Ctrl+K';
+			});
 	});
 </script>

--- a/apps/kbve/astro-kbve/src/components/theme/ThemeProvider.astro
+++ b/apps/kbve/astro-kbve/src/components/theme/ThemeProvider.astro
@@ -4,19 +4,27 @@ import DefaultThemeProvider from '@astrojs/starlight/components/ThemeProvider.as
 
 <DefaultThemeProvider />
 
-{/* Right sidebar state — inlined to prevent flash of expanded panel */}
+{
+	/* Right sidebar state — inlined to prevent flash of expanded panel.
+    Re-applies on every ClientRouter swap via `astro:after-swap` so the
+    flash doesn't return on SPA navigation. */
+}
 <script is:inline>
 	(function () {
-		try {
-			var d = document.documentElement;
-			var l = localStorage;
-			d.setAttribute(
-				'data-right-sidebar-collapsed',
-				l.getItem('sl-right-sidebar-collapsed') !== 'false'
-					? 'true'
-					: 'false',
-			);
-		} catch (e) {}
+		var apply = function () {
+			try {
+				var d = document.documentElement;
+				var l = localStorage;
+				d.setAttribute(
+					'data-right-sidebar-collapsed',
+					l.getItem('sl-right-sidebar-collapsed') !== 'false'
+						? 'true'
+						: 'false',
+				);
+			} catch (e) {}
+		};
+		apply();
+		document.addEventListener('astro:after-swap', apply);
 	})();
 </script>
 

--- a/apps/kbve/astro-kbve/src/components/user/AstroProfileShell.astro
+++ b/apps/kbve/astro-kbve/src/components/user/AstroProfileShell.astro
@@ -171,11 +171,17 @@ import AstroWalletCard from '@/components/wallet/AstroWalletCard.astro';
 
 <script>
 	import { bootProfile } from './profile-controller';
-	bootProfile();
+	import { onMount } from '@kbve/astro/utils/clientRouter';
 
-	// Tiny script: stamp the current year in the footer.
-	const yearEl = document.getElementById('profile-footer-year');
-	if (yearEl) yearEl.textContent = String(new Date().getFullYear());
+	onMount(() => {
+		// bootProfile() guards itself against double-init through the
+		// supabase init OnceCell + persistent profile cache, so calling
+		// it on every ClientRouter swap is cheap (cache-hit fast-paint).
+		bootProfile();
+
+		const yearEl = document.getElementById('profile-footer-year');
+		if (yearEl) yearEl.textContent = String(new Date().getFullYear());
+	});
 </script>
 
 <style>

--- a/apps/kbve/astro-kbve/src/components/wallet/AccountSignInFallback.astro
+++ b/apps/kbve/astro-kbve/src/components/wallet/AccountSignInFallback.astro
@@ -9,20 +9,25 @@
 </aside>
 
 <script>
-	const fallback = document.querySelector('[data-account-signin]');
-	const wallet = document.querySelector('[data-kbve-wallet-shell]');
-	if (fallback && wallet) {
+	import { onMount } from '@kbve/astro/utils/clientRouter';
+
+	onMount(() => {
+		const fallback = document.querySelector('[data-account-signin]');
+		const wallet = document.querySelector('[data-kbve-wallet-shell]');
+		if (!fallback || !wallet) return;
 		const sync = () => {
 			if (!wallet.hasAttribute('hidden')) {
 				fallback.setAttribute('hidden', '');
 			}
 		};
 		sync();
-		new MutationObserver(sync).observe(wallet, {
+		const mo = new MutationObserver(sync);
+		mo.observe(wallet, {
 			attributes: true,
 			attributeFilter: ['hidden'],
 		});
-	}
+		return () => mo.disconnect();
+	});
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
Continuation of the [Phase 1 audit](https://github.com/KBVE/kbve/pull/11371). Wraps the most-visible / most-recent component scripts in \`onMount\` from \`@kbve/astro/utils/clientRouter\` so they re-init on every ClientRouter swap, native view-transition, and bfcache restore — with automatic cleanup wired to \`astro:before-swap\` + \`pagehide\`.

ClientRouter is **still not enabled**. This is prep-only; Phase 4 ships the flip.

## Pattern
\`\`\`ts
<script>
  import { onMount } from '@kbve/astro/utils/clientRouter';
  onMount(() => {
    const root = document.querySelector('[data-root]');
    if (!root) return;
    // init: queries, subscriptions, observers, async fetch
    return () => { /* cleanup */ };
  });
</script>
\`\`\`

## Files
| File | Change |
|---|---|
| \`theme/ThemeProvider.astro\` | Right-sidebar attr re-applied pre-paint via \`astro:after-swap\` listener |
| \`wallet/AccountSignInFallback.astro\` | Wallet/fallback MutationObserver wrapped in \`onMount\` with cleanup |
| \`user/AstroProfileShell.astro\` | \`bootProfile()\` + footer-year inside \`onMount\` |
| \`referral/AstroReferralCard.astro\` | Long script body wrapped in \`onMount\` |
| \`market/AstroMarketAccountSummary.astro\` | Wrapped + \`cancelled\` flag for in-flight fetch |

## Surveyed, no change
- \`navigation/NavContainer.astro\` — module-level work is pure helpers, single \`window.__navHelpers\` assignment, one-shot \`setTimeout\`. Helpers query DOM at call time. Safe.

## Deferred to Phase 2b
Askama forum providers, astropad widgets, hero, search, twitch, TradingView, MDX page-level scripts.

## Test plan
- [ ] \`pnpm exec astro sync\` clean (verified)
- [ ] No regression on the affected pages with router still off (same as today's behavior — single initial \`onMount\` run)
- [ ] \`/dashboard/account/\` referral + market + signin-fallback all render
- [ ] \`/dashboard/profile/\` AstroProfileShell still boots