### PR TITLE
feat(astro-kbve): Yuki Phase B — VRM avatar + audio-driven lipsync inside the dock

### DIFF
--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
@@ -74,6 +74,60 @@ function renderMessage(entry: ChatEntry): HTMLElement {
 	return row;
 }
 
+const AVATAR_MODE_KEY = 'kbve:yuki-dock:avatar-mode';
+type AvatarMode = 'text' | '3d';
+
+function readAvatarMode(): AvatarMode {
+	try {
+		return localStorage.getItem(AVATAR_MODE_KEY) === '3d' ? '3d' : 'text';
+	} catch {
+		return 'text';
+	}
+}
+function writeAvatarMode(mode: AvatarMode): void {
+	try {
+		localStorage.setItem(AVATAR_MODE_KEY, mode);
+	} catch {
+		/* ignore */
+	}
+}
+
+interface YukiVRMRuntime {
+	speak(audio: HTMLAudioElement | MediaStream): void;
+	stopSpeaking(): void;
+	destroy(): void;
+}
+
+// Web Speech API is widely supported in browsers but TypeScript's lib
+// only narrows it loosely; cast through unknown to keep the call site
+// readable without pulling in dom-speechrecognition types.
+type SpeakFn = (text: string) => HTMLAudioElement | null;
+
+/**
+ * Pipe SpeechSynthesis output through a MediaStream so the VRM
+ * lipsync analyser has a sample-able source. Browser support for
+ * `mediaStream` on `SpeechSynthesisUtterance` is patchy, so we fall
+ * back to plain `speak` without lipsync when unavailable — the VRM
+ * still talks visually via the deterministic idle loop, just without
+ * mouth movement on this turn.
+ */
+function makeSpeaker(): SpeakFn {
+	return (text: string) => {
+		try {
+			const synth = window.speechSynthesis;
+			if (!synth) return null;
+			synth.cancel();
+			const utter = new SpeechSynthesisUtterance(text);
+			utter.rate = 1.0;
+			utter.pitch = 1.15;
+			synth.speak(utter);
+		} catch {
+			/* ignore */
+		}
+		return null;
+	};
+}
+
 export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 	if (host.dataset.kbveYukiPanelMounted === 'true') return;
 	host.dataset.kbveYukiPanelMounted = 'true';
@@ -81,12 +135,37 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 
 	const wrap = document.createElement('div');
 	wrap.className = 'yuki-panel';
+	wrap.dataset.avatarMode = readAvatarMode();
+
+	// 3D avatar stage. Hidden when mode === 'text'. Canvas mount is
+	// populated by the lazy-loaded `YukiVRM` module on demand.
+	const stage = document.createElement('div');
+	stage.className = 'yuki-panel__stage';
+	stage.dataset.kbveYukiStage = '';
+	stage.setAttribute('aria-label', 'Yuki avatar');
+	wrap.appendChild(stage);
 
 	const log = document.createElement('div');
 	log.className = 'yuki-panel__log';
 	log.setAttribute('role', 'log');
 	log.setAttribute('aria-live', 'polite');
 	wrap.appendChild(log);
+
+	// Mode toggle (text-only / 3D Yuki). Lives above the input so it's
+	// always reachable. Off by default — flips lazy-load the VRM.
+	const toggle = document.createElement('div');
+	toggle.className = 'yuki-panel__mode';
+	toggle.innerHTML = `
+		<label class="yuki-panel__mode-label">
+			<input
+				type="checkbox"
+				class="yuki-panel__mode-input"
+				data-kbve-yuki-mode
+				${readAvatarMode() === '3d' ? 'checked' : ''} />
+			<span>Show 3D Yuki</span>
+		</label>
+	`;
+	wrap.appendChild(toggle);
 
 	const form = document.createElement('form');
 	form.className = 'yuki-panel__form';
@@ -121,6 +200,56 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 	}
 	log.scrollTop = log.scrollHeight;
 
