### PR TITLE
feat(kbve): sell kbve-spider-egg in the Exchange (v0.0.3)

### DIFF
--- a/apps/agones/factorio/mods-local/kbve/changelog.txt
+++ b/apps/agones/factorio/mods-local/kbve/changelog.txt
@@ -1,4 +1,14 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.0.3
+Date: 2026-06-01
+  Features:
+    - KBVE Exchange now stocks Spider Eggs (kbve-spider-egg) at 100 coins each.
+      Eggs hatch into ally spiders on the buyer's force after 30 seconds.
+  Dependencies:
+    - Added optional dependency on `kbve-spider`. Without that mod loaded the
+      exchange row silently skips the entry (existing `if proto then` guard in
+      exchange_gui.lua handles it).
+---------------------------------------------------------------------------------------------------
 Version: 0.0.2
 Date: 2026-06-01
   Changes:

--- a/apps/agones/factorio/mods-local/kbve/info.json
+++ b/apps/agones/factorio/mods-local/kbve/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "kbve",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"factorio_version": "2.0",
 	"title": "KBVE Fleet Commander",
 	"author": "kbve",
@@ -13,6 +13,7 @@
 		"? space-age",
 		"? aai-programmable-vehicles",
 		"? aai-zones",
-		"? aai-industry"
+		"? aai-industry",
+		"? kbve-spider"
 	]
 }

--- a/apps/agones/factorio/mods-local/kbve/modules/market.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/market.lua
@@ -30,6 +30,7 @@ Market.ITEMS = {
 	{ item = 'defender-capsule', price = 40, count = 10 },
 	{ item = 'distractor-capsule', price = 150, count = 5 },
 	{ item = 'destroyer-capsule', price = 300, count = 5 },
+	{ item = 'kbve-spider-egg', price = 100, count = 1 },
 	{ item = 'modular-armor', price = 500, count = 1 },
 	{ item = 'roboport', price = 500, count = 1 },
 	{ item = 'power-armor', price = 2000, count = 1 },


### PR DESCRIPTION
## Summary

Adds **Spider Egg** (\`kbve-spider-egg\`) to the KBVE Exchange catalog so players can buy them with coins instead of needing \`/editor\` access. Eggs hatch into ally spiders on the buyer's force ~30s after placement (see kbve-spider \`control.lua\` hatch loop).

| Change | File |
| --- | --- |
| New shop entry: \`{ item = 'kbve-spider-egg', price = 100, count = 1 }\` between destroyer-capsule and modular-armor in the combat-tier band. | \`apps/agones/factorio/mods-local/kbve/modules/market.lua\` |
| Bump mod to \`0.0.3\`, add \`? kbve-spider\` optional dep. | \`apps/agones/factorio/mods-local/kbve/info.json\` |
| Changelog entry. | \`apps/agones/factorio/mods-local/kbve/changelog.txt\` |

## Soft-dependency safety

\`exchange_gui.lua:34\` already guards each row with \`if proto then ... end\` (the \`prototypes.item[entry.item]\` lookup). Servers without \`kbve-spider\` loaded will see the row silently disappear — no crash, no broken layout.

## Publish loop

The Factorio mod portal CI matrix from #11554 will pick up the \`0.0.3\` bump on the next \`agones-factorio\` CI run and auto-publish to mods.factorio.com (gate compares \`info.json::version\` against \`/api/mods/kbve\`).

## Test plan

- [ ] CI: \`pnpm nx run agones-factorio:container\` builds clean.
- [ ] CI: \`pnpm nx run agones-factorio:e2e\` — server reaches \`Hosting game\` with \`kbve\` 0.0.3 + \`kbve-spider\` 0.2.0 both loaded.
- [ ] Manual: \`/c game.players[1].insert{name='coin', count=200}\` → open Exchange → Spider Egg row visible at 100 coins → buy → place egg → 30s later ally spider hatches.