### PR TITLE
fix(astro-kbve): sidebar active-link tracker for persisted sidebar

### DIFF
--- a/apps/kbve/astro-kbve/src/components/navigation/Sidebar.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/Sidebar.astro
@@ -1,17 +1,56 @@
 ---
-/**
- * KBVE Sidebar override — wraps Starlight's default left sidebar in a
- * `transition:persist` container so the DOM survives ClientRouter
- * navigation. Eliminates the cross-fade flicker where the sidebar
- * briefly re-renders between pages: active-link highlight, group
- * collapsed state, and `data-auth-visibility` gates all stay stable
- * across swaps. Starlight's internal JS updates the active-link
- * class via `astro:after-swap` so the sidebar still tracks the
- * current route.
- */
 import Default from '@astrojs/starlight/components/Sidebar.astro';
 ---
 
-<div transition:persist="kbve-sidebar">
+<div transition:persist="kbve-sidebar" data-kbve-sidebar-root>
 	<Default />
 </div>
+
+<script is:inline data-astro-rerun>
+	(function () {
+		const ROOT_SELECTOR = '[data-kbve-sidebar-root]';
+		const normalize = (p) => {
+			if (!p) return '/';
+			let v = p.split('#')[0].split('?')[0];
+			if (v.length > 1 && v.endsWith('/')) v = v.slice(0, -1);
+			return v || '/';
+		};
+		const update = () => {
+			const root = document.querySelector(ROOT_SELECTOR);
+			if (!root) return;
+			const current = normalize(window.location.pathname);
+			const links = root.querySelectorAll('a[href]');
+			let match = null;
+			for (const link of links) {
+				const href = link.getAttribute('href') || '';
+				if (
+					href.startsWith('http') ||
+					href.startsWith('//') ||
+					href.startsWith('mailto:') ||
+					href.startsWith('tel:')
+				) {
+					continue;
+				}
+				if (normalize(href) === current) {
+					link.setAttribute('aria-current', 'page');
+					match = link;
+				} else if (link.getAttribute('aria-current') === 'page') {
+					link.removeAttribute('aria-current');
+				}
+			}
+			if (match) {
+				let parent = match.parentElement;
+				while (parent && parent !== root) {
+					if (parent.tagName === 'DETAILS') parent.open = true;
+					parent = parent.parentElement;
+				}
+			}
+		};
+		update();
+		if (!window.__kbveSidebarBound) {
+			window.__kbveSidebarBound = true;
+			document.addEventListener('astro:after-swap', update);
+			document.addEventListener('astro:page-load', update);
+		}
+	})();
+</script>


### PR DESCRIPTION
## Summary

\`Sidebar.astro\` wraps Starlight's default sidebar in \`transition:persist=\"kbve-sidebar\"\` so the DOM survives ClientRouter swaps — but that defeats Starlight's own server-side \`aria-current=\"page\"\` marker: the highlight from whichever page first rendered the sidebar stays put, so navigating from \`/dashboard/argo/\` to \`/dashboard/gameops/rows/\` leaves **ArgoCD** highlighted under ROWS.

Adds an inline \`data-astro-rerun\` updater that re-runs the exact-match active-link calculation against \`window.location.pathname\` on initial load + every \`astro:after-swap\` / \`astro:page-load\`:

- Normalises trailing slashes + strips hash / query before compare → exact match only, no prefix bleed.
- Skips external / \`mailto:\` / \`tel:\` links.
- Applies \`aria-current=\"page\"\` to the matching link, clears it from whichever link held it before.
- Opens every ancestor \`<details>\` of the matched link so a deeply-nested current page is visible without manual expansion.
- Document listeners bound once via \`window.__kbveSidebarBound\` so the persisted DOM doesn't accumulate handlers across swaps.

\`nx run astro-kbve:build\` → **7682 pages, 0 errors**. The 3 pre-existing \`astro check\` errors in \`TowerDefenseScene.ts\` / \`environment/grass.ts\` are unrelated to this PR.

## Test plan

- [ ] Load \`/dashboard/argo/\` → ArgoCD highlighted
- [ ] Click \`/dashboard/gameops/rows/\` link → ROWS highlighted, ArgoCD cleared
- [ ] GameOps \`<details>\` auto-opens to reveal the active ROWS link if previously collapsed
- [ ] Navigate to an external link (e.g. GitHub) → no aria-current shift, no errors
- [ ] Land on a page with no matching sidebar entry (e.g. an arcade route) → previous aria-current cleared, nothing newly highlighted
- [ ] Refresh on \`/dashboard/gameops/rows/\` → ROWS highlighted on first paint (server render already sets it; this PR doesn't break that path)