### PR TITLE
fix(agones-factorio): bump mods emptyDir 256Mi -> 1Gi to stop eviction loop

### DIFF
--- a/apps/kube/agones/factorio/manifests/gameserver.yaml
+++ b/apps/kube/agones/factorio/manifests/gameserver.yaml
@@ -47,7 +47,7 @@ spec:
                       sizeLimit: 8Mi
                 - name: mods
                   emptyDir:
-                      sizeLimit: 256Mi
+                      sizeLimit: 1Gi
             containers:
                 - name: factorio
                   image: ghcr.io/kbve/agones-factorio:0.0.9


### PR DESCRIPTION
## Summary

Prod GameServer was in an eviction loop:

\`\`\`
Warning Evicted   pod/factorio   Usage of EmptyDir volume "mods" exceeds the limit "256Mi"
Normal  Killing   pod/factorio   Stopping container factorio
Normal  Shutdown  gameserver/factorio  Deletion started
\`\`\`

The shim downloads every entry in mod-list.json from the Factorio portal into /factorio/mods. With the current pack the download total is ~440 MB:

- alien-biomes-graphics 197 MB
- Explosive_biters 121 MB
- aai-vehicles-miner 60 MB
- aai-signal-transmission 18 MB
- rest of the AAI / QoL pack ~40 MB

256 Mi is hit about 90 s into boot. Kubelet evicts the pod, Agones marks the GameServer \`Shutdown\`, ArgoCD recreates it, the shim re-downloads everything, repeats forever.

Bump the limit to 1 Gi so the current pack plus headroom for future mods (graphics-pack updates, additional AAI expansions) fits.

## Test plan

- [ ] ArgoCD selfHeal picks up the change → GameServer recreates with new sizeLimit
- [ ] \`kubectl get gs/factorio -n factorio\` reaches \`Ready\` and stays there past the 90 s eviction window
- [ ] No further \`Evicted\` events
- [ ] Server appears in the public browser under \`kbve\` tag

## Follow-up

For a permanent fix, /factorio/mods should be a PVC so the mod cache survives pod restarts and we don't re-download ~440 MB from the portal every boot. Tracking in Phase 5.