### PR TITLE
chore(unity-rareicon): bump 0.1.7 + disable Unity splash → triggers Steam beta+promote flow

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -718,7 +718,7 @@
 				"license_method": "personal"
 			},
 			"source_path": "apps/rareicon/unity-rareicon",
-			"version": "0.1.6",
+			"version": "0.1.7",
 			"version_toml": "apps/rareicon/unity-rareicon/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unity-rareicon.mdx",
 			"runner": "ubuntu-latest",

--- a/apps/kbve/astro-kbve/src/content/docs/project/unity-rareicon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unity-rareicon.mdx
@@ -14,7 +14,7 @@ pipeline: unity
 app_name: rareicon
 source_path: apps/rareicon/unity-rareicon
 version_toml: apps/rareicon/unity-rareicon/version.toml
-version: "0.1.6"
+version: "0.1.7"
 runner: ubuntu-latest
 author: h0lybyte
 license: KBVE

--- a/apps/rareicon/unity-rareicon/ProjectSettings/ProjectSettings.asset
+++ b/apps/rareicon/unity-rareicon/ProjectSettings/ProjectSettings.asset
@@ -17,8 +17,8 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
-  m_ShowUnitySplashLogo: 1
+  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashLogo: 0
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
   m_SplashScreenLogoStyle: 1


### PR DESCRIPTION
## Summary

Trigger the StreamingAssets fix from #11510 by bumping `version`:

- `unity-rareicon` `0.1.6` → `0.1.7` ([unity-rareicon.mdx](apps/kbve/astro-kbve/src/content/docs/project/unity-rareicon.mdx#L17))
- Disable "Made with Unity" splash — Unity 6 lets Personal-tier disable: `m_ShowUnitySplashScreen` + `m_ShowUnitySplashLogo` flipped 1 → 0 in [ProjectSettings.asset](apps/rareicon/unity-rareicon/ProjectSettings/ProjectSettings.asset#L20-L21)
- Manifest regen via `astro-kbve:sync:ci-manifest`

Once merged: ci-main → ci-unity builds with regenerated itemdb.json/binpb → uploads to Steam `beta` → auto-dispatches `ci-steam-promote.yml` → blocks on `steam-prod` env → approve in GH UI → `SetAppBuildLive` flips demo `default` pointer to the new BuildID.

## Test plan

- [ ] CI - Unity green; build artifacts contain populated `StreamingAssets/itemdb.json` (count=180)
- [ ] `deploy_steam` matrix step `Dispatch Steam branch promotion` logs a notice with numeric `buildId` for app 3791950
- [ ] `ci-steam-promote.yml` run appears in Actions; `promote` job waiting on `steam-prod` approval
- [ ] After approval: HTTP 200 + `result=OK` from SetAppBuildLive
- [ ] Steam → install demo → items render with names, no Unity splash on boot