### PR TITLE
feat(astro-kbve): /dashboard/gameops/ panel — fold ROWS, add Factorio + MC stubs

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -27,6 +27,8 @@ export default defineConfig({
 		'/profile/account/': '/dashboard/account/',
 		'/profile/market': '/dashboard/market/',
 		'/profile/market/': '/dashboard/market/',
+		'/dashboard/rows': '/dashboard/gameops/rows/',
+		'/dashboard/rows/': '/dashboard/gameops/rows/',
 	},
 	markdown: {
 		rehypePlugins: [rehypeLinkAttrs],
@@ -210,7 +212,16 @@ export default defineConfig({
 						{ label: 'Grafana', link: '/dashboard/grafana/', attrs: { 'data-auth-visibility': 'staff' } },
 						{ label: 'Virtual Machines', link: '/dashboard/vm/', attrs: { 'data-auth-visibility': 'staff' } },
 						{ label: 'IDE', link: '/dashboard/ide/', attrs: { 'data-auth-visibility': 'staff' } },
-						{ label: 'ROWS (Game Ops)', link: '/dashboard/rows/', attrs: { 'data-auth-visibility': 'staff' } },
+						{
+							label: 'GameOps',
+							collapsed: true,
+							items: [
+								{ label: 'Overview', link: '/dashboard/gameops/', attrs: { 'data-auth-visibility': 'staff' } },
+								{ label: 'ROWS', link: '/dashboard/gameops/rows/', attrs: { 'data-auth-visibility': 'staff' } },
+								{ label: 'Factorio', link: '/dashboard/gameops/factorio/', attrs: { 'data-auth-visibility': 'staff' } },
+								{ label: 'Minecraft', link: '/dashboard/gameops/mc/', attrs: { 'data-auth-visibility': 'staff' } },
+							],
+						},
 					],
 				},
 				{

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroFactorioDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroFactorioDashboard.astro
@@ -1,0 +1,45 @@
+---
+import ReactHomeAuth from './ReactHomeAuth';
+import ReactFactorioDashboard from './ReactFactorioDashboard';
+---
+
+<section
+	id="factorio-dashboard-wrapper"
+	class="factorio-dashboard-wrapper kbve-dashboard-page"
+	aria-label="Factorio GameOps Dashboard">
+	<div id="factorio-dashboard-content" class="factorio-dashboard-content">
+		<ReactHomeAuth client:only="react">
+			<div class="not-content factorio-dashboard">
+				<ReactFactorioDashboard client:only="react" />
+			</div>
+		</ReactHomeAuth>
+	</div>
+</section>
+
+<style>
+	.factorio-dashboard-wrapper {
+		background: transparent;
+		min-height: 100vh;
+		position: relative;
+		width: 100%;
+	}
+
+	.factorio-dashboard-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 2rem 1rem;
+	}
+
+	@media (min-width: 768px) {
+		.factorio-dashboard-content {
+			padding: 2rem 1.5rem;
+		}
+	}
+
+	.factorio-dashboard {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		min-height: 60vh;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroGameOpsPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroGameOpsPanel.astro
@@ -1,0 +1,45 @@
+---
+import ReactHomeAuth from './ReactHomeAuth';
+import ReactGameOpsPanel from './ReactGameOpsPanel';
+---
+
+<section
+	id="gameops-panel-wrapper"
+	class="gameops-panel-wrapper kbve-dashboard-page"
+	aria-label="GameOps Dashboard">
+	<div id="gameops-panel-content" class="gameops-panel-content">
+		<ReactHomeAuth client:only="react">
+			<div class="not-content gameops-panel">
+				<ReactGameOpsPanel client:only="react" />
+			</div>
+		</ReactHomeAuth>
+	</div>
+</section>
+
+<style>
+	.gameops-panel-wrapper {
+		background: transparent;
+		min-height: 100vh;
+		position: relative;
+		width: 100%;
+	}
+
+	.gameops-panel-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 2rem 1rem;
+	}
+
+	@media (min-width: 768px) {
+		.gameops-panel-content {
+			padding: 2rem 1.5rem;
+		}
+	}
+
+	.gameops-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		min-height: 60vh;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroMcDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroMcDashboard.astro
@@ -1,0 +1,45 @@
+---
+import ReactHomeAuth from './ReactHomeAuth';
+import ReactMcDashboard from './ReactMcDashboard';
+---
+
+<section
+	id="mc-dashboard-wrapper"
+	class="mc-dashboard-wrapper kbve-dashboard-page"
+	aria-label="Minecraft GameOps Dashboard">
+	<div id="mc-dashboard-content" class="mc-dashboard-content">
+		<ReactHomeAuth client:only="react">
+			<div class="not-content mc-dashboard">
+				<ReactMcDashboard client:only="react" />
+			</div>
+		</ReactHomeAuth>
+	</div>
+</section>
+
+<style>
+	.mc-dashboard-wrapper {
+		background: transparent;
+		min-height: 100vh;
+		position: relative;
+		width: 100%;
+	}
+
+	.mc-dashboard-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 2rem 1rem;
+	}
+
+	@media (min-width: 768px) {
+		.mc-dashboard-content {
+			padding: 2rem 1.5rem;
+		}
+	}
+
+	.mc-dashboard {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		min-height: 60vh;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactFactorioDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactFactorioDashboard.tsx
@@ -1,0 +1,227 @@
+import { useStore } from '@nanostores/react';
+import {
+	Factory,
+	ShieldOff,
+	Github,
+	ExternalLink,
+	Container,
+	Server,
+	Clock,
+} from 'lucide-react';
+import { homeService } from './homeService';
+
+const IMAGE_NAME = 'ghcr.io/kbve/agones-factorio';
+const FACTORIO_VERSION = '2.0.76';
+const ISSUE_URL = 'https://github.com/KBVE/kbve/issues/11138';
+const PROJECT_MDX = '/docs/project/agones-factorio/';
+
+const styles = {
+	centered: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '1rem',
+		minHeight: '40vh',
+		textAlign: 'center' as const,
+	},
+	heading: {
+		margin: 0,
+		fontSize: '1.75rem',
+		color: 'var(--sl-color-text, #e6edf3)',
+	},
+	sub: {
+		margin: 0,
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		maxWidth: '40rem',
+	},
+	header: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.75rem',
+		marginBottom: '1rem',
+	},
+	statusRow: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.5rem',
+		padding: '0.35rem 0.75rem',
+		borderRadius: '999px',
+		fontSize: '0.85rem',
+		fontWeight: 500,
+		background: 'rgba(210, 153, 34, 0.15)',
+		color: 'var(--sl-color-orange, #d29922)',
+		border: '1px solid rgba(210, 153, 34, 0.4)',
+	},
+	statusDot: {
+		width: '0.5rem',
+		height: '0.5rem',
+		borderRadius: '50%',
+		background: 'var(--sl-color-orange, #d29922)',
+	},
+	grid: {
+		display: 'grid',
+		gap: '1rem',
+		gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+		marginTop: '1.5rem',
+	},
+	card: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '0.5rem',
+		padding: '1rem 1.25rem',
+		borderRadius: '0.75rem',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		background: 'var(--sl-color-bg-nav, rgba(13, 17, 23, 0.6))',
+	},
+	cardLabel: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.5rem',
+		fontSize: '0.85rem',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+	},
+	cardValue: {
+		margin: 0,
+		fontSize: '1rem',
+		fontFamily: 'var(--sl-font-mono, ui-monospace, monospace)',
+		color: 'var(--sl-color-text, #e6edf3)',
+		wordBreak: 'break-all' as const,
+	},
+	roadmap: {
+		marginTop: '2rem',
+		padding: '1.25rem',
+		borderRadius: '0.75rem',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		background: 'var(--sl-color-bg-nav, rgba(13, 17, 23, 0.6))',
+	},
+	roadmapList: {
+		margin: '0.75rem 0 0',
+		paddingLeft: '1.25rem',
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '0.4rem',
+		color: 'var(--sl-color-gray-2, #c9d1d9)',
+		fontSize: '0.9rem',
+	},
+	links: {
+		display: 'flex',
+		gap: '0.75rem',
+		flexWrap: 'wrap' as const,
+		marginTop: '1.5rem',
+	},
+	linkButton: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.5rem',
+		padding: '0.5rem 0.9rem',
+		borderRadius: '0.5rem',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		background: 'var(--sl-color-bg-nav, rgba(13, 17, 23, 0.6))',
+		color: 'var(--sl-color-text, #e6edf3)',
+		textDecoration: 'none',
+		fontSize: '0.9rem',
+	},
+};
+
+export default function ReactFactorioDashboard() {
+	const isStaff = useStore(homeService.$isStaff);
+
+	if (!isStaff) {
+		return (
+			<div style={styles.centered}>
+				<ShieldOff size={48} color="var(--sl-color-gray-3)" />
+				<h2 style={styles.heading}>Staff Access Required</h2>
+				<p style={styles.sub}>
+					The Factorio control panel is restricted to KBVE staff.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div>
+			<div style={styles.header}>
+				<Factory size={28} color="var(--sl-color-accent, #2f81f7)" />
+				<h1 style={styles.heading}>Factorio</h1>
+			</div>
+			<span style={styles.statusRow}>
+				<span style={styles.statusDot} />
+				Phase 0 · Image published · No live data yet
+			</span>
+
+			<div style={styles.grid}>
+				<div style={styles.card}>
+					<div style={styles.cardLabel}>
+						<Container size={16} />
+						Image
+					</div>
+					<p style={styles.cardValue}>{IMAGE_NAME}</p>
+				</div>
+				<div style={styles.card}>
+					<div style={styles.cardLabel}>
+						<Server size={16} />
+						Factorio version
+					</div>
+					<p style={styles.cardValue}>{FACTORIO_VERSION}</p>
+				</div>
+				<div style={styles.card}>
+					<div style={styles.cardLabel}>
+						<Clock size={16} />
+						GameServer / Fleet
+					</div>
+					<p style={styles.cardValue}>not deployed (Phase 1)</p>
+				</div>
+			</div>
+
+			<div style={styles.roadmap}>
+				<strong>Phasing</strong>
+				<ul style={styles.roadmapList}>
+					<li>
+						Phase 0 — Custom image, KBVE scenario, lifecycle shim
+						(done).
+					</li>
+					<li>
+						Phase 1 — <code>apps/kube/agones/factorio/</code>{' '}
+						GameServer / Fleet + UDP service.
+					</li>
+					<li>
+						Phase 2 — ConfigMap-driven{' '}
+						<code>server-settings.json</code> +{' '}
+						<code>ExternalSecret</code> for matchmaking token and
+						RCON password.
+					</li>
+					<li>
+						Phase 3 — <code>apps/agones/factorio/relay/</code> chat
+						relay sidecar (Rust) → IRC → existing Discord bridge.
+					</li>
+					<li>
+						Phase 2.5+ — <code>factorio-ctl</code> Axum REST API;
+						wires player count, save rotation, RCON passthrough into
+						this dashboard.
+					</li>
+					<li>
+						Phase 4 — PVC + rotation CronJob, public save download
+						URL.
+					</li>
+					<li>Phase 5 — Log / RCON metrics + UPS / player alerts.</li>
+				</ul>
+			</div>
+
+			<div style={styles.links}>
+				<a
+					href={ISSUE_URL}
+					target="_blank"
+					rel="noopener"
+					style={styles.linkButton}>
+					<Github size={16} /> Tracking issue #11138
+					<ExternalLink size={14} />
+				</a>
+				<a href={PROJECT_MDX} style={styles.linkButton}>
+					<Container size={16} /> Project docs
+					<ExternalLink size={14} />
+				</a>
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGameOpsPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGameOpsPanel.tsx
@@ -1,0 +1,208 @@
+import { useStore } from '@nanostores/react';
+import {
+	ShieldOff,
+	Gamepad2,
+	Factory,
+	Pickaxe,
+	ArrowRight,
+} from 'lucide-react';
+import { homeService } from './homeService';
+
+type TileStatus = 'live' | 'phase-0' | 'planned';
+
+interface Tile {
+	key: string;
+	label: string;
+	description: string;
+	href: string;
+	icon: React.ComponentType<{ size?: number; color?: string }>;
+	status: TileStatus;
+	statusNote: string;
+}
+
+const TILES: Tile[] = [
+	{
+		key: 'rows',
+		label: 'ROWS — ChuckRPG',
+		description:
+			'Agones fleet for the ChuckRPG MMO. Live RCON-equivalent control plane, fleet status, telemetry.',
+		href: '/dashboard/gameops/rows/',
+		icon: Gamepad2,
+		status: 'live',
+		statusNote: 'Live · Agones fleet + telemetry',
+	},
+	{
+		key: 'factorio',
+		label: 'Factorio',
+		description:
+			'KBVE-baked Factorio dedicated server. Image landed; GameServer manifests + factorio-ctl backend land in later phases.',
+		href: '/dashboard/gameops/factorio/',
+		icon: Factory,
+		status: 'phase-0',
+		statusNote: 'Phase 0 · Image published, no live data yet',
+	},
+	{
+		key: 'mc',
+		label: 'Minecraft',
+		description:
+			'Velocity proxy + Paper backends already deployed under apps/kube/agones/mc/. Live dashboard wiring still TBD.',
+		href: '/dashboard/gameops/mc/',
+		icon: Pickaxe,
+		status: 'planned',
+		statusNote: 'Planned · Deployed in cluster, not yet wired to dashboard',
+	},
+];
+
+const statusColors: Record<TileStatus, string> = {
+	live: 'var(--sl-color-green, #3fb950)',
+	'phase-0': 'var(--sl-color-orange, #d29922)',
+	planned: 'var(--sl-color-gray-3, #8b949e)',
+};
+
+const styles = {
+	centered: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '1rem',
+		minHeight: '40vh',
+		textAlign: 'center' as const,
+	},
+	heading: {
+		margin: 0,
+		fontSize: '1.75rem',
+		color: 'var(--sl-color-text, #e6edf3)',
+	},
+	sub: {
+		margin: 0,
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		maxWidth: '40rem',
+	},
+	header: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '0.5rem',
+		marginBottom: '1.5rem',
+	},
+	grid: {
+		display: 'grid',
+		gap: '1rem',
+		gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+	},
+	tile: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '0.75rem',
+		padding: '1.25rem',
+		borderRadius: '0.75rem',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		background: 'var(--sl-color-bg-nav, rgba(13, 17, 23, 0.6))',
+		color: 'var(--sl-color-text, #e6edf3)',
+		textDecoration: 'none',
+		transition: 'border-color 0.15s ease, transform 0.15s ease',
+		minHeight: '12rem',
+	},
+	tileRow: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.75rem',
+	},
+	tileTitle: {
+		margin: 0,
+		fontSize: '1.1rem',
+		fontWeight: 600,
+	},
+	tileDesc: {
+		margin: 0,
+		flex: 1,
+		fontSize: '0.9rem',
+		color: 'var(--sl-color-gray-2, #c9d1d9)',
+	},
+	statusBadge: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+		fontSize: '0.8rem',
+		fontWeight: 500,
+	},
+	statusDot: {
+		width: '0.5rem',
+		height: '0.5rem',
+		borderRadius: '50%',
+		display: 'inline-block',
+	},
+	tileFooter: {
+		display: 'flex',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		fontSize: '0.85rem',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+	},
+};
+
+export default function ReactGameOpsPanel() {
+	const isStaff = useStore(homeService.$isStaff);
+
+	if (!isStaff) {
+		return (
+			<div style={styles.centered}>
+				<ShieldOff size={48} color="var(--sl-color-gray-3)" />
+				<h2 style={styles.heading}>Staff Access Required</h2>
+				<p style={styles.sub}>
+					GameOps is restricted to KBVE staff. Sign in with a staff
+					account, or contact an administrator if you believe this is
+					an error.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<header style={styles.header}>
+				<h1 style={styles.heading}>GameOps</h1>
+				<p style={styles.sub}>
+					Central console for the KBVE game-server fleet. Each tile is
+					a live or planned control plane for one Agones-managed
+					title.
+				</p>
+			</header>
+
+			<div style={styles.grid} role="list">
+				{TILES.map((tile) => {
+					const Icon = tile.icon;
+					return (
+						<a
+							key={tile.key}
+							href={tile.href}
+							role="listitem"
+							style={styles.tile}>
+							<div style={styles.tileRow}>
+								<Icon
+									size={24}
+									color="var(--sl-color-accent, #2f81f7)"
+								/>
+								<h3 style={styles.tileTitle}>{tile.label}</h3>
+							</div>
+							<p style={styles.tileDesc}>{tile.description}</p>
+							<div style={styles.tileFooter}>
+								<span style={styles.statusBadge}>
+									<span
+										style={{
+											...styles.statusDot,
+											background:
+												statusColors[tile.status],
+										}}
+									/>
+									{tile.statusNote}
+								</span>
+								<ArrowRight size={16} />
+							</div>
+						</a>
+					);
+				})}
+			</div>
+		</>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactHomeServiceCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactHomeServiceCards.tsx
@@ -496,12 +496,12 @@ export default function ReactHomeServiceCards() {
 				</ServiceCard>
 			)}
 
-			{/* ROWS — Game Server Operations (staff only) */}
+			{/* GameOps — central panel for all game servers (staff only) */}
 			{isStaff && (
 				<ServiceCard
-					title="Game Ops (ROWS)"
-					description="ChuckRPG game server backend"
-					href="/dashboard/rows/"
+					title="GameOps"
+					description="ROWS, Factorio, and MC control panels"
+					href="/dashboard/gameops/"
 					icon={<Gamepad2 size={18} />}
 					accentColor="#f97316"
 					status={rowsStatus}>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactMcDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactMcDashboard.tsx
@@ -1,0 +1,186 @@
+import { useStore } from '@nanostores/react';
+import {
+	Pickaxe,
+	ShieldOff,
+	Github,
+	ExternalLink,
+	Container,
+	Server,
+	Boxes,
+} from 'lucide-react';
+import { homeService } from './homeService';
+
+const VELOCITY_IMAGE = 'ghcr.io/kbve/mc-velocity';
+const LOBBY_IMAGE = 'ghcr.io/kbve/mc-lobby';
+const MANIFESTS_PATH = '/docs/project/mc-velocity/';
+const REPO_PATH = 'https://github.com/KBVE/kbve/tree/main/apps/kube/agones/mc';
+
+const styles = {
+	centered: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '1rem',
+		minHeight: '40vh',
+		textAlign: 'center' as const,
+	},
+	heading: {
+		margin: 0,
+		fontSize: '1.75rem',
+		color: 'var(--sl-color-text, #e6edf3)',
+	},
+	sub: {
+		margin: 0,
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		maxWidth: '40rem',
+	},
+	header: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.75rem',
+		marginBottom: '1rem',
+	},
+	statusRow: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.5rem',
+		padding: '0.35rem 0.75rem',
+		borderRadius: '999px',
+		fontSize: '0.85rem',
+		fontWeight: 500,
+		background: 'rgba(139, 148, 158, 0.15)',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		border: '1px solid rgba(139, 148, 158, 0.4)',
+	},
+	statusDot: {
+		width: '0.5rem',
+		height: '0.5rem',
+		borderRadius: '50%',
+		background: 'var(--sl-color-gray-3, #8b949e)',
+	},
+	grid: {
+		display: 'grid',
+		gap: '1rem',
+		gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+		marginTop: '1.5rem',
+	},
+	card: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '0.5rem',
+		padding: '1rem 1.25rem',
+		borderRadius: '0.75rem',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		background: 'var(--sl-color-bg-nav, rgba(13, 17, 23, 0.6))',
+	},
+	cardLabel: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.5rem',
+		fontSize: '0.85rem',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+	},
+	cardValue: {
+		margin: 0,
+		fontSize: '1rem',
+		fontFamily: 'var(--sl-font-mono, ui-monospace, monospace)',
+		color: 'var(--sl-color-text, #e6edf3)',
+		wordBreak: 'break-all' as const,
+	},
+	links: {
+		display: 'flex',
+		gap: '0.75rem',
+		flexWrap: 'wrap' as const,
+		marginTop: '1.5rem',
+	},
+	linkButton: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.5rem',
+		padding: '0.5rem 0.9rem',
+		borderRadius: '0.5rem',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		background: 'var(--sl-color-bg-nav, rgba(13, 17, 23, 0.6))',
+		color: 'var(--sl-color-text, #e6edf3)',
+		textDecoration: 'none',
+		fontSize: '0.9rem',
+	},
+};
+
+export default function ReactMcDashboard() {
+	const isStaff = useStore(homeService.$isStaff);
+
+	if (!isStaff) {
+		return (
+			<div style={styles.centered}>
+				<ShieldOff size={48} color="var(--sl-color-gray-3)" />
+				<h2 style={styles.heading}>Staff Access Required</h2>
+				<p style={styles.sub}>
+					The Minecraft control panel is restricted to KBVE staff.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div>
+			<div style={styles.header}>
+				<Pickaxe size={28} color="var(--sl-color-accent, #2f81f7)" />
+				<h1 style={styles.heading}>Minecraft</h1>
+			</div>
+			<span style={styles.statusRow}>
+				<span style={styles.statusDot} />
+				Deployed in cluster · Live dashboard wiring planned
+			</span>
+
+			<div style={styles.grid}>
+				<div style={styles.card}>
+					<div style={styles.cardLabel}>
+						<Container size={16} />
+						Velocity proxy image
+					</div>
+					<p style={styles.cardValue}>{VELOCITY_IMAGE}</p>
+				</div>
+				<div style={styles.card}>
+					<div style={styles.cardLabel}>
+						<Container size={16} />
+						Lobby image
+					</div>
+					<p style={styles.cardValue}>{LOBBY_IMAGE}</p>
+				</div>
+				<div style={styles.card}>
+					<div style={styles.cardLabel}>
+						<Server size={16} />
+						Cluster manifests
+					</div>
+					<p style={styles.cardValue}>apps/kube/agones/mc/</p>
+				</div>
+				<div style={styles.card}>
+					<div style={styles.cardLabel}>
+						<Boxes size={16} />
+						Live RCON / player count
+					</div>
+					<p style={styles.cardValue}>
+						not yet wired into this dashboard
+					</p>
+				</div>
+			</div>
+
+			<div style={styles.links}>
+				<a
+					href={REPO_PATH}
+					target="_blank"
+					rel="noopener"
+					style={styles.linkButton}>
+					<Github size={16} /> Manifests on GitHub
+					<ExternalLink size={14} />
+				</a>
+				<a href={MANIFESTS_PATH} style={styles.linkButton}>
+					<Container size={16} /> mc-velocity project docs
+					<ExternalLink size={14} />
+				</a>
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/factorio/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/factorio/index.mdx
@@ -1,0 +1,21 @@
+---
+title: Factorio Dashboard
+description: Agones-managed Factorio dedicated server — staff control panel.
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: Factorio
+    order: 3
+unsplash: 1605647540924-852290f6b0d5
+img: https://images.unsplash.com/photo-1605647540924-852290f6b0d5?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - factorio
+    - agones
+    - staff
+---
+
+import AstroFactorioDashboard from '@/components/dashboard/AstroFactorioDashboard.astro';
+
+<AstroFactorioDashboard />

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/index.mdx
@@ -1,0 +1,21 @@
+---
+title: GameOps Dashboard
+description: Central staff console for the KBVE game-server fleet — ROWS (ChuckRPG), Factorio, and Minecraft.
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: GameOps (Staff)
+    order: 1
+unsplash: 1538481199705-c710c4e965fc
+img: https://images.unsplash.com/photo-1538481199705-c710c4e965fc?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - gameops
+    - agones
+    - staff
+---
+
+import AstroGameOpsPanel from '@/components/dashboard/AstroGameOpsPanel.astro';
+
+<AstroGameOpsPanel />

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/mc/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/mc/index.mdx
@@ -1,0 +1,21 @@
+---
+title: Minecraft Dashboard
+description: Agones-managed Minecraft fleet (Velocity proxy + Paper backends) — staff control panel.
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: Minecraft
+    order: 4
+unsplash: 1587573089734-09cb69c0f2b4
+img: https://images.unsplash.com/photo-1587573089734-09cb69c0f2b4?fit=crop&w=1400&h=700&q=75
+tags:
+    - dashboard
+    - minecraft
+    - agones
+    - staff
+---
+
+import AstroMcDashboard from '@/components/dashboard/AstroMcDashboard.astro';
+
+<AstroMcDashboard />

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/rows/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/rows/index.mdx
@@ -5,7 +5,7 @@ tableOfContents: false
 graph:
     visible: false
 sidebar:
-    label: ROWS (Game Ops)
+    label: ROWS
     order: 2
 unsplash: 1558494949-ef010cbdcc31
 img: https://images.unsplash.com/photo-1558494949-ef010cbdcc31?fit=crop&w=1400&h=700&q=75


### PR DESCRIPTION
## Summary

Stand up a central staff console for the KBVE game-server fleet at `/dashboard/gameops/`. Each tile is a dedicated nested route gated on the existing `homeService.\$isStaff` store, so the panel itself and every sub-page render `"Staff Access Required"` for non-staff sessions.

### Routes

| Path | Purpose |
|---|---|
| `/dashboard/gameops/` | Tile grid landing — Astro `AstroGameOpsPanel` + `ReactGameOpsPanel` |
| `/dashboard/gameops/rows/` | Existing ChuckRPG dashboard, moved from `/dashboard/rows/` (no code changes inside — same `AstroRowsDashboard` + `AstroRowsTelemetry`) |
| `/dashboard/gameops/factorio/` | Phase 0 stub: image name, factorio version, GameServer state placeholder, phasing list, links to issue #11138 + project MDX |
| `/dashboard/gameops/mc/` | Cluster-deployed stub: velocity + lobby image tags, manifest path, placeholder for player count / RCON passthrough |

### Migration

- `astro.config.mjs` redirects `/dashboard/rows/` → `/dashboard/gameops/rows/` (preserves existing bookmarks; verified the built `dashboard/rows/index.html` is a meta-refresh page pointing at the new URL).
- `ReactHomeServiceCards.tsx` — the home dashboard card now reads `"GameOps — ROWS, Factorio, and MC control panels"` and links to the new index.
- Starlight sidebar — replaced the flat `ROWS (Game Ops)` entry with a collapsable `GameOps` group containing Overview, ROWS, Factorio, MC (each carrying the `data-auth-visibility: staff` attr the existing auth-visibility CSS layer reads).

### What lands later (not in this PR)

Phase 3+ wiring for the Factorio / MC tiles: `factorio-ctl` (Axum REST, planned in #11138) + a future `mc-ctl` will back live data (player count, save rotation, RCON passthrough). The panel structure keeps that wiring at the React component level, so no URL or sidebar changes are needed when those backends come online.

Refs: #11138

## Test plan

- [x] \`./kbve.sh -nx astro-kbve:build\` succeeds.
- [x] Built tree contains \`dist/apps/astro-kbve/dashboard/gameops/{index,rows/index,factorio/index,mc/index}.html\`.
- [x] \`dist/apps/astro-kbve/dashboard/rows/index.html\` is a meta-refresh redirect to \`/dashboard/gameops/rows/\`.
- [ ] Sign in as staff → panel renders with three tiles, each navigates to its sub-page.
- [ ] Sign in as non-staff → panel + each sub-page render "Staff Access Required".