### PR TITLE
feat(yuki): vtuber polish — alive + reactive + efficient (Phase D.1)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
@@ -1,7 +1,12 @@
 const HISTORY_KEY = 'kbve:yuki-dock:history';
 const FLOAT_KEY = 'kbve:yuki-dock:float-mode';
 const FLOAT_POS_KEY = 'kbve:yuki-dock:float-pos';
+const GREETED_KEY = 'kbve:yuki-dock:greeted';
 const MAX_HISTORY = 24;
+
+const GREETING =
+	"Hi! I'm Yuki — your KBVE concierge. Tap the chat or just say hello.";
+const CLICK_GREET = 'Hi there! Need a hand finding something?';
 
 type Role = 'user' | 'yuki';
 interface ChatEntry {
@@ -94,6 +99,21 @@ function writeFloat(on: boolean): void {
 	}
 }
 
+function readGreeted(): boolean {
+	try {
+		return localStorage.getItem(GREETED_KEY) === '1';
+	} catch {
+		return false;
+	}
+}
+function writeGreeted(): void {
+	try {
+		localStorage.setItem(GREETED_KEY, '1');
+	} catch {
+		void 0;
+	}
+}
+
 interface FloatPos {
 	x: number;
 	y: number;
@@ -122,6 +142,7 @@ interface YukiVRMRuntime {
 	speak(audio: HTMLAudioElement | MediaStream): void;
 	stopSpeaking(): void;
 	pointAt(x: number, y: number): void;
+	setActive(active: boolean): void;
 	destroy(): void;
 }
 
@@ -187,7 +208,7 @@ function ensureFloatLayer(): HTMLElement {
 	`;
 	const stage = document.createElement('div');
 	stage.id = FLOAT_HOST_ID;
-	stage.style.cssText = 'position:absolute;inset:0;';
+	stage.style.cssText = 'position:absolute;inset:0;cursor:pointer;';
 	layer.appendChild(stage);
 	layer.appendChild(handle);
 	layer.appendChild(close);
@@ -315,10 +336,29 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 	}
 	log.scrollTop = log.scrollHeight;
 
+	const speak = makeSpeaker();
+
 	let vrmRuntime: YukiVRMRuntime | null = null;
 	let vrmLoading = false;
 	let vrmHost: HTMLElement = stage;
 	let vrmTransparent = false;
+	let wanderRaf = 0;
+	let wanderLastMove = performance.now();
+	let pageMoveBound = false;
+
+	const fireFirstGreet = (): void => {
+		if (!vrmRuntime) return;
+		if (readGreeted()) return;
+		writeGreeted();
+		vrmRuntime.setState('wave');
+		speak(GREETING);
+	};
+
+	const clickGreet = (): void => {
+		if (!vrmRuntime) return;
+		vrmRuntime.setState('wave');
+		speak(CLICK_GREET);
+	};
 
 	const ensureVRM = async (
 		hostEl: HTMLElement,
@@ -348,6 +388,7 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 			vrmHost = hostEl;
 			vrmTransparent = transparent;
 			hostEl.dataset.state = 'ready';
+			setTimeout(fireFirstGreet, 600);
 		} catch (err) {
 			console.warn('[yuki-panel] VRM load failed', err);
 			hostEl.innerHTML =
@@ -379,6 +420,63 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 		}
 	};
 
+	const onPageMove = (ev: PointerEvent): void => {
+		if (!readFloat()) return;
+		const layer = document.getElementById(FLOAT_LAYER_ID);
+		if (!layer) return;
+		const fh = layer.querySelector<HTMLElement>(`#${FLOAT_HOST_ID}`);
+		if (!fh) return;
+		const rect = fh.getBoundingClientRect();
+		const cx = rect.left + rect.width / 2;
+		const cy = rect.top + rect.height / 2;
+		const dx = ev.clientX - cx;
+		const dy = ev.clientY - cy;
+		const maxR = Math.max(window.innerWidth, window.innerHeight) / 2;
+		const fx = Math.max(-1.4, Math.min(1.4, dx / maxR));
+		const fy = Math.max(-1.4, Math.min(1.4, dy / maxR));
+		const px = rect.left + rect.width / 2 + (fx * rect.width) / 2;
+		const py = rect.top + rect.height / 2 + (fy * rect.height) / 2;
+		vrmRuntime?.pointAt(px, py);
+		wanderLastMove = performance.now();
+	};
+
+	const bindPageMove = (): void => {
+		if (pageMoveBound) return;
+		pageMoveBound = true;
+		window.addEventListener('pointermove', onPageMove);
+	};
+	const unbindPageMove = (): void => {
+		if (!pageMoveBound) return;
+		pageMoveBound = false;
+		window.removeEventListener('pointermove', onPageMove);
+	};
+
+	const wanderTick = (): void => {
+		wanderRaf = requestAnimationFrame(wanderTick);
+		if (!readFloat() || !vrmRuntime) return;
+		const idleMs = performance.now() - wanderLastMove;
+		if (idleMs < 8000) return;
+		const layer = document.getElementById(FLOAT_LAYER_ID);
+		if (!layer || layer.style.display === 'none') return;
+		const fh = layer.querySelector<HTMLElement>(`#${FLOAT_HOST_ID}`);
+		if (!fh) return;
+		const rect = fh.getBoundingClientRect();
+		const t = performance.now() / 2200;
+		const px = rect.left + rect.width / 2 + Math.cos(t) * rect.width * 0.3;
+		const py =
+			rect.top + rect.height / 2 + Math.sin(t * 1.3) * rect.height * 0.2;
+		vrmRuntime.pointAt(px, py);
+	};
+	wanderRaf = requestAnimationFrame(wanderTick);
+
+	const dock = document.getElementById('kbve-yuki-dock');
+	const evaluateActive = (): void => {
+		if (!vrmRuntime) return;
+		const expanded = dock?.dataset.state === 'expanded';
+		const floating = readFloat();
+		vrmRuntime.setActive(expanded || floating);
+	};
+
 	const applyFloat = (on: boolean): void => {
 		wrap.dataset.floatMode = on ? '1' : '0';
 		const btn = toggle.querySelector<HTMLButtonElement>(
@@ -399,8 +497,10 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 			stage.innerHTML = '';
 			stage.removeAttribute('data-state');
 			void ensureVRM(floatStage, true);
+			bindPageMove();
 		} else {
 			layer.style.display = 'none';
+			unbindPageMove();
 			if (readAvatarMode() === '3d') {
 				const fh = layer.querySelector<HTMLElement>(
 					`#${FLOAT_HOST_ID}`,
@@ -411,6 +511,7 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 				tearDownVRM();
 			}
 		}
+		evaluateActive();
 	};
 
 	if (readAvatarMode() === '3d') {
@@ -426,6 +527,14 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 		writeFloat(false);
 		applyFloat(false);
 	});
+
+	const floatStage = layer.querySelector<HTMLElement>(`#${FLOAT_HOST_ID}`);
+	floatStage?.addEventListener('click', (ev) => {
+		const target = ev.target as HTMLElement | null;
+		if (target?.id === 'kbve-yuki-float-close') return;
+		clickGreet();
+	});
+	stage.addEventListener('click', clickGreet);
 
 	const modeInput = toggle.querySelector<HTMLInputElement>(
 		'[data-kbve-yuki-mode]',
@@ -457,8 +566,15 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 		applyFloat(next);
 	});
 
