### PR TITLE
feat(isometric): window state + PauseMenu polish + unread chat badge

### DIFF
--- a/apps/kbve/isometric/src-tauri/Cargo.toml
+++ b/apps/kbve/isometric/src-tauri/Cargo.toml
@@ -91,6 +91,7 @@ log = "0.4"
 tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-deep-link = "2"
+tauri-plugin-window-state = "2"
 urlencoding = "2"
 wgpu = "27"
 pollster = "0.4"

--- a/apps/kbve/isometric/src-tauri/capabilities/default.json
+++ b/apps/kbve/isometric/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
 		"core:window:allow-inner-size",
 		"core:window:allow-maximize",
 		"core:window:allow-unmaximize",
-		"core:window:allow-is-maximized"
+		"core:window:allow-is-maximized",
+		"window-state:default"
 	]
 }

--- a/apps/kbve/isometric/src-tauri/src/game/pause_menu.rs
+++ b/apps/kbve/isometric/src-tauri/src/game/pause_menu.rs
@@ -101,14 +101,36 @@ impl Plugin for PauseMenuPlugin {
     }
 }
 
-fn category_text(cat: SettingsCategory) -> &'static str {
+fn category_text(cat: SettingsCategory, settings: &super::settings::GameSettings) -> String {
     match cat {
-        SettingsCategory::General => "Game settings will be added here.",
-        SettingsCategory::Audio => "Volume controls will be added here.",
-        SettingsCategory::Video => "Resolution and display options will be added here.",
+        SettingsCategory::General => format!(
+            "Player: {}\nVSync: {}\nTransport: {}",
+            crate::auth_common::current_signin_snapshot()
+                .username
+                .unwrap_or_else(|| "Guest".into()),
+            if settings.vsync { "On" } else { "Off" },
+            transport_label(settings.transport_override),
+        ),
+        SettingsCategory::Audio => format!(
+            "Master  {}%\nMusic   {}%\nSfx     {}%\n\nOpen the settings panel from the title screen to adjust.",
+            settings.master_volume, settings.music_volume, settings.sfx_volume,
+        ),
+        SettingsCategory::Video => format!(
+            "VSync: {}\n\nResolution + display options coming soon.",
+            if settings.vsync { "On" } else { "Off" },
+        ),
         SettingsCategory::Controls => {
-            "W/A/S/D \u{2014} Move\nSpace \u{2014} Jump\nI \u{2014} Inventory\nEscape \u{2014} Toggle Menu"
+            "W/A/S/D \u{2014} Move\nSpace \u{2014} Jump\nT or / \u{2014} Chat\nI \u{2014} Inventory\nEscape \u{2014} Toggle Menu"
+                .to_string()
         }
+    }
+}
+
+fn transport_label(t: Option<super::phase::TransportKind>) -> &'static str {
+    match t {
+        None | Some(super::phase::TransportKind::Unknown) => "Auto",
+        Some(super::phase::TransportKind::WebSocket) => "WebSocket",
+        Some(super::phase::TransportKind::WebTransport) => "WebTransport",
     }
 }
 
@@ -121,7 +143,8 @@ fn category_title(cat: SettingsCategory) -> &'static str {
     }
 }
 
