### PR TITLE
feat(agones,nd-server): Phase 1 GameServer Fleet + autoscaler

### DIFF
--- a/apps/kube/agones/nd-server/application.yaml
+++ b/apps/kube/agones/nd-server/application.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: agones-nd-server
+    namespace: argocd
+    labels:
+        app.kubernetes.io/part-of: nexus-defense
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/kbve/kbve
+        targetRevision: main
+        path: apps/kube/agones/nd-server/manifests
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: nexus-defense
+    ignoreDifferences:
+        # FleetAutoscaler manages replica count — ArgoCD should not fight it.
+        - group: agones.dev
+          kind: Fleet
+          jsonPointers:
+              - /spec/replicas
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true

--- a/apps/kube/agones/nd-server/manifests/external-secret.yaml
+++ b/apps/kube/agones/nd-server/manifests/external-secret.yaml
@@ -1,0 +1,27 @@
+# Pulls the Supabase JWT secret (HS256) the GoTrue project signs access
+# tokens with. The nd-server image reads `SUPABASE_JWT_SECRET` from env on
+# boot; empty = dev-accept mode (rejected outside dev).
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: nd-server-supabase-jwt
+    namespace: nexus-defense
+    labels:
+        app.kubernetes.io/part-of: nexus-defense
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        kind: SecretStore
+        name: k8s-secret-store
+    target:
+        name: nd-server-supabase-jwt
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                SUPABASE_JWT_SECRET: '{{ .jwt_secret }}'
+    data:
+        - secretKey: jwt_secret
+          remoteRef:
+              key: supabase-jwt
+              property: secret

--- a/apps/kube/agones/nd-server/manifests/fleet-autoscaler.yaml
+++ b/apps/kube/agones/nd-server/manifests/fleet-autoscaler.yaml
@@ -1,0 +1,24 @@
+# Buffer-1 autoscaler — keep one warm `Ready` GameServer at all times so the
+# next Allocator request lands instantly. Scales to 0 between matches once
+# the buffer drains. Cap at 20 while we figure out match throughput; bump
+# alongside the cluster c8 capacity plan if real load shows up.
+apiVersion: autoscaling.agones.dev/v1
+kind: FleetAutoscaler
+metadata:
+    name: nd-server-autoscaler
+    namespace: nexus-defense
+    labels:
+        app: nd-server
+        app.kubernetes.io/part-of: nexus-defense
+spec:
+    fleetName: nd-server
+    policy:
+        type: Buffer
+        buffer:
+            bufferSize: 1
+            minReplicas: 0
+            maxReplicas: 20
+    sync:
+        type: FixedInterval
+        fixedInterval:
+            seconds: 30

--- a/apps/kube/agones/nd-server/manifests/fleet.yaml
+++ b/apps/kube/agones/nd-server/manifests/fleet.yaml
@@ -1,0 +1,110 @@
+# Nexus Defense Agones Fleet
+#
+# Phase 1 of #11294. Replicas start at 0; the upcoming lobby endpoint in
+# `jedi` calls the Agones Allocator API to spin a `Ready` GameServer per
+# match. Each replica is a long-lived axum WS host backed by the bevy
+# headless sim.
+#
+# IMPORTANT: nd-server doesn't talk the Agones SDK yet. It exposes a plain
+# HTTP `/healthz` that always returns `ok`, so for Agones to flip the
+# GameServer to `Ready` we lean on the `agones.dev/sdk-grpc-port` startup
+# behavior — when the container doesn't open the SDK socket, Agones treats
+# the pod as healthy/ready via the configured TCP health probe instead.
+# The SDK + `Ready()` / `Health()` calls land in the Phase-3 follow-up
+# (see Agones Game Server Integration in apps/kbve/astro-kbve docs).
+apiVersion: agones.dev/v1
+kind: Fleet
+metadata:
+    name: nd-server
+    namespace: nexus-defense
+    labels:
+        app: nd-server
+        app.kubernetes.io/part-of: nexus-defense
+spec:
+    replicas: 0
+    scheduling: Packed
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxSurge: 25%
+            maxUnavailable: 25%
+    template:
+        metadata:
+            labels:
+                app: nd-server
+                app.kubernetes.io/part-of: nexus-defense
+        spec:
+            ports:
+                - name: ws
+                  portPolicy: Dynamic
+                  containerPort: 7878
+                  protocol: TCP
+            health:
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                failureThreshold: 5
+            sdkServer:
+                # Sidecar runs even without SDK calls — Agones uses it as the
+                # health-probe surface until nd-server speaks SDK directly.
+                logLevel: Info
+            template:
+                spec:
+                    securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 10001
+                        runAsGroup: 10001
+                        fsGroup: 10001
+                        seccompProfile:
+                            type: RuntimeDefault
+                    containers:
+                        - name: nd-server
+                          image: ghcr.io/kbve/nd-server:0.0.2
+                          imagePullPolicy: IfNotPresent
+                          env:
+                              # Bind to the Dynamic-allocated port the SDK
+                              # injects as $AGONES_SDK_HTTP_PORT companion.
+                              # Until the SDK call is wired we fall back to
+                              # the static container port; Agones still NATs
+                              # the external Dynamic port to it.
+                              - name: TD_SERVER_ADDR
+                                value: '0.0.0.0:7878'
+                              - name: TD_SERVER_SEED
+                                value: '0'
+                              - name: RUST_LOG
+                                value: 'info,nd_server=debug,q=info'
+                              - name: SUPABASE_JWT_SECRET
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: nd-server-supabase-jwt
+                                        key: SUPABASE_JWT_SECRET
+                          ports:
+                              - name: ws
+                                containerPort: 7878
+                                protocol: TCP
+                          readinessProbe:
+                              httpGet:
+                                  path: /healthz
+                                  port: 7878
+                              initialDelaySeconds: 3
+                              periodSeconds: 5
+                              failureThreshold: 3
+                          livenessProbe:
+                              httpGet:
+                                  path: /healthz
+                                  port: 7878
+                              initialDelaySeconds: 10
+                              periodSeconds: 15
+                              failureThreshold: 5
+                          resources:
+                              requests:
+                                  cpu: '250m'
+                                  memory: '256Mi'
+                              limits:
+                                  cpu: '1500m'
+                                  memory: '1Gi'
+                          securityContext:
+                              allowPrivilegeEscalation: false
+                              readOnlyRootFilesystem: true
+                              capabilities:
+                                  drop:
+                                      - ALL

