### PR TITLE
chore(deps): drop @peculiar/webcrypto — Node 24 + happy-dom 20 provide Web Crypto natively

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
 		"@hcaptcha/react-hcaptcha": "^2.0.2",
 		"@hookform/resolvers": "^5.2.2",
 		"@novnc/novnc": "1.5.0",
-		"@peculiar/webcrypto": "^1.5.0",
 		"@phaserjs/rapier-connector": "^1.0.2",
 		"@pixiv/three-vrm": "^3.5.3",
 		"@react-three/drei": "^10.7.7",

--- a/packages/npm/khashvault/src/test-setup.ts
+++ b/packages/npm/khashvault/src/test-setup.ts
@@ -1,6 +1,1 @@
-import { Crypto } from '@peculiar/webcrypto';
 import 'fake-indexeddb/auto';
-
-// Polyfill Web Crypto API for test environment
-const crypto = new Crypto();
-Object.defineProperty(globalThis, 'crypto', { value: crypto });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,9 +70,6 @@ importers:
       '@novnc/novnc':
         specifier: 1.5.0
         version: 1.5.0
-      '@peculiar/webcrypto':
-        specifier: ^1.5.0
-        version: 1.5.0
       '@phaserjs/rapier-connector':
         specifier: ^1.0.2
         version: 1.0.2
@@ -4138,17 +4135,6 @@ packages:
     resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
     engines: {node: '>= 10.0.0'}
 
-  '@peculiar/asn1-schema@2.6.0':
-    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
-
-  '@peculiar/json-schema@1.1.12':
-    resolution: {integrity: sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==}
-    engines: {node: '>=8.0.0'}
-
-  '@peculiar/webcrypto@1.5.0':
-    resolution: {integrity: sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==}
-    engines: {node: '>=10.12.0'}
-
   '@phaserjs/rapier-connector@1.0.2':
     resolution: {integrity: sha512-BZonkC7Pm6gzu1ylG7yoqzn8XEJvaZePGXjnb0atSe1pXmKc/WDPLn8BbUp96tP9MRlhKalbwgXLxMMnzwsHYA==}
 
@@ -7164,10 +7150,6 @@ packages:
 
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-
-  asn1js@3.0.7:
-    resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
-    engines: {node: '>=12.0.0'}
 
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
@@ -13225,13 +13207,6 @@ packages:
   pure-rand@8.4.0:
     resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
 
-  pvtsutils@1.3.6:
-    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
-
-  pvutils@1.1.5:
-    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
-    engines: {node: '>=16.0.0'}
-
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
     hasBin: true
@@ -15969,9 +15944,6 @@ packages:
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
-
-  webcrypto-core@1.8.1:
-    resolution: {integrity: sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==}
 
   webgl-constants@1.1.1:
     resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
@@ -21637,24 +21609,6 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.4.1
     optional: true
 
-  '@peculiar/asn1-schema@2.6.0':
-    dependencies:
-      asn1js: 3.0.7
-      pvtsutils: 1.3.6
-      tslib: 2.8.1
-
-  '@peculiar/json-schema@1.1.12':
-    dependencies:
-      tslib: 2.8.1
-
-  '@peculiar/webcrypto@1.5.0':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/json-schema': 1.1.12
-      pvtsutils: 1.3.6
-      tslib: 2.8.1
-      webcrypto-core: 1.8.1
-
   '@phaserjs/rapier-connector@1.0.2': {}
 
   '@phenomnomnominal/tsquery@6.2.0(typescript@5.9.3)':
@@ -25471,12 +25425,6 @@ snapshots:
   asn1@0.2.6:
     dependencies:
       safer-buffer: 2.1.2
-
-  asn1js@3.0.7:
-    dependencies:
-      pvtsutils: 1.3.6
-      pvutils: 1.1.5
-      tslib: 2.8.1
 
   assert-plus@1.0.0: {}
 
@@ -33338,12 +33286,6 @@ snapshots:
 
   pure-rand@8.4.0: {}
 
-  pvtsutils@1.3.6:
-    dependencies:
-      tslib: 2.8.1
-
-  pvutils@1.1.5: {}
-
   qrcode-terminal@0.11.0:
     optional: true
 
@@ -36498,14 +36440,6 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   web-worker@1.5.0: {}
-
-  webcrypto-core@1.8.1:
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/json-schema': 1.1.12
-      asn1js: 3.0.7
-      pvtsutils: 1.3.6
-      tslib: 2.8.1
 
   webgl-constants@1.1.1: {}
 


### PR DESCRIPTION
## Summary
Resolves dependabot #11568 by **removing** the dep instead of bumping 1.5.0 → 1.7.1. The only consumer was \`packages/npm/khashvault/src/test-setup.ts\`, which polyfilled \`globalThis.crypto\` for vitest under happy-dom. Both layers ship native Web Crypto now:
- Node 24 (workspace runtime) — \`subtle\` / \`getRandomValues\` on \`globalThis\`.
- happy-dom 20.8.9 (vitest env) — full \`crypto\` + \`subtle\`.

So the polyfill is dead weight.

## Diff
- \`package.json\` — drop \`"@peculiar/webcrypto": "^1.5.0"\`.
- \`pnpm-lock.yaml\` — −66 lines (the package + its transitives).
- \`packages/npm/khashvault/src/test-setup.ts\` — now just \`import 'fake-indexeddb/auto';\`.

## Validation
- [x] \`nx run khashvault:test\` — 8 test files / 48 tests pass.
- [x] Crypto-heavy suites green: \`aes\`, \`kdf\`, \`pgp\`, \`keys\`, \`hash\`.

## Follow-up
Close dependabot #11568 after merge.