### PR TITLE
feat(irc,nd-server): RBAC scaffold for nd-bot game-chat relay

### DIFF
--- a/apps/kube/agones/nd-server/manifests/fleet.yaml
+++ b/apps/kube/agones/nd-server/manifests/fleet.yaml
@@ -79,6 +79,23 @@ spec:
                                     secretKeyRef:
                                         name: nd-server-supabase-jwt
                                         key: SUPABASE_JWT_SECRET
+                              - name: IRC_SERVER
+                                value: 'ergo-irc-service.irc.svc.cluster.local'
+                              - name: IRC_PORT
+                                value: '6667'
+                              - name: IRC_USE_TLS
+                                value: 'false'
+                              - name: IRC_NICK
+                                value: 'nd-bot'
+                              - name: IRC_CHANNEL
+                                value: '#general'
+                              - name: IRC_OPER_USER
+                                value: 'nd-bot'
+                              - name: IRC_OPER_PASSWORD
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: nd-server-irc-bot
+                                        key: IRC_OPER_PASSWORD
                           ports:
                               - name: ws
                                 containerPort: 7878

--- a/apps/kube/agones/nd-server/manifests/irc-bot-external-secret.yaml
+++ b/apps/kube/agones/nd-server/manifests/irc-bot-external-secret.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: nd-server-external-secrets
+    namespace: nexus-defense
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-remote-secret-store
+    namespace: nexus-defense
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: nd-server-external-secrets
+                    namespace: nexus-defense
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: nd-server-irc-bot
+    namespace: nexus-defense
+    labels:
+        app.kubernetes.io/part-of: nexus-defense
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        kind: SecretStore
+        name: kilobase-remote-secret-store
+    target:
+        name: nd-server-irc-bot
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                IRC_OPER_PASSWORD: '{{ .password }}'
+    data:
+        - secretKey: password
+          remoteRef:
+              key: irc-game-relay
+              property: nd-bot-password

--- a/apps/kube/irc/manifests/ergo-configmap.yaml
+++ b/apps/kube/irc/manifests/ergo-configmap.yaml
@@ -1,133 +1,141 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ergo-config
-  namespace: irc
+    name: ergo-config
+    namespace: irc
 data:
