### PR TITLE
refactor(jedi): extract Source RCON client into shared crate

### DIFF
--- a/apps/kbve/axum-kbve/src/db/mc.rs
+++ b/apps/kbve/axum-kbve/src/db/mc.rs
@@ -1,27 +1,12 @@
-// MC RCON client with multi-server support, DashMap-cached player data,
-// Mojang profile enrichment, and ClickHouse snapshot publishing.
-//
-// Background task polls every configured RCON endpoint in parallel every
-// 15s, tags each player with the backend server they're on, resolves
-// UUIDs + textures via Mojang, and writes a snapshot row per player to
-// `mc.player_snapshots_distributed` in ClickHouse. axum-kbve serves its
-// own /api/v1/mc/players from an in-memory cache for low latency; edge
-// functions and other consumers read historical state from ClickHouse.
-
 use dashmap::DashMap;
 use futures_util::future::join_all;
+use jedi::rcon::{RconClient, RconEndpoint as RconConn};
 use serde::Serialize;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
 use tracing::{debug, warn};
 
 use super::ensure_https;
-
-// ---------------------------------------------------------------------------
-// Configuration
-// ---------------------------------------------------------------------------
 
 const REFRESH_INTERVAL: Duration = Duration::from_secs(15);
 const PLAYER_TTL: Duration = Duration::from_secs(3600); // 1h
@@ -31,14 +16,10 @@ const CH_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
 const MOJANG_API: &str = "https://api.mojang.com/users/profiles/minecraft";
 const MOJANG_SESSION: &str = "https://sessionserver.mojang.com/session/minecraft/profile";
 
-// Names we probe for multi-server env var prefixes. Add new backends
-// by listing their env var suffix here — each maps to
-// MC_RCON_<NAME>_HOST / _PORT / _PASSWORD.
+/// Probed env-var suffixes for the multi-server scheme. Add a new backend
+/// by listing its suffix here — each maps to `MC_RCON_<NAME>_HOST` / `_PORT`
+/// / `_PASSWORD`.
 const KNOWN_SERVERS: &[&str] = &["LOBBY", "SURVIVAL"];
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 /// API response model — serialized to JSON for `/api/v1/mc/players`.
 #[derive(Clone, Debug, Serialize)]