-	const speak = makeSpeaker();
 	const input = form.querySelector<HTMLInputElement>('.yuki-panel__input');
+	input?.addEventListener('focus', () => {
+		if (!input || !vrmRuntime) return;
+		const rect = input.getBoundingClientRect();
+		vrmRuntime.pointAt(
+			rect.left + rect.width / 2,
+			rect.top + rect.height / 2,
+		);
+	});
 
 	let activeStream: EventSource | null = null;
 
@@ -472,6 +588,8 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 		history.push(user);
 		log.appendChild(renderMessage(user));
 		log.scrollTop = log.scrollHeight;
+
+		vrmRuntime?.setState('nod');
 
 		const yuki: ChatEntry = { role: 'yuki', text: '', ts: Date.now() };
 		history.push(yuki);
@@ -501,7 +619,11 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 			es.close();
 			activeStream = null;
 			writeHistory(history);
-			if (assembled) speak(assembled);
+			if (assembled) {
+				speak(assembled);
+				vrmRuntime?.setState('happy');
+				setTimeout(() => vrmRuntime?.setState('idle'), 2200);
+			}
 		});
 		es.onerror = () => {
 			es.close();
@@ -511,10 +633,25 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 					"I couldn't reach my backend just now — try again in a sec.";
 				yuki.text = fallback;
 				if (yukiBubble) yukiBubble.textContent = fallback;
+				vrmRuntime?.setState('shake');
 			}
 			writeHistory(history);
 		};
 	});
