### PR TITLE
feat(kbve-spider): locale + mod settings + migrations scaffold

### DIFF
--- a/apps/factorio/mods/kbve-spider/README.md
+++ b/apps/factorio/mods/kbve-spider/README.md
@@ -21,18 +21,36 @@ Custom pre-rendered isometric spider for Factorio 2.0. Drops in as a hostile `un
 kbve-spider/
 ├── info.json
 ├── data.lua
+├── settings.lua            # runtime + startup mod settings
+├── control.lua             # event hooks (hatch loop, hit reactions, sprint, flee, nervous)
 ├── changelog.txt
 ├── README.md
+├── thumbnail.png           # 144×144 mod-portal listing image
+├── locale/en/
+│   └── kbve-spider.cfg     # entity/item/setting names + descriptions
+├── migrations/
+│   └── README.md           # add <version>.lua here when storage shape changes
 ├── prototypes/
-│   └── spider.lua          # unit prototype + rotated animation helper
-├── graphics/entity/spider/ # baked direction-major sheets (Body + Shadow per anim)
-│   ├── Idle_Body.png
-│   ├── Idle_Shadow.png
-│   ├── Walk_Body.png
-│   └── ...
-└── tools/
-    └── bake_sheets.py      # source per-direction sheets → Factorio sheets
+│   └── spider.lua          # entity + corpse + sticker prototypes
+├── graphics/
+│   ├── icon.png            # 64×64 single-frame icon for HUD / alerts
+│   ├── item/spider-egg.png # egg sprite
+│   └── entity/spider/      # 16-direction body + shadow sheets per animation
+└── tools/                  # bake_sheets / optimize_pngs / test_mod / build_zip / make_icon
 ```
+
+## Mod settings
+
+Configurable in **Mod settings → Map** (runtime-global) and **Settings → Mods** (startup):
+
+| Setting                               | Type    | Default | Tunes                                                        |
+| ------------------------------------- | ------- | ------- | ------------------------------------------------------------ |
+| `kbve-spider-hatch-seconds`           | runtime | 30      | Seconds between placing a Spider Egg and the Ally hatching.  |
+| `kbve-spider-sprint-chance`           | runtime | 0.45    | Probability per 3-second tick that a chasing spider sprints. |
+| `kbve-spider-flee-health-threshold`   | runtime | 0.3     | Fraction of max HP below which a spider switches to `flee`.  |
+| `kbve-spider-nervous-pick-count`      | runtime | 3       | Random idle spiders that twitch every 15-second pass.        |
+| `kbve-spider-sprint-speed-multiplier` | startup | 1.9     | Sprint sticker movement modifier (baked into the prototype). |
+| `kbve-spider-ally-max-health`         | startup | 60      | Ally spider HP (wild spider stays at 80).                    |
 
 ## nx targets
 

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -12,7 +12,6 @@
 local SPIDER = "kbve-spider"
 local SPIDER_ALLY = "kbve-spider-ally"
 local EGG_ENTITY = "kbve-spider-egg-entity"
-local HATCH_TICKS = 60 * 30
 
 local SPIDER_NAMES = { [SPIDER] = true, [SPIDER_ALLY] = true }
 
