### PR TITLE
feat(q,nexus-defense): MatchPhase state machine + starter buildings + kill counter

### DIFF
--- a/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e2fb0856a59b50a65dfea7ffb579b449e196ba1f1226defe955d27b04b9e93d
+oid sha256:daf8c3f49c25e4e85890d0579ad2fbbaf2e63af9cc7aa3ecc05cba3f9611dc0d
 size 4200128

--- a/apps/godot/nexus-defense/scenes/game.gd
+++ b/apps/godot/nexus-defense/scenes/game.gd
@@ -229,23 +229,48 @@ func _on_welcome(slot: int, seed: int) -> void:
 
 var _last_snapshot_tick: int = 0
 var _last_building_count: int = 0
+var _last_phase: int = -1
+var _last_kills: int = 0
 
-func _on_snapshot(tick: int, wave: int, enemy_count: int, building_count: int, gold: int, lives: int) -> void:
+const PHASE_PREPARE := 0
+const PHASE_WAVE := 1
+const PHASE_INTERMISSION := 2
+const PHASE_GAMEOVER := 3
+
+func _phase_name(phase: int) -> String:
+	match phase:
+		PHASE_PREPARE: return "Prepare"
+		PHASE_WAVE: return "Wave"
+		PHASE_INTERMISSION: return "Intermission"
+		PHASE_GAMEOVER: return "Game Over"
+		_: return "Unknown"
+
+func _on_snapshot(tick: int, wave: int, enemy_count: int, building_count: int, gold: int, lives: int, phase: int, phase_remaining_ms: int, kills: int) -> void:
 	_last_snapshot_tick = tick
 	var wave_changed: bool = wave != _wave
 	var building_changed: bool = building_count != _last_building_count
+	var phase_changed: bool = phase != _last_phase
 	_last_building_count = building_count
-	if wave_changed:
+	if wave_changed and phase == PHASE_WAVE:
 		_wave = wave
 		Ui.open("wave_banner", {"title": "Wave %d" % wave, "subtitle": "%d enemies inbound" % enemy_count})
 		_spawn_wave_enemies(enemy_count)
+	elif phase_changed and phase == PHASE_PREPARE:
+		var secs := int(ceil(float(phase_remaining_ms) / 1000.0))
+		Ui.open("wave_banner", {"title": "Prepare", "subtitle": "Wave %d in %ds" % [max(wave, 1), secs]})
+	elif phase_changed and phase == PHASE_GAMEOVER:
+		Ui.open("wave_banner", {"title": "Game Over", "subtitle": "Survived %d wave(s)" % wave})
+	if kills > _last_kills:
+		_last_kills = kills
+	_last_phase = phase
+	_wave = wave
 	_lives = lives
 	_gold = gold
 	_enemies = enemy_count
 	Ui.open("hud_top", {"wave": _wave, "lives": _lives, "gold": _gold, "enemies": _enemies})
-	if _last_snapshot_log_tick < 0 or tick - _last_snapshot_log_tick >= 10 or wave_changed or building_changed:
+	if _last_snapshot_log_tick < 0 or tick - _last_snapshot_log_tick >= 10 or wave_changed or building_changed or phase_changed:
 		_last_snapshot_log_tick = tick
-		_log("snapshot tick=%d wave=%d enemies=%d buildings=%d gold=%d lives=%d" % [tick, wave, enemy_count, building_count, gold, lives])
+		_log("snapshot tick=%d phase=%s wave=%d enemies=%d buildings=%d gold=%d lives=%d kills=%d remaining_ms=%d" % [tick, _phase_name(phase), wave, enemy_count, building_count, gold, lives, kills, phase_remaining_ms])
 
 func _on_disconnected(reason: String) -> void:
 	_log("disconnected: %s" % reason)

