### PR TITLE
content(astro-kbve): bump 50 OSRS items v2 → v3

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-dragon-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-dragon-shield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Anti-dragon shield | OSRS Price Data
-description: "Anti-dragon shield is a F2P shield slot item. High alch: 12 GP, GE limit: 125."
+description: "Anti-dragon shield: This provides partial protection from dragonbreath attacks. High alch: 12 GP, GE limit: 125."
 osrs:
   id: 1540
   name: Anti-dragon shield
@@ -14,7 +14,7 @@ osrs:
   limit: 125
   equipment:
     slot: shield
-    weight: 2.721
+    weight: 5.443
     attack_bonus:
       stab: 0
       slash: 0
@@ -23,70 +23,84 @@ osrs:
       ranged: 0
     defence_bonus:
       stab: 7
-      slash: 8
-      crush: 7
+      slash: 9
+      crush: 8
       magic: 2
-      ranged: 0
+      ranged: 8
     other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  special_effect:
-    name: Dragonfire Protection
-    description: Provides partial protection against dragonfire attacks.
-    triggers: passive
-  obtaining:
-    methods:
-      - source: Duke Horacio
-        location: Lumbridge Castle
-        method: Free during Dragon Slayer
-      - source: Oziach
-        location: Edgeville
-        method: Purchase
+  special_attack:
+    name: Dragonfire protection
+    energy: 0
+    description: Passively provides partial protection against dragonfire attacks; required for antifire potion stacking.
+  shops:
+    - shop_name: Oziach's Armour
+      location: Edgeville
+      price: 26
+      stock: 5
+      members_only: false
+      currency: coins
+  drop_table:
+    sources:
+      - source: Duke Horacio (Dragon Slayer I)
+        quantity: "1"
+        rarity: always
+        members_only: false
   related_items:
     - item_id: 11284
       item_name: Dragonfire shield
       slug: dragonfire-shield
       relationship: upgrade
-      description: Superior version
+      description: Superior fused version with draconic visage
     - item_id: 22003
       item_name: Dragonfire ward
       slug: dragonfire-ward
       relationship: alternative
-      description: Ranged variant upgrade
+      description: Magic/ranged-defence variant
     - item_id: 21634
       item_name: Ancient wyvern shield
       slug: ancient-wyvern-shield
       relationship: alternative
-      description: Wyvern protection variant
-  about: |-
-    | Defence | Bonus |
-    |---------|-------|
-    | Stab | +7 |
-    | Slash | +8 |
-    | Crush | +7 |
-    | Magic | +2 |
-
-    Provides partial protection against dragonfire.
-
-    Usage: Essential for fighting dragons without antifire potions.
-
-    Combine with antifire for full protection.
+      description: Wyvern protection alternative
   market_strategy:
+    title: Quest staple and DFS feeder
     notes:
-      - Required for Dragon Slayer
-      - Cheap and accessible
-      - Component for DFS
-      - New players
-      - Dragon Slayer quest
-      - Ironmen
-      - DFS creation
-      - Free from Duke Horacio
-      - Combine with draconic visage for DFS
-      - Keep one for dragon tasks
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cheap, accessible Dragon Slayer reward
+      - Component for the Dragonfire shield via draconic visage
+      - Free from Duke Horacio during the quest, 26 GP from Oziach
+      - Ironmen and new players sustain steady demand
+  history:
+    - date: "2001-09-23"
+      update: Dragon Slayer
+      description: Anti-dragon shield released as the Dragon Slayer reward shield.
+    - date: "2005-04-18"
+      update: Item rename
+      description: Renamed from Dragonfire shield to Anti-dragon shield.
+    - date: "2018-07-05"
+      update: Antifire requirement clarification
+      description: Players must start Dragon Slayer I before antifire protection applies.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  about: Anti-dragon shield is the F2P Dragon Slayer reward shield that provides partial dragonfire protection.
+  properties:
+    release_date: "23 September 2001"
+    update: Dragon Slayer
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/apples-5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/apples-5.mdx
@@ -1,6 +1,6 @@
 ---
 title: Apples(5) | OSRS Price Data
-description: "Apples(5): A fruit basket filled with apples.. High alch: 1 GP, GE limit: 600."
+description: "Apples(5): A fruit basket filled with apples. High alch: 1 GP, GE limit: 600."
 osrs:
   id: 5386
   name: Apples(5)
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 600
-  about: "Apples(5) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: farming
+      level: 0
+      xp: 0
+      materials:
+        - item_name: Basket
+          quantity: 1
+        - item_name: Cooking apple
+          quantity: 5
+      product: Apples(5)
+      product_id: 5386
+  related_items:
+    - item_id: 5454
+      item_name: Basket
+      slug: basket
+      relationship: component
+      description: Empty basket container
+    - item_id: 1955
+      item_name: Cooking apple
+      slug: cooking-apple
+      relationship: component
+      description: Filler fruit
+    - item_id: 5286
+      item_name: Orange tree seed
+      slug: orange-tree-seed
+      relationship: alternative
+      description: Comparable farmer payment alternative
+  about: A basket of five cooking apples used as farmer payment to protect strawberry, willow and banana patches.
+  market_strategy:
+    notes:
+      - Used as farmer protection payment
+      - One basket protects strawberry or willow patch
+      - Four baskets protect banana trees
+      - Supply tied to player baskets filled, not GE
+      - Niche farming utility item
+  history:
+    - date: "2005-07-11"
+      update: Farming update
+      description: Item released as part of the Farming skill launch.
+    - date: "2018-03-15"
+      update: Inventory option improvements
+      description: Added Empty option and shift-click empty for single-apple baskets.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Fill
+      - Remove-one
+      - Empty
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/arctic-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/arctic-pyre-logs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Arctic pyre logs | OSRS Price Data
-description: "Arctic pyre logs: Arctic pine logs prepared with sacred oil for a funeral pyre.. High alch: 120 GP, GE limit: 11,000."
+description: "Arctic pyre logs: Arctic pine logs prepared with sacred oil for a funeral pyre. High alch: 120 GP, GE limit: 11,000."
 osrs:
   id: 10808
   name: Arctic pyre logs
@@ -12,9 +12,66 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 11000
-  about: "Arctic pyre logs is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: pyre_log
+    tier: mid
+  recipes:
+    - skill: firemaking
+      level: 47
+      xp: 5
+      materials:
+        - item_name: Arctic pine logs
+          quantity: 1
+        - item_name: Sacred oil(2)
+          quantity: 1
+      product: Arctic pyre logs
+      product_id: 10808
+  related_items:
+    - item_id: 3438
+      item_name: Pyre logs
+      slug: pyre-logs
+      relationship: downgrade
+      description: Lowest tier pyre log
+    - item_id: 10810
+      item_name: Magic pyre logs
+      slug: magic-pyre-logs
+      relationship: upgrade
+      description: Highest tier pyre log
+    - item_id: 10810
+      item_name: Redwood pyre logs
+      slug: redwood-pyre-logs
+      relationship: upgrade
+      description: High-tier Shades of Mort'ton supply
+  about: Arctic pine logs treated with sacred oil, used to cremate Loar, Phrin and Riyl shade remains at Mort'ton.
+  market_strategy:
+    notes:
+      - Shades of Mort'ton minigame supply
+      - 47 Firemaking gates cremation
+      - 158.5 Firemaking XP per cremation
+      - Riyl shade gives 61.4 Prayer XP
+      - Sacred oil(2) cost drives margins
+  history:
+    - date: "2007-02-06"
+      update: Fremennik Isles
+      description: Released alongside arctic pine logs and the Fremennik Isles quest.
+    - date: "2024-07-31"
+      update: Pyre log creation rework
+      description: Standardised Firemaking XP to 5 XP per dose of sacred oil and added a Make-All menu.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-02-06"
+    update: Fremennik Isles
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armageddon-teleport-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armageddon-teleport-scroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Armageddon teleport scroll | OSRS Price Data
-description: "Armageddon teleport scroll: A scroll which unlocks the Deadman: Armageddon home teleport animation.. High alch: 15,000 GP, GE limit: 5."
+description: "Armageddon teleport scroll: A scroll which unlocks the Deadman: Armageddon home teleport animation. High alch: 15,000 GP, GE limit: 5."
 osrs:
   id: 29622
   name: Armageddon teleport scroll
@@ -12,9 +12,55 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 5
-  about: "Armageddon teleport scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Deadman Reward Store
+      location: Deadman Mode reward shop
+      price: 9000
+      stock: 1
+      members_only: true
+      currency: Deadman Points
+  teleport:
+    destinations:
+      - Home Teleport target
+    type: animation-override
+    charges: 1
+    recharge_method: Consumed on use; unlocks animation permanently
+  related_items:
+    - item_id: 26500
+      item_name: Crystal teleport seed
+      slug: crystal-teleport-seed
+      relationship: alternative
+      description: Other cosmetic teleport unlock
+  about: One-time use scroll that permanently unlocks the Deadman Armageddon home teleport animation.
+  market_strategy:
+    notes:
+      - Supply driven by Deadman Mode reward shop purchases
+      - One-time consumable cosmetic — demand falls off after unlock
+      - Tradable but low buy limit (5/4h) keeps spreads thin
+  history:
+    - date: "2026-03-11"
+      update: Death's Coffer Update
+      description: Item became sacrificeable to Death's Coffer.
+    - date: "2024-08-07"
+      update: Poll 82 Changes
+      description: Item made available for purchase from the Deadman Reward Store.
+    - date: "2024-07-17"
+      update: Deadman Armageddon Launch
+      description: Item added to the game (initially unobtainable).
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "17 Jul 2024"
+    update: Deadman Armageddon Launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options: [Read, Drop]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/beer-glass.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/beer-glass.mdx
@@ -1,6 +1,6 @@
 ---
 title: Beer glass | OSRS Price Data
-description: "Beer glass: I need to fill this with beer.. High alch: 1 GP, GE limit: 10,000."
+description: "Beer glass: I need to fill this with beer. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 1919
   name: Beer glass
@@ -14,10 +14,7 @@ osrs:
   limit: 10000
   material:
     type: glass_product
-    tier: basic
-  crafting:
-    level: 1
-    xp: 17.5
+    tier: low
   recipes:
     - skill: crafting
       level: 1
@@ -28,8 +25,6 @@ osrs:
           quantity: 1
       product: Beer glass
       product_id: 1919
-      product_quantity: 1
-      facility: Glassblowing pipe
   related_items:
     - item_id: 1775
       item_name: Molten glass
@@ -40,25 +35,37 @@ osrs:
       item_name: Beer
       slug: beer
       relationship: product
-      description: Container use
-  about: |-
-    | Method | Level | Materials |
-    |--------|-------|-----------|
-    | Glassblowing | 1 | 1 Molten glass |
-    | XP | 17.5 | - |
-
-    Used to hold beer and various other drinks.
+      description: Container fills with beer
+  about: Lowest-level glassblowing product, used as a vessel for beers, ales and stouts.
   market_strategy:
     notes:
