### PR TITLE
ci(agones-factorio): auto-publish kbve mod to mods.factorio.com on version bump

### DIFF
--- a/.github/workflows/ci-factorio-mod-publish.yml
+++ b/.github/workflows/ci-factorio-mod-publish.yml
@@ -1,0 +1,106 @@
+name: Factorio Mod Portal Publish
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - 'apps/agones/factorio/mods-local/kbve/info.json'
+            - 'apps/agones/factorio/mods-local/kbve/**'
+            - 'apps/agones/factorio/scripts/build-mod.sh'
+            - '.github/workflows/ci-factorio-mod-publish.yml'
+    workflow_dispatch:
+        inputs:
+            force_upload:
+                description: 'Upload even if info.json version did not change'
+                required: false
+                default: 'false'
+                type: choice
+                options: ['false', 'true']
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 2
+
+            - name: Resolve version + diff
+              id: ver
+              run: |
+                  set -euo pipefail
+                  NEW=$(jq -r .version apps/agones/factorio/mods-local/kbve/info.json)
+                  OLD=$(git show HEAD~1:apps/agones/factorio/mods-local/kbve/info.json 2>/dev/null | jq -r .version 2>/dev/null || echo "")
+                  echo "new=$NEW" >> "$GITHUB_OUTPUT"
+                  echo "old=$OLD" >> "$GITHUB_OUTPUT"
+                  if [ "$NEW" = "$OLD" ]; then
+                    echo "changed=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "changed=true" >> "$GITHUB_OUTPUT"
+                  fi
+                  echo "::notice::info.json version old=$OLD new=$NEW"
+
+            - name: Decide whether to publish
+              id: gate
+              run: |
+                  set -euo pipefail
+                  FORCED='${{ github.event.inputs.force_upload }}'
+                  CHANGED='${{ steps.ver.outputs.changed }}'
+                  if [ "$FORCED" = "true" ] || [ "$CHANGED" = "true" ]; then
+                    echo "publish=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "publish=false" >> "$GITHUB_OUTPUT"
+                    echo "::notice::info.json version unchanged; skipping upload."
+                  fi
+
+            - name: Install deps
+              if: steps.gate.outputs.publish == 'true'
+              run: |
+                  sudo apt-get update -qq
+                  sudo apt-get install -y --no-install-recommends jq zip
+
+            - name: Build mod zip
+              if: steps.gate.outputs.publish == 'true'
+              run: bash apps/agones/factorio/scripts/build-mod.sh
+
+            - name: Upload to mods.factorio.com
+              if: steps.gate.outputs.publish == 'true'
+              env:
+                  FACTORIO_API_KEY: ${{ secrets.FACTORIO }}
+                  MOD_NAME: kbve
+                  MOD_VERSION: ${{ steps.ver.outputs.new }}
+              run: |
+                  set -euo pipefail
+                  if [ -z "${FACTORIO_API_KEY}" ]; then
+                    echo "secrets.FACTORIO is empty — aborting" >&2
+                    exit 1
+                  fi
+                  ZIP="apps/agones/factorio/mods-local/dist/${MOD_NAME}_${MOD_VERSION}.zip"
+                  if [ ! -f "$ZIP" ]; then
+                    echo "expected zip not found: $ZIP" >&2
+                    ls -R apps/agones/factorio/mods-local/dist/ || true
+                    exit 1
+                  fi
+                  echo "::notice::posting init_upload for ${MOD_NAME}_${MOD_VERSION}"
+                  INIT=$(curl -sS --fail-with-body -X POST \
+                      -H "Authorization: Bearer ${FACTORIO_API_KEY}" \
+                      -F "mod=${MOD_NAME}" \
+                      "https://mods.factorio.com/api/v2/mods/releases/init_upload")
+                  echo "init response: $INIT"
+                  UPLOAD_URL=$(printf '%s' "$INIT" | jq -r '.upload_url // empty')
+                  if [ -z "$UPLOAD_URL" ]; then
+                    echo "init_upload did not return upload_url" >&2
+                    exit 1
+                  fi
+                  echo "::notice::uploading zip"
+                  RESP=$(curl -sS --fail-with-body -X POST \
+                      -F "file=@${ZIP}" \
+                      "$UPLOAD_URL")
+                  echo "upload response: $RESP"
+                  if printf '%s' "$RESP" | jq -e '.error // empty | length > 0' >/dev/null 2>&1; then
+                    echo "::error::mod portal rejected the upload"
+                    exit 1
+                  fi
+                  echo "::notice::published kbve ${MOD_VERSION} to https://mods.factorio.com/mod/kbve"

--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ mono_crash.*.json
 # Solitaire standalone (single-HTML itch.io build)
 apps/kbve/astro-kbve/dist/solitaire-standalone/
 apps/kbve/astro-kbve/dist/solitaire-standalone.zip
+apps/agones/factorio/mods-local/dist/

--- a/apps/agones/factorio/mods-local/kbve/LICENSE
+++ b/apps/agones/factorio/mods-local/kbve/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2026 KBVE
+
+Full terms, attribution, and contact: https://kbve.com/legal/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/agones/factorio/mods-local/kbve/changelog.txt
+++ b/apps/agones/factorio/mods-local/kbve/changelog.txt
@@ -1,0 +1,16 @@
+---------------------------------------------------------------------------------------------------
+Version: 0.0.1
+Date: 2026-06-01
+  Features:
+    - KBVE Exchange entity with a tabbed Buy / Vault GUI.
+    - Per-player coin economy backed by the vanilla coin item.
+    - Per-player vault inventory that persists across deaths and rejoins.
+    - Walled spawn compound with starter chests, warehouses, and starter research applied to the player force.
+    - KBVE Fleet Commander entity for bulk AAI vehicle control.
+    - Zones tab: tag any AAI zone as mining / defense / refuel / deposit / highway.
+    - Mining tab: filter to miners, fan units across the zone, auto-skip depleted tiles, auto-deposit when cargo fills.
+    - Defense tab: filter to combat units, patrol cadence, retreat-on-HP.
+    - Combat tab: one-shot offensive dispatch to a typed map position.
+    - Squads tab: persist named subsets of the fleet with mission badge.
+    - Mission tick loop: low-fuel routes to refuel zone, low-HP routes to refuel zone, multi-waypoint return path via highway tiles.
+    - Coin payouts for AAI vehicle kills and hauler deposits.

