### PR TITLE
fix(agones-factorio): install wget so the shim's SDK health pinger runs

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "agones_factorio",
 			"app_name": "agones-factorio",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"version_toml": "apps/agones/factorio/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx",
 			"source_path": "apps/agones/factorio",
@@ -234,7 +234,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.20",
+			"version": "0.1.21",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",

--- a/apps/agones/factorio/Dockerfile
+++ b/apps/agones/factorio/Dockerfile
@@ -3,6 +3,10 @@ FROM factoriotools/factorio:${FACTORIO_VERSION}-rootless
 
 USER root
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --chown=1000:1000 apps/agones/factorio/scenarios/kbve /factorio/scenarios/kbve
 COPY --chown=1000:1000 apps/agones/factorio/config /opt/factorio/config-defaults
 COPY apps/agones/factorio/shim/agones-shim.sh /usr/local/bin/agones-shim

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_factorio
 pipeline: docker
 app_name: agones-factorio
-version: "0.0.4"
+version: "0.0.5"
 source_path: apps/agones/factorio
 version_toml: apps/agones/factorio/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Summary

GameServer reaches \`Scheduled\` and the factorio container boots fine (`Hosting game`, RCON 27015 bound), but Agones flips to `Unhealthy` ~75s in. The SDK sidecar logs `GameServer Health Check failed` repeatedly until the auto-injected livenessProbe at `/gshealthz:8080` kills the container.

### Root cause

`agones-shim` uses `wget` to POST `/ready` and `/health` to `localhost:9358`. `factoriotools/factorio:2.0.76-rootless` is based on debian-slim, which **doesn't ship wget by default**. Every `sdk_post` call fails, and the failure is masked by `|| true` in the shim, so it looks healthy from the outside while the SDK never receives a single `Ready()` or `Health()`.

### Fix

`apt-get install -y --no-install-recommends wget` at image build time. `--no-install-recommends` keeps the layer at ~1MB, apt lists cleaned up.

Local validation didn't catch this because `AGONES_SDK_HTTP` was unset on the laptop docker runs, so the entire pinger subshell was skipped. The bug only surfaces in the cluster where Agones is actually listening.

MDX `0.0.4` → `0.0.5`. `version.toml` stays at `0.0.4`. The `deployment_yaml` auto-bump from #11465 will rewrite the gameserver.yaml factorio image tag once the publish lands.

Refs: #11138, follow-up to #11427 / #11465.

## Test plan

- [ ] After merge: ghcr.io/kbve/agones-factorio:0.0.5 published.
- [ ] post-publish job auto-rewrites gameserver.yaml factorio image tag → 0.0.5.
- [ ] `kubectl -n factorio delete gameserver factorio` → new pod boots → GameServer transitions Scheduled → Ready within ~60s and stays Ready (no Unhealthy flips).
- [ ] SDK sidecar logs no longer show `GameServer Health Check failed`.