### PR TITLE
chore(agones-factorio): bump kbve mod content to v0.0.2

### DIFF
--- a/apps/agones/factorio/mods-local/kbve/changelog.txt
+++ b/apps/agones/factorio/mods-local/kbve/changelog.txt
@@ -1,4 +1,10 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.0.2
+Date: 2026-06-01
+  Changes:
+    - Realigns the portal release with the docker image source so server + clients pulling from mods.factorio.com match on connect.
+    - Server image now defers the kbve mod entirely to the portal sync (FACTORIO_PORTAL_ONLY_MODS=kbve) instead of pre-packaging from local sources.
+---------------------------------------------------------------------------------------------------
 Version: 0.0.1
 Date: 2026-06-01
   Features:

--- a/apps/agones/factorio/mods-local/kbve/info.json
+++ b/apps/agones/factorio/mods-local/kbve/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "kbve",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"factorio_version": "2.0",
 	"title": "KBVE Fleet Commander",
 	"author": "kbve",


### PR DESCRIPTION
## Summary

Bumps the kbve mod content version so the next docker image build's Phase B job uploads a fresh release to https://mods.factorio.com/mod/kbve that matches what the image is actually shipping.

- \`info.json#version\` \`0.0.1\` → \`0.0.2\`
- \`changelog.txt\` gets a \`Version: 0.0.2\` block dated 2026-06-01

## Why

The currently-published portal release is \`kbve_0.0.1\` (from the manual web upload before Phase B CI existed). Since then the image source has gained the Phase 2-4 work and the portal-only shim changes, but \`info.json#version\` stayed at \`0.0.1\` so Phase B's "skip when version already on portal" gate prevented re-publishing. Result: server source ≠ portal source ≠ client zip → \`mod-script files are not identical\` on connect.

Bumping to \`0.0.2\` makes Phase B treat this as a new release. CI uploads \`kbve_0.0.2.zip\` from the current source, the running container (with \`FACTORIO_PORTAL_ONLY_MODS=kbve\`) downloads it, and clients pulling from the portal converge on the same artifact.

## Test plan

- [ ] After merge + image build, watch the \`factorio_mod_portal\` job in the agones-factorio ci-docker run — it should upload \`kbve_0.0.2.zip\`.
- [ ] \`curl -sS https://mods.factorio.com/api/mods/kbve | jq .releases[].version\` should list \`["0.0.1", "0.0.2"]\`.
- [ ] After the new image deploys, server boot log shows \`[agones-shim] kbve marked portal-only\` followed by \`[agones-shim] installed kbve_0.0.2.zip\`.
- [ ] Connecting clients with mod auto-sync converge on \`0.0.2\` and no longer hit the mod-script hash mismatch.

## Notes

- This PR ships on top of the in-flight \`v0.0.11\` docker image (PR #11550). MDX version stays at \`0.0.11\` — this is a mod content bump, not an image bump.
- Once the post-publish sync runs for both \`v0.0.11\` docker and \`v0.0.2\` mod, the loop is fully automated for future content changes.