### PR TITLE
feat(astro-kbve): nest dashboard sidebar — Account + Workspace groups

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -198,8 +198,25 @@ export default defineConfig({
 					collapsed: true,
 					items: [
 						{ label: 'Overview', link: '/dashboard/', attrs: { 'data-auth-visibility': 'auth' } },
-						{ label: 'Profile', link: '/dashboard/profile/', attrs: { 'data-auth-visibility': 'auth' } },
-						{ label: 'Account', link: '/dashboard/account/', attrs: { 'data-auth-visibility': 'auth' } },
+						{
+							label: 'Account',
+							collapsed: true,
+							items: [
+								{ label: 'Profile', link: '/dashboard/profile/', attrs: { 'data-auth-visibility': 'auth' } },
+								{ label: 'Account', link: '/dashboard/account/', attrs: { 'data-auth-visibility': 'auth' } },
+								{ label: 'Marketplace', link: '/dashboard/market/', attrs: { 'data-auth-visibility': 'auth' } },
+							],
+						},
+						{
+							label: 'Workspace',
+							collapsed: true,
+							items: [
+								{ label: 'Kanban', link: '/dashboard/kanban/', attrs: { 'data-auth-visibility': 'auth' } },
+								{ label: 'Report', link: '/dashboard/report/', attrs: { 'data-auth-visibility': 'auth' } },
+								{ label: 'Graph', link: '/dashboard/graph/', attrs: { 'data-auth-visibility': 'auth' } },
+								{ label: 'Security', link: '/dashboard/security/', attrs: { 'data-auth-visibility': 'auth' } },
+							],
+						},
 						{
 							label: 'Agents',
 							collapsed: true,
@@ -209,12 +226,7 @@ export default defineConfig({
 								{ label: 'DiscordSH', link: '/dashboard/agents/discordsh/', attrs: { 'data-auth-visibility': 'auth' } },
 							],
 						},
-						{ label: 'Marketplace', link: '/dashboard/market/', attrs: { 'data-auth-visibility': 'auth' } },
 						{ label: 'API', link: '/dashboard/api/' },
-						{ label: 'Kanban', link: '/dashboard/kanban/', attrs: { 'data-auth-visibility': 'auth' } },
-						{ label: 'Report', link: '/dashboard/report/', attrs: { 'data-auth-visibility': 'auth' } },
-						{ label: 'Graph', link: '/dashboard/graph/', attrs: { 'data-auth-visibility': 'auth' } },
-						{ label: 'Security', link: '/dashboard/security/', attrs: { 'data-auth-visibility': 'auth' } },
 						{ label: 'ArgoCD', link: '/dashboard/argo/', attrs: { 'data-auth-visibility': 'staff' } },
 						{ label: 'ClickHouse', link: '/dashboard/clickhouse/', attrs: { 'data-auth-visibility': 'staff' } },
 						{ label: 'Edge', link: '/dashboard/edge/', attrs: { 'data-auth-visibility': 'auth' } },


### PR DESCRIPTION
## Summary

Cleans up the Dashboard sidebar by peeling two obvious clusters off the long flat list — start small with the obvious wins, leave the ops tooling cluster (ArgoCD / Grafana / ClickHouse / VM / IDE / Edge / Forgejo) for a follow-up once we've felt these out in dogfood.

| Group | Contents |
|-------|----------|
| **Account** (collapsed) | Profile, Account, Marketplace |
| **Workspace** (collapsed) | Kanban, Report, Graph, Security |

Everything else (Overview, Agents, API, the flat ops links, GameOps) stays put. Route paths, \`data-auth-visibility\` gates, and link labels unchanged.

\`nx run astro-kbve:build\` → **7682 pages, 0 errors**. The 3 \`astro check\` errors in \`TowerDefenseScene.ts\` / \`environment/grass.ts\` are pre-existing in dev and untouched by this PR.

## Test plan

- [ ] Sign in → sidebar shows collapsed Account + Workspace groups in that order under Overview
- [ ] Expand Account → Profile / Account / Marketplace each route correctly
- [ ] Expand Workspace → Kanban / Report / Graph / Security each route correctly
- [ ] As anon user → all four \`data-auth-visibility="auth"\` entries inside the new groups are hidden
- [ ] As staff → unchanged: flat ArgoCD / Grafana / VM / IDE / Edge / Forgejo / ClickHouse all visible below Agents