-  ircd.yaml: |
-    # Ergo IRC Server Configuration
-    
-    network:
-      name: "KBVE-Network"
-    
-    server:
-      name: irc.kbve.com
-      enforce-utf8: true
-      max-sendq: "1MB"
-      connection-limits:
-        enabled: true
-        cidr-len-ipv4: 32
-        cidr-len-ipv6: 64
-        connections-per-cidr: 12
-        throttle-duration: "10m"
-        exempted:
-          - "localhost"
-          - "127.0.0.1"
-      listeners:
-        ":6667": {}
-        ":6697":
-          tls:
-            cert: /etc/ssl/certs/tls.crt
-            key: /etc/ssl/certs/tls.key        
-        ":8080":
-          websocket: true
-        ":8067":
-          websocket: true
-    
-    # Data storage
-    datastore:
-      path: /ircd/db/ircd.db
-      autoupgrade: true
-      mysql:
-        enabled: false
-    
-    # Accounts and registration
-    accounts:
-      authentication-enabled: true
-      registration:
-        enabled: true
-        allow-before-connect: true
-        throttling:
+    ircd.yaml: |
+        # Ergo IRC Server Configuration
+
+        network:
+          name: "KBVE-Network"
+
+        server:
+          name: irc.kbve.com
+          enforce-utf8: true
+          max-sendq: "1MB"
+          connection-limits:
+            enabled: true
+            cidr-len-ipv4: 32
+            cidr-len-ipv6: 64
+            connections-per-cidr: 12
+            throttle-duration: "10m"
+            exempted:
+              - "localhost"
+              - "127.0.0.1"
+          listeners:
+            ":6667": {}
+            ":6697":
+              tls:
+                cert: /etc/ssl/certs/tls.crt
+                key: /etc/ssl/certs/tls.key        
+            ":8080":
+              websocket: true
+            ":8067":
+              websocket: true
+
+        # Data storage
+        datastore:
+          path: /ircd/db/ircd.db
+          autoupgrade: true
+          mysql:
+            enabled: false
+
+        # Accounts and registration
+        accounts:
+          authentication-enabled: true
+          registration:
+            enabled: true
+            allow-before-connect: true
+            throttling:
+              enabled: true
+              duration: 10m
+              max-attempts: 30
+            bcrypt-cost: 4
+            verify-timeout: "120h"
+            enabled-callbacks:
+              - none
+          nick-reservation:
+            enabled: true
+            additional-nick-limit: 2
+            method: strict
+            allow-custom-enforcement: true
+            rename-timeout: 30s
+            rename-prefix: "Guest-"
+            force-nick-equals-account: true
+          multiclient:
+            enabled: true
+            allowed-by-default: true
+            always-on: "opt-in"
+            auto-away: "opt-in"
+            always-on-expiration: "720h"
+
+        # Channels
+        channels:
+          default-modes: +ntC
+          max-channels-per-client: 100
+          registration:
+            enabled: true
+            max-channels-per-account: 15
+
+        # Operator configuration
+        opers:
+          admin:
+            class: "server-admin"
+            whois-line: "is a server administrator"
+            password: "$2a$04$LiytCxaY0lI.guDj2pBN4eSRcunHZskZn0t6wF1sJCqzx9HNKbONu"
+          nd-bot:
+            class: "game-relay"
+            whois-line: "is the Nexus Defense match-chat relay"
+            password: "$2a$04$REPLACE_ME_WITH_BCRYPT_HASH"
+
+        oper-classes:
+          "server-admin":
+            title: Server Admin
+            capabilities:
+              - "rehash"
+              - "die"
+              - "accreg"
+              - "sajoin"
+              - "samode"
+              - "vhosts"
+              - "chanreg"
+              - "history"
+              - "defcon"
+              - "ban"
+          "game-relay":
+            title: Game Chat Relay
+            capabilities:
+              - "history"
+              - "chanreg"
+
+        # Limits
+        limits:
+          nicklen: 32
+          channellen: 64
+          awaylen: 390
+          kicklen: 390
+          topiclen: 390
+          monitor-entries: 100
+          whowas-entries: 100
+          registration-messages: 1024
+
+        # History
+        history:
           enabled: true
-          duration: 10m
-          max-attempts: 30
-        bcrypt-cost: 4
-        verify-timeout: "120h"
-        enabled-callbacks:
-          - none
-      nick-reservation:
-        enabled: true
-        additional-nick-limit: 2
-        method: strict
-        allow-custom-enforcement: true
-        rename-timeout: 30s
-        rename-prefix: "Guest-"
-        force-nick-equals-account: true
-      multiclient:
-        enabled: true
-        allowed-by-default: true
-        always-on: "opt-in"
-        auto-away: "opt-in"
-        always-on-expiration: "720h"
-    
-    # Channels
-    channels:
-      default-modes: +ntC
-      max-channels-per-client: 100
-      registration:
-        enabled: true
-        max-channels-per-account: 15
-    
-    # Operator configuration
-    opers:
-      admin:
-        class: "server-admin"
-        whois-line: "is a server administrator"
-        password: "$2a$04$LiytCxaY0lI.guDj2pBN4eSRcunHZskZn0t6wF1sJCqzx9HNKbONu"
-    
-    # Operator classes
-    oper-classes:
-      "server-admin":
-        title: Server Admin
-        capabilities:
-          - "rehash"
-          - "die"
-          - "accreg"
-          - "sajoin"
-          - "samode"
-          - "vhosts"
-          - "chanreg"
-          - "history"
-          - "defcon"
-          - "ban"
-    
-    # Limits
-    limits:
-      nicklen: 32
-      channellen: 64
-      awaylen: 390
-      kicklen: 390
-      topiclen: 390
-      monitor-entries: 100
-      whowas-entries: 100
-      registration-messages: 1024
-    
-    # History
-    history:
-      enabled: true
-      channel-length: 2048
-      client-length: 256
-      autoresize-window: 3d
-      autoreplay-on-join: 0
-      chathistory-maxmessages: 100
-      znc-maxmessages: 2048
-      query-restrictions:
-        expire-time: 168h
-        query-cutoff: 720h
-        grace-period: 1h
-    
-    # Debug and logging
-    logging:
-      - method: stderr
-        type: "*"
-        level: info
+          channel-length: 2048
+          client-length: 256
+          autoresize-window: 3d
+          autoreplay-on-join: 0
+          chathistory-maxmessages: 100
+          znc-maxmessages: 2048
+          query-restrictions:
+            expire-time: 168h
+            query-cutoff: 720h
+            grace-period: 1h
+
+        # Debug and logging
+        logging:
+          - method: stderr
+            type: "*"
+            level: info


