### PR TITLE
fix(astro-kbve): persist Discord provider_token + request guilds scope

### DIFF
--- a/apps/kbve/astro-kbve/src/components/auth/AuthBridge.ts
+++ b/apps/kbve/astro-kbve/src/components/auth/AuthBridge.ts
@@ -3,6 +3,37 @@ import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { SUPABASE_URL, SUPABASE_ANON_KEY } from '@/lib/supa';
 import { IDBStorage } from '@/lib/storage';
 
+const DISCORD_OAUTH_SCOPES = 'identify email guilds';
+const DISCORD_PROVIDER_TOKEN_KEY = 'kbve_discord_provider_token';
+const DISCORD_PROVIDER_TOKEN_AT_KEY = 'kbve_discord_provider_token_captured_at';
+
+function safeLocalGet(key: string): string | null {
+	if (typeof window === 'undefined') return null;
+	try {
+		return window.localStorage.getItem(key);
+	} catch {
+		return null;
+	}
+}
+
+function safeLocalSet(key: string, value: string): void {
+	if (typeof window === 'undefined') return;
+	try {
+		window.localStorage.setItem(key, value);
+	} catch {
+		// quota / private mode — non-fatal
+	}
+}
+
+function safeLocalRemove(key: string): void {
+	if (typeof window === 'undefined') return;
+	try {
+		window.localStorage.removeItem(key);
+	} catch {
+		// non-fatal
+	}
+}
+
 /**
  * AuthBridge handles OAuth flows in the main window context.
  * After OAuth completes, it syncs the session with the SharedWorker via IndexedDB.
@@ -41,8 +72,9 @@ class AuthBridge {
 			provider,
 			options: {
 				redirectTo: `${window.location.origin}/auth/callback`,
-				// Skip if already logged in
 				skipBrowserRedirect: false,
+				scopes:
+					provider === 'discord' ? DISCORD_OAUTH_SCOPES : undefined,
 			},
 		});
 
@@ -62,9 +94,31 @@ class AuthBridge {
 
 		if (error) throw error;
 
-		// Session is now stored in IndexedDB
-		// The SharedWorker will automatically pick it up
+		// Supabase clears OAuth provider_token from session on auto-refresh,
+		// so stash it now while it's still attached. The agents dashboard
+		// reads this fallback for verifyGuildOwnership / Discord API calls.
+		const session = data.session as {
+			provider_token?: string | null;
+			user?: { app_metadata?: { provider?: string } | null } | null;
+		} | null;
+		const providerToken = session?.provider_token ?? null;
+		const provider = session?.user?.app_metadata?.provider ?? null;
+		if (providerToken && provider === 'discord') {
+			safeLocalSet(DISCORD_PROVIDER_TOKEN_KEY, providerToken);
+			safeLocalSet(DISCORD_PROVIDER_TOKEN_AT_KEY, String(Date.now()));
+		}
+
 		return data.session;
+	}
+
+	/** Returns the Discord OAuth access token captured during the last callback. */
+	getDiscordProviderToken(): string | null {
+		return safeLocalGet(DISCORD_PROVIDER_TOKEN_KEY);
+	}
+
+	clearDiscordProviderToken(): void {
+		safeLocalRemove(DISCORD_PROVIDER_TOKEN_KEY);
+		safeLocalRemove(DISCORD_PROVIDER_TOKEN_AT_KEY);
 	}
 
 	/**
@@ -72,6 +126,7 @@ class AuthBridge {
 	 */
 	async signOut() {
 		const client = this.ensureClient();
+		this.clearDiscordProviderToken();
 		const { error } = await client.auth.signOut();
 		if (error) throw error;
 	}
