### PR TITLE
fix(towerdefense): scrollable palette + canvas-scoped wheel capture

### DIFF
--- a/apps/kbve/astro-kbve/e2e/towerdefense.spec.ts
+++ b/apps/kbve/astro-kbve/e2e/towerdefense.spec.ts
@@ -65,6 +65,21 @@ test.describe('tower defense HUD', () => {
 	});
 });
 
+test.describe('tower defense palette', () => {
+	test('village palette button is reachable and selectable', async ({
+		page,
+	}) => {
+		await startGame(page);
+		const palette = page.locator('.td-palette');
+		await expect(palette).toBeVisible();
+		const village = page.locator('button[data-pal-id="village"]');
+		await expect(village).toHaveCount(1, { timeout: 15_000 });
+		await village.scrollIntoViewIfNeeded();
+		await village.click();
+		await expect(village).toHaveClass(/td-pal-active/);
+	});
+});
+
 test.describe('tower defense input', () => {
 	test('digit keys 1–9 do not throw and stay on the TD route', async ({
 		page,

--- a/apps/kbve/astro-kbve/src/arcade/towerdefense/AstroTowerDefense.astro
+++ b/apps/kbve/astro-kbve/src/arcade/towerdefense/AstroTowerDefense.astro
@@ -1007,7 +1007,7 @@ import TdHud from './TdHud';
 		right: 8px;
 		bottom: 8px;
 		display: flex;
-		justify-content: center;
+		justify-content: flex-start;
 		gap: 6px;
 		padding: 6px 10px;
 		background: rgba(11, 14, 20, 0.78);
@@ -1017,6 +1017,17 @@ import TdHud from './TdHud';
 		-webkit-backdrop-filter: blur(10px) saturate(140%);
 		pointer-events: auto;
 		overflow-x: auto;
+		overflow-y: hidden;
+		scroll-behavior: smooth;
+		overscroll-behavior-x: contain;
+		scrollbar-width: thin;
+	}
+	.td-palette::-webkit-scrollbar {
+		height: 6px;
+	}
+	.td-palette::-webkit-scrollbar-thumb {
+		background: rgba(148, 163, 184, 0.45);
+		border-radius: 3px;
 	}
 
 	.td-pal {
@@ -1111,3 +1122,23 @@ import TdHud from './TdHud';
 		color: var(--pal-accent, #fbd38d);
 	}
 </style>
+
+<script>
+	const container = document.getElementById('towerdefense-game-container');
+	if (container) {
+		container.addEventListener(
+			'wheel',
+			(event) => {
+				const target = event.target;
+				if (
+					target instanceof Element &&
+					target.closest('.td-palette')
+				) {
+					return;
+				}
+				event.preventDefault();
+			},
+			{ passive: false },
+		);
+	}
+</script>

--- a/apps/kbve/astro-kbve/src/arcade/towerdefense/TdHud.tsx
+++ b/apps/kbve/astro-kbve/src/arcade/towerdefense/TdHud.tsx
@@ -1,4 +1,5 @@
 import { useStore } from '@nanostores/react';
+import { useEffect, useRef } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 import {
 	bestWaveAtom,
@@ -330,8 +331,45 @@ function PaletteBar() {
 	const selected = useStore(selectedBuildAtom);
 	const gold = useStore(goldAtom);
 	const freeTowers = useStore(freeTowersAtom);
+	const paletteRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const el = paletteRef.current;
+		if (!el) return;
+		const btn = el.querySelector<HTMLButtonElement>(
+			`button[data-pal-id="${selected}"]`,
+		);
+		if (!btn) return;
+		const elLeft = el.scrollLeft;
+		const elRight = elLeft + el.clientWidth;
+		const btnLeft = btn.offsetLeft;
+		const btnRight = btnLeft + btn.offsetWidth;
+		if (btnLeft < elLeft || btnRight > elRight) {
+			btn.scrollIntoView({
+				behavior: 'smooth',
+				inline: 'center',
+				block: 'nearest',
+			});
+		}
+	}, [selected]);
+
+	useEffect(() => {
+		const el = paletteRef.current;
+		if (!el) return;
+		const onWheel = (event: globalThis.WheelEvent) => {
+			const dx = event.deltaX;
+			const dy = event.deltaY;
+			const dominant = Math.abs(dy) > Math.abs(dx) ? dy : dx;
+			if (dominant === 0) return;
+			el.scrollLeft += dominant;
+			event.preventDefault();
+		};
+		el.addEventListener('wheel', onWheel, { passive: false });
+		return () => el.removeEventListener('wheel', onWheel);
+	}, []);
+
 	return (
-		<div className="td-palette">
+		<div ref={paletteRef} className="td-palette">
 			{PALETTE_ORDER.map((id: BuildId, i) => {
 				const spec = specFor(id);
 				const isFree = id === 'basic' && freeTowers > 0;
@@ -361,6 +399,7 @@ function PaletteBar() {
 					<button
 						key={id}
 						type="button"
+						data-pal-id={id}
 						className={className}
 						style={style}
 						title={`${spec.name} — ${costLabel}${powerSuffix ? ' · ' + powerSuffix : ''}`}


### PR DESCRIPTION
## Summary
Two bugs reported in tower defense:
1. Village (and Castle) could not be selected — the palette was centered with overflow-x: auto, so PALETTE_ORDER items past the visible width were clipped with no scroll affordance.
2. Mouse wheel scrolled the page instead of staying inside the game canvas, and the palette could only be scrolled with Shift+wheel.

## Fixes
| Change | File |
|---|---|
| `justify-content: flex-start` (was `center`) + smooth scroll-behavior + overscroll-behavior-x: contain + thin custom scrollbar | `AstroTowerDefense.astro` (`.td-palette`) |
| Native `wheel` listener on `.td-palette` (via `useEffect` + `passive: false`) — dominant `deltaY`/`deltaX` becomes `scrollLeft` and preventDefaults | `TdHud.tsx` (`PaletteBar`) |
| `useEffect` on `selectedBuildAtom` scrolls the active button into view (`inline: 'center'`, smooth) when out of view | `TdHud.tsx` (`PaletteBar`) |
| `data-pal-id={id}` on each palette button for the scroll-into-view query (and e2e selector) | `TdHud.tsx` |
| Container-level `wheel` listener — preventDefaults wheel events whose target is **not** inside `.td-palette`, so canvas wheel no longer bleeds into page scroll. Palette's own handler still owns wheel inside the palette. | `AstroTowerDefense.astro` `<script>` |

## e2e
- New `tower defense palette` spec: asserts `button[data-pal-id="village"]` is in DOM, scrolls into view, clicks, and gains `td-pal-active`.
- All 7 tests pass against the built static output.

## Verified
- `nx run astro-kbve:build` — 7682 pages clean.
- `playwright test` from worktree — **7 passed in 21s**, including the new village selection test.
- Manual repro path: load `/arcade/towerdefense`, click Play, scroll wheel over palette → palette scrolls horizontally, village button appears and is clickable.

## Test plan
- [ ] Pull dev, `pnpm install`, `nx run astro-kbve:build`
- [ ] `nx e2e astro-kbve` — 7 tests pass
- [ ] Manual: load TD, click Play
- [ ] Scroll wheel over palette without holding Shift → palette scrolls horizontally
- [ ] Scroll wheel over canvas → page does NOT scroll
- [ ] Click Village → button highlights and selection works for placement