### PR TITLE
feat(discordsh-bot): gh.issue_event → Discord forum sync worker (P2 of #11262)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -109,7 +109,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.15",
+			"version": "0.1.16",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",

--- a/apps/discordsh/discordsh-bot/src/discord/bot.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/bot.rs
@@ -184,6 +184,8 @@ async fn event_handler(
 
             super::relay::spawn_irc_forwarder(data.app.clone(), ctx.http.clone());
 
+            super::gh_sync::spawn_gh_sync_worker(data.app.clone(), ctx.http.clone());
+
             // Record shard in tracker (best-effort)
             if let Some(ref tracker) = data.app.tracker {
                 let instance_id = std::env::var("HOSTNAME")

--- a/apps/discordsh/discordsh-bot/src/discord/bot.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/bot.rs
@@ -184,7 +184,11 @@ async fn event_handler(
 
             super::relay::spawn_irc_forwarder(data.app.clone(), ctx.http.clone());
 
-            super::gh_sync::spawn_gh_sync_worker(data.app.clone(), ctx.http.clone());
+            super::gh_sync::spawn_gh_sync_worker(
+                data.app.clone(),
+                ctx.http.clone(),
+                ctx.cache.clone(),
+            );
 
             // Record shard in tracker (best-effort)
             if let Some(ref tracker) = data.app.tracker {

--- a/apps/discordsh/discordsh-bot/src/discord/gh_sync.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/gh_sync.rs
@@ -1,48 +1,34 @@
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+use kbve::entity::client::vault::VaultClient;
 use kbve::{CachedIssue, GithubStore, UndeliveredEvent};
 use poise::serenity_prelude as serenity;
+use serde::Deserialize;
 use serenity::builder::{CreateForumPost, CreateMessage};
+use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
 use crate::state::AppState;
 
-const DEFAULT_OWNER: &str = "KBVE";
-const DEFAULT_REPO: &str = "kbve";
 const DEFAULT_POLL_SECS: u64 = 30;
 const DEFAULT_BATCH: u32 = 10;
 const DEFAULT_LEASE_SECS: u32 = 300;
 const DEFAULT_MAX_ATTEMPTS: u32 = 25;
+const DEFAULT_ROUTING_TTL_SECS: u64 = 300;
 
 #[derive(Debug, Clone)]
 pub struct GhSyncConfig {
-    pub forum_channel_id: serenity::ChannelId,
-    pub guild_id: serenity::GuildId,
-    pub owner: String,
-    pub repo: String,
     pub poll: Duration,
     pub batch: u32,
     pub lease_secs: u32,
     pub max_attempts: u32,
+    pub routing_ttl: Duration,
 }
 
 impl GhSyncConfig {
-    pub fn from_env() -> Option<Self> {
-        let forum = std::env::var("GH_FORUM_CHANNEL_ID")
-            .ok()?
-            .parse::<u64>()
-            .ok()?;
-        let guild = std::env::var("GH_SYNC_GUILD_ID")
-            .or_else(|_| std::env::var("RELAY_GUILD_ID"))
-            .ok()?
-            .parse::<u64>()
-            .ok()?;
-        if forum == 0 || guild == 0 {
-            return None;
-        }
-        let owner = std::env::var("GH_SYNC_OWNER").unwrap_or_else(|_| DEFAULT_OWNER.to_owned());
-        let repo = std::env::var("GH_SYNC_REPO").unwrap_or_else(|_| DEFAULT_REPO.to_owned());
+    pub fn from_env() -> Self {
         let poll_secs = std::env::var("GH_SYNC_POLL_SECS")
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
@@ -63,46 +49,114 @@ impl GhSyncConfig {
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(DEFAULT_MAX_ATTEMPTS)
             .clamp(1, 1000);
+        let routing_ttl_secs = std::env::var("GH_SYNC_ROUTING_TTL_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_ROUTING_TTL_SECS)
+            .max(30);
 
-        Some(Self {
-            forum_channel_id: serenity::ChannelId::new(forum),
-            guild_id: serenity::GuildId::new(guild),
-            owner,
-            repo,
+        Self {
             poll: Duration::from_secs(poll_secs),
             batch,
             lease_secs,
             max_attempts,
-        })
+            routing_ttl: Duration::from_secs(routing_ttl_secs),
+        }
     }
 }
 
-pub fn spawn_gh_sync_worker(app: Arc<AppState>, http: Arc<serenity::Http>) {
-    let Some(cfg) = GhSyncConfig::from_env() else {
-        info!("gh sync not configured (set GH_FORUM_CHANNEL_ID + GH_SYNC_GUILD_ID to enable)");
-        return;
-    };
+#[derive(Debug, Deserialize, Default)]
+struct DiscordshGuildConfig {
+    #[serde(default)]
+    default_repo: Option<String>,
+    #[serde(default)]
+    forum_channel_id: Option<String>,
+    #[serde(default)]
+    active: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum GhReposPayload {
+    Array(Vec<String>),
+    Wrapped { repos: Vec<String> },
+}
+
+impl GhReposPayload {
+    fn into_vec(self) -> Vec<String> {
+        match self {
+            GhReposPayload::Array(v) => v,
+            GhReposPayload::Wrapped { repos } => repos,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Route {
+    guild_id: serenity::GuildId,
+    forum_channel_id: serenity::ChannelId,
+}
+
+#[derive(Debug, Default)]
+struct RoutingTable {
+    map: HashMap<(String, String), Route>,
+    refreshed_at: Option<Instant>,
+}
+
+impl RoutingTable {
+    fn is_fresh(&self, ttl: Duration) -> bool {
+        self.refreshed_at
+            .map(|t| t.elapsed() < ttl)
+            .unwrap_or(false)
+    }
+
+    fn lookup(&self, owner: &str, repo: &str) -> Option<Route> {
+        let key = (owner.to_ascii_lowercase(), repo.to_ascii_lowercase());
+        self.map.get(&key).cloned()
+    }
+}
+
+pub fn spawn_gh_sync_worker(
+    app: Arc<AppState>,
+    http: Arc<serenity::Http>,
+    cache: Arc<serenity::Cache>,
+) {
     if !app.github_store.is_enabled() {
-        warn!("gh sync configured but GithubStore is not — skipping");
+        info!("gh sync: GithubStore not configured, skipping worker");
         return;
     }
+    let Some(vault) = VaultClient::from_env() else {
+        warn!("gh sync: SUPABASE_URL/SERVICE_ROLE_KEY missing, multi-guild routing disabled");
+        return;
+    };
+    let cfg = GhSyncConfig::from_env();
     info!(
-        guild = %cfg.guild_id,
-        forum = %cfg.forum_channel_id,
-        owner = %cfg.owner,
-        repo = %cfg.repo,
         poll_secs = cfg.poll.as_secs(),
-        "Spawning GitHub event → Discord forum sync worker"
+        routing_ttl_secs = cfg.routing_ttl.as_secs(),
+        "Spawning multi-guild GitHub event → Discord forum sync worker"
     );
     let store = app.github_store.clone();
+    let vault = Arc::new(vault);
     tokio::spawn(async move {
-        run_loop(store, http, cfg).await;
+        run_loop(store, http, cache, vault, cfg).await;
     });
 }
 
-async fn run_loop(store: Arc<GithubStore>, http: Arc<serenity::Http>, cfg: GhSyncConfig) {
+async fn run_loop(
+    store: Arc<GithubStore>,
+    http: Arc<serenity::Http>,
+    cache: Arc<serenity::Cache>,
+    vault: Arc<VaultClient>,
+    cfg: GhSyncConfig,
+) {
+    let routes: Arc<RwLock<RoutingTable>> = Arc::new(RwLock::new(RoutingTable::default()));
     loop {
         tokio::time::sleep(cfg.poll).await;
+
+        if !routes.read().await.is_fresh(cfg.routing_ttl) {
+            refresh_routes(&cache, &vault, &routes).await;
+        }
+
         let events = match store.claim_undelivered(cfg.batch, cfg.lease_secs).await {
             Ok(rows) => rows,
             Err(e) => {
@@ -115,31 +169,148 @@ async fn run_loop(store: Arc<GithubStore>, http: Arc<serenity::Http>, cfg: GhSyn
         }
         debug!(count = events.len(), "gh sync: processing batch");
         for ev in events {
-            handle_event(&store, &http, &cfg, ev).await;
+            handle_event(&store, &http, &cfg, &routes, ev).await;
         }
     }
+}
+
+async fn refresh_routes(
+    cache: &Arc<serenity::Cache>,
+    vault: &Arc<VaultClient>,
+    routes: &Arc<RwLock<RoutingTable>>,
+) {
+    let guild_ids: Vec<serenity::GuildId> = cache.guilds();
+    if guild_ids.is_empty() {
+        debug!("gh sync: cache has no guilds yet, deferring routing refresh");
+        return;
+    }
+    let mut new_map: HashMap<(String, String), Route> = HashMap::new();
+    let mut routed_guilds: u32 = 0;
+
+    for gid in guild_ids {
+        let gid_str = gid.get().to_string();
+        let cfg_tag = format!("discordsh_config:{gid_str}");
+        let cfg_json = match vault.get_secret_by_tag(&cfg_tag).await {
+            Ok(s) => s,
+            Err(e) => {
+                debug!(guild = %gid, error = %e, "gh sync: no discordsh_config (guild not opted in)");
+                continue;
+            }
+        };
+        let cfg: DiscordshGuildConfig = match serde_json::from_str(&cfg_json) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(guild = %gid, error = %e, "gh sync: malformed discordsh_config json");
+                continue;
+            }
+        };
+        if !cfg.active {
+            debug!(guild = %gid, "gh sync: discordsh_config inactive");
+            continue;
+        }
+        let Some(forum_id) = cfg
+            .forum_channel_id
+            .as_deref()
+            .and_then(|s| s.parse::<u64>().ok())
+            .filter(|v| *v != 0)
+        else {
+            debug!(guild = %gid, "gh sync: no forum_channel_id set");
+            continue;
+        };
+        let route = Route {
+            guild_id: gid,
+            forum_channel_id: serenity::ChannelId::new(forum_id),
+        };
+
+        let mut repos: Vec<String> = Vec::new();
+        let repos_tag = format!("github_repos:{gid_str}");
+        match vault.get_secret_by_tag(&repos_tag).await {
+            Ok(repos_json) => match serde_json::from_str::<GhReposPayload>(&repos_json) {
+                Ok(p) => repos = p.into_vec(),
+                Err(e) => {
+                    warn!(guild = %gid, error = %e, "gh sync: malformed github_repos json");
+                }
+            },
+            Err(e) => {
+                debug!(guild = %gid, error = %e, "gh sync: no github_repos allowlist");
+            }
+        }
+        if repos.is_empty()
+            && let Some(d) = cfg.default_repo.as_deref()
+        {
+            repos.push(d.to_owned());
+        }
+        if repos.is_empty() {
+            debug!(guild = %gid, "gh sync: no repos to route");
+            continue;
+        }
+        let mut added = 0u32;
+        for spec in repos {
+            let Some((owner, repo)) = parse_owner_repo(&spec) else {
+                warn!(guild = %gid, spec = %spec, "gh sync: bad repo spec, skipping");
+                continue;
+            };
+            let key = (owner.to_ascii_lowercase(), repo.to_ascii_lowercase());
+            if let Some(prev) = new_map.insert(key.clone(), route.clone()) {
+                warn!(
+                    guild = %gid,
+                    prev_guild = %prev.guild_id,
+                    owner = %key.0,
+                    repo = %key.1,
+                    "gh sync: repo claimed by multiple guilds, last writer wins"
+                );
+            }
+            added += 1;
+        }
+        if added > 0 {
+            routed_guilds += 1;
+        }
+    }
+
+    let total_routes = new_map.len();
+    let mut guard = routes.write().await;
+    guard.map = new_map;
+    guard.refreshed_at = Some(Instant::now());
+    info!(
+        guilds = routed_guilds,
+        repos = total_routes,
+        "gh sync: routing table refreshed"
+    );
+}
+
+fn parse_owner_repo(spec: &str) -> Option<(String, String)> {
+    let s = spec.trim().trim_start_matches('@');
+    let mut parts = s.splitn(2, '/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_owned(), repo.to_owned()))
 }
 
 async fn handle_event(
     store: &Arc<GithubStore>,
     http: &Arc<serenity::Http>,
     cfg: &GhSyncConfig,
+    routes: &Arc<RwLock<RoutingTable>>,
     ev: UndeliveredEvent,
 ) {
-    if !ev.owner.eq_ignore_ascii_case(&cfg.owner) || !ev.repo.eq_ignore_ascii_case(&cfg.repo) {
+    let route = routes.read().await.lookup(&ev.owner, &ev.repo);
+    let Some(route) = route else {
         debug!(
             owner = %ev.owner,
             repo = %ev.repo,
             number = ev.number,
-            "gh sync: out-of-scope event, dropping"
+            "gh sync: no guild route for repo, draining event"
         );
         if let Err(e) = store.mark_event_delivered(ev.id, ev.claim_token).await {
-            warn!(error = %e, id = ev.id, "gh sync: failed to discard out-of-scope event");
+            warn!(error = %e, id = ev.id, "gh sync: failed to drain unrouted event");
         }
         return;
-    }
+    };
 
-    match dispatch(store, http, cfg, &ev).await {
+    match dispatch(store, http, &route, &ev).await {
         Ok(()) => match store.mark_event_delivered(ev.id, ev.claim_token).await {
             Ok(true) => {
                 debug!(id = ev.id, event = %ev.event_type, "gh sync: delivered")
@@ -177,7 +348,7 @@ enum DispatchError {
 async fn dispatch(
     store: &Arc<GithubStore>,
     http: &Arc<serenity::Http>,
-    cfg: &GhSyncConfig,
+    route: &Route,
     ev: &UndeliveredEvent,
 ) -> Result<(), DispatchError> {
     let issue = store
@@ -186,9 +357,9 @@ async fn dispatch(
         .ok_or(DispatchError::IssueMissing(ev.number))?;
 
     match ev.event_type.as_str() {
-        "opened" => ensure_thread(store, http, cfg, &issue).await,
+        "opened" => ensure_thread(store, http, route, &issue).await,
         "closed" | "reopened" | "commented" | "labeled" | "assigned" | "unassigned"
-        | "unlabeled" | "edited" | "renamed" => post_into_thread(http, cfg, &issue, ev).await,
+        | "unlabeled" | "edited" | "renamed" => post_into_thread(http, &issue, ev).await,
         _ => {
             debug!(
                 event = %ev.event_type,
@@ -203,7 +374,7 @@ async fn dispatch(
 async fn ensure_thread(
     store: &Arc<GithubStore>,
     http: &Arc<serenity::Http>,
-    cfg: &GhSyncConfig,
+    route: &Route,
     issue: &CachedIssue,
 ) -> Result<(), DispatchError> {
     if issue.discord_thread_id.is_some() {
@@ -218,7 +389,7 @@ async fn ensure_thread(
 
     let msg = CreateMessage::new().content(body);
     let builder = CreateForumPost::new(title, msg);
-    let thread = cfg
+    let thread = route
         .forum_channel_id
         .create_forum_post(&**http, builder)
         .await?;
@@ -229,22 +400,24 @@ async fn ensure_thread(
             &issue.owner,
             &issue.repo,
             issue.number,
-            cfg.guild_id.get() as i64,
-            cfg.forum_channel_id.get() as i64,
+            route.guild_id.get() as i64,
+            route.forum_channel_id.get() as i64,
             thread_id,
         )
         .await?;
     info!(
+        guild = %route.guild_id,
+        owner = %issue.owner,
+        repo = %issue.repo,
         number = issue.number,
         thread = thread_id,
-        "gh sync: forum thread created for issue"
+        "gh sync: forum thread created"
     );
     Ok(())
 }
 
 async fn post_into_thread(
     http: &Arc<serenity::Http>,
-    _cfg: &GhSyncConfig,
     issue: &CachedIssue,
     ev: &UndeliveredEvent,
 ) -> Result<(), DispatchError> {
@@ -326,4 +499,63 @@ fn truncate(s: &str, max: usize) -> String {
     }
     let cut = s.char_indices().nth(max).map(|(i, _)| i).unwrap_or(max);
     format!("{}…", &s[..cut])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_owner_repo_basic() {
+        assert_eq!(
+            parse_owner_repo("KBVE/kbve"),
+            Some(("KBVE".to_owned(), "kbve".to_owned()))
+        );
+    }
+
+    #[test]
+    fn parse_owner_repo_strips_at_and_whitespace() {
+        assert_eq!(
+            parse_owner_repo(" @KBVE/kbve "),
+            Some(("KBVE".to_owned(), "kbve".to_owned()))
+        );
+    }
+
+    #[test]
+    fn parse_owner_repo_rejects_missing_slash() {
+        assert!(parse_owner_repo("kbve").is_none());
+    }
+
+    #[test]
+    fn parse_owner_repo_rejects_empty_side() {
+        assert!(parse_owner_repo("/kbve").is_none());
+        assert!(parse_owner_repo("KBVE/").is_none());
+    }
+
+    #[test]
+    fn routing_lookup_is_case_insensitive() {
+        let mut t = RoutingTable::default();
+        t.map.insert(
+            ("kbve".into(), "kbve".into()),
+            Route {
+                guild_id: serenity::GuildId::new(123),
+                forum_channel_id: serenity::ChannelId::new(456),
+            },
+        );
+        assert!(t.lookup("KBVE", "kbve").is_some());
+        assert!(t.lookup("kbve", "KBVE").is_some());
+        assert!(t.lookup("other", "kbve").is_none());
+    }
+
+    #[test]
+    fn repos_payload_accepts_array() {
+        let p: GhReposPayload = serde_json::from_str(r#"["KBVE/kbve","foo/bar"]"#).unwrap();
+        assert_eq!(p.into_vec(), vec!["KBVE/kbve", "foo/bar"]);
+    }
+
+    #[test]
+    fn repos_payload_accepts_wrapped() {
+        let p: GhReposPayload = serde_json::from_str(r#"{"repos":["KBVE/kbve"]}"#).unwrap();
+        assert_eq!(p.into_vec(), vec!["KBVE/kbve"]);
+    }
 }

--- a/apps/discordsh/discordsh-bot/src/discord/gh_sync.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/gh_sync.rs
@@ -1,0 +1,329 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use kbve::{CachedIssue, GithubStore, UndeliveredEvent};
+use poise::serenity_prelude as serenity;
+use serenity::builder::{CreateForumPost, CreateMessage};
+use tracing::{debug, error, info, warn};
+
+use crate::state::AppState;
+
+const DEFAULT_OWNER: &str = "KBVE";
+const DEFAULT_REPO: &str = "kbve";
+const DEFAULT_POLL_SECS: u64 = 30;
+const DEFAULT_BATCH: u32 = 10;
+const DEFAULT_LEASE_SECS: u32 = 300;
+const DEFAULT_MAX_ATTEMPTS: u32 = 25;
+
+#[derive(Debug, Clone)]
+pub struct GhSyncConfig {
+    pub forum_channel_id: serenity::ChannelId,
+    pub guild_id: serenity::GuildId,
+    pub owner: String,
+    pub repo: String,
+    pub poll: Duration,
+    pub batch: u32,
+    pub lease_secs: u32,
+    pub max_attempts: u32,
+}
+
+impl GhSyncConfig {
+    pub fn from_env() -> Option<Self> {
+        let forum = std::env::var("GH_FORUM_CHANNEL_ID")
+            .ok()?
+            .parse::<u64>()
+            .ok()?;
+        let guild = std::env::var("GH_SYNC_GUILD_ID")
+            .or_else(|_| std::env::var("RELAY_GUILD_ID"))
+            .ok()?
+            .parse::<u64>()
+            .ok()?;
+        if forum == 0 || guild == 0 {
+            return None;
+        }
+        let owner = std::env::var("GH_SYNC_OWNER").unwrap_or_else(|_| DEFAULT_OWNER.to_owned());
+        let repo = std::env::var("GH_SYNC_REPO").unwrap_or_else(|_| DEFAULT_REPO.to_owned());
+        let poll_secs = std::env::var("GH_SYNC_POLL_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_POLL_SECS)
+            .max(5);
+        let batch = std::env::var("GH_SYNC_BATCH")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(DEFAULT_BATCH)
+            .clamp(1, 100);
+        let lease_secs = std::env::var("GH_SYNC_LEASE_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(DEFAULT_LEASE_SECS)
+            .max(30);
+        let max_attempts = std::env::var("GH_SYNC_MAX_ATTEMPTS")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(DEFAULT_MAX_ATTEMPTS)
+            .clamp(1, 1000);
+
+        Some(Self {
+            forum_channel_id: serenity::ChannelId::new(forum),
+            guild_id: serenity::GuildId::new(guild),
+            owner,
+            repo,
+            poll: Duration::from_secs(poll_secs),
+            batch,
+            lease_secs,
+            max_attempts,
+        })
+    }
+}
+
+pub fn spawn_gh_sync_worker(app: Arc<AppState>, http: Arc<serenity::Http>) {
+    let Some(cfg) = GhSyncConfig::from_env() else {
+        info!("gh sync not configured (set GH_FORUM_CHANNEL_ID + GH_SYNC_GUILD_ID to enable)");
+        return;
+    };
+    if !app.github_store.is_enabled() {
+        warn!("gh sync configured but GithubStore is not — skipping");
+        return;
+    }
+    info!(
+        guild = %cfg.guild_id,
+        forum = %cfg.forum_channel_id,
+        owner = %cfg.owner,
+        repo = %cfg.repo,
+        poll_secs = cfg.poll.as_secs(),
+        "Spawning GitHub event → Discord forum sync worker"
+    );
+    let store = app.github_store.clone();
+    tokio::spawn(async move {
+        run_loop(store, http, cfg).await;
+    });
+}
+
+async fn run_loop(store: Arc<GithubStore>, http: Arc<serenity::Http>, cfg: GhSyncConfig) {
+    loop {
+        tokio::time::sleep(cfg.poll).await;
+        let events = match store.claim_undelivered(cfg.batch, cfg.lease_secs).await {
+            Ok(rows) => rows,
+            Err(e) => {
+                warn!(error = %e, "gh sync: claim_undelivered failed");
+                continue;
+            }
+        };
+        if events.is_empty() {
+            continue;
+        }
+        debug!(count = events.len(), "gh sync: processing batch");
+        for ev in events {
+            handle_event(&store, &http, &cfg, ev).await;
+        }
+    }
+}
+
+async fn handle_event(
+    store: &Arc<GithubStore>,
+    http: &Arc<serenity::Http>,
+    cfg: &GhSyncConfig,
+    ev: UndeliveredEvent,
+) {
+    if !ev.owner.eq_ignore_ascii_case(&cfg.owner) || !ev.repo.eq_ignore_ascii_case(&cfg.repo) {
+        debug!(
+            owner = %ev.owner,
+            repo = %ev.repo,
+            number = ev.number,
+            "gh sync: out-of-scope event, dropping"
+        );
+        if let Err(e) = store.mark_event_delivered(ev.id, ev.claim_token).await {
+            warn!(error = %e, id = ev.id, "gh sync: failed to discard out-of-scope event");
+        }
+        return;
+    }
+
+    match dispatch(store, http, cfg, &ev).await {
+        Ok(()) => match store.mark_event_delivered(ev.id, ev.claim_token).await {
+            Ok(true) => {
+                debug!(id = ev.id, event = %ev.event_type, "gh sync: delivered")
+            }
+            Ok(false) => warn!(
+                id = ev.id,
+                "gh sync: mark_delivered no-op (token mismatch?)"
+            ),
+            Err(e) => warn!(error = %e, id = ev.id, "gh sync: mark_delivered failed"),
+        },
+        Err(err) => {
+            let msg = err.to_string();
+            warn!(error = %msg, id = ev.id, event = %ev.event_type, "gh sync: dispatch failed");
+            match store
+                .mark_event_failed(ev.id, ev.claim_token, &msg, cfg.max_attempts)
+                .await
+            {
+                Ok(state) => debug!(id = ev.id, ?state, "gh sync: failure recorded"),
+                Err(e) => warn!(error = %e, id = ev.id, "gh sync: mark_failed errored"),
+            }
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum DispatchError {
+    #[error("gh.issue not in cache for #{0}")]
+    IssueMissing(u32),
+    #[error("store error: {0}")]
+    Store(#[from] kbve::GithubStoreError),
+    #[error("discord http: {0}")]
+    Serenity(#[from] serenity::Error),
+}
+
+async fn dispatch(
+    store: &Arc<GithubStore>,
+    http: &Arc<serenity::Http>,
+    cfg: &GhSyncConfig,
+    ev: &UndeliveredEvent,
+) -> Result<(), DispatchError> {
+    let issue = store
+        .get_issue(&ev.owner, &ev.repo, ev.number)
+        .await?
+        .ok_or(DispatchError::IssueMissing(ev.number))?;
+
+    match ev.event_type.as_str() {
+        "opened" => ensure_thread(store, http, cfg, &issue).await,
+        "closed" | "reopened" | "commented" | "labeled" | "assigned" | "unassigned"
+        | "unlabeled" | "edited" | "renamed" => post_into_thread(http, cfg, &issue, ev).await,
+        _ => {
+            debug!(
+                event = %ev.event_type,
+                number = ev.number,
+                "gh sync: event type not mirrored — dropping"
+            );
+            Ok(())
+        }
+    }
+}
+
+async fn ensure_thread(
+    store: &Arc<GithubStore>,
+    http: &Arc<serenity::Http>,
+    cfg: &GhSyncConfig,
+    issue: &CachedIssue,
+) -> Result<(), DispatchError> {
+    if issue.discord_thread_id.is_some() {
+        debug!(
+            number = issue.number,
+            "gh sync: thread already linked, skipping create"
+        );
+        return Ok(());
+    }
+    let title = truncate(&format!("#{} · {}", issue.number, issue.title), 96);
+    let body = render_issue_body(issue);
+
+    let msg = CreateMessage::new().content(body);
+    let builder = CreateForumPost::new(title, msg);
+    let thread = cfg
+        .forum_channel_id
+        .create_forum_post(&**http, builder)
+        .await?;
+    let thread_id = thread.id.get() as i64;
+
+    store
+        .set_discord_thread(
+            &issue.owner,
+            &issue.repo,
+            issue.number,
+            cfg.guild_id.get() as i64,
+            cfg.forum_channel_id.get() as i64,
+            thread_id,
+        )
+        .await?;
+    info!(
+        number = issue.number,
+        thread = thread_id,
+        "gh sync: forum thread created for issue"
+    );
+    Ok(())
+}
+
+async fn post_into_thread(
+    http: &Arc<serenity::Http>,
+    _cfg: &GhSyncConfig,
+    issue: &CachedIssue,
+    ev: &UndeliveredEvent,
+) -> Result<(), DispatchError> {
+    let Some(thread_id) = issue.discord_thread_id else {
+        debug!(
+            number = issue.number,
+            event = %ev.event_type,
+            "gh sync: no thread linked yet, dropping follow-up event"
+        );
+        return Ok(());
+    };
+    let thread = serenity::ChannelId::new(thread_id as u64);
+    let content = render_event_message(issue, ev);
+    thread.say(&**http, content).await?;
+    Ok(())
+}
+
+fn render_issue_body(issue: &CachedIssue) -> String {
+    let mut out = String::new();
+    let labels = issue.label_names();
+    let assignees = issue.assignee_logins();
+    let author = issue.author.as_deref().unwrap_or("unknown");
+    out.push_str(&format!("Opened by `{author}`\n"));
+    if !labels.is_empty() {
+        out.push_str(&format!("Labels: `{}`\n", labels.join("`, `")));
+    }
+    if !assignees.is_empty() {
+        out.push_str(&format!("Assignees: `{}`\n", assignees.join("`, `")));
+    }
+    out.push_str(&format!("{}\n\n", issue.html_url));
+    if let Some(body) = issue.body.as_deref()
+        && !body.is_empty()
+    {
+        out.push_str(&truncate(body, 1600));
+    }
+    truncate(&out, 1990)
+}
+
+fn render_event_message(issue: &CachedIssue, ev: &UndeliveredEvent) -> String {
+    let actor = ev.actor.as_deref().unwrap_or("unknown");
+    let base = match ev.event_type.as_str() {
+        "closed" => format!("🔒 `{actor}` closed this"),
+        "reopened" => format!("🔄 `{actor}` reopened this"),
+        "commented" => format!("💬 `{actor}` commented"),
+        "labeled" => format!("🏷️ `{actor}` updated labels"),
+        "unlabeled" => format!("🏷️ `{actor}` removed a label"),
+        "assigned" => format!("👤 `{actor}` updated assignees"),
+        "unassigned" => format!("👤 `{actor}` removed an assignee"),
+        "edited" => format!("✏️ `{actor}` edited"),
+        "renamed" => format!("📝 `{actor}` renamed to {}", issue.title),
+        other => format!("`{actor}` {other}"),
+    };
+    let detail = match ev.event_type.as_str() {
+        "commented" => extract_comment_excerpt(&ev.payload),
+        "labeled" | "unlabeled" => Some(format!("Now: {}", issue.label_names().join(", "))),
+        "assigned" | "unassigned" => Some(format!("Now: {}", issue.assignee_logins().join(", "))),
+        _ => None,
+    };
+    match detail {
+        Some(d) if !d.is_empty() => truncate(&format!("{base}\n{}", d), 1900),
+        _ => truncate(&base, 1900),
+    }
+}
+
+fn extract_comment_excerpt(payload: &serde_json::Value) -> Option<String> {
+    let body = payload
+        .get("comment")
+        .and_then(|c| c.get("body"))
+        .and_then(|b| b.as_str())?;
+    if body.is_empty() {
+        return None;
+    }
+    Some(format!("> {}", truncate(body, 800)))
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let cut = s.char_indices().nth(max).map(|(i, _)| i).unwrap_or(max);
+    format!("{}…", &s[..cut])
+}

--- a/apps/discordsh/discordsh-bot/src/discord/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/mod.rs
@@ -4,6 +4,7 @@ pub mod commands;
 pub mod components;
 pub mod embeds;
 pub mod game;
+pub mod gh_sync;
 #[allow(dead_code)]
 pub mod github;
 pub mod github_cache;

--- a/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx
@@ -11,7 +11,7 @@ tags:
 key: discordsh_bot
 pipeline: docker
 app_name: discordsh-bot
-version: "0.1.15"
+version: "0.1.16"
 source_path: apps/discordsh/discordsh-bot
 version_toml: apps/discordsh/discordsh-bot/version.toml
 version_target: apps/discordsh/discordsh-bot/Cargo.toml


### PR DESCRIPTION
Long-pending feature payoff for the L2 cache + webhook plumbing. \`discordsh-bot\` now drains the \`gh.issue_event\` queue and mirrors GitHub activity into a Discord forum channel — one post per issue, with subsequent comments + state changes appended into the same thread. Webhook ingest has been live since edge v0.1.33; this is the consumer.

## Scope (per request)

**Single guild + KBVE/kbve only.** Multi-guild / multi-repo lands once the Rust \`BotGuildConfig\` consumer reads per-guild \`forum_channel_id\` from Vault (next slice). For now config is purely env-driven.

## New module — \`apps/discordsh/discordsh-bot/src/discord/gh_sync.rs\`

\`GhSyncConfig::from_env\` requires \`GH_FORUM_CHANNEL_ID\` + \`GH_SYNC_GUILD_ID\` (falls back to \`RELAY_GUILD_ID\`) and accepts \`GH_SYNC_OWNER\` / \`GH_SYNC_REPO\` / \`GH_SYNC_POLL_SECS\` / \`GH_SYNC_BATCH\` / \`GH_SYNC_LEASE_SECS\` / \`GH_SYNC_MAX_ATTEMPTS\`.

Worker (tokio::spawn):
1. \`store.claim_undelivered(batch, lease_secs)\` — uses the lease pattern from the gh schema; state 0/expired-1 → 1 with a fresh \`claim_token\`.
2. Out-of-scope events (different owner/repo) → \`mark_event_delivered\` immediately to drain the queue safely.
3. On success → \`mark_event_delivered(id, claim_token)\`; on failure → \`mark_event_failed(id, claim_token, error, max_attempts)\` which auto-promotes to \`dead_letter\` past max attempts.

Event handlers:
- **opened** — \`CreateForumPost\` on the configured forum channel, then \`gh.set_discord_thread\` writes the thread_id + guild_id + channel_id back to \`gh.issue\`. Skips if already set (idempotent).
- **closed / reopened / commented / labeled / unlabeled / assigned / unassigned / edited / renamed** — post a follow-up message into the existing thread. If \`discord_thread_id\` not yet set on the row, drop silently (issue not mirrored yet; catch-up handled separately).
- Other event types — drop with debug log (still marked delivered to avoid retrying forever).

Renderers:
- Issue body: author + labels + assignees + html_url + body excerpt (truncated to fit Discord's 2000-char limit).
- Per-event message: actor + verb + per-event detail (comment excerpt, labels-now snapshot, assignees-now snapshot).

## Wiring

\`apps/discordsh/discordsh-bot/src/discord/mod.rs\` registers the module; \`bot.rs\` spawns the worker alongside the existing IRC forwarder in the on-ready hook.

## Version

\`apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx\` v0.1.15 → v0.1.16. Triggers ci-docker to publish the new bot image.

## Caveats / future work

- Single-guild only (next: \`kbve::BotGuildConfig\` consumer reads per-guild \`forum_channel_id\` from Vault, plus active / max_assignees / default_repo).
- No bi-directional sync (Discord reply → GitHub comment). Tracked as #11262 P3.
- Issues whose \`opened\` event pre-dated the integration won't have a thread; a manual \`/github admin sync-threads\` command can backfill the gap later.

## Verification

- \`cargo check -p discordsh-bot\` (direct, per the @monodon/rust worktree bug memory) → builds clean
- \`astro-kbve build\` + manifest regen ✓
- No new dependencies on the Rust side