+
+	if (dock) {
+		const dockObserver = new MutationObserver(evaluateActive);
+		dockObserver.observe(dock, {
+			attributes: true,
+			attributeFilter: ['data-state'],
+		});
+	}
+
+	const onSwap = (): void => {
+		cancelAnimationFrame(wanderRaf);
+		unbindPageMove();
+	};
+	document.addEventListener('astro:before-swap', onSwap, { once: true });
 
 	if (!document.getElementById('kbve-yuki-panel-css')) {
 		const css = document.createElement('style');
@@ -523,7 +660,7 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 			.yuki-panel { display: grid; grid-template-rows: auto 1fr auto auto; gap: 0.5rem; height: 100%; }
 			.yuki-panel[data-avatar-mode='text'] .yuki-panel__stage { display: none; }
 			.yuki-panel[data-float-mode='1'] .yuki-panel__stage { display: none; }
-			.yuki-panel__stage { height: 180px; border-radius: 12px; overflow: hidden; background: rgba(15,23,42,0.6); border: 1px solid rgba(255,255,255,0.08); position: relative; }
+			.yuki-panel__stage { height: 180px; border-radius: 12px; overflow: hidden; background: rgba(15,23,42,0.6); border: 1px solid rgba(255,255,255,0.08); position: relative; cursor: pointer; }
 			.yuki-panel__stage-skeleton, .yuki-panel__stage-error { position: absolute; inset: 0; display: grid; place-items: center; font-size: 0.78rem; color: rgba(255,255,255,0.5); }
 			.yuki-panel__stage-error { color: #f87171; }
 			.yuki-panel__log { display: grid; gap: 0.5rem; align-content: start; overflow-y: auto; padding-right: 0.25rem; }

--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
@@ -28,6 +28,7 @@ export interface YukiVRMHandle {
 	speak(audio: HTMLAudioElement | MediaStream): void;
 	stopSpeaking(): void;
 	pointAt(x: number, y: number): void;
+	setActive(active: boolean): void;
 	destroy(): void;
 }
 
@@ -54,6 +55,14 @@ function applyRestPose(vrm: VRM): void {
 		);
 		if (bone) bone.rotation.set(x, y, z);
 	}
+}
+
+type ExpressionTargets = Partial<Record<VRMExpressionPresetName, number>>;
+
+interface Gesture {
+	name: 'wave' | 'nod' | 'shake';
+	elapsed: number;
+	duration: number;
 }
 
 export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
@@ -118,6 +127,14 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 	scene.add(vrm.scene);
 	applyRestPose(vrm);
 
+	try {
+		(
+			vrm as unknown as { springBoneManager?: { reset?: () => void } }
+		).springBoneManager?.reset?.();
+	} catch {
+		void 0;
+	}
+
 	const lookAtTarget = new Object3D();
 	lookAtTarget.position.set(0, 1.45, 0.6);
 	scene.add(lookAtTarget);
@@ -125,31 +142,59 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 
 	const targetWorld = new Vector3(0, 1.45, 0.6);
 	const targetCurrent = new Vector3(0, 1.45, 0.6);
