### PR TITLE
feat(nexus-defense): server-authoritative enemy positions + interpolation + HP bars

### DIFF
--- a/apps/godot/nexus-defense/scenes/game.gd
+++ b/apps/godot/nexus-defense/scenes/game.gd
@@ -398,20 +398,46 @@ func _on_enemies_update(entities: Array) -> void:
 		if destroyed:
 			_despawn_enemy(eid)
 			continue
-		if not _enemy_sprites.has(eid):
-			_spawn_snapshot_enemy(eid)
+		var pos_x: float = float(data.get("pos_x", 0.0))
+		var hp: float = float(data.get("hp", 1.0))
+		var max_hp: float = float(data.get("max_hp", 1.0))
+		var pixel: Vector2 = _server_pos_to_pixel(pos_x)
+		var sprite: Node2D = _enemy_sprites.get(eid)
+		if sprite == null:
+			sprite = _spawn_snapshot_enemy(eid, pixel)
+		if sprite and sprite.has_method("update_from_server"):
+			sprite.call("update_from_server", pixel, hp, max_hp)
 	for eid in _enemy_sprites.keys():
 		if not seen.has(eid):
 			_despawn_enemy(eid)
 
-func _spawn_snapshot_enemy(eid: int) -> void:
+# Maps server-side `Position.x` (0..PLAYFIELD_WIDTH) to the client's hex path
+# by sampling `_path_points()` at the same fractional progress. Server uses a
+# 32px square grid; client renders on a hex map with a different edge length,
+# so we go through the path-sample helper instead of trying to share units.
+const SERVER_PLAYFIELD_WIDTH: float = 800.0
+
+func _server_pos_to_pixel(server_x: float) -> Vector2:
 	var pts: PackedVector2Array = _path_points()
-	if pts.size() < 2:
-		return
+	if pts.size() == 0:
+		return Vector2.ZERO
+	if pts.size() == 1:
+		return pts[0]
+	var t: float = clamp(server_x / SERVER_PLAYFIELD_WIDTH, 0.0, 1.0)
+	var segments: float = float(pts.size() - 1)
+	var pos_f: float = t * segments
+	var idx: int = int(floor(pos_f))
+	var frac: float = pos_f - float(idx)
+	if idx >= pts.size() - 1:
+		return pts[pts.size() - 1]
+	return pts[idx].lerp(pts[idx + 1], frac)
+
+func _spawn_snapshot_enemy(eid: int, initial_pos: Vector2) -> Node2D:
 	var sprite: Node2D = EnemySprite.new()
+	sprite.position = initial_pos
 	_hex_map.add_child(sprite)
-	sprite.call("start", pts, ENEMY_MARCH_DURATION)
 	_enemy_sprites[eid] = sprite
+	return sprite
 
 func _despawn_enemy(eid: int) -> void:
 	if not _enemy_sprites.has(eid):

--- a/apps/godot/nexus-defense/ui/components/enemy_sprite.gd
+++ b/apps/godot/nexus-defense/ui/components/enemy_sprite.gd
@@ -2,6 +2,17 @@ extends Node2D
 
 const ENEMY_SHADER := preload("res://ui/shaders/enemy.gdshader")
 
+# Default snapshot interval the server emits at (10 Hz → 100 ms). When the
+# client gets a position update we lerp the sprite from its current pos to
+# the new server pos over roughly this window so the motion stays smooth
+# instead of teleporting every 100 ms.
+const SERVER_LERP_SECONDS: float = 0.1
+
+# HP bar layout.
+const HP_BAR_WIDTH: float = 26.0
+const HP_BAR_HEIGHT: float = 3.0
+const HP_BAR_Y_OFFSET: float = -18.0
+
 signal reached_end()
 
 @export var sprite_size: Vector2 = Vector2(28, 28):
@@ -24,6 +35,7 @@ signal reached_end()
 		radius_px = clamp(value, 4.0, 16.0)
 		_push_uniforms()
 
+# Cosmetic (offline) path-march state.
 var path_points: PackedVector2Array = PackedVector2Array()
 var duration: float = 8.0
 var _elapsed: float = 0.0
@@ -31,6 +43,18 @@ var _running: bool = false
 var _phase: float = 0.0
 var _rect: ColorRect = null
 var _mat: ShaderMaterial = null
+
+# Server-authoritative interpolation state.
+var _server_driven: bool = false
+var _lerp_from: Vector2 = Vector2.ZERO
+var _lerp_to: Vector2 = Vector2.ZERO
+var _lerp_elapsed: float = 0.0
+var _lerp_duration: float = SERVER_LERP_SECONDS
+
+# HP bar state.
+var hp: float = 1.0
+var max_hp: float = 1.0
+var _hp_root: Node2D = null
 
 func _ready() -> void:
 	_build()
@@ -44,6 +68,11 @@ func _build() -> void:
 	_rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_rect.material = _mat
 	add_child(_rect)
+	_hp_root = Node2D.new()
+	_hp_root.position = Vector2(0, HP_BAR_Y_OFFSET)
+	_hp_root.visible = false
+	_hp_root.draw.connect(_draw_hp_bar)
+	add_child(_hp_root)
 	_push_uniforms()
 
 func _push_uniforms() -> void:
