### PR TITLE
feat(q,nexus-defense): per-entity snapshot signals + diff-rendered sprites

### DIFF
--- a/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
+++ b/apps/godot/nexus-defense/addons/q/bin/release/libq.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:daf8c3f49c25e4e85890d0579ad2fbbaf2e63af9cc7aa3ecc05cba3f9611dc0d
-size 4200128
+oid sha256:c24fb5fb37495051d2835d32372263fbde259b712a3af7ef1ced6e4242dde3da
+size 4200144

--- a/apps/godot/nexus-defense/scenes/game.gd
+++ b/apps/godot/nexus-defense/scenes/game.gd
@@ -12,6 +12,30 @@ const EnemySprite := preload("res://ui/components/enemy_sprite.gd")
 const ENEMY_MARCH_DURATION := 8.0
 const ENEMY_SPAWN_STAGGER := 0.35
 
+# Tower discriminants from proto::BuildKind. Used by build_bar id →
+# server kind_idx + reverse for sprite rendering.
+const BUILD_KIND_TOWER := 0
+const BUILD_KIND_GENERATOR := 1
+const BUILD_KIND_BATTERY := 2
+const BUILD_KIND_REPAIR := 3
+const BUILD_KIND_ARMOURY := 4
+const BUILD_KIND_VILLAGE := 5
+const BUILD_KIND_TOWN := 6
+const BUILD_KIND_CASTLE := 7
+const BUILD_KIND_NEXUS := 8
+
+const BUILD_KIND_TO_SPRITE_ID := {
+	BUILD_KIND_TOWER: "arrow",
+	BUILD_KIND_GENERATOR: "magic",
+	BUILD_KIND_BATTERY: "frost",
+	BUILD_KIND_REPAIR: "frost",
+	BUILD_KIND_ARMOURY: "cannon",
+	BUILD_KIND_VILLAGE: "arrow",
+	BUILD_KIND_TOWN: "cannon",
+	BUILD_KIND_CASTLE: "cannon",
+	BUILD_KIND_NEXUS: "magic",
+}
+
 var _wave: int = 1
 var _lives: int = 20
 var _gold: int = 150
@@ -22,6 +46,12 @@ var _last_snapshot_log_tick: int = -1
 var _selected_tower: String = ""
 var _hex_map: Node2D = null
 var _world: Node2D = null
+
+# Snapshot-driven entity registries. Keys are server eids (int); values
+# are the godot nodes rendering each. We diff incoming snapshots against
+# these to spawn / despawn sprites without re-creating the whole scene.
+var _enemy_sprites: Dictionary = {}
+var _building_sprites: Dictionary = {}
 
 func _ready() -> void:
 	_world = get_node_or_null("World")
@@ -45,6 +75,8 @@ func _ready() -> void:
 		socket.connect("connected", _on_connected)
 		socket.connect("welcome", _on_welcome)
 		socket.connect("snapshot", _on_snapshot)
+		socket.connect("enemies_update", _on_enemies_update)
+		socket.connect("buildings_update", _on_buildings_update)
 		socket.connect("disconnected", _on_disconnected)
 		socket.connect("decode_error", _on_decode_error)
 		await _begin_session()
@@ -60,7 +92,11 @@ func _ready() -> void:
 
 	Ui.open("wave_banner", {"title": "Wave %d" % _wave, "subtitle": "%d enemies inbound" % _enemies})
 	Ui.toast("Godot %s · gecs + q · %s" % [Engine.get_version_info()["string"], msg], 3.0, "info")
-	_spawn_wave_enemies(_enemies)
+	# Offline / no server → keep the cosmetic enemy marchers so the
+	# visual stays alive; when connected the snapshot stream drives
+	# entity lifecycle instead.
+	if socket == null:
+		_spawn_wave_enemies(_enemies)
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("pause"):
@@ -108,7 +144,11 @@ func _try_place(screen_pos: Vector2) -> void:
 	occupied.append(axial)
 	_hex_map.set_occupied(occupied)
 	_send_place_building(axial.x, axial.y, _tower_kind_idx(_selected_tower))