+	let lastInteractionMs = performance.now();
+	let lastPointNx = 0;
 
 	const pointAt = (clientX: number, clientY: number): void => {
 		const rect = host.getBoundingClientRect();
 		const nx = ((clientX - rect.left) / rect.width) * 2 - 1;
 		const ny = ((clientY - rect.top) / rect.height) * 2 - 1;
-		targetWorld.set(nx * 0.45, 1.45 - ny * 0.3, 0.6);
+		const cnx = Math.max(-1.5, Math.min(1.5, nx));
+		const cny = Math.max(-1.5, Math.min(1.5, ny));
+		targetWorld.set(cnx * 0.45, 1.45 - cny * 0.3, 0.6);
+		lastPointNx = cnx;
+		lastInteractionMs = performance.now();
 	};
 
 	const onPointerMove = (ev: PointerEvent) => pointAt(ev.clientX, ev.clientY);
 	host.addEventListener('pointermove', onPointerMove);
 	host.addEventListener('pointerleave', () => {
 		targetWorld.set(0, 1.45, 0.6);
+		lastPointNx = 0;
 	});
 
 	const clock = new Clock();
 	let currentState: YukiState = 'idle';
 	let blinkCooldown = 1.5 + Math.random() * 2;
 	let blinkPhase = 0;
+	let activeGesture: Gesture | null = null;
 
-	const setExpression = (name: VRMExpressionPresetName, value: number) => {
+	const expressionCurrent: Record<string, number> = {};
+	const expressionTarget: ExpressionTargets = {};
+
+	const setExpression = (
+		name: VRMExpressionPresetName,
+		value: number,
+	): void => {
+		expressionTarget[name] = value;
+		lastInteractionMs = performance.now();
+	};
+
+	const setExpressionInstant = (
+		name: VRMExpressionPresetName,
+		value: number,
+	): void => {
+		expressionTarget[name] = value;
+		expressionCurrent[name] = value;
 		vrm.expressionManager?.setValue(name, value);
 	};
 
 	let audioCtx: AudioContext | null = null;
 	let analyser: AnalyserNode | null = null;
+	let activeSourceNode:
+		| MediaElementAudioSourceNode
+		| MediaStreamAudioSourceNode
+		| null = null;
 	let buffer: Uint8Array<ArrayBuffer> | null = null;
 	let speakingActive = false;
 
@@ -167,33 +212,57 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		return audioCtx;
 	};
 
