### PR TITLE
feat(kasm-void): bundle Discord + CloakBrowser with respawn supervisors

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "agones_factorio",
 			"app_name": "agones-factorio",
-			"version": "0.0.8",
+			"version": "0.0.9",
 			"version_toml": "apps/agones/factorio/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx",
 			"source_path": "apps/agones/factorio",
@@ -28,7 +28,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.176",
+			"version": "1.0.177",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -122,7 +122,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.16",
+			"version": "0.1.17",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
@@ -244,6 +244,18 @@
 			"e2e_name": "irc",
 			"deployment_yaml": "apps/kube/irc/manifests/irc-gateway-deployment.yaml",
 			"has_test": true
+		},
+		{
+			"key": "kasm_void",
+			"app_name": "kasm-void",
+			"version": "0.0.1",
+			"version_toml": "packages/docker/kasm-void/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx",
+			"source_path": "packages/docker/kasm-void",
+			"runner": "ubuntu-latest",
+			"image": "kbve/kasm-void",
+			"deployment_yaml": "apps/kube/kasm/manifest/deployment.yaml",
+			"has_test": false
 		},
 		{
 			"key": "kilobase",
@@ -748,7 +760,7 @@
 	"unreal_game": [],
 	"bevy_game": [],
 	"summary": {
-		"docker": 28,
+		"docker": 29,
 		"npm": 4,
 		"crates": 24,
 		"python": 2,
@@ -758,6 +770,6 @@
 		"godot": 1,
 		"unreal_game": 0,
 		"bevy_game": 0,
-		"total": 68
+		"total": 69
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
@@ -1,0 +1,98 @@
+---
+title: KASM Void
+description: |
+    Custom KASM workspace image. Bundles the upstream `kasmweb/discord` install with CloakBrowser (stealth Chromium fork) inside the same container, both auto-launched and supervised so the desktop stays populated even if either app crashes or is closed. Designed for in-session Discord screen-share of the bundled browser.
+sidebar:
+    label: KASM Void
+    order: 470
+tags:
+    - docker
+    - kasm
+    - workspace
+    - discord
+    - cloakbrowser
+key: kasm_void
+pipeline: docker
+app_name: kasm-void
+version: "0.0.1"
+source_path: packages/docker/kasm-void
+version_toml: packages/docker/kasm-void/version.toml
+runner: ubuntu-latest
+image: kbve/kasm-void
+deployment_yaml: apps/kube/kasm/manifest/deployment.yaml
+has_test: false
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Overview
+
+`kasm-void` is the production workspace image used by the `kasm-vpn`
+Deployment in `apps/kube/kasm/`. It extends `kasmweb/discord` with
+[CloakBrowser](https://github.com/CloakHQ/CloakBrowser) so the KASM session
+exposes both Discord and a browser side-by-side. The browser is the canonical
+screen-share target inside Discord — the operator opens any URL in the bundled
+Chromium build and streams the window through Discord's video feature.
+
+## Why a custom image
+
+- The stock `kasmweb/discord` image ships only Discord; closing it leaves an
+  empty desktop with no way to recover.
+- We need a known, reproducible browser binary inside the workspace so the
+  Discord stream picks up consistent fonts/codecs across sessions.
+- Resource targets are higher than the stock image's defaults — bundling lets
+  us own the `requests/limits` against a single artifact instead of patching
+  a vendor tag.
+
+## Crash recovery
+
+`/dockerstartup/custom_startup.sh` spawns two background supervisors:
+
+| Loop | Process matched (`pgrep -f`) | Action |
+|------|------------------------------|--------|
+| `cloak_loop` | `cloakbrowser` | Relaunches `/opt/cloakbrowser/cloakbrowser $CLOAK_APP_ARGS $START_URL` |
+| `discord_loop` | `discord|electron` | Relaunches the upstream `discord_startup.sh` |
+
+Each loop polls every 3 seconds. Closing the Discord window or the browser
+window from the desktop triggers a respawn — no manual KASM session restart
+needed.
+
+The original `kasmweb/discord` startup script is preserved as
+`/dockerstartup/discord_startup.sh` so its arg-handling, profile setup, and
+maximize logic continue to work unchanged.
+
+## Runtime env
+
+| Variable          | Default              | Notes                                          |
+| ----------------- | -------------------- | ---------------------------------------------- |
+| `START_URL`       | `https://kbve.com`   | Launch URL for the cloakbrowser instance       |
+| `CLOAK_APP_ARGS`  | (chromium defaults)  | Override the full cloakbrowser arg list        |
+| `LAUNCH_DISCORD`  | `1`                  | Set to `0` to disable the Discord supervisor   |
+| `LAUNCH_CLOAK`    | `1`                  | Set to `0` to disable the browser supervisor   |
+| `VNC_PW`          | (k8s secret)         | Provided by the kasm `Deployment`              |
+| `APP_ARGS`        | (inherited)          | Discord-side Electron args, consumed upstream  |
+
+## Resources
+
+The `workspace` container in `apps/kube/kasm/manifest/deployment.yaml` is
+sized for Discord + a browser tab + a screenshare encoder running in parallel:
+
+| | CPU | Memory |
+|---|---|---|
+| `requests` | `2` | `4Gi` |
+| `limits` | `4` | `8Gi` |
+
+The Gluetun sidecar keeps its own modest profile (`100m`/`128Mi` request,
+`500m`/`384Mi` limit) — bumping it does not buy noticeable latency since
+the VPN tunnel is bandwidth-, not CPU-bound.
+
+## Build
+
+```sh
+npx nx run kasm-void:container
+npx nx run kasm-void:test
+```
+
+Published tags land at `ghcr.io/kbve/kasm-void:<version>`; the post-publish
+chore workflow syncs the Deployment image pin to match `version.toml`.

--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -158,7 +158,8 @@ spec:
                           cpu: '500m'
 
                 - name: workspace
-                  image: kasmweb/discord:1.18.0-rolling-daily
+                  image: ghcr.io/kbve/kasm-void:0.0.0
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                       runAsNonRoot: true
                       runAsUser: 1000
@@ -179,16 +180,22 @@ spec:
                         value: >-
                             --no-sandbox --disable-gpu --disable-dev-shm-usage
                             --user-agent="Mozilla/5.0 (X11; Linux x86_64; rv:144.0) Gecko/20100101 Firefox/144.0"
+                      - name: START_URL
+                        value: 'https://kbve.com'
+                      - name: LAUNCH_DISCORD
+                        value: '1'
+                      - name: LAUNCH_CLOAK
+                        value: '1'
                   volumeMounts:
                       - name: discord-profile
                         mountPath: /home/kasm-user
                   resources:
                       requests:
-                          memory: '1Gi'
-                          cpu: '500m'
-                      limits:
                           memory: '4Gi'
                           cpu: '2'
+                      limits:
+                          memory: '8Gi'
+                          cpu: '4'
             volumes:
                 - name: discord-profile
                   persistentVolumeClaim:

--- a/packages/docker/kasm-void/Dockerfile
+++ b/packages/docker/kasm-void/Dockerfile
@@ -1,0 +1,58 @@
+ARG BASE_TAG=1.18.0-rolling-daily
+FROM kasmweb/discord:${BASE_TAG}
+
+ARG CLOAK_VERSION=chromium-v146.0.7680.177.4
+ARG CLOAK_SHA256=
+ENV CLOAK_HOME=/opt/cloakbrowser \
+    CLOAK_BIN=/opt/cloakbrowser/cloakbrowser
+
+USER root
+
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates curl tar xz-utils procps \
+        libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libdrm2 libxkbcommon0 \
+        libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libgtk-3-0 \
+        libasound2 libpango-1.0-0 libcairo2 libcups2 libdbus-1-3 fonts-liberation; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) asset="cloakbrowser-linux-x64.tar.gz" ;; \
+      arm64) asset="cloakbrowser-linux-arm64.tar.gz" ;; \
+      *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    url="https://github.com/CloakHQ/CloakBrowser/releases/download/${CLOAK_VERSION}/${asset}"; \
+    curl -fL --retry 5 -o /tmp/cloak.tar.gz "$url"; \
+    if [ -n "$CLOAK_SHA256" ]; then echo "$CLOAK_SHA256  /tmp/cloak.tar.gz" | sha256sum -c -; fi; \
+    mkdir -p "$CLOAK_HOME"; \
+    tar -C "$CLOAK_HOME" --strip-components=1 -xzf /tmp/cloak.tar.gz; \
+    rm /tmp/cloak.tar.gz; \
+    if [ ! -x "$CLOAK_BIN" ]; then \
+      candidate="$(find "$CLOAK_HOME" -maxdepth 2 -type f \( -name cloakbrowser -o -name chrome -o -name chromium \) -perm -u+x | head -1)"; \
+      [ -n "$candidate" ] && ln -sf "$candidate" "$CLOAK_BIN"; \
+    fi; \
+    [ -x "$CLOAK_BIN" ]; \
+    chown -R 1000:1000 "$CLOAK_HOME"
+
+RUN set -eux; \
+    if [ -f /dockerstartup/custom_startup.sh ]; then \
+      mv /dockerstartup/custom_startup.sh /dockerstartup/discord_startup.sh; \
+    fi
+
+COPY custom_startup.sh /dockerstartup/custom_startup.sh
+COPY cloakbrowser.desktop /home/kasm-user/Desktop/cloakbrowser.desktop
+
+RUN set -eux; \
+    chmod +x /dockerstartup/custom_startup.sh; \
+    [ -f /dockerstartup/discord_startup.sh ] && chmod +x /dockerstartup/discord_startup.sh || true; \
+    chown -R 1000:1000 /home/kasm-user /dockerstartup/custom_startup.sh /dockerstartup/discord_startup.sh 2>/dev/null || true
+
+USER 1000
+ENV HOME=/home/kasm-user \
+    START_URL=https://kbve.com \
+    LAUNCH_DISCORD=1 \
+    LAUNCH_CLOAK=1
+WORKDIR /home/kasm-user

--- a/packages/docker/kasm-void/README.md
+++ b/packages/docker/kasm-void/README.md
@@ -1,0 +1,43 @@
+# kasm-void
+
+KASM workspace image that bundles the upstream `kasmweb/discord` install with
+[CloakBrowser](https://github.com/CloakHQ/CloakBrowser), a stealth Chromium
+fork. Both apps auto-launch on session start and are individually supervised
+— if either crashes or is closed it is respawned by the startup loop.
+
+Use case: run Discord inside the KASM session and screenshare the bundled
+browser through Discord's video/stream feature.
+
+## Tags
+
+- `ghcr.io/kbve/kasm-void:dev` — local build
+- `ghcr.io/kbve/kasm-void:latest` — published
+
+## Build
+
+```sh
+npx nx run kasm-void:container
+npx nx run kasm-void:test
+```
+
+## Runtime env
+
+| Variable         | Default             | Notes                                    |
+| ---------------- | ------------------- | ---------------------------------------- |
+| `START_URL`      | `https://kbve.com`  | Launch URL for the cloakbrowser instance |
+| `CLOAK_APP_ARGS` | (chromium defaults) | Override the full cloakbrowser arg list  |
+| `LAUNCH_DISCORD` | `1`                 | Set to `0` to disable Discord supervisor |
+| `LAUNCH_CLOAK`   | `0`/`1`             | Set to `0` to disable browser supervisor |
+| `VNC_PW`         | (k8s secret)        | Provided by the kasm Deployment          |
+
+## Crash recovery
+
+`custom_startup.sh` spawns two background supervisors. Each polls `pgrep`
+every 3 seconds and re-launches its app if missing — closing Discord or
+the browser window from the desktop simply triggers a respawn.
+
+## Deployment
+
+Used by `apps/kube/kasm/manifest/deployment.yaml` as the `workspace`
+container. Resource requests/limits are bumped to req `2`/`4Gi`, lim
+`4`/`8Gi` to accommodate Discord + browser + screenshare encoding.

--- a/packages/docker/kasm-void/cloakbrowser.desktop
+++ b/packages/docker/kasm-void/cloakbrowser.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=CloakBrowser
+Comment=Stealth Chromium build
+Exec=/opt/cloakbrowser/cloakbrowser --no-sandbox %U
+Icon=web-browser
+Terminal=false
+Categories=Network;WebBrowser;
+StartupNotify=true

--- a/packages/docker/kasm-void/custom_startup.sh
+++ b/packages/docker/kasm-void/custom_startup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -e
+
+export MAXIMIZE="${MAXIMIZE:-true}"
+MAXIMIZE_SCRIPT="${STARTUPDIR:-/dockerstartup}/maximize_window.sh"
+
+CLOAK_BIN="${CLOAK_BIN:-/opt/cloakbrowser/cloakbrowser}"
+CLOAK_PGREP="cloakbrowser"
+CLOAK_DEFAULT_ARGS="--no-sandbox --disable-gpu --disable-dev-shm-usage --start-maximized --no-first-run --no-default-browser-check --password-store=basic"
+CLOAK_ARGS=${CLOAK_APP_ARGS:-$CLOAK_DEFAULT_ARGS}
+CLOAK_URL="${START_URL:-https://kbve.com}"
+
+DISCORD_STARTUP="/dockerstartup/discord_startup.sh"
+
+wait_desktop() {
+    [ -x /usr/bin/filter_ready ] && /usr/bin/filter_ready || true
+    [ -x /usr/bin/desktop_ready ] && /usr/bin/desktop_ready || true
+}
+
+cloak_loop() {
+    wait_desktop
+    while true; do
+        if ! pgrep -f "$CLOAK_PGREP" >/dev/null 2>&1; then
+            echo "[startup] launching cloakbrowser"
+            [ -x "$MAXIMIZE_SCRIPT" ] && bash "$MAXIMIZE_SCRIPT" &
+            "$CLOAK_BIN" $CLOAK_ARGS "$CLOAK_URL" >/tmp/cloakbrowser.log 2>&1 &
+        fi
+        sleep 3
+    done
+}
+
+discord_loop() {
+    wait_desktop
+    if [ ! -x "$DISCORD_STARTUP" ]; then
+        echo "[startup] discord_startup.sh missing; skipping discord supervisor"
+        return
+    fi
+    while true; do
+        if ! pgrep -f -i 'discord|electron' >/dev/null 2>&1; then
+            echo "[startup] launching discord"
+            "$DISCORD_STARTUP" >/tmp/discord.log 2>&1 &
+        fi
+        sleep 3
+    done
+}
+
+if [ -n "$DISABLE_CUSTOM_STARTUP" ]; then
+    echo "[startup] DISABLE_CUSTOM_STARTUP set; idling"
+    exec sleep infinity
+fi
+
+[ "${LAUNCH_CLOAK:-1}" = "1" ] && cloak_loop &
+[ "${LAUNCH_DISCORD:-1}" = "1" ] && discord_loop &
+
+wait -n || true
+exec sleep infinity

--- a/packages/docker/kasm-void/project.json
+++ b/packages/docker/kasm-void/project.json
@@ -1,0 +1,66 @@
+{
+	"name": "kasm-void",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "library",
+	"sourceRoot": "packages/docker/kasm-void",
+	"targets": {
+		"container": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["npx nx run kasm-void:containerx"],
+				"parallel": false
+			},
+			"configurations": {
+				"local": {},
+				"production": {
+					"commands": ["npx nx run kasm-void:containerx:production"]
+				}
+			}
+		},
+		"containerx": {
+			"executor": "@nx-tools/nx-container:build",
+			"options": {
+				"engine": "docker",
+				"context": "packages/docker/kasm-void",
+				"file": "packages/docker/kasm-void/Dockerfile",
+				"platforms": ["linux/amd64"],
+				"load": true,
+				"push": false,
+				"tags": ["ghcr.io/kbve/kasm-void:dev"]
+			},
+			"configurations": {
+				"local": {
+					"tags": ["ghcr.io/kbve/kasm-void:dev"]
+				},
+				"production": {
+					"tags": ["ghcr.io/kbve/kasm-void:latest"],
+					"push": true,
+					"metadata": {
+						"images": ["ghcr.io/kbve/kasm-void"]
+					},
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/kasm-void:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/kasm-void:buildcache,mode=max"
+					]
+				}
+			}
+		},
+		"test": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["container"],
+			"options": {
+				"commands": [
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{.Config.User}}' | grep -q '^1000$' && echo 'PASS: drops to uid 1000'",
+					"docker run --rm --entrypoint /opt/cloakbrowser/cloakbrowser ghcr.io/kbve/kasm-void:dev --version && echo 'PASS: cloakbrowser binary runs --version'",
+					"docker run --rm --entrypoint cat ghcr.io/kbve/kasm-void:dev /dockerstartup/custom_startup.sh | grep -q cloak_loop && echo 'PASS: custom_startup.sh has cloak supervisor'",
+					"docker run --rm --entrypoint cat ghcr.io/kbve/kasm-void:dev /dockerstartup/custom_startup.sh | grep -q discord_loop && echo 'PASS: custom_startup.sh has discord supervisor'",
+					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/discord_startup.sh && echo 'PASS: upstream discord startup preserved'"
+				],
+				"parallel": false
+			}
+		}
+	},
+	"tags": ["docker", "kasm", "workspace"]
+}

