### PR TITLE
feat(agones-factorio): Fleet Commander Phase 2 — zone roles, mission tabs, mining auto-fan, squads

### DIFF
--- a/apps/agones/factorio/mods-local/kbve/control.lua
+++ b/apps/agones/factorio/mods-local/kbve/control.lua
@@ -3,6 +3,8 @@ local Spawn = require('modules.spawn')
 local Vault = require('modules.vault')
 local ExchangeGui = require('modules.exchange_gui')
 local FleetGui = require('modules.fleet_gui')
+local FleetState = require('modules.fleet_state')
+local FleetMissions = require('modules.fleet_missions')
 
 local function on_player_joined(event)
 	local player = game.get_player(event.player_index)
@@ -35,6 +37,7 @@ end
 local function init_world()
 	Coins.init_state()
 	Vault.init_state()
+	FleetState.init()
 	local surface = game.surfaces['nauvis'] or game.surfaces[1]
 	if surface then
 		Spawn.build_compound(surface)
@@ -46,6 +49,7 @@ script.on_init(init_world)
 script.on_configuration_changed(function()
 	Coins.init_state()
 	Vault.init_state()
+	FleetState.init()
 end)
 
 script.on_event(defines.events.on_player_joined_game, on_player_joined)
@@ -54,5 +58,7 @@ script.on_event(defines.events.on_pre_player_mined_item, Coins.handle_pre_player
 script.on_event(defines.events.on_entity_died, Coins.handle_entity_died)
 script.on_event(defines.events.on_gui_click, on_gui_click)
 script.on_event(defines.events.on_gui_closed, on_gui_closed)
+script.on_event(defines.events.on_gui_selection_state_changed, FleetGui.on_gui_selection_state_changed)
 script.on_event('kbve-open-exchange', ExchangeGui.on_custom_input)
 script.on_event('kbve-open-fleet', FleetGui.on_custom_input)
+script.on_event(defines.events.on_tick, FleetMissions.on_tick)

--- a/apps/agones/factorio/mods-local/kbve/modules/fleet_gui.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/fleet_gui.lua
@@ -1,3 +1,6 @@
+local FleetState = require('modules.fleet_state')
+local FleetMissions = require('modules.fleet_missions')
+
 local FleetGui = {}
 
 local GUI_NAME = 'kbve_fleet'
@@ -5,6 +8,10 @@ local TABBED_NAME = 'kbve_fleet_tabbed'
 local VEHICLES_TAB = 'kbve_fleet_vehicles'
 local ZONES_TAB = 'kbve_fleet_zones'
 local DISPATCH_TAB = 'kbve_fleet_dispatch'
+local MINING_TAB = 'kbve_fleet_mining'
+local DEFENSE_TAB = 'kbve_fleet_defense'
+local COMBAT_TAB = 'kbve_fleet_combat'
+local GROUPS_TAB = 'kbve_fleet_groups'
 local CLOSE_NAME = 'kbve_fleet_close'
 local REFRESH_NAME = 'kbve_fleet_refresh'
 local SYNC_NAME = 'kbve_fleet_sync'
@@ -12,6 +19,34 @@ local DISPATCH_PREFIX = 'kbve_fleet_dispatch_'
 local TYPE_DROPDOWN = 'kbve_fleet_type'
 local ZONE_DROPDOWN = 'kbve_fleet_zone'
 local DISPATCH_BUTTON = 'kbve_fleet_dispatch_btn'
+local ZONE_ROLE_PREFIX = 'kbve_fleet_zonerole_'
+local MINING_DISPATCH = 'kbve_fleet_mining_dispatch'
+local MINING_ZONE_DROPDOWN = 'kbve_fleet_mining_zone'
+local DEFENSE_DISPATCH = 'kbve_fleet_defense_dispatch'
+local DEFENSE_ZONE_DROPDOWN = 'kbve_fleet_defense_zone'
+local COMBAT_DISPATCH = 'kbve_fleet_combat_dispatch'
+local COMBAT_X = 'kbve_fleet_combat_x'
+local COMBAT_Y = 'kbve_fleet_combat_y'
+local GROUP_NEW = 'kbve_fleet_group_new'
+local GROUP_NAME_FIELD = 'kbve_fleet_group_name'
+local GROUP_DELETE_PREFIX = 'kbve_fleet_group_del_'
+local GROUP_DISPATCH_PREFIX = 'kbve_fleet_group_dispatch_'
+local GROUP_ZONE_PREFIX = 'kbve_fleet_group_zone_'
+
+local ROLE_NONE = '— none —'
+
+local function is_miner(name)
+	return string.find(name, 'vehicle%-miner', 1, false) ~= nil
+end
+
+local function is_combat(name)
+	return string.find(name, 'vehicle%-warden', 1, false) ~= nil
+		or string.find(name, 'vehicle%-chaingunner', 1, false) ~= nil
+		or string.find(name, 'vehicle%-laser%-tank', 1, false) ~= nil
+		or string.find(name, 'vehicle%-flame%-tank', 1, false) ~= nil
+		or string.find(name, 'vehicle%-flame%-tumbler', 1, false) ~= nil
+		or string.find(name, 'vehicle%-ironclad', 1, false) ~= nil
+end
 
 local VEHICLE_NAMES_CANDIDATES = {
 	'vehicle-miner-0',
@@ -330,9 +365,12 @@ local function render_zones(content, player)
 		return
 	end
 
+	local roles = { ROLE_NONE }
+	for _, r in ipairs(FleetState.roles()) do table.insert(roles, r) end
+
 	local scroll = content.add({ type = 'scroll-pane', direction = 'vertical' })
 	scroll.style.maximal_height = 360
-	scroll.style.minimal_width = 480
+	scroll.style.minimal_width = 600
 	for _, zone in ipairs(active) do
 		local row = scroll.add({ type = 'flow', direction = 'horizontal' })
 		local proto = prototypes.entity[zone.name]
@@ -346,9 +384,20 @@ local function render_zones(content, player)
 		row.add({
 			type = 'label',
 			caption = proto and proto.localised_name or zone.name,
-		}).style.minimal_width = 280
-		row.add({ type = 'empty-widget' }).style.horizontally_stretchable = true
-		row.add({ type = 'label', caption = { '', zone.count, ' tiles' } })
+		}).style.minimal_width = 260
+		row.add({ type = 'label', caption = { '', zone.count, ' tiles' } }).style.minimal_width = 80
+		row.add({ type = 'label', caption = 'Role:' })
+		local current = FleetState.get_zone_role(zone.name)
+		local selected = 1
+		for i, r in ipairs(roles) do
+			if r == current then selected = i; break end
+		end
+		row.add({
+			type = 'drop-down',
+			name = ZONE_ROLE_PREFIX .. zone.name,
+			items = roles,
+			selected_index = selected,
+		})
 	end
 end
 
