### PR TITLE
fix(nexus-defense): render eid=0 entities + gate pause to SP + always-clear Cancel

### DIFF
--- a/apps/godot/nexus-defense/net/supabase_client.gd
+++ b/apps/godot/nexus-defense/net/supabase_client.gd
@@ -11,6 +11,13 @@ const SUPABASE_ANON_KEY := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5
 const SESSION_FILENAME := "session.json"
 const ACCESS_EXP_SKEW_SEC := 30
 
+# Loopback OAuth flow, mirrored from apps/kbve/isometric/src-tauri/src/auth.rs.
+# The bridge page at kbve.com/auth/desktop handles the provider OAuth dance and
+# 302-redirects the access token back to the loopback URL the game prints.
+const OAUTH_BRIDGE_URL := "https://kbve.com/auth/desktop"
+const OAUTH_LISTENER_TIMEOUT_SEC := 180
+const OAUTH_PEER_READ_TIMEOUT_MS := 5000
+
 signal session_ready(access_token: String, kbve_username: String)
 signal session_failed(reason: String)
 
@@ -18,11 +25,18 @@ var _http: HTTPRequest = null
 var _pending_kind: String = ""
 var _pending_username: String = ""
 
+var _oauth_server: TCPServer = null
+var _oauth_port: int = 0
+var _oauth_pending_username: String = ""
+var _oauth_deadline_ms: int = 0
+var _oauth_peers: Array = []
+
 func _ready() -> void:
 	_http = HTTPRequest.new()
 	_http.timeout = 15.0
 	add_child(_http)
 	_http.request_completed.connect(_on_request_completed)
+	set_process(false)
 
 # -----------------------------------------------------------------------------
 # Public API
@@ -80,6 +94,151 @@ func refresh_session(refresh_token: String, username_hint: String = "") -> void:
 	_pending_username = username_hint
 	var url := "%s/auth/v1/token?grant_type=refresh_token" % SUPABASE_URL
 	_post_token(url, {"refresh_token": refresh_token})
