### PR TITLE
feat(vm-dashboard): kasm workspace CPU/memory pills

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmCards.tsx
@@ -9,7 +9,45 @@ import {
 	Shield,
 	ShieldOff,
 	Loader2,
+	Cpu,
+	MemoryStick,
 } from 'lucide-react';
+
+interface ResourcePillProps {
+	label: string;
+	value: string;
+	color: string;
+	Icon: typeof Cpu;
+	title: string;
+}
+
+function ResourcePill({ label, value, color, Icon, title }: ResourcePillProps) {
+	return (
+		<span
+			title={title}
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: '0.3rem',
+				padding: '0.2rem 0.55rem',
+				borderRadius: '6px',
+				fontSize: '0.72rem',
+				background: `${color}1a`,
+				border: `1px solid ${color}40`,
+				color,
+			}}>
+			<Icon size={11} />
+			<span style={{ opacity: 0.7 }}>{label}</span>
+			<strong style={{ fontWeight: 600 }}>{value}</strong>
+		</span>
+	);
+}
+
+function formatRange(req?: string, lim?: string): string | null {
+	if (!req && !lim) return null;
+	if (req && lim && req !== lim) return `${req} → ${lim}`;
+	return lim ?? req ?? '';
+}
 
 function KasmCard({ info }: { info: KasmInfo }) {
 	const actionInProgress = useStore(kasmService.$actionInProgress);
@@ -120,6 +158,46 @@ function KasmCard({ info }: { info: KasmInfo }) {
 					)}
 				</span>
 			</div>
+
+			{(() => {
+				const cpu = formatRange(
+					workspace.resources?.requests?.cpu,
+					workspace.resources?.limits?.cpu,
+				);
+				const mem = formatRange(
+					workspace.resources?.requests?.memory,
+					workspace.resources?.limits?.memory,
+				);
+				if (!cpu && !mem) return null;
+				return (
+					<div
+						style={{
+							display: 'flex',
+							flexWrap: 'wrap',
+							gap: '0.4rem',
+							marginTop: '-0.25rem',
+						}}>
+						{cpu && (
+							<ResourcePill
+								label="CPU"
+								value={cpu}
+								color="#38bdf8"
+								Icon={Cpu}
+								title={`requests ${workspace.resources?.requests?.cpu ?? '—'} · limits ${workspace.resources?.limits?.cpu ?? '—'}`}
+							/>
+						)}
+						{mem && (
+							<ResourcePill
+								label="Memory"
+								value={mem}
+								color="#f59e0b"
+								Icon={MemoryStick}
+								title={`requests ${workspace.resources?.requests?.memory ?? '—'} · limits ${workspace.resources?.limits?.memory ?? '—'}`}
+							/>
+						)}
+					</div>
+				);
+			})()}
 
 			{/* Actions */}
 			<div

--- a/apps/kbve/astro-kbve/src/components/dashboard/kasmService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/kasmService.ts
@@ -5,6 +5,16 @@ import { getSupa } from '@/lib/supa';
 // Types
 // ---------------------------------------------------------------------------
 
+export interface KasmResourceSpec {
+	cpu?: string;
+	memory?: string;
+}
+
+export interface KasmResources {
+	requests?: KasmResourceSpec;
+	limits?: KasmResourceSpec;
+}
+
 export interface KasmWorkspace {
 	name: string;
 	namespace: string;
@@ -16,6 +26,8 @@ export interface KasmWorkspace {
 	port: number;
 	/** Service URL for accessing the workspace */
 	serviceUrl: string;
+	/** Resources from the workspace container (not gluetun) */
+	resources?: KasmResources;
 }
 
 export type KasmPhase = 'Running' | 'Stopped' | 'Starting' | 'Error';
@@ -99,6 +111,10 @@ interface K8sDeployment {
 					name: string;
 					image: string;
 					ports?: Array<{ containerPort: number }>;
+					resources?: {
+						requests?: { cpu?: string; memory?: string };
+						limits?: { cpu?: string; memory?: string };
+					};
 				}>;
 			};
 		};
@@ -133,6 +149,24 @@ function deploymentToWorkspace(dep: K8sDeployment): KasmWorkspace {
 		vpnStatus = ready > 0 ? 'connected' : 'disconnected';
 	}
 
+	const rawResources = workspaceContainer?.resources;
+	const resources: KasmResources | undefined = rawResources
+		? {
+				requests: rawResources.requests
+					? {
+							cpu: rawResources.requests.cpu,
+							memory: rawResources.requests.memory,
+						}
+					: undefined,
+				limits: rawResources.limits
+					? {
+							cpu: rawResources.limits.cpu,
+							memory: rawResources.limits.memory,
+						}
+					: undefined,
+			}
+		: undefined;
+
 	return {
 		name: dep.metadata.name,
 		namespace: dep.metadata.namespace,
@@ -142,6 +176,7 @@ function deploymentToWorkspace(dep: K8sDeployment): KasmWorkspace {
 		vpnStatus,
 		port: 6901,
 		serviceUrl: `${dep.metadata.name}-service.${KASM_NAMESPACE}.svc.cluster.local:6901`,
+		resources,
 	};
 }
 


### PR DESCRIPTION
## Summary

Second PR in the /dashboard/vm improvement stack (PR1: #11533).

Surface the resource budget of each KASM workspace's `workspace` container as chips on the card. Useful now that the kasm-void deployment runs at req 2cpu/4Gi → lim 4cpu/8Gi — without this you have to \`kubectl describe\` to see why a stream is or isn't lagging.

- `KasmWorkspace` gains a `resources` field populated from the workspace container; gluetun's tighter limits are intentionally ignored.
- New \`ResourcePill\` + \`formatRange\` helpers in \`ReactKasmCards\`. Two chips (CPU + Memory):
  - Collapses to a single value when \`requests === limits\`.
  - Renders \`req → lim\` otherwise.
  - Title attribute always carries the full \`requests / limits\` breakdown.
- No new RBAC. The dashboard proxy already grants Deployment read on the \`kasm\` namespace; this just consumes a field that was already in the JSON.

## Test plan

- [ ] Local astro-kbve build passes
- [ ] Cards render two new chips for \`kasm-vpn\` showing \`2 → 4\` (CPU) and \`4Gi → 8Gi\` (Memory) after the kasm-void chore-sync lands
- [ ] No chip row when a workspace lacks resources (defensive fallback)
- [ ] Hover shows full requests/limits breakdown