### PR TITLE
feat(yuki): organic rest pose + cursor lookAt + draggable float-detach (Phase D)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
@@ -1,19 +1,6 @@
-/**
- * Yuki panel — the heavy chunk lazy-imported by `yuki-dock.ts` the
- * first time a user opens the dock.
- *
- * Phase A (this file): minimal vanilla chat scaffold so the dock
- * shows something useful when expanded — a sticky input row + a
- * scroll buffer for messages — without dragging React + Three.js
- * into the initial bundle.
- *
- * Phase B (follow-up PR): swap this for a React mount of the existing
- * `ReactJayYuki` (or a lighter variant) wired to a real assistant
- * backend. The mount API is intentionally a single
- * `mountYukiPanel(host)` function so the swap is one-line.
- */
-
 const HISTORY_KEY = 'kbve:yuki-dock:history';
+const FLOAT_KEY = 'kbve:yuki-dock:float-mode';
+const FLOAT_POS_KEY = 'kbve:yuki-dock:float-pos';
 const MAX_HISTORY = 24;
 
 type Role = 'user' | 'yuki';
@@ -51,7 +38,7 @@ function writeHistory(history: ChatEntry[]): void {
 			JSON.stringify(history.slice(-MAX_HISTORY)),
 		);
 	} catch {
-		/* ignore quota */
+		void 0;
 	}
 }
 
@@ -88,29 +75,58 @@ function writeAvatarMode(mode: AvatarMode): void {
 	try {
 		localStorage.setItem(AVATAR_MODE_KEY, mode);
 	} catch {
-		/* ignore */
+		void 0;
+	}
+}
+
+function readFloat(): boolean {
+	try {
+		return localStorage.getItem(FLOAT_KEY) === '1';
+	} catch {
+		return false;
+	}
+}
+function writeFloat(on: boolean): void {
+	try {
+		localStorage.setItem(FLOAT_KEY, on ? '1' : '0');
+	} catch {
+		void 0;
+	}
+}
+
+interface FloatPos {
+	x: number;
+	y: number;
+}
+function readFloatPos(): FloatPos | null {
+	try {
+		const raw = localStorage.getItem(FLOAT_POS_KEY);
+		if (!raw) return null;
+		const p = JSON.parse(raw);
+		if (typeof p?.x !== 'number' || typeof p?.y !== 'number') return null;
+		return p;
+	} catch {
+		return null;
+	}
+}
+function writeFloatPos(pos: FloatPos): void {
+	try {
+		localStorage.setItem(FLOAT_POS_KEY, JSON.stringify(pos));
+	} catch {
+		void 0;
 	}
 }
 
 interface YukiVRMRuntime {
+	setState(state: string): void;
 	speak(audio: HTMLAudioElement | MediaStream): void;
 	stopSpeaking(): void;
+	pointAt(x: number, y: number): void;
 	destroy(): void;
 }
 
-// Web Speech API is widely supported in browsers but TypeScript's lib
-// only narrows it loosely; cast through unknown to keep the call site
-// readable without pulling in dom-speechrecognition types.
 type SpeakFn = (text: string) => HTMLAudioElement | null;
 
