### PR TITLE
feat(kubevirt): ArgoCD-manage Windows autologon as PostSync hook

### DIFF
--- a/apps/kube/kubevirt/autologon-application.yaml
+++ b/apps/kube/kubevirt/autologon-application.yaml
@@ -1,0 +1,36 @@
+# Autologon — configures Windows builder VM autologon + VNC-ready
+# registry keys via a PostSync Job that exec's into virt-launcher and
+# drives the QEMU Guest Agent. Idempotent; safe to re-run on each sync.
+# When the VM is stopped the Job exits 0 so the sync stays Healthy.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: kubevirt-autologon
+    namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '4'
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: main
+        path: apps/kube/kubevirt/autologon
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: angelscript
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: false
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+        retry:
+            limit: 3
+            backoff:
+                duration: 30s
+                factor: 2
+                maxDuration: 10m
+    revisionHistoryLimit: 3

--- a/apps/kube/kubevirt/autologon/configmap.yaml
+++ b/apps/kube/kubevirt/autologon/configmap.yaml
@@ -29,7 +29,22 @@ data:
 
         echo "=== Configuring Windows autologon + VNC-ready: ${VM_NAME} ==="
 
-        # ── Wait for VMI to be running ──
+        # ── Skip cleanly if the VMI is absent at sync time ──
+        # ArgoCD runs this Job on every PostSync. If the VM is stopped
+        # (no VMI object) exit 0 instead of waiting + failing, so the
+        # sync stays Healthy. The next sync after the VM is started will
+        # reapply the settings.
+        INITIAL_PHASE=$(kubectl get vmi "${VM_NAME}" -n "${NAMESPACE}" \
+            -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+        if [ -z "${INITIAL_PHASE}" ] || \
+           [ "${INITIAL_PHASE}" = "Stopped" ] || \
+           [ "${INITIAL_PHASE}" = "Succeeded" ] || \
+           [ "${INITIAL_PHASE}" = "Failed" ]; then
+            echo "VM not running (phase=${INITIAL_PHASE:-absent}), skipping autologon configuration"
+            exit 0
+        fi
+
+        # ── Wait for VMI to reach Running phase ──
         echo "Waiting for VM to be running..."
         for i in $(seq 1 60); do
             PHASE=$(kubectl get vmi "${VM_NAME}" -n "${NAMESPACE}" \
@@ -39,8 +54,8 @@ data:
                 break
             fi
             if [ "$i" -eq 60 ]; then
-                echo "ERROR: VM not running after 10 minutes"
-                exit 1
+                echo "VM did not reach Running phase within 10 minutes; skipping"
+                exit 0
             fi
             echo "  Phase: ${PHASE:-not found} (${i}/60)"
             sleep 10
@@ -57,10 +72,11 @@ data:
                 break
             fi
             if [ "$i" -eq 30 ]; then
-                echo "ERROR: Guest agent not connected after 5 minutes"
+                echo "Guest agent not connected after 5 minutes; skipping."
                 echo "Ensure QEMU Guest Agent is installed as a Windows service"
-                echo "(from virtio-win ISO: guest-agent/qemu-ga-x86_64.msi)"
-                exit 1
+                echo "(from virtio-win ISO: guest-agent/qemu-ga-x86_64.msi)."
+                echo "Next ArgoCD sync after the agent registers will reapply."
+                exit 0
             fi
             echo "  Agent: ${AGENT:-not connected} (${i}/30)"
             sleep 10

--- a/apps/kube/kubevirt/autologon/job.yaml
+++ b/apps/kube/kubevirt/autologon/job.yaml
@@ -1,9 +1,10 @@
-# One-shot Job to configure Windows autologon + VNC-ready settings on the builder VM.
+# ArgoCD-managed Job to configure Windows autologon + VNC-ready settings on
+# the builder VM.
 #
-# Uses the QEMU Guest Agent to set registry keys inside Windows so the
-# VM auto-logs in as Administrator on every boot — no lock screen, no
-# Ctrl+Alt+Del prompt, no screensaver, no idle lock. VNC users see the
-# desktop immediately without any interaction.
+# Uses the QEMU Guest Agent to set registry keys inside Windows so the VM
+# auto-logs in as Administrator on every boot — no lock screen, no
+# Ctrl+Alt+Del prompt, no screensaver, no idle lock. Guacamole / VNC users
+# see the desktop immediately without any interaction.
 #
 # What it configures (7 steps):
 #   1. Autologon registry keys (AutoAdminLogon, DefaultUserName, DefaultPassword)
@@ -14,20 +15,25 @@
 #   6. Disable Server Manager auto-start (DoNotOpenServerManagerAtLogon)
 #   7. Disable machine inactivity lock (InactivityTimeoutSecs=0)
 #
+# Lifecycle: ArgoCD treats this as a Sync hook. Each sync of the autologon
+# app deletes the previous completed Job (BeforeHookCreation) and creates a
+# fresh one. The script is idempotent — re-running just rewrites the same
+# registry keys.
+#
+# If the VM is stopped at sync time the script exits 0 without configuring
+# anything, so the sync stays Healthy. The next sync triggered after the
+# VM comes back online will reapply the settings.
+#
 # Prerequisites:
-#   1. windows-builder VM is running with QEMU Guest Agent installed
-#   2. Secret 'windows-builder-admin' exists in angelscript namespace
-#      with key 'password' containing the Administrator password
-#   3. vm-scaler RBAC includes pod/exec permissions (auto-deployed via KEDA app)
+#   1. windows-builder VM with QEMU Guest Agent installed (cold-start once
+#      via virtctl + virtio-win ISO).
+#   2. Secret 'windows-builder-admin' in angelscript namespace with key
+#      'password' containing the Administrator password.
+#   3. vm-scaler RBAC includes pod/exec permissions (deployed via KEDA app).
 #
-# Apply manually (NOT managed by ArgoCD — this is a one-shot job):
-#   kubectl apply -f apps/kube/kubevirt/autologon/ -n angelscript
-#
-# Re-run (if the Job already completed):
-#   kubectl delete job vm-autologon-windows -n angelscript
-#   kubectl apply -f apps/kube/kubevirt/autologon/ -n angelscript
-#
-# The settings persist across reboots — only needs to run once.
+# The settings persist across reboots — the Job only needs to land once
+# successfully per VM lifecycle, but Argo will keep retrying on each sync
+# until that happens.
 #
 # Note: the pod template intentionally does NOT carry `app: angelscript`
 # because the namespace NetworkPolicy (podSelector app=angelscript) only
@@ -43,6 +49,13 @@ metadata:
     labels:
         app: angelscript
         component: vm-autologon
+    annotations:
+        # PostSync so the autologon Job runs after every successful sync of
+        # the autologon app itself (e.g. when the script ConfigMap or the
+        # Job spec changes). BeforeHookCreation deletes the prior completed
+        # Job before recreating, sidestepping the immutable-Job-spec error.
+        argocd.argoproj.io/hook: PostSync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
     backoffLimit: 3
     ttlSecondsAfterFinished: 86400

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -110,3 +110,6 @@ resources:
     - kubevirt/file-server-application.yaml
     # Guacamole — browser-based RDP gateway for Windows VMs
     - kubevirt/guacamole-application.yaml
+    # Autologon — configures Windows VM autologon + VNC-ready registry keys
+    # via a PostSync Job. Idempotent; skips cleanly when the VM is stopped.
+    - kubevirt/autologon-application.yaml


### PR DESCRIPTION
## Summary
- Promotes the Windows-builder autologon Job from \`kubectl apply\`-by-hand to a regular ArgoCD-managed Application, so the autologon + VNC-ready registry keys reconcile alongside every other angelscript workload instead of relying on operator memory.
- Adds \`argocd.argoproj.io/hook: PostSync\` + \`hook-delete-policy: BeforeHookCreation\` on the Job, so each sync of the autologon app deletes the prior completed Job and recreates it. Sidesteps the immutable-Job-spec error and lets the idempotent script re-run on every sync.
- Makes the script soft-fail when the VM is stopped, the VMI is absent, or the QEMU Guest Agent has not registered yet: sync stays Healthy, next sync after the VM is back online reapplies the keys.
- New \`apps/kube/kubevirt/autologon-application.yaml\` mirrors the guacamole / file-server app shape; wired into the root \`apps/kube/kustomization.yaml\` so the app-of-apps picks it up.
- Follow-up to #11570 and #11620 — closes out the manual operator steps for the Windows builder.

## Test plan
- [ ] App-of-apps sync creates \`kubevirt-autologon\` Application in ArgoCD.
- [ ] First sync with VM Stopped: Job exits 0, sync reports Healthy.
- [ ] After \`virtctl start windows-builder\`, manual ArgoCD sync (or commit bump): Job runs, all 7 registry steps land green.
- [ ] Delete + recreate the VMI; next sync recreates the Job under \`BeforeHookCreation\` cleanly with no immutable-spec error.
- [ ] Verify inside the VM (after reboot): autologon kicks in to the Administrator desktop, no Ctrl+Alt+Del, no lock screen, no Server Manager.