### PR TITLE
fix(kbve-gateway): collapse memes listeners to unblock meme.sh

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/memes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/memes.mdx
@@ -31,19 +31,27 @@ Memes application service serving [meme.sh](https://meme.sh) and `www.meme.sh`. 
 
 ## Routing
 
-Public traffic enters via Cloudflare → CNAME to `gateway.kbve.com` → `142.132.206.71` (Cilium gateway LB) → [`kbve-gateway`](apps/kube/kbve/manifest/) `https-memes` / `https-memes-www` listeners → [`memes-route`](apps/kube/memes/manifest/httproute.yaml) → `memes-service:4321`.
+Public traffic enters via Cloudflare → CNAME to `gateway.kbve.com` → `142.132.206.71` (Cilium gateway LB) → [`kbve-gateway`](apps/kube/kbve/manifest/kbve-gateway.yaml) `https-memes` listener (hostname `meme.sh`, cert `memes-tls` covers both `meme.sh` and `www.meme.sh` via SAN) → [`memes-route`](apps/kube/memes/manifest/httproute.yaml) (spec.hostnames = `[meme.sh, www.meme.sh]`) → `memes-service:4321`.
 
 The cert lives in `memes/memes-tls` and is consumed cross-namespace by `kbve-gateway` via [`memes-tls-from-kbve-gateway` ReferenceGrant](apps/kube/memes/manifest/memes-refgrant.yaml).
 
 ## TLS / certificate
 
-[`memes-cert`](apps/kube/memes/manifest/memes-cert.yaml) is **RSA 2048**, issued by the `letsencrypt-http` ClusterIssuer (HTTP-01). The algorithm matches the cert already in `memes-tls`; do not change to ECDSA without first verifying that the ACME HTTP-01 challenge path on Cilium gateway is healthy (see runbook below) — otherwise cert-manager flags `IncorrectCertificate` and queues a reissue that can never complete, while two `cm-acme-http-solver` HTTPRoutes ghost-attach to the listener and break `/` routing for `meme.sh`. Lost about 8 days of `meme.sh` uptime to this in May 2026.
+[`memes-cert`](apps/kube/memes/manifest/memes-cert.yaml) is **RSA 2048**, issued by the `letsencrypt-http` ClusterIssuer (HTTP-01). The algorithm matches the cert already in `memes-tls`; do not change to ECDSA without first verifying that the ACME HTTP-01 challenge path on Cilium gateway is healthy (see runbook below) — otherwise cert-manager flags `IncorrectCertificate` and queues a reissue that can never complete.
+
+## Cilium gateway gotcha — never split apex + www across listeners with one cert
+
+The original setup had two listeners (`https-memes` for `meme.sh`, `https-memes-www` for `www.meme.sh`) both pointing at the same `memes-tls` Secret. Cilium derives the Envoy filter chain SNI list from the **cert SAN** (not the listener `hostname`), so each listener emitted a filter chain with the same SNI array `[meme.sh, www.meme.sh]`. Envoy rejects duplicate filter chain match → falls through to the default 404 handler → 73 days of `meme.sh` returning nginx-style 404s while `kubectl get gateway` reported `Programmed=True / Accepted=True / ResolvedRefs=True` and the `memes-service` cluster sat healthy with zero `cx_total`.
+
+A second-order victim was ACME HTTP-01 — `cm-acme-http-solver-*` HTTPRoutes share the same listener, so the cert reissue loop also couldn't complete (`Ready=False, Reason=IncorrectCertificate`).
+
+**Rule for this gateway:** if one cert covers multiple SANs, use **one listener** with the apex hostname and let the HTTPRoute `spec.hostnames` enumerate every hostname the route serves. If you need per-host listeners, issue one cert per hostname so the SNI lists don't collide.
 
 ## Runbook — meme.sh returns 404
 
 1. Confirm origin is the actual culprit (not Cloudflare): `curl -s https://meme.sh/ | head` — an `nginx`-flavored 404 body means the request reached origin and the gateway returned it.
 2. Compare against a sibling host on the same gateway, e.g. `curl -sk --resolve kbve.com:443:142.132.206.71 -H 'Host: kbve.com' https://kbve.com/` — if that's 200, the gateway is healthy and the breakage is memes-specific.
-3. Check `kubectl get cert memes-cert -n memes` for `Ready=False, Reason=IncorrectCertificate` and `kubectl get httproute -n memes` for `cm-acme-http-solver-*` HTTPRoutes older than a few hours.
-4. If both present: the cert spec drifted from the live secret. Re-align `memes-cert.yaml` `spec.privateKey.algorithm` to the live secret (`openssl x509 -in <(kubectl get secret memes-tls -n memes -o jsonpath='{.data.tls\.crt}' | base64 -d) -text -noout | grep "Public Key Algorithm"`) and reapply via ArgoCD.
-5. After the cert reissue lock clears (the cm-acme HTTPRoutes get garbage-collected), kick the gateway: `kubectl rollout restart -n kube-system ds/cilium-envoy` so Envoy reloads its listener config.
+3. Dump the Envoy filter chains and look for two with overlapping SNI arrays: `kubectl exec -n kube-system <cilium-pod> -- cilium-dbg envoy admin config | jq '.. | objects | select(.filter_chains) | .filter_chains[] | select(.filter_chain_match.server_names[]? | contains("meme")) | .filter_chain_match.server_names'` — if you see the SAN list duplicated across two chains, the listener split is the bug.
+4. Collapse to one listener (this PR's fix), reapply via ArgoCD, and `kubectl rollout restart -n kube-system ds/cilium-envoy` to flush the stale filter chains.
+5. The stuck `cm-acme-http-solver-*` HTTPRoutes drain automatically once the cert can validate; if they don't, `kubectl delete httproute -l acme.cert-manager.io/http01-solver -n memes` to force cert-manager to recreate fresh ones.
 6. Re-curl `meme.sh` — should return 200.

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -49,24 +49,30 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        # Single listener for both meme.sh (apex) and www.meme.sh.
+        #
+        # `memes-tls` covers both names via SAN, and the Cilium gateway
+        # controller derives the filter chain SNI list from the cert SANs
+        # — not the listener `hostname` field. Splitting this into two
+        # listeners (one per hostname) made Cilium emit two filter chains
+        # with identical SNI=[meme.sh, www.meme.sh], which Envoy rejects
+        # as duplicate filter chain match. The whole memes routing block
+        # then fell through to a default 404 handler — meme.sh returned
+        # nginx-style 404s for 73 days even though the HTTPRoute was
+        # Accepted=True and the memes-service cluster was healthy. The
+        # ACME HTTP-01 challenge routes shared the same listener, so the
+        # cert reissue loop also couldn't complete (Reason=
+        # IncorrectCertificate stuck for 8 days).
+        #
+        # The HTTPRoute `memes/memes-route` has both hostnames in its
+        # spec.hostnames, so the single listener's SAN-driven SNI match
+        # still covers both names. Don't add a second listener here for
+        # any additional cert that already covers multiple SANs — issue
+        # a separate cert per hostname if you need per-host listeners.
         - name: https-memes
           protocol: HTTPS
           port: 443
           hostname: meme.sh
-          tls:
-              mode: Terminate
-              certificateRefs:
-                  - kind: Secret
-                    group: ''
-                    name: memes-tls
-                    namespace: memes
-          allowedRoutes:
-              namespaces:
-                  from: All
-        - name: https-memes-www
-          protocol: HTTPS
-          port: 443
-          hostname: www.meme.sh
           tls:
               mode: Terminate
               certificateRefs:


### PR DESCRIPTION
## Summary
Drops the duplicate \`https-memes-www\` listener on [kbve-gateway](apps/kube/kbve/manifest/kbve-gateway.yaml). The remaining \`https-memes\` listener (hostname=\`meme.sh\`) loads the same SAN-multi cert and serves both names through one filter chain.

## Root cause
Cilium's gateway controller derives Envoy filter chain SNI lists from the cert SAN, not the listener \`hostname\`. The original config had two listeners both pointing at \`memes/memes-tls\` (cert SAN = [meme.sh, www.meme.sh]), so Cilium emitted **two filter chains with identical SNI arrays**. Envoy rejects duplicate filter chain match and falls through to the default 404 handler.

The Gateway / HTTPRoute statuses didn't surface it — \`kubectl get gateway\` reported \`Programmed=True / Accepted=True / ResolvedRefs=True\` on every listener, the HTTPRoute reported \`Accepted=True\`, and the \`memes-service\` cluster was healthy. Only \`cilium-dbg envoy admin config\` showed the duplicate filter chains:

\`\`\`json
[
  { \"sni\": [\"meme.sh\", \"www.meme.sh\"], \"tls\": \"cilium-secrets/memes-memes-tls\" },
  { \"sni\": [\"meme.sh\", \"www.meme.sh\"], \"tls\": \"cilium-secrets/memes-memes-tls\" }
]
\`\`\`

Compare rareicon (works): two listeners, **two different certs** (\`rareicon-tls\` for apex, \`rareicon-api-tls\` for api), two non-overlapping SNI arrays. Envoy happy.

## Damage
- \`meme.sh\` returning 404 for **73 days** (since the second listener landed)
- ACME HTTP-01 reissue loop stuck **8 days** because the cm-acme-http-solver HTTPRoutes share the same broken listener — that's what produced the misleading \`Reason=IncorrectCertificate\` symptom on the cert
- Three earlier PRs chased the cert and ACME paths (#11505 + the cilium-envoy restart + ghost solver deletion) without finding this

## Docs
- Added "Cilium gateway gotcha" + updated runbook in [memes.mdx](apps/kbve/astro-kbve/src/content/docs/project/memes.mdx)
- Saved \`project_cilium_gateway_san_listener_dup\` memory so the next multi-SAN host setup catches this before merge

## Post-merge
1. ArgoCD reconciles \`kbve-gateway\` → listener block updated, \`https-memes-www\` drops.
2. Cilium re-emits Envoy config without the duplicate filter chain.
3. \`kubectl rollout restart -n kube-system ds/cilium-envoy\` to flush the stale config (subject to greenlight).
4. \`curl https://meme.sh/\` → 200.
5. cert-manager's stuck \`memes-cert\` retries automatically; \`cm-acme-http-solver-*\` HTTPRoutes drain.

## Test plan
- [ ] \`kubectl get gateway kbve-gateway -n kbve\` shows only one memes listener (\`https-memes\`)
- [ ] \`cilium-dbg envoy admin config | jq '.. | select(.filter_chains)? | .filter_chains[] | select(.filter_chain_match.server_names[]? | contains(\"meme\"))'\` returns exactly **one** filter chain
- [ ] \`curl --resolve meme.sh:443:142.132.206.71 -H 'Host: meme.sh' https://meme.sh/\` → 200
- [ ] \`curl --resolve www.meme.sh:443:142.132.206.71 -H 'Host: www.meme.sh' https://www.meme.sh/\` → 200
- [ ] \`kubectl get cert memes-cert -n memes\` flips \`Ready=True\` within one renewal cycle