### PR TITLE
fix(astro-kbve): persist sidebar/header across ClientRouter swap + prefetchAll/hover

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -17,7 +17,16 @@ export default defineConfig({
 	image: {
 		domains: ['images.unsplash.com'],
 	},
-	prefetch: true,
+	// Prefetch warms destination HTML on hover so ClientRouter's swap
+	// has zero wait-for-network latency on the common case. `hover`
+	// strategy avoids the bandwidth cost of `viewport`/`load` while
+	// still feeling instant. `prefetchAll: true` opts every internal
+	// link in by default — individual links can opt out with
+	// `data-astro-prefetch="false"`.
+	prefetch: {
+		prefetchAll: true,
+		defaultStrategy: 'hover',
+	},
 	redirects: {
 		'/account': '/dashboard/account/',
 		'/account/': '/dashboard/account/',
@@ -92,6 +101,7 @@ export default defineConfig({
 				ThemeProvider: './src/components/theme/ThemeProvider.astro',
 				Head: './src/components/navigation/Head.astro',
 				Header: './src/components/navigation/Header.astro',
+				Sidebar: './src/components/navigation/Sidebar.astro',
 			},
 			head: [
 				{

--- a/apps/kbve/astro-kbve/src/components/navigation/Header.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/Header.astro
@@ -1,7 +1,18 @@
 ---
+/**
+ * KBVE Header override.
+ *
+ * Wrap in `transition:persist` so the navbar (auth icon, wallet badge,
+ * profile dropdown, search button) survives ClientRouter swaps. Without
+ * this, the entire top bar re-hydrates per nav — React islands
+ * remount, the auth probe re-runs, wallet badge re-fetches, and the
+ * navbar visibly flickers.
+ */
 import Default from '@astrojs/starlight/components/Header.astro';
 import AstroKbveSearch from '../search/AstroKbveSearch.astro';
 ---
 
-<Default />
-<AstroKbveSearch />
+<div transition:persist="kbve-header">
+	<Default />
+	<AstroKbveSearch />
+</div>

--- a/apps/kbve/astro-kbve/src/components/navigation/Sidebar.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/Sidebar.astro
@@ -1,0 +1,17 @@
+---
+/**
+ * KBVE Sidebar override — wraps Starlight's default left sidebar in a
+ * `transition:persist` container so the DOM survives ClientRouter
+ * navigation. Eliminates the cross-fade flicker where the sidebar
+ * briefly re-renders between pages: active-link highlight, group
+ * collapsed state, and `data-auth-visibility` gates all stay stable
+ * across swaps. Starlight's internal JS updates the active-link
+ * class via `astro:after-swap` so the sidebar still tracks the
+ * current route.
+ */
+import Default from '@astrojs/starlight/components/Sidebar.astro';
+---
+
+<div transition:persist="kbve-sidebar">
+	<Default />
+</div>


### PR DESCRIPTION
## Summary
Two follow-ups to the Phase 4 ClientRouter rollout.

### 1. Persist sidebar + header DOM
Without \`transition:persist\` the left sidebar + top navbar re-render on every same-origin nav, causing:
- active-link highlight + group-collapsed state jitter on the left sidebar
- React wallet badge / profile dropdown / search button re-hydrating per nav (auth probe re-runs, balance re-fetches, keycap flashes)

Override Starlight's \`Sidebar\` (new \`navigation/Sidebar.astro\`) wrapping default in \`<div transition:persist="kbve-sidebar">\`. Same for existing \`Header.astro\` override. Register Sidebar in \`astro.config.mjs\`.

Starlight's own JS updates active-link classes via \`astro:after-swap\` so persisted sidebar still tracks the current route.

**NOT persisted:** PageSidebar (right TOC — content is per-page) and Footer (uses per-onMount nanostore subscription).

### 2. \`prefetchAll: true\` + hover strategy
Promote prefetch from opt-in to all-internal-links-on-hover. Zero wait-for-network on ClientRouter swap for the common case. Per-link opt-out via \`data-astro-prefetch="false"\`.

## Test plan
- [ ] Click around docs sidebar — left sidebar + navbar no longer flicker
- [ ] Hover a link — DevTools Network shows the destination prefetched before click
- [ ] Active-link highlight on left sidebar tracks the current page after each swap
- [ ] Wallet badge balance stays visible across nav (no refetch flash)
- [ ] Right TOC (PageSidebar) still updates per page
- [ ] Footer still renders per page (intentional, see PR body for rationale)