### PR TITLE
refactor(astro-kbve): make /agents/github page agnostic across consumers

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
@@ -5,17 +5,36 @@ import ReactAgentGithubWizard from './ReactAgentGithubWizard';
 <section
 	id="agent-github-wizard-wrapper"
 	class="agent-github-wizard-wrapper kbve-dashboard-page"
-	aria-label="discordsh GitHub wizard — provision webhook secret, PAT, and smoke-backfill">
+	aria-label="GitHub provider — webhook secret, PAT, repo allowlist (future), smoke-backfill">
 	<div class="dashboard-content">
 		<header class="agent-header not-content">
-			<h1 class="agent-title">discordsh · GitHub</h1>
+			<h1 class="agent-title">GitHub</h1>
 			<p class="agent-lede">
-				Four-step wizard that walks a guild owner through provisioning
-				the Vault rows discordsh needs for GitHub integration: an HMAC
-				webhook secret (<code>github_webhook:&lt;guild&gt;</code>) and a
-				PAT (<code>github:&lt;guild&gt;</code>). Step 4 smoke-tests the
-				full webhook + backfill path.
+				Per-guild GitHub integration. The four-step wizard provisions
+				the Vault rows that any KBVE agent consumes when it needs to
+				read or write against GitHub: an HMAC webhook secret (<code>
+					github_webhook:&lt;guild&gt;
+				</code>) and a PAT (<code>github:&lt;guild&gt;</code>). Step 4
+				smoke-tests the full webhook + backfill path so you know
+				downstream agents can use the credentials.
 			</p>
+
+			<div
+				class="agent-consumers"
+				aria-label="Agents that consume these rows">
+				<span class="agent-consumers__label">Used by:</span>
+				<a
+					class="agent-consumers__chip agent-consumers__chip--available"
+					href="/dashboard/agents/discordsh/">
+					discordsh
+				</a>
+				<span class="agent-consumers__chip agent-consumers__chip--soon">
+					pr-review (future)
+				</span>
+				<span class="agent-consumers__chip agent-consumers__chip--soon">
+					ci-bot (future)
+				</span>
+			</div>
 		</header>
 
 		<ReactAgentGithubWizard client:only="react" />
@@ -68,5 +87,49 @@ import ReactAgentGithubWizard from './ReactAgentGithubWizard';
 		padding: 0.05rem 0.35rem;
 		border-radius: 4px;
 		font-size: 0.85em;
+	}
+
+	.agent-consumers {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.4rem;
+		margin-top: 0.85rem;
+	}
+
+	.agent-consumers__label {
+		font-size: 0.78rem;
+		color: var(--sl-color-gray-3, #9ca0aa);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-weight: 600;
+		margin-right: 0.2rem;
+	}
+
+	.agent-consumers__chip {
+		display: inline-flex;
+		align-items: center;
+		font-size: 0.78rem;
+		padding: 0.18rem 0.6rem;
+		border-radius: 999px;
+		font-family: var(--sl-font-mono, ui-monospace, monospace);
+		border: 1px solid transparent;
+		text-decoration: none;
+	}
+
+	.agent-consumers__chip--available {
+		background: rgba(74, 222, 128, 0.12);
+		color: #4ade80;
+		border-color: rgba(74, 222, 128, 0.3);
+	}
+
+	.agent-consumers__chip--available:hover {
+		background: rgba(74, 222, 128, 0.2);
+	}
+
+	.agent-consumers__chip--soon {
+		background: rgba(148, 163, 184, 0.12);
+		color: #94a3b8;
+		border-color: rgba(148, 163, 184, 0.25);
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
@@ -7,11 +7,11 @@ import {
 	ExternalLink,
 	Eye,
 	EyeOff,
-	Github,
 	Loader2,
 	LogIn,
 	PlayCircle,
 	Shuffle,
+	Webhook,
 } from 'lucide-react';
 import {
 	agentsService,
@@ -118,12 +118,12 @@ export default function ReactAgentGithubWizard() {
 						fontSize: '0.85rem',
 						color: 'var(--sl-color-gray-3, #9ca0aa)',
 					}}>
-					The wizard provisions Vault rows scoped to the picked guild
-					(<code>github_pat:&lt;guild&gt;</code> +{' '}
-					<code>github_webhook:&lt;guild&gt;</code>). The selection is
-					shared with{' '}
-					<a href="/dashboard/agents/discordsh/">discordsh</a> and any
-					other agent that consumes GitHub credentials.
+					The wizard provisions per-guild Vault rows (
+					<code>github_pat:&lt;guild&gt;</code> +{' '}
+					<code>github_webhook:&lt;guild&gt;</code>) that any KBVE
+					agent (discordsh today, future PR-review / CI / chatops bots
+					later) can consume. Guild selection is shared across the
+					whole agents surface.
 				</p>
 			</div>
 		);
@@ -168,11 +168,9 @@ function WizardBody({ guild, tokens }: WizardBodyProps) {
 					borderRadius: 12,
 					background: 'rgba(88,166,255,0.06)',
 				}}>
