### PR TITLE
fix(kbve-gateway): add HTTPS listeners for rareicon.com + api.rareicon.com

### DIFF
--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -77,6 +77,34 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        - name: https-rareicon
+          protocol: HTTPS
+          port: 443
+          hostname: rareicon.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rareicon-tls
+                    namespace: rareicon
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-rareicon-api
+          protocol: HTTPS
+          port: 443
+          hostname: api.rareicon.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rareicon-api-tls
+                    namespace: rareicon
+          allowedRoutes:
+              namespaces:
+                  from: All
 ---
 ## kbve.com routes
 apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
## Summary

Different incident from the factorio LB IP one — pure config gap.

`rareicon.com` and `api.rareicon.com` were both returning Cloudflare `525` (\"SSL handshake failed at origin\"). Direct probe against the Cilium gateway IP with `openssl s_client -connect 142.132.206.74:443 -servername rareicon.com` returned **\"no peer certificate available\"** — the gateway was not presenting any cert for the rareicon SNI even though everything else looked fine:

- The HTTPRoutes (`rareicon-routes`, `rareicon-api-routes`) correctly reference `parentRef: kbve/kbve-gateway`.
- The Certificates `rareicon-tls` + `rareicon-api-tls` in the `rareicon` ns are `Ready=True`.
- `apps/kube/rareicon/manifest/reference-grant.yaml` already allows the kbve Gateway to read Secrets in the `rareicon` ns.

### Root cause

`apps/kube/kbve/manifest/kbve-gateway.yaml` only declared listeners for `kbve.com`, `*.kbve.com`, `meme.sh`, and `www.meme.sh`. **No listener matched `rareicon.com` or `api.rareicon.com`**, so TLS terminated with an empty cert chain → CF couldn't validate → `525`.

### Fix

Add two listeners on port 443 mirroring the existing `https-memes` / `https-memes-www` pattern:

- `https-rareicon` — hostname `rareicon.com`, cert `rareicon/rareicon-tls`.
- `https-rareicon-api` — hostname `api.rareicon.com`, cert `rareicon/rareicon-api-tls`.

Both use `tls.mode: Terminate` + `allowedRoutes.namespaces.from: All` (same as the other listeners). ArgoCD reconciles the `kbve` app → Cilium gateway picks up the new listeners → both hostnames start presenting their Let's Encrypt certs on next SNI handshake → CF stops returning 525.

## Test plan

- [x] Confirmed via `openssl s_client` that `rareicon.com` currently has no peer cert presented.
- [x] Confirmed `kbve.com` works on the same IP (so the gateway itself is fine; just missing listeners).
- [ ] After merge: `openssl s_client -connect 142.132.206.74:443 -servername rareicon.com` returns a valid LE cert.
- [ ] `curl -I https://rareicon.com` returns `200`.
- [ ] `curl -I https://api.rareicon.com` returns whatever the rareicon-service responds with (200 / 4xx, not 525).