-	const speak = (source: HTMLAudioElement | MediaStream): void => {
-		const ctx = ensureAudio();
-		void ctx.resume();
+	const ensureAnalyser = (ctx: AudioContext): AnalyserNode => {
+		if (analyser) return analyser;
 		analyser = ctx.createAnalyser();
 		analyser.fftSize = 256;
 		buffer = new Uint8Array(new ArrayBuffer(analyser.frequencyBinCount));
+		return analyser;
+	};
+
+	const speak = (source: HTMLAudioElement | MediaStream): void => {
+		const ctx = ensureAudio();
+		void ctx.resume();
+		const a = ensureAnalyser(ctx);
+		try {
+			activeSourceNode?.disconnect();
+		} catch {
+			void 0;
+		}
 		const node =
 			source instanceof HTMLAudioElement
 				? ctx.createMediaElementSource(source)
 				: ctx.createMediaStreamSource(source);
-		node.connect(analyser);
+		node.connect(a);
 		if (source instanceof HTMLAudioElement) {
-			analyser.connect(ctx.destination);
+			a.connect(ctx.destination);
 		}
+		activeSourceNode = node;
 		speakingActive = true;
 		currentState = 'talking';
+		lastInteractionMs = performance.now();
 	};
 
 	const stopSpeaking = (): void => {
 		speakingActive = false;
-		analyser?.disconnect();
-		analyser = null;
-		buffer = null;
+		try {
+			activeSourceNode?.disconnect();
+		} catch {
+			void 0;
+		}
+		activeSourceNode = null;
 		currentState = 'idle';
 		setExpression('aa', 0);
 		setExpression('ih', 0);
 		setExpression('ou', 0);
+	};
+
+	const triggerGesture = (
+		name: 'wave' | 'nod' | 'shake',
+		duration: number,
+	): void => {
+		activeGesture = { name, elapsed: 0, duration };
+		lastInteractionMs = performance.now();
 	};
 
 	const setState = (state: YukiState): void => {
@@ -202,24 +271,80 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 			case 'happy':
 				setExpression('happy', 1);
 				break;
+			case 'wave':
+				triggerGesture('wave', 1.6);
+				setExpression('happy', 0.6);
+				break;
+			case 'nod':
+				triggerGesture('nod', 0.7);
+				break;
+			case 'shake':
+				triggerGesture('shake', 0.8);
+				break;
 			case 'idle':
 				setExpression('happy', 0);
 				setExpression('angry', 0);
 				setExpression('sad', 0);
 				break;
 		}
+		lastInteractionMs = performance.now();
+	};
+
+	const applyGesture = (vrmRef: VRM, gesture: Gesture, _delta: number) => {
+		const p = Math.min(1, gesture.elapsed / gesture.duration);
+		const fade = Math.sin(p * Math.PI);
+		const hum = vrmRef.humanoid;
+		if (!hum) return;
+		if (gesture.name === 'wave') {
+			const rUpper = hum.getNormalizedBoneNode(
+				VRMHumanBoneName.RightUpperArm,
+			);
+			const rLower = hum.getNormalizedBoneNode(
+				VRMHumanBoneName.RightLowerArm,
+			);
+			if (rUpper) {
+				const baseZ = MathUtils.degToRad(-75);
+				const lift = MathUtils.degToRad(-115) - baseZ;
+				rUpper.rotation.z = baseZ + lift * fade;
+				rUpper.rotation.x = MathUtils.degToRad(-10) * fade;
+			}
+			if (rLower) {
+				const sway = Math.sin(gesture.elapsed * 14) * 0.5 * fade;
+				rLower.rotation.y = MathUtils.degToRad(12) + sway;
+			}
+		} else if (gesture.name === 'nod') {
+			const head = hum.getNormalizedBoneNode(VRMHumanBoneName.Head);
+			if (head)
+				head.rotation.x += Math.sin(p * Math.PI * 2) * 0.18 * fade;
+		} else if (gesture.name === 'shake') {
+			const head = hum.getNormalizedBoneNode(VRMHumanBoneName.Head);
+			if (head)
+				head.rotation.y += Math.sin(p * Math.PI * 2) * 0.22 * fade;
+		}
 	};
 
 	const coarse = window.matchMedia('(pointer: coarse)').matches;
-	const minFrameMs = coarse ? 1000 / 30 : 1000 / 60;
+	const activeFps = coarse ? 30 : 60;
+	const idleFps = 15;
 	let lastFrame = 0;
 	let rafId = 0;
 	let disposed = false;
+	let active = true;
 
 	const tick = (now: number) => {
 		if (disposed) return;
 		rafId = requestAnimationFrame(tick);
+		if (!active) return;
 		if (document.visibilityState !== 'visible') return;
+
+		const idleMs = now - lastInteractionMs;
+		const isIdle =
+			!speakingActive &&
+			!activeGesture &&
+			currentState === 'idle' &&
+			idleMs > 2000;
+		const fps = isIdle ? idleFps : activeFps;
+		const minFrameMs = 1000 / fps;
 		if (now - lastFrame < minFrameMs) return;
 		const delta = clock.getDelta();
 		lastFrame = now;
@@ -233,9 +358,9 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 			for (let i = 0; i < buffer.length; i++) sum += buffer[i];
 			const avg = sum / buffer.length / 255;
 			const mouth = Math.min(1, avg * 2.3);
-			setExpression('aa', mouth);
-			setExpression('ih', mouth * 0.35);
-			setExpression('ou', mouth * 0.25);
+			expressionTarget['aa'] = mouth;
+			expressionTarget['ih'] = mouth * 0.35;
+			expressionTarget['ou'] = mouth * 0.25;
 		}
 
 		const t = performance.now();
@@ -245,10 +370,24 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		if (spine) {
 			spine.rotation.x = Math.sin(t / 1400) * 0.018;
 			spine.rotation.z = Math.sin(t / 2700) * 0.012;
+			spine.rotation.y = MathUtils.lerp(
+				spine.rotation.y,
+				lastPointNx * 0.12,
+				Math.min(1, delta * 4),
+			);
 		}
 		const hips = vrm.humanoid?.getNormalizedBoneNode(VRMHumanBoneName.Hips);
 		if (hips) {
 			hips.position.y = Math.sin(t / 1100) * 0.005;
+		}
+
+		if (activeGesture) {
+			activeGesture.elapsed += delta;
+			applyGesture(vrm, activeGesture, delta);
+			if (activeGesture.elapsed >= activeGesture.duration) {
+				activeGesture = null;
+				applyRestPose(vrm);
+			}
 		}
 
 		blinkCooldown -= delta;