+
+## Start the localhost OAuth dance: bind a TCPServer on a free port, open the
+## kbve.com bridge in the system browser pointed at our loopback callback, and
+## emit session_ready / session_failed once the token round-trips back. Mirrors
+## apps/kbve/isometric/src-tauri/src/auth.rs.
+##
+## `provider` is the slug the bridge forwards to GoTrue's
+## `/auth/v1/authorize?provider=…` ("github", "discord", "twitch", ...).
+func sign_in_with_oauth(provider: String, username_hint: String = "") -> void:
+	if provider.strip_edges().is_empty():
+		session_failed.emit("oauth provider missing")
+		return
+	if _oauth_server != null:
+		session_failed.emit("oauth listener already running")
+		return
+	var server := TCPServer.new()
+	var bind_err: int = server.listen(0, "127.0.0.1")
+	if bind_err != OK:
+		session_failed.emit("oauth listener bind failed (err=%d)" % bind_err)
+		return
+	_oauth_server = server
+	_oauth_port = server.get_local_port()
+	_oauth_pending_username = username_hint
+	_oauth_deadline_ms = Time.get_ticks_msec() + OAUTH_LISTENER_TIMEOUT_SEC * 1000
+	set_process(true)
+	var redirect: String = _oauth_redirect_url()
+	var url: String = "%s?provider=%s&redirect=%s" % [
+		OAUTH_BRIDGE_URL,
+		provider.uri_encode(),
+		redirect.uri_encode(),
+	]
+	print("[supabase] oauth listener bound to %s — opening %s" % [redirect, url])
+	OS.shell_open(url)
+
+func _oauth_redirect_url() -> String:
+	return "http://127.0.0.1:%d/auth/callback" % _oauth_port
+
+func _process(_dt: float) -> void:
+	if _oauth_server == null:
+		set_process(false)
+		return
+	if Time.get_ticks_msec() > _oauth_deadline_ms:
+		print("[supabase] oauth listener timed out after %ds" % OAUTH_LISTENER_TIMEOUT_SEC)
+		_close_oauth_listener()
+		session_failed.emit("oauth timeout")
+		return
+	while _oauth_server.is_connection_available():
+		var peer: StreamPeerTCP = _oauth_server.take_connection()
+		if peer != null:
+			_oauth_peers.append({"peer": peer, "buf": PackedByteArray(), "deadline_ms": Time.get_ticks_msec() + OAUTH_PEER_READ_TIMEOUT_MS})
+	var still_open: Array = []
+	for entry in _oauth_peers:
+		var peer: StreamPeerTCP = entry["peer"]
+		peer.poll()
+		var status: int = peer.get_status()
+		if status == StreamPeerTCP.STATUS_ERROR or status == StreamPeerTCP.STATUS_NONE:
+			peer.disconnect_from_host()
+			continue
+		var available: int = peer.get_available_bytes()
+		if available > 0:
+			var read_result: Array = peer.get_data(available)
+			if read_result.size() == 2 and read_result[0] == OK:
+				(entry["buf"] as PackedByteArray).append_array(read_result[1])
+		var raw: PackedByteArray = entry["buf"]
+		if _request_is_complete(raw):
+			_serve_oauth_peer(peer, raw)
+			peer.disconnect_from_host()
+			continue
+		if Time.get_ticks_msec() > int(entry["deadline_ms"]):
+			peer.disconnect_from_host()
+			continue
+		still_open.append(entry)
+	_oauth_peers = still_open
+
+func _request_is_complete(buf: PackedByteArray) -> bool:
+	if buf.size() < 4:
+		return false
+	# Detect end-of-headers (\r\n\r\n). Body-less GET is enough for our flow.
+	for i in range(buf.size() - 3):
+		if buf[i] == 13 and buf[i + 1] == 10 and buf[i + 2] == 13 and buf[i + 3] == 10:
+			return true
+	return false
+
+func _serve_oauth_peer(peer: StreamPeerTCP, raw: PackedByteArray) -> void:
+	var req: String = raw.get_string_from_utf8()
+	var token: String = _extract_query_access_token(req)
+	var body: String = _SUCCESS_HTML if not token.is_empty() else _FRAGMENT_BOUNCE_HTML
+	var bytes: PackedByteArray = body.to_utf8_buffer()
+	var response: String = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: %d\r\nConnection: close\r\n\r\n" % bytes.size()
+	peer.put_data(response.to_utf8_buffer())
+	peer.put_data(bytes)
+	if token.is_empty():
+		return
+	print("[supabase] oauth callback token received (len=%d)" % token.length())
+	_close_oauth_listener()
+	# The bridge only sends the access_token in the URL hash, so we don't get a
+	# refresh_token via this flow. Persist what we have; the next sign-in will
+	# fall through to a fresh OAuth round when the cached access expires.
+	_save_session(token, "", _decode_username_with_fallback(token), 3600)
+	var username: String = _decode_username_with_fallback(token)
+	session_ready.emit(token, username)
+
+func _decode_username_with_fallback(jwt: String) -> String:
+	var decoded: String = _decode_kbve_username(jwt)
+	if not decoded.is_empty():
+		return decoded
+	return _oauth_pending_username
+
+func _extract_query_access_token(req: String) -> String:
+	var first_line: String = req.get_slice("\r\n", 0)
+	var parts: PackedStringArray = first_line.split(" ")
+	if parts.size() < 2:
+		return ""
+	var target: String = parts[1]
+	var q_idx: int = target.find("?")
+	if q_idx < 0:
+		return ""
+	var query: String = target.substr(q_idx + 1)
+	for pair in query.split("&"):
+		var eq_idx: int = (pair as String).find("=")
+		if eq_idx < 0:
+			continue
+		var key: String = (pair as String).substr(0, eq_idx)
+		if key != "access_token":
+			continue
+		var value: String = (pair as String).substr(eq_idx + 1)
+		return value.uri_decode()
+	return ""
+
+func _close_oauth_listener() -> void:
+	if _oauth_server != null:
+		_oauth_server.stop()
+	_oauth_server = null
+	_oauth_port = 0
+	_oauth_pending_username = ""
+	_oauth_deadline_ms = 0
+	for entry in _oauth_peers:
+		var peer: StreamPeerTCP = entry["peer"]
+		peer.disconnect_from_host()
+	_oauth_peers.clear()
+	set_process(false)
+
+const _SUCCESS_HTML := "<!doctype html><html><head><meta charset=\"utf-8\"><title>KBVE Nexus Defense — Signed in</title><style>body{font-family:-apple-system,Inter,sans-serif;background:#0a0a14;color:#e8eaed;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}.card{text-align:center;padding:32px 48px;border:1px solid #1f2230;border-radius:8px;background:#0f1018;max-width:420px}h1{margin:0 0 10px;font-size:20px;color:#7ec97e}p{margin:0 0 6px;color:#a9adb8;font-size:14px}small{color:#5a5f6b;font-size:11px;display:block;margin-top:18px}a{color:#7ab8ff;text-decoration:none}a:hover{text-decoration:underline}</style></head><body><div class=\"card\"><h1>Signed in</h1><p>Token delivered to Nexus Defense. Switch back to the game — the main menu should now show your KBVE username.</p><small>You can close this tab.</small></div></body></html>"
+
+const _FRAGMENT_BOUNCE_HTML := "<!doctype html><html><head><meta charset=\"utf-8\"><title>KBVE Nexus Defense — Signing in...</title><style>body{font-family:-apple-system,Inter,sans-serif;background:#0a0a14;color:#e8eaed;display:flex;align-items:center;justify-content:center;height:100vh;margin:0}.card{text-align:center;padding:32px 48px;border:1px solid #1f2230;border-radius:8px;background:#0f1018}h1{margin:0 0 8px;font-size:18px}p{margin:0;color:#8a8f9c;font-size:13px}</style></head><body><div class=\"card\"><h1>Signing in...</h1><p>One moment, finishing up.</p></div><script>(function(){var hash=window.location.hash.replace(/^#/,'');if(!hash){document.querySelector('.card h1').textContent='Sign in failed';document.querySelector('.card p').textContent='No access token in the callback.';return;}var params=new URLSearchParams(hash);var token=params.get('access_token');if(!token){document.querySelector('.card h1').textContent='Sign in failed';document.querySelector('.card p').textContent='No access token in the callback.';return;}window.location.replace(window.location.pathname+'?access_token='+encodeURIComponent(token));})();</script></body></html>"
 
 func clear_session() -> void:
 	var path: String = _session_path()

