### PR TITLE
feat(nd-server): wire Agones SDK lifecycle (Ready / Health / Shutdown)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10568,6 +10568,7 @@ checksum = "a846cbc04412cf509efcd8f3694b114fc700a035fb5a37f21517f9fb019f1ebc"
 name = "nd-server"
 version = "0.0.2"
 dependencies = [
+ "agones",
  "axum 0.7.9",
  "q",
  "tokio",

--- a/apps/godot/nexus-defense/server/Cargo.toml
+++ b/apps/godot/nexus-defense/server/Cargo.toml
@@ -15,3 +15,8 @@ axum = { version = "0.7", default-features = false, features = ["ws", "json", "h
 tokio = { version = "1.49", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
+# Agones SDK — connects to the in-pod sidecar at $AGONES_SDK_GRPC_PORT and
+# proxies `Ready()` / `Health()` / `Shutdown()` calls. Degrades gracefully
+# outside Agones (local dev, CI smoke) by logging once and dropping the loop.
+agones = "1.57"

--- a/apps/godot/nexus-defense/server/src/agones.rs
+++ b/apps/godot/nexus-defense/server/src/agones.rs
@@ -1,0 +1,80 @@
+//! Agones SDK lifecycle for the Nexus Defense game server.
+//!
+//! Connects to the in-pod sidecar (`localhost:$AGONES_SDK_GRPC_PORT`,
+//! default 9357), marks the GameServer `Ready` once the axum listener is
+//! bound, then pings the SDK health channel every
+//! [`HEALTH_PING_INTERVAL`] so the Agones controller keeps the pod alive.
+//! On graceful shutdown the orchestrator calls [`shutdown`] so Agones
+//! can drain the Fleet without waiting for the health timeout.
+//!
+//! Outside Agones (local `cargo run`, CI smoke) the sidecar isn't
+//! reachable — both helpers log a single warning and exit cleanly so
+//! the rest of the binary keeps working unchanged.
+//!
+//! Mirrors the proven pattern from `apps/mc/mc_auth/src/agones.rs`.
+
+use std::time::Duration;
+
+use tokio::time::{MissedTickBehavior, interval};
+use tracing::{error, info, warn};
+
+const HEALTH_PING_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Long-running task that owns the Agones SDK connection.
+///
+/// Spawned once main.rs has bound its WS listener. Returns when:
+/// - the sidecar can't be reached (no Agones environment), or
+/// - the health channel is closed (sidecar gone away).
+pub async fn run_health_loop() {
+    let mut sdk = match agones::Sdk::new(None, None).await {
+        Ok(sdk) => {
+            info!("[nd-server/agones] Connected to Agones SDK sidecar");
+            sdk
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                "[nd-server/agones] Agones SDK unavailable — running outside Agones (local dev?)"
+            );
+            return;
+        }
+    };
+
+    if let Err(e) = sdk.ready().await {
+        error!(error = %e, "[nd-server/agones] Failed to mark gameserver Ready");
+        return;
+    }
+    info!("[nd-server/agones] GameServer marked Ready");
+
+    let health_tx = sdk.health_check();
+    let mut ticker = interval(HEALTH_PING_INTERVAL);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+        if health_tx.send(()).await.is_err() {
+            error!("[nd-server/agones] Health channel closed — sidecar gone");
+            return;
+        }
+    }
+}
+
+/// Best-effort graceful Shutdown. Failures are non-fatal: Agones will
+/// reap the pod via the health timeout if the SDK is unreachable.
+pub async fn shutdown() {
+    let mut sdk = match agones::Sdk::new(None, None).await {
+        Ok(sdk) => sdk,
+        Err(e) => {
+            warn!(
+                error = %e,
+                "[nd-server/agones] Skipping graceful Shutdown — SDK unreachable"
+            );
+            return;
+        }
+    };
+    if let Err(e) = sdk.shutdown().await {
+        warn!(error = %e, "[nd-server/agones] Shutdown call failed");
+    } else {
+        info!("[nd-server/agones] Shutdown signal sent to Agones");
+    }
+}

--- a/apps/godot/nexus-defense/server/src/main.rs
+++ b/apps/godot/nexus-defense/server/src/main.rs
@@ -2,8 +2,11 @@
 //!
 //! Boots the bevy headless sim, wires its snapshot broadcast into the axum
 //! WS router (`q::net::server`), and serves both from the same tokio
-//! runtime. Agones lifecycle + JWT verify land in follow-up commits per
-//! the phase plan in KBVE/kbve#11294.
+//! runtime. Agones lifecycle (`Ready` / `Health` / `Shutdown`) is proxied
+//! through the [`agones`] module so the Fleet flips this pod to `Ready`
+//! the moment the WS listener accepts connections.
+
+mod agones;
 
 use std::net::SocketAddr;
 
@@ -63,11 +66,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!(%addr, %seed, auth = %auth_mode, "nd-server listening");
 
     let listener = TcpListener::bind(addr).await?;
+
+    // Bring the Agones SDK heartbeat up the moment the listener is bound.
+    // The loop owns the SDK handle for the process lifetime; outside
+    // Agones it logs once and exits, so `cargo run` still works.
+    let agones_handle = tokio::spawn(agones::run_health_loop());
+
     let serve = axum::serve(listener, router).with_graceful_shutdown(shutdown_signal());
 
     if let Err(e) = serve.await {
         tracing::error!("serve error: {e}");
     }
+
+    // Best-effort graceful Shutdown so the Fleet can drain this pod
+    // without waiting for the health timeout. Bounded to 1s — Agones
+    // reaps via the health probe if the SDK call is wedged.
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(1), agones::shutdown()).await;
+    agones_handle.abort();
 
     // The sim task lives on a current-thread runtime inside spawn_blocking;
     // letting main return drops the JoinHandle and the process exits.

--- a/apps/kube/agones/nd-server/manifests/fleet.yaml
+++ b/apps/kube/agones/nd-server/manifests/fleet.yaml
@@ -5,13 +5,12 @@
 # match. Each replica is a long-lived axum WS host backed by the bevy
 # headless sim.
 #
-# IMPORTANT: nd-server doesn't talk the Agones SDK yet. It exposes a plain
-# HTTP `/healthz` that always returns `ok`, so for Agones to flip the
-# GameServer to `Ready` we lean on the `agones.dev/sdk-grpc-port` startup
-# behavior — when the container doesn't open the SDK socket, Agones treats
-# the pod as healthy/ready via the configured TCP health probe instead.
-# The SDK + `Ready()` / `Health()` calls land in the Phase-3 follow-up
-# (see Agones Game Server Integration in apps/kbve/astro-kbve docs).
+# nd-server now speaks the Agones SDK directly (`apps/godot/nexus-defense/
+# server/src/agones.rs`): it marks the GameServer `Ready` as soon as the
+# WS listener binds and pings `Health()` every 2s. The plain HTTP
+# `/healthz` endpoint stays as a belt-and-suspenders kubelet probe so
+# pod restarts still happen if the process wedges before the SDK loop
+# can stop sending heartbeats.
 apiVersion: agones.dev/v1
 kind: Fleet
 metadata:
@@ -44,8 +43,11 @@ spec:
                 periodSeconds: 10
                 failureThreshold: 5
             sdkServer:
-                # Sidecar runs even without SDK calls — Agones uses it as the
-                # health-probe surface until nd-server speaks SDK directly.
+                # Sidecar is the primary health surface — nd-server's
+                # in-process loop calls Ready() then pings Health() every
+                # 2s (HEALTH_PING_INTERVAL). Agones reaps the pod if the
+                # health channel goes silent for failureThreshold *
+                # periodSeconds.
                 logLevel: Info
             template:
                 spec:


### PR DESCRIPTION
## Summary

Drops the implicit "Agones treats us as Ready because the sidecar can't reach us" hack and replaces it with a real SDK conversation, mirroring the pattern proven in `apps/mc/mc_auth/src/agones.rs`.

- **`apps/godot/nexus-defense/server/Cargo.toml`** — adds `agones = "1.57"` (already in the workspace lockfile via `mc_auth`).
- **`apps/godot/nexus-defense/server/src/agones.rs`** (new) — `run_health_loop()` connects to the sidecar at `localhost:$AGONES_SDK_GRPC_PORT`, calls `Ready()` once, then pings the health channel every 2s (`HEALTH_PING_INTERVAL`). `shutdown()` best-effort calls `Sdk::shutdown` so the Fleet can drain without waiting for the health timeout. Both helpers degrade gracefully when the sidecar isn't reachable (local `cargo run`, CI smoke): one warning, then exit cleanly.
- **`apps/godot/nexus-defense/server/src/main.rs`** — spawns `agones::run_health_loop()` the moment the WS listener binds; on graceful shutdown awaits `agones::shutdown()` (bounded to 1s) before aborting the health task and dropping the sim handle.
- **`apps/kube/agones/nd-server/manifests/fleet.yaml`** — drops the stale "we don't speak the SDK yet" comment, notes the in-process health loop, keeps the kubelet HTTP probes as belt-and-suspenders for a wedged process before the heartbeat falls silent.

Unblocks the rest of the Agones path (lobby allocator endpoint in `jedi`, fleet autoscaler driven by `Allocated` counts instead of TCP probes).

## Test plan

- [x] `cargo clippy --release -p nd-server -- -D warnings` clean
- [x] `cargo build --release -p nd-server` clean (~1m 09s cold)
- [x] Local boot outside Agones: `./nd-server` starts, `curl /healthz → ok`, SIGTERM triggers graceful shutdown without crashing on the missing sidecar (graceful-degrade path).
- [ ] CI `Lint and Test` green
- [ ] Deploy to a Fleet pod and confirm `kubectl get gs` flips to `Ready` from inside the SDK call (next ops verification — manual).