### PR TITLE
feat(astro-kbve,edge): per-guild repo allowlist + DiscordSH config (P4+P5 of #11362)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -15,7 +15,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.171",
+			"version": "1.0.172",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -123,7 +123,7 @@
 		{
 			"key": "edge",
 			"app_name": "edge",
-			"version": "0.1.33",
+			"version": "0.1.34",
 			"version_toml": "apps/kbve/edge/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
 			"version_target": "apps/kbve/edge/deno.json",
@@ -221,7 +221,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.19",
+			"version": "0.1.20",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
@@ -1,5 +1,6 @@
 ---
 import ReactAgentDiscordsh from './ReactAgentDiscordsh';
+import ReactAgentBotConfig from './ReactAgentBotConfig';
 ---
 
 <section
@@ -29,7 +30,10 @@ import ReactAgentDiscordsh from './ReactAgentDiscordsh';
 			</p>
 		</header>
 
-		<ReactAgentDiscordsh client:only="react" />
+		<div class="agent-stack">
+			<ReactAgentBotConfig client:only="react" />
+			<ReactAgentDiscordsh client:only="react" />
+		</div>
 	</div>
 </section>
 
@@ -79,5 +83,11 @@ import ReactAgentDiscordsh from './ReactAgentDiscordsh';
 		padding: 0.05rem 0.35rem;
 		border-radius: 4px;
 		font-size: 0.85em;
+	}
+
+	.agent-stack {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
@@ -1,5 +1,6 @@
 ---
 import ReactAgentGithubWizard from './ReactAgentGithubWizard';
+import ReactAgentRepoAllowlist from './ReactAgentRepoAllowlist';
 ---
 
 <section
@@ -37,7 +38,10 @@ import ReactAgentGithubWizard from './ReactAgentGithubWizard';
 			</div>
 		</header>
 
-		<ReactAgentGithubWizard client:only="react" />
+		<div class="agent-stack">
+			<ReactAgentRepoAllowlist client:only="react" />
+			<ReactAgentGithubWizard client:only="react" />
+		</div>
 	</div>
 </section>
 
@@ -131,5 +135,11 @@ import ReactAgentGithubWizard from './ReactAgentGithubWizard';
 		background: rgba(148, 163, 184, 0.12);
 		color: #94a3b8;
 		border-color: rgba(148, 163, 184, 0.25);
+	}
+
+	.agent-stack {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
 	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
@@ -1,0 +1,483 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import { Loader2, RefreshCw, Save, Settings2 } from 'lucide-react';
+import { agentsService, type DiscordshConfig } from './agentsService';
+import { styles } from './dashboard-ui';
+
+const SNOWFLAKE_RE = /^[0-9]{17,20}$/;
+const REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}\/[A-Za-z0-9._-]{1,100}$/;
+
+interface FormState {
+	default_repo: string;
+	claim_channel_id: string;
+	forum_channel_id: string;
+	noticeboard_channel_id: string;
+	taskboard_channel_id: string;
+	max_assignees: string;
+	mirror_pr_events: boolean;
+	active: boolean;
+}
+
+function emptyForm(): FormState {
+	return {
+		default_repo: '',
+		claim_channel_id: '',
+		forum_channel_id: '',
+		noticeboard_channel_id: '',
+		taskboard_channel_id: '',
+		max_assignees: '2',
+		mirror_pr_events: true,
+		active: true,
+	};
+}
+
+function configToForm(c: DiscordshConfig): FormState {
+	const base = emptyForm();
+	return {
+		default_repo: c.default_repo ?? base.default_repo,
+		claim_channel_id: c.claim_channel_id ?? base.claim_channel_id,
+		forum_channel_id: c.forum_channel_id ?? base.forum_channel_id,
+		noticeboard_channel_id:
+			c.noticeboard_channel_id ?? base.noticeboard_channel_id,
+		taskboard_channel_id:
+			c.taskboard_channel_id ?? base.taskboard_channel_id,
+		max_assignees:
+			typeof c.max_assignees === 'number'
+				? String(c.max_assignees)
+				: base.max_assignees,
+		mirror_pr_events:
+			typeof c.mirror_pr_events === 'boolean'
+				? c.mirror_pr_events
+				: base.mirror_pr_events,
+		active: typeof c.active === 'boolean' ? c.active : base.active,
+	};
+}
+
+function formToConfig(f: FormState): DiscordshConfig {
+	const cfg: DiscordshConfig = {
+		mirror_pr_events: f.mirror_pr_events,
+		active: f.active,
+	};
+	if (f.default_repo.trim()) cfg.default_repo = f.default_repo.trim();
+	if (f.claim_channel_id.trim())
+		cfg.claim_channel_id = f.claim_channel_id.trim();
+	if (f.forum_channel_id.trim())
+		cfg.forum_channel_id = f.forum_channel_id.trim();
+	if (f.noticeboard_channel_id.trim())
+		cfg.noticeboard_channel_id = f.noticeboard_channel_id.trim();
+	if (f.taskboard_channel_id.trim())
+		cfg.taskboard_channel_id = f.taskboard_channel_id.trim();
+	const max = parseInt(f.max_assignees, 10);
+	if (!Number.isNaN(max) && max > 0) cfg.max_assignees = max;
+	return cfg;
+}
+
+function fieldError(
+	value: string,
+	kind: 'snowflake' | 'repo' | 'int',
+	required = false,
+): string | null {
+	const trimmed = value.trim();
+	if (!trimmed) return required ? 'Required' : null;
+	if (kind === 'snowflake' && !SNOWFLAKE_RE.test(trimmed)) {
+		return 'Must be a Discord snowflake (17–20 digits)';
+	}
+	if (kind === 'repo' && !REPO_RE.test(trimmed)) {
+		return 'Must be owner/repo';
+	}
+	if (kind === 'int') {
+		const n = parseInt(trimmed, 10);
+		if (Number.isNaN(n) || n < 1 || n > 10) return 'Must be 1–10';
+	}
+	return null;
+}
+
+export default function ReactAgentBotConfig() {
+	const guildId = useStore(agentsService.$selectedGuildId);
+	const guilds = useStore(agentsService.$guilds);
+
+	const [form, setForm] = useState<FormState>(emptyForm);
+	const [loading, setLoading] = useState(false);
+	const [saving, setSaving] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [success, setSuccess] = useState<string | null>(null);
+
+	const load = useCallback(async () => {
+		if (!guildId) return;
+		setLoading(true);
+		setError(null);
+		setSuccess(null);
+		const r = await agentsService.getBotConfig();
+		setLoading(false);
+		if (!r.ok) {
+			setError(r.error);
+			return;
+		}
+		setForm(configToForm(r.config));
+	}, [guildId]);
+
+	useEffect(() => {
+		void load();
+	}, [load]);
+
+	if (!guildId) {
+		return (
+			<section style={styles.sectionBorder}>
+				<div style={{ padding: '0.85rem 1rem' }}>
+					<p
+						style={{
+							margin: 0,
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+						}}>
+						Pick a guild above to manage its DiscordSH config.
+					</p>
+				</div>
+			</section>
+		);
+	}
+
+	const guild = guilds.find((g) => g.id === guildId);
+
+	const errors = {
+		default_repo: fieldError(form.default_repo, 'repo'),
+		claim_channel_id: fieldError(form.claim_channel_id, 'snowflake'),
+		forum_channel_id: fieldError(form.forum_channel_id, 'snowflake'),
+		noticeboard_channel_id: fieldError(
+			form.noticeboard_channel_id,
+			'snowflake',
+		),
+		taskboard_channel_id: fieldError(
+			form.taskboard_channel_id,
+			'snowflake',
+		),
+		max_assignees: fieldError(form.max_assignees, 'int', true),
+	};
+	const anyError = Object.values(errors).some((e) => e !== null);
+
+	async function save() {
+		if (anyError || saving) return;
+		setSaving(true);
+		setError(null);
+		setSuccess(null);
+		const cfg = formToConfig(form);
+		const r = await agentsService.setBotConfig(cfg);
+		setSaving(false);
+		if (!r.ok) {
+			setError(r.error);
+			return;
+		}
+		setSuccess('Saved.');
+		setTimeout(() => setSuccess(null), 2500);
+	}
+
+	function patch<K extends keyof FormState>(k: K, v: FormState[K]) {
+		setForm((prev) => ({ ...prev, [k]: v }));
+	}
+
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<Settings2 size={18} color="#58a6ff" />
+				<strong>Bot config</strong>
+				{guild && (
+					<span
+						style={{
+							marginLeft: '0.4rem',
+							fontSize: '0.75rem',
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontFamily:
+								'var(--sl-font-mono, ui-monospace, monospace)',
+						}}>
+						{guild.id}
+					</span>
+				)}
+				<button
+					type="button"
+					onClick={() => void load()}
+					disabled={loading || saving}
+					style={refreshBtn(loading || saving)}
+					aria-label="Refresh">
+					<RefreshCw
+						size={14}
+						style={loading ? spinIcon : undefined}
+					/>
+					Refresh
+				</button>
+			</header>
+
+			<div
+				style={{
+					padding: '0.85rem 1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.85rem',
+				}}>
+				<p style={muted}>
+					Per-guild knobs the bot reads at startup. Stored as
+					<code> discordsh_config:&lt;guild&gt;</code> in Vault.
+					Channels are raw Discord snowflakes — pick them via
+					right-click → Copy ID in your Discord client (Developer Mode
+					required).
+				</p>
+
+				<Field
+					label="Default repository"
+					hint="Used by /gh shortcuts when no repo argument is supplied. Format: owner/repo."
+					error={errors.default_repo}>
+					<input
+						type="text"
+						value={form.default_repo}
+						placeholder="KBVE/kbve"
+						onChange={(e) => patch('default_repo', e.target.value)}
+						style={mono}
+						spellCheck={false}
+					/>
+				</Field>
+
+				<ChannelField
+					label="Claim channel"
+					hint="Channel that /gh claim posts confirmations to."
+					value={form.claim_channel_id}
+					error={errors.claim_channel_id}
+					onChange={(v) => patch('claim_channel_id', v)}
+				/>
+
+				<ChannelField
+					label="Forum channel"
+					hint="Forum channel where issue threads are created (P2 of #11262)."
+					value={form.forum_channel_id}
+					error={errors.forum_channel_id}
+					onChange={(v) => patch('forum_channel_id', v)}
+				/>
+
+				<ChannelField
+					label="Notice board channel"
+					hint="Channel for /github noticeboard embeds."
+					value={form.noticeboard_channel_id}
+					error={errors.noticeboard_channel_id}
+					onChange={(v) => patch('noticeboard_channel_id', v)}
+				/>
+
+				<ChannelField
+					label="Task board channel"
+					hint="Channel for /github taskboard embeds."
+					value={form.taskboard_channel_id}
+					error={errors.taskboard_channel_id}
+					onChange={(v) => patch('taskboard_channel_id', v)}
+				/>
+
+				<Field
+					label="Max assignees per claim"
+					hint="Refuse /gh claim once an issue already has this many GitHub assignees."
+					error={errors.max_assignees}>
+					<input
+						type="number"
+						value={form.max_assignees}
+						min={1}
+						max={10}
+						onChange={(e) => patch('max_assignees', e.target.value)}
+						style={{ ...input, width: 100 }}
+					/>
+				</Field>
+
+				<label style={toggleRow}>
+					<input
+						type="checkbox"
+						checked={form.mirror_pr_events}
+						onChange={(e) =>
+							patch('mirror_pr_events', e.target.checked)
+						}
+					/>
+					<span>
+						<strong>Mirror PR events</strong>
+						<span style={subtle}>
+							Include pull_request + PR review events when the bot
+							syncs GitHub activity to Discord.
+						</span>
+					</span>
+				</label>
+
+				<label style={toggleRow}>
+					<input
+						type="checkbox"
+						checked={form.active}
+						onChange={(e) => patch('active', e.target.checked)}
+					/>
+					<span>
+						<strong>Active</strong>
+						<span style={subtle}>
+							Mute the bot for this guild without removing it.
+							When false, slash commands no-op and webhook events
+							are dropped.
+						</span>
+					</span>
+				</label>
+
+				{error && <p style={errText}>{error}</p>}
+				{success && (
+					<p style={{ ...muted, color: '#4ade80' }}>{success}</p>
+				)}
+
+				<div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+					<button
+						type="button"
+						onClick={() => void save()}
+						disabled={anyError || saving}
+						style={primaryBtn(!anyError && !saving)}>
+						{saving ? (
+							<Loader2 size={14} style={spinIcon} />
+						) : (
+							<Save size={14} />
+						)}
+						{saving ? 'Saving…' : 'Save config'}
+					</button>
+				</div>
+			</div>
+		</section>
+	);
+}
+
+function Field({
+	label,
+	hint,
+	error,
+	children,
+}: {
+	label: string;
+	hint?: string;
+	error?: string | null;
+	children: React.ReactNode;
+}) {
+	return (
+		<label
+			style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+			<span style={fieldLabel}>{label}</span>
+			{children}
+			{hint && !error && <span style={subtle}>{hint}</span>}
+			{error && <span style={errText}>{error}</span>}
+		</label>
+	);
+}
+
+function ChannelField({
+	label,
+	hint,
+	value,
+	error,
+	onChange,
+}: {
+	label: string;
+	hint?: string;
+	value: string;
+	error: string | null;
+	onChange: (v: string) => void;
+}) {
+	return (
+		<Field label={label} hint={hint} error={error}>
+			<input
+				type="text"
+				value={value}
+				placeholder="Discord snowflake"
+				onChange={(e) => onChange(e.target.value)}
+				style={mono}
+				spellCheck={false}
+			/>
+		</Field>
+	);
+}
+
+const muted: React.CSSProperties = {
+	margin: 0,
+	fontSize: '0.85rem',
+	color: 'var(--sl-color-gray-2, #c2c5cc)',
+	lineHeight: 1.5,
+};
+
+const subtle: React.CSSProperties = {
+	display: 'block',
+	fontSize: '0.75rem',
+	color: 'var(--sl-color-gray-3, #9ca0aa)',
+	marginTop: '0.15rem',
+};
+
+const fieldLabel: React.CSSProperties = {
+	fontSize: '0.8rem',
+	fontWeight: 600,
+	color: 'var(--sl-color-white, #fff)',
+};
+
+const errText: React.CSSProperties = {
+	margin: 0,
+	color: '#f87171',
+	fontSize: '0.78rem',
+};
+
+const input: React.CSSProperties = {
+	background: 'rgba(255,255,255,0.04)',
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	borderRadius: 6,
+	color: 'var(--sl-color-white, #fff)',
+	padding: '0.5rem 0.65rem',
+	fontSize: '0.9rem',
+	boxSizing: 'border-box',
+};
+
+const mono: React.CSSProperties = {
+	...input,
+	fontFamily: 'var(--sl-font-mono, ui-monospace, monospace)',
+	width: '100%',
+};
+
+function primaryBtn(enabled: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+		padding: '0.5rem 1rem',
+		borderRadius: 8,
+		border: 'none',
+		background: enabled ? '#58a6ff' : 'rgba(88,166,255,0.4)',
+		color: '#0d1117',
+		fontWeight: 600,
+		cursor: enabled ? 'pointer' : 'not-allowed',
+		fontSize: '0.9rem',
+	};
+}
+
+function refreshBtn(busy: boolean): React.CSSProperties {
+	return {
+		marginLeft: 'auto',
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.35rem',
+		padding: '0.3rem 0.6rem',
+		borderRadius: 6,
+		border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+		background: 'transparent',
+		color: 'var(--sl-color-white, #fff)',
+		cursor: busy ? 'wait' : 'pointer',
+		fontSize: '0.8rem',
+	};
+}
+
+const toggleRow: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'flex-start',
+	gap: '0.55rem',
+	padding: '0.5rem 0.7rem',
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	borderRadius: 8,
+	background: 'rgba(255,255,255,0.02)',
+};
+
+const spinIcon: React.CSSProperties = {
+	animation: 'spin 1s linear infinite',
+};

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentRepoAllowlist.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentRepoAllowlist.tsx
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import { GitBranch, Loader2, Plus, RefreshCw, Trash2 } from 'lucide-react';
+import { agentsService } from './agentsService';
+import { styles } from './dashboard-ui';
+
+const REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}\/[A-Za-z0-9._-]{1,100}$/;
+
+export default function ReactAgentRepoAllowlist() {
+	const guildId = useStore(agentsService.$selectedGuildId);
+	const guilds = useStore(agentsService.$guilds);
+
+	const [repos, setRepos] = useState<string[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [draft, setDraft] = useState('');
+	const [saving, setSaving] = useState(false);
+
+	const load = useCallback(async () => {
+		if (!guildId) {
+			setRepos([]);
+			return;
+		}
+		setLoading(true);
+		setError(null);
+		const r = await agentsService.getRepoAllowlist();
+		setLoading(false);
+		if (!r.ok) {
+			setError(r.error);
+			return;
+		}
+		setRepos(r.repos);
+	}, [guildId]);
+
+	useEffect(() => {
+		void load();
+	}, [load]);
+
+	if (!guildId) {
+		return (
+			<section style={styles.sectionBorder}>
+				<div style={{ padding: '0.85rem 1rem' }}>
+					<p
+						style={{
+							margin: 0,
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+						}}>
+						Pick a guild above to manage its repo allowlist.
+					</p>
+				</div>
+			</section>
+		);
+	}
+
+	const guild = guilds.find((g) => g.id === guildId);
+	const draftOk = REPO_RE.test(draft) && !repos.includes(draft);
+
+	async function add() {
+		if (!draftOk) return;
+		setSaving(true);
+		setError(null);
+		const next = [...repos, draft];
+		const r = await agentsService.setRepoAllowlist(next);
+		setSaving(false);
+		if (!r.ok) {
+			setError(r.error);
+			return;
+		}
+		setRepos(next);
+		setDraft('');
+	}
+
+	async function remove(repo: string) {
+		setSaving(true);
+		setError(null);
+		const next = repos.filter((r) => r !== repo);
+		const r = await agentsService.setRepoAllowlist(next);
+		setSaving(false);
+		if (!r.ok) {
+			setError(r.error);
+			return;
+		}
+		setRepos(next);
+	}
+
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<GitBranch size={18} color="#34d399" />
+				<strong>Repo allowlist</strong>
+				{guild && (
+					<span
+						style={{
+							marginLeft: '0.4rem',
+							fontSize: '0.75rem',
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontFamily:
+								'var(--sl-font-mono, ui-monospace, monospace)',
+						}}>
+						{guild.id}
+					</span>
+				)}
+				<button
+					type="button"
+					onClick={() => void load()}
+					disabled={loading || saving}
+					style={refreshBtn(loading || saving)}
+					aria-label="Refresh">
+					<RefreshCw
+						size={14}
+						style={loading ? spinIcon : undefined}
+					/>
+					Refresh
+				</button>
+			</header>
+
+			<div
+				style={{
+					padding: '0.85rem 1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.65rem',
+				}}>
+				<p style={muted}>
+					Repos that gh-webhook will accept events for and that
+					gh-backfill defaults to. Stored as{' '}
+					<code>github_repos:&lt;guild&gt;</code> in Vault. Falls back
+					to the edge env <code>GH_WEBHOOK_ALLOWED_REPOS</code> when
+					no row is set.
+				</p>
+
+				{error && <p style={errText}>{error}</p>}
+
+				{!loading && repos.length === 0 && (
+					<p style={{ ...muted, fontStyle: 'italic' }}>
+						No repos in the allowlist yet. Add at least one for this
+						guild to receive webhook events.
+					</p>
+				)}
+
+				{repos.length > 0 && (
+					<ul
+						style={{
+							margin: 0,
+							padding: 0,
+							listStyle: 'none',
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '0.3rem',
+						}}>
+						{repos.map((r) => (
+							<li
+								key={r}
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									justifyContent: 'space-between',
+									padding: '0.4rem 0.6rem',
+									borderRadius: 6,
+									border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+									background: 'rgba(255,255,255,0.02)',
+								}}>
+								<code
+									style={{
+										fontFamily:
+											'var(--sl-font-mono, ui-monospace, monospace)',
+									}}>
+									{r}
+								</code>
+								<button
+									type="button"
+									onClick={() => void remove(r)}
+									disabled={saving}
+									style={dangerSmallBtn(saving)}
+									aria-label={`Remove ${r}`}>
+									<Trash2 size={12} />
+									Remove
+								</button>
+							</li>
+						))}
+					</ul>
+				)}
+
+				<div
+					style={{
+						display: 'flex',
+						gap: '0.4rem',
+						alignItems: 'stretch',
+					}}>
+					<input
+						type="text"
+						value={draft}
+						placeholder="owner/repo (e.g. KBVE/kbve)"
+						onChange={(e) => setDraft(e.target.value)}
+						style={{
+							...inputStyle,
+							fontFamily:
+								'var(--sl-font-mono, ui-monospace, monospace)',
+							flex: 1,
+						}}
+						spellCheck={false}
+					/>
+					<button
+						type="button"
+						onClick={() => void add()}
+						disabled={!draftOk || saving}
+						style={primaryBtn(draftOk && !saving)}>
+						{saving ? (
+							<Loader2 size={14} style={spinIcon} />
+						) : (
+							<Plus size={14} />
+						)}
+						{saving ? 'Saving…' : 'Add'}
+					</button>
+				</div>
+				{draft.length > 0 && !REPO_RE.test(draft) && (
+					<p style={errText}>
+						Expected <code>owner/repo</code> matching GitHub's name
+						rules.
+					</p>
+				)}
+			</div>
+		</section>
+	);
+}
+
+const muted: React.CSSProperties = {
+	margin: 0,
+	fontSize: '0.85rem',
+	color: 'var(--sl-color-gray-2, #c2c5cc)',
+	lineHeight: 1.5,
+};
+
+const errText: React.CSSProperties = {
+	margin: 0,
+	color: '#f87171',
+	fontSize: '0.82rem',
+};
+
+const inputStyle: React.CSSProperties = {
+	background: 'rgba(255,255,255,0.04)',
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	borderRadius: 6,
+	color: 'var(--sl-color-white, #fff)',
+	padding: '0.5rem 0.65rem',
+	fontSize: '0.9rem',
+	boxSizing: 'border-box',
+};
+
+function primaryBtn(enabled: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+		padding: '0.45rem 0.9rem',
+		borderRadius: 8,
+		border: 'none',
+		background: enabled ? '#58a6ff' : 'rgba(88,166,255,0.4)',
+		color: '#0d1117',
+		fontWeight: 600,
+		cursor: enabled ? 'pointer' : 'not-allowed',
+		fontSize: '0.85rem',
+	};
+}
+
+function refreshBtn(busy: boolean): React.CSSProperties {
+	return {
+		marginLeft: 'auto',
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.35rem',
+		padding: '0.3rem 0.6rem',
+		borderRadius: 6,
+		border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+		background: 'transparent',
+		color: 'var(--sl-color-white, #fff)',
+		cursor: busy ? 'wait' : 'pointer',
+		fontSize: '0.8rem',
+	};
+}
+
+function dangerSmallBtn(busy: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.25rem',
+		padding: '0.25rem 0.5rem',
+		borderRadius: 6,
+		border: '1px solid rgba(239,68,68,0.4)',
+		background: 'transparent',
+		color: '#f87171',
+		cursor: busy ? 'wait' : 'pointer',
+		fontSize: '0.75rem',
+	};
+}
+
+const spinIcon: React.CSSProperties = {
+	animation: 'spin 1s linear infinite',
+};

