### PR TITLE
fix(astro): scope ScrollRing listeners to page lifetime via onMount

### DIFF
--- a/packages/npm/astro/src/components/hero/observer/ScrollRing.astro
+++ b/packages/npm/astro/src/components/hero/observer/ScrollRing.astro
@@ -69,18 +69,14 @@ const {
 </div>
 
 <script>
+	import { onMount } from '../../../utils/clientRouter';
 	import {
 		ringNavigate,
 		isRingNavLocked,
 		consumeRingNavDir,
 	} from './_ringNav';
 
-	const RING_DISABLED = true;
-
-	const init = () => {
-		if (RING_DISABLED) return;
-
-		// Disable browser scroll restoration so back-nav lands at our bottom.
+	onMount(() => {
 		if ('scrollRestoration' in history) {
 			history.scrollRestoration = 'manual';
 		}
@@ -99,12 +95,11 @@ const {
 			window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
 		}
 
+		const cleanups: Array<() => void> = [];
+
 		document
 			.querySelectorAll<HTMLElement>('[data-ring-root]')
 			.forEach((root) => {
-				if (root.dataset.ringInit === 'true') return;
-				root.dataset.ringInit = 'true';
-
 				const prev = root.dataset.ringPrev || '';
 				const next = root.dataset.ringNext || '';
 				const threshold = Number(root.dataset.ringThreshold) || 220;
@@ -204,8 +199,6 @@ const {
 				};
 				const onTouchEnd = () => {
 					lastTouchY = null;
-					// Don't reset immediately — let the pulseTimer fade the
-					// hint out so the user sees the next-page label linger.
 				};
 
 				const onKey = (e: KeyboardEvent) => {
@@ -231,23 +224,20 @@ const {
 				});
 				window.addEventListener('keydown', onKey);
 
-				const cleanup = () => {
+				cleanups.push(() => {
 					window.removeEventListener('wheel', onWheel);
 					window.removeEventListener('touchstart', onTouchStart);
 					window.removeEventListener('touchmove', onTouchMove);
 					window.removeEventListener('touchend', onTouchEnd);
 					window.removeEventListener('keydown', onKey);
 					window.clearTimeout(pulseTimer);
-				};
-				window.addEventListener('pagehide', cleanup, { once: true });
+				});
 			});
-	};
 
-	if (document.readyState === 'loading') {
-		document.addEventListener('DOMContentLoaded', init, { once: true });
-	} else {
-		init();
-	}
+		return () => {
+			for (const fn of cleanups) fn();
+		};
+	});
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
- Supersedes the short-term kill from #11484. Rewires `ScrollRing.astro`'s inline script to use `onMount` from [`packages/npm/astro/src/utils/clientRouter.ts`](packages/npm/astro/src/utils/clientRouter.ts) so the wheel/touch/keydown listeners are bound on every arrival (initial load, Astro SPA `astro:after-swap`, native cross-document `pagereveal`, bfcache `pageshow`) and torn down on `astro:before-swap` / `pagehide`.
- Previously the script only released listeners on `pagehide`. `<ClientRouter />` SPA swaps fire `astro:before-swap`, not `pagehide`, so listeners leaked into every subsequent page (e.g. `/application/php`) with the home page's stale `prev`/`next`, hijacking the scroll at page bottom.
- Per-root cleanups are now collected and returned from the `onMount` init so all listeners + the `pulseTimer` are released on swap. Dropped the now-unused `data-ring-init` dedupe flag — each SPA arrival gets a fresh DOM.

## Files changed
- [packages/npm/astro/src/components/hero/observer/ScrollRing.astro](packages/npm/astro/src/components/hero/observer/ScrollRing.astro)

## Test plan
- [ ] Hard reload `/` — confirm ScrollRing fires at top/bottom and navigates to `/projects/` / `/service/` after threshold.
- [ ] SPA-navigate `/` → `/application/php` and wheel-scroll the bottom of the PHP page — confirm no auto-navigation to `/service/` and no `data-ring-active` hint appears.
- [ ] Wheel-scroll the bottom of `/`, then back-button to `/projects/`, wheel-scroll to top — confirm ring back-nav still works after SPA swap.
- [ ] `PageDown` at bottom of `/application/php` — confirm default browser behavior, no ring nav.
- [ ] Verify `astro check` shows no new errors in `ScrollRing.astro` (existing repo errors in GamingHub / YukiVRM / AstroReferralCard are unrelated).