### PR TITLE
fix(agones-factorio-relay): publish versioned image tag + auto-bump gameserver

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -10,23 +10,25 @@
 			"runner": "ubuntu-latest",
 			"image": "kbve/agones-factorio",
 			"e2e_name": "agones-factorio",
+			"deployment_yaml": "apps/kube/agones/factorio/manifests/gameserver.yaml",
 			"has_test": true
 		},
 		{
 			"key": "agones_factorio_relay",
 			"app_name": "agones-factorio-relay",
-			"version": "0.0.2",
+			"version": "0.0.3",
 			"version_toml": "apps/agones/factorio/relay/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx",
 			"source_path": "apps/agones/factorio/relay",
 			"runner": "ubuntu-latest",
 			"image": "kbve/agones-factorio-relay",
+			"deployment_yaml": "apps/kube/agones/factorio/manifests/gameserver.yaml",
 			"has_test": false
 		},
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.174",
+			"version": "1.0.175",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",

--- a/apps/agones/factorio/relay/project.json
+++ b/apps/agones/factorio/relay/project.json
@@ -31,6 +31,27 @@
 			}
 		},
 		"container": {
+			"executor": "nx:run-commands",
+			"defaultConfiguration": "local",
+			"options": {
+				"parallel": false
+			},
+			"configurations": {
+				"local": {
+					"commands": [
+						"./kbve.sh -nx agones-factorio-relay:containerx",
+						"VERSION=$(sed -n 's/^version *= *\"\\(.*\\)\"/\\1/p' apps/agones/factorio/relay/version.toml | head -1) && docker tag kbve/agones-factorio-relay:latest kbve/agones-factorio-relay:$VERSION && echo \"Tagged kbve/agones-factorio-relay:$VERSION\""
+					]
+				},
+				"production": {
+					"commands": [
+						"./kbve.sh -nx agones-factorio-relay:containerx --configuration=production",
+						"VERSION=$(sed -n 's/^version *= *\"\\(.*\\)\"/\\1/p' apps/agones/factorio/relay/version.toml | head -1) && docker tag kbve/agones-factorio-relay:latest kbve/agones-factorio-relay:$VERSION && docker tag kbve/agones-factorio-relay:latest ghcr.io/kbve/agones-factorio-relay:latest && docker tag kbve/agones-factorio-relay:latest ghcr.io/kbve/agones-factorio-relay:$VERSION && echo \"Tagged ghcr.io/kbve/agones-factorio-relay:$VERSION\""
+					]
+				}
+			}
+		},
+		"containerx": {
 			"executor": "@nx-tools/nx-container:build",
 			"defaultConfiguration": "local",
 			"options": {
@@ -46,8 +67,15 @@
 					"tags": ["kbve/agones-factorio-relay:latest"]
 				},
 				"production": {
-					"push": true,
-					"tags": ["ghcr.io/kbve/agones-factorio-relay:latest"],
+					"load": true,
+					"push": false,
+					"metadata": {
+						"images": [
+							"ghcr.io/kbve/agones-factorio-relay",
+							"kbve/agones-factorio-relay"
+						],
+						"tags": ["latest"]
+					},
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/agones-factorio-relay:buildcache"
 					],

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx
@@ -15,11 +15,12 @@ tags:
 key: agones_factorio_relay
 pipeline: docker
 app_name: agones-factorio-relay
-version: "0.0.2"
+version: "0.0.3"
 source_path: apps/agones/factorio/relay
 version_toml: apps/agones/factorio/relay/version.toml
 runner: ubuntu-latest
 image: kbve/agones-factorio-relay
+deployment_yaml: apps/kube/agones/factorio/manifests/gameserver.yaml
 has_test: false
 author: h0lybyte
 license: KBVE

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
@@ -18,6 +18,7 @@ source_path: apps/agones/factorio
 version_toml: apps/agones/factorio/version.toml
 runner: ubuntu-latest
 image: kbve/agones-factorio
+deployment_yaml: apps/kube/agones/factorio/manifests/gameserver.yaml
 has_test: true
 e2e_name: agones-factorio
 test_framework: typescript

--- a/apps/kube/agones/factorio/manifests/gameserver.yaml
+++ b/apps/kube/agones/factorio/manifests/gameserver.yaml
@@ -114,7 +114,7 @@ spec:
                           drop:
                               - ALL
                 - name: factorio-relay
-                  image: ghcr.io/kbve/agones-factorio-relay:0.0.2
+                  image: ghcr.io/kbve/agones-factorio-relay:0.0.3
                   imagePullPolicy: IfNotPresent
                   env:
                       - name: FACTORIO_CONSOLE_LOG


### PR DESCRIPTION
## Summary

The factorio GameServer pod is stuck on \`ImagePullBackOff\` for the relay sidecar:

\`\`\`
factorio-relay: ghcr.io/kbve/agones-factorio-relay:0.0.2
  → failed to resolve reference \"ghcr.io/kbve/agones-factorio-relay:0.0.2\":
    not found
\`\`\`

Two separate gaps fixed here.

### 1. Versioned image tag was never actually published

The relay's CI run logs proudly say `Promoted ... v0.0.2`, but a bearer-token query against ghcr confirms only `latest` + `buildcache` tags exist for `kbve/agones-factorio-relay`:

\`\`\`
$ curl -H \"Authorization: Bearer <ghcr-token>\" https://ghcr.io/v2/kbve/agones-factorio-relay/tags/list
{\"name\":\"kbve/agones-factorio-relay\",\"tags\":[\"latest\",\"buildcache\"]}
\`\`\`

vs `kbve/agones-factorio`:

\`\`\`
{\"name\":\"kbve/agones-factorio\",\"tags\":[\"0.0.2\",\"0.0.3\",\"0.0.4\",\"latest\",\"ci-...\"]}
\`\`\`

#### Why it failed for relay specifically

The relay MDX has `has_test: false`, so the CI test job that builds + pushes `ci-${SHORT_SHA}` is skipped. `utils-publish-docker-image.yml`'s **promote path** (which retags that `ci-` image as `:VERSION` + `:latest` and pushes both) is therefore skipped too. The workflow falls through to the **full-build path**, which calls Nx, then tries to re-export the just-built image into the local docker daemon via:

\`\`\`bash
docker buildx build -f $(find . -path \"*/agones-factorio-relay/Dockerfile\" ...)
\`\`\`

That `find` returns empty because our folder is `relay/`, not `agones-factorio-relay/`. The error is swallowed by `2>/dev/null` — only `:latest` (which Nx already pushed directly) ends up on ghcr, and the gameserver pod hits `ImagePullBackOff` on `:0.0.2`.

#### Fix

Mirror the `firecracker-ctl` pattern in `apps/agones/factorio/relay/project.json`:

- `containerx` runs the Nx-driven build with `load: true, push: false`, so the image lands in the docker daemon as `kbve/agones-factorio-relay:latest`.
- `container` (wrapper) runs `containerx`, then `docker tag`s the `:VERSION` explicitly (reading from `version.toml`). The workflow's downstream \"Push Docker Images\" step then finds the loaded image, tags it for both registries, and pushes `:VERSION` + `:latest`.

mc-velocity gets versioned tags because `has_test: true` keeps it on the promote path; the full-build path always had this `find` bug, it's just never been exercised before. Future no-test docker projects will hit the same wall — same wrapper fix as a copy-paste template.

### 2. gameserver.yaml image refs aren't auto-bumped

I hand-edited the image tag in `apps/kube/agones/factorio/manifests/gameserver.yaml` in #11427. Compare with `mc-velocity.mdx` which carries:

\`\`\`yaml
deployment_yaml: apps/kube/agones/mc/manifests/velocity-deployment.yaml
\`\`\`

The post-publish workflow auto-rewrites the image tag in the file pointed at by `deployment_yaml`. Add the field to **both** `agones-factorio.mdx` and `agones-factorio-relay.mdx` so future bumps don't drift between the two manifests and the gameserver pod.

Both MDX entries point at the same `gameserver.yaml`; the post-publish step bumps only the row matching that project's `image:` value.

### Version bumps

- relay MDX `0.0.2` → `0.0.3` so the next ci-main dispatch re-fires the publish (now via the fixed wrapper).
- gameserver.yaml relay pin → `0.0.3` so the pod picks up the freshly-tagged image. Once the auto-bump lands, future versions update on their own.
- `.github/ci-dispatch-manifest.json` regenerated via `astro-kbve:sync:ci-manifest`.
- `version.toml` stays at `0.0.2` — chases on next publish success per the sentinel pattern.

Refs: #11138, follow-up to #11418 / #11427.

## Test plan

- [ ] After merge: CI builds + pushes `ghcr.io/kbve/agones-factorio-relay:0.0.3` AND `:latest`.
- [ ] \`curl -H \"Authorization: Bearer <token>\" https://ghcr.io/v2/kbve/agones-factorio-relay/tags/list\` includes `0.0.3`.
- [ ] \`kubectl -n factorio delete gameserver factorio\` → pod respawns and pulls the relay image cleanly (no ImagePullBackOff).
- [ ] Future relay bumps: change MDX version, the post-publish job rewrites `gameserver.yaml` line 117 automatically.