### PR TITLE
harden(irc-gateway): allow-list CORS, cap WS frames, server-side heartbeat

### DIFF
--- a/apps/irc/irc-gateway/src/gateway/minechat.rs
+++ b/apps/irc/irc-gateway/src/gateway/minechat.rs
@@ -49,10 +49,15 @@ use axum::{
 use bevy_chat::{ChatMessage, MessageKind};
 use futures_util::{SinkExt, StreamExt};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
+use tokio::time::{interval, timeout};
 use tracing::{debug, error, info, warn};
+
+const WS_PING_INTERVAL: Duration = Duration::from_secs(30);
+const WS_READ_DEADLINE: Duration = Duration::from_secs(90);
 
 use crate::auth::jwt;
 
@@ -90,7 +95,9 @@ pub async fn ws_handler(ws: WebSocketUpgrade, req: Request) -> impl IntoResponse
     let nick = format!("mc-{}", sanitize_sub(&claims.sub, 8));
 
     info!(user = %nick, "minechat upgrade accepted");
-    ws.on_upgrade(move |socket| session(socket, nick))
+    ws.max_frame_size(16 * 1024)
+        .max_message_size(64 * 1024)
+        .on_upgrade(move |socket| session(socket, nick))
         .into_response()
 }
 
@@ -135,12 +142,22 @@ async fn session(client_ws: WebSocket, nick: String) {
     }
 
     let (mut client_tx, mut client_rx) = client_ws.split();
