### PR TITLE
chore(astro-kbve): brand discordsh → DiscordSH in agents dashboard display

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -194,7 +194,7 @@ export default defineConfig({
 							items: [
 								{ label: 'Overview', link: '/dashboard/agents/', attrs: { 'data-auth-visibility': 'auth' } },
 								{ label: 'GitHub', link: '/dashboard/agents/github/', attrs: { 'data-auth-visibility': 'auth' } },
-								{ label: 'discordsh', link: '/dashboard/agents/discordsh/', attrs: { 'data-auth-visibility': 'auth' } },
+								{ label: 'DiscordSH', link: '/dashboard/agents/discordsh/', attrs: { 'data-auth-visibility': 'auth' } },
 							],
 						},
 						{ label: 'Marketplace', link: '/dashboard/market/', attrs: { 'data-auth-visibility': 'auth' } },

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
@@ -8,7 +8,7 @@ import ReactAgentDiscordsh from './ReactAgentDiscordsh';
 	aria-label="Discordsh agent — token management for owned Discord guilds">
 	<div class="dashboard-content">
 		<header class="agent-header not-content">
-			<h1 class="agent-title">discordsh</h1>
+			<h1 class="agent-title">DiscordSH</h1>
 			<p class="agent-lede">
 				Manage tokens for guilds you own. Each row in <code>
 					vault.secrets

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentsDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentsDashboard.astro
@@ -29,7 +29,7 @@ const CARDS: AgentCard[] = [
 	},
 	{
 		key: 'discordsh',
-		name: 'discordsh',
+		name: 'DiscordSH',
 		kind: 'bot',
 		tagline:
 			'Discord gateway bot — slash commands, GitHub bridge, dungeon game.',

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/agents/discordsh/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/agents/discordsh/index.mdx
@@ -1,11 +1,11 @@
 ---
-title: discordsh agent
-description: Manage discordsh bot integration tokens for guilds you own.
+title: DiscordSH agent
+description: Manage DiscordSH bot integration tokens for guilds you own.
 tableOfContents: false
 graph:
     visible: false
 sidebar:
-    label: discordsh
+    label: DiscordSH
     order: 1
 unsplash: 1558494949-ef010cbdcc31
 img: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75


### PR DESCRIPTION
Cosmetic-only. Lowercase \`discordsh\` is the binary / repo / route slug; the brand spelling is **DiscordSH**. Sidebar + page title + catalog card now match the brand. Routes, slugs, repo refs, and tags stay lowercase.

## Changes (display strings only)

- \`astro.config.mjs\` — Agents sidebar leaf \`discordsh\` → \`DiscordSH\`
- \`src/content/docs/dashboard/agents/discordsh/index.mdx\` — page title + description + \`sidebar.label\`
- \`src/components/dashboard/AstroAgentDiscordsh.astro\` — page \`<h1>\`
- \`src/components/dashboard/AstroAgentsDashboard.astro\` — catalog card display name (key stays \`discordsh\`)

## Unchanged

- Routes (\`/dashboard/agents/discordsh/\`)
- Card \`key\` + content \`tags\`
- Docs link (\`/project/discordsh-bot/\`)
- Image (\`ghcr.io/kbve/discordsh-bot\`)
- Code constants (\`DISCORD_API_BASE\`, etc.)

## No version bump

axum-kbve v1.0.171 still pre-publish — same image tag as the rest of the open agents PRs.

## Verification

- \`./kbve.sh -nx astro-kbve:build\` ✓