### PR TITLE
fix(ci): unblock Dev→Main lint — jsdom spec match + relay clippy

### DIFF
--- a/apps/agones/factorio/relay/src/log_tail.rs
+++ b/apps/agones/factorio/relay/src/log_tail.rs
@@ -57,7 +57,7 @@ pub async fn run(cfg: Config, tx: Sender<GameEvent>) -> Result<()> {
 }
 
 fn parse_line(line: &str) -> Option<GameEvent> {
-    let trimmed = line.trim_end_matches(|c: char| c == '\n' || c == '\r');
+    let trimmed = line.trim_end_matches(['\n', '\r']);
     let kind = if trimmed.contains("[CHAT]") {
         GameEventKind::Chat
     } else if trimmed.contains("[JOIN]") {

--- a/packages/npm/devops/package.json
+++ b/packages/npm/devops/package.json
@@ -38,7 +38,7 @@
 	"dependencies": {
 		"@bufbuild/protobuf": "^2.11.0",
 		"dompurify": "^3.4.1",
-		"jsdom": "~29.0.0",
+		"jsdom": "~29.1.0",
 		"marked": "^18.0.2",
 		"openapi-fetch": "^0.15.2",
 		"zod": "^4.3.6"


### PR DESCRIPTION
## Summary
Two-piece fix for the Dev→Main validate-lint job that's failing on the 1.X release PR (issue #11517).

## Failures
\`\`\`
✖ devops:lint
   error  The version specifier does not contain the installed version
          of "jsdom" package: 29.1.1  @nx/dependency-checks
✖ agones-factorio-relay (warning, but on -D warnings tracks)
   warning  clippy::manual_pattern_char_comparison
            line.trim_end_matches(|c: char| c == '\n' || c == '\r')
\`\`\`

## Fixes
1. **\`packages/npm/devops/package.json\`** — devops declared \`jsdom: "~29.0.0"\` while root \`package.json\` declares \`~29.1.1\`. pnpm hoists the root resolution (29.1.1) into devops's node_modules, so \`@nx/dependency-checks\` sees a mismatch. Bump devops to \`~29.1.0\` to stay in range with the root.
2. **\`apps/agones/factorio/relay/src/log_tail.rs\`** — Rust 1.94 clippy lint \`manual_pattern_char_comparison\`. Switch the closure-based pattern to an array literal:
   \`\`\`rust
   - line.trim_end_matches(|c: char| c == '\n' || c == '\r')
   + line.trim_end_matches(['\n', '\r'])
   \`\`\`
   Same behavior, no warning, faster.

## Validation
- [x] \`nx run devops:lint\` — 30 warnings, 0 errors → success.
- [x] \`cargo clippy -p agones-factorio-relay\` — clean.

## Notes
Issue #11156 (scheduled \`ci-e2e.yml\` failure tracker) is a separate older problem — May-25 logs are expired (HTTP 410 from GitHub). Want to keep that scoped to its own PR once we trigger a fresh run.