### PR TITLE
fix(astro-kbve): make /dashboard/api/ Scalar viewer client-router-safe

### DIFF
--- a/apps/kbve/astro-kbve/src/components/api/scalar-auth-bridge.ts
+++ b/apps/kbve/astro-kbve/src/components/api/scalar-auth-bridge.ts
@@ -1,7 +1,7 @@
 import { initSupa, getSupa } from '@/lib/supa';
 
 type ScalarInstance = {
-	updateConfiguration: (cfg: Record<string, unknown>) => void;
+	updateConfiguration?: (cfg: Record<string, unknown>) => void;
 };
 
 declare global {
@@ -12,25 +12,6 @@ declare global {
 }
 
 const BEARER_SCHEME = 'bearerAuth';
-
-function waitForInstance(timeoutMs = 10_000): Promise<ScalarInstance | null> {
-	return new Promise((resolve) => {
-		if (window.__scalarRef) {
-			resolve(window.__scalarRef);
-			return;
-		}
-		const start = performance.now();
-		const id = window.setInterval(() => {
-			if (window.__scalarRef) {
-				window.clearInterval(id);
-				resolve(window.__scalarRef);
-			} else if (performance.now() - start > timeoutMs) {
-				window.clearInterval(id);
-				resolve(null);
-			}
-		}, 50);
-	});
-}
 
 function withAuth(
 	base: Record<string, unknown>,
@@ -48,26 +29,42 @@ function withAuth(
 	};
 }
 
-void (async () => {
-	const instance = await waitForInstance();
-	if (!instance) return;
-	const baseConfig = window.__scalarBaseConfig ?? {};
+let latestToken: string | null = null;
+let supaInitialized = false;
 
+function applyToCurrent(): void {
+	const instance = window.__scalarRef;
+	const base = window.__scalarBaseConfig;
+	if (!instance?.updateConfiguration || !base) return;
+	instance.updateConfiguration(withAuth(base, latestToken));
+}
+
+/**
+ * Sync the latest Supabase token onto the live Scalar instance. Idempotent —
+ * the first call wires the Supabase listener once; every subsequent call
+ * (one per client-router mount) just re-applies the cached token to whatever
+ * `window.__scalarRef` is currently bound to.
+ */
+export async function attachScalarAuthBridge(): Promise<void> {
+	applyToCurrent();
+	if (supaInitialized) return;
+	supaInitialized = true;
 	try {
 		await initSupa();
 		const supa = getSupa();
 		const result = await supa.getSession().catch(() => null);
-		const token = result?.session?.access_token as string | undefined;
-		if (token) instance.updateConfiguration(withAuth(baseConfig, token));
+		latestToken = result?.session?.access_token ?? null;
+		applyToCurrent();
 		supa.on('auth', (payload: unknown) => {
 			const msg = payload as
 				| { session?: { access_token?: string } }
 				| undefined;
-			instance.updateConfiguration(
-				withAuth(baseConfig, msg?.session?.access_token ?? null),
-			);
+			latestToken = msg?.session?.access_token ?? null;
+			applyToCurrent();
 		});
 	} catch (e) {
+		// Reset so a later mount can retry once supa starts answering.
+		supaInitialized = false;
 		console.warn('Scalar auth bridge skipped:', e);
 	}
-})();
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroApiDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroApiDashboard.astro
@@ -14,8 +14,6 @@ interface Props {
 	title?: string;
 }
 
-const SCALAR_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference';
-
 const {
 	specUrl = '/api/openapi.json',
 	sources,
@@ -37,6 +35,12 @@ const configJson = JSON.stringify(configuration);
 ---
 
 <div id="scalar-app"></div>
+<script
+	is:inline
+	type="application/json"
+	id="scalar-config"
+	set:html={configJson}
+/>
 
 <style is:global>
 	#scalar-app {
@@ -84,27 +88,70 @@ const configJson = JSON.stringify(configuration);
 	}
 </style>
 
-<script is:inline src={SCALAR_CDN}></script>
-<script is:inline define:vars={{ configJson }} data-astro-rerun>
-	(function () {
-		// Skip when the host mount node isn't on the swap target (router
-		// can re-fire this script on any page; only run where the
-		// Scalar mount exists).
-		if (!document.getElementById('scalar-app')) return;
-		var cfg = JSON.parse(configJson);
-		window.__scalarBaseConfig = cfg;
-		if (!window.Scalar) return;
-		// Tear down any previous instance bound to the now-removed DOM.
+<script>
+	// Module script — Astro bundles `@scalar/api-reference` so we don't
+	// depend on a CDN tag racing the mount script (the CDN approach
+	// broke on client-router transitions: the inline `<script src=...>`
+	// re-injected async, but the inline mount script ran immediately
+	// and bailed on `window.Scalar` not being defined yet — blank page
+	// until a full reload).
+	import { createApiReference } from '@scalar/api-reference';
+	import '@scalar/api-reference/style.css';
+	import { attachScalarAuthBridge } from '@/components/api/scalar-auth-bridge';
+
+	type ScalarInstance = {
+		updateConfiguration?: (cfg: Record<string, unknown>) => void;
+		destroy?: () => void;
+	};
+
+	declare global {
+		interface Window {
+			__scalarRef?: ScalarInstance;
+			__scalarBaseConfig?: Record<string, unknown>;
+		}
+	}
+
+	function readConfig(): Record<string, unknown> | null {
+		const node = document.getElementById('scalar-config');
+		if (!node?.textContent) return null;
 		try {
-			window.__scalarRef?.destroy?.();
-		} catch (e) {}
-		window.__scalarRef = window.Scalar.createApiReference(
+			return JSON.parse(node.textContent) as Record<string, unknown>;
+		} catch {
+			return null;
+		}
+	}
+
+	function mount() {
+		// astro:page-load fires on every route; bail when the route the
+		// user landed on doesn't have the Scalar mount node.
+		const host = document.getElementById('scalar-app');
+		if (!host) return;
+		const cfg = readConfig();
+		if (!cfg) return;
+		window.__scalarBaseConfig = cfg;
+		// Reuse the existing instance when the same DOM node is still
+		// alive (e.g. partial swap that left the host mounted); destroy
+		// otherwise so the new mount doesn't double-render.
+		const existing = window.__scalarRef;
+		if (existing && host.childElementCount > 0) {
+			existing.updateConfiguration?.(cfg);
+			void attachScalarAuthBridge();
+			return;
+		}
+		try {
+			existing?.destroy?.();
+		} catch {
+			/* old instance already gone */
+		}
+		window.__scalarRef = createApiReference(
 			'#scalar-app',
 			cfg,
-		);
-	})();
-</script>
+		) as ScalarInstance;
+		void attachScalarAuthBridge();
+	}
 
-<script>
-	import '@/components/api/scalar-auth-bridge';
+	// astro:page-load fires after the initial parse AND after every
+	// client-router swap, so a single subscription covers both modes
+	// without any data-astro-rerun gymnastics.
+	document.addEventListener('astro:page-load', mount);
 </script>


### PR DESCRIPTION
## Summary
Clicking into \`/dashboard/api/\` from another dashboard route landed on a blank page; only a full reload mounted the Scalar viewer.

## Root cause
\`AstroApiDashboard.astro\` loaded Scalar via an inline \`<script src=cdn>\` tag and ran an inline \`<script data-astro-rerun>\` mount block.

- **Full HTML parse:** the CDN tag is blocking, so the mount block always saw \`window.Scalar\` defined → worked.
- **Client-router swap:** Astro re-injects both scripts via \`document.createElement('script')\` and appends them. The \`src=\` tag becomes a parallel async fetch; the mount script runs immediately after the tag is appended, sees no \`window.Scalar\`, and bails. \`#scalar-app\` host stays empty until the next full reload — the white page the user reported.

## Fix
- **\`AstroApiDashboard.astro\`** — replace the CDN script with \`import { createApiReference } from '@scalar/api-reference'\` (already pinned at \`^1.55.3\`) plus the bundled stylesheet. The mount function listens on **\`astro:page-load\`** so a single subscription covers the initial parse AND every client-router transition — no \`data-astro-rerun\` gymnastics, no CDN race.
- The Scalar config is rendered into a sibling \`<script type="application/json" id="scalar-config">\` so the module script can read it after a swap (\`define:vars\` is inline-only).
- The mount block reuses an existing instance when the same DOM node is still alive and only destroys/recreates when \`#scalar-app\` was actually swapped, avoiding double mounts.
- **\`scalar-auth-bridge.ts\`** — drop the import-time IIFE and expose \`attachScalarAuthBridge()\`. First call subscribes to Supabase auth changes and caches the latest token; every later call (one per mount) re-applies the cached token to whichever \`window.__scalarRef\` is currently bound.

## Validation
- [x] \`nx run astro-kbve:build\` — clean, 7682 pages built.
- [ ] Manual smoke after merge: \`/dashboard\` → click into \`/dashboard/api/\`, confirm Scalar renders inline without reload; navigate away + back, confirm Scalar re-mounts cleanly.