### PR TITLE
fix(astro): disable ScrollRing wheel/touch loop site-wide

### DIFF
--- a/packages/npm/astro/src/components/hero/observer/ScrollRing.astro
+++ b/packages/npm/astro/src/components/hero/observer/ScrollRing.astro
@@ -75,7 +75,11 @@ const {
 		consumeRingNavDir,
 	} from './_ringNav';
 
+	const RING_DISABLED = true;
+
 	const init = () => {
+		if (RING_DISABLED) return;
+
 		// Disable browser scroll restoration so back-nav lands at our bottom.
 		if ('scrollRestoration' in history) {
 			history.scrollRestoration = 'manual';


### PR DESCRIPTION
## Summary
- ScrollRing inline script bound `wheel`/`touchmove`/`keydown` to `window` and only cleaned up on `pagehide`. Astro `<ClientRouter />` SPA swaps fire `astro:before-swap`, not `pagehide`, so listeners leaked into every subsequent page (e.g. `/application/php`) carrying the home page's stale `prev`/`next` and hijacking the scroll at page bottom.
- Short-term kill: early-return in `init()` so no listeners bind. MDX imports and the `.ring` element remain valid; nothing renders visibly without `data-ring-active`.
- Proper fix tracked separately: register cleanup on `astro:before-swap` via `onSwap` from [`packages/npm/astro/src/utils/clientRouter.ts`](packages/npm/astro/src/utils/clientRouter.ts), or scope the listeners to the page's lifetime through `onMount`.

## Files changed
- [packages/npm/astro/src/components/hero/observer/ScrollRing.astro](packages/npm/astro/src/components/hero/observer/ScrollRing.astro)

## Test plan
- [ ] Load `/` — confirm no scroll hijack at bottom of viewport, page scrolls normally.
- [ ] SPA-navigate `/` → `/application/php` and wheel-scroll the bottom of the PHP page — confirm no auto-navigation to `/service/`.
- [ ] Hard reload `/application/php` and wheel-scroll — confirm same.
- [ ] `PageDown` at page bottom on `/application/php` — confirm default browser behavior, no ring nav.