### PR TITLE
feat(axum-kbve): generic POST /api/v1/rcon/{game}/{server}/exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "sha2 0.10.9",
  "socket2 0.6.3",

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -10,6 +10,8 @@ anyhow = "1.0"
 thiserror = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+# RCON allowlist (packages/data/rcon/commands.yaml) baked via include_str! at compile time.
+serde_yaml = "0.9"
 tower = { version = "0.5.3", features = ["util", "timeout", "load-shed", "limit"] }
 tower-http = { version = "0.6.8", features = [
     "compression-full",

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -5,6 +5,7 @@ pub mod gameserver;
 mod mcp;
 mod openapi;
 mod proto;
+mod rcon;
 mod telemetry;
 mod transport;
 pub mod version;
@@ -88,6 +89,15 @@ async fn main() -> anyhow::Result<()> {
         info!("MC service initialized - player list + texture proxy enabled");
     } else {
         info!("MC service not configured (set MC_RCON_HOST to enable)");
+    }
+
+    match rcon::init_rcon_registry() {
+        Ok(reg) => info!(
+            "RCON registry initialized — {} commands, {} endpoints configured",
+            reg.command_count(),
+            reg.endpoint_count()
+        ),
+        Err(e) => warn!(error = %e, "RCON registry init failed — /api/v1/rcon/* will 503"),
     }
 
     if db::init_forum_service() {

--- a/apps/kbve/axum-kbve/src/openapi.rs
+++ b/apps/kbve/axum-kbve/src/openapi.rs
@@ -67,6 +67,7 @@ impl Modify for SecurityAddon {
         (name = "forum", description = "Public forum threads, comments, spaces, and tags."),
         (name = "osrs", description = "Old School RuneScape item lookups."),
         (name = "mc", description = "Minecraft RCON-backed live data: player list, head textures."),
+        (name = "rcon", description = "Generic RCON exec — staff-gated, allowlist-driven, MC + Factorio backends."),
         (name = "telemetry", description = "Client-side error reporting from WASM/JS."),
         (name = "dashboard", description = "Staff-only routes powering kbve.com/dashboard. Gated on DASHBOARD_VIEW."),
         (name = "wallet", description = "Authenticated wallet surface: balance, coupons, claim flows."),
@@ -90,6 +91,8 @@ impl Modify for SecurityAddon {
         crate::transport::https::mc_players_handler,
         crate::transport::https::mc_player_by_uuid_handler,
         crate::transport::https::mc_texture_handler,
+        // rcon (generic exec)
+        crate::rcon::handler::exec_handler,
         // forum
         crate::transport::https::api_me,
         crate::transport::https::api_me_staff,
@@ -166,6 +169,9 @@ impl Modify for SecurityAddon {
             crate::transport::wallet::ServiceRevokeCouponBody,
             crate::transport::wallet::ServiceRevokeDto,
             crate::transport::wallet::ServiceVerifyBalanceDto,
+            // rcon
+            crate::rcon::handler::RconExecRequest,
+            crate::rcon::handler::RconExecResponse,
             // marketplace
             crate::transport::market::MarketListingDto,
             crate::transport::market::MarketListingDetailDto,

--- a/apps/kbve/axum-kbve/src/rcon/handler.rs
+++ b/apps/kbve/axum-kbve/src/rcon/handler.rs
@@ -1,0 +1,344 @@
+//! `POST /api/v1/rcon/{game}/{server}/exec`
+//!
+//! Generic RCON exec route shared by every backend (MC / Factorio / future).
+//! Auth is the same Supabase-JWT cookie/bearer pattern used elsewhere in
+//! axum-kbve; staff gating reads `is_staff` off the cached `TokenInfo`.
+
+use std::time::{Duration, Instant};
+
+use axum::{
+    Json,
+    extract::Path,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+};
+use jedi::rcon::RconClient;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use utoipa::ToSchema;
+
+use crate::auth::{extract_request_token, get_jwt_cache};
+use crate::rcon::registry::{Game, get_rcon_registry};
+
+const RCON_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Wire shape mirrors `kbve.rcon.RconRequest`. The path captures cover
+/// `game` and `server`, so the body only carries the command + args.
+#[derive(Clone, Debug, Deserialize, ToSchema)]
+pub struct RconExecRequest {
+    /// Canonical command name (must match an allowlist entry).
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+/// Wire shape mirrors `kbve.rcon.RconResponse`.
+#[derive(Clone, Debug, Serialize, ToSchema)]
+pub struct RconExecResponse {
+    pub ok: bool,
+    pub output: String,
+    pub latency_ms: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// `POST /api/v1/rcon/{game}/{server}/exec` — auth + allowlist + jedi::rcon.
+#[utoipa::path(
+    post,
+    path = "/api/v1/rcon/{game}/{server}/exec",
+    tag = "rcon",
+    params(
+        ("game" = String, Path, description = "Game id — `mc` or `factorio`"),
+        ("server" = String, Path, description = "Logical server name, e.g. `lobby`, `survival`, `main`"),
+    ),
+    request_body = RconExecRequest,
+    responses(
+        (status = 200, description = "RCON exec result", body = RconExecResponse),
+        (status = 400, description = "Unknown game / unknown command / arg validation failure"),
+        (status = 401, description = "Missing or invalid bearer token"),
+        (status = 403, description = "Command requires staff and caller is not staff"),
+        (status = 404, description = "Endpoint not configured for this game/server"),
+        (status = 502, description = "RCON connect / auth / exec failure"),
+        (status = 503, description = "Auth or RCON registry not initialized"),
+    ),
+)]
+pub async fn exec_handler(
+    Path((game_raw, server_raw)): Path<(String, String)>,
+    headers: HeaderMap,
+    Json(body): Json<RconExecRequest>,
+) -> impl IntoResponse {
+    let game = match parse_game(&game_raw) {
+        Some(g) => g,
+        None => {
+            return error(
+                StatusCode::BAD_REQUEST,
+                format!("unknown game `{game_raw}` — expected `mc` or `factorio`"),
+            );
+        }
+    };
+
+    let registry = match get_rcon_registry() {
+        Some(r) => r,
+        None => {
+            return error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "RCON registry not initialized",
+            );
+        }
+    };
+
+    let endpoint = match registry.endpoint(game, &server_raw) {
+        Some(ep) => ep.clone(),
+        None => {
+            return error(
+                StatusCode::NOT_FOUND,
+                format!("no RCON endpoint configured for {game_raw}/{server_raw}"),
+            );
+        }
+    };
+
+    let spec = match registry.command(game, &body.command) {
+        Some(s) => s.clone(),
+        None => {
+            return error(
+                StatusCode::BAD_REQUEST,
+                format!("command `{}` not in allowlist for {game_raw}", body.command),
+            );
+        }
+    };
+
+    let token = match extract_request_token(&headers) {
+        Some(t) => t,
+        None => return error(StatusCode::UNAUTHORIZED, "Missing authentication"),
+    };
+
+    let token_info = match get_jwt_cache() {
+        Some(cache) => match cache.verify_and_cache(&token).await {
+            Ok(info) => info,
+            Err(e) => {
+                tracing::warn!(error = %e, "JWT verify failed in rcon exec");
+                return error(StatusCode::UNAUTHORIZED, "Invalid or expired token");
+            }
+        },
+        None => return error(StatusCode::SERVICE_UNAVAILABLE, "Auth service unavailable"),
+    };
+
+    if spec.staff_only && !token_info.is_staff() {
+        return error(
+            StatusCode::FORBIDDEN,
+            format!("command `{}` requires staff", body.command),
+        );
+    }
+
+    if let Err(msg) = validate_args(&spec.arg_validators, &body.args) {
+        return error(StatusCode::BAD_REQUEST, msg);
+    }
+
+    let wire_command = match render_template(&spec.template, &body.args) {
+        Ok(s) => s,
+        Err(msg) => return error(StatusCode::BAD_REQUEST, msg),
+    };
+
+    let started = Instant::now();
+    let exec_result = exec_rcon(&endpoint, &wire_command).await;
+    let latency_ms = started.elapsed().as_millis().min(u32::MAX as u128) as u32;
+
+    match exec_result {
+        Ok(output) => {
+            tracing::info!(
+                target: "rcon_audit",
+                source = "axum",
+                game = ?game,
+                server = %server_raw,
+                command = %spec.name,
+                user_id = %token_info.user_id,
+                ok = true,
+                latency_ms = latency_ms,
+                "rcon exec ok"
+            );
+            (
+                StatusCode::OK,
+                Json(RconExecResponse {
+                    ok: true,
+                    output,
+                    latency_ms,
+                    error: None,
+                }),
+            )
+                .into_response()
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "rcon_audit",
+                source = "axum",
+                game = ?game,
+                server = %server_raw,
+                command = %spec.name,
+                user_id = %token_info.user_id,
+                ok = false,
+                latency_ms = latency_ms,
+                error = %err,
+                "rcon exec failed"
+            );
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(RconExecResponse {
+                    ok: false,
+                    output: String::new(),
+                    latency_ms,
+                    error: Some(err.to_string()),
+                }),
+            )
+                .into_response()
+        }
+    }
+}
+
+fn parse_game(raw: &str) -> Option<Game> {
+    match raw.to_ascii_lowercase().as_str() {
+        "mc" => Some(Game::Mc),
+        "factorio" => Some(Game::Factorio),
+        _ => None,
+    }
+}
+
+async fn exec_rcon(
+    endpoint: &jedi::rcon::RconEndpoint,
+    command: &str,
+) -> Result<String, jedi::rcon::RconError> {
+    let mut client = RconClient::connect(endpoint, RCON_CONNECT_TIMEOUT).await?;
+    client.exec(command).await
+}
+
+/// Substitute positional `{N}` placeholders in the template. Stays
+/// intentionally simple — there's no `{0:?}` formatter syntax, no escape
+/// sequence, no nested braces. Anything fancier should be a separate
+/// command in the allowlist with a richer template.
+fn render_template(template: &str, args: &[String]) -> Result<String, String> {
+    let mut out = String::with_capacity(template.len());
+    let mut chars = template.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '{' {
+            out.push(c);
+            continue;
+        }
+        let mut idx_str = String::new();
+        let mut closed = false;
+        for inner in chars.by_ref() {
+            if inner == '}' {
+                closed = true;
+                break;
+            }
+            idx_str.push(inner);
+        }
+        if !closed {
+            return Err(format!("template has unterminated `{{` in `{template}`"));
+        }
+        let idx: usize = idx_str
+            .parse()
+            .map_err(|_| format!("template placeholder `{{{idx_str}}}` is not numeric"))?;
+        let value = args
+            .get(idx)
+            .ok_or_else(|| format!("template needs arg {idx} but only {} provided", args.len()))?;
+        out.push_str(value);
+    }
+    Ok(out)
+}
+
+/// Per-arg validators referenced in the allowlist. New validator names need
+/// a branch here AND a code review — they're part of the security boundary.
+fn validate_args(validators: &[String], args: &[String]) -> Result<(), String> {
+    if validators.is_empty() {
+        return Ok(());
+    }
+    if args.len() < validators.len() {
+        return Err(format!(
+            "expected {} args, got {}",
+            validators.len(),
+            args.len()
+        ));
+    }
+    for (i, name) in validators.iter().enumerate() {
+        let arg = &args[i];
+        match name.as_str() {
+            "string" => {
+                if arg.is_empty() {
+                    return Err(format!("arg {i} (string) must be non-empty"));
+                }
+            }
+            "int" => {
+                arg.parse::<i64>()
+                    .map_err(|_| format!("arg {i} (int) is not a valid integer"))?;
+            }
+            "lua_snippet" => {
+                if arg.is_empty() {
+                    return Err(format!("arg {i} (lua_snippet) must be non-empty"));
+                }
+            }
+            other => {
+                return Err(format!("unknown validator `{other}` for arg {i}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn error(status: StatusCode, msg: impl Into<String>) -> axum::response::Response {
+    (status, Json(json!({"error": msg.into()}))).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_game_accepts_canonical_strings() {
+        assert_eq!(parse_game("mc"), Some(Game::Mc));
+        assert_eq!(parse_game("MC"), Some(Game::Mc));
+        assert_eq!(parse_game("factorio"), Some(Game::Factorio));
+        assert_eq!(parse_game("Factorio"), Some(Game::Factorio));
+        assert_eq!(parse_game("doom"), None);
+    }
+
+    #[test]
+    fn render_template_substitutes_positional_args() {
+        let out = render_template("tp {0} {1}", &["alice".into(), "bob".into()]).unwrap();
+        assert_eq!(out, "tp alice bob");
+    }
+
+    #[test]
+    fn render_template_repeats_same_arg() {
+        let out = render_template("say [{0}] {0}", &["hi".into()]).unwrap();
+        assert_eq!(out, "say [hi] hi");
+    }
+
+    #[test]
+    fn render_template_passes_through_no_args() {
+        let out = render_template("list", &[]).unwrap();
+        assert_eq!(out, "list");
+    }
+
+    #[test]
+    fn render_template_errors_on_missing_arg() {
+        let err = render_template("tp {0} {1}", &["alice".into()]).unwrap_err();
+        assert!(err.contains("arg 1"));
+    }
+
+    #[test]
+    fn render_template_errors_on_bad_index() {
+        let err = render_template("tp {foo}", &[]).unwrap_err();
+        assert!(err.contains("not numeric"));
+    }
+
+    #[test]
+    fn validate_args_string_int_and_lua() {
+        assert!(validate_args(&[], &[]).is_ok());
+        assert!(validate_args(&["string".into()], &["x".into()]).is_ok());
+        assert!(validate_args(&["string".into()], &["".into()]).is_err());
+        assert!(validate_args(&["int".into()], &["42".into()]).is_ok());
+        assert!(validate_args(&["int".into()], &["nope".into()]).is_err());
+        assert!(validate_args(&["lua_snippet".into()], &["game.print('hi')".into()]).is_ok());
+        assert!(validate_args(&["unknown".into()], &["x".into()]).is_err());
+        assert!(validate_args(&["string".into(), "int".into()], &["x".into()]).is_err());
+    }
+}

--- a/apps/kbve/axum-kbve/src/rcon/mod.rs
+++ b/apps/kbve/axum-kbve/src/rcon/mod.rs
@@ -1,0 +1,20 @@
+//! HTTP-facing RCON layer for axum-kbve.
+//!
+//! The Source-RCON transport itself lives in `jedi::rcon`. This module wires
+//! it to:
+//!   * a `Game` enum (`mc` | `factorio`) that matches `kbve.rcon.Game`,
+//!   * a generic env-var scheme — `RCON_{GAME}_{SERVER}_{HOST|PORT|PASSWORD}`,
+//!   * a checked-in allowlist (`packages/data/rcon/commands.yaml`) loaded
+//!     via `include_str!` so the binary IS the policy boundary — there's no
+//!     DB, no admin UI, no runtime reload,
+//!   * a Supabase-JWT staff gate (mirrors the pattern already used by forum
+//!     write routes), and
+//!   * a structured `tracing::info!` audit event with `target = "rcon_audit"`
+//!     so Vector → ClickHouse picks it up next to the edge fn's audit lines
+//!     (slice C).
+
+pub mod handler;
+pub mod registry;
+
+pub use handler::exec_handler;
+pub use registry::init_rcon_registry;

--- a/apps/kbve/axum-kbve/src/rcon/registry.rs
+++ b/apps/kbve/axum-kbve/src/rcon/registry.rs
@@ -1,0 +1,229 @@
+//! Compile-time allowlist + runtime endpoint map.
+//!
+//! ## Allowlist
+//! Single source of truth lives at `packages/data/rcon/commands.yaml` and is
+//! baked into the binary with `include_str!`. Adding / changing a command
+//! requires a rebuild — that's deliberate: the allowlist is a security
+//! boundary, so a binary build IS the policy artifact.
+//!
+//! ## Endpoint env scheme
+//! `RCON_{GAME}_{SERVER}_{HOST|PORT|PASSWORD}` — game and server upper-cased.
+//! Examples:
+//!   `RCON_MC_LOBBY_HOST` / `_PORT` / `_PASSWORD`
+//!   `RCON_FACTORIO_MAIN_HOST` / `_PORT` / `_PASSWORD`
+//!
+//! Endpoints are parsed once at startup. The legacy `MC_RCON_*` scheme used
+//! by `src/db/mc.rs` polling stays untouched — both schemes can coexist
+//! without one leaking into the other.
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use jedi::rcon::RconEndpoint;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use utoipa::ToSchema;
+
+/// `kbve.rcon.Game` mirror. Serialized lowercase to match the proto enum's
+/// stripped form (`GAME_MC` → `"mc"`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Game {
+    Mc,
+    Factorio,
+}
+
+impl Game {
+    fn env_prefix(self) -> &'static str {
+        match self {
+            Game::Mc => "MC",
+            Game::Factorio => "FACTORIO",
+        }
+    }
+
+    fn well_known_servers(self) -> &'static [&'static str] {
+        match self {
+            Game::Mc => &["LOBBY", "SURVIVAL"],
+            Game::Factorio => &["MAIN"],
+        }
+    }
+
+    const ALL: &'static [Game] = &[Game::Mc, Game::Factorio];
+}
+
+/// One allowlisted command (`kbve.rcon.RconCommandSpec`).
+#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
+pub struct RconCommandSpec {
+    pub game: Game,
+    pub name: String,
+    #[serde(default)]
+    pub staff_only: bool,
+    pub template: String,
+    #[serde(default)]
+    pub arg_validators: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RconCommandRegistryFile {
+    commands: Vec<RconCommandSpec>,
+}
+
+#[derive(Debug, Error)]
+pub enum RegistryError {
+    #[error("allowlist YAML parse: {0}")]
+    YamlParse(#[from] serde_yaml::Error),
+
+    #[error("duplicate command in allowlist: {game:?}/{name}")]
+    DuplicateCommand { game: Game, name: String },
+}
+
+const COMMANDS_YAML: &str = include_str!("../../../../../packages/data/rcon/commands.yaml");
+
+/// Resolved at startup: allowlist + endpoint table. Cheap to clone (Arc).
+#[derive(Clone, Debug)]
+pub struct RconRegistry {
+    commands: Arc<HashMap<(Game, String), RconCommandSpec>>,
+    endpoints: Arc<HashMap<(Game, String), RconEndpoint>>,
+}
+
+impl RconRegistry {
+    /// Parse the baked YAML allowlist and the env-var endpoint table.
+    /// Returns `Ok` even when no endpoints are configured — that just
+    /// means every exec call will 404 until an env var is set.
+    pub fn from_env() -> Result<Self, RegistryError> {
+        let parsed: RconCommandRegistryFile = serde_yaml::from_str(COMMANDS_YAML)?;
+
+        let mut commands: HashMap<(Game, String), RconCommandSpec> = HashMap::new();
+        for spec in parsed.commands {
+            let key = (spec.game, spec.name.clone());
+            if commands.contains_key(&key) {
+                return Err(RegistryError::DuplicateCommand {
+                    game: spec.game,
+                    name: spec.name,
+                });
+            }
+            commands.insert(key, spec);
+        }
+
+        Ok(Self {
+            commands: Arc::new(commands),
+            endpoints: Arc::new(parse_endpoints_from_env()),
+        })
+    }
+
+    pub fn command(&self, game: Game, name: &str) -> Option<&RconCommandSpec> {
+        self.commands.get(&(game, name.to_string()))
+    }
+
+    pub fn endpoint(&self, game: Game, server: &str) -> Option<&RconEndpoint> {
+        self.endpoints.get(&(game, server.to_lowercase()))
+    }
+
+    pub fn endpoint_count(&self) -> usize {
+        self.endpoints.len()
+    }
+
+    pub fn command_count(&self) -> usize {
+        self.commands.len()
+    }
+}
+
+fn parse_endpoints_from_env() -> HashMap<(Game, String), RconEndpoint> {
+    let mut out = HashMap::new();
+    for game in Game::ALL {
+        let game_prefix = game.env_prefix();
+        for server in game.well_known_servers() {
+            let host_var = format!("RCON_{game_prefix}_{server}_HOST");
+            let Ok(host) = std::env::var(&host_var) else {
+                continue;
+            };
+            let port: u16 = std::env::var(format!("RCON_{game_prefix}_{server}_PORT"))
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(default_port(*game));
+            let password =
+                std::env::var(format!("RCON_{game_prefix}_{server}_PASSWORD")).unwrap_or_default();
+            out.insert(
+                (*game, server.to_lowercase()),
+                RconEndpoint::new(host, port, password),
+            );
+        }
+    }
+    out
+}
+
+fn default_port(game: Game) -> u16 {
+    match game {
+        Game::Mc => 25575,
+        Game::Factorio => 27015,
+    }
+}
+
+static RCON_REGISTRY: OnceLock<RconRegistry> = OnceLock::new();
+
+/// Build + install the global registry. Returns the resolved registry so
+/// `main.rs` can log a summary, and stashes it in a OnceLock so handlers
+/// can pull it without threading through `AppState`.
+pub fn init_rcon_registry() -> Result<&'static RconRegistry, RegistryError> {
+    let reg = RconRegistry::from_env()?;
+    let _ = RCON_REGISTRY.set(reg);
+    Ok(RCON_REGISTRY.get().expect("registry set above"))
+}
+
+pub fn get_rcon_registry() -> Option<&'static RconRegistry> {
+    RCON_REGISTRY.get()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowlist_yaml_parses() {
+        // The baked YAML must always be valid — a broken file should fail
+        // builds, not panic at boot in prod.
+        let parsed: RconCommandRegistryFile =
+            serde_yaml::from_str(COMMANDS_YAML).expect("packaged commands.yaml must parse");
+        assert!(!parsed.commands.is_empty());
+        assert!(
+            parsed
+                .commands
+                .iter()
+                .any(|c| c.game == Game::Mc && c.name == "list")
+        );
+        assert!(
+            parsed
+                .commands
+                .iter()
+                .any(|c| c.game == Game::Factorio && c.name == "silent_command" && c.staff_only)
+        );
+    }
+
+    #[test]
+    fn registry_rejects_duplicate_command() {
+        let mut commands: HashMap<(Game, String), RconCommandSpec> = HashMap::new();
+        let spec = RconCommandSpec {
+            game: Game::Mc,
+            name: "list".into(),
+            staff_only: false,
+            template: "list".into(),
+            arg_validators: vec![],
+        };
+        commands.insert((Game::Mc, "list".into()), spec.clone());
+
+        let parsed = RconCommandRegistryFile {
+            commands: vec![spec.clone(), spec],
+        };
+        let mut seen: HashMap<(Game, String), RconCommandSpec> = HashMap::new();
+        let mut dup = false;
+        for s in parsed.commands {
+            let k = (s.game, s.name.clone());
+            if seen.contains_key(&k) {
+                dup = true;
+                break;
+            }
+            seen.insert(k, s);
+        }
+        assert!(dup);
+    }
+}

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -292,6 +292,10 @@ fn router(state: AppState) -> Router {
             get(mc_player_by_uuid_handler),
         )
         .route("/api/v1/mc/textures/{hash}", get(mc_texture_handler))
+        .route(
+            "/api/v1/rcon/{game}/{server}/exec",
+            post(crate::rcon::exec_handler),
+        )
         .route("/@{username}", get(profile_handler))
         .route("/osrs/{item}", get(osrs_item_handler))
         .route("/osrs/{item}/", get(osrs_item_handler_trailing))

--- a/packages/data/rcon/commands.yaml
+++ b/packages/data/rcon/commands.yaml
@@ -1,0 +1,56 @@
+# Shared RCON allowlist — one source of truth consumed by axum-kbve
+# (POST /rcon/{game}/{server}/exec) and, in a follow-up PR, by the
+# Deno edge `rcon/` function. Both paths load this file at boot.
+#
+# Schema matches kbve.rcon.RconCommandRegistry from
+# packages/data/proto/kbve/rcon.proto. Adding a command = PR to this
+# file; the server has no DB, no admin UI, no runtime reload.
+#
+# Fields per entry:
+#   game             — "mc" or "factorio" (matches kbve.rcon.Game enum)
+#   name             — canonical command id, snake_case
+#   staff_only       — true gates against the JWT `is_staff` claim
+#   template         — wire command rendered with positional {N} args
+#   arg_validators   — per-arg validator names; resolved by the server
+#                       (currently: "string", "int", "lua_snippet")
+
+commands:
+    # ---- Minecraft (vanilla / Fabric) ----
+    - game: mc
+      name: list
+      staff_only: false
+      template: list
+      arg_validators: []
+
+    - game: mc
+      name: say
+      staff_only: true
+      template: 'say {0}'
+      arg_validators:
+          - string
+
+    - game: mc
+      name: tp
+      staff_only: true
+      template: 'tp {0} {1}'
+      arg_validators:
+          - string
+          - string
+
+    # ---- Factorio (vanilla) ----
+    # `players online` — read-only, safe for everyone signed in.
+    - game: factorio
+      name: players_online
+      staff_only: false
+      template: '/players online'
+      arg_validators: []
+
+    # `/silent-command` runs arbitrary Lua. Staff only, validator forces a
+    # plain Lua snippet (no length limit here — Source RCON enforces 4096B
+    # at the wire layer in jedi::rcon).
+    - game: factorio
+      name: silent_command
+      staff_only: true
+      template: '/silent-command {0}'
+      arg_validators:
+          - lua_snippet


### PR DESCRIPTION
## Summary
Slice B of the rcon plan — generic, staff-gated, allowlist-driven RCON exec endpoint shared by MC + Factorio. Builds on \`jedi::rcon\` (#11470) and the unified proto (#11464). The Deno edge fn forwarder (slice C, Path A) and the direct edge → public-LB path (slice E, Path B) ship in follow-ups.

\`\`\`
POST /api/v1/rcon/{game}/{server}/exec
     Authorization: Bearer <Supabase JWT>
     { "command": "say", "args": ["hello"] }
→    { "ok": true, "output": "...", "latency_ms": 12 }
\`\`\`

Path A wiring lives entirely in-cluster: the runtime endpoint table maps \`(game, server)\` to \`RCON_{GAME}_{SERVER}_{HOST|PORT|PASSWORD}\` env vars (e.g. \`RCON_MC_LOBBY_HOST\`, \`RCON_FACTORIO_MAIN_HOST\`). The legacy \`MC_RCON_*\` scheme used by \`src/db/mc.rs\` for read-only player polling is unchanged; neither leaks into the other.

## Allowlist
\`packages/data/rcon/commands.yaml\` is the single source of truth and is baked into the binary with \`include_str!\`. Adding or changing a command requires a rebuild because the allowlist IS the security boundary — there's no DB, no admin UI, no runtime reload. Slice C's Deno edge fn will load the same file at build time so both paths share the policy artifact.

Initial entries:
| game | name | staff | template |
|---|---|---|---|
| mc | \`list\` | – | \`list\` |
| mc | \`say\` | ✔ | \`say {0}\` |
| mc | \`tp\` | ✔ | \`tp {0} {1}\` |
| factorio | \`players_online\` | – | \`/players online\` |
| factorio | \`silent_command\` | ✔ | \`/silent-command {0}\` |

## Auth + audit
- Reuses the existing Supabase JWT cache (\`auth::get_jwt_cache()\`).
- Per-command \`staff_only\` checks \`TokenInfo::is_staff()\` (proto \`kbve.rcon.RconCommandSpec.staff_only\`).
- Every exec emits \`tracing::info!(target = "rcon_audit", source = "axum", ...)\`. Vector → ClickHouse routes both axum and edge audit lines into the same table (slice C will emit \`source = "edge"\`).
- Passwords stay env-only — never logged, never serialized into responses.

## Security
- Path captures validated against an enum; any value other than \`mc\` / \`factorio\` is rejected before touching env or registry.
- Template rendering is positional \`{N}\` only — no \`{0:?}\` formatter syntax, no escape grammar; arg count must satisfy the validator list.
- Validators (\`string\` / \`int\` / \`lua_snippet\`) live in code; adding a new validator name in YAML without a matching code branch fails fast at request time.
- \`jedi::rcon\` enforces a 4096-byte packet body cap on the wire.

## Validation
- [x] \`cargo check -p axum-kbve\` — clean.
- [x] \`cargo test -p axum-kbve rcon::\` — 9/9 unit tests pass.

## Test plan
- [ ] After merge: set \`RCON_MC_LOBBY_HOST/PORT/PASSWORD\` in axum-kbve runtime, \`curl\` \`POST /api/v1/rcon/mc/lobby/exec\` with \`{ "command": "list" }\` and a Supabase JWT, expect \`{ ok: true, output: "..." }\`.
- [ ] Confirm \`{ "command": "say", "args": ["hi"] }\` returns 403 without staff perms, 200 with.
- [ ] Confirm Vector picks up the \`target=rcon_audit\` lines into ClickHouse.

## Follow-up
- Slice C: \`apps/kbve/edge/functions/rcon/\` Deno forwarder (Path A).
- Slice D: Agones Factorio \`Service\` + MC RCON exposure manifests.
- Slice E: Deno-direct Source RCON client for Path B redundancy.