### PR TITLE
chore(agones-factorio): kbve mod portal-ready (info, changelog, LICENSE, build script)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ mono_crash.*.json
 # Solitaire standalone (single-HTML itch.io build)
 apps/kbve/astro-kbve/dist/solitaire-standalone/
 apps/kbve/astro-kbve/dist/solitaire-standalone.zip
+apps/agones/factorio/mods-local/dist/

--- a/apps/agones/factorio/mods-local/kbve/LICENSE
+++ b/apps/agones/factorio/mods-local/kbve/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2026 KBVE
+
+Full terms, attribution, and contact: https://kbve.com/legal/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/agones/factorio/mods-local/kbve/changelog.txt
+++ b/apps/agones/factorio/mods-local/kbve/changelog.txt
@@ -1,0 +1,16 @@
+---------------------------------------------------------------------------------------------------
+Version: 0.0.1
+Date: 2026-06-01
+  Features:
+    - KBVE Exchange entity with a tabbed Buy / Vault GUI.
+    - Per-player coin economy backed by the vanilla coin item.
+    - Per-player vault inventory that persists across deaths and rejoins.
+    - Walled spawn compound with starter chests, warehouses, and starter research applied to the player force.
+    - KBVE Fleet Commander entity for bulk AAI vehicle control.
+    - Zones tab: tag any AAI zone as mining / defense / refuel / deposit / highway.
+    - Mining tab: filter to miners, fan units across the zone, auto-skip depleted tiles, auto-deposit when cargo fills.
+    - Defense tab: filter to combat units, patrol cadence, retreat-on-HP.
+    - Combat tab: one-shot offensive dispatch to a typed map position.
+    - Squads tab: persist named subsets of the fleet with mission badge.
+    - Mission tick loop: low-fuel routes to refuel zone, low-HP routes to refuel zone, multi-waypoint return path via highway tiles.
+    - Coin payouts for AAI vehicle kills and hauler deposits.

--- a/apps/agones/factorio/mods-local/kbve/info.json
+++ b/apps/agones/factorio/mods-local/kbve/info.json
@@ -2,10 +2,17 @@
 	"name": "kbve",
 	"version": "0.0.1",
 	"factorio_version": "2.0",
-	"title": "KBVE",
+	"title": "KBVE Fleet Commander",
 	"author": "kbve",
 	"contact": "https://kbve.com",
 	"homepage": "https://kbve.com",
-	"description": "KBVE Factorio server scenario + exchange terminal. Coin economy, market, personal vault, scenario starter compound.",
-	"dependencies": ["base >= 2.0", "? space-age"]
+	"license": "MIT — see https://kbve.com/legal/",
+	"description": "KBVE community server pack: an in-game economy and an AAI fleet command center. Spawn inside a walled starter compound with the KBVE Exchange (buy items, deposit into a per-player vault that survives deaths and rejoins) and the KBVE Fleet Commander (single GUI for every AAI vehicle on the surface - sync unregistered cars, fan a miner squad across a mining zone, send combat units to a defense zone, route returns through highway tiles, auto-deposit when cargo is full, retreat under fire). Designed for the public KBVE Factorio server but works standalone with AAI Programmable Vehicles, AAI Zones, and AAI Industry installed.",
+	"dependencies": [
+		"base >= 2.0",
+		"? space-age",
+		"? aai-programmable-vehicles",
+		"? aai-zones",
+		"? aai-industry"
+	]
 }

--- a/apps/agones/factorio/scripts/build-mod.sh
+++ b/apps/agones/factorio/scripts/build-mod.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Packages mods-local/kbve into a Factorio mod-portal-ready zip.
+#
+# Output: apps/agones/factorio/mods-local/dist/kbve_<version>.zip
+# The inner directory is renamed to "kbve_<version>" to satisfy the
+# portal's "zip root must match <name>_<version>" rule.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOD_ROOT="$(cd "$SCRIPT_DIR/../mods-local/kbve" && pwd)"
+DIST_DIR="$(cd "$SCRIPT_DIR/../mods-local" && pwd)/dist"
+
+if [ ! -f "$MOD_ROOT/info.json" ]; then
+    echo "info.json not found at $MOD_ROOT" >&2
+    exit 1
+fi
+
+NAME=$(jq -r .name "$MOD_ROOT/info.json")
+VERSION=$(jq -r .version "$MOD_ROOT/info.json")
+ZIP_NAME="${NAME}_${VERSION}.zip"
+INNER_DIR="${NAME}_${VERSION}"
+
+mkdir -p "$DIST_DIR"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -R "$MOD_ROOT" "$WORK/$INNER_DIR"
+
+# Strip dev cruft.
+find "$WORK/$INNER_DIR" -name '.DS_Store' -delete
+
+(cd "$WORK" && zip -qr "$DIST_DIR/$ZIP_NAME" "$INNER_DIR")
+echo "Built: $DIST_DIR/$ZIP_NAME"
+ls -l "$DIST_DIR/$ZIP_NAME"


### PR DESCRIPTION
## Summary

Prep the kbve mod for its first upload to https://mods.factorio.com/.

- \`info.json\` — title bumped to **KBVE Fleet Commander**, description expanded to cover Exchange + Vault + the Fleet Commander mission tabs, \`license\` set to \`MIT — see https://kbve.com/legal/\`, optional aai-* deps added.
- \`changelog.txt\` — Factorio's canonical block format, dated 2026-06-01, listing the v0.0.1 feature set.
- \`LICENSE\` — MIT body with the \`https://kbve.com/legal/\` pointer inlined between the copyright header and the standard text.
- \`apps/agones/factorio/scripts/build-mod.sh\` — packages \`mods-local/kbve\` into \`apps/agones/factorio/mods-local/dist/kbve_<version>.zip\` with the inner directory named \`kbve_<version>\` to satisfy the portal's "zip root must match \`<name>_<version>\`" rule. \`dist/\` is gitignored.

## Next steps (out of scope for this PR)

1. Hand-upload the resulting zip via https://mods.factorio.com/upload — first publish needs human review (~24h).
2. Once approved, wire a CI job that builds the zip on \`info.json\` version bump, then POSTs to https://mods.factorio.com/api/v2/mods/releases/init_upload using the \`FACTORIO\` repo secret (api key) and multipart-uploads to the returned \`upload_url\`.