-/**
- * Pipe SpeechSynthesis output through a MediaStream so the VRM
- * lipsync analyser has a sample-able source. Browser support for
- * `mediaStream` on `SpeechSynthesisUtterance` is patchy, so we fall
- * back to plain `speak` without lipsync when unavailable — the VRM
- * still talks visually via the deterministic idle loop, just without
- * mouth movement on this turn.
- */
 function makeSpeaker(): SpeakFn {
 	return (text: string) => {
 		try {
@@ -122,10 +138,105 @@ function makeSpeaker(): SpeakFn {
 			utter.pitch = 1.15;
 			synth.speak(utter);
 		} catch {
-			/* ignore */
+			void 0;
 		}
 		return null;
 	};
+}
+
+const FLOAT_LAYER_ID = 'kbve-yuki-float-layer';
+const FLOAT_HOST_ID = 'kbve-yuki-float-host';
+
+function ensureFloatLayer(): HTMLElement {
+	let layer = document.getElementById(FLOAT_LAYER_ID);
+	if (layer) return layer;
+	layer = document.createElement('div');
+	layer.id = FLOAT_LAYER_ID;
+	layer.setAttribute('transition:persist', 'kbve-yuki-float');
+	layer.dataset.astroTransitionPersist = 'kbve-yuki-float';
+	const pos = readFloatPos() ?? {
+		x: Math.max(24, window.innerWidth - 220),
+		y: Math.max(24, window.innerHeight - 320),
+	};
+	layer.style.cssText = `
+		position: fixed;
+		left: ${pos.x}px;
+		top: ${pos.y}px;
+		width: 196px;
+		height: 260px;
+		z-index: 60;
+		pointer-events: auto;
+		display: none;
+		filter: drop-shadow(0 8px 24px rgba(0,0,0,0.35));
+	`;
+	const handle = document.createElement('div');
+	handle.id = 'kbve-yuki-float-drag';
+	handle.style.cssText =
+		'position:absolute;inset:0 0 auto 0;height:18px;cursor:grab;user-select:none;';
+	const close = document.createElement('button');
+	close.id = 'kbve-yuki-float-close';
+	close.type = 'button';
+	close.setAttribute('aria-label', 'Return Yuki to dock');
+	close.textContent = '×';
+	close.style.cssText = `
+		position:absolute;top:4px;right:6px;width:22px;height:22px;
+		display:grid;place-items:center;border-radius:999px;
+		background:rgba(15,23,42,0.65);color:rgba(255,255,255,0.9);
+		border:1px solid rgba(255,255,255,0.15);font-size:14px;
+		line-height:1;cursor:pointer;z-index:2;
+	`;
+	const stage = document.createElement('div');
+	stage.id = FLOAT_HOST_ID;
+	stage.style.cssText = 'position:absolute;inset:0;';
+	layer.appendChild(stage);
+	layer.appendChild(handle);
+	layer.appendChild(close);
+	document.body.appendChild(layer);
+	return layer;
+}
+
+function clampFloatPos(x: number, y: number): FloatPos {
+	const w = 196;
+	const h = 260;
+	const nx = Math.min(Math.max(8, x), window.innerWidth - w - 8);
+	const ny = Math.min(Math.max(8, y), window.innerHeight - h - 8);
+	return { x: nx, y: ny };
+}
+
+function bindFloatDrag(layer: HTMLElement): void {
+	if (layer.dataset.dragBound === '1') return;
+	layer.dataset.dragBound = '1';
+	const handle = layer.querySelector<HTMLElement>('#kbve-yuki-float-drag');
+	if (!handle) return;
+	let dragging = false;
+	let offX = 0;
+	let offY = 0;
+	const onMove = (ev: PointerEvent) => {
+		if (!dragging) return;
+		const pos = clampFloatPos(ev.clientX - offX, ev.clientY - offY);
+		layer.style.left = `${pos.x}px`;
+		layer.style.top = `${pos.y}px`;
+	};
+	const onUp = (ev: PointerEvent) => {
+		if (!dragging) return;
+		dragging = false;
+		handle.style.cursor = 'grab';
+		(ev.target as Element).releasePointerCapture?.(ev.pointerId);
+		const rect = layer.getBoundingClientRect();
+		writeFloatPos({ x: rect.left, y: rect.top });
+		window.removeEventListener('pointermove', onMove);
+		window.removeEventListener('pointerup', onUp);
+	};
+	handle.addEventListener('pointerdown', (ev) => {
+		dragging = true;
+		const rect = layer.getBoundingClientRect();
+		offX = ev.clientX - rect.left;
+		offY = ev.clientY - rect.top;
+		handle.style.cursor = 'grabbing';
+		(ev.target as Element).setPointerCapture?.(ev.pointerId);
+		window.addEventListener('pointermove', onMove);
+		window.addEventListener('pointerup', onUp);
+	});
 }
 
 export async function mountYukiPanel(host: HTMLElement): Promise<void> {
@@ -136,9 +247,8 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 	const wrap = document.createElement('div');
 	wrap.className = 'yuki-panel';
 	wrap.dataset.avatarMode = readAvatarMode();
+	wrap.dataset.floatMode = readFloat() ? '1' : '0';
 
-	// 3D avatar stage. Hidden when mode === 'text'. Canvas mount is
-	// populated by the lazy-loaded `YukiVRM` module on demand.
 	const stage = document.createElement('div');
 	stage.className = 'yuki-panel__stage';
 	stage.dataset.kbveYukiStage = '';
@@ -151,8 +261,6 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 	log.setAttribute('aria-live', 'polite');
 	wrap.appendChild(log);
 
-	// Mode toggle (text-only / 3D Yuki). Lives above the input so it's
-	// always reachable. Off by default — flips lazy-load the VRM.
 	const toggle = document.createElement('div');
 	toggle.className = 'yuki-panel__mode';
 	toggle.innerHTML = `
@@ -164,6 +272,13 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 				${readAvatarMode() === '3d' ? 'checked' : ''} />
 			<span>Show 3D Yuki</span>
 		</label>
+		<button
+			type="button"
+			class="yuki-panel__float-btn"
+			data-kbve-yuki-float
+			aria-pressed="${readFloat() ? 'true' : 'false'}">
+			${readFloat() ? 'Dock' : 'Float'}
+		</button>
 	`;
 	wrap.appendChild(toggle);
 
@@ -200,39 +315,117 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 	}
 	log.scrollTop = log.scrollHeight;
 
-	// ── 3D avatar lifecycle ────────────────────────────────────────────
 	let vrmRuntime: YukiVRMRuntime | null = null;
 	let vrmLoading = false;
-	const ensureVRM = async (): Promise<void> => {
-		if (vrmRuntime || vrmLoading) return;
+	let vrmHost: HTMLElement = stage;
+	let vrmTransparent = false;
+
+	const ensureVRM = async (
+		hostEl: HTMLElement,
+		transparent: boolean,
+	): Promise<void> => {
+		if (vrmLoading) return;
+		if (vrmRuntime && vrmHost === hostEl && vrmTransparent === transparent)
+			return;
+		if (vrmRuntime) {
+			try {
+				vrmRuntime.destroy();
+			} catch {
+				void 0;
+			}
+			vrmRuntime = null;
+		}
 		vrmLoading = true;
-		stage.dataset.state = 'loading';
-		stage.innerHTML =
+		hostEl.dataset.state = 'loading';
+		hostEl.innerHTML =
 			'<div class="yuki-panel__stage-skeleton">Loading Yuki…</div>';
 		try {
 			const mod = await import('./YukiVRM');
-			vrmRuntime = await mod.mountYukiVRM({ host: stage });
-			stage.dataset.state = 'ready';
+			vrmRuntime = (await mod.mountYukiVRM({
+				host: hostEl,
+				transparent,
+			})) as unknown as YukiVRMRuntime;
+			vrmHost = hostEl;
+			vrmTransparent = transparent;
+			hostEl.dataset.state = 'ready';
 		} catch (err) {
 			console.warn('[yuki-panel] VRM load failed', err);
-			stage.innerHTML =
+			hostEl.innerHTML =
 				'<div class="yuki-panel__stage-error">Avatar failed to load.</div>';
-			stage.dataset.state = 'error';
+			hostEl.dataset.state = 'error';
 		} finally {
 			vrmLoading = false;
 		}
 	};
+
 	const tearDownVRM = (): void => {
 		try {
 			vrmRuntime?.destroy();
 		} catch {
-			/* ignore */
+			void 0;
 		}
 		vrmRuntime = null;
 		stage.innerHTML = '';
 		stage.removeAttribute('data-state');
+		const floatLayer = document.getElementById(FLOAT_LAYER_ID);
+		if (floatLayer) {
+			const fh = floatLayer.querySelector<HTMLElement>(
+				`#${FLOAT_HOST_ID}`,
+			);
+			if (fh) {
+				fh.innerHTML = '';
+				fh.removeAttribute('data-state');
+			}
+		}
 	};
-	if (readAvatarMode() === '3d') void ensureVRM();
+
+	const applyFloat = (on: boolean): void => {
+		wrap.dataset.floatMode = on ? '1' : '0';
+		const btn = toggle.querySelector<HTMLButtonElement>(
+			'[data-kbve-yuki-float]',
+		);
+		if (btn) {
+			btn.textContent = on ? 'Dock' : 'Float';
+			btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+		}
+		const layer = ensureFloatLayer();
+		bindFloatDrag(layer);
+		const floatStage = layer.querySelector<HTMLElement>(
+			`#${FLOAT_HOST_ID}`,
+		);
+		if (!floatStage) return;
+		if (on && readAvatarMode() === '3d') {
+			layer.style.display = 'block';
+			stage.innerHTML = '';
+			stage.removeAttribute('data-state');
+			void ensureVRM(floatStage, true);
+		} else {
+			layer.style.display = 'none';
+			if (readAvatarMode() === '3d') {
+				const fh = layer.querySelector<HTMLElement>(
+					`#${FLOAT_HOST_ID}`,
+				);
+				if (fh) fh.innerHTML = '';
+				void ensureVRM(stage, false);
+			} else {
+				tearDownVRM();
+			}
+		}
+	};
+
+	if (readAvatarMode() === '3d') {
+		applyFloat(readFloat());
+	}
+
+	const layer = ensureFloatLayer();
+	bindFloatDrag(layer);
+	const closeBtn = layer.querySelector<HTMLButtonElement>(
+		'#kbve-yuki-float-close',
+	);
+	closeBtn?.addEventListener('click', () => {
+		writeFloat(false);
+		applyFloat(false);
+	});
 
 	const modeInput = toggle.querySelector<HTMLInputElement>(
 		'[data-kbve-yuki-mode]',
@@ -242,19 +435,31 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 		writeAvatarMode(next);
 		wrap.dataset.avatarMode = next;
 		if (next === '3d') {
-			void ensureVRM();
+			applyFloat(readFloat());
 		} else {
+			writeFloat(false);
+			applyFloat(false);
 			tearDownVRM();
 		}
 	});
 
-	// ── Chat submit ────────────────────────────────────────────────────
+	const floatBtn = toggle.querySelector<HTMLButtonElement>(
+		'[data-kbve-yuki-float]',
+	);
+	floatBtn?.addEventListener('click', () => {
+		if (readAvatarMode() !== '3d') {
+			writeAvatarMode('3d');
+			wrap.dataset.avatarMode = '3d';
+			if (modeInput) modeInput.checked = true;
+		}
+		const next = !readFloat();
+		writeFloat(next);
+		applyFloat(next);
+	});
+
 	const speak = makeSpeaker();
 	const input = form.querySelector<HTMLInputElement>('.yuki-panel__input');
 
-	// Cancel any in-flight stream when the user sends a new prompt OR
-	// closes / nav-swaps away. EventSource doesn't expose AbortSignal
-	// directly, so we keep a manual handle to `.close()`.
 	let activeStream: EventSource | null = null;
 
 	form.addEventListener('submit', (ev) => {
@@ -263,8 +468,6 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 		if (!value || !input) return;
 		input.value = '';
 
-		// Push the user bubble immediately. The Yuki bubble starts
-		// empty and grows as SSE chunks arrive.
 		const user: ChatEntry = { role: 'user', text: value, ts: Date.now() };
 		history.push(user);
 		log.appendChild(renderMessage(user));
@@ -298,9 +501,6 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 			es.close();
 			activeStream = null;
 			writeHistory(history);
-			// Hand the fully-assembled text to SpeechSynthesis so the
-			// VRM lipsync analyser sees the whole utterance in one
-			// stretch instead of token-fragmented chirps.
 			if (assembled) speak(assembled);
 		});
 		es.onerror = () => {
@@ -322,13 +522,17 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 		css.textContent = `
 			.yuki-panel { display: grid; grid-template-rows: auto 1fr auto auto; gap: 0.5rem; height: 100%; }
 			.yuki-panel[data-avatar-mode='text'] .yuki-panel__stage { display: none; }
+			.yuki-panel[data-float-mode='1'] .yuki-panel__stage { display: none; }
 			.yuki-panel__stage { height: 180px; border-radius: 12px; overflow: hidden; background: rgba(15,23,42,0.6); border: 1px solid rgba(255,255,255,0.08); position: relative; }
 			.yuki-panel__stage-skeleton, .yuki-panel__stage-error { position: absolute; inset: 0; display: grid; place-items: center; font-size: 0.78rem; color: rgba(255,255,255,0.5); }
 			.yuki-panel__stage-error { color: #f87171; }
 			.yuki-panel__log { display: grid; gap: 0.5rem; align-content: start; overflow-y: auto; padding-right: 0.25rem; }
-			.yuki-panel__mode { display: flex; justify-content: flex-end; }
+			.yuki-panel__mode { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
 			.yuki-panel__mode-label { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.72rem; color: rgba(255,255,255,0.55); cursor: pointer; user-select: none; }
 			.yuki-panel__mode-input { accent-color: rgb(6,182,212); }
+			.yuki-panel__float-btn { font-size: 0.7rem; padding: 0.25rem 0.55rem; border-radius: 8px; background: rgba(6,182,212,0.16); border: 1px solid rgba(6,182,212,0.4); color: rgba(255,255,255,0.85); cursor: pointer; }
+			.yuki-panel__float-btn:hover { background: rgba(6,182,212,0.28); }
+			.yuki-panel__float-btn[aria-pressed='true'] { background: rgba(244,114,182,0.18); border-color: rgba(244,114,182,0.5); }
 			.yuki-msg { display: flex; }
 			.yuki-msg--user { justify-content: flex-end; }
 			.yuki-msg__bubble { max-width: 80%; padding: 0.55rem 0.75rem; border-radius: 12px; font-size: 0.85rem; line-height: 1.4; word-wrap: break-word; }
@@ -339,6 +543,8 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 			.yuki-panel__input:focus { outline: 2px solid rgba(6,182,212,0.6); outline-offset: -1px; }
 			.yuki-panel__send { display: grid; place-items: center; width: 36px; background: rgba(6,182,212,0.6); border: none; border-radius: 10px; color: white; cursor: pointer; }
 			.yuki-panel__send:hover { background: rgba(6,182,212,0.85); }
+			#${FLOAT_LAYER_ID} { transition: filter 0.2s ease; }
+			#${FLOAT_LAYER_ID}:hover { filter: drop-shadow(0 12px 32px rgba(244,114,182,0.45)); }
 		`;
 		document.head.appendChild(css);
 	}

--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
@@ -1,39 +1,13 @@
-/**
- * Yuki VRM renderer — lazy-loaded Three.js scene that mounts a VRM
- * avatar inside the dock panel.
- *
- * Loaded only when the user toggles "3D Yuki" on, so the cost
- * (Three + GLTFLoader + @pixiv/three-vrm + the ~12 MB .vrm asset)
- * never lands on cold boot. The runtime is hand-coded vanilla Three
- * (no React Three Fiber) so it doesn't drag in `@react-three/*` or
- * a React tree — the dock panel hosts a raw `<canvas>` and this
- * module owns the render loop.
- *
- * Animation comes from three sources, all driven by the chat layer:
- *
- *   1. Idle: spring-based breath on the spine bone + auto-blink.
- *   2. Talking: mouth blendshapes (`aa`, `ih`, `ou`) driven by an
- *      AnalyserNode tapping the SpeechSynthesis output. Volume per
- *      frame → mouth shape value.
- *   3. Gestures: hand-authored bone rotation lerps for wave / nod /
- *      shake, triggered by `setState('wave')` etc.
- *
- * No webcam, no Kalidokit, no Mediapipe — pose data is either
- * deterministic (idle / canned gestures) or audio-derived (lipsync).
- *
- * Performance gates:
- *   - render loop pauses when `document.visibilityState !== 'visible'`
- *   - frame rate caps at 30 fps on coarse pointers (mobile)
- *   - render loop stops + WebGL context destroyed on `destroy()`
- */
 import {
-	AnimationMixer,
 	Clock,
 	Color,
 	DirectionalLight,
 	HemisphereLight,
+	MathUtils,
+	Object3D,
 	PerspectiveCamera,
 	Scene,
+	Vector3,
 	WebGLRenderer,
 } from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
@@ -53,18 +27,38 @@ export interface YukiVRMHandle {
 	setState(state: YukiState): void;
 	speak(audio: HTMLAudioElement | MediaStream): void;
 	stopSpeaking(): void;
+	pointAt(x: number, y: number): void;
 	destroy(): void;
 }
 
 interface MountOpts {
 	host: HTMLElement;
 	vrmUrl?: string;
+	transparent?: boolean;
+}
+
+const REST_POSE: Partial<Record<VRMHumanBoneName, [number, number, number]>> = {
+	[VRMHumanBoneName.LeftUpperArm]: [0, 0, MathUtils.degToRad(75)],
+	[VRMHumanBoneName.RightUpperArm]: [0, 0, MathUtils.degToRad(-75)],
+	[VRMHumanBoneName.LeftLowerArm]: [0, MathUtils.degToRad(-12), 0],
+	[VRMHumanBoneName.RightLowerArm]: [0, MathUtils.degToRad(12), 0],
+	[VRMHumanBoneName.LeftHand]: [0, 0, MathUtils.degToRad(8)],
+	[VRMHumanBoneName.RightHand]: [0, 0, MathUtils.degToRad(-8)],
+};
+
+function applyRestPose(vrm: VRM): void {
+	if (!vrm.humanoid) return;
+	for (const [name, [x, y, z]] of Object.entries(REST_POSE)) {
+		const bone = vrm.humanoid.getNormalizedBoneNode(
+			name as VRMHumanBoneName,
+		);
+		if (bone) bone.rotation.set(x, y, z);
+	}
 }
 
 export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
-	const { host, vrmUrl = DEFAULT_VRM_URL } = opts;
+	const { host, vrmUrl = DEFAULT_VRM_URL, transparent = false } = opts;
 
-	// ── DOM + WebGL bootstrap ──────────────────────────────────────────
 	host.innerHTML = '';
 	const canvas = document.createElement('canvas');
 	canvas.className = 'yuki-vrm__canvas';
@@ -78,6 +72,14 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		alpha: true,
 	});
 	renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+	const scene = new Scene();
