### PR TITLE
chore(ci): bump actions/upload-artifact v4 -> v7 (+ matched v8 download)

### DIFF
--- a/.github/workflows/ci-bevy-game.yml
+++ b/.github/workflows/ci-bevy-game.yml
@@ -195,7 +195,7 @@ jobs:
                   esac
                   echo "path=${{ inputs.project_path }}/target/${{ matrix.target }}/release/${{ inputs.app_name }}${EXT}" >> "$GITHUB_OUTPUT"
             - name: Upload artefact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: ${{ inputs.app_name }}-${{ matrix.target }}
                   path: ${{ steps.art.outputs.path }}
@@ -215,7 +215,7 @@ jobs:
                 target: ${{ fromJSON(inputs.build_targets) }}
         steps:
             - name: Download artefact
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: ${{ inputs.app_name }}-${{ matrix.target }}
                   path: ./build

--- a/.github/workflows/ci-godot.yml
+++ b/.github/workflows/ci-godot.yml
@@ -173,7 +173,7 @@ jobs:
                   godot --headless --export-release "${{ matrix.preset }}" \
                         "build/${{ steps.san.outputs.name }}/${{ inputs.app_name }}"
             - name: Upload artefact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: ${{ inputs.app_name }}-${{ steps.san.outputs.name }}
                   path: ${{ inputs.project_path }}/build/${{ steps.san.outputs.name }}
@@ -193,7 +193,7 @@ jobs:
             - name: Sanitize preset name
               id: san
               run: echo "name=$(echo '${{ matrix.preset }}' | tr '/' '-' | tr ' ' '-')" >> "$GITHUB_OUTPUT"
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v8
               with:
                   name: ${{ inputs.app_name }}-${{ steps.san.outputs.name }}
                   path: ./build

--- a/.github/workflows/ci-mc-smoke.yml
+++ b/.github/workflows/ci-mc-smoke.yml
@@ -102,7 +102,7 @@ jobs:
 
             - name: Upload client log on failure
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: client-smoke-log
                   path: /tmp/mc-headless-client.log

--- a/.github/workflows/ci-uniti.yml
+++ b/.github/workflows/ci-uniti.yml
@@ -164,7 +164,7 @@ jobs:
               run: cargo build -p uniti --release --target x86_64-unknown-linux-gnu
 
             - name: Upload Linux libuniti.so
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: uniti-linux-x86_64
                   path: ${{ env.CARGO_TARGET_DIR }}/x86_64-unknown-linux-gnu/release/libuniti.so
@@ -212,7 +212,7 @@ jobs:
                       -o ./android-out build -p uniti --release
 
             - name: Upload Android per-ABI .so
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: uniti-android
                   path: packages/rust/bevy/uniti/android-out
@@ -257,7 +257,7 @@ jobs:
                       -output ios-out/uniti.xcframework
 
             - name: Upload iOS XCFramework
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: uniti-ios
                   path: ios-out/uniti.xcframework


### PR DESCRIPTION
## Summary
Resolves dependabot #10438. The repo already standardized the rest of the workflows on \`actions/upload-artifact@v7\` (28 refs) and \`actions/download-artifact@v8\` (15 refs); these four workflow files were the v4 stragglers.

## Diff
Bulk \`sed\`:
- \`upload-artifact@v4\` → \`@v7\` (4 files / 6 sites):
  - \`ci-uniti.yml\` — 3 sites (linux \`.so\`, android per-ABI, ios xcframework)
  - \`ci-mc-smoke.yml\` — 1 site (client-smoke-log on failure)
  - \`ci-godot.yml\` — 1 site (build artefact)
  - \`ci-bevy-game.yml\` — 1 site (build artefact)
- \`download-artifact@v4\` → \`@v8\` (2 files):
  - \`ci-godot.yml\` — itch.io publish flow
  - \`ci-bevy-game.yml\` — itch.io publish flow

## Compatibility
- Upload v4 → v7 is safe — none of our call sites use any parameter that changed. Every call only sets \`name\`, \`path\`, \`if-no-files-found\`, \`retention-days\`.
- Download v4 → v8 pairs with v7 upload (artefact API is version-aligned across the rest of the repo).

## Follow-up
Close dependabot #10438 after merge.