### PR TITLE
feat(guacamole): tune RDP params + reloader for windows-builder

### DIFF
--- a/apps/kube/kubevirt/guacamole/deployment.yaml
+++ b/apps/kube/kubevirt/guacamole/deployment.yaml
@@ -83,6 +83,13 @@ metadata:
     labels:
         app: guacamole
         component: guacamole
+    annotations:
+        # Pod runs an init container that renders user-mapping.xml from
+        # this ConfigMap + the admin Secret. Neither edit triggers a
+        # rollout on its own — Reloader rotates the pod whenever either
+        # changes, so RDP param tweaks land without manual rollout.
+        configmap.reloader.stakater.com/reload: 'guacamole-user-mapping'
+        secret.reloader.stakater.com/reload: 'windows-builder-admin'
 spec:
     replicas: 1
     selector:

--- a/apps/kube/kubevirt/guacamole/user-mapping-configmap.yaml
+++ b/apps/kube/kubevirt/guacamole/user-mapping-configmap.yaml
@@ -1,6 +1,30 @@
 # Guacamole user-mapping.xml — initial auth + RDP connection config.
 # Default password: guacadmin (sha256 hash below). CHANGE after first login.
 # For production, migrate to PostgreSQL backend.
+#
+# RDP param choices (Windows Server builder over WAN through Guacamole):
+#   - color-depth 24       — readable text without saturating the link
+#   - resize-method
+#     display-update       — true resolution change in the guest on browser
+#                            resize / fullscreen toggle; needs guest-agent
+#   - disable-wallpaper /
+#     theming / fwd-drag /
+#     desktop-composition /
+#     menu-animations      — strip expensive repaints; massive bandwidth win
+#                            and unblocks fullscreen mode rendering on slow
+#                            links
+#   - enable-font-smoothing — keep ClearType so MSVC / VS panes stay legible
+#   - bitmap / offscreen /
+#     glyph caching ON     — cuts repaint cost during long build log scroll
+#   - disable-audio        — VM has no audio device, avoids RDP channel error
+#   - enable-printing /
+#     enable-drive false   — no host file passthrough until we explicitly
+#                            wire a redirected drive
+#   - server-layout en-us  — fixes wrong characters on AltGr / dead keys
+#   - console false        — connect to interactive session (so autologon
+#                            takes effect); console=true would land on the
+#                            session 0 lock screen and CAD would target it
+#                            instead of the desktop
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,7 +46,22 @@ data:
                     <param name="username">Administrator</param>
                     <param name="security">nla</param>
                     <param name="ignore-cert">true</param>
+                    <param name="console">false</param>
+                    <param name="server-layout">en-us-qwerty</param>
+                    <param name="color-depth">24</param>
                     <param name="resize-method">display-update</param>
+                    <param name="enable-wallpaper">false</param>
+                    <param name="enable-theming">false</param>
+                    <param name="enable-font-smoothing">true</param>
+                    <param name="enable-full-window-drag">false</param>
+                    <param name="enable-desktop-composition">false</param>
+                    <param name="enable-menu-animations">false</param>
+                    <param name="disable-bitmap-caching">false</param>
+                    <param name="disable-offscreen-caching">false</param>
+                    <param name="disable-glyph-caching">false</param>
+                    <param name="disable-audio">true</param>
+                    <param name="enable-printing">false</param>
+                    <param name="enable-drive">false</param>
                 </connection>
             </authorize>
         </user-mapping>


### PR DESCRIPTION
## Summary
- Adds bandwidth + reliability RDP params to the `Windows Builder` connection in `guacamole-user-mapping`: strips Aero/wallpaper/animations, keeps bitmap+glyph+offscreen caches on, sets `color-depth: 24`, pins `server-layout: en-us-qwerty`, and sets `console: false` so the Ctrl+Alt+Del chord from Guacamole's menu targets the auto-logged-in desktop session instead of the session-0 lock screen.
- Annotates the `guacamole` Deployment with Stakater Reloader on the `guacamole-user-mapping` ConfigMap and the `windows-builder-admin` Secret. The pod renders `user-mapping.xml` at init from the ConfigMap + Secret, so changes to either previously needed a manual `kubectl rollout restart` — Reloader now rotates the pod whenever either is updated.
- Follow-up to #11570 (gluetun-builder-egress) — same builder VM, polishing the operator UX.

## Test plan
- [ ] ArgoCD syncs and Reloader rolls the `guacamole` pod once the ConfigMap hash changes.
- [ ] Open the Windows Builder connection in Guacamole; verify session opens straight to desktop (autologon Job applied beforehand) with no wallpaper/Aero.
- [ ] Toggle browser fullscreen — confirm display-update resizes the RDP session smoothly.
- [ ] From Guacamole menu, send Ctrl+Alt+Del; verify the chord reaches the desktop (Task Manager option) instead of a lock screen.
- [ ] Keyboard sanity: type `\`, `|`, `@`, `#` — confirm `server-layout: en-us-qwerty` produces correct characters.