### PR TITLE
fix(memes): align memes-cert spec to RSA 2048 to unblock meme.sh

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/memes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/memes.mdx
@@ -27,4 +27,23 @@ status: active
 
 ## Overview
 
-Memes application service.
+Memes application service serving [meme.sh](https://meme.sh) and `www.meme.sh`. Built from `apps/memes/axum-memes` (Rust backend + Askama templates) plus the `apps/memes/astro-memes` static frontend, packaged into the `kbve/memes` image. Deployment lives at [apps/kube/memes/manifest/](apps/kube/memes/manifest/).
+
+## Routing
+
+Public traffic enters via Cloudflare → CNAME to `gateway.kbve.com` → `142.132.206.71` (Cilium gateway LB) → [`kbve-gateway`](apps/kube/kbve/manifest/) `https-memes` / `https-memes-www` listeners → [`memes-route`](apps/kube/memes/manifest/httproute.yaml) → `memes-service:4321`.
+
+The cert lives in `memes/memes-tls` and is consumed cross-namespace by `kbve-gateway` via [`memes-tls-from-kbve-gateway` ReferenceGrant](apps/kube/memes/manifest/memes-refgrant.yaml).
+
+## TLS / certificate
+
+[`memes-cert`](apps/kube/memes/manifest/memes-cert.yaml) is **RSA 2048**, issued by the `letsencrypt-http` ClusterIssuer (HTTP-01). The algorithm matches the cert already in `memes-tls`; do not change to ECDSA without first verifying that the ACME HTTP-01 challenge path on Cilium gateway is healthy (see runbook below) — otherwise cert-manager flags `IncorrectCertificate` and queues a reissue that can never complete, while two `cm-acme-http-solver` HTTPRoutes ghost-attach to the listener and break `/` routing for `meme.sh`. Lost about 8 days of `meme.sh` uptime to this in May 2026.
+
+## Runbook — meme.sh returns 404
+
+1. Confirm origin is the actual culprit (not Cloudflare): `curl -s https://meme.sh/ | head` — an `nginx`-flavored 404 body means the request reached origin and the gateway returned it.
+2. Compare against a sibling host on the same gateway, e.g. `curl -sk --resolve kbve.com:443:142.132.206.71 -H 'Host: kbve.com' https://kbve.com/` — if that's 200, the gateway is healthy and the breakage is memes-specific.
+3. Check `kubectl get cert memes-cert -n memes` for `Ready=False, Reason=IncorrectCertificate` and `kubectl get httproute -n memes` for `cm-acme-http-solver-*` HTTPRoutes older than a few hours.
+4. If both present: the cert spec drifted from the live secret. Re-align `memes-cert.yaml` `spec.privateKey.algorithm` to the live secret (`openssl x509 -in <(kubectl get secret memes-tls -n memes -o jsonpath='{.data.tls\.crt}' | base64 -d) -text -noout | grep "Public Key Algorithm"`) and reapply via ArgoCD.
+5. After the cert reissue lock clears (the cm-acme HTTPRoutes get garbage-collected), kick the gateway: `kubectl rollout restart -n kube-system ds/cilium-envoy` so Envoy reloads its listener config.
+6. Re-curl `meme.sh` — should return 200.

--- a/apps/kube/memes/manifest/memes-cert.yaml
+++ b/apps/kube/memes/manifest/memes-cert.yaml
@@ -11,8 +11,17 @@ spec:
     dnsNames:
         - meme.sh
         - www.meme.sh
+    # Aligned with the RSA 2048 cert already in the live `memes-tls` secret
+    # (issued Apr 21 2026 by Let's Encrypt R12, valid through Jul 20 2026).
+    # Previously declared ECDSA/256, which made cert-manager flag the secret
+    # as IncorrectCertificate and queue an HTTP-01 reissue. The challenge
+    # never validated because the Cilium gateway listener was also dropping
+    # the cm-acme-http-solver HTTPRoutes (8 days of stuck challenges), so
+    # meme.sh stayed 404 while the cert ghost-rotated. Switching the spec
+    # back to RSA matches reality and stops the reissue loop. ECDSA migration
+    # is a separate task that needs a working ACME path first.
     privateKey:
-        algorithm: ECDSA
-        size: 256
+        algorithm: RSA
+        size: 2048
     duration: 2160h
     renewBefore: 720h


### PR DESCRIPTION
## Summary
[\`memes-cert\`](apps/kube/memes/manifest/memes-cert.yaml) declared \`ECDSA/256\`; the live \`memes-tls\` secret has been \`RSA 2048\` (Let's Encrypt R12, expires Jul 20 2026) for over a month. cert-manager flagged \`IncorrectCertificate\` and queued an HTTP-01 reissue that's been stuck **8 days** because the \`cm-acme-http-solver\` HTTPRoutes also fail to route on the Cilium gateway listener — same root cause that makes \`/\` 404 for the real \`memes-route\`.

Switches the spec to RSA 2048 to match reality. Stops the reissue loop and clears the ghost ACME HTTPRoutes that have been ghost-attached to \`https-memes\` / \`https-memes-www\`.

## Evidence

| Test | Result |
|---|---|
| \`curl https://meme.sh/\` (via CF, origin \`gateway.kbve.com\` = \`.71\`) | 404 nginx-style body, \`server: cloudflare\` |
| \`curl --resolve meme.sh:443:142.132.206.71 https://meme.sh/\` | byte-identical 404 — origin is Cilium gateway, not CF |
| \`curl --resolve kbve.com:443:142.132.206.71 https://kbve.com/\` | 200 — same gateway serves other hosts fine |
| \`curl https://meme.sh/.well-known/acme-challenge/<token>\` via \`.71\` | 404 — ACME challenges also broken, explains the cert loop |
| \`openssl x509 -in <memes-tls cert>\` | \`Public Key Algorithm: rsaEncryption (2048 bit)\` |
| \`Certificate memes-cert\` status | \`Ready=False, Reason=IncorrectCertificate\` |
| Two \`cm-acme-http-solver\` pods + HTTPRoutes in \`memes\` namespace | running 8d |

## Post-merge runbook (manual, requires greenlight)
1. ArgoCD reconciles \`apps/kube/memes/manifest/\` → \`memes-cert\` updates spec only.
2. Watch \`kubectl get cert memes-cert -n memes\` flip to \`Ready=True\`. Should happen within a reconcile cycle since the existing secret already satisfies the spec — no ACME round trip needed.
3. \`cm-acme-http-solver-*\` HTTPRoutes + pods garbage-collect.
4. \`kubectl rollout restart -n kube-system ds/cilium-envoy\` to flush stale listener config.
5. \`curl https://meme.sh/\` → 200.

## Follow-up (separate PRs)
- ECDSA migration of \`memes-cert\` after the gateway ACME path is verified end-to-end on a sibling host first
- Cilium listener config drift / CA rotation cascade — likely a Cilium-side issue per [project_cilium_gotchas](memory/project_cilium_gotchas.md), worth a separate trace ticket

## Docs
Added a "TLS / certificate" + "Runbook — meme.sh returns 404" section to [memes.mdx](apps/kbve/astro-kbve/src/content/docs/project/memes.mdx) so the next person finds the answer in five minutes.

## Test plan
- [ ] ArgoCD app \`memes\` flips from Degraded → Healthy after merge + reconcile
- [ ] \`kubectl get cert memes-cert -n memes\` \`Ready=True\`
- [ ] \`https://meme.sh/\` returns 200 with the actual memes site