--- a/packages/docker/kasm-void/version.toml
+++ b/packages/docker/kasm-void/version.toml
@@ -1,0 +1,2 @@
+version = "0.0.1"
+publish = true


### PR DESCRIPTION
## Summary

- New custom KASM workspace image **`kbve/kasm-void`** extending `kasmweb/discord:1.18.0-rolling-daily` with [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) (stealth Chromium fork) baked in.
- Both apps auto-launch on session start and are individually supervised by `custom_startup.sh` — each loop `pgrep`s every 3 seconds and respawns on crash/close so the desktop never sits empty mid-session.
- Designed for in-session Discord screen-share of the bundled browser window (the original ask).

## What changed

- `packages/docker/kasm-void/` — new image dir: Dockerfile, supervisor script, desktop entry, `project.json` (nx container target `ghcr.io/kbve/kasm-void`), README, `version.toml` (`0.0.1`, `publish=true`).
- `apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx` — CI registry entry. Sets `version_toml` + `deployment_yaml` so the post-publish chore syncs the deployment image pin on first publish.
- `apps/kube/kasm/manifest/deployment.yaml`
  - `workspace.image`: `kasmweb/discord:1.18.0-rolling-daily` → `ghcr.io/kbve/kasm-void:0.0.0` (placeholder pin; chore-sync bumps it on first publish).
  - Resources: req `500m`/`1Gi` → `2`/`4Gi`, lim `2`/`4Gi` → `4`/`8Gi` to cover Discord + browser + screenshare encoder.
  - Adds `START_URL`, `LAUNCH_DISCORD`, `LAUNCH_CLOAK` env knobs.
