### PR TITLE
chore(deps-dev): bump babel-plugin-styled-components from 2.1.4 to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"astro-vtbot": "^2.1.11",
 		"autoprefixer": "^10.4.24",
 		"babel-plugin-macros": "^3.1.0",
-		"babel-plugin-styled-components": "2.1.4",
+		"babel-plugin-styled-components": "2.3.0",
 		"cssnano": "^7.1.4",
 		"esbuild": "0.28.0",
 		"eslint": "8.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -474,8 +474,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       babel-plugin-styled-components:
-        specifier: 2.1.4
-        version: 2.1.4(@babel/core@7.26.10)(styled-components@6.3.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        specifier: 2.3.0
+        version: 2.3.0(@babel/core@7.26.10)(styled-components@6.3.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       cssnano:
         specifier: ^7.1.4
         version: 7.1.4(postcss@8.5.14)
@@ -7369,9 +7369,10 @@ packages:
   babel-plugin-react-native-web@0.21.2:
     resolution: {integrity: sha512-SPD0J6qjJn8231i0HZhlAGH6NORe+QvRSQM2mwQEzJ2Fb3E4ruWTiiicPlHjmeWShDXLcvoorOCXjeR7k/lyWA==}
 
-  babel-plugin-styled-components@2.1.4:
-    resolution: {integrity: sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==}
+  babel-plugin-styled-components@2.3.0:
+    resolution: {integrity: sha512-nP/y6PbBqS/qtKROnJCgpGo8hYUzlBAVXN1QAjSBANL6vZiQXPQN7FYW/nUwoxY7nZhBEGm9T5tjL9gbzwulDw==}
     peerDependencies:
+      '@babel/core': ^7.0.0
       styled-components: '>= 2'
 
   babel-plugin-syntax-hermes-parser@0.29.1:
@@ -12766,10 +12767,6 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
 
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
@@ -25946,16 +25943,15 @@ snapshots:
   babel-plugin-react-native-web@0.21.2:
     optional: true
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.26.10)(styled-components@6.3.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  babel-plugin-styled-components@2.3.0(@babel/core@7.26.10)(styled-components@6.3.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
+      '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.28.6
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.26.10)
-      lodash: 4.17.23
-      picomatch: 2.3.1
+      picomatch: 4.0.4
       styled-components: 6.3.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
-      - '@babel/core'
       - supports-color
 
   babel-plugin-syntax-hermes-parser@0.29.1:
@@ -32892,8 +32888,6 @@ snapshots:
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
-
-  picomatch@2.3.1: {}
 
   picomatch@2.3.2: {}
 


### PR DESCRIPTION
## Summary
Targeted re-do of dependabot #11348. Lockfile delta is ~22 lines vs dependabot's ~2,651-line cascade; smaller review surface, e2e matrix only has to validate the package that actually moved.

## Diff
- \`package.json\` — \`babel-plugin-styled-components\` exact spec \`2.1.4\` → \`2.3.0\`.
- \`pnpm-lock.yaml\` — spec + version bumped; new explicit \`@babel/core: ^7.0.0\` peer dep declared on the package; one stale \`picomatch@2.3.1\` entry consolidated away.

## Upstream notes (2.2 → 2.3)
- New \`cssPropImportPath\` option so React Native targets resolve auto-injected \`styled-components\` to \`styled-components/native\`.
- Detect styled declarations through TS theme-typing alias chains (\`const styled = baseStyled as ThemedStyledInterface<MyTheme>\`).
- Fix \`css={{ ... }}\` mis-output when the object key matches a local binding name.

## Consumers
Workspace babel preset stack: styled-components SSR/runtime in astro builds. Same \`@babel/core@7.26\` already in use, no app-level change.

## Test plan
- [ ] CI e2e matrix passes (astro + anything that exercises styled-components SSR).
- [ ] After merge, close dependabot #11348.