+	if (!transparent) scene.background = new Color(0x0f172a);
+
+	const camera = new PerspectiveCamera(30, 1, 0.1, 20);
+	camera.position.set(0, 1.45, 1.1);
+	camera.lookAt(0, 1.42, 0);
+
 	const setSize = () => {
 		const w = host.clientWidth || 320;
 		const h = host.clientHeight || 360;
@@ -85,31 +87,21 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		camera.aspect = w / h;
 		camera.updateProjectionMatrix();
 	};
-
-	const scene = new Scene();
-	scene.background = new Color(0x0f172a);
-
-	const camera = new PerspectiveCamera(28, 1, 0.1, 20);
-	camera.position.set(0, 1.35, 1.4);
-	camera.lookAt(0, 1.25, 0);
+	setSize();
+	const resizeObserver = new ResizeObserver(setSize);
+	resizeObserver.observe(host);
 
 	scene.add(new HemisphereLight(0xffffff, 0x404060, 0.9));
 	const key = new DirectionalLight(0xffffff, 1.0);
 	key.position.set(1, 2, 1.5);
 	scene.add(key);
 
-	setSize();
-	const resizeObserver = new ResizeObserver(setSize);
-	resizeObserver.observe(host);
-
-	// ── VRM load ───────────────────────────────────────────────────────
 	const loader = new GLTFLoader();
 	loader.register((parser) => new VRMLoaderPlugin(parser));
 	const gltf = await loader.loadAsync(vrmUrl);
 	const vrm: VRM | undefined = gltf.userData.vrm;
 	if (!vrm) throw new Error('VRM payload missing on loaded GLTF');
