### PR TITLE
fix(angelscript): bump PodSecurity to privileged for gluetun-builder-egress

### DIFF
--- a/apps/kube/angelscript/manifest/namespace.yaml
+++ b/apps/kube/angelscript/manifest/namespace.yaml
@@ -4,4 +4,10 @@ metadata:
     name: angelscript
     labels:
         name: angelscript
-        pod-security.kubernetes.io/enforce: baseline
+        # Hosts KubeVirt virt-launcher pods (windows-builder, macos-builder)
+        # and the gluetun-builder-egress proxy, both of which require
+        # NET_ADMIN + /dev/net/tun hostPath. Matches the `kasm` and
+        # `firecracker` namespaces that run the same kind of workload.
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/audit: privileged
+        pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary
- The \`gluetun-builder-egress\` deployment added in #11570 has been stuck at 0/1 with PodSecurity \"baseline:latest\" rejecting both \`NET_ADMIN\` and the \`/dev/net/tun\` hostPath. Identical Gluetun + KubeVirt workloads in \`kasm\` and \`firecracker\` namespaces already run under \`pod-security.kubernetes.io/enforce: privileged\`; bring \`angelscript\` in line so windows-builder, future macos-builder, and the egress pod stop failing admission.

## Evidence
\`\`\`
$ kubectl describe rs gluetun-builder-egress-... -n angelscript | tail
Warning  FailedCreate  ...  Error creating: pods is forbidden:
violates PodSecurity \"baseline:latest\": non-default capabilities
(container \"gluetun\" must not include \"NET_ADMIN\" in
securityContext.capabilities.add), hostPath volumes
(volume \"tun-device\")
\`\`\`

## Test plan
- [ ] ArgoCD syncs the \`angelscript\` Application; namespace labels show \`enforce/audit/warn: privileged\`.
- [ ] \`kubectl rollout status deploy/gluetun-builder-egress -n angelscript\` reaches Available.
- [ ] \`kubectl logs deploy/gluetun-builder-egress -n angelscript\` shows WG handshake success + HTTP proxy ready on :8888.
- [ ] \`curl -x http://gluetun-builder-egress.angelscript.svc.cluster.local:8888 https://ifconfig.me\` from a test pod with \`app: angelscript\` returns the VPN exit IP.