--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -16,6 +16,17 @@ export interface DiscordGuild {
 	permissions: string;
 }
 
+export interface DiscordshConfig {
+	default_repo?: string;
+	claim_channel_id?: string;
+	forum_channel_id?: string;
+	noticeboard_channel_id?: string;
+	taskboard_channel_id?: string;
+	max_assignees?: number;
+	mirror_pr_events?: boolean;
+	active?: boolean;
+}
+
 export interface AgentTokenRow {
 	token_id: string;
 	token_name: string;
@@ -254,6 +265,118 @@ class AgentsService {
 			severity: 'success',
 			duration: 3500,
 		});
+		return { ok: true };
+	}
+
+	public async peekToken(
+		service: string,
+	): Promise<
+		{ ok: true; value: string | null } | { ok: false; error: string }
+	> {
+		const guildId = this.$selectedGuildId.get();
+		const accessToken = this.$accessToken.get();
+		const providerToken = this.$providerToken.get();
+		if (!guildId || !accessToken || !providerToken) {
+			return { ok: false, error: 'No guild selected or session missing' };
+		}
+
+		const resp = await this.callGuildVault(
+			'tokens.peek_token',
+			accessToken,
+			{
+				server_id: guildId,
+				provider_token: providerToken,
+				service,
+			},
+		);
+
+		if (!resp.ok) return { ok: false, error: resp.error };
+		const value =
+			(resp.body as { value?: string | null } | null)?.value ?? null;
+		return { ok: true, value };
+	}
+
+	public async getRepoAllowlist(): Promise<
+		| {
+				ok: true;
+				repos: string[];
+				raw: string | null;
+		  }
+		| { ok: false; error: string }
+	> {
+		const r = await this.peekToken('github_repos');
+		if (!r.ok) return { ok: false, error: r.error };
+		if (!r.value) return { ok: true, repos: [], raw: null };
+		try {
+			const parsed = JSON.parse(r.value) as { repos?: unknown };
+			const repos = Array.isArray(parsed.repos)
+				? parsed.repos.filter((x): x is string => typeof x === 'string')
+				: [];
+			return { ok: true, repos, raw: r.value };
+		} catch {
+			return { ok: true, repos: [], raw: r.value };
+		}
+	}
+
+	public async setRepoAllowlist(
+		repos: string[],
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		const tokens = this.$tokens.get();
+		const existing = tokens.find((t) => t.service === 'github_repos');
+		const value = JSON.stringify({ repos });
+
+		if (existing) {
+			const r = await this.deleteToken(existing.token_id);
+			if (!r.ok) return { ok: false, error: r.error };
+		}
+		const r = await this.addToken({
+			tokenName: 'github-repos',
+			service: 'github_repos',
+			tokenValue: value,
+			description:
+				'Per-guild repo allowlist consumed by gh-webhook and gh-backfill',
+		});
+		if (!r.ok) return { ok: false, error: r.error };
+		return { ok: true };
+	}
+
+	public async getBotConfig(): Promise<
+		| {
+				ok: true;
+				config: DiscordshConfig;
+		  }
+		| { ok: false; error: string }
+	> {
+		const r = await this.peekToken('discordsh_config');
+		if (!r.ok) return { ok: false, error: r.error };
+		if (!r.value) return { ok: true, config: {} };
+		try {
+			const parsed = JSON.parse(r.value) as Record<string, unknown>;
+			return { ok: true, config: parsed as DiscordshConfig };
+		} catch {
+			return { ok: true, config: {} };
+		}
+	}
+
+	public async setBotConfig(
+		config: DiscordshConfig,
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		const tokens = this.$tokens.get();
+		const existing = tokens.find((t) => t.service === 'discordsh_config');
+		const value = JSON.stringify(config);
+
+		if (existing) {
+			const r = await this.deleteToken(existing.token_id);
+			if (!r.ok) return { ok: false, error: r.error };
+		}
+		const r = await this.addToken({
+			tokenName: 'discordsh-config',
+			service: 'discordsh_config',
+			tokenValue: value,
+			description:
+				'Per-guild DiscordSH bot config (channels, defaults, toggles)',
+		});
+		if (!r.ok) return { ok: false, error: r.error };
 		return { ok: true };
 	}
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.33"
+version: "0.1.34"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json