@@ -59,25 +88,74 @@ func start(points: PackedVector2Array, march_seconds: float) -> void:
 	path_points = points
 	duration = max(march_seconds, 0.1)
 	_elapsed = 0.0
+	_server_driven = false
 	if path_points.size() > 0:
 		position = path_points[0]
 	_running = path_points.size() >= 2
 	set_process(_running)
 
+## Snapshot-driven entry point — first call seeds the sprite at `pos` without
+## interpolation; subsequent calls lerp from the current sprite position to the
+## new `pos` over roughly `SERVER_LERP_SECONDS`.
+func update_from_server(pos: Vector2, hp_value: float, max_hp_value: float) -> void:
+	if not _server_driven:
+		_server_driven = true
+		_running = false
+		position = pos
+		_lerp_from = pos
+		_lerp_to = pos
+		_lerp_elapsed = _lerp_duration
+	else:
+		_lerp_from = position
+		_lerp_to = pos
+		_lerp_elapsed = 0.0
+	hp = hp_value
+	max_hp = max(max_hp_value, 0.0001)
+	if _hp_root:
+		_hp_root.visible = true
+		_hp_root.queue_redraw()
+	set_process(true)
+
 func _process(delta: float) -> void:
-	if not _running:
-		return
-	_elapsed += delta
 	_phase += delta * 8.0
 	if _mat:
 		_mat.set_shader_parameter("jitter_phase", _phase)
-	var t: float = clamp(_elapsed / duration, 0.0, 1.0)
-	position = _sample_path(t)
-	if t >= 1.0:
+	if _server_driven:
+		if _lerp_elapsed < _lerp_duration:
+			_lerp_elapsed = min(_lerp_elapsed + delta, _lerp_duration)
+			var t: float = _lerp_elapsed / _lerp_duration
+			position = _lerp_from.lerp(_lerp_to, t)
+		else:
+			position = _lerp_to
+		return
+	if not _running:
+		return
+	_elapsed += delta
+	var t_path: float = clamp(_elapsed / duration, 0.0, 1.0)
+	position = _sample_path(t_path)
+	if t_path >= 1.0:
 		_running = false
 		set_process(false)
 		reached_end.emit()
 		queue_free()
+
+func _draw_hp_bar() -> void:
+	if _hp_root == null:
+		return
+	var ratio: float = clamp(hp / max_hp, 0.0, 1.0)
+	var bg := Rect2(Vector2(-HP_BAR_WIDTH * 0.5, 0), Vector2(HP_BAR_WIDTH, HP_BAR_HEIGHT))
+	_hp_root.draw_rect(bg, Color(0, 0, 0, 0.6), true)
+	if ratio > 0.0:
+		var fill := Rect2(bg.position, Vector2(HP_BAR_WIDTH * ratio, HP_BAR_HEIGHT))
+		_hp_root.draw_rect(fill, _hp_color(ratio), true)
+	_hp_root.draw_rect(bg, Color(0.05, 0.05, 0.08, 0.85), false, 1.0)
+
+func _hp_color(ratio: float) -> Color:
+	if ratio > 0.5:
+		return Color(0.36, 0.78, 0.46)
+	if ratio > 0.25:
+		return Color(0.95, 0.78, 0.32)
+	return Color(0.95, 0.42, 0.46)
 
 func _sample_path(t: float) -> Vector2:
 	var n: int = path_points.size()


### PR DESCRIPTION
## Summary

Next polish pass on the godot client — replaces the client-side path-march animation for snapshot-driven enemies with the actual server \`Position.x\` coming through the \`enemies_update\` signal, smoothed across the 100 ms snapshot interval so motion stays readable at 10 Hz.

**EnemySprite (\`ui/components/enemy_sprite.gd\`)**

- Adds an \`update_from_server(pos, hp, max_hp)\` entry point. The first call seeds the sprite at \`pos\` without interpolation; subsequent calls lerp the sprite from its current position to the new server position over \`SERVER_LERP_SECONDS\` (100 ms, matches the server's \`SNAPSHOT_EVERY_N_TICKS = 2\` cadence at 20 Hz sim).
- \`start()\` path-march stays as the offline / cosmetic fallback (no socket → keep marchers alive for the empty-server visual).
- Draws a small HP bar above the sprite once it goes server-driven. Bar fill colour ramps green → yellow → red across the hp/max_hp ratio so a low-HP runner is obvious even at small sizes.

**game.gd**

- \`_on_enemies_update\` now reads \`pos_x\`, \`hp\`, \`max_hp\` off the per-entity dictionary and feeds them into \`update_from_server\` on every snapshot (spawn the sprite on first sight, then keep pushing positions and HP into the same instance).
- New \`_server_pos_to_pixel(server_x)\` maps server \`Position.x\` in \`[0, PLAYFIELD_WIDTH=800]\` onto the hex path by sampling \`_path_points()\` at the same fractional progress. Server uses a 32 px square grid and the client renders on a 36 px hex grid, so this routes through the existing path sampler instead of trying to share coordinate units.

## Test plan

- [x] \`bash apps/godot/nexus-defense/scripts/test.sh\` → 121/121 passing
- [x] \`bash apps/godot/nexus-defense/scripts/test-e2e.sh\` → 130/130 passing (live nd-server smoke included)
- [ ] CI \`Lint and Test\` green
- [ ] CI \`nexus-defense:test\` green