### PR TITLE
fix(astro-kbve): make ArgoCD dashboard rows tappable on mobile

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
@@ -28,6 +28,25 @@ import {
 	Clock,
 } from 'lucide-react';
 
+const ARGO_TABLE_CSS = `
+.kbve-argo-row {
+	display: grid;
+	grid-template-columns: 24px 1fr 100px 120px 120px 180px;
+}
+.kbve-argo-header {
+	display: grid;
+}
+@media (max-width: 768px) {
+	.kbve-argo-row {
+		grid-template-columns: 24px 1fr auto auto;
+	}
+	.kbve-argo-col-project,
+	.kbve-argo-col-last {
+		display: none;
+	}
+}
+`;
+
 function StallBadge({
 	reason,
 	ageMs,
@@ -192,7 +211,8 @@ function ResourceRow({
 	};
 	return (
 		<>
-			<div
+			<button
+				type="button"
 				onClick={() => onSelectResource(sel)}
 				style={{
 					display: 'flex',
@@ -208,6 +228,12 @@ function ResourceRow({
 						? 'rgba(139, 92, 246, 0.12)'
 						: 'transparent',
 					transition: 'background 0.12s',
+					border: 'none',
+					textAlign: 'left',
+					width: '100%',
+					font: 'inherit',
+					touchAction: 'manipulation',
+					WebkitTapHighlightColor: 'transparent',
 				}}
 				onMouseEnter={(e) => {
 					if (!selected) {
@@ -258,7 +284,7 @@ function ResourceRow({
 						</span>
 					) : null;
 				})()}
-			</div>
+			</button>
 			{selected && (
 				<ReactArgoResourceDetail
 					token={token}
@@ -812,15 +838,24 @@ function ApplicationRow({
 				marginBottom: 8,
 				transition: 'background 0.2s',
 			}}>
-			<div
+			<button
+				type="button"
 				onClick={onToggle}
+				className="kbve-argo-row"
+				aria-expanded={expanded}
 				style={{
-					display: 'grid',
-					gridTemplateColumns: '24px 1fr 100px 120px 120px 180px',
 					alignItems: 'center',
 					padding: '0.75rem 1rem',
 					cursor: 'pointer',
 					gap: 8,
+					background: 'transparent',
+					border: 'none',
+					color: 'inherit',
+					font: 'inherit',
+					textAlign: 'left',
+					width: '100%',
+					touchAction: 'manipulation',
+					WebkitTapHighlightColor: 'transparent',
 				}}>
 				<span style={{ color: 'var(--sl-color-gray-4, #6b7280)' }}>
 					{expanded ? (
@@ -837,6 +872,10 @@ function ApplicationRow({
 						fontWeight: 600,
 						color: 'var(--sl-color-text, #e6edf3)',
 						fontSize: '0.9rem',
+						minWidth: 0,
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
 					}}>
 					{app.metadata.name}
 					{(() => {
@@ -851,6 +890,7 @@ function ApplicationRow({
 					})()}
 				</span>
 				<span
+					className="kbve-argo-col-project"
 					style={{
 						color: 'var(--sl-color-gray-4, #6b7280)',
 						fontSize: '0.8rem',
@@ -868,13 +908,14 @@ function ApplicationRow({
 					iconFn={healthIcon}
 				/>
 				<span
+					className="kbve-argo-col-last"
 					style={{
 						color: 'var(--sl-color-gray-4, #6b7280)',
 						fontSize: '0.75rem',
 					}}>
 					{lastSync}
 				</span>
-			</div>
+			</button>
 			{expanded && (
 				<AppExpandedPanel
 					app={app}
@@ -952,11 +993,11 @@ export default function ReactArgoAppTable() {
 
 	return (
 		<>
+			<style>{ARGO_TABLE_CSS}</style>
 			{/* Table header */}
 			<div
+				className="kbve-argo-row kbve-argo-header"
 				style={{
-					display: 'grid',
-					gridTemplateColumns: '24px 1fr 100px 120px 120px 180px',
 					padding: '0 1rem 0.5rem',
 					fontSize: '0.7rem',
 					fontWeight: 600,
@@ -967,10 +1008,10 @@ export default function ReactArgoAppTable() {
 				}}>
 				<span></span>
 				<span>Name</span>
-				<span>Project</span>
+				<span className="kbve-argo-col-project">Project</span>
 				<span>Sync</span>
 				<span>Health</span>
-				<span>Last Sync</span>
+				<span className="kbve-argo-col-last">Last Sync</span>
 			</div>
 
 			{/* Application rows */}


### PR DESCRIPTION
## Summary

The ArgoCD dashboard rendered clickable rows as \`<div onClick>\` with a fixed \`24px 1fr 100px 120px 120px 180px\` grid (~544 px min). Combined, the row failed on phones for three reasons:

1. **iOS Safari + \`<div onClick>\`** — treats unstyled divs as non-interactive for tap purposes more often than a real \`<button>\`, and bakes in the legacy ~300 ms tap delay.
2. **Grid overflows phone viewports** — the row scrolls horizontally, so the chevron + click hit-area drift off the visible page and taps land on sibling rows or empty space.
3. **\`client:only=\"react\"\` re-hydration race** — re-mounts on every ClientRouter swap. On a slower mobile CPU there's a brief window where the DOM is painted but handlers aren't attached yet. Desktop is fast enough that it's invisible.

## Changes

- App row header + resource-tree row → real \`<button type=\"button\">\` with \`aria-expanded\` + \`touch-action: manipulation\` + \`-webkit-tap-highlight-color: transparent\`. Tap is treated as a click immediately, no 300 ms delay, no grey flash.
- Grid moved from inline style into a single injected \`<style>\` block. Class \`.kbve-argo-row\` carries the desktop 6-column grid and a mobile 4-column collapse (chevron + name + sync + health) under \`@media (max-width: 768px)\`. The Project + Last Sync columns are hidden on phones — there isn't room for them, and they're available again as soon as the row expands.
- Ellipsis + \`min-width: 0\` on the name cell so long app names don't push the row wider than the viewport.

Expand behaviour, resource tree, and the desktop look are unchanged.

\`nx run astro-kbve:build\` → **7682 pages, 0 errors**.

## Test plan

- [ ] Desktop \`/dashboard/argo/\` → rows still 6 columns, click expand/collapse works
- [ ] Phone (or DevTools mobile emulation) → row collapses to 4 columns, no horizontal scroll, tap on the row expands cleanly
- [ ] Long app names → name ellipses cleanly without spilling the grid
- [ ] Tap on a resource inside an expanded app → opens the detail panel, no double-tap needed
- [ ] Keyboard \`Tab\` lands on each row, \`Enter\` / \`Space\` toggles expand (free with the \`<button>\` swap)