--- a/apps/kbve/edge/functions/gh-backfill/index.ts
+++ b/apps/kbve/edge/functions/gh-backfill/index.ts
@@ -48,6 +48,27 @@ function isValidSegment(s: unknown): s is string {
   return typeof s === "string" && REPO_RE.test(s);
 }
 
+async function loadRepoAllowlist(
+  // deno-lint-ignore no-explicit-any
+  sb: any,
+  guildId: string,
+): Promise<Set<string>> {
+  try {
+    const { data, error } = await sb.rpc("bot_get_guild_token", {
+      p_server_id: guildId,
+      p_service: "github_repos",
+    });
+    if (error || typeof data !== "string") return new Set();
+    const parsed = JSON.parse(data) as { repos?: unknown };
+    const list = Array.isArray(parsed.repos)
+      ? parsed.repos.filter((x): x is string => typeof x === "string")
+      : [];
+    return new Set(list.map((r) => r.trim().toLowerCase()));
+  } catch {
+    return new Set();
+  }
+}
+
 async function fetchPage(
   token: string,
   owner: string,
@@ -146,6 +167,21 @@ serve(async (req) => {
       },
       404,
     );
+  }
+
+  const allowlist = await loadRepoAllowlist(sb, guildId);
+  if (allowlist.size > 0) {
+    const requested = `${body.owner}/${body.repo}`.toLowerCase();
+    if (!allowlist.has(requested)) {
+      return jsonResponse(
+        {
+          error:
+            `Repo '${requested}' is not in this guild's allowlist. Add it under /dashboard/agents/github/.`,
+          allowlist: Array.from(allowlist),
+        },
+        403,
+      );
+    }
   }
 
   let upserted = 0;