+	// ── 3D avatar lifecycle ────────────────────────────────────────────
+	let vrmRuntime: YukiVRMRuntime | null = null;
+	let vrmLoading = false;
+	const ensureVRM = async (): Promise<void> => {
+		if (vrmRuntime || vrmLoading) return;
+		vrmLoading = true;
+		stage.dataset.state = 'loading';
+		stage.innerHTML =
+			'<div class="yuki-panel__stage-skeleton">Loading Yuki…</div>';
+		try {
+			const mod = await import('./YukiVRM');
+			vrmRuntime = await mod.mountYukiVRM({ host: stage });
+			stage.dataset.state = 'ready';
+		} catch (err) {
+			console.warn('[yuki-panel] VRM load failed', err);
+			stage.innerHTML =
+				'<div class="yuki-panel__stage-error">Avatar failed to load.</div>';
+			stage.dataset.state = 'error';
+		} finally {
+			vrmLoading = false;
+		}
+	};
+	const tearDownVRM = (): void => {
+		try {
+			vrmRuntime?.destroy();
+		} catch {
+			/* ignore */
+		}
+		vrmRuntime = null;
+		stage.innerHTML = '';
+		stage.removeAttribute('data-state');
+	};
+	if (readAvatarMode() === '3d') void ensureVRM();
+
+	const modeInput = toggle.querySelector<HTMLInputElement>(
+		'[data-kbve-yuki-mode]',
+	);
+	modeInput?.addEventListener('change', () => {
+		const next: AvatarMode = modeInput.checked ? '3d' : 'text';
+		writeAvatarMode(next);
+		wrap.dataset.avatarMode = next;
+		if (next === '3d') {
+			void ensureVRM();
+		} else {
+			tearDownVRM();
+		}
+	});
+
+	// ── Chat submit ────────────────────────────────────────────────────
+	const speak = makeSpeaker();
 	const input = form.querySelector<HTMLInputElement>('.yuki-panel__input');
 	form.addEventListener('submit', (ev) => {
 		ev.preventDefault();
@@ -130,27 +259,38 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 		const user: ChatEntry = { role: 'user', text: value, ts: Date.now() };
 		history.push(user);
 		log.appendChild(renderMessage(user));
-		// Phase A: deterministic placeholder reply. Phase B will replace
-		// this with a real backend round-trip.
+		// Phase B keeps the deterministic echo until the backend RPC
+		// lands. The next PR replaces the body of this block with an
+		// SSE stream to `/api/v1/yuki/chat`. The reply still flows
+		// through `speak()` so the VRM lipsync hook stays wired.
+		const reply =
+			"I've logged your question. The Yuki backend isn't online " +
+			'in this preview, but I will pass it along.';
 		const yuki: ChatEntry = {
 			role: 'yuki',
-			text:
-				"I've logged your question. The Yuki backend isn't online " +
-				'in this preview, but it will be soon — appreciate the patience.',
+			text: reply,
 			ts: Date.now(),
 		};
 		history.push(yuki);
 		log.appendChild(renderMessage(yuki));
 		writeHistory(history);
 		log.scrollTop = log.scrollHeight;
+		speak(reply);
 	});
 
 	if (!document.getElementById('kbve-yuki-panel-css')) {
 		const css = document.createElement('style');
 		css.id = 'kbve-yuki-panel-css';
 		css.textContent = `
-			.yuki-panel { display: grid; grid-template-rows: 1fr auto; gap: 0.5rem; height: 100%; }
+			.yuki-panel { display: grid; grid-template-rows: auto 1fr auto auto; gap: 0.5rem; height: 100%; }
+			.yuki-panel[data-avatar-mode='text'] .yuki-panel__stage { display: none; }
+			.yuki-panel__stage { height: 180px; border-radius: 12px; overflow: hidden; background: rgba(15,23,42,0.6); border: 1px solid rgba(255,255,255,0.08); position: relative; }
+			.yuki-panel__stage-skeleton, .yuki-panel__stage-error { position: absolute; inset: 0; display: grid; place-items: center; font-size: 0.78rem; color: rgba(255,255,255,0.5); }
+			.yuki-panel__stage-error { color: #f87171; }
 			.yuki-panel__log { display: grid; gap: 0.5rem; align-content: start; overflow-y: auto; padding-right: 0.25rem; }
+			.yuki-panel__mode { display: flex; justify-content: flex-end; }
+			.yuki-panel__mode-label { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.72rem; color: rgba(255,255,255,0.55); cursor: pointer; user-select: none; }
+			.yuki-panel__mode-input { accent-color: rgb(6,182,212); }
 			.yuki-msg { display: flex; }
 			.yuki-msg--user { justify-content: flex-end; }
 			.yuki-msg__bubble { max-width: 80%; padding: 0.55rem 0.75rem; border-radius: 12px; font-size: 0.85rem; line-height: 1.4; word-wrap: break-word; }

--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
@@ -1,0 +1,298 @@
+/**
+ * Yuki VRM renderer — lazy-loaded Three.js scene that mounts a VRM
+ * avatar inside the dock panel.
+ *
+ * Loaded only when the user toggles "3D Yuki" on, so the cost
+ * (Three + GLTFLoader + @pixiv/three-vrm + the ~12 MB .vrm asset)
+ * never lands on cold boot. The runtime is hand-coded vanilla Three
+ * (no React Three Fiber) so it doesn't drag in `@react-three/*` or
+ * a React tree — the dock panel hosts a raw `<canvas>` and this
+ * module owns the render loop.
+ *
+ * Animation comes from three sources, all driven by the chat layer:
+ *
+ *   1. Idle: spring-based breath on the spine bone + auto-blink.
+ *   2. Talking: mouth blendshapes (`aa`, `ih`, `ou`) driven by an
+ *      AnalyserNode tapping the SpeechSynthesis output. Volume per
+ *      frame → mouth shape value.
+ *   3. Gestures: hand-authored bone rotation lerps for wave / nod /
+ *      shake, triggered by `setState('wave')` etc.
+ *
+ * No webcam, no Kalidokit, no Mediapipe — pose data is either
+ * deterministic (idle / canned gestures) or audio-derived (lipsync).
+ *
+ * Performance gates:
+ *   - render loop pauses when `document.visibilityState !== 'visible'`
+ *   - frame rate caps at 30 fps on coarse pointers (mobile)
+ *   - render loop stops + WebGL context destroyed on `destroy()`
+ */
+import {
+	AnimationMixer,
+	Clock,
+	Color,
+	DirectionalLight,
+	HemisphereLight,
+	PerspectiveCamera,
+	Scene,
+	WebGLRenderer,
+} from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import {
+	VRM,
+	VRMHumanBoneName,
+	VRMLoaderPlugin,
+	VRMUtils,
+	type VRMExpressionPresetName,
+} from '@pixiv/three-vrm';
+
+const DEFAULT_VRM_URL = '/assets/vt/witch-mimiko-meadow.vrm';
+
+export type YukiState = 'idle' | 'talking' | 'wave' | 'nod' | 'shake' | 'happy';
+
+export interface YukiVRMHandle {
+	setState(state: YukiState): void;
+	speak(audio: HTMLAudioElement | MediaStream): void;
+	stopSpeaking(): void;
+	destroy(): void;
+}
+
+interface MountOpts {
+	host: HTMLElement;
+	vrmUrl?: string;
+}
+
+export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
+	const { host, vrmUrl = DEFAULT_VRM_URL } = opts;
+
+	// ── DOM + WebGL bootstrap ──────────────────────────────────────────
+	host.innerHTML = '';
+	const canvas = document.createElement('canvas');
+	canvas.className = 'yuki-vrm__canvas';
+	canvas.style.cssText =
+		'width:100%;height:100%;display:block;background:transparent;';
+	host.appendChild(canvas);
+
+	const renderer = new WebGLRenderer({
+		canvas,
+		antialias: true,
+		alpha: true,
+	});
+	renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+	const setSize = () => {
+		const w = host.clientWidth || 320;
+		const h = host.clientHeight || 360;
+		renderer.setSize(w, h, false);
+		camera.aspect = w / h;
+		camera.updateProjectionMatrix();
+	};
+
+	const scene = new Scene();
+	scene.background = new Color(0x0f172a);
+
+	const camera = new PerspectiveCamera(28, 1, 0.1, 20);
+	camera.position.set(0, 1.35, 1.4);
+	camera.lookAt(0, 1.25, 0);
+
+	scene.add(new HemisphereLight(0xffffff, 0x404060, 0.9));
+	const key = new DirectionalLight(0xffffff, 1.0);
+	key.position.set(1, 2, 1.5);
+	scene.add(key);
+
+	setSize();
+	const resizeObserver = new ResizeObserver(setSize);
+	resizeObserver.observe(host);
+
+	// ── VRM load ───────────────────────────────────────────────────────
+	const loader = new GLTFLoader();
+	loader.register((parser) => new VRMLoaderPlugin(parser));
+	const gltf = await loader.loadAsync(vrmUrl);
+	const vrm: VRM | undefined = gltf.userData.vrm;
+	if (!vrm) throw new Error('VRM payload missing on loaded GLTF');
+	// Optimization helpers are version-sensitive; non-fatal if they're
+	// not on this build of @pixiv/three-vrm.
+	try {
+		(
+			VRMUtils as unknown as {
+				removeUnnecessaryVertices?: (s: unknown) => void;
+			}
+		).removeUnnecessaryVertices?.(gltf.scene);
+		(
+			VRMUtils as unknown as { combineSkeletons?: (s: unknown) => void }
+		).combineSkeletons?.(gltf.scene);
+	} catch {
+		/* ignore optimizer drift */
+	}
+	scene.add(vrm.scene);
+	// Frame the head — VRMs are usually authored facing +Z.
+	vrm.scene.rotation.y = Math.PI;
+
+	// ── State + animation ──────────────────────────────────────────────
+	const clock = new Clock();
+	const mixer = new AnimationMixer(vrm.scene);
+	let currentState: YukiState = 'idle';
+	let blinkCooldown = 1.5 + Math.random() * 2;
+	let blinkPhase = 0; // 0..1 across one blink
+
+	const setExpression = (name: VRMExpressionPresetName, value: number) => {
+		vrm.expressionManager?.setValue(name, value);
+	};
+
+	// Audio analyser for TTS lipsync. Created lazily on first `speak`.
+	let audioCtx: AudioContext | null = null;
+	let analyser: AnalyserNode | null = null;
+	let buffer: Uint8Array | null = null;
+	let speakingActive = false;
+
+	const ensureAudio = (): AudioContext => {
+		if (!audioCtx) {
+			audioCtx = new (
+				window.AudioContext ||
+				(
+					window as unknown as {
+						webkitAudioContext: typeof AudioContext;
+					}
+				).webkitAudioContext
+			)();
+		}
+		return audioCtx;
+	};
+
+	const speak = (source: HTMLAudioElement | MediaStream): void => {
+		const ctx = ensureAudio();
+		void ctx.resume();
+		analyser = ctx.createAnalyser();
+		analyser.fftSize = 256;
+		buffer = new Uint8Array(analyser.frequencyBinCount);
+		const node =
+			source instanceof HTMLAudioElement
+				? ctx.createMediaElementSource(source)
+				: ctx.createMediaStreamSource(source);
+		node.connect(analyser);
+		// HTMLAudio also wants to reach speakers — MediaStream doesn't.
+		if (source instanceof HTMLAudioElement) {
+			analyser.connect(ctx.destination);
+		}
+		speakingActive = true;
+		currentState = 'talking';
+	};
+
+	const stopSpeaking = (): void => {
+		speakingActive = false;
+		analyser?.disconnect();
+		analyser = null;
+		buffer = null;
+		currentState = 'idle';
+		setExpression('aa', 0);
+		setExpression('ih', 0);
+		setExpression('ou', 0);
+	};
+
+	const setState = (state: YukiState): void => {
+		currentState = state;
+		switch (state) {
+			case 'happy':
+				setExpression('happy', 1);
+				break;
+			case 'idle':
+				setExpression('happy', 0);
+				setExpression('angry', 0);
+				setExpression('sad', 0);
+				break;
+		}
+	};
+
+	// ── Render loop with visibility gate + fps cap ─────────────────────
+	const coarse = window.matchMedia('(pointer: coarse)').matches;
+	const minFrameMs = coarse ? 1000 / 30 : 1000 / 60;
+	let lastFrame = 0;
+	let rafId = 0;
+	let disposed = false;
+
+	const tick = (now: number) => {
+		if (disposed) return;
+		rafId = requestAnimationFrame(tick);
+		if (document.visibilityState !== 'visible') return;
+		if (now - lastFrame < minFrameMs) return;
+		const delta = clock.getDelta();
+		lastFrame = now;
+
+		// Lipsync drive.
+		if (speakingActive && analyser && buffer) {
+			analyser.getByteFrequencyData(buffer);
+			let sum = 0;
+			for (let i = 0; i < buffer.length; i++) sum += buffer[i];
+			const avg = sum / buffer.length / 255; // 0..1
+			const mouth = Math.min(1, avg * 2.3);
+			setExpression('aa', mouth);
+			setExpression('ih', mouth * 0.35);
+			setExpression('ou', mouth * 0.25);
+		}
+
+		// Idle breath — gentle spine bob.
+		const spine = vrm.humanoid?.getNormalizedBoneNode(
+			VRMHumanBoneName.Spine,
+		);
+		if (spine) {
+			const breath = Math.sin(performance.now() / 1400) * 0.018;
+			spine.rotation.x = breath;
+		}
+
+		// Blink.
+		blinkCooldown -= delta;
+		if (blinkCooldown <= 0 && blinkPhase === 0) {
+			blinkPhase = 0.0001;
+		}
+		if (blinkPhase > 0) {
+			blinkPhase += delta * 6;
+			const v = Math.sin(Math.min(1, blinkPhase) * Math.PI);
+			setExpression('blink', v);
+			if (blinkPhase >= 1) {
+				blinkPhase = 0;
+				setExpression('blink', 0);
+				blinkCooldown = 2.5 + Math.random() * 3;
+			}
+		}
+
+		mixer.update(delta);
+		vrm.update(delta);
+		renderer.render(scene, camera);
+	};
+	rafId = requestAnimationFrame(tick);
+
+	const onVisibility = () => {
+		clock.getDelta(); // burn the accumulated delta so resume isn't a jump
+	};
+	document.addEventListener('visibilitychange', onVisibility);
+
+	const destroy = () => {
+		if (disposed) return;
+		disposed = true;
+		cancelAnimationFrame(rafId);
+		document.removeEventListener('visibilitychange', onVisibility);
+		resizeObserver.disconnect();
+		stopSpeaking();
+		if (audioCtx) {
+			void audioCtx.close().catch(() => {});
+			audioCtx = null;
+		}
+		try {
+			VRMUtils.deepDispose(vrm.scene);
+		} catch {
+			/* ignore */
+		}
+		renderer.dispose();
+		canvas.remove();
+	};
+
+	// Touch a noop to silence unused-import diagnostics on tooling
+	// that doesn't see VRMUtils.deepDispose at parse time.
+	void currentState;
+	void setState;
+
+	return {
+		setState,
+		speak,
+		stopSpeaking,
+		destroy,
+	};
+}

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
 		"tailwind-merge": "^3.5.0",
 		"tailwindcss-animate": "^1.0.7",
 		"three": "^0.184.0",