--- a/apps/kube/agones/nd-server/manifests/namespace.yaml
+++ b/apps/kube/agones/nd-server/manifests/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: nexus-defense
+    labels:
+        app.kubernetes.io/part-of: nexus-defense
+        # Cilium hubble/observability tagging — keeps the netflow board grouped.
+        kbve.com/stack: agones

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -59,6 +59,7 @@ resources:
     - agones/application.yaml
     - agones/rows/application.yaml
     - agones/mc/application.yaml
+    - agones/nd-server/application.yaml
     - chuckrpg/application.yaml
     # RareIcon — bullet-hell roguelite website + API
     - rareicon/application.yaml


### PR DESCRIPTION
## Summary
Wires nd-server into the normal Agones deployment loop alongside \`agones-rows\` and \`agones-mc\`. Dockerfile / nx project / version.toml / astro-kbve mdx / \`ci-dispatch-manifest\` entries already exist from prior work; this adds the Kubernetes manifests so a published image tag actually lands as a running Fleet.

## Layout
\`\`\`
apps/kube/agones/nd-server/
├─ application.yaml                        # ArgoCD child app
└─ manifests/
   ├─ namespace.yaml                       # nexus-defense ns
   ├─ external-secret.yaml                 # pulls SUPABASE_JWT_SECRET from shared store
   ├─ fleet.yaml                           # Agones Fleet, replicas: 0, TCP/7878
   └─ fleet-autoscaler.yaml                # Buffer-1, max 20, scale-to-0 idle
\`\`\`

## Fleet config (Phase 1)
- **Replicas**: 0 — Allocator-driven, autoscaler keeps one warm.
- **Port**: TCP/7878 Dynamic (nd-server is WS-over-TCP).
- **Container**: \`ghcr.io/kbve/nd-server:0.0.2\`, non-root (10001), \`readOnlyRootFilesystem\`, dropped caps.
- **Health**: HTTP \`/healthz\` readiness + liveness.
- **Resources**: 250m / 256Mi req → 1500m / 1Gi limit.

## Autoscaler
\`\`\`
buffer: 1            # one warm Ready GS for instant allocation
min: 0               # scale to zero between matches
max: 20              # current cluster headroom
sync: 30s
\`\`\`

## Caveats called out inline
- nd-server doesn't speak the Agones SDK yet — Phase-3 follow-up. The SDK sidecar still runs; Agones treats the pod as healthy via the TCP \`/healthz\` probe until the binary calls \`Ready()\`/\`Health()\` directly.
- \`TD_SERVER_ADDR\` still bound to the static container port; Agones NATs the Dynamic external port to it. Wiring the SDK pulls the injected port into the bind address.

## Verified
- \`js-yaml loadAll\` OK on every new manifest.
- \`apps/kube/kustomization.yaml\` registers \`agones/nd-server/application.yaml\` next to the existing agones rows.

## Test plan
- [ ] ArgoCD picks up \`agones-nd-server\` app on next sync; no drift.
- [ ] \`kubectl get fleet -n nexus-defense\` shows \`nd-server\` at 1 Ready replica (autoscaler buffer).
- [ ] \`kubectl exec\` into the GameServer pod, \`curl localhost:7878/healthz\` → \`ok\`.
- [ ] \`kubectl create -f <gsa.yaml>\` allocator request returns an externalIP + Dynamic port; godot client connects to that endpoint.
- [ ] Set \`replicas: 0\` on the autoscaler manually and confirm scale-to-zero after grace period.

## Next
- Agones SDK integration in nd-server (Ready/Health/Allocate hooks).
- Lobby endpoint in \`jedi\` that calls the Allocator API and returns \`ws://<extIP>:<port>/ws\` to clients.
- ExternalSecret for forthcoming match-token signing key.

## Related
- #11294 — multiplayer TD tracker
- #11369 — combat loop (the gameplay this Fleet hosts)