### PR TITLE
fix(kbve-spider): allies actually follow + walkable egg collision

### DIFF
--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -283,9 +283,17 @@ script.on_nth_tick(60, function(event)
 	end
 end)
 
-local FOLLOW_TICK_INTERVAL = 120
-local FOLLOW_RADIUS_SQ = 64 * 64
-local FOLLOW_MIN_DIST_SQ = 4 * 4
+-- Follow loop: re-issued every second so the ally tracks the owner smoothly
+-- even when the owner is moving. We re-issue UNCONDITIONALLY (modulo the
+-- "already on top of owner" early-out) because once the unit reaches
+-- `radius` of a go_to_location target it idles, and Factorio's player-force
+-- unit AI does not pick a new destination on its own. The teleport-far cap
+-- prevents the loop from spamming commands for allies the owner abandoned
+-- on a different chunk; once back within range the loop picks up again.
+local FOLLOW_TICK_INTERVAL = 60
+local FOLLOW_RADIUS_SQ = 128 * 128   -- keep tracking up to ~128 tiles away
+local FOLLOW_REST_DIST_SQ = 2 * 2    -- already on top of owner → don't churn
+local FOLLOW_DESTINATION_RADIUS = 2  -- ally settles within 2 tiles of owner
 
 script.on_nth_tick(FOLLOW_TICK_INTERVAL, function(event)
 	storage.ally_owners = storage.ally_owners or {}
@@ -318,16 +326,21 @@ script.on_nth_tick(FOLLOW_TICK_INTERVAL, function(event)
 					owner = nearest
 				end
 				if owner then
-					local dx = owner.position.x - ally.position.x
-					local dy = owner.position.y - ally.position.y
+					local ox, oy = owner.position.x, owner.position.y
+					local dx = ox - ally.position.x
+					local dy = oy - ally.position.y
 					local d2 = dx * dx + dy * dy
-					if d2 > FOLLOW_MIN_DIST_SQ and d2 < FOLLOW_RADIUS_SQ then
+					if d2 > FOLLOW_REST_DIST_SQ and d2 < FOLLOW_RADIUS_SQ then
 						pcall(function()
 							ally.set_command{
 								type = defines.command.go_to_location,
-								destination = { x = owner.position.x, y = owner.position.y },
-								distraction = defines.distraction.by_enemy,
-								radius = 3,
+								destination = { x = ox, y = oy },
+								-- by_damage = ally engages only when hit, not at every
+								-- ambient enemy. Keeps the follow tether intact while
+								-- the owner is just walking past biter spawners.
+								distraction = defines.distraction.by_damage,
+								radius = FOLLOW_DESTINATION_RADIUS,
+								pathfind_flags = { allow_destroy_friendly_entities = false },
 							}
 						end)
 					end

--- a/apps/factorio/mods/kbve-spider/prototypes/spider.lua
+++ b/apps/factorio/mods/kbve-spider/prototypes/spider.lua
@@ -209,8 +209,12 @@ local spider_egg_entity = {
 	icon_size = 64,
 	icon_mipmaps = 4,
 	flags = { "placeable-neutral", "placeable-off-grid", "not-blueprintable", "player-creation" },
-	collision_box = { { -0.3, -0.3 }, { 0.3, 0.3 } },
-	selection_box = { { -0.5, -0.5 }, { 0.5, 0.5 } },
+	-- Tiny collision footprint so the egg sits on the ground without blocking
+	-- the player walking over it. Selection box stays at half-tile so the
+	-- egg is still easy to click + mine before it hatches.
+	collision_box = { { -0.15, -0.15 }, { 0.15, 0.15 } },
+	collision_mask = { layers = {} },
+	selection_box = { { -0.45, -0.45 }, { 0.45, 0.45 } },
 	selectable_in_game = true,
 	picture = {
 		filename = "__kbve-spider__/graphics/item/spider-egg.png",


### PR DESCRIPTION
## Summary

Two bugs from #11603 that surfaced on the live server.

### 1. Ally spider stops following after one hop

**Symptom:** ally hatches, walks to the player once, then never moves again no matter how far the player wanders.

**Root cause:** the follow loop only re-issued `go_to_location` when the ally was **more than 4 tiles** from the owner, but `go_to_location` completes once the unit is within `radius=3`. After the first hop the ally sits inside that 4-tile dead zone and the loop never fires again. Player walks away, ally stays put.

**Fix in `control.lua`:**

| Knob | Before | After | Why |
| --- | --- | --- | --- |
| `FOLLOW_TICK_INTERVAL` | 120 ticks (2s) | 60 ticks (1s) | Smoother tracking against a moving owner |
| `FOLLOW_REST_DIST_SQ` | `4² = 16` | `2² = 4` | Re-issue as soon as the owner takes one step |
| `FOLLOW_DESTINATION_RADIUS` (passed to `set_command`) | 3 | 2 | Ally settles closer |
| `FOLLOW_RADIUS_SQ` | `64² = 4096` | `128² = 16384` | Larger chunks of map covered |
| `distraction` | `by_enemy` | `by_damage` | `by_enemy` was clearing the follow command every time a hostile drifted into sensor range; `by_damage` only breaks the tether when the ally is actually being hit, which still lets the spider defend itself |
| `pathfind_flags.allow_destroy_friendly_entities` | _unset_ | `false` | Ally won't chew through the owner's own structures while routing |

### 2. Egg collision blocks the player

**Symptom:** placing an egg on the ground in front of you leaves a knee-high invisible wall — the player bumps off the 0.6×0.6 collision box and has to step around the egg until it hatches.

**Fix in `prototypes/spider.lua::spider_egg_entity`:**

```diff
- collision_box = { { -0.3, -0.3 }, { 0.3, 0.3 } },
- selection_box = { { -0.5, -0.5 }, { 0.5, 0.5 } },
+ collision_box = { { -0.15, -0.15 }, { 0.15, 0.15 } },
+ collision_mask = { layers = {} },
+ selection_box = { { -0.45, -0.45 }, { 0.45, 0.45 } },
```

- Smaller box (0.3 tile wide) so the egg has a visual footprint but doesn't body-check the player.
- Empty `collision_mask.layers` means the egg participates in **no** collision layers at all. Player + bots walk straight over it.
- Selection box stays near a full tile so the egg is still easy to click + mine before it hatches.
- `placeable-off-grid` flag stays on, so eggs still snap visually to tile centers.

## Test plan

- [x] `./kbve.sh -nx kbve-spider:test` → PASS.
- [ ] CI re-runs `kbve-spider:test` clean.
- [ ] Manual: walk over a placed egg → no bump.
- [ ] Manual: hatch ally → walk 30 tiles → ally trails at 1-2s lag, never stops dead.
- [ ] Manual: ally engaged by biter → ally fights → owner walks away → ally resumes following after kill.