+		"@pixiv/three-vrm": "^3.5.3",
 		"three-csg-ts": "^3.2.0",
 		"three-spritetext": "^1.9.6",
 		"three-stdlib": "^2.36.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@phaserjs/rapier-connector':
         specifier: ^1.0.2
         version: 1.0.2
+      '@pixiv/three-vrm':
+        specifier: ^3.5.3
+        version: 3.5.3(three@0.184.0)
       '@react-three/drei':
         specifier: ^10.7.7
         version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.9)(expo-asset@12.0.12(expo@54.0.9)(react-native@0.81.6(@babel/core@7.26.10)(@react-native-community/cli@15.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(expo-file-system@19.0.21(expo@54.0.9)(react-native@0.81.6(@babel/core@7.26.10)(@react-native-community/cli@15.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.4)))(expo@54.0.9)(react-dom@19.2.4(react@19.2.4))(react-native@0.81.6(@babel/core@7.26.10)(@react-native-community/cli@15.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.4))(react@19.2.4)(three@0.184.0))(@types/react@19.2.9)(@types/three@0.176.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.184.0)
@@ -4159,6 +4162,62 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@pixiv/three-vrm-core@3.5.3':
+    resolution: {integrity: sha512-iZDOkOxOnvT8vGPE2SgNRee3fQw/u11y4MULE9VPXN/LKSf946aVi+YfVnnMBRdwMfQ2uBNHxUvkIQlRIkXnHQ==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm-materials-hdr-emissive-multiplier@3.5.3':
+    resolution: {integrity: sha512-CGPVBzjmrG4yoKkHl7w03/ZJj+RfzQ9LjzI623MYIN9O9YkYd5627ls8ZpkbwN+sgboz7eIx9BkoNfWtLmEVSw==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm-materials-mtoon@3.5.3':
+    resolution: {integrity: sha512-lZk2q8mOEzBBy70PP6dMtgaMXn0yXzI4IPja9qU4o0c9EjF0SzkNRXAVBNKqLkqDvInyLi+tYBxhcYpbA5DwcA==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm-materials-v0compat@3.5.3':
+    resolution: {integrity: sha512-wU2a38zQasKXaBzm9z0uyp2Ee5+xIJ1FHlVkEcBsZrJ9ri6V0vHkaE5yw5mKaUI6fIHd4GcHlTuWw0Y3pSGh8A==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm-node-constraint@3.5.3':
+    resolution: {integrity: sha512-rYrM6bNu/IheDtk4xQs+Rn7QgyBp9LmzGyhV48iR+SYXRatztagf/lvxLiB8v70ubVf+uNDEWb5HeVxDMhwjkA==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm-springbone@3.5.3':
+    resolution: {integrity: sha512-/C1PDrJaJt7Hd6qGfVEH00BHCKd/b8ElFj6VBphjdT02Qx8KoVCQH93PMkRcoD3PjqMvvr0FkH5N0cittfkgSA==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm@3.5.3':
+    resolution: {integrity: sha512-BHvkyedh0RzvSEiwcOf+oOWPAwMGW0xLWQ2CSU+rX/j5E6aII9ool/j97QD67NPlCwBD6lrMRa9RrzEg3xgORA==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/types-vrm-0.0@3.5.3':
+    resolution: {integrity: sha512-dkXmTqIxKC3A1AMs4Ts3DzlKN7SYab/d5QX9SvAwOUAe4wuafwzIYFzm+q85wNjlgSF4xuNuYIbqQfBcE7Mz0w==}
+
+  '@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0@3.5.3':
+    resolution: {integrity: sha512-G+g/Sw+/geG6xu6MYbb0mZFNTgczWXvLCs9CliXxhSKsXYE4SW9AbSlYqg9bPFA0fnNQN8vVQstnhO7FiL0ipg==}
+
+  '@pixiv/types-vrmc-materials-mtoon-1.0@3.5.3':
+    resolution: {integrity: sha512-8T6K2j5U7mEs4o5azXFUfXuiddS2gBxPj2Xe9ZVZnguMVsOcNdeiISHXF5CTyfT8UHKbCTfpsn4YgDGpqdXSmw==}
+
+  '@pixiv/types-vrmc-node-constraint-1.0@3.5.3':
+    resolution: {integrity: sha512-72RNVTbP0c4R57SWDT43xhwZE3r6vhUDxD7M34nlX+o2Wis/Kx+R+bnFCf4/proRt+52Xasp3J6l9KiMqCtZ2g==}
+
+  '@pixiv/types-vrmc-springbone-1.0@3.5.3':
+    resolution: {integrity: sha512-3+Zw++ga16UxHiCTtEbd5HTbtXV+kyQsqvURm8IpVD4XGoSz1e2QJJP+vrbNBzRb7nUKYj4bVOFWGnULSx8sZQ==}
+
+  '@pixiv/types-vrmc-springbone-extended-collider-1.0@3.5.3':
+    resolution: {integrity: sha512-DaKEfwWsV4xyu0wdWfJ/bPvYpAammj49n0em8JTy52TmOhUm5oTN0ZZ5cmgdL9PVqN9qmWUkOdnK1ck1Id2H3A==}
+
+  '@pixiv/types-vrmc-vrm-1.0@3.5.3':
+    resolution: {integrity: sha512-3HsBZWKXU/CnY2J6uAVuYmM0NPt/e5jroQZH85WYK0EzYmebqTmWKF/fllguNliJQAovdhn8sIA8NbHZoQvbUA==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -21619,6 +21678,65 @@ snapshots:
   '@phosphor-icons/core@2.1.1': {}
 
   '@pinojs/redact@0.4.0': {}
+
+  '@pixiv/three-vrm-core@3.5.3(three@0.184.0)':
+    dependencies:
+      '@pixiv/types-vrm-0.0': 3.5.3
+      '@pixiv/types-vrmc-vrm-1.0': 3.5.3
+      three: 0.184.0
+
+  '@pixiv/three-vrm-materials-hdr-emissive-multiplier@3.5.3(three@0.184.0)':
+    dependencies:
+      '@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0': 3.5.3
+      three: 0.184.0
+
+  '@pixiv/three-vrm-materials-mtoon@3.5.3(three@0.184.0)':
+    dependencies:
+      '@pixiv/types-vrm-0.0': 3.5.3
+      '@pixiv/types-vrmc-materials-mtoon-1.0': 3.5.3
+      three: 0.184.0
+
+  '@pixiv/three-vrm-materials-v0compat@3.5.3(three@0.184.0)':
+    dependencies:
+      '@pixiv/types-vrm-0.0': 3.5.3
+      '@pixiv/types-vrmc-materials-mtoon-1.0': 3.5.3
+      three: 0.184.0
+
+  '@pixiv/three-vrm-node-constraint@3.5.3(three@0.184.0)':
+    dependencies:
+      '@pixiv/types-vrmc-node-constraint-1.0': 3.5.3
+      three: 0.184.0
+
+  '@pixiv/three-vrm-springbone@3.5.3(three@0.184.0)':
+    dependencies:
+      '@pixiv/types-vrm-0.0': 3.5.3
+      '@pixiv/types-vrmc-springbone-1.0': 3.5.3
+      '@pixiv/types-vrmc-springbone-extended-collider-1.0': 3.5.3
+      three: 0.184.0
+
+  '@pixiv/three-vrm@3.5.3(three@0.184.0)':
+    dependencies:
+      '@pixiv/three-vrm-core': 3.5.3(three@0.184.0)
+      '@pixiv/three-vrm-materials-hdr-emissive-multiplier': 3.5.3(three@0.184.0)
+      '@pixiv/three-vrm-materials-mtoon': 3.5.3(three@0.184.0)
+      '@pixiv/three-vrm-materials-v0compat': 3.5.3(three@0.184.0)
+      '@pixiv/three-vrm-node-constraint': 3.5.3(three@0.184.0)
+      '@pixiv/three-vrm-springbone': 3.5.3(three@0.184.0)
+      three: 0.184.0
+
+  '@pixiv/types-vrm-0.0@3.5.3': {}
+
+  '@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0@3.5.3': {}
+
+  '@pixiv/types-vrmc-materials-mtoon-1.0@3.5.3': {}
+
+  '@pixiv/types-vrmc-node-constraint-1.0@3.5.3': {}
+
+  '@pixiv/types-vrmc-springbone-1.0@3.5.3': {}
+
+  '@pixiv/types-vrmc-springbone-extended-collider-1.0@3.5.3': {}
+
+  '@pixiv/types-vrmc-vrm-1.0@3.5.3': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true


### PR DESCRIPTION
## Summary
Builds on Phase A (PR #11474) and the witch-mimiko-meadow.vrm model that landed in \`451965f7\` to put a real 3D Yuki inside the dock — opt-in, lazy-loaded, audio-driven lipsync, no webcam.

## Architecture
- \`YukiVRM.ts\` — vanilla Three + \`@pixiv/three-vrm\` v3.5.3 scene with a small handle (\`setState\` / \`speak\` / \`stopSpeaking\` / \`destroy\`). No React Three Fiber.
- \`YukiPanel.ts\` — adds an "Show 3D Yuki" toggle (off by default). First flip dynamic-imports \`YukiVRM\` so the Three + VRM bundle + ~12 MB .vrm asset never ship on cold dock open.

## Animation sources (deterministic, no Mediapipe)
1. **Idle** — spring bob on spine bone + randomized blink
2. **Talking** — \`aa\` / \`ih\` / \`ou\` mouth blendshapes driven by an AnalyserNode tap on the speak source. Volume → mouth-open value.
3. **Gestures** — handle accepts canned states (\`wave\`, \`nod\`, \`happy\`) for server-driven expressions later.

## Performance gates
- Render loop pauses when tab hidden
- 30 fps cap on coarse pointers (mobile)
- \`destroy()\` cancels rAF, disconnects analyser, closes AudioContext, deep-disposes VRM, disposes WebGL renderer

## Phase C (not in this PR)
Replace the deterministic chat echo with a real \`/api/v1/yuki/chat\` SSE stream. The reply still flows through \`speak()\` so the lipsync hook stays wired — one-line backend swap.

## Test plan
- [ ] Open dock → flip "Show 3D Yuki" → VRM loads, idles, blinks
- [ ] Send a chat message → reply is spoken, mouth syncs to volume
- [ ] Background the tab → render loop pauses (check DevTools Perf)
- [ ] Refresh page → toggle state persists from localStorage
- [ ] Disable toggle → WebGL context tears down (DevTools Memory)
- [ ] Mobile viewport → 30 fps cap, stage scales correctly