-				<Github size={20} color="#58a6ff" />
+				<Webhook size={20} color="#58a6ff" />
 				<div>
-					<div style={{ fontWeight: 600 }}>
-						discordsh · GitHub setup
-					</div>
+					<div style={{ fontWeight: 600 }}>GitHub provider setup</div>
 					<div
 						style={{
 							fontSize: '0.78rem',
@@ -264,9 +262,9 @@ function Step1Webhook({
 						{WEBHOOK_SERVICE}:{guild.id}
 					</code>{' '}
 					(token <code>{existing!.token_name}</code>). To rotate,
-					delete the existing row from{' '}
-					<a href="/dashboard/agents/discordsh/">discordsh page</a>{' '}
-					and run this wizard again.
+					delete the existing row from the per-guild{' '}
+					<a href="/dashboard/agents/discordsh/">token list</a> and
+					run this wizard again.
 				</p>
 			) : (
 				<>


### PR DESCRIPTION
Cosmetic follow-up. The GitHub provider page still carried discordsh-specific copy ("discordsh · GitHub", "the Vault rows discordsh needs", "delete from discordsh page"). The rows are guild-scoped, not bot-scoped — any future agent (PR review, CI, chatops) reads the same Vault entries. This patch strips the bot-specific framing so the page reads as a provider surface before more consumers ship.

## Changes

**\`AstroAgentGithubWizard.astro\`**
- Title: \`discordsh · GitHub\` → \`GitHub\`
- Lede rewritten — describes per-guild GitHub integration consumed by any KBVE agent
- New **Used by** chip strip under the lede: \`discordsh\` (Available, linked) + \`pr-review (future)\` + \`ci-bot (future)\`. Append more chips as consumers come online without changing the page identity.
- CSS for the chip strip (available / soon variants)

**\`ReactAgentGithubWizard.tsx\`**
- Wizard header \`discordsh · GitHub setup\` → \`GitHub provider setup\`
- Icon: \`Github\` (deprecated by lucide-react) → \`Webhook\`
- Step 1 rotate hint: \`delete the existing row from discordsh page\` → \`delete the existing row from the per-guild token list\`
- No-guild-selected branch description: generalized to \"any KBVE agent (discordsh today, future PR-review / CI / chatops bots later)\"

## What this PR does NOT touch

- Token list still lives at \`/dashboard/agents/discordsh/\`. Hoisting it to a neutral \`/agents/tokens/\` (or making it shared across pages) is the next refactor — out of scope here.
- \`agentsService\` / \`guild-vault\` contracts unchanged.

## No version bump

axum-kbve v1.0.171 still pre-publish; all open agents PRs ride the same image tag.

## Verification

- \`./kbve.sh -nx astro-kbve:build\` ✓
- No new dependencies