@@ -31,23 +30,18 @@ local DEATH_CORPSES = {
 local STAGGER_STICKER = "kbve-spider-stagger"
 local SPRINT_STICKER = "kbve-spider-sprint"
 
--- How often to roll sprint checks across all active spiders. 180 ticks = 3s.
+-- Fixed cadences. Per-spider cooldown stays hardcoded so the tuning surface
+-- is small; the runtime-global settings cover everything an admin would
+-- reasonably want to flip mid-game.
 local SPRINT_TICK_INTERVAL = 180
--- Per-spider cooldown after a sprint fires.
 local SPRINT_COOLDOWN_TICKS = 600
--- Chance per check (when pursuing + off cooldown) that sprint fires.
-local SPRINT_CHANCE = 0.45
-
--- Flee threshold: when a spider drops below this health ratio after a hit,
--- switch its command to "flee from attacker" and slap a sprint sticker on
--- it for that adrenaline burst.
-local FLEE_HEALTH_RATIO = 0.3
-
--- Nervous twitch: every NERVOUS_TICK_INTERVAL ticks, pick a few spiders at
--- random and overlay the Nervous animation as a one-shot corpse. Visual
--- only, no mechanical change.
 local NERVOUS_TICK_INTERVAL = 900
-local NERVOUS_PICK_COUNT = 3
+
+local function setting(name, default)
+	local s = settings.global[name]
+	if not s then return default end
+	return s.value
+end
 local NERVOUS_CORPSE = "kbve-spider-corpse-nervous"
 
 -- Map an attacker→spider vector + spider orientation into a hit side.
@@ -104,7 +98,7 @@ script.on_event(defines.events.on_entity_damaged, function(event)
 	local key = e.unit_number
 	if cause and cause.valid and key and not storage.fleeing[key] then
 		local health_ratio = e.get_health_ratio() or 1
-		if health_ratio < FLEE_HEALTH_RATIO then
+		if health_ratio < setting("kbve-spider-flee-health-threshold", 0.3) then
 			storage.fleeing[key] = true
 			e.set_command{
 				type = defines.command.flee,
@@ -165,7 +159,7 @@ end)
 local function track_egg(entity, tick)
 	storage.pending_eggs = storage.pending_eggs or {}
 	storage.pending_eggs[entity.unit_number] = {
-		tick_due = tick + HATCH_TICKS,
+		tick_due = tick + math.floor(60 * setting("kbve-spider-hatch-seconds", 30)),
 		surface_index = entity.surface_index,
 		position = { x = entity.position.x, y = entity.position.y },
 		force = entity.force.name,
@@ -230,7 +224,7 @@ script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 		local n = #spiders
 		if n == 0 then goto continue end
 
-		local picks = math.min(NERVOUS_PICK_COUNT, n)
+		local picks = math.min(setting("kbve-spider-nervous-pick-count", 3), n)
 		for _ = 1, picks do
 			local s = spiders[math.random(1, n)]
 			if s.valid then
@@ -269,7 +263,7 @@ script.on_nth_tick(SPRINT_TICK_INTERVAL, function(event)
 					local in_group = false
 					local ok, ug = pcall(function() return s.unit_group end)
 					if ok and ug then in_group = true end
-					if in_group and math.random() < SPRINT_CHANCE then
+					if in_group and math.random() < setting("kbve-spider-sprint-chance", 0.45) then
 						surface.create_entity{
 							name = SPRINT_STICKER,
 							position = s.position,

--- a/apps/factorio/mods/kbve-spider/locale/en/kbve-spider.cfg
+++ b/apps/factorio/mods/kbve-spider/locale/en/kbve-spider.cfg
@@ -1,0 +1,41 @@
+[mod-name]
+kbve-spider=KBVE Spider
+
+[mod-description]
+kbve-spider=Adds a pre-rendered isometric spider as a hostile unit, plus a tameable ally variant hatched from a buyable Spider Egg item. 16-direction sprites, hit / stagger / flee / sprint / nervous reactions wired through control.lua. Model by engvee, music by OpenFret.
+
+[entity-name]
+kbve-spider=Spider
+kbve-spider-ally=Ally Spider
+kbve-spider-egg-entity=Spider Egg
+
+[entity-description]
+kbve-spider=A wild spider that hunts on sight. Sprints in attack groups, flees below 30% HP, twitches when idle. 80 HP, melee 12 damage.
+kbve-spider-ally=A spider hatched from a Spider Egg, bound to the force of whoever placed the egg. Lighter than the wild variant (60 HP) but faster and quicker to swing. Lives until killed.
+kbve-spider-egg-entity=A Spider Egg waiting to hatch. Mineable back into a Spider Egg item before the timer runs out. Hatches into an Ally Spider on the placer's force.
+
+[item-name]
+kbve-spider-egg=Spider Egg
+
+[item-description]
+kbve-spider-egg=Place on a tile to drop a Spider Egg entity. Hatches into an Ally Spider on your force after 30 seconds. Mineable back into an egg before it hatches. Buy from the KBVE Exchange.
+
+[mod-setting-name]
+kbve-spider-hatch-seconds=Egg hatch time
+kbve-spider-sprint-chance=Sprint chance per check
+kbve-spider-sprint-speed-multiplier=Sprint speed multiplier
+kbve-spider-flee-health-threshold=Flee health threshold
+kbve-spider-nervous-pick-count=Nervous twitches per pass
+kbve-spider-ally-max-health=Ally spider max HP
+
+[mod-setting-description]
+kbve-spider-hatch-seconds=Seconds between placing a Spider Egg and the Ally Spider hatching. Mining the egg before this fires returns the item.
+kbve-spider-sprint-chance=Probability (0–1) that a spider in an attack group rolls a sprint each 3-second tick. The 10-second per-spider cooldown is not configurable.
+kbve-spider-sprint-speed-multiplier=Movement modifier applied during a sprint. 1.0 = no change, 2.0 = double speed. Sprint duration is fixed at 3s.
+kbve-spider-flee-health-threshold=Wild + ally spiders set their command to `flee` when their HP drops below this fraction. Only fires once per spider; reset on death.
+kbve-spider-nervous-pick-count=How many random idle spiders get a Nervous animation overlay every 15-second pass. Visual only.
+kbve-spider-ally-max-health=HP value applied to the Ally Spider prototype at data-stage. Wild spiders stay at 80; this only tunes the friendly variant.
+
+[mod-setting-section]
+kbve-spider-runtime=Spider runtime tuning
+kbve-spider-startup=Spider startup tuning

--- a/apps/factorio/mods/kbve-spider/migrations/README.md
+++ b/apps/factorio/mods/kbve-spider/migrations/README.md
@@ -1,0 +1,14 @@
+# Migrations
+
+Factorio runs every file in this directory as Lua against existing save games
+when a player loads a save that was created against an older version of this
+mod. Add files named `<version>.lua` (semver of the version that introduces the
+schema change) when:
+
+- The shape of `storage.*` tables changes.
+- A prototype name is renamed / removed (use `game.surfaces[...].find_entities_filtered` + `entity.destroy()` to clean stale entities).
+- A new event handler depends on `storage.*` state that didn't exist on older saves.
+
+Empty directory is fine — Factorio skips it cleanly.
+
+Reference: https://lua-api.factorio.com/latest/auxiliary/migrations.html

--- a/apps/factorio/mods/kbve-spider/prototypes/spider.lua
+++ b/apps/factorio/mods/kbve-spider/prototypes/spider.lua
@@ -165,19 +165,26 @@ local stagger_sticker = {
 	single_particle = true,
 }
 
+local SPRINT_SPEED_MULTIPLIER = settings.startup["kbve-spider-sprint-speed-multiplier"]
+		and settings.startup["kbve-spider-sprint-speed-multiplier"].value
+	or 1.9
+local ALLY_MAX_HEALTH = settings.startup["kbve-spider-ally-max-health"]
+		and settings.startup["kbve-spider-ally-max-health"].value
+	or 60
+
 local sprint_sticker = {
 	type = "sticker",
 	name = "kbve-spider-sprint",
 	flags = { "not-on-map" },
 	duration_in_ticks = 180,
-	target_movement_modifier = 1.9,
+	target_movement_modifier = SPRINT_SPEED_MULTIPLIER,
 	single_particle = true,
 }
 
 local ally_spider = util.table.deepcopy(spider)
 ally_spider.name = "kbve-spider-ally"
 ally_spider.order = "b-b-z-kbve-spider-ally"
-ally_spider.max_health = 60
+ally_spider.max_health = ALLY_MAX_HEALTH
 ally_spider.movement_speed = 0.22
 ally_spider.attack_parameters.cooldown = 50
 

--- a/apps/factorio/mods/kbve-spider/settings.lua
+++ b/apps/factorio/mods/kbve-spider/settings.lua
@@ -1,0 +1,67 @@
+--[[
+  KBVE Spider mod settings.
+
+  Runtime settings (per-map): control.lua reads these via
+    settings.global["<name>"].value
+  on tick — change without restart by editing in Mod settings → Map.
+
+  Startup settings: data-stage prototype values (ally HP). Requires
+  game restart to apply because prototypes are frozen after data-final-fixes.
+]]
+
+data:extend({
+	{
+		type = "double-setting",
+		name = "kbve-spider-hatch-seconds",
+		setting_type = "runtime-global",
+		default_value = 30,
+		minimum_value = 1,
+		maximum_value = 3600,
+		order = "a-a",
+	},
+	{
+		type = "double-setting",
+		name = "kbve-spider-sprint-chance",
+		setting_type = "runtime-global",
+		default_value = 0.45,
+		minimum_value = 0,
+		maximum_value = 1,
+		order = "b-a",
+	},
+	{
+		type = "double-setting",
+		name = "kbve-spider-sprint-speed-multiplier",
+		setting_type = "startup",
+		default_value = 1.9,
+		minimum_value = 1.0,
+		maximum_value = 5.0,
+		order = "z-b",
+	},
+	{
+		type = "double-setting",
+		name = "kbve-spider-flee-health-threshold",
+		setting_type = "runtime-global",
+		default_value = 0.3,
+		minimum_value = 0,
+		maximum_value = 1,
+		order = "c-a",
+	},
+	{
+		type = "int-setting",
+		name = "kbve-spider-nervous-pick-count",
+		setting_type = "runtime-global",
+		default_value = 3,
+		minimum_value = 0,
+		maximum_value = 20,
+		order = "d-a",
+	},
+	{
+		type = "int-setting",
+		name = "kbve-spider-ally-max-health",
+		setting_type = "startup",
+		default_value = 60,
+		minimum_value = 1,
+		maximum_value = 10000,
+		order = "z-a",
+	},
+})

--- a/apps/factorio/mods/kbve-spider/tools/test_mod.py
+++ b/apps/factorio/mods/kbve-spider/tools/test_mod.py
@@ -152,6 +152,56 @@ def check_extras() -> None:
     print(f"  extras OK     ({len(EXTRA_PNGS)} required assets)")
 
 
+LOCALE_PATH = ROOT / "locale" / "en" / "kbve-spider.cfg"
+SETTINGS_PATH = ROOT / "settings.lua"
+LOCALE_REQUIRED_SECTIONS = (
+    "[mod-name]",
+    "[entity-name]",
+    "[entity-description]",
+    "[item-name]",
+    "[item-description]",
+    "[mod-setting-name]",
+)
+LOCALE_REQUIRED_KEYS = (
+    "kbve-spider",
+    "kbve-spider-ally",
+    "kbve-spider-egg-entity",
+    "kbve-spider-egg",
+)
+
+
+def check_locale() -> None:
+    if not LOCALE_PATH.exists():
+        raise TestFail(f"missing {LOCALE_PATH.relative_to(ROOT)}")
+    text = LOCALE_PATH.read_text()
+    for section in LOCALE_REQUIRED_SECTIONS:
+        if section not in text:
+            raise TestFail(f"locale missing section {section}")
+    for key in LOCALE_REQUIRED_KEYS:
+        if f"{key}=" not in text:
+            raise TestFail(f"locale missing key {key}")
+    print(
+        f"  locale OK     ({len(LOCALE_REQUIRED_KEYS)} required keys present)")
+
+
+def check_settings() -> None:
+    if not SETTINGS_PATH.exists():
+        raise TestFail(f"missing {SETTINGS_PATH.relative_to(ROOT)}")
+    src = SETTINGS_PATH.read_text()
+    required = (
+        "kbve-spider-hatch-seconds",
+        "kbve-spider-sprint-chance",
+        "kbve-spider-sprint-speed-multiplier",
+        "kbve-spider-flee-health-threshold",
+        "kbve-spider-nervous-pick-count",
+        "kbve-spider-ally-max-health",
+    )
+    missing = [k for k in required if k not in src]
+    if missing:
+        raise TestFail(f"settings.lua missing setting(s): {missing}")
+    print(f"  settings OK   ({len(required)} declared)")
+
+
 def check_wired_anims(frames: dict[str, int]) -> None:
     src = PROTO_PATH.read_text()
     wired = set(find_rotated_calls(src))
@@ -178,6 +228,8 @@ def main() -> int:
     check_all_sheets(frames)
     check_wired_anims(frames)
     check_extras()
+    check_locale()
+    check_settings()
 
     print("PASS")
     return 0


### PR DESCRIPTION
## Summary

Mod-portal polish pass aimed at getting kbve-spider to "grade A" without bumping the version. Stays at **0.2.0** — we're not ready to release.

### What changed

| Area | Before | After |
| --- | --- | --- |
| Locale | Factorio rendered raw prototype names (`kbve-spider`, `kbve-spider-egg-entity`, etc.) | `locale/en/kbve-spider.cfg` provides proper names + descriptions for mod, entities, items, and every mod setting |
| Mod settings | All knobs hardcoded in control.lua + prototypes/spider.lua | `settings.lua` exposes 4 runtime + 2 startup knobs (hatch time, sprint chance, sprint speed, flee threshold, nervous count, ally HP) |
| Migrations | No directory | `migrations/README.md` placeholder for future storage-shape changes |
| Tests | Validated info.json, sheets, wired anims, extras (3 PNGs) | Added `check_locale()` + `check_settings()` to verify both new layers stay in sync with prototype/control.lua usage |
| README | Layout block + sprite docs | Updated layout, new "Mod settings" table documenting each knob with type + default + what it tunes |

### Why no version bump

User direction: "we keep it at v0.2.0 because we are not yet ready to release". This is iteration on top of the published 0.1.0 release; 0.2.0 stays the next-publish target.

### Safety

Settings reads (both `settings.startup[...]` in prototypes/spider.lua and `settings.global[...]` via the `setting(name, default)` helper in control.lua) fall back to the previous hardcoded defaults when the entry is missing. Existing saves and partial mod states keep working unchanged.

## Test plan

- [x] `./kbve.sh -nx kbve-spider:test` → PASS (info.json, FRAMES, 26 sheets, wiring, 3 extras, 4 locale keys, 6 settings)
- [ ] CI re-runs `kbve-spider:test` clean.
- [ ] Manual: Mods menu shows "KBVE Spider"; place a spider, hover → tooltip reads "Spider" not "kbve-spider"; open Mod settings → Map → all 4 runtime knobs visible with localized names + descriptions.