### PR TITLE
docs(vm-dashboard): add note on how kasm/firecracker image tags stay current

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/vm/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/vm/index.mdx
@@ -18,3 +18,52 @@ tags:
 import AstroVMDashboard from '@/components/dashboard/AstroVMDashboard.astro';
 
 <AstroVMDashboard />
+
+<div
+    style={{
+        maxWidth: '1200px',
+        margin: '0 auto',
+        padding: '0 1rem 2rem',
+        fontSize: '0.8rem',
+        color: 'rgba(255,255,255,0.45)',
+        lineHeight: 1.5,
+    }}>
+    <details
+        style={{
+            background: 'rgba(255,255,255,0.03)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            borderRadius: '8px',
+            padding: '0.75rem 1rem',
+        }}>
+        <summary
+            style={{
+                cursor: 'pointer',
+                color: 'rgba(255,255,255,0.7)',
+                fontWeight: 500,
+            }}>
+            How image tags stay current
+        </summary>
+        <p style={{ marginTop: '0.75rem' }}>
+            Each entry in the dashboard reads the image tag straight from
+            its Kubernetes manifest — KubeVirt <code>VirtualMachine</code>{' '}
+            specs for the VM cards, the <code>kasm-vpn</code>{' '}
+            <code>Deployment</code> for KASM workspaces, and the
+            firecracker manifests for the microVM rows. Tags are pinned
+            (no <code>:latest</code>), so what you see is exactly what's
+            running.
+        </p>
+        <p style={{ marginTop: '0.5rem' }}>
+            Bumps happen automatically: each tracked image has a{' '}
+            <code>version.toml</code> + an MDX entry under{' '}
+            <a href="/project/">/project/</a> referencing the manifest via{' '}
+            <code>deployment_yaml</code>. After CI publishes a new tag, a
+            post-publish chore PR rewrites the pin and ArgoCD rolls the
+            pod. Card image strings (e.g.{' '}
+            <a href="/project/kasm-void/">
+                <code>kasm-void:0.0.1</code>
+            </a>
+            ) link back to the project page where the env knobs and
+            recovery behaviour live.
+        </p>
+    </details>
+</div>


### PR DESCRIPTION
## Summary

Third PR in the /dashboard/vm improvement stack (PR1: #11533 · PR2: #11537).

Adds a collapsible \`<details>\` block below the dashboard explaining the pin-tag flow:

- Each card reads the image tag directly from its manifest (KubeVirt VM specs, the kasm-vpn Deployment, firecracker manifests).
- No \`:latest\` anywhere — what you see is exactly what's running.
- Bumps happen via the post-publish chore PR (driven by \`version.toml\` + the project MDX entry's \`deployment_yaml\` field).
- Card image strings already link back to \`/project/<slug>/\` (added in #11533), where env knobs + recovery behaviour live.

Pure content — no component or service changes. Block stays closed by default so the dashboard layout doesn't shift.

## Test plan

- [ ] /dashboard/vm renders with the \`<details>\` block below the existing dashboard
- [ ] Block is closed by default, opens on click
- [ ] Links to \`/project/\` index and \`/project/kasm-void/\` work after the kasm-void chore-sync lands