-	// Optimization helpers are version-sensitive; non-fatal if they're
-	// not on this build of @pixiv/three-vrm.
+
 	try {
 		(
 			VRMUtils as unknown as {
@@ -120,27 +112,45 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 			VRMUtils as unknown as { combineSkeletons?: (s: unknown) => void }
 		).combineSkeletons?.(gltf.scene);
 	} catch {
-		/* ignore optimizer drift */
+		void 0;
 	}
-	scene.add(vrm.scene);
-	// Frame the head — VRMs are usually authored facing +Z.
-	vrm.scene.rotation.y = Math.PI;
 
-	// ── State + animation ──────────────────────────────────────────────
+	scene.add(vrm.scene);
+	applyRestPose(vrm);
+
+	const lookAtTarget = new Object3D();
+	lookAtTarget.position.set(0, 1.45, 0.6);
+	scene.add(lookAtTarget);
+	if (vrm.lookAt) vrm.lookAt.target = lookAtTarget;
+
+	const targetWorld = new Vector3(0, 1.45, 0.6);
+	const targetCurrent = new Vector3(0, 1.45, 0.6);
+
+	const pointAt = (clientX: number, clientY: number): void => {
+		const rect = host.getBoundingClientRect();
+		const nx = ((clientX - rect.left) / rect.width) * 2 - 1;
+		const ny = ((clientY - rect.top) / rect.height) * 2 - 1;
+		targetWorld.set(nx * 0.45, 1.45 - ny * 0.3, 0.6);
+	};
+
+	const onPointerMove = (ev: PointerEvent) => pointAt(ev.clientX, ev.clientY);
+	host.addEventListener('pointermove', onPointerMove);
+	host.addEventListener('pointerleave', () => {
+		targetWorld.set(0, 1.45, 0.6);
+	});
+
 	const clock = new Clock();
-	const mixer = new AnimationMixer(vrm.scene);
 	let currentState: YukiState = 'idle';
 	let blinkCooldown = 1.5 + Math.random() * 2;
-	let blinkPhase = 0; // 0..1 across one blink
+	let blinkPhase = 0;
 
 	const setExpression = (name: VRMExpressionPresetName, value: number) => {
 		vrm.expressionManager?.setValue(name, value);
 	};
 
-	// Audio analyser for TTS lipsync. Created lazily on first `speak`.
 	let audioCtx: AudioContext | null = null;
 	let analyser: AnalyserNode | null = null;
-	let buffer: Uint8Array | null = null;
+	let buffer: Uint8Array<ArrayBuffer> | null = null;
 	let speakingActive = false;
 
 	const ensureAudio = (): AudioContext => {
@@ -162,13 +172,12 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		void ctx.resume();
 		analyser = ctx.createAnalyser();
 		analyser.fftSize = 256;
-		buffer = new Uint8Array(analyser.frequencyBinCount);
+		buffer = new Uint8Array(new ArrayBuffer(analyser.frequencyBinCount));
 		const node =
 			source instanceof HTMLAudioElement
 				? ctx.createMediaElementSource(source)
 				: ctx.createMediaStreamSource(source);
 		node.connect(analyser);
-		// HTMLAudio also wants to reach speakers — MediaStream doesn't.
 		if (source instanceof HTMLAudioElement) {
 			analyser.connect(ctx.destination);
 		}
@@ -201,7 +210,6 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		}
 	};
 
