### PR TITLE
fix(agones-factorio): label namespace pod-security=privileged for hostPort

### DIFF
--- a/apps/kube/agones/factorio/manifests/namespace.yaml
+++ b/apps/kube/agones/factorio/manifests/namespace.yaml
@@ -5,3 +5,10 @@ metadata:
     labels:
         app.kubernetes.io/part-of: factorio
         kbve.com/stack: agones
+        # Agones GameServer uses hostPort 34197 for the public UDP listener,
+        # which the cluster-wide `baseline` PodSecurity profile forbids. Match
+        # the arc-runners ns (which runs the mc / ows Agones fleets) and
+        # downgrade to `privileged` for all three PodSecurity dimensions.
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/audit: privileged
+        pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary

After #11448 added `factorio` to `gameservers.namespaces` (which got Agones to provision the `agones-sdk` ServiceAccount), I forced a GameServer recreate to retry pod scheduling. Immediately re-entered \`Error\` with:

\`\`\`
pods \"factorio\" is forbidden: violates PodSecurity \"baseline:latest\":
  hostPort (container \"factorio\" uses hostPort 34197)
\`\`\`

### Root cause

`apps/kube/agones/factorio/manifests/namespace.yaml` only carried `app.kubernetes.io/part-of` and `kbve.com/stack`. With **no `pod-security.kubernetes.io/*` labels** the namespace falls back to the cluster-wide default of `baseline:latest`, which **forbids `hostPort`**.

`arc-runners` (where the mc and ows GameServer fleets run) is labelled `privileged` for all three PodSecurity dimensions (`enforce` / `audit` / `warn`), which is why its hostPort-using GameServers schedule fine.

### Fix

Mirror the `arc-runners` labels on the `factorio` namespace:

\`\`\`yaml
pod-security.kubernetes.io/enforce: privileged
pod-security.kubernetes.io/audit: privileged
pod-security.kubernetes.io/warn: privileged
\`\`\`

ArgoCD reconciles the namespace → admission controller stops blocking the pod → GameServer scheduling unsticks.

Refs: #11138, follow-up to #11448 / #11449.

## Test plan

- [ ] After merge + ArgoCD reconcile of `agones-factorio`: \`kubectl get ns factorio -o jsonpath='{.metadata.labels}'\` includes all three pod-security labels.
- [ ] \`kubectl -n factorio delete gameserver factorio\` (force re-evaluate) → ArgoCD recreates → GameServer transitions Error → Scheduled → Starting → Ready.
- [ ] \`kubectl -n factorio get pod\` shows the two-container pod (factorio + factorio-relay) + the auto-injected agones-sdk sidecar.
- [ ] \`kubectl -n factorio logs <pod> -c factorio | grep \"Hosting game\"\` confirms factorio is up on UDP 34197.