### PR TITLE
feat(agones-factorio): Fleet Commander Phase 4 — highway routing, squad badge, coin payouts

### DIFF
--- a/apps/agones/factorio/mods-local/kbve/modules/coins.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/coins.lua
@@ -96,16 +96,49 @@ function Coins.handle_pre_player_mined(event)
 	end
 end
 
+local function grant_to_all_admins(amount, reason)
+	if not amount or amount <= 0 then return end
+	for _, p in pairs(game.connected_players) do
+		if p.admin then
+			Coins.grant(p.index, amount, reason)
+		end
+	end
+end
+
 function Coins.handle_entity_died(event)
-	local cause = event.cause
-	if not (cause and cause.valid and cause.type == 'character') then return end
-	local player = cause.player
-	if not player then return end
 	local entity = event.entity
 	if not (entity and entity.valid) then return end
 	local reward = KILL_REWARD[entity.name]
 	if not reward then return end
-	Coins.grant(player.index, reward, 'kill')
+	local cause = event.cause
+	if not (cause and cause.valid) then return end
+	if cause.type == 'character' then
+		local player = cause.player
+		if not player then return end
+		Coins.grant(player.index, reward, 'kill')
+		return
+	end
+	if cause.type == 'car' or cause.type == 'spider-vehicle' then
+		grant_to_all_admins(math.max(1, math.floor(reward * 0.5)), 'fleet_kill')
+	end
+end
+
+function Coins.grant_deposit_reward(item_name, count)
+	if not item_name or not count or count <= 0 then return end
+	local proto = prototypes.item[item_name]
+	if not proto then return end
+	local per_unit_coins
+	if proto.subgroup and proto.subgroup.name == 'raw-resource' then
+		per_unit_coins = 0.01
+	elseif proto.fuel_value and proto.fuel_value > 0 then
+		per_unit_coins = 0.02
+	else
+		per_unit_coins = 0.05
+	end
+	local total = math.floor(count * per_unit_coins)
+	if total > 0 then
+		grant_to_all_admins(total, 'fleet_deposit')
+	end
 end
 
 return Coins

--- a/apps/agones/factorio/mods-local/kbve/modules/fleet_gui.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/fleet_gui.lua
@@ -660,28 +660,48 @@ local function render_groups(content, player)
 	scroll.style.maximal_height = 320
 	scroll.style.minimal_width = 560
 
+	local fleet = FleetState.get()
 	for _, g in ipairs(groups) do
