### PR TITLE
test(astro-kbve-e2e): cover dashboard + sidebar nesting + all redirect aliases (#11589)

### DIFF
--- a/apps/kbve/astro-kbve-e2e/e2e/dashboard-routes.spec.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/dashboard-routes.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+import { DASHBOARD_ROUTES } from './helpers/routes';
+
+const titleRe = /<title>([^<]+)<\/title>/i;
+
+function extractTitle(body: string): string {
+	const match = body.match(titleRe);
+	return match ? match[1].trim() : '';
+}
+
+describe('Dashboard routes', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	for (const route of DASHBOARD_ROUTES) {
+		describe(`${route.path}`, () => {
+			it('returns HTTP 200 with HTML', async () => {
+				const res = await fetch(`${BASE_URL}${route.path}`);
+				expect(res.status).toBe(200);
+				expect(res.headers.get('content-type') ?? '').toContain(
+					'text/html',
+				);
+			});
+
+			it('renders a non-empty <title> containing the page title', async () => {
+				const body = await (
+					await fetch(`${BASE_URL}${route.path}`)
+				).text();
+				const title = extractTitle(body);
+				expect(title.length).toBeGreaterThan(0);
+				expect(title).toContain(route.title);
+			});
+
+			it('emits no console-noise headers (x-powered-by absent)', async () => {
+				const res = await fetch(`${BASE_URL}${route.path}`);
+				expect(res.headers.get('x-powered-by')).toBeNull();
+			});
+
+			it('declares a canonical link', async () => {
+				const body = await (
+					await fetch(`${BASE_URL}${route.path}`)
+				).text();
+				expect(body).toMatch(
+					/<link[^>]+rel=["']canonical["'][^>]+href=["'][^"']+["']/i,
+				);
+			});
+
+			it('embeds the dashboard sidebar root', async () => {
+				const body = await (
+					await fetch(`${BASE_URL}${route.path}`)
+				).text();
+				expect(body).toContain('data-kbve-sidebar-root');
+			});
+		});
+	}
+});

--- a/apps/kbve/astro-kbve-e2e/e2e/dashboard-routes.spec.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/dashboard-routes.spec.ts
@@ -3,10 +3,21 @@ import { BASE_URL, waitForReady } from './helpers/http';
 import { DASHBOARD_ROUTES } from './helpers/routes';
 
 const titleRe = /<title>([^<]+)<\/title>/i;
+const h1Re = /<h1[^>]*id=["']_top["'][^>]*>([\s\S]*?)<\/h1>/i;
+
+function escapeRe(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 function extractTitle(body: string): string {
 	const match = body.match(titleRe);
 	return match ? match[1].trim() : '';
+}
+
+function extractH1(body: string): string | null {
+	const match = body.match(h1Re);
+	if (!match) return null;
+	return match[1].replace(/<[^>]+>/g, '').trim();
 }
 
 describe('Dashboard routes', () => {
@@ -16,8 +27,25 @@ describe('Dashboard routes', () => {
 
 	for (const route of DASHBOARD_ROUTES) {
 		describe(`${route.path}`, () => {
+			let bodyPromise: Promise<string> | null = null;
+			let resPromise: Promise<Response> | null = null;
+			const getRes = () => {
+				if (!resPromise) {
+					resPromise = fetch(`${BASE_URL}${route.path}`);
+				}
+				return resPromise;
+			};
+			const getBody = async () => {
+				if (!bodyPromise) {
+					bodyPromise = fetch(`${BASE_URL}${route.path}`).then((r) =>
+						r.text(),
+					);
+				}
+				return bodyPromise;
+			};
+
 			it('returns HTTP 200 with HTML', async () => {
-				const res = await fetch(`${BASE_URL}${route.path}`);
+				const res = await getRes();
 				expect(res.status).toBe(200);
 				expect(res.headers.get('content-type') ?? '').toContain(
 					'text/html',
@@ -25,34 +53,76 @@ describe('Dashboard routes', () => {
 			});
 
 			it('renders a non-empty <title> containing the page title', async () => {
-				const body = await (
-					await fetch(`${BASE_URL}${route.path}`)
-				).text();
+				const body = await getBody();
 				const title = extractTitle(body);
 				expect(title.length).toBeGreaterThan(0);
 				expect(title).toContain(route.title);
 			});
 
+			if (route.splash) {
+				it('uses the splash template (no <h1 id="_top">)', async () => {
+					const body = await getBody();
+					expect(body).toContain('data-splash-no-title');
+					expect(body).not.toMatch(/<h1[^>]*id=["']_top["']/i);
+				});
+			} else {
+				it('renders the Starlight <h1 id="_top"> with the page title', async () => {
+					const body = await getBody();
+					const h1 = extractH1(body);
+					expect(
+						h1,
+						`<h1 id="_top"> missing on ${route.path}`,
+					).not.toBeNull();
+					expect(h1).toBe(route.title);
+				});
+			}
+
 			it('emits no console-noise headers (x-powered-by absent)', async () => {
-				const res = await fetch(`${BASE_URL}${route.path}`);
+				const res = await getRes();
 				expect(res.headers.get('x-powered-by')).toBeNull();
 			});
 
-			it('declares a canonical link', async () => {
-				const body = await (
-					await fetch(`${BASE_URL}${route.path}`)
-				).text();
-				expect(body).toMatch(
-					/<link[^>]+rel=["']canonical["'][^>]+href=["'][^"']+["']/i,
+			it('declares a canonical link with absolute URL', async () => {
+				const body = await getBody();
+				const m = body.match(
+					/<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["']/i,
 				);
+				expect(
+					m,
+					`canonical link missing on ${route.path}`,
+				).not.toBeNull();
+				expect(m![1]).toMatch(/^https?:\/\//);
 			});
 
-			it('embeds the dashboard sidebar root', async () => {
-				const body = await (
-					await fetch(`${BASE_URL}${route.path}`)
-				).text();
-				expect(body).toContain('data-kbve-sidebar-root');
+			it('emits Open Graph + Twitter card tags', async () => {
+				const body = await getBody();
+				expect(body).toMatch(/property=["']og:title["']/i);
+				expect(body).toMatch(/property=["']og:type["']/i);
+				expect(body).toMatch(/(name|property)=["']twitter:card["']/i);
 			});
+
+			if (!route.splash) {
+				it('embeds the dashboard sidebar root', async () => {
+					const body = await getBody();
+					expect(body).toContain('data-kbve-sidebar-root');
+				});
+			} else {
+				it('omits the dashboard sidebar root on splash template', async () => {
+					const body = await getBody();
+					expect(body).not.toContain('data-kbve-sidebar-root');
+				});
+			}
+
+			if (route.inSidebar !== false && !route.splash) {
+				it('links to itself from the sidebar nav', async () => {
+					const body = await getBody();
+					const re = new RegExp(
+						`<a\\b[^>]*\\bhref=["']${escapeRe(route.path)}["']`,
+						'i',
+					);
+					expect(body).toMatch(re);
+				});
+			}
 		});
 	}
 });

--- a/apps/kbve/astro-kbve-e2e/e2e/helpers/routes.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/helpers/routes.ts
@@ -33,7 +33,15 @@ export const API_ROUTES = [
 	{ path: '/api/mapdb.json', label: 'MapDB API' },
 ] as const;
 
-export const DASHBOARD_ROUTES = [
+export type DashboardRoute = {
+	path: string;
+	label: string;
+	title: string;
+	splash?: boolean;
+	inSidebar?: boolean;
+};
+
+export const DASHBOARD_ROUTES: readonly DashboardRoute[] = [
 	{ path: '/dashboard/', label: 'Dashboard overview', title: 'Dashboard' },
 	{ path: '/dashboard/profile/', label: 'Profile', title: 'Profile' },
 	{ path: '/dashboard/account/', label: 'Account', title: 'Account' },
@@ -43,6 +51,7 @@ export const DASHBOARD_ROUTES = [
 		path: '/dashboard/kanban-data/',
 		label: 'Kanban raw data',
 		title: 'Kanban Raw Data',
+		inSidebar: false,
 	},
 	{
 		path: '/dashboard/report/',
@@ -55,7 +64,13 @@ export const DASHBOARD_ROUTES = [
 		label: 'Security',
 		title: 'Security Audit Report',
 	},
-	{ path: '/dashboard/api/', label: 'API reference', title: 'API Reference' },
+	{
+		path: '/dashboard/api/',
+		label: 'API reference',
+		title: 'API Reference',
+		splash: true,
+		inSidebar: false,
+	},
 	{ path: '/dashboard/agents/', label: 'Agents overview', title: 'Agents' },
 	{
 		path: '/dashboard/agents/github/',
@@ -93,6 +108,7 @@ export const DASHBOARD_ROUTES = [
 		path: '/dashboard/vm/kasm/',
 		label: 'KASM workspace',
 		title: 'KASM Workspace',
+		inSidebar: false,
 	},
 	{
 		path: '/dashboard/ide/',
@@ -119,21 +135,58 @@ export const DASHBOARD_ROUTES = [
 		label: 'Minecraft',
 		title: 'Minecraft Dashboard',
 	},
-] as const;
+];
+
+export type SidebarGroupItem = { label: string; href: string };
+export type SidebarGroup = {
+	label: string;
+	items: readonly SidebarGroupItem[];
+};
+
+export const SIDEBAR_DASHBOARD_ROOT_LABEL = 'Dashboard';
 
 export const SIDEBAR_GROUPS = {
-	Account: [
-		{ label: 'Profile', href: '/dashboard/profile/' },
-		{ label: 'Account', href: '/dashboard/account/' },
-		{ label: 'Marketplace', href: '/dashboard/market/' },
-	],
-	Workspace: [
-		{ label: 'Kanban', href: '/dashboard/kanban/' },
-		{ label: 'Report', href: '/dashboard/report/' },
-		{ label: 'Graph', href: '/dashboard/graph/' },
-		{ label: 'Security', href: '/dashboard/security/' },
-	],
-} as const;
+	Account: {
+		label: 'Account',
+		items: [
+			{ label: 'Profile', href: '/dashboard/profile/' },
+			{ label: 'Account', href: '/dashboard/account/' },
+			{ label: 'Marketplace', href: '/dashboard/market/' },
+		],
+	},
+	Workspace: {
+		label: 'Workspace',
+		items: [
+			{ label: 'Kanban', href: '/dashboard/kanban/' },
+			{ label: 'Report', href: '/dashboard/report/' },
+			{ label: 'Graph', href: '/dashboard/graph/' },
+			{ label: 'Security', href: '/dashboard/security/' },
+		],
+	},
+	Agents: {
+		label: 'Agents',
+		items: [
+			{ label: 'Overview', href: '/dashboard/agents/' },
+			{ label: 'GitHub', href: '/dashboard/agents/github/' },
+			{ label: 'DiscordSH', href: '/dashboard/agents/discordsh/' },
+		],
+	},
+	GameOps: {
+		label: 'GameOps',
+		items: [
+			{ label: 'Overview', href: '/dashboard/gameops/' },
+			{ label: 'ROWS', href: '/dashboard/gameops/rows/' },
+			{ label: 'Factorio', href: '/dashboard/gameops/factorio/' },
+			{ label: 'Minecraft', href: '/dashboard/gameops/mc/' },
+		],
+	},
+} as const satisfies Record<string, SidebarGroup>;
+
+export const SIDEBAR_GROUP_ORDER = [
+	'Account',
+	'Workspace',
+	'Agents',
+] as const satisfies ReadonlyArray<keyof typeof SIDEBAR_GROUPS>;
 
 export const REDIRECT_ALIASES = [
 	{ from: '/account', to: '/dashboard/account/' },

--- a/apps/kbve/astro-kbve-e2e/e2e/helpers/routes.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/helpers/routes.ts
@@ -32,3 +32,118 @@ export const API_ROUTES = [
 	{ path: '/api/questdb.json', label: 'QuestDB API' },
 	{ path: '/api/mapdb.json', label: 'MapDB API' },
 ] as const;
+
+export const DASHBOARD_ROUTES = [
+	{ path: '/dashboard/', label: 'Dashboard overview', title: 'Dashboard' },
+	{ path: '/dashboard/profile/', label: 'Profile', title: 'Profile' },
+	{ path: '/dashboard/account/', label: 'Account', title: 'Account' },
+	{ path: '/dashboard/market/', label: 'Marketplace', title: 'Marketplace' },
+	{ path: '/dashboard/kanban/', label: 'Kanban', title: 'Project Kanban' },
+	{
+		path: '/dashboard/kanban-data/',
+		label: 'Kanban raw data',
+		title: 'Kanban Raw Data',
+	},
+	{
+		path: '/dashboard/report/',
+		label: 'Report',
+		title: 'NX Workspace Report',
+	},
+	{ path: '/dashboard/graph/', label: 'Graph', title: 'NX Dependency Graph' },
+	{
+		path: '/dashboard/security/',
+		label: 'Security',
+		title: 'Security Audit Report',
+	},
+	{ path: '/dashboard/api/', label: 'API reference', title: 'API Reference' },
+	{ path: '/dashboard/agents/', label: 'Agents overview', title: 'Agents' },
+	{
+		path: '/dashboard/agents/github/',
+		label: 'GitHub agent',
+		title: 'GitHub provider',
+	},
+	{
+		path: '/dashboard/agents/discordsh/',
+		label: 'DiscordSH agent',
+		title: 'DiscordSH agent',
+	},
+	{ path: '/dashboard/argo/', label: 'ArgoCD', title: 'ArgoCD Dashboard' },
+	{
+		path: '/dashboard/clickhouse/',
+		label: 'ClickHouse',
+		title: 'ClickHouse Logs',
+	},
+	{
+		path: '/dashboard/edge/',
+		label: 'Edge functions',
+		title: 'Edge Functions',
+	},
+	{
+		path: '/dashboard/forgejo/',
+		label: 'Forgejo',
+		title: 'Forgejo Dashboard',
+	},
+	{
+		path: '/dashboard/grafana/',
+		label: 'Grafana',
+		title: 'Grafana Dashboard',
+	},
+	{ path: '/dashboard/vm/', label: 'VM dashboard', title: 'VM Dashboard' },
+	{
+		path: '/dashboard/vm/kasm/',
+		label: 'KASM workspace',
+		title: 'KASM Workspace',
+	},
+	{
+		path: '/dashboard/ide/',
+		label: 'Firecracker IDE',
+		title: 'Firecracker IDE',
+	},
+	{
+		path: '/dashboard/gameops/',
+		label: 'GameOps overview',
+		title: 'GameOps Dashboard',
+	},
+	{
+		path: '/dashboard/gameops/rows/',
+		label: 'ROWS',
+		title: 'ROWS Dashboard',
+	},
+	{
+		path: '/dashboard/gameops/factorio/',
+		label: 'Factorio',
+		title: 'Factorio Dashboard',
+	},
+	{
+		path: '/dashboard/gameops/mc/',
+		label: 'Minecraft',
+		title: 'Minecraft Dashboard',
+	},
+] as const;
+
+export const SIDEBAR_GROUPS = {
+	Account: [
+		{ label: 'Profile', href: '/dashboard/profile/' },
+		{ label: 'Account', href: '/dashboard/account/' },
+		{ label: 'Marketplace', href: '/dashboard/market/' },
+	],
+	Workspace: [
+		{ label: 'Kanban', href: '/dashboard/kanban/' },
+		{ label: 'Report', href: '/dashboard/report/' },
+		{ label: 'Graph', href: '/dashboard/graph/' },
+		{ label: 'Security', href: '/dashboard/security/' },
+	],
+} as const;
+
+export const REDIRECT_ALIASES = [
+	{ from: '/account', to: '/dashboard/account/' },
+	{ from: '/account/', to: '/dashboard/account/' },
+	{ from: '/profile', to: '/dashboard/profile/' },
+	{ from: '/profile/', to: '/dashboard/profile/' },
+	{ from: '/profile/account', to: '/dashboard/account/' },
+	{ from: '/profile/account/', to: '/dashboard/account/' },
+	{ from: '/profile/market', to: '/dashboard/market/' },
+	{ from: '/profile/market/', to: '/dashboard/market/' },
+	{ from: '/dashboard/rows', to: '/dashboard/gameops/rows/' },
+	{ from: '/dashboard/rows/', to: '/dashboard/gameops/rows/' },
+] as const;

--- a/apps/kbve/astro-kbve-e2e/e2e/redirects.spec.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/redirects.spec.ts
@@ -45,5 +45,11 @@ describe('Static redirects', () => {
 			const ct = res.headers.get('content-type') ?? '';
 			expect(ct).toContain('text/html');
 		});
+
+		it(`${from} destination ${to} embeds the dashboard sidebar root`, async () => {
+			const res = await fetch(`${BASE_URL}${from}`);
+			const body = await res.text();
+			expect(body).toContain('data-kbve-sidebar-root');
+		});
 	}
 });

--- a/apps/kbve/astro-kbve-e2e/e2e/redirects.spec.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/redirects.spec.ts
@@ -1,26 +1,42 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { BASE_URL, waitForReady } from './helpers/http';
+import { REDIRECT_ALIASES } from './helpers/routes';
+
+function escapeRe(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function destinationRe(to: string): RegExp {
+	const trimmed = to.replace(/\/$/, '');
+	return new RegExp(`${escapeRe(trimmed)}/?$`);
+}
+
+function refreshRe(to: string): RegExp {
+	const trimmed = to.replace(/\/$/, '');
+	return new RegExp(
+		`<meta[^>]+http-equiv=["']?refresh["']?[^>]+${escapeRe(trimmed)}/?`,
+		'i',
+	);
+}
 
 describe('Static redirects', () => {
 	beforeAll(async () => {
 		await waitForReady();
 	});
 
-	for (const from of ['/account', '/account/']) {
-		it(`${from} redirects to /profile/account/`, async () => {
+	for (const { from, to } of REDIRECT_ALIASES) {
+		it(`${from} redirects to ${to}`, async () => {
 			const res = await fetch(`${BASE_URL}${from}`, {
 				redirect: 'manual',
 			});
 			if ([301, 302, 303, 307, 308].includes(res.status)) {
 				const location = res.headers.get('location') ?? '';
-				expect(location).toMatch(/\/profile\/account\/?$/);
+				expect(location).toMatch(destinationRe(to));
 				return;
 			}
 			expect(res.status).toBe(200);
 			const body = await res.text();
-			expect(body).toMatch(
-				/<meta[^>]+http-equiv=["']?refresh["']?[^>]+\/profile\/account\/?/i,
-			);
+			expect(body).toMatch(refreshRe(to));
 		});
 
 		it(`${from} ultimately resolves to a 200 HTML page when followed`, async () => {

--- a/apps/kbve/astro-kbve-e2e/e2e/sidebar.spec.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/sidebar.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+import { SIDEBAR_GROUPS, DASHBOARD_ROUTES } from './helpers/routes';
+
+function escapeRe(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function summaryRe(label: string): RegExp {
+	return new RegExp(
+		`<summary[^>]*>\\s*(?:<[^>]+>\\s*)*${escapeRe(label)}`,
+		'i',
+	);
+}
+
+function hrefRe(href: string): RegExp {
+	return new RegExp(`<a\\b[^>]*\\bhref=["']${escapeRe(href)}["']`, 'i');
+}
+
+function ariaCurrentRe(href: string): RegExp {
+	const esc = escapeRe(href);
+	return new RegExp(
+		`<a\\b[^>]*?(?:href=["']${esc}["'][^>]*?aria-current=["']page["']|aria-current=["']page["'][^>]*?href=["']${esc}["'])`,
+		'i',
+	);
+}
+
+const ARIA_CURRENT_ROUTES = [
+	'/dashboard/profile/',
+	'/dashboard/account/',
+	'/dashboard/market/',
+	'/dashboard/kanban/',
+	'/dashboard/report/',
+	'/dashboard/graph/',
+	'/dashboard/security/',
+] as const;
+
+describe('Sidebar nesting (Account + Workspace groups)', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	for (const route of DASHBOARD_ROUTES) {
+		describe(`as rendered on ${route.path}`, () => {
+			let bodyPromise: Promise<string> | null = null;
+			const getBody = () => {
+				if (!bodyPromise) {
+					bodyPromise = fetch(`${BASE_URL}${route.path}`).then((r) =>
+						r.text(),
+					);
+				}
+				return bodyPromise;
+			};
+
+			it('mounts the kbve sidebar wrapper', async () => {
+				const body = await getBody();
+				expect(body).toContain('data-kbve-sidebar-root');
+			});
+
+			it('renders the Account group with Profile + Account + Marketplace', async () => {
+				const body = await getBody();
+				expect(body).toMatch(summaryRe('Account'));
+				for (const item of SIDEBAR_GROUPS.Account) {
+					expect(body).toMatch(hrefRe(item.href));
+				}
+			});
+
+			it('renders the Workspace group with Kanban + Report + Graph + Security', async () => {
+				const body = await getBody();
+				expect(body).toMatch(summaryRe('Workspace'));
+				for (const item of SIDEBAR_GROUPS.Workspace) {
+					expect(body).toMatch(hrefRe(item.href));
+				}
+			});
+		});
+	}
+
+	describe('aria-current=page on server render', () => {
+		for (const path of ARIA_CURRENT_ROUTES) {
+			it(`${path} marks its own sidebar link as current`, async () => {
+				const body = await (await fetch(`${BASE_URL}${path}`)).text();
+				expect(body).toMatch(ariaCurrentRe(path));
+			});
+		}
+	});
+});

--- a/apps/kbve/astro-kbve-e2e/e2e/sidebar.spec.ts
+++ b/apps/kbve/astro-kbve-e2e/e2e/sidebar.spec.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { BASE_URL, waitForReady } from './helpers/http';
-import { SIDEBAR_GROUPS, DASHBOARD_ROUTES } from './helpers/routes';
+import {
+	SIDEBAR_GROUPS,
+	SIDEBAR_GROUP_ORDER,
+	SIDEBAR_DASHBOARD_ROOT_LABEL,
+	DASHBOARD_ROUTES,
+} from './helpers/routes';
 
 function escapeRe(s: string): string {
 	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -8,7 +13,7 @@ function escapeRe(s: string): string {
 
 function summaryRe(label: string): RegExp {
 	return new RegExp(
-		`<summary[^>]*>\\s*(?:<[^>]+>\\s*)*${escapeRe(label)}`,
+		`<summary[^>]*>(?:\\s|<[^>]+>)*${escapeRe(label)}\\b`,
 		'i',
 	);
 }
@@ -25,6 +30,28 @@ function ariaCurrentRe(href: string): RegExp {
 	);
 }
 
+function authVisibilityHrefRe(href: string): RegExp {
+	const esc = escapeRe(href);
+	return new RegExp(
+		`<a\\b[^>]*?(?:href=["']${esc}["'][^>]*?data-auth-visibility=["'][a-z]+["']|data-auth-visibility=["'][a-z]+["'][^>]*?href=["']${esc}["'])`,
+		'i',
+	);
+}
+
+function extractSidebarHtml(body: string): string {
+	const start = body.indexOf('data-kbve-sidebar-root');
+	if (start === -1) return body;
+	const slice = body.slice(start);
+	let depth = 1;
+	const tagRe = /<(\/?)div\b[^>]*>/gi;
+	let m: RegExpExecArray | null;
+	while ((m = tagRe.exec(slice)) !== null) {
+		depth += m[1] ? -1 : 1;
+		if (depth === 0) return slice.slice(0, m.index + m[0].length);
+	}
+	return slice;
+}
+
 const ARIA_CURRENT_ROUTES = [
 	'/dashboard/profile/',
 	'/dashboard/account/',
@@ -33,14 +60,23 @@ const ARIA_CURRENT_ROUTES = [
 	'/dashboard/report/',
 	'/dashboard/graph/',
 	'/dashboard/security/',
+	'/dashboard/agents/',
+	'/dashboard/agents/github/',
+	'/dashboard/agents/discordsh/',
+	'/dashboard/gameops/',
+	'/dashboard/gameops/rows/',
+	'/dashboard/gameops/factorio/',
+	'/dashboard/gameops/mc/',
 ] as const;
 
-describe('Sidebar nesting (Account + Workspace groups)', () => {
+describe('Sidebar nesting (Account + Workspace + Agents + GameOps)', () => {
 	beforeAll(async () => {
 		await waitForReady();
 	});
 
-	for (const route of DASHBOARD_ROUTES) {
+	const sidebarRoutes = DASHBOARD_ROUTES.filter((r) => !r.splash);
+
+	for (const route of sidebarRoutes) {
 		describe(`as rendered on ${route.path}`, () => {
 			let bodyPromise: Promise<string> | null = null;
 			const getBody = () => {
@@ -57,19 +93,51 @@ describe('Sidebar nesting (Account + Workspace groups)', () => {
 				expect(body).toContain('data-kbve-sidebar-root');
 			});
 
-			it('renders the Account group with Profile + Account + Marketplace', async () => {
+			it(`renders the top-level "${SIDEBAR_DASHBOARD_ROOT_LABEL}" group`, async () => {
 				const body = await getBody();
-				expect(body).toMatch(summaryRe('Account'));
-				for (const item of SIDEBAR_GROUPS.Account) {
-					expect(body).toMatch(hrefRe(item.href));
+				expect(body).toMatch(summaryRe(SIDEBAR_DASHBOARD_ROOT_LABEL));
+			});
+
+			for (const groupKey of [
+				'Account',
+				'Workspace',
+				'Agents',
+				'GameOps',
+			] as const) {
+				const group = SIDEBAR_GROUPS[groupKey];
+				it(`renders the ${group.label} group with ${group.items.map((i) => i.label).join(' + ')}`, async () => {
+					const body = await getBody();
+					const sidebar = extractSidebarHtml(body);
+					expect(sidebar).toMatch(summaryRe(group.label));
+					for (const item of group.items) {
+						expect(sidebar).toMatch(hrefRe(item.href));
+					}
+				});
+			}
+
+			it('orders Account before Workspace before Agents in the sidebar', async () => {
+				const sidebar = extractSidebarHtml(await getBody());
+				const positions = SIDEBAR_GROUP_ORDER.map((key) => {
+					const label = SIDEBAR_GROUPS[key].label;
+					return sidebar.search(summaryRe(label));
+				});
+				for (const pos of positions) expect(pos).toBeGreaterThan(-1);
+				for (let i = 1; i < positions.length; i++) {
+					expect(positions[i]).toBeGreaterThan(positions[i - 1]);
 				}
 			});
 
-			it('renders the Workspace group with Kanban + Report + Graph + Security', async () => {
-				const body = await getBody();
-				expect(body).toMatch(summaryRe('Workspace'));
-				for (const item of SIDEBAR_GROUPS.Workspace) {
-					expect(body).toMatch(hrefRe(item.href));
+			it('marks Account-group items with data-auth-visibility', async () => {
+				const sidebar = extractSidebarHtml(await getBody());
+				for (const item of SIDEBAR_GROUPS.Account.items) {
+					expect(sidebar).toMatch(authVisibilityHrefRe(item.href));
+				}
+			});
+
+			it('marks Workspace-group items with data-auth-visibility', async () => {
+				const sidebar = extractSidebarHtml(await getBody());
+				for (const item of SIDEBAR_GROUPS.Workspace.items) {
+					expect(sidebar).toMatch(authVisibilityHrefRe(item.href));
 				}
 			});
 		});
@@ -79,8 +147,19 @@ describe('Sidebar nesting (Account + Workspace groups)', () => {
 		for (const path of ARIA_CURRENT_ROUTES) {
 			it(`${path} marks its own sidebar link as current`, async () => {
 				const body = await (await fetch(`${BASE_URL}${path}`)).text();
-				expect(body).toMatch(ariaCurrentRe(path));
+				const sidebar = extractSidebarHtml(body);
+				expect(sidebar).toMatch(ariaCurrentRe(path));
 			});
 		}
+
+		it('only one sidebar link is aria-current=page per dashboard page', async () => {
+			const body = await (
+				await fetch(`${BASE_URL}/dashboard/profile/`)
+			).text();
+			const sidebar = extractSidebarHtml(body);
+			const matches = sidebar.match(/aria-current=["']page["']/gi) ?? [];
+			expect(matches.length).toBeGreaterThan(0);
+			expect(matches.length).toBe(1);
+		});
 	});
 });


### PR DESCRIPTION
Closes #11589.

## Summary

- Add `e2e/dashboard-routes.spec.ts` — enumerates every `/dashboard/*` route from a new `DASHBOARD_ROUTES` helper (overview, profile, account, market, kanban, kanban-data, report, graph, security, api, agents + github + discordsh, argo, clickhouse, edge, forgejo, grafana, vm + kasm, ide, gameops + rows + factorio + mc). Asserts HTTP 200 + HTML, non-empty `<title>` containing the page title, no `x-powered-by` console-noise header, canonical `<link>`, and the kbve sidebar root mount.
- Add `e2e/sidebar.spec.ts` — parses the rendered sidebar on each dashboard page for the Account group (Profile + Account + Marketplace) and the Workspace group (Kanban + Report + Graph + Security) introduced in #11563, plus `aria-current=\"page\"` on the matching link in the server-rendered HTML for each grouped page.
- Rewrite `e2e/redirects.spec.ts` against a new `REDIRECT_ALIASES` table so every alias declared in `astro.config.mjs` is covered (`/account`, `/account/`, `/profile`, `/profile/`, `/profile/account`, `/profile/account/`, `/profile/market`, `/profile/market/`, `/dashboard/rows`, `/dashboard/rows/`) instead of just the `/account` pair.

All HTTP-smoke tier (vitest), no Playwright. Browser-level sidebar coverage stays with #11585.

## Test plan

- [ ] `nx run astro-kbve-e2e:e2e` (boots axum + the container, runs the full vitest suite against `:4323`)
- [ ] New specs flag any regression in dashboard route coverage, sidebar nesting, or redirect aliases