- `.github/ci-dispatch-manifest.json` — regenerated via `astro-kbve:sync:ci-manifest`; adds `kasm_void` and picks up incidental upstream version bumps already in the MDXs (agones-factorio `0.0.9`, axum-kbve `1.0.177`, discordsh-bot `0.1.17`).

## Crash recovery design

| Loop | Process matched (`pgrep -f`) | Action |
|------|------------------------------|--------|
| `cloak_loop` | `cloakbrowser` | Relaunches `/opt/cloakbrowser/cloakbrowser $CLOAK_APP_ARGS $START_URL` |
| `discord_loop` | `discord|electron` | Relaunches the upstream `discord_startup.sh` |

The original `kasmweb/discord` startup script is preserved as `/dockerstartup/discord_startup.sh` so its arg-handling, profile setup, and maximize logic continue to work unchanged.

## Test plan

- [ ] CI builds `ghcr.io/kbve/kasm-void:0.0.1`, smoke test target passes (`kasm-void:test` — uid 1000, cloakbrowser `--version`, both supervisors present in `custom_startup.sh`, upstream discord startup preserved)
- [ ] Post-publish chore PR bumps `apps/kube/kasm/manifest/deployment.yaml` image pin from `:0.0.0` to `:0.0.1`
- [ ] ArgoCD rolls out `kasm-vpn` pod with new image
- [ ] KASM session loads — Discord auto-launches, CloakBrowser auto-launches, both visible on desktop
- [ ] Close Discord window → respawns within 3 seconds
- [ ] Close CloakBrowser window → respawns within 3 seconds
- [ ] Start Discord screen-share, share the CloakBrowser window, verify stream is visible to viewer
- [ ] PVC `kasm-discord-profile` retains Discord login + CloakBrowser profile across pod restarts