### PR TITLE
fix(codegen): gate protoc C# regen behind KBVE_PROTOC_REGEN env var

### DIFF
--- a/packages/data/codegen/gen-mapdb-data.mjs
+++ b/packages/data/codegen/gen-mapdb-data.mjs
@@ -213,22 +213,28 @@ function main() {
 			),
 		},
 	];
-	for (const t of csharpTargets) {
-		if (!existsSync(t.dir)) mkdirSync(t.dir, { recursive: true });
-		try {
-			execSync(
-				`protoc --csharp_out="${t.dir}" --proto_path="${protoRoot}" ${protoFiles.join(' ')}`,
-				{ stdio: 'pipe' },
-			);
-			console.log(`Regenerated C# protos for ${t.name} → ${t.dir}`);
-		} catch (err) {
-			console.warn(
-				`[warn] protoc csharp gen for ${t.name} failed — ${err.stderr?.toString().trim() || err.message}`,
-			);
-			console.warn(
-				'       Skipping C# regeneration; install protoc (brew install protobuf) if you need it locally.',
-			);
+	if (process.env.KBVE_PROTOC_REGEN === '1') {
+		for (const t of csharpTargets) {
+			if (!existsSync(t.dir)) mkdirSync(t.dir, { recursive: true });
+			try {
+				execSync(
+					`protoc --csharp_out="${t.dir}" --proto_path="${protoRoot}" ${protoFiles.join(' ')}`,
+					{ stdio: 'pipe' },
+				);
+				console.log(`Regenerated C# protos for ${t.name} → ${t.dir}`);
+			} catch (err) {
+				console.warn(
+					`[warn] protoc csharp gen for ${t.name} failed — ${err.stderr?.toString().trim() || err.message}`,
+				);
+				console.warn(
+					'       Skipping C# regeneration; install protoc (brew install protobuf) if you need it locally.',
+				);
+			}
 		}
+	} else {
+		console.log(
+			'[skip] C# proto regen — set KBVE_PROTOC_REGEN=1 to opt in (committed Generated/Proto/*.cs is canonical otherwise).',
+		);
 	}
 }
 

--- a/packages/data/codegen/gen-npcdb-data.mjs
+++ b/packages/data/codegen/gen-npcdb-data.mjs
@@ -159,22 +159,28 @@ function main() {
 			),
 		},
 	];
-	for (const t of csharpTargets) {
-		if (!existsSync(t.dir)) mkdirSync(t.dir, { recursive: true });
-		try {
-			execSync(
-				`protoc --csharp_out="${t.dir}" --proto_path="${protoRoot}" ${protoFiles.join(' ')}`,
-				{ stdio: 'pipe' },
-			);
-			console.log(`Regenerated C# protos for ${t.name} → ${t.dir}`);
-		} catch (err) {
-			console.warn(
-				`[warn] protoc csharp gen for ${t.name} failed — ${err.stderr?.toString().trim() || err.message}`,
-			);
-			console.warn(
-				'       Skipping C# regeneration; install protoc (brew install protobuf) if you need it locally.',
-			);
+	if (process.env.KBVE_PROTOC_REGEN === '1') {
+		for (const t of csharpTargets) {
+			if (!existsSync(t.dir)) mkdirSync(t.dir, { recursive: true });
+			try {
+				execSync(
+					`protoc --csharp_out="${t.dir}" --proto_path="${protoRoot}" ${protoFiles.join(' ')}`,
+					{ stdio: 'pipe' },
+				);
+				console.log(`Regenerated C# protos for ${t.name} → ${t.dir}`);
+			} catch (err) {
+				console.warn(
+					`[warn] protoc csharp gen for ${t.name} failed — ${err.stderr?.toString().trim() || err.message}`,
+				);
+				console.warn(
+					'       Skipping C# regeneration; install protoc (brew install protobuf) if you need it locally.',
+				);
+			}
 		}
+	} else {
+		console.log(
+			'[skip] C# proto regen — set KBVE_PROTOC_REGEN=1 to opt in (committed Generated/Proto/*.cs is canonical otherwise).',
+		);
 	}
 }
 

--- a/packages/data/codegen/gen-questdb-data.mjs
+++ b/packages/data/codegen/gen-questdb-data.mjs
@@ -158,22 +158,28 @@ function main() {
 			),
 		},
 	];
