### PR TITLE
feat(agones-factorio): safe rotation — preStop RCON announce + save flush + drift watcher

### DIFF
--- a/apps/agones/factorio/Dockerfile
+++ b/apps/agones/factorio/Dockerfile
@@ -4,15 +4,16 @@ FROM factoriotools/factorio:${FACTORIO_VERSION}-rootless
 USER root
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget jq ca-certificates zip && \
+    apt-get install -y --no-install-recommends wget jq ca-certificates zip python3-minimal && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --chown=1000:1000 apps/agones/factorio/config /opt/factorio/config-defaults
 COPY --chown=1000:1000 apps/agones/factorio/mods /opt/factorio/mods-defaults
 COPY --chown=1000:1000 apps/agones/factorio/mods-local/kbve /opt/factorio/mods-defaults/kbve
 COPY apps/agones/factorio/shim/agones-shim.sh /usr/local/bin/agones-shim
+COPY apps/agones/factorio/shim/agones-shim-prestop.sh /usr/local/bin/agones-shim-prestop
 
-RUN chmod +x /usr/local/bin/agones-shim && \
+RUN chmod +x /usr/local/bin/agones-shim /usr/local/bin/agones-shim-prestop && \
     mkdir -p /shared/log /factorio/config /factorio/mods /factorio/scenarios && \
     ln -sfn /opt/factorio/mods-defaults/kbve/scenarios/kbve /factorio/scenarios/kbve && \
     chown -R 1000:1000 /shared/log /factorio/config /factorio/mods /factorio/scenarios