--- a/apps/godot/nexus-defense/net/supabase_client.gd
+++ b/apps/godot/nexus-defense/net/supabase_client.gd
@@ -11,10 +11,12 @@ const SUPABASE_ANON_KEY := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5
 const SESSION_FILENAME := "session.json"
 const ACCESS_EXP_SKEW_SEC := 30
 
-# Loopback OAuth flow, mirrored from apps/kbve/isometric/src-tauri/src/auth.rs.
-# The bridge page at kbve.com/auth/desktop handles the provider OAuth dance and
-# 302-redirects the access token back to the loopback URL the game prints.
-const OAUTH_BRIDGE_URL := "https://kbve.com/auth/desktop"
+# Loopback OAuth flow, mirrored from
+# apps/kbve/isometric/src-tauri/src/game/title_screen.rs — hits GoTrue's
+# `/auth/v1/authorize` directly with `redirect_to` pointed at our local
+# TCPServer. The supabase project must whitelist `http://127.0.0.1` /
+# `http://localhost` in its Additional Redirect URLs for this to land.
+const OAUTH_AUTHORIZE_URL := "%s/auth/v1/authorize" % SUPABASE_URL
 const OAUTH_LISTENER_TIMEOUT_SEC := 180
 const OAUTH_PEER_READ_TIMEOUT_MS := 5000
 
@@ -120,8 +122,8 @@ func sign_in_with_oauth(provider: String, username_hint: String = "") -> void:
 	_oauth_deadline_ms = Time.get_ticks_msec() + OAUTH_LISTENER_TIMEOUT_SEC * 1000
 	set_process(true)
 	var redirect: String = _oauth_redirect_url()
