### PR TITLE
chore(kube): register agones/factorio in the app-of-apps kustomization

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -60,6 +60,7 @@ resources:
     - agones/rows/application.yaml
     - agones/mc/application.yaml
     - agones/nd-server/application.yaml
+    - agones/factorio/application.yaml
     - chuckrpg/application.yaml
     # RareIcon — bullet-hell roguelite website + API
     - rareicon/application.yaml


### PR DESCRIPTION
## Summary

#11427 landed `apps/kube/agones/factorio/application.yaml` + `manifests/` but missed adding the Application to `apps/kube/kustomization.yaml` — the canonical list that the root `kube-root` Application syncs via the kustomize directory generator (`apps/kube/root.yaml`). Without the entry, ArgoCD never picks up `agones-factorio` and the GameServer never schedules.

Adds the one missing line next to its agones siblings:

\`\`\`yaml
- agones/application.yaml
- agones/rows/application.yaml
- agones/mc/application.yaml
- agones/nd-server/application.yaml
+ agones/factorio/application.yaml
\`\`\`

After this merges + the next root reconcile, the chain unfolds automatically: kube-root → creates `agones-factorio` Application → which syncs `apps/kube/agones/factorio/manifests/` → which brings up the `factorio` namespace + PVC + GameServer + Service. The GameServer pod will sit in `ContainerCreating` until the SealedSecret payloads for `factorio-rcon` (required) and `factorio-irc` (optional keys) land — operator runs `seal-rcon.sh` + `seal-irc-creds.sh` and commits the output before or after this PR merges.

Refs: #11138, follow-up to #11427.