--- a/apps/agones/factorio/mods-local/kbve/info.json
+++ b/apps/agones/factorio/mods-local/kbve/info.json
@@ -2,10 +2,17 @@
 	"name": "kbve",
 	"version": "0.0.1",
 	"factorio_version": "2.0",
-	"title": "KBVE",
+	"title": "KBVE Fleet Commander",
 	"author": "kbve",
 	"contact": "https://kbve.com",
 	"homepage": "https://kbve.com",
-	"description": "KBVE Factorio server scenario + exchange terminal. Coin economy, market, personal vault, scenario starter compound.",
-	"dependencies": ["base >= 2.0", "? space-age"]
+	"license": "MIT — see https://kbve.com/legal/",
+	"description": "KBVE community server pack: an in-game economy and an AAI fleet command center. Spawn inside a walled starter compound with the KBVE Exchange (buy items, deposit into a per-player vault that survives deaths and rejoins) and the KBVE Fleet Commander (single GUI for every AAI vehicle on the surface - sync unregistered cars, fan a miner squad across a mining zone, send combat units to a defense zone, route returns through highway tiles, auto-deposit when cargo is full, retreat under fire). Designed for the public KBVE Factorio server but works standalone with AAI Programmable Vehicles, AAI Zones, and AAI Industry installed.",
+	"dependencies": [
+		"base >= 2.0",
+		"? space-age",
+		"? aai-programmable-vehicles",
+		"? aai-zones",
+		"? aai-industry"
+	]
 }

--- a/apps/agones/factorio/scripts/build-mod.sh
+++ b/apps/agones/factorio/scripts/build-mod.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Packages mods-local/kbve into a Factorio mod-portal-ready zip.
+#
+# Output: apps/agones/factorio/mods-local/dist/kbve_<version>.zip
+# The inner directory is renamed to "kbve_<version>" to satisfy the
+# portal's "zip root must match <name>_<version>" rule.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOD_ROOT="$(cd "$SCRIPT_DIR/../mods-local/kbve" && pwd)"
+DIST_DIR="$(cd "$SCRIPT_DIR/../mods-local" && pwd)/dist"
+
+if [ ! -f "$MOD_ROOT/info.json" ]; then
+    echo "info.json not found at $MOD_ROOT" >&2
+    exit 1
+fi
+
+NAME=$(jq -r .name "$MOD_ROOT/info.json")
+VERSION=$(jq -r .version "$MOD_ROOT/info.json")
+ZIP_NAME="${NAME}_${VERSION}.zip"
+INNER_DIR="${NAME}_${VERSION}"
+
+mkdir -p "$DIST_DIR"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cp -R "$MOD_ROOT" "$WORK/$INNER_DIR"
+
+# Strip dev cruft.
+find "$WORK/$INNER_DIR" -name '.DS_Store' -delete
+
+(cd "$WORK" && zip -qr "$DIST_DIR/$ZIP_NAME" "$INNER_DIR")
+echo "Built: $DIST_DIR/$ZIP_NAME"
+ls -l "$DIST_DIR/$ZIP_NAME"


### PR DESCRIPTION
## Summary

Stacked on #11526. Adds the GitHub Actions workflow that publishes the kbve mod to https://mods.factorio.com/mod/kbve any time \`info.json#version\` changes on main.

## Workflow flow

1. **Trigger** — push to \`main\` touching \`apps/agones/factorio/mods-local/kbve/**\` or the build script, plus a manual \`workflow_dispatch\` with a \`force_upload\` input.
2. **Diff guard** — read \`info.json#version\` at HEAD and HEAD~1. Exit cleanly with an \`::notice::\` line when unchanged unless \`force_upload=true\`.
3. **Build** — \`bash apps/agones/factorio/scripts/build-mod.sh\` writes \`apps/agones/factorio/mods-local/dist/kbve_<version>.zip\` with the inner directory name the portal requires.
4. **Init upload** — \`POST https://mods.factorio.com/api/v2/mods/releases/init_upload\` with the \`FACTORIO\` repo secret as a Bearer token and \`mod=kbve\` in the form body. Captures \`upload_url\` from the JSON response.
5. **Upload zip** — \`POST upload_url\` with \`file=@<zip>\`. Fails the run if the response carries a non-empty \`.error\`.

## Secret

\`secrets.FACTORIO\` — mod portal API key with the \`ModPortal: Upload Mods\` scope (already added to the repo). Workflow aborts immediately if the secret is empty so a missed rotation surfaces as a red CI run rather than a silent skip.

## Test plan

- [ ] After #11526 + this PR merge, bump \`info.json#version\` to \`0.0.2\` in a follow-up commit + verify the workflow uploads to the portal page.
- [ ] Run \`workflow_dispatch\` with \`force_upload=true\` to confirm the manual path works.

## Follow-up

- Bump \`info.json\` for each substantive mod-source change so the portal release matches what the server runs.
- Eventually wire into the existing dispatch manifest pattern so the post-publish version sync PR auto-bumps \`info.json\` like \`version.toml\`.