-	// ── Render loop with visibility gate + fps cap ─────────────────────
 	const coarse = window.matchMedia('(pointer: coarse)').matches;
 	const minFrameMs = coarse ? 1000 / 30 : 1000 / 60;
 	let lastFrame = 0;
@@ -216,28 +224,33 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		const delta = clock.getDelta();
 		lastFrame = now;
 
-		// Lipsync drive.
+		targetCurrent.lerp(targetWorld, Math.min(1, delta * 6));
+		lookAtTarget.position.copy(targetCurrent);
+
 		if (speakingActive && analyser && buffer) {
 			analyser.getByteFrequencyData(buffer);
 			let sum = 0;
 			for (let i = 0; i < buffer.length; i++) sum += buffer[i];
-			const avg = sum / buffer.length / 255; // 0..1
+			const avg = sum / buffer.length / 255;
 			const mouth = Math.min(1, avg * 2.3);
 			setExpression('aa', mouth);
 			setExpression('ih', mouth * 0.35);
 			setExpression('ou', mouth * 0.25);
 		}
 
-		// Idle breath — gentle spine bob.
+		const t = performance.now();
 		const spine = vrm.humanoid?.getNormalizedBoneNode(
 			VRMHumanBoneName.Spine,
 		);
 		if (spine) {
-			const breath = Math.sin(performance.now() / 1400) * 0.018;
-			spine.rotation.x = breath;
+			spine.rotation.x = Math.sin(t / 1400) * 0.018;
+			spine.rotation.z = Math.sin(t / 2700) * 0.012;
+		}
+		const hips = vrm.humanoid?.getNormalizedBoneNode(VRMHumanBoneName.Hips);
+		if (hips) {
+			hips.position.y = Math.sin(t / 1100) * 0.005;
 		}
 