-		local grow = scroll.add({ type = 'flow', direction = 'horizontal' })
-		grow.add({ type = 'label', caption = '#' .. g.id .. ' ' .. g.name }).style.minimal_width = 180
-		grow.add({ type = 'label', caption = { '', 'units: ', #g.unit_ids } }).style.minimal_width = 90
-		grow.add({
+		local mission_counts = {}
+		for _, uid in ipairs(g.unit_ids) do
+			local st = fleet.unit_state[uid]
+			local m = (st and st.mission) or 'idle'
+			mission_counts[m] = (mission_counts[m] or 0) + 1
+		end
+		local badge_parts = {}
+		for m, c in pairs(mission_counts) do
+			table.insert(badge_parts, m .. ':' .. c)
+		end
+		table.sort(badge_parts)
+		local badge = table.concat(badge_parts, '  ')
+		if badge == '' then badge = 'no members' end
+
+		local grow = scroll.add({ type = 'flow', direction = 'vertical' })
+		local header = grow.add({ type = 'flow', direction = 'horizontal' })
+		header.add({ type = 'label', caption = '#' .. g.id .. ' ' .. g.name }).style.minimal_width = 180
+		header.add({ type = 'label', caption = { '', 'units: ', #g.unit_ids } }).style.minimal_width = 90
+		header.add({
 			type = 'drop-down',
 			name = GROUP_ZONE_PREFIX .. g.id,
 			items = mining_items,
 			selected_index = 1,
 		})
-		grow.add({
+		header.add({
 			type = 'button',
 			name = GROUP_DISPATCH_PREFIX .. g.id,
 			caption = 'Dispatch',
 			enabled = #g.unit_ids > 0 and #mining_names > 0 and mining_names[1] ~= '',
 		})
-		grow.add({
+		header.add({
 			type = 'button',
 			name = GROUP_DELETE_PREFIX .. g.id,
 			caption = 'X',
 			tooltip = 'Delete squad',
 		})
+		grow.add({
+			type = 'label',
+			caption = '    ' .. badge,
+		}).style.font_color = { r = 0.75, g = 0.85, b = 1 }
 	end
 end
 

--- a/apps/agones/factorio/mods-local/kbve/modules/fleet_missions.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/fleet_missions.lua
@@ -1,4 +1,5 @@
 local FleetState = require('modules.fleet_state')
+local Coins = require('modules.coins')
 
 local FleetMissions = {}
 
@@ -78,6 +79,35 @@ local function nearest_zone_position(player_force, surface_index, zone_name, fro
 	return best
 end
 
+local function nearest_highway_position(force, surface_index, from)
+	local highway_zones = FleetState.zones_by_role('highway')
+	if #highway_zones == 0 then return nil end
+	local best, best_d = nil, math.huge
+	for _, zone_name in ipairs(highway_zones) do
+		local pos = nearest_zone_position(force, surface_index, zone_name, from)
+		if pos then
+			local dx = pos.x - from.x
+			local dy = pos.y - from.y
+			local d = dx * dx + dy * dy
+			if d < best_d then best_d, best = d, pos end
+		end
+	end
+	return best
+end
+
+local function plan_route(force, surface_index, from, destination)
+	if not destination then return nil end
+	local entry = nearest_highway_position(force, surface_index, from)
+	if not entry then return { destination } end
+	local exit_point = nearest_highway_position(force, surface_index, destination)
+	local waypoints = { entry }
+	if exit_point and (exit_point.x ~= entry.x or exit_point.y ~= entry.y) then
+		table.insert(waypoints, exit_point)
+	end
+	table.insert(waypoints, destination)
+	return waypoints
+end
+
 local function unit_fuel_low(u)
 	if not (u.vehicle and u.vehicle.valid and u.vehicle.burner) then return false end
 	if u.vehicle.burner.remaining_burning_fuel > FUEL_LOW_BURN then return false end
@@ -106,6 +136,40 @@ local function ore_under(surface, position)
 		limit = 1,
 	})
 	return r[1]
+end
+
+local function send_via_route(unit_id, force, surface_index, from, destination)
+	local route = plan_route(force, surface_index, from, destination)
+	if not (route and #route > 0) then return false end
+	local st = FleetState.get_unit_state(unit_id) or {}
+	st.route = route
+	st.route_index = 1
+	FleetState.get().unit_state[unit_id] = st
+	local next_pos = route[1]
+	aai_set(unit_id, { target_speed = 0.1 })
+	aai_set(unit_id, { target_position = next_pos })
+	return true
+end
+
+local function advance_route(unit_id, u)
+	local st = FleetState.get_unit_state(unit_id)
+	if not (st and st.route and st.route_index) then return false end
+	if not (u.vehicle and u.vehicle.valid and u.target_position) then return false end
+	local current = st.route[st.route_index]
+	if not current then return false end
+	local dx = current.x - u.vehicle.position.x
+	local dy = current.y - u.vehicle.position.y
+	if (dx * dx + dy * dy) > (PATROL_ARRIVAL_RADIUS * PATROL_ARRIVAL_RADIUS) then return false end
+	st.route_index = st.route_index + 1
+	local next_pos = st.route[st.route_index]
+	if not next_pos then
+		st.route = nil
+		st.route_index = nil
+		return false
+	end
+	aai_set(unit_id, { target_speed = 0.1 })
+	aai_set(unit_id, { target_position = next_pos })
+	return true
 end
 
 local function any_connected_player()
@@ -255,16 +319,14 @@ local function tick_mining()
 						pos = SPAWN_REGROUP_POSITION
 					end
 					FleetState.set_unit_mission(unit_id, 'retreating', refuel)
-					aai_set(unit_id, { target_speed = 0.1 })
-					aai_set(unit_id, { target_position = pos })
+					send_via_route(unit_id, u.vehicle.force, u.vehicle.surface.index, u.vehicle.position, pos)
 				elseif unit_cargo_full(u) then
 					local deposit = FleetState.zones_by_role('deposit')[1]
 					if deposit then
 						local pos = nearest_zone_position(u.vehicle.force, u.vehicle.surface.index, deposit, u.vehicle.position)
 						if pos then
 							FleetState.set_unit_mission(unit_id, 'depositing', deposit)
-							aai_set(unit_id, { target_speed = 0.1 })
-							aai_set(unit_id, { target_position = pos })
+							send_via_route(unit_id, u.vehicle.force, u.vehicle.surface.index, u.vehicle.position, pos)
 						end
 					else
 						warn_no_zone('deposit')
@@ -275,8 +337,7 @@ local function tick_mining()
 						local pos = nearest_zone_position(u.vehicle.force, u.vehicle.surface.index, refuel, u.vehicle.position)
 						if pos then
 							FleetState.set_unit_mission(unit_id, 'refueling', refuel)
-							aai_set(unit_id, { target_speed = 0.1 })
-							aai_set(unit_id, { target_position = pos })
+							send_via_route(unit_id, u.vehicle.force, u.vehicle.surface.index, u.vehicle.position, pos)
 						end
 					else
 						warn_no_zone('refuel')
@@ -305,6 +366,7 @@ local function tick_refueling()
 		if st.mission == 'refueling' and registered[unit_id] then
 			local u = registered[unit_id]
 			if u.vehicle and u.vehicle.valid then
+				advance_route(unit_id, u)
 				local has_fuel = u.vehicle.burner
 					and u.vehicle.burner.inventory
 					and not u.vehicle.burner.inventory.is_empty()
@@ -322,6 +384,18 @@ local function tick_refueling()
 	end
 end
 
+local function trunk_contents(vehicle)
+	if not (vehicle and vehicle.valid) then return {} end
+	local inv = vehicle.get_inventory(defines.inventory.car_trunk)
+	if not inv then return {} end
+	local out = {}
+	local raw = inv.get_contents()
+	for _, item in pairs(raw) do
+		if item.name and item.count then out[item.name] = (out[item.name] or 0) + item.count end
+	end
+	return out
+end
+
 local function tick_depositing()
 	local fleet = FleetState.get()
 	local registered = aai_units()
@@ -329,7 +403,21 @@ local function tick_depositing()
 		if st.mission == 'depositing' and registered[unit_id] then
 			local u = registered[unit_id]
 			if u.vehicle and u.vehicle.valid then
+				advance_route(unit_id, u)
+				local now = trunk_contents(u.vehicle)
+				local prev_snapshot = st.deposit_snapshot
+				if prev_snapshot then
+					for name, before in pairs(prev_snapshot) do
+						local after = now[name] or 0
+						if after < before then
+							Coins.grant_deposit_reward(name, before - after)
+						end
+					end
+				end
+				st.deposit_snapshot = now
+
 				if not unit_cargo_full(u) then
+					st.deposit_snapshot = nil
 					local prev = st.previous_mission
 					local prev_zone = st.previous_zone
 					if prev and prev_zone then
@@ -360,16 +448,14 @@ local function tick_defense()
 						pos = SPAWN_REGROUP_POSITION
 					end
 					FleetState.set_unit_mission(unit_id, 'retreating', refuel)
-					aai_set(unit_id, { target_speed = 0.1 })
-					aai_set(unit_id, { target_position = pos })
+					send_via_route(unit_id, u.vehicle.force, u.vehicle.surface.index, u.vehicle.position, pos)
 				elseif unit_fuel_low(u) then
 					local refuel = FleetState.zones_by_role('refuel')[1]
 					if refuel then
 						local pos = nearest_zone_position(u.vehicle.force, u.vehicle.surface.index, refuel, u.vehicle.position)
 						if pos then
 							FleetState.set_unit_mission(unit_id, 'refueling', refuel)
-							aai_set(unit_id, { target_speed = 0.1 })
-							aai_set(unit_id, { target_position = pos })
+							send_via_route(unit_id, u.vehicle.force, u.vehicle.surface.index, u.vehicle.position, pos)
 						end
 					else
 						warn_no_zone('refuel')
@@ -411,8 +497,7 @@ local function tick_combat()
 					pos = SPAWN_REGROUP_POSITION
 				end
 				FleetState.set_unit_mission(unit_id, 'retreating', refuel)
-				aai_set(unit_id, { target_speed = 0.1 })
-				aai_set(unit_id, { target_position = pos })
+				send_via_route(unit_id, u.vehicle.force, u.vehicle.surface.index, u.vehicle.position, pos)
 			end
 		end
 	end
@@ -425,7 +510,10 @@ local function tick_retreating()
 		if st.mission == 'retreating' and registered[unit_id] then
 			local u = registered[unit_id]
 			if u.vehicle and u.vehicle.valid then
+				advance_route(unit_id, u)
 				if unit_hp_ratio(u) > 0.95 then
+					st.route = nil
+					st.route_index = nil
 					FleetState.set_unit_mission(unit_id, nil, nil)
 				end
 			end


### PR DESCRIPTION
## Summary

Closes the four Phase 3 follow-ups (highway routing, per-squad mission badge, coin payouts, stability) in the order they unblock gameplay.

### Highway routing
- `plan_route(force, surface_index, from, destination)` builds up to 3 waypoints: nearest highway tile to the unit → nearest highway tile to the destination → the destination itself. Falls back to direct dispatch when no `highway`-tagged zone exists.
- `send_via_route` + `advance_route` keep the unit walking the route. Per tick, the route consumer (refuel / deposit / retreat) calls `advance_route(unit_id, u)`; when the current waypoint is within `PATROL_ARRIVAL_RADIUS`, the next leg is dispatched.
- Wired into tick_mining (HP retreat, cargo-full deposit, low-fuel refuel), tick_defense (HP retreat + low-fuel refuel), tick_combat (HP retreat), tick_refueling / tick_depositing / tick_retreating (per-tick waypoint advance + route cleanup on mission end).

### Squad mission badge
- Squads tab rolls each squad's members by current mission and renders a soft-blue badge under the squad header: `mining:3  depositing:1  idle:2`. Members with no FleetState.unit_state entry count as `idle`.
- Existing dispatch / delete / zone drop-down stay in the squad header flow; the badge sits on its own line so the header stays readable.

### Coin payouts
- `Coins.handle_entity_died` now accepts `car` / `spider-vehicle` causes. AAI vehicle kills pay half the `KILL_REWARD` to every connected admin under `reason="fleet_kill"` so it shows up in the same `[STATS] coin_grant` log stream as player kills.
- New `Coins.grant_deposit_reward(item_name, count)` rewards based on what an AAI hauler dropped at a deposit zone: 0.01/unit for raw resources, 0.02/unit for fuel items, 0.05/unit for everything else; result floored to integer coins.
- `tick_depositing` snapshots the trunk contents per tick. When a stack shrinks (i.e. the hauler unloaded into a chest/loader at the deposit zone), the diff feeds `grant_deposit_reward`. The snapshot clears when the mission resumes.

### Stability
- All new remote calls (highway lookups, advance_route) reuse the existing `pcall`-wrapped `aai_set` / `zone_count` / `zone_tile_at` helpers so any AAI exception is contained.
- Route state lives in `storage.kbve.fleet.unit_state[uid].route / route_index` so it survives save / load.

## Test plan

- [ ] `docker compose -f apps/agones/factorio/docker-compose.yml up -d --build`
- [ ] Paint zones: mining over an ore patch, deposit near spawn (with a chest + loader), refuel near a fuel chest, **highway** as a straight line connecting them
- [ ] Zones tab: tag them
- [ ] Mining tab: Send miners → verify they fan out, mine, and when full they head along the highway path to deposit
- [ ] Wait for a unit fuel to drop → it routes refuel via highway
- [ ] Drop a biter into a defense zone → verify damaged units retreat via highway
- [ ] Squads tab: badge should show live counts per mission
- [ ] Kill a biter with an AAI vehicle → coins show `[STATS] kind=coin_grant ... reason=fleet_kill` in factorio runtime log
- [ ] Hauler deposits into chest → coins appear with `reason=fleet_deposit`

## Phase 5 (next)

- Per-squad mission assignment from the UI (squad Dispatch currently sends mining only).
- Depleted-zone full cleanup pass (currently per-tile only).
- `FleetState.prune()` scheduled on a slow tick.
- Per-mission tick cursor + cap to keep frame time stable when the fleet grows past 50 units.