### PR TITLE
feat(auth): embed Discord owned_guilds in JWT (P5.8a of #11362)

### DIFF
--- a/packages/data/sql/dbmate/init/01-auth-stub.sql
+++ b/packages/data/sql/dbmate/init/01-auth-stub.sql
@@ -16,6 +16,27 @@ CREATE TABLE IF NOT EXISTS auth.users (
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+-- Minimal auth.identities mirror (FK target for tracker.find_claim_identity_by_discord_id
+-- and source for the custom_access_token_hook owned_guilds claim). Schema follows
+-- Supabase's auth.identities so migrations that read identity_data->>'...' or
+-- filter on provider work identically against local + prod.
+CREATE TABLE IF NOT EXISTS auth.identities (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id       UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    provider      TEXT NOT NULL,
+    provider_id   TEXT NOT NULL,
+    identity_data JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at    TIMESTAMPTZ DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (provider, provider_id)
+);
+
+-- supabase_auth_admin needs USAGE on auth + SELECT on auth.identities so the
+-- custom_access_token_hook (SECURITY DEFINER owned by that role) can read
+-- identity_data->'owned_guilds' at JWT mint time.
+GRANT USAGE  ON SCHEMA auth            TO supabase_auth_admin;
+GRANT SELECT ON TABLE  auth.identities TO supabase_auth_admin;
+
 -- Stub auth.uid() — reads request.jwt.claims (matches Supabase auth's
 -- behaviour closely enough for proxy-function tests that set the GUC
 -- via `SET LOCAL request.jwt.claims = '{"role":...,"sub":...}'`.

--- a/packages/data/sql/dbmate/init/01-auth-stub.sql
+++ b/packages/data/sql/dbmate/init/01-auth-stub.sql
@@ -16,27 +16,6 @@ CREATE TABLE IF NOT EXISTS auth.users (
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
--- Minimal auth.identities mirror (FK target for tracker.find_claim_identity_by_discord_id
--- and source for the custom_access_token_hook owned_guilds claim). Schema follows
--- Supabase's auth.identities so migrations that read identity_data->>'...' or
--- filter on provider work identically against local + prod.
-CREATE TABLE IF NOT EXISTS auth.identities (
-    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id       UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-    provider      TEXT NOT NULL,
-    provider_id   TEXT NOT NULL,
-    identity_data JSONB NOT NULL DEFAULT '{}'::jsonb,
-    created_at    TIMESTAMPTZ DEFAULT NOW(),
-    updated_at    TIMESTAMPTZ DEFAULT NOW(),
-    UNIQUE (provider, provider_id)
-);
-
--- supabase_auth_admin needs USAGE on auth + SELECT on auth.identities so the
--- custom_access_token_hook (SECURITY DEFINER owned by that role) can read
--- identity_data->'owned_guilds' at JWT mint time.
-GRANT USAGE  ON SCHEMA auth            TO supabase_auth_admin;
-GRANT SELECT ON TABLE  auth.identities TO supabase_auth_admin;
-
 -- Stub auth.uid() — reads request.jwt.claims (matches Supabase auth's
 -- behaviour closely enough for proxy-function tests that set the GUC
 -- via `SET LOCAL request.jwt.claims = '{"role":...,"sub":...}'`.

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -124,13 +124,13 @@ REVOKE ALL ON TABLE profile.discord_bootstrap_cache
 
 GRANT USAGE  ON SCHEMA profile                         TO supabase_auth_admin;
 GRANT SELECT ON TABLE  profile.discord_bootstrap_cache TO supabase_auth_admin;
--- Round 9 #2: explicit schema USAGE for service_role. Function
--- + table privileges alone aren't enough — without USAGE on the
--- containing schema, name resolution of profile.* by service_role
--- (RPC EXECUTE, dashboard SELECT peek) fails with "permission
--- denied for schema profile". Earlier migrations may or may not
--- guarantee this; the grant is idempotent and the assertion below
--- catches future revoke drift.
+-- Round 9 #2 (updated round 11 #2): explicit schema USAGE for
+-- service_role. Function privileges alone are not enough — without
+-- USAGE on the containing schema, service_role cannot resolve
+-- profile.* RPC names and gets "permission denied for schema
+-- profile". Earlier migrations may or may not guarantee this; the
+-- grant is idempotent and the assertion below catches future
+-- revoke drift.
 GRANT USAGE ON SCHEMA profile TO service_role;
 -- Round 10 #1: service_role intentionally has NO direct privilege
 -- on the cache table. Earlier rounds granted SELECT for "dashboard
@@ -150,17 +150,15 @@ GRANT USAGE ON SCHEMA profile TO service_role;
 -- off postgres or if a non-superuser caller gains direct DML.
 ALTER TABLE profile.discord_bootstrap_cache ENABLE ROW LEVEL SECURITY;
 
--- Round 6 #7: policy is SELECT-only (was FOR ALL). Matches actual
--- grants and prevents future privilege drift where someone re-adds
--- UPDATE and a stale FOR ALL policy silently permits it.
+-- Round 11 #1: service_role has NO direct table privileges (the
+-- freshness RPC is the only read path), so no service_role policy
+-- is created. Defensively drop any prior policy name in case a
+-- previous deploy of this migration left one behind. The drift
+-- assertion in the privilege block (round 11 #10) RAISEs if any
+-- service_role policy reappears later — pairs with the no-direct-
+-- table-privilege assertions to lock the privilege model in place.
 DROP POLICY IF EXISTS "service_role_full_access" ON profile.discord_bootstrap_cache;
 DROP POLICY IF EXISTS "service_role_select"      ON profile.discord_bootstrap_cache;
-CREATE POLICY "service_role_select"
-    ON profile.discord_bootstrap_cache
-    AS PERMISSIVE
-    FOR SELECT
-    TO service_role
-    USING (true);
 
 DROP POLICY IF EXISTS "supabase_auth_admin_select" ON profile.discord_bootstrap_cache;
 CREATE POLICY "supabase_auth_admin_select"
@@ -203,6 +201,7 @@ DECLARE
     v_canonical        text[];
     v_now              timestamptz := statement_timestamp();
     v_input_count      integer     := cardinality(COALESCE(p_owned_guilds, ARRAY[]::text[]));
+    v_valid_count      integer;
     v_relinked_user_id uuid;
 BEGIN
     -- Round 7 #7: USING ERRCODE = '22023' (invalid_parameter_value)
@@ -272,27 +271,44 @@ BEGIN
     -- Round 10 #4: silent canonicalisation filter is the chosen
     -- policy — Discord's API isn't fully under our control, so
     -- one bad guild id shouldn't break the whole OAuth refresh.
-    -- But we RAISE LOG when filtering so the drop shows up in
-    -- Postgres logs (log_min_messages=log captures it).
-    IF v_input_count <> cardinality(v_canonical) THEN
-        RAISE LOG 'service_upsert_discord_bootstrap_cache: filtered % of % owned_guilds (NULL/non-snowflake/dup/cap) for user=%',
-            v_input_count - cardinality(v_canonical), v_input_count, p_user_id;
+    -- Round 11 #3 + #4: split the log into two signals so we can
+    -- tell "Discord sent us malformed snowflakes" apart from
+    -- "we deduped or capped duplicates". User-id is omitted from
+    -- these logs since counts alone are the actionable signal
+    -- (avoids spraying user identifiers into pg_log unnecessarily).
+    SELECT count(*)::integer
+      INTO v_valid_count
+      FROM unnest(COALESCE(p_owned_guilds, ARRAY[]::text[])) AS e(g)
+     WHERE g IS NOT NULL
+       AND g ~ '^[0-9]{17,20}$';
+
+    IF v_valid_count <> v_input_count THEN
+        RAISE LOG 'service_upsert_discord_bootstrap_cache: filtered % invalid owned_guild entries (of % input)',
+            v_input_count - v_valid_count, v_input_count;
+    END IF;
+
+    IF v_valid_count <> cardinality(v_canonical) THEN
+        RAISE LOG 'service_upsert_discord_bootstrap_cache: deduped/capped % owned_guild entries (% valid -> % stored)',
+            v_valid_count - cardinality(v_canonical), v_valid_count, cardinality(v_canonical);
     END IF;
 
     -- Account relinking: drop stale row carrying same provider_id
     -- under a different user_id so the upsert below can succeed
     -- against the discord_provider_id UNIQUE constraint without
-    -- raising a raw unique_violation. Round 10 #3: capture the
-    -- displaced user_id into v_relinked_user_id + RAISE LOG so
-    -- relinks are observable in Postgres logs.
+    -- raising a raw unique_violation. Round 10 #3 / 11 #3: capture
+    -- the displaced user_id into v_relinked_user_id + RAISE LOG so
+    -- relinks are observable in Postgres logs. Raw provider_id is
+    -- omitted from the log to avoid leaking it into pg_log; the
+    -- before/after user_ids are kept because that pair is the
+    -- actionable info for incident response.
     DELETE FROM profile.discord_bootstrap_cache
      WHERE discord_provider_id = p_discord_provider_id
        AND user_id <> p_user_id
     RETURNING user_id INTO v_relinked_user_id;
 
     IF v_relinked_user_id IS NOT NULL THEN
-        RAISE LOG 'service_upsert_discord_bootstrap_cache: relinked discord_provider_id=% from user=% to user=%',
-            p_discord_provider_id, v_relinked_user_id, p_user_id;
+        RAISE LOG 'service_upsert_discord_bootstrap_cache: relinked discord provider from user=% to user=%',
+            v_relinked_user_id, p_user_id;
     END IF;
 
     -- Round 10 #5: ON CONFLICT (user_id) DO UPDATE intentionally
@@ -346,15 +362,21 @@ LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+ROWS 1
 AS $$
+    -- Round 11 #5: LEFT JOIN over a single-row input so the caller
+    -- always gets exactly one row back — NULL timestamps + 0
+    -- guild_count when no cache exists. Saves the Axum side an
+    -- explicit empty-result-set branch.
     SELECT
         c.refreshed_at,
         c.updated_at,
         c.created_at,
-        cardinality(c.owned_guilds)::integer AS guild_count
-    FROM profile.discord_bootstrap_cache AS c
-    WHERE p_user_id IS NOT NULL
-      AND c.user_id  = p_user_id;
+        COALESCE(cardinality(c.owned_guilds), 0)::integer AS guild_count
+    FROM (SELECT p_user_id AS user_id) AS input
+    LEFT JOIN profile.discord_bootstrap_cache AS c
+      ON c.user_id = input.user_id
+    WHERE input.user_id IS NOT NULL;
 $$;
 
 ALTER FUNCTION profile.service_get_discord_bootstrap_cache_freshness(uuid)
@@ -528,7 +550,8 @@ BEGIN
     IF NOT has_schema_privilege('supabase_auth_admin', 'profile', 'USAGE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema profile.';
     END IF;
-    -- Round 9 #2: service_role schema USAGE for RPC + dashboard SELECT.
+    -- Round 9 #2 (updated round 11 #2): service_role schema USAGE
+    -- for RPC execution.
     IF NOT has_schema_privilege('service_role', 'profile', 'USAGE') THEN
         RAISE EXCEPTION 'service_role must hold USAGE on schema profile for bootstrap cache RPC access.';
     END IF;
@@ -580,6 +603,19 @@ BEGIN
     END IF;
     IF NOT has_function_privilege('service_role', 'profile.service_get_discord_bootstrap_cache_freshness(uuid)', 'EXECUTE') THEN
         RAISE EXCEPTION 'service_role must hold EXECUTE on profile.service_get_discord_bootstrap_cache_freshness for dashboard freshness peeks.';
+    END IF;
+    -- Round 11 #10: drift guard. Any future PR that re-creates a
+    -- service_role RLS policy on this table will fail the
+    -- migration here, forcing the author to explicitly justify
+    -- giving service_role table-level read access.
+    IF EXISTS (
+        SELECT 1
+          FROM pg_policies
+         WHERE schemaname = 'profile'
+           AND tablename  = 'discord_bootstrap_cache'
+           AND roles @> ARRAY['service_role']::name[]
+    ) THEN
+        RAISE EXCEPTION 'no service_role RLS policy may exist on profile.discord_bootstrap_cache; service_role reads go through the freshness RPC.';
     END IF;
     IF has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'INSERT') THEN
         RAISE EXCEPTION 'service_role must NOT have direct INSERT on profile.discord_bootstrap_cache; use service_upsert RPC.';

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -85,7 +85,7 @@ REVOKE EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(text[])
 CREATE TABLE profile.discord_bootstrap_cache (
     user_id              uuid PRIMARY KEY,
     discord_provider_id  text NOT NULL
-                              CHECK (discord_provider_id ~ '^[0-9]{15,25}$'),
+                              CHECK (discord_provider_id ~ '^[0-9]{17,20}$'),
     owned_guilds         text[] NOT NULL DEFAULT ARRAY[]::text[],
     refreshed_at         timestamptz NOT NULL DEFAULT NOW(),
     created_at           timestamptz NOT NULL DEFAULT NOW(),
@@ -111,7 +111,7 @@ CREATE TABLE profile.discord_bootstrap_cache (
 );
 
 COMMENT ON TABLE profile.discord_bootstrap_cache IS
-    'Per-user Discord bootstrap cache. Populated exclusively via profile.service_upsert_discord_bootstrap_cache RPC. Read by custom_access_token_hook at JWT mint to embed owned_guilds claim. service_role has SELECT only; INSERT/UPDATE/DELETE flow through the RPC for centralised validation + canonicalisation. supabase_auth_admin has SELECT for the hook.';
+    'Per-user Discord bootstrap cache. Populated exclusively via profile.service_upsert_discord_bootstrap_cache RPC; service_role has SELECT only (no direct INSERT/UPDATE/DELETE) so all writes are funnelled through the RPC for centralised validation, canonicalisation, advisory-lock serialisation, and account-relink handling. SELECT is granted to service_role specifically so dashboard freshness peeks and the RPC''s ON CONFLICT visibility work without going through another RPC layer. supabase_auth_admin has SELECT for custom_access_token_hook at JWT mint.';
 
 REVOKE ALL ON TABLE profile.discord_bootstrap_cache
     FROM PUBLIC, anon, authenticated;
@@ -179,11 +179,14 @@ DECLARE
     v_canonical text[];
     v_now       timestamptz := statement_timestamp();
 BEGIN
+    -- Round 7 #7: USING ERRCODE = '22023' (invalid_parameter_value)
+    -- on all validation failures so service callers (axum-kbve etc.)
+    -- can match on a stable SQLSTATE instead of message text.
     IF p_user_id IS NULL THEN
-        RAISE EXCEPTION 'user_id required';
+        RAISE EXCEPTION 'user_id required' USING ERRCODE = '22023';
     END IF;
-    IF p_discord_provider_id IS NULL OR p_discord_provider_id !~ '^[0-9]{15,25}$' THEN
-        RAISE EXCEPTION 'invalid discord_provider_id';
+    IF p_discord_provider_id IS NULL OR p_discord_provider_id !~ '^[0-9]{17,20}$' THEN
+        RAISE EXCEPTION 'invalid discord_provider_id' USING ERRCODE = '22023';
     END IF;
 
     IF p_refreshed_at IS NULL THEN
@@ -191,17 +194,27 @@ BEGIN
     END IF;
     IF p_refreshed_at > v_now + interval '30 seconds' THEN
         RAISE EXCEPTION 'refreshed_at too far in future (got %, max %)',
-            p_refreshed_at, v_now + interval '30 seconds';
+            p_refreshed_at, v_now + interval '30 seconds'
+            USING ERRCODE = '22023';
     END IF;
     IF p_refreshed_at < '2025-01-01'::timestamptz THEN
         RAISE EXCEPTION 'refreshed_at below floor (got %, min 2025-01-01)',
-            p_refreshed_at;
+            p_refreshed_at
+            USING ERRCODE = '22023';
     END IF;
 
-    -- Round 6 #4 + #5: serialise concurrent writes for this account.
-    -- Always lock user first, then provider, for consistent ordering.
-    PERFORM pg_advisory_xact_lock(hashtextextended(p_user_id::text, 1));
-    PERFORM pg_advisory_xact_lock(hashtextextended(p_discord_provider_id, 2));
+    -- Round 7 #4: single coarse advisory lock for the entire relink
+    -- namespace. The previous per-key locks on (user_id, provider_id)
+    -- closed the same-account race but left a rare cross-swap race
+    -- open: concurrent calls A→Y / B→X each locked their own keys
+    -- but neither held the other side's lock before DELETE'ing the
+    -- target provider row. A single namespace lock serialises ALL
+    -- relinks. The cost is one global serialisation point at human-
+    -- OAuth call rates (≤ hundreds/sec at peak), which is well
+    -- within Postgres advisory-lock contention budgets.
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('profile.discord_bootstrap_cache.relink', 0)
+    );
 
     -- Canonicalise: NULL + non-snowflake elements filtered; duplicates
     -- collapsed by first-seen order; capped at 50 (matches table CHECK
@@ -243,7 +256,7 @@ ALTER FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[]
     OWNER TO postgres;
 
 COMMENT ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz) IS
-    'Service-role upsert for profile.discord_bootstrap_cache. Validates inputs, canonicalises owned_guilds (dedup + first-seen + cap 50), enforces future-timestamp guard + 2025 floor, handles account relinking, advisory-locks on (user_id, provider_id) in fixed order, maintains updated_at. Owner pinned to postgres for stable SECURITY DEFINER behaviour. Only sanctioned write path — service_role has no direct INSERT/UPDATE/DELETE on the cache.';
+    'Service-role upsert for profile.discord_bootstrap_cache. Validates inputs (raises SQLSTATE 22023 on invalid params), canonicalises owned_guilds (dedup + first-seen + cap 50), enforces future-timestamp guard + 2025 floor, handles account relinking, takes a single coarse advisory lock on the relink namespace to serialise concurrent writes (closes cross-swap race), maintains updated_at. Owner pinned to postgres for stable SECURITY DEFINER behaviour. Only sanctioned write path — service_role has no direct INSERT/UPDATE/DELETE on the cache.';
 
 REVOKE EXECUTE ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz)
     FROM PUBLIC, anon, authenticated;
@@ -315,6 +328,14 @@ DECLARE
     v_claims       jsonb;
     v_now          timestamptz := statement_timestamp();
 BEGIN
+    -- Round 7 #3: defensive top-level guard. GoTrue always passes an
+    -- object, but jsonb_set on NULL / scalar input misbehaves, so
+    -- coerce malformed payloads to {} before any work. Catches
+    -- manual-invocation footguns + future GoTrue-payload changes.
+    IF event IS NULL OR jsonb_typeof(event) <> 'object' THEN
+        event := '{}'::jsonb;
+    END IF;
+
     v_claims :=
         CASE
             WHEN jsonb_typeof(event->'claims') = 'object'
@@ -354,6 +375,12 @@ BEGIN
         v_claims := v_claims - 'kbve_username';
     END IF;
 
+    -- Round 7 #2: explicit strip before set, matching the invalid-
+    -- user branches above. Visually documents that any inbound
+    -- caller-supplied owned_guilds claim is never trusted —
+    -- jsonb_set would overwrite anyway, but the explicit strip
+    -- makes the security boundary obvious.
+    v_claims := v_claims - 'owned_guilds';
     v_owned_guilds := profile.get_discord_owned_guilds_claim(v_user_id, v_now);
     v_claims := jsonb_set(v_claims, '{owned_guilds}', v_owned_guilds, true);
 
@@ -416,6 +443,13 @@ BEGIN
     END IF;
     IF NOT has_table_privilege('supabase_auth_admin', 'profile.discord_bootstrap_cache', 'SELECT') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.discord_bootstrap_cache.';
+    END IF;
+    -- Round 7 #1: assert the v1 grant survives. profile.username
+    -- SELECT was granted by 20260510210000; this assertion catches
+    -- future privilege drift that would silently break the
+    -- kbve_username arm of the hook.
+    IF NOT has_table_privilege('supabase_auth_admin', 'profile.username', 'SELECT') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.username for custom_access_token_hook.';
     END IF;
     IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'SELECT') THEN
         RAISE EXCEPTION 'service_role must hold SELECT on profile.discord_bootstrap_cache (dashboard peek + ON CONFLICT visibility).';
@@ -621,5 +655,12 @@ DROP FUNCTION  IF EXISTS profile.get_discord_owned_guilds_claim(uuid, timestampt
 DROP FUNCTION  IF EXISTS profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz);
 DROP TABLE     IF EXISTS profile.discord_bootstrap_cache;
 DROP FUNCTION  IF EXISTS profile.discord_owned_guilds_are_valid(text[]);
+
+-- Round 7 #6: intentionally do NOT revoke USAGE on schema profile
+-- from supabase_auth_admin here. That grant was first established by
+-- 20260510210000 (v1 hook reads profile.username) and is required
+-- for the restored v1 hook to keep functioning after rollback.
+-- Revoking would break sign-in on every account that has a
+-- profile.username row.
 
 COMMIT;

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -18,28 +18,34 @@ BEGIN;
 -- provider_token ages out.
 --
 -- Source of truth is our own cache table, profile.discord_bootstrap_cache,
--- NOT auth.identities.identity_data. Reviewer pushback on the first draft
--- (PR #11488 review point #2) was that coupling a JWT-mint hot path to a
--- semi-opaque Supabase-managed table is fragile across Supabase upgrades
--- and harder to RLS / index cleanly. The cache table gives us:
+-- NOT auth.identities.identity_data. PR #11488 first review (point #2)
+-- pushed back on coupling a JWT-mint hot path to a semi-opaque Supabase-
+-- managed table. The cache table gives us:
 --   - stable PK lookup (one row per user_id)
 --   - no dependency on auth.identities JSON shape
 --   - service_role-owned writes, easy to GRANT for the bootstrap edge fn
 --   - cheap CASCADE on auth.users delete
---   - smoke tests stop touching auth.users entirely
 --
--- The hook still reads pre-cached state only. Zero external calls. JWT
--- mint stays synchronous. Population of the cache row is the job of the
--- discord-bootstrap edge fn (P5.8b), which calls Discord and upserts
--- here with service_role.
+-- Population is the job of the discord-bootstrap edge fn (P5.8b), which
+-- calls Discord once after OAuth and upserts here with service_role.
+--
+-- The hook itself does NO external calls and never blocks. It reads one
+-- row by PK, validates + dedupes guild IDs, applies a freshness window,
+-- and embeds the result as a JWT claim.
 -- ============================================================
 
 -- ------------------------------------------------------------
 -- Cache table
 -- ------------------------------------------------------------
+-- Hardening reflected in this DDL (PR #11488 second-round review):
+--   #3  GRANT only the privileges the edge fn needs (no ALL)
+--   #4  Explicit REVOKE ALL from PUBLIC, anon, authenticated
+--   #6  Service-role policy WITH CHECK mirrors the shape constraints
+--   #7  IMMUTABLE validator fn + CHECK so junk rows never land at rest
+--   #14 Named FK constraint for forward maintainability
+
 CREATE TABLE IF NOT EXISTS profile.discord_bootstrap_cache (
-    user_id              uuid PRIMARY KEY
-                              REFERENCES auth.users(id) ON DELETE CASCADE,
+    user_id              uuid PRIMARY KEY,
     discord_provider_id  text NOT NULL
                               CHECK (discord_provider_id ~ '^[0-9]{15,25}$'),
     owned_guilds         jsonb NOT NULL DEFAULT '[]'::jsonb,
@@ -48,11 +54,43 @@ CREATE TABLE IF NOT EXISTS profile.discord_bootstrap_cache (
     CONSTRAINT discord_bootstrap_cache_owned_guilds_is_array
         CHECK (jsonb_typeof(owned_guilds) = 'array'),
     CONSTRAINT discord_bootstrap_cache_owned_guilds_size_cap
-        CHECK (jsonb_array_length(owned_guilds) <= 100)
+        CHECK (jsonb_array_length(owned_guilds) <= 100),
+    CONSTRAINT discord_bootstrap_cache_user_id_fkey
+        FOREIGN KEY (user_id)
+        REFERENCES auth.users(id)
+        ON DELETE CASCADE
 );
 
 COMMENT ON TABLE profile.discord_bootstrap_cache IS
     'Per-user Discord bootstrap cache. Populated by the discord-bootstrap edge fn after OAuth. Read by custom_access_token_hook at JWT mint to embed owned_guilds claim. Owned by service_role; supabase_auth_admin has SELECT for the hook.';
+
+REVOKE ALL ON TABLE profile.discord_bootstrap_cache
+    FROM PUBLIC, anon, authenticated;
+
+-- #7: validator fn — IMMUTABLE so it can sit in a CHECK constraint and
+-- the planner can prove cache-safety. Rejects non-arrays, oversized
+-- arrays, and any element that isn't a 17-20 digit Discord snowflake.
+CREATE OR REPLACE FUNCTION profile.discord_owned_guilds_are_valid(p_guilds jsonb)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+SET search_path = ''
+AS $$
+    SELECT jsonb_typeof(p_guilds) = 'array'
+       AND jsonb_array_length(p_guilds) <= 100
+       AND NOT EXISTS (
+           SELECT 1
+           FROM jsonb_array_elements_text(p_guilds) AS e(g)
+           WHERE g !~ '^[0-9]{17,20}$'
+       );
+$$;
+
+COMMENT ON FUNCTION profile.discord_owned_guilds_are_valid(jsonb) IS
+    'IMMUTABLE shape validator for profile.discord_bootstrap_cache.owned_guilds. Backs both a CHECK constraint and the service-role RLS WITH CHECK clause.';
+
+ALTER TABLE profile.discord_bootstrap_cache
+    ADD CONSTRAINT discord_bootstrap_cache_owned_guilds_valid
+    CHECK (profile.discord_owned_guilds_are_valid(owned_guilds));
 
 ALTER TABLE profile.discord_bootstrap_cache ENABLE ROW LEVEL SECURITY;
 
@@ -63,7 +101,10 @@ CREATE POLICY "service_role_full_access"
     FOR ALL
     TO service_role
     USING (true)
-    WITH CHECK (true);
+    WITH CHECK (
+        profile.discord_owned_guilds_are_valid(owned_guilds)
+        AND discord_provider_id ~ '^[0-9]{15,25}$'
+    );
 
 DROP POLICY IF EXISTS "supabase_auth_admin_select" ON profile.discord_bootstrap_cache;
 CREATE POLICY "supabase_auth_admin_select"
@@ -73,30 +114,45 @@ CREATE POLICY "supabase_auth_admin_select"
     TO supabase_auth_admin
     USING (true);
 
-GRANT USAGE  ON SCHEMA profile                             TO supabase_auth_admin;
-GRANT SELECT ON TABLE  profile.discord_bootstrap_cache     TO supabase_auth_admin;
-GRANT ALL    ON TABLE  profile.discord_bootstrap_cache     TO service_role;
+GRANT USAGE  ON SCHEMA profile                         TO supabase_auth_admin;
+GRANT SELECT ON TABLE  profile.discord_bootstrap_cache TO supabase_auth_admin;
+
+-- #3: least-privilege grants for service_role. No TRIGGER, REFERENCES,
+-- or TRUNCATE — the edge fn only needs CRUD.
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON TABLE profile.discord_bootstrap_cache
+    TO service_role;
 
 -- ------------------------------------------------------------
 -- Hook v2
 -- ------------------------------------------------------------
--- Reads from profile.discord_bootstrap_cache via a single PK lookup.
--- Hardening applied (per PR #11488 reviewer points):
---   #3  [0-9] over \d (locale-safe, same cost)
---   #4  WITH ORDINALITY + explicit jsonb_agg ORDER BY (deterministic
---       claim order)
---   #5  GROUP BY g + min(ord) (duplicate snowflakes suppressed,
---       first-seen order preserved)
---   #6  Strip kbve_username + owned_guilds on invalid/missing user_id
---       (defense-in-depth for SECURITY DEFINER)
---   #10 / #16 Typecheck event->'claims' as object before jsonb_set
---   #11 Soft size cap (>1200 chars -> []) so malformed cache rows
---       cannot bloat the JWT
---   #15 CTE rewrite for the owned_guilds extraction
+-- Hardening reflected in the function body (PR #11488 review fold-ins):
+--   #3, #4, #5, #15  CTE rewrite with WITH ORDINALITY + GROUP BY +
+--                    explicit ORDER BY in jsonb_agg — deterministic
+--                    claim order, duplicates suppressed, first-seen
+--                    order preserved.
+--   #6               Invalid / missing user_id strips kbve_username +
+--                    owned_guilds from inbound claims before returning.
+--   #8               Soft size cap raised to 1600 (was 1200). Math:
+--                    50 snowflakes × 22 chars + 49 × 2 chars (", ")
+--                    + 2 brackets = 1200 exactly — no safety margin.
+--                    1600 leaves ~400 chars of headroom for any
+--                    canonicalization differences across PG versions.
+--   #10              7-day freshness window via statement_timestamp().
+--                    Stale rows return [] so the browser triggers the
+--                    bootstrap edge fn to refresh, instead of trusting
+--                    stale ownership forever.
+--   #10/#16          Typecheck event->'claims' as object before
+--                    jsonb_set; non-object input rebuilt as {}.
+--   #11              VOLATILE — function reads mutable cache state in
+--                    a login flow. Performance cost is theoretical
+--                    (no set-query memoization opportunity); semantic
+--                    clarity wins for auth code.
+
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
-STABLE
+VOLATILE
 SECURITY DEFINER
 SET search_path = ''
 AS $$
@@ -105,8 +161,8 @@ DECLARE
     v_username     text;
     v_owned_guilds jsonb;
     v_claims       jsonb;
+    v_freshness    interval := interval '7 days';
 BEGIN
-    -- #10 / #16: claims must be a json object before we set into it.
     v_claims :=
         CASE
             WHEN jsonb_typeof(event->'claims') = 'object'
@@ -118,9 +174,6 @@ BEGIN
         v_user_id := NULLIF(event->>'user_id', '')::uuid;
     EXCEPTION
         WHEN invalid_text_representation THEN
-            -- #6: malformed user_id -> strip any pre-existing privileged
-            -- claims and return early. Caller cannot smuggle claims via a
-            -- garbage user_id.
             RETURN jsonb_set(
                 event,
                 '{claims}',
@@ -138,7 +191,6 @@ BEGIN
         );
     END IF;
 
-    -- kbve_username (unchanged from v1)
     SELECT u.username
       INTO v_username
       FROM profile.username AS u
@@ -150,11 +202,12 @@ BEGIN
         v_claims := v_claims - 'kbve_username';
     END IF;
 
-    -- owned_guilds: single PK lookup against the cache table.
+    -- owned_guilds: PK lookup against the cache, gated by freshness.
     WITH src AS (
         SELECT c.owned_guilds AS arr
           FROM profile.discord_bootstrap_cache AS c
-         WHERE c.user_id = v_user_id
+         WHERE c.user_id      = v_user_id
+           AND c.refreshed_at >= statement_timestamp() - v_freshness
            AND jsonb_typeof(c.owned_guilds) = 'array'
     ),
     valid AS (
@@ -170,11 +223,11 @@ BEGIN
       INTO v_owned_guilds
       FROM valid;
 
-    -- #11: soft size cap. The 50-snowflake LIMIT above should make this
-    -- unreachable in practice (~1.5 KB worst case) but a malformed cache
-    -- row with massive strings would otherwise leak straight into the
-    -- JWT. Degrade silently to [] rather than failing the sign-in.
-    IF length(v_owned_guilds::text) > 1200 THEN
+    -- Soft size cap. Should be unreachable in practice given the 50-
+    -- element LIMIT above, but a malformed cache row with massive
+    -- strings would otherwise leak straight into the JWT. Degrade
+    -- silently to [] rather than failing the sign-in.
+    IF length(v_owned_guilds::text) > 1600 THEN
         v_owned_guilds := '[]'::jsonb;
     END IF;
 
@@ -194,7 +247,7 @@ GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
 COMMENT ON FUNCTION public.custom_access_token_hook(jsonb) IS
-    'GoTrue access-token hook v2: embeds profile.username as kbve_username and profile.discord_bootstrap_cache.owned_guilds (cap 50, deterministic order, dedup, soft size cap) as owned_guilds. No external calls — reads pre-cached state populated by the discord-bootstrap edge fn.';
+    'GoTrue access-token hook v2: embeds profile.username as kbve_username and profile.discord_bootstrap_cache.owned_guilds (cap 50, deterministic order, dedup, 7-day freshness window, soft 1600-char size cap) as owned_guilds. No external calls — reads pre-cached state populated by the discord-bootstrap edge fn.';
 
 -- ------------------------------------------------------------
 -- Privilege + plumbing assertions
@@ -202,9 +255,10 @@ COMMENT ON FUNCTION public.custom_access_token_hook(jsonb) IS
 DO $$
 BEGIN
     PERFORM 'public.custom_access_token_hook(jsonb)'::regprocedure;
+    PERFORM 'profile.discord_owned_guilds_are_valid(jsonb)'::regprocedure;
 
     IF NOT has_schema_privilege('supabase_auth_admin', 'public', 'USAGE') THEN
-        RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema public for the hook to resolve.';
+        RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema public.';
     END IF;
     IF NOT has_schema_privilege('supabase_auth_admin', 'profile', 'USAGE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema profile.';
@@ -226,22 +280,37 @@ BEGIN
     IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'INSERT') THEN
         RAISE EXCEPTION 'service_role must hold INSERT on profile.discord_bootstrap_cache for the bootstrap edge fn.';
     END IF;
+    IF has_table_privilege('anon', 'profile.discord_bootstrap_cache', 'SELECT')
+       OR has_table_privilege('authenticated', 'profile.discord_bootstrap_cache', 'SELECT') THEN
+        RAISE EXCEPTION 'anon/authenticated must NOT have SELECT on profile.discord_bootstrap_cache.';
+    END IF;
 END;
 $$ LANGUAGE plpgsql;
 
 -- ------------------------------------------------------------
--- Behavioural smoke checks (no auth.users writes — runs entirely
--- against the cache table + a synthetic user_id that has no rows
--- anywhere).
+-- Behavioural smoke checks (SQL-only — no writes to auth.users)
+--
+-- Scenarios 1-4 exercise hook behaviour on the existing schema with no
+-- inserts anywhere. The LIMIT-1-on-unnest regression that would
+-- previously have been tested by Scenario 5 (insert into auth.users +
+-- cache row, assert dedup + ordering) is moved to a dedicated pgTAP
+-- suite that runs against the kilobase production image in CI. Reasons:
+--   - Production image has trigger fan-out we can't safely fire here
+--     (wallet_on_auth_user_created, future Supabase audit hooks,
+--     pg_net-based webhooks, etc.) even with a sentinel rollback —
+--     async side effects don't honour the transaction.
+--   - Local dev compose runs vanilla postgres:17-alpine, NOT the
+--     kilobase image, so a smoke check inside the migration would
+--     pass locally but its parity with prod is not guaranteed.
+--   - pgTAP test is reusable, lives outside the migration body, and
+--     can run on every CI build instead of only at migration apply.
 -- ------------------------------------------------------------
 DO $$
 DECLARE
-    v_in      jsonb;
-    v_out     jsonb;
-    v_guilds  jsonb;
+    v_out  jsonb;
 BEGIN
-    -- Scenario 1: empty event / no user_id -> claims object preserved,
-    -- privileged claims stripped, no exception.
+    -- 1: empty event / no user_id -> claims preserved, privileged
+    -- claims absent.
     v_out := public.custom_access_token_hook(
         jsonb_build_object('claims', jsonb_build_object('role','authenticated'))
     );
@@ -252,18 +321,23 @@ BEGIN
         RAISE EXCEPTION 'smoke 1: invalid user_id must NOT emit owned_guilds, got %', v_out->'claims';
     END IF;
 
-    -- Scenario 2: invalid user_id text -> same behaviour as scenario 1.
+    -- 2: malformed user_id with attacker-supplied owned_guilds claim
+    -- -> claim stripped, attacker cannot smuggle privileged state.
     v_out := public.custom_access_token_hook(
         jsonb_build_object(
             'user_id', 'not-a-uuid',
-            'claims', jsonb_build_object('role','authenticated','owned_guilds',jsonb_build_array('attacker'))
+            'claims', jsonb_build_object(
+                'role','authenticated',
+                'owned_guilds', jsonb_build_array('attacker')
+            )
         )
     );
     IF v_out->'claims' ? 'owned_guilds' THEN
         RAISE EXCEPTION 'smoke 2: malformed user_id must strip attacker-supplied owned_guilds, got %', v_out->'claims';
     END IF;
 
-    -- Scenario 3: non-object claims -> rebuilt as object, hook still emits owned_guilds [].
+    -- 3: non-object claims -> rebuilt as object, hook still emits
+    -- owned_guilds [].
     v_out := public.custom_access_token_hook(
         jsonb_build_object(
             'user_id', '00000000-0000-0000-0000-000000000000',
@@ -279,12 +353,13 @@ BEGIN
             v_out->'claims'->'owned_guilds';
     END IF;
 
-    -- Scenario 4: valid user_id, no cache row -> owned_guilds [].
-    v_in := jsonb_build_object(
-        'user_id', '00000000-0000-0000-0000-000000000000',
-        'claims',  jsonb_build_object('role','authenticated')
+    -- 4: valid user_id, no cache row -> owned_guilds [].
+    v_out := public.custom_access_token_hook(
+        jsonb_build_object(
+            'user_id', '00000000-0000-0000-0000-000000000000',
+            'claims',  jsonb_build_object('role','authenticated')
+        )
     );
-    v_out := public.custom_access_token_hook(v_in);
     IF jsonb_typeof(v_out->'claims'->'owned_guilds') <> 'array' THEN
         RAISE EXCEPTION 'smoke 4: owned_guilds must be a jsonb array, got %',
             jsonb_typeof(v_out->'claims'->'owned_guilds');
@@ -293,56 +368,34 @@ BEGIN
         RAISE EXCEPTION 'smoke 4: no cache row, expected empty owned_guilds, got %',
             v_out->'claims'->'owned_guilds';
     END IF;
+END;
+$$ LANGUAGE plpgsql;
 
-    -- Scenario 5: cache row with 3 valid + 1 malformed + 1 duplicate
-    -- snowflake. Wrap in an EXCEPTION subtransaction with a sentinel
-    -- rollback so the synthetic auth.users + cache rows are undone
-    -- atomically. No writes to auth.identities involved.
-    BEGIN
-        INSERT INTO auth.users (id) VALUES ('00000000-0000-0000-0000-fffe00000001');
-        INSERT INTO profile.discord_bootstrap_cache
-            (user_id, discord_provider_id, owned_guilds)
-        VALUES (
-            '00000000-0000-0000-0000-fffe00000001',
-            '999000111222333444',
-            jsonb_build_array(
-                '111111111111111111',
-                '222222222222222222',
-                '333333333333333333',
-                '111111111111111111', -- duplicate
-                'not-a-snowflake'
-            )
-        );
-
-        v_out := public.custom_access_token_hook(jsonb_build_object(
-            'user_id', '00000000-0000-0000-0000-fffe00000001',
-            'claims',  jsonb_build_object('role','authenticated')
-        ));
-        v_guilds := v_out->'claims'->'owned_guilds';
-
-        IF jsonb_array_length(v_guilds) <> 3 THEN
-            RAISE EXCEPTION
-                'smoke 5: expected 3 unique valid snowflakes (LIMIT-1 / dedup regression?), got % from %',
-                jsonb_array_length(v_guilds), v_guilds;
-        END IF;
-        IF NOT (v_guilds @> '["111111111111111111","222222222222222222","333333333333333333"]'::jsonb) THEN
-            RAISE EXCEPTION 'smoke 5: expected snowflakes missing from %', v_guilds;
-        END IF;
-        IF v_guilds @> '["not-a-snowflake"]'::jsonb THEN
-            RAISE EXCEPTION 'smoke 5: malformed snowflake leaked into %', v_guilds;
-        END IF;
-        -- Determinism: first-seen order preserved.
-        IF v_guilds->>0 <> '111111111111111111' THEN
-            RAISE EXCEPTION 'smoke 5: first-seen order not preserved, got %', v_guilds;
-        END IF;
-
-        RAISE EXCEPTION 'hook_smoke_sentinel_rollback';
-    EXCEPTION
-        WHEN OTHERS THEN
-            IF SQLERRM <> 'hook_smoke_sentinel_rollback' THEN
-                RAISE;
-            END IF;
-    END;
+-- ------------------------------------------------------------
+-- Validator smoke (table-only, no triggers, no auth.users)
+-- ------------------------------------------------------------
+DO $$
+BEGIN
+    -- Valid: array of 17-20 digit snowflakes, ≤100 elements.
+    IF NOT profile.discord_owned_guilds_are_valid('["111111111111111111","222222222222222222"]'::jsonb) THEN
+        RAISE EXCEPTION 'validator: rejected a valid 2-snowflake array';
+    END IF;
+    -- Valid: empty array (default).
+    IF NOT profile.discord_owned_guilds_are_valid('[]'::jsonb) THEN
+        RAISE EXCEPTION 'validator: rejected empty array';
+    END IF;
+    -- Invalid: non-array.
+    IF profile.discord_owned_guilds_are_valid('{"not":"array"}'::jsonb) THEN
+        RAISE EXCEPTION 'validator: accepted non-array';
+    END IF;
+    -- Invalid: malformed element.
+    IF profile.discord_owned_guilds_are_valid('["111111111111111111","garbage"]'::jsonb) THEN
+        RAISE EXCEPTION 'validator: accepted malformed element';
+    END IF;
+    -- Invalid: too short snowflake.
+    IF profile.discord_owned_guilds_are_valid('["123"]'::jsonb) THEN
+        RAISE EXCEPTION 'validator: accepted too-short snowflake';
+    END IF;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -354,9 +407,21 @@ COMMIT;
 
 BEGIN;
 
--- Restore the v1 hook body (kbve_username only). Deliberately do NOT
--- drop the function — GoTrue is configured to call it; a missing
--- function would break all sign-in.
+-- Restore the v1 hook body. Preserves the hardening from v2:
+--   #12 Object typecheck of event->'claims' before jsonb_set
+--   #12 Invalid / missing user_id strips kbve_username from inbound
+--       claims before returning
+--   #13 Explicitly strips owned_guilds from inbound claims so a
+--       rollback during a sign-in flow can't leak v2 state into a v1
+--       JWT.
+--
+-- v1's owned_guilds production logic itself is removed (this is the
+-- whole point of the down migration); only the security posture is
+-- carried forward.
+--
+-- Function is REPLACE'd, not DROPPED — GoTrue is configured to call
+-- it and a missing function would break all sign-in.
+
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -369,18 +434,38 @@ DECLARE
     v_username text;
     v_claims   jsonb;
 BEGIN
+    v_claims :=
+        CASE
+            WHEN jsonb_typeof(event->'claims') = 'object'
+                THEN event->'claims'
+            ELSE '{}'::jsonb
+        END;
+
+    -- Strip any v2-era claim before any other work; prevents stale
+    -- owned_guilds leaking past a rollback even if the inbound event
+    -- already carries one.
+    v_claims := v_claims - 'owned_guilds';
+
     BEGIN
         v_user_id := NULLIF(event->>'user_id', '')::uuid;
     EXCEPTION
         WHEN invalid_text_representation THEN
-            RETURN event;
+            RETURN jsonb_set(
+                event,
+                '{claims}',
+                v_claims - 'kbve_username',
+                true
+            );
     END;
 
     IF v_user_id IS NULL THEN
-        RETURN event;
+        RETURN jsonb_set(
+            event,
+            '{claims}',
+            v_claims - 'kbve_username',
+            true
+        );
     END IF;
-
-    v_claims := COALESCE(event->'claims', '{}'::jsonb);
 
     SELECT u.username
       INTO v_username
@@ -406,9 +491,9 @@ REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
 GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
--- Drop the cache table last so the function above no longer references
--- it. ON DELETE CASCADE on user_id means the table goes away cleanly
--- without orphaning anything.
-DROP TABLE IF EXISTS profile.discord_bootstrap_cache;
+-- Drop the cache table + its validator. ON DELETE CASCADE on user_id
+-- keeps cleanup trivial.
+DROP TABLE     IF EXISTS profile.discord_bootstrap_cache;
+DROP FUNCTION  IF EXISTS profile.discord_owned_guilds_are_valid(jsonb);
 
 COMMIT;

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -17,35 +17,32 @@ BEGIN;
 -- the agents page with "Discord session expired" whenever the cached
 -- provider_token ages out.
 --
--- Source of truth is our own cache table, profile.discord_bootstrap_cache,
--- NOT auth.identities.identity_data. Populated by the discord-bootstrap
--- edge fn (P5.8b) which calls Discord once after OAuth and upserts here
--- with service_role.
+-- Source of truth is profile.discord_bootstrap_cache, populated by the
+-- discord-bootstrap edge fn (P5.8b) which calls Discord once after
+-- OAuth and upserts here with service_role.
 --
--- The hook itself does NO external calls and never blocks. It reads one
--- row by PK, validates + dedupes guild IDs, applies a freshness window
--- (rejects rows older than 7 days OR more than 5 minutes in the future),
--- and embeds the result as a JWT claim.
+-- The hook does NO external calls and never blocks. It reads one row
+-- by PK, validates + dedupes guild IDs, applies a freshness window
+-- (rejects rows older than 7 days OR more than 30 seconds in the
+-- future), wraps in jsonb, and embeds as a JWT claim.
 --
--- Order: validator function first, then table with all constraints
--- inline. Avoids split-brain DDL and lets every constraint be audited
--- in one place. CREATE TABLE is NOT IF NOT EXISTS — dbmate does not
--- rerun applied migrations, so the defensive guard is dead weight and
--- removing it makes schema drift fail loudly.
+-- Storage uses text[] not jsonb (GPT round-4 #1) — Discord snowflakes
+-- are flat strings; jsonb traversal in the JWT mint hot path was
+-- overkill. Validator, hook CTE, and constraints all operate on
+-- native arrays; only the final claim is wrapped in to_jsonb().
 -- ============================================================
 
 -- ------------------------------------------------------------
--- Validator function (block #A on review pass 3)
+-- Validator function (text[] variant — GPT round-4 #1)
 -- ------------------------------------------------------------
 -- IMMUTABLE STRICT so it can sit in a CHECK constraint and the planner
 -- can prove cache-safety. STRICT documents NULL-input intent (the
 -- column is NOT NULL anyway).
 --
--- CASE is used instead of AND-chained predicates because SQL boolean
--- evaluation order is not guaranteed to short-circuit. jsonb_array_length
--- and jsonb_array_elements_text would otherwise be evaluable on
--- non-array input and could throw.
-CREATE OR REPLACE FUNCTION profile.discord_owned_guilds_are_valid(p_guilds jsonb)
+-- CASE preserves the short-circuit safety we got in pass 3. text[]
+-- removes the need for jsonb_typeof (the type system already
+-- guarantees array shape).
+CREATE OR REPLACE FUNCTION profile.discord_owned_guilds_are_valid(p_guilds text[])
 RETURNS boolean
 LANGUAGE sql
 IMMUTABLE
@@ -53,58 +50,69 @@ STRICT
 SET search_path = ''
 AS $$
     SELECT CASE
-        WHEN jsonb_typeof(p_guilds) <> 'array' THEN false
-        WHEN jsonb_array_length(p_guilds) > 100 THEN false
+        WHEN array_length(p_guilds, 1) IS NULL THEN true
+        WHEN array_length(p_guilds, 1) > 100 THEN false
         ELSE NOT EXISTS (
             SELECT 1
-            FROM jsonb_array_elements_text(p_guilds) AS e(g)
+            FROM unnest(p_guilds) AS g
             WHERE g !~ '^[0-9]{17,20}$'
         )
     END;
 $$;
 
-COMMENT ON FUNCTION profile.discord_owned_guilds_are_valid(jsonb) IS
-    'IMMUTABLE shape validator for profile.discord_bootstrap_cache.owned_guilds. Backs both a CHECK constraint and the service-role RLS WITH CHECK clause.';
+COMMENT ON FUNCTION profile.discord_owned_guilds_are_valid(text[]) IS
+    'IMMUTABLE shape validator for profile.discord_bootstrap_cache.owned_guilds. Accepts empty arrays as valid (array_length on empty returns NULL). Backs both a CHECK constraint and serves as the canonical write-path invariant.';
 
-REVOKE EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(jsonb)
+REVOKE EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(text[])
     FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(jsonb)
+GRANT EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(text[])
     TO service_role, supabase_auth_admin;
 
 -- ------------------------------------------------------------
 -- Cache table (no IF NOT EXISTS; all constraints inline)
 -- ------------------------------------------------------------
--- Three CHECK constraints are kept deliberately even though the
--- validator subsumes the first two. Reason: clearer per-failure
--- error messages (_is_array / _size_cap / _valid). Auth-adjacent
--- low-write table so the redundancy cost is irrelevant.
+-- Changes from round 3 of the review fold-in:
+--   GPT #1   owned_guilds is text[] (was jsonb)
+--   GPT #4   discord_provider_id is UNIQUE (mirrors auth.identities'
+--            (provider, provider_id) integrity)
+--   GPT #9   refreshed_at floor CHECK against absurd historical
+--            timestamps (combined with created_at/updated_at floor)
+--   GPT #17  created_at + updated_at columns for row-lifecycle audit
+--            (distinct from refreshed_at which tracks Discord-data
+--            freshness)
 CREATE TABLE profile.discord_bootstrap_cache (
     user_id              uuid PRIMARY KEY,
     discord_provider_id  text NOT NULL
                               CHECK (discord_provider_id ~ '^[0-9]{15,25}$'),
-    owned_guilds         jsonb NOT NULL DEFAULT '[]'::jsonb,
+    owned_guilds         text[] NOT NULL DEFAULT ARRAY[]::text[],
     refreshed_at         timestamptz NOT NULL DEFAULT NOW(),
+    created_at           timestamptz NOT NULL DEFAULT NOW(),
+    updated_at           timestamptz NOT NULL DEFAULT NOW(),
 
     CONSTRAINT discord_bootstrap_cache_user_id_fkey
         FOREIGN KEY (user_id)
         REFERENCES auth.users(id)
         ON DELETE CASCADE,
-    CONSTRAINT discord_bootstrap_cache_owned_guilds_is_array
-        CHECK (jsonb_typeof(owned_guilds) = 'array'),
+    CONSTRAINT discord_bootstrap_cache_discord_provider_id_unique
+        UNIQUE (discord_provider_id),
     CONSTRAINT discord_bootstrap_cache_owned_guilds_size_cap
-        CHECK (jsonb_array_length(owned_guilds) <= 100),
+        CHECK (
+            array_length(owned_guilds, 1) IS NULL
+            OR array_length(owned_guilds, 1) <= 100
+        ),
     CONSTRAINT discord_bootstrap_cache_owned_guilds_valid
-        CHECK (profile.discord_owned_guilds_are_valid(owned_guilds))
+        CHECK (profile.discord_owned_guilds_are_valid(owned_guilds)),
+    CONSTRAINT discord_bootstrap_cache_timestamps_floor
+        CHECK (
+            refreshed_at >= '2025-01-01'::timestamptz
+            AND created_at >= '2025-01-01'::timestamptz
+            AND updated_at >= '2025-01-01'::timestamptz
+        )
 );
 
 COMMENT ON TABLE profile.discord_bootstrap_cache IS
-    'Per-user Discord bootstrap cache. Populated by the discord-bootstrap edge fn after OAuth. Read by custom_access_token_hook at JWT mint to embed owned_guilds claim. service_role has CRUD; supabase_auth_admin has SELECT for the hook.';
+    'Per-user Discord bootstrap cache. Populated by the discord-bootstrap edge fn after OAuth. Read by custom_access_token_hook at JWT mint to embed owned_guilds claim. service_role has CRUD; supabase_auth_admin has SELECT for the hook. refreshed_at tracks Discord-data freshness; created_at/updated_at track row lifecycle.';
 
--- Privileges — explicit revoke then granular grants. No GRANT ALL
--- anywhere (TRIGGER/REFERENCES/TRUNCATE are not needed by the edge
--- fn). Ownership intentionally left to the migrating role
--- (supabase_admin in prod). Setting OWNER TO service_role would
--- bypass RLS, which we don't want.
 REVOKE ALL ON TABLE profile.discord_bootstrap_cache
     FROM PUBLIC, anon, authenticated;
 
@@ -139,29 +147,25 @@ CREATE POLICY "supabase_auth_admin_select"
 -- ------------------------------------------------------------
 -- Hook v2
 -- ------------------------------------------------------------
--- Hardening folded in across three review passes — see PR #11488
--- review threads for the full decision history. Highlights:
---   - CTE rewrite with WITH ORDINALITY + GROUP BY + explicit jsonb_agg
---     ORDER BY for deterministic claim order with dedup + first-seen
---     preservation.
---   - Invalid / missing user_id strips kbve_username + owned_guilds
---     from inbound claims before returning (attacker can't smuggle a
---     privileged claim via garbage user_id).
---   - 7-day freshness window AND 5-minute future-timestamp guard
---     (latter prevents a bad write with future refreshed_at from
---     keeping stale ownership trusted longer than intended).
---   - Soft size cap 1600 chars (50 snowflakes serialize to ~1200; 1600
---     buys ~400 chars of canonicalization headroom). Degrades to []
---     rather than failing sign-in.
---   - Non-object claims rebuilt as {} before any jsonb_set.
---   - VOLATILE since the function reads mutable cache state in a
---     login flow.
---   - src CTE no longer re-validates jsonb_typeof — the table CHECK +
---     validator guarantee array shape at storage.
+-- Round 4 changes folded in:
+--   GPT #1   unnest(text[]) instead of jsonb_array_elements_text
+--            in the src CTE; only the final claim is wrapped via
+--            to_jsonb(array_agg(...)).
+--   GPT #8   Future-timestamp tolerance tightened from 5 minutes
+--            to 30 seconds. 5min was over-conservative for in-cluster
+--            clock skew and gave an attacker a meaningful trust
+--            extension window. 30s covers real Deno/Postgres skew.
+--   GPT #11  v_now local timestamptz variable to make the freshness
+--            window edits safer and avoid repeated function calls.
+--   GPT #12  STABLE (was VOLATILE in round 2). Function reads but
+--            never mutates → STABLE is the documented semantics for
+--            read-only functions. Round 2 reviewer pushed VOLATILE on
+--            pure safety; round 4 correctly flagged STABLE as
+--            technically accurate. Flipping back.
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
-VOLATILE
+STABLE
 SECURITY DEFINER
 SET search_path = ''
 AS $$
@@ -170,6 +174,7 @@ DECLARE
     v_username     text;
     v_owned_guilds jsonb;
     v_claims       jsonb;
+    v_now          timestamptz := statement_timestamp();
 BEGIN
     v_claims :=
         CASE
@@ -210,28 +215,32 @@ BEGIN
         v_claims := v_claims - 'kbve_username';
     END IF;
 
-    -- owned_guilds: PK lookup, freshness-gated, with future-timestamp
-    -- guard. Inline interval (no PL/pgSQL variable) for the hot path.
+    -- owned_guilds: PK lookup, freshness-gated, future-ts guarded.
+    -- text[] removes the jsonb_typeof / jsonb_array_elements_text
+    -- overhead; only the final claim is wrapped via to_jsonb.
     WITH src AS (
         SELECT c.owned_guilds AS arr
           FROM profile.discord_bootstrap_cache AS c
          WHERE c.user_id      = v_user_id
-           AND c.refreshed_at <= statement_timestamp() + interval '5 minutes'
-           AND c.refreshed_at >= statement_timestamp() - interval '7 days'
+           AND c.refreshed_at <= v_now + interval '30 seconds'
+           AND c.refreshed_at >= v_now - interval '7 days'
     ),
     valid AS (
         SELECT g, MIN(ord) AS ord
           FROM src,
-               LATERAL jsonb_array_elements_text(src.arr) WITH ORDINALITY AS e(g, ord)
+               LATERAL unnest(src.arr) WITH ORDINALITY AS e(g, ord)
          WHERE g ~ '^[0-9]{17,20}$'
          GROUP BY g
          ORDER BY MIN(ord)
          LIMIT 50
     )
-    SELECT COALESCE(jsonb_agg(g ORDER BY ord), '[]'::jsonb)
+    SELECT COALESCE(to_jsonb(array_agg(g ORDER BY ord)), '[]'::jsonb)
       INTO v_owned_guilds
       FROM valid;
 
+    -- Soft size cap on the final JWT claim. Should be unreachable in
+    -- practice given the 50-element LIMIT (50 × 22 + 49 × 2 + 2 = 1200
+    -- canonical bytes); 1600 leaves ~400 chars headroom.
     IF length(v_owned_guilds::text) > 1600 THEN
         v_owned_guilds := '[]'::jsonb;
     END IF;
@@ -251,7 +260,7 @@ GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
 COMMENT ON FUNCTION public.custom_access_token_hook(jsonb) IS
-    'GoTrue access-token hook v2: embeds profile.username as kbve_username and profile.discord_bootstrap_cache.owned_guilds (cap 50, deterministic order, dedup, 7-day freshness + 5-minute future-timestamp guard, soft 1600-char size cap) as owned_guilds. No external calls — reads pre-cached state populated by the discord-bootstrap edge fn.';
+    'GoTrue access-token hook v2: embeds profile.username as kbve_username and profile.discord_bootstrap_cache.owned_guilds (text[] storage, cap 50, deterministic order, dedup, 7-day freshness + 30-second future-timestamp guard, soft 1600-char size cap) as owned_guilds JWT claim. No external calls — reads pre-cached state populated by the discord-bootstrap edge fn.';
 
 -- ------------------------------------------------------------
 -- Privilege + plumbing assertions
@@ -259,7 +268,7 @@ COMMENT ON FUNCTION public.custom_access_token_hook(jsonb) IS
 DO $$
 BEGIN
     PERFORM 'public.custom_access_token_hook(jsonb)'::regprocedure;
-    PERFORM 'profile.discord_owned_guilds_are_valid(jsonb)'::regprocedure;
+    PERFORM 'profile.discord_owned_guilds_are_valid(text[])'::regprocedure;
 
     IF NOT has_schema_privilege('supabase_auth_admin', 'public', 'USAGE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema public.';
@@ -270,19 +279,19 @@ BEGIN
     IF NOT has_function_privilege('supabase_auth_admin', 'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on public.custom_access_token_hook(jsonb).';
     END IF;
-    IF NOT has_function_privilege('service_role', 'profile.discord_owned_guilds_are_valid(jsonb)', 'EXECUTE') THEN
-        RAISE EXCEPTION 'service_role must hold EXECUTE on profile.discord_owned_guilds_are_valid(jsonb) for RLS WITH CHECK eval.';
+    IF NOT has_function_privilege('service_role', 'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must hold EXECUTE on profile.discord_owned_guilds_are_valid(text[]).';
     END IF;
-    IF NOT has_function_privilege('supabase_auth_admin', 'profile.discord_owned_guilds_are_valid(jsonb)', 'EXECUTE') THEN
-        RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on profile.discord_owned_guilds_are_valid(jsonb).';
+    IF NOT has_function_privilege('supabase_auth_admin', 'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on profile.discord_owned_guilds_are_valid(text[]).';
     END IF;
     IF has_function_privilege('anon',          'public.custom_access_token_hook(jsonb)', 'EXECUTE')
        OR has_function_privilege('authenticated','public.custom_access_token_hook(jsonb)', 'EXECUTE')
        OR has_function_privilege('public',     'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
         RAISE EXCEPTION 'public.custom_access_token_hook(jsonb) must not be executable by anon/authenticated/public.';
     END IF;
-    IF has_function_privilege('anon',          'profile.discord_owned_guilds_are_valid(jsonb)', 'EXECUTE')
-       OR has_function_privilege('authenticated','profile.discord_owned_guilds_are_valid(jsonb)', 'EXECUTE') THEN
+    IF has_function_privilege('anon',          'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE')
+       OR has_function_privilege('authenticated','profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE') THEN
         RAISE EXCEPTION 'validator must not be executable by anon/authenticated.';
     END IF;
     IF NOT has_table_privilege('supabase_auth_admin', 'profile.username', 'SELECT') THEN
@@ -309,12 +318,6 @@ $$ LANGUAGE plpgsql;
 
 -- ------------------------------------------------------------
 -- Behavioural smoke checks (SQL-only — no writes to auth.users)
---
--- Scenarios 1-4 exercise hook behaviour with no inserts. The LIMIT-1-
--- on-unnest regression that previously needed Scenario 5 (insert into
--- auth.users + cache row) moves to a pgTAP suite running against the
--- kilobase production image in CI. Reasons documented in the prior
--- review fold-in commit.
 -- ------------------------------------------------------------
 DO $$
 DECLARE
@@ -383,43 +386,33 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- ------------------------------------------------------------
--- Validator smoke (no triggers, no auth.users)
+-- Validator smoke (text[] variant)
 -- ------------------------------------------------------------
 DO $$
 BEGIN
-    -- CASE rewrite specifically guards against this — non-array MUST
-    -- NOT trigger an exception via jsonb_array_length / unnest, only
-    -- a clean false return.
-    IF profile.discord_owned_guilds_are_valid('{"not":"array"}'::jsonb) THEN
-        RAISE EXCEPTION 'validator: accepted non-array object';
-    END IF;
-    IF profile.discord_owned_guilds_are_valid('"string"'::jsonb) THEN
-        RAISE EXCEPTION 'validator: accepted string';
-    END IF;
-    IF profile.discord_owned_guilds_are_valid('42'::jsonb) THEN
-        RAISE EXCEPTION 'validator: accepted number';
-    END IF;
-    IF profile.discord_owned_guilds_are_valid('null'::jsonb) THEN
-        RAISE EXCEPTION 'validator: accepted jsonb null';
-    END IF;
-    -- STRICT means SQL NULL input returns NULL, which is falsy in a
-    -- CHECK constraint -> rejection. Confirm.
+    -- STRICT: SQL NULL input returns NULL.
     IF profile.discord_owned_guilds_are_valid(NULL) IS NOT NULL THEN
         RAISE EXCEPTION 'validator: STRICT must return NULL for NULL input';
     END IF;
-    -- Valid shapes
-    IF NOT profile.discord_owned_guilds_are_valid('[]'::jsonb) THEN
+    -- Empty array is valid (array_length on empty returns NULL).
+    IF NOT profile.discord_owned_guilds_are_valid(ARRAY[]::text[]) THEN
         RAISE EXCEPTION 'validator: rejected empty array';
     END IF;
-    IF NOT profile.discord_owned_guilds_are_valid('["111111111111111111","222222222222222222"]'::jsonb) THEN
-        RAISE EXCEPTION 'validator: rejected a valid 2-snowflake array';
+    -- Valid 2-snowflake array.
+    IF NOT profile.discord_owned_guilds_are_valid(ARRAY['111111111111111111','222222222222222222']) THEN
+        RAISE EXCEPTION 'validator: rejected valid 2-snowflake array';
     END IF;
-    -- Invalid elements
-    IF profile.discord_owned_guilds_are_valid('["111111111111111111","garbage"]'::jsonb) THEN
+    -- Malformed element.
+    IF profile.discord_owned_guilds_are_valid(ARRAY['111111111111111111','garbage']) THEN
         RAISE EXCEPTION 'validator: accepted malformed element';
     END IF;
-    IF profile.discord_owned_guilds_are_valid('["123"]'::jsonb) THEN
+    -- Too-short snowflake.
+    IF profile.discord_owned_guilds_are_valid(ARRAY['123']) THEN
         RAISE EXCEPTION 'validator: accepted too-short snowflake';
+    END IF;
+    -- Too-long snowflake (21 digits).
+    IF profile.discord_owned_guilds_are_valid(ARRAY['123456789012345678901']) THEN
+        RAISE EXCEPTION 'validator: accepted too-long snowflake';
     END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -501,8 +494,9 @@ REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
 GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
--- DROP TABLE cascades policies. Validator goes last.
+-- DROP TABLE cascades policies. Validator goes last. text[] overload
+-- is dropped explicitly since v1 didn't define any version.
 DROP TABLE     IF EXISTS profile.discord_bootstrap_cache;
-DROP FUNCTION  IF EXISTS profile.discord_owned_guilds_are_valid(jsonb);
+DROP FUNCTION  IF EXISTS profile.discord_owned_guilds_are_valid(text[]);
 
 COMMIT;

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -364,10 +364,12 @@ SECURITY DEFINER
 SET search_path = ''
 ROWS 1
 AS $$
-    -- Round 11 #5: LEFT JOIN over a single-row input so the caller
-    -- always gets exactly one row back — NULL timestamps + 0
-    -- guild_count when no cache exists. Saves the Axum side an
-    -- explicit empty-result-set branch.
+    -- Round 11 #5 (clarified round 12 #5): LEFT JOIN over a
+    -- single-row input so a non-NULL p_user_id always yields
+    -- exactly one row — NULL timestamps + 0 guild_count when no
+    -- cache row exists. A NULL p_user_id returns zero rows
+    -- (no input row passes the WHERE), which is the intentional
+    -- "garbage in, nothing out" semantics for the auth boundary.
     SELECT
         c.refreshed_at,
         c.updated_at,
@@ -604,18 +606,36 @@ BEGIN
     IF NOT has_function_privilege('service_role', 'profile.service_get_discord_bootstrap_cache_freshness(uuid)', 'EXECUTE') THEN
         RAISE EXCEPTION 'service_role must hold EXECUTE on profile.service_get_discord_bootstrap_cache_freshness for dashboard freshness peeks.';
     END IF;
-    -- Round 11 #10: drift guard. Any future PR that re-creates a
-    -- service_role RLS policy on this table will fail the
-    -- migration here, forcing the author to explicitly justify
-    -- giving service_role table-level read access.
+    -- Round 11 #10 (updated round 12 #1): drift guard. Any future
+    -- PR that re-creates a service_role RLS policy on this table
+    -- will fail the migration here, forcing the author to
+    -- explicitly justify giving service_role table-level read
+    -- access. ANY(roles) is more idiomatic than @> ARRAY[...]
+    -- when probing pg_policies.roles (which is name[]).
     IF EXISTS (
         SELECT 1
           FROM pg_policies
          WHERE schemaname = 'profile'
            AND tablename  = 'discord_bootstrap_cache'
-           AND roles @> ARRAY['service_role']::name[]
+           AND 'service_role' = ANY (roles)
     ) THEN
         RAISE EXCEPTION 'no service_role RLS policy may exist on profile.discord_bootstrap_cache; service_role reads go through the freshness RPC.';
+    END IF;
+
+    -- Round 12 #2: positive assertion — the supabase_auth_admin
+    -- SELECT policy must exist for the hook's JWT-mint reads to
+    -- pass RLS. Catches accidental policy drops or edits in
+    -- future migrations.
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_policies
+         WHERE schemaname = 'profile'
+           AND tablename  = 'discord_bootstrap_cache'
+           AND policyname = 'supabase_auth_admin_select'
+           AND cmd        = 'SELECT'
+           AND 'supabase_auth_admin' = ANY (roles)
+    ) THEN
+        RAISE EXCEPTION 'supabase_auth_admin_select policy must exist on profile.discord_bootstrap_cache for JWT mint reads.';
     END IF;
     IF has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'INSERT') THEN
         RAISE EXCEPTION 'service_role must NOT have direct INSERT on profile.discord_bootstrap_cache; use service_upsert RPC.';

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -8,34 +8,91 @@
 BEGIN;
 
 -- ============================================================
--- GoTrue Custom Access Token Hook: extend with owned_guilds
+-- profile.discord_bootstrap_cache + custom_access_token_hook v2
 --
--- Builds on 20260510210000_profile_custom_access_token_hook.sql by adding
--- a second claim `owned_guilds` populated from the user's Discord
--- identity row in auth.identities.
+-- v1 of the hook (20260510210000) embedded a single claim: kbve_username.
+-- v2 adds a second claim: owned_guilds — an array of Discord guild
+-- snowflakes the user owns. The dashboard reads it from the JWT and
+-- skips the live Discord /users/@me/guilds call that currently blanks
+-- the agents page with "Discord session expired" whenever the cached
+-- provider_token ages out.
 --
--- Source of truth: auth.identities.identity_data->'owned_guilds' as a
--- jsonb array of Discord guild snowflake strings (text). This column is
--- populated by the edge function `discord-bootstrap` (P5.8b) using the
--- user's provider_token. The hook itself does NO external calls — it
--- just reads pre-cached state, so JWT mint stays synchronous and fast.
+-- Source of truth is our own cache table, profile.discord_bootstrap_cache,
+-- NOT auth.identities.identity_data. Reviewer pushback on the first draft
+-- (PR #11488 review point #2) was that coupling a JWT-mint hot path to a
+-- semi-opaque Supabase-managed table is fragile across Supabase upgrades
+-- and harder to RLS / index cleanly. The cache table gives us:
+--   - stable PK lookup (one row per user_id)
+--   - no dependency on auth.identities JSON shape
+--   - service_role-owned writes, easy to GRANT for the bootstrap edge fn
+--   - cheap CASCADE on auth.users delete
+--   - smoke tests stop touching auth.users entirely
 --
--- Soft-failure semantics: when no Discord identity exists, or the
--- column is missing/malformed, the hook emits an empty array. Browsers
--- treat empty as "not bootstrapped yet" and call the bootstrap edge fn
--- once before flipping the dashboard to authenticated state.
---
--- Cap: array_length capped at 50 inside the hook to bound JWT size.
--- Discord platform allows up to 100 owned guilds for phone-verified
--- accounts; the 0.01% above 50 fall through to the live Discord API
--- path on the edge fn side.
+-- The hook still reads pre-cached state only. Zero external calls. JWT
+-- mint stays synchronous. Population of the cache row is the job of the
+-- discord-bootstrap edge fn (P5.8b), which calls Discord and upserts
+-- here with service_role.
 -- ============================================================
 
--- supabase_auth_admin already owns the auth schema, so explicit grants
--- on auth.identities are redundant — but we assert them in the health
--- block below so future grant revocations surface as a migration error
--- rather than a silent claim drop.
+-- ------------------------------------------------------------
+-- Cache table
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS profile.discord_bootstrap_cache (
+    user_id              uuid PRIMARY KEY
+                              REFERENCES auth.users(id) ON DELETE CASCADE,
+    discord_provider_id  text NOT NULL
+                              CHECK (discord_provider_id ~ '^[0-9]{15,25}$'),
+    owned_guilds         jsonb NOT NULL DEFAULT '[]'::jsonb,
+    refreshed_at         timestamptz NOT NULL DEFAULT NOW(),
 
+    CONSTRAINT discord_bootstrap_cache_owned_guilds_is_array
+        CHECK (jsonb_typeof(owned_guilds) = 'array'),
+    CONSTRAINT discord_bootstrap_cache_owned_guilds_size_cap
+        CHECK (jsonb_array_length(owned_guilds) <= 100)
+);
+
+COMMENT ON TABLE profile.discord_bootstrap_cache IS
+    'Per-user Discord bootstrap cache. Populated by the discord-bootstrap edge fn after OAuth. Read by custom_access_token_hook at JWT mint to embed owned_guilds claim. Owned by service_role; supabase_auth_admin has SELECT for the hook.';
+
+ALTER TABLE profile.discord_bootstrap_cache ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_full_access" ON profile.discord_bootstrap_cache;
+CREATE POLICY "service_role_full_access"
+    ON profile.discord_bootstrap_cache
+    AS PERMISSIVE
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+DROP POLICY IF EXISTS "supabase_auth_admin_select" ON profile.discord_bootstrap_cache;
+CREATE POLICY "supabase_auth_admin_select"
+    ON profile.discord_bootstrap_cache
+    AS PERMISSIVE
+    FOR SELECT
+    TO supabase_auth_admin
+    USING (true);
+
+GRANT USAGE  ON SCHEMA profile                             TO supabase_auth_admin;
+GRANT SELECT ON TABLE  profile.discord_bootstrap_cache     TO supabase_auth_admin;
+GRANT ALL    ON TABLE  profile.discord_bootstrap_cache     TO service_role;
+
+-- ------------------------------------------------------------
+-- Hook v2
+-- ------------------------------------------------------------
+-- Reads from profile.discord_bootstrap_cache via a single PK lookup.
+-- Hardening applied (per PR #11488 reviewer points):
+--   #3  [0-9] over \d (locale-safe, same cost)
+--   #4  WITH ORDINALITY + explicit jsonb_agg ORDER BY (deterministic
+--       claim order)
+--   #5  GROUP BY g + min(ord) (duplicate snowflakes suppressed,
+--       first-seen order preserved)
+--   #6  Strip kbve_username + owned_guilds on invalid/missing user_id
+--       (defense-in-depth for SECURITY DEFINER)
+--   #10 / #16 Typecheck event->'claims' as object before jsonb_set
+--   #11 Soft size cap (>1200 chars -> []) so malformed cache rows
+--       cannot bloat the JWT
+--   #15 CTE rewrite for the owned_guilds extraction
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -44,25 +101,44 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-    v_user_id       uuid;
-    v_username      text;
-    v_owned_guilds  jsonb;
-    v_claims        jsonb;
+    v_user_id      uuid;
+    v_username     text;
+    v_owned_guilds jsonb;
+    v_claims       jsonb;
 BEGIN
+    -- #10 / #16: claims must be a json object before we set into it.
+    v_claims :=
+        CASE
+            WHEN jsonb_typeof(event->'claims') = 'object'
+                THEN event->'claims'
+            ELSE '{}'::jsonb
+        END;
+
     BEGIN
         v_user_id := NULLIF(event->>'user_id', '')::uuid;
     EXCEPTION
         WHEN invalid_text_representation THEN
-            RETURN event;
+            -- #6: malformed user_id -> strip any pre-existing privileged
+            -- claims and return early. Caller cannot smuggle claims via a
+            -- garbage user_id.
+            RETURN jsonb_set(
+                event,
+                '{claims}',
+                v_claims - 'kbve_username' - 'owned_guilds',
+                true
+            );
     END;
 
     IF v_user_id IS NULL THEN
-        RETURN event;
+        RETURN jsonb_set(
+            event,
+            '{claims}',
+            v_claims - 'kbve_username' - 'owned_guilds',
+            true
+        );
     END IF;
 
-    v_claims := COALESCE(event->'claims', '{}'::jsonb);
-
-    -- kbve_username (existing behaviour)
+    -- kbve_username (unchanged from v1)
     SELECT u.username
       INTO v_username
       FROM profile.username AS u
@@ -74,34 +150,33 @@ BEGIN
         v_claims := v_claims - 'kbve_username';
     END IF;
 
-    -- owned_guilds from Discord identity (capped at 50 snowflakes).
-    -- The inner SELECT picks the latest discord identity row for this user
-    -- and pins it via LIMIT 1; the outer LATERAL then unnests its
-    -- owned_guilds array. Inlining the unnest into the same SELECT would
-    -- collapse "LIMIT 1 on identity rows" with "LIMIT 1 on array elements"
-    -- and silently drop all but the first guild.
-    SELECT COALESCE(
-             (
-                 SELECT jsonb_agg(g)
-                   FROM (
-                       SELECT g
-                         FROM (
-                             SELECT i.identity_data->'owned_guilds' AS arr
-                               FROM auth.identities AS i
-                              WHERE i.user_id  = v_user_id
-                                AND i.provider = 'discord'
-                                AND jsonb_typeof(i.identity_data->'owned_guilds') = 'array'
-                              ORDER BY i.updated_at DESC NULLS LAST, i.id DESC
-                              LIMIT 1
-                         ) AS latest,
-                         LATERAL jsonb_array_elements_text(latest.arr) AS g
-                        WHERE g ~ '^\d{17,20}$'
-                        LIMIT 50
-                   ) AS s
-             ),
-             '[]'::jsonb
-           )
-      INTO v_owned_guilds;
+    -- owned_guilds: single PK lookup against the cache table.
+    WITH src AS (
+        SELECT c.owned_guilds AS arr
+          FROM profile.discord_bootstrap_cache AS c
+         WHERE c.user_id = v_user_id
+           AND jsonb_typeof(c.owned_guilds) = 'array'
+    ),
+    valid AS (
+        SELECT g, MIN(ord) AS ord
+          FROM src,
+               LATERAL jsonb_array_elements_text(src.arr) WITH ORDINALITY AS e(g, ord)
+         WHERE g ~ '^[0-9]{17,20}$'
+         GROUP BY g
+         ORDER BY MIN(ord)
+         LIMIT 50
+    )
+    SELECT COALESCE(jsonb_agg(g ORDER BY ord), '[]'::jsonb)
+      INTO v_owned_guilds
+      FROM valid;
+
+    -- #11: soft size cap. The 50-snowflake LIMIT above should make this
+    -- unreachable in practice (~1.5 KB worst case) but a malformed cache
+    -- row with massive strings would otherwise leak straight into the
+    -- JWT. Degrade silently to [] rather than failing the sign-in.
+    IF length(v_owned_guilds::text) > 1200 THEN
+        v_owned_guilds := '[]'::jsonb;
+    END IF;
 
     v_claims := jsonb_set(v_claims, '{owned_guilds}', v_owned_guilds, true);
 
@@ -119,8 +194,11 @@ GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
 COMMENT ON FUNCTION public.custom_access_token_hook(jsonb) IS
-    'GoTrue access-token hook: embeds profile.username as kbve_username and the Discord identity owned_guilds array (cap 50) as owned_guilds. No external calls — reads pre-cached state populated by the discord-bootstrap edge fn.';
+    'GoTrue access-token hook v2: embeds profile.username as kbve_username and profile.discord_bootstrap_cache.owned_guilds (cap 50, deterministic order, dedup, soft size cap) as owned_guilds. No external calls — reads pre-cached state populated by the discord-bootstrap edge fn.';
 
+-- ------------------------------------------------------------
+-- Privilege + plumbing assertions
+-- ------------------------------------------------------------
 DO $$
 BEGIN
     PERFORM 'public.custom_access_token_hook(jsonb)'::regprocedure;
@@ -128,123 +206,136 @@ BEGIN
     IF NOT has_schema_privilege('supabase_auth_admin', 'public', 'USAGE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema public for the hook to resolve.';
     END IF;
-
     IF NOT has_schema_privilege('supabase_auth_admin', 'profile', 'USAGE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema profile.';
     END IF;
-
-    IF NOT has_schema_privilege('supabase_auth_admin', 'auth', 'USAGE') THEN
-        RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema auth for the hook to read identities.';
-    END IF;
-
     IF NOT has_function_privilege('supabase_auth_admin', 'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on public.custom_access_token_hook(jsonb).';
     END IF;
-
     IF has_function_privilege('anon',          'public.custom_access_token_hook(jsonb)', 'EXECUTE')
        OR has_function_privilege('authenticated','public.custom_access_token_hook(jsonb)', 'EXECUTE')
        OR has_function_privilege('public',     'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
         RAISE EXCEPTION 'public.custom_access_token_hook(jsonb) must not be executable by anon/authenticated/public.';
     END IF;
-
     IF NOT has_table_privilege('supabase_auth_admin', 'profile.username', 'SELECT') THEN
-        RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.username for the hook to read usernames.';
+        RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.username.';
     END IF;
-
-    IF NOT has_table_privilege('supabase_auth_admin', 'auth.identities', 'SELECT') THEN
-        RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on auth.identities for the hook to read owned_guilds.';
+    IF NOT has_table_privilege('supabase_auth_admin', 'profile.discord_bootstrap_cache', 'SELECT') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.discord_bootstrap_cache.';
+    END IF;
+    IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'INSERT') THEN
+        RAISE EXCEPTION 'service_role must hold INSERT on profile.discord_bootstrap_cache for the bootstrap edge fn.';
     END IF;
 END;
 $$ LANGUAGE plpgsql;
 
 -- ------------------------------------------------------------
--- Behavioural smoke check
+-- Behavioural smoke checks (no auth.users writes — runs entirely
+-- against the cache table + a synthetic user_id that has no rows
+-- anywhere).
 -- ------------------------------------------------------------
--- Verifies the hook returns an `owned_guilds` array (empty when no
--- Discord identity is present) and preserves the rest of the event.
--- Runs against a synthetic user_id with no rows in auth.identities or
--- profile.username, so the expected output is the input event with an
--- empty owned_guilds claim appended.
-
--- Scenario 1: synthetic user with no Discord identity yields empty array.
--- Scenario 2: synthetic user with Discord identity carrying 3 valid + 1
--- malformed snowflake yields exactly the 3 valid ones (regression guard
--- for the LIMIT-1-on-unnest bug — see comment above the SELECT).
-
 DO $$
 DECLARE
-    v_synthetic_user uuid := '00000000-0000-0000-0000-fffe00000001';
-    v_in             jsonb;
-    v_out            jsonb;
-    v_guilds         jsonb;
+    v_in      jsonb;
+    v_out     jsonb;
+    v_guilds  jsonb;
 BEGIN
-    -- Scenario 1
+    -- Scenario 1: empty event / no user_id -> claims object preserved,
+    -- privileged claims stripped, no exception.
+    v_out := public.custom_access_token_hook(
+        jsonb_build_object('claims', jsonb_build_object('role','authenticated'))
+    );
+    IF v_out->'claims'->>'role' <> 'authenticated' THEN
+        RAISE EXCEPTION 'smoke 1: role claim lost in %', v_out;
+    END IF;
+    IF v_out->'claims' ? 'owned_guilds' THEN
+        RAISE EXCEPTION 'smoke 1: invalid user_id must NOT emit owned_guilds, got %', v_out->'claims';
+    END IF;
+
+    -- Scenario 2: invalid user_id text -> same behaviour as scenario 1.
+    v_out := public.custom_access_token_hook(
+        jsonb_build_object(
+            'user_id', 'not-a-uuid',
+            'claims', jsonb_build_object('role','authenticated','owned_guilds',jsonb_build_array('attacker'))
+        )
+    );
+    IF v_out->'claims' ? 'owned_guilds' THEN
+        RAISE EXCEPTION 'smoke 2: malformed user_id must strip attacker-supplied owned_guilds, got %', v_out->'claims';
+    END IF;
+
+    -- Scenario 3: non-object claims -> rebuilt as object, hook still emits owned_guilds [].
+    v_out := public.custom_access_token_hook(
+        jsonb_build_object(
+            'user_id', '00000000-0000-0000-0000-000000000000',
+            'claims', '"not-an-object"'::jsonb
+        )
+    );
+    IF jsonb_typeof(v_out->'claims') <> 'object' THEN
+        RAISE EXCEPTION 'smoke 3: claims must be rebuilt as object, got % from %',
+            jsonb_typeof(v_out->'claims'), v_out;
+    END IF;
+    IF jsonb_array_length(v_out->'claims'->'owned_guilds') <> 0 THEN
+        RAISE EXCEPTION 'smoke 3: no cache row yet, owned_guilds must be empty, got %',
+            v_out->'claims'->'owned_guilds';
+    END IF;
+
+    -- Scenario 4: valid user_id, no cache row -> owned_guilds [].
     v_in := jsonb_build_object(
         'user_id', '00000000-0000-0000-0000-000000000000',
-        'claims',  jsonb_build_object('role', 'authenticated')
+        'claims',  jsonb_build_object('role','authenticated')
     );
     v_out := public.custom_access_token_hook(v_in);
-
-    IF v_out->'claims'->'owned_guilds' IS NULL THEN
-        RAISE EXCEPTION 'hook smoke 1: owned_guilds claim missing from output: %', v_out;
-    END IF;
     IF jsonb_typeof(v_out->'claims'->'owned_guilds') <> 'array' THEN
-        RAISE EXCEPTION 'hook smoke 1: owned_guilds must be a jsonb array, got %',
+        RAISE EXCEPTION 'smoke 4: owned_guilds must be a jsonb array, got %',
             jsonb_typeof(v_out->'claims'->'owned_guilds');
     END IF;
     IF jsonb_array_length(v_out->'claims'->'owned_guilds') <> 0 THEN
-        RAISE EXCEPTION 'hook smoke 1: empty Discord identity must yield empty owned_guilds, got %',
+        RAISE EXCEPTION 'smoke 4: no cache row, expected empty owned_guilds, got %',
             v_out->'claims'->'owned_guilds';
     END IF;
-    IF v_out->'claims'->>'role' <> 'authenticated' THEN
-        RAISE EXCEPTION 'hook smoke 1: existing claims must be preserved, role lost from %', v_out;
-    END IF;
 
-    -- Scenario 2 — run inside a PL/pgSQL EXCEPTION subtransaction so the
-    -- synthetic INSERT into auth.users (and any trigger-spawned rows like
-    -- the wallet/account auto-provision) are rolled back atomically. We
-    -- complete the assertions, then RAISE a sentinel exception to force
-    -- the subtransaction to roll back; the outer handler swallows that
-    -- specific sentinel and re-raises everything else.
+    -- Scenario 5: cache row with 3 valid + 1 malformed + 1 duplicate
+    -- snowflake. Wrap in an EXCEPTION subtransaction with a sentinel
+    -- rollback so the synthetic auth.users + cache rows are undone
+    -- atomically. No writes to auth.identities involved.
     BEGIN
-        INSERT INTO auth.users (id) VALUES (v_synthetic_user);
-        INSERT INTO auth.identities (user_id, provider, provider_id, identity_data)
+        INSERT INTO auth.users (id) VALUES ('00000000-0000-0000-0000-fffe00000001');
+        INSERT INTO profile.discord_bootstrap_cache
+            (user_id, discord_provider_id, owned_guilds)
         VALUES (
-            v_synthetic_user,
-            'discord',
-            'smoke-' || v_synthetic_user::text,
-            jsonb_build_object(
-                'owned_guilds',
-                jsonb_build_array(
-                    '111111111111111111',
-                    '222222222222222222',
-                    '333333333333333333',
-                    'not-a-snowflake'
-                )
+            '00000000-0000-0000-0000-fffe00000001',
+            '999000111222333444',
+            jsonb_build_array(
+                '111111111111111111',
+                '222222222222222222',
+                '333333333333333333',
+                '111111111111111111', -- duplicate
+                'not-a-snowflake'
             )
         );
 
-        v_in := jsonb_build_object(
-            'user_id', v_synthetic_user,
-            'claims',  jsonb_build_object('role', 'authenticated')
-        );
-        v_out    := public.custom_access_token_hook(v_in);
+        v_out := public.custom_access_token_hook(jsonb_build_object(
+            'user_id', '00000000-0000-0000-0000-fffe00000001',
+            'claims',  jsonb_build_object('role','authenticated')
+        ));
         v_guilds := v_out->'claims'->'owned_guilds';
 
         IF jsonb_array_length(v_guilds) <> 3 THEN
             RAISE EXCEPTION
-                'hook smoke 2: expected 3 valid snowflakes (LIMIT-1-on-unnest regression?), got % from %',
+                'smoke 5: expected 3 unique valid snowflakes (LIMIT-1 / dedup regression?), got % from %',
                 jsonb_array_length(v_guilds), v_guilds;
         END IF;
         IF NOT (v_guilds @> '["111111111111111111","222222222222222222","333333333333333333"]'::jsonb) THEN
-            RAISE EXCEPTION 'hook smoke 2: expected snowflakes missing from %', v_guilds;
+            RAISE EXCEPTION 'smoke 5: expected snowflakes missing from %', v_guilds;
         END IF;
         IF v_guilds @> '["not-a-snowflake"]'::jsonb THEN
-            RAISE EXCEPTION 'hook smoke 2: malformed snowflake leaked into %', v_guilds;
+            RAISE EXCEPTION 'smoke 5: malformed snowflake leaked into %', v_guilds;
+        END IF;
+        -- Determinism: first-seen order preserved.
+        IF v_guilds->>0 <> '111111111111111111' THEN
+            RAISE EXCEPTION 'smoke 5: first-seen order not preserved, got %', v_guilds;
         END IF;
 
-        -- Sentinel: forces subtransaction rollback so synthetic rows do
-        -- not leak past this migration. Caught immediately below.
         RAISE EXCEPTION 'hook_smoke_sentinel_rollback';
     EXCEPTION
         WHEN OTHERS THEN
@@ -263,11 +354,9 @@ COMMIT;
 
 BEGIN;
 
--- Restore the v1 hook body (kbve_username only). We deliberately do not
--- DROP the function, since GoTrue is configured to call it and a missing
--- function would break sign-in. We just revert to the pre-owned_guilds
--- behaviour.
-
+-- Restore the v1 hook body (kbve_username only). Deliberately do NOT
+-- drop the function — GoTrue is configured to call it; a missing
+-- function would break all sign-in.
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -316,5 +405,10 @@ REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
 
 GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
+
+-- Drop the cache table last so the function above no longer references
+-- it. ON DELETE CASCADE on user_id means the table goes away cleanly
+-- without orphaning anything.
+DROP TABLE IF EXISTS profile.discord_bootstrap_cache;
 
 COMMIT;

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -35,11 +35,17 @@ BEGIN;
 --        - updated_at maintenance
 --      Owner pinned to postgres explicitly so SECURITY DEFINER
 --      behaviour is stable across local/CI/prod environments.
---   4. profile.get_discord_owned_guilds_claim(uuid, timestamptz) —
+--   4. profile.service_get_discord_bootstrap_cache_freshness(uuid)
+--      — narrow read RPC for dashboard freshness peeks. Returns
+--      refreshed_at/updated_at/created_at/guild_count for a single
+--      user_id; never exposes discord_provider_id or the
+--      owned_guilds list. service_role has EXECUTE only — no
+--      direct table SELECT.
+--   5. profile.get_discord_owned_guilds_claim(uuid, timestamptz) —
 --      SQL helper that fetches the claim. STABLE + COST 20 so the
 --      planner can inline + cost-estimate around the call. Hook
 --      delegates here instead of carrying a CTE.
---   5. public.custom_access_token_hook(jsonb) — slim PL/pgSQL hook,
+--   6. public.custom_access_token_hook(jsonb) — slim PL/pgSQL hook,
 --      defers guild lookup to the helper, applies the JWT claim.
 --
 -- The hook does NO external calls and never blocks. The helper does
@@ -111,7 +117,7 @@ CREATE TABLE profile.discord_bootstrap_cache (
 );
 
 COMMENT ON TABLE profile.discord_bootstrap_cache IS
-    'Per-user Discord bootstrap cache. Populated exclusively via profile.service_upsert_discord_bootstrap_cache RPC; service_role has SELECT only (no direct INSERT/UPDATE/DELETE) so all writes are funnelled through the RPC for centralised validation, canonicalisation, advisory-lock serialisation, and account-relink handling. SELECT is granted to service_role specifically for dashboard freshness peeks; the RPC''s ON CONFLICT path is satisfied by the SECURITY DEFINER owner (postgres) and does not require caller SELECT. supabase_auth_admin has SELECT for custom_access_token_hook at JWT mint.';
+    'Per-user Discord bootstrap cache. All access flows through SECURITY DEFINER RPCs (postgres-owned) — service_role has NO direct table privileges. Writes go through profile.service_upsert_discord_bootstrap_cache (centralised validation + canonicalisation + advisory-lock serialisation + relink handling). Dashboard freshness reads go through profile.service_get_discord_bootstrap_cache_freshness (returns only refreshed_at/updated_at/guild_count for a specific user_id; never exposes the full provider_id + owned_guilds list to broad service-role reads). supabase_auth_admin has SELECT for custom_access_token_hook at JWT mint.';
 
 REVOKE ALL ON TABLE profile.discord_bootstrap_cache
     FROM PUBLIC, anon, authenticated;
@@ -126,14 +132,14 @@ GRANT SELECT ON TABLE  profile.discord_bootstrap_cache TO supabase_auth_admin;
 -- guarantee this; the grant is idempotent and the assertion below
 -- catches future revoke drift.
 GRANT USAGE ON SCHEMA profile TO service_role;
--- Round 8 #4: corrected justification. The RPC runs SECURITY
--- DEFINER as postgres, so ON CONFLICT visibility is satisfied by
--- the RPC owner's privileges — service_role SELECT is NOT needed
--- for the upsert path. The real reason service_role keeps SELECT
--- is dashboard freshness peeks (e.g. P5.8c surfacing "last
--- refreshed N minutes ago" without going through another RPC
--- layer). Writes still flow only through the SECURITY DEFINER RPC.
-GRANT SELECT ON TABLE profile.discord_bootstrap_cache TO service_role;
+-- Round 10 #1: service_role intentionally has NO direct privilege
+-- on the cache table. Earlier rounds granted SELECT for "dashboard
+-- freshness peeks" but that exposed every cached row's
+-- discord_provider_id + owned_guilds list to broad service-role
+-- read access. Replaced with a narrow SECURITY DEFINER RPC
+-- (profile.service_get_discord_bootstrap_cache_freshness below)
+-- that returns only refreshed_at / updated_at / guild_count for
+-- a specific user_id. Dashboard (P5.8c) reads through the RPC.
 
 -- Round 9 #4: RLS is enabled for caller roles. FORCE ROW LEVEL
 -- SECURITY is intentionally NOT used here because the postgres-
@@ -194,8 +200,10 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-    v_canonical text[];
-    v_now       timestamptz := statement_timestamp();
+    v_canonical        text[];
+    v_now              timestamptz := statement_timestamp();
+    v_input_count      integer     := cardinality(COALESCE(p_owned_guilds, ARRAY[]::text[]));
+    v_relinked_user_id uuid;
 BEGIN
     -- Round 7 #7: USING ERRCODE = '22023' (invalid_parameter_value)
     -- on all validation failures so service callers (axum-kbve etc.)
@@ -261,14 +269,39 @@ BEGIN
            LIMIT 50
       ) AS s;
 
+    -- Round 10 #4: silent canonicalisation filter is the chosen
+    -- policy — Discord's API isn't fully under our control, so
+    -- one bad guild id shouldn't break the whole OAuth refresh.
+    -- But we RAISE LOG when filtering so the drop shows up in
+    -- Postgres logs (log_min_messages=log captures it).
+    IF v_input_count <> cardinality(v_canonical) THEN
+        RAISE LOG 'service_upsert_discord_bootstrap_cache: filtered % of % owned_guilds (NULL/non-snowflake/dup/cap) for user=%',
+            v_input_count - cardinality(v_canonical), v_input_count, p_user_id;
+    END IF;
+
     -- Account relinking: drop stale row carrying same provider_id
     -- under a different user_id so the upsert below can succeed
     -- against the discord_provider_id UNIQUE constraint without
-    -- raising a raw unique_violation.
+    -- raising a raw unique_violation. Round 10 #3: capture the
+    -- displaced user_id into v_relinked_user_id + RAISE LOG so
+    -- relinks are observable in Postgres logs.
     DELETE FROM profile.discord_bootstrap_cache
      WHERE discord_provider_id = p_discord_provider_id
-       AND user_id <> p_user_id;
+       AND user_id <> p_user_id
+    RETURNING user_id INTO v_relinked_user_id;
 
+    IF v_relinked_user_id IS NOT NULL THEN
+        RAISE LOG 'service_upsert_discord_bootstrap_cache: relinked discord_provider_id=% from user=% to user=%',
+            p_discord_provider_id, v_relinked_user_id, p_user_id;
+    END IF;
+
+    -- Round 10 #5: ON CONFLICT (user_id) DO UPDATE intentionally
+    -- allows the SAME user to swap their discord_provider_id
+    -- (e.g. user re-OAuths under a different Discord account but
+    -- the same Supabase identity). This is symmetric with the
+    -- account-relink case handled above (different user_ids
+    -- pointing at the same provider_id). Both flows are normal
+    -- OAuth lifecycle events.
     INSERT INTO profile.discord_bootstrap_cache AS c
         (user_id, discord_provider_id, owned_guilds, refreshed_at, created_at, updated_at)
     VALUES
@@ -290,6 +323,49 @@ COMMENT ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, t
 REVOKE EXECUTE ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz)
     FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz)
+    TO service_role;
+
+-- ------------------------------------------------------------
+-- Narrow read RPC for dashboard freshness peeks (round 10 #1)
+-- ------------------------------------------------------------
+-- Returns only the row metadata the dashboard needs to render
+-- "last refreshed N minutes ago" — never exposes
+-- discord_provider_id or the owned_guilds list. SECURITY DEFINER +
+-- owned by postgres so service_role doesn't need direct SELECT on
+-- the table.
+CREATE OR REPLACE FUNCTION profile.service_get_discord_bootstrap_cache_freshness(
+    p_user_id uuid
+)
+RETURNS TABLE (
+    refreshed_at timestamptz,
+    updated_at   timestamptz,
+    created_at   timestamptz,
+    guild_count  integer
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT
+        c.refreshed_at,
+        c.updated_at,
+        c.created_at,
+        cardinality(c.owned_guilds)::integer AS guild_count
+    FROM profile.discord_bootstrap_cache AS c
+    WHERE p_user_id IS NOT NULL
+      AND c.user_id  = p_user_id;
+$$;
+
+ALTER FUNCTION profile.service_get_discord_bootstrap_cache_freshness(uuid)
+    OWNER TO postgres;
+
+COMMENT ON FUNCTION profile.service_get_discord_bootstrap_cache_freshness(uuid) IS
+    'Narrow read RPC for dashboard freshness rendering. Returns refreshed_at + updated_at + created_at + guild_count for a single user_id; never exposes discord_provider_id or the owned_guilds list. SECURITY DEFINER + owned by postgres; service_role has EXECUTE only.';
+
+REVOKE EXECUTE ON FUNCTION profile.service_get_discord_bootstrap_cache_freshness(uuid)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION profile.service_get_discord_bootstrap_cache_freshness(uuid)
     TO service_role;
 
 -- ------------------------------------------------------------
@@ -319,7 +395,9 @@ AS $$
     -- unnecessary (no row matches NULL user_id), but documents
     -- intent and protects against planner edge cases on future
     -- index/partition changes.
-    SELECT COALESCE(to_jsonb(array_agg(g ORDER BY ord)), '[]'::jsonb)
+    -- Round 10 #6: jsonb_agg over to_jsonb(array_agg(...)) — one
+    -- pass instead of two (array build then jsonb cast).
+    SELECT COALESCE(jsonb_agg(g ORDER BY ord), '[]'::jsonb)
       FROM (
           SELECT g, ord
             FROM profile.discord_bootstrap_cache AS c,
@@ -441,6 +519,7 @@ BEGIN
     PERFORM 'public.custom_access_token_hook(jsonb)'::regprocedure;
     PERFORM 'profile.discord_owned_guilds_are_valid(text[])'::regprocedure;
     PERFORM 'profile.service_upsert_discord_bootstrap_cache(uuid,text,text[],timestamptz)'::regprocedure;
+    PERFORM 'profile.service_get_discord_bootstrap_cache_freshness(uuid)'::regprocedure;
     PERFORM 'profile.get_discord_owned_guilds_claim(uuid,timestamptz)'::regprocedure;
 
     IF NOT has_schema_privilege('supabase_auth_admin', 'public', 'USAGE') THEN
@@ -466,6 +545,10 @@ BEGIN
        OR has_function_privilege('authenticated', 'profile.service_upsert_discord_bootstrap_cache(uuid,text,text[],timestamptz)', 'EXECUTE') THEN
         RAISE EXCEPTION 'service_upsert RPC must not be executable by anon/authenticated.';
     END IF;
+    IF has_function_privilege('anon', 'profile.service_get_discord_bootstrap_cache_freshness(uuid)', 'EXECUTE')
+       OR has_function_privilege('authenticated', 'profile.service_get_discord_bootstrap_cache_freshness(uuid)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_get_..._freshness RPC must not be executable by anon/authenticated.';
+    END IF;
     IF has_function_privilege('anon',          'public.custom_access_token_hook(jsonb)', 'EXECUTE')
        OR has_function_privilege('authenticated','public.custom_access_token_hook(jsonb)', 'EXECUTE')
        OR has_function_privilege('public',     'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
@@ -489,8 +572,14 @@ BEGIN
     IF NOT has_table_privilege('supabase_auth_admin', 'profile.username', 'SELECT') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.username for custom_access_token_hook.';
     END IF;
-    IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'SELECT') THEN
-        RAISE EXCEPTION 'service_role must hold SELECT on profile.discord_bootstrap_cache for dashboard freshness peeks.';
+    -- Round 10 #1: service_role intentionally has NO direct table
+    -- privileges. Dashboard freshness goes through the narrow
+    -- service_get_discord_bootstrap_cache_freshness RPC instead.
+    IF has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'SELECT') THEN
+        RAISE EXCEPTION 'service_role must NOT have direct SELECT on profile.discord_bootstrap_cache; use service_get_..._freshness RPC.';
+    END IF;
+    IF NOT has_function_privilege('service_role', 'profile.service_get_discord_bootstrap_cache_freshness(uuid)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must hold EXECUTE on profile.service_get_discord_bootstrap_cache_freshness for dashboard freshness peeks.';
     END IF;
     IF has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'INSERT') THEN
         RAISE EXCEPTION 'service_role must NOT have direct INSERT on profile.discord_bootstrap_cache; use service_upsert RPC.';
@@ -624,6 +713,25 @@ BEGIN
     IF jsonb_typeof(v_out->'claims') <> 'object' THEN
         RAISE EXCEPTION 'smoke 6: claims must be object after NULL coerce, got %', v_out;
     END IF;
+
+    -- Round 10 #7: valid UUID with no cache row but an attacker-
+    -- supplied owned_guilds claim → must be stripped + replaced
+    -- with the canonical empty cache result. Covers the security
+    -- boundary on the valid-but-empty path (smoke 2 covers the
+    -- malformed-user_id path).
+    v_out := public.custom_access_token_hook(
+        jsonb_build_object(
+            'user_id', '00000000-0000-0000-0000-000000000000',
+            'claims', jsonb_build_object(
+                'role', 'authenticated',
+                'owned_guilds', jsonb_build_array('999999999999999999')
+            )
+        )
+    );
+    IF v_out->'claims'->'owned_guilds' <> '[]'::jsonb THEN
+        RAISE EXCEPTION 'smoke 7: valid-no-cache attacker owned_guilds must be overwritten with empty claim, got %',
+            v_out->'claims'->'owned_guilds';
+    END IF;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -740,9 +848,11 @@ REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
 GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
--- Drop in dependency order: helper (called by nothing in down), RPC
--- (writes to table), table (cascades policies), validator.
+-- Drop in dependency order: helper + freshness RPC (called by
+-- nothing in down), upsert RPC (writes to table), table (cascades
+-- policies), validator.
 DROP FUNCTION  IF EXISTS profile.get_discord_owned_guilds_claim(uuid, timestamptz);
+DROP FUNCTION  IF EXISTS profile.service_get_discord_bootstrap_cache_freshness(uuid);
 DROP FUNCTION  IF EXISTS profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz);
 DROP TABLE     IF EXISTS profile.discord_bootstrap_cache;
 DROP FUNCTION  IF EXISTS profile.discord_owned_guilds_are_valid(text[]);

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -17,31 +17,32 @@ BEGIN;
 -- the agents page with "Discord session expired" whenever the cached
 -- provider_token ages out.
 --
--- Source of truth is profile.discord_bootstrap_cache, populated by the
--- discord-bootstrap edge fn (P5.8b) which calls Discord once after
--- OAuth and upserts here with service_role.
+-- Storage uses text[] (round 4) so the JWT-mint hot path avoids jsonb
+-- traversal. The write path goes through a single service RPC
+-- (profile.service_upsert_discord_bootstrap_cache) — service_role does
+-- NOT have direct INSERT/UPDATE/DELETE on the cache table. The RPC
+-- centralises:
+--   - input validation (snowflake regex, NULL-element filter)
+--   - canonicalisation (dedup + first-seen ordering + cap 100)
+--   - account relinking (DELETE old row if discord_provider_id moves
+--     between user_ids)
+--   - future-timestamp rejection
+--   - updated_at maintenance
 --
--- The hook does NO external calls and never blocks. It reads one row
--- by PK, validates + dedupes guild IDs, applies a freshness window
--- (rejects rows older than 7 days OR more than 30 seconds in the
--- future), wraps in jsonb, and embeds as a JWT claim.
---
--- Storage uses text[] not jsonb (GPT round-4 #1) — Discord snowflakes
--- are flat strings; jsonb traversal in the JWT mint hot path was
--- overkill. Validator, hook CTE, and constraints all operate on
--- native arrays; only the final claim is wrapped in to_jsonb().
+-- The hook itself does NO external calls and never blocks. It reads
+-- one row by PK, slices to 50, applies a defensive NULL+regex filter
+-- (belt+suspender even though storage is canonical), wraps in jsonb,
+-- and embeds as a JWT claim.
 -- ============================================================
 
 -- ------------------------------------------------------------
--- Validator function (text[] variant — GPT round-4 #1)
+-- Validator function (text[] variant — fixes round-5 #5 NULL bypass)
 -- ------------------------------------------------------------
--- IMMUTABLE STRICT so it can sit in a CHECK constraint and the planner
--- can prove cache-safety. STRICT documents NULL-input intent (the
--- column is NOT NULL anyway).
---
--- CASE preserves the short-circuit safety we got in pass 3. text[]
--- removes the need for jsonb_typeof (the type system already
--- guarantees array shape).
+-- Round 5 #4: single COALESCE(array_length, 0) instead of two
+-- array_length calls.
+-- Round 5 #5: explicit NULL-element check. Without `g IS NULL OR`,
+-- `g !~ '...'` returns NULL for NULL inputs and NOT EXISTS never
+-- sees the bad row → ARRAY['valid', NULL] would pass validation.
 CREATE OR REPLACE FUNCTION profile.discord_owned_guilds_are_valid(p_guilds text[])
 RETURNS boolean
 LANGUAGE sql
@@ -50,18 +51,17 @@ STRICT
 SET search_path = ''
 AS $$
     SELECT CASE
-        WHEN array_length(p_guilds, 1) IS NULL THEN true
-        WHEN array_length(p_guilds, 1) > 100 THEN false
+        WHEN COALESCE(array_length(p_guilds, 1), 0) > 100 THEN false
         ELSE NOT EXISTS (
             SELECT 1
             FROM unnest(p_guilds) AS g
-            WHERE g !~ '^[0-9]{17,20}$'
+            WHERE g IS NULL OR g !~ '^[0-9]{17,20}$'
         )
     END;
 $$;
 
 COMMENT ON FUNCTION profile.discord_owned_guilds_are_valid(text[]) IS
-    'IMMUTABLE shape validator for profile.discord_bootstrap_cache.owned_guilds. Accepts empty arrays as valid (array_length on empty returns NULL). Backs both a CHECK constraint and serves as the canonical write-path invariant.';
+    'IMMUTABLE shape validator for profile.discord_bootstrap_cache.owned_guilds. Rejects NULL elements, non-snowflake strings (regex ^[0-9]{17,20}$), and arrays larger than 100 elements. Empty arrays are valid.';
 
 REVOKE EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(text[])
     FROM PUBLIC, anon, authenticated;
@@ -69,17 +69,10 @@ GRANT EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(text[])
     TO service_role, supabase_auth_admin;
 
 -- ------------------------------------------------------------
--- Cache table (no IF NOT EXISTS; all constraints inline)
+-- Cache table
 -- ------------------------------------------------------------
--- Changes from round 3 of the review fold-in:
---   GPT #1   owned_guilds is text[] (was jsonb)
---   GPT #4   discord_provider_id is UNIQUE (mirrors auth.identities'
---            (provider, provider_id) integrity)
---   GPT #9   refreshed_at floor CHECK against absurd historical
---            timestamps (combined with created_at/updated_at floor)
---   GPT #17  created_at + updated_at columns for row-lifecycle audit
---            (distinct from refreshed_at which tracks Discord-data
---            freshness)
+-- Round 5 #9: updated_at >= created_at ordering invariant folded
+-- into the timestamps_floor CHECK (now timestamps_ordering_and_floor).
 CREATE TABLE profile.discord_bootstrap_cache (
     user_id              uuid PRIMARY KEY,
     discord_provider_id  text NOT NULL
@@ -102,28 +95,34 @@ CREATE TABLE profile.discord_bootstrap_cache (
         ),
     CONSTRAINT discord_bootstrap_cache_owned_guilds_valid
         CHECK (profile.discord_owned_guilds_are_valid(owned_guilds)),
-    CONSTRAINT discord_bootstrap_cache_timestamps_floor
+    CONSTRAINT discord_bootstrap_cache_timestamps_ordering_and_floor
         CHECK (
-            refreshed_at >= '2025-01-01'::timestamptz
-            AND created_at >= '2025-01-01'::timestamptz
-            AND updated_at >= '2025-01-01'::timestamptz
+            updated_at >= created_at
+            AND refreshed_at >= '2025-01-01'::timestamptz
+            AND created_at  >= '2025-01-01'::timestamptz
+            AND updated_at  >= '2025-01-01'::timestamptz
         )
 );
 
 COMMENT ON TABLE profile.discord_bootstrap_cache IS
-    'Per-user Discord bootstrap cache. Populated by the discord-bootstrap edge fn after OAuth. Read by custom_access_token_hook at JWT mint to embed owned_guilds claim. service_role has CRUD; supabase_auth_admin has SELECT for the hook. refreshed_at tracks Discord-data freshness; created_at/updated_at track row lifecycle.';
+    'Per-user Discord bootstrap cache. Populated exclusively via profile.service_upsert_discord_bootstrap_cache RPC. Read by custom_access_token_hook at JWT mint to embed owned_guilds claim. service_role has SELECT only; INSERT/UPDATE/DELETE flow through the RPC for centralised validation + canonicalisation. supabase_auth_admin has SELECT for the hook.';
 
 REVOKE ALL ON TABLE profile.discord_bootstrap_cache
     FROM PUBLIC, anon, authenticated;
 
 GRANT USAGE  ON SCHEMA profile                         TO supabase_auth_admin;
 GRANT SELECT ON TABLE  profile.discord_bootstrap_cache TO supabase_auth_admin;
-GRANT SELECT, INSERT, UPDATE, DELETE
-    ON TABLE profile.discord_bootstrap_cache
-    TO service_role;
+-- Round 5 #2: service_role keeps SELECT (dashboard freshness peeks +
+-- ON CONFLICT visibility for the RPC's INSERT), but loses
+-- INSERT/UPDATE/DELETE. All writes go through the RPC.
+GRANT SELECT ON TABLE profile.discord_bootstrap_cache TO service_role;
 
 ALTER TABLE profile.discord_bootstrap_cache ENABLE ROW LEVEL SECURITY;
 
+-- Round 5 #3: WITH CHECK simplified to true. The RPC validates
+-- inputs explicitly and the table CHECK constraints remain
+-- authoritative — RLS WITH CHECK was paying duplicate validation
+-- cost for a code path service_role no longer takes directly.
 DROP POLICY IF EXISTS "service_role_full_access" ON profile.discord_bootstrap_cache;
 CREATE POLICY "service_role_full_access"
     ON profile.discord_bootstrap_cache
@@ -131,10 +130,7 @@ CREATE POLICY "service_role_full_access"
     FOR ALL
     TO service_role
     USING (true)
-    WITH CHECK (
-        profile.discord_owned_guilds_are_valid(owned_guilds)
-        AND discord_provider_id ~ '^[0-9]{15,25}$'
-    );
+    WITH CHECK (true);
 
 DROP POLICY IF EXISTS "supabase_auth_admin_select" ON profile.discord_bootstrap_cache;
 CREATE POLICY "supabase_auth_admin_select"
@@ -145,23 +141,107 @@ CREATE POLICY "supabase_auth_admin_select"
     USING (true);
 
 -- ------------------------------------------------------------
--- Hook v2
+-- Service-role RPC: the only write path for the cache
 -- ------------------------------------------------------------
--- Round 4 changes folded in:
---   GPT #1   unnest(text[]) instead of jsonb_array_elements_text
---            in the src CTE; only the final claim is wrapped via
---            to_jsonb(array_agg(...)).
---   GPT #8   Future-timestamp tolerance tightened from 5 minutes
---            to 30 seconds. 5min was over-conservative for in-cluster
---            clock skew and gave an attacker a meaningful trust
---            extension window. 30s covers real Deno/Postgres skew.
---   GPT #11  v_now local timestamptz variable to make the freshness
---            window edits safer and avoid repeated function calls.
---   GPT #12  STABLE (was VOLATILE in round 2). Function reads but
---            never mutates → STABLE is the documented semantics for
---            read-only functions. Round 2 reviewer pushed VOLATILE on
---            pure safety; round 4 correctly flagged STABLE as
---            technically accurate. Flipping back.
+-- Centralised write surface that handles validation, dedup +
+-- canonical ordering, account relinking, future-timestamp guard, and
+-- updated_at maintenance. SECURITY DEFINER + owned by the migrating
+-- role (effectively superuser) so it can bypass the absent direct
+-- INSERT grant for service_role.
+--
+-- Folds in round-5 #1, #2, #7, #10, #12.
+CREATE OR REPLACE FUNCTION profile.service_upsert_discord_bootstrap_cache(
+    p_user_id              uuid,
+    p_discord_provider_id  text,
+    p_owned_guilds         text[]      DEFAULT ARRAY[]::text[],
+    p_refreshed_at         timestamptz DEFAULT statement_timestamp()
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_canonical text[];
+    v_now       timestamptz := statement_timestamp();
+BEGIN
+    -- Belt 1: input shape validation. Cleaner errors than letting the
+    -- table constraints fail later.
+    IF p_user_id IS NULL THEN
+        RAISE EXCEPTION 'service_upsert_discord_bootstrap_cache: user_id required';
+    END IF;
+    IF p_discord_provider_id IS NULL OR p_discord_provider_id !~ '^[0-9]{15,25}$' THEN
+        RAISE EXCEPTION 'service_upsert_discord_bootstrap_cache: invalid discord_provider_id';
+    END IF;
+
+    -- Round 5 #10: reject future-dated writes >30s before they hit
+    -- storage. Table CHECK can't express now()+30s (not IMMUTABLE),
+    -- so it has to be enforced here.
+    IF p_refreshed_at > v_now + interval '30 seconds' THEN
+        RAISE EXCEPTION
+            'service_upsert_discord_bootstrap_cache: p_refreshed_at too far in future (got %, max %)',
+            p_refreshed_at, v_now + interval '30 seconds';
+    END IF;
+    IF p_refreshed_at < '2025-01-01'::timestamptz THEN
+        RAISE EXCEPTION
+            'service_upsert_discord_bootstrap_cache: p_refreshed_at below floor (got %, min 2025-01-01)',
+            p_refreshed_at;
+    END IF;
+
+    -- Round 5 #7: canonicalise. NULL + non-snowflake elements are
+    -- filtered; duplicates collapsed by first-seen order; capped at
+    -- 100 to match the table CHECK.
+    SELECT COALESCE(array_agg(g ORDER BY ord), ARRAY[]::text[])
+      INTO v_canonical
+      FROM (
+          SELECT g, MIN(ord) AS ord
+            FROM unnest(COALESCE(p_owned_guilds, ARRAY[]::text[]))
+                 WITH ORDINALITY AS e(g, ord)
+           WHERE g IS NOT NULL
+             AND g ~ '^[0-9]{17,20}$'
+           GROUP BY g
+           ORDER BY MIN(ord)
+           LIMIT 100
+      ) AS s;
+
+    -- Round 5 #12: account relinking. If the same Discord provider
+    -- id is cached under a different user_id (rare, but possible
+    -- when a user re-OAuths under a fresh Supabase identity), drop
+    -- the stale row first so the upsert below succeeds against the
+    -- discord_provider_id UNIQUE constraint instead of raising a
+    -- raw unique_violation to the caller.
+    DELETE FROM profile.discord_bootstrap_cache
+     WHERE discord_provider_id = p_discord_provider_id
+       AND user_id <> p_user_id;
+
+    INSERT INTO profile.discord_bootstrap_cache AS c
+        (user_id, discord_provider_id, owned_guilds, refreshed_at, created_at, updated_at)
+    VALUES
+        (p_user_id, p_discord_provider_id, v_canonical, p_refreshed_at, v_now, v_now)
+    ON CONFLICT (user_id) DO UPDATE
+       SET discord_provider_id = EXCLUDED.discord_provider_id,
+           owned_guilds        = EXCLUDED.owned_guilds,
+           refreshed_at        = EXCLUDED.refreshed_at,
+           updated_at          = v_now;
+END;
+$$;
+
+COMMENT ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz) IS
+    'Service-role upsert for profile.discord_bootstrap_cache. Validates inputs, canonicalises owned_guilds (dedup + first-seen order + cap 100), enforces future-timestamp guard, handles account relinking, maintains updated_at. The only sanctioned write path — service_role has no direct INSERT/UPDATE/DELETE on the table.';
+
+REVOKE EXECUTE ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz)
+    TO service_role;
+
+-- ------------------------------------------------------------
+-- Hook v2 (slimmed — round 5 #6, #8)
+-- ------------------------------------------------------------
+-- Slices to 50 (storage is canonical via the RPC, so no GROUP BY
+-- needed) but keeps a defensive NULL + snowflake regex filter as
+-- belt+suspender. JWT mint is a security boundary — even if the
+-- RPC develops a bug or a superuser does manual DML, the hook
+-- still emits only well-formed snowflakes.
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -215,9 +295,6 @@ BEGIN
         v_claims := v_claims - 'kbve_username';
     END IF;
 
-    -- owned_guilds: PK lookup, freshness-gated, future-ts guarded.
-    -- text[] removes the jsonb_typeof / jsonb_array_elements_text
-    -- overhead; only the final claim is wrapped via to_jsonb.
     WITH src AS (
         SELECT c.owned_guilds AS arr
           FROM profile.discord_bootstrap_cache AS c
@@ -225,22 +302,19 @@ BEGIN
            AND c.refreshed_at <= v_now + interval '30 seconds'
            AND c.refreshed_at >= v_now - interval '7 days'
     ),
-    valid AS (
-        SELECT g, MIN(ord) AS ord
+    guarded AS (
+        SELECT g, ord
           FROM src,
                LATERAL unnest(src.arr) WITH ORDINALITY AS e(g, ord)
-         WHERE g ~ '^[0-9]{17,20}$'
-         GROUP BY g
-         ORDER BY MIN(ord)
+         WHERE g IS NOT NULL
+           AND g ~ '^[0-9]{17,20}$'
+         ORDER BY ord
          LIMIT 50
     )
     SELECT COALESCE(to_jsonb(array_agg(g ORDER BY ord)), '[]'::jsonb)
       INTO v_owned_guilds
-      FROM valid;
+      FROM guarded;
 
-    -- Soft size cap on the final JWT claim. Should be unreachable in
-    -- practice given the 50-element LIMIT (50 × 22 + 49 × 2 + 2 = 1200
-    -- canonical bytes); 1600 leaves ~400 chars headroom.
     IF length(v_owned_guilds::text) > 1600 THEN
         v_owned_guilds := '[]'::jsonb;
     END IF;
@@ -260,7 +334,7 @@ GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
 COMMENT ON FUNCTION public.custom_access_token_hook(jsonb) IS
-    'GoTrue access-token hook v2: embeds profile.username as kbve_username and profile.discord_bootstrap_cache.owned_guilds (text[] storage, cap 50, deterministic order, dedup, 7-day freshness + 30-second future-timestamp guard, soft 1600-char size cap) as owned_guilds JWT claim. No external calls — reads pre-cached state populated by the discord-bootstrap edge fn.';
+    'GoTrue access-token hook v2: embeds profile.username as kbve_username and profile.discord_bootstrap_cache.owned_guilds (canonical text[] storage, slice 50 + defensive NULL/regex filter, 7-day freshness + 30-second future-timestamp guard, soft 1600-char size cap) as owned_guilds JWT claim. No external calls.';
 
 -- ------------------------------------------------------------
 -- Privilege + plumbing assertions
@@ -269,6 +343,7 @@ DO $$
 BEGIN
     PERFORM 'public.custom_access_token_hook(jsonb)'::regprocedure;
     PERFORM 'profile.discord_owned_guilds_are_valid(text[])'::regprocedure;
+    PERFORM 'profile.service_upsert_discord_bootstrap_cache(uuid,text,text[],timestamptz)'::regprocedure;
 
     IF NOT has_schema_privilege('supabase_auth_admin', 'public', 'USAGE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema public.';
@@ -282,32 +357,34 @@ BEGIN
     IF NOT has_function_privilege('service_role', 'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE') THEN
         RAISE EXCEPTION 'service_role must hold EXECUTE on profile.discord_owned_guilds_are_valid(text[]).';
     END IF;
-    IF NOT has_function_privilege('supabase_auth_admin', 'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE') THEN
-        RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on profile.discord_owned_guilds_are_valid(text[]).';
+    IF NOT has_function_privilege('service_role', 'profile.service_upsert_discord_bootstrap_cache(uuid,text,text[],timestamptz)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must hold EXECUTE on profile.service_upsert_discord_bootstrap_cache for bootstrap writes.';
+    END IF;
+    IF has_function_privilege('anon', 'profile.service_upsert_discord_bootstrap_cache(uuid,text,text[],timestamptz)', 'EXECUTE')
+       OR has_function_privilege('authenticated', 'profile.service_upsert_discord_bootstrap_cache(uuid,text,text[],timestamptz)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_upsert RPC must not be executable by anon/authenticated.';
     END IF;
     IF has_function_privilege('anon',          'public.custom_access_token_hook(jsonb)', 'EXECUTE')
        OR has_function_privilege('authenticated','public.custom_access_token_hook(jsonb)', 'EXECUTE')
        OR has_function_privilege('public',     'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
         RAISE EXCEPTION 'public.custom_access_token_hook(jsonb) must not be executable by anon/authenticated/public.';
     END IF;
-    IF has_function_privilege('anon',          'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE')
-       OR has_function_privilege('authenticated','profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE') THEN
-        RAISE EXCEPTION 'validator must not be executable by anon/authenticated.';
-    END IF;
-    IF NOT has_table_privilege('supabase_auth_admin', 'profile.username', 'SELECT') THEN
-        RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.username.';
-    END IF;
     IF NOT has_table_privilege('supabase_auth_admin', 'profile.discord_bootstrap_cache', 'SELECT') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.discord_bootstrap_cache.';
     END IF;
     IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'SELECT') THEN
-        RAISE EXCEPTION 'service_role must hold SELECT on profile.discord_bootstrap_cache for upsert ON CONFLICT visibility.';
+        RAISE EXCEPTION 'service_role must hold SELECT on profile.discord_bootstrap_cache (dashboard peek + ON CONFLICT visibility).';
     END IF;
-    IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'INSERT') THEN
-        RAISE EXCEPTION 'service_role must hold INSERT on profile.discord_bootstrap_cache for the bootstrap edge fn.';
+    -- Round 5 #2 negative assertions: direct write privileges
+    -- intentionally NOT granted. Writes go through the RPC.
+    IF has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'INSERT') THEN
+        RAISE EXCEPTION 'service_role must NOT have direct INSERT on profile.discord_bootstrap_cache; use service_upsert RPC.';
     END IF;
-    IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'UPDATE') THEN
-        RAISE EXCEPTION 'service_role must hold UPDATE on profile.discord_bootstrap_cache for upsert DO UPDATE.';
+    IF has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'UPDATE') THEN
+        RAISE EXCEPTION 'service_role must NOT have direct UPDATE on profile.discord_bootstrap_cache; use service_upsert RPC.';
+    END IF;
+    IF has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'DELETE') THEN
+        RAISE EXCEPTION 'service_role must NOT have direct DELETE on profile.discord_bootstrap_cache.';
     END IF;
     IF has_table_privilege('anon', 'profile.discord_bootstrap_cache', 'SELECT')
        OR has_table_privilege('authenticated', 'profile.discord_bootstrap_cache', 'SELECT') THEN
@@ -386,33 +463,31 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- ------------------------------------------------------------
--- Validator smoke (text[] variant)
+-- Validator smoke (with explicit NULL-element regression guard)
 -- ------------------------------------------------------------
 DO $$
 BEGIN
-    -- STRICT: SQL NULL input returns NULL.
     IF profile.discord_owned_guilds_are_valid(NULL) IS NOT NULL THEN
         RAISE EXCEPTION 'validator: STRICT must return NULL for NULL input';
     END IF;
-    -- Empty array is valid (array_length on empty returns NULL).
     IF NOT profile.discord_owned_guilds_are_valid(ARRAY[]::text[]) THEN
         RAISE EXCEPTION 'validator: rejected empty array';
     END IF;
-    -- Valid 2-snowflake array.
     IF NOT profile.discord_owned_guilds_are_valid(ARRAY['111111111111111111','222222222222222222']) THEN
         RAISE EXCEPTION 'validator: rejected valid 2-snowflake array';
     END IF;
-    -- Malformed element.
     IF profile.discord_owned_guilds_are_valid(ARRAY['111111111111111111','garbage']) THEN
         RAISE EXCEPTION 'validator: accepted malformed element';
     END IF;
-    -- Too-short snowflake.
     IF profile.discord_owned_guilds_are_valid(ARRAY['123']) THEN
         RAISE EXCEPTION 'validator: accepted too-short snowflake';
     END IF;
-    -- Too-long snowflake (21 digits).
     IF profile.discord_owned_guilds_are_valid(ARRAY['123456789012345678901']) THEN
         RAISE EXCEPTION 'validator: accepted too-long snowflake';
+    END IF;
+    -- Round 5 #5 regression guard.
+    IF profile.discord_owned_guilds_are_valid(ARRAY['111111111111111111', NULL]::text[]) THEN
+        RAISE EXCEPTION 'validator: accepted NULL element (round 5 #5 regression)';
     END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -432,10 +507,6 @@ BEGIN;
 --   - Explicitly strips owned_guilds from inbound claims so a
 --     rollback during a sign-in flow can't leak v2 state into a v1
 --     JWT
---
--- v1's owned_guilds production logic itself is removed (this is the
--- whole point of the down migration); only the security posture is
--- carried forward.
 --
 -- Function is REPLACE'd, not DROPPED — GoTrue is configured to call
 -- it and a missing function would break all sign-in.
@@ -494,8 +565,10 @@ REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
 GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
--- DROP TABLE cascades policies. Validator goes last. text[] overload
--- is dropped explicitly since v1 didn't define any version.
+-- Round 5 #13: explicit drops for new objects this migration added.
+-- Order: RPC first (no deps), then table (cascades policies), then
+-- validator overload.
+DROP FUNCTION  IF EXISTS profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz);
 DROP TABLE     IF EXISTS profile.discord_bootstrap_cache;
 DROP FUNCTION  IF EXISTS profile.discord_owned_guilds_are_valid(text[]);
 

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -11,38 +11,49 @@ BEGIN;
 -- profile.discord_bootstrap_cache + custom_access_token_hook v2
 --
 -- v1 of the hook (20260510210000) embedded a single claim: kbve_username.
--- v2 adds a second claim: owned_guilds — an array of Discord guild
--- snowflakes the user owns. The dashboard reads it from the JWT and
--- skips the live Discord /users/@me/guilds call that currently blanks
--- the agents page with "Discord session expired" whenever the cached
--- provider_token ages out.
+-- v2 adds a second claim: owned_guilds — Discord guild snowflakes the
+-- user owns. The dashboard reads it from the JWT and skips the live
+-- Discord /users/@me/guilds call that currently blanks the agents page
+-- with "Discord session expired" whenever the cached provider_token
+-- ages out.
 --
--- Storage uses text[] (round 4) so the JWT-mint hot path avoids jsonb
--- traversal. The write path goes through a single service RPC
--- (profile.service_upsert_discord_bootstrap_cache) — service_role does
--- NOT have direct INSERT/UPDATE/DELETE on the cache table. The RPC
--- centralises:
---   - input validation (snowflake regex, NULL-element filter)
---   - canonicalisation (dedup + first-seen ordering + cap 100)
---   - account relinking (DELETE old row if discord_provider_id moves
---     between user_ids)
---   - future-timestamp rejection
---   - updated_at maintenance
+-- Architecture (after 6 review rounds on PR #11488)
+--   1. profile.discord_bootstrap_cache — text[] storage, capped at 50
+--      (matches the JWT mint cap; anything more is dead weight)
+--   2. profile.discord_owned_guilds_are_valid(text[]) — IMMUTABLE
+--      shape validator (rejects NULLs, non-snowflakes, oversized)
+--   3. profile.service_upsert_discord_bootstrap_cache(...) — the
+--      ONLY sanctioned write path. Service_role has no direct
+--      INSERT/UPDATE/DELETE on the cache. The RPC centralises:
+--        - Input validation with clean error messages
+--        - Canonicalisation (dedup + first-seen + NULL/regex filter
+--          + cap 50)
+--        - Future-timestamp rejection >30s
+--        - Account relinking (DELETE old row with same provider_id)
+--        - Advisory locking on (user_id, provider_id) to serialise
+--          concurrent OAuth refreshes
+--        - updated_at maintenance
+--      Owner pinned to postgres explicitly so SECURITY DEFINER
+--      behaviour is stable across local/CI/prod environments.
+--   4. profile.get_discord_owned_guilds_claim(uuid, timestamptz) —
+--      SQL helper that fetches the claim. STABLE + COST 20 so the
+--      planner can inline + cost-estimate around the call. Hook
+--      delegates here instead of carrying a CTE.
+--   5. public.custom_access_token_hook(jsonb) — slim PL/pgSQL hook,
+--      defers guild lookup to the helper, applies the JWT claim.
 --
--- The hook itself does NO external calls and never blocks. It reads
--- one row by PK, slices to 50, applies a defensive NULL+regex filter
--- (belt+suspender even though storage is canonical), wraps in jsonb,
--- and embeds as a JWT claim.
+-- The hook does NO external calls and never blocks. The helper does
+-- one PK lookup, freshness check, defensive NULL+regex filter,
+-- jsonb_agg. No external work.
 -- ============================================================
 
 -- ------------------------------------------------------------
--- Validator function (text[] variant — fixes round-5 #5 NULL bypass)
+-- Validator (text[] variant; round 5 #5 NULL bypass fix preserved)
 -- ------------------------------------------------------------
--- Round 5 #4: single COALESCE(array_length, 0) instead of two
--- array_length calls.
--- Round 5 #5: explicit NULL-element check. Without `g IS NULL OR`,
--- `g !~ '...'` returns NULL for NULL inputs and NOT EXISTS never
--- sees the bad row → ARRAY['valid', NULL] would pass validation.
+-- Round 6 #6: validator EXECUTE revoked from service_role +
+-- supabase_auth_admin. CHECK constraints run as table owner
+-- regardless of caller, so direct EXECUTE rights aren't needed.
+-- Round 6 #14: cardinality() instead of COALESCE(array_length).
 CREATE OR REPLACE FUNCTION profile.discord_owned_guilds_are_valid(p_guilds text[])
 RETURNS boolean
 LANGUAGE sql
@@ -51,7 +62,7 @@ STRICT
 SET search_path = ''
 AS $$
     SELECT CASE
-        WHEN COALESCE(array_length(p_guilds, 1), 0) > 100 THEN false
+        WHEN cardinality(p_guilds) > 50 THEN false
         ELSE NOT EXISTS (
             SELECT 1
             FROM unnest(p_guilds) AS g
@@ -61,18 +72,16 @@ AS $$
 $$;
 
 COMMENT ON FUNCTION profile.discord_owned_guilds_are_valid(text[]) IS
-    'IMMUTABLE shape validator for profile.discord_bootstrap_cache.owned_guilds. Rejects NULL elements, non-snowflake strings (regex ^[0-9]{17,20}$), and arrays larger than 100 elements. Empty arrays are valid.';
+    'IMMUTABLE shape validator for profile.discord_bootstrap_cache.owned_guilds. Rejects NULL elements, non-snowflake strings, and arrays > 50. Empty arrays valid. Called from a table CHECK; no direct EXECUTE grants needed.';
 
 REVOKE EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(text[])
-    FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(text[])
-    TO service_role, supabase_auth_admin;
+    FROM PUBLIC, anon, authenticated, service_role, supabase_auth_admin;
 
 -- ------------------------------------------------------------
 -- Cache table
 -- ------------------------------------------------------------
--- Round 5 #9: updated_at >= created_at ordering invariant folded
--- into the timestamps_floor CHECK (now timestamps_ordering_and_floor).
+-- Round 6 #14: cardinality() in CHECK.
+-- Round 6 #15: cap 100 -> 50. JWT-bound, more is dead weight.
 CREATE TABLE profile.discord_bootstrap_cache (
     user_id              uuid PRIMARY KEY,
     discord_provider_id  text NOT NULL
@@ -89,10 +98,7 @@ CREATE TABLE profile.discord_bootstrap_cache (
     CONSTRAINT discord_bootstrap_cache_discord_provider_id_unique
         UNIQUE (discord_provider_id),
     CONSTRAINT discord_bootstrap_cache_owned_guilds_size_cap
-        CHECK (
-            array_length(owned_guilds, 1) IS NULL
-            OR array_length(owned_guilds, 1) <= 100
-        ),
+        CHECK (cardinality(owned_guilds) <= 50),
     CONSTRAINT discord_bootstrap_cache_owned_guilds_valid
         CHECK (profile.discord_owned_guilds_are_valid(owned_guilds)),
     CONSTRAINT discord_bootstrap_cache_timestamps_ordering_and_floor
@@ -112,25 +118,24 @@ REVOKE ALL ON TABLE profile.discord_bootstrap_cache
 
 GRANT USAGE  ON SCHEMA profile                         TO supabase_auth_admin;
 GRANT SELECT ON TABLE  profile.discord_bootstrap_cache TO supabase_auth_admin;
--- Round 5 #2: service_role keeps SELECT (dashboard freshness peeks +
--- ON CONFLICT visibility for the RPC's INSERT), but loses
--- INSERT/UPDATE/DELETE. All writes go through the RPC.
+-- service_role keeps SELECT (dashboard freshness peeks + ON CONFLICT
+-- visibility for the RPC's internal INSERT, even though that runs
+-- under SECURITY DEFINER as the RPC owner).
 GRANT SELECT ON TABLE profile.discord_bootstrap_cache TO service_role;
 
 ALTER TABLE profile.discord_bootstrap_cache ENABLE ROW LEVEL SECURITY;
 
--- Round 5 #3: WITH CHECK simplified to true. The RPC validates
--- inputs explicitly and the table CHECK constraints remain
--- authoritative — RLS WITH CHECK was paying duplicate validation
--- cost for a code path service_role no longer takes directly.
+-- Round 6 #7: policy is SELECT-only (was FOR ALL). Matches actual
+-- grants and prevents future privilege drift where someone re-adds
+-- UPDATE and a stale FOR ALL policy silently permits it.
 DROP POLICY IF EXISTS "service_role_full_access" ON profile.discord_bootstrap_cache;
-CREATE POLICY "service_role_full_access"
+DROP POLICY IF EXISTS "service_role_select"      ON profile.discord_bootstrap_cache;
+CREATE POLICY "service_role_select"
     ON profile.discord_bootstrap_cache
     AS PERMISSIVE
-    FOR ALL
+    FOR SELECT
     TO service_role
-    USING (true)
-    WITH CHECK (true);
+    USING (true);
 
 DROP POLICY IF EXISTS "supabase_auth_admin_select" ON profile.discord_bootstrap_cache;
 CREATE POLICY "supabase_auth_admin_select"
@@ -141,20 +146,29 @@ CREATE POLICY "supabase_auth_admin_select"
     USING (true);
 
 -- ------------------------------------------------------------
--- Service-role RPC: the only write path for the cache
+-- Service-role write RPC (the only sanctioned write surface)
 -- ------------------------------------------------------------
--- Centralised write surface that handles validation, dedup +
--- canonical ordering, account relinking, future-timestamp guard, and
--- updated_at maintenance. SECURITY DEFINER + owned by the migrating
--- role (effectively superuser) so it can bypass the absent direct
--- INSERT grant for service_role.
+-- Round 6 #4 + #5: advisory locks on (user_id, provider_id) in
+-- fixed order to serialise concurrent OAuth refreshes for the same
+-- account and avoid races between DELETE (relinking) and INSERT
+-- (upsert). Lock order is invariant (user_id first, then
+-- provider_id) so any caller doing both takes them in the same
+-- sequence -> no deadlocks.
 --
--- Folds in round-5 #1, #2, #7, #10, #12.
+-- Round 6 #9: owner pinned to postgres explicitly so SECURITY
+-- DEFINER behaviour is stable across env/migrating-role variance.
+--
+-- Round 6 #10: error messages trimmed of function-name prefixes —
+-- expected validation failures, not internal-state leaks.
+--
+-- Round 6 #11: explicit NULL handling for p_refreshed_at so a
+-- caller passing NULL doesn't bypass the future/floor checks and
+-- hit the table NOT NULL violation downstream.
 CREATE OR REPLACE FUNCTION profile.service_upsert_discord_bootstrap_cache(
     p_user_id              uuid,
     p_discord_provider_id  text,
     p_owned_guilds         text[]      DEFAULT ARRAY[]::text[],
-    p_refreshed_at         timestamptz DEFAULT statement_timestamp()
+    p_refreshed_at         timestamptz DEFAULT NULL
 )
 RETURNS void
 LANGUAGE plpgsql
@@ -165,32 +179,33 @@ DECLARE
     v_canonical text[];
     v_now       timestamptz := statement_timestamp();
 BEGIN
-    -- Belt 1: input shape validation. Cleaner errors than letting the
-    -- table constraints fail later.
     IF p_user_id IS NULL THEN
-        RAISE EXCEPTION 'service_upsert_discord_bootstrap_cache: user_id required';
+        RAISE EXCEPTION 'user_id required';
     END IF;
     IF p_discord_provider_id IS NULL OR p_discord_provider_id !~ '^[0-9]{15,25}$' THEN
-        RAISE EXCEPTION 'service_upsert_discord_bootstrap_cache: invalid discord_provider_id';
+        RAISE EXCEPTION 'invalid discord_provider_id';
     END IF;
 
-    -- Round 5 #10: reject future-dated writes >30s before they hit
-    -- storage. Table CHECK can't express now()+30s (not IMMUTABLE),
-    -- so it has to be enforced here.
+    IF p_refreshed_at IS NULL THEN
+        p_refreshed_at := v_now;
+    END IF;
     IF p_refreshed_at > v_now + interval '30 seconds' THEN
-        RAISE EXCEPTION
-            'service_upsert_discord_bootstrap_cache: p_refreshed_at too far in future (got %, max %)',
+        RAISE EXCEPTION 'refreshed_at too far in future (got %, max %)',
             p_refreshed_at, v_now + interval '30 seconds';
     END IF;
     IF p_refreshed_at < '2025-01-01'::timestamptz THEN
-        RAISE EXCEPTION
-            'service_upsert_discord_bootstrap_cache: p_refreshed_at below floor (got %, min 2025-01-01)',
+        RAISE EXCEPTION 'refreshed_at below floor (got %, min 2025-01-01)',
             p_refreshed_at;
     END IF;
 
-    -- Round 5 #7: canonicalise. NULL + non-snowflake elements are
-    -- filtered; duplicates collapsed by first-seen order; capped at
-    -- 100 to match the table CHECK.
+    -- Round 6 #4 + #5: serialise concurrent writes for this account.
+    -- Always lock user first, then provider, for consistent ordering.
+    PERFORM pg_advisory_xact_lock(hashtextextended(p_user_id::text, 1));
+    PERFORM pg_advisory_xact_lock(hashtextextended(p_discord_provider_id, 2));
+
+    -- Canonicalise: NULL + non-snowflake elements filtered; duplicates
+    -- collapsed by first-seen order; capped at 50 (matches table CHECK
+    -- and JWT mint cap).
     SELECT COALESCE(array_agg(g ORDER BY ord), ARRAY[]::text[])
       INTO v_canonical
       FROM (
@@ -201,15 +216,13 @@ BEGIN
              AND g ~ '^[0-9]{17,20}$'
            GROUP BY g
            ORDER BY MIN(ord)
-           LIMIT 100
+           LIMIT 50
       ) AS s;
 
-    -- Round 5 #12: account relinking. If the same Discord provider
-    -- id is cached under a different user_id (rare, but possible
-    -- when a user re-OAuths under a fresh Supabase identity), drop
-    -- the stale row first so the upsert below succeeds against the
-    -- discord_provider_id UNIQUE constraint instead of raising a
-    -- raw unique_violation to the caller.
+    -- Account relinking: drop stale row carrying same provider_id
+    -- under a different user_id so the upsert below can succeed
+    -- against the discord_provider_id UNIQUE constraint without
+    -- raising a raw unique_violation.
     DELETE FROM profile.discord_bootstrap_cache
      WHERE discord_provider_id = p_discord_provider_id
        AND user_id <> p_user_id;
@@ -226,8 +239,11 @@ BEGIN
 END;
 $$;
 
+ALTER FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz)
+    OWNER TO postgres;
+
 COMMENT ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz) IS
-    'Service-role upsert for profile.discord_bootstrap_cache. Validates inputs, canonicalises owned_guilds (dedup + first-seen order + cap 100), enforces future-timestamp guard, handles account relinking, maintains updated_at. The only sanctioned write path — service_role has no direct INSERT/UPDATE/DELETE on the table.';
+    'Service-role upsert for profile.discord_bootstrap_cache. Validates inputs, canonicalises owned_guilds (dedup + first-seen + cap 50), enforces future-timestamp guard + 2025 floor, handles account relinking, advisory-locks on (user_id, provider_id) in fixed order, maintains updated_at. Owner pinned to postgres for stable SECURITY DEFINER behaviour. Only sanctioned write path — service_role has no direct INSERT/UPDATE/DELETE on the cache.';
 
 REVOKE EXECUTE ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz)
     FROM PUBLIC, anon, authenticated;
@@ -235,13 +251,56 @@ GRANT EXECUTE ON FUNCTION profile.service_upsert_discord_bootstrap_cache(uuid, t
     TO service_role;
 
 -- ------------------------------------------------------------
--- Hook v2 (slimmed — round 5 #6, #8)
+-- SQL helper: guild claim lookup (round 6 #1, #18)
 -- ------------------------------------------------------------
--- Slices to 50 (storage is canonical via the RPC, so no GROUP BY
--- needed) but keeps a defensive NULL + snowflake regex filter as
--- belt+suspender. JWT mint is a security boundary — even if the
--- RPC develops a bug or a superuser does manual DML, the hook
--- still emits only well-formed snowflakes.
+-- Extracted out of the hook so Postgres can inline + cost-estimate
+-- the call. STABLE + COST 20. INVOKER (default) — when called from
+-- the hook (SECURITY DEFINER owned by supabase_auth_admin), the
+-- helper runs as supabase_auth_admin, which has SELECT on the cache.
+--
+-- Storage is canonical via the RPC, so dedup + GROUP BY aren't
+-- needed here. The defensive NULL + regex filter stays because
+-- JWT mint is a security boundary — even if the RPC develops a bug
+-- or a superuser does manual DML, the hook still emits only
+-- well-formed snowflakes.
+CREATE OR REPLACE FUNCTION profile.get_discord_owned_guilds_claim(
+    p_user_id uuid,
+    p_now     timestamptz DEFAULT statement_timestamp()
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = ''
+COST 20
+AS $$
+    SELECT COALESCE(to_jsonb(array_agg(g ORDER BY ord)), '[]'::jsonb)
+      FROM (
+          SELECT g, ord
+            FROM profile.discord_bootstrap_cache AS c,
+                 LATERAL unnest(c.owned_guilds) WITH ORDINALITY AS e(g, ord)
+           WHERE c.user_id      = p_user_id
+             AND c.refreshed_at <= p_now + interval '30 seconds'
+             AND c.refreshed_at >= p_now - interval '7 days'
+             AND g IS NOT NULL
+             AND g ~ '^[0-9]{17,20}$'
+           ORDER BY ord
+           LIMIT 50
+      ) AS s;
+$$;
+
+COMMENT ON FUNCTION profile.get_discord_owned_guilds_claim(uuid, timestamptz) IS
+    'Returns the owned_guilds JWT claim for a user as a jsonb array (max 50 snowflakes, first-seen order, NULL + non-snowflake elements filtered). Reads profile.discord_bootstrap_cache; applies 7-day freshness window + 30-second future-timestamp guard. STABLE + COST 20 so the planner can inline / cost-estimate when called from custom_access_token_hook.';
+
+REVOKE EXECUTE ON FUNCTION profile.get_discord_owned_guilds_claim(uuid, timestamptz)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION profile.get_discord_owned_guilds_claim(uuid, timestamptz)
+    TO supabase_auth_admin;
+
+-- ------------------------------------------------------------
+-- Hook v2 (slimmed — round 6 #1 delegates guild lookup to helper)
+-- ------------------------------------------------------------
+-- Round 6 #3 + #15: storage cap 50 makes the runtime length check
+-- unreachable; dropped from hook.
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -295,30 +354,7 @@ BEGIN
         v_claims := v_claims - 'kbve_username';
     END IF;
 
-    WITH src AS (
-        SELECT c.owned_guilds AS arr
-          FROM profile.discord_bootstrap_cache AS c
-         WHERE c.user_id      = v_user_id
-           AND c.refreshed_at <= v_now + interval '30 seconds'
-           AND c.refreshed_at >= v_now - interval '7 days'
-    ),
-    guarded AS (
-        SELECT g, ord
-          FROM src,
-               LATERAL unnest(src.arr) WITH ORDINALITY AS e(g, ord)
-         WHERE g IS NOT NULL
-           AND g ~ '^[0-9]{17,20}$'
-         ORDER BY ord
-         LIMIT 50
-    )
-    SELECT COALESCE(to_jsonb(array_agg(g ORDER BY ord)), '[]'::jsonb)
-      INTO v_owned_guilds
-      FROM guarded;
-
-    IF length(v_owned_guilds::text) > 1600 THEN
-        v_owned_guilds := '[]'::jsonb;
-    END IF;
-
+    v_owned_guilds := profile.get_discord_owned_guilds_claim(v_user_id, v_now);
     v_claims := jsonb_set(v_claims, '{owned_guilds}', v_owned_guilds, true);
 
     RETURN jsonb_set(event, '{claims}', v_claims, true);
@@ -334,7 +370,7 @@ GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
 COMMENT ON FUNCTION public.custom_access_token_hook(jsonb) IS
-    'GoTrue access-token hook v2: embeds profile.username as kbve_username and profile.discord_bootstrap_cache.owned_guilds (canonical text[] storage, slice 50 + defensive NULL/regex filter, 7-day freshness + 30-second future-timestamp guard, soft 1600-char size cap) as owned_guilds JWT claim. No external calls.';
+    'GoTrue access-token hook v2: embeds profile.username as kbve_username and delegates owned_guilds lookup to profile.get_discord_owned_guilds_claim. No external calls. Slim PL/pgSQL orchestration; guild work happens in the SQL helper for planner inlining.';
 
 -- ------------------------------------------------------------
 -- Privilege + plumbing assertions
@@ -344,6 +380,7 @@ BEGIN
     PERFORM 'public.custom_access_token_hook(jsonb)'::regprocedure;
     PERFORM 'profile.discord_owned_guilds_are_valid(text[])'::regprocedure;
     PERFORM 'profile.service_upsert_discord_bootstrap_cache(uuid,text,text[],timestamptz)'::regprocedure;
+    PERFORM 'profile.get_discord_owned_guilds_claim(uuid,timestamptz)'::regprocedure;
 
     IF NOT has_schema_privilege('supabase_auth_admin', 'public', 'USAGE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema public.';
@@ -354,8 +391,8 @@ BEGIN
     IF NOT has_function_privilege('supabase_auth_admin', 'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on public.custom_access_token_hook(jsonb).';
     END IF;
-    IF NOT has_function_privilege('service_role', 'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE') THEN
-        RAISE EXCEPTION 'service_role must hold EXECUTE on profile.discord_owned_guilds_are_valid(text[]).';
+    IF NOT has_function_privilege('supabase_auth_admin', 'profile.get_discord_owned_guilds_claim(uuid,timestamptz)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on profile.get_discord_owned_guilds_claim for the hook to delegate.';
     END IF;
     IF NOT has_function_privilege('service_role', 'profile.service_upsert_discord_bootstrap_cache(uuid,text,text[],timestamptz)', 'EXECUTE') THEN
         RAISE EXCEPTION 'service_role must hold EXECUTE on profile.service_upsert_discord_bootstrap_cache for bootstrap writes.';
@@ -369,14 +406,20 @@ BEGIN
        OR has_function_privilege('public',     'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
         RAISE EXCEPTION 'public.custom_access_token_hook(jsonb) must not be executable by anon/authenticated/public.';
     END IF;
+    -- Round 6 #6: validator EXECUTE intentionally revoked from
+    -- everyone. CHECK constraint runs the function as table owner.
+    IF has_function_privilege('service_role',       'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE')
+       OR has_function_privilege('supabase_auth_admin', 'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE')
+       OR has_function_privilege('anon',            'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE')
+       OR has_function_privilege('authenticated',   'profile.discord_owned_guilds_are_valid(text[])', 'EXECUTE') THEN
+        RAISE EXCEPTION 'validator EXECUTE must be revoked from all roles; CHECK constraint runs it under table owner.';
+    END IF;
     IF NOT has_table_privilege('supabase_auth_admin', 'profile.discord_bootstrap_cache', 'SELECT') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.discord_bootstrap_cache.';
     END IF;
     IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'SELECT') THEN
         RAISE EXCEPTION 'service_role must hold SELECT on profile.discord_bootstrap_cache (dashboard peek + ON CONFLICT visibility).';
     END IF;
-    -- Round 5 #2 negative assertions: direct write privileges
-    -- intentionally NOT granted. Writes go through the RPC.
     IF has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'INSERT') THEN
         RAISE EXCEPTION 'service_role must NOT have direct INSERT on profile.discord_bootstrap_cache; use service_upsert RPC.';
     END IF;
@@ -390,18 +433,27 @@ BEGIN
        OR has_table_privilege('authenticated', 'profile.discord_bootstrap_cache', 'SELECT') THEN
         RAISE EXCEPTION 'anon/authenticated must NOT have SELECT on profile.discord_bootstrap_cache.';
     END IF;
+    -- Round 6 #9: RPC owner must be postgres for stable
+    -- SECURITY DEFINER behaviour.
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_roles r ON r.oid = p.proowner
+        WHERE p.oid = 'profile.service_upsert_discord_bootstrap_cache(uuid,text,text[],timestamptz)'::regprocedure
+          AND r.rolname = 'postgres'
+    ) THEN
+        RAISE EXCEPTION 'profile.service_upsert_discord_bootstrap_cache must be owned by postgres.';
+    END IF;
 END;
 $$ LANGUAGE plpgsql;
 
 -- ------------------------------------------------------------
--- Behavioural smoke checks (SQL-only — no writes to auth.users)
+-- Hook behavioural smoke checks (SQL-only — no writes to auth.users)
 -- ------------------------------------------------------------
 DO $$
 DECLARE
     v_out  jsonb;
 BEGIN
-    -- 1: empty event / no user_id -> claims preserved, privileged
-    -- claims absent.
     v_out := public.custom_access_token_hook(
         jsonb_build_object('claims', jsonb_build_object('role','authenticated'))
     );
@@ -412,8 +464,6 @@ BEGIN
         RAISE EXCEPTION 'smoke 1: invalid user_id must NOT emit owned_guilds, got %', v_out->'claims';
     END IF;
 
-    -- 2: malformed user_id with attacker-supplied owned_guilds claim
-    -- -> claim stripped.
     v_out := public.custom_access_token_hook(
         jsonb_build_object(
             'user_id', 'not-a-uuid',
@@ -427,8 +477,6 @@ BEGIN
         RAISE EXCEPTION 'smoke 2: malformed user_id must strip attacker-supplied owned_guilds, got %', v_out->'claims';
     END IF;
 
-    -- 3: non-object claims -> rebuilt as object, hook still emits
-    -- owned_guilds [].
     v_out := public.custom_access_token_hook(
         jsonb_build_object(
             'user_id', '00000000-0000-0000-0000-000000000000',
@@ -444,7 +492,6 @@ BEGIN
             v_out->'claims'->'owned_guilds';
     END IF;
 
-    -- 4: valid user_id, no cache row -> owned_guilds [].
     v_out := public.custom_access_token_hook(
         jsonb_build_object(
             'user_id', '00000000-0000-0000-0000-000000000000',
@@ -463,7 +510,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- ------------------------------------------------------------
--- Validator smoke (with explicit NULL-element regression guard)
+-- Validator smoke (NULL-element regression guard preserved)
 -- ------------------------------------------------------------
 DO $$
 BEGIN
@@ -485,9 +532,17 @@ BEGIN
     IF profile.discord_owned_guilds_are_valid(ARRAY['123456789012345678901']) THEN
         RAISE EXCEPTION 'validator: accepted too-long snowflake';
     END IF;
-    -- Round 5 #5 regression guard.
     IF profile.discord_owned_guilds_are_valid(ARRAY['111111111111111111', NULL]::text[]) THEN
         RAISE EXCEPTION 'validator: accepted NULL element (round 5 #5 regression)';
+    END IF;
+    -- Round 6 #15: 51-element array exceeds new cap.
+    IF profile.discord_owned_guilds_are_valid(
+        ARRAY(
+            SELECT LPAD(i::text, 18, '1')
+            FROM generate_series(1, 51) AS gs(i)
+        )::text[]
+    ) THEN
+        RAISE EXCEPTION 'validator: accepted 51-element array (cap is 50)';
     END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -496,20 +551,15 @@ COMMIT;
 
 -- migrate:down transaction:false
 
--- transaction:false: matches the up section.
-
 BEGIN;
 
--- Restore the v1 hook body. Preserves the hardening from v2:
+-- Restore the v1 hook body. Preserves hardening from v2:
 --   - Object typecheck of event->'claims' before jsonb_set
 --   - Invalid / missing user_id strips kbve_username from inbound
 --     claims before returning
 --   - Explicitly strips owned_guilds from inbound claims so a
 --     rollback during a sign-in flow can't leak v2 state into a v1
 --     JWT
---
--- Function is REPLACE'd, not DROPPED — GoTrue is configured to call
--- it and a missing function would break all sign-in.
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -565,9 +615,9 @@ REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
 GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
--- Round 5 #13: explicit drops for new objects this migration added.
--- Order: RPC first (no deps), then table (cascades policies), then
--- validator overload.
+-- Drop in dependency order: helper (called by nothing in down), RPC
+-- (writes to table), table (cascades policies), validator.
+DROP FUNCTION  IF EXISTS profile.get_discord_owned_guilds_claim(uuid, timestamptz);
 DROP FUNCTION  IF EXISTS profile.service_upsert_discord_bootstrap_cache(uuid, text, text[], timestamptz);
 DROP TABLE     IF EXISTS profile.discord_bootstrap_cache;
 DROP FUNCTION  IF EXISTS profile.discord_owned_guilds_are_valid(text[]);

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -1,0 +1,320 @@
+-- migrate:up transaction:false
+
+-- transaction:false: this migration manages its own BEGIN/COMMIT below.
+-- The outer dbmate transaction collides with the inner COMMIT and surfaces
+-- as "pq: unexpected transaction status idle" otherwise. Matches the
+-- pattern in 20260510210000_profile_custom_access_token_hook.sql.
+
+BEGIN;
+
+-- ============================================================
+-- GoTrue Custom Access Token Hook: extend with owned_guilds
+--
+-- Builds on 20260510210000_profile_custom_access_token_hook.sql by adding
+-- a second claim `owned_guilds` populated from the user's Discord
+-- identity row in auth.identities.
+--
+-- Source of truth: auth.identities.identity_data->'owned_guilds' as a
+-- jsonb array of Discord guild snowflake strings (text). This column is
+-- populated by the edge function `discord-bootstrap` (P5.8b) using the
+-- user's provider_token. The hook itself does NO external calls — it
+-- just reads pre-cached state, so JWT mint stays synchronous and fast.
+--
+-- Soft-failure semantics: when no Discord identity exists, or the
+-- column is missing/malformed, the hook emits an empty array. Browsers
+-- treat empty as "not bootstrapped yet" and call the bootstrap edge fn
+-- once before flipping the dashboard to authenticated state.
+--
+-- Cap: array_length capped at 50 inside the hook to bound JWT size.
+-- Discord platform allows up to 100 owned guilds for phone-verified
+-- accounts; the 0.01% above 50 fall through to the live Discord API
+-- path on the edge fn side.
+-- ============================================================
+
+-- supabase_auth_admin already owns the auth schema, so explicit grants
+-- on auth.identities are redundant — but we assert them in the health
+-- block below so future grant revocations surface as a migration error
+-- rather than a silent claim drop.
+
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_user_id       uuid;
+    v_username      text;
+    v_owned_guilds  jsonb;
+    v_claims        jsonb;
+BEGIN
+    BEGIN
+        v_user_id := NULLIF(event->>'user_id', '')::uuid;
+    EXCEPTION
+        WHEN invalid_text_representation THEN
+            RETURN event;
+    END;
+
+    IF v_user_id IS NULL THEN
+        RETURN event;
+    END IF;
+
+    v_claims := COALESCE(event->'claims', '{}'::jsonb);
+
+    -- kbve_username (existing behaviour)
+    SELECT u.username
+      INTO v_username
+      FROM profile.username AS u
+     WHERE u.user_id = v_user_id;
+
+    IF v_username IS NOT NULL THEN
+        v_claims := jsonb_set(v_claims, '{kbve_username}', to_jsonb(v_username), true);
+    ELSE
+        v_claims := v_claims - 'kbve_username';
+    END IF;
+
+    -- owned_guilds from Discord identity (capped at 50 snowflakes).
+    -- The inner SELECT picks the latest discord identity row for this user
+    -- and pins it via LIMIT 1; the outer LATERAL then unnests its
+    -- owned_guilds array. Inlining the unnest into the same SELECT would
+    -- collapse "LIMIT 1 on identity rows" with "LIMIT 1 on array elements"
+    -- and silently drop all but the first guild.
+    SELECT COALESCE(
+             (
+                 SELECT jsonb_agg(g)
+                   FROM (
+                       SELECT g
+                         FROM (
+                             SELECT i.identity_data->'owned_guilds' AS arr
+                               FROM auth.identities AS i
+                              WHERE i.user_id  = v_user_id
+                                AND i.provider = 'discord'
+                                AND jsonb_typeof(i.identity_data->'owned_guilds') = 'array'
+                              ORDER BY i.updated_at DESC NULLS LAST, i.id DESC
+                              LIMIT 1
+                         ) AS latest,
+                         LATERAL jsonb_array_elements_text(latest.arr) AS g
+                        WHERE g ~ '^\d{17,20}$'
+                        LIMIT 50
+                   ) AS s
+             ),
+             '[]'::jsonb
+           )
+      INTO v_owned_guilds;
+
+    v_claims := jsonb_set(v_claims, '{owned_guilds}', v_owned_guilds, true);
+
+    RETURN jsonb_set(event, '{claims}', v_claims, true);
+END;
+$$;
+
+ALTER FUNCTION public.custom_access_token_hook(jsonb)
+    OWNER TO supabase_auth_admin;
+
+REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
+    FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
+    TO supabase_auth_admin;
+
+COMMENT ON FUNCTION public.custom_access_token_hook(jsonb) IS
+    'GoTrue access-token hook: embeds profile.username as kbve_username and the Discord identity owned_guilds array (cap 50) as owned_guilds. No external calls — reads pre-cached state populated by the discord-bootstrap edge fn.';
+
+DO $$
+BEGIN
+    PERFORM 'public.custom_access_token_hook(jsonb)'::regprocedure;
+
+    IF NOT has_schema_privilege('supabase_auth_admin', 'public', 'USAGE') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema public for the hook to resolve.';
+    END IF;
+
+    IF NOT has_schema_privilege('supabase_auth_admin', 'profile', 'USAGE') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema profile.';
+    END IF;
+
+    IF NOT has_schema_privilege('supabase_auth_admin', 'auth', 'USAGE') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema auth for the hook to read identities.';
+    END IF;
+
+    IF NOT has_function_privilege('supabase_auth_admin', 'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on public.custom_access_token_hook(jsonb).';
+    END IF;
+
+    IF has_function_privilege('anon',          'public.custom_access_token_hook(jsonb)', 'EXECUTE')
+       OR has_function_privilege('authenticated','public.custom_access_token_hook(jsonb)', 'EXECUTE')
+       OR has_function_privilege('public',     'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'public.custom_access_token_hook(jsonb) must not be executable by anon/authenticated/public.';
+    END IF;
+
+    IF NOT has_table_privilege('supabase_auth_admin', 'profile.username', 'SELECT') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.username for the hook to read usernames.';
+    END IF;
+
+    IF NOT has_table_privilege('supabase_auth_admin', 'auth.identities', 'SELECT') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on auth.identities for the hook to read owned_guilds.';
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ------------------------------------------------------------
+-- Behavioural smoke check
+-- ------------------------------------------------------------
+-- Verifies the hook returns an `owned_guilds` array (empty when no
+-- Discord identity is present) and preserves the rest of the event.
+-- Runs against a synthetic user_id with no rows in auth.identities or
+-- profile.username, so the expected output is the input event with an
+-- empty owned_guilds claim appended.
+
+-- Scenario 1: synthetic user with no Discord identity yields empty array.
+-- Scenario 2: synthetic user with Discord identity carrying 3 valid + 1
+-- malformed snowflake yields exactly the 3 valid ones (regression guard
+-- for the LIMIT-1-on-unnest bug — see comment above the SELECT).
+
+DO $$
+DECLARE
+    v_synthetic_user uuid := '00000000-0000-0000-0000-fffe00000001';
+    v_in             jsonb;
+    v_out            jsonb;
+    v_guilds         jsonb;
+BEGIN
+    -- Scenario 1
+    v_in := jsonb_build_object(
+        'user_id', '00000000-0000-0000-0000-000000000000',
+        'claims',  jsonb_build_object('role', 'authenticated')
+    );
+    v_out := public.custom_access_token_hook(v_in);
+
+    IF v_out->'claims'->'owned_guilds' IS NULL THEN
+        RAISE EXCEPTION 'hook smoke 1: owned_guilds claim missing from output: %', v_out;
+    END IF;
+    IF jsonb_typeof(v_out->'claims'->'owned_guilds') <> 'array' THEN
+        RAISE EXCEPTION 'hook smoke 1: owned_guilds must be a jsonb array, got %',
+            jsonb_typeof(v_out->'claims'->'owned_guilds');
+    END IF;
+    IF jsonb_array_length(v_out->'claims'->'owned_guilds') <> 0 THEN
+        RAISE EXCEPTION 'hook smoke 1: empty Discord identity must yield empty owned_guilds, got %',
+            v_out->'claims'->'owned_guilds';
+    END IF;
+    IF v_out->'claims'->>'role' <> 'authenticated' THEN
+        RAISE EXCEPTION 'hook smoke 1: existing claims must be preserved, role lost from %', v_out;
+    END IF;
+
+    -- Scenario 2 — run inside a PL/pgSQL EXCEPTION subtransaction so the
+    -- synthetic INSERT into auth.users (and any trigger-spawned rows like
+    -- the wallet/account auto-provision) are rolled back atomically. We
+    -- complete the assertions, then RAISE a sentinel exception to force
+    -- the subtransaction to roll back; the outer handler swallows that
+    -- specific sentinel and re-raises everything else.
+    BEGIN
+        INSERT INTO auth.users (id) VALUES (v_synthetic_user);
+        INSERT INTO auth.identities (user_id, provider, provider_id, identity_data)
+        VALUES (
+            v_synthetic_user,
+            'discord',
+            'smoke-' || v_synthetic_user::text,
+            jsonb_build_object(
+                'owned_guilds',
+                jsonb_build_array(
+                    '111111111111111111',
+                    '222222222222222222',
+                    '333333333333333333',
+                    'not-a-snowflake'
+                )
+            )
+        );
+
+        v_in := jsonb_build_object(
+            'user_id', v_synthetic_user,
+            'claims',  jsonb_build_object('role', 'authenticated')
+        );
+        v_out    := public.custom_access_token_hook(v_in);
+        v_guilds := v_out->'claims'->'owned_guilds';
+
+        IF jsonb_array_length(v_guilds) <> 3 THEN
+            RAISE EXCEPTION
+                'hook smoke 2: expected 3 valid snowflakes (LIMIT-1-on-unnest regression?), got % from %',
+                jsonb_array_length(v_guilds), v_guilds;
+        END IF;
+        IF NOT (v_guilds @> '["111111111111111111","222222222222222222","333333333333333333"]'::jsonb) THEN
+            RAISE EXCEPTION 'hook smoke 2: expected snowflakes missing from %', v_guilds;
+        END IF;
+        IF v_guilds @> '["not-a-snowflake"]'::jsonb THEN
+            RAISE EXCEPTION 'hook smoke 2: malformed snowflake leaked into %', v_guilds;
+        END IF;
+
+        -- Sentinel: forces subtransaction rollback so synthetic rows do
+        -- not leak past this migration. Caught immediately below.
+        RAISE EXCEPTION 'hook_smoke_sentinel_rollback';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLERRM <> 'hook_smoke_sentinel_rollback' THEN
+                RAISE;
+            END IF;
+    END;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;
+
+-- migrate:down transaction:false
+
+-- transaction:false: matches the up section.
+
+BEGIN;
+
+-- Restore the v1 hook body (kbve_username only). We deliberately do not
+-- DROP the function, since GoTrue is configured to call it and a missing
+-- function would break sign-in. We just revert to the pre-owned_guilds
+-- behaviour.
+
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_user_id  uuid;
+    v_username text;
+    v_claims   jsonb;
+BEGIN
+    BEGIN
+        v_user_id := NULLIF(event->>'user_id', '')::uuid;
+    EXCEPTION
+        WHEN invalid_text_representation THEN
+            RETURN event;
+    END;
+
+    IF v_user_id IS NULL THEN
+        RETURN event;
+    END IF;
+
+    v_claims := COALESCE(event->'claims', '{}'::jsonb);
+
+    SELECT u.username
+      INTO v_username
+      FROM profile.username AS u
+     WHERE u.user_id = v_user_id;
+
+    IF v_username IS NOT NULL THEN
+        v_claims := jsonb_set(v_claims, '{kbve_username}', to_jsonb(v_username), true);
+    ELSE
+        v_claims := v_claims - 'kbve_username';
+    END IF;
+
+    RETURN jsonb_set(event, '{claims}', v_claims, true);
+END;
+$$;
+
+ALTER FUNCTION public.custom_access_token_hook(jsonb)
+    OWNER TO supabase_auth_admin;
+
+REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
+    FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
+    TO supabase_auth_admin;
+
+COMMIT;

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -111,16 +111,20 @@ CREATE TABLE profile.discord_bootstrap_cache (
 );
 
 COMMENT ON TABLE profile.discord_bootstrap_cache IS
-    'Per-user Discord bootstrap cache. Populated exclusively via profile.service_upsert_discord_bootstrap_cache RPC; service_role has SELECT only (no direct INSERT/UPDATE/DELETE) so all writes are funnelled through the RPC for centralised validation, canonicalisation, advisory-lock serialisation, and account-relink handling. SELECT is granted to service_role specifically so dashboard freshness peeks and the RPC''s ON CONFLICT visibility work without going through another RPC layer. supabase_auth_admin has SELECT for custom_access_token_hook at JWT mint.';
+    'Per-user Discord bootstrap cache. Populated exclusively via profile.service_upsert_discord_bootstrap_cache RPC; service_role has SELECT only (no direct INSERT/UPDATE/DELETE) so all writes are funnelled through the RPC for centralised validation, canonicalisation, advisory-lock serialisation, and account-relink handling. SELECT is granted to service_role specifically for dashboard freshness peeks; the RPC''s ON CONFLICT path is satisfied by the SECURITY DEFINER owner (postgres) and does not require caller SELECT. supabase_auth_admin has SELECT for custom_access_token_hook at JWT mint.';
 
 REVOKE ALL ON TABLE profile.discord_bootstrap_cache
     FROM PUBLIC, anon, authenticated;
 
 GRANT USAGE  ON SCHEMA profile                         TO supabase_auth_admin;
 GRANT SELECT ON TABLE  profile.discord_bootstrap_cache TO supabase_auth_admin;
--- service_role keeps SELECT (dashboard freshness peeks + ON CONFLICT
--- visibility for the RPC's internal INSERT, even though that runs
--- under SECURITY DEFINER as the RPC owner).
+-- Round 8 #4: corrected justification. The RPC runs SECURITY
+-- DEFINER as postgres, so ON CONFLICT visibility is satisfied by
+-- the RPC owner's privileges — service_role SELECT is NOT needed
+-- for the upsert path. The real reason service_role keeps SELECT
+-- is dashboard freshness peeks (e.g. P5.8c surfacing "last
+-- refreshed N minutes ago" without going through another RPC
+-- layer). Writes still flow only through the SECURITY DEFINER RPC.
 GRANT SELECT ON TABLE profile.discord_bootstrap_cache TO service_role;
 
 ALTER TABLE profile.discord_bootstrap_cache ENABLE ROW LEVEL SECURITY;
@@ -209,9 +213,20 @@ BEGIN
     -- open: concurrent calls A→Y / B→X each locked their own keys
     -- but neither held the other side's lock before DELETE'ing the
     -- target provider row. A single namespace lock serialises ALL
-    -- relinks. The cost is one global serialisation point at human-
-    -- OAuth call rates (≤ hundreds/sec at peak), which is well
-    -- within Postgres advisory-lock contention budgets.
+    -- relinks. This is acceptable because the RPC runs at OAuth /
+    -- session-refresh rates, not per-request application traffic.
+    -- If write volume grows enough that this serialisation point
+    -- shows up in metrics, the alternative is deterministic row-
+    -- level locking across affected rows:
+    --   SELECT 1 FROM profile.discord_bootstrap_cache
+    --   WHERE user_id = p_user_id
+    --      OR discord_provider_id = p_discord_provider_id
+    --   ORDER BY user_id
+    --   FOR UPDATE;
+    -- Row locks alone don't cover the "row does not yet exist" case
+    -- that the advisory lock handles, so the migration would need
+    -- to combine both — keep the simple coarse lock until metrics
+    -- justify the complexity.
     PERFORM pg_advisory_xact_lock(
         hashtextextended('profile.discord_bootstrap_cache.relink', 0)
     );
@@ -452,7 +467,7 @@ BEGIN
         RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.username for custom_access_token_hook.';
     END IF;
     IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'SELECT') THEN
-        RAISE EXCEPTION 'service_role must hold SELECT on profile.discord_bootstrap_cache (dashboard peek + ON CONFLICT visibility).';
+        RAISE EXCEPTION 'service_role must hold SELECT on profile.discord_bootstrap_cache for dashboard freshness peeks.';
     END IF;
     IF has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'INSERT') THEN
         RAISE EXCEPTION 'service_role must NOT have direct INSERT on profile.discord_bootstrap_cache; use service_upsert RPC.';
@@ -477,6 +492,20 @@ BEGIN
           AND r.rolname = 'postgres'
     ) THEN
         RAISE EXCEPTION 'profile.service_upsert_discord_bootstrap_cache must be owned by postgres.';
+    END IF;
+    -- Round 8 #6: hook owner must be supabase_auth_admin. The SQL
+    -- helper get_discord_owned_guilds_claim is INVOKER and relies on
+    -- being called under the hook's SECURITY DEFINER owner — if the
+    -- hook owner drifts, the helper would run as a different role
+    -- without SELECT on the cache and silently emit empty claims.
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_proc p
+        JOIN pg_roles r ON r.oid = p.proowner
+        WHERE p.oid = 'public.custom_access_token_hook(jsonb)'::regprocedure
+          AND r.rolname = 'supabase_auth_admin'
+    ) THEN
+        RAISE EXCEPTION 'public.custom_access_token_hook must be owned by supabase_auth_admin.';
     END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -539,6 +568,22 @@ BEGIN
     IF jsonb_array_length(v_out->'claims'->'owned_guilds') <> 0 THEN
         RAISE EXCEPTION 'smoke 4: no cache row, expected empty owned_guilds, got %',
             v_out->'claims'->'owned_guilds';
+    END IF;
+
+    -- Round 8 #5: scalar-event regression guard for the round-7
+    -- top-level event-object guard. A NULL or scalar event must
+    -- coerce to {} and emit an object-shaped response.
+    v_out := public.custom_access_token_hook('"not-an-object"'::jsonb);
+    IF jsonb_typeof(v_out) <> 'object' THEN
+        RAISE EXCEPTION 'smoke 5: scalar event must coerce to object, got %', v_out;
+    END IF;
+    IF jsonb_typeof(v_out->'claims') <> 'object' THEN
+        RAISE EXCEPTION 'smoke 5: claims must be object after scalar coerce, got %', v_out;
+    END IF;
+
+    v_out := public.custom_access_token_hook(NULL);
+    IF jsonb_typeof(v_out) <> 'object' THEN
+        RAISE EXCEPTION 'smoke 6: NULL event must coerce to object, got %', v_out;
     END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -606,6 +651,13 @@ DECLARE
     v_username text;
     v_claims   jsonb;
 BEGIN
+    -- Round 8 #1: top-level event guard mirrors v2 hardening so the
+    -- restored v1 hook doesn't regress against malformed/manual
+    -- invocations after rollback.
+    IF event IS NULL OR jsonb_typeof(event) <> 'object' THEN
+        event := '{}'::jsonb;
+    END IF;
+
     v_claims :=
         CASE
             WHEN jsonb_typeof(event->'claims') = 'object'

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -18,79 +18,101 @@ BEGIN;
 -- provider_token ages out.
 --
 -- Source of truth is our own cache table, profile.discord_bootstrap_cache,
--- NOT auth.identities.identity_data. PR #11488 first review (point #2)
--- pushed back on coupling a JWT-mint hot path to a semi-opaque Supabase-
--- managed table. The cache table gives us:
---   - stable PK lookup (one row per user_id)
---   - no dependency on auth.identities JSON shape
---   - service_role-owned writes, easy to GRANT for the bootstrap edge fn
---   - cheap CASCADE on auth.users delete
---
--- Population is the job of the discord-bootstrap edge fn (P5.8b), which
--- calls Discord once after OAuth and upserts here with service_role.
+-- NOT auth.identities.identity_data. Populated by the discord-bootstrap
+-- edge fn (P5.8b) which calls Discord once after OAuth and upserts here
+-- with service_role.
 --
 -- The hook itself does NO external calls and never blocks. It reads one
--- row by PK, validates + dedupes guild IDs, applies a freshness window,
+-- row by PK, validates + dedupes guild IDs, applies a freshness window
+-- (rejects rows older than 7 days OR more than 5 minutes in the future),
 -- and embeds the result as a JWT claim.
+--
+-- Order: validator function first, then table with all constraints
+-- inline. Avoids split-brain DDL and lets every constraint be audited
+-- in one place. CREATE TABLE is NOT IF NOT EXISTS — dbmate does not
+-- rerun applied migrations, so the defensive guard is dead weight and
+-- removing it makes schema drift fail loudly.
 -- ============================================================
 
 -- ------------------------------------------------------------
--- Cache table
+-- Validator function (block #A on review pass 3)
 -- ------------------------------------------------------------
--- Hardening reflected in this DDL (PR #11488 second-round review):
---   #3  GRANT only the privileges the edge fn needs (no ALL)
---   #4  Explicit REVOKE ALL from PUBLIC, anon, authenticated
---   #6  Service-role policy WITH CHECK mirrors the shape constraints
---   #7  IMMUTABLE validator fn + CHECK so junk rows never land at rest
---   #14 Named FK constraint for forward maintainability
+-- IMMUTABLE STRICT so it can sit in a CHECK constraint and the planner
+-- can prove cache-safety. STRICT documents NULL-input intent (the
+-- column is NOT NULL anyway).
+--
+-- CASE is used instead of AND-chained predicates because SQL boolean
+-- evaluation order is not guaranteed to short-circuit. jsonb_array_length
+-- and jsonb_array_elements_text would otherwise be evaluable on
+-- non-array input and could throw.
+CREATE OR REPLACE FUNCTION profile.discord_owned_guilds_are_valid(p_guilds jsonb)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+STRICT
+SET search_path = ''
+AS $$
+    SELECT CASE
+        WHEN jsonb_typeof(p_guilds) <> 'array' THEN false
+        WHEN jsonb_array_length(p_guilds) > 100 THEN false
+        ELSE NOT EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements_text(p_guilds) AS e(g)
+            WHERE g !~ '^[0-9]{17,20}$'
+        )
+    END;
+$$;
 
-CREATE TABLE IF NOT EXISTS profile.discord_bootstrap_cache (
+COMMENT ON FUNCTION profile.discord_owned_guilds_are_valid(jsonb) IS
+    'IMMUTABLE shape validator for profile.discord_bootstrap_cache.owned_guilds. Backs both a CHECK constraint and the service-role RLS WITH CHECK clause.';
+
+REVOKE EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(jsonb)
+    FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION profile.discord_owned_guilds_are_valid(jsonb)
+    TO service_role, supabase_auth_admin;
+
+-- ------------------------------------------------------------
+-- Cache table (no IF NOT EXISTS; all constraints inline)
+-- ------------------------------------------------------------
+-- Three CHECK constraints are kept deliberately even though the
+-- validator subsumes the first two. Reason: clearer per-failure
+-- error messages (_is_array / _size_cap / _valid). Auth-adjacent
+-- low-write table so the redundancy cost is irrelevant.
+CREATE TABLE profile.discord_bootstrap_cache (
     user_id              uuid PRIMARY KEY,
     discord_provider_id  text NOT NULL
                               CHECK (discord_provider_id ~ '^[0-9]{15,25}$'),
     owned_guilds         jsonb NOT NULL DEFAULT '[]'::jsonb,
     refreshed_at         timestamptz NOT NULL DEFAULT NOW(),
 
+    CONSTRAINT discord_bootstrap_cache_user_id_fkey
+        FOREIGN KEY (user_id)
+        REFERENCES auth.users(id)
+        ON DELETE CASCADE,
     CONSTRAINT discord_bootstrap_cache_owned_guilds_is_array
         CHECK (jsonb_typeof(owned_guilds) = 'array'),
     CONSTRAINT discord_bootstrap_cache_owned_guilds_size_cap
         CHECK (jsonb_array_length(owned_guilds) <= 100),
-    CONSTRAINT discord_bootstrap_cache_user_id_fkey
-        FOREIGN KEY (user_id)
-        REFERENCES auth.users(id)
-        ON DELETE CASCADE
+    CONSTRAINT discord_bootstrap_cache_owned_guilds_valid
+        CHECK (profile.discord_owned_guilds_are_valid(owned_guilds))
 );
 
 COMMENT ON TABLE profile.discord_bootstrap_cache IS
-    'Per-user Discord bootstrap cache. Populated by the discord-bootstrap edge fn after OAuth. Read by custom_access_token_hook at JWT mint to embed owned_guilds claim. Owned by service_role; supabase_auth_admin has SELECT for the hook.';
+    'Per-user Discord bootstrap cache. Populated by the discord-bootstrap edge fn after OAuth. Read by custom_access_token_hook at JWT mint to embed owned_guilds claim. service_role has CRUD; supabase_auth_admin has SELECT for the hook.';
 
+-- Privileges — explicit revoke then granular grants. No GRANT ALL
+-- anywhere (TRIGGER/REFERENCES/TRUNCATE are not needed by the edge
+-- fn). Ownership intentionally left to the migrating role
+-- (supabase_admin in prod). Setting OWNER TO service_role would
+-- bypass RLS, which we don't want.
 REVOKE ALL ON TABLE profile.discord_bootstrap_cache
     FROM PUBLIC, anon, authenticated;
 
--- #7: validator fn — IMMUTABLE so it can sit in a CHECK constraint and
--- the planner can prove cache-safety. Rejects non-arrays, oversized
--- arrays, and any element that isn't a 17-20 digit Discord snowflake.
-CREATE OR REPLACE FUNCTION profile.discord_owned_guilds_are_valid(p_guilds jsonb)
-RETURNS boolean
-LANGUAGE sql
-IMMUTABLE
-SET search_path = ''
-AS $$
-    SELECT jsonb_typeof(p_guilds) = 'array'
-       AND jsonb_array_length(p_guilds) <= 100
-       AND NOT EXISTS (
-           SELECT 1
-           FROM jsonb_array_elements_text(p_guilds) AS e(g)
-           WHERE g !~ '^[0-9]{17,20}$'
-       );
-$$;
-
-COMMENT ON FUNCTION profile.discord_owned_guilds_are_valid(jsonb) IS
-    'IMMUTABLE shape validator for profile.discord_bootstrap_cache.owned_guilds. Backs both a CHECK constraint and the service-role RLS WITH CHECK clause.';
-
-ALTER TABLE profile.discord_bootstrap_cache
-    ADD CONSTRAINT discord_bootstrap_cache_owned_guilds_valid
-    CHECK (profile.discord_owned_guilds_are_valid(owned_guilds));
+GRANT USAGE  ON SCHEMA profile                         TO supabase_auth_admin;
+GRANT SELECT ON TABLE  profile.discord_bootstrap_cache TO supabase_auth_admin;
+GRANT SELECT, INSERT, UPDATE, DELETE
+    ON TABLE profile.discord_bootstrap_cache
+    TO service_role;
 
 ALTER TABLE profile.discord_bootstrap_cache ENABLE ROW LEVEL SECURITY;
 
@@ -114,41 +136,28 @@ CREATE POLICY "supabase_auth_admin_select"
     TO supabase_auth_admin
     USING (true);
 
-GRANT USAGE  ON SCHEMA profile                         TO supabase_auth_admin;
-GRANT SELECT ON TABLE  profile.discord_bootstrap_cache TO supabase_auth_admin;
-
--- #3: least-privilege grants for service_role. No TRIGGER, REFERENCES,
--- or TRUNCATE — the edge fn only needs CRUD.
-GRANT SELECT, INSERT, UPDATE, DELETE
-    ON TABLE profile.discord_bootstrap_cache
-    TO service_role;
-
 -- ------------------------------------------------------------
 -- Hook v2
 -- ------------------------------------------------------------
--- Hardening reflected in the function body (PR #11488 review fold-ins):
---   #3, #4, #5, #15  CTE rewrite with WITH ORDINALITY + GROUP BY +
---                    explicit ORDER BY in jsonb_agg — deterministic
---                    claim order, duplicates suppressed, first-seen
---                    order preserved.
---   #6               Invalid / missing user_id strips kbve_username +
---                    owned_guilds from inbound claims before returning.
---   #8               Soft size cap raised to 1600 (was 1200). Math:
---                    50 snowflakes × 22 chars + 49 × 2 chars (", ")
---                    + 2 brackets = 1200 exactly — no safety margin.
---                    1600 leaves ~400 chars of headroom for any
---                    canonicalization differences across PG versions.
---   #10              7-day freshness window via statement_timestamp().
---                    Stale rows return [] so the browser triggers the
---                    bootstrap edge fn to refresh, instead of trusting
---                    stale ownership forever.
---   #10/#16          Typecheck event->'claims' as object before
---                    jsonb_set; non-object input rebuilt as {}.
---   #11              VOLATILE — function reads mutable cache state in
---                    a login flow. Performance cost is theoretical
---                    (no set-query memoization opportunity); semantic
---                    clarity wins for auth code.
-
+-- Hardening folded in across three review passes — see PR #11488
+-- review threads for the full decision history. Highlights:
+--   - CTE rewrite with WITH ORDINALITY + GROUP BY + explicit jsonb_agg
+--     ORDER BY for deterministic claim order with dedup + first-seen
+--     preservation.
+--   - Invalid / missing user_id strips kbve_username + owned_guilds
+--     from inbound claims before returning (attacker can't smuggle a
+--     privileged claim via garbage user_id).
+--   - 7-day freshness window AND 5-minute future-timestamp guard
+--     (latter prevents a bad write with future refreshed_at from
+--     keeping stale ownership trusted longer than intended).
+--   - Soft size cap 1600 chars (50 snowflakes serialize to ~1200; 1600
+--     buys ~400 chars of canonicalization headroom). Degrades to []
+--     rather than failing sign-in.
+--   - Non-object claims rebuilt as {} before any jsonb_set.
+--   - VOLATILE since the function reads mutable cache state in a
+--     login flow.
+--   - src CTE no longer re-validates jsonb_typeof — the table CHECK +
+--     validator guarantee array shape at storage.
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -161,7 +170,6 @@ DECLARE
     v_username     text;
     v_owned_guilds jsonb;
     v_claims       jsonb;
-    v_freshness    interval := interval '7 days';
 BEGIN
     v_claims :=
         CASE
@@ -202,13 +210,14 @@ BEGIN
         v_claims := v_claims - 'kbve_username';
     END IF;
 
-    -- owned_guilds: PK lookup against the cache, gated by freshness.
+    -- owned_guilds: PK lookup, freshness-gated, with future-timestamp
+    -- guard. Inline interval (no PL/pgSQL variable) for the hot path.
     WITH src AS (
         SELECT c.owned_guilds AS arr
           FROM profile.discord_bootstrap_cache AS c
          WHERE c.user_id      = v_user_id
-           AND c.refreshed_at >= statement_timestamp() - v_freshness
-           AND jsonb_typeof(c.owned_guilds) = 'array'
+           AND c.refreshed_at <= statement_timestamp() + interval '5 minutes'
+           AND c.refreshed_at >= statement_timestamp() - interval '7 days'
     ),
     valid AS (
         SELECT g, MIN(ord) AS ord
@@ -223,10 +232,6 @@ BEGIN
       INTO v_owned_guilds
       FROM valid;
 
-    -- Soft size cap. Should be unreachable in practice given the 50-
-    -- element LIMIT above, but a malformed cache row with massive
-    -- strings would otherwise leak straight into the JWT. Degrade
-    -- silently to [] rather than failing the sign-in.
     IF length(v_owned_guilds::text) > 1600 THEN
         v_owned_guilds := '[]'::jsonb;
     END IF;
@@ -242,12 +247,11 @@ ALTER FUNCTION public.custom_access_token_hook(jsonb)
 
 REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     FROM PUBLIC, anon, authenticated;
-
 GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
 COMMENT ON FUNCTION public.custom_access_token_hook(jsonb) IS
-    'GoTrue access-token hook v2: embeds profile.username as kbve_username and profile.discord_bootstrap_cache.owned_guilds (cap 50, deterministic order, dedup, 7-day freshness window, soft 1600-char size cap) as owned_guilds. No external calls — reads pre-cached state populated by the discord-bootstrap edge fn.';
+    'GoTrue access-token hook v2: embeds profile.username as kbve_username and profile.discord_bootstrap_cache.owned_guilds (cap 50, deterministic order, dedup, 7-day freshness + 5-minute future-timestamp guard, soft 1600-char size cap) as owned_guilds. No external calls — reads pre-cached state populated by the discord-bootstrap edge fn.';
 
 -- ------------------------------------------------------------
 -- Privilege + plumbing assertions
@@ -266,10 +270,20 @@ BEGIN
     IF NOT has_function_privilege('supabase_auth_admin', 'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on public.custom_access_token_hook(jsonb).';
     END IF;
+    IF NOT has_function_privilege('service_role', 'profile.discord_owned_guilds_are_valid(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'service_role must hold EXECUTE on profile.discord_owned_guilds_are_valid(jsonb) for RLS WITH CHECK eval.';
+    END IF;
+    IF NOT has_function_privilege('supabase_auth_admin', 'profile.discord_owned_guilds_are_valid(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on profile.discord_owned_guilds_are_valid(jsonb).';
+    END IF;
     IF has_function_privilege('anon',          'public.custom_access_token_hook(jsonb)', 'EXECUTE')
        OR has_function_privilege('authenticated','public.custom_access_token_hook(jsonb)', 'EXECUTE')
        OR has_function_privilege('public',     'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
         RAISE EXCEPTION 'public.custom_access_token_hook(jsonb) must not be executable by anon/authenticated/public.';
+    END IF;
+    IF has_function_privilege('anon',          'profile.discord_owned_guilds_are_valid(jsonb)', 'EXECUTE')
+       OR has_function_privilege('authenticated','profile.discord_owned_guilds_are_valid(jsonb)', 'EXECUTE') THEN
+        RAISE EXCEPTION 'validator must not be executable by anon/authenticated.';
     END IF;
     IF NOT has_table_privilege('supabase_auth_admin', 'profile.username', 'SELECT') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.username.';
@@ -277,8 +291,14 @@ BEGIN
     IF NOT has_table_privilege('supabase_auth_admin', 'profile.discord_bootstrap_cache', 'SELECT') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold SELECT on profile.discord_bootstrap_cache.';
     END IF;
+    IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'SELECT') THEN
+        RAISE EXCEPTION 'service_role must hold SELECT on profile.discord_bootstrap_cache for upsert ON CONFLICT visibility.';
+    END IF;
     IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'INSERT') THEN
         RAISE EXCEPTION 'service_role must hold INSERT on profile.discord_bootstrap_cache for the bootstrap edge fn.';
+    END IF;
+    IF NOT has_table_privilege('service_role', 'profile.discord_bootstrap_cache', 'UPDATE') THEN
+        RAISE EXCEPTION 'service_role must hold UPDATE on profile.discord_bootstrap_cache for upsert DO UPDATE.';
     END IF;
     IF has_table_privilege('anon', 'profile.discord_bootstrap_cache', 'SELECT')
        OR has_table_privilege('authenticated', 'profile.discord_bootstrap_cache', 'SELECT') THEN
@@ -290,20 +310,11 @@ $$ LANGUAGE plpgsql;
 -- ------------------------------------------------------------
 -- Behavioural smoke checks (SQL-only — no writes to auth.users)
 --
--- Scenarios 1-4 exercise hook behaviour on the existing schema with no
--- inserts anywhere. The LIMIT-1-on-unnest regression that would
--- previously have been tested by Scenario 5 (insert into auth.users +
--- cache row, assert dedup + ordering) is moved to a dedicated pgTAP
--- suite that runs against the kilobase production image in CI. Reasons:
---   - Production image has trigger fan-out we can't safely fire here
---     (wallet_on_auth_user_created, future Supabase audit hooks,
---     pg_net-based webhooks, etc.) even with a sentinel rollback —
---     async side effects don't honour the transaction.
---   - Local dev compose runs vanilla postgres:17-alpine, NOT the
---     kilobase image, so a smoke check inside the migration would
---     pass locally but its parity with prod is not guaranteed.
---   - pgTAP test is reusable, lives outside the migration body, and
---     can run on every CI build instead of only at migration apply.
+-- Scenarios 1-4 exercise hook behaviour with no inserts. The LIMIT-1-
+-- on-unnest regression that previously needed Scenario 5 (insert into
+-- auth.users + cache row) moves to a pgTAP suite running against the
+-- kilobase production image in CI. Reasons documented in the prior
+-- review fold-in commit.
 -- ------------------------------------------------------------
 DO $$
 DECLARE
@@ -322,7 +333,7 @@ BEGIN
     END IF;
 
     -- 2: malformed user_id with attacker-supplied owned_guilds claim
-    -- -> claim stripped, attacker cannot smuggle privileged state.
+    -- -> claim stripped.
     v_out := public.custom_access_token_hook(
         jsonb_build_object(
             'user_id', 'not-a-uuid',
@@ -372,27 +383,41 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- ------------------------------------------------------------
--- Validator smoke (table-only, no triggers, no auth.users)
+-- Validator smoke (no triggers, no auth.users)
 -- ------------------------------------------------------------
 DO $$
 BEGIN
-    -- Valid: array of 17-20 digit snowflakes, ≤100 elements.
-    IF NOT profile.discord_owned_guilds_are_valid('["111111111111111111","222222222222222222"]'::jsonb) THEN
-        RAISE EXCEPTION 'validator: rejected a valid 2-snowflake array';
+    -- CASE rewrite specifically guards against this — non-array MUST
+    -- NOT trigger an exception via jsonb_array_length / unnest, only
+    -- a clean false return.
+    IF profile.discord_owned_guilds_are_valid('{"not":"array"}'::jsonb) THEN
+        RAISE EXCEPTION 'validator: accepted non-array object';
     END IF;
-    -- Valid: empty array (default).
+    IF profile.discord_owned_guilds_are_valid('"string"'::jsonb) THEN
+        RAISE EXCEPTION 'validator: accepted string';
+    END IF;
+    IF profile.discord_owned_guilds_are_valid('42'::jsonb) THEN
+        RAISE EXCEPTION 'validator: accepted number';
+    END IF;
+    IF profile.discord_owned_guilds_are_valid('null'::jsonb) THEN
+        RAISE EXCEPTION 'validator: accepted jsonb null';
+    END IF;
+    -- STRICT means SQL NULL input returns NULL, which is falsy in a
+    -- CHECK constraint -> rejection. Confirm.
+    IF profile.discord_owned_guilds_are_valid(NULL) IS NOT NULL THEN
+        RAISE EXCEPTION 'validator: STRICT must return NULL for NULL input';
+    END IF;
+    -- Valid shapes
     IF NOT profile.discord_owned_guilds_are_valid('[]'::jsonb) THEN
         RAISE EXCEPTION 'validator: rejected empty array';
     END IF;
-    -- Invalid: non-array.
-    IF profile.discord_owned_guilds_are_valid('{"not":"array"}'::jsonb) THEN
-        RAISE EXCEPTION 'validator: accepted non-array';
+    IF NOT profile.discord_owned_guilds_are_valid('["111111111111111111","222222222222222222"]'::jsonb) THEN
+        RAISE EXCEPTION 'validator: rejected a valid 2-snowflake array';
     END IF;
-    -- Invalid: malformed element.
+    -- Invalid elements
     IF profile.discord_owned_guilds_are_valid('["111111111111111111","garbage"]'::jsonb) THEN
         RAISE EXCEPTION 'validator: accepted malformed element';
     END IF;
-    -- Invalid: too short snowflake.
     IF profile.discord_owned_guilds_are_valid('["123"]'::jsonb) THEN
         RAISE EXCEPTION 'validator: accepted too-short snowflake';
     END IF;
@@ -408,12 +433,12 @@ COMMIT;
 BEGIN;
 
 -- Restore the v1 hook body. Preserves the hardening from v2:
---   #12 Object typecheck of event->'claims' before jsonb_set
---   #12 Invalid / missing user_id strips kbve_username from inbound
---       claims before returning
---   #13 Explicitly strips owned_guilds from inbound claims so a
---       rollback during a sign-in flow can't leak v2 state into a v1
---       JWT.
+--   - Object typecheck of event->'claims' before jsonb_set
+--   - Invalid / missing user_id strips kbve_username from inbound
+--     claims before returning
+--   - Explicitly strips owned_guilds from inbound claims so a
+--     rollback during a sign-in flow can't leak v2 state into a v1
+--     JWT
 --
 -- v1's owned_guilds production logic itself is removed (this is the
 -- whole point of the down migration); only the security posture is
@@ -421,7 +446,6 @@ BEGIN;
 --
 -- Function is REPLACE'd, not DROPPED — GoTrue is configured to call
 -- it and a missing function would break all sign-in.
-
 CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
 RETURNS jsonb
 LANGUAGE plpgsql
@@ -441,30 +465,17 @@ BEGIN
             ELSE '{}'::jsonb
         END;
 
-    -- Strip any v2-era claim before any other work; prevents stale
-    -- owned_guilds leaking past a rollback even if the inbound event
-    -- already carries one.
     v_claims := v_claims - 'owned_guilds';
 
     BEGIN
         v_user_id := NULLIF(event->>'user_id', '')::uuid;
     EXCEPTION
         WHEN invalid_text_representation THEN
-            RETURN jsonb_set(
-                event,
-                '{claims}',
-                v_claims - 'kbve_username',
-                true
-            );
+            RETURN jsonb_set(event, '{claims}', v_claims - 'kbve_username', true);
     END;
 
     IF v_user_id IS NULL THEN
-        RETURN jsonb_set(
-            event,
-            '{claims}',
-            v_claims - 'kbve_username',
-            true
-        );
+        RETURN jsonb_set(event, '{claims}', v_claims - 'kbve_username', true);
     END IF;
 
     SELECT u.username
@@ -487,12 +498,10 @@ ALTER FUNCTION public.custom_access_token_hook(jsonb)
 
 REVOKE EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     FROM PUBLIC, anon, authenticated;
-
 GRANT EXECUTE ON FUNCTION public.custom_access_token_hook(jsonb)
     TO supabase_auth_admin;
 
--- Drop the cache table + its validator. ON DELETE CASCADE on user_id
--- keeps cleanup trivial.
+-- DROP TABLE cascades policies. Validator goes last.
 DROP TABLE     IF EXISTS profile.discord_bootstrap_cache;
 DROP FUNCTION  IF EXISTS profile.discord_owned_guilds_are_valid(jsonb);
 

--- a/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
+++ b/packages/data/sql/dbmate/migrations/20260531005655_auth_hook_owned_guilds_claim.sql
@@ -30,8 +30,8 @@ BEGIN;
 --          + cap 50)
 --        - Future-timestamp rejection >30s
 --        - Account relinking (DELETE old row with same provider_id)
---        - Advisory locking on (user_id, provider_id) to serialise
---          concurrent OAuth refreshes
+--        - Coarse advisory locking on the relink namespace to
+--          serialise concurrent OAuth refreshes + cross-swap races
 --        - updated_at maintenance
 --      Owner pinned to postgres explicitly so SECURITY DEFINER
 --      behaviour is stable across local/CI/prod environments.
@@ -118,6 +118,14 @@ REVOKE ALL ON TABLE profile.discord_bootstrap_cache
 
 GRANT USAGE  ON SCHEMA profile                         TO supabase_auth_admin;
 GRANT SELECT ON TABLE  profile.discord_bootstrap_cache TO supabase_auth_admin;
+-- Round 9 #2: explicit schema USAGE for service_role. Function
+-- + table privileges alone aren't enough — without USAGE on the
+-- containing schema, name resolution of profile.* by service_role
+-- (RPC EXECUTE, dashboard SELECT peek) fails with "permission
+-- denied for schema profile". Earlier migrations may or may not
+-- guarantee this; the grant is idempotent and the assertion below
+-- catches future revoke drift.
+GRANT USAGE ON SCHEMA profile TO service_role;
 -- Round 8 #4: corrected justification. The RPC runs SECURITY
 -- DEFINER as postgres, so ON CONFLICT visibility is satisfied by
 -- the RPC owner's privileges — service_role SELECT is NOT needed
@@ -127,6 +135,13 @@ GRANT SELECT ON TABLE  profile.discord_bootstrap_cache TO supabase_auth_admin;
 -- layer). Writes still flow only through the SECURITY DEFINER RPC.
 GRANT SELECT ON TABLE profile.discord_bootstrap_cache TO service_role;
 
+-- Round 9 #4: RLS is enabled for caller roles. FORCE ROW LEVEL
+-- SECURITY is intentionally NOT used here because the postgres-
+-- owned SECURITY DEFINER RPC is the sanctioned write path; the
+-- RPC's INSERT/UPDATE/DELETE bypasses RLS via the owner anyway
+-- and forcing RLS would only matter for a non-superuser owner
+-- scenario we don't have. Revisit if we ever move the RPC owner
+-- off postgres or if a non-superuser caller gains direct DML.
 ALTER TABLE profile.discord_bootstrap_cache ENABLE ROW LEVEL SECURITY;
 
 -- Round 6 #7: policy is SELECT-only (was FOR ALL). Matches actual
@@ -152,12 +167,11 @@ CREATE POLICY "supabase_auth_admin_select"
 -- ------------------------------------------------------------
 -- Service-role write RPC (the only sanctioned write surface)
 -- ------------------------------------------------------------
--- Round 6 #4 + #5: advisory locks on (user_id, provider_id) in
--- fixed order to serialise concurrent OAuth refreshes for the same
--- account and avoid races between DELETE (relinking) and INSERT
--- (upsert). Lock order is invariant (user_id first, then
--- provider_id) so any caller doing both takes them in the same
--- sequence -> no deadlocks.
+-- Round 7 #4: takes a single coarse advisory lock on the relink
+-- namespace to serialise concurrent OAuth refreshes and close the
+-- cross-swap race (concurrent A→Y / B→X relinks). See the inline
+-- comment on the PERFORM pg_advisory_xact_lock call for the history
+-- and the row-lock alternative for higher-throughput workloads.
 --
 -- Round 6 #9: owner pinned to postgres explicitly so SECURITY
 -- DEFINER behaviour is stable across env/migrating-role variance.
@@ -301,12 +315,17 @@ STABLE
 SET search_path = ''
 COST 20
 AS $$
+    -- Round 9 #6: explicit p_user_id IS NOT NULL guard. Logically
+    -- unnecessary (no row matches NULL user_id), but documents
+    -- intent and protects against planner edge cases on future
+    -- index/partition changes.
     SELECT COALESCE(to_jsonb(array_agg(g ORDER BY ord)), '[]'::jsonb)
       FROM (
           SELECT g, ord
             FROM profile.discord_bootstrap_cache AS c,
                  LATERAL unnest(c.owned_guilds) WITH ORDINALITY AS e(g, ord)
-           WHERE c.user_id      = p_user_id
+           WHERE p_user_id      IS NOT NULL
+             AND c.user_id      = p_user_id
              AND c.refreshed_at <= p_now + interval '30 seconds'
              AND c.refreshed_at >= p_now - interval '7 days'
              AND g IS NOT NULL
@@ -430,6 +449,10 @@ BEGIN
     IF NOT has_schema_privilege('supabase_auth_admin', 'profile', 'USAGE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold USAGE on schema profile.';
     END IF;
+    -- Round 9 #2: service_role schema USAGE for RPC + dashboard SELECT.
+    IF NOT has_schema_privilege('service_role', 'profile', 'USAGE') THEN
+        RAISE EXCEPTION 'service_role must hold USAGE on schema profile for bootstrap cache RPC access.';
+    END IF;
     IF NOT has_function_privilege('supabase_auth_admin', 'public.custom_access_token_hook(jsonb)', 'EXECUTE') THEN
         RAISE EXCEPTION 'supabase_auth_admin must hold EXECUTE on public.custom_access_token_hook(jsonb).';
     END IF;
@@ -481,6 +504,17 @@ BEGIN
     IF has_table_privilege('anon', 'profile.discord_bootstrap_cache', 'SELECT')
        OR has_table_privilege('authenticated', 'profile.discord_bootstrap_cache', 'SELECT') THEN
         RAISE EXCEPTION 'anon/authenticated must NOT have SELECT on profile.discord_bootstrap_cache.';
+    END IF;
+    -- Round 9 #3: defense-in-depth — also assert no direct DML by
+    -- anon or authenticated. REVOKE ALL on the table covers this;
+    -- the assertion catches future privilege drift.
+    IF has_table_privilege('anon',          'profile.discord_bootstrap_cache', 'INSERT')
+       OR has_table_privilege('anon',          'profile.discord_bootstrap_cache', 'UPDATE')
+       OR has_table_privilege('anon',          'profile.discord_bootstrap_cache', 'DELETE')
+       OR has_table_privilege('authenticated', 'profile.discord_bootstrap_cache', 'INSERT')
+       OR has_table_privilege('authenticated', 'profile.discord_bootstrap_cache', 'UPDATE')
+       OR has_table_privilege('authenticated', 'profile.discord_bootstrap_cache', 'DELETE') THEN
+        RAISE EXCEPTION 'anon/authenticated must NOT have direct DML on profile.discord_bootstrap_cache.';
     END IF;
     -- Round 6 #9: RPC owner must be postgres for stable
     -- SECURITY DEFINER behaviour.
@@ -584,6 +618,11 @@ BEGIN
     v_out := public.custom_access_token_hook(NULL);
     IF jsonb_typeof(v_out) <> 'object' THEN
         RAISE EXCEPTION 'smoke 6: NULL event must coerce to object, got %', v_out;
+    END IF;
+    -- Round 9 #5: also assert claims shape on NULL event for
+    -- symmetry with the scalar-event check above.
+    IF jsonb_typeof(v_out->'claims') <> 'object' THEN
+        RAISE EXCEPTION 'smoke 6: claims must be object after NULL coerce, got %', v_out;
     END IF;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- Extends `public.custom_access_token_hook` to embed an `owned_guilds` JWT claim sourced from `auth.identities.identity_data->'owned_guilds'` (the user's Discord identity row)
- Step 1 of 3 in the fix for the "Discord session expired" dead-end on \`/dashboard/agents/*\` — see [#11362](https://github.com/KBVE/kbve/issues/11362) and discussion on PR #11434
- Migration only — no edge fn / frontend changes here

## Why
Today's failure path: the agents dashboard calls Discord's \`/users/@me/guilds\` directly from the browser using \`provider_token\`. When that token ages out (~7 days) the browser gets a 401 and the page blanks with "Discord session expired", even though the Supabase \`access_token\` is still valid for every vault operation downstream.

The fix is to stop relying on a live Discord call to gate page rendering. Instead, the JWT carries the owned-guild list directly. The dashboard reads from JWT claims, never blanks the page, and only prompts re-auth when the user attempts a mutation that needs fresh proof of ownership.

This PR delivers the JWT plumbing. P5.8b adds the bootstrap edge fn that populates \`identity_data\`. P5.8c wires the frontend to read the claim.

## What the hook does now

\`\`\`
event.user_id ──┐
                ├──► profile.username    ──► kbve_username  (existing)
                └──► auth.identities WHERE provider='discord'
                       └─► identity_data->'owned_guilds'
                             └─► filter ^\\d{17,20}$ + LIMIT 50  ──► owned_guilds
\`\`\`

- **Synchronous, no external calls** — JWT mint stays fast. No \`http\`, \`pg_net\`, or \`plpython3u\` extensions involved.
- **Soft-failure** — missing identity / missing column / wrong jsonb type → \`owned_guilds: []\`. Browser treats empty as "not bootstrapped yet" and calls the P5.8b edge fn before flipping to authenticated state.
- **Cap 50** — Discord allows up to 100 owned guilds for phone-verified accounts; the rare 50+ case falls through to the live API path on the edge fn side.

## Trap dodged
The first draft used \`SELECT jsonb_array_elements_text(...) FROM auth.identities ... LIMIT 1\` directly. Combined with the set-returning function, \`LIMIT 1\` collapsed both "pick latest identity row" and "first element of the unnested array" into one truncation → only the first guild ever made it through. Caught during development; smoke check #2 now explicitly asserts \`length == 3\` for a 3-valid + 1-malformed test fixture so this can't regress silently.

## Embedded smoke checks
Both run inside the migration body and \`RAISE EXCEPTION\` (aborting the migration) on failure:

1. **Empty Discord identity** → \`owned_guilds: []\` + existing claims preserved
2. **3 valid + 1 malformed snowflake** → exactly the 3 valid ones, malformed filtered. Test fixture is rolled back via a sentinel-exception subtransaction so \`wallet_on_auth_user_created\` and other trigger side effects on \`auth.users\` are also undone atomically.

## Local stub
\`packages/data/sql/dbmate/init/01-auth-stub.sql\` gains a minimal \`auth.identities\` mirror + grants \`supabase_auth_admin\` USAGE on \`auth\` + SELECT on \`auth.identities\`. Lets this migration and \`20260523033932_tracker_find_claim_identity_by_discord_id\` apply against a fresh \`dev-docker-compose.yml\`. Stub-only — production \`auth.identities\` is Supabase-owned.

## Down
Restores the v1 hook body (kbve_username only). Deliberately does **not** drop the function, since GoTrue is configured to call it and a missing function breaks all sign-in.

## Test plan
- [x] \`dbmate up\` → applies clean, embedded smoke checks pass
- [x] \`dbmate rollback\` → restores v1 hook (no \`owned_guilds\` emitted)
- [x] \`dbmate up\` again → re-applies clean
- [x] Manual probe — synthetic user with no Discord identity → \`{"role":"authenticated","owned_guilds":[]}\`
- [x] Manual probe — synthetic Discord identity with 3 valid + 1 malformed → \`["111...","222...","333..."]\` (malformed dropped)
- [x] No leftover \`auth.users\` row after smoke checks (sentinel rollback verified)
- [ ] Prod deploy via \`ci-dbmate-deploy.yml\` — manual approval at \`kilobase-prod\` env gate

## Next in series
- **P5.8b** — \`discord-bootstrap\` edge fn populates \`auth.identities.identity_data->'owned_guilds'\` via Discord API (service-role write)
- **P5.8c** — \`agentsService.ts\` reads JWT claim, drops the browser-side Discord API call, caches in localStorage, never blanks the page

Part of #11362.