-	_spawn_tower_sprite(_selected_tower, axial)
+	# When connected the server snapshot will include the new building on
+	# the next tick; offline (no socket) we render an optimistic local
+	# sprite so placement still feels responsive.
+	if socket == null:
+		_spawn_tower_sprite(_selected_tower, axial)
 	Ui.toast("Placed %s at (%d,%d)" % [_selected_tower, axial.x, axial.y], 1.6, "ok")
 	_cancel_placement()
 
@@ -193,7 +233,11 @@ func _advance_wave() -> void:
 		bar.apply({"gold": _gold})
 	Ui.open("wave_banner", {"title": "Wave %d" % _wave, "subtitle": "%d enemies inbound" % _enemies})
 	Ui.toast("+50 gold reward", 1.6, "ok")
-	_spawn_wave_enemies(_enemies)
+	# skip_wave is a local debug shortcut — only spawn cosmetic
+	# marchers when offline. Connected play gets enemies from the
+	# server's wave system.
+	if socket == null:
+		_spawn_wave_enemies(_enemies)
 
 func _return_to_menu() -> void:
 	for panel_name in ["hud_top", "build_bar", "wave_banner", "pause"]:
@@ -254,7 +298,6 @@ func _on_snapshot(tick: int, wave: int, enemy_count: int, building_count: int, g
 	if wave_changed and phase == PHASE_WAVE:
 		_wave = wave
 		Ui.open("wave_banner", {"title": "Wave %d" % wave, "subtitle": "%d enemies inbound" % enemy_count})
-		_spawn_wave_enemies(enemy_count)
 	elif phase_changed and phase == PHASE_PREPARE:
 		var secs := int(ceil(float(phase_remaining_ms) / 1000.0))
 		Ui.open("wave_banner", {"title": "Prepare", "subtitle": "Wave %d in %ds" % [max(wave, 1), secs]})
@@ -313,3 +356,97 @@ func _on_supabase_failed(reason: String) -> void:
 func _dial(jwt: String, kbve_username: String) -> void:
 	_log("dialing %s as %s" % [SERVER_URL, kbve_username])
 	socket.call("connect_to", SERVER_URL, jwt, kbve_username)
+
+# -----------------------------------------------------------------------------
+# Snapshot-driven entity rendering
+#
+# The server is the source of truth for what exists on the field. Each
+# snapshot carries the full per-slot roster of enemies + buildings; we
+# diff against the maps below to spawn / despawn sprites.
+#
+# Entities are keyed by server eid (u32 → int). When an eid appears in
+# the incoming list and we don't have a sprite for it yet → spawn. When
+# an eid we know about is missing from the list (or has `destroyed:
+# true`) → queue_free + erase. Position-only updates can be added later
+# once enemies move along a path the client can interpolate.
+# -----------------------------------------------------------------------------
+
+func _on_enemies_update(entities: Array) -> void:
+	if _hex_map == null:
+		return
+	var seen: Dictionary = {}
+	for entry in entities:
+		if typeof(entry) != TYPE_DICTIONARY:
+			continue
+		var data: Dictionary = entry
+		var eid: int = int(data.get("eid", 0))
+		if eid == 0:
+			continue
+		seen[eid] = true
+		var destroyed: bool = bool(data.get("destroyed", false))
+		if destroyed:
+			_despawn_enemy(eid)
+			continue
+		if not _enemy_sprites.has(eid):
+			_spawn_snapshot_enemy(eid)
+	for eid in _enemy_sprites.keys():
+		if not seen.has(eid):
+			_despawn_enemy(eid)
+
+func _spawn_snapshot_enemy(eid: int) -> void:
+	var pts: PackedVector2Array = _path_points()
+	if pts.size() < 2:
+		return
+	var sprite: Node2D = EnemySprite.new()
+	_hex_map.add_child(sprite)
+	sprite.call("start", pts, ENEMY_MARCH_DURATION)
+	_enemy_sprites[eid] = sprite
+
+func _despawn_enemy(eid: int) -> void:
+	if not _enemy_sprites.has(eid):
+		return
+	var node: Variant = _enemy_sprites[eid]
+	if node is Node and is_instance_valid(node):
+		(node as Node).queue_free()
+	_enemy_sprites.erase(eid)
+
+func _on_buildings_update(entities: Array) -> void:
+	if _hex_map == null:
+		return
+	var seen: Dictionary = {}
+	for entry in entities:
+		if typeof(entry) != TYPE_DICTIONARY:
+			continue
+		var data: Dictionary = entry
+		var eid: int = int(data.get("eid", 0))
+		if eid == 0:
+			continue
+		seen[eid] = true
+		var destroyed: bool = bool(data.get("destroyed", false))
+		if destroyed:
+			_despawn_building(eid)
+			continue
+		var col: int = int(data.get("col", 0))
+		var row: int = int(data.get("row", 0))
+		var kind: int = int(data.get("kind", BUILD_KIND_TOWER))
+		if not _building_sprites.has(eid):
+			_spawn_snapshot_building(eid, kind, col, row)
+	for eid in _building_sprites.keys():
+		if not seen.has(eid):
+			_despawn_building(eid)
+
+func _spawn_snapshot_building(eid: int, kind: int, col: int, row: int) -> void:
+	var sprite: Node2D = TowerSprite.new()
+	var sprite_id: String = String(BUILD_KIND_TO_SPRITE_ID.get(kind, "arrow"))
+	sprite.apply_id(sprite_id)
+	sprite.position = _hex_map.axial_to_pixel(col, row)
+	_hex_map.add_child(sprite)
+	_building_sprites[eid] = sprite
+
+func _despawn_building(eid: int) -> void:
+	if not _building_sprites.has(eid):
+		return
+	var node: Variant = _building_sprites[eid]
+	if node is Node and is_instance_valid(node):
+		(node as Node).queue_free()
+	_building_sprites.erase(eid)

--- a/packages/rust/q/src/nexus_defense/match_socket.rs
+++ b/packages/rust/q/src/nexus_defense/match_socket.rs
@@ -5,6 +5,13 @@
 //! them across a crossbeam channel; `_process` drains the channel on the main
 //! thread and fires GDScript signals so the scene tree can react.
 
+// godot `#[signal]` macros expand into fn declarations; the `snapshot` signal
+// has 9 args (HUD summary) which trips clippy's too-many-arguments lint.
+// Packing the fields into a Dictionary would push the cost to every GDScript
+// reader on every snapshot tick — not worth it. Scoped allow at module level
+// so the lint stays enforced everywhere else in q.
+#![allow(clippy::too_many_arguments)]
+
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use futures_util::{SinkExt, StreamExt};
 use godot::classes::INode;
@@ -17,6 +24,33 @@ use crate::threads::runtime::RuntimeManager;
 enum Outbound {
     Send(Vec<u8>),
     Close,
+}
+
+/// Flat, godot-friendly mirror of `proto::EnemyDelta` — only the fields
+/// the client actually renders, primitives only so the Variant cast in
+/// `process` is cheap. `kind` is the discriminant of `proto::EnemyKind`.
+struct EnemyView {
+    eid: u32,
+    kind: i32,
+    pos_x: f32,
+    pos_y: f32,
+    hp: f32,
+    max_hp: f32,
+    destroyed: bool,
+}
+
+/// Same shape as `EnemyView` but for `proto::BuildingDelta`. `kind` is
+/// the discriminant of `proto::BuildKind`. `col` / `row` are the axial
+/// grid coords the client already speaks via hex_map.
+struct BuildingView {
+    eid: u32,
+    kind: i32,
+    col: i32,
+    row: i32,
+    hp: f32,
+    max_hp: f32,
+    online: bool,
+    destroyed: bool,
 }
 
 enum Inbound {
@@ -35,6 +69,8 @@ enum Inbound {
         phase: u8,
         phase_remaining_ms: u32,
         kills: u32,
+        enemies: Vec<EnemyView>,
+        buildings: Vec<BuildingView>,
     },
     Disconnected {
         reason: String,
@@ -93,7 +129,11 @@ impl INode for MatchSocket {
                     phase,
                     phase_remaining_ms,
                     kills,
+                    enemies,
+                    buildings,
                 } => {
+                    let enemy_array = enemies_to_array(&enemies);
+                    let building_array = buildings_to_array(&buildings);
                     self.base_mut().emit_signal(
                         &StringName::from("snapshot"),
                         &[
@@ -107,6 +147,14 @@ impl INode for MatchSocket {
                             (phase_remaining_ms as i64).to_variant(),
                             (kills as i64).to_variant(),
                         ],
+                    );
+                    self.base_mut().emit_signal(
+                        &StringName::from("enemies_update"),
+                        &[enemy_array.to_variant()],
+                    );
+                    self.base_mut().emit_signal(
+                        &StringName::from("buildings_update"),
+                        &[building_array.to_variant()],
                     );
                 }
                 Inbound::Disconnected { reason } => {
@@ -133,9 +181,9 @@ impl MatchSocket {
     #[signal]
     fn welcome(slot: i64, seed: i64);
 
-    /// Snapshot landed — summary surface for the HUD. Per-entity detail can
-    /// be pulled from a future ring buffer; for now we plumb the headline
-    /// numbers so GDScript can render a wave/enemies/gold display.
+    /// Snapshot landed — summary surface for the HUD. Per-entity detail
+    /// rides alongside on `enemies_update` + `buildings_update` so HUD
+    /// consumers don't pay for entity arrays they don't need.
     #[signal]
     fn snapshot(
         tick: i64,
@@ -148,6 +196,24 @@ impl MatchSocket {
         phase_remaining_ms: i64,
         kills: i64,
     );
+
+    /// Per-snapshot enemy roster. Each entry is a Dictionary:
+    ///   { "eid": int, "kind": int, "pos_x": float, "pos_y": float,
+    ///     "hp": float, "max_hp": float, "destroyed": bool }
+    /// `kind` is the discriminant of `proto::EnemyKind`. Authoritative
+    /// — drives the visual layer; cosmetic client spawners should defer
+    /// to this list when the WS is connected.
+    #[signal]
+    fn enemies_update(entities: Array<Variant>);
+
+    /// Per-snapshot building roster. Each entry is a Dictionary:
+    ///   { "eid": int, "kind": int, "col": int, "row": int,
+    ///     "hp": float, "max_hp": float, "online": bool,
+    ///     "destroyed": bool }
+    /// `kind` is the discriminant of `proto::BuildKind`. Includes
+    /// server-spawned starters plus anything `apply_input` placed.
+    #[signal]
+    fn buildings_update(entities: Array<Variant>);
 
     #[signal]
     fn disconnected(reason: GString);
@@ -363,6 +429,39 @@ async fn run_socket(
                     let phase = field.map(|f| f.phase as u8).unwrap_or(0);
                     let phase_remaining_ms = field.map(|f| f.phase_remaining_ms).unwrap_or(0);
                     let kills = field.map(|f| f.kills).unwrap_or(0);
+                    let enemies = field
+                        .map(|f| {
+                            f.enemies
+                                .iter()
+                                .map(|e| EnemyView {
+                                    eid: e.eid.0,
+                                    kind: e.kind as i32,
+                                    pos_x: e.pos.x,
+                                    pos_y: e.pos.y,
+                                    hp: e.hp,
+                                    max_hp: e.max_hp,
+                                    destroyed: e.destroyed,
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let buildings = field
+                        .map(|f| {
+                            f.buildings
+                                .iter()
+                                .map(|b| BuildingView {
+                                    eid: b.eid.0,
+                                    kind: b.kind as i32,
+                                    col: b.col,
+                                    row: b.row,
+                                    hp: b.hp,
+                                    max_hp: b.max_hp,
+                                    online: b.online,
+                                    destroyed: b.destroyed,
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
                     let _ = tx.send(Inbound::Snapshot {
                         tick: snap.tick,
                         wave,
@@ -373,6 +472,8 @@ async fn run_socket(
                         phase,
                         phase_remaining_ms,
                         kills,
+                        enemies,
+                        buildings,
                     });
                 }
                 Ok(ServerEvent::Reject { reason }) => {
@@ -399,4 +500,37 @@ async fn run_socket(
     let _ = tx.send(Inbound::Disconnected {
         reason: "stream ended".into(),
     });
+}
+
+fn enemies_to_array(enemies: &[EnemyView]) -> Array<Variant> {
+    let mut arr: Array<Variant> = Array::new();
+    for e in enemies {
+        let mut dict: Dictionary<Variant, Variant> = Dictionary::new();
+        dict.set("eid", e.eid as i64);
+        dict.set("kind", e.kind as i64);
+        dict.set("pos_x", e.pos_x as f64);
+        dict.set("pos_y", e.pos_y as f64);
+        dict.set("hp", e.hp as f64);
+        dict.set("max_hp", e.max_hp as f64);
+        dict.set("destroyed", e.destroyed);
+        arr.push(&dict.to_variant());
+    }
+    arr
+}
+
+fn buildings_to_array(buildings: &[BuildingView]) -> Array<Variant> {
+    let mut arr: Array<Variant> = Array::new();
+    for b in buildings {
+        let mut dict: Dictionary<Variant, Variant> = Dictionary::new();
+        dict.set("eid", b.eid as i64);
+        dict.set("kind", b.kind as i64);
+        dict.set("col", b.col as i64);
+        dict.set("row", b.row as i64);
+        dict.set("hp", b.hp as f64);
+        dict.set("max_hp", b.max_hp as f64);
+        dict.set("online", b.online);
+        dict.set("destroyed", b.destroyed);
+        arr.push(&dict.to_variant());
+    }
+    arr
 }


### PR DESCRIPTION
## Summary
Closes the longest-standing gap in the client: the visible game was mostly local fiction (cosmetic marchers, optimistic-only tower sprites) while the server held the real sim state. Snapshots now carry per-entity rosters that the client diffs against an eid-keyed sprite registry, so what you see is what the bevy app is actually running.

## Wire layer
\`packages/rust/q/src/nexus_defense/match_socket.rs\`:

- New \`EnemyView\` + \`BuildingView\` flat mirrors of \`proto::EnemyDelta\` / \`proto::BuildingDelta\` — only the fields the client renders.
- \`Inbound::Snapshot\` carries \`enemies: Vec<EnemyView>\` + \`buildings: Vec<BuildingView>\` filled from the matched \`FieldDelta\`.
- Two new signals fire alongside the existing aggregate \`snapshot\`:
  - \`enemies_update(entities: Array<Variant>)\`
  - \`buildings_update(entities: Array<Variant>)\`
  Each entry is a \`Dictionary<Variant, Variant>\` so GDScript reads by string key. \`enemies_to_array\` / \`buildings_to_array\` helpers handle the cast.
- Module-level \`#![allow(clippy::too_many_arguments)]\` because the \`snapshot\` signal macro expands into a 9-arg fn that trips clippy 1.94. Packing into a Dictionary would push the cost to every GDScript reader per tick; the allow is cheaper.
- \`libq.dylib\` refreshed.

## Client
\`apps/godot/nexus-defense/scenes/game.gd\`:

- Two new dicts — \`_enemy_sprites\` and \`_building_sprites\` — keyed by server eid → live \`EnemySprite\` / \`TowerSprite\` node.
- \`_on_enemies_update\` + \`_on_buildings_update\` diff incoming entries against the registries: spawn on new eid, erase on \`destroyed: true\` or absence, leave existing alone.
- \`BUILD_KIND_TO_SPRITE_ID\` maps \`proto::BuildKind\` discriminants onto existing TowerSprite ids so the procedural shader keeps the right silhouette.
- Cosmetic local spawners now no-op when \`socket\` is connected — snapshot stream is authoritative. Offline play keeps the fallback so the scene still renders.

## Test plan
- [x] \`cargo clippy -p q --features nexus-defense -- -D warnings\` clean
- [x] \`cargo clippy -p nd-server --all-targets -- -D warnings\` clean
- [x] \`scripts/test.sh\` — 121/121
- [x] \`scripts/test-e2e.sh\` — 130/130 (incl. live nd-server smoke)
- [ ] Eyes-on: launch godot client + nd-server locally, watch starter towers appear from snapshot instead of optimistic-only path

## Follow-ups
- Position interpolation: enemy sprites currently march along the hex_map path on spawn; drive smooth movement from snapshot \`pos\` instead of fixed-duration marches once the server emits path waypoints or the heuristic stabilizes.
- HP bars on building sprites + dim/grey when \`online: false\`.
- Per-EnemyKind shader variant.