--- a/apps/kbve/edge/functions/gh-webhook/index.ts
+++ b/apps/kbve/edge/functions/gh-webhook/index.ts
@@ -70,6 +70,36 @@ function parseAllowlist(raw: string | undefined): Set<string> {
   );
 }
 
+async function resolveAllowlist(
+  // deno-lint-ignore no-explicit-any
+  sb: any,
+  guildId: string,
+): Promise<Set<string>> {
+  try {
+    const { data, error } = await sb.rpc("bot_get_guild_token", {
+      p_server_id: guildId,
+      p_service: "github_repos",
+    });
+    if (error) {
+      console.warn(
+        "gh-webhook: github_repos lookup failed; falling back to env",
+        error.message,
+      );
+      return ALLOWED_REPOS;
+    }
+    if (typeof data !== "string") return ALLOWED_REPOS;
+    const parsed = JSON.parse(data) as { repos?: unknown };
+    const list = Array.isArray(parsed.repos)
+      ? parsed.repos.filter((x): x is string => typeof x === "string")
+      : [];
+    if (list.length === 0) return ALLOWED_REPOS;
+    return new Set(list.map((r) => r.trim().toLowerCase()));
+  } catch (e) {
+    console.warn("gh-webhook: parse error on github_repos; env fallback", e);
+    return ALLOWED_REPOS;
+  }
+}
+
 async function verifySignature(
   secret: string,
   signatureHeader: string | null,
@@ -217,7 +247,8 @@ serve(async (req) => {
   }
 
   const fullName = `${repoInfo.owner}/${repoInfo.repo}`.toLowerCase();
-  if (ALLOWED_REPOS.size > 0 && !ALLOWED_REPOS.has(fullName)) {
+  const allowlist = await resolveAllowlist(sb, guildId);
+  if (allowlist.size > 0 && !allowlist.has(fullName)) {
     return jsonResponse(
       { ok: true, skipped: `repo not allowlisted: ${fullName}`, guild: guildId },
       200,

--- a/apps/kbve/edge/functions/guild-vault/tokens.ts
+++ b/apps/kbve/edge/functions/guild-vault/tokens.ts
@@ -23,6 +23,13 @@ import { safeRpcError } from "../_shared/validators.ts";
 
 type Handler = (req: GuildVaultRequest) => Promise<Response>;
 
+// Services whose decrypted value is non-secret config that the agents
+// dashboard needs to render. Everything not on this list stays bot-only.
+const PEEKABLE_SERVICES = new Set([
+	"github_repos",
+	"discordsh_config",
+]);
+
 const handlers: Record<string, Handler> = {
   async set_token({ userId, body }) {
     const {
@@ -223,6 +230,49 @@ const handlers: Record<string, Handler> = {
       row.success ? 200 : 400,
     );
   },
+	async peek_token({ userId, body }) {
+		const { server_id, service, provider_token } = body;
+
+		const ptErr = validateProviderToken(provider_token);
+		if (ptErr) return ptErr;
+
+		const sidErr = validateSnowflake(server_id, "server_id");
+		if (sidErr) return sidErr;
+
+		const svcErr = validateService(service);
+		if (svcErr) return svcErr;
+
+		if (!PEEKABLE_SERVICES.has(service as string)) {
+			return jsonResponse(
+				{
+					error:
+						`service '${service}' is not peekable. Only non-secret config rows are readable through the dashboard.`,
+				},
+				403,
+			);
+		}
+
+		const ownerErr = await verifyGuildOwnership(
+			userId,
+			server_id as string,
+			provider_token as string,
+		);
+		if (ownerErr) return ownerErr;
+
+		const supabase = createServiceClient();
+		const { data, error } = await supabase.rpc("bot_get_guild_token", {
+			p_server_id: server_id as string,
+			p_service: service as string,
+		});
+
+		if (error) {
+			invalidateOwnershipCache(userId, server_id as string);
+			return safeRpcError(error, "guild_vault_rpc");
+		}
+
+		const value = typeof data === "string" ? data : null;
+		return jsonResponse({ success: true, value });
+	},
 };
 
 export const TOKEN_ACTIONS = Object.keys(handlers);


### PR DESCRIPTION
Self-serve slice. After this lands, a Discord guild owner can sign in and configure both the GitHub provider (which repos webhook + backfill accept for their guild) and the DiscordSH bot (default repo, channels, max-assignees, mute toggle) entirely from the dashboard with no curl + no env edits.

## Edge

\`guild-vault/tokens.ts\` — new \`tokens.peek_token\` action. Returns decrypted value only when \`service\` is on a tiny allowlist (\`PEEKABLE_SERVICES = {github_repos, discordsh_config}\`). Everything else stays bot-only. Calls existing \`public.bot_get_guild_token\` RPC server-side after \`verifyGuildOwnership\` succeeds. Lets the UI populate forms from current state without leaking secret tokens.

\`gh-webhook\` — \`resolveAllowlist(sb, guildId)\` reads \`github_repos:<guild>\` via \`bot_get_guild_token\`, parses \`{repos:[...]}\` JSON. Falls back to env \`GH_WEBHOOK_ALLOWED_REPOS\` when row missing / unparseable. Per-delivery repo check now uses this resolved set.

\`gh-backfill\` — \`loadRepoAllowlist(sb, guildId)\`. When set, request's \`owner/repo\` must be in list; 403 otherwise with allowlist returned for context. When missing, preserved existing behavior (any \`owner/repo\` allowed gated only by snowflake + PAT checks).

## Dashboard

\`agentsService.ts\` — \`peekToken(service)\`, \`getRepoAllowlist\` / \`setRepoAllowlist\`, \`getBotConfig\` / \`setBotConfig\`, plus \`DiscordshConfig\` type.

\`ReactAgentRepoAllowlist.tsx\` (new) — list of \`owner/repo\` entries with add + remove + regex validation. Mounted on \`/agents/github/\` above the wizard.

\`ReactAgentBotConfig.tsx\` (new) — per-guild bot config form: default repo, 4 channel IDs (raw Discord snowflakes), \`max_assignees\` (1-10), \`mirror_pr_events\` + \`active\` toggles. Pre-populates from \`peek_token\`. Mounted on \`/agents/discordsh/\` above the token list.

## Version

\`edge.mdx\` 0.1.33 → 0.1.34. Triggers ci-docker rebuild + publish.

## Deferred to follow-up

discordsh-bot (Rust) does not yet read \`discordsh_config:<guild>\`. Storage + UI lands now; bot consumption is the next slice — \`BotGuildConfig\` loader + LRU cache + use sites in \`/gh claim\`, \`/github board\`, default-repo resolution, channel-id routing.

## Verification

- \`./kbve.sh -nx astro-kbve:build\` ✓
- Manifest regenerated
- No new dependencies