### PR TITLE
ci(lint-test): install protobuf-compiler for nd-server agones build script

### DIFF
--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -105,11 +105,12 @@ jobs:
                   toolchain: '1.94'
                   components: clippy
 
-            - name: Install system libraries for wry/webkit2gtk
+            - name: Install system libraries for wry/webkit2gtk + protoc
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends \
-                    pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev
+                    pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
+                    protobuf-compiler
 
             - name: Setup PostgreSQL 17 for pgrx
               run: |


### PR DESCRIPTION
## Summary

Fixes the `nx run nd-server:lint` failure on the dev→main validation workflow that surfaced after #11453 merged.

\`agones = \"1.57\"\` ships a \`build.rs\` that compiles its \`.proto\` schema via \`prost-build\`, which shells out to \`protoc\`. The shared \`utils-ci-lint-test.yml\` workflow only had \`pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev\` installed, so the build script aborted with:

\`\`\`
error: failed to run custom build command for \`agones v1.57.0\`
failed to compile protobuffers: Custom { kind: NotFound, error:
"Could not find \`protoc\`. ..."
\`\`\`

Adds \`protobuf-compiler\` to the same apt-get install line that already brings in the wry/webkit2gtk deps. \`rust-test-crate.yml\` already installs it for crate-level CI; this just brings the affected-lint workflow into parity.

## Test plan

- [x] \`./kbve.sh -nx nd-server:lint\` clean locally (protoc already on dev machine; reproduces the missing-dep on CI runner image).
- [ ] CI \`Lint and Test\` green.
- [ ] Dev→Main validation workflow green on the next dev push.