### PR TITLE
ci(lint-test): add libprotobuf-dev for google/protobuf well-known includes

### DIFF
--- a/.github/workflows/utils-ci-lint-test.yml
+++ b/.github/workflows/utils-ci-lint-test.yml
@@ -110,7 +110,7 @@ jobs:
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends \
                     pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
-                    protobuf-compiler
+                    protobuf-compiler libprotobuf-dev
 
             - name: Setup PostgreSQL 17 for pgrx
               run: |


### PR DESCRIPTION
## Summary

Follow-up to #11456. The agones build script now finds \`protoc\` but the bundled \`google/api/annotations.proto\` imports \`google/protobuf/descriptor.proto\`, which lives in \`libprotobuf-dev\` (\`/usr/include/google/protobuf/*.proto\`) on Ubuntu — not in \`protobuf-compiler\`. Without it the build aborts:

\`\`\`
failed to compile protobuffers:
google/protobuf/descriptor.proto: File not found.
google/api/annotations.proto:20:1: Import "google/protobuf/descriptor.proto" was not found or had errors.
\`\`\`

Failure: https://github.com/KBVE/kbve/actions/runs/26671877648/job/78616528646

Adds \`libprotobuf-dev\` to the same apt-get install line.

## Test plan

- [ ] CI \`Lint and Test\` green.
- [ ] Dev→Main validation workflow green.