### PR TITLE
fix(astro-kbve,isometric): full reload across arcade route + comment cleanup

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/isometric/AstroIsometric.astro
+++ b/apps/kbve/astro-kbve/src/arcade/isometric/AstroIsometric.astro
@@ -40,10 +40,6 @@
 	<script>
 		import { authBridge } from '@/components/auth';
 
-		// Expose a Promise<string|null> on `window` so `main.tsx` can `await`
-		// the Supabase session probe BEFORE calling `set_signed_in` — the
-		// `<script>` block below kicks off WASM loading synchronously, so
-		// without a promise the session resolution would race the import.
 		(
 			window as Window & {
 				__KBVE_SESSION_PROBE__?: Promise<string | null>;
@@ -54,19 +50,45 @@
 			.catch(() => null);
 	</script>
 	<script is:inline>
+		// WASM Bevy + web workers + WebGPU context can't be torn down
+		// cleanly through Astro's view-transition swap. Force a real
+		// navigation whenever the route crosses /arcade/isometric in
+		// either direction, so the browser disposes the GPU + thread
+		// resources naturally on unload and re-inits cleanly on return.
 		(function () {
-			// Downscale droid workers to free threads for WASM pthreads
+			var ISO_PREFIX = '/arcade/isometric';
+			function pathOf(input) {
+				if (!input) return '';
+				if (typeof input === 'string') {
+					try {
+						return new URL(input, location.href).pathname;
+					} catch (_) {
+						return '';
+					}
+				}
+				if (input.pathname) return input.pathname;
+				return '';
+			}
+			document.addEventListener('astro:before-preparation', function (e) {
+				var fromIso = location.pathname.indexOf(ISO_PREFIX) === 0;
+				var toIso = pathOf(e.to).indexOf(ISO_PREFIX) === 0;
+				if (!fromIso && !toIso) return;
+				if (e.to && e.to.href) {
+					e.preventDefault();
+					window.location.assign(e.to.href);
+				}
+			});
+
 			function downscaleDroid() {
 				if (
 					window.kbve &&
 					typeof window.kbve.downscale === 'function'
 				) {
-					window.kbve.downscale().catch(function (e) {
-						console.warn('[Isometric] Droid downscale failed:', e);
+					window.kbve.downscale().catch(function (err) {
+						console.warn('[isometric] droid downscale failed', err);
 					});
 					return;
 				}
-				// Poll until droid is ready (max ~5s)
 				var attempts = 0;
 				var poll = setInterval(function () {
 					attempts++;
@@ -75,10 +97,10 @@
 						typeof window.kbve.downscale === 'function'
 					) {
 						clearInterval(poll);
-						window.kbve.downscale().catch(function (e) {
+						window.kbve.downscale().catch(function (err) {
 							console.warn(
-								'[Isometric] Droid downscale failed:',
-								e,
+								'[isometric] droid downscale failed',
+								err,
 							);
 						});
 					} else if (attempts > 50) {
@@ -87,7 +109,14 @@
 				}, 100);
 			}
 
-			if (navigator.gpu) {
+			function bootIsometric() {
+				if (window.__KBVE_ISOMETRIC_BOOTED__) return;
+				window.__KBVE_ISOMETRIC_BOOTED__ = true;
+				if (!navigator.gpu) {
+					document.getElementById('webgpu-warning').style.display =
+						'flex';
+					return;
+				}
 				document.getElementById('game-loading').style.display = 'flex';
 				document.getElementById('bevy-canvas').style.display = '';
 				document.getElementById('root').style.display = '';
@@ -97,10 +126,9 @@
 				s.src = '/isometric/assets/index.js';
 				s.crossOrigin = '';
 				document.head.appendChild(s);
-			} else {
-				document.getElementById('webgpu-warning').style.display =
-					'flex';
 			}
+
+			bootIsometric();
 		})();
 	</script>
 </div>

--- a/apps/kbve/isometric/index.html
+++ b/apps/kbve/isometric/index.html
@@ -68,10 +68,9 @@
         <script src="bug-report-shim.js"></script>
         <script src="safari-shim.js"></script>
         <script>
-            // Tauri macOS bug: WKWebView treats desktop clicks as touch with
-            // ~500ms delay, causing the click to register at the previous
-            // pointer position. Block touch listeners before they're attached.
-            // Ref: https://github.com/orgs/tauri-apps/discussions/11957
+            // Tauri macOS WKWebView treats desktop clicks as touch with
+            // ~500ms delay; block touch listeners before they're attached.
+            // https://github.com/orgs/tauri-apps/discussions/11957
             (function () {
                 if (!/Mac|Macintosh/i.test(navigator.userAgent)) return;
                 var origAdd = EventTarget.prototype.addEventListener;
@@ -83,66 +82,42 @@
             })();
         </script>
         <script>
-            // Native Tauri build renders Bevy directly to the webview's wgpu
-            // surface (no canvas attachment). The bevy-canvas element + body
-            // would otherwise eat clicks before tao forwards them to Bevy.
-            // Detect Tauri and make the DOM click-through; React UI children
-            // opt back in via pointer-events: auto when needed.
+            // Native Tauri renders Bevy onto the webview surface; capture
+            // pointer/key events at window level and forward them via
+            // Tauri commands so Bevy receives them regardless of which DOM
+            // element has focus. The DOM stays interactive (no pointer-
+            // events: none on html/body) so WKWebView keeps compositing.
             var isTauri = !!(window.__TAURI_INTERNALS__ || window.__TAURI__);
-            console.log('[native-input] script booted; isTauri=', isTauri, '__TAURI_INTERNALS__=', !!window.__TAURI_INTERNALS__);
             if (isTauri) {
-                // NOTE: Do NOT set `pointer-events: none` on html/body.
-                // WKWebView treats non-interactive documents as paint-skip
-                // candidates and defers DOM composition until devtools opens.
-                // The capture-phase window listeners below forward every
-                // pointer/key event to Bevy regardless of pointer-events, so
-                // the click-through behaviour is preserved without breaking
-                // composition. Only the bevy-canvas itself needs to opt out.
                 var canvas = document.getElementById('bevy-canvas');
                 if (canvas) canvas.style.pointerEvents = 'none';
 
                 var dpr = window.devicePixelRatio || 1;
-                console.log('[native-input] __TAURI__=', window.__TAURI__,
-                    'core=', window.__TAURI__ && window.__TAURI__.core,
-                    'INTERNALS keys=', window.__TAURI_INTERNALS__ ? Object.keys(window.__TAURI_INTERNALS__) : null);
 
                 var invokeRef = null;
-                var firstSuccess = false;
                 var loggedErr = false;
                 var call = function (cmd, args) {
                     if (!invokeRef) {
-                        // Tauri 2 preferred path: window.__TAURI__.core.invoke
-                        // (exposed when withGlobalTauri: true).
                         invokeRef = (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
                             || (window.__TAURI__ && window.__TAURI__.invoke)
                             || (window.__TAURI_INTERNALS__ && window.__TAURI_INTERNALS__.invoke);
                         if (!invokeRef) {
                             if (!loggedErr) {
-                                console.error('[native-input] no invoke fn — TAURI=', window.__TAURI__,
-                                    'INTERNALS=', window.__TAURI_INTERNALS__);
+                                console.error('[native-input] no invoke fn');
                                 loggedErr = true;
                             }
                             return;
                         }
-                        console.log('[native-input] invokeRef resolved as', invokeRef.name || 'anonymous');
                     }
                     try {
                         var p = invokeRef(cmd, args);
-                        if (p && p.then) {
-                            p.then(function () {
-                                if (!firstSuccess) {
-                                    console.log('[native-input] first invoke succeeded:', cmd);
-                                    firstSuccess = true;
-                                }
-                            }).catch(function (err) {
+                        if (p && p.catch) {
+                            p.catch(function (err) {
                                 if (!loggedErr) {
                                     console.error('[native-input] invoke failed', cmd, err);
                                     loggedErr = true;
                                 }
                             });
-                        } else if (!firstSuccess) {
-                            console.log('[native-input] invoke returned non-promise:', cmd, p);
-                            firstSuccess = true;
                         }
                     } catch (err) {
                         if (!loggedErr) {
@@ -187,7 +162,6 @@
                 };
                 window.addEventListener('pointerdown', function (e) {
                     if (isDragRegion(e)) return;
-                    console.log('[native-input] pointerdown fired button=', e.button);
                     call('forward_pointer_button', { button: e.button, pressed: true });
                 }, true);
                 window.addEventListener('pointerup', function (e) {
@@ -197,11 +171,9 @@
                 window.addEventListener('wheel', function (e) {
                     call('forward_wheel', { dx: e.deltaX, dy: -e.deltaY });
                 }, { capture: true, passive: true });
-                // Skip forwarding when focus is on a text input — the
-                // React chat UI (and any other future input widget) needs
-                // raw key strokes for editing without Bevy also reacting
-                // to them as gameplay hotkeys (e.g. typing `i` while in
-                // chat opening the inventory).
+                // Don't forward keys to Bevy when focus is on a text widget
+                // — React chat etc. need raw input without triggering game
+                // hotkeys (typing `i` while in chat opening the inventory).
                 var keyTargetIsEditable = function (e) {
                     var t = e.target;
                     if (!t || !t.tagName) return false;
@@ -221,10 +193,8 @@
                     if (keyTargetIsEditable(e)) return;
                     call('forward_key', { code: e.code, pressed: false, repeat: false });
                 }, true);
-                console.log('[native-input] forwarder armed (listeners attached)');
             } else {
-                // WASM browser build keeps the canvas focused so winit's web
-                // backend receives keyboard events.
+                // WASM browser build: keep canvas focused so winit gets keys.
                 document.addEventListener('pointerup', function() {
                     var c = document.getElementById('bevy-canvas');
                     if (c && document.activeElement !== c) c.focus();

--- a/apps/kbve/isometric/src-tauri/src/commands.rs
+++ b/apps/kbve/isometric/src-tauri/src/commands.rs
@@ -100,10 +100,6 @@ pub fn greet(name: &str) -> String {
 #[cfg(not(target_arch = "wasm32"))]
 #[tauri::command]
 pub fn forward_pointer_move(x: f64, y: f64) {
-    static FIRST: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
-    if FIRST.swap(false, std::sync::atomic::Ordering::Relaxed) {
-        eprintln!("[native-input] first pointer move received x={x} y={y}");
-    }
     crate::game::native_input::push_event(
         crate::game::native_input::NativeInputEvent::PointerMove { x, y },
     );
@@ -112,7 +108,6 @@ pub fn forward_pointer_move(x: f64, y: f64) {
 #[cfg(not(target_arch = "wasm32"))]
 #[tauri::command]
 pub fn forward_pointer_button(button: u8, pressed: bool) {
-    eprintln!("[native-input] pointer button={button} pressed={pressed}");
     crate::game::native_input::push_event(
         crate::game::native_input::NativeInputEvent::PointerButton { button, pressed },
     );
@@ -154,9 +149,6 @@ pub fn forward_viewport(css_w: f64, css_h: f64, dpr: f64) {
 #[cfg(not(target_arch = "wasm32"))]
 #[tauri::command]
 pub fn forward_key(code: String, pressed: bool, repeat: bool) {
-    if !repeat {
-        eprintln!("[native-input] key code={code} pressed={pressed}");
-    }
     crate::game::native_input::push_event(crate::game::native_input::NativeInputEvent::Key {
         code,
         pressed,
@@ -218,7 +210,6 @@ pub fn open_oauth_url(app: tauri::AppHandle, provider: String) -> Result<(), Str
         provider,
         urlencoding::encode(&redirect),
     );
-    eprintln!("[auth] opening OAuth url for provider={provider}: {url}");
     app.opener()
         .open_url(url, None::<&str>)
         .map_err(|e| e.to_string())

--- a/apps/kbve/isometric/src-tauri/src/game/chat.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/chat.rs
@@ -1,11 +1,4 @@
-//! IRC chat bridge for the isometric game.
-//!
-//! Connects to the IRC gateway via WebSocket (`wss://chat.kbve.com`) and bridges
-//! incoming world events into Bevy `Toast` notifications. On WASM the transport
-//! is `web_sys::WebSocket`; on native (desktop Tauri) it's tokio TCP.
-//!
-//! Gracefully degrades: if IRC is unreachable, the game continues without
-//! cross-platform world events.
+//! IRC chat bridge wired into the Bevy game (native + WASM).
 
 use bevy::prelude::*;
 use bevy_chat::{ChatMessage, ChatPlugin, IncomingChatEvent, IrcConfig, IrcTransport, MessageKind};
@@ -16,23 +9,15 @@ use std::sync::{Mutex, OnceLock};
 
 use super::toast::Toast;
 
-/// Default channel new messages from the React input box land on.
-/// Must match the Discord bot's `RELAY_IRC_CHANNEL` (and the chat.kbve.com
-/// web embed default) so all three audiences fan out through the same Ergo
-/// channel.
+/// Channel game messages fan out through. Must match the Discord relay's
+/// `RELAY_IRC_CHANNEL` and the chat.kbve.com web default so game/Discord/web
+/// all see the same Ergo room.
 pub const DEFAULT_SEND_CHANNEL: &str = "#general";
 
-/// Outbox sender exposed for the `send_chat` Tauri command + wasm-bindgen
-/// export. Set once when the chat plugin builds; readers must tolerate a
-/// `None` value before that happens.
 static OUTBOX_TX: OnceLock<Sender<ChatMessage>> = OnceLock::new();
 
 const SNAPSHOT_LOG_CAP: usize = 60;
 
-/// Thread-safe snapshot of recent #general chat lines exposed to React via the
-/// `get_chat_log` Tauri command. Mirrors the Bevy-side ChatLog used by the
-/// in-game overlay but lives outside the ECS so the React panel can read it
-/// at any phase (title screen included).
 static SNAPSHOT_LOG: Mutex<VecDeque<ChatLogEntry>> = Mutex::new(VecDeque::new());
 
 #[derive(Clone, Serialize)]
@@ -61,8 +46,6 @@ pub fn snapshot_log() -> Vec<ChatLogEntry> {
         .unwrap_or_default()
 }
 
-/// Build and queue a `ChatMessage` from raw user input. Returns `false` if
-/// chat hasn't initialized yet or the user is not signed in (no nick).
 pub fn queue_outgoing_chat(text: &str) -> bool {
     let trimmed = text.trim();
     if trimmed.is_empty() {
@@ -91,47 +74,22 @@ pub fn queue_outgoing_chat(text: &str) -> bool {
     sent
 }
 
-// ---------------------------------------------------------------------------
-// Configuration
-// ---------------------------------------------------------------------------
-
-/// Default IRC gateway URL for browser clients.
-/// In WASM mode this is the public chat.kbve.com WebSocket endpoint.
 const DEFAULT_WS_URL: &str = "wss://chat.kbve.com/ws";
-
-/// Default IRC host for native (desktop) clients.
 const DEFAULT_NATIVE_HOST: &str = "irc.kbve.com";
-
-/// Channels every isometric client auto-joins. `#general` is the shared
-/// fan-out (game ↔ Discord ↔ chat.kbve.com web); `#world-events` is game-
-/// internal for toast events.
 const DEFAULT_CHANNELS: &[&str] = &["#general", "#world-events"];
 
-// ---------------------------------------------------------------------------
-// Plugin
-// ---------------------------------------------------------------------------
-
-/// Bridges IRC world events into the isometric game's toast notifications.
-///
-/// Adds:
-/// - `bevy_chat::ChatPlugin` (inbox/outbox crossbeam channels + ECS event)
-/// - Startup system that creates a `ChatClient` and connects (graceful failure)
-/// - Update system that converts `IncomingChatEvent` → `Toast`
 pub struct GameChatPlugin;
 
 impl Plugin for GameChatPlugin {
     fn build(&self, app: &mut App) {
-        // Crossbeam channels for IRC ↔ ECS bridging
         let (inbox_tx, inbox_rx) = unbounded();
         let (outbox_tx, outbox_rx) = unbounded();
 
-        // Add the bevy_chat plugin (creates ChatInbox/ChatOutbox resources + IncomingChatEvent)
         app.add_plugins(ChatPlugin {
             inbox_rx: inbox_rx.clone(),
             outbox_tx: outbox_tx.clone(),
         });
 
-        // Store the senders + receivers for the connect system
         app.insert_resource(ChatBridgeChannels {
             inbox_tx,
             outbox_rx,
@@ -139,24 +97,14 @@ impl Plugin for GameChatPlugin {
         app.init_resource::<ChatSession>();
         let _ = OUTBOX_TX.set(outbox_tx);
 
-        // Connect chat lazily: wait for the user to sign in (PreFlight
-        // observes `kbve_username` + JWT), then dial `wss://chat.kbve.com`
-        // with the JWT as the IRC `PASS` and the username as the nick.
         app.add_systems(Update, connect_chat_on_signin);
-
-        // Bridge incoming world events to toast notifications
         app.add_systems(Update, world_events_to_toasts);
-        // Mirror chat-channel messages into the React-visible snapshot.
         app.add_systems(Update, snapshot_incoming);
     }
 }
 
 fn snapshot_incoming(mut events: MessageReader<IncomingChatEvent>) {
     for IncomingChatEvent(msg) in events.read() {
-        info!(
-            "[chat] incoming sender={} channel={} content={}",
-            msg.sender, msg.channel, msg.content
-        );
         if msg.channel == "#world-events" {
             continue;
         }
@@ -173,8 +121,6 @@ fn snapshot_incoming(mut events: MessageReader<IncomingChatEvent>) {
     }
 }
 
-/// Tracks whether we've already started a chat connection for the current
-/// session. Reset on disconnect/re-auth in a future iteration.
 #[derive(Resource, Default)]
 struct ChatSession {
     connected: bool,
@@ -191,8 +137,6 @@ fn connect_chat_on_signin(mut session: ResMut<ChatSession>, channels: Res<ChatBr
     }
     let nick = match snapshot.username {
         Some(name) if !name.is_empty() => name,
-        // No canonical username yet — chat needs one to register, so wait
-        // until the player picks one via the in-game username modal.
         _ => return,
     };
     let jwt = match crate::auth_common::current_jwt() {
@@ -201,7 +145,7 @@ fn connect_chat_on_signin(mut session: ResMut<ChatSession>, channels: Res<ChatBr
     };
     session.connected = true;
     session.nick = Some(nick.clone());
-    info!("[chat] sign-in observed; dialing chat.kbve.com as {nick}");
+    info!("[chat] connecting as {nick}");
     spawn_chat_connection(
         channels.inbox_tx.clone(),
         channels.outbox_rx.clone(),
@@ -210,24 +154,17 @@ fn connect_chat_on_signin(mut session: ResMut<ChatSession>, channels: Res<ChatBr
     );
 }
 
-/// Stores the inbox sender (called by the IRC client when messages arrive)
-/// and the outbox receiver (read by the outbox flush task).
 #[derive(Resource)]
 struct ChatBridgeChannels {
     inbox_tx: Sender<bevy_chat::ChatMessage>,
-    #[allow(dead_code)] // Used by future outbox flush task
+    #[allow(dead_code)]
     outbox_rx: Receiver<bevy_chat::ChatMessage>,
 }
 
-// ---------------------------------------------------------------------------
-// IRC connection (platform-specific)
-// ---------------------------------------------------------------------------
-
 fn chat_config(nick: String, jwt: String) -> IrcConfig {
-    // chat.kbve.com gateway authenticates the WS upgrade itself, not the IRC
-    // PASS line — it reads `Authorization: Bearer <jwt>` or the `?token=`
-    // query param. Bake the token into the URL since bevy_chat doesn't
-    // forward custom upgrade headers.
+    // chat.kbve.com authenticates the WS upgrade via `?token=`; PASS line
+    // is ignored. Skip IRC registration since the gateway pre-registers us
+    // from the JWT claims.
     let url = format!("{}?token={}", DEFAULT_WS_URL, jwt);
     IrcConfig {
         host: url,
@@ -253,19 +190,12 @@ fn spawn_chat_connection(
     use wasm_bindgen::JsCast;
 
     let config = chat_config(nick, jwt);
-    info!(
-        "[chat] connecting to IRC gateway at {} (nick={})",
-        config.host, config.nick
-    );
     let client = ChatClient::new(config);
     if let Err(e) = client.connect() {
-        warn!("[chat] IRC connect failed: {} — world events disabled", e);
+        warn!("[chat] connect failed: {e}");
         return;
     }
 
-    // Inbound: drain WASM client buffer into ECS crossbeam inbox each tick.
-    // Outbound: pull queued ChatMessages and ship via the WebSocket. Both
-    // run inside the same setInterval so we don't leak two timers.
     let client_for_poll = client.clone();
     let closure = wasm_bindgen::prelude::Closure::wrap(Box::new(move || {
         for msg in client_for_poll.drain_incoming() {
@@ -285,7 +215,6 @@ fn spawn_chat_connection(
         );
         closure.forget();
     }
-    info!("[chat] IRC bridge active (wasm)");
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -298,17 +227,6 @@ fn spawn_chat_connection(
     use bevy_chat::ChatClient;
 
     let config = chat_config(nick, jwt);
-    let host = config.host.clone();
-    info!(
-        "[chat] connecting to IRC gateway at {} (nick={})",
-        host, config.nick
-    );
-
-    // Bevy runs sync — drive the async connect on a dedicated tokio
-    // runtime spawned on a worker thread. The runtime lives for the
-    // process lifetime; one task forwards incoming messages into the
-    // crossbeam inbox, another drains the outbox channel and pushes each
-    // queued ChatMessage onto the WebSocket.
     std::thread::Builder::new()
         .name("chat-irc-ws".to_string())
         .spawn(move || {
@@ -326,16 +244,10 @@ fn spawn_chat_connection(
                 let mut client = ChatClient::new(config);
                 let mut subscriber = client.subscribe();
                 if let Err(e) = client.connect().await {
-                    warn!("[chat] native IRC-WS connect failed: {e}");
+                    warn!("[chat] connect failed: {e}");
                     return;
                 }
-                info!("[chat] native IRC-WS bridge active");
 
-                // Outbound: spawn a task that pulls from the crossbeam
-                // outbox in a blocking loop on a tokio blocking thread,
-                // forwarding each message via the async send. Using
-                // spawn_blocking keeps the synchronous Receiver::recv
-                // call off the async executor.
                 let client_send = client.clone();
                 tokio::spawn(async move {
                     loop {
@@ -352,7 +264,6 @@ fn spawn_chat_connection(
                             break;
                         }
                     }
-                    warn!("[chat] native outbound pump ended");
                 });
 
                 while let Ok(msg) = subscriber.recv().await {
@@ -360,19 +271,13 @@ fn spawn_chat_connection(
                         break;
                     }
                 }
-                warn!("[chat] native IRC-WS subscriber loop ended");
             });
         })
         .expect("failed to spawn chat-irc-ws thread");
 }
 
-// ---------------------------------------------------------------------------
-// Event bridge: IncomingChatEvent → Toast
-// ---------------------------------------------------------------------------
-
 fn world_events_to_toasts(mut events: MessageReader<IncomingChatEvent>, mut commands: Commands) {
     for IncomingChatEvent(msg) in events.read() {
-        // Only render world-events channel as toasts (avoid spamming chat)
         if msg.channel != "#world-events" {
             continue;
         }
@@ -389,7 +294,7 @@ fn world_events_to_toasts(mut events: MessageReader<IncomingChatEvent>, mut comm
             MessageKind::Custom(ref tag) if tag == "VICTORY" => {
                 Toast::success(format!("\u{1F451} {}", msg.content))
             }
-            _ => continue, // Skip unknown event types
+            _ => continue,
         };
 
         commands.trigger(toast);

--- a/apps/kbve/isometric/src-tauri/src/tauri_plugin.rs
+++ b/apps/kbve/isometric/src-tauri/src/tauri_plugin.rs
@@ -199,7 +199,6 @@ mod desktop {
             frame_count += 1;
             if last_fps_update.elapsed() >= Duration::from_secs(1) {
                 AVERAGE_FRAME_RATE.store(frame_count, Ordering::Relaxed);
-                eprintln!("[fps] store {frame_count}");
                 frame_count = 0;
                 last_fps_update = Instant::now();
             }

--- a/apps/kbve/isometric/src/components/DragBar.tsx
+++ b/apps/kbve/isometric/src/components/DragBar.tsx
@@ -39,12 +39,6 @@ async function fetchChrome(): Promise<UiChromeState | null> {
 	}
 }
 
-/**
- * Window drag handle shown only at Title (phase=0) or while the in-game
- * Settings modal is open. The rest of the time the chrome stays hidden so
- * gameplay feels like a windowless idle RPG. Tauri reads
- * `data-tauri-drag-region` and turns the element into a draggable area.
- */
 export function DragBar() {
 	const [visible, setVisible] = useState(false);
 	const isTauri = detectTauri();
@@ -77,9 +71,6 @@ export function DragBar() {
 		if (e.button !== 0) return;
 		e.preventDefault();
 		e.stopPropagation();
-		// Fire synchronously so AppKit still has the active mousedown when
-		// the IPC reaches the Tauri backend. Awaiting an import first lets
-		// the OS gesture complete before startDragging executes.
 		getCurrentWindow()
 			.startDragging()
 			.catch((err) => console.warn('[drag] startDragging failed', err));

--- a/apps/kbve/isometric/src/main.tsx
+++ b/apps/kbve/isometric/src/main.tsx
@@ -11,14 +11,10 @@ function setLoadingProgress(status: string, percent: number) {
 	if (bar) bar.style.width = percent + '%';
 }
 
-/**
- * macOS WKWebView defers composition on transparent + click-through documents
- * (html/body with `pointer-events: none`). React mounts but paint stays stale
- * until devtools opens or the window resizes. Force a layout/resize on every
- * animation frame for the first ~600ms, then drop to a 500ms interval so
- * later UI state changes (chat panel opening, FPS counter updates) still get
- * composited.
- */
+// macOS WKWebView defers DOM composition on transparent + click-through
+// documents until something triggers a real OS resize (Web Inspector does
+// this naturally). Force a layout pulse + a stepped window-size nudge so
+// the React overlay paints from boot instead of staying invisible.
 function kickPaint() {
 	const force = () => {
 		document.documentElement.getBoundingClientRect();
@@ -32,17 +28,12 @@ function kickPaint() {
 	requestAnimationFrame(rafTick);
 	setInterval(force, 500);
 
-	// macOS WKWebView only reconfigures its compositor surface on real OS
-	// window-size changes (opening devtools triggers this naturally). Multi-
-	// stage nudge with a perceptible delta and a real delay so AppKit treats
-	// it as a true resize event, not a coalesced no-op.
 	(async () => {
 		try {
 			const winApi = await import('@tauri-apps/api/window');
 			const w = winApi.getCurrentWindow();
 			const size = await w.innerSize();
 			const PhysicalSize = winApi.PhysicalSize;
-			console.log('[paint] window-nudge starting; size=', size);
 			await w.setSize(
 				new PhysicalSize(size.width + 20, size.height + 20),
 			);
@@ -52,7 +43,6 @@ function kickPaint() {
 			await w.setSize(new PhysicalSize(size.width + 1, size.height));
 			await new Promise((r) => setTimeout(r, 100));
 			await w.setSize(new PhysicalSize(size.width, size.height));
-			console.log('[paint] window-nudge complete');
 		} catch (err) {
 			console.warn('[paint] window-nudge failed', err);
 		}
@@ -68,11 +58,6 @@ function hideLoadingScreen() {
 	}
 }
 
-/**
- * Probe browser capabilities and persist to localStorage as JSON.
- * Run ONCE before WASM init so the Rust side can read a complete
- * ClientProfile without scattered JS interop calls.
- */
 function resolveEndpoints() {
 	const hostname = window.location.hostname;
 	const protocol = window.location.protocol;
@@ -113,7 +98,6 @@ function probeClientProfile() {
 	try {
 		localStorage.setItem('kbve_client_profile', JSON.stringify(profile));
 	} catch {
-		// Private browsing or storage full — WASM will fall back to safe defaults.
 		console.warn(
 			'[profile] localStorage unavailable, WASM will use defaults',
 		);
@@ -124,11 +108,9 @@ function probeClientProfile() {
 async function bootstrap() {
 	const profile = probeClientProfile();
 
-	// Native Tauri build runs Bevy as a real Rust binary via wgpu and the
-	// webview's raw window handle — DO NOT load the WASM game on top of it,
-	// or two Bevy instances fight for input/render and wasm-bindgen
-	// closures get invoked recursively (visible as "closure invoked
-	// recursively or after being dropped" panics in the webview console).
+	// Native Tauri runs Bevy as a real Rust binary on the webview's raw
+	// window. Loading the WASM build on top of it spawns a second Bevy +
+	// recursive wasm-bindgen closures and crashes the webview.
 	const isTauri = !!(
 		(
 			window as typeof window & {
@@ -156,7 +138,6 @@ async function bootstrap() {
 		return;
 	}
 
-	// Verify WebGPU is available before loading the WASM game
 	if (!profile.has_webgpu) {
 		const root = document.getElementById('root');
 		if (root) {
@@ -172,8 +153,6 @@ async function bootstrap() {
 
 	setLoadingProgress('Loading game module...', 20);
 
-	// Load and initialize Bevy WASM — starts the game loop (non-blocking)
-	// Tower-http serves pre-compressed .wasm.br/.wasm.gz transparently via Content-Encoding
 	const wasmModule = await import('../wasm-pkg/isometric_game.js');
 	const { default: init } = wasmModule;
 
@@ -181,11 +160,8 @@ async function bootstrap() {
 
 	const wasm = await init();
 
-	// Hand the Supabase access token (resolved by the arcade page's
-	// authBridge probe) to Bevy so the title screen flips straight to
-	// "Signed in as X" and the netcode handshake starts without a Play
-	// Online click. Awaiting the probe avoids a race where WASM finishes
-	// init before the IndexedDB-backed session is read.
+	// Await the Supabase session probe so set_signed_in fires before
+	// netcode handshake — otherwise WASM races the IndexedDB read.
 	const probe = (
 		window as Window & {
 			__KBVE_SESSION_PROBE__?: Promise<string | null>;
@@ -200,8 +176,8 @@ async function bootstrap() {
 		}
 	}
 
-	// Spawn web workers for WASM pthreads (chunk computation, etc.)
-	// Only when SharedArrayBuffer is available (cross-origin isolated).
+	// WASM pthreads via web workers, only when SharedArrayBuffer is
+	// available (cross-origin isolated context).
 	if (
 		typeof SharedArrayBuffer !== 'undefined' &&
 		'worker_entry_point' in wasm
@@ -212,15 +188,12 @@ async function bootstrap() {
 		);
 		setLoadingProgress(`Spawning ${numWorkers} workers...`, 75);
 
-		// wasm-bindgen doesn't export the WebAssembly.Module, so compile it ourselves.
-		// The memory IS on instance.exports since we use --shared-memory.
 		const wasmUrl = new URL(
 			'../wasm-pkg/isometric_game_bg.wasm',
 			import.meta.url,
 		);
 		const wasmMemory = (wasm as unknown as { memory: WebAssembly.Memory })
 			.memory;
-		// Resolve the wasm-bindgen JS URL for workers to import dynamically.
 		const bindgenUrl = new URL(
 			'../wasm-pkg/isometric_game.js',
 			import.meta.url,
@@ -242,15 +215,13 @@ async function bootstrap() {
 					bindgenUrl,
 				});
 			}
-			console.log(`[pthreads] Spawned ${numWorkers} WASM worker threads`);
 		} catch (err) {
-			console.warn('[pthreads] Failed to compile WASM for workers:', err);
+			console.warn('[pthreads] worker setup failed', err);
 		}
 	}
 
 	setLoadingProgress('Starting...', 90);
 
-	// Render React UI overlay
 	ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 		<React.StrictMode>
 			<GameUIProvider>

--- a/packages/rust/bevy/bevy_chat/src/client_native.rs
+++ b/packages/rust/bevy/bevy_chat/src/client_native.rs
@@ -206,43 +206,24 @@ impl ChatClient {
         let nick = self.config.nick.clone();
         let writer_clone = self.writer.clone();
         tokio::spawn(async move {
-            tracing::info!("[ws-in] read loop started");
             while let Some(item) = stream.next().await {
                 let payload = match item {
-                    Ok(WsMessage::Text(t)) => {
-                        tracing::info!("[ws-in] frame text len={}", t.len());
-                        t.to_string()
-                    }
-                    Ok(WsMessage::Binary(b)) => {
-                        tracing::info!("[ws-in] frame binary len={}", b.len());
-                        match String::from_utf8(b.to_vec()) {
-                            Ok(s) => s,
-                            Err(_) => continue,
-                        }
-                    }
-                    Ok(WsMessage::Ping(_)) => {
-                        tracing::info!("[ws-in] frame ping");
-                        continue;
-                    }
-                    Ok(WsMessage::Pong(_)) => {
-                        tracing::info!("[ws-in] frame pong");
-                        continue;
-                    }
-                    Ok(WsMessage::Close(c)) => {
-                        tracing::warn!("[ws-in] close frame: {:?}", c);
-                        break;
-                    }
+                    Ok(WsMessage::Text(t)) => t.to_string(),
+                    Ok(WsMessage::Binary(b)) => match String::from_utf8(b.to_vec()) {
+                        Ok(s) => s,
+                        Err(_) => continue,
+                    },
+                    Ok(WsMessage::Ping(_)) | Ok(WsMessage::Pong(_)) => continue,
+                    Ok(WsMessage::Close(_)) => break,
                     Ok(_) => continue,
                     Err(e) => {
                         tracing::warn!("IRC-WS read error: {e}");
                         break;
                     }
                 };
-                // The chat.kbve.com gateway delivers each IRC line as its
-                // own WebSocket text frame WITHOUT a trailing CRLF, but raw
-                // IRC TCP and some other gateways include `\r\n` (and may
-                // batch multiple lines per frame). Split on `\n` if present;
-                // otherwise treat the whole frame as a single IRC line.
+                // chat.kbve.com sends each IRC line as a standalone WS frame
+                // without CRLF; raw-TCP gateways batch multiple lines per
+                // frame. Handle both shapes.
                 let trimmed = payload
                     .trim_end_matches('\n')
                     .trim_end_matches('\r')
@@ -259,7 +240,6 @@ impl ChatClient {
                     vec![trimmed]
                 };
                 for line in &lines {
-                    tracing::info!("[ws-in] <= {line}");
                     if line.starts_with("PING") {
                         let pong = line.replacen("PING", "PONG", 1);
                         if let Some(Writer::Ws(ref out)) = *writer_clone.lock().await {
@@ -268,12 +248,6 @@ impl ChatClient {
                         continue;
                     }
                     if let Some(privmsg) = parse_privmsg(line, &nick) {
-                        tracing::info!(
-                            "[ws-in] parsed PRIVMSG sender={} channel={} content={}",
-                            privmsg.sender,
-                            privmsg.channel,
-                            privmsg.content
-                        );
                         let _ = tx.send(privmsg);
                     }
                 }


### PR DESCRIPTION
## Summary
- Astro's ClientRouter swap cannot tear down the WASM Bevy app, its web workers, or the WebGPU context the isometric page installs on \`window\` + \`document\`. Listen on \`astro:before-preparation\` and force \`window.location.assign\` whenever navigation crosses \`/arcade/isometric\` in either direction so the browser disposes everything naturally on unload and re-inits cleanly on return.
- Move boot behind a \`__KBVE_ISOMETRIC_BOOTED__\` guard so the inlined script can't double-init if Astro ever re-executes it.
- Strip diagnostic \`console.log\`/\`eprintln!\` spam left over from chat/paint debugging (every WS frame in bevy_chat, every keypress in \`forward_key\`/\`forward_pointer_button\`, FPS-store probe, OAuth URL echo).
- Trim narrative comments to the load-bearing why-lines; identifiers + structure carry the rest.

## Test plan
- [ ] kbve.com → /arcade/isometric: WASM loads, signed-in user shows
- [ ] From the game, navigate back to /arcade/ (via UI link): full reload, no orphan workers in devtools Application > Service Workers / Threads
- [ ] Return to /arcade/isometric: fresh boot, no \`closure invoked recursively\` panics
- [ ] Tauri native dev still builds + runs (\`cargo tauri dev\` in apps/kbve/isometric)