@@ -77,16 +58,13 @@ pub struct McPlayerList {
 /// poll. Factored out to silence the `type_complexity` clippy lint.
 type RconPollResult = (String, anyhow::Result<(Vec<String>, usize)>);
 
-/// One RCON endpoint. Multiple can be configured for lobby + survival +
-/// future backends.
+/// One named MC backend keyed by its env-var suffix ("lobby", "survival").
+/// The transport-level connection params live in [`RconConn`]; this wrapper
+/// adds the logical name surfaced on each `McPlayer` and ClickHouse row.
 #[derive(Clone, Debug)]
 struct RconEndpoint {
-    /// Lowercase server name ("lobby", "survival"). Surfaced on each
-    /// McPlayer and written to ClickHouse.
     name: String,
-    host: String,
-    port: u16,
-    password: String,
+    conn: RconConn,
 }
 
 /// Single cache entry holding all resolved data for a Minecraft player.
@@ -114,15 +92,9 @@ pub struct McService {
     /// Optional — writes every snapshot to ClickHouse when configured.
     /// None means CH env vars were missing and we're in-memory only.
     clickhouse: Option<ClickHouseWriter>,
-    // Cached player list (refreshed by background task)
     player_list: Arc<tokio::sync::RwLock<Option<McPlayerList>>>,
-    // Single cache for all player data (name → uuid + skin_url + texture_bytes)
     players: Arc<DashMap<String, CachedPlayer>>,
 }
-
-// ---------------------------------------------------------------------------
-// Global singleton (same pattern as osrs.rs, discord.rs)
-// ---------------------------------------------------------------------------
 
 static MC_SERVICE: OnceLock<Arc<McService>> = OnceLock::new();
 
@@ -151,7 +123,6 @@ pub fn init_mc_service() -> bool {
         return false;
     }
 
-    // Spawn background refresh task with panic recovery
     tokio::spawn(async move {
         loop {
             let svc_ref = svc.clone();
@@ -185,9 +156,7 @@ fn parse_rcon_endpoints() -> Vec<RconEndpoint> {
             let password = std::env::var(format!("MC_RCON_{name}_PASSWORD")).unwrap_or_default();
             out.push(RconEndpoint {
                 name: name.to_lowercase(),
-                host,
-                port,
-                password,
+                conn: RconConn::new(host, port, password),
             });
         }
     }
@@ -201,19 +170,13 @@ fn parse_rcon_endpoints() -> Vec<RconEndpoint> {
             let password = std::env::var("MC_RCON_PASSWORD").unwrap_or_default();
             out.push(RconEndpoint {
                 name: "default".to_string(),
-                host,
-                port,
-                password,
+                conn: RconConn::new(host, port, password),
             });
         }
     }
 
     out
 }
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
 
 impl McService {
     pub async fn get_players(&self) -> McPlayerList {
@@ -251,7 +214,6 @@ impl McService {
     pub async fn fetch_texture(&self, hash: &str) -> Option<Vec<u8>> {
         let target_suffix = format!("/texture/{hash}");
 
-        // Check if any cached player already has the bytes
         for entry in self.players.iter() {
             if let Some(ref url) = entry.skin_url {
                 if url.ends_with(&target_suffix) {
@@ -263,7 +225,6 @@ impl McService {
             }
         }
 
-        // Fetch from Mojang
         let url = format!("https://textures.minecraft.net/texture/{hash}");
         let resp = self.http.get(&url).send().await.ok()?;
         if !resp.status().is_success() {
@@ -271,7 +232,6 @@ impl McService {
         }
         let bytes = resp.bytes().await.ok()?.to_vec();
 
-        // Store in matching player's entry (if found)
         for mut entry in self.players.iter_mut() {
             if let Some(ref skin_url) = entry.skin_url {
                 if skin_url.ends_with(&target_suffix) {
@@ -285,14 +245,10 @@ impl McService {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Background refresh
-// ---------------------------------------------------------------------------
-
 impl McService {
+    /// Poll every configured endpoint in parallel so one unreachable backend
+    /// (e.g. an Agones fleet with 0 Fabric pods) doesn't sink the others.
     async fn refresh_player_list(&self) {
-        // Poll every configured endpoint in parallel. If one is down
-        // (e.g. Agones fleet has 0 Fabric pods), the others still land.
         let polls = self.endpoints.iter().map(|ep| {
             let ep = ep.clone();
             async move {
@@ -350,7 +306,6 @@ impl McService {
 
         *self.player_list.write().await = Some(list);
 
-        // Evict expired entries
         self.players.retain(|_, v| !v.is_expired());
 
         debug!(
@@ -359,7 +314,7 @@ impl McService {
             server_statuses.len()
         );
 
-        // ClickHouse write is best-effort — failures don't affect the
+        // ClickHouse write is best-effort: failures don't affect the
         // in-memory cache that serves /api/v1/mc/players.
         if let Some(ref ch) = self.clickhouse {
             if let Err(e) = ch.write_snapshot(&server_statuses, &all_players).await {
@@ -373,14 +328,12 @@ impl McService {
     async fn resolve_player(&self, name: &str) -> Option<CachedPlayer> {
         let lower = name.to_lowercase();
 
-        // Check cache
         if let Some(entry) = self.players.get(&lower) {
             if !entry.is_expired() {
                 return Some(entry.clone());
             }
         }
 
-        // Fetch UUID from Mojang
         let url = format!("{MOJANG_API}/{name}");
         let url = ensure_https(&url).ok()?;
         let resp = self.http.get(url).send().await.ok()?;
@@ -390,10 +343,9 @@ impl McService {
         let body: serde_json::Value = resp.json().await.ok()?;
         let uuid = body.get("id")?.as_str()?.to_string();
 
-        // Fetch skin URL from Mojang session server
         let skin_url = self.fetch_skin_url(&uuid).await;
 
-        // Preserve existing texture_bytes if the skin_url hasn't changed
+        // Preserve cached texture_bytes when the skin_url hasn't changed.
         let texture_bytes = self.players.get(&lower).and_then(|old| {
             if old.skin_url == skin_url {
                 old.texture_bytes.clone()
@@ -427,90 +379,19 @@ impl McService {
     }
 }
 
-// ---------------------------------------------------------------------------
-// RCON protocol (Minecraft/Source RCON — simple length-prefixed TCP packets)
-// ---------------------------------------------------------------------------
-
-// Packet types
-const RCON_AUTH: i32 = 3;
-const RCON_EXEC: i32 = 2;
-
 impl McService {
-    /// Connect to RCON, authenticate, run `list`, return (player_names, max_players).
+    /// Connect to RCON, run `list`, return (player_names, max_players).
     /// Associated function so each endpoint can be polled in parallel without
     /// borrowing &self across the join_all boundary.
     async fn rcon_list(ep: &RconEndpoint) -> anyhow::Result<(Vec<String>, usize)> {
-        let addr = format!("{}:{}", ep.host, ep.port);
-        let mut stream = tokio::time::timeout(RCON_TIMEOUT, TcpStream::connect(&addr)).await??;
-
-        // Authenticate
-        rcon_send(&mut stream, 1, RCON_AUTH, &ep.password).await?;
-        let (req_id, _, _) = rcon_recv(&mut stream).await?;
-        if req_id == -1 {
-            anyhow::bail!("RCON authentication failed");
-        }
-
-        // Send `list` command
-        rcon_send(&mut stream, 2, RCON_EXEC, "list").await?;
-        let (_, _, body) = rcon_recv(&mut stream).await?;
-
+        let mut client = RconClient::connect(&ep.conn, RCON_TIMEOUT).await?;
+        let body = client.exec("list").await?;
         parse_list_response(&body)
     }
 }
 
-/// Send an RCON packet: [length:4][req_id:4][type:4][body + \0][pad \0]
-///
-/// The entire packet is buffered and sent in a single write to avoid
-/// TCP segmentation issues with RCON servers that expect atomic reads.
-async fn rcon_send(
-    stream: &mut TcpStream,
-    req_id: i32,
-    ptype: i32,
-    body: &str,
-) -> anyhow::Result<()> {
-    let body_bytes = body.as_bytes();
-    let length = 4 + 4 + body_bytes.len() as i32 + 2; // req_id + type + body + 2 nulls
-
-    let mut buf = Vec::with_capacity(4 + length as usize);
-    buf.extend_from_slice(&length.to_le_bytes());
-    buf.extend_from_slice(&req_id.to_le_bytes());
-    buf.extend_from_slice(&ptype.to_le_bytes());
-    buf.extend_from_slice(body_bytes);
-    buf.extend_from_slice(&[0, 0]);
-
-    stream.write_all(&buf).await?;
-    stream.flush().await?;
-    Ok(())
-}
-
-/// Read an RCON response packet, returns (req_id, type, body).
-async fn rcon_recv(stream: &mut TcpStream) -> anyhow::Result<(i32, i32, String)> {
-    let mut len_buf = [0u8; 4];
-    stream.read_exact(&mut len_buf).await?;
-    let length = i32::from_le_bytes(len_buf) as usize;
-
-    if !(10..=4096).contains(&length) {
-        anyhow::bail!("RCON packet length out of range: {length}");
-    }
-
-    let mut payload = vec![0u8; length];
-    stream.read_exact(&mut payload).await?;
-
-    let req_id = i32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
-    let ptype = i32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
-    // Body is everything after the 8-byte header, minus 2 trailing nulls
-    let body_end = length.saturating_sub(2);
-    let body = String::from_utf8_lossy(&payload[8..body_end]).to_string();
-
-    Ok((req_id, ptype, body))
-}
-
-// ---------------------------------------------------------------------------
-// ClickHouse writer — snapshot per player per poll into
-// mc.player_snapshots_distributed. Schema lives in
-// apps/kube/kbve/manifest/mc-presence-ch-setup-job.yaml.
-// ---------------------------------------------------------------------------
-
+/// Writer for the per-poll snapshot into `mc.player_snapshots_distributed`.
+/// Schema lives in `apps/kube/kbve/manifest/mc-presence-ch-setup-job.yaml`.
 struct ClickHouseWriter {
     endpoint: String,
     user: String,
@@ -540,9 +421,9 @@ impl ClickHouseWriter {
         servers: &[McServerStatus],
         players: &[McPlayer],
     ) -> anyhow::Result<()> {
-        // Skip empty snapshots — the schema is per-player, so there's
-        // nothing to record when every server is empty. The reachable
-        // flag + in-memory cache cover server liveness at query time.
+        // Skip empty snapshots — the schema is per-player, so there's nothing
+        // to record when every server is empty. The `reachable` flag + the
+        // in-memory cache cover server liveness at query time.
         if players.is_empty() {
             return Ok(());
         }
@@ -590,15 +471,10 @@ impl ClickHouseWriter {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Response parsing
-// ---------------------------------------------------------------------------
-
 /// Parse Minecraft `list` response:
 /// "There are N of a max of M players online: name1, name2, ..."
 /// or "There are 0 of a max of M players online:"
 fn parse_list_response(response: &str) -> anyhow::Result<(Vec<String>, usize)> {
-    // Find "max of N" to extract max players
     let max = response
         .split("max of ")
         .nth(1)
@@ -606,7 +482,6 @@ fn parse_list_response(response: &str) -> anyhow::Result<(Vec<String>, usize)> {
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(0);
 
-    // Find player names after the colon
     let names = if let Some(after_colon) = response.split(':').nth(1) {
         let trimmed = after_colon.trim();
         if trimmed.is_empty() {
@@ -624,10 +499,6 @@ fn parse_list_response(response: &str) -> anyhow::Result<(Vec<String>, usize)> {
 
     Ok((names, max))
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 /// Extract the 60-64 char hex texture hash from a textures.minecraft.net URL.
 pub fn extract_texture_hash(skin_url: &str) -> Option<String> {
@@ -697,10 +568,6 @@ fn now_epoch() -> u64 {
         .unwrap_or_default()
         .as_secs()
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {

--- a/packages/rust/jedi/src/lib.rs
+++ b/packages/rust/jedi/src/lib.rs
@@ -7,11 +7,11 @@ mod tests {
     }
 }
 
-
 pub mod builder;
 pub mod entity;
-pub mod state;
 pub mod proto;
+pub mod rcon;
+pub mod state;
 pub mod wrapper;
 
 pub use builder::*;

--- a/packages/rust/jedi/src/rcon.rs
+++ b/packages/rust/jedi/src/rcon.rs
@@ -1,0 +1,188 @@
+//! Source RCON client — game-agnostic implementation of the Valve Source
+//! protocol (Minecraft, Factorio, and every other game that speaks
+//! length-prefixed TCP RCON).
+//!
+//! Shared so axum-kbve, the discord bot, internal scripts, and future Rust
+//! services all hit the same wire implementation instead of re-rolling the
+//! packet framing.
+//!
+//! Higher layers stay in their own crates:
+//!   * command grammars (MC `list`, Factorio `/silent-command`, …)
+//!   * allowlist / auth gating
+//!   * per-endpoint env-var schemes
+//!   * audit logging
+//!
+//! Only the transport lives here.
+
+use std::time::Duration;
+use thiserror::Error;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+/// Source RCON packet types we send. Server-auth response also reuses these.
+const PACKET_TYPE_AUTH: i32 = 3;
+const PACKET_TYPE_EXEC: i32 = 2;
+
+/// Hard ceiling on packet body length. Source RCON is documented at 4096
+/// bytes per packet; reject anything outside [10, 4096] so a corrupt stream
+/// can't bait us into a huge allocation.
+const PACKET_MIN_LEN: usize = 10;
+const PACKET_MAX_LEN: usize = 4096;
+
+/// Failed-auth sentinel returned by the server in the `id` field per the
+/// Source RCON spec.
+const AUTH_FAILED_ID: i32 = -1;
+
+#[derive(Debug, Error)]
+pub enum RconError {
+    #[error("rcon connect to {addr} timed out after {timeout:?}")]
+    ConnectTimeout { addr: String, timeout: Duration },
+
+    #[error("rcon i/o: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("rcon auth rejected by server")]
+    AuthRejected,
+
+    #[error("rcon packet length {0} out of range [{PACKET_MIN_LEN}, {PACKET_MAX_LEN}]")]
+    PacketLength(usize),
+}
+
+pub type RconResult<T> = Result<T, RconError>;
+
+/// Connection params for one RCON endpoint. Cheap to clone — meant to be
+/// built once at startup from env vars / config and reused per call.
+#[derive(Clone, Debug)]
+pub struct RconEndpoint {
+    pub host: String,
+    pub port: u16,
+    pub password: String,
+}
+
+impl RconEndpoint {
+    pub fn new(host: impl Into<String>, port: u16, password: impl Into<String>) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            password: password.into(),
+        }
+    }
+
+    pub fn addr(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+/// Authenticated RCON session. Holds the TCP stream and a monotonically
+/// increasing request id. Drop the value to close the connection.
+pub struct RconClient {
+    stream: TcpStream,
+    next_id: i32,
+}
+
+impl RconClient {
+    /// Connect and authenticate against an endpoint, returning a session
+    /// ready to `exec`.
+    pub async fn connect(ep: &RconEndpoint, connect_timeout: Duration) -> RconResult<Self> {
+        let stream = timeout(connect_timeout, TcpStream::connect(ep.addr()))
+            .await
+            .map_err(|_| RconError::ConnectTimeout {
+                addr: ep.addr(),
+                timeout: connect_timeout,
+            })??;
+
+        let mut client = Self { stream, next_id: 1 };
+        client.authenticate(&ep.password).await?;
+        Ok(client)
+    }
+
+    async fn authenticate(&mut self, password: &str) -> RconResult<()> {
+        let id = self.alloc_id();
+        send_packet(&mut self.stream, id, PACKET_TYPE_AUTH, password).await?;
+        let (resp_id, _, _) = recv_packet(&mut self.stream).await?;
+        if resp_id == AUTH_FAILED_ID {
+            return Err(RconError::AuthRejected);
+        }
+        Ok(())
+    }
+
+    /// Send an EXEC packet and return the body of the server's response.
+    pub async fn exec(&mut self, command: &str) -> RconResult<String> {
+        let id = self.alloc_id();
+        send_packet(&mut self.stream, id, PACKET_TYPE_EXEC, command).await?;
+        let (_, _, body) = recv_packet(&mut self.stream).await?;
+        Ok(body)
+    }
+
+    fn alloc_id(&mut self) -> i32 {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        id
+    }
+}
+
+/// Wire format: [length:4][req_id:4][type:4][body + \0][pad \0]
+///
+/// Buffered into one write so RCON servers that expect atomic reads don't
+/// race a TCP segmentation boundary.
+async fn send_packet(
+    stream: &mut TcpStream,
+    req_id: i32,
+    ptype: i32,
+    body: &str,
+) -> RconResult<()> {
+    let body_bytes = body.as_bytes();
+    let length = 4 + 4 + body_bytes.len() as i32 + 2;
+
+    let mut buf = Vec::with_capacity(4 + length as usize);
+    buf.extend_from_slice(&length.to_le_bytes());
+    buf.extend_from_slice(&req_id.to_le_bytes());
+    buf.extend_from_slice(&ptype.to_le_bytes());
+    buf.extend_from_slice(body_bytes);
+    buf.extend_from_slice(&[0, 0]);
+
+    stream.write_all(&buf).await?;
+    stream.flush().await?;
+    Ok(())
+}
+
+async fn recv_packet(stream: &mut TcpStream) -> RconResult<(i32, i32, String)> {
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).await?;
+    let length = i32::from_le_bytes(len_buf) as usize;
+
+    if !(PACKET_MIN_LEN..=PACKET_MAX_LEN).contains(&length) {
+        return Err(RconError::PacketLength(length));
+    }
+
+    let mut payload = vec![0u8; length];
+    stream.read_exact(&mut payload).await?;
+
+    let req_id = i32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+    let ptype = i32::from_le_bytes([payload[4], payload[5], payload[6], payload[7]]);
+    let body_end = length.saturating_sub(2);
+    let body = String::from_utf8_lossy(&payload[8..body_end]).to_string();
+
+    Ok((req_id, ptype, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_addr_formats_host_port() {
+        let ep = RconEndpoint::new("mc-lobby.kbve.svc.cluster.local", 25575, "hunter2");
+        assert_eq!(ep.addr(), "mc-lobby.kbve.svc.cluster.local:25575");
+    }
+
+    #[test]
+    fn endpoint_clone_is_cheap_and_independent() {
+        let ep = RconEndpoint::new("a", 1, "p");
+        let cloned = ep.clone();
+        assert_eq!(cloned.host, "a");
+        assert_eq!(cloned.port, 1);
+        assert_eq!(cloned.password, "p");
+    }
+}


### PR DESCRIPTION
## Summary
Pure refactor — no behavior change, no new routes, no new env vars. Follow-up to #11464 (rcon proto). Pulls the Source-RCON wire protocol out of \`apps/kbve/axum-kbve/src/db/mc.rs\` and into \`packages/rust/jedi/src/rcon.rs\` so the upcoming generic \`POST /rcon/{game}/{server}/exec\` route, the discord bot, and future internal services share one implementation instead of re-rolling packet framing.

Only the transport lives in jedi. Higher layers (command grammars, allowlist, per-endpoint env scheme, audit) stay in their callers.

## API
\`\`\`rust
use jedi::rcon::{RconClient, RconEndpoint, RconError};

let ep = RconEndpoint::new("mc-lobby.kbve.svc.cluster.local", 25575, "hunter2");
let mut client = RconClient::connect(&ep, Duration::from_secs(5)).await?;
let body = client.exec("list").await?;
\`\`\`

\`RconError\` via \`thiserror\` (connect-timeout / i/o / auth-rejected / packet-length). No \`anyhow\` dep added to jedi.

## axum-kbve mc.rs delta
- Local \`RconEndpoint\` becomes a thin wrapper carrying the logical \`name\` (\`lobby\` / \`survival\` / \`default\`) plus a \`jedi::rcon::RconEndpoint\` for transport bits.
- \`McService::rcon_list\` is now ~3 lines: connect → \`exec("list")\` → \`parse_list_response\`.
- Stale \`RCON_AUTH\` / \`RCON_EXEC\` consts, \`rcon_send\`, \`rcon_recv\`, and the section-banner / inline-narration comments are dropped.
- \`///\` rustdocs preserved.

## Validation
- [x] \`cargo check -p jedi\` clean.
- [x] \`cargo check -p axum-kbve\` clean.
- [x] \`cargo test -p jedi rcon\` — 2/2 unit tests pass.

## Test plan
- [ ] After merge: trigger axum-kbve build, confirm \`/api/v1/mc/players\` continues to return cached snapshot.
- [ ] Smoke against \`mc-lobby\` RCON in cluster, confirm player list still populates.

## Follow-up (slice C of the rcon plan)
1. Add \`POST /rcon/{game}/{server}/exec\` in axum-kbve consuming \`kbve.rcon.RconRequest\` from #11464 and \`jedi::rcon::RconClient\`.
2. Allowlist YAML at \`packages/data/rcon/commands.yaml\`.
3. Factorio env scheme \`RCON_FACTORIO_<SERVER>_HOST|PORT|PASSWORD\`.
4. \`apps/kbve/edge/functions/rcon/\` forwarder (Path A).