### PR TITLE
fix(kube/kbve-gateway): add cryptothrone.com HTTPS listener

### DIFF
--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -105,6 +105,20 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        - name: https-cryptothrone
+          protocol: HTTPS
+          port: 443
+          hostname: cryptothrone.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: cryptothrone-tls
+                    namespace: cryptothrone
+          allowedRoutes:
+              namespaces:
+                  from: All
 ---
 ## kbve.com routes
 apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
## Summary
- cryptothrone.com returned CF 526 because `kbve-gateway` had no HTTPS listener bound to that hostname — SNI fell through to default cert, CF rejected origin TLS
- cert (`cryptothrone-tls`), ReferenceGrant (`allow-gateway-tls`), and HTTPRoute (`cryptothrone-route`) already in place; only the listener block was missing
- Adds `https-cryptothrone` listener mirroring `https-rareicon`, refs `cryptothrone-tls` in cryptothrone ns via existing ReferenceGrant

## Test plan
- [ ] ArgoCD syncs `kbve` app, Gateway reconciles with 8th HTTPS listener
- [ ] `kubectl get gateway -n kbve kbve-gateway -o jsonpath='{.status.listeners[?(@.name=="https-cryptothrone")].conditions}'` → Programmed + ResolvedRefs True, attachedRoutes=1
- [ ] `curl -sI https://cryptothrone.com` returns 200 (not 526)
- [ ] `openssl s_client -connect 142.132.206.71:443 -servername cryptothrone.com </dev/null` shows Let's Encrypt cert for cryptothrone.com