### PR TITLE
feat(vm-dashboard): surface kasm supervisor activity from project_logs

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmCards.tsx
@@ -13,6 +13,7 @@ import {
 	MemoryStick,
 	MessageCircle,
 	Globe,
+	Activity,
 } from 'lucide-react';
 
 type BundledApp = 'discord' | 'cloakbrowser';
@@ -129,8 +130,10 @@ function formatRange(req?: string, lim?: string): string | null {
 function KasmCard({ info }: { info: KasmInfo }) {
 	const actionInProgress = useStore(kasmService.$actionInProgress);
 	const lastAction = useStore(kasmService.$lastAction);
+	const supervisorActivity = useStore(kasmService.$supervisorActivity);
 	const token = useStore(vmService.$accessToken);
 	const { workspace, phase, state } = info;
+	const activity = supervisorActivity[workspace.name];
 
 	const isActing = actionInProgress?.includes(workspace.name) ?? false;
 	const cardAction = lastAction?.name === workspace.name ? lastAction : null;
@@ -303,6 +306,32 @@ function KasmCard({ info }: { info: KasmInfo }) {
 					{imageMeta.bundledApps.map((app) => (
 						<AppChip key={app} app={app} />
 					))}
+				</div>
+			)}
+
+			{activity && (activity.cloak > 0 || activity.discord > 0) && (
+				<div
+					title={`Supervisor launches in the last ${activity.windowMin}m — includes the cold pod start. Anything above 2 per app is likely respawns after a crash or window close.`}
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.4rem',
+						fontSize: '0.72rem',
+						color: 'rgba(255,255,255,0.55)',
+						marginTop: '-0.25rem',
+					}}>
+					<Activity size={12} style={{ color: '#a78bfa' }} />
+					<span>
+						Last {activity.windowMin}m:{' '}
+						<strong style={{ color: '#a78bfa' }}>
+							{activity.cloak}
+						</strong>{' '}
+						browser ·{' '}
+						<strong style={{ color: '#a78bfa' }}>
+							{activity.discord}
+						</strong>{' '}
+						discord launches
+					</span>
 				</div>
 			)}
 

--- a/apps/kbve/astro-kbve/src/components/dashboard/kasmService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/kasmService.ts
@@ -1,5 +1,6 @@
 import { atom, computed } from 'nanostores';
 import { getSupa } from '@/lib/supa';
+import { fetchIndexedLogs } from './clickhouseService';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -58,6 +59,21 @@ export const KasmState = {
 const PROXY_BASE = '/dashboard/vm/proxy';
 const KASM_NAMESPACE = 'kasm';
 const REFRESH_INTERVAL_MS = 15_000;
+const SUPERVISOR_WINDOW_MIN = 60;
+const SUPERVISOR_REFRESH_MS = 60_000;
+const SUPERVISOR_FETCH_LIMIT = 500;
+
+export interface SupervisorActivity {
+	cloak: number;
+	discord: number;
+	windowMin: number;
+	fetchedAt: Date;
+}
+
+const SUPERVISOR_PATTERNS = {
+	cloak: 'launching cloakbrowser',
+	discord: 'launching discord',
+} as const;
 
 // ---------------------------------------------------------------------------
 // API helpers
@@ -218,6 +234,12 @@ class KasmService {
 	public readonly $loading = atom<boolean>(true);
 	public readonly $error = atom<string | null>(null);
 	public readonly $actionInProgress = atom<string | null>(null);
+	public readonly $supervisorActivity = atom<
+		Record<string, SupervisorActivity>
+	>({});
+
+	private _supervisorInterval: ReturnType<typeof setInterval> | undefined;
+	private _supervisorInflight = false;
 
 	public readonly $runningCount = computed(
 		[this.$workspaces],
@@ -292,6 +314,56 @@ class KasmService {
 			() => this.fetchData(token),
 			REFRESH_INTERVAL_MS,
 		);
+		this.fetchSupervisorActivity(token);
+		if (this._supervisorInterval) clearInterval(this._supervisorInterval);
+		this._supervisorInterval = setInterval(
+			() => this.fetchSupervisorActivity(token),
+			SUPERVISOR_REFRESH_MS,
+		);
+	}
+
+	public async fetchSupervisorActivity(token: string): Promise<void> {
+		if (this._supervisorInflight) return;
+		const workspaces = this.$workspaces.get();
+		if (workspaces.length === 0) return;
+		this._supervisorInflight = true;
+		try {
+			const [cloakRows, discordRows] = await Promise.all([
+				fetchIndexedLogs(token, {
+					namespace: KASM_NAMESPACE,
+					search: SUPERVISOR_PATTERNS.cloak,
+					minutes: SUPERVISOR_WINDOW_MIN,
+					limit: SUPERVISOR_FETCH_LIMIT,
+				}).catch(() => []),
+				fetchIndexedLogs(token, {
+					namespace: KASM_NAMESPACE,
+					search: SUPERVISOR_PATTERNS.discord,
+					minutes: SUPERVISOR_WINDOW_MIN,
+					limit: SUPERVISOR_FETCH_LIMIT,
+				}).catch(() => []),
+			]);
+
+			const fetchedAt = new Date();
+			const next: Record<string, SupervisorActivity> = {};
+			for (const info of workspaces) {
+				const name = info.workspace.name;
+				const cloak = cloakRows.filter((r) =>
+					r.pod_name?.startsWith(name),
+				).length;
+				const discord = discordRows.filter((r) =>
+					r.pod_name?.startsWith(name),
+				).length;
+				next[name] = {
+					cloak,
+					discord,
+					windowMin: SUPERVISOR_WINDOW_MIN,
+					fetchedAt,
+				};
+			}
+			this.$supervisorActivity.set(next);
+		} finally {
+			this._supervisorInflight = false;
+		}
 	}
 
 	/** Per-workspace action result — cleared after 5s or on next action */


### PR DESCRIPTION
## Summary

Fourth PR in the /dashboard/vm improvement stack (PR1: #11533 · PR2: #11537 · PR5: #11539).

Reuses the existing Vector → ClickHouse log pipeline to count supervisor (re)spawns inside the kasm-void container, surfacing them on the card. **No image change**, no new RBAC, no new prometheus textfile collector.

- \`custom_startup.sh\` in kasm-void already echoes \`[startup] launching cloakbrowser\` / \`[startup] launching discord\` on every spawn. Vector scrapes the \`kasm\` namespace into \`project_logs\` like every other namespace.
- New \`$supervisorActivity\` atom in \`kasmService\` keyed by workspace name. \`fetchSupervisorActivity()\` calls the existing \`/dashboard/clickhouse/proxy\` via \`fetchIndexedLogs\` (two parallel queries: one per pattern, namespace \`kasm\`, last 60m).
- Triggered immediately on \`startAutoRefresh()\` and then once per minute. In-flight de-dupe via a private flag — no overlap if a refresh runs long.
- Card renders an \`Activity\` row under the resource pills when either counter > 0. Tooltip explains the cold-start vs crash-recovery interpretation (anything > ~2 per app in 60m is most likely a respawn after window close or crash).

## Test plan

- [ ] Local astro-kbve build passes
- [ ] Cards show \`Last 60m: N browser · M discord launches\` after a session has run for a few minutes
- [ ] Counts increment after manually closing the Discord or CloakBrowser window (supervisor respawns within 3s; CH polls within 60s)
- [ ] Card stays clean (no row) when the workspace has no activity in the window (e.g., fresh pod, just started)
- [ ] Tooltip surfaces the interpretation note