### PR TITLE
fix(agones-factorio-relay): bump RUST_VERSION 1.84 → 1.94

### DIFF
--- a/apps/agones/factorio/relay/Dockerfile
+++ b/apps/agones/factorio/relay/Dockerfile
@@ -1,4 +1,4 @@
-ARG RUST_VERSION=1.84
+ARG RUST_VERSION=1.94
 
 FROM --platform=linux/amd64 rust:${RUST_VERSION}-bookworm AS builder
 ENV CARGO_INCREMENTAL=0


### PR DESCRIPTION
## Summary

Resolves the `CI - Docker / agones-factorio-relay` failure from [run 26538946527](https://github.com/KBVE/kbve/actions/runs/26538946527):

\`\`\`
0.853 error: failed to parse manifest at
  /usr/local/cargo/registry/src/index.crates.io-.../idna_adapter-1.2.2/Cargo.toml
\`\`\`

`idna_adapter 1.2.2` uses manifest fields that need Rust ≥ 1.85. The relay Dockerfile was pinned at 1.84, which is also out-of-step with the rest of the workspace — `firecracker-ctl` and the shared `chisel-ubuntu-axum:24.04-builder` image both ride 1.94. Align to 1.94 so the relay shares the same Rust across CI lanes and the parse goes through.

### Why no version bump

The previous publish attempt never landed, so `apps/agones/factorio/relay/version.toml` stayed at `0.0.1` while the MDX still reads `version: "0.0.2"`. The `ci-main.yml` dispatch version-fallback (`is_newer(0.0.2, 0.0.1) = true`) will fire on the next main push. The `source_path` change on this PR also flips `is_altered`, so this is a belt-and-suspenders retry.

Refs: #11138, follow-up to #11418.

## Test plan

- [ ] CI: \`CI - Docker / agones-factorio-relay\` reaches `cargo build --release` past the manifest-parse step on this branch.
- [ ] After merge + next ci-main dispatch, \`ghcr.io/kbve/agones-factorio-relay:0.0.2\` is finally published.