+    let (pulse_tx, mut pulse_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
 
-    // client JSON → ergo IRC (filtered + stamped)
     let nick_c2i = nick.clone();
     let ergo_w_c2i = Arc::clone(&ergo_w);
+    let pulse_tx_c2i = pulse_tx.clone();
     let c2i = async move {
-        while let Some(Ok(msg)) = client_rx.next().await {
+        loop {
+            let msg = match timeout(WS_READ_DEADLINE, client_rx.next()).await {
+                Ok(Some(Ok(m))) => m,
+                Ok(Some(Err(_))) | Ok(None) => break,
+                Err(_) => {
+                    warn!(user = %nick_c2i, "minechat client idle past read deadline");
+                    break;
+                }
+            };
+            let _ = pulse_tx_c2i.send(());
             let text = match msg {
                 Message::Text(t) => t.to_string(),
                 Message::Close(_) => break,
@@ -189,44 +206,51 @@ async fn session(client_ws: WebSocket, nick: String) {
         }
     };
 
-    // ergo IRC → client JSON (parse PRIVMSGs, answer PINGs, drop the rest)
     let nick_i2c = nick.clone();
     let ergo_w_i2c = Arc::clone(&ergo_w);
     let i2c = async move {
         let mut line = String::new();
+        let mut ping_timer = interval(WS_PING_INTERVAL);
+        ping_timer.tick().await;
         loop {
-            line.clear();
-            let read = ergo_reader.read_line(&mut line).await;
-            let n = match read {
-                Ok(0) => break, // ergo closed
-                Ok(n) => n,
-                Err(e) => {
-                    warn!(user = %nick_i2c, "ergo read failed: {e}");
-                    break;
-                }
-            };
-            let raw = line[..n].trim_end_matches(['\r', '\n']).to_string();
-
-            // Answer PINGs so ergo keeps the session alive.
-            if let Some(rest) = raw.strip_prefix("PING ") {
-                let pong = format!("PONG {rest}");
-                if let Err(e) = write_irc_line(&ergo_w_i2c, &pong).await {
-                    warn!(user = %nick_i2c, "PONG write failed: {e}");
-                    break;
-                }
-                continue;
-            }
-
-            // Only PRIVMSG lines get surfaced to the client. JOINs, numerics,
-            // MODE, etc. stay hidden — clients speak the JSON abstraction.
-            if let Some((channel, payload)) = parse_privmsg(&raw) {
-                if let Some(mut msg) = ChatMessage::from_irc_privmsg(&channel, &payload) {
-                    if msg.platform.is_empty() {
-                        msg.platform = "irc".into();
+            tokio::select! {
+                read = ergo_reader.read_line(&mut line) => {
+                    let n = match read {
+                        Ok(0) => break,
+                        Ok(n) => n,
+                        Err(e) => {
+                            warn!(user = %nick_i2c, "ergo read failed: {e}");
+                            break;
+                        }
+                    };
+                    let raw = line[..n].trim_end_matches(['\r', '\n']).to_string();
+                    line.clear();
+                    if let Some(rest) = raw.strip_prefix("PING ") {
+                        let pong = format!("PONG {rest}");
+                        if let Err(e) = write_irc_line(&ergo_w_i2c, &pong).await {
+                            warn!(user = %nick_i2c, "PONG write failed: {e}");
+                            break;
+                        }
+                        continue;
                     }
-                    if send_json(&mut client_tx, &msg).await.is_err() {
+                    if let Some((channel, payload)) = parse_privmsg(&raw) {
+                        if let Some(mut msg) = ChatMessage::from_irc_privmsg(&channel, &payload) {
+                            if msg.platform.is_empty() {
+                                msg.platform = "irc".into();
+                            }
+                            if send_json(&mut client_tx, &msg).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+                _ = ping_timer.tick() => {
+                    if client_tx.send(Message::Ping(Default::default())).await.is_err() {
                         break;
                     }
+                }
+                _ = pulse_rx.recv() => {
+                    ping_timer.reset();
                 }
             }
         }

--- a/apps/irc/irc-gateway/src/gateway/websocket.rs
+++ b/apps/irc/irc-gateway/src/gateway/websocket.rs
@@ -5,12 +5,19 @@ use axum::{
     response::IntoResponse,
 };
 use futures_util::{SinkExt, StreamExt};
+use std::time::Duration;
+use tokio::time::{interval, timeout};
 use tokio_tungstenite::connect_async;
 use tracing::{error, info, warn};
 
 use crate::auth::jwt;
 
 const NO_USERNAME_MSG: &str = "No provider username configured. Set a username on your OAuth provider (Discord/GitHub/Twitch) before joining IRC.";
+
+const WS_MAX_FRAME_BYTES: usize = 16 * 1024;
+const WS_MAX_MESSAGE_BYTES: usize = 64 * 1024;
+const WS_PING_INTERVAL: Duration = Duration::from_secs(30);
+const WS_READ_DEADLINE: Duration = Duration::from_secs(90);
 
 pub async fn ws_handler(ws: WebSocketUpgrade, req: Request) -> impl IntoResponse {
     let token = match jwt::extract_token(&req) {
@@ -33,7 +40,9 @@ pub async fn ws_handler(ws: WebSocketUpgrade, req: Request) -> impl IntoResponse
 
     info!(user = %username, "WebSocket upgrade accepted");
 
-    ws.on_upgrade(move |socket| proxy_to_ergo(socket, username))
+    ws.max_frame_size(WS_MAX_FRAME_BYTES)
+        .max_message_size(WS_MAX_MESSAGE_BYTES)
+        .on_upgrade(move |socket| proxy_to_ergo(socket, username))
         .into_response()
 }
 
@@ -77,9 +86,19 @@ async fn proxy_to_ergo(client_ws: WebSocket, username: String) {
 
     info!(user = %username, "Connected to Ergo");
 
-    // Bidirectional proxy
+    let (client_pulse_tx, mut client_pulse_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+
     let client_to_ergo = async {
-        while let Some(Ok(msg)) = client_stream.next().await {
+        loop {
+            let msg = match timeout(WS_READ_DEADLINE, client_stream.next()).await {
+                Ok(Some(Ok(m))) => m,
+                Ok(Some(Err(_))) | Ok(None) => break,
+                Err(_) => {
+                    warn!(user = %username, "client idle past read deadline; closing");
+                    break;
+                }
+            };
+            let _ = client_pulse_tx.send(());
             let ergo_msg = match msg {
                 Message::Text(t) => {
                     tokio_tungstenite::tungstenite::Message::Text(t.to_string().into())
@@ -96,19 +115,37 @@ async fn proxy_to_ergo(client_ws: WebSocket, username: String) {
     };
 
     let ergo_to_client = async {
-        while let Some(Ok(msg)) = ergo_stream.next().await {
-            let client_msg = match msg {
-                tokio_tungstenite::tungstenite::Message::Text(t) => {
-                    Message::Text(t.to_string().into())
+        let mut ping_timer = interval(WS_PING_INTERVAL);
+        ping_timer.tick().await;
+        loop {
+            tokio::select! {
+                msg = ergo_stream.next() => {
+                    let msg = match msg {
+                        Some(Ok(m)) => m,
+                        _ => break,
+                    };
+                    let client_msg = match msg {
+                        tokio_tungstenite::tungstenite::Message::Text(t) => {
+                            Message::Text(t.to_string().into())
+                        }
+                        tokio_tungstenite::tungstenite::Message::Binary(b) => Message::Binary(b.into()),
+                        tokio_tungstenite::tungstenite::Message::Ping(p) => Message::Ping(p.into()),
+                        tokio_tungstenite::tungstenite::Message::Pong(p) => Message::Pong(p.into()),
+                        tokio_tungstenite::tungstenite::Message::Close(_) => break,
+                        _ => continue,
+                    };
+                    if client_sink.send(client_msg).await.is_err() {
+                        break;
+                    }
                 }
-                tokio_tungstenite::tungstenite::Message::Binary(b) => Message::Binary(b.into()),
-                tokio_tungstenite::tungstenite::Message::Ping(p) => Message::Ping(p.into()),
-                tokio_tungstenite::tungstenite::Message::Pong(p) => Message::Pong(p.into()),
-                tokio_tungstenite::tungstenite::Message::Close(_) => break,
-                _ => continue,
-            };
-            if client_sink.send(client_msg).await.is_err() {
-                break;
+                _ = ping_timer.tick() => {
+                    if client_sink.send(Message::Ping(Default::default())).await.is_err() {
+                        break;
+                    }
+                }
+                _ = client_pulse_rx.recv() => {
+                    ping_timer.reset();
+                }
             }
         }
     };

--- a/apps/irc/irc-gateway/src/transport/https.rs
+++ b/apps/irc/irc-gateway/src/transport/https.rs
@@ -3,11 +3,12 @@ use std::{net::SocketAddr, time::Duration};
 
 use axum::{
     Json, Router,
-    http::{HeaderName, HeaderValue, header},
+    http::{HeaderName, HeaderValue, Method, header, request::Parts as RequestParts},
     response::IntoResponse,
     routing::get,
 };
 use tokio::net::TcpListener;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::info;
 
@@ -44,7 +45,7 @@ fn router(static_config: &crate::astro::StaticConfig) -> Router {
                 tower_http::trace::DefaultMakeSpan::new().level(tracing::Level::INFO),
             ),
         )
-        .layer(tower_http::cors::CorsLayer::permissive())
+        .layer(build_cors_layer())
         .layer(SetResponseHeaderLayer::overriding(
             header::X_CONTENT_TYPE_OPTIONS,
             HeaderValue::from_static("nosniff"),
@@ -99,6 +100,51 @@ static START_TIME: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock
 
 pub fn init_start_time() {
     START_TIME.get_or_init(std::time::Instant::now);
+}
+
+fn is_origin_allowed(origin: &HeaderValue, _parts: &RequestParts) -> bool {
+    let raw = match origin.to_str() {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    if let Some(host) = raw.strip_prefix("https://") {
+        let host = host.split('/').next().unwrap_or(host);
+        if host == "kbve.com" || host.ends_with(".kbve.com") {
+            return true;
+        }
+    }
+    if let Some(host) = raw.strip_prefix("http://") {
+        let host = host.split('/').next().unwrap_or(host);
+        if host == "localhost"
+            || host.starts_with("localhost:")
+            || host == "127.0.0.1"
+            || host.starts_with("127.0.0.1:")
+        {
+            return true;
+        }
+    }
+    if let Ok(extra) = std::env::var("CORS_EXTRA_ORIGINS") {
+        for allowed in extra.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            if allowed == raw {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn build_cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::predicate(is_origin_allowed))
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers([
+            header::AUTHORIZATION,
+            header::CONTENT_TYPE,
+            header::ACCEPT,
+            HeaderName::from_static("x-requested-with"),
+        ])
+        .allow_credentials(true)
+        .max_age(std::time::Duration::from_secs(600))
 }
 
 async fn health() -> impl IntoResponse {
@@ -214,5 +260,68 @@ mod tests {
             response.headers().get("referrer-policy").unwrap(),
             "strict-origin-when-cross-origin"
         );
+    }
+
+    fn parts_for(uri: &str) -> RequestParts {
+        Request::builder().uri(uri).body(()).unwrap().into_parts().0
+    }
+
+    #[test]
+    fn cors_allows_kbve_apex() {
+        let origin = HeaderValue::from_static("https://kbve.com");
+        assert!(is_origin_allowed(&origin, &parts_for("/")));
+    }
+
+    #[test]
+    fn cors_allows_kbve_subdomain() {
+        for sub in ["chat", "docs", "rareicon", "edge.staging"] {
+            let raw = format!("https://{sub}.kbve.com");
+            let origin = HeaderValue::from_str(&raw).unwrap();
+            assert!(is_origin_allowed(&origin, &parts_for("/")), "{raw}");
+        }
+    }
+
+    #[test]
+    fn cors_rejects_foreign_origin() {
+        for raw in [
+            "https://evil.example.com",
+            "https://kbve.com.attacker.net",
+            "http://kbve.com",
+            "https://notkbve.com",
+        ] {
+            let origin = HeaderValue::from_str(raw).unwrap();
+            assert!(!is_origin_allowed(&origin, &parts_for("/")), "{raw}");
+        }
+    }
+
+    #[test]
+    fn cors_allows_localhost_for_dev() {
+        for raw in [
+            "http://localhost",
+            "http://localhost:4321",
+            "http://127.0.0.1:5173",
+        ] {
+            let origin = HeaderValue::from_str(raw).unwrap();
+            assert!(is_origin_allowed(&origin, &parts_for("/")), "{raw}");
+        }
+    }
+
+    #[test]
+    fn cors_extra_env_origins() {
+        unsafe {
+            std::env::set_var(
+                "CORS_EXTRA_ORIGINS",
+                "https://partner.example, https://other.test",
+            );
+        }
+        let allowed = HeaderValue::from_static("https://partner.example");
+        let other = HeaderValue::from_static("https://other.test");
+        let denied = HeaderValue::from_static("https://not-listed.test");
+        assert!(is_origin_allowed(&allowed, &parts_for("/")));
+        assert!(is_origin_allowed(&other, &parts_for("/")));
+        assert!(!is_origin_allowed(&denied, &parts_for("/")));
+        unsafe {
+            std::env::remove_var("CORS_EXTRA_ORIGINS");
+        }
     }
 }


### PR DESCRIPTION
Closes #11581

## What ships

### 1. CORS allow-list — `transport/https.rs`

Replaces \`CorsLayer::permissive()\` with a predicate that accepts:

- \`https://kbve.com\` (apex)
- any \`https://*.kbve.com\` subdomain
- \`http://localhost\` / \`http://127.0.0.1\` (any port) for local dev
- anything listed in \`CORS_EXTRA_ORIGINS\` env var (comma-separated, exact match)

Methods narrowed to \`GET / POST / OPTIONS\`. Headers narrowed to \`Authorization\`, \`Content-Type\`, \`Accept\`, \`X-Requested-With\`. \`allow_credentials(true)\` retained so the \`kbve_auth_token\` cookie still rides cross-subdomain. 10 min preflight cache.

\`script\` tags don't preflight, so embedding chat.js on third-party hosts is unaffected. Only \`fetch()\` / \`XHR\` and the upgrade-preflight for \`/ws\` get gated.

### 2. WS frame + message size cap — both handlers

\`/ws\`, \`/webirc\`, \`/minechat\`: \`max_frame_size = 16 KB\`, \`max_message_size = 64 KB\`. Down from the implicit default. Oversized payloads now close with code 1009 instead of consuming memory.

### 3. Server-side PING/PONG heartbeat — both handlers

- 30s ping interval
- 90s client read deadline (resets on any client traffic)
- Idle/zombie connections close cleanly within ~90s instead of lingering at the OS layer

Same logic shape on \`/ws\` and \`/minechat\` — kept inline rather than abstracted into a helper since the two handlers have different inner loops (ws-to-ws proxy vs ws-to-TCP terminator).

## Tests

5 new tests in \`transport::https::tests\`:
- \`cors_allows_kbve_apex\`
- \`cors_allows_kbve_subdomain\` (chat, docs, rareicon, edge.staging)
- \`cors_rejects_foreign_origin\` (look-alikes, plain HTTP, suffix attacks)
- \`cors_allows_localhost_for_dev\`
- \`cors_extra_env_origins\`

\`cargo test\` green — 40 passed, 0 failed.

## Acceptance checklist (from #11581)

- [x] CORS layer replaces \`permissive()\` with explicit allow-list
- [x] WS frame size cap landed on \`/ws\`, \`/webirc\`, \`/minechat\`
- [x] Heartbeat: idle ws auto-closes after 90s; healthy clients re-pong on 30s schedule
- [x] Unit tests cover CORS allow + reject + extra-env paths
- [ ] Container republished + chat.kbve.com smoke-tested (post-merge)

## Audit notes (carried from #11581 for reviewers)

The original raw audit had three claims that didn't survive verification — flagged so reviewers don't chase ghosts:
- \"XSS via \`innerHTML = ''\`\" — false alarm. MessageFeed builds DOM via \`textContent\`, no injection path.
- \"CORS exfil of \`/api/v1/users\`\" — that endpoint doesn't exist. Only \`/health\`, \`/api/v1/*\`, \`/ws\`, \`/webirc\`, \`/minechat\`.
- \"Site chat uses \`window.kbve.ws\` without type safety\" — assertion is loose but \`if (!kbve?.ws)\` guards do exist.

CORS hardening here still tightens the surface even though nothing was actively leaking.