-      - Brewing minigame
-      - Collecting ales
-      - F2P crafting training
-      - Lowest level glassblowing product
-      - F2P accessible
-      - Not very profitable
-      - Good for early crafting XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - F2P crafting product, level 1 entry
+      - Brewing minigame and pub fills consume supply
+      - Molten glass cost sets the floor
+      - Low margin, primarily XP-driven
+      - Compatible with Asgarnian ale, Dwarven stout and friends
+  history:
+    - date: "2002-03-18"
+      update: Latest RuneScape News (18 March 2002)
+      description: Released as the introductory glassblowing product.
+    - date: "2015-02-26"
+      update: POH change
+      description: Player-owned house version of beer glass was made members-only.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-18"
+    update: Latest RuneScape News (18 March 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-cavalier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-cavalier.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 4
-  about: "Black cavalier is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.08
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  about: Cosmetic head slot hat awarded from hard Treasure Trails.
+  market_strategy:
+    notes:
+      - Tight 4 buy limit creates volatile spreads
+      - Cosmetic-only demand drives long-term value
+      - Hard clue casket reward sole supply
+  history:
+    - date: "2005-05-17"
+      update: Item rename
+      description: Renamed from "Cavalier" to "Black cavalier".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "5 May 2004"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-full-helm-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-full-helm-g.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black full helm (g) | OSRS Price Data
-description: "Black full helm (g) is a F2P head slot item requiring 10 Defence. High alch: 633 GP, GE limit: 8."
+description: "Black full helm (g): Black full helmet with gold trim. High alch: 633 GP, GE limit: 8."
 osrs:
   id: 2595
   name: Black full helm (g)
@@ -14,20 +14,61 @@ osrs:
   limit: 8
   equipment:
     slot: head
+    weight: 2.721
     requirements:
       defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 12
+      slash: 13
+      crush: 10
+      magic: -1
+      ranged: 12
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers: [easy]
   related_items:
     - item_id: 2587
       item_name: Black full helm (t)
       slug: black-full-helm-t
       relationship: variant
       description: Trimmed variant
-  about: |-
-    > *"Black full helm with gold trim."*
-
-    The black full helm (g) is a gold-trimmed cosmetic variant of the standard black full helm. Identical stats, requiring 10 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1165
+      item_name: Black full helm
+      slug: black-full-helm
+      relationship: variant
+      description: Plain version, identical stats
+  about: Gold-trimmed cosmetic black full helm exclusive to Easy clue scroll rewards; identical combat stats to the plain version.
+  history:
+    - date: "2021-04-01"
+      update: Combat Stat Tweaks
+      description: Ranged attack bonus adjusted from -2 to -3.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "5 May 2004"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options: [Wear, Drop]
+    worn_options: [Remove]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-warlock-item.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-warlock-item.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black warlock (item) | OSRS Price Data
-description: "Black warlock (item): There's a black warlock butterfly in here.. High alch: 42 GP, GE limit: 125."
+description: "Black warlock (item): There's a black warlock butterfly in here. High alch: 42 GP, GE limit: 125."
 osrs:
   id: 10014
   name: Black warlock (item)
@@ -12,9 +12,53 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 125
-  about: "Black warlock (item) is a members-only item in Old School RuneScape. High alchemy value: 42 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: butterfly
+    tier: mid
+  drop_table:
+    sources:
+      - source: Black warlock (Hunter)
+        quantity: "1"
+        rarity: always
+        members_only: true
+  related_items:
+    - item_id: 10012
+      item_name: Ruby harvest
+      slug: ruby-harvest
+      relationship: variant
+      description: Lower-tier hunter butterfly
+    - item_id: 10016
+      item_name: Sapphire glacialis
+      slug: sapphire-glacialis
+      relationship: variant
+      description: Other hunter butterfly variant
+    - item_id: 10018
+      item_name: Snowy knight
+      slug: snowy-knight
+      relationship: variant
+      description: Other hunter butterfly variant
+  about: Caught Black warlock butterfly used in Hunter mixes; captured with a butterfly net at 45 Hunter (or barehanded at 55 Hunter) in Feldip Hunter area and Farming Guild.
+  history:
+    - date: "2024-09-25"
+      update: Hunter Icon Refresh
+      description: Inventory icon adjusted.
+    - date: "2024-04-03"
+      update: Group Ironman Sharing
+      description: Group Ironmen gained the ability to share hunter mixes and butterflies within their group.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "21 Nov 2006"
+    update: Hunter Skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options: [Release, Drop]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/butterfly-jar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/butterfly-jar.mdx
@@ -1,6 +1,6 @@
 ---
 title: Butterfly jar | OSRS Price Data
-description: "Butterfly jar: It's got little holes in the top.. High alch: 1 GP, GE limit: 40."
+description: "Butterfly jar: It's got little holes in the top. High alch: 1 GP, GE limit: 40."
 osrs:
   id: 10012
   name: Butterfly jar
@@ -12,9 +12,78 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 40
-  about: "Butterfly jar is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Nardah Hunter Shop
+      location: Nardah
+      price: 1
+      stock: 100
+      members_only: true
+      currency: coins
+    - shop_name: Aleck's Hunter Emporium
+      location: Yanille
+      price: 1
+      stock: 100
+      members_only: true
+      currency: coins
+    - shop_name: Imia's Supplies
+      location: Hunter Guild
+      price: 1
+      stock: 100
+      members_only: true
+      currency: coins
+    - shop_name: Elder Strom's Hunting Stall
+      location: The Summer Shore
+      price: 1
+      stock: 100
+      members_only: true
+      currency: coins
+  related_items:
+    - item_id: 11260
+      item_name: Impling jar
+      slug: impling-jar
+      relationship: alternative
+      description: Converted via imp repellent
+    - item_id: 10014
+      item_name: Butterfly net
+      slug: butterfly-net
+      relationship: component
+      description: Needed to catch butterflies
+    - item_id: 10006
+      item_name: Magic butterfly net
+      slug: magic-butterfly-net
+      relationship: upgrade
+      description: Higher-tier catching tool
+  about: Hunter jar with holes in the lid used to store caught butterflies and moths; converts to impling jar with imp repellent.
+  market_strategy:
+    title: Hunter Storage Staple
+    notes:
+      - 1gp from shops, very thin GE margins
+      - High daily volume (~50k traded)
+      - Tight 40-unit buy limit
+      - Cannot hold implings directly
+      - Cornerstone of butterfly catching
+  history:
+    - date: "2024-09-25"
+      update: Varlamore
+      description: The item's inventory icon was adjusted during the Varlamore update.
+    - date: "2006-11-21"
+      update: HUNTER SKILL!
+      description: Released alongside the Hunter skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "21 Nov 2006"
+    update: HUNTER SKILL!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    alchable: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cannon-stand.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cannon-stand.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cannon stand | OSRS Price Data
-description: "Cannon stand: The mounting for the multicannon.. High alch: 112,500 GP, GE limit: 70."
+description: "Cannon stand: The mounting for the multicannon. High alch: 112,500 GP, GE limit: 70."
 osrs:
   id: 8
   name: Cannon stand
@@ -12,6 +12,13 @@ osrs:
   lowalch: 75000
   highalch: 112500
   limit: 70
+  shops:
+    - shop_name: Multicannon parts for sale
+      location: Ice Mountain dwarven workshop
+      price: 200625
+      stock: 5
+      members_only: true
+      currency: Coins
   related_items:
     - item_id: 6
       item_name: Cannon base
@@ -28,12 +35,25 @@ osrs:
       slug: cannon-furnace
       relationship: set-piece
       description: Multicannon furnace component
-  about: |-
-    > _"The mounting for the multicannon."_
-
-    The cannon stand is the second component placed when assembling a dwarf multicannon. Requires completion of the Dwarf Cannon quest to use. Placed on top of the cannon base. Tradeable on the Grand Exchange.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Second component of the dwarf multicannon; placed atop the cannon base during assembly and requires Dwarf Cannon quest completion.
+  history:
+    - date: "2004-09-01"
+      update: Examine Text Fix
+      description: Examine text corrected from "muticannon" misspelling to "multicannon".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "27 May 2003"
+    update: New Dwarf Cannon Quest
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.907
+    options: [Drop]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chopped-tomato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chopped-tomato.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chopped tomato | OSRS Price Data
-description: "Chopped tomato: A mixture of tomatoes in a bowl.. High alch: 1 GP, GE limit: 11,000."
+description: "Chopped tomato: A mixture of tomatoes in a bowl. High alch: 1 GP, GE limit: 11,000."
 osrs:
   id: 1869
   name: Chopped tomato
@@ -12,9 +12,74 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Chopped tomato is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Bowl
+          item_id: 1923
+          quantity: 1
+        - item_name: Tomato
+          item_id: 1982
+          quantity: 1
+      product: Chopped tomato
+      product_id: 1869
+  related_items:
+    - item_id: 1982
+      item_name: Tomato
+      slug: tomato
+      relationship: component
+      description: Raw ingredient
+    - item_id: 1923
+      item_name: Bowl
+      slug: bowl
+      relationship: component
+      description: Container
+    - item_id: 2289
+      item_name: Uncooked pizza
+      slug: uncooked-pizza
+      relationship: product
+      description: Used in pizza making
+    - item_id: 7062
+      item_name: Spicy tomato
+      slug: spicy-tomato
+      relationship: product
+      description: Gnome cuisine mix
+  about: Knife-prepared tomato in a bowl; a building-block ingredient for pizzas, gnome dishes and chinchompa bait.
+  market_strategy:
+    title: Cooking Prep Component
+    notes:
+      - Cheap intermediate ingredient
+      - Used in pizza base recipes
+      - Light daily volume on GE
+      - 1.2-second prep tick
+      - Profitable when tomatoes are oversupplied
+  trading_tips:
+    - Watch tomato spawn farming bursts that crash the input price
+  history:
+    - date: "2006-01-30"
+      update: Cooking polish
+      description: Graphical update applied; "Eat" option added.
+    - date: "2003-04-14"
+      update: Tourist Trap Quest Online!
+      description: Released with the Tourist Trap quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "14 Apr 2003"
+    update: Tourist Trap Quest Online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Eat
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/colossal-wyrm-teleport-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/colossal-wyrm-teleport-scroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Colossal wyrm teleport scroll | OSRS Price Data
-description: "Colossal wyrm teleport scroll: A teleport to the Colossal Wyrm Remains in the Avium Savannah.. High alch: 6 GP."
+description: "Colossal wyrm teleport scroll: A teleport to the Colossal Wyrm Remains in the Avium Savannah. High alch: 6 GP."
 osrs:
   id: 30040
   name: Colossal wyrm teleport scroll
@@ -12,9 +12,55 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: null
-  about: "Colossal wyrm teleport scroll is a members-only item in Old School RuneScape. High alchemy value: 6 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destinations:
+      - Colossal Wyrm Remains (Avium Savannah)
+    type: consumable
+    charges: 1
+    recharge_method: Buy more from Worm Tongue's Wares
+  shops:
+    - shop_name: Worm Tongue's Wares
+      location: Colossal Wyrm Remains
+      price: 40
+      members_only: true
+      currency: Termites
+  related_items:
+    - item_id: 29776
+      item_name: Termites
+      slug: termites
+      relationship: component
+      description: Currency earned at the Colossal Wyrm Agility Course
+  market_strategy:
+    title: Agility supply, daily teleport sink
+    notes:
+      - Single-use consumable, demand renews each trip
+      - Supply gated by Colossal Wyrm Agility termite farming
+      - No GE buy limit allows bulk purchases
+      - Quest gate (Children of the Sun) trims pool of buyers
+  history:
+    - date: "2024-09-25"
+      update: "Varlamore: The Rising Darkness"
+      description: Colossal wyrm teleport scroll added with the Avium Savannah expansion.
+    - date: "2024-09-27"
+      update: Hotfix
+      description: Collection log functionality restored after purchase.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  about: Colossal wyrm teleport scroll is a single-use scroll teleporting players to the Colossal Wyrm Remains in the Avium Savannah.
+  properties:
+    release_date: "25 September 2024"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Teleport
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-twisted-bow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-twisted-bow.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: null
-  about: "Corrupted twisted bow is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: 2h
+    weapon_type: bow
+    attack_speed: 6
+    weight: 1.814
+    requirements:
+      ranged: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 56
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 2
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 20997
+      item_name: Twisted bow
+      slug: twisted-bow
+      relationship: alternative
+      description: Standard PvM-grade variant of the bow.
+  about: Deadman Mode exclusive variant of the twisted bow, obtained from breach trinkets.
+  market_strategy:
+    notes:
+      - Deadman seasonal availability only
+      - Inferno "Budget Setup" achievement blocker
+      - Far weaker ranged strength than standard twisted bow
+  history:
+    - date: "2023-08-23"
+      update: Deadman Mode breach trinkets
+      description: Released as a 1/8 reward from trinket of advanced weaponry during Deadman events.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "23 August 2023"
+    update: Deadman Mode
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cosmic-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cosmic-rune.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cosmic rune | OSRS Price Data
-description: "Cosmic rune: Used for enchant spells.. High alch: 30 GP, GE limit: 18,000."
+description: "Cosmic rune: Used for enchant spells. High alch: 30 GP, GE limit: 18,000."
 osrs:
   id: 564
   name: Cosmic rune
@@ -12,15 +12,9 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
-  rune:
-    type: utility
-  runecraft:
-    level: 27
-    xp: 8
-    multiple_at: 59
-    altar: Cosmic Altar
-    altar_location: Zanaris
-    essence_type: pure
+  material:
+    type: rune
+    tier: mid
   recipes:
     - skill: runecraft
       level: 27
@@ -31,9 +25,28 @@ osrs:
           quantity: 1
       product: Cosmic rune
       product_id: 564
-      product_quantity: 1
-      facility: Cosmic altar
+    - skill: runecraft
+      level: 27
+      xp: 12
+      materials:
+        - item_name: Daeyalt essence
+          item_id: 24704
+          quantity: 1
+      product: Cosmic rune
+      product_id: 564
+  shops:
+    - shop_name: Lundail's Arena-side Rune Shop
+      location: Mage Arena, Wilderness
+      price: 80
+      stock: 250
       members_only: true
+      currency: coins
+    - shop_name: Amlodd's Magical Supplies
+      location: Prifddinas
+      price: 80
+      stock: 250
+      members_only: true
+      currency: coins
   related_items:
     - item_id: 7936
       item_name: Pure essence
@@ -55,34 +68,38 @@ osrs:
       slug: law-rune
       relationship: upgrade
       description: Higher tier rune
-  about: |-
-    Craft at the Cosmic Altar (Zanaris) with Pure essence.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Runecrafting Level | 27 |
-    | XP per essence | 8 |
-    | Double runes | 59 RC |
-
-    Cosmic runes power enchantment magic:
-    - Enchant Sapphire/Emerald/Ruby/Diamond/Dragonstone/Onyx
-    - Lunar spells (NPC Contact, Cure spells)
-    - Arceuus resurrection spells
+  about: Mid-tier rune crafted at the Cosmic Altar in Zanaris; powers enchantment magic and select Lunar/Arceuus spells.
   market_strategy:
-    profit_formulas:
-      - (Cosmic rune × runes) - Pure essence = Profit
+    title: Cosmic Runecrafting
     notes:
-      - Entry-level profitable rune (27 RC)
-      - "At 59+ RC: Double runes"
-      - "Calculate:"
-      - Jewelry enchanting (rings of dueling, games necklaces)
+      - Entry profitable RC at level 27
+      - Doubles to 2 per essence at 59 RC
+      - Jewelry enchanting drives demand
       - Lunar spellbook users
-      - Consistent demand
-      - Requires Fairy ring access (Lost City)
-      - Good early RC money maker
-      - Lower value than law/nature but easier access
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Requires Fairy ring access from Lost City
+      - Lower value than law/nature but easier
+  trading_tips:
+    - Stock up before patch days that buff enchant spells
+    - Sell during Lunar spellbook events
+  history:
+    - date: "2001-05-24"
+      update: New magic system online!
+      description: Released with the magic system rework.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "24 May 2001"
+    update: New magic system online!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-ball-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-ball-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Crystal ball (flatpack) | OSRS Price Data
-description: "Crystal ball (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Crystal ball (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8624
   name: Crystal ball (flatpack)
@@ -12,9 +12,48 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Crystal ball (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    flatpack: true
+    room: Study
+    hotspot: Crystal ball
+  related_items:
+    - item_id: 8622
+      item_name: Crystal ball
+      slug: crystal-ball
+      relationship: alternative
+      description: Construction hotspot equivalent
+    - item_id: 8780
+      item_name: Plank
+      slug: plank
+      relationship: component
+      description: Construction material
+  about: Scrapped Construction flatpack that survived in the cache; tradeable on the GE but cannot be built or used in-game.
+  market_strategy:
+    title: Scrapped Flatpack Curiosity
+    notes:
+      - No in-game obtain method
+      - Limited supply, mostly collector demand
+      - Zero daily volume
+      - Wikipedia oddity from 2006 Construction launch
+  history:
+    - date: "2006-05-31"
+      update: PLAYER-OWNED HOUSES!
+      description: Released alongside the Construction skill but ultimately scrapped from the live game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "31 May 2006"
+    update: PLAYER-OWNED HOUSES!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/curry-leaf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/curry-leaf.mdx
@@ -1,6 +1,6 @@
 ---
 title: Curry leaf | OSRS Price Data
-description: "Curry leaf: I could make a spicy curry with this.. High alch: 11 GP, GE limit: 11,000."
+description: "Curry leaf: I could make a spicy curry with this. High alch: 11 GP, GE limit: 11,000."
 osrs:
   id: 5970
   name: Curry leaf
@@ -12,9 +12,68 @@ osrs:
   lowalch: 7
   highalch: 11
   limit: 11000
-  about: "Curry leaf is a members-only item in Old School RuneScape. High alchemy value: 11 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: herb
+    tier: low
+  drop_table:
+    sources:
+      - source: Gourmet impling jar
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Eclectic impling jar
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+  shops:
+    - shop_name: The Spice Is Right
+      location: Sophanem
+      price: 28
+      stock: 10
+      members_only: true
+      currency: coins
+  farming:
+    farming_level: 42
+    patch_type: fruit tree
+    notes: Curry tree saplings grow into curry trees; farmers protect for 5 baskets of bananas.
+  related_items:
+    - item_id: 5286
+      item_name: Curry sapling
+      slug: curry-sapling
+      relationship: component
+      description: Plant in fruit tree patch to grow curry trees
+    - item_id: 2011
+      item_name: Curry
+      slug: curry
+      relationship: product
+      description: Cook 3 curry leaves with uncooked stew
+  market_strategy:
+    title: Steady farming + impling supply
+    notes:
+      - High GE buy limit (11,000) supports bulk
+      - Used in compost (15 leaves) and cooking
+      - Impling hunters and farmers feed supply
+      - Gardener payment for higher fruit trees
+  history:
+    - date: "2005-07-11"
+      update: Farming update
+      description: Curry leaf released as part of the Farming skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  about: Curry leaf is a members herb harvested from curry trees, used in cooking and compost.
+  properties:
+    release_date: "11 July 2005"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dagon-hai-robes-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dagon-hai-robes-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dagon'hai robes set | OSRS Price Data
-description: "Dagon'hai robes set: A set containing a Dagon'hai hat, robe top and robe bottom.. High alch: 130,200 GP."
+description: "Dagon'hai robes set: A set containing a Dagon'hai hat, robe top and robe bottom. High alch: 130,200 GP."
 osrs:
   id: 24333
   name: Dagon'hai robes set
@@ -12,9 +12,55 @@ osrs:
   lowalch: 86800
   highalch: 130200
   limit: null
-  about: "Dagon'hai robes set is a members-only item in Old School RuneScape. High alchemy value: 130,200 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Grand Exchange (Sets)
+      location: Grand Exchange
+      members_only: true
+      currency: coins
+  related_items:
+    - item_id: 24288
+      item_name: Dagon'hai hat
+      slug: dagon-hai-hat
+      relationship: set-piece
+      description: Head slot piece of the set
+    - item_id: 24291
+      item_name: Dagon'hai robe top
+      slug: dagon-hai-robe-top
+      relationship: set-piece
+      description: Body slot piece of the set
+    - item_id: 24294
+      item_name: Dagon'hai robe bottom
+      slug: dagon-hai-robe-bottom
+      relationship: set-piece
+      description: Legs slot piece of the set
+  market_strategy:
+    title: Set arbitrage
+    notes:
+      - Bundled via Grand Exchange clerk Sets interface
+      - Watch component sum vs set price for arbitrage
+      - Convenience markup when set sells at a premium
+      - No buy limit makes flips uncapped
+  history:
+    - date: "2019-11-07"
+      update: Bounty Hunter Rework
+      description: Dagon'hai robes set added alongside the Bounty Hunter rework.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  about: Dagon'hai robes set bundles the Dagon'hai hat, robe top, and robe bottom for Grand Exchange convenience.
+  properties:
+    release_date: "7 November 2019"
+    update: Bounty Hunter Rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dark-tuxedo-jacket.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dark-tuxedo-jacket.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dark tuxedo jacket | OSRS Price Data
-description: "Dark tuxedo jacket: A dark tuxedo jacket with a white shirt.. High alch: 6,000 GP, GE limit: 4."
+description: "Dark tuxedo jacket: A dark tuxedo jacket with a white shirt. High alch: 6,000 GP, GE limit: 4."
 osrs:
   id: 19958
   name: Dark tuxedo jacket
@@ -12,9 +12,82 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Dark tuxedo jacket is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_id: 19961
+      item_name: Dark tuxedo trousers
+      slug: dark-tuxedo-trousers
+      relationship: set-piece
+      description: Matching trousers from the dark tuxedo set
+    - item_id: 19964
+      item_name: Dark tuxedo cuffs
+      slug: dark-tuxedo-cuffs
+      relationship: set-piece
+      description: Matching cuffs from the dark tuxedo set
+    - item_id: 19967
+      item_name: Dark tuxedo shoes
+      slug: dark-tuxedo-shoes
+      relationship: set-piece
+      description: Matching shoes from the dark tuxedo set
+    - item_id: 19955
+      item_name: Dark tuxedo cyatt
+      slug: dark-tuxedo-cyatt
+      relationship: set-piece
+      description: Matching cyatt hat from the dark tuxedo set
+  market_strategy:
+    title: Elite clue cosmetic
+    notes:
+      - Rare elite clue scroll reward (1/12,750)
+      - Cosmetic body slot, no combat bonus
+      - Demand driven by fashionscape collectors
+      - Low buy limit of 4 per 4 hours restricts flips
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion
+      description: Dark tuxedo jacket added as an elite clue reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  about: Dark tuxedo jacket is a cosmetic body slot item rewarded from elite Treasure Trails.
+  properties:
+    release_date: "6 July 2016"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/echo-crystal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/echo-crystal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Echo crystal | OSRS Price Data
-description: "Echo crystal: A crystal of rebounding potential.. High alch: 90,000 GP, GE limit: 8."
+description: "Echo crystal: A crystal of rebounding potential. High alch: 90,000 GP, GE limit: 8."
 osrs:
   id: 28942
   name: Echo crystal
@@ -12,69 +12,70 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 8
-  item:
-    type: material
-    tradeable: true
-    weight: 0.5
+  material:
+    type: crystal
+    tier: high
   drop_table:
-    primary_source: Fortis Colosseum
-    best_drop_rate: Varies
     sources:
-      - source: Fortis Colosseum
+      - source: Fortis Colosseum reward chest
         quantity: "1"
         rarity: varies
-        drop_rate: Varies (waves 4-12)
         members_only: true
-  market:
-    buy_limit: 8
-    price_estimate: 1798350
+  recipes:
+    - skill: smithing
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Guardian boots
+          item_id: 21733
+          quantity: 1
+        - item_name: Echo crystal
+          item_id: 28942
+          quantity: 1
+      product: Echo boots
+      product_id: 28945
   related_items:
     - item_id: 28945
       item_name: Echo boots
       slug: echo-boots
       relationship: product
-      description: Upgrades guardian boots
+      description: Upgrades guardian boots to BiS prayer melee boots
     - item_id: 21733
       item_name: Guardian boots
       slug: guardian-boots
       relationship: component
       description: Base item for upgrade
-  about: |-
-    The Echo crystal is a rare material dropped from the Fortis Colosseum used to upgrade Guardian boots into the powerful Echo boots. This shimmering crystal contains the echoes of battles fought in the arena.
-
-    Type: Material
-    Stackable: No
-    Tradeable: Yes
-    Weight: 0.5 kg
-
-    Echo crystals have a single purpose:
-
-    ### Creating Echo Boots
-    Combine with Guardian boots to create Echo boots:
-
-    Materials Required:
-    - 1x Guardian boots (Item ID: 21733)
-    - 1x Echo crystal (Item ID: 28942)
-
-    Result: Echo boots (Item ID: 28945) - Untradeable
-
-    Important: This is a one-way upgrade. Echo boots cannot be reverted to Guardian boots.
-
-    The upgrade provides:
-    - +4 Prayer bonus (Guardian boots have 0)
-    - Recoil effect: Deals 1 damage to attackers in 3x3 area
-    - 60,000 charges on the recoil effect
-    - Best-in-slot melee boots for prayer builds
+  about: Rare Fortis Colosseum material; combine with Guardian boots to create Echo boots (+2 prayer, 6,000-charge recoil).
   market_strategy:
+    title: Echo crystal trading
     notes:
       - Price largely determined by Guardian boots price
       - "Calculate total upgrade cost: Echo crystal + Guardian boots"
       - Consider if untradeable result is worth investment
-      - High demand from players seeking BiS melee boots
+      - High demand from players seeking BiS prayer melee boots
       - Price fluctuates with Colosseum activity levels
       - More valuable earlier in the week (fresh restocks)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2024-04-10"
+      update: Varlamore Hotfix
+      description: Charges per crystal raised from 2,500 to 6,000; multi-crystal charging enabled; item value raised from 500 to 150,000.
+    - date: "2024-03-20"
+      update: "Varlamore: Part One"
+      description: Echo crystal added with the Fortis Colosseum release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "20 Mar 2024"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options: [Drop]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-ring.mdx
@@ -1,6 +1,6 @@
 ---
 title: Emerald ring | OSRS Price Data
-description: "Emerald ring is a F2P ring slot item. High alch: 765 GP, GE limit: 10,000."
+description: "Emerald ring: A valuable ring. High alch: 765 GP, GE limit: 10,000."
 osrs:
   id: 1639
   name: Emerald ring
@@ -14,56 +14,94 @@ osrs:
   limit: 10000
   equipment:
     slot: ring
+    weight: 0.006
     requirements:
       crafting: 27
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 27
       xp: 55
-      inputs:
-        - item_id: 1658
+      materials:
+        - item_id: 1605
           item_name: Emerald
           quantity: 1
         - item_id: 2357
           item_name: Gold bar
           quantity: 1
-      output_quantity: 1
+      product: Emerald ring
+      product_id: 1639
   related_items:
     - item_id: 1637
       item_name: Sapphire ring
       slug: sapphire-ring
       relationship: downgrade
-      description: Previous tier ring
+      description: Previous tier gem ring
     - item_id: 1641
       item_name: Ruby ring
       slug: ruby-ring
       relationship: upgrade
-      description: Next tier ring
+      description: Next tier gem ring
     - item_id: 2552
       item_name: Ring of dueling(8)
       slug: ring-of-dueling-8
       relationship: upgrade
-      description: Enchanted version (teleports)
-  about: |-
-    Crafting (Level 27): Emerald + Gold bar at a furnace (55 XP)
-
-    > *"An emerald ring."*
-
-    Lvl-2 Enchant (27 Magic): 1 cosmic rune + 3 air runes (37 XP)
-
-    The Ring of dueling provides 8 charges of teleportation to:
-    - Duel Arena (Al Kharid)
-    - Castle Wars lobby
-    - Ferox Enclave (free restoration pool)
-
-    The Ferox Enclave teleport makes this one of the most useful budget teleports — providing free HP/Prayer restoration and a bank.
+      description: Lvl-2 Enchant produces 8-charge teleport ring
   market_strategy:
+    title: Crafting + enchanting flow
     notes:
-      - Ring of dueling consumed after 8 charges — steady demand
-      - Ferox Enclave access drives most of the demand
-      - Enchanting is frequently profitable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Ring of dueling consumed after 8 charges drives steady demand
+      - Ferox Enclave teleport powers most of the demand
+      - Enchanting (Lvl-2) is frequently profitable
+      - Watch Emerald + Gold bar costs vs ring price
+  history:
+    - date: "2001-05-08"
+      update: Runescape updated (8 May 2001)
+      description: Emerald ring released.
+    - date: "2007-04-30"
+      update: Graphical update
+      description: Inventory sprite graphically updated.
+    - date: "2018-02-22"
+      update: Inventory sprite rotation
+      description: Inventory sprite rotated for readability.
+    - date: "2018-12-13"
+      update: Sprite adjustment
+      description: Inventory sprite adjusted.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  about: Emerald ring is a F2P ring slot item crafted from an emerald and gold bar, enchantable into a Ring of dueling.
+  properties:
+    release_date: "8 May 2001"
+    update: Runescape updated (8 May 2001)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extended antifire mix(1) | OSRS Price Data
-description: "Extended antifire mix(1): One dose of fishy extended anti-firebreath potion.. High alch: 96 GP, GE limit: 2,000."
+description: "Extended antifire mix(1): One dose of fishy extended anti-firebreath potion. High alch: 96 GP, GE limit: 2,000."
 osrs:
   id: 11962
   name: Extended antifire mix(1)
@@ -12,9 +12,70 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 2000
-  about: "Extended antifire mix(1) is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    herblore_level: 91
+    herblore_xp: 61
+    effect: Provides 12 minutes of dragonfire resistance and restores 6 Hitpoints.
+    effects:
+      - description: Extended antifire protection (12 minutes per full dose)
+        duration: 1200
+      - stat: hitpoints
+        boost_value: 6
+        description: Restores 6 Hitpoints per dose
+  recipes:
+    - skill: herblore
+      level: 91
+      xp: 61
+      materials:
+        - item_name: Extended antifire(1)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      product: Extended antifire mix(1)
+      product_id: 11962
+  related_items:
+    - item_id: 11960
+      item_name: Extended antifire mix(2)
+      slug: extended-antifire-mix-2
+      relationship: variant
+      description: Two-dose version
+    - item_id: 22209
+      item_name: Extended antifire(4)
+      slug: extended-antifire-4
+      relationship: upgrade
+      description: Standard four-dose Herblore potion
+  about: Barbarian-mix variant of the extended antifire potion that also restores 6 Hitpoints per dose.
+  market_strategy:
+    notes:
+      - 91 Herblore gates supply
+      - Caviar cost determines floor price
+      - Barbarian Herblore training prerequisite
+      - Niche demand vs standard antifire(4)
+  history:
+    - date: "2014-03-27"
+      update: Wilderness Feedback Update
+      description: Item released with the extended antifire potion line.
+    - date: "2016-04-15"
+      update: Bank placeholder update
+      description: Partially-used potions became convertible to bank placeholders.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-03-27"
+    update: Wilderness Feedback Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fish-food.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fish-food.mdx
@@ -12,18 +12,48 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
+  recipes:
+    - skill: Quest
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Fish food
+          quantity: 1
+        - item_name: Poison
+          quantity: 1
+      product: Poisoned fish food
+      product_id: 274
   related_items:
     - item_id: 273
       item_name: Poison
       slug: poison-item
       relationship: component
-      description: Combined to make poisoned fish food
-  about: |-
-    > _"Keeps your pet fish strong and healthy."_
-
-    Fish food is a quest item used in Ernest the Chicken. Combined with poison to create poisoned fish food, which kills piranhas in a fountain to retrieve a pressure gauge.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Combined to make poisoned fish food.
+    - item_id: 274
+      item_name: Poisoned fish food
+      slug: poisoned-fish-food
+      relationship: product
+      description: Result of combining fish food with poison.
+  about: Quest item used in Ernest the Chicken to poison piranhas in the Draynor Manor fountain.
+  history:
+    - date: "2006-12-18"
+      update: Christmas Update
+      description: Graphically updated.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "21 January 2001"
+    update: Newsletter 1
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-stole.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-stole.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthix stole | OSRS Price Data
-description: "Guthix stole is a members neck slot item. High alch: 1,500 GP, GE limit: 8."
+description: "Guthix stole: A Guthix stole. High alch: 1,500 GP, GE limit: 8."
 osrs:
   id: 10472
   name: Guthix stole
@@ -14,10 +14,31 @@ osrs:
   limit: 8
   equipment:
     slot: neck
+    weight: 0.01
     requirements:
       prayer: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 10
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 10470
       item_name: Saradomin stole
@@ -29,12 +50,36 @@ osrs:
       slug: zamorak-stole
       relationship: variant
       description: Zamorak equivalent stole
-  about: |-
-    > *"A Guthix stole."*
-
-    The Guthix stole is a neck slot item from the Guthix vestment set. It provides a +10 Prayer bonus and requires 60 Prayer to equip. One of the highest prayer bonus items available in the neck slot. Counts as a Guthixian item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    title: Hard clue prayer neck
+    notes:
+      - Best-in-slot Prayer neck bonus for many setups
+      - Counts as Guthixian for God Wars Dungeon entry
+      - Hard clue reward — supply tied to clue completions
+      - Low GE buy limit of 8 limits flips
+  history:
+    - date: "2006-12-05"
+      update: Treasure Trails expansion
+      description: Guthix stole added as a hard clue scroll reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  about: Guthix stole is a hard clue scroll neck slot item with +10 Prayer; requires 60 Prayer and counts as Guthixian in the God Wars Dungeon.
+  properties:
+    release_date: "5 December 2006"
+    update: Treasure Trails expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/initiate-cuisse.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/initiate-cuisse.mdx
@@ -1,6 +1,6 @@
 ---
 title: Initiate cuisse | OSRS Price Data
-description: "Initiate cuisse is a members legs slot item requiring 20 Defence. High alch: 4,800 GP, GE limit: 125."
+description: "Initiate cuisse: An initiate Temple Knight's leg armour. High alch: 4,800 GP, GE limit: 125."
 osrs:
   id: 5576
   name: Initiate cuisse
@@ -14,17 +14,40 @@ osrs:
   limit: 125
   equipment:
     slot: legs
-    type: armour
-    prayer_bonus: 5
+    weight: 7.711
     requirements:
       defence: 20
       prayer: 10
-    combat_stats:
-      stab_defence: 26
-      slash_defence: 25
-      crush_defence: 24
-      magic_defence: -4
-      ranged_defence: 26
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 24
+      slash: 22
+      crush: 20
+      magic: -4
+      ranged: 22
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 5
+  shops:
+    - shop_name: Initiate Temple Knight Armoury
+      location: Falador Park
+      price: 8000
+      stock: 30
+      members_only: true
+      currency: coins
+    - shop_name: Proselyte Temple Knight Armoury
+      location: Falador Park
+      price: 8000
+      stock: 30
+      members_only: true
+      currency: coins
   related_items:
     - item_id: 5575
       item_name: Initiate hauberk
@@ -46,34 +69,43 @@ osrs:
       slug: monks-robe
       relationship: downgrade
       description: No defence (+5 Prayer)
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Legs |
-    | Prayer Bonus | +5 |
-    | Defence Req | 20 |
-    | Prayer Req | 10 |
-
-    - Mid-tier prayer armour
-    - Bridge to Proselyte
-    - Lower requirements than Proselyte
-
-    | Piece | Prayer Bonus |
-    |-------|--------------|
-    | Initiate sallet | +3 |
-    | Initiate hauberk | +6 |
-    | Initiate cuisse | +5 |
-    | Total | +14 |
+  about: Mid-tier prayer leg armour rewarded from Recruitment Drive; bridge between monk's robes and Proselyte.
   market_strategy:
+    title: Quest-Gated Prayer Legs
     notes:
-      - Requires quest completion
-      - Shop purchase only
-      - No GE trading (untradeable)
-      - Must complete Recruitment Drive
-      - Stepping stone to Proselyte
-      - Lower requirements good for pures
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Requires Recruitment Drive completion
+      - Shop purchase at Falador Park armoury
+      - Stepping stone to Proselyte cuisse
+      - Lower requirements suit pures
+      - Best mid-game prayer legs at 20 Defence
+  history:
+    - date: "2021-04-21"
+      update: Combat stat rebalance
+      description: Ranged attack bonus decreased from -7 to -11.
+    - date: "2006-09-20"
+      update: Item rename
+      description: Renamed from "Initiate platelegs" to "Initiate cuisse".
+    - date: "2005-10-17"
+      update: Wanted!
+      description: Graphically updated alongside the Wanted! quest release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "27 Jun 2005"
+    update: Recruitment Drive
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 7.711
+    options:
+      - Drop
+    worn_options:
+      - Wear
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platelegs-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platelegs-g.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 112
   highalch: 168
   limit: 4
-  about: "Iron platelegs (g) is a free-to-play item in Old School RuneScape. High alchemy value: 168 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 9.071
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: -4
+      ranged: 10
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  about: Gold-trimmed iron platelegs awarded from easy Treasure Trails, part of the iron gold-trimmed set.
+  market_strategy:
+    notes:
+      - Easy clue casket supply
+      - Cosmetic demand drives the spread
+      - Stores in costume room with iron (g) set
+  history:
+    - date: "2021-04-21"
+      update: Equipment rebalance
+      description: Ranged attack penalty changed from -7 to -11.
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Added as a reward from easy clue scrolls.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "12 June 2014"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-shortbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-shortbow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Magic shortbow | OSRS Price Data
-description: "Magic shortbow is a members two-handed weapon. High alch: 960 GP, GE limit: 18,000."
+description: "Magic shortbow: Short and magical, but still effective. High alch: 960 GP, GE limit: 18,000."
 osrs:
   id: 861
   name: Magic shortbow
@@ -14,25 +14,45 @@ osrs:
   limit: 18000
   equipment:
     slot: 2h
-    type: shortbow
-    attack_style: ranged
+    weapon_type: shortbow
     attack_speed: 4
-  requirements:
-    ranged: 50
-  stats:
-    attack:
+    weight: 1.36
+    requirements:
+      ranged: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 69
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
-    range: 7
+      magic_damage: 0
+      prayer: 0
   special_attack:
     name: Snapshot
-    description: Fires 2 arrows quickly with reduced accuracy
-    energy_cost: 55
-  fletching:
-    level: 80
-    xp: 83.3
-    method: Magic shortbow (u) + bowstring
+    energy: 55
+    description: Fires two arrows in rapid succession with an accuracy boost of +107 (~43%).
+  recipes:
+    - skill: fletching
+      level: 80
+      xp: 83.3
+      materials:
+        - item_name: Magic shortbow (u)
+          item_id: 70
+          quantity: 1
+        - item_name: Bow string
+          item_id: 1777
+          quantity: 1
+      product: Magic shortbow
+      product_id: 861
   drop_table:
     sources:
       - source: Spiritual ranger
@@ -46,7 +66,7 @@ osrs:
       item_name: Magic shortbow (i)
       slug: magic-shortbow-i
       relationship: upgrade
-      description: Imbued version (+75 ranged)
+      description: Imbued version (+75 ranged, 50% spec)
     - item_id: 21326
       item_name: Amethyst arrow
       slug: amethyst-arrow
@@ -62,9 +82,31 @@ osrs:
       slug: bow-string
       relationship: component
       description: Stringing material
-  about: "Snapshot: Fires 2 arrows quickly. Costs 55% spec."
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Magic shortbow with the Snapshot special attack: fires two arrows for 55% spec energy."
+  market_strategy:
+    notes:
+      - Fletching supply at 80 Fletching keeps prices near material cost
+      - PvP and mid-level PvM demand sustain steady turnover
+      - Imbued variant locks higher-end players out of the base bow market
+  history:
+    - date: "2002-03-25"
+      update: Ranged Update
+      description: Magic shortbow added to the game alongside the Ranged rework.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "25 Mar 2002"
+    update: Ranged Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options: [Wield, Drop]
+    worn_options: [Remove]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-armchair-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-armchair-flatpack.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Mahogany armchair (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Construction
+      level: 50
+      xp: 280
+      materials:
+        - item_name: Mahogany plank
+          quantity: 2
+      product: Mahogany armchair (flatpack)
+      product_id: 8508
+  construction:
+    construction_level: 50
+    construction_xp: 280
+    room: Parlour
+    hotspot: Chair space
+    flatpack: true
+  about: Mahogany armchair sold as a flatpack, built at a steel framed workbench.
+  market_strategy:
+    notes:
+      - Construction XP fodder around level 50
+      - Production typically loses GP vs plank cost
+      - Useful for hosting parlour seating without on-site assembly
+  history:
+    - date: "2006-05-31"
+      update: PLAYER-OWNED HOUSES!
+      description: Released with the Construction skill and flatpack system.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "31 May 2006"
+    update: PLAYER-OWNED HOUSES!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/monkey-bar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/monkey-bar.mdx
@@ -1,6 +1,6 @@
 ---
 title: Monkey bar | OSRS Price Data
-description: "Monkey bar: It's a monkey bar. It looks highly nutritious.. High alch: 30 GP, GE limit: 6,000."
+description: "Monkey bar: It's a monkey bar. It looks highly nutritious. High alch: 30 GP, GE limit: 6,000."
 osrs:
   id: 4014
   name: Monkey bar
@@ -12,9 +12,55 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 6000
-  about: "Monkey bar is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 5
+    type: standard
+  shops:
+    - shop_name: Solihib's Food Stall
+      location: Ape Atoll
+      price: 5
+      stock: 50
+      members_only: true
+      currency: coins
+  related_items:
+    - item_id: 1963
+      item_name: Banana
+      slug: banana
+      relationship: alternative
+      description: Other Ape Atoll food
+    - item_id: 5074
+      item_name: Monkey nuts
+      slug: monkey-nuts
+      relationship: alternative
+      description: Used alongside in spirit tree protection
+  about: Edible monkey snack sold by Solihib on Ape Atoll; heals 5 hitpoints and used in Farming spirit-tree protection.
+  market_strategy:
+    title: Ape Atoll Snack
+    notes:
+      - Cheap shop buy at 5 coins
+      - Niche use as spirit-tree payment
+      - Low daily volume on the GE
+      - Heals only 5 hp - not for combat
+  history:
+    - date: "2004-12-06"
+      update: Monkey Madness
+      description: Released with the Monkey Madness quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "6 Dec 2004"
+    update: Monkey Madness
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.15
+    options:
+      - Eat
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mud-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mud-pie.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mud pie | OSRS Price Data
-description: "Mud pie: All the good of the earth.. High alch: 32 GP, GE limit: 11,000."
+description: "Mud pie: All the good of the earth. High alch: 32 GP, GE limit: 11,000."
 osrs:
   id: 7170
   name: Mud pie
@@ -12,11 +12,33 @@ osrs:
   lowalch: 21
   highalch: 32
   limit: 11000
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 4
+    weight: 0.001
+    attack_bonus:
+      stab: -100
+      slash: -100
+      crush: -50
+      magic: 0
+      ranged: 3
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: -10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: cooking
       level: 29
       xp: 128
-      inputs:
+      materials:
         - item_name: Pastry dough
           quantity: 1
         - item_name: Pie dish
@@ -27,7 +49,8 @@ osrs:
           quantity: 1
         - item_name: Clay
           quantity: 1
-      output_quantity: 1
+      product: Mud pie
+      product_id: 7170
   related_items:
     - item_id: 7208
       item_name: Wild pie
@@ -39,26 +62,31 @@ osrs:
       slug: admiral-pie
       relationship: alternative
       description: +5 Fishing boost pie
-  about: |-
-    The mud pie is a throwable weapon that drains the target's run energy by 25% (rounded down). It deals no damage and only works on other players.
-
-    Ranged stats: Thrown weapon, 4-tick speed, 6-tile range
-
-    Mud pies are used in PvP to slow fleeing targets:
-    - Drains 25% run energy per throw
-    - 4 pies = nearly all run energy depleted
-    - Forces targets to walk, making them easier to catch
-    - Used by teams in multi-combat to lock down targets
-    - No combat requirements to throw
-
-    The pie dish drops at the target's feet after throwing.
+  about: Throwable PvP weapon that drains 25% of the target player's current run energy on hit; no damage, no NPC effect.
   market_strategy:
     notes:
       - PvP demand drives pricing
       - Ingredients are cheap and easy to gather
       - Only useful against players, not NPCs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2006-05-16"
+      update: Wear/Wield Rename
+      description: The "Wear" option was renamed to "Wield".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "20 Feb 2006"
+    update: Updates, updates and more updates...
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.001
+    options: [Wield, Drop]
+    worn_options: [Remove]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mummy-s-hands.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mummy-s-hands.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Mummy's hands is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: hands
+    weight: 0.5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  about: Cosmetic hands slot of the mummy outfit awarded from master Treasure Trails.
+  market_strategy:
+    notes:
+      - Master clue reward, very scarce
+      - Pure cosmetic with 0 stats
+      - Set piece demand drives price
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion (2016)
+      description: Added as a reward from master clue scrolls alongside the rest of the mummy outfit.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "6 July 2016"
+    update: Treasure Trail Expansion (2016)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/orange.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/orange.mdx
@@ -1,6 +1,6 @@
 ---
 title: Orange | OSRS Price Data
-description: "Orange is a members food item. High alch: 1 GP, GE limit: 13,000."
+description: "Orange: A fresh orange. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 2108
   name: Orange
@@ -12,16 +12,13 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  properties:
-    tradeable: true
-    tradeable_ge: true
-    weight: 0.11
   food:
-    heals: 0
-  skilling_sources:
-    - skill: farming
-      level: 39
-      xp: 35.5
+    heals: 2
+    type: fruit
+  farming:
+    farming_level: 39
+    harvest_xp: 35.5
+    patch_type: fruit_tree
   related_items:
     - item_id: 5286
       item_name: Orange tree seed
@@ -32,21 +29,40 @@ osrs:
       item_name: Orange slices
       slug: orange-slices
       relationship: product
-      description: Sliced product
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Farming Product / Food |
-    | Tradeable | Yes |
-    | Weight | 0.11 kg |
-    | Requirements | 39 Farming |
-
-    Cooking: Ingredient for gnome cocktails
-
-    Food: Slice into orange slices
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Knife-cut slices, ingredient in gnome cocktails
+    - item_id: 2112
+      item_name: Orange chunks
+      slug: orange-chunks
+      relationship: product
+      description: Further-cut chunks for gnome cooking
+  about: A fresh orange harvested from a fruit tree patch, used in gnome cocktails and as farmer payment.
+  market_strategy:
+    notes:
+      - 39 Farming patch supply
+      - Gnome cocktail ingredient demand
+      - Used as farmer payment for maple trees
+      - Compost bin material for regular compost
+      - Heals only 2 HP, not a combat food
+  history:
+    - date: "2002-12-12"
+      update: Agility skill update
+      description: Item added alongside the original RuneScape Classic Agility update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.11
+    options:
+      - Eat
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-wild-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-wild-pie.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw wild pie | OSRS Price Data
-description: "Raw wild pie: Good as it looks, I'd better cook it.. High alch: 54 GP, GE limit: 13,000."
+description: "Raw wild pie: Good as it looks, I'd better cook it. High alch: 54 GP, GE limit: 13,000."
 osrs:
   id: 7206
   name: Raw wild pie
@@ -12,9 +12,59 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 13000
-  about: "Raw wild pie is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: cooking
+      level: 85
+      xp: 240
+      materials:
+        - item_name: Part wild pie
+          quantity: 1
+        - item_name: Raw rabbit
+          quantity: 1
+      product: Wild pie
+      product_id: 7208
+      notes: Cook on a range; burns under 85 Cooking
+  related_items:
+    - item_id: 7204
+      item_name: Part wild pie
+      slug: part-wild-pie
+      relationship: component
+      description: Pie shell + raw bear meat + raw chompy stage
+    - item_id: 7208
+      item_name: Wild pie
+      slug: wild-pie
+      relationship: product
+      description: Cooked wild pie, two-bite +5 Slayer / +4 Ranged / +4 Fishing boost
+  about: Uncooked wild pie containing bear meat, chompy and rabbit, cooked into the +Slayer/Ranged/Fishing boosting wild pie.
+  market_strategy:
+    notes:
+      - 85 Cooking required to stop burning
+      - Bear meat and raw chompy gate supply
+      - Wild pie boosts Slayer, Ranged and Fishing
+      - Niche skiller demand
+      - Buy limit allows bulk stockpiling
+  history:
+    - date: "2006-02-20"
+      update: Updates, updates and more updates...
+      description: Released with the Hunter precursor cooking expansion.
+    - date: "2015-03-12"
+      update: GE tradeable uncooked pies
+      description: Uncooked pies became tradeable on the Grand Exchange.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-02-20"
+    update: Updates, updates and more updates...
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ray-barbs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ray-barbs.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: 15
-  about: "Ray barbs is a members-only item in Old School RuneScape. High alchemy value: 4,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Manta Ray
+        combat_level: 133
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Stingray
+        combat_level: 92
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Butterfly Ray
+        combat_level: 68
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Eagle Ray
+        combat_level: 44
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+  about: Stackable ray drop introduced with Sailing, harvested from various ray encounters.
+  market_strategy:
+    notes:
+      - Sailing-era resource with limited stock
+      - Tight 15 buy limit keeps spreads wide
+      - Higher tier rays drop more frequently
+  history:
+    - date: "2025-11-05"
+      update: Sailing release
+      description: Item added to the game but initially unobtainable.
+    - date: "2025-11-19"
+      update: Sailing is OUT TODAY!
+      description: Ray barbs became obtainable as drops from ray encounters.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "19 November 2025"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Inspect
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-returning-5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-returning-5.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ring of returning(5) | OSRS Price Data
-description: "Ring of returning(5): This ring returns you to your spawn point.. High alch: 765 GP, GE limit: 10,000."
+description: "Ring of returning(5): This ring returns you to your spawn point. High alch: 765 GP, GE limit: 10,000."
 osrs:
   id: 21129
   name: Ring of returning(5)
@@ -12,9 +12,87 @@ osrs:
   lowalch: 510
   highalch: 765
   limit: 10000
-  about: "Ring of returning(5) is a members-only item in Old School RuneScape. High alchemy value: 765 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: ring
+    weight: 0.006
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: magic
+      level: 27
+      xp: 0
+      materials:
+        - item_name: Jade ring
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Air rune
+          quantity: 3
+      product: Ring of returning(5)
+      product_id: 21129
+  teleport:
+    destinations:
+      - Lumbridge respawn
+      - Camelot respawn
+      - Falador respawn
+      - Edgeville respawn
+      - Prifddinas respawn
+      - Ferox Enclave respawn
+      - Kourend Castle respawn
+      - Civitas illa Fortis respawn
+    type: rub-or-wear
+    charges: 5
+    recharge_method: Re-craft from a fresh jade ring
+  charges:
+    max_charges: 5
+    repairable: false
+  related_items:
+    - item_id: 1635
+      item_name: Jade ring
+      slug: jade-ring
+      relationship: component
+      description: Base ring used in Magic enchant
+    - item_id: 21133
+      item_name: Ring of returning(1)
+      slug: ring-of-returning-1
+      relationship: variant
+      description: Lowest charge variant
+  about: Five-charge teleport ring that returns the wearer to their currently set respawn point; blocked above level 20 Wilderness.
+  market_strategy:
+    notes:
+      - Crafted by Magic enchant on a jade ring at 27 Magic
+      - Excluded from jewellery boxes, sustaining standalone demand
+      - Mid-Wilderness PvMers and Wilderness Slayer drive volume
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2 Feb 2017"
+    update: Ring of Returning
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options: [Wear, Rub, Drop]
+    worn_options: [Rub, Remove]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-gloves.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rock-shell gloves | OSRS Price Data
-description: "Rock-shell gloves: Fremennik gloves stitched together from rock crab shell shards.. High alch: 390 GP, GE limit: 125."
+description: "Rock-shell gloves: Fremennik gloves stitched together from rock crab shell shards. High alch: 390 GP, GE limit: 125."
 osrs:
   id: 6151
   name: Rock-shell gloves
@@ -12,9 +12,90 @@ osrs:
   lowalch: 260
   highalch: 390
   limit: 125
-  about: "Rock-shell gloves is a members-only item in Old School RuneScape. High alchemy value: 390 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: hands
+    weight: 3.175
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Giant Rock Crab
+        combat_level: 137
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: King Sand Crab
+        combat_level: 107
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+  related_items:
+    - item_id: 6147
+      item_name: Rock-shell legs
+      slug: rock-shell-legs
+      relationship: set-piece
+      description: Set legs
+    - item_id: 6145
+      item_name: Rock-shell plate
+      slug: rock-shell-plate
+      relationship: set-piece
+      description: Set body
+    - item_id: 6128
+      item_name: Rock-shell helm
+      slug: rock-shell-helm
+      relationship: set-piece
+      description: Set helm
+    - item_id: 6161
+      item_name: Rock-shell splinter
+      slug: rock-shell-splinter
+      relationship: component
+      description: Shell fragment dropped by the same crabs
+  about: Fremennik shell gloves dropped by giant and king rock crabs; modest crush/slash defence and no requirements to wear.
+  market_strategy:
+    title: Rock-shell Set Glove
+    notes:
+      - Only drops from giant/king sand crabs
+      - 2/128 drop rate per kill
+      - Niche Fremennik gear collector demand
+      - Low daily GE volume
+      - Storable in costume room armour case
+  history:
+    - date: "2005-08-01"
+      update: Waterbirth Island
+      description: Released with the Waterbirth Island update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "1 Aug 2005"
+    update: Waterbirth Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    worn_options:
+      - Wear
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-splinter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-splinter.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rock-shell splinter | OSRS Price Data
-description: "Rock-shell splinter: A slim piece of rock-shell.. High alch: 36 GP, GE limit: 11,000."
+description: "Rock-shell splinter: A slim piece of rock-shell. High alch: 36 GP, GE limit: 11,000."
 osrs:
   id: 6161
   name: Rock-shell splinter
@@ -12,9 +12,78 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 11000
-  about: "Rock-shell splinter is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: shell
+    tier: mid
+  drop_table:
+    sources:
+      - source: Giant Rock Crab
+        combat_level: 137
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: King Sand Crab
+        combat_level: 107
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Rock-shell splinter
+          item_id: 6161
+          quantity: 1
+        - item_name: Dagannoth hide
+          item_id: 6155
+          quantity: 2
+      product: Rock-shell legs
+      product_id: 6147
+  related_items:
+    - item_id: 6147
+      item_name: Rock-shell legs
+      slug: rock-shell-legs
+      relationship: product
+      description: Crafted via Skulgrimen with 2 dagannoth hides + 7,500gp
+    - item_id: 6151
+      item_name: Rock-shell gloves
+      slug: rock-shell-gloves
+      relationship: set-piece
+      description: Part of the rock-shell armour set
+    - item_id: 6155
+      item_name: Dagannoth hide
+      slug: dagannoth-hide
+      relationship: component
+      description: Required to craft rock-shell legs
+  about: Slim shell fragment dropped by giant and king rock crabs; combines with dagannoth hides to make rock-shell legs.
+  market_strategy:
+    title: Rock-shell Legs Component
+    notes:
+      - Only drops from giant/king sand crabs
+      - 2/128 drop rate per kill
+      - Required for rock-shell legs craft
+      - Niche Fremennik gear demand
+      - Low daily volume on the GE
+  history:
+    - date: "2005-08-01"
+      update: Waterbirth Island
+      description: Released with the Waterbirth Island update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "1 Aug 2005"
+    update: Waterbirth Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saw.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saw.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 40
-  about: "Saw is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Sawmill
+      location: Lumber Yard, northeast of Varrock
+      price: 13
+      stock: 1000
+      members_only: false
+      currency: coins
+    - shop_name: Woodcutting Guild construction supplies
+      location: Woodcutting Guild
+      price: 13
+      stock: 1000
+      members_only: true
+      currency: coins
+    - shop_name: Construction supplies
+      location: Prifddinas
+      price: 13
+      stock: 1000
+      members_only: true
+      currency: coins
+    - shop_name: Construction supplies
+      location: Auburnvale
+      price: 13
+      stock: 1000
+      members_only: true
+      currency: coins
+  about: Core Construction tool required to build furniture in player-owned houses.
+  market_strategy:
+    notes:
+      - Cheap shop alternative widely available
+      - Required for Construction along with a hammer
+      - Multiple free spawn locations across Gielinor
+  history:
+    - date: "2006-05-31"
+      update: Player-Owned Houses
+      description: Released with the Construction skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "31 May 2006"
+    update: Player-Owned Houses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shayzien-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shayzien-banner.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shayzien banner | OSRS Price Data
-description: "Shayzien banner: A war torn banner baring the sigil of house Shayzien.. High alch: 42 GP, GE limit: 4."
+description: "Shayzien banner: A war torn banner baring the sigil of house Shayzien. High alch: 42 GP, GE limit: 4."
 osrs:
   id: 20263
   name: Shayzien banner
@@ -12,9 +12,73 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 4
-  about: "Shayzien banner is a members-only item in Old School RuneScape. High alchemy value: 42 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: polestaff
+    attack_speed: 5
+    weight: 2.267
+    attack_bonus:
+      stab: 12
+      slash: 12
+      crush: 12
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers: [hard]
+  related_items:
+    - item_id: 20259
+      item_name: Arceuus banner
+      slug: arceuus-banner
+      relationship: variant
+      description: Other Kourend house banner
+    - item_id: 20261
+      item_name: Hosidius banner
+      slug: hosidius-banner
+      relationship: variant
+      description: Other Kourend house banner
+    - item_id: 20265
+      item_name: Piscarilius banner
+      slug: piscarilius-banner
+      relationship: variant
+      description: Other Kourend house banner
+    - item_id: 20267
+      item_name: Lovakengj banner
+      slug: lovakengj-banner
+      relationship: variant
+      description: Other Kourend house banner
+  about: Polestaff-class cosmetic banner of House Shayzien obtained from Hard clue scroll rewards.
+  history:
+    - date: "2019-01-01"
+      update: Examine Text Fix
+      description: Examine text corrected from "baring" to "bearing".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "6 Jul 2016"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options: [Wield, Drop]
+    worn_options: [Remove]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snapdragon-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snapdragon-potion-unf.mdx
@@ -1,6 +1,6 @@
 ---
 title: Snapdragon potion (unf) | OSRS Price Data
-description: "Snapdragon potion (unf) is a 4-dose members potion. High alch: 35 GP, GE limit: 10,000."
+description: "Snapdragon potion (unf): I need another ingredient to finish this Snapdragon potion. High alch: 35 GP, GE limit: 10,000."
 osrs:
   id: 3004
   name: Snapdragon potion (unf)
@@ -12,15 +12,14 @@ osrs:
   lowalch: 23
   highalch: 35
   limit: 10000
+  material:
+    type: potion-base
+    tier: high
   potion:
     doses: 0
-    type: unfinished
-    base_herb: snapdragon
-    base_herb_id: 3000
-  properties:
-    tradeable: true
-    tradeable_ge: true
-    weight: 0.056
+    herblore_level: 63
+    herblore_xp: 0
+    effect: unfinished base for Super restore
   recipes:
     - skill: herblore
       level: 63
@@ -34,8 +33,18 @@ osrs:
           quantity: 1
       product: Snapdragon potion (unf)
       product_id: 3004
-      product_quantity: 1
-      members_only: true
+    - skill: herblore
+      level: 63
+      xp: 142.5
+      materials:
+        - item_name: Snapdragon potion (unf)
+          item_id: 3004
+          quantity: 1
+        - item_name: Red spiders' eggs
+          item_id: 223
+          quantity: 1
+      product: Super restore(3)
+      product_id: 3026
   related_items:
     - item_id: 3000
       item_name: Snapdragon
@@ -51,20 +60,32 @@ osrs:
       item_name: Super restore(4)
       slug: super-restore-4
       relationship: product
-      description: Final product
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Unfinished Potion |
-    | Tradeable | Yes |
-    | Weight | 0.056 kg |
-    | Requirements | 63 Herblore |
-
-    Add secondary ingredient to create:
-    - Super restore (+ red spiders' eggs)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Final potion product
+  about: Unfinished Snapdragon potion, the base used to brew Super restore at 63 Herblore.
+  history:
+    - date: "2016-04-15"
+      update: Bank Placeholders
+      description: Bank placeholder functionality added.
+    - date: "2014-05-01"
+      update: Rename Update
+      description: Renamed from "Unfinished potion" to current name.
+    - date: "2004-10-26"
+      update: Herblore Tweaks
+      description: '"Empty" option added.'
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "27 Jul 2004"
+    update: Agility, Potions and Parties!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options: [Empty, Drop]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/soft-clay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/soft-clay.mdx
@@ -1,6 +1,6 @@
 ---
 title: Soft clay | OSRS Price Data
-description: "Soft clay: Clay soft enough to mould.. High alch: 1 GP, GE limit: 13,000."
+description: "Soft clay: Clay soft enough to mould. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 1761
   name: Soft clay
@@ -13,75 +13,76 @@ osrs:
   highalch: 1
   limit: 13000
   material:
-    type: dragonhide
-    tier: high
-  tanning:
-    product_id: 2507
-    product_name: Red dragon leather
-    npc_cost: 20
-    canifis_cost: 45
-    spell_level: 78
-  drop_table:
-    sources:
-      - source: Red dragon
-        source_id: 247
-        combat_level: 152
-        quantity: "1"
-        rarity: always
-        members_only: true
-      - source: Brutal red dragon
-        source_id: 8079
-        combat_level: 289
-        quantity: "2"
-        rarity: always
-        members_only: true
-      - source: Vorkath
-        source_id: 8059
-        combat_level: 732
-        quantity: 20-25
-        rarity: common
-        members_only: true
-        notes: noted
-      - source: Sarachnis
-        source_id: 8713
-        combat_level: 318
-        quantity: 15-25
-        rarity: common
-        members_only: true
-        notes: noted
+    type: clay
+    tier: low
+  recipes:
+    - skill: crafting
+      level: 0
+      xp: 0
+      materials:
+        - item_name: Clay
+          item_id: 434
+          quantity: 1
+        - item_name: Bucket of water
+          quantity: 1
+      product: Soft clay
+      product_id: 1761
+    - skill: magic
+      level: 68
+      xp: 65
+      materials:
+        - item_name: Clay
+          item_id: 434
+          quantity: 1
+      product: Soft clay
+      product_id: 1761
+      notes: Humidify spell (requires Dream Mentor)
   related_items:
-    - item_id: 2507
-      item_name: Red dragon leather
-      slug: red-dragon-leather
+    - item_id: 434
+      item_name: Clay
+      slug: clay
+      relationship: component
+      description: Raw mining product
+    - item_id: 1763
+      item_name: Bowl (unfired)
+      slug: unfired-bowl
       relationship: product
-      description: Tanned form
-    - item_id: 1753
-      item_name: Green dragonhide
-      slug: green-dragonhide
-      relationship: alternative
-      description: Entry-level d'hide
-    - item_id: 1751
-      item_name: Blue dragonhide
-      slug: blue-dragonhide
-      relationship: alternative
-      description: Mid-tier d'hide
-    - item_id: 1747
-      item_name: Black dragonhide
-      slug: black-dragonhide
-      relationship: alternative
-      description: Highest tier
+      description: Pottery wheel product
+    - item_id: 1787
+      item_name: Pot (unfired)
+      slug: unfired-pot
+      relationship: product
+      description: Beginner pottery product
+  about: Clay moistened with water, the base material for pottery, magic tablets and Construction projects.
   market_strategy:
-    profit_formulas:
-      - Leather price - Hide price - 20 gp = Profit per hide
     notes:
-      - Tans 5 hides per cast
-      - 81 Magic XP per cast
-      - "Buy limit: 11,000 per 4 hours"
-      - "Calculate:"
-      - Tan Leather spell is significantly more profitable
-      - Pairs well with other hides for batch tanning
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - 13,000 buy limit allows bulk supply
+      - Humidify spell (68 Magic) bulk-creates 27 per cast
+      - Construction and magic tablet demand drives volume
+      - Bucket/jug of water + clay arbitrage on GE
+      - F2P accessible material
+  history:
+    - date: "2001-02-28"
+      update: Yet another new quest, and new options menu
+      description: Soft clay introduced in the early RuneScape Classic era.
+    - date: "2024-01-10"
+      update: Soft clay creation
+      description: Vials of water may now be used to create soft clay.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-02-28"
+    update: Yet another new quest, and new options menu
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-cannonball.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-cannonball.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel cannonball | OSRS Price Data
-description: "Steel cannonball: Ammo suited for a boat's cannon or for a dwarf multicannon.. High alch: 3 GP, GE limit: 11,000."
+description: "Steel cannonball: Ammo suited for a boat's cannon or for a dwarf multicannon. High alch: 3 GP, GE limit: 11,000."
 osrs:
   id: 2
   name: Steel cannonball
@@ -12,14 +12,9 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 11000
-  ammunition:
-    type: cannonball
-  smithing:
-    level: 35
-    xp: 25.6
-    method: Ammo mould
-    bars_per_craft: 1
-    output_quantity: 4
+  material:
+    type: ammunition
+    tier: mid
   recipes:
     - skill: smithing
       level: 35
@@ -28,12 +23,8 @@ osrs:
         - item_name: Steel bar
           item_id: 2353
           quantity: 1
-      product: Cannonball
+      product: Steel cannonball
       product_id: 2
-      product_quantity: 4
-      facility: Furnace
-      tool: Ammo mould
-      members_only: true
   related_items:
     - item_id: 2353
       item_name: Steel bar
@@ -60,28 +51,48 @@ osrs:
       slug: double-ammo-mould
       relationship: alternative
       description: 2x production speed
-  about: |-
-    Cannonballs can be upgraded with granite dust:
-
-    | Upgrade | Smithing Level | Result |
-    |---------|----------------|--------|
-    | + Granite dust | 50 | Granite cannonball |
+  about: Standard Dwarf multicannon ammo smithed from steel bars at level 35 Smithing; four cannonballs per bar.
   market_strategy:
     title: Steel Bar Processing
-    profit_formulas:
-      - (Cannonball price × 4) - Steel bar price = Profit
     notes:
-      - Buy Steel bar → Smith → Sell cannonballs
+      - Buy Steel bar - Smith - Sell cannonballs
       - 1 bar = 4 cannonballs
-      - "Calculate:"
-      - ~306 GP profit per steel bar (after GE tax)
-      - ~179,400 GP/hour at optimal speed
-      - Very AFK method - popular for alts
-      - Extremely AFK - good for mobile/alts
+      - ~306 GP profit per steel bar after GE tax
+      - ~179,400 GP/hour at optimal pace
+      - Very AFK - popular for alts and mobile
       - High daily volume (~206M traded)
-      - Consistent demand from slayer/PvM
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Consistent slayer/PvM demand
+  trading_tips:
+    - Buy steel bars in bulk during off-peak hours
+    - Sell finished cannonballs during prime PvM windows
+  history:
+    - date: "2026-05-27"
+      update: Steel item graphics
+      description: Item graphically updated to better match other steel items.
+    - date: "2026-03-18"
+      update: Ship combat rebalance
+      description: Ranged Strength bonus increased from +26 to +74 for ship combat.
+    - date: "2025-11-05"
+      update: Cannonball rename
+      description: Item renamed from "Cannonball" to "Steel cannonball".
+    - date: "2003-05-27"
+      update: New Dwarf Cannon Quest
+      description: Released alongside the Dwarf Cannon quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "27 May 2003"
+    update: New Dwarf Cannon Quest
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-crossbow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel crossbow | OSRS Price Data
-description: "Steel crossbow is a members weapon slot item requiring 31 Ranged. High alch: 216 GP, GE limit: 125."
+description: "Steel crossbow: A steel crossbow. High alch: 216 GP, GE limit: 125."
 osrs:
   id: 9179
   name: Steel crossbow
@@ -14,48 +14,96 @@ osrs:
   limit: 125
   equipment:
     slot: weapon
-    type: crossbow
-    tradeable: true
+    weapon_type: crossbow
+    attack_speed: 6
     weight: 5
     requirements:
       ranged: 31
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 54
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 54
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    attack_range: 7
   recipes:
     - skill: fletching
       level: 46
+      xp: 54
       materials:
-        - item_name: Steel crossbow (u)
+        - item_id: 9457
+          item_name: Steel crossbow (u)
           quantity: 1
-        - item_name: Crossbow string
+        - item_id: 9438
+          item_name: Crossbow string
           quantity: 1
+      product: Steel crossbow
+      product_id: 9179
   related_items:
     - item_id: 9181
       item_name: Mithril crossbow
       slug: mithril-crossbow
       relationship: upgrade
       description: Next tier crossbow
+    - item_id: 9177
+      item_name: Iron crossbow
+      slug: iron-crossbow
+      relationship: downgrade
+      description: Previous tier crossbow
     - item_id: 9141
       item_name: Steel bolts
       slug: steel-bolts
       relationship: alternative
-      description: Compatible ammo
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Compatible bolt ammunition
+  market_strategy:
+    title: Mid-tier ranged training weapon
+    notes:
+      - Bridges iron and mithril crossbows for 31 Ranged training
+      - Fletchable from steel crossbow (u) + string for level 46 XP
+      - Low GE buy limit of 125 caps flipping
+      - Demand modest — players quickly upgrade
+  history:
+    - date: "2006-07-31"
+      update: Crossbows
+      description: Steel crossbow released with the Crossbows update.
+    - date: "2014-09-04"
+      update: Item renaming
+      description: Renamed from "Steel c'bow" to Steel crossbow.
+    - date: "2015-05-07"
+      update: Fletching boosted-level support
+      description: Boosted Fletching levels accepted when stringing.
+    - date: "2021-08-25"
+      update: Animation update
+      description: Wield animation adjusted.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  about: Steel crossbow is a members 31 Ranged crossbow accepting bolts up to steel, fletched at level 46.
+  properties:
+    release_date: "31 July 2006"
+    update: Crossbows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-javelin-p-5650.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-javelin-p-5650.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel javelin(p++) | OSRS Price Data
-description: "Steel javelin(p++): A steel tipped javelin.. High alch: 14 GP, GE limit: 7,000."
+description: "Steel javelin(p++): A steel tipped javelin. High alch: 14 GP, GE limit: 7,000."
 osrs:
   id: 5650
   name: Steel javelin(p++)
@@ -12,9 +12,86 @@ osrs:
   lowalch: 9
   highalch: 14
   limit: 7000
-  about: "Steel javelin(p++) is a members-only item in Old School RuneScape. High alchemy value: 14 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: ammo
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 64
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 826
+      item_name: Steel javelin
+      slug: steel-javelin
+      relationship: variant
+      description: Unpoisoned base javelin
+    - item_id: 5648
+      item_name: Steel javelin(p)
+      slug: steel-javelin-p
+      relationship: variant
+      description: Weapon poison variant
+    - item_id: 5649
+      item_name: Steel javelin(p+)
+      slug: steel-javelin-p-plus
+      relationship: variant
+      description: Weapon poison(+) variant
+    - item_id: 828
+      item_name: Mithril javelin
+      slug: mithril-javelin
+      relationship: upgrade
+      description: Higher-tier javelin
+  about: Steel javelin coated with weapon poison(++); used as Heavy ballista ammunition for venom-tier ranged damage.
+  market_strategy:
+    title: Poisoned Javelin Niche
+    notes:
+      - Ballista ammo for poison setups
+      - Crafted from base javelin + weapon poison(++)
+      - Production loss makes Smithing/Herblore costly
+      - GE price often below alch
+      - Niche PvP/PvM demand
+  history:
+    - date: "2016-10-31"
+      update: Ranged rebalance
+      description: Ranged Strength decreased from +75 to +64.
+    - date: "2016-05-06"
+      update: Ranged slot rework
+      description: Changed to ammunition slot; Ranged Attack bonus removed and Ranged Strength increased.
+    - date: "2006-09-20"
+      update: Poison naming
+      description: Poison naming standardized across + and ++ variants.
+    - date: "2004-03-29"
+      update: RS2 Launched!
+      description: Released with the RS2 client launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "29 Mar 2004"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-tool-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-tool-ornament-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trailblazer tool ornament kit | OSRS Price Data
-description: "Trailblazer tool ornament kit is a members-only OSRS item. High alch: 15,000 GP, GE limit: 5."
+description: "Trailblazer tool ornament kit: A kit which can be attached to any Dragon or Infernal axe, pickaxe or harpoon to recolour it. High alch: 15,000 GP, GE limit: 5."
 osrs:
   id: 25090
   name: Trailblazer tool ornament kit
@@ -12,9 +12,65 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 5
-  about: "Trailblazer tool ornament kit is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues Reward interface
+      price: 1500
+      members_only: true
+      currency: League Points
+  related_items:
+    - item_id: 1359
+      item_name: Dragon axe
+      slug: dragon-axe
+      relationship: component
+      description: Compatible woodcutting tool for recolour
+    - item_id: 13661
+      item_name: Infernal axe
+      slug: infernal-axe
+      relationship: component
+      description: Compatible woodcutting tool for recolour
+    - item_id: 11920
+      item_name: Dragon harpoon
+      slug: dragon-harpoon
+      relationship: component
+      description: Compatible fishing tool for recolour
+    - item_id: 13243
+      item_name: Infernal harpoon
+      slug: infernal-harpoon
+      relationship: component
+      description: Compatible fishing tool for recolour
+  market_strategy:
+    title: League cosmetic, capped supply
+    notes:
+      - Tradeable Leagues II reward, supply locked to past event
+      - Very low buy limit of 5 throttles flips
+      - Demand sustained by fashionscape skillers
+      - Watch for spikes around new League cosmetic announcements
+  history:
+    - date: "2020-10-28"
+      update: Leagues II - Trailblazer Launch
+      description: Trailblazer tool ornament kit introduced as a Leagues II reward.
+    - date: "2021-01-06"
+      update: Soul Wars and 20th Anniversary
+      description: Tradeable release rolled into the main game with adjusted value.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  about: Trailblazer tool ornament kit recolours dragon and infernal axes, pickaxes, and harpoons; sourced from the Leagues II reward shop.
+  properties:
+    release_date: "6 January 2021"
+    update: Soul Wars and 20th Anniversary Event
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    destroy: You will need to claim a new one from the Leagues Reward Shop.
+    options:
+      - Attach
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trousers-lilac.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trousers-lilac.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 280
   highalch: 420
   limit: 150
-  about: "Trousers (lilac) is a members-only item in Old School RuneScape. High alchemy value: 420 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Agmundi Quality Clothes
+      location: Keldagrim
+      price: 910
+      stock: 3
+      members_only: true
+      currency: coins
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania and Etceteria Dungeon
+      price: 700
+      stock: 3
+      members_only: true
+      currency: coins
+  about: Cosmetic dwarven legwear sold by Keldagrim and Miscellania clothing shops.
+  history:
+    - date: "2005-07-26"
+      update: Examine text changed
+      description: Examine text changed from "These look pretty heavy." to current text.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "31 May 2005"
+    update: Keldagrim - The Dwarven City
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-blueprints.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-blueprints.mdx
@@ -1,6 +1,6 @@
 ---
 title: Twisted blueprints | OSRS Price Data
-description: "Twisted blueprints: A scroll which unlocks the twisted player-owned house wall-kit.. High alch: 15,000 GP, GE limit: 5."
+description: "Twisted blueprints: A scroll which unlocks the twisted player-owned house wall-kit. High alch: 15,000 GP, GE limit: 5."
 osrs:
   id: 24463
   name: Twisted blueprints
@@ -12,9 +12,52 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 5
-  about: "Twisted blueprints is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Lumbridge Castle
+      price: 4000
+      stock: unlimited
+      members_only: true
+      currency: League Points
+  related_items:
+    - item_id: 24443
+      item_name: Twisted relic hunter (t1) armour set
+      slug: twisted-relic-hunter-t1-armour-set
+      relationship: alternative
+      description: Other Leagues reward shop cosmetic
+    - item_id: 24565
+      item_name: Trailblazer blueprints
+      slug: trailblazer-blueprints
+      relationship: variant
+      description: Trailblazer League house style equivalent
+  about: A Twisted League reward scroll that unlocks the twisted POH wall-kit when handed to an Estate Agent.
+  market_strategy:
+    notes:
+      - Fixed Leagues supply, no farmable source
+      - Buy limit of 5 keeps merchanting controlled
+      - Returns to inventory when changing POH style
+      - Cosmetic-only, no stat benefit
+      - Twisted League prestige item
+  history:
+    - date: "2020-01-16"
+      update: Twisted League Reward Shop and Game Improvements
+      description: Released as a 4,000 League Points reward from the Twisted League shop.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-01-16"
+    update: Twisted League Reward Shop and Game Improvements
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Inspect
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/voidwaker-gem.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/voidwaker-gem.mdx
@@ -1,6 +1,6 @@
 ---
 title: Voidwaker gem | OSRS Price Data
-description: "Voidwaker gem: The gem of a broken sword.. High alch: 480,000 GP, GE limit: 8."
+description: "Voidwaker gem: The gem of a broken sword. High alch: 480,000 GP, GE limit: 8."
 osrs:
   id: 27687
   name: Voidwaker gem
@@ -12,9 +12,69 @@ osrs:
   lowalch: 320000
   highalch: 480000
   limit: 8
-  about: "Voidwaker gem is a members-only item in Old School RuneScape. High alchemy value: 480,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Venenatis
+        source_id: 6610
+        combat_level: 464
+        quantity: "1"
+        rarity: rare
+        members_only: true
+        notes: 1/360 drop rate
+      - source: Spindel
+        source_id: 12056
+        combat_level: 302
+        quantity: "1"
+        rarity: very-rare
+        members_only: true
+        notes: 1/912 drop rate
+  related_items:
+    - item_id: 27681
+      item_name: Voidwaker hilt
+      slug: voidwaker-hilt
+      relationship: component
+      description: Callisto/Artio drop, combined with gem and blade
+    - item_id: 27684
+      item_name: Voidwaker blade
+      slug: voidwaker-blade
+      relationship: component
+      description: Vet'ion/Calvar'ion drop, combined with gem and hilt
+    - item_id: 27690
+      item_name: Voidwaker
+      slug: voidwaker
+      relationship: product
+      description: Final assembled weapon
+  about: One of three Voidwaker pieces dropped by Wilderness bosses, combined at Madam Sikaro for the assembled weapon.
+  market_strategy:
+    notes:
+      - Wilderness boss drop, exposed to PKers
+      - Venenatis 1/360 is the primary supply
+      - Spindel 1/912 thins out lower-risk supply
+      - Demand driven by Voidwaker assembly + skip costs
+      - 500,000 coin combine fee plus three pieces
+  history:
+    - date: "2023-01-25"
+      update: Wilderness Boss Rework
+      description: Released as part of the Wilderness boss rework alongside Voidwaker hilt and blade.
+    - date: "2023-02-02"
+      update: Wilderness death mechanics
+      description: No longer converts to coins on death in the Wilderness.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-01-25"
+    update: Wilderness Boss Rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Inspect
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-gloves.mdx
@@ -1,6 +1,6 @@
 ---
 title: White gloves | OSRS Price Data
-description: "White gloves: These will keep my hands warm!. High alch: 3 GP, GE limit: 125."
+description: "White gloves: These will keep my hands warm! High alch: 3 GP, GE limit: 125."
 osrs:
   id: 6629
   name: White gloves
@@ -12,9 +12,72 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 125
-  about: "White gloves is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: hands
+    weight: 0.226
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_id: 6627
+      item_name: Black gloves
+      slug: black-gloves
+      relationship: variant
+      description: Alternate colour cosmetic gloves
+    - item_id: 1059
+      item_name: Leather gloves
+      slug: leather-gloves
+      relationship: alternative
+      description: Common F2P leather gloves
+  market_strategy:
+    title: Cheap prayer-bonus gloves
+    notes:
+      - Easy clue reward, plentiful supply
+      - +1 Prayer bonus is unique for cheap hands
+      - Low GE buy limit of 125 caps flipping
+      - Fashionscape demand keeps a floor
+  history:
+    - date: "2005-10-17"
+      update: Wanted!
+      description: White gloves added with the Wanted! quest update as a clue scroll reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  about: White gloves are easy clue scroll hand-slot gloves offering minor defence and +1 Prayer.
+  properties:
+    release_date: "17 October 2005"
+    update: Wanted!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-chaps.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zamorak chaps | OSRS Price Data
-description: "Zamorak chaps is a members legs slot item requiring 70 Ranged. High alch: 3,600 GP, GE limit: 8."
+description: "Zamorak chaps: Zamorak blessed dragonhide chaps. High alch: 3,600 GP, GE limit: 8."
 osrs:
   id: 10372
   name: Zamorak chaps
@@ -14,6 +14,9 @@ osrs:
   limit: 8
   equipment:
     slot: legs
+    weight: 5
+    requirements:
+      ranged: 70
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,54 +34,73 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 10380
       item_name: Guthix chaps
       slug: guthix-chaps
       relationship: variant
+      description: Guthix blessed god variant
     - item_id: 12502
       item_name: Bandos chaps
       slug: bandos-chaps
       relationship: variant
+      description: Bandos blessed god variant
     - item_id: 12510
       item_name: Armadyl chaps
       slug: armadyl-chaps
       relationship: variant
+      description: Armadyl blessed god variant
     - item_id: 12494
       item_name: Ancient chaps
       slug: ancient-chaps
       relationship: variant
+      description: Ancient blessed god variant
     - item_id: 2497
       item_name: Black d'hide chaps
       slug: black-d-hide-chaps
       relationship: downgrade
-      description: Standard version requiring 40 Defence
-  about: |-
-    > *"Zamorak blessed dragonhide chaps."*
-
-    | Stat | Blessed | Black D'hide |
-    |------|--------:|-----------:|
-    | Ranged Attack | +8 | +8 |
-    | Stab Defence | +17 | +17 |
-    | Slash Defence | +20 | +20 |
-    | Crush Defence | +16 | +16 |
-    | Magic Defence | +18 | +18 |
-    | Ranged Defence | +17 | +17 |
-    | Prayer | +1 | 0 |
-    | Ranged Req | 70 | 70 |
-    | Defence Req | None | 40 |
-
-    The key advantage: blessed chaps have no Defence requirement, making them ideal for pures and ranged-focused accounts. They also offer a +1 prayer bonus.
+      description: Standard chaps requiring 40 Defence
+  about: Zamorak-blessed dragonhide chaps from hard clues with +1 Prayer and no Defence requirement, ideal for pures.
   market_strategy:
     notes:
-      - Hard clue exclusive — supply tied to clue completion rates
-      - Popular with 1-Defence pures who need best-in-slot ranged legs
+      - Hard clue exclusive, supply tied to clue completion
+      - Popular with 1-Defence pures
       - All god variants are functionally identical
-      - Armadyl and Ancient variants tend to have slight premiums
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Armadyl and Ancient variants carry slight premiums
+      - +1 Prayer edge over standard black d'hide chaps
+  history:
+    - date: "2006-12-05"
+      update: Treasure Trails, spiders and sheep
+      description: Released as a hard clue scroll reward alongside other god-blessed dragonhide.
+    - date: "2014-03-27"
+      update: Wilderness Feedback Update
+      description: Added +1 Prayer bonus to god-blessed dragonhide chaps.
+    - date: "2021-09-22"
+      update: Quality of Life
+      description: Defence requirement of 40 was removed, leaving only the 70 Ranged requirement.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails, spiders and sheep
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-platebody.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
-  about: "Zamorak platebody is a free-to-play item in Old School RuneScape. High alchemy value: 39,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 9.979
+    requirements:
+      defence: 40
+      quest: Dragon Slayer I
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 82
+      slash: 80
+      crush: 72
+      magic: -6
+      ranged: 80
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  about: Zamorak-themed rune platebody awarded from hard Treasure Trails.
+  market_strategy:
+    notes:
+      - Hard clue reward, limited supply
+      - +1 Prayer bonus over plain rune platebody
+      - Requires Dragon Slayer I to equip
+  history:
+    - date: "2021-04-21"
+      update: Equipment rebalance
+      description: Ranged attack bonus decreased from -10 to -15.
+    - date: "2014-01-09"
+      update: God platebody prayer bonus
+      description: Added +1 Prayer bonus to all god platebodies.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "5 May 2004"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Migrate 50 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Reshape `equipment.stats.*` → `equipment.{attack_bonus,defence_bonus,other_bonus}.*` per the v3 Zod schema.
- Add v3 `properties` block (release_date, update, weight, options, alchable, etc.), `material` classification, structured `drop_table` / `shops` / `recipes` / `treasure_trail`, condensed single-line `about`, and a `history` block from the wiki Changes section.

Validated locally via `astro sync` — content collection compiles clean.

## Items (50)

armageddon-teleport-scroll, snapdragon-potion-unf, mud-pie, black-full-helm-g, cannon-stand, shayzien-banner, ring-of-returning-5, magic-shortbow, echo-crystal, black-warlock-item, trousers-lilac, ray-barbs, fish-food, corrupted-twisted-bow, saw, mahogany-armchair-flatpack, black-cavalier, iron-platelegs-g, zamorak-platebody, mummy-s-hands, dark-tuxedo-jacket, emerald-ring, curry-leaf, dagon-hai-robes-set, white-gloves, trailblazer-tool-ornament-kit, anti-dragon-shield, colossal-wyrm-teleport-scroll, guthix-stole, steel-crossbow, extended-antifire-mix-1, apples-5, arctic-pyre-logs, voidwaker-gem, beer-glass, orange, soft-clay, twisted-blueprints, zamorak-chaps, raw-wild-pie, initiate-cuisse, monkey-bar, crystal-ball-flatpack, cosmic-rune, steel-cannonball, rock-shell-splinter, chopped-tomato, steel-javelin-p-5650, rock-shell-gloves, butterfly-jar.

## Test plan

- [x] `astro sync` clean — content collection schema validates all 50 entries.
- [ ] Smoke-check 2-3 pages on preview (e.g. `/osrs/magic-shortbow`, `/osrs/abyssal-shield` analogue, `/osrs/snapdragon-potion-unf`) to confirm OSRSItemPanel renders v3 frontmatter correctly.
- [ ] CI build green.

## Follow-ups

- 4273 v2 items remain. Next batch of 50 can fire on same template.