### PR TITLE
fix(isometric): shorter night + FourWay creature direction + chop diag

### DIFF
--- a/apps/kbve/isometric/src-tauri/src/game/actions.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/actions.rs
@@ -197,6 +197,10 @@ fn process_action_buffer(
         }
 
         let Ok(mut ec) = commands.get_entity(entity) else {
+            warn!(
+                "[actions] entity {:?} not found for action '{}' — stale snapshot or already despawned",
+                entity, req.action
+            );
             continue;
         };
 

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/simulate.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/simulate.rs
@@ -102,13 +102,17 @@ pub fn simulate_sprite_creatures(
             let ground = terrain.height_at_world(spawn_x, spawn_z);
             cr.anchor = Vec3::new(spawn_x, ground, spawn_z);
 
-            // Reset direction
+            // Reset direction. For FourWay we must translate the random
+            // quadrant through `quadrant_to_row` so the marker stores a row
+            // offset (same convention the move/flee branches use), not a raw
+            // quadrant index.
             match &ctype.direction_model {
                 DirectionModel::Flip => {
                     sd.facing_left = hash_f32(ps + 300) > 0.5;
                 }
-                DirectionModel::FourWay { .. } => {
-                    marker.direction = (hash_f32(ps + 300) * 4.0) as u32 % 4;
+                DirectionModel::FourWay { quadrant_to_row } => {
+                    let q = (hash_f32(ps + 300) * 4.0) as usize % 4;
+                    marker.direction = quadrant_to_row[q];
                 }
             }
 

--- a/apps/kbve/isometric/src-tauri/src/game/creatures/generic/spawn.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/creatures/generic/spawn.rs
@@ -86,9 +86,18 @@ pub fn spawn_sprite_creatures(
         for i in 0..count {
             let seed = (i as u32).wrapping_add(seed_offset);
             let phase = hash_f32(seed * 11 + 1);
+            // For FourWay sprites we pick a quadrant (0..3) and translate it
+            // through `quadrant_to_row` so the stored direction matches what
+            // the simulate path writes on every move/flee tick. Previously the
+            // spawn path stored the raw quadrant index and used it as a row
+            // offset, so freshly-spawned creatures rendered in the wrong row
+            // until their first behavior decision fired.
             let direction = match &creature_type.direction_model {
                 DirectionModel::Flip => 0,
-                DirectionModel::FourWay { .. } => (hash_f32(seed * 37 + 5) * 4.0) as u32 % 4,
+                DirectionModel::FourWay { quadrant_to_row } => {
+                    let q = (hash_f32(seed * 37 + 5) * 4.0) as usize % 4;
+                    quadrant_to_row[q]
+                }
             };
             let idle_timer = creature_type.idle_min
                 + hash_f32(seed * 53 + 11) * (creature_type.idle_max - creature_type.idle_min);
@@ -97,7 +106,7 @@ pub fn spawn_sprite_creatures(
 
             let initial_row = match &creature_type.direction_model {
                 DirectionModel::Flip => idle_anim.base_row,
-                DirectionModel::FourWay { quadrant_to_row } => idle_anim.base_row + direction,
+                DirectionModel::FourWay { .. } => idle_anim.base_row + direction,
             };
 
             // Spawn blob shadow

--- a/apps/kbve/isometric/src-tauri/src/game/weather.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/weather.rs
@@ -401,11 +401,24 @@ fn update_blob_shadows(
 /// Advance the game clock. When connected to a server, snap to the server's
 /// authoritative time and interpolate locally between syncs. Otherwise run
 /// the local clock at default speed.
+/// Multiply `day.speed` by this factor while it's night (hour < 5 or > 19)
+/// so players spend less wall-clock time in darkness. Day stays at 1×.
+const NIGHT_SPEED_MULT: f32 = 3.0;
+
+fn night_speed_multiplier(hour: f32) -> f32 {
+    if !(5.0..=19.0).contains(&hour) {
+        NIGHT_SPEED_MULT
+    } else {
+        1.0
+    }
+}
+
 fn update_day_cycle(
     time: Res<Time>,
     mut day: ResMut<DayCycle>,
     server_time: Option<Res<ServerTime>>,
 ) {
+    let mult = night_speed_multiplier(day.hour);
     if let Some(st) = server_time {
         if st.active {
             // Smoothly interpolate toward server time to avoid jarring snaps.
@@ -423,12 +436,12 @@ fn update_day_cycle(
             };
             // Blend: fast correction (10x/sec) so we converge within a few frames
             let correction = wrapped_diff * (10.0 * time.delta_secs()).min(1.0);
-            day.hour += time.delta_secs() * day.speed + correction;
+            day.hour += time.delta_secs() * day.speed * mult + correction;
         } else {
-            day.hour += time.delta_secs() * day.speed;
+            day.hour += time.delta_secs() * day.speed * mult;
         }
     } else {
-        day.hour += time.delta_secs() * day.speed;
+        day.hour += time.delta_secs() * day.speed * mult;
     }
     if day.hour >= 24.0 {
         day.hour -= 24.0;


### PR DESCRIPTION
## Summary
- Night hours (19:00–5:00) advance 3× faster — day stays at normal pace so wall-clock dark time shrinks to ~⅓.
- FourWay sprite creatures (boar/badger/wolf/stag): spawn + patrol-reset paths were stuffing the raw quadrant index into the marker; movement paths store the post-\`quadrant_to_row\` row offset. Same field, two value spaces — creatures rendered in the wrong sheet row until the first behavior tick. Both paths now go through \`quadrant_to_row\`.
- \`actions::handle_actions\`: emit \`warn!\` when a queued entity no longer exists. Previously silent skip — most likely cause of the WASM "chop sometimes doesn't fire" reports.

## Test plan
- [ ] Run game, watch hour: night clearly passes faster than day
- [ ] Watch boar/badger/wolf/stag idle pose right after spawn — sprite faces the direction it moves on first run
- [ ] In WASM, try chopping trees rapidly — if dispatches fail, terminal shows \`[actions] entity ... not found for action 'chop_tree' — stale snapshot or already despawned\`