@@ -81,6 +136,7 @@ class AuthBridge {
 	 * Call this during logout to avoid blocking deleteDatabase from other tabs.
 	 */
 	async destroy() {
+		this.clearDiscordProviderToken();
 		try {
 			await this.storage.clearAll();
 		} catch {

--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -58,9 +58,17 @@ class AgentsService {
 
 			this.$accessToken.set(session.access_token as string);
 
-			const providerToken =
+			const sessionProviderToken =
 				(session as { provider_token?: string | null } | null)
 					?.provider_token ?? null;
+
+			let providerToken: string | null = sessionProviderToken;
+			if (!providerToken) {
+				const { authBridge } =
+					await import('@/components/auth/AuthBridge');
+				providerToken = authBridge.getDiscordProviderToken();
+			}
+
 			if (!providerToken) {
 				this.$authState.set('discord_reauth_required');
 				return;
@@ -90,6 +98,13 @@ class AgentsService {
 			if (resp.status === 401) {
 				this.$authState.set('discord_reauth_required');
 				this.$providerToken.set(null);
+				try {
+					const { authBridge } =
+						await import('@/components/auth/AuthBridge');
+					authBridge.clearDiscordProviderToken();
+				} catch {
+					// non-fatal
+				}
 				this.$guildsError.set(
 					'Discord session expired. Re-sign-in required.',
 				);


### PR DESCRIPTION
Two real bugs in the agents dashboard auth wiring surfaced after the P3 + provider-centric refactor landed: signed-in users hit \"Discord session expired\" on \`/dashboard/agents/github/\` even immediately after signing in. Bot + edge deployments are already live and fine (\`discordsh-bot:0.1.15\`, \`edge:0.1.33\`) — this is purely a frontend session-handling bug.

## Root causes

| # | Bug | Effect |
|---|-----|--------|
| 1 | \`signInWithOAuth\` doesn't pass any \`scopes\` for Discord | Supabase defaults to \`identify + email\` only. No \`guilds\` → \`/users/@me/guilds\` returns 401 even when \`provider_token\` is valid |
| 2 | supabase-js retains \`session.access_token\` across auto-refresh (~1h) but **strips \`session.provider_token\`** on every refresh | After the first refresh, \`agentsService\` saw \`provider_token = null\` and forced \`discord_reauth_required\` every hour |

## Why this is not a bot-token bug

Important framing: bot tokens (GitHub PAT, webhook HMAC, etc.) are **user-pasted** through the P2/P3 modals and stored encrypted in Supabase Vault — not OAuth. The Discord \`provider_token\` is purely the **ownership gatekeeper**: \`guild-vault\` server-side calls \`https://discord.com/api/v10/users/@me/guilds\` with this token and checks \`owner: true\` for the target \`server_id\` before allowing the user to write Vault rows for that guild. Drop OAuth gate → any signed-in user could write tokens to any guild.

## Fix

\`apps/kbve/astro-kbve/src/components/auth/AuthBridge.ts\`:
- New \`DISCORD_OAUTH_SCOPES = 'identify email guilds'\` passed via \`options.scopes\` when \`provider === 'discord'\`. \`github\` / \`twitch\` retain Supabase defaults.
- \`handleCallback\` extracts \`session.provider_token\` (while still attached to the immediate post-callback session) and stashes it in \`localStorage\` under \`kbve_discord_provider_token\` (+ captured-at timestamp). Gated on \`app_metadata.provider === 'discord'\` so other providers can't leak their tokens.
- New helpers: \`getDiscordProviderToken()\` / \`clearDiscordProviderToken()\`.
- \`signOut\` + \`destroy\` now clear the localStorage stash.

\`apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts\`:
- \`initAuth\` reads \`session.provider_token\` first (still attached immediately after callback) then falls back to \`authBridge.getDiscordProviderToken()\`. \`discord_reauth_required\` only fires when both are null.
- On Discord API 401 during \`loadOwnedGuilds\`, clear the localStorage stash via \`authBridge.clearDiscordProviderToken()\` so a stale token can't be reused on next page load.

## Migration impact

Anyone who signed in before this change has no \`guilds\` scope in their existing Discord token. The fallback fixes the \"token not present\" half, but they still need a **one-time re-sign-in** to upgrade scopes. The existing \`discord_reauth_required\` UI handles this exactly — click Re-sign-in, Discord prompts for the new scopes (now including \`guilds\`), callback stashes the new token, page works.

## No version bump

axum-kbve v1.0.171 from the P0 PR has not yet published. P1 (#11368), P2 (#11372), P3 (#11385), provider-centric refactor (#11393), and this fix all ride the same image tag.

## Verification

- \`./kbve.sh -nx astro-kbve:build\` ✓
- No new dependencies
- Tokens are scoped to the browser's localStorage; no cross-tab leak beyond the existing Supabase session sharing.