--- a/apps/agones/factorio/shim/agones-shim-prestop.sh
+++ b/apps/agones/factorio/shim/agones-shim-prestop.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+set -eu
+
+RCON_HOST="${FACTORIO_RCON_BIND:-127.0.0.1}"
+RCON_PORT="${FACTORIO_RCON_PORT:-27015}"
+RCON_PASS="${FACTORIO_RCON_PASSWORD:-}"
+CONSOLE_LOG="${FACTORIO_CONSOLE_LOG:-/shared/log/console.log}"
+PRESTOP_WARN_SECS="${PRESTOP_WARN_SECS:-60}"
+PRESTOP_SAVE_TIMEOUT="${PRESTOP_SAVE_TIMEOUT:-30}"
+
+if [ -z "$RCON_PASS" ]; then
+    echo "[prestop] FACTORIO_RCON_PASSWORD unset — skipping graceful save"
+    exit 0
+fi
+
+rcon() {
+    PYTHONUNBUFFERED=1 python3 - "$RCON_HOST" "$RCON_PORT" "$RCON_PASS" "$1" <<'PY' || true
+import socket, struct, sys
+host, port, pw, cmd = sys.argv[1], int(sys.argv[2]), sys.argv[3], sys.argv[4]
+def pkt(rid, t, body):
+    p = struct.pack('<ii', rid, t) + body.encode() + b'\x00\x00'
+    return struct.pack('<i', len(p)) + p
+def recv_n(s, n):
+    buf = b''
+    while len(buf) < n:
+        c = s.recv(n - len(buf))
+        if not c: raise EOFError
+        buf += c
+    return buf
+def recv_pkt(s):
+    sz = struct.unpack('<i', recv_n(s, 4))[0]
+    return recv_n(s, sz)
+s = socket.create_connection((host, port), timeout=5)
+s.send(pkt(1, 3, pw))
+recv_pkt(s)
+s.send(pkt(2, 2, cmd))
+print(recv_pkt(s)[8:-2].decode(errors='replace'))
+s.close()
+PY
+}
+
+now_epoch() { date +%s; }
+
+countdown() {
+    total="$1"
+    elapsed=0
+    while [ "$elapsed" -lt "$total" ]; do
+        remaining=$((total - elapsed))
+        if [ "$remaining" -gt 30 ]; then step=15
+        elif [ "$remaining" -gt 10 ]; then step=10
+        else step=5
+        fi
+        rcon "/silent-command game.print('[KBVE] Server restarting in ${remaining}s for an update — your progress will be saved.')" >/dev/null
+        if [ "$step" -ge "$remaining" ]; then
+            sleep "$remaining"
+            elapsed=$total
+        else
+            sleep "$step"
+            elapsed=$((elapsed + step))
+        fi
+    done
+}
+
+wait_for_save() {
+    timeout_at=$(( $(now_epoch) + PRESTOP_SAVE_TIMEOUT ))
+    [ -f "$CONSOLE_LOG" ] || return 0
+    start_size=$(wc -c < "$CONSOLE_LOG" 2>/dev/null || echo 0)
+    while [ "$(now_epoch)" -lt "$timeout_at" ]; do
+        if [ "$start_size" -gt 0 ]; then
+            tail -c +$((start_size + 1)) "$CONSOLE_LOG" 2>/dev/null | grep -q 'Saving finished' && return 0
+        else
+            grep -q 'Saving finished' "$CONSOLE_LOG" 2>/dev/null && return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+echo "[prestop] starting graceful rotation"
+countdown "$PRESTOP_WARN_SECS"
+rcon "/silent-command game.print('[KBVE] Saving map now…')" >/dev/null
+rcon "/server-save" >/dev/null
+if wait_for_save; then
+    echo "[prestop] save confirmed in console log"
+else
+    echo "[prestop] save confirmation timed out after ${PRESTOP_SAVE_TIMEOUT}s — proceeding to SIGTERM anyway"
+fi
+rcon "/silent-command game.print('[KBVE] Restart now. See you in a minute.')" >/dev/null
+echo "[prestop] done"
+exit 0

--- a/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx
@@ -13,7 +13,7 @@ tags:
 key: agones_factorio
 pipeline: docker
 app_name: agones-factorio
-version: "0.0.11"
+version: "0.0.12"
 source_path: apps/agones/factorio
 version_toml: apps/agones/factorio/version.toml
 runner: ubuntu-latest

--- a/apps/kube/agones/factorio/manifests/gameserver.yaml
+++ b/apps/kube/agones/factorio/manifests/gameserver.yaml
@@ -26,6 +26,7 @@ spec:
                 app: factorio
                 app.kubernetes.io/part-of: factorio
         spec:
+            terminationGracePeriodSeconds: 120
             securityContext:
                 runAsNonRoot: true
                 runAsUser: 1000
@@ -120,6 +121,11 @@ spec:
                       capabilities:
                           drop:
                               - ALL
+                  lifecycle:
+                      preStop:
+                          exec:
+                              command:
+                                  - /usr/local/bin/agones-shim-prestop
                 - name: factorio-relay
                   image: ghcr.io/kbve/agones-factorio-relay:0.0.5
                   imagePullPolicy: IfNotPresent

--- a/apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
+++ b/apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
@@ -1,0 +1,67 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+    name: factorio-rotator
+    namespace: factorio
+spec:
+    schedule: '*/5 * * * *'
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 3
+    jobTemplate:
+        spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 3600
+            template:
+                spec:
+                    serviceAccountName: factorio-rotator
+                    restartPolicy: Never
+                    securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 65532
+                        runAsGroup: 65532
+                        seccompProfile:
+                            type: RuntimeDefault
+                    containers:
+                        - name: rotator
+                          image: bitnami/kubectl:1.31
+                          imagePullPolicy: IfNotPresent
+                          securityContext:
+                              allowPrivilegeEscalation: false
+                              capabilities:
+                                  drop:
+                                      - ALL
+                              readOnlyRootFilesystem: true
+                          command:
+                              - /bin/bash
+                              - -c
+                              - |
+                                  set -euo pipefail
+                                  NS=factorio
+                                  GS=factorio
+                                  desired=$(kubectl -n "$NS" get gs/"$GS" -o jsonpath='{.spec.template.spec.containers[?(@.name=="factorio")].image}' 2>/dev/null || true)
+                                  running=$(kubectl -n "$NS" get pod/"$GS" -o jsonpath='{.spec.containers[?(@.name=="factorio")].image}' 2>/dev/null || true)
+                                  state=$(kubectl -n "$NS" get gs/"$GS" -o jsonpath='{.status.state}' 2>/dev/null || true)
+                                  echo "desired=${desired} running=${running} state=${state}"
+                                  if [ -z "$desired" ] || [ -z "$running" ]; then
+                                    echo "missing gs or pod — nothing to rotate"
+                                    exit 0
+                                  fi
+                                  if [ "$desired" = "$running" ]; then
+                                    echo "images match — no rotation needed"
+                                    exit 0
+                                  fi
+                                  if [ "$state" != "Ready" ] && [ "$state" != "Allocated" ]; then
+                                    echo "gs not Ready/Allocated (state=${state}) — skipping rotate, will retry next tick"
+                                    exit 0
+                                  fi
+                                  echo "image drift detected: ${running} -> ${desired}; rotating"
+                                  kubectl -n "$NS" delete gs/"$GS" --timeout=180s
+                                  echo "delete sent; ArgoCD selfHeal will recreate from ${desired}"
+                          resources:
+                              requests:
+                                  cpu: 25m
+                                  memory: 64Mi
+                              limits:
+                                  cpu: 100m
+                                  memory: 128Mi

--- a/apps/kube/agones/factorio/manifests/rotation-rbac.yaml
+++ b/apps/kube/agones/factorio/manifests/rotation-rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: factorio-rotator
+    namespace: factorio
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: factorio-rotator
+    namespace: factorio
+rules:
+    - apiGroups: ['']
+      resources: ['pods']
+      verbs: ['get', 'list']
+    - apiGroups: ['agones.dev']
+      resources: ['gameservers']
+      verbs: ['get', 'list', 'delete']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: factorio-rotator
+    namespace: factorio
+subjects:
+    - kind: ServiceAccount
+      name: factorio-rotator
+      namespace: factorio
+roleRef:
+    kind: Role
+    name: factorio-rotator
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary

Three pieces wired together so every future image bump rolls cleanly without wiping the map or cold-cutting an active session:

1. **preStop hook on the factorio container** announces the restart 60 s out, forces a synchronous \`/server-save\` via RCON, waits for \`Saving finished\` in the console log, then exits so Kubelet sends SIGTERM. The existing SIGTERM handler does a redundant second flush.
2. **CronJob watcher** every 5 min compares \`gs/factorio.spec.containers[factorio].image\` against \`pod/factorio.spec.containers[factorio].image\`. If they differ AND the GS is \`Ready\` or \`Allocated\`, it \`kubectl delete gs/factorio\`. ArgoCD selfHeal recreates from the new spec, the preStop runs, players are warned and saved, new pod boots on the same PVC.
3. **Scoped RBAC** (Role + RoleBinding in the \`factorio\` namespace). No cluster-wide access. Just \`get,list\` on pods and \`get,list,delete\` on \`gameservers.agones.dev\`.

## Files

| Path | Change |
|---|---|
| \`apps/agones/factorio/shim/agones-shim-prestop.sh\` | New. POSIX sh + python3 stdlib socket for RCON. \`PRESTOP_WARN_SECS\` and \`PRESTOP_SAVE_TIMEOUT\` are env-overridable (default 60 / 30). |
| \`apps/agones/factorio/Dockerfile\` | Adds \`python3-minimal\` to apt install. Copies + chmods the new prestop binary. |
| \`apps/kube/agones/factorio/manifests/gameserver.yaml\` | \`terminationGracePeriodSeconds: 120\`, \`lifecycle.preStop.exec.command\` on the factorio container. |
| \`apps/kube/agones/factorio/manifests/rotation-rbac.yaml\` | New ServiceAccount + Role + RoleBinding. |
| \`apps/kube/agones/factorio/manifests/rotation-cronjob.yaml\` | New CronJob. Bitnami kubectl image, read-only rootfs, non-root, drop ALL caps. |
| \`apps/kbve/astro-kbve/.../agones-factorio.mdx\` | Bump \`version: 0.0.12\` so the new image builds. |

## Why a CronJob and not Reloader

Agones \`GameServer\` is mostly immutable. Reloader knows Deployments / StatefulSets / DaemonSets — not the GameServer CRD. A small polling Job that does \`kubectl delete\` is the simplest path that respects the GS lifecycle. The CronJob exits cleanly during boot (\`state != Ready\`) and waits for the next tick, so it can't race the 60-90 s startup window when mods are still downloading.

## Test plan

- [ ] After this PR's image (\`v0.0.12\`) lands, \`kubectl exec -n factorio factorio -c factorio -- ls /usr/local/bin/agones-shim-prestop\` is present.
- [ ] Manually rotate: \`kubectl delete gs/factorio -n factorio\`. Watch the preStop print the countdown to in-game chat; new pod boots on \`v0.0.12\`.
- [ ] Cut a hypothetical \`v0.0.13\` (any small change). ArgoCD updates the spec to \`:0.0.13\`. Within 5 min the rotator job runs, sees \`desired != running\`, and rotates. Verify the in-game chat shows the announce + save lines before disconnect.
- [ ] Confirm save PVC content survives the rotate (\`/factorio/saves/_autosave1.zip\` mtime updates before SIGTERM; new pod loads it).