### PR TITLE
chore(kubectl): track factorio-rotator manifest in kbve-kubectl deployment_yamls

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "agones_factorio",
 			"app_name": "agones-factorio",
-			"version": "0.0.11",
+			"version": "0.0.12",
 			"version_toml": "apps/agones/factorio/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx",
 			"source_path": "apps/agones/factorio",
@@ -290,6 +290,11 @@
 			"runner": "arc-runner-set",
 			"image": "kbve/kubectl",
 			"e2e_name": "kubectl-e2e",
+			"deployment_yamls": [
+				"apps/kube/kubevirt/autologon/job.yaml",
+				"apps/kube/kubevirt/runner/job.yaml",
+				"apps/kube/agones/factorio/manifests/rotation-cronjob.yaml"
+			],
 			"has_test": true
 		},
 		{

--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -19,6 +19,10 @@ version_toml: apps/vm/kubectl/version.toml
 version_target: apps/vm/kubectl/Cargo.toml
 runner: arc-runner-set
 image: kbve/kubectl
+deployment_yamls:
+    - apps/kube/kubevirt/autologon/job.yaml
+    - apps/kube/kubevirt/runner/job.yaml
+    - apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
 has_test: true
 e2e_name: kubectl-e2e
 test_framework: typescript
@@ -57,6 +61,18 @@ containers:
       image: ghcr.io/kbve/kubectl:0.1.0
       command: ['/bin/sh', '/scripts/my-script.sh']
 ```
+
+### Where it ships
+
+The image is pinned in three manifests today, all kept in sync by the `deployment_yamls` field above:
+
+| Manifest | Job | Pattern |
+|---|---|---|
+| `apps/kube/kubevirt/autologon/job.yaml` | KubeVirt Windows autologon setup | One-shot Job, kubectl + virtctl |
+| `apps/kube/kubevirt/runner/job.yaml` | KubeVirt runner orchestration | One-shot Job, kubectl + virtctl |
+| `apps/kube/agones/factorio/manifests/rotation-cronjob.yaml` | Factorio GameServer image rotator | CronJob every 5 min, compares `gs.spec.image` vs `pod.spec.image`, deletes the GameServer when they drift so ArgoCD selfHeal recreates from the new spec |
+
+When a new behavior needs to land across all rotator and KubeVirt jobs (RCON-aware save-flush probes, Agones SDK Health calls, retry-with-backoff, ConfigMap-driven rotation policy), extend the Rust CLI in `apps/vm/kubectl/src/`, bump `version.toml`, and every manifest above auto-bumps via the post-publish sync.
 
 Or using the Rust CLI directly:
 


### PR DESCRIPTION
## Summary

#11625 swapped the factorio-rotator CronJob onto the in-house \`ghcr.io/kbve/kubectl\` image. Now we wire it into the version-sync pipeline so any future kbve-kubectl release auto-bumps the rotator manifest the same way it already auto-bumps the KubeVirt jobs.

## Changes

\`apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx\`:
- Adds \`apps/kube/agones/factorio/manifests/rotation-cronjob.yaml\` to the \`deployment_yamls\` array (was just the two KubeVirt entries).
- New "Where it ships" doc section enumerating the three manifests + the path forward for extending rotator behavior in the Rust CLI.

\`.github/ci-dispatch-manifest.json\` regenerated end-to-end via \`nx run astro-kbve:sync:ci-manifest\` (no surgical edits).

## Why this matters

When a future kbve-kubectl release lands extra capabilities — e.g. RCON-aware save-flush probes before \`kubectl delete gs/factorio\`, Agones SDK \`/health\` pokes, retry-with-backoff on the GameServer delete, ConfigMap-driven rotation policy — they live in \`apps/vm/kubectl/src/\` and one \`version.toml\` bump rolls the new image into:

| Manifest | Consumer |
|---|---|
| \`apps/kube/kubevirt/autologon/job.yaml\` | KubeVirt Windows autologon |
| \`apps/kube/kubevirt/runner/job.yaml\` | KubeVirt runner orchestration |
| \`apps/kube/agones/factorio/manifests/rotation-cronjob.yaml\` | Factorio GameServer rotator |

No follow-up bumps, no per-manifest sed.

## Test plan

- [ ] After merge, next kbve-kubectl release publishes a docker image.
- [ ] post-publish sync workflow updates all three YAML files to the new tag in a single commit.
- [ ] ArgoCD applies the bump; rotator + KubeVirt jobs pick up the new image on next launch.