-		// Blink.
 		blinkCooldown -= delta;
 		if (blinkCooldown <= 0 && blinkPhase === 0) {
 			blinkPhase = 0.0001;
@@ -253,14 +266,13 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 			}
 		}
 
-		mixer.update(delta);
 		vrm.update(delta);
 		renderer.render(scene, camera);
 	};
 	rafId = requestAnimationFrame(tick);
 
 	const onVisibility = () => {
-		clock.getDelta(); // burn the accumulated delta so resume isn't a jump
+		clock.getDelta();
 	};
 	document.addEventListener('visibilitychange', onVisibility);
 
@@ -269,6 +281,7 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		disposed = true;
 		cancelAnimationFrame(rafId);
 		document.removeEventListener('visibilitychange', onVisibility);
+		host.removeEventListener('pointermove', onPointerMove);
 		resizeObserver.disconnect();
 		stopSpeaking();
 		if (audioCtx) {
@@ -278,14 +291,12 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		try {
 			VRMUtils.deepDispose(vrm.scene);
 		} catch {
-			/* ignore */
+			void 0;
 		}
 		renderer.dispose();
 		canvas.remove();
 	};
 
-	// Touch a noop to silence unused-import diagnostics on tooling
-	// that doesn't see VRMUtils.deepDispose at parse time.
 	void currentState;
 	void setState;
 