--- a/packages/rust/q/src/nexus_defense/match_socket.rs
+++ b/packages/rust/q/src/nexus_defense/match_socket.rs
@@ -32,6 +32,9 @@ enum Inbound {
         building_count: u32,
         gold: i32,
         lives: i32,
+        phase: u8,
+        phase_remaining_ms: u32,
+        kills: u32,
     },
     Disconnected {
         reason: String,
@@ -87,6 +90,9 @@ impl INode for MatchSocket {
                     building_count,
                     gold,
                     lives,
+                    phase,
+                    phase_remaining_ms,
+                    kills,
                 } => {
                     self.base_mut().emit_signal(
                         &StringName::from("snapshot"),
@@ -97,6 +103,9 @@ impl INode for MatchSocket {
                             (building_count as i64).to_variant(),
                             (gold as i64).to_variant(),
                             (lives as i64).to_variant(),
+                            (phase as i64).to_variant(),
+                            (phase_remaining_ms as i64).to_variant(),
+                            (kills as i64).to_variant(),
                         ],
                     );
                 }
@@ -128,7 +137,17 @@ impl MatchSocket {
     /// be pulled from a future ring buffer; for now we plumb the headline
     /// numbers so GDScript can render a wave/enemies/gold display.
     #[signal]
-    fn snapshot(tick: i64, wave: i64, enemy_count: i64, building_count: i64, gold: i64, lives: i64);
+    fn snapshot(
+        tick: i64,
+        wave: i64,
+        enemy_count: i64,
+        building_count: i64,
+        gold: i64,
+        lives: i64,
+        phase: i64,
+        phase_remaining_ms: i64,
+        kills: i64,
+    );
 
     #[signal]
     fn disconnected(reason: GString);
@@ -341,6 +360,9 @@ async fn run_socket(
                     let wave = field.map(|f| f.wave).unwrap_or(0);
                     let gold = field.map(|f| f.gold).unwrap_or(0);
                     let lives = field.map(|f| f.lives).unwrap_or(0);
+                    let phase = field.map(|f| f.phase as u8).unwrap_or(0);
+                    let phase_remaining_ms = field.map(|f| f.phase_remaining_ms).unwrap_or(0);
+                    let kills = field.map(|f| f.kills).unwrap_or(0);
                     let _ = tx.send(Inbound::Snapshot {
                         tick: snap.tick,
                         wave,
@@ -348,6 +370,9 @@ async fn run_socket(
                         building_count,
                         gold,
                         lives,
+                        phase,
+                        phase_remaining_ms,
+                        kills,
                     });
                 }
                 Ok(ServerEvent::Reject { reason }) => {

--- a/packages/rust/q/src/nexus_defense_server/mod.rs
+++ b/packages/rust/q/src/nexus_defense_server/mod.rs
@@ -48,6 +48,39 @@ const ENEMIES_PER_WAVE: u32 = 10;
 const SPAWN_INTERVAL_TICKS: u32 = 10;
 /// Ticks between waves (5 s at 20 Hz).
 const WAVE_INTERVAL_TICKS: u32 = SIM_TICK_HZ * 5;
+const PREPARE_PHASE_TICKS: u32 = SIM_TICK_HZ * 6;
+
+const STARTER_BUILDING_AXIALS: &[(i32, i32, proto::BuildKind)] = &[
+    (-4, 0, proto::BuildKind::Tower),
+    (4, 0, proto::BuildKind::Tower),
+];
+
+/// Map current SlotWave state + lives to (phase, phase_remaining_ms).
+/// Wave-active when enemies are still being spawned this wave;
+/// Intermission while waiting for the next wave to start; Prepare for
+/// the very first window before the match opens; GameOver once lives
+/// hit zero.
+fn derive_phase(slot_wave: Option<SlotWave>, lives: i32, tick: u32) -> (proto::MatchPhase, u32) {
+    if lives <= 0 {
+        return (proto::MatchPhase::GameOver, 0);
+    }
+    let Some(entry) = slot_wave else {
+        return (proto::MatchPhase::Prepare, 0);
+    };
+    if tick < entry.prepare_until_tick {
+        let remaining = entry.prepare_until_tick.saturating_sub(tick);
+        return (proto::MatchPhase::Prepare, ticks_to_ms(remaining));
+    }
+    if entry.spawned_in_wave < ENEMIES_PER_WAVE {
+        return (proto::MatchPhase::Wave, 0);
+    }
+    let remaining = entry.next_wave_tick.saturating_sub(tick);
+    (proto::MatchPhase::Intermission, ticks_to_ms(remaining))
+}
+
+const fn ticks_to_ms(ticks: u32) -> u32 {
+    ticks.saturating_mul(1000) / SIM_TICK_HZ
+}
 /// Vertical stripe assigned to each slot — slot 0 at y=120, slot 1 at y=280, etc.
 const SLOT_STRIPE_BASE: f32 = 120.0;
 const SLOT_STRIPE_HEIGHT: f32 = 160.0;
@@ -122,6 +155,13 @@ pub struct SlotWave {
     pub spawned_in_wave: u32,
     pub next_spawn_tick: u32,
     pub next_wave_tick: u32,
+    /// Tick at which the Prepare phase ends and the very first wave is
+    /// allowed to spawn. 0 means the slot has not been initialised yet
+    /// and sync_per_slot_state will seed it on the next tick.
+    pub prepare_until_tick: u32,
+    /// Set true once a slot has had its starter buildings spawned, so
+    /// the rest of the loop doesn't re-spawn them every tick.
+    pub starter_spawned: bool,
 }
 
 #[derive(Resource)]
@@ -254,10 +294,12 @@ fn tick_sim(mut clock: ResMut<SimClock>, mut budget: ResMut<InputBudget>) {
 }
 
 fn sync_per_slot_state(
+    clock: Res<SimClock>,
     roster: Res<RosterHandle>,
     mut wave: ResMut<WaveState>,
     mut economy: ResMut<PlayerEconomy>,
     mut over: ResMut<GameOverFlags>,
+    mut commands: Commands,
 ) {
     let active = match roster.0.read() {
         Ok(r) => r.active_slots(),
@@ -271,7 +313,13 @@ fn sync_per_slot_state(
         }
         active_mask[idx] = true;
         if wave.slots[idx].is_none() {
-            wave.slots[idx] = Some(SlotWave::default());
+            let prepare_until = clock.tick.saturating_add(PREPARE_PHASE_TICKS);
+            wave.slots[idx] = Some(SlotWave {
+                next_wave_tick: prepare_until,
+                next_spawn_tick: prepare_until,
+                prepare_until_tick: prepare_until,
+                ..SlotWave::default()
+            });
         }
         if economy.slots[idx].is_none() {
             economy.slots[idx] = Some(PlayerEconomyEntry {
@@ -281,12 +329,44 @@ fn sync_per_slot_state(
             });
             over.fired[idx] = false;
         }
+        // Spawn the slot's starter defensive towers exactly once.
+        if let Some(entry) = wave.slots[idx].as_mut()
+            && !entry.starter_spawned
+        {
+            spawn_starter_buildings(*slot, &mut commands, clock.tick);
+            entry.starter_spawned = true;
+        }
     }
     for (idx, &is_active) in active_mask.iter().enumerate().take(proto::MAX_PLAYERS) {
         if !is_active {
             wave.slots[idx] = None;
             economy.slots[idx] = None;
             over.fired[idx] = false;
+        }
+    }
+}
+
+fn spawn_starter_buildings(slot: proto::PlayerSlot, commands: &mut Commands, tick: u32) {
+    for (col, row, kind) in STARTER_BUILDING_AXIALS {
+        let x = (*col as f32) * 32.0 + 16.0;
+        let y = (*row as f32) * 32.0 + 16.0;
+        let mut spawn = commands.spawn((
+            BuildingTag {
+                kind: *kind,
+                owner: slot,
+                col: *col,
+                row: *row,
+            },
+            Position(x, y),
+            Health {
+                hp: BUILDING_HP,
+                max_hp: BUILDING_HP,
+            },
+        ));
+        if building_is_offensive(*kind) {
+            spawn.insert(TowerStats {
+                last_fire_tick: tick,
+            });
         }
     }
 }
@@ -365,6 +445,12 @@ fn spawn_wave_enemies(clock: Res<SimClock>, mut wave: ResMut<WaveState>, mut com
             continue;
         };
         let slot = proto::PlayerSlot(idx as u8);
+
+        // Prepare phase gate — no enemies before the slot's initial
+        // countdown finishes.
+        if clock.tick < entry.prepare_until_tick {
+            continue;
+        }
 
         if clock.tick >= entry.next_wave_tick && entry.spawned_in_wave >= ENEMIES_PER_WAVE {
             entry.wave = entry.wave.wrapping_add(1);
@@ -621,12 +707,8 @@ fn emit_snapshot(
         .iter()
         .map(|slot| {
             let idx = slot.0 as usize;
-            let slot_wave = wave
-                .slots
-                .get(idx)
-                .and_then(|w| w.as_ref())
-                .map(|w| w.wave)
-                .unwrap_or(0);
+            let slot_wave_state = wave.slots.get(idx).and_then(|w| w.as_ref()).copied();
+            let slot_wave = slot_wave_state.map(|w| w.wave).unwrap_or(0);
             let econ = economy
                 .slots
                 .get(idx)
@@ -637,6 +719,7 @@ fn emit_snapshot(
                     lives: STARTING_LIVES,
                     kills: 0,
                 });
+            let (phase, phase_remaining_ms) = derive_phase(slot_wave_state, econ.lives, clock.tick);
             proto::FieldDelta {
                 owner: *slot,
                 buildings: building_bins.remove(&slot.0).unwrap_or_default(),
@@ -645,6 +728,9 @@ fn emit_snapshot(
                 gold: econ.gold,
                 lives: econ.lives,
                 wave: slot_wave,
+                phase,
+                phase_remaining_ms,
+                kills: econ.kills,
             }
         })
         .collect();

--- a/packages/rust/q/src/proto/mod.rs
+++ b/packages/rust/q/src/proto/mod.rs
@@ -153,6 +153,25 @@ pub struct ProjectileDelta {
     pub destroyed: bool,
 }
 
+/// Per-slot match phase — drives the client HUD's pacing chip + banner.
+/// Mapped to u8 on the wire so older clients can ignore unknown variants
+/// without crashing the decoder.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum MatchPhase {
+    /// Inter-wave breather + initial countdown before the first enemy
+    /// spawn. Towers can be placed; no enemies on the field yet.
+    #[default]
+    Prepare = 0,
+    /// Spawn window is open — enemies are being added each spawn-tick.
+    Wave = 1,
+    /// Spawning is done; remaining enemies still walking the path. Wave
+    /// counter has not yet ticked over to the next number.
+    Intermission = 2,
+    /// Player ran out of lives. No more enemies will be spawned for them.
+    GameOver = 3,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FieldDelta {
     pub owner: PlayerSlot,
@@ -162,6 +181,13 @@ pub struct FieldDelta {
     pub gold: i32,
     pub lives: i32,
     pub wave: u16,
+    /// Current pacing state for this slot.
+    pub phase: MatchPhase,
+    /// Milliseconds remaining in the current phase (countdown for
+    /// Prepare/Intermission; 0 for Wave/GameOver).
+    pub phase_remaining_ms: u32,
+    /// Cumulative enemy kills for this slot since the match started.
+    pub kills: u32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
Closes the spawn → fight → reward loop with a proper pacing layer and a non-empty board on join. Wire-level changes are additive — old clients keep working, new fields default to zero.

## Proto
- New \`MatchPhase\` enum: \`Prepare\` / \`Wave\` / \`Intermission\` / \`GameOver\`, \`#[repr(u8)]\` so the discriminant is stable on the wire.
- \`FieldDelta\` gains \`phase\`, \`phase_remaining_ms\`, and \`kills\` (the kill counter already lived on \`PlayerEconomyEntry\` but wasn't broadcast).

## Server (\`q::nexus_defense_server\`)
- \`SlotWave\` gains \`prepare_until_tick\` and \`starter_spawned\`. New slots seed both spawn timers \`PREPARE_PHASE_TICKS\` (6 s @ 20 Hz) into the future, so the player gets a countdown banner before the first wave instead of being bullrushed on connect.
- \`spawn_wave_enemies\` short-circuits while \`tick < prepare_until_tick\`.
- \`sync_per_slot_state\` now takes \`Commands\` and calls \`spawn_starter_buildings(slot)\` exactly once per slot (gated by \`starter_spawned\`). Hardcoded \`STARTER_BUILDING_AXIALS\` drops two \`Tower\` buildings at (-4, 0) and (4, 0). **Follow-up**: lift these to a shared TD-map MDX/MapDB entry so other games can reuse the layout.
- New \`derive_phase(slot_wave, lives, tick) -> (MatchPhase, ms)\` computes the snapshot fields from existing state — no separate phase enum to keep in sync.
- \`emit_snapshot\` fills the three new \`FieldDelta\` fields.

## MatchSocket
- \`Inbound::Snapshot\` + the \`snapshot\` godot signal grow \`phase\`, \`phase_remaining_ms\`, \`kills\`. Reader extracts them from the matched FieldDelta with the same fallback-to-0 on missing field.
- \`libq.dylib\` refreshed.

## Godot client (\`scenes/game.gd\`)
- \`_on_snapshot\` signature + handlers updated.
- Phase transitions drive the WaveBanner:
  - \`Wave\` start → "Wave N · X enemies inbound" + spawns local cosmetic marchers.
  - \`Prepare\` → "Prepare · Wave N in Xs" using \`phase_remaining_ms\`.
  - \`GameOver\` → "Game Over · Survived N wave(s)".
- Snapshot log line now includes phase, kills, and remaining_ms.

## Test plan
- [x] \`cargo build --release -p nd-server\` — clean
- [x] \`cargo clippy -p nd-server --all-targets -- -D warnings\` — clean
- [x] \`scripts/test.sh\` — 121/121
- [x] \`scripts/test-e2e.sh\` — 130/130 (incl. live nd-server smoke; new dylib loaded)
- [ ] Eyes on it locally: launch godot, click Play, watch the Prepare countdown then the first wave spawn

## Follow-up
- Lift \`STARTER_BUILDING_AXIALS\` (and the enemy path) into a shared TD-map proto so future TD games can reuse the layout without code edits.
- Wire a HUD phase chip + visible countdown ring (right now the only phase indicator is the WaveBanner).