### PR TITLE
feat(discordsh-bot): /n8n forwarder w/ HMAC + in-cluster routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,6 +952,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_type_match"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3699,6 +3709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -5110,6 +5121,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5345,6 +5374,9 @@ dependencies = [
  "chrono",
  "dashmap 6.1.0",
  "dotenvy",
+ "globset",
+ "hex",
+ "hmac 0.12.1",
  "jedi",
  "kbve",
  "lru 0.16.3",
@@ -5356,6 +5388,7 @@ dependencies = [
  "serde_json",
  "serenity",
  "serial_test",
+ "sha2 0.10.9",
  "sysinfo 0.38.4",
  "thiserror 2.0.18",
  "tikv-jemallocator",
@@ -5363,6 +5396,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -7154,6 +7188,19 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "gloo-timers"
@@ -19650,6 +19697,29 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/apps/discordsh/discordsh-bot/Cargo.toml
+++ b/apps/discordsh/discordsh-bot/Cargo.toml
@@ -26,6 +26,10 @@ uuid = { version = "1", features = ["v4", "serde"] }
 rand = "0.10"
 rand_chacha = "0.10"
 chrono = "0.4"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4.3"
+globset = "0.4.18"
 
 # Workspace path dependencies
 jedi = { path = "../../../packages/rust/jedi" }
@@ -49,6 +53,7 @@ tikv-jemallocator = { version = "0.6", optional = true }
 
 [dev-dependencies]
 serial_test = "3"
+wiremock = "0.6"
 
 [features]
 default = []

--- a/apps/discordsh/discordsh-bot/src/discord/commands/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/mod.rs
@@ -3,6 +3,7 @@ mod dungeon;
 pub(crate) mod gh;
 pub(crate) mod github_board;
 mod health;
+mod n8n;
 mod ping;
 mod skills;
 mod status;
@@ -21,5 +22,6 @@ pub fn all() -> Vec<poise::Command<Data, Error>> {
         github_board::github(),
         gh::gh(),
         skills::skills(),
+        n8n::n8n(),
     ]
 }

