### PR TITLE
feat(yuki): Phase C — SSE chat stream + axum handler + project docs

### DIFF
--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
@@ -251,31 +251,69 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 	// ── Chat submit ────────────────────────────────────────────────────
 	const speak = makeSpeaker();
 	const input = form.querySelector<HTMLInputElement>('.yuki-panel__input');
+
+	// Cancel any in-flight stream when the user sends a new prompt OR
+	// closes / nav-swaps away. EventSource doesn't expose AbortSignal
+	// directly, so we keep a manual handle to `.close()`.
+	let activeStream: EventSource | null = null;
+
 	form.addEventListener('submit', (ev) => {
 		ev.preventDefault();
 		const value = input?.value.trim();
 		if (!value || !input) return;
 		input.value = '';
+
+		// Push the user bubble immediately. The Yuki bubble starts
+		// empty and grows as SSE chunks arrive.
 		const user: ChatEntry = { role: 'user', text: value, ts: Date.now() };
 		history.push(user);
 		log.appendChild(renderMessage(user));
-		// Phase B keeps the deterministic echo until the backend RPC
-		// lands. The next PR replaces the body of this block with an
-		// SSE stream to `/api/v1/yuki/chat`. The reply still flows
-		// through `speak()` so the VRM lipsync hook stays wired.
-		const reply =
-			"I've logged your question. The Yuki backend isn't online " +
-			'in this preview, but I will pass it along.';
-		const yuki: ChatEntry = {
-			role: 'yuki',
-			text: reply,
-			ts: Date.now(),
-		};
-		history.push(yuki);
-		log.appendChild(renderMessage(yuki));
-		writeHistory(history);
 		log.scrollTop = log.scrollHeight;
-		speak(reply);
+
+		const yuki: ChatEntry = { role: 'yuki', text: '', ts: Date.now() };
+		history.push(yuki);
+		const yukiRow = renderMessage(yuki);
+		const yukiBubble =
+			yukiRow.querySelector<HTMLElement>('.yuki-msg__bubble');
+		log.appendChild(yukiRow);
+		log.scrollTop = log.scrollHeight;
+
+		activeStream?.close();
+		const url = `/api/v1/yuki/chat?q=${encodeURIComponent(value)}`;
+		const es = new EventSource(url);
+		activeStream = es;
+
+		let assembled = '';
+		const append = (text: string): void => {
+			assembled += (assembled ? ' ' : '') + text;
+			yuki.text = assembled;
+			if (yukiBubble) yukiBubble.textContent = assembled;
+			log.scrollTop = log.scrollHeight;
+		};
+
+		es.onmessage = (msg) => {
+			if (msg.data) append(msg.data);
+		};
+		es.addEventListener('done', () => {
+			es.close();
+			activeStream = null;
+			writeHistory(history);
+			// Hand the fully-assembled text to SpeechSynthesis so the
+			// VRM lipsync analyser sees the whole utterance in one
+			// stretch instead of token-fragmented chirps.
+			if (assembled) speak(assembled);
+		});
+		es.onerror = () => {
+			es.close();
+			activeStream = null;
+			if (!assembled) {
+				const fallback =
+					"I couldn't reach my backend just now — try again in a sec.";
+				yuki.text = fallback;
+				if (yukiBubble) yukiBubble.textContent = fallback;
+			}
+			writeHistory(history);
+		};
 	});
 
 	if (!document.getElementById('kbve-yuki-panel-css')) {

--- a/apps/kbve/astro-kbve/src/content/docs/project/yuki.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/yuki.mdx
@@ -1,0 +1,144 @@
+---
+title: Yuki
+description: |
+    Persistent virtual concierge that lives in the lower-right corner of
+    every kbve.com page — chat panel, optional VRM avatar, audio-driven
+    lipsync, SSE-streamed replies.
+tableOfContents: true
+graph:
+    visible: true
+sidebar:
+    label: Yuki
+    order: 5
+tags:
+    - project
+    - astro-kbve
+    - axum-kbve
+    - vrm
+---
+
+import Adsense from '@/components/astropad/adsense/Adsense.astro';
+
+Yuki is the always-available concierge that ships inside the right-side
+dock on every kbve.com page. Persistent across `<ClientRouter />`
+navigation, deferred until the user opens her, and architected so the
+heavy parts (VRM model, Three.js scene, AudioContext) only land in the
+browser when the user opts in.
+
+## At a glance
+
+| Phase | Status | What ships |
+|-------|--------|------------|
+| **A** — Dock shell | ✅ merged (#11474) | Persistent FAB + collapsed panel, vanilla driver, lazy-mount contract, localStorage state, ESC-to-close, reduced-motion respect |
+| **B** — VRM avatar | ✅ merged (#11475) | `@pixiv/three-vrm@^3.5.3` scene, idle/blink animation, `aa`/`ih`/`ou` lipsync via AnalyserNode tap, render-loop visibility + fps gates |
+| **C** — SSE stream | 🚧 this PR | `GET /api/v1/yuki/chat?q=<…>` returns `text/event-stream` chunks; panel streams tokens into the bubble + hands assembled text to `speak()` for lipsync |
+| **D** — Real backend | 🗓 next | Swap the canned reply in `transport/yuki.rs` for a jedi/q-routed LLM call. Prompt template, conversation compaction, rate limit. Front-end unchanged. |
+| **E** — Voice in | 🗓 later | Push-to-talk mic capture → on-device VAD → server STT → same SSE response path |
+| **F** — Tools / actions | 🗓 later | Function-call schema so Yuki can navigate the site, open the wallet card, queue a forum post, etc. |
+
+<Adsense />
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│ AstroYukiDock.astro                                             │
+│   • transition:persist="kbve-yuki-dock"                         │
+│   • static HTML/CSS — zero JS on first paint                    │
+└───────────────┬─────────────────────────────────────────────────┘
+                │   user clicks FAB → first time only
+                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ yuki-dock.ts (vanilla)                                          │
+│   • toggle + localStorage state                                 │
+│   • dynamic import('./YukiPanel')                               │
+└───────────────┬─────────────────────────────────────────────────┘
+                │   panel mounts inside the dock body
+                ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ YukiPanel.ts                                                    │
+│   • chat log + input                                            │
+│   • "Show 3D Yuki" toggle → dynamic import('./YukiVRM')         │
+│   • submit → EventSource('/api/v1/yuki/chat?q=…')               │
+│   • SSE chunks stream into the bubble; on `done` → speak(text)  │
+└─────────┬──────────────────────────────────┬────────────────────┘
+          │                                  │
+          ▼ (optional)                        ▼
+┌──────────────────────────┐    ┌─────────────────────────────────┐
+│ YukiVRM.ts               │    │ axum-kbve transport/yuki.rs     │
+│  Three + three-vrm       │    │  GET /api/v1/yuki/chat          │
+│  idle / blink / lipsync  │    │  text/event-stream, 15s keep-   │
+│  destroy() releases all  │    │  alive, `event: done` terminator│
+│  resources               │    └─────────────────────────────────┘
+└──────────────────────────┘
+```
+
+### Why no React for the panel?
+
+The chat layer needs to live inside a `transition:persist` node that
+the rest of the dock shell wraps. React's reconciliation tree is
+allergic to having its root DOM swap-mutated under it by Astro's
+ClientRouter, so the safer move is vanilla DOM that owns its own state.
+Bundle-wise we save the React + ReactDOM payload on first dock open —
+and the VRM scene that *does* use Three.js never crosses into React's
+tree either.
+
+### Why no Mediapipe / webcam?
+
+Yuki's pose data is either ours (canned animations, server-driven
+flags) or audio-derived (lipsync from the speak source). We
+deliberately don't ask the visitor for camera access — the avatar is
+a concierge, not a mirror.
+
+## Public surface
+
+### Frontend
+
+```ts
+// Loaded only after first dock expand.
+import { mountYukiPanel } from '@/components/jay/dock/YukiPanel';
+
+// Lazily imported by the panel when "Show 3D Yuki" is on.
+import { mountYukiVRM } from '@/components/jay/dock/YukiVRM';
+//   const handle = await mountYukiVRM({ host });
+//   handle.setState('happy');
+//   handle.speak(audioElement);   // analyser tap → mouth blendshapes
+//   handle.destroy();             // releases WebGL ctx + AudioContext
+```
+
+### Backend
+
+```
+GET /api/v1/yuki/chat?q=<utf8 prompt>
+
+Content-Type: text/event-stream
+:keepalive                 ← every 15s while idle
+data: <chunk>              ← repeats per token / sentence fragment
+data: <chunk>
+event: done                ← terminator
+data:
+```
+
+The handler trims and rejects empty prompts with a 400. There is no
+authentication on the route in Phase C; Phase D will gate it on a
+Supabase JWT once the real LLM call costs money to run.
+
+## Storage
+
+| Key | Purpose |
+|-----|---------|
+| `kbve:yuki-dock:state` | `'collapsed'` or `'expanded'` — restores last view across reloads |
+| `kbve:yuki-dock:avatar-mode` | `'text'` or `'3d'` — restores 3D toggle |
+| `kbve:yuki-dock:history` | Last 24 chat entries, `{role, text, ts}` |
+
+All three are localStorage-only, never sent to the server.
+
+## What's next
+
+- **Phase D**: replace `compose_reply` in `apps/kbve/axum-kbve/src/transport/yuki.rs` with a real LLM call. Likely q-routed so we keep our existing tracing + Supabase JWT verification. Front-end stays identical.
+- **Site-context**: feed the current page slug into the prompt so Yuki can answer "where am I?" without a tool call.
+- **Tool calls**: small JSON-schema function set (`navigate`, `open_dock_card`, `compose_forum_post`) so Yuki can act on the page, not just talk about it.
+- **Voice input** behind a push-to-talk gate, on-device VAD to keep the mic OFF except while the button is held.
+
+If you have feedback, drop it in the [forum](/forum/) — the link is
+literally what the Phase C stub tells you to do.

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -427,6 +427,10 @@ fn router(state: AppState) -> Router {
             post(super::referral::me_set_default),
         )
         // service_role JWT required; anon / authenticated JWTs are rejected with 403.
+        // Yuki dock — SSE chat stream. Phase C is a deterministic
+        // canned reply; Phase D swaps the handler body for a real
+        // LLM round-trip without touching the route or the front-end.
+        .route("/api/v1/yuki/chat", get(super::yuki::chat_handler))
         .route(
             "/api/v1/wallet/service/balance/{user_id}",
             get(super::wallet::service_balance),

--- a/apps/kbve/axum-kbve/src/transport/mod.rs
+++ b/apps/kbve/axum-kbve/src/transport/mod.rs
@@ -4,3 +4,4 @@ pub mod proxy;
 pub mod referral;
 pub mod vnc_hub;
 pub mod wallet;
+pub mod yuki;

--- a/apps/kbve/axum-kbve/src/transport/yuki.rs
+++ b/apps/kbve/axum-kbve/src/transport/yuki.rs
@@ -1,0 +1,101 @@
+//! `/api/v1/yuki/chat` — server-sent events stream for the Yuki dock.
+//!
+//! Phase C ships only the **stream plumbing**: handler signature,
+//! per-request token shaping, keep-alive cadence, and a deterministic
+//! canned reply that lets the dock panel exercise the full SSE +
+//! lipsync path end-to-end without committing to an LLM provider.
+//!
+//! Phase D swaps the body of `stream_reply` for a real chat backend
+//! (jedi / q-routed). Everything else — the route signature, the
+//! `data: <chunk>\n\n` framing, the `event: done` terminator — stays
+//! exactly the way it is here so the front-end does not need to change
+//! again when the upgrade lands.
+
+use std::convert::Infallible;
+use std::time::Duration;
+
+use axum::{
+    extract::Query,
+    response::{
+        IntoResponse,
+        sse::{Event, KeepAlive, Sse},
+    },
+};
+use futures_util::stream::{self, Stream, StreamExt};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct YukiChatQuery {
+    /// Prompt text. Whitespace-trimmed by the handler; rejected when
+    /// empty after trim. No max length right now — Phase D will gate
+    /// on token count once a tokenizer is wired.
+    pub q: String,
+}
+
+/// `GET /api/v1/yuki/chat?q=<prompt>`
+///
+/// Streams the reply as `text/event-stream`:
+///   data: <utf8 chunk>\n\n        (one per token / sentence fragment)
+///   event: done\ndata: \n\n        (terminator)
+///
+/// `EventStream` from the front-end calls `onmessage` for the data
+/// frames and `addEventListener('done', …)` for the terminator. The
+/// dock panel aggregates the chunks into a single message bubble and
+/// hands the assembled text to `speak()` once the stream completes,
+/// so SpeechSynthesis can drive the VRM lipsync.
+///
+/// Keep-alive comments fire every 15s so corporate proxies / CDNs
+/// don't time the connection out mid-reply.
+pub(crate) async fn chat_handler(Query(params): Query<YukiChatQuery>) -> impl IntoResponse {
+    let prompt = params.q.trim().to_string();
+    if prompt.is_empty() {
+        // 400 — empty prompt. SSE clients treat this as a fail, the
+        // panel surfaces the body as an inline error bubble.
+        return (axum::http::StatusCode::BAD_REQUEST, "prompt is required").into_response();
+    }
+
+    let stream = stream_reply(prompt);
+    Sse::new(stream)
+        .keep_alive(
+            KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text("keepalive"),
+        )
+        .into_response()
+}
+
+/// Deterministic placeholder generator — chunks a canned reply into
+/// ~3-word fragments with a short delay between sends so the lipsync
+/// analyser on the front-end sees realistic amplitude variation.
+fn stream_reply(prompt: String) -> impl Stream<Item = Result<Event, Infallible>> {
+    let reply = compose_reply(&prompt);
+    let words: Vec<&str> = reply.split_whitespace().collect();
+    // Pre-allocate so the stream is owning, not borrowing the prompt.
+    let chunks: Vec<String> = words.chunks(3).map(|w| w.join(" ")).collect();
+
+    let body = stream::iter(chunks).then(|chunk| async move {
+        // ~80ms between chunks ≈ a comfortable reading + speaking pace.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        Ok::<Event, Infallible>(Event::default().data(chunk))
+    });
+
+    let done =
+        stream::once(async { Ok::<Event, Infallible>(Event::default().event("done").data("")) });
+
+    body.chain(done)
+}
+
+/// Phase C canned reply — acknowledges the prompt and points the
+/// user at the forum + the docs page. Phase D replaces the body of
+/// this function with the real LLM call.
+fn compose_reply(prompt: &str) -> String {
+    let trimmed: String = prompt.chars().take(160).collect();
+    format!(
+        "Heard you — \"{}\". The real Yuki backend is still wiring up; \
+         for now I'm running on a canned reply so we can stress-test \
+         the SSE plumbing and the lipsync hook. Track the rollout on \
+         the project/yuki page, or drop the question in the forum and \
+         a human will get back to you.",
+        trimmed
+    )
+}


### PR DESCRIPTION
## Summary
Wires the Yuki dock to a real streaming endpoint so the SSE plumbing and the VRM lipsync path can be tested end-to-end before a real LLM provider is selected.

## What ships
- **\`apps/kbve/axum-kbve/src/transport/yuki.rs\`** — \`GET /api/v1/yuki/chat?q=<prompt>\` returns \`text/event-stream\`. Reply is split into ~3-word \`data: <chunk>\n\n\` frames every ~80ms, terminated by \`event: done\`. KeepAlive 15s. Canned reply for now; Phase D swaps the \`compose_reply\` body for the real LLM call without touching the route or front-end.
- **\`YukiPanel.ts\`** — \`EventSource\` consumer. Empty Yuki bubble grows as chunks arrive. On \`done\`, the assembled text is handed to \`speak()\` so SpeechSynthesis voices the whole sentence in one utterance and the VRM AnalyserNode sees a smooth amplitude envelope.
- **\`content/docs/project/yuki.mdx\`** — phase table, architecture diagram, API contracts, localStorage keys, future roadmap.

## Wiring
\`apps/kbve/axum-kbve/src/transport/mod.rs\` registers the module; \`https.rs\` wires the route next to the wallet service group.

## Test plan
- [ ] \`curl -N 'http://localhost:4321/api/v1/yuki/chat?q=hello'\` — see chunked SSE frames + \`done\` terminator
- [ ] Empty \`?q=\` → 400
- [ ] Dock chat → text appears progressively, lipsync drives mouth on \`done\`
- [ ] Send a second prompt while the first is streaming → old stream closes, new one starts
- [ ] Toggle 3D Yuki off mid-stream → text still completes, no console error
- [ ] Navigate via ClientRouter mid-stream → \`activeStream.close()\` fires, no leaked EventSource

## Phase D (next PR)
Swap \`compose_reply\` for a real LLM round-trip (likely q-routed). Gate the route on a Supabase JWT. Add prompt template + conversation compaction. Front-end unchanged.