### PR TITLE
fix(ci): install playwright browsers in npm-test-package — fixes #11530

### DIFF
--- a/.github/workflows/npm-test-package.yml
+++ b/.github/workflows/npm-test-package.yml
@@ -46,7 +46,22 @@ jobs:
                       ${{ runner.os }}-pnpm-store-
 
             - name: Install pnpm Dependencies
-              run: pnpm install --frozen-lockfile
+              timeout-minutes: 10
+              env:
+                  UV_THREADPOOL_SIZE: '16'
+              run: pnpm install --frozen-lockfile --prefer-offline
+
+            # Every NPM package the dispatcher fans into this workflow
+            # (devops, droid, khashvault, laser) has a sibling `<pkg>-e2e`
+            # Playwright suite, so always install chromium up front. The
+            # `pnpm install` step's UV_THREADPOOL_SIZE bump carries over to
+            # avoid the chromium-extract libuv-threadpool deadlock seen in
+            # earlier runs.
+            - name: Install Playwright Browsers
+              timeout-minutes: 15
+              env:
+                  UV_THREADPOOL_SIZE: '16'
+              run: pnpm exec playwright install --with-deps chromium
 
             - name: Nx e2e ${{ inputs.project }}
               run: pnpm nx e2e ${{ inputs.project }} --no-cloud


### PR DESCRIPTION
## Summary
\`CI - Publish / npm/laser\` (#11530) was failing 100% of the time on every Playwright test in \`laser-e2e\` with:

\`\`\`
Error: browserType.launch: Executable doesn't exist at
/home/runner/.cache/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell-linux64/chrome-headless-shell
\`\`\`

\`.github/workflows/npm-test-package.yml\` runs \`pnpm nx e2e <project>\` which boots the package's Playwright suite, but never invokes \`pnpm exec playwright install\`. So the chrome-headless-shell binary was missing on every fresh \`ubuntu-latest\` runner, and chromium failed at launch.

## Fix
Add a \`Install Playwright Browsers\` step before the \`nx e2e\` step. Every NPM package the dispatcher fans through this workflow (\`devops\`, \`droid\`, \`khashvault\`, \`laser\`) has a sibling \`<pkg>-e2e\` Playwright project, so the install is required unconditionally — no need for a per-package input flag.

The install step is hardened the same way \`docker-test-app.yml\` was after the libuv-threadpool deadlocks earlier this month:
- \`UV_THREADPOOL_SIZE=16\` on both \`pnpm install\` and \`playwright install\` steps so the chromium-extract path has enough worker threads to avoid the \`libwidevinecdm.so\` deadlock.
- Step-level \`timeout-minutes\` (10 / 15) so a future hang fails fast instead of burning the job-level budget.
- \`--frozen-lockfile --prefer-offline\` on \`pnpm install\` for cache-warm + deterministic resolution.

## Validation
- [ ] Trigger a manual \`ci-publish\` run for \`laser\` after merge, confirm Playwright launches successfully and the laser-e2e suite executes.
- [ ] Same for \`devops\`, \`droid\`, \`khashvault\` — they share the workflow.

## Out of scope
Dropping the third-party \`@phaserjs/rapier-connector\` for an in-house rapier wiring is a separate change; \`packages/npm/laser/src/lib/physics/rapier.ts\` is currently a 1-line re-export, so it doesn't block this fix.