### PR TITLE
feat(kasm-void): URL launcher via CDP + nav shim (image + axum + dashboard)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "agones_factorio",
 			"app_name": "agones-factorio",
-			"version": "0.0.11",
+			"version": "0.0.12",
 			"version_toml": "apps/agones/factorio/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx",
 			"source_path": "apps/agones/factorio",
@@ -260,7 +260,7 @@
 		{
 			"key": "kasm_void",
 			"app_name": "kasm-void",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"version_toml": "packages/docker/kasm-void/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx",
 			"source_path": "packages/docker/kasm-void",

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmCards.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactKasmCards.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useStore } from '@nanostores/react';
 import { kasmService, KasmState, type KasmInfo } from './kasmService';
 import { vmService } from './vmService';
@@ -14,6 +14,7 @@ import {
 	MessageCircle,
 	Globe,
 	Activity,
+	ExternalLink,
 } from 'lucide-react';
 
 type BundledApp = 'discord' | 'cloakbrowser';
@@ -125,6 +126,86 @@ function formatRange(req?: string, lim?: string): string | null {
 	if (!req && !lim) return null;
 	if (req && lim && req !== lim) return `${req} → ${lim}`;
 	return lim ?? req ?? '';
+}
+
+function UrlLauncherRow({
+	workspaceName,
+	disabled,
+}: {
+	workspaceName: string;
+	disabled: boolean;
+}) {
+	const token = useStore(vmService.$accessToken);
+	const actionInProgress = useStore(kasmService.$actionInProgress);
+	const [url, setUrl] = useState('');
+	const launching =
+		actionInProgress === `launch-url:${workspaceName}` || disabled;
+
+	const submit = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!token || !url.trim()) return;
+		kasmService.launchUrl(token, workspaceName, url.trim());
+	};
+
+	return (
+		<form
+			onSubmit={submit}
+			style={{
+				display: 'flex',
+				gap: '0.4rem',
+				alignItems: 'center',
+				background: 'rgba(167, 139, 250, 0.06)',
+				border: '1px solid rgba(167, 139, 250, 0.18)',
+				borderRadius: '8px',
+				padding: '0.4rem 0.5rem',
+			}}>
+			<ExternalLink
+				size={14}
+				style={{ color: '#a78bfa', flexShrink: 0 }}
+			/>
+			<input
+				type="url"
+				value={url}
+				onChange={(e) => setUrl(e.target.value)}
+				placeholder="https://example.com"
+				disabled={launching}
+				maxLength={2048}
+				required
+				style={{
+					flex: 1,
+					background: 'rgba(0, 0, 0, 0.25)',
+					border: '1px solid rgba(255,255,255,0.08)',
+					borderRadius: '4px',
+					padding: '0.25rem 0.5rem',
+					color: 'var(--sl-color-text, #e6edf3)',
+					fontSize: '0.78rem',
+					outline: 'none',
+				}}
+			/>
+			<button
+				type="submit"
+				disabled={launching || !url.trim()}
+				style={{
+					display: 'inline-flex',
+					alignItems: 'center',
+					gap: '0.25rem',
+					padding: '0.25rem 0.65rem',
+					background: '#a78bfa22',
+					border: '1px solid #a78bfa55',
+					borderRadius: '4px',
+					color: '#a78bfa',
+					fontSize: '0.75rem',
+					cursor: launching ? 'wait' : 'pointer',
+				}}>
+				{launching ? (
+					<Loader2 size={12} className="animate-spin" />
+				) : (
+					<ExternalLink size={12} />
+				)}
+				Open
+			</button>
+		</form>
+	);
 }
 
 function KasmCard({ info }: { info: KasmInfo }) {
@@ -333,6 +414,13 @@ function KasmCard({ info }: { info: KasmInfo }) {
 						discord launches
 					</span>
 				</div>
+			)}
+
+			{canConnect && imageMeta.bundledApps.includes('cloakbrowser') && (
+				<UrlLauncherRow
+					workspaceName={workspace.name}
+					disabled={isActing}
+				/>
 			)}
 
 			{/* Actions */}