### PR DESCRIPTION
## Summary
PR1 of the nd-server → IRC chat-relay track. Lands the IRC-side oper account + namespace plumbing nd-server needs to send match chat into \`#general\`. Bridge code itself is PR2.

## Why split
Two separate concerns and two separate review surfaces:
1. **RBAC** (this PR) — Ergo oper config, secret plumbing, env wiring. All YAML. Touches the shared \`ergo-configmap\` so admin needs to control the bcrypt hash + plaintext rollout.
2. **Bridge code** (PR2) — Rust module in q/nd-server that subscribes to a bevy chat event and pumps PRIVMSGs. Same env-var names as the factorio relay so PR2 can reuse the pattern.

## Changes

### \`apps/kube/irc/manifests/ergo-configmap.yaml\`
- New \`game-relay\` oper-class with the minimum caps a relay bot needs (\`history\` + \`chanreg\`); no kick / ban / die / rehash / accreg / SA-*.
- New \`nd-bot\` oper bound to that class. Password is a placeholder bcrypt hash — replaced by admin before merge (see steps below).

### \`apps/kube/agones/nd-server/manifests/irc-bot-external-secret.yaml\` (new)
- ServiceAccount + SecretStore + ExternalSecret tuple mirroring the existing \`irc-gateway-externalsecret\` pattern.
- Pulls \`nd-bot-password\` out of an \`irc-game-relay\` Secret in the kilobase namespace into a local \`nd-server-irc-bot\` Secret with key \`IRC_OPER_PASSWORD\`.

### \`apps/kube/agones/nd-server/manifests/fleet.yaml\`
- New env block on the gameserver container:
  - \`IRC_SERVER=ergo-irc-service.irc.svc.cluster.local\`
  - \`IRC_PORT=6667\`
  - \`IRC_USE_TLS=false\` (in-cluster)
  - \`IRC_NICK=nd-bot\`
  - \`IRC_CHANNEL=#general\`
  - \`IRC_OPER_USER=nd-bot\`
  - \`IRC_OPER_PASSWORD\` from the new secret
- Var names match what agones-factorio-relay already consumes so PR2 can drop the bridge module in without renaming.

## Required admin steps after merge
1. Generate the bcrypt hash:
   \`\`\`bash
   kubectl -n irc exec deploy/ergo-irc -- ergo genpasswd <plaintext>
   \`\`\`
   Replace \`$2a$04$REPLACE_ME_WITH_BCRYPT_HASH\` in the configmap.
2. Create the upstream secret:
   \`\`\`bash
   kubectl -n kilobase create secret generic irc-game-relay \\
       --from-literal=nd-bot-password=<plaintext>
   \`\`\`
3. Restart ergo to pick up the new oper; ExternalSecret in nexus-defense syncs on next reconcile (≤ 1 h).

## Test plan
- [ ] \`kubectl -n irc rollout restart deploy/ergo-irc\` — oper visible via \`/STATS o\`.
- [ ] \`kubectl -n nexus-defense get secret nd-server-irc-bot\` shows \`IRC_OPER_PASSWORD\` key.
- [ ] Restart any nd-server Fleet pod, exec in, verify \`IRC_OPER_PASSWORD\` env is non-empty.
- [ ] Manually OPER from a test client using the same creds — confirm only \`history\` + \`chanreg\` caps are advertised.

## Next
PR2 adds \`q::irc_bridge\` (feature-flagged) that:
- Connects to \`IRC_SERVER:IRC_PORT\` from a tokio task spawned in nd-server's main.
- \`/OPER nd-bot $IRC_OPER_PASSWORD\` on connect.
- \`/JOIN $IRC_CHANNEL\`.
- Subscribes to a bevy chat event resource; relays each line as \`PRIVMSG #general :<slot> <kbve_username>: <msg>\`.

## Related
- #11294 — multiplayer TD tracker
- #11499 — browser WSS HTTPRoute (this is the same Fleet)