### PR TITLE
feat(vm-dashboard): link kasm image tag to project page + bundled-apps chips

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmCards.tsx
@@ -11,7 +11,84 @@ import {
 	Loader2,
 	Cpu,
 	MemoryStick,
+	MessageCircle,
+	Globe,
 } from 'lucide-react';
+
+type BundledApp = 'discord' | 'cloakbrowser';
+
+interface ImageMeta {
+	display: string;
+	projectSlug?: string;
+	bundledApps: BundledApp[];
+}
+
+const KASM_IMAGE_BUNDLES: Record<
+	string,
+	{ apps: BundledApp[]; projectSlug?: string }
+> = {
+	'kasm-void': {
+		apps: ['discord', 'cloakbrowser'],
+		projectSlug: 'kasm-void',
+	},
+	'kasm-cloakbrowser': {
+		apps: ['cloakbrowser'],
+		projectSlug: 'kasm-cloakbrowser',
+	},
+	discord: { apps: ['discord'] },
+	cloakbrowser: { apps: ['cloakbrowser'] },
+};
+
+function parseImage(image: string): ImageMeta {
+	const lastSlash = image.lastIndexOf('/');
+	const tail = lastSlash >= 0 ? image.slice(lastSlash + 1) : image;
+	const colonIdx = tail.indexOf(':');
+	const name = colonIdx >= 0 ? tail.slice(0, colonIdx) : tail;
+	const tag = colonIdx >= 0 ? tail.slice(colonIdx + 1) : 'latest';
+	const bundle = KASM_IMAGE_BUNDLES[name];
+	return {
+		display: `${name}:${tag}`,
+		projectSlug: bundle?.projectSlug,
+		bundledApps: bundle?.apps ?? [],
+	};
+}
+
+function AppChip({ app }: { app: BundledApp }) {
+	const config: Record<
+		BundledApp,
+		{ label: string; color: string; Icon: typeof MessageCircle }
+	> = {
+		discord: {
+			label: 'Discord',
+			color: '#5865f2',
+			Icon: MessageCircle,
+		},
+		cloakbrowser: {
+			label: 'CloakBrowser',
+			color: '#a78bfa',
+			Icon: Globe,
+		},
+	};
+	const { label, color, Icon } = config[app];
+	return (
+		<span
+			title={`Bundled: ${label}`}
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: '0.25rem',
+				padding: '0.15rem 0.45rem',
+				borderRadius: '999px',
+				fontSize: '0.7rem',
+				background: `${color}22`,
+				border: `1px solid ${color}44`,
+				color,
+			}}>
+			<Icon size={11} />
+			{label}
+		</span>
+	);
+}
 
 interface ResourcePillProps {
 	label: string;
@@ -71,7 +148,7 @@ function KasmCard({ info }: { info: KasmInfo }) {
 					? '#ef4444'
 					: '#6b7280';
 
-	const imageName = workspace.image.split('/').pop() ?? workspace.image;
+	const imageMeta = parseImage(workspace.image);
 
 	return (
 		<div
@@ -133,7 +210,23 @@ function KasmCard({ info }: { info: KasmInfo }) {
 					fontSize: '0.8rem',
 					color: 'rgba(255,255,255,0.6)',
 				}}>
-				<span>Image: {imageName}</span>
+				<span style={{ gridColumn: 'span 2' }}>
+					Image:{' '}
+					{imageMeta.projectSlug ? (
+						<a
+							href={`/project/${imageMeta.projectSlug}/`}
+							title={workspace.image}
+							style={{
+								color: '#a78bfa',
+								textDecoration: 'none',
+								borderBottom: '1px dashed #a78bfa66',
+							}}>
+							{imageMeta.display}
+						</a>
+					) : (
+						<span title={workspace.image}>{imageMeta.display}</span>
+					)}
+				</span>
 				<span>Port: {workspace.port}</span>
 				<span>
 					Replicas: {workspace.readyReplicas}/{workspace.replicas}
@@ -198,6 +291,20 @@ function KasmCard({ info }: { info: KasmInfo }) {
 					</div>
 				);
 			})()}
+
+			{imageMeta.bundledApps.length > 0 && (
+				<div
+					style={{
+						display: 'flex',
+						flexWrap: 'wrap',
+						gap: '0.35rem',
+						marginTop: '-0.25rem',
+					}}>
+					{imageMeta.bundledApps.map((app) => (
+						<AppChip key={app} app={app} />
+					))}
+				</div>
+			)}
 
 			{/* Actions */}
 			<div


### PR DESCRIPTION
## Summary

First of a stack of small improvements to /dashboard/vm aimed at making the KASM workspace cards more informative now that we run a custom `kasm-void` image (Discord + CloakBrowser).

- Image string parsed via `parseImage()` — when the basename matches a known kbve project, the rendered \`name:tag\` becomes a link to \`/project/<slug>/\` (so \`kasm-void:0.0.1\` → \`/project/kasm-void/\` after the next post-publish chore-sync lands).
- New chip row under the details grid driven by `KASM_IMAGE_BUNDLES`:
  - `kasm-void` → Discord + CloakBrowser chips
  - `kasm-cloakbrowser` → CloakBrowser chip
  - unknown image → no chip row (existing layout)
- Hover surfaces the full \`ghcr.io/...\` path / bundled app name via title attributes.

Pure frontend; no service, RBAC, or schema changes.

## Test plan

- [ ] Local astro-kbve build passes, no new TS errors on `ReactKasmCards.tsx`
- [ ] /dashboard/vm shows the linked tag for `kasm-vpn` once the deployment image is on `kasm-void`
- [ ] Click on the tag navigates to `/project/kasm-void/`
- [ ] Discord + CloakBrowser chips render under the details grid
- [ ] Falls back cleanly when image is `kasmweb/discord:1.18.0-rolling-daily` (no link, no chip row)

## Follow-ups (queued in this worktree)

- PR2: resource pills sourced from the Deployment (req/lim CPU + memory)
- PR3: per-session URL launcher (let user set `START_URL` from the card)
- PR4: respawn metrics surfaced as a tooltip on the chip row
- PR5: short auto-update note on /dashboard/vm/ index explaining the chore-sync image bump flow