### PR TITLE
feat(agones-factorio-relay): RCON-gated Agones health heartbeat

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -16,7 +16,7 @@
 		{
 			"key": "agones_factorio_relay",
 			"app_name": "agones-factorio-relay",
-			"version": "0.0.3",
+			"version": "0.0.4",
 			"version_toml": "apps/agones/factorio/relay/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx",
 			"source_path": "apps/agones/factorio/relay",
@@ -28,7 +28,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.175",
+			"version": "1.0.176",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",

--- a/apps/agones/factorio/relay/src/agones_health.rs
+++ b/apps/agones/factorio/relay/src/agones_health.rs
@@ -1,0 +1,69 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::{net::TcpStream, time};
+use tracing::{debug, warn};
+
+use crate::config::Config;
+
+pub async fn run(cfg: Config) -> Result<()> {
+    let Some(sdk_base) = cfg.agones_sdk_http.clone() else {
+        warn!("agones_health disabled: AGONES_SDK_HTTP not set");
+        return Ok(());
+    };
+
+    let health_url = format!("{}/health", sdk_base.trim_end_matches('/'));
+    let ready_url = format!("{}/ready", sdk_base.trim_end_matches('/'));
+    let interval = Duration::from_secs(cfg.agones_health_interval_secs);
+    let rcon_probe_timeout = Duration::from_secs(cfg.agones_rcon_probe_timeout_secs);
+    let initial_delay = Duration::from_secs(cfg.agones_initial_ready_delay_secs);
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()?;
+
+    debug!(
+        sdk = %sdk_base,
+        interval_secs = cfg.agones_health_interval_secs,
+        rcon = %cfg.rcon_addr,
+        initial_delay_secs = cfg.agones_initial_ready_delay_secs,
+        "agones_health starting"
+    );
+
+    let mut sent_ready = false;
+    let started = time::Instant::now();
+    let mut ticker = time::interval(interval);
+    ticker.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+
+    loop {
+        ticker.tick().await;
+
+        let rcon_ok = matches!(
+            time::timeout(rcon_probe_timeout, TcpStream::connect(cfg.rcon_addr)).await,
+            Ok(Ok(_))
+        );
+
+        if !rcon_ok {
+            debug!(rcon = %cfg.rcon_addr, "rcon probe failed; skipping Agones heartbeat");
+            continue;
+        }
+
+        if let Err(e) = client.post(&health_url).body("{}").send().await {
+            warn!(url = %health_url, error = %e, "Agones /health POST failed");
+            continue;
+        }
+        debug!(url = %health_url, "Agones /health heartbeat sent");
+
+        if !sent_ready && started.elapsed() >= initial_delay {
+            match client.post(&ready_url).body("{}").send().await {
+                Ok(_) => {
+                    sent_ready = true;
+                    debug!(url = %ready_url, "Agones /ready posted from relay");
+                }
+                Err(e) => {
+                    warn!(url = %ready_url, error = %e, "Agones /ready POST failed; will retry");
+                }
+            }
+        }
+    }
+}

--- a/apps/agones/factorio/relay/src/config.rs
+++ b/apps/agones/factorio/relay/src/config.rs
@@ -19,6 +19,10 @@ pub struct Config {
     pub clickhouse_user: Option<String>,
     pub clickhouse_password: Option<String>,
     pub clickhouse_database: String,
+    pub agones_sdk_http: Option<String>,
+    pub agones_health_interval_secs: u64,
+    pub agones_rcon_probe_timeout_secs: u64,
+    pub agones_initial_ready_delay_secs: u64,
 }
 
 impl Config {
@@ -48,7 +52,18 @@ impl Config {
             clickhouse_password: std::env::var("CLICKHOUSE_PASSWORD").ok(),
             clickhouse_database: std::env::var("CLICKHOUSE_DATABASE")
                 .unwrap_or_else(|_| "gameops".into()),
+            agones_sdk_http: std::env::var("AGONES_SDK_HTTP").ok(),
+            agones_health_interval_secs: parse_env_u64("AGONES_HEALTH_INTERVAL_SECS", 5)?,
+            agones_rcon_probe_timeout_secs: parse_env_u64("AGONES_RCON_PROBE_TIMEOUT_SECS", 2)?,
+            agones_initial_ready_delay_secs: parse_env_u64("AGONES_INITIAL_READY_DELAY_SECS", 0)?,
         })
+    }
+}
+
+fn parse_env_u64(name: &str, default: u64) -> Result<u64> {
+    match std::env::var(name).ok() {
+        Some(s) => s.parse().with_context(|| format!("{name} not a u64")),
+        None => Ok(default),
     }
 }
 

