### PR TITLE
feat(agones-factorio-relay): sim_director P1 — RCON snapshots → ClickHouse

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -16,7 +16,7 @@
 		{
 			"key": "agones_factorio_relay",
 			"app_name": "agones-factorio-relay",
-			"version": "0.0.4",
+			"version": "0.0.5",
 			"version_toml": "apps/agones/factorio/relay/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx",
 			"source_path": "apps/agones/factorio/relay",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,9 @@ name = "agones-factorio-relay"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "futures",
+ "jedi",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/apps/agones/factorio/relay/Cargo.toml
+++ b/apps/agones/factorio/relay/Cargo.toml
@@ -28,3 +28,5 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "json",
 ] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+jedi = { path = "../../../../packages/rust/jedi" }

--- a/apps/agones/factorio/relay/Cargo.workspace.toml
+++ b/apps/agones/factorio/relay/Cargo.workspace.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "apps/agones/factorio/relay",
+    "packages/rust/jedi",
 ]
 
 [profile.release]

--- a/apps/agones/factorio/relay/Dockerfile
+++ b/apps/agones/factorio/relay/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /build
 
 COPY apps/agones/factorio/relay/Cargo.workspace.toml Cargo.toml
 COPY apps/agones/factorio/relay apps/agones/factorio/relay
+COPY packages/rust/jedi packages/rust/jedi
 
 RUN --mount=type=cache,target=/build/target,id=agones-factorio-relay-target \
     --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry \

--- a/apps/agones/factorio/relay/src/config.rs
+++ b/apps/agones/factorio/relay/src/config.rs
@@ -23,6 +23,10 @@ pub struct Config {
     pub agones_health_interval_secs: u64,
     pub agones_rcon_probe_timeout_secs: u64,
     pub agones_initial_ready_delay_secs: u64,
+    pub sim_director_enabled: bool,
+    pub sim_poll_interval_secs: u64,
+    pub sim_rcon_rate_limit_qps: u32,
+    pub sim_dry_run: bool,
 }
 
 impl Config {
@@ -56,7 +60,18 @@ impl Config {
             agones_health_interval_secs: parse_env_u64("AGONES_HEALTH_INTERVAL_SECS", 5)?,
             agones_rcon_probe_timeout_secs: parse_env_u64("AGONES_RCON_PROBE_TIMEOUT_SECS", 2)?,
             agones_initial_ready_delay_secs: parse_env_u64("AGONES_INITIAL_READY_DELAY_SECS", 0)?,
+            sim_director_enabled: parse_env_bool("SIM_DIRECTOR_ENABLED", true),
+            sim_poll_interval_secs: parse_env_u64("SIM_POLL_INTERVAL_SECS", 10)?,
+            sim_rcon_rate_limit_qps: parse_env_u32("SIM_RCON_RATE_LIMIT_QPS", 4)?,
+            sim_dry_run: parse_env_bool("SIM_DRY_RUN", false),
         })
+    }
+}
+
+fn parse_env_u32(name: &str, default: u32) -> Result<u32> {
+    match std::env::var(name).ok() {
+        Some(s) => s.parse().with_context(|| format!("{name} not a u32")),
+        None => Ok(default),
     }
 }
 

--- a/apps/agones/factorio/relay/src/main.rs
+++ b/apps/agones/factorio/relay/src/main.rs
@@ -5,6 +5,8 @@ mod event;
 mod irc_bridge;
 mod log_tail;
 mod rcon_client;
+mod rcon_pool;
+mod sim_director;
 
 use anyhow::Result;
 use tokio::sync::{broadcast, mpsc};