-fn spawn_pause_menu(mut commands: Commands) {
+fn spawn_pause_menu(mut commands: Commands, settings: Res<super::settings::GameSettings>) {
+    let settings_snapshot = settings.clone();
     commands
         .spawn((
             Node {
@@ -249,7 +272,10 @@ fn spawn_pause_menu(mut commands: Commands) {
                                 CategoryContent,
                             ));
                             content.spawn((
-                                Text::new(category_text(SettingsCategory::General)),
+                                Text::new(category_text(
+                                    SettingsCategory::General,
+                                    &settings_snapshot,
+                                )),
                                 TextFont {
                                     font_size: 11.0,
                                     ..default()
@@ -361,6 +387,7 @@ fn handle_category_buttons(
     mut all_btns: Query<(&CategoryBtn, &mut BackgroundColor, &Children)>,
     mut text_colors: Query<&mut TextColor>,
     mut content_q: Query<&mut Text, With<CategoryContent>>,
+    settings: Res<super::settings::GameSettings>,
 ) {
     for (interaction, clicked) in &btn_q {
         if *interaction != Interaction::Pressed {
@@ -394,7 +421,7 @@ fn handle_category_buttons(
             **title = category_title(state.category).to_string();
         }
         if let Some(mut body) = iter.next() {
-            **body = category_text(state.category).to_string();
+            **body = category_text(state.category, &settings);
         }
     }
 }

--- a/apps/kbve/isometric/src-tauri/src/main.rs
+++ b/apps/kbve/isometric/src-tauri/src/main.rs
@@ -59,6 +59,15 @@ fn main() {
             builder
                 .plugin(tauri_plugin_opener::init())
                 .plugin(tauri_plugin_deep_link::init())
+                .plugin(
+                    tauri_plugin_window_state::Builder::new()
+                        .with_state_flags(
+                            tauri_plugin_window_state::StateFlags::POSITION
+                                | tauri_plugin_window_state::StateFlags::SIZE
+                                | tauri_plugin_window_state::StateFlags::MAXIMIZED,
+                        )
+                        .build(),
+                )
                 .invoke_handler(tauri::generate_handler![
                     isometric_game::commands::dispatch_action,
                     isometric_game::commands::greet,

--- a/apps/kbve/isometric/src/components/ChatInput.tsx
+++ b/apps/kbve/isometric/src/components/ChatInput.tsx
@@ -99,7 +99,14 @@ export function ChatInput() {
 	const [signedIn, setSignedIn] = useState(false);
 	const [username, setUsername] = useState<string | null>(null);
 	const [log, setLog] = useState<ChatLogEntry[]>([]);
-	const [open, setOpen] = useState(false);
+	// `openState` tracks both the visible state and the snapshot length the
+	// player has acknowledged. Bundling them in one state object keeps the
+	// "open the panel + clear unread" transition atomic and pure (no
+	// during-render setState or ref mutation).
+	const [openState, setOpenState] = useState<{ open: boolean; seen: number }>(
+		{ open: false, seen: 0 },
+	);
+	const { open } = openState;
 	const inputRef = useRef<HTMLInputElement>(null);
 	const logRef = useRef<HTMLDivElement>(null);
 
@@ -123,6 +130,9 @@ export function ChatInput() {
 		};
 	}, []);
 
+	const openChat = () => setOpenState({ open: true, seen: log.length });
+	const closeChat = () => setOpenState({ open: false, seen: log.length });
+
 	useEffect(() => {
 		if (!open) return;
 		const el = logRef.current;
@@ -143,7 +153,7 @@ export function ChatInput() {
 				if (target === inputRef.current && e.key === 'Escape') {
 					e.preventDefault();
 					if (inputRef.current) inputRef.current.value = '';
-					setOpen(false);
+					closeChat();
 				}
 				return;
 			}
@@ -157,9 +167,10 @@ export function ChatInput() {
 			if (isOpenChat && !e.metaKey && !e.ctrlKey && !e.altKey) {
 				e.preventDefault();
 				e.stopPropagation();
-				setOpen((prev) => !prev);
+				if (open) closeChat();
+				else openChat();
 			} else if (e.key === 'Escape' && open) {
-				setOpen(false);
+				closeChat();
 			}
 		};
 		window.addEventListener('keydown', onKeyDown, true);
@@ -187,7 +198,42 @@ export function ChatInput() {
 		}
 	}, []);
 
-	if (!signedIn || !open) return null;
+	if (!signedIn) return null;
+
+	const unread = open ? 0 : Math.max(0, log.length - openState.seen);
+
+	if (!open) {
+		if (unread === 0) return null;
+		return (
+			<button
+				type="button"
+				onClick={openChat}
+				style={{
+					position: 'fixed',
+					left: 12,
+					top: 48,
+					zIndex: 9999,
+					pointerEvents: 'auto',
+					padding: '4px 10px',
+					background: 'rgba(10, 10, 16, 0.86)',
+					border: '1px solid #b83030',
+					borderRadius: 12,
+					color: '#e8d8b8',
+					fontFamily: 'monospace',
+					fontSize: 11,
+					cursor: 'pointer',
+					display: 'flex',
+					alignItems: 'center',
+					gap: 6,
+				}}
+				title="Press T to open chat">
+				<span style={{ color: '#b83030', fontWeight: 'bold' }}>
+					{unread}
+				</span>
+				<span>chat</span>
+			</button>
+		);
+	}
 
 	return (
 		<div
@@ -226,7 +272,7 @@ export function ChatInput() {
 				</span>
 				<button
 					type="button"
-					onClick={() => setOpen(false)}
+					onClick={closeChat}
 					style={{
 						background: 'transparent',
 						border: 'none',


### PR DESCRIPTION
## Summary

Three small feel-of-game improvements bundled as separate commits:

### 1. Tauri window state persistence (\`39660c021\`)
- Add \`tauri-plugin-window-state\` configured for position, size, maximized.
- Capability grant via \`window-state:default\`.
- Game reopens where the player closed it instead of always re-centering at the default 1024×768.

### 2. PauseMenu settings panels go live (\`058cdf1d3\`)
- Replace the four placeholder strings with real readouts driven by \`GameSettings\` + current sign-in.
- General → player nick + vsync + transport.
- Audio → master/music/sfx percentages.
- Video → vsync (more controls noted as TODO).
- Controls → real keybinds including \`T\` or \`/\` for chat.

### 3. Unread chat badge (\`27f722dd8\`)
- ChatInput now stays mounted; when closed AND new messages have arrived past the last seen count, render a compact \`N chat\` pill at the same anchor.
- Clicking the pill, pressing T, or pressing / opens the panel and resets unread → 0.
- Keeps the chrome out of the way during normal play while still surfacing new activity.

## Test plan

- [ ] **Window state**: resize/move the Tauri window, quit, relaunch — window opens in the same place and size.
- [ ] **PauseMenu**: enter game, press Esc, click through General/Audio/Video/Controls. Each panel reflects real values (volumes, transport choice, sign-in nick).
- [ ] **Unread badge**: sign in, send a message from Discord while panel is closed — pill appears in top-left within ~1s with the unread count. T opens the panel, badge disappears.