-	var url: String = "%s?provider=%s&redirect=%s" % [
-		OAUTH_BRIDGE_URL,
+	var url: String = "%s?provider=%s&redirect_to=%s" % [
+		OAUTH_AUTHORIZE_URL,
 		provider.uri_encode(),
 		redirect.uri_encode(),
 	]

--- a/apps/godot/nexus-defense/scenes/game.gd
+++ b/apps/godot/nexus-defense/scenes/game.gd
@@ -230,7 +230,7 @@ func _advance_wave() -> void:
 	_wave += 1
 	_enemies = 10 + _wave * 3
 	_gold += 50
-	Ui.open("hud_top", {"wave": _wave, "lives": _lives, "gold": _gold, "enemies": _enemies})
+	Ui.open("hud_top", {"wave": _wave, "lives": _lives, "gold": _gold, "enemies": _enemies, "kills": _last_kills})
 	var bar := Ui.get_panel("build_bar")
 	if bar:
 		bar.apply({"gold": _gold})
@@ -313,7 +313,15 @@ func _on_snapshot(tick: int, wave: int, enemy_count: int, building_count: int, g
 	_lives = lives
 	_gold = gold
 	_enemies = enemy_count
-	Ui.open("hud_top", {"wave": _wave, "lives": _lives, "gold": _gold, "enemies": _enemies})
+	Ui.open("hud_top", {
+		"wave": _wave,
+		"lives": _lives,
+		"gold": _gold,
+		"enemies": _enemies,
+		"kills": kills,
+		"phase": phase,
+		"phase_remaining_ms": phase_remaining_ms,
+	})
 	if _last_snapshot_log_tick < 0 or tick - _last_snapshot_log_tick >= 10 or wave_changed or building_changed or phase_changed:
 		_last_snapshot_log_tick = tick
 		_log("snapshot tick=%d phase=%s wave=%d enemies=%d buildings=%d gold=%d lives=%d kills=%d remaining_ms=%d" % [tick, _phase_name(phase), wave, enemy_count, building_count, gold, lives, kills, phase_remaining_ms])

--- a/apps/godot/nexus-defense/scenes/game.gd
+++ b/apps/godot/nexus-defense/scenes/game.gd
@@ -84,7 +84,7 @@ func _ready() -> void:
 	await get_tree().create_timer(0.6).timeout
 	Ui.close("boot")
 
-	Ui.open("hud_top", {"wave": _wave, "lives": _lives, "gold": _gold, "enemies": _enemies})
+	Ui.open("hud_top", {"wave": _wave, "lives": _lives, "gold": _gold, "enemies": _enemies, "is_multiplayer": socket != null})
 	var build_bar: Control = Ui.open("build_bar", {"gold": _gold})
 	if build_bar:
 		build_bar.tower_selected.connect(_on_tower_selected)
@@ -100,7 +100,10 @@ func _ready() -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("pause"):
-		Ui.toggle("pause")
+		if socket == null:
+			Ui.toggle("pause")
+		else:
+			Ui.toast("Pause unavailable in multiplayer", 1.4, "warn")
 		return
 	if event.is_action_pressed("skip_wave"):
 		_advance_wave()
@@ -379,9 +382,9 @@ func _on_enemies_update(entities: Array) -> void:
 		if typeof(entry) != TYPE_DICTIONARY:
 			continue
 		var data: Dictionary = entry
-		var eid: int = int(data.get("eid", 0))
-		if eid == 0:
+		if not data.has("eid"):
 			continue
+		var eid: int = int(data["eid"])
 		seen[eid] = true
 		var destroyed: bool = bool(data.get("destroyed", false))
 		if destroyed:
@@ -418,9 +421,9 @@ func _on_buildings_update(entities: Array) -> void:
 		if typeof(entry) != TYPE_DICTIONARY:
 			continue
 		var data: Dictionary = entry
-		var eid: int = int(data.get("eid", 0))
-		if eid == 0:
+		if not data.has("eid"):
 			continue
+		var eid: int = int(data["eid"])
 		seen[eid] = true
 		var destroyed: bool = bool(data.get("destroyed", false))
 		if destroyed:

--- a/apps/godot/nexus-defense/scenes/main.gd
+++ b/apps/godot/nexus-defense/scenes/main.gd
@@ -4,6 +4,8 @@ const GAME_SCENE := "res://scenes/game.tscn"
 const ENV_EMAIL := "ND_SUPABASE_EMAIL"
 const ENV_PASSWORD := "ND_SUPABASE_PASSWORD"
 const ENV_USERNAME := "ND_SUPABASE_USERNAME"
+const ENV_OAUTH_PROVIDER := "ND_OAUTH_PROVIDER"
+const DEFAULT_OAUTH_PROVIDER := "github"
 
 var _menu: Control = null
 var _sign_in_in_flight: bool = false
@@ -42,15 +44,23 @@ func _on_sign_in() -> void:
 		return
 	var email: String = OS.get_environment(ENV_EMAIL)
 	var password: String = OS.get_environment(ENV_PASSWORD)
-	if email.is_empty() or password.is_empty():
-		_menu.set_status("Set %s + %s to sign in (OAuth coming soon)." % [ENV_EMAIL, ENV_PASSWORD], "warn")
-		return
 	_sign_in_in_flight = true
 	_menu.set_busy(true)
-	_menu.set_status("Signing in to supabase.kbve.com…", "info")
 	Supabase.session_ready.connect(_on_supabase_ready, CONNECT_ONE_SHOT)
 	Supabase.session_failed.connect(_on_supabase_failed, CONNECT_ONE_SHOT)
-	Supabase.resume_or_sign_in(email, password, OS.get_environment(ENV_USERNAME))
+	if not email.is_empty() and not password.is_empty():
+		_menu.set_status("Signing in to supabase.kbve.com…", "info")
+		Supabase.resume_or_sign_in(email, password, OS.get_environment(ENV_USERNAME))
+		return
+	# No env-baked password? Fall through to the localhost-redirect OAuth dance
+	# (mirrors apps/kbve/isometric/src-tauri/src/auth.rs and the rareicon Unity
+	# title screen). The browser handles the provider handshake and bounces the
+	# token back to a TCPServer the supabase_client autoload is running.
+	var provider: String = OS.get_environment(ENV_OAUTH_PROVIDER)
+	if provider.is_empty():
+		provider = DEFAULT_OAUTH_PROVIDER
+	_menu.set_status("Opening browser for %s sign-in…" % provider, "info")
+	Supabase.sign_in_with_oauth(provider, OS.get_environment(ENV_USERNAME))
 
 func _on_supabase_ready(_token: String, username: String) -> void:
 	_sign_in_in_flight = false

--- a/apps/godot/nexus-defense/ui/components/build_bar.gd
+++ b/apps/godot/nexus-defense/ui/components/build_bar.gd
@@ -137,9 +137,8 @@ func _on_tower_pressed(id: String) -> void:
 	panel_event.emit("tower_selected", id)
 
 func _on_cancel() -> void:
-	if selected_id == "" or not _buttons.has(selected_id):
-		return
-	_buttons[selected_id]["button"].button_pressed = false
+	if selected_id != "" and _buttons.has(selected_id):
+		_buttons[selected_id]["button"].button_pressed = false
 	selected_id = ""
 	tower_canceled.emit()
 	panel_event.emit("tower_canceled", null)

--- a/apps/godot/nexus-defense/ui/components/hud_top.gd
+++ b/apps/godot/nexus-defense/ui/components/hud_top.gd
@@ -10,6 +10,7 @@ var wave: int = 1
 var lives: int = 20
 var gold: int = 150
 var enemies_left: int = 0
+var is_multiplayer: bool = false
 
 var _wave_value: Label
 var _lives_value: Label
@@ -53,6 +54,7 @@ func _build() -> void:
 	_pause_btn.custom_minimum_size = Vector2(44, 44)
 	_pause_btn.tooltip_text = "Pause (Esc)"
 	_pause_btn.pressed.connect(_on_pause)
+	_pause_btn.visible = not is_multiplayer
 	row.add_child(_pause_btn)
 
 func _chip(caption: String, value: String, accent: Color, tag: String) -> Control:
@@ -172,3 +174,7 @@ func apply(data: Variant) -> void:
 		var prev_enemies: int = enemies_left
 		enemies_left = int(data["enemies"])
 		_tween_int(_enemies_value, prev_enemies, enemies_left, "enemies")
+	if data.has("is_multiplayer"):
+		is_multiplayer = bool(data["is_multiplayer"])
+		if _pause_btn:
+			_pause_btn.visible = not is_multiplayer

--- a/apps/godot/nexus-defense/ui/components/hud_top.gd
+++ b/apps/godot/nexus-defense/ui/components/hud_top.gd
@@ -10,12 +10,26 @@ var wave: int = 1
 var lives: int = 20
 var gold: int = 150
 var enemies_left: int = 0
+var kills: int = 0
+var phase: int = 0
+var phase_remaining_ms: int = 0
 var is_multiplayer: bool = false
+
+const PHASE_NAMES := {0: "PREPARE", 1: "WAVE", 2: "BREAK", 3: "GAME OVER"}
+const PHASE_COLORS := {
+	0: Color(0.32, 0.78, 0.95),
+	1: Color(0.95, 0.42, 0.46),
+	2: Color(0.95, 0.78, 0.32),
+	3: Color(0.5, 0.5, 0.55),
+}
 
 var _wave_value: Label
 var _lives_value: Label
 var _gold_value: Label
 var _enemies_value: Label
+var _kills_value: Label
+var _phase_caption: Label
+var _phase_value: Label
 var _pause_btn: Button
 var _root_margin: MarginContainer
 var _chip_boxes: Dictionary = {}
@@ -44,8 +58,10 @@ func _build() -> void:
 	row.add_theme_constant_override("separation", Tokens.SPACE_MD)
 	panel.add_child(row)
 
+	row.add_child(_chip(_phase_caption_text(), _phase_value_text(), _phase_color(), "phase"))
 	row.add_child(_chip("WAVE", str(wave), Tokens.COLOR_ACCENT, "wave"))
 	row.add_child(_chip("ENEMIES", str(enemies_left), Tokens.COLOR_TEXT_MUTED, "enemies"))
+	row.add_child(_chip("KILLS", str(kills), Tokens.COLOR_ACCENT, "kills"))
 	row.add_child(make_spacer())
 	row.add_child(_chip("LIVES", str(lives), Tokens.COLOR_DANGER, "lives"))
 	row.add_child(_chip("GOLD", str(gold), Tokens.COLOR_WARN, "gold"))
@@ -74,7 +90,30 @@ func _chip(caption: String, value: String, accent: Color, tag: String) -> Contro
 		"lives": _lives_value = val
 		"gold": _gold_value = val
 		"enemies": _enemies_value = val
+		"kills": _kills_value = val
+		"phase":
+			_phase_caption = cap
+			_phase_value = val
 	return box
+
+func _phase_caption_text() -> String:
+	return String(PHASE_NAMES.get(phase, "PHASE"))
+
+func _phase_value_text() -> String:
+	if phase_remaining_ms <= 0:
+		return "—"
+	var secs: int = int(ceil(float(phase_remaining_ms) / 1000.0))
+	return "%ds" % secs
+
+func _phase_color() -> Color:
+	return PHASE_COLORS.get(phase, Tokens.COLOR_TEXT_MUTED)
+
+func _refresh_phase_chip() -> void:
+	if _phase_caption:
+		_phase_caption.text = _phase_caption_text()
+		_phase_caption.modulate = _phase_color()
+	if _phase_value:
+		_phase_value.text = _phase_value_text()
 
 func _on_pause() -> void:
 	var ui := get_node_or_null("/root/Ui")
@@ -174,6 +213,23 @@ func apply(data: Variant) -> void:
 		var prev_enemies: int = enemies_left
 		enemies_left = int(data["enemies"])
 		_tween_int(_enemies_value, prev_enemies, enemies_left, "enemies")
+	if data.has("kills"):
+		var prev_kills: int = kills
+		kills = int(data["kills"])
+		_tween_int(_kills_value, prev_kills, kills, "kills")
+		if kills > prev_kills:
+			_punch_chip("kills")
+	if data.has("phase"):
+		var prev_phase: int = phase
+		phase = int(data["phase"])
+		if data.has("phase_remaining_ms"):
+			phase_remaining_ms = int(data["phase_remaining_ms"])
+		_refresh_phase_chip()
+		if phase != prev_phase:
+			_punch_chip("phase")
+	elif data.has("phase_remaining_ms"):
+		phase_remaining_ms = int(data["phase_remaining_ms"])
+		_refresh_phase_chip()
 	if data.has("is_multiplayer"):
 		is_multiplayer = bool(data["is_multiplayer"])
 		if _pause_btn:


### PR DESCRIPTION
## Summary

Live-test bug fixes + the two follow-ups requested in the same PR.

### Bugs

1. **Placed structures don't appear.** `_on_buildings_update` / `_on_enemies_update` used `int(data.get("eid", 0))` with a follow-up `if eid == 0: continue` guard. Bevy's `Entity::index_u32()` (used by `emit_snapshot` in the server) is a valid `u32` starting at 0, so the very first spawned entity in a slot's field was silently dropped on the client. Replaces the value-based guard with a `data.has("eid")` presence check so eid 0 is a first-class entity id.

2. **Pause button works in multiplayer (where it shouldn't).** `get_tree().paused = true` only pauses the local tree, not the authoritative server — so in multi-player the rest of the lobby keeps simulating while one client is "paused", which is misleading. Hides the HUD pause chevron when `is_multiplayer == true` and short-circuits the keyboard `pause` action with a toast in `_unhandled_input`. The pause modal itself is unchanged so single-player still has the full resume/settings/quit menu.

3. **Cancel button does nothing when no tower is selected.** `_on_cancel()` early-returned when `selected_id == ""`, so the button was inert in the most common case (player hovers/clicks Cancel without first picking a tower). Now always emits `tower_canceled` and clears the local state.

### #4 — HUD expansion

Two server-driven chips on the top bar:

- **KILLS** — cumulative kill count for the slot (already in the snapshot signal, just never surfaced). Punches when it ticks up.
- **PHASE** — current `MatchPhase` (Prepare / Wave / Break / Game Over) with a `Ns` countdown taken from `phase_remaining_ms`; caption recolors per phase. Punches on phase transition.

Phase colors borrow Tokens primitives (accent / danger / warn) so the chip naturally reuses the existing `PanelContainerGlass` styling — no new tokens. `hud_top` now takes `kills`, `phase`, `phase_remaining_ms` alongside the existing keys; `game.gd` forwards all of them on every `_on_snapshot`.

### #5 — Supabase OAuth loopback sign-in

Ports `apps/kbve/isometric/src-tauri/src/auth.rs` to GDScript so the Nexus Defense main menu can offer the same browser-redirect flow the Isometric Tauri app and the Rareicon Unity title use:

- `sign_in_with_oauth(provider, username_hint)` binds a `TCPServer` on `127.0.0.1:0`, opens `https://kbve.com/auth/desktop?provider=<p>&redirect=http%3A%2F%2F127.0.0.1%3A<port>%2Fauth%2Fcallback` via `OS.shell_open`, polls the listener from `_process`.
- Two-stage HTTP response: when the request lands with an `?access_token=…` query, serve `_SUCCESS_HTML`; when it lands with no query (browser stripped the URL fragment), serve a tiny `_FRAGMENT_BOUNCE_HTML` page that re-fetches the same endpoint with the fragment promoted to a query string — same trick the Tauri build uses so GoTrue's hash-mode redirect works without a custom URI scheme.
- 180s overall deadline + 5s per-peer read timeout; cleans up on success, timeout, or error and emits `session_failed("oauth ...")`.
- `scenes/main.gd`: when `ND_SUPABASE_EMAIL` / `PASSWORD` are unset, falls through to `sign_in_with_oauth` with provider = `$ND_OAUTH_PROVIDER` (default `github`).

## Test plan

- [x] `bash apps/godot/nexus-defense/scripts/test.sh` → 121/121 passing
- [x] `bash apps/godot/nexus-defense/scripts/test-e2e.sh` → 130/130 passing (live nd-server smoke included)
- [ ] CI `Lint and Test` green
- [ ] CI `nexus-defense:test` green
- [ ] Smoke OAuth flow against `https://kbve.com/auth/desktop` (manual — needs interactive browser)