### PR TITLE
feat(astro-kbve): client-router audit Phase 4 — enable Astro ClientRouter

### DIFF
--- a/apps/kbve/astro-kbve/src/components/navigation/Head.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/Head.astro
@@ -11,6 +11,8 @@
  *
  * Mirrors the rareicon Head override (apps/rareicon/astro-rareicon/...).
  */
+import { ClientRouter } from 'astro:transitions';
+
 const route = Astro.locals.starlightRoute;
 const head = route.head;
 const data = route.entry.data as Record<string, unknown>;
@@ -71,6 +73,16 @@ const overrideTags: HeadTag[] = Object.entries(owned).map(([key, content]) => {
 {overrideTags.map(({ tag: Tag, attrs }) => <Tag {...attrs} />)}
 
 <slot />
+
+{
+	/* Astro SPA-style nav. Pairs with the native browser
+   `<meta name="view-transition">` below so supporting browsers also
+   get cross-doc transitions when the router falls back to a full nav
+   (initial entry, external links with prefetch off, manual reload).
+   onMount() from @kbve/astro/utils/clientRouter is wired across the
+   component scripts to re-init per swap. */
+}
+<ClientRouter />
 <meta name="view-transition" content="same-origin" />
 
 <!-- YouTube hero-bg DNS + TLS warm so the iframe doesn't gate LCP -->


### PR DESCRIPTION
## Summary
Final phase of the four-phase audit. Flips on \`<ClientRouter />\` in the KBVE Head override after three prep PRs converted every inline-script lifecycle hook + per-page DOM-init helper to the swap-safe \`onMount\` pattern from \`@kbve/astro/utils/clientRouter\`.

## What changes for users
- Same-origin nav no longer does a full document reload. Astro intercepts \`<a>\` clicks, fetches HTML, cross-fades the \`<main>\` region in place.
- JS modules stay in memory across the swap — no supabase re-init, no SharedWorker reboot, no React tree teardown for islands that already follow proper cleanup.

## Belt-and-suspenders
Existing \`<meta name="view-transition" content="same-origin">\` stays as fallback for the rare cases the router falls through to a full nav (initial entry, manual reload, external linkout-then-back). Supporting browsers still get native cross-doc View Transitions API in that path.

## Phases summary
- **Phase 1**: \`DOMContentLoaded\` → \`astro:page-load\` / \`data-astro-rerun\` IIFEs.
- **Phase 2 + 2b**: every component script with per-page DOM side effects wrapped in \`onMount\`. Globals (nanostores, supabase init, SharedWorker, \`window.__scalarRef\`, adsbygoogle) audited as idempotent.
- **Phase 3** (audit-only, no diff): sampled the highest-traffic React islands and confirmed each already follows SPA-friendly cleanup patterns.

## Test plan
- [ ] Click around docs sidebar — pages cross-fade, no nav/footer flicker.
- [ ] /dashboard/profile/ → /dashboard/account/ → wallet + referral + market cards boot on first nav, survive subsequent in-place nav.
- [ ] Forum compose / thread pages — auth gate still hides form for anon, textarea normalize fires per swap, submit posts.
- [ ] /arcade/* and /mc/* heavy-island pages — Unity / TD / item browsers re-mount cleanly.
- [ ] Dev console: no \`astro:before-swap\` / \`astro:after-swap\` warnings.

## Rollback
Single-file change. \`git revert\` if anything explodes.