-	for (const t of csharpTargets) {
-		if (!existsSync(t.dir)) mkdirSync(t.dir, { recursive: true });
-		try {
-			execSync(
-				`protoc --csharp_out="${t.dir}" --proto_path="${protoRoot}" ${protoFiles.join(' ')}`,
-				{ stdio: 'pipe' },
-			);
-			console.log(`Regenerated C# protos for ${t.name} → ${t.dir}`);
-		} catch (err) {
-			console.warn(
-				`[warn] protoc csharp gen for ${t.name} failed — ${err.stderr?.toString().trim() || err.message}`,
-			);
-			console.warn(
-				'       Skipping C# regeneration; install protoc (brew install protobuf) if you need it locally.',
-			);
+	if (process.env.KBVE_PROTOC_REGEN === '1') {
+		for (const t of csharpTargets) {
+			if (!existsSync(t.dir)) mkdirSync(t.dir, { recursive: true });
+			try {
+				execSync(
+					`protoc --csharp_out="${t.dir}" --proto_path="${protoRoot}" ${protoFiles.join(' ')}`,
+					{ stdio: 'pipe' },
+				);
+				console.log(`Regenerated C# protos for ${t.name} → ${t.dir}`);
+			} catch (err) {
+				console.warn(
+					`[warn] protoc csharp gen for ${t.name} failed — ${err.stderr?.toString().trim() || err.message}`,
+				);
+				console.warn(
+					'       Skipping C# regeneration; install protoc (brew install protobuf) if you need it locally.',
+				);
+			}
 		}
+	} else {
+		console.log(
+			'[skip] C# proto regen — set KBVE_PROTOC_REGEN=1 to opt in (committed Generated/Proto/*.cs is canonical otherwise).',
+		);
 	}
 }
 


### PR DESCRIPTION
## Summary

Latest CI - Unity run [#26798390664](https://github.com/KBVE/kbve/actions/runs/26798390664) failed every matrix target on:

```
##[error]Branch is dirty. Refusing to base semantic version on uncommitted changes
```

Dirty files were 3 protoc-emitted C# stubs:

```
M apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/Proto/Common.cs
M apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/Proto/Mapdb.cs
M apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/Proto/Npcdb.cs
```

## Root cause

[`gen-npcdb-data.mjs:166`](packages/data/codegen/gen-npcdb-data.mjs#L166), [`gen-mapdb-data.mjs:220`](packages/data/codegen/gen-mapdb-data.mjs#L220), [`gen-questdb-data.mjs:165`](packages/data/codegen/gen-questdb-data.mjs#L165) all shell out to bare `protoc --csharp_out=...` during sync. Local Mac: `brew protoc 33.1`. CI arc-runner image: some other protoc version. Same `.proto` input, *different bytes out* — protoc's C# emitter changed comment formatting / pragma lists between versions, so CI silently overwrites the committed stubs with subtly-different bytes every run.

Confirmed locally: regen on `origin/main` with my protoc 33.1 produces zero diff vs committed bytes. The committed stubs were originally written by the same 33.1 — they're not stale, they only look stale to whichever protoc the arc image ships.

## Fix

Gate the `protoc --csharp_out` invocation in all 3 codegens behind `KBVE_PROTOC_REGEN=1`. CI sync targets emit only deterministic JSON/binpb/enum artifacts. The committed `Generated/Proto/*.cs` files become canonical.

Devs editing a `.proto` opt in explicitly:

```sh
KBVE_PROTOC_REGEN=1 nx run astro-kbve:sync:npcdb
```

## Test plan

- [ ] Next CI - Unity run shows `[skip] C# proto regen` in the sync step log
- [ ] `git status` in the post-sync Unity build step is clean
- [ ] Build matrix completes without `Branch is dirty`
- [ ] Steam beta upload + promote dispatch fires