### PR TITLE
fix(astro-kbve): clear two pre-existing astro check errors

### DIFF
--- a/apps/kbve/astro-kbve/src/components/gaming/GamingHub.astro
+++ b/apps/kbve/astro-kbve/src/components/gaming/GamingHub.astro
@@ -21,7 +21,7 @@ const games = allDocs
 			typeof rawDesc === 'string'
 				? rawDesc.replace(/\s+/g, ' ').trim()
 				: '';
-		const tags = (entry.data.tags ?? []).filter(
+		const tags = ((entry.data as { tags?: string[] }).tags ?? []).filter(
 			(t: string) => t.toLowerCase() !== 'gaming',
 		);
 		return {

--- a/apps/kbve/astro-kbve/src/components/referral/AstroReferralCard.astro
+++ b/apps/kbve/astro-kbve/src/components/referral/AstroReferralCard.astro
@@ -460,7 +460,9 @@
 			const supa = getSupa();
 			const sessionResult = await supa.getSession().catch(() => null);
 			const token = sessionResult?.session?.access_token;
-			const userId = sessionResult?.session?.user?.id;
+			const userId = sessionResult?.session?.user?.id as
+				| string
+				| undefined;
 			if (!token) {
 				setState('signed-out');
 				return;


### PR DESCRIPTION
## Summary

Re-lands two type-narrowing fixes that were prepared in #11492 but landed on a commit that didn't make it into the merge.

- **`GamingHub.astro`**: cast `entry.data` → `{ tags?: string[] }` before reading the optional `tags` field. Starlight's docs schema doesn't ship `tags` by default; our content extends it, but the global docs typing doesn't know. The cast keeps the call site honest without widening the global schema.
- **`AstroReferralCard.astro`**: cast `sessionResult?.session?.user?.id` to `string | undefined`. Gateway types model `Session.user` as `Record<string, unknown>`, which narrows to `{}` after a truthy check — passing that to a `string` parameter triggered ts(2345).

After this PR, `nx run astro-kbve:check` reports **0 errors, 0 warnings** (255 hints, all pre-existing zod-deprecation hints).

## Test plan

- [ ] `./kbve.sh -nx astro-kbve:check --skip-nx-cache` — expect 0 errors, 0 warnings
- [ ] Smoke `/gaming/` — guide cards render with their tag chips
- [ ] Smoke `/account/` (referral card) — username pulled from session populates the snippet placeholders