@@ -258,12 +397,21 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		if (blinkPhase > 0) {
 			blinkPhase += delta * 6;
 			const v = Math.sin(Math.min(1, blinkPhase) * Math.PI);
-			setExpression('blink', v);
+			expressionTarget['blink'] = v;
 			if (blinkPhase >= 1) {
 				blinkPhase = 0;
-				setExpression('blink', 0);
+				expressionTarget['blink'] = 0;
 				blinkCooldown = 2.5 + Math.random() * 3;
 			}
+		}
+
+		const expSpeed = Math.min(1, delta * 8);
+		for (const k of Object.keys(expressionTarget)) {
+			const target = expressionTarget[k as VRMExpressionPresetName] ?? 0;
+			const current = expressionCurrent[k] ?? 0;
+			const next = current + (target - current) * expSpeed;
+			expressionCurrent[k] = next;
+			vrm.expressionManager?.setValue(k as VRMExpressionPresetName, next);
 		}
 
 		vrm.update(delta);
@@ -276,6 +424,14 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 	};
 	document.addEventListener('visibilitychange', onVisibility);
 
+	const setActive = (next: boolean): void => {
+		active = next;
+		if (next) {
+			clock.getDelta();
+			lastInteractionMs = performance.now();
+		}
+	};
+
 	const destroy = () => {
 		if (disposed) return;
 		disposed = true;
@@ -284,6 +440,13 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		host.removeEventListener('pointermove', onPointerMove);
 		resizeObserver.disconnect();
 		stopSpeaking();
+		try {
+			analyser?.disconnect();
+		} catch {
+			void 0;
+		}
+		analyser = null;
+		buffer = null;
 		if (audioCtx) {
 			void audioCtx.close().catch(() => {});
 			audioCtx = null;
@@ -298,13 +461,14 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 	};
 
 	void currentState;
-	void setState;
+	void setExpressionInstant;
 
 	return {
 		setState,
 		speak,
 		stopSpeaking,
 		pointAt,
+		setActive,
 		destroy,
 	};
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/yuki.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/yuki.mdx
@@ -32,7 +32,8 @@ browser when the user opts in.
 | **A** — Dock shell | ✅ merged (#11474) | Persistent FAB + collapsed panel, vanilla driver, lazy-mount contract, localStorage state, ESC-to-close, reduced-motion respect |
 | **B** — VRM avatar | ✅ merged (#11475) | `@pixiv/three-vrm@^3.5.3` scene, idle/blink animation, `aa`/`ih`/`ou` lipsync via AnalyserNode tap, render-loop visibility + fps gates |
 | **C** — SSE stream | ✅ merged (#11476) | `GET /api/v1/yuki/chat?q=<…>` returns `text/event-stream` chunks; panel streams tokens into the bubble + hands assembled text to `speak()` for lipsync |
-| **D** — Organic + float | 🚧 this PR | Manual rest pose (no T-pose), portrait camera framing, `vrm.lookAt` cursor tracking, spine/hips micro-sway, draggable float-detach layer that persists across `<ClientRouter />` swaps |
+| **D** — Organic + float | ✅ merged (#11492) | Manual rest pose (no T-pose), portrait camera framing, `vrm.lookAt` cursor tracking, spine/hips micro-sway, draggable float-detach layer that persists across `<ClientRouter />` swaps |
+| **D.1** — Vtuber polish | 🚧 this PR | Spring-bone reset + body-twist on extreme gaze (Bundle A); first-open wave + greet, input-focus look, nod-on-send, happy-on-done, click-to-wave, blendshape lerp smoothing (Bundle B); analyser reuse, idle FPS drop to 15, render pause when dock collapsed + not floating (Bundle C); page-wide cursor follow + autonomous wander when floating |
 | **E** — Real backend | 🗓 next | Swap the canned reply in `transport/yuki.rs` for a jedi/q-routed LLM call. Prompt template, conversation compaction, rate limit. Front-end unchanged. |
 | **F** — Voice in | 🗓 later | Push-to-talk mic capture → on-device VAD → server STT → same SSE response path |
 | **G** — Tools / actions | 🗓 later | Function-call schema so Yuki can navigate the site, open the wallet card, queue a forum post, etc. |
@@ -133,8 +134,9 @@ Supabase JWT once the real LLM call costs money to run.
 | `kbve:yuki-dock:history` | Last 24 chat entries, `{role, text, ts}` |
 | `kbve:yuki-dock:float-mode` | `'1'` or `'0'` — restores float-detach state across reloads |
 | `kbve:yuki-dock:float-pos` | `{x, y}` viewport coords of the float layer — restores last drag position |
+| `kbve:yuki-dock:greeted` | `'1'` once Yuki has fired her first-open wave + greet on this device |
 
-All five are localStorage-only, never sent to the server.
+All six are localStorage-only, never sent to the server.
 
 ## What's next
 


### PR DESCRIPTION
## Summary

Phase D.1 — three bundles in one PR, all touching the Yuki dock.

### Bundle A — Alive
- Spring-bone reset after rest-pose tweak so the witch outfit's hair / skirt springs settle into the new pose instead of whip-snapping on the first frame.
- Page-wide cursor follow when floating — gaze now tracks the user across the whole viewport, not just within the avatar canvas.
- Autonomous slow wander when floating + idle > 8s via a Lissajous curve through \`pointAt()\`.
- Spine y-rotation biased by horizontal gaze direction so extreme side-looks pull the torso a few degrees with the head.

### Bundle B — Reactive
- First-open welcome — \`wave\` gesture + SpeechSynthesis greet, gated by \`kbve:yuki-dock:greeted\`.
- Chat input focus → look at the input element.
- Submit → \`nod\`, \`done\` → \`happy\` for ~2s then back to idle, error → \`shake\`.
- Click on the avatar (panel stage or float layer body) → \`wave\` + short greet.
- Blendshape lerp — every expression channel interpolates toward its target each frame instead of instant set, smoothing mouth + expressions.

### Bundle C — Efficient
- Single AnalyserNode per AudioContext, re-used across \`speak()\` calls. Source disconnect on stop / re-speak instead of leaking analyser nodes.
- Idle FPS drop — when idle (no interaction in 2s, not speaking, no active gesture), the tick targets 15 fps instead of 60 / 30.
- Render pause via \`setActive(bool)\`, driven by a MutationObserver on the dock's \`data-state\` — when the dock is collapsed AND not floating, the render loop is skipped, RAF keeps spinning so we can resume on the next state change.

### Internals
Adds a \`wave|nod|shake\` gesture system on the VRM handle. Each gesture has a duration + sin-fade window applied as bone-rotation deltas so transient gestures don't fight the rest-pose. Rest pose is re-applied after a gesture completes.

\`astro-kbve:check\` reports **0 errors, 0 warnings**.

## Test plan

- [ ] Hard reload, open dock → 3D Yuki mounts, waves + greets exactly once per device (\`localStorage.kbve:yuki-dock:greeted\` flips to \`'1'\`)
- [ ] Click in the chat input → her gaze snaps to the input
- [ ] Type something + submit → she nods, then on stream \`done\` flips \`happy\` for ~2s then back to idle
- [ ] Disconnect network / break the SSE → she does a \`shake\` on the error path
- [ ] Click the avatar canvas (dock OR float) → wave + short greet
- [ ] Toggle Float → cursor follow now tracks across the entire viewport, not just the dock panel
- [ ] Stop moving the cursor for ~8s while floating → she slowly looks around on her own (wander)
- [ ] Collapse the dock with float OFF → render loop pauses (CPU drops, fps in DevTools goes to 0)
- [ ] Re-expand dock or flip float ON → render resumes immediately
- [ ] During an extended speak() → no analyser-node leak across multiple turns (check via about:perf / chrome://media-internals)