@@ -293,6 +304,7 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		setState,
 		speak,
 		stopSpeaking,
+		pointAt,
 		destroy,
 	};
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/yuki.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/yuki.mdx
@@ -31,10 +31,11 @@ browser when the user opts in.
 |-------|--------|------------|
 | **A** — Dock shell | ✅ merged (#11474) | Persistent FAB + collapsed panel, vanilla driver, lazy-mount contract, localStorage state, ESC-to-close, reduced-motion respect |
 | **B** — VRM avatar | ✅ merged (#11475) | `@pixiv/three-vrm@^3.5.3` scene, idle/blink animation, `aa`/`ih`/`ou` lipsync via AnalyserNode tap, render-loop visibility + fps gates |
-| **C** — SSE stream | 🚧 this PR | `GET /api/v1/yuki/chat?q=<…>` returns `text/event-stream` chunks; panel streams tokens into the bubble + hands assembled text to `speak()` for lipsync |
-| **D** — Real backend | 🗓 next | Swap the canned reply in `transport/yuki.rs` for a jedi/q-routed LLM call. Prompt template, conversation compaction, rate limit. Front-end unchanged. |
-| **E** — Voice in | 🗓 later | Push-to-talk mic capture → on-device VAD → server STT → same SSE response path |
-| **F** — Tools / actions | 🗓 later | Function-call schema so Yuki can navigate the site, open the wallet card, queue a forum post, etc. |
+| **C** — SSE stream | ✅ merged (#11476) | `GET /api/v1/yuki/chat?q=<…>` returns `text/event-stream` chunks; panel streams tokens into the bubble + hands assembled text to `speak()` for lipsync |
+| **D** — Organic + float | 🚧 this PR | Manual rest pose (no T-pose), portrait camera framing, `vrm.lookAt` cursor tracking, spine/hips micro-sway, draggable float-detach layer that persists across `<ClientRouter />` swaps |
+| **E** — Real backend | 🗓 next | Swap the canned reply in `transport/yuki.rs` for a jedi/q-routed LLM call. Prompt template, conversation compaction, rate limit. Front-end unchanged. |
+| **F** — Voice in | 🗓 later | Push-to-talk mic capture → on-device VAD → server STT → same SSE response path |
+| **G** — Tools / actions | 🗓 later | Function-call schema so Yuki can navigate the site, open the wallet card, queue a forum post, etc. |
 
 <Adsense />
 
@@ -130,15 +131,18 @@ Supabase JWT once the real LLM call costs money to run.
 | `kbve:yuki-dock:state` | `'collapsed'` or `'expanded'` — restores last view across reloads |
 | `kbve:yuki-dock:avatar-mode` | `'text'` or `'3d'` — restores 3D toggle |
 | `kbve:yuki-dock:history` | Last 24 chat entries, `{role, text, ts}` |
+| `kbve:yuki-dock:float-mode` | `'1'` or `'0'` — restores float-detach state across reloads |
+| `kbve:yuki-dock:float-pos` | `{x, y}` viewport coords of the float layer — restores last drag position |
 
-All three are localStorage-only, never sent to the server.
+All five are localStorage-only, never sent to the server.
 
 ## What's next
 
-- **Phase D**: replace `compose_reply` in `apps/kbve/axum-kbve/src/transport/yuki.rs` with a real LLM call. Likely q-routed so we keep our existing tracing + Supabase JWT verification. Front-end stays identical.
+- **Phase E**: replace `compose_reply` in `apps/kbve/axum-kbve/src/transport/yuki.rs` with a real LLM call. Likely q-routed so we keep our existing tracing + Supabase JWT verification. Front-end stays identical.
 - **Site-context**: feed the current page slug into the prompt so Yuki can answer "where am I?" without a tool call.
 - **Tool calls**: small JSON-schema function set (`navigate`, `open_dock_card`, `compose_forum_post`) so Yuki can act on the page, not just talk about it.
 - **Voice input** behind a push-to-talk gate, on-device VAD to keep the mic OFF except while the button is held.
+- **Wander**: replace the static float layer with a slow drift loop so Yuki actually walks the viewport edges between turns.
 
 If you have feedback, drop it in the [forum](/forum/) — the link is
 literally what the Phase C stub tells you to do.


### PR DESCRIPTION
## Summary

- **Rest pose fix**: drops the default VRM T-pose by applying a manual bone-rotation table (`LeftUpperArm`/`RightUpperArm` 75°, lower-arm tuck, hand cant) at scene load — Yuki now stands relaxed instead of crucified.
- **Camera reframe**: head/shoulders portrait at (0, 1.45, 1.1) → (0, 1.42, 0), FOV 30 — no more back-of-head view.
- **Organic head + eye tracking**: wires `vrm.lookAt.target` to an `Object3D` that follows the cursor (clamped, smoothed via `lerp(delta * 6)`), plus a slow spine x/z sway and hip y bob so she keeps subtle micro-motion while idle.
- **Float-detach mode**: new \"Float\" toggle on the chat panel re-mounts the VRM canvas into a body-level fixed-position layer with transparent background. Layer is draggable, persists across `<ClientRouter />` swaps via `transition:persist=\"kbve-yuki-float\"`, position + mode persisted to `localStorage`. Close button (×) returns her to the dock.
- **Docs**: `content/docs/project/yuki.mdx` updated — Phase C marked merged (#11476), Phase D documented, Phase E pushed to backend swap. New storage keys (`float-mode`, `float-pos`) added.

## Test plan

- [ ] Open dock → toggle \"Show 3D Yuki\" → verify arms are at side (no T-pose) and camera frames head/shoulders
- [ ] Move cursor across the panel → head + eyes track the pointer; release → eyes recentre forward
- [ ] Click \"Float\" → VRM detaches from the panel into a draggable floating layer
- [ ] Drag the floating layer by its top edge → position clamps to viewport bounds
- [ ] Navigate to another route via `<ClientRouter />` → float layer survives the swap
- [ ] Reload the page → `kbve:yuki-dock:float-mode` + `kbve:yuki-dock:float-pos` restore state
- [ ] Click \"×\" on float layer or \"Dock\" button → returns Yuki to the dock panel stage
- [ ] Toggle \"Show 3D Yuki\" off while floating → VRM tears down, float layer hides
- [ ] Submit a chat prompt while floating → SSE chunks still stream into the bubble, `speak()` lipsync still drives the floating avatar's mouth