### PR TITLE
fix(axum-kbve): COPY packages/data/rcon into Docker builder

### DIFF
--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -203,6 +203,7 @@ COPY --from=astro-precompressor /static /app/apps/kbve/axum-kbve/templates/dist
 
 # Foundation crate source (cargo needs source to verify fingerprints)
 COPY packages/data/proto packages/data/proto
+COPY packages/data/rcon packages/data/rcon
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/rust/kbve packages/rust/kbve
 COPY packages/rust/holy packages/rust/holy


### PR DESCRIPTION
## Summary
- `include_str!` at [apps/kbve/axum-kbve/src/rcon/registry.rs:80](apps/kbve/axum-kbve/src/rcon/registry.rs#L80) loads `packages/data/rcon/commands.yaml` at compile time.
- Builder stage in [apps/kbve/axum-kbve/Dockerfile](apps/kbve/axum-kbve/Dockerfile) never `COPY`d that directory, so `cargo build -p axum-kbve` failed: `couldn't read … No such file or directory (os error 2)` → exit 101.
- Add one `COPY packages/data/rcon packages/data/rcon` next to the existing `packages/data/proto` copy.

Regression from #11479.

Closes #11482.

## Test plan
- [ ] CI - Docker / axum-kbve goes green on this PR
- [ ] Resulting image starts and `/api/v1/rcon/{game}/{server}/exec` registry loads