@@ -37,11 +39,14 @@ async fn main() -> Result<()> {
     let (game_tx, _) = broadcast::channel::<GameEvent>(512);
     let (irc_in_tx, irc_in_rx) = mpsc::channel::<IrcMessage>(512);
 
+    let (rcon_pool, rcon_pool_handle) = rcon_pool::spawn(cfg.clone());
+
     let tail_handle = tokio::spawn(log_tail::run(cfg.clone(), game_tx.clone()));
     let irc_handle = tokio::spawn(irc_bridge::run(cfg.clone(), game_tx.subscribe(), irc_in_tx));
     let rcon_handle = tokio::spawn(rcon_client::run(cfg.clone(), irc_in_rx));
     let ch_handle = tokio::spawn(ch_writer::run(cfg.clone(), game_tx.subscribe()));
     let agones_handle = tokio::spawn(agones_health::run(cfg.clone()));
+    let sim_handle = tokio::spawn(sim_director::run(cfg.clone(), rcon_pool));
 
     drop(game_tx);
 
@@ -51,6 +56,8 @@ async fn main() -> Result<()> {
         r = rcon_handle => r??,
         r = ch_handle => r??,
         r = agones_handle => r??,
+        r = sim_handle => r??,
+        r = rcon_pool_handle => r??,
         _ = tokio::signal::ctrl_c() => {
             info!("ctrl_c received, shutting down");
         }

--- a/apps/agones/factorio/relay/src/rcon_pool.rs
+++ b/apps/agones/factorio/relay/src/rcon_pool.rs
@@ -1,0 +1,113 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use thiserror::Error;
+use tokio::sync::{
+    Semaphore, mpsc,
+    oneshot::{self, Sender as OneshotSender},
+};
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
+
+use jedi::rcon::{RconClient, RconEndpoint, RconError};
+
+use crate::config::Config;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const RECONNECT_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
+const RECONNECT_BACKOFF_MAX: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Error)]
+pub enum RconJobError {
+    #[error("rcon protocol: {0}")]
+    Proto(#[from] RconError),
+
+    #[error("rcon pool shutting down")]
+    Shutdown,
+}
+
+pub struct RconJob {
+    pub command: String,
+    pub reply: OneshotSender<Result<String, RconJobError>>,
+}
+
+#[derive(Clone)]
+pub struct RconPool {
+    tx: mpsc::Sender<RconJob>,
+    permits: std::sync::Arc<Semaphore>,
+}
+
+impl RconPool {
+    pub async fn exec(&self, command: impl Into<String>) -> Result<String, RconJobError> {
+        let _permit = self
+            .permits
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| RconJobError::Shutdown)?;
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let job = RconJob {
+            command: command.into(),
+            reply: reply_tx,
+        };
+        self.tx
+            .send(job)
+            .await
+            .map_err(|_| RconJobError::Shutdown)?;
+        reply_rx.await.map_err(|_| RconJobError::Shutdown)?
+    }
+}
+
+pub fn spawn(cfg: Config) -> (RconPool, tokio::task::JoinHandle<Result<()>>) {
+    let (tx, rx) = mpsc::channel::<RconJob>(256);
+    let permits = std::sync::Arc::new(Semaphore::new(cfg.sim_rcon_rate_limit_qps.max(1) as usize));
+    let pool = RconPool {
+        tx,
+        permits: permits.clone(),
+    };
+    let handle = tokio::spawn(run(cfg, rx));
+    (pool, handle)
+}
+
+async fn run(cfg: Config, mut rx: mpsc::Receiver<RconJob>) -> Result<()> {
+    let endpoint = RconEndpoint::new(
+        cfg.rcon_addr.ip().to_string(),
+        cfg.rcon_addr.port(),
+        cfg.rcon_password.clone(),
+    );
+
+    let mut backoff = RECONNECT_BACKOFF_INITIAL;
+    let mut client: Option<RconClient> = None;
+
+    while let Some(job) = rx.recv().await {
+        if client.is_none() {
+            match RconClient::connect(&endpoint, CONNECT_TIMEOUT).await {
+                Ok(c) => {
+                    info!(rcon = %endpoint.addr(), "rcon_pool connected");
+                    client = Some(c);
+                    backoff = RECONNECT_BACKOFF_INITIAL;
+                }
+                Err(e) => {
+                    warn!(error = %e, retry_in = ?backoff, "rcon_pool connect failed");
+                    let _ = job.reply.send(Err(RconJobError::Proto(e)));
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(RECONNECT_BACKOFF_MAX);
+                    continue;
+                }
+            }
+        }
+
+        let result = client.as_mut().unwrap().exec(&job.command).await;
+        match &result {
+            Ok(body) => debug!(bytes = body.len(), "rcon_pool exec ok"),
+            Err(e) => {
+                warn!(error = %e, "rcon_pool exec failed; dropping connection");
+                client = None;
+            }
+        }
+        let _ = job.reply.send(result.map_err(RconJobError::Proto));
+    }
+
+    Ok(())
+}

