### PR TITLE
feat(q,nd-server): load starter buildings + pacing from shared mapdb Zone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12930,6 +12930,7 @@ version = "0.1.1"
 dependencies = [
  "axum 0.7.9",
  "bevy",
+ "bevy_mapdb",
  "bincode",
  "bitflags 2.11.0",
  "crossbeam-channel",

--- a/packages/rust/bevy/bevy_mapdb/src/lib.rs
+++ b/packages/rust/bevy/bevy_mapdb/src/lib.rs
@@ -30,6 +30,7 @@
 mod proto;
 mod registry;
 
+pub use proto::map;
 pub use proto::map::*;
 pub use registry::{MapDb, ProtoMapId};
 

--- a/packages/rust/q/Cargo.toml
+++ b/packages/rust/q/Cargo.toml
@@ -58,6 +58,7 @@ nexus-defense-server = [
     "net-server",
     "bevy-server",
     "supabase-auth",
+    "dep:bevy_mapdb",
 ]
 
 # -----------------------------------------------------------------------------
@@ -83,6 +84,11 @@ rapier2d = { version = "0.22", optional = true }
 
 # Bevy ECS — headless server. No render, no winit; we drive App::update from a tokio task.
 bevy = { version = "0.18", optional = true, default-features = false, features = ["bevy_state"] }
+
+# Shared map registry — Zone authoring lives in the mapdb proto, not in
+# game-specific schema. Server-only because the godot client doesn't load
+# zones today.
+bevy_mapdb = { path = "../bevy/bevy_mapdb", optional = true }
 
 # Networking
 tokio-tungstenite = { version = "0.24", optional = true, default-features = false, features = ["rustls-tls-webpki-roots", "connect"] }

--- a/packages/rust/q/src/nexus_defense_server/mod.rs
+++ b/packages/rust/q/src/nexus_defense_server/mod.rs
@@ -19,11 +19,14 @@ use bevy::ecs::system::Commands;
 use bevy::prelude::{
     Component, IntoScheduleConfigs, Query, Res, ResMut, Resource, Update, With, Without,
 };
+use bevy_mapdb::map;
 use tokio::sync::{broadcast, mpsc};
 use tokio::time;
 
 use crate::net::server::Roster;
 use crate::proto::{self, Input, ServerEvent};
+
+pub mod zone;
 
 /// Server sim tick rate. 20 Hz matches the design budget in #11294.
 pub const SIM_TICK_HZ: u32 = 20;
@@ -50,17 +53,34 @@ const SPAWN_INTERVAL_TICKS: u32 = 10;
 const WAVE_INTERVAL_TICKS: u32 = SIM_TICK_HZ * 5;
 const PREPARE_PHASE_TICKS: u32 = SIM_TICK_HZ * 6;
 
-const STARTER_BUILDING_AXIALS: &[(i32, i32, proto::BuildKind)] = &[
-    (-4, 0, proto::BuildKind::Tower),
-    (4, 0, proto::BuildKind::Tower),
-];
+/// Map a mapdb `WorldObjectDef.ref` slug onto the wire-side `BuildKind`
+/// enum the server already understands. Slugs that aren't known fall
+/// back to `Tower` — the most common starter kind.
+fn build_kind_from_ref(object_def_ref: &str) -> proto::BuildKind {
+    match object_def_ref {
+        "nd-generator" | "solar" | "diesel" | "nuclear" => proto::BuildKind::Generator,
+        "nd-battery" | "battery" => proto::BuildKind::Battery,
+        "nd-repair" | "repair" => proto::BuildKind::Repair,
+        "nd-armoury" | "armoury" => proto::BuildKind::Armoury,
+        "nd-village" | "village" => proto::BuildKind::Village,
+        "nd-town" | "town" => proto::BuildKind::Town,
+        "nd-castle" | "castle" => proto::BuildKind::Castle,
+        "nexus" => proto::BuildKind::Nexus,
+        _ => proto::BuildKind::Tower,
+    }
+}
 
 /// Map current SlotWave state + lives to (phase, phase_remaining_ms).
 /// Wave-active when enemies are still being spawned this wave;
 /// Intermission while waiting for the next wave to start; Prepare for
 /// the very first window before the match opens; GameOver once lives
 /// hit zero.
-fn derive_phase(slot_wave: Option<SlotWave>, lives: i32, tick: u32) -> (proto::MatchPhase, u32) {
+fn derive_phase(
+    slot_wave: Option<SlotWave>,
+    lives: i32,
+    tick: u32,
+    enemies_per_wave: u32,
+) -> (proto::MatchPhase, u32) {
     if lives <= 0 {
         return (proto::MatchPhase::GameOver, 0);
     }
@@ -71,7 +91,7 @@ fn derive_phase(slot_wave: Option<SlotWave>, lives: i32, tick: u32) -> (proto::M
         let remaining = entry.prepare_until_tick.saturating_sub(tick);
         return (proto::MatchPhase::Prepare, ticks_to_ms(remaining));
     }
-    if entry.spawned_in_wave < ENEMIES_PER_WAVE {
+    if entry.spawned_in_wave < enemies_per_wave {
         return (proto::MatchPhase::Wave, 0);
     }
     let remaining = entry.next_wave_tick.saturating_sub(tick);
@@ -247,6 +267,35 @@ pub struct ProjectileTag {
     pub remaining_range: f32,
 }
 
+/// Server-side wrapper around the mapdb [`map::Zone`] currently driving
+/// the match. Constructed once at boot from [`zone::default_zone`]; the
+/// follow-up MDX/codegen integration will swap the constructor for a
+/// runtime lookup against the shared mapdb registry.
+#[derive(Resource, Clone)]
+pub struct ZoneLayout(pub map::Zone);
+
+impl Default for ZoneLayout {
+    fn default() -> Self {
+        Self(zone::default_zone())
+    }
+}
+
+impl ZoneLayout {
+    pub fn enemies_per_wave(&self) -> u32 {
+        zone::read_int_extension(&self.0, zone::EXT_ENEMIES_PER_WAVE)
+            .filter(|v| *v > 0)
+            .map(|v| v as u32)
+            .unwrap_or(ENEMIES_PER_WAVE)
+    }
+
+    pub fn prepare_ticks(&self) -> u32 {
+        zone::read_int_extension(&self.0, zone::EXT_PREPARE_SECONDS)
+            .filter(|v| *v > 0)
+            .map(|v| (v as u32).saturating_mul(SIM_TICK_HZ))
+            .unwrap_or(PREPARE_PHASE_TICKS)
+    }
+}
+
 pub fn build_app(
     tx: broadcast::Sender<ServerEvent>,
     input_rx: mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>,
@@ -265,6 +314,7 @@ pub fn build_app(
         .insert_resource(PlayerEconomy::default())
         .insert_resource(InputBudget::default())
         .insert_resource(GameOverFlags::default())
+        .insert_resource(ZoneLayout::default())
         .add_systems(
             Update,
             (
@@ -296,6 +346,7 @@ fn tick_sim(mut clock: ResMut<SimClock>, mut budget: ResMut<InputBudget>) {
 fn sync_per_slot_state(
     clock: Res<SimClock>,
     roster: Res<RosterHandle>,
+    zone_layout: Res<ZoneLayout>,
     mut wave: ResMut<WaveState>,
     mut economy: ResMut<PlayerEconomy>,
     mut over: ResMut<GameOverFlags>,
@@ -313,7 +364,7 @@ fn sync_per_slot_state(
         }
         active_mask[idx] = true;
         if wave.slots[idx].is_none() {
-            let prepare_until = clock.tick.saturating_add(PREPARE_PHASE_TICKS);
+            let prepare_until = clock.tick.saturating_add(zone_layout.prepare_ticks());
             wave.slots[idx] = Some(SlotWave {
                 next_wave_tick: prepare_until,
                 next_spawn_tick: prepare_until,
@@ -333,7 +384,7 @@ fn sync_per_slot_state(
         if let Some(entry) = wave.slots[idx].as_mut()
             && !entry.starter_spawned
         {
-            spawn_starter_buildings(*slot, &mut commands, clock.tick);
+            spawn_starter_buildings(*slot, &zone_layout.0, &mut commands, clock.tick);
             entry.starter_spawned = true;
         }
     }
@@ -346,16 +397,27 @@ fn sync_per_slot_state(
     }
 }
 
-fn spawn_starter_buildings(slot: proto::PlayerSlot, commands: &mut Commands, tick: u32) {
-    for (col, row, kind) in STARTER_BUILDING_AXIALS {
-        let x = (*col as f32) * 32.0 + 16.0;
-        let y = (*row as f32) * 32.0 + 16.0;
+fn spawn_starter_buildings(
+    slot: proto::PlayerSlot,
+    zone: &map::Zone,
+    commands: &mut Commands,
+    tick: u32,
+) {
+    for placement in &zone.objects {
+        let Some(grid_pos) = placement.grid_pos.as_ref() else {
+            continue;
+        };
+        let col = grid_pos.x;
+        let row = grid_pos.y;
+        let kind = build_kind_from_ref(&placement.object_def_ref);
+        let x = (col as f32) * 32.0 + 16.0;
+        let y = (row as f32) * 32.0 + 16.0;
         let mut spawn = commands.spawn((
             BuildingTag {
-                kind: *kind,
+                kind,
                 owner: slot,
-                col: *col,
-                row: *row,
+                col,
+                row,
             },
             Position(x, y),
             Health {
@@ -363,7 +425,7 @@ fn spawn_starter_buildings(slot: proto::PlayerSlot, commands: &mut Commands, tic
                 max_hp: BUILDING_HP,
             },
         ));
-        if building_is_offensive(*kind) {
+        if building_is_offensive(kind) {
             spawn.insert(TowerStats {
                 last_fire_tick: tick,
             });
@@ -439,7 +501,13 @@ fn apply_input(
     }
 }
 
-fn spawn_wave_enemies(clock: Res<SimClock>, mut wave: ResMut<WaveState>, mut commands: Commands) {
+fn spawn_wave_enemies(
+    clock: Res<SimClock>,
+    zone_layout: Res<ZoneLayout>,
+    mut wave: ResMut<WaveState>,
+    mut commands: Commands,
+) {
+    let enemies_per_wave = zone_layout.enemies_per_wave();
     for idx in 0..proto::MAX_PLAYERS {
         let Some(entry) = wave.slots[idx].as_mut() else {
             continue;
@@ -452,14 +520,14 @@ fn spawn_wave_enemies(clock: Res<SimClock>, mut wave: ResMut<WaveState>, mut com
             continue;
         }
 
-        if clock.tick >= entry.next_wave_tick && entry.spawned_in_wave >= ENEMIES_PER_WAVE {
+        if clock.tick >= entry.next_wave_tick && entry.spawned_in_wave >= enemies_per_wave {
             entry.wave = entry.wave.wrapping_add(1);
             entry.spawned_in_wave = 0;
             entry.next_spawn_tick = clock.tick;
             entry.next_wave_tick = clock.tick + WAVE_INTERVAL_TICKS;
         }
 
-        if entry.spawned_in_wave >= ENEMIES_PER_WAVE {
+        if entry.spawned_in_wave >= enemies_per_wave {
             continue;
         }
         if clock.tick < entry.next_spawn_tick {
@@ -646,6 +714,7 @@ fn emit_snapshot(
     economy: Res<PlayerEconomy>,
     bcast: Res<SnapshotBroadcast>,
     roster: Res<RosterHandle>,
+    zone_layout: Res<ZoneLayout>,
     enemies: Query<(Entity, &EnemyTag, &Position, &Health)>,
     buildings: Query<(Entity, &BuildingTag, &Health)>,
     projectiles: Query<(Entity, &Position, &Velocity, &ProjectileTag)>,
@@ -719,7 +788,12 @@ fn emit_snapshot(
                     lives: STARTING_LIVES,
                     kills: 0,
                 });
-            let (phase, phase_remaining_ms) = derive_phase(slot_wave_state, econ.lives, clock.tick);
+            let (phase, phase_remaining_ms) = derive_phase(
+                slot_wave_state,
+                econ.lives,
+                clock.tick,
+                zone_layout.enemies_per_wave(),
+            );
             proto::FieldDelta {
                 owner: *slot,
                 buildings: building_bins.remove(&slot.0).unwrap_or_default(),

--- a/packages/rust/q/src/nexus_defense_server/zone.rs
+++ b/packages/rust/q/src/nexus_defense_server/zone.rs
@@ -1,0 +1,112 @@
+//! Default Nexus Defense match zone, expressed as a `bevy_mapdb::map::Zone`.
+//!
+//! Lives in Rust today; a follow-up PR lifts this into an MDX entry under
+//! `apps/kbve/astro-kbve/src/content/docs/mapdb/` once the gen-mapdb-data
+//! pipeline learns how to route `type: "zone"` records into
+//! `MapRegistry.zones[]`. Until then, this constructor is the source of
+//! truth and keeps the proto shape stable across the cutover.
+//!
+//! The zone is **mode-agnostic** — only existing mapdb primitives are
+//! used (no `tower_defense` proto extension). Any future TD-style game
+//! (or co-op survival, or PvE arena) can load a zone via `bevy_mapdb`
+//! and walk:
+//!
+//! - `objects[]` — pre-placed defensive buildings (uses
+//!   `WorldObjectPlacement.grid_pos = {x: q, y: r}`).
+//! - `spawn_points[]` — enemy spawn endpoints with
+//!   `category = SPAWN_CATEGORY_ENEMY`.
+//! - `pois[]` — landmark positions (nexus, waypoints, etc).
+//! - `extensions[]` — typed key/value pacing knobs
+//!   (`prepare_seconds`, `enemies_per_wave`).
+
+use bevy_mapdb::map;
+
+/// Extension keys honoured by the server. Use the `nexus_defense.` prefix
+/// so co-existing mapdb consumers can scope their own knobs without
+/// stepping on TD pacing.
+pub const EXT_PREPARE_SECONDS: &str = "nexus_defense.prepare_seconds";
+pub const EXT_ENEMIES_PER_WAVE: &str = "nexus_defense.enemies_per_wave";
+
+pub const ZONE_REF: &str = "nexus-defense-default";
+
+pub const DEFAULT_PREPARE_SECONDS: i64 = 6;
+pub const DEFAULT_ENEMIES_PER_WAVE: i64 = 10;
+
+const STARTER_TOWER_REF: &str = "nd-tower-basic";
+const ENEMY_REF: &str = "nd-enemy-runner";
+
+fn grid(q: i32, r: i32) -> map::GridPos {
+    map::GridPos { x: q, y: r }
+}
+
+fn placement(object_def_ref: &str, q: i32, r: i32) -> map::WorldObjectPlacement {
+    map::WorldObjectPlacement {
+        object_def_ref: object_def_ref.to_string(),
+        grid_pos: Some(grid(q, r)),
+        position: None,
+        rotation_y: None,
+        scale_override: None,
+        seed: None,
+    }
+}
+
+fn extension_int(key: &str, value: i64) -> map::MapExtension {
+    map::MapExtension {
+        key: key.to_string(),
+        value: Some(map::map_extension::Value::IntValue(value)),
+    }
+}
+
+/// Build the default Nexus Defense zone. The fields populated here are
+/// the only ones the server currently reads; everything else stays at
+/// proto defaults so the zone serializes compactly.
+pub fn default_zone() -> map::Zone {
+    map::Zone {
+        r#ref: ZONE_REF.to_string(),
+        name: "Nexus Defense — Default".to_string(),
+        description: Some(
+            "Single-lane horizontal track. Spawn on the left, nexus on the right, \
+             two starter towers flanking the path."
+                .to_string(),
+        ),
+        r#type: map::ZoneType::Arena as i32,
+        biome: map::Biome::Grassland as i32,
+        objects: vec![
+            placement(STARTER_TOWER_REF, -4, 0),
+            placement(STARTER_TOWER_REF, 4, 0),
+        ],
+        spawn_points: vec![map::SpawnPoint {
+            id: "spawn-west".to_string(),
+            category: map::SpawnCategory::Enemy as i32,
+            entity_ref: Some(ENEMY_REF.to_string()),
+            grid_pos: Some(grid(-6, 0)),
+            group_min: Some(1),
+            group_max: Some(1),
+            ..Default::default()
+        }],
+        pois: vec![map::PointOfInterest {
+            id: "nexus-east".to_string(),
+            r#ref: "nexus".to_string(),
+            name: "Nexus".to_string(),
+            r#type: map::PoiType::PoiTower as i32,
+            grid_pos: Some(grid(6, 0)),
+            ..Default::default()
+        }],
+        extensions: vec![
+            extension_int(EXT_PREPARE_SECONDS, DEFAULT_PREPARE_SECONDS),
+            extension_int(EXT_ENEMIES_PER_WAVE, DEFAULT_ENEMIES_PER_WAVE),
+        ],
+        ..Default::default()
+    }
+}
+
+/// Read an int64 extension value by key, or `None` if absent / wrong type.
+pub fn read_int_extension(zone: &map::Zone, key: &str) -> Option<i64> {
+    zone.extensions
+        .iter()
+        .find(|ext| ext.key == key)
+        .and_then(|ext| match ext.value.as_ref()? {
+            map::map_extension::Value::IntValue(v) => Some(*v),
+            _ => None,
+        })
+}


### PR DESCRIPTION
## Summary
Drops the hardcoded \`STARTER_BUILDING_AXIALS\` array in \`q::nexus_defense_server\` and replaces it with a \`bevy_mapdb::map::Zone\` constructed in code. Starter placements, enemy spawn endpoint, nexus POI, and pacing knobs (\`prepare_seconds\`, \`enemies_per_wave\`) all live as mapdb primitives now — **no TD-specific proto message**.

## Why no \`tower_defense\` proto extension?
The mapdb schema already covers what a TD layout needs. Reuse over expansion:

| TD concept | mapdb primitive |
|---|---|
| Starter defensive buildings | \`Zone.objects[]\` (\`WorldObjectPlacement\` with \`grid_pos\`) — \`grid_pos.x = q, grid_pos.y = r\` matches the godot client's axial convention |
| Enemy spawn endpoint(s) | \`Zone.spawn_points[]\` with \`category = SPAWN_CATEGORY_ENEMY\` |
| Nexus marker | \`Zone.pois[]\` with \`type = POI_TOWER\` |
| Pacing constants | \`Zone.extensions[]\` (typed K/V) under the \`nexus_defense.*\` namespace so co-existing mapdb consumers don't collide |

Any future TD-style game can author its own zone in MDX without touching proto.

## Changes
- \`packages/rust/bevy/bevy_mapdb/src/lib.rs\` — re-export the \`map\` module alongside the flat type re-exports so consumers can use \`bevy_mapdb::map::Zone\` (already idiomatic in \`discordsh-bot\`).
- \`packages/rust/q/Cargo.toml\` — \`bevy_mapdb\` joins under the \`nexus-defense-server\` feature.
- \`packages/rust/q/src/nexus_defense_server/zone.rs\` (new) — \`default_zone() -> map::Zone\` constructs the live layout from mapdb primitives; \`read_int_extension(zone, key)\` decodes typed pacing.
- \`packages/rust/q/src/nexus_defense_server/mod.rs\`:
  - new \`ZoneLayout(map::Zone)\` Bevy resource with \`enemies_per_wave()\` + \`prepare_ticks()\` accessors that fall back to the existing consts when the zone omits an extension.
  - \`sync_per_slot_state\` reads \`prepare_ticks\` from the zone and walks \`zone.objects[]\` to spawn starters via the new \`build_kind_from_ref\` slug → \`BuildKind\` mapper.
  - \`spawn_wave_enemies\` + \`derive_phase\` read \`enemies_per_wave\` from the zone instead of the const.
  - \`spawn_starter_buildings\` walks \`WorldObjectPlacement\`s directly.

## Follow-up
- Lift \`default_zone()\` into an MDX entry under \`apps/kbve/astro-kbve/src/content/docs/mapdb/\` and teach \`gen-mapdb-data.mjs\` to route \`type: "zone"\` records into \`MapRegistry.zones[]\`. Until then the constructor IS the source of truth and produces the same proto shape; the cutover is a one-line swap (\`MapDb::from_bytes\` lookup instead of \`default_zone()\`).

## Test plan
- [x] \`cargo clippy -p nd-server --all-targets -- -D warnings\` — clean
- [x] \`cargo build --release -p nd-server\` — clean
- [x] \`./dist/target/release/nd-server\` boots, \`/healthz\` returns \`ok\`, SIGTERM clean
- [ ] PR CI: full lint + manifest guard