--- a/apps/kbve/astro-kbve/src/components/dashboard/kasmService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/kasmService.ts
@@ -430,6 +430,67 @@ class KasmService {
 	public async stopWorkspace(token: string, name: string): Promise<void> {
 		await this.scaleWorkspace(token, name, 0);
 	}
+
+	public async launchUrl(
+		token: string,
+		name: string,
+		url: string,
+	): Promise<void> {
+		const trimmed = url.trim();
+		if (!trimmed) {
+			this.$lastAction.set({
+				name,
+				ok: false,
+				message: 'URL is empty',
+			});
+			return;
+		}
+		this.$actionInProgress.set(`launch-url:${name}`);
+		this.$lastAction.set({
+			name,
+			ok: true,
+			message: `Opening ${trimmed.slice(0, 60)}…`,
+		});
+		try {
+			const resp = await fetch(`/dashboard/kasm/launch-url/${name}`, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ url: trimmed }),
+				signal: AbortSignal.timeout(15000),
+			});
+			if (!resp.ok) {
+				const text = await resp.text().catch(() => '');
+				throw new Error(
+					`Launch failed ${resp.status}: ${text.slice(0, 200)}`,
+				);
+			}
+			this.$lastAction.set({
+				name,
+				ok: true,
+				message: `Browser navigated to ${trimmed.slice(0, 60)}…`,
+			});
+			setTimeout(() => {
+				if (this.$lastAction.get()?.name === name) {
+					this.$lastAction.set(null);
+				}
+			}, 5000);
+		} catch (e) {
+			const msg =
+				e instanceof Error ? e.message : `Failed to launch ${name}`;
+			this.$error.set(msg);
+			this.$lastAction.set({ name, ok: false, message: msg });
+			setTimeout(() => {
+				if (this.$lastAction.get()?.name === name) {
+					this.$lastAction.set(null);
+				}
+			}, 8000);
+		} finally {
+			this.$actionInProgress.set(null);
+		}
+	}
 }
 
 export const kasmService = new KasmService();

--- a/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
@@ -14,7 +14,7 @@ tags:
 key: kasm_void
 pipeline: docker
 app_name: kasm-void
-version: "0.0.1"
+version: "0.0.2"
 source_path: packages/docker/kasm-void
 version_toml: packages/docker/kasm-void/version.toml
 runner: ubuntu-latest
@@ -47,14 +47,15 @@ Chromium build and streams the window through Discord's video feature.
 
 ## Crash recovery
 
-`/dockerstartup/custom_startup.sh` spawns two background supervisors:
+`/dockerstartup/custom_startup.sh` spawns three background supervisors:
 
 | Loop | Process matched (`pgrep -f`) | Action |
 |------|------------------------------|--------|
 | `cloak_loop` | `cloakbrowser` | Relaunches `/opt/cloakbrowser/cloakbrowser $CLOAK_APP_ARGS $START_URL` |
 | `discord_loop` | `discord|electron` | Relaunches the upstream `discord_startup.sh` |
+| `nav_shim_loop` | `nav_shim.py` | Relaunches `python3 /dockerstartup/nav_shim.py` |
 
-Each loop polls every 3 seconds. Closing the Discord window or the browser
+Each loop polls every 3–5 seconds. Closing the Discord window or the browser
 window from the desktop triggers a respawn — no manual KASM session restart
 needed.
 
@@ -64,14 +65,37 @@ maximize logic continue to work unchanged.
 
 ## Runtime env
 
