### PR TITLE
chore(ci): bump actions/checkout v4 -> v6 in utils-external-publish

### DIFF
--- a/.github/workflows/utils-external-publish.yml
+++ b/.github/workflows/utils-external-publish.yml
@@ -626,7 +626,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Resolve mod metadata
               id: meta


### PR DESCRIPTION
## Summary
Closes the gap dependabot flagged in #11565. The repo standardized on \`actions/checkout@v6\` (101 references) — \`utils-external-publish.yml\` had one straggler at \`@v4\` on the Factorio mod-publish job. Bump it to match.

## Diff
One-line bump:
\`\`\`diff
- - uses: actions/checkout@v4
+ - uses: actions/checkout@v6
\`\`\`

## Compatibility notes
- v5 → v6 moves persisted credentials under \`$RUNNER_TEMP\` instead of the local git config; transparent for our existing \`gh\` / \`git\` usage downstream.
- v6 requires runner v2.327.1+; every workflow already on v6 confirms our runners are fine.

## Follow-up
Close dependabot #11565 after merge.