--- a/apps/agones/factorio/relay/src/main.rs
+++ b/apps/agones/factorio/relay/src/main.rs
@@ -1,3 +1,4 @@
+mod agones_health;
 mod ch_writer;
 mod config;
 mod event;
@@ -40,6 +41,7 @@ async fn main() -> Result<()> {
     let irc_handle = tokio::spawn(irc_bridge::run(cfg.clone(), game_tx.subscribe(), irc_in_tx));
     let rcon_handle = tokio::spawn(rcon_client::run(cfg.clone(), irc_in_rx));
     let ch_handle = tokio::spawn(ch_writer::run(cfg.clone(), game_tx.subscribe()));
+    let agones_handle = tokio::spawn(agones_health::run(cfg.clone()));
 
     drop(game_tx);
 
@@ -48,6 +50,7 @@ async fn main() -> Result<()> {
         r = irc_handle => r??,
         r = rcon_handle => r??,
         r = ch_handle => r??,
+        r = agones_handle => r??,
         _ = tokio::signal::ctrl_c() => {
             info!("ctrl_c received, shutting down");
         }

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx
@@ -15,7 +15,7 @@ tags:
 key: agones_factorio_relay
 pipeline: docker
 app_name: agones-factorio-relay
-version: "0.0.3"
+version: "0.0.4"
 source_path: apps/agones/factorio/relay
 version_toml: apps/agones/factorio/relay/version.toml
 runner: ubuntu-latest

--- a/apps/kube/agones/factorio/manifests/gameserver.yaml
+++ b/apps/kube/agones/factorio/manifests/gameserver.yaml
@@ -121,7 +121,7 @@ spec:
                           drop:
                               - ALL
                 - name: factorio-relay
-                  image: ghcr.io/kbve/agones-factorio-relay:0.0.3
+                  image: ghcr.io/kbve/agones-factorio-relay:0.0.4
                   imagePullPolicy: IfNotPresent
                   env:
                       - name: FACTORIO_CONSOLE_LOG
@@ -145,6 +145,14 @@ spec:
                         value: 'factorio-bot'
                       - name: IRC_CHANNEL
                         value: '#general'
+                      - name: AGONES_SDK_HTTP
+                        value: 'http://127.0.0.1:9358'
+                      - name: AGONES_HEALTH_INTERVAL_SECS
+                        value: '5'
+                      - name: AGONES_RCON_PROBE_TIMEOUT_SECS
+                        value: '2'
+                      - name: AGONES_INITIAL_READY_DELAY_SECS
+                        value: '60'
                       - name: RUST_LOG
                         value: 'info,agones_factorio_relay=debug'
                   volumeMounts:


### PR DESCRIPTION
## Summary
- Relay sidecar now owns Agones GS liveness. New module [agones_health.rs](apps/agones/factorio/relay/src/agones_health.rs) ticks every \`AGONES_HEALTH_INTERVAL_SECS\` (default 5s), TCP-probes the local Factorio RCON port; on success POSTs to Agones SDK \`/health\`.
- After \`AGONES_INITIAL_READY_DELAY_SECS\` (default 60s) the relay also fires \`/ready\` so the relay is the single liveness source.
- Bumps [agones-factorio-relay.mdx](apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx) → \`0.0.4\`, regenerates [.github/ci-dispatch-manifest.json](.github/ci-dispatch-manifest.json), pins [kbve-deployment gameserver.yaml](apps/kube/agones/factorio/manifests/gameserver.yaml) to the new tag + new env vars (\`AGONES_SDK_HTTP\`, \`AGONES_HEALTH_INTERVAL_SECS\`, \`AGONES_RCON_PROBE_TIMEOUT_SECS\`, \`AGONES_INITIAL_READY_DELAY_SECS\`).

## Why
\`gs/factorio\` was sitting Unhealthy for 25h. Container exited cleanly at t=208s right after \`[agones-shim] sending Ready()\` because nothing was sending periodic \`SDK.Health()\` — Agones marked the GS Unhealthy after \`initialDelaySeconds(60) + failureThreshold(5) * periodSeconds(15) = 135s\` and SIGTERMed the game. Moving the heartbeat into the relay (which already has localhost RCON + SDK access) gives a single, RCON-gated source of liveness.

Follow-up: wrap the GS in a Fleet so a future Unhealthy gets auto-replaced; tracked as a separate PR.

## Test plan
- [ ] CI - Docker / agones-factorio-relay green
- [ ] After deploy, \`kubectl get gs -n factorio\` stays \`Ready\` (not \`Unhealthy\`) past the 135s mark
- [ ] \`kubectl logs factorio -n factorio -c factorio-relay\` shows debug-level \`Agones /health heartbeat sent\` lines