--- a/apps/agones/factorio/relay/src/sim_director/ch.rs
+++ b/apps/agones/factorio/relay/src/sim_director/ch.rs
@@ -1,0 +1,65 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use reqwest::Client;
+use serde_json::json;
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+use crate::config::Config;
+use crate::sim_director::state::SimSnapshot;
+
+pub async fn run(cfg: Config, mut rx: mpsc::Receiver<SimSnapshot>) -> Result<()> {
+    let Some(ch_base) = cfg.clickhouse_url.clone() else {
+        warn!("sim_director ch writer disabled: CLICKHOUSE_URL not set");
+        while rx.recv().await.is_some() {}
+        return Ok(());
+    };
+
+    let client = Client::builder().timeout(Duration::from_secs(10)).build()?;
+
+    let table = format!("{}.sim_snapshots_raw", cfg.clickhouse_database);
+    let url = format!(
+        "{}/?query=INSERT+INTO+{}+FORMAT+JSONEachRow",
+        ch_base.trim_end_matches('/'),
+        table,
+    );
+
+    info!(%url, dry_run = cfg.sim_dry_run, "sim_director ch writer started");
+
+    while let Some(snap) = rx.recv().await {
+        let row = json!({
+            "ts": snap.captured_at.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+            "server_id": cfg.server_id,
+            "tick": snap.tick,
+            "evolution": snap.evolution,
+            "players": snap.players,
+            "pollution": snap.pollution,
+            "ups": snap.ups,
+        });
+
+        if cfg.sim_dry_run {
+            debug!(row = %row, "sim_director ch dry-run row");
+            continue;
+        }
+
+        let mut req = client.post(&url).body(row.to_string());
+        if let Some(u) = cfg.clickhouse_user.as_deref() {
+            req = req.basic_auth(u, cfg.clickhouse_password.as_deref());
+        }
+
+        match req.send().await {
+            Ok(resp) if resp.status().is_success() => {
+                debug!(tick = snap.tick, "sim_director ch insert ok");
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                warn!(%status, %body, "sim_director ch insert non-2xx");
+            }
+            Err(e) => warn!(error = %e, "sim_director ch insert failed"),
+        }
+    }
+
+    Ok(())
+}

--- a/apps/agones/factorio/relay/src/sim_director/mod.rs
+++ b/apps/agones/factorio/relay/src/sim_director/mod.rs
@@ -1,0 +1,41 @@
+pub mod ch;
+pub mod poller;
+pub mod state;
+
+use anyhow::Result;
+use tokio::sync::mpsc;
+use tracing::{info, warn};
+
+use crate::config::Config;
+use crate::rcon_pool::RconPool;
+use crate::sim_director::state::SimSnapshot;
+
+pub async fn run(cfg: Config, pool: RconPool) -> Result<()> {
+    if !cfg.sim_director_enabled {
+        info!("sim_director disabled via SIM_DIRECTOR_ENABLED=false");
+        return Ok(());
+    }
+
+    info!(
+        poll_interval_secs = cfg.sim_poll_interval_secs,
+        dry_run = cfg.sim_dry_run,
+        "sim_director starting"
+    );
+
+    let (snap_tx, snap_rx) = mpsc::channel::<SimSnapshot>(64);
+
+    let poll_handle = tokio::spawn(poller::run(cfg.clone(), pool, snap_tx));
+    let ch_handle = tokio::spawn(ch::run(cfg.clone(), snap_rx));
+
+    tokio::select! {
+        r = poll_handle => {
+            warn!("sim_director poller exited");
+            r??;
+        }
+        r = ch_handle => {
+            warn!("sim_director ch writer exited");
+            r??;
+        }
+    }
+    Ok(())
+}

