### PR TITLE
feat(agones,nd-server): in-cluster Service + browser WSS HTTPRoute

### DIFF
--- a/apps/kube/agones/nd-server/manifests/httproute.yaml
+++ b/apps/kube/agones/nd-server/manifests/httproute.yaml
@@ -1,0 +1,29 @@
+# Browser-facing WSS endpoint for Nexus Defense.
+#
+# Terminates TLS at the shared `kbve-gateway` (Cilium Gateway API) using the
+# wildcard cert provisioned by cert-manager for *.kbve.com, then forwards
+# the WebSocket upgrade to the nd-server Service on port 7878. The Service
+# round-robins across whichever Agones Fleet pods are Ready, so browser /
+# WASM clients ride the standard ingress while native clients can still
+# direct-connect via the Agones-allocated Dynamic node port.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: nd-server-route
+    namespace: nexus-defense
+    labels:
+        app.kubernetes.io/part-of: nexus-defense
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - nd.kbve.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: nd-server
+                port: 7878

--- a/apps/kube/agones/nd-server/manifests/service.yaml
+++ b/apps/kube/agones/nd-server/manifests/service.yaml
@@ -1,0 +1,24 @@
+# ClusterIP service in front of the Agones Fleet pods.
+#
+# Agones-allocated Dynamic ports are for direct outside-cluster access
+# (native godot client connecting straight to nodeIP:dynPort). For browser /
+# WASM clients we need a stable in-cluster Service the Cilium Gateway can
+# target. Selector matches the Fleet's pod label so every Ready GameServer
+# becomes a backend; the Fleet handles add/drop as pods cycle.
+apiVersion: v1
+kind: Service
+metadata:
+    name: nd-server
+    namespace: nexus-defense
+    labels:
+        app: nd-server
+        app.kubernetes.io/part-of: nexus-defense
+spec:
+    type: ClusterIP
+    selector:
+        app: nd-server
+    ports:
+        - name: ws
+          port: 7878
+          targetPort: 7878
+          protocol: TCP


### PR DESCRIPTION
## Summary
Browser / WASM godot clients couldn't reach the Agones-allocated Dynamic node ports (no TLS, no stable hostname). Native clients already work via direct \`ws://nodeIP:dynPort\`.

This adds a standard \`ClusterIP\` Service in front of the existing Agones Fleet pods plus a Cilium Gateway HTTPRoute for \`wss://nd.kbve.com/ws\`. Same Fleet, no parallel Deployment, all under the single \`agones/nd-server\` tree — keeps the orchestration story coherent.

## Flow
\`\`\`
browser  ─wss://nd.kbve.com─> Cilium Gateway (TLS, *.kbve.com cert)
                                │
                                v
                              Service nd-server :7878
                                │  selector app=nd-server
                                v
                              Agones Fleet pod (existing)

native godot client ─ws://nodeIP:dynPort/ws─> Agones GS directly (existing path, unchanged)
\`\`\`

## Files
- \`apps/kube/agones/nd-server/manifests/service.yaml\` — ClusterIP :7878, selector matches the Fleet pod template's \`app: nd-server\` label.
- \`apps/kube/agones/nd-server/manifests/httproute.yaml\` — \`kbve-gateway\` parent (shared Cilium Gateway), hostname \`nd.kbve.com\`, PathPrefix \`/\` → \`nd-server:7878\`.

No new ArgoCD app — the existing \`agones/nd-server/application.yaml\` already syncs the manifests dir. No kustomization change.

## Notes
- Service round-robins across whichever Fleet pods are \`Ready\` at the moment of connection; no per-match isolation for browser clients (small-population trade-off).
- \`cert-manager\` wildcard cert + Cilium Gateway combo is the same pattern \`apps/kube/irc/\` and \`apps/kube/discordsh/\` use; no new infra needed.
- \`SUPABASE_JWT_SECRET\` already wired into Fleet pods from the existing \`nd-server-supabase-jwt\` ExternalSecret — unchanged.

## Verified
- \`js-yaml loadAll\` OK on both new manifests.

## Test plan
- [ ] ArgoCD re-syncs \`agones-nd-server\` app, picks up Service + HTTPRoute.
- [ ] \`kubectl get svc -n nexus-defense nd-server\` shows endpoints matching Ready Fleet pods.
- [ ] \`curl https://nd.kbve.com/healthz\` returns \`ok\` (DNS + cert + Gateway path).
- [ ] Browser \`new WebSocket('wss://nd.kbve.com/ws')\` connects + receives \`Welcome\` postcard.
- [ ] Native godot client on \`ws://<nodeIP>:<dynPort>/ws\` still works (regression check).

## Related
- #11294 — multiplayer TD tracker
- #11404 — Phase 1 Agones Fleet