### PR TITLE
fix(agones): register the factorio namespace in gameservers.namespaces

### DIFF
--- a/apps/kube/agones/values.yaml
+++ b/apps/kube/agones/values.yaml
@@ -61,6 +61,7 @@ gameservers:
     namespaces:
         - ows
         - arc-runners
+        - factorio
 
     # Port range for game server host ports.
     # Capped at 7900 to avoid MetalLB speaker memberlist port (7946).


### PR DESCRIPTION
## Summary

ArgoCD synced `agones-factorio` cleanly after [#11444](https://github.com/KBVE/kbve/pull/11444), but the GameServer stayed in `Error` state. `kubectl -n factorio describe gameserver factorio` reported:

\`\`\`
Warning  Error  gameserver-controller  pods \"factorio\" is forbidden:
  error looking up service account factorio/agones-sdk:
  serviceaccount \"agones-sdk\" not found
\`\`\`

The Agones Helm chart provisions a per-namespace `agones-sdk` ServiceAccount + RoleBinding **only for namespaces listed under `gameservers.namespaces`** in `apps/kube/agones/values.yaml`. Without that SA the Agones controller refuses to inject the SDK sidecar into the GameServer pod, which is what makes the pod fail to schedule.

`arc-runners` (mc, ows) and `ows` were already in the list. `factorio` wasn't — we added the namespace + ArgoCD app + GameServer across #11427 / #11438 / #11441 / #11444 but never came back to register the namespace with Agones itself.

### Change

One-line append:

\`\`\`yaml
gameservers:
    namespaces:
        - ows
        - arc-runners
+       - factorio
\`\`\`

ArgoCD reconciles the `agones-system` Helm release on next pass, the chart creates the `agones-sdk` SA in the `factorio` namespace, the GameServer controller retries the pod, and the sidecar lands.

Refs: #11138

## Test plan

- [ ] After merge + ArgoCD sync of `agones`: \`kubectl -n factorio get sa agones-sdk\` returns the SA.
- [ ] \`kubectl -n factorio get gameserver factorio -w\` flips from \`Error\` → \`Starting\` → \`Ready\` within ~60s.
- [ ] \`kubectl -n factorio get pod\` shows the two-container pod (factorio + factorio-relay) plus the auto-injected \`agones-sdk\` sidecar.
- [ ] \`kubectl -n factorio logs <pod> -c factorio | grep \"Hosting game\"\` confirms factorio is up.
- [ ] \`kubectl -n factorio get svc factorio-public\` gets an EXTERNAL-IP from Cilium LB IPAM (no longer \`<pending>\`).