### PR TITLE
feat(agones-factorio): defer kbve mod to factorio portal sync + bump to v0.0.11

### DIFF
--- a/apps/agones/factorio/shim/agones-shim.sh
+++ b/apps/agones/factorio/shim/agones-shim.sh
@@ -26,6 +26,8 @@ AGONES_SDK_HTTP="${AGONES_SDK_HTTP:-}"
 AGONES_HEALTH_INTERVAL="${AGONES_HEALTH_INTERVAL:-5}"
 AGONES_READY_DELAY="${AGONES_READY_DELAY:-30}"
 
+FACTORIO_PORTAL_ONLY_MODS="${FACTORIO_PORTAL_ONLY_MODS:-kbve}"
+
 mkdir -p "$FACTORIO_CONFIG_DIR" "$FACTORIO_MODS_DIR" "$FACTORIO_LOG_DIR"
 for f in server-settings.json map-gen-settings.json map-settings.json; do
     if [ ! -f "${FACTORIO_CONFIG_DIR}/${f}" ] && [ -f "${FACTORIO_DEFAULTS_DIR}/${f}" ]; then
@@ -42,6 +44,21 @@ for local_mod in "${FACTORIO_MODS_DEFAULTS_DIR}"/*/; do
     [ -d "$local_mod" ] || continue
     [ -f "${local_mod}info.json" ] || continue
     mod_name=$(basename "$local_mod")
+    skip_local=0
+    for portal_only in $FACTORIO_PORTAL_ONLY_MODS; do
+        if [ "$mod_name" = "$portal_only" ]; then
+            skip_local=1
+            break
+        fi
+    done
+    if [ "$skip_local" = "1" ]; then
+        rm -f "${FACTORIO_MODS_DIR}/${mod_name}_"*.zip
+        if [ -d "${FACTORIO_MODS_DIR}/${mod_name}" ]; then
+            rm -rf "${FACTORIO_MODS_DIR}/${mod_name}"
+        fi
+        echo "[agones-shim] ${mod_name} marked portal-only, deferring to mod portal sync"
+        continue
+    fi
     mod_version=$(jq -r '.version // "0.0.1"' "${local_mod}info.json")
     target_zip="${FACTORIO_MODS_DIR}/${mod_name}_${mod_version}.zip"
     if [ -d "${FACTORIO_MODS_DIR}/${mod_name}" ]; then

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_factorio
 pipeline: docker
 app_name: agones-factorio
-version: "0.0.10"
+version: "0.0.11"
 source_path: apps/agones/factorio
 version_toml: apps/agones/factorio/version.toml
 runner: ubuntu-latest


### PR DESCRIPTION
## Summary

Stacks on the in-flight v0.0.10 release. Bumps \`agones-factorio\` to **v0.0.11** so the shim change ships in its own image build.

Adds \`FACTORIO_PORTAL_ONLY_MODS\` env (default \`kbve\`) to \`agones-shim.sh\`. Mods listed there are explicitly NOT pre-packaged from \`/opt/factorio/mods-defaults\` at boot — any stale zip is removed first so the portal-sync pass downloads the authoritative copy from https://mods.factorio.com/.

## Why

With the kbve mod now published on the portal, server + clients should both pull from the same portal release so the mod-script-files hash matches on join. Pre-packaging locally drifts as soon as zip metadata or script content differs from the portal artifact — and was the cause of the recent "mod-kbve script files are not identical" connection refusal.

## Behavior

- \`FACTORIO_PORTAL_ONLY_MODS\` is a space-separated list of mod names.
- For each mod under \`/opt/factorio/mods-defaults/\`, the shim checks the list. If matched: any pre-existing \`<name>_*.zip\` or \`<name>/\` directory in \`/factorio/mods/\` is wiped, and the local-packaging step is skipped.
- The standard \`sync_mod\` pass then downloads the named mod from the portal using \`FACTORIO_USERNAME\` + \`FACTORIO_TOKEN\`.
- The mod source still ships into the image at \`/opt/factorio/mods-defaults/kbve\` so an operator can flip the env (\`FACTORIO_PORTAL_ONLY_MODS=""\`) and fall back to local packaging without rebuilding.

## Test plan

- [ ] After this image build deploys, container boot log shows \`[agones-shim] kbve marked portal-only, deferring to mod portal sync\` followed by \`[agones-shim] downloading kbve_0.0.1.zip...\`.
- [ ] Server reaches Ready and clients connect without the \`mod script files are not identical\` error.
- [ ] Toggle env to \`FACTORIO_PORTAL_ONLY_MODS=""\` and confirm local packaging resumes.