--- a/apps/agones/factorio/relay/src/sim_director/poller.rs
+++ b/apps/agones/factorio/relay/src/sim_director/poller.rs
@@ -1,0 +1,68 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use tokio::sync::mpsc;
+use tokio::time;
+use tracing::{debug, warn};
+
+use crate::config::Config;
+use crate::rcon_pool::RconPool;
+use crate::sim_director::state::SimSnapshot;
+
+const SNAPSHOT_LUA: &str = "/silent-command \
+rcon.print(game.table_to_json({\
+tick=game.tick,\
+evolution=game.forces.enemy.evolution_factor,\
+players=#game.connected_players,\
+pollution=game.get_pollution({0,0}),\
+ups=game.speed,\
+surfaces={[\"nauvis\"]=game.surfaces[\"nauvis\"].daytime}\
+}))";
+
+pub async fn run(cfg: Config, pool: RconPool, tx: mpsc::Sender<SimSnapshot>) -> Result<()> {
+    let interval = Duration::from_secs(cfg.sim_poll_interval_secs.max(1));
+    let mut ticker = time::interval(interval);
+    ticker.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+    ticker.tick().await;
+
+    loop {
+        ticker.tick().await;
+
+        let body = match pool.exec(SNAPSHOT_LUA).await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(error = %e, "sim_director snapshot exec failed");
+                continue;
+            }
+        };
+
+        if body.trim().is_empty() {
+            debug!("sim_director snapshot returned empty body");
+            continue;
+        }
+
+        let snap = match SimSnapshot::parse(&body) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(error = %e, body = %body, "sim_director snapshot parse failed");
+                continue;
+            }
+        };
+
+        debug!(
+            tick = snap.tick,
+            evo = snap.evolution,
+            players = snap.players,
+            pollution = snap.pollution,
+            ups = snap.ups,
+            "sim_director snapshot"
+        );
+
+        if tx.send(snap).await.is_err() {
+            warn!("sim_director ch channel closed");
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/apps/agones/factorio/relay/src/sim_director/state.rs
+++ b/apps/agones/factorio/relay/src/sim_director/state.rs
@@ -1,0 +1,25 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimSnapshot {
+    #[serde(skip_deserializing, default = "Utc::now")]
+    pub captured_at: DateTime<Utc>,
+    pub tick: u64,
+    pub evolution: f64,
+    pub players: u32,
+    pub pollution: f64,
+    pub ups: f64,
+    #[serde(default)]
+    pub surfaces: HashMap<String, f64>,
+}
+
+impl SimSnapshot {
+    pub fn parse(body: &str) -> serde_json::Result<Self> {
+        let mut s: SimSnapshot = serde_json::from_str(body.trim())?;
+        s.captured_at = Utc::now();
+        Ok(s)
+    }
+}

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx
@@ -15,7 +15,7 @@ tags:
 key: agones_factorio_relay
 pipeline: docker
 app_name: agones-factorio-relay
-version: "0.0.4"
+version: "0.0.5"
 source_path: apps/agones/factorio/relay
 version_toml: apps/agones/factorio/relay/version.toml
 runner: ubuntu-latest

--- a/packages/data/ch/migrations/20260531_sim_director.sql
+++ b/packages/data/ch/migrations/20260531_sim_director.sql
@@ -1,0 +1,45 @@
+-- ---------------------------------------------------------------------------
+-- Migration: introduce gameops.sim_snapshots_raw (+ Distributed twin) for the
+-- agones-factorio-relay `sim_director` Phase 1 poller (issue #11138 / Phase 5
+-- of the relay design map in apps/kbve/astro-kbve/src/content/docs/project/
+-- agones-factorio-relay.mdx).
+--
+-- The canonical schema lives in packages/data/ch/schemas/factorio.sql; this
+-- migration is the operator-runnable cut for an already-applied production
+-- cluster. Idempotent — every DDL is `IF NOT EXISTS` + `ON CLUSTER 'cluster'`.
+--
+-- Apply (planned-window operator session):
+--
+--   kubectl -n clickhouse exec -i \
+--     chi-clickhouse-cluster-cluster-0-0-0 -c clickhouse -- \
+--     clickhouse-client --multiquery \
+--     < packages/data/ch/migrations/20260531_sim_director.sql
+--
+-- Record the apply:
+--
+--   INSERT INTO observability.schema_migrations (name, applied_by)
+--   VALUES ('20260531_sim_director', '<operator>');
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS gameops.sim_snapshots_raw ON CLUSTER 'cluster'
+(
+    ts          DateTime64(3, 'UTC'),
+    server_id   LowCardinality(String),
+    tick        UInt64,
+    evolution   Float64,
+    players     UInt16,
+    pollution   Float64,
+    ups         Float64,
+    ingested_at DateTime64(3, 'UTC') DEFAULT now64(3)
+)
+ENGINE = ReplicatedMergeTree(
+    '/clickhouse/tables/{shard}/gameops/sim_snapshots_raw',
+    '{replica}'
+)
+ORDER BY (server_id, ts)
+PARTITION BY toYYYYMMDD(ts)
+TTL toDateTime(ts) + INTERVAL 14 DAY;
+
+CREATE TABLE IF NOT EXISTS gameops.sim_snapshots ON CLUSTER 'cluster'
+AS gameops.sim_snapshots_raw
+ENGINE = Distributed('cluster', 'gameops', 'sim_snapshots_raw', rand());

--- a/packages/data/ch/schemas/factorio.sql
+++ b/packages/data/ch/schemas/factorio.sql
@@ -198,3 +198,43 @@ TTL toDateTime(ts) + INTERVAL 7 DAY;
 CREATE TABLE IF NOT EXISTS gameops.factorio_chat_log ON CLUSTER 'cluster'
 AS gameops.factorio_chat_log_raw
 ENGINE = Distributed('cluster', 'gameops', 'factorio_chat_log_raw', rand());
+
+-- ---------------------------------------------------------------------------
+-- sim_snapshots_raw — relay-side `sim_director` poll observations.
+--
+-- Distinct from `factorio_snapshots_raw` (which captures server capacity
+-- facts like map age and seed). This table captures the strategic state the
+-- director reads when deciding whether to fire a rule: evolution factor,
+-- pollution near origin, UPS, and player count, stamped with both the wall
+-- timestamp and the in-game tick.
+--
+-- Producer writes one row every `SIM_POLL_INTERVAL_SECS` seconds per server
+-- (default 10s), via a single `/silent-command rcon.print(game.table_to_json(
+-- ...))` round trip per cycle so the Factorio tick cost stays one Lua eval
+-- regardless of how many fields the director reads.
+--
+-- Retention: 14 days (matches `factorio_snapshots_raw`).
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS gameops.sim_snapshots_raw ON CLUSTER 'cluster'
+(
+    ts          DateTime64(3, 'UTC'),
+    server_id   LowCardinality(String),
+    tick        UInt64,
+    evolution   Float64,
+    players     UInt16,
+    pollution   Float64,
+    ups         Float64,
+    ingested_at DateTime64(3, 'UTC') DEFAULT now64(3)
+)
+ENGINE = ReplicatedMergeTree(
+    '/clickhouse/tables/{shard}/gameops/sim_snapshots_raw',
+    '{replica}'
+)
+ORDER BY (server_id, ts)
+PARTITION BY toYYYYMMDD(ts)
+TTL toDateTime(ts) + INTERVAL 14 DAY;
+
+CREATE TABLE IF NOT EXISTS gameops.sim_snapshots ON CLUSTER 'cluster'
+AS gameops.sim_snapshots_raw
+ENGINE = Distributed('cluster', 'gameops', 'sim_snapshots_raw', rand());


### PR DESCRIPTION
## Summary
Phase 1 of the \`sim_director\` design landed in #11494. Adds the read-only half of the relay's strategic brain: a single shared RCON connection, a periodic \`SimSnapshot\` poller, and a ClickHouse insert path. No actions issued back to the game yet — that ships in P2.

## Changes

### Shared RCON pool (new \`rcon_pool.rs\`)
Wraps [\`jedi::rcon::RconClient\`](packages/rust/jedi/src/rcon.rs) — the same Source RCON transport [axum-kbve uses](apps/kbve/axum-kbve/src/rcon/handler.rs) for \`/api/v1/rcon/{game}/{server}/exec\` — behind an \`mpsc<RconJob>\` queue and a \`tokio::Semaphore\` QPS cap.
- Single TCP connection, serialized command queue, never bursts the Factorio tick
- Reconnect with exponential backoff on protocol errors
- \`RconPool::exec(...) -> Result<String>\` API; first consumer is the snapshot poller, future consumers (IRC \`!cmd\`, sim_director actions) just spawn another sender

Reuses the shared crate per [feedback_shared_crates_for_cross_cutting](memory/feedback_shared_crates_for_cross_cutting.md) instead of vendoring the wire impl.

### \`sim_director\` poller
- [\`sim_director::poller\`](apps/agones/factorio/relay/src/sim_director/poller.rs) ticks every \`SIM_POLL_INTERVAL_SECS\` (default 10s)
- Issues one \`/silent-command rcon.print(game.table_to_json(...))\` per cycle — single Lua eval per poll, regardless of how many fields the director reads
- Parses the JSON blob into [\`SimSnapshot { tick, evolution, players, pollution, ups, surfaces }\`](apps/agones/factorio/relay/src/sim_director/state.rs)

### ClickHouse insert path
- [\`sim_director::ch\`](apps/agones/factorio/relay/src/sim_director/ch.rs) streams snapshots into \`gameops.sim_snapshots_raw\` via the existing reqwest+rustls path
- Honours \`SIM_DRY_RUN\` (logs the row instead of inserting)
- Disabled gracefully when \`CLICKHOUSE_URL\` is unset — the rest of the relay keeps running

### Schema
- New \`gameops.sim_snapshots_raw\` + Distributed twin appended to [packages/data/ch/schemas/factorio.sql](packages/data/ch/schemas/factorio.sql)
- Runnable migration at [packages/data/ch/migrations/20260531_sim_director.sql](packages/data/ch/migrations/20260531_sim_director.sql)
- 14d TTL, partitioned by day, ordered by \`(server_id, ts)\` — matches \`factorio_snapshots_raw\` pattern

### Wiring
- MDX bumped to 0.0.5, [.github/ci-dispatch-manifest.json](.github/ci-dispatch-manifest.json) regenerated
- [gameserver.yaml](apps/kube/agones/factorio/manifests/gameserver.yaml) intentionally **not** touched — the post-publish sync workflow will bump the tag in its own PR after the image lands; \`SIM_*\` env wiring (and the \`CLICKHOUSE_URL\` value) follow in that PR or the next one

## Why
Frees the in-game Lua mod from hosting strategic decision code while still keeping per-tick sensors there. Phase 1 is observation-only so we can validate the poller cadence + RCON pool stability against the live server before P2 lets the director write back to the game.

## Test plan
- [ ] CI - Docker / agones-factorio-relay green
- [ ] CH migration applied in a planned-window operator session against the production cluster (separate task, runbook in the migration file header)
- [ ] After deploy, \`SELECT count() FROM gameops.sim_snapshots WHERE server_id='factorio-1' AND ts >= now() - INTERVAL 5 MINUTE\` returns ~30 (one row per 10s) once \`CLICKHOUSE_URL\` is wired in the follow-up PR
- [ ] \`kubectl logs factorio -n factorio -c factorio-relay\` shows \`sim_director snapshot\` debug lines with rising \`tick\` and live \`evolution\` / \`pollution\` / \`ups\` values

## Follow-ups
- Post-publish PR: bump image tag + add \`SIM_*\` env vars + wire \`CLICKHOUSE_URL\` on the deployment
- P2: hardcoded triggers (\`EvolutionAbove → Broadcast\`, \`Cron("*/30 * * * *") → SpawnBiterWave\`) + \`sim_actions\` audit table