--- a/apps/discordsh/discordsh-bot/src/discord/commands/n8n.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/commands/n8n.rs
@@ -1,0 +1,109 @@
+use poise::CreateReply;
+use tracing::{info, warn};
+
+use crate::discord::bot::{Context, Error};
+use crate::discord::n8n::{DiscordContext, split_args};
+
+#[poise::command(slash_command, rename = "n8n")]
+pub async fn n8n(
+    ctx: Context<'_>,
+    #[description = "Webhook path (must match N8N_ALLOWED_PATHS)"] webhook_path: String,
+    #[description = "Space-separated args forwarded to n8n"] args: Option<String>,
+) -> Result<(), Error> {
+    let Some(cfg) = ctx.data().app.n8n.clone() else {
+        ctx.send(
+            CreateReply::default()
+                .content("n8n forwarder is not configured on this bot.")
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    };
+
+    let args = args.map(|s| split_args(&s)).unwrap_or_default();
+    let path_for_log = webhook_path.clone();
+    let arg_count = args.len();
+
+    let discord = DiscordContext {
+        user_id: ctx.author().id.get().to_string(),
+        username: ctx.author().name.clone(),
+        guild_id: ctx.guild_id().map(|g| g.get().to_string()),
+        channel_id: ctx.channel_id().get().to_string(),
+    };
+
+    ctx.defer().await?;
+
+    match cfg.forward(&webhook_path, &args, &discord).await {
+        Ok(value) => {
+            info!(
+                webhook_path = %path_for_log,
+                user = %discord.username,
+                args = arg_count,
+                "n8n forward ok"
+            );
+            let body = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+            let trimmed = truncate_for_discord(&body);
+            ctx.send(
+                CreateReply::default()
+                    .content(format!(
+                        "`/n8n {path_for_log}` ok:\n```json\n{trimmed}\n```"
+                    ))
+                    .ephemeral(true),
+            )
+            .await?;
+        }
+        Err(e) => {
+            warn!(
+                webhook_path = %path_for_log,
+                user = %discord.username,
+                error = %e,
+                "n8n forward failed"
+            );
+            ctx.send(
+                CreateReply::default()
+                    .content(format!("n8n error: {e}"))
+                    .ephemeral(true),
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+fn truncate_for_discord(s: &str) -> String {
+    const MAX: usize = 1800;
+    if s.len() <= MAX {
+        return s.to_owned();
+    }
+    let mut cut = MAX;
+    while !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}…(truncated)", &s[..cut])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_for_discord;
+
+    #[test]
+    fn truncate_passthrough() {
+        assert_eq!(truncate_for_discord("short"), "short");
+    }
+
+    #[test]
+    fn truncate_long() {
+        let s = "a".repeat(3000);
+        let out = truncate_for_discord(&s);
+        assert!(out.ends_with("…(truncated)"));
+        assert!(out.len() < 3000);
+    }
+
+    #[test]
+    fn truncate_respects_char_boundary() {
+        let mut s = "é".repeat(1000);
+        s.push('é');
+        let out = truncate_for_discord(&s);
+        assert!(out.ends_with("…(truncated)"));
+    }
+}

--- a/apps/discordsh/discordsh-bot/src/discord/mod.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/mod.rs
@@ -9,5 +9,6 @@ pub mod gh_sync;
 pub mod github;
 pub mod github_cache;
 pub mod github_permissions;
+pub mod n8n;
 pub mod relay;
 pub mod scheduler;

--- a/apps/discordsh/discordsh-bot/src/discord/n8n.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/n8n.rs
@@ -1,0 +1,502 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use hmac::{Hmac, Mac};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::Sha256;
+use tracing::info;
+
+use crate::discord::github_permissions::CommandRateLimiter;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const DEFAULT_COOLDOWN_SECS: u64 = 5;
+const DEFAULT_MAX_PER_WINDOW: u32 = 1;
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+const ARG_LIMIT: usize = 16;
+const ARG_LEN_LIMIT: usize = 512;
+
+#[derive(Debug, Serialize)]
+pub struct DiscordContext {
+    pub user_id: String,
+    pub username: String,
+    pub guild_id: Option<String>,
+    pub channel_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Payload<'a> {
+    pub webhook_path: &'a str,
+    pub args: &'a [String],
+    pub discord: &'a DiscordContext,
+    pub ts: i64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ForwardError {
+    PathNotAllowed,
+    RateLimited,
+    TooManyArgs,
+    ArgTooLong,
+    EmptyPath,
+    Upstream(String),
+}
+
+impl std::fmt::Display for ForwardError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PathNotAllowed => write!(f, "Webhook path not in allowlist."),
+            Self::RateLimited => write!(f, "Rate limit hit. Wait a few seconds."),
+            Self::TooManyArgs => write!(f, "Too many args (max {ARG_LIMIT})."),
+            Self::ArgTooLong => write!(f, "Single arg too long (max {ARG_LEN_LIMIT})."),
+            Self::EmptyPath => write!(f, "Webhook path is empty."),
+            Self::Upstream(s) => write!(f, "n8n upstream error: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for ForwardError {}
+
+pub struct N8nConfig {
+    pub base_url: String,
+    pub hmac_secret: String,
+    pub allowed_paths: GlobSet,
+    pub rate_limiter: CommandRateLimiter,
+    pub client: reqwest::Client,
+}
+
+impl N8nConfig {
+    pub fn from_env() -> Option<Arc<Self>> {
+        let base_url = std::env::var("N8N_BASE_URL")
+            .ok()
+            .filter(|s| !s.is_empty())?;
+        let hmac_secret = std::env::var("N8N_HMAC_SECRET")
+            .ok()
+            .filter(|s| !s.is_empty())?;
+        let allowed_raw = std::env::var("N8N_ALLOWED_PATHS")
+            .ok()
+            .filter(|s| !s.is_empty())?;
+
+        let allowed_paths = match build_globset(&allowed_raw) {
+            Ok(set) => set,
+            Err(e) => {
+                tracing::error!(error = %e, "N8N_ALLOWED_PATHS invalid; /n8n disabled");
+                return None;
+            }
+        };
+
+        let max = std::env::var("N8N_RATE_LIMIT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_MAX_PER_WINDOW);
+        let window = std::env::var("N8N_RATE_WINDOW")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(DEFAULT_COOLDOWN_SECS);
+
+        let base_url = if base_url.ends_with('/') {
+            base_url
+        } else {
+            format!("{base_url}/")
+        };
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .ok()?;
+
+        info!(
+            base_url = %base_url,
+            patterns = %allowed_raw,
+            cooldown_secs = window,
+            max_per_window = max,
+            "n8n forwarder configured"
+        );
+
+        Some(Arc::new(Self {
+            base_url,
+            hmac_secret,
+            allowed_paths,
+            rate_limiter: CommandRateLimiter::new(max, window),
+            client,
+        }))
+    }
+
+    pub fn path_allowed(&self, path: &str) -> bool {
+        self.allowed_paths.is_match(path)
+    }
+
+    pub async fn forward(
+        &self,
+        webhook_path: &str,
+        args: &[String],
+        discord: &DiscordContext,
+    ) -> Result<Value, ForwardError> {
+        let path = webhook_path.trim().trim_start_matches('/');
+        if path.is_empty() {
+            return Err(ForwardError::EmptyPath);
+        }
+        if !self.path_allowed(path) {
+            return Err(ForwardError::PathNotAllowed);
+        }
+        if args.len() > ARG_LIMIT {
+            return Err(ForwardError::TooManyArgs);
+        }
+        if args.iter().any(|a| a.len() > ARG_LEN_LIMIT) {
+            return Err(ForwardError::ArgTooLong);
+        }
+
+        let user_key: u64 = discord.user_id.parse().unwrap_or(0);
+        if user_key != 0 && !self.rate_limiter.check_user(user_key) {
+            return Err(ForwardError::RateLimited);
+        }
+
+        let ts = chrono::Utc::now().timestamp();
+        let payload = Payload {
+            webhook_path: path,
+            args,
+            discord,
+            ts,
+        };
+        let body = serde_json::to_vec(&payload)
+            .map_err(|e| ForwardError::Upstream(format!("encode: {e}")))?;
+        let signature = sign(&self.hmac_secret, ts, &body);
+        let url = format!("{}{}", self.base_url, path);
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("X-KBVE-Timestamp", ts.to_string())
+            .header("X-KBVE-Signature", format!("sha256={signature}"))
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| ForwardError::Upstream(format!("send: {e}")))?;
+
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(ForwardError::Upstream(format!("HTTP {status}: {text}")));
+        }
+        let value: Value = serde_json::from_str(&text).unwrap_or(Value::String(text));
+        Ok(value)
+    }
+}
+
+fn build_globset(raw: &str) -> Result<GlobSet> {
+    let mut builder = GlobSetBuilder::new();
+    let mut count = 0;
+    for pat in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+        builder.add(Glob::new(pat).map_err(|e| anyhow!("glob `{pat}`: {e}"))?);
+        count += 1;
+    }
+    if count == 0 {
+        return Err(anyhow!("no glob patterns"));
+    }
+    builder.build().map_err(|e| anyhow!("globset build: {e}"))
+}
+
+pub fn sign(secret: &str, ts: i64, body: &[u8]) -> String {
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(ts.to_string().as_bytes());
+    mac.update(b".");
+    mac.update(body);
+    hex::encode(mac.finalize().into_bytes())
+}
+
+pub fn split_args(raw: &str) -> Vec<String> {
+    raw.split_whitespace().map(|s| s.to_owned()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn globset_exact_match() {
+        let set = build_globset("foo,bar/baz").unwrap();
+        assert!(set.is_match("foo"));
+        assert!(set.is_match("bar/baz"));
+        assert!(!set.is_match("foo/bar"));
+        assert!(!set.is_match("qux"));
+    }
+
+    #[test]
+    fn globset_wildcard() {
+        // globset `*` is shell-style and crosses `/` by default; callers who
+        // need single-segment scoping should compose explicit patterns.
+        let set = build_globset("kbve/*,deploy-*").unwrap();
+        assert!(set.is_match("kbve/start"));
+        assert!(set.is_match("kbve/start/extra"));
+        assert!(set.is_match("deploy-prod"));
+        assert!(!set.is_match("random"));
+    }
+
+    #[test]
+    fn globset_recursive() {
+        let set = build_globset("kbve/**").unwrap();
+        assert!(set.is_match("kbve/a"));
+        assert!(set.is_match("kbve/a/b/c"));
+    }
+
+    #[test]
+    fn globset_empty_rejected() {
+        assert!(build_globset("").is_err());
+        assert!(build_globset("   ").is_err());
+    }
+
+    #[test]
+    fn sign_stable() {
+        let s1 = sign("secret", 1000, b"{\"a\":1}");
+        let s2 = sign("secret", 1000, b"{\"a\":1}");
+        assert_eq!(s1, s2);
+        assert_eq!(s1.len(), 64);
+    }
+
+    #[test]
+    fn sign_changes_with_inputs() {
+        let base = sign("secret", 1000, b"body");
+        assert_ne!(base, sign("secret2", 1000, b"body"));
+        assert_ne!(base, sign("secret", 1001, b"body"));
+        assert_ne!(base, sign("secret", 1000, b"body2"));
+    }
+
+    #[test]
+    fn split_args_basic() {
+        assert_eq!(split_args("a b c"), vec!["a", "b", "c"]);
+        assert_eq!(split_args("  a   b  "), vec!["a", "b"]);
+        assert!(split_args("").is_empty());
+    }
+
+    // ── Integration tests against a wiremock'd fake n8n ────────────
+
+    use wiremock::matchers::{header, header_exists, method, path};
+    use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+    fn discord_ctx() -> DiscordContext {
+        DiscordContext {
+            user_id: "999".to_owned(),
+            username: "tester".to_owned(),
+            guild_id: Some("42".to_owned()),
+            channel_id: "7".to_owned(),
+        }
+    }
+
+    fn make_cfg(base_url: String, allow: &str, max: u32, window: u64) -> Arc<N8nConfig> {
+        Arc::new(N8nConfig {
+            base_url: if base_url.ends_with('/') {
+                base_url
+            } else {
+                format!("{base_url}/")
+            },
+            hmac_secret: "topsecret".to_owned(),
+            allowed_paths: build_globset(allow).unwrap(),
+            rate_limiter: CommandRateLimiter::new(max, window),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .unwrap(),
+        })
+    }
+
+    #[tokio::test]
+    async fn forward_success_signs_payload() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/deploy-prod"))
+            .and(header("Content-Type", "application/json"))
+            .and(header_exists("X-KBVE-Signature"))
+            .and(header_exists("X-KBVE-Timestamp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "echo": "hello",
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "deploy-*", 10, 60);
+        let args = vec!["alpha".to_owned(), "beta".to_owned()];
+        let resp = cfg
+            .forward("deploy-prod", &args, &discord_ctx())
+            .await
+            .expect("forward ok");
+
+        assert_eq!(resp["ok"], serde_json::Value::Bool(true));
+        assert_eq!(resp["echo"], serde_json::Value::String("hello".into()));
+    }
+
+    #[tokio::test]
+    async fn forward_signature_matches_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/foo"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "foo", 10, 60);
+        cfg.forward("foo", &[], &discord_ctx()).await.unwrap();
+
+        let req = &server.received_requests().await.unwrap()[0];
+        let ts = req
+            .headers
+            .get("X-KBVE-Timestamp")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse::<i64>()
+            .unwrap();
+        let sig_header = req
+            .headers
+            .get("X-KBVE-Signature")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        let sig = sig_header.strip_prefix("sha256=").unwrap();
+        let expected = sign("topsecret", ts, &req.body);
+        assert_eq!(sig, expected);
+    }
+
+    #[tokio::test]
+    async fn forward_rejects_path_outside_allowlist() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "allowed-*", 10, 60);
+        let err = cfg
+            .forward("blocked", &[], &discord_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err, ForwardError::PathNotAllowed);
+    }
+
+    #[tokio::test]
+    async fn forward_strips_leading_slash() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/kbve/start"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "kbve/**", 10, 60);
+        cfg.forward("/kbve/start", &[], &discord_ctx())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn forward_rate_limited_second_call() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/foo"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "foo", 1, 60);
+        cfg.forward("foo", &[], &discord_ctx()).await.unwrap();
+        let err = cfg.forward("foo", &[], &discord_ctx()).await.unwrap_err();
+        assert_eq!(err, ForwardError::RateLimited);
+    }
+
+    #[tokio::test]
+    async fn forward_upstream_error_propagates() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/foo"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "foo", 10, 60);
+        let err = cfg.forward("foo", &[], &discord_ctx()).await.unwrap_err();
+        match err {
+            ForwardError::Upstream(s) => {
+                assert!(s.contains("500"));
+                assert!(s.contains("boom"));
+            }
+            other => panic!("expected upstream error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn forward_too_many_args_rejected() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "foo", 10, 60);
+        let args: Vec<String> = (0..ARG_LIMIT + 1).map(|i| i.to_string()).collect();
+        let err = cfg.forward("foo", &args, &discord_ctx()).await.unwrap_err();
+        assert_eq!(err, ForwardError::TooManyArgs);
+    }
+
+    #[tokio::test]
+    async fn forward_arg_too_long_rejected() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "foo", 10, 60);
+        let big = "x".repeat(ARG_LEN_LIMIT + 1);
+        let err = cfg
+            .forward("foo", &[big], &discord_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err, ForwardError::ArgTooLong);
+    }
+
+    #[tokio::test]
+    async fn forward_empty_path_rejected() {
+        let server = MockServer::start().await;
+        let cfg = make_cfg(server.uri(), "*", 10, 60);
+        let err = cfg.forward("   ", &[], &discord_ctx()).await.unwrap_err();
+        assert_eq!(err, ForwardError::EmptyPath);
+    }
+
+    #[tokio::test]
+    async fn forward_body_contains_discord_context() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/echo"))
+            .respond_with(|req: &Request| {
+                let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+                assert_eq!(body["webhook_path"], "echo");
+                assert_eq!(body["discord"]["user_id"], "999");
+                assert_eq!(body["discord"]["username"], "tester");
+                assert_eq!(body["discord"]["guild_id"], "42");
+                assert_eq!(body["discord"]["channel_id"], "7");
+                assert_eq!(body["args"][0], "hello");
+                ResponseTemplate::new(200).set_body_string("{}")
+            })
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let cfg = make_cfg(server.uri(), "echo", 10, 60);
+        cfg.forward("echo", &["hello".to_owned()], &discord_ctx())
+            .await
+            .unwrap();
+    }
+}

--- a/apps/discordsh/discordsh-bot/src/state.rs
+++ b/apps/discordsh/discordsh-bot/src/state.rs
@@ -40,6 +40,7 @@ impl RelayConfig {
 use crate::discord::game::{ProfileStore, SessionStore};
 use crate::discord::github_cache::GitHubCache;
 use crate::discord::github_permissions::GitHubCommandGuard;
+use crate::discord::n8n::N8nConfig;
 use crate::health::HealthMonitor;
 use crate::tracker::ShardTracker;
 
@@ -105,6 +106,11 @@ pub struct AppState {
     pub irc: Option<ChatClient>,
 
     pub relay: Option<RelayConfig>,
+
+    /// Optional n8n webhook forwarder. `None` when `N8N_BASE_URL`,
+    /// `N8N_HMAC_SECRET`, or `N8N_ALLOWED_PATHS` are missing — in which case
+    /// `/n8n` is not registered as a usable command.
+    pub n8n: Option<Arc<N8nConfig>>,
 
     /// Optional persistent KV store (redb). Opened from `DB_PATH` env var
     /// at startup. `None` when the variable is unset or the file fails to
@@ -205,6 +211,13 @@ impl AppState {
         let local_db = open_local_db();
         let profiles = Arc::new(ProfileStore::from_env_with_local(local_db.clone()));
 
+        let n8n = N8nConfig::from_env();
+        if n8n.is_none() {
+            tracing::info!(
+                "n8n not configured (set N8N_BASE_URL + N8N_HMAC_SECRET + N8N_ALLOWED_PATHS to enable /n8n)"
+            );
+        }
+
         let relay = RelayConfig::from_env();
         if let Some(ref r) = relay {
             tracing::info!(
@@ -238,6 +251,7 @@ impl AppState {
             github_store: Arc::new(GithubStore::from_env()),
             irc,
             relay,
+            n8n,
             local_db,
         }
     }

--- a/apps/kube/discordsh/manifest/configmap.yaml
+++ b/apps/kube/discordsh/manifest/configmap.yaml
@@ -13,3 +13,7 @@ data:
     PUBLIC_DISCORD_CLIENT_ID: 'placeholder-discord-client-id'
     PUBLIC_ENV: 'production'
     RUST_LOG: 'debug'
+    N8N_BASE_URL: 'http://n8n.n8n.svc.cluster.local:5678/webhook/'
+    N8N_ALLOWED_PATHS: 'kbve/*,deploy-*'
+    N8N_RATE_LIMIT: '1'
+    N8N_RATE_WINDOW: '5'

--- a/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
+++ b/apps/kube/discordsh/manifest/discordsh-bot-deployment.yaml
@@ -58,6 +58,9 @@ spec:
                             name: discordsh-config
                       - secretRef:
                             name: discordsh-redis-secret
+                      - secretRef:
+                            name: discordsh-n8n-hmac
+                            optional: true
                   env:
                       - name: RUST_LOG
                         value: 'discordsh_bot=debug,kbve=debug'

--- a/apps/kube/discordsh/manifest/discordsh-externalsecret.yaml
+++ b/apps/kube/discordsh/manifest/discordsh-externalsecret.yaml
@@ -1,93 +1,137 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: discordsh-external-secrets
-  namespace: discordsh
+    name: discordsh-external-secrets
+    namespace: discordsh
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
-  name: discordsh-redis-secret-store
-  namespace: discordsh
-spec:
-  provider:
-    kubernetes:
-      remoteNamespace: redis
-      auth:
-        serviceAccount:
-          name: discordsh-external-secrets
-          namespace: discordsh
-      server:
-        url: https://kubernetes.default.svc
-        caProvider:
-          type: ConfigMap
-          name: kube-root-ca.crt
-          key: ca.crt
-          namespace: kube-system
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: discordsh-redis-secrets
-  namespace: discordsh
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
     name: discordsh-redis-secret-store
-    kind: SecretStore
-  target:
-    name: discordsh-redis-secret
-    creationPolicy: Owner
-    template:
-      engineVersion: v2
-      data:
-        REDIS_PASSWORD: "{{ .redispassword }}"
-  data:
-  - secretKey: redispassword
-    remoteRef:
-      key: redis-auth
-      property: redis-password
----
-apiVersion: external-secrets.io/v1beta1
-kind: SecretStore
-metadata:
-  name: discordsh-supabase-secret-store
-  namespace: discordsh
+    namespace: discordsh
 spec:
-  provider:
-    kubernetes:
-      remoteNamespace: kilobase
-      auth:
-        serviceAccount:
-          name: discordsh-external-secrets
-          namespace: discordsh
-      server:
-        url: https://kubernetes.default.svc
-        caProvider:
-          type: ConfigMap
-          name: kube-root-ca.crt
-          key: ca.crt
-          namespace: kube-system
+    provider:
+        kubernetes:
+            remoteNamespace: redis
+            auth:
+                serviceAccount:
+                    name: discordsh-external-secrets
+                    namespace: discordsh
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: discordsh-supabase-secrets
-  namespace: discordsh
+    name: discordsh-redis-secrets
+    namespace: discordsh
 spec:
-  refreshInterval: 1h
-  secretStoreRef:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: discordsh-redis-secret-store
+        kind: SecretStore
+    target:
+        name: discordsh-redis-secret
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                REDIS_PASSWORD: '{{ .redispassword }}'
+    data:
+        - secretKey: redispassword
+          remoteRef:
+              key: redis-auth
+              property: redis-password
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
     name: discordsh-supabase-secret-store
-    kind: SecretStore
-  target:
-    name: discordsh-supabase-shared
-    creationPolicy: Owner
-    template:
-      engineVersion: v2
-      data:
-        service-role-key: "{{ .servicekey }}"
-  data:
-  - secretKey: servicekey
-    remoteRef:
-      key: supabase-jwt
-      property: service-key
+    namespace: discordsh
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: discordsh-external-secrets
+                    namespace: discordsh
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: discordsh-supabase-secrets
+    namespace: discordsh
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: discordsh-supabase-secret-store
+        kind: SecretStore
+    target:
+        name: discordsh-supabase-shared
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                service-role-key: '{{ .servicekey }}'
+    data:
+        - secretKey: servicekey
+          remoteRef:
+              key: supabase-jwt
+              property: service-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: discordsh-n8n-hmac-store
+    namespace: discordsh
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: n8n
+            auth:
+                serviceAccount:
+                    name: discordsh-external-secrets
+                    namespace: discordsh
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: discordsh-n8n-hmac
+    namespace: discordsh
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: discordsh-n8n-hmac-store
+        kind: SecretStore
+    target:
+        name: discordsh-n8n-hmac
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                N8N_HMAC_SECRET: '{{ .hmac }}'
+    data:
+        - secretKey: hmac
+          remoteRef:
+              key: discordsh-n8n-hmac
+              property: N8N_HMAC_SECRET

--- a/apps/kube/discordsh/seal-n8n-hmac.sh
+++ b/apps/kube/discordsh/seal-n8n-hmac.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# seal-n8n-hmac.sh — Generate the shared discordsh ↔ n8n HMAC and seal it
+# into the n8n namespace (canonical source). The discordsh namespace pulls
+# it across via ExternalSecret + cross-namespace SecretStore.
+#
+# Re-running this script ROTATES the HMAC. Reloader rolls both Deployments
+# once the SealedSecret + the mirrored Secret update.
+#
+# Usage:
+#   ./seal-n8n-hmac.sh
+#   # Output: apps/kube/n8n/manifest/n8n-hmac-sealedsecret.yaml
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+OUTPUT_FILE="${REPO_ROOT}/apps/kube/n8n/manifest/n8n-hmac-sealedsecret.yaml"
+
+SECRET_NAME="discordsh-n8n-hmac"
+ENV_KEY="N8N_HMAC_SECRET"
+
+for cmd in kubectl kubeseal openssl; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "missing: $cmd" >&2; exit 1; }
+done
+
+kubectl cluster-info >/dev/null 2>&1 || { echo "no cluster access" >&2; exit 1; }
+kubectl get deployment sealed-secrets-controller -n kube-system >/dev/null 2>&1 \
+    || { echo "sealed-secrets-controller not found in kube-system" >&2; exit 1; }
+
+openssl rand -hex 32 | tr -d '\n' \
+    | kubectl create secret generic "${SECRET_NAME}" \
+        --namespace=n8n \
+        --from-file="${ENV_KEY}=/dev/stdin" \
+        --dry-run=client \
+        -o yaml \
+    | kubeseal \
+        --controller-name=sealed-secrets-controller \
+        --controller-namespace=kube-system \
+        --format=yaml \
+    > "${OUTPUT_FILE}"
+
+echo "Sealed secret written: ${OUTPUT_FILE}"

--- a/apps/kube/n8n/manifest/n8n-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-deployment.yaml
@@ -57,6 +57,9 @@ spec:
                   envFrom:
                       - secretRef:
                             name: n8n-redis-secret
+                      - secretRef:
+                            name: discordsh-n8n-hmac
+                            optional: true
                   env:
                       # PostgreSQL (shared supabase database, dedicated n8n schema)
                       - name: DB_TYPE

--- a/apps/kube/n8n/manifest/n8n-hmac-sealedsecret.yaml
+++ b/apps/kube/n8n/manifest/n8n-hmac-sealedsecret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: discordsh-n8n-hmac
+    namespace: n8n
+spec:
+    encryptedData:
+        N8N_HMAC_SECRET: AgAQkbZvy7vEbV5ZMVr2QTwUnqxYYp1VlIf/baXOlasebMCxtSeFTDUkcc4o0ZJcS7tyu1KRCB9yeFPje0fp5CZpMa5WAsEK4VqSuXU67BQtSK6lOkj2Yb7kW2pxLyzgDvTkOyLcorUjv+vyLbQVs9axEWHwRTBrkVu4QkUtS3DQrJbdbfNxJSsWFA7NWK4PNPWw37Mh0M1YpcmFMeYiuwMiuOtAKSJqYLj6IlAXBl2+A+Frw7GWM10RFtui52eSRSF81D1Teb78AIlamBThw47KEnNTpEnhjikp1MmhxWuXRvVSfNGMoNxDtaxRCzrwgDCDXUBF/9HixA5pEKxz3/A0wXwf22GuBxA6bLGas6d6MY2SV0G1iY+jS15NHFsRfgVNnQq2D2w7gRnlbDFFBqa7IZiFnpGGnzbgbMc592i2ox4urkTj4kcybWFUVRM+xhuwCE83lSyRUpEqlIEe+sxfY/raaShQhuBefsMRtjtc22/83T/pE0T8qY0EGktwuovTRvP7tz0nSEQiCQZI0MA2BjZOQGnphMsBAbnJt6j96yC6l9MI73MG2NqqDMVrVkMn6GYICtxPh8/dKl/CFvAfn7bymF4tTb/M0kkW7Jar6TkzY+pjsTzM9+/Sc8BmJKf8xiNA3lyT2ziJjUJopRBVztL0vra0lC9SwqPz10X5pmWOR5jB+A0cNXe8KsaQStHpYWLcyy7GZkS/8OowQnytkTA/rE1EvsTd93V1L9Lm22H4sJ3wFFHhJN4rVJKOai4XaG9d7g6KrIsNDzDHCZgt
+    template:
+        metadata:
+            name: discordsh-n8n-hmac
+            namespace: n8n

--- a/apps/kube/n8n/manifest/n8n-worker-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-worker-deployment.yaml
@@ -56,6 +56,9 @@ spec:
                   envFrom:
                       - secretRef:
                             name: n8n-redis-secret
+                      - secretRef:
+                            name: discordsh-n8n-hmac
+                            optional: true
                   env:
                       # PostgreSQL (same DB as main instance)
                       - name: DB_TYPE

--- a/apps/kube/n8n/manifest/rbac.yaml
+++ b/apps/kube/n8n/manifest/rbac.yaml
@@ -65,6 +65,31 @@ subjects:
       name: n8n-external-secrets
       namespace: n8n
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: discordsh-n8n-hmac-access
+    namespace: n8n
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['discordsh-n8n-hmac']
+      verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: discordsh-n8n-hmac-access-binding
+    namespace: n8n
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: discordsh-n8n-hmac-access
+subjects:
+    - kind: ServiceAccount
+      name: discordsh-external-secrets
+      namespace: discordsh
+---
 # NetworkPolicy: Allow n8n pods to reach Redis on port 6379
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## Summary

- Adds `/n8n <webhook_path> [args]` slash command. Forwards to the in-cluster n8n webhook receiver (`n8n.n8n.svc.cluster.local:5678/webhook/`) — no round-trip through `n8n.kbve.com`.
- Every payload is HMAC-SHA256 signed: `X-KBVE-Signature: sha256=HMAC(secret, "{ts}.{body}")` + `X-KBVE-Timestamp` for replay rejection. n8n workflows verify in a Function node via `$env.N8N_HMAC_SECRET`.
- Globset allowlist (`N8N_ALLOWED_PATHS=kbve/*,deploy-*`), per-user sliding-window rate limit (default 1/5s), arg count + length guards.
- Plaintext HMAC lives in one place: a SealedSecret in the `n8n` namespace. `discordsh` mirrors it via ExternalSecret + cross-namespace SecretStore (matches the existing redis / supabase pull pattern). Rotation = re-run `seal-n8n-hmac.sh` + sync; Reloader rolls both Deployments.

## Code

- `apps/discordsh/discordsh-bot/src/discord/n8n.rs` — `N8nConfig` (env load, globset, rate limiter, reqwest client) + `forward()` w/ signing.
- `apps/discordsh/discordsh-bot/src/discord/commands/n8n.rs` — poise slash command (deferred ACK, ephemeral reply, JSON pretty-print truncated to 1.8 KiB for Discord).
- `Cargo.toml`: `hmac 0.12`, `sha2 0.10` (matches workspace dedup w/ axum-kbve), `hex 0.4.3`, `globset 0.4.18`, dev-dep `wiremock 0.6`.

## Kube

- `apps/kube/discordsh/seal-n8n-hmac.sh` — one-shot script: generates a random 256-bit HMAC, seals into `n8n` ns.
- `apps/kube/n8n/manifest/n8n-hmac-sealedsecret.yaml` — sealed ciphertext (generated by the script).
- `apps/kube/n8n/manifest/rbac.yaml` — Role + RoleBinding grants `discordsh-external-secrets` SA `get` on `discordsh-n8n-hmac` in `n8n`.
- `apps/kube/discordsh/manifest/discordsh-externalsecret.yaml` — new SecretStore + ExternalSecret mirrors the secret into `discordsh`.
- `apps/kube/discordsh/manifest/configmap.yaml` — `N8N_BASE_URL`, `N8N_ALLOWED_PATHS`, `N8N_RATE_LIMIT`, `N8N_RATE_WINDOW`.
- discordsh-bot + n8n + n8n-worker Deployments `envFrom: secretRef discordsh-n8n-hmac optional: true`.

## Test plan

- [x] `cargo test discord::n8n::` — 17/17 (8 wiremock e2e + 9 unit; covers signature byte-equality, allowlist enforcement, rate-limit, upstream error propagation, arg limits, Discord context echo, leading-slash strip, empty path)
- [x] `cargo test discord::commands::n8n::` — 3/3 (Discord truncation)
- [x] `cargo check` — clean
- [x] `cargo clippy` — clean on new code (pre-existing warnings elsewhere untouched)
- [ ] Apply via ArgoCD; verify discordsh-bot logs `n8n forwarder configured`
- [ ] Trigger `/n8n kbve/test arg1 arg2` from Discord; verify n8n workflow receives `X-KBVE-Signature` + correct payload
- [ ] Verify rate limit kicks in on second call within 5s
- [ ] Verify `/n8n unknown-path` returns "Webhook path not in allowlist"

## n8n workflow snippet (verification, paste into Function node)

```js
const crypto = require('crypto');
const sig = $headers['x-kbve-signature'].replace('sha256=', '');
const ts = $headers['x-kbve-timestamp'];
const raw = Buffer.from(JSON.stringify($json));
const expected = crypto.createHmac('sha256', $env.N8N_HMAC_SECRET)
  .update(`${ts}.${raw}`).digest('hex');
if (!crypto.timingSafeEqual(Buffer.from(sig,'hex'), Buffer.from(expected,'hex'))) {
  throw new Error('bad signature');
}
if (Math.abs(Date.now()/1000 - parseInt(ts)) > 300) throw new Error('replay');
return $input.all();
```

Note: the Webhook node must capture the raw body (not the parsed JSON) for HMAC bytes to match end-to-end. If your workflow re-serializes, switch to "Raw Body" mode.