### PR TITLE
fix(astro-irc): isolate chat embed stacking + drop redundant host overflow

### DIFF
--- a/apps/irc/astro-irc/src/components/home/HomeChatEmbed.astro
+++ b/apps/irc/astro-irc/src/components/home/HomeChatEmbed.astro
@@ -34,15 +34,22 @@ const { channel = '#general', height = '420px', theme = 'dark' } = Astro.props;
 	.home-chat-embed {
 		margin: 2rem auto;
 		max-width: 960px;
+		position: relative;
+		z-index: 0;
+		isolation: isolate;
 	}
 
 	.home-chat-embed__frame {
 		border-radius: 16px;
-		overflow: hidden;
 		box-shadow:
 			0 24px 64px -20px rgba(0, 0, 0, 0.4),
 			0 0 0 1px var(--sl-color-border);
 		background: var(--sl-color-bg-nav, #0a0d14);
+	}
+
+	.home-chat-embed__frame > [id^='kbve-chat'] {
+		display: block;
+		border-radius: 16px;
 	}
 
 	.home-chat-embed__caption {

--- a/apps/irc/astro-irc/src/embed/styles.ts
+++ b/apps/irc/astro-irc/src/embed/styles.ts
@@ -15,6 +15,10 @@ export const EMBED_CSS = `
 :host {
   all: initial;
   display: block;
+  position: relative;
+  z-index: 0;
+  isolation: isolate;
+  contain: layout paint;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, 'Segoe UI', Roboto, sans-serif;
   color: var(--kbc-text);
 

--- a/apps/kbve/astro-kbve/src/components/kbve/KbveChatEmbed.astro
+++ b/apps/kbve/astro-kbve/src/components/kbve/KbveChatEmbed.astro
@@ -33,11 +33,14 @@ const { channel = '#general', height = '70vh', theme = 'auto' } = Astro.props;
 	.kbve-chat-embed-wrapper {
 		margin: 1.5rem auto;
 		max-width: 1100px;
+		position: relative;
+		z-index: 0;
+		isolation: isolate;
 	}
 
 	.kbve-chat-embed-wrapper #kbve-chat-embed {
+		display: block;
 		border-radius: 14px;
-		overflow: hidden;
 		box-shadow:
 			0 24px 64px -20px
 				color-mix(in srgb, var(--sl-color-accent) 30%, transparent),


### PR DESCRIPTION
## Report

Side rails (channels / members) in the windowed embed on kbve.com/chat were getting clipped along the z-axis depending on scroll/viewport.

## Hypothesis

Two plausible causes, both addressed defensively in one PR (low blast radius):

1. **Stacking context bleed.** The shadow host inherited the page stacking context, so Starlight's sticky header / sidebar could overlap the embed corners. Fix: every embed wrapper now opens its own stacking context with \`position: relative; z-index: 0; isolation: isolate\`. \`:host\` also gets \`contain: layout paint\` so internal layout work can't ripple into the host page.

2. **Redundant outer overflow.** Both \`KbveChatEmbed\` and \`HomeChatEmbed\` set \`overflow: hidden\` on the shadow host element to clip the border-radius. The shadow boundary already establishes its own containing block, and the inner \`.root\` already carries \`overflow: hidden\` for the rounded corner, so the outer rule was redundant — and it was the layer that visibly clipped panels when the host page column came in narrower than expected. Removed at the wrapper level; rounded corners now come from the \`.root\` clip alone.

## Bundle

215.90 KB / **67.30 KB gz** (no meaningful change).

## Test plan

- [ ] kbve.com/chat — scroll the page; side rails stay visible, no clipping along corners
- [ ] kbve.com/chat — viewport narrower than 1100px; embed renders without overlap from Starlight's sticky chrome
- [ ] chat.kbve.com landing — live-preview section still renders end-to-end
- [ ] /embed/example.html — four panels still visually correct