### PR TITLE
feat(astro-kbve): Yuki dock — persistent deferred virtual concierge (Phase A)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
+++ b/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
@@ -4,6 +4,7 @@ import AstroDroidFooter from './AstroDroidFooter.astro';
 import SocialTooltip from '@kbve/astro/components/tooltip/social/SocialTooltip.astro';
 import SocialIcon from '@/components/social/SocialIcon.astro';
 import { SOCIALS, withUtm } from '@/data/socials';
+import AstroYukiDock from '@/components/jay/dock/AstroYukiDock.astro';
 
 const legalLinks = [
 	{ href: '/legal/privacy', label: 'Privacy' },
@@ -150,6 +151,8 @@ const currentYear = new Date().getFullYear();
 	<FooterQuickLinks />
 	<AstroDroidFooter />
 </footer>
+
+<AstroYukiDock />
 
 <style>
 	.kf-footer {

--- a/apps/kbve/astro-kbve/src/components/jay/dock/AstroYukiDock.astro
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/AstroYukiDock.astro
@@ -1,0 +1,357 @@
+---
+/**
+ * Persistent right-side virtual-assistant dock — Yuki, the chibi
+ * concierge that lives in the lower-right corner of every page.
+ *
+ * Design goals (per the dogfood thread that produced PR #11472):
+ *
+ *  1. Zero main-thread work on initial paint. The collapsed shell is
+ *     a single `<button>` + skeleton `<aside>` rendered as static HTML
+ *     and styled with CSS. No React, no Three.js, no model fetch.
+ *
+ *  2. Persist across every ClientRouter swap. Wrapped in
+ *     `transition:persist="kbve-yuki-dock"` so the dock survives
+ *     internal navigation — toggle state, chat history, mounted React
+ *     panel (once expanded) all stay in place. Lives outside the
+ *     Footer's auto-rendered region so it isn't tied to the footer's
+ *     own re-render cadence.
+ *
+ *  3. Lazy-mount the heavy panel on first expand. The vanilla driver
+ *     `yuki-dock.ts` dynamically `import()`s the React island the
+ *     first time the user clicks the FAB. Until then the bundle never
+ *     ships down the wire.
+ *
+ *  4. Survive the obvious foot-guns. Toggle state persists to
+ *     `localStorage` so a reload (or full nav) restores the
+ *     last-known expand/collapsed state. `prefers-reduced-motion`
+ *     respected. Mobile collapses to a full-screen sheet so the
+ *     button stays thumb-reachable.
+ *
+ * Future expansion: the placeholder panel currently shows a "Yuki is
+ * warming up" message. Phase B (separate PR) wires the existing
+ * `ReactJayYuki` 3D model + chat backend behind a feature flag so we
+ * can dogfood without committing to the full assistant immediately.
+ */
+const AVATAR_SRC = '/assets/images/brand/earth_ceo.png';
+---
+
+<div
+	id="kbve-yuki-dock"
+	class="kbve-yuki-dock"
+	data-kbve-yuki-dock
+	data-state="collapsed"
+	aria-live="polite"
+	transition:persist="kbve-yuki-dock">
+	<button
+		type="button"
+		class="kbve-yuki-dock__fab"
+		data-kbve-yuki-toggle
+		aria-controls="kbve-yuki-panel"
+		aria-expanded="false"
+		aria-label="Open Yuki assistant">
+		<img
+			class="kbve-yuki-dock__avatar"
+			src={AVATAR_SRC}
+			alt=""
+			loading="lazy"
+			decoding="async"
+			draggable="false"
+		/>
+		<span class="kbve-yuki-dock__pulse" aria-hidden="true"></span>
+	</button>
+
+	<aside
+		id="kbve-yuki-panel"
+		class="kbve-yuki-dock__panel"
+		role="dialog"
+		aria-modal="false"
+		aria-labelledby="kbve-yuki-panel-title"
+		hidden>
+		<header class="kbve-yuki-dock__header">
+			<div class="kbve-yuki-dock__title-row">
+				<img
+					class="kbve-yuki-dock__title-avatar"
+					src={AVATAR_SRC}
+					alt=""
+					loading="lazy"
+					decoding="async"
+					draggable="false"
+				/>
+				<div>
+					<h2
+						id="kbve-yuki-panel-title"
+						class="kbve-yuki-dock__title">
+						Yuki
+					</h2>
+					<p class="kbve-yuki-dock__subtitle">
+						Virtual concierge · early preview
+					</p>
+				</div>
+			</div>
+			<button
+				type="button"
+				class="kbve-yuki-dock__close"
+				data-kbve-yuki-toggle
+				aria-label="Close Yuki assistant">
+				<svg
+					width="16"
+					height="16"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					aria-hidden="true">
+					<line x1="18" y1="6" x2="6" y2="18"></line>
+					<line x1="6" y1="6" x2="18" y2="18"></line>
+				</svg>
+			</button>
+		</header>
+
+		<div
+			class="kbve-yuki-dock__body"
+			id="kbve-yuki-mount"
+			data-kbve-yuki-mount>
+			<p class="kbve-yuki-dock__placeholder">
+				Yuki is warming up — the assistant runtime ships in a follow-up
+				release. For now, drop feedback in the
+				<a href="/forum/">forum</a>.
+			</p>
+		</div>
+	</aside>
+</div>
+
+<script>
+	import { initYukiDock } from './yuki-dock';
+
+	initYukiDock();
+</script>
+
+<style is:global>
+	.kbve-yuki-dock {
+		--yuki-fab-size: 56px;
+		--yuki-fab-offset: 1.25rem;
+		--yuki-panel-width: 360px;
+		--yuki-panel-height: min(70vh, 560px);
+		--yuki-bg: rgba(15, 23, 42, 0.92);
+		--yuki-bg-soft: rgba(30, 41, 59, 0.85);
+		--yuki-border: rgba(255, 255, 255, 0.08);
+		--yuki-accent: #06b6d4;
+		--yuki-text: rgba(255, 255, 255, 0.92);
+		--yuki-muted: rgba(255, 255, 255, 0.55);
+		--yuki-radius: 18px;
+		--yuki-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+
+		position: fixed;
+		bottom: var(--yuki-fab-offset);
+		right: var(--yuki-fab-offset);
+		z-index: 9998;
+		pointer-events: none;
+	}
+
+	.kbve-yuki-dock__fab,
+	.kbve-yuki-dock__panel {
+		pointer-events: auto;
+	}
+
+	.kbve-yuki-dock__fab {
+		position: relative;
+		width: var(--yuki-fab-size);
+		height: var(--yuki-fab-size);
+		border-radius: 999px;
+		border: 1px solid var(--yuki-border);
+		background:
+			radial-gradient(circle at 30% 30%, #1e293b, #0f172a 70%),
+			var(--yuki-bg);
+		color: var(--yuki-text);
+		padding: 0;
+		cursor: pointer;
+		display: grid;
+		place-items: center;
+		box-shadow: var(--yuki-shadow);
+		transition:
+			transform 0.18s ease,
+			box-shadow 0.18s ease,
+			border-color 0.18s ease;
+		appearance: none;
+	}
+
+	.kbve-yuki-dock__fab:hover {
+		transform: translateY(-2px);
+		border-color: color-mix(in srgb, var(--yuki-accent) 60%, transparent);
+		box-shadow:
+			var(--yuki-shadow),
+			0 0 0 4px color-mix(in srgb, var(--yuki-accent) 18%, transparent);
+	}
+
+	.kbve-yuki-dock__fab:focus-visible {
+		outline: 2px solid var(--yuki-accent);
+		outline-offset: 3px;
+	}
+
+	.kbve-yuki-dock__avatar {
+		width: 70%;
+		height: 70%;
+		object-fit: contain;
+		image-rendering: auto;
+		pointer-events: none;
+	}
+
+	.kbve-yuki-dock__pulse {
+		position: absolute;
+		inset: -4px;
+		border-radius: 999px;
+		border: 1px solid
+			color-mix(in srgb, var(--yuki-accent) 50%, transparent);
+		opacity: 0;
+		pointer-events: none;
+		animation: kbve-yuki-pulse 2.8s ease-out infinite;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.kbve-yuki-dock__pulse {
+			display: none;
+		}
+		.kbve-yuki-dock__fab {
+			transition: none;
+		}
+	}
+
+	@keyframes kbve-yuki-pulse {
+		0% {
+			transform: scale(0.9);
+			opacity: 0.7;
+		}
+		70% {
+			transform: scale(1.4);
+			opacity: 0;
+		}
+		100% {
+			opacity: 0;
+		}
+	}
+
+	.kbve-yuki-dock__panel {
+		position: absolute;
+		bottom: calc(var(--yuki-fab-size) + 0.85rem);
+		right: 0;
+		width: var(--yuki-panel-width);
+		max-width: calc(100vw - 2 * var(--yuki-fab-offset));
+		height: var(--yuki-panel-height);
+		background: var(--yuki-bg);
+		border: 1px solid var(--yuki-border);
+		border-radius: var(--yuki-radius);
+		box-shadow: var(--yuki-shadow);
+		color: var(--yuki-text);
+		display: grid;
+		grid-template-rows: auto 1fr;
+		overflow: hidden;
+		transform-origin: bottom right;
+		opacity: 0;
+		transform: translateY(8px) scale(0.96);
+		transition:
+			transform 0.18s ease,
+			opacity 0.18s ease;
+	}
+
+	.kbve-yuki-dock[data-state='expanded'] .kbve-yuki-dock__panel {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+
+	.kbve-yuki-dock[data-state='expanded'] .kbve-yuki-dock__panel[hidden] {
+		display: grid;
+	}
+
+	.kbve-yuki-dock[data-state='collapsed']
+		.kbve-yuki-dock__panel:not([hidden]) {
+		visibility: hidden;
+	}
+
+	@media (max-width: 640px) {
+		.kbve-yuki-dock {
+			--yuki-fab-offset: 0.85rem;
+			--yuki-panel-width: calc(100vw - 1rem);
+			--yuki-panel-height: min(75vh, 540px);
+		}
+		.kbve-yuki-dock__panel {
+			right: 0;
+		}
+	}
+
+	.kbve-yuki-dock__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.6rem;
+		padding: 0.85rem 1rem;
+		border-bottom: 1px solid var(--yuki-border);
+		background: var(--yuki-bg-soft);
+	}
+
+	.kbve-yuki-dock__title-row {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		min-width: 0;
+	}
+
+	.kbve-yuki-dock__title-avatar {
+		width: 34px;
+		height: 34px;
+		border-radius: 999px;
+		object-fit: cover;
+		background: rgba(255, 255, 255, 0.05);
+		border: 1px solid var(--yuki-border);
+		pointer-events: none;
+	}
+
+	.kbve-yuki-dock__title {
+		margin: 0;
+		font-size: 0.95rem;
+		font-weight: 700;
+		letter-spacing: -0.01em;
+	}
+
+	.kbve-yuki-dock__subtitle {
+		margin: 0;
+		font-size: 0.72rem;
+		color: var(--yuki-muted);
+	}
+
+	.kbve-yuki-dock__close {
+		appearance: none;
+		display: grid;
+		place-items: center;
+		width: 30px;
+		height: 30px;
+		border-radius: 8px;
+		background: transparent;
+		border: 1px solid var(--yuki-border);
+		color: var(--yuki-muted);
+		cursor: pointer;
+		flex: 0 0 auto;
+	}
+
+	.kbve-yuki-dock__close:hover {
+		color: var(--yuki-text);
+		border-color: color-mix(in srgb, var(--yuki-accent) 50%, transparent);
+	}
+
+	.kbve-yuki-dock__body {
+		padding: 1rem;
+		overflow-y: auto;
+		font-size: 0.85rem;
+		line-height: 1.5;
+		color: var(--yuki-muted);
+	}
+
+	.kbve-yuki-dock__placeholder {
+		margin: 0;
+	}
+
+	.kbve-yuki-dock__placeholder a {
+		color: var(--yuki-accent);
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
@@ -1,0 +1,167 @@
+/**
+ * Yuki panel — the heavy chunk lazy-imported by `yuki-dock.ts` the
+ * first time a user opens the dock.
+ *
+ * Phase A (this file): minimal vanilla chat scaffold so the dock
+ * shows something useful when expanded — a sticky input row + a
+ * scroll buffer for messages — without dragging React + Three.js
+ * into the initial bundle.
+ *
+ * Phase B (follow-up PR): swap this for a React mount of the existing
+ * `ReactJayYuki` (or a lighter variant) wired to a real assistant
+ * backend. The mount API is intentionally a single
+ * `mountYukiPanel(host)` function so the swap is one-line.
+ */
+
+const HISTORY_KEY = 'kbve:yuki-dock:history';
+const MAX_HISTORY = 24;
+
+type Role = 'user' | 'yuki';
+interface ChatEntry {
+	role: Role;
+	text: string;
+	ts: number;
+}
+
+function readHistory(): ChatEntry[] {
+	try {
+		const raw = localStorage.getItem(HISTORY_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		return parsed
+			.slice(-MAX_HISTORY)
+			.filter(
+				(e): e is ChatEntry =>
+					e &&
+					typeof e === 'object' &&
+					typeof e.text === 'string' &&
+					(e.role === 'user' || e.role === 'yuki') &&
+					typeof e.ts === 'number',
+			);
+	} catch {
+		return [];
+	}
+}
+
+function writeHistory(history: ChatEntry[]): void {
+	try {
+		localStorage.setItem(
+			HISTORY_KEY,
+			JSON.stringify(history.slice(-MAX_HISTORY)),
+		);
+	} catch {
+		/* ignore quota */
+	}
+}
+
+const WELCOME: ChatEntry = {
+	role: 'yuki',
+	text:
+		"Hi! I'm Yuki — your KBVE concierge. The full assistant backend " +
+		'is still warming up; for now I can point you at docs and recent ' +
+		'releases. Drop a question and I will log it.',
+	ts: Date.now(),
+};
+
+function renderMessage(entry: ChatEntry): HTMLElement {
+	const row = document.createElement('div');
+	row.className = `yuki-msg yuki-msg--${entry.role}`;
+	const bubble = document.createElement('div');
+	bubble.className = 'yuki-msg__bubble';
+	bubble.textContent = entry.text;
+	row.appendChild(bubble);
+	return row;
+}
+
+export async function mountYukiPanel(host: HTMLElement): Promise<void> {
+	if (host.dataset.kbveYukiPanelMounted === 'true') return;
+	host.dataset.kbveYukiPanelMounted = 'true';
+	host.innerHTML = '';
+
+	const wrap = document.createElement('div');
+	wrap.className = 'yuki-panel';
+
+	const log = document.createElement('div');
+	log.className = 'yuki-panel__log';
+	log.setAttribute('role', 'log');
+	log.setAttribute('aria-live', 'polite');
+	wrap.appendChild(log);
+
+	const form = document.createElement('form');
+	form.className = 'yuki-panel__form';
+	form.innerHTML = `
+		<input
+			type="text"
+			class="yuki-panel__input"
+			name="prompt"
+			autocomplete="off"
+			placeholder="Ask Yuki…"
+			aria-label="Ask Yuki"
+			maxlength="500" />
+		<button type="submit" class="yuki-panel__send" aria-label="Send">
+			<svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+				stroke="currentColor" stroke-width="2" stroke-linecap="round"
+				stroke-linejoin="round" aria-hidden="true">
+				<line x1="22" y1="2" x2="11" y2="13"></line>
+				<polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+			</svg>
+		</button>
+	`;
+	wrap.appendChild(form);
+	host.appendChild(wrap);
+
+	let history = readHistory();
+	if (history.length === 0) {
+		history = [WELCOME];
+		writeHistory(history);
+	}
+	for (const entry of history) {
+		log.appendChild(renderMessage(entry));
+	}
+	log.scrollTop = log.scrollHeight;
+
+	const input = form.querySelector<HTMLInputElement>('.yuki-panel__input');
+	form.addEventListener('submit', (ev) => {
+		ev.preventDefault();
+		const value = input?.value.trim();
+		if (!value || !input) return;
+		input.value = '';
+		const user: ChatEntry = { role: 'user', text: value, ts: Date.now() };
+		history.push(user);
+		log.appendChild(renderMessage(user));
+		// Phase A: deterministic placeholder reply. Phase B will replace
+		// this with a real backend round-trip.
+		const yuki: ChatEntry = {
+			role: 'yuki',
+			text:
+				"I've logged your question. The Yuki backend isn't online " +
+				'in this preview, but it will be soon — appreciate the patience.',
+			ts: Date.now(),
+		};
+		history.push(yuki);
+		log.appendChild(renderMessage(yuki));
+		writeHistory(history);
+		log.scrollTop = log.scrollHeight;
+	});
+
+	if (!document.getElementById('kbve-yuki-panel-css')) {
+		const css = document.createElement('style');
+		css.id = 'kbve-yuki-panel-css';
+		css.textContent = `
+			.yuki-panel { display: grid; grid-template-rows: 1fr auto; gap: 0.5rem; height: 100%; }
+			.yuki-panel__log { display: grid; gap: 0.5rem; align-content: start; overflow-y: auto; padding-right: 0.25rem; }
+			.yuki-msg { display: flex; }
+			.yuki-msg--user { justify-content: flex-end; }
+			.yuki-msg__bubble { max-width: 80%; padding: 0.55rem 0.75rem; border-radius: 12px; font-size: 0.85rem; line-height: 1.4; word-wrap: break-word; }
+			.yuki-msg--user .yuki-msg__bubble { background: rgba(6,182,212,0.18); border: 1px solid rgba(6,182,212,0.4); color: rgba(255,255,255,0.95); }
+			.yuki-msg--yuki .yuki-msg__bubble { background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1); color: rgba(255,255,255,0.85); }
+			.yuki-panel__form { display: grid; grid-template-columns: 1fr auto; gap: 0.4rem; padding-top: 0.5rem; border-top: 1px solid rgba(255,255,255,0.06); }
+			.yuki-panel__input { padding: 0.5rem 0.75rem; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.1); border-radius: 10px; color: rgba(255,255,255,0.95); font-size: 0.85rem; font-family: inherit; }
+			.yuki-panel__input:focus { outline: 2px solid rgba(6,182,212,0.6); outline-offset: -1px; }
+			.yuki-panel__send { display: grid; place-items: center; width: 36px; background: rgba(6,182,212,0.6); border: none; border-radius: 10px; color: white; cursor: pointer; }
+			.yuki-panel__send:hover { background: rgba(6,182,212,0.85); }
+		`;
+		document.head.appendChild(css);
+	}
+}

--- a/apps/kbve/astro-kbve/src/components/jay/dock/yuki-dock.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/yuki-dock.ts
@@ -1,0 +1,137 @@
+/**
+ * Vanilla driver for the Yuki dock — toggle, persist, and lazy-mount.
+ *
+ * The dock itself is server-rendered HTML (see `AstroYukiDock.astro`).
+ * This file boots the runtime behavior:
+ *
+ *   1. Wires up the FAB + close button to toggle between
+ *      `data-state="collapsed"` and `data-state="expanded"`.
+ *   2. Persists the toggle state to `localStorage` so a hard reload
+ *      restores whichever state the user left it in.
+ *   3. Lazy-mounts the heavy React panel the FIRST time the dock is
+ *      expanded. The dynamic `import()` resolves the React island's
+ *      chunk only when the user actually opens the dock, so the
+ *      initial bundle stays cold-load cheap.
+ *
+ * Idempotent: safe to call `initYukiDock()` multiple times. Under
+ * ClientRouter we wrap the boot in `onMount` so it fires on initial
+ * load + every nav swap; the `claimOnce`-style guard skips re-binding
+ * when the persisted dock is still the same DOM node we already wired.
+ */
+import { onMount } from '@kbve/astro/utils/clientRouter';
+
+const STORAGE_KEY = 'kbve:yuki-dock:state';
+const BOUND_ATTR = 'data-kbve-yuki-bound';
+
+type DockState = 'collapsed' | 'expanded';
+
+function readStoredState(): DockState {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		return raw === 'expanded' ? 'expanded' : 'collapsed';
+	} catch {
+		return 'collapsed';
+	}
+}
+
+function writeStoredState(state: DockState): void {
+	try {
+		localStorage.setItem(STORAGE_KEY, state);
+	} catch {
+		/* localStorage unavailable — silently ignore */
+	}
+}
+
+function applyState(dock: HTMLElement, state: DockState): void {
+	dock.dataset.state = state;
+	const fab = dock.querySelector<HTMLButtonElement>('.kbve-yuki-dock__fab');
+	const panel = dock.querySelector<HTMLElement>('.kbve-yuki-dock__panel');
+	if (fab)
+		fab.setAttribute(
+			'aria-expanded',
+			state === 'expanded' ? 'true' : 'false',
+		);
+	if (panel) {
+		if (state === 'expanded') panel.removeAttribute('hidden');
+		// Keep the panel mounted in the DOM even when collapsed so
+		// `transition:persist` carries any lazy-mounted React tree
+		// across nav. CSS handles the visual hide.
+	}
+}
+
+let lazyPanelLoaded = false;
+async function ensureLazyPanel(dock: HTMLElement): Promise<void> {
+	if (lazyPanelLoaded) return;
+	lazyPanelLoaded = true;
+	const mount = dock.querySelector<HTMLElement>('[data-kbve-yuki-mount]');
+	if (!mount) return;
+	try {
+		// Vite splits this into its own chunk; nothing about the dock
+		// shell pulls it in until the user opens the dock.
+		const mod = await import('./YukiPanel');
+		await mod.mountYukiPanel(mount);
+	} catch (err) {
+		console.warn('[yuki-dock] lazy panel mount failed', err);
+		mount.innerHTML =
+			'<p class="kbve-yuki-dock__placeholder">Yuki failed to load. Refresh to try again.</p>';
+	}
+}
+
+function bindDock(dock: HTMLElement): () => void {
+	if (dock.getAttribute(BOUND_ATTR) === 'true') return () => {};
+	dock.setAttribute(BOUND_ATTR, 'true');
+
+	const initial = readStoredState();
+	applyState(dock, initial);
+	if (initial === 'expanded') {
+		void ensureLazyPanel(dock);
+	}
+
+	const toggles = dock.querySelectorAll<HTMLElement>(
+		'[data-kbve-yuki-toggle]',
+	);
+	const onToggleClick = (ev: Event) => {
+		ev.preventDefault();
+		const current = (dock.dataset.state as DockState) ?? 'collapsed';
+		const next: DockState =
+			current === 'expanded' ? 'collapsed' : 'expanded';
+		applyState(dock, next);
+		writeStoredState(next);
+		if (next === 'expanded') void ensureLazyPanel(dock);
+	};
+	for (const t of toggles) {
+		t.addEventListener('click', onToggleClick);
+	}
+
+	const onKeyDown = (ev: KeyboardEvent) => {
+		if (
+			ev.key === 'Escape' &&
+			(dock.dataset.state as DockState) === 'expanded'
+		) {
+			applyState(dock, 'collapsed');
+			writeStoredState('collapsed');
+		}
+	};
+	document.addEventListener('keydown', onKeyDown);
+
+	return () => {
+		for (const t of toggles) {
+			t.removeEventListener('click', onToggleClick);
+		}
+		document.removeEventListener('keydown', onKeyDown);
+		dock.removeAttribute(BOUND_ATTR);
+	};
+}
+
+export function initYukiDock(): void {
+	onMount(() => {
+		const dock = document.getElementById('kbve-yuki-dock');
+		if (!dock) return;
+		// `transition:persist` keeps the dock's DOM identity across
+		// ClientRouter swaps. The bind flag short-circuits when we're
+		// already wired against this exact node so we don't double-bind
+		// keyboard listeners on a swap that didn't actually replace the
+		// dock element.
+		return bindDock(dock);
+	});
+}


### PR DESCRIPTION
## Summary
Ships Yuki as a persistent right-side dock on every page:
- **Persistent across nav** — \`transition:persist\` on the dock root so ClientRouter swaps don't tear it down
- **Deferred main-thread work** — HTML + CSS only on initial paint, no React/Three.js until first expand
- **Lazy chunk** — \`yuki-dock.ts\` dynamic-imports the panel body on first user click; never in the entry bundle

## What ships in Phase A
- \`AstroYukiDock.astro\` — server-rendered FAB + collapsed panel skeleton wrapped in \`transition:persist="kbve-yuki-dock"\`
- \`yuki-dock.ts\` — vanilla driver wrapped in \`onMount\` from \`@kbve/astro/utils/clientRouter\`; persists state to localStorage; idempotent re-bind across swaps
- \`YukiPanel.ts\` — placeholder chat scaffold (welcome + deterministic echo) with localStorage-persisted history. Single \`mountYukiPanel(host)\` contract so Phase B can swap the body without touching the dock shell
- Footer wires \`<AstroYukiDock />\` as a sibling of \`<footer>\` so the persist contract is clean

## Defensive details
- \`prefers-reduced-motion\` respected
- Mobile (<640px) panel collapses to near-full-width sheet
- \`Escape\` closes
- Avatar uses existing \`earth_ceo.png\` placeholder — swap to real Yuki render in a content PR

## Phase B (follow-up PR, not in this one)
- Real assistant backend (jedi/q-routed LLM)
- Optional VRM avatar via \`@pixiv/three-vrm\` + \`kalidokit\` for landmark-driven expressions, gated behind a "show 3D Yuki" toggle so the default panel stays cheap

## Test plan
- [ ] FAB appears bottom-right on every page
- [ ] Click → panel expands; close button + Escape both collapse it
- [ ] Reload preserves last expand/collapse state
- [ ] Navigate via ClientRouter — dock + chat history survive the swap
- [ ] DevTools Network shows \`YukiPanel\` chunk only after first click
- [ ] Mobile viewport renders the panel as a wide sheet