@@ -423,6 +472,175 @@ local function render_dispatch(content, player)
 	})
 end
 
+local function build_role_zone_items(role)
+	local items, names = {}, {}
+	local fleet = FleetState.get()
+	for zone_name, r in pairs(fleet.zone_roles) do
+		if r == role then
+			local proto = prototypes.entity[zone_name]
+			table.insert(items, proto and proto.localised_name or zone_name)
+			table.insert(names, zone_name)
+		end
+	end
+	if #items == 0 then
+		table.insert(items, 'No ' .. role .. ' zones — set one in the Zones tab')
+		table.insert(names, '')
+	end
+	return items, names
+end
+
+local function units_matching(player, predicate)
+	local out = {}
+	if not (remote and remote.interfaces and remote.interfaces['aai-programmable-vehicles']) then return out end
+	local ok, registered = pcall(remote.call, 'aai-programmable-vehicles', 'get_units')
+	if not ok or type(registered) ~= 'table' then return out end
+	for _, u in pairs(registered) do
+		if u.vehicle and u.vehicle.valid
+			and u.vehicle.surface.index == player.surface.index
+			and predicate(u.vehicle.name)
+		then
+			table.insert(out, u.unit_id)
+		end
+	end
+	return out
+end
+
+local function render_mission_tab(content, player, opts)
+	content.clear()
+	content.add({ type = 'label', caption = opts.title, style = 'heading_2_label' })
+	content.add({ type = 'label', caption = opts.subtitle })
+
+	local zone_row = content.add({ type = 'flow', name = opts.zone_row_name, direction = 'horizontal' })
+	zone_row.add({ type = 'label', caption = opts.zone_label })
+	local items, _ = build_role_zone_items(opts.role)
+	zone_row.add({
+		type = 'drop-down',
+		name = opts.dropdown_name,
+		items = items,
+		selected_index = 1,
+	})
+
+	local matching = units_matching(player, opts.predicate)
+	content.add({
+		type = 'label',
+		caption = { '', opts.match_label, tostring(#matching) },
+	})
+
+	content.add({
+		type = 'button',
+		name = opts.button_name,
+		caption = opts.button_caption,
+		style = 'green_button',
+		enabled = #matching > 0,
+	})
+end
+
+local function render_mining(content, player)
+	render_mission_tab(content, player, {
+		title = 'Mining missions',
+		subtitle = 'Send AAI miners to a mining-tagged zone. Auto-fan keeps them on ore tiles.',
+		zone_label = 'Mining zone:',
+		zone_row_name = 'kbve_fleet_mining_row',
+		dropdown_name = MINING_ZONE_DROPDOWN,
+		button_name = MINING_DISPATCH,
+		button_caption = 'Send miners',
+		match_label = 'Miners on this surface: ',
+		predicate = is_miner,
+		role = 'mining',
+	})
+end
+
+local function render_defense(content, player)
+	render_mission_tab(content, player, {
+		title = 'Defense missions',
+		subtitle = 'Hold a defense-tagged zone with warden, chaingunner, laser-tank, ironclad, or flame units.',
+		zone_label = 'Defense zone:',
+		zone_row_name = 'kbve_fleet_defense_row',
+		dropdown_name = DEFENSE_ZONE_DROPDOWN,
+		button_name = DEFENSE_DISPATCH,
+		button_caption = 'Send combat units',
+		match_label = 'Combat units on this surface: ',
+		predicate = is_combat,
+		role = 'defense',
+	})
+end
+
+local function render_combat(content, player)
+	content.clear()
+	content.add({ type = 'label', caption = 'Combat mission', style = 'heading_2_label' })
+	content.add({
+		type = 'label',
+		caption = 'One-shot offensive — every combat unit drives straight to the entered map position.',
+	})
+
+	local row = content.add({ type = 'flow', name = 'kbve_fleet_combat_row', direction = 'horizontal' })
+	row.add({ type = 'label', caption = 'Target x:' })
+	row.add({ type = 'textfield', name = COMBAT_X, text = tostring(math.floor(player.position.x)), numeric = true, allow_negative = true })
+	row.add({ type = 'label', caption = 'y:' })
+	row.add({ type = 'textfield', name = COMBAT_Y, text = tostring(math.floor(player.position.y)), numeric = true, allow_negative = true })
+
+	local matching = units_matching(player, is_combat)
+	content.add({ type = 'label', caption = { '', 'Combat units on this surface: ', tostring(#matching) } })
+	content.add({
+		type = 'button',
+		name = COMBAT_DISPATCH,
+		caption = 'Strike',
+		style = 'red_back_button',
+		enabled = #matching > 0,
+	})
+end
+
+local function render_groups(content, player)
+	content.clear()
+	content.add({ type = 'label', caption = 'Squads', style = 'heading_2_label' })
+	content.add({
+		type = 'label',
+		caption = 'Persist named subsets of the fleet. Each squad keeps its own member list across saves.',
+	})
+
+	local row = content.add({ type = 'flow', name = 'kbve_fleet_group_new_row', direction = 'horizontal' })
+	row.add({ type = 'label', caption = 'New squad name:' })
+	row.add({ type = 'textfield', name = GROUP_NAME_FIELD, text = '' })
+	row.add({ type = 'button', name = GROUP_NEW, caption = 'Create' })
+
+	local groups = FleetState.groups_list()
+	if #groups == 0 then
+		content.add({ type = 'label', caption = 'No squads yet.' })
+		return
+	end
+
+	local _, role_zone_names = build_role_zone_items('defense')
+	local mining_items, mining_names = build_role_zone_items('mining')
+
+	local scroll = content.add({ type = 'scroll-pane', direction = 'vertical' })
+	scroll.style.maximal_height = 320
+	scroll.style.minimal_width = 560
+
+	for _, g in ipairs(groups) do
+		local grow = scroll.add({ type = 'flow', direction = 'horizontal' })
+		grow.add({ type = 'label', caption = '#' .. g.id .. ' ' .. g.name }).style.minimal_width = 180
+		grow.add({ type = 'label', caption = { '', 'units: ', #g.unit_ids } }).style.minimal_width = 90
+		grow.add({
+			type = 'drop-down',
+			name = GROUP_ZONE_PREFIX .. g.id,
+			items = mining_items,
+			selected_index = 1,
+		})
+		grow.add({
+			type = 'button',
+			name = GROUP_DISPATCH_PREFIX .. g.id,
+			caption = 'Dispatch',
+			enabled = #g.unit_ids > 0 and #mining_names > 0 and mining_names[1] ~= '',
+		})
+		grow.add({
+			type = 'button',
+			name = GROUP_DELETE_PREFIX .. g.id,
+			caption = 'X',
+			tooltip = 'Delete squad',
+		})
+	end
+end
+
 function FleetGui.show(player)
 	destroy(player)
 	local frame = player.gui.screen.add({
@@ -467,6 +685,42 @@ function FleetGui.show(player)
 	tabbed.add_tab(dispatch_tab, dispatch_content)
 	render_dispatch(dispatch_content, player)
 
+	local mining_tab = tabbed.add({ type = 'tab', caption = 'Mining' })
+	local mining_content = tabbed.add({
+		type = 'flow',
+		name = MINING_TAB,
+		direction = 'vertical',
+	})
+	tabbed.add_tab(mining_tab, mining_content)
+	render_mining(mining_content, player)
+
+	local defense_tab = tabbed.add({ type = 'tab', caption = 'Defense' })
+	local defense_content = tabbed.add({
+		type = 'flow',
+		name = DEFENSE_TAB,
+		direction = 'vertical',
+	})
+	tabbed.add_tab(defense_tab, defense_content)
+	render_defense(defense_content, player)
+
+	local combat_tab = tabbed.add({ type = 'tab', caption = 'Combat' })
+	local combat_content = tabbed.add({
+		type = 'flow',
+		name = COMBAT_TAB,
+		direction = 'vertical',
+	})
+	tabbed.add_tab(combat_tab, combat_content)
+	render_combat(combat_content, player)
+
+	local groups_tab = tabbed.add({ type = 'tab', caption = 'Squads' })
+	local groups_content = tabbed.add({
+		type = 'flow',
+		name = GROUPS_TAB,
+		direction = 'vertical',
+	})
+	tabbed.add_tab(groups_tab, groups_content)
+	render_groups(groups_content, player)
+
 	player.opened = frame
 end
 
@@ -485,6 +739,10 @@ local function refresh(player)
 	if tabbed[VEHICLES_TAB] then render_vehicles(tabbed[VEHICLES_TAB], player) end
 	if tabbed[ZONES_TAB] then render_zones(tabbed[ZONES_TAB], player) end
 	if tabbed[DISPATCH_TAB] then render_dispatch(tabbed[DISPATCH_TAB], player) end
+	if tabbed[MINING_TAB] then render_mining(tabbed[MINING_TAB], player) end
+	if tabbed[DEFENSE_TAB] then render_defense(tabbed[DEFENSE_TAB], player) end
+	if tabbed[COMBAT_TAB] then render_combat(tabbed[COMBAT_TAB], player) end
+	if tabbed[GROUPS_TAB] then render_groups(tabbed[GROUPS_TAB], player) end
 end
 
 local function dispatch(player)
@@ -613,6 +871,120 @@ function FleetGui.on_custom_input(event)
 	FleetGui.show(player)
 end
 
+local function mining_dispatch(player)
+	local frame = player.gui.screen[GUI_NAME]
+	if not frame then return end
+	local tabbed = frame[TABBED_NAME]
+	local content = tabbed and tabbed[MINING_TAB]
+	if not content then return end
+	local row = content['kbve_fleet_mining_row']
+	local dd = row and row[MINING_ZONE_DROPDOWN]
+	if not dd then return end
+	local _, names = build_role_zone_items('mining')
+	local zone_name = names[dd.selected_index]
+	if not zone_name or zone_name == '' then
+		player.print('No mining zone selected. Tag a zone "mining" in the Zones tab first.')
+		return
+	end
+	local unit_ids = units_matching(player, is_miner)
+	local n = FleetMissions.assign_mining(player, unit_ids, zone_name)
+	player.print({ '', 'Mining mission: ', tostring(n), ' miner(s) sent to ', zone_name, '.' })
+end
+
+local function defense_dispatch(player)
+	local frame = player.gui.screen[GUI_NAME]
+	if not frame then return end
+	local tabbed = frame[TABBED_NAME]
+	local content = tabbed and tabbed[DEFENSE_TAB]
+	if not content then return end
+	local row = content['kbve_fleet_defense_row']
+	local dd = row and row[DEFENSE_ZONE_DROPDOWN]
+	if not dd then return end
+	local _, names = build_role_zone_items('defense')
+	local zone_name = names[dd.selected_index]
+	if not zone_name or zone_name == '' then
+		player.print('No defense zone selected. Tag a zone "defense" in the Zones tab first.')
+		return
+	end
+	local unit_ids = units_matching(player, is_combat)
+	local n = FleetMissions.assign_mining(player, unit_ids, zone_name)
+	for _, uid in ipairs(unit_ids) do
+		FleetState.set_unit_mission(uid, 'defense', zone_name)
+	end
+	player.print({ '', 'Defense mission: ', tostring(n), ' combat unit(s) holding ', zone_name, '.' })
+end
+
+local function combat_dispatch(player)
+	local frame = player.gui.screen[GUI_NAME]
+	if not frame then return end
+	local tabbed = frame[TABBED_NAME]
+	local content = tabbed and tabbed[COMBAT_TAB]
+	if not content then return end
+	local row = content['kbve_fleet_combat_row']
+	local xf = row and row[COMBAT_X]
+	local yf = row and row[COMBAT_Y]
+	if not (xf and yf) then return end
+	local x = tonumber(xf.text)
+	local y = tonumber(yf.text)
+	if not (x and y) then
+		player.print('Enter numeric x,y target coordinates.')
+		return
+	end
+	local unit_ids = units_matching(player, is_combat)
+	local n = FleetMissions.assign_combat(player, unit_ids, { x = x, y = y })
+	player.print({ '', 'Combat strike: ', tostring(n), ' unit(s) en route to (', tostring(x), ',', tostring(y), ').' })
+end
+
+local function set_zone_role_from_dropdown(player, elem, zone_name)
+	local idx = elem.selected_index
+	if idx <= 1 then
+		FleetState.set_zone_role(zone_name, nil)
+		player.print({ '', 'Cleared role for ', zone_name, '.' })
+	else
+		local role = FleetState.roles()[idx - 1]
+		FleetState.set_zone_role(zone_name, role)
+		player.print({ '', zone_name, ' tagged as ', role, '.' })
+	end
+end
+
+local function group_create(player)
+	local frame = player.gui.screen[GUI_NAME]
+	local tabbed = frame and frame[TABBED_NAME]
+	local content = tabbed and tabbed[GROUPS_TAB]
+	if not content then return end
+	local row = content['kbve_fleet_group_new_row']
+	local field = row and row[GROUP_NAME_FIELD]
+	if not field then return end
+	local name = field.text
+	local id = FleetState.create_group(name)
+	field.text = ''
+	player.print({ '', 'Created squad #', tostring(id), '.' })
+end
+
+local function group_delete(player, group_id)
+	FleetState.delete_group(group_id)
+	player.print({ '', 'Deleted squad #', tostring(group_id), '.' })
+end
+
+local function group_dispatch(player, group_id)
+	local frame = player.gui.screen[GUI_NAME]
+	local tabbed = frame and frame[TABBED_NAME]
+	local content = tabbed and tabbed[GROUPS_TAB]
+	if not content then return end
+	local dd = content[GROUP_ZONE_PREFIX .. group_id]
+	if not dd then return end
+	local _, names = build_role_zone_items('mining')
+	local zone_name = names[dd.selected_index]
+	if not zone_name or zone_name == '' then
+		player.print('No mining zone selected for this squad.')
+		return
+	end
+	local g = FleetState.get().groups[group_id]
+	if not g then return end
+	local n = FleetMissions.assign_mining(player, g.unit_ids, zone_name)
+	player.print({ '', 'Squad ', g.name, ': ', tostring(n), ' unit(s) dispatched to ', zone_name, '.' })
+end
+
 function FleetGui.on_gui_click(event)
 	local elem = event.element
 	if not (elem and elem.valid) then return end
@@ -637,6 +1009,54 @@ function FleetGui.on_gui_click(event)
 		dispatch(player)
 		refresh(player)
 		return
+	end
+	if name == MINING_DISPATCH then
+		mining_dispatch(player)
+		refresh(player)
+		return
+	end
+	if name == DEFENSE_DISPATCH then
+		defense_dispatch(player)
+		refresh(player)
+		return
+	end
+	if name == COMBAT_DISPATCH then
+		combat_dispatch(player)
+		refresh(player)
+		return
+	end
+	if name == GROUP_NEW then
+		group_create(player)
+		refresh(player)
+		return
+	end
+	if name:sub(1, #GROUP_DELETE_PREFIX) == GROUP_DELETE_PREFIX then
+		local id = tonumber(name:sub(#GROUP_DELETE_PREFIX + 1))
+		if id then
+			group_delete(player, id)
+			refresh(player)
+		end
+		return
+	end
+	if name:sub(1, #GROUP_DISPATCH_PREFIX) == GROUP_DISPATCH_PREFIX then
+		local id = tonumber(name:sub(#GROUP_DISPATCH_PREFIX + 1))
+		if id then
+			group_dispatch(player, id)
+			refresh(player)
+		end
+		return
+	end
+end
+
+function FleetGui.on_gui_selection_state_changed(event)
+	local elem = event.element
+	if not (elem and elem.valid) then return end
+	local name = elem.name or ''
+	if name:sub(1, #ZONE_ROLE_PREFIX) == ZONE_ROLE_PREFIX then
+		local player = game.get_player(event.player_index)
+		if not player then return end
+		local zone_name = name:sub(#ZONE_ROLE_PREFIX + 1)
+		set_zone_role_from_dropdown(player, elem, zone_name)
 	end
 end
 

--- a/apps/agones/factorio/mods-local/kbve/modules/fleet_missions.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/fleet_missions.lua
@@ -1,0 +1,259 @@
+local FleetState = require('modules.fleet_state')
+
+local FleetMissions = {}
+
+local TICK_INTERVAL = 60
+local FUEL_LOW_BURN = 200000
+local CARGO_FULL_RATIO = 0.9
+
+local function has_aai_vehicles()
+	return remote and remote.interfaces and remote.interfaces['aai-programmable-vehicles'] ~= nil
+end
+
+local function has_aai_zones()
+	return remote and remote.interfaces and remote.interfaces['aai-zones'] ~= nil
+end
+
+local function aai_set(unit_id, args)
+	args.unit_id = unit_id
+	pcall(remote.call, 'aai-programmable-vehicles', 'set_unit_command', args)
+end
+
+local function aai_units()
+	if not has_aai_vehicles() then return {} end
+	local ok, r = pcall(remote.call, 'aai-programmable-vehicles', 'get_units')
+	if not ok or type(r) ~= 'table' then return {} end
+	return r
+end
+
+local function zone_count(force, surface_index, zone_name)
+	if not has_aai_zones() then return 0 end
+	local ok, r = pcall(remote.call, 'aai-zones', 'get_zone_count_of_type', {
+		force = force,
+		surface_index = surface_index,
+		type = zone_name,
+	})
+	if not ok then return 0 end
+	return r or 0
+end
+
+local function zone_tile_at(force, surface_index, zone_name, index)
+	if not has_aai_zones() then return nil end
+	local ok, r = pcall(remote.call, 'aai-zones', 'get_zone_by_index', {
+		force = force,
+		surface_index = surface_index,
+		type = zone_name,
+		index = index,
+	})
+	if not ok or type(r) ~= 'table' or not (r.x and r.y) then return nil end
+	return r
+end
+
+local function pick_zone_tile_index(unit_index, n_units, zone_n)
+	if zone_n <= 0 then return nil end
+	return math.floor(((unit_index - 1) * zone_n) / math.max(1, n_units)) + 1
+end
+
+local function nearest_zone_position(player_force, surface_index, zone_name, from)
+	local n = zone_count(player_force, surface_index, zone_name)
+	if n <= 0 then return nil end
+	local best, best_d = nil, math.huge
+	local step = math.max(1, math.floor(n / 16))
+	for i = 1, n, step do
+		local t = zone_tile_at(player_force, surface_index, zone_name, i)
+		if t then
+			local dx = (t.x + 0.5) - from.x
+			local dy = (t.y + 0.5) - from.y
+			local d = dx * dx + dy * dy
+			if d < best_d then
+				best_d, best = d, { x = t.x + 0.5, y = t.y + 0.5 }
+			end
+		end
+	end
+	return best
+end
+
+local function unit_fuel_low(u)
+	if not (u.vehicle and u.vehicle.valid and u.vehicle.burner) then return false end
+	if u.vehicle.burner.remaining_burning_fuel > FUEL_LOW_BURN then return false end
+	if u.vehicle.burner.inventory and not u.vehicle.burner.inventory.is_empty() then return false end
+	return true
+end
+
+local function unit_cargo_full(u)
+	if not (u.vehicle and u.vehicle.valid) then return false end
+	local inv = u.vehicle.get_inventory(defines.inventory.car_trunk)
+	if not inv then return false end
+	local count = #inv
+	if count == 0 then return false end
+	local used = 0
+	for i = 1, count do
+		if inv[i].valid_for_read then used = used + 1 end
+	end
+	return (used / count) >= CARGO_FULL_RATIO
+end
+
+local function ore_under(surface, position)
+	local r = surface.find_entities_filtered({
+		position = position,
+		radius = 1,
+		type = 'resource',
+		limit = 1,
+	})
+	return r[1]
+end
+
+local function units_on_mission(mission)
+	local out = {}
+	local fleet = FleetState.get()
+	local registered = aai_units()
+	for unit_id, st in pairs(fleet.unit_state) do
+		if st.mission == mission and registered[unit_id] then
+			table.insert(out, registered[unit_id])
+		end
+	end
+	return out
+end
+
+local function dispatch_unit_to_zone(unit, force, surface_index, zone_name, unit_index, n_units)
+	local n = zone_count(force, surface_index, zone_name)
+	if n <= 0 then return false end
+	local idx = pick_zone_tile_index(unit_index, n_units, n)
+	local tile = zone_tile_at(force, surface_index, zone_name, idx)
+	if not tile then return false end
+	local pos = { x = tile.x + 0.5, y = tile.y + 0.5 }
+	aai_set(unit.unit_id, { target_speed = 0.1 })
+	aai_set(unit.unit_id, { target_position = pos })
+	return true
+end
+
+function FleetMissions.assign_mining(player, unit_ids, zone_name)
+	if not has_aai_zones() then return 0 end
+	local registered = aai_units()
+	local valid_units = {}
+	for _, uid in ipairs(unit_ids) do
+		if registered[uid] then table.insert(valid_units, registered[uid]) end
+	end
+	for i, u in ipairs(valid_units) do
+		FleetState.set_unit_mission(u.unit_id, 'mining', zone_name)
+		dispatch_unit_to_zone(u, player.force, player.surface.index, zone_name, i, #valid_units)
+	end
+	return #valid_units
+end
+
+function FleetMissions.assign_defense(player, unit_ids, zone_name)
+	return FleetMissions.assign_mining(player, unit_ids, zone_name)
+		and FleetMissions._rebrand(unit_ids, 'defense', zone_name)
+end
+
+function FleetMissions._rebrand(unit_ids, mission, zone_name)
+	for _, uid in ipairs(unit_ids) do
+		FleetState.set_unit_mission(uid, mission, zone_name)
+	end
+	return #unit_ids
+end
+
+function FleetMissions.assign_combat(player, unit_ids, target_position)
+	local registered = aai_units()
+	local n = 0
+	for _, uid in ipairs(unit_ids) do
+		if registered[uid] then
+			FleetState.set_unit_mission(uid, 'combat', nil)
+			aai_set(uid, { target_speed = 0.1 })
+			aai_set(uid, { target_position = target_position })
+			n = n + 1
+		end
+	end
+	return n
+end
+
+local function tick_mining()
+	local fleet = FleetState.get()
+	local registered = aai_units()
+	for unit_id, st in pairs(fleet.unit_state) do
+		if st.mission == 'mining' and registered[unit_id] then
+			local u = registered[unit_id]
+			if u.vehicle and u.vehicle.valid then
+				if unit_fuel_low(u) then
+					local refuel = FleetState.zones_by_role('refuel')[1]
+					if refuel then
+						local pos = nearest_zone_position(u.vehicle.force, u.vehicle.surface.index, refuel, u.vehicle.position)
+						if pos then
+							FleetState.set_unit_mission(unit_id, 'refueling', refuel)
+							aai_set(unit_id, { target_speed = 0.1 })
+							aai_set(unit_id, { target_position = pos })
+						end
+					end
+				elseif u.target_position == nil or u.mode == 'passive' then
+					local n = zone_count(u.vehicle.force, u.vehicle.surface.index, st.zone)
+					if n > 0 then
+						for i = 1, math.min(n, 8) do
+							local idx = ((game.tick + unit_id + i) % n) + 1
+							local tile = zone_tile_at(u.vehicle.force, u.vehicle.surface.index, st.zone, idx)
+							if tile and ore_under(u.vehicle.surface, { x = tile.x + 0.5, y = tile.y + 0.5 }) then
+								aai_set(unit_id, { target_speed = 0.1 })
+								aai_set(unit_id, { target_position = { x = tile.x + 0.5, y = tile.y + 0.5 } })
+								break
+							end
+						end
+					end
+				end
+			end
+		end
+	end
+end
+
+local function tick_refueling()
+	local fleet = FleetState.get()
+	local registered = aai_units()
+	for unit_id, st in pairs(fleet.unit_state) do
+		if st.mission == 'refueling' and registered[unit_id] then
+			local u = registered[unit_id]
+			if u.vehicle and u.vehicle.valid then
+				local has_fuel = u.vehicle.burner
+					and u.vehicle.burner.inventory
+					and not u.vehicle.burner.inventory.is_empty()
+				if has_fuel then
+					local prev = st.previous_mission
+					local prev_zone = st.previous_zone
+					if prev and prev_zone then
+						FleetState.set_unit_mission(unit_id, prev, prev_zone)
+					else
+						FleetState.set_unit_mission(unit_id, nil, nil)
+					end
+				end
+			end
+		end
+	end
+end
+
+local function tick_depositing()
+	local fleet = FleetState.get()
+	local registered = aai_units()
+	for unit_id, st in pairs(fleet.unit_state) do
+		if st.mission == 'depositing' and registered[unit_id] then
+			local u = registered[unit_id]
+			if u.vehicle and u.vehicle.valid then
+				if not unit_cargo_full(u) then
+					local prev = st.previous_mission
+					local prev_zone = st.previous_zone
+					if prev and prev_zone then
+						FleetState.set_unit_mission(unit_id, prev, prev_zone)
+					else
+						FleetState.set_unit_mission(unit_id, nil, nil)
+					end
+				end
+			end
+		end
+	end
+end
+
+function FleetMissions.on_tick(event)
+	if (event.tick % TICK_INTERVAL) ~= 0 then return end
+	if not has_aai_vehicles() then return end
+	tick_mining()
+	tick_refueling()
+	tick_depositing()
+end
+
+return FleetMissions

--- a/apps/agones/factorio/mods-local/kbve/modules/fleet_state.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/fleet_state.lua
@@ -1,0 +1,160 @@
+local FleetState = {}
+
+local ROLES = {
+	mining = true,
+	defense = true,
+	highway = true,
+	refuel = true,
+	deposit = true,
+}
+
+function FleetState.init()
+	storage.kbve = storage.kbve or {}
+	storage.kbve.fleet = storage.kbve.fleet or {}
+	local f = storage.kbve.fleet
+	f.zone_roles = f.zone_roles or {}
+	f.groups = f.groups or {}
+	f.next_group_id = f.next_group_id or 1
+	f.unit_state = f.unit_state or {}
+end
+
+function FleetState.get()
+	FleetState.init()
+	return storage.kbve.fleet
+end
+
+function FleetState.is_valid_role(role)
+	return role == nil or role == '' or ROLES[role] == true
+end
+
+function FleetState.roles()
+	return { 'mining', 'defense', 'highway', 'refuel', 'deposit' }
+end
+
+function FleetState.set_zone_role(zone_name, role)
+	if not zone_name or zone_name == '' then return end
+	if not FleetState.is_valid_role(role) then return end
+	local f = FleetState.get()
+	if role == nil or role == '' then
+		f.zone_roles[zone_name] = nil
+	else
+		f.zone_roles[zone_name] = role
+	end
+end
+
+function FleetState.get_zone_role(zone_name)
+	return FleetState.get().zone_roles[zone_name]
+end
+
+function FleetState.zones_by_role(role)
+	local out = {}
+	for zone_name, r in pairs(FleetState.get().zone_roles) do
+		if r == role then table.insert(out, zone_name) end
+	end
+	return out
+end
+
+function FleetState.create_group(name)
+	local f = FleetState.get()
+	local id = f.next_group_id
+	f.next_group_id = id + 1
+	f.groups[id] = {
+		id = id,
+		name = (name and name ~= '') and name or ('Squad ' .. id),
+		unit_ids = {},
+	}
+	return id
+end
+
+function FleetState.rename_group(group_id, name)
+	local g = FleetState.get().groups[group_id]
+	if g and name and name ~= '' then g.name = name end
+end
+
+function FleetState.delete_group(group_id)
+	local f = FleetState.get()
+	f.groups[group_id] = nil
+	for unit_id, st in pairs(f.unit_state) do
+		if st.group_id == group_id then st.group_id = nil end
+	end
+end
+
+function FleetState.assign_units_to_group(group_id, unit_ids)
+	local f = FleetState.get()
+	local g = f.groups[group_id]
+	if not g then return end
+	local seen = {}
+	for _, uid in ipairs(g.unit_ids) do seen[uid] = true end
+	for _, uid in ipairs(unit_ids) do
+		if not seen[uid] then
+			table.insert(g.unit_ids, uid)
+			seen[uid] = true
+		end
+		f.unit_state[uid] = f.unit_state[uid] or {}
+		f.unit_state[uid].group_id = group_id
+	end
+end
+
+function FleetState.remove_unit_from_group(group_id, unit_id)
+	local g = FleetState.get().groups[group_id]
+	if not g then return end
+	for i, uid in ipairs(g.unit_ids) do
+		if uid == unit_id then
+			table.remove(g.unit_ids, i)
+			break
+		end
+	end
+	local f = FleetState.get()
+	if f.unit_state[unit_id] and f.unit_state[unit_id].group_id == group_id then
+		f.unit_state[unit_id].group_id = nil
+	end
+end
+
+function FleetState.groups_list()
+	local out = {}
+	for id, g in pairs(FleetState.get().groups) do
+		table.insert(out, g)
+	end
+	table.sort(out, function(a, b) return a.id < b.id end)
+	return out
+end
+
+function FleetState.set_unit_mission(unit_id, mission, zone_name)
+	local f = FleetState.get()
+	f.unit_state[unit_id] = f.unit_state[unit_id] or {}
+	local st = f.unit_state[unit_id]
+	if st.mission ~= mission then
+		st.previous_mission = st.mission
+		st.previous_zone = st.zone
+	end
+	st.mission = mission
+	st.zone = zone_name
+	st.last_tick = game.tick
+end
+
+function FleetState.get_unit_state(unit_id)
+	return FleetState.get().unit_state[unit_id]
+end
+
+function FleetState.prune()
+	local f = FleetState.get()
+	local valid_ids = {}
+	if remote and remote.interfaces and remote.interfaces['aai-programmable-vehicles'] then
+		local ok, units = pcall(remote.call, 'aai-programmable-vehicles', 'get_units')
+		if ok and type(units) == 'table' then
+			for id, _ in pairs(units) do valid_ids[id] = true end
+		end
+	end
+	for uid, _ in pairs(f.unit_state) do
+		if not valid_ids[uid] then f.unit_state[uid] = nil end
+	end
+	for _, g in pairs(f.groups) do
+		local kept = {}
+		for _, uid in ipairs(g.unit_ids) do
+			if valid_ids[uid] then table.insert(kept, uid) end
+		end
+		g.unit_ids = kept
+	end
+end
+
+return FleetState


### PR DESCRIPTION
## Summary

Phase 2 of the Fleet Commander. Builds the mission-typed verbs on top of the working Phase 1 dispatch.

### New foundation
- `modules/fleet_state.lua` — per-mod storage namespace (`storage.kbve.fleet`): zone roles, squads, per-unit mission/zone state, prune for stale unit ids.
- `modules/fleet_missions.lua` — 60-tick mission loop. Mining auto-fan, low-fuel refuel diversion, cargo-full deposit diversion, combat one-shot dispatch.

### GUI
- **Zones tab** — Role drop-down per zone (`mining` / `defense` / `highway` / `refuel` / `deposit` / none), persisted via `on_gui_selection_state_changed`.
- **Mining tab** — pick a mining zone, "Send miners" filters fleet to `vehicle-miner-*`. Tile assignments fan across the zone, idle miners hop to fresh tiles with ore underneath.
- **Defense tab** — same flow for `vehicle-warden-*` / `vehicle-chaingunner-*` / `vehicle-laser-tank-*` / `vehicle-flame-tank-*` / `vehicle-flame-tumbler-*` / `vehicle-ironclad-*`.
- **Combat tab** — x/y textfields + Strike button, drives every combat unit to that point.
- **Squads tab** — create / delete named squads, per-row mining-zone dropdown + Dispatch.

The Phase 1 Vehicles + Dispatch tabs stay untouched so the working flow doesn't regress while the mission verbs build out.

### Mission semantics

- **Mining**: idle units (no `target_position` or back in `mode=passive`) pick a new tile from the zone with ore underneath (sampled by `unit_id` rotation). On low fuel (`burner.remaining_burning_fuel < 200000` AND inventory empty), the unit's mission stashes and it's routed to the nearest `refuel`-tagged zone.
- **Refuel**: when the burner inventory is no longer empty, the previous mission resumes.
- **Deposit**: when cargo drops below 90 %, previous mission resumes. (Hauler routing to deposit zones to be wired in Phase 3 — scaffolding is here.)
- **Defense**: same `assign_mining` plumbing but flagged `defense` in unit state. Patrol cadence comes in Phase 3.
- **Combat**: one-shot, no auto-return.

### Server name / tag

Already correct from Phase 1: `"name": "KBVE Factorio"`, `"tags": ["kbve", "community"]`, `"autosave_interval": 30`.

## Test plan

- [ ] `docker compose -f apps/agones/factorio/docker-compose.yml up -d --build`
- [ ] Connect, take AI-variant vehicles from the warehouse, place them
- [ ] Paint two zones with the Zone Planner (different patterns)
- [ ] Fleet Commander → Zones → tag zone A `mining`, zone B `refuel`
- [ ] Mining tab → pick zone A → Send miners → verify chat reports `Mining mission: N miner(s)` and the units fan out across the zone tiles
- [ ] Drain a miner's fuel below threshold → verify it diverts to zone B → after refuel it resumes mining at A
- [ ] Squads tab → Create "Alpha" squad (currently no assignment UI for individual units in this PR; squads will accept members in the Phase 3 selection patch)
- [ ] Combat tab → enter biter base coords → Strike → combat units head there

## Phase 3 (next PR)

- Zone tile shrink-as-mined (verify or work around `aai-zones` lack of removal API).
- Highway-preferred path routing during refuel returns (multi-waypoint via highway nodes).
- Defense patrol cadence (re-dispatch to fresh random tile on arrival).
- Combat retreat-on-low-HP.
- Hauler routing to `deposit` zones.
- Per-unit selection checkboxes in the Vehicles tab to assign units into squads.