### PR TITLE
fix(agones-factorio): rotator image -> ghcr.io/kbve/kubectl:0.1.2 (in-house, keeps room to extend)

### DIFF
--- a/apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
+++ b/apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
@@ -18,13 +18,13 @@ spec:
                     restartPolicy: Never
                     securityContext:
                         runAsNonRoot: true
-                        runAsUser: 65532
-                        runAsGroup: 65532
+                        runAsUser: 10001
+                        runAsGroup: 10001
                         seccompProfile:
                             type: RuntimeDefault
                     containers:
                         - name: rotator
-                          image: bitnami/kubectl:1.31
+                          image: ghcr.io/kbve/kubectl:0.1.2
                           imagePullPolicy: IfNotPresent
                           securityContext:
                               allowPrivilegeEscalation: false
@@ -33,7 +33,7 @@ spec:
                                       - ALL
                               readOnlyRootFilesystem: true
                           command:
-                              - /bin/bash
+                              - /bin/sh
                               - -c
                               - |
                                   set -euo pipefail


### PR DESCRIPTION
## Summary

The factorio-rotator CronJob from #11575 has been stuck in ImagePullBackOff for 67+ minutes — bitnami/kubectl:1.31 stopped being pullable from Docker Hub after the Bitnami container catalog change. The live cluster still runs \`agones-factorio:0.0.10\` even though ArgoCD synced the GameServer spec to \`:0.0.12\`, because the rotator never gets to call \`kubectl delete gs/factorio\`.

## Fix

Swap to **\`ghcr.io/kbve/kubectl:0.1.2\`** — the in-house image already powering the KubeVirt autologon + runner jobs. Built from \`apps/vm/kubectl/\`:

- Alpine 3.21 base
- Static kubectl 1.33.2 binary
- Rust-built \`kbve-kubectl\` CLI (musl-static)
- \`/bin/sh\`, \`jq\`, \`curl\`, \`ca-certificates\`
- Non-root \`appuser\` (uid 10001)

Keeps the rotator on a kbve-controlled image so future extensions (custom RCON helpers, save-flush probes, Agones SDK pokes, retry-with-backoff) can land in \`apps/vm/kubectl\` and roll out via one tag bump.

## Manifest adjustments

- \`image: bitnami/kubectl:1.31\` → \`image: ghcr.io/kbve/kubectl:0.1.2\`
- \`/bin/bash\` → \`/bin/sh\`. The image is Alpine; busybox sh 1.37 supports \`set -euo pipefail\` so the script body is unchanged.
- \`command:\` overrides the image's ENTRYPOINT (which defaults to the \`kbve-kubectl\` Rust CLI) so we still run the inline \`kubectl get / delete\` logic.
- \`runAsUser / runAsGroup 65532 → 10001\` to match the image's \`appuser\`. \`runAsNonRoot\`, \`readOnlyRootFilesystem\`, dropped capabilities all stay.

## Test plan

- [ ] After merge + ArgoCD sync, the next CronJob tick (within 5 min) launches a job that completes.
- [ ] Job log shows \`desired=ghcr.io/kbve/agones-factorio:0.0.12 running=ghcr.io/kbve/agones-factorio:0.0.10 ... image drift detected ... rotating\`.
- [ ] preStop announce + save runs on the dying pod, ArgoCD selfHeals \`gs/factorio\`, new pod boots on \`:0.0.12\`.
- [ ] Save PVC content survives the rotate.