-| Variable          | Default              | Notes                                          |
-| ----------------- | -------------------- | ---------------------------------------------- |
-| `START_URL`       | `https://kbve.com`   | Launch URL for the cloakbrowser instance       |
-| `CLOAK_APP_ARGS`  | (chromium defaults)  | Override the full cloakbrowser arg list        |
-| `LAUNCH_DISCORD`  | `1`                  | Set to `0` to disable the Discord supervisor   |
-| `LAUNCH_CLOAK`    | `1`                  | Set to `0` to disable the browser supervisor   |
-| `VNC_PW`          | (k8s secret)         | Provided by the kasm `Deployment`              |
-| `APP_ARGS`        | (inherited)          | Discord-side Electron args, consumed upstream  |
+| Variable             | Default              | Notes                                          |
+| -------------------- | -------------------- | ---------------------------------------------- |
+| `START_URL`          | `https://kbve.com`   | Launch URL for the cloakbrowser instance       |
+| `CLOAK_APP_ARGS`     | (chromium defaults)  | Override the full cloakbrowser arg list        |
+| `LAUNCH_DISCORD`     | `1`                  | Set to `0` to disable the Discord supervisor   |
+| `LAUNCH_CLOAK`       | `1`                  | Set to `0` to disable the browser supervisor   |
+| `LAUNCH_NAV_SHIM`    | `1`                  | Set to `0` to disable the URL launcher shim    |
+| `NAV_SHIM_PORT`      | `9998`               | Shim listens on this port (0.0.0.0)            |
+| `CDP_PORT`           | `9222`               | Cloakbrowser CDP port (bound to 127.0.0.1)     |
+| `URL_LAUNCHER_TOKEN` | (k8s secret)         | Reuses `kasm-vnc-pw` value as bearer token     |
+| `VNC_PW`             | (k8s secret)         | Provided by the kasm `Deployment`              |
+| `APP_ARGS`           | (inherited)          | Discord-side Electron args, consumed upstream  |
+
+## URL launcher (`nav_shim`)
+
+The bundled browser opens whatever `START_URL` was at session start. To
+swap it without restarting the pod, the dashboard `POST`s a JSON body to
+`/dashboard/kasm/launch-url/{workspace}` (axum-kbve). axum forwards to the
+in-pod `nav_shim.py` over an internal `kasm-vpn-service:9998` route.
+
+The shim is a thin HTTP front for [CDP](https://chromedevtools.github.io/devtools-protocol/)
+`Page.navigate` and **only** exposes that one method. Defense in depth:
+
+| Layer | Mitigation |
+|-------|------------|
+| Cloakbrowser CDP | Bound to `127.0.0.1` inside the workspace container only |
+| Shim API surface | Only `POST /open {url}` and `GET /healthz` are routed; everything else 404s |
+| Bearer auth | Every request must carry the `URL_LAUNCHER_TOKEN` (= rotated `kasm-vnc-pw`) |
+| Cilium NetworkPolicy | Port 9998 is only reachable from the `kbve` namespace |
+| URL policy | Scheme allowlist (http/https), no embedded creds, no loopback/private/link-local hosts, no `.cluster.local`/`.svc` |
+| Audit | Each launch request and shim response is captured via the existing Vector → ClickHouse `project_logs` pipeline |
 
 ## Resources
 

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -629,6 +629,10 @@ fn router(state: AppState) -> Router {
             axum::routing::get(super::proxy::kasm_launch_handler),
         )
         .route(
+            "/dashboard/kasm/launch-url/{name}",
+            axum::routing::post(super::proxy::kasm_launch_url_handler),
+        )
+        .route(
             "/dashboard/guac/proxy/guacamole/websocket-tunnel",
             axum::routing::get(super::proxy::guacamole_ws_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -1511,6 +1511,229 @@ pub async fn kasm_launch_handler(req: Request<Body>) -> Response {
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }
 
+const KASM_NAV_SHIM_PORT: u16 = 9998;
+const MAX_LAUNCH_URL_LEN: usize = 2048;
+
+fn url_passes_policy(raw: &str) -> Result<(), &'static str> {
+    if raw.is_empty() || raw.len() > MAX_LAUNCH_URL_LEN {
+        return Err("invalid url length");
+    }
+    let parsed = url::Url::parse(raw).map_err(|_| "url parse failed")?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        _ => return Err("scheme not allowed"),
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("embedded credentials rejected");
+    }
+    let host = parsed.host().ok_or("host required")?;
+    match host {
+        url::Host::Domain(d) => {
+            let lower = d.to_ascii_lowercase();
+            if lower == "localhost"
+                || lower.ends_with(".localhost")
+                || lower.ends_with(".internal")
+                || lower.ends_with(".cluster.local")
+                || lower.ends_with(".svc")
+            {
+                return Err("host not allowed");
+            }
+        }
+        url::Host::Ipv4(ip) => {
+            if ip.is_loopback()
+                || ip.is_private()
+                || ip.is_link_local()
+                || ip.is_broadcast()
+                || ip.is_documentation()
+                || ip.is_unspecified()
+                || ip.is_multicast()
+            {
+                return Err("ipv4 host not allowed");
+            }
+        }
+        url::Host::Ipv6(ip) => {
+            if ip.is_loopback()
+                || ip.is_unspecified()
+                || ip.is_multicast()
+                || (ip.segments()[0] & 0xfe00) == 0xfc00
+            {
+                return Err("ipv6 host not allowed");
+            }
+        }
+    }
+    Ok(())
+}
+
+/// POST /dashboard/kasm/launch-url/{name} body `{"url": "..."}` — forwards
+/// to the kasm-void nav shim. Reuses `kasm-vnc-pw` as the bearer token; the
+/// nav shim only exposes Page.navigate on top of localhost-bound CDP.
+pub async fn kasm_launch_url_handler(Path(name): Path<String>, req: Request<Body>) -> Response {
+    let headers = req.headers().clone();
+    if let Err(resp) = require_dashboard_view(&headers, "KASM-LaunchURL").await {
+        return resp;
+    }
+
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') || name.len() > 63 {
+        return (
+            StatusCode::BAD_REQUEST,
+            axum::Json(json!({"error": "Invalid deployment name"})),
+        )
+            .into_response();
+    }
+
+    let body_bytes = match axum::body::to_bytes(req.into_body(), 4096).await {
+        Ok(b) => b,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                axum::Json(json!({"error": "Invalid request body"})),
+            )
+                .into_response();
+        }
+    };
+
+    let payload: serde_json::Value = match serde_json::from_slice(&body_bytes) {
+        Ok(v) => v,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                axum::Json(json!({"error": "Body is not valid JSON"})),
+            )
+                .into_response();
+        }
+    };
+
+    let url = match payload.get("url").and_then(|v| v.as_str()) {
+        Some(s) => s.trim().to_string(),
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                axum::Json(json!({"error": "Missing `url` field"})),
+            )
+                .into_response();
+        }
+    };
+
+    if let Err(reason) = url_passes_policy(&url) {
+        return (
+            StatusCode::BAD_REQUEST,
+            axum::Json(json!({"error": reason})),
+        )
+            .into_response();
+    }
+
+    let kasm = match KASM.get() {
+        Some(k) => k,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(json!({"error": "KASM proxy not configured"})),
+            )
+                .into_response();
+        }
+    };
+
+    let token = match cached_kasm_password(false).await {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("KASM-LaunchURL token fetch failed: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                axum::Json(json!({"error": format!("token unavailable: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let nav_url = format!(
+        "http://kasm-vpn-service.{KASM_NAMESPACE}.svc.cluster.local:{KASM_NAV_SHIM_PORT}/open"
+    );
+    let body = json!({"url": url});
+
+    let attempt = |bearer: String| {
+        let nav_url = nav_url.clone();
+        let body = body.clone();
+        let client = kasm.client.clone();
+        async move {
+            client
+                .post(&nav_url)
+                .timeout(Duration::from_secs(10))
+                .bearer_auth(bearer)
+                .json(&body)
+                .send()
+                .await
+        }
+    };
+
+    let resp = match attempt(token.clone()).await {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                axum::Json(json!({"error": format!("nav shim unreachable: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    if resp.status() != reqwest::StatusCode::UNAUTHORIZED {
+        return relay_nav_response(&name, resp).await;
+    }
+
+    // Token may be stale after a session-driven password rotation; refresh and retry once.
+    let refreshed = match cached_kasm_password(true).await {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("KASM-LaunchURL token refresh failed: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                axum::Json(json!({"error": format!("token refresh failed: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    match attempt(refreshed).await {
+        Ok(retry) => relay_nav_response(&name, retry).await,
+        Err(e) => (
+            StatusCode::BAD_GATEWAY,
+            axum::Json(json!({"error": format!("nav shim unreachable on retry: {e}")})),
+        )
+            .into_response(),
+    }
+}
+
+async fn relay_nav_response(workspace: &str, resp: reqwest::Response) -> Response {
+    let upstream_status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    let truncated = &body[..body.len().min(512)];
+
+    if upstream_status.is_success() {
+        return axum::Json(json!({
+            "success": true,
+            "workspace": workspace,
+            "upstream": truncated,
+        }))
+        .into_response();
+    }
+
+    let mapped = if upstream_status == reqwest::StatusCode::UNAUTHORIZED {
+        StatusCode::BAD_GATEWAY
+    } else if upstream_status == reqwest::StatusCode::BAD_REQUEST {
+        StatusCode::BAD_REQUEST
+    } else {
+        StatusCode::BAD_GATEWAY
+    };
+
+    (
+        mapped,
+        axum::Json(json!({
+            "error": format!("nav shim {upstream_status}: {truncated}"),
+        })),
+    )
+        .into_response()
+}
+
 async fn resolve_account_for_token(token: &TokenInfo) -> Option<uuid::Uuid> {
     let user_id = token.user_id.parse::<uuid::Uuid>().ok()?;
     let wallet = crate::db::get_wallet_client()?;

--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -123,7 +123,7 @@ spec:
                       - name: HTTPPROXY_LOG
                         value: 'off'
                       - name: FIREWALL_INPUT_PORTS
-                        value: '6901,9999'
+                        value: '6901,9998,9999'
                       - name: FIREWALL_OUTBOUND_SUBNETS
                         value: '10.0.0.0/8,172.16.0.0/12'
                       - name: DOT
@@ -168,10 +168,19 @@ spec:
                       capabilities:
                           drop:
                               - ALL
+                  ports:
+                      - name: nav-shim
+                        containerPort: 9998
+                        protocol: TCP
                   env:
                       - name: KASM_PORT
                         value: '6901'
                       - name: VNC_PW
+                        valueFrom:
+                            secretKeyRef:
+                                name: kasm-vnc-pw
+                                key: password
+                      - name: URL_LAUNCHER_TOKEN
                         valueFrom:
                             secretKeyRef:
                                 name: kasm-vnc-pw
@@ -186,6 +195,12 @@ spec:
                         value: '1'
                       - name: LAUNCH_CLOAK
                         value: '1'
+                      - name: LAUNCH_NAV_SHIM
+                        value: '1'
+                      - name: NAV_SHIM_PORT
+                        value: '9998'
+                      - name: CDP_PORT
+                        value: '9222'
                   volumeMounts:
                       - name: discord-profile
                         mountPath: /home/kasm-user
@@ -221,4 +236,8 @@ spec:
         - name: web
           port: 6901
           targetPort: 6901
+          protocol: TCP
+        - name: nav-shim
+          port: 9998
+          targetPort: 9998
           protocol: TCP

--- a/apps/kube/kasm/manifest/network-policy.yaml
+++ b/apps/kube/kasm/manifest/network-policy.yaml
@@ -66,3 +66,14 @@ spec:
               - ports:
                     - port: '6901'
                       protocol: TCP
+        # Nav shim — URL launcher endpoint. CDP is bound to
+        # 127.0.0.1 inside the workspace container; only this
+        # shim is reachable. Restricted to kbve namespace (axum
+        # is the only legitimate caller).
+        - fromEndpoints:
+              - matchLabels:
+                    k8s:io.kubernetes.pod.namespace: kbve
+          toPorts:
+              - ports:
+                    - port: '9998'
+                      protocol: TCP

--- a/packages/docker/kasm-void/Dockerfile
+++ b/packages/docker/kasm-void/Dockerfile
@@ -12,9 +12,11 @@ RUN set -eux; \
     apt-get update; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates curl tar xz-utils procps \
+        python3 python3-pip \
         libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libdrm2 libxkbcommon0 \
         libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libgtk-3-0 \
         libasound2 libpango-1.0-0 libcairo2 libcups2 libdbus-1-3 fonts-liberation; \
+    pip3 install --no-cache-dir --break-system-packages websocket-client==1.8.0; \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
@@ -43,16 +45,20 @@ RUN set -eux; \
     fi
 
 COPY custom_startup.sh /dockerstartup/custom_startup.sh
+COPY nav_shim.py /dockerstartup/nav_shim.py
 COPY cloakbrowser.desktop /home/kasm-user/Desktop/cloakbrowser.desktop
 
 RUN set -eux; \
-    chmod +x /dockerstartup/custom_startup.sh; \
+    chmod +x /dockerstartup/custom_startup.sh /dockerstartup/nav_shim.py; \
     [ -f /dockerstartup/discord_startup.sh ] && chmod +x /dockerstartup/discord_startup.sh || true; \
-    chown -R 1000:1000 /home/kasm-user /dockerstartup/custom_startup.sh /dockerstartup/discord_startup.sh 2>/dev/null || true
+    chown -R 1000:1000 /home/kasm-user /dockerstartup/custom_startup.sh /dockerstartup/nav_shim.py /dockerstartup/discord_startup.sh 2>/dev/null || true
 
 USER 1000
 ENV HOME=/home/kasm-user \
     START_URL=https://kbve.com \
     LAUNCH_DISCORD=1 \
-    LAUNCH_CLOAK=1
+    LAUNCH_CLOAK=1 \
+    LAUNCH_NAV_SHIM=1 \
+    NAV_SHIM_PORT=9998 \
+    CDP_PORT=9222
 WORKDIR /home/kasm-user

--- a/packages/docker/kasm-void/custom_startup.sh
+++ b/packages/docker/kasm-void/custom_startup.sh
@@ -6,11 +6,15 @@ MAXIMIZE_SCRIPT="${STARTUPDIR:-/dockerstartup}/maximize_window.sh"
 
 CLOAK_BIN="${CLOAK_BIN:-/opt/cloakbrowser/cloakbrowser}"
 CLOAK_PGREP="cloakbrowser"
-CLOAK_DEFAULT_ARGS="--no-sandbox --disable-gpu --disable-dev-shm-usage --start-maximized --no-first-run --no-default-browser-check --password-store=basic"
+CDP_PORT="${CDP_PORT:-9222}"
+CLOAK_CDP_ARGS="--remote-debugging-port=${CDP_PORT} --remote-debugging-address=127.0.0.1 --remote-allow-origins=http://127.0.0.1"
+CLOAK_DEFAULT_ARGS="--no-sandbox --disable-gpu --disable-dev-shm-usage --start-maximized --no-first-run --no-default-browser-check --password-store=basic ${CLOAK_CDP_ARGS}"
 CLOAK_ARGS=${CLOAK_APP_ARGS:-$CLOAK_DEFAULT_ARGS}
 CLOAK_URL="${START_URL:-https://kbve.com}"
 
 DISCORD_STARTUP="/dockerstartup/discord_startup.sh"
+NAV_SHIM="/dockerstartup/nav_shim.py"
+NAV_SHIM_PGREP="nav_shim.py"
 
 wait_desktop() {
     [ -x /usr/bin/filter_ready ] && /usr/bin/filter_ready || true
@@ -44,6 +48,20 @@ discord_loop() {
     done
 }
 
+nav_shim_loop() {
+    if [ ! -x "$NAV_SHIM" ]; then
+        echo "[startup] nav_shim.py missing; skipping URL launcher supervisor"
+        return
+    fi
+    while true; do
+        if ! pgrep -f "$NAV_SHIM_PGREP" >/dev/null 2>&1; then
+            echo "[startup] launching nav_shim"
+            python3 "$NAV_SHIM" >/tmp/nav_shim.log 2>&1 &
+        fi
+        sleep 5
+    done
+}
+
 if [ -n "$DISABLE_CUSTOM_STARTUP" ]; then
     echo "[startup] DISABLE_CUSTOM_STARTUP set; idling"
     exec sleep infinity
@@ -51,6 +69,7 @@ fi
 
 [ "${LAUNCH_CLOAK:-1}" = "1" ] && cloak_loop &
 [ "${LAUNCH_DISCORD:-1}" = "1" ] && discord_loop &
+[ "${LAUNCH_NAV_SHIM:-1}" = "1" ] && nav_shim_loop &
 
 wait -n || true
 exec sleep infinity

--- a/packages/docker/kasm-void/nav_shim.py
+++ b/packages/docker/kasm-void/nav_shim.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+import hmac
+import ipaddress
+import json
+import logging
+import os
+import re
+import sys
+import time
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+try:
+    import websocket
+except ImportError:
+    sys.stderr.write('[nav-shim] websocket-client not installed; exiting\n')
+    sys.exit(1)
+
+PORT = int(os.environ.get('NAV_SHIM_PORT', '9998'))
+CDP_HOST = '127.0.0.1'
+CDP_PORT = int(os.environ.get('CDP_PORT', '9222'))
+MAX_BODY = 4096
+MAX_URL = 2048
+ALLOWED_SCHEMES = {'http', 'https'}
+CDP_TIMEOUT = 5
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='[nav-shim] %(asctime)s %(levelname)s %(message)s',
+    datefmt='%Y-%m-%dT%H:%M:%S',
+)
+log = logging.getLogger('nav-shim')
+
+
+def current_token() -> str:
+    return os.environ.get('URL_LAUNCHER_TOKEN') or os.environ.get('VNC_PW') or ''
+
+
+def url_safe(raw: str) -> bool:
+    if not isinstance(raw, str) or not raw or len(raw) > MAX_URL:
+        return False
+    try:
+        p = urlparse(raw)
+    except ValueError:
+        return False
+    if p.scheme.lower() not in ALLOWED_SCHEMES:
+        return False
+    if p.username or p.password:
+        return False
+    host = (p.hostname or '').lower()
+    if not host:
+        return False
+    if host in {'localhost', 'broadcasthost'}:
+        return False
+    try:
+        ip = ipaddress.ip_address(host)
+        if (
+            ip.is_loopback
+            or ip.is_private
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            return False
+    except ValueError:
+        if not re.match(r'^[a-z0-9.-]+$', host):
+            return False
+    return True
+
+
+def cdp_targets():
+    req = urllib.request.Request(
+        f'http://{CDP_HOST}:{CDP_PORT}/json/list',
+        method='GET',
+    )
+    with urllib.request.urlopen(req, timeout=CDP_TIMEOUT) as resp:
+        return json.loads(resp.read())
+
+
+def cdp_navigate(url: str) -> tuple[bool, str]:
+    targets = cdp_targets()
+    page = next(
+        (t for t in targets if t.get('type') ==
+         'page' and t.get('webSocketDebuggerUrl')),
+        None,
+    )
+    if not page:
+        return False, 'no page target available'
+
+    ws = websocket.create_connection(
+        page['webSocketDebuggerUrl'],
+        timeout=CDP_TIMEOUT,
+        origin='http://127.0.0.1',
+    )
+    try:
+        ws.send(
+            json.dumps(
+                {
+                    'id': int(time.time() * 1000) & 0x7FFFFFFF,
+                    'method': 'Page.navigate',
+                    'params': {'url': url},
+                }
+            )
+        )
+        reply = json.loads(ws.recv())
+    finally:
+        ws.close()
+
+    if 'error' in reply:
+        return False, str(reply['error'].get('message', 'CDP error'))
+    return True, reply.get('result', {}).get('frameId', '')
+
+
+def auth_ok(header_value: str) -> bool:
+    token = current_token()
+    if not token or not header_value:
+        return False
+    if not header_value.lower().startswith('bearer '):
+        return False
+    presented = header_value.split(' ', 1)[1].strip()
+    return hmac.compare_digest(presented.encode(), token.encode())
+
+
+class NavHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        log.info('%s - %s', self.client_address[0], fmt % args)
+
+    def _send_json(self, status: int, body: dict):
+        payload = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(payload)))
+        self.send_header('Cache-Control', 'no-store')
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self):
+        if self.path == '/healthz':
+            self._send_json(200, {'ok': True})
+            return
+        self._send_json(404, {'error': 'not found'})
+
+    def do_POST(self):
+        if self.path != '/open':
+            self._send_json(404, {'error': 'not found'})
+            return
+        if not auth_ok(self.headers.get('Authorization', '')):
+            self._send_json(401, {'error': 'unauthorized'})
+            return
+
+        length = int(self.headers.get('Content-Length') or 0)
+        if length <= 0 or length > MAX_BODY:
+            self._send_json(400, {'error': 'invalid body length'})
+            return
+        try:
+            raw = self.rfile.read(length)
+            payload = json.loads(raw)
+        except (ValueError, OSError):
+            self._send_json(400, {'error': 'invalid json'})
+            return
+
+        url = payload.get('url') if isinstance(payload, dict) else None
+        if not url_safe(url):
+            self._send_json(400, {'error': 'url rejected by policy'})
+            return
+
+        try:
+            ok, detail = cdp_navigate(url)
+        except urllib.error.URLError as e:
+            log.warning('CDP unreachable: %s', e)
+            self._send_json(503, {'error': 'cdp unreachable'})
+            return
+        except Exception as e:
+            log.exception('CDP failure')
+            self._send_json(
+                502, {'error': f'cdp failure: {e.__class__.__name__}'})
+            return
+
+        if not ok:
+            self._send_json(502, {'error': detail or 'navigation failed'})
+            return
+        self._send_json(200, {'ok': True, 'frameId': detail})
+
+
+def main():
+    if not current_token():
+        log.warning(
+            'starting with empty URL_LAUNCHER_TOKEN; every request will 401')
+    httpd = ThreadingHTTPServer(('0.0.0.0', PORT), NavHandler)
+    log.info('listening on 0.0.0.0:%d, CDP at 127.0.0.1:%d', PORT, CDP_PORT)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/docker/kasm-void/version.toml
+++ b/packages/docker/kasm-void/version.toml
@@ -1,2 +1,2 @@
-version = "0.0.1"
+version = "0.0.2"
 publish = true

--- a/packages/docker/kasm-void/version.toml
+++ b/packages/docker/kasm-void/version.toml
@@ -1,2 +1,2 @@
-version = "0.0.2"
+version = "0.0.1"
 publish = true


### PR DESCRIPTION
## Summary

End-to-end URL launcher for the bundled cloakbrowser inside kasm-void. Operator types a URL on the KASM card on /dashboard/vm; the request reaches an in-pod nav shim through a layered security model and the running browser navigates to it without a session restart.

This is the single-PR γ variant of \"PR3\" in the dashboard-improvement stack (PR1: #11533 · PR2: #11537 · PR4: #11542 · PR5: #11539). It bumps **kasm-void to v0.0.2** and ships the image + axum + dashboard pieces atomically.

## What ships

### kasm-void image (v0.0.2)
- `Dockerfile`: install `python3` + `websocket-client` for the CDP round-trip.
- `nav_shim.py`: tiny `ThreadingHTTPServer` on `0.0.0.0:9998` exposing only `GET /healthz` and `POST /open {url}`. Bearer-token auth against \`URL_LAUNCHER_TOKEN\` (reuses VNC_PW), URL policy (http/https only, no embedded creds, no loopback/private/link-local hosts), single `Page.navigate` over a localhost-bound CDP socket.
- `custom_startup.sh`: cloakbrowser launches with `--remote-debugging-port=9222 --remote-debugging-address=127.0.0.1 --remote-allow-origins=http://127.0.0.1`; new `nav_shim_loop` respawns the shim if it dies.

### K8s manifests
- `deployment.yaml`: workspace container exposes \`containerPort: 9998\`, new \`URL_LAUNCHER_TOKEN\` env from \`kasm-vnc-pw\`, gluetun \`FIREWALL_INPUT_PORTS\` picks up 9998.
- `kasm-vpn-service` adds the \`nav-shim\` port (9998).
- `CiliumNetworkPolicy`: ingress to 9998 allowed only from the kbve namespace.

### axum-kbve
- `transport/proxy.rs`: new \`kasm_launch_url_handler\`. JWT-gated, URL validation (mirrors the shim), bearer-authed POST to \`http://kasm-vpn-service.kasm.svc.cluster.local:9998/open\`, **401 retry with cache-forced token refresh** to handle the per-session VNC password rotation cleanly.
- `transport/https.rs`: \`POST /dashboard/kasm/launch-url/{name}\` wired up.

### Dashboard
- \`kasmService.launchUrl\`: trims input, posts to the endpoint, reuses the existing \`$lastAction\` toast plumbing.
- \`ReactKasmCards\`: new \`UrlLauncherRow\` form on cards where \`bundledApps\` includes \`cloakbrowser\` and the workspace is connectable. Type=url input + Open button + spinner.

### Docs / CI
- \`kasm-void.mdx\`: version 0.0.1 → 0.0.2, env vars table updated, new \"URL launcher\" + defense-in-depth section.
- \`.github/ci-dispatch-manifest.json\`: regenerated via \`astro-kbve:sync:ci-manifest\`. Picks up an incidental upstream agones-factorio 0.0.11 → 0.0.12 bump that was already in MDX but unsynced.

## Defense in depth

| Layer | Mitigation |
|-------|------------|
| Cloakbrowser CDP | Bound to \`127.0.0.1\` inside the workspace container only — no in-cluster pod can reach raw CDP |
| Shim API surface | Only \`POST /open\` and \`GET /healthz\` are routed; everything else 404s |
| Bearer auth | Every shim request must carry \`URL_LAUNCHER_TOKEN\` (= rotated \`kasm-vnc-pw\`); 401 retry on axum side handles the session-driven rotation |
| Cilium NetworkPolicy | Port 9998 is reachable only from the kbve namespace |
| URL policy (shim + axum) | http/https only, no embedded creds, no loopback/private/link-local/multicast, no \`.cluster.local\` / \`.svc\` |
| Audit | Each launch request + shim log line is captured via the existing Vector → ClickHouse \`project_logs\` pipeline |

## Test plan

- [ ] \`cargo check\` passes (verified locally)
- [ ] TypeScript typecheck passes (verified locally)
- [ ] CI builds \`ghcr.io/kbve/kasm-void:0.0.2\` cleanly
- [ ] Post-publish chore PR bumps \`apps/kube/kasm/manifest/deployment.yaml\` image pin to \`:0.0.2\`
- [ ] ArgoCD rolls the kasm-vpn pod with the new image
- [ ] KASM session: nav shim listening (\`curl http://kasm-vpn-service.kasm.svc.cluster.local:9998/healthz\` from a kbve-namespace pod returns 200)
- [ ] Same probe from a non-kbve namespace pod is dropped by the NetworkPolicy
- [ ] POST to \`/dashboard/kasm/launch-url/kasm-vpn\` with \`{\"url\":\"https://example.com\"}\` returns 200 and the cloakbrowser navigates
- [ ] URL with \`file://\` / \`javascript:\` / \`http://10.0.0.1\` is rejected before reaching the pod (400 from axum)
- [ ] Closing the nav shim window (\`pkill -f nav_shim.py\`) triggers respawn within 5 seconds
- [ ] After a fresh pod start, the first launch-URL request succeeds with the cache-refreshed token (no manual restart needed)

## Notes

- Dev currently fails its astro-kbve build because of an unrelated react-window 2.x migration (#11616) — \`src/components/osrs/OSRSItemBrowser.tsx\` imports \`{ List }\` which was renamed/removed in v2. Not in scope for this PR. The manifest regen above ran against the pre-rebase tree before the breakage; the resulting manifest is consistent with the post-rebase MDX state (spot-checked).