### PR TITLE
harden(astro-irc): embed popup lifecycle + data-signin-url override

### DIFF
--- a/apps/irc/astro-irc/public/embed/example.html
+++ b/apps/irc/astro-irc/public/embed/example.html
@@ -95,6 +95,14 @@
 				<p class="label">Starlight host via --sl-color-* vars</p>
 				<div id="kbve-chat-4" class="host sl-themed"></div>
 			</div>
+			<div class="card">
+				<p class="label">Custom signin URL (data-signin-url)</p>
+				<div
+					id="kbve-chat-5"
+					class="host"
+					data-channel="#general"
+					data-signin-url="https://chat.kbve.com/auth/?source=staging"></div>
+			</div>
 		</div>
 
 		<script src="/embed/chat.js" defer></script>

--- a/apps/irc/astro-irc/src/embed/EmbedChat.tsx
+++ b/apps/irc/astro-irc/src/embed/EmbedChat.tsx
@@ -31,7 +31,7 @@ import {
 import { readSharedTokenCookie } from './auth';
 import { formatTime, nickColor, nickInitial } from './format';
 
-const SIGNIN_URL = 'https://chat.kbve.com/auth/';
+export const DEFAULT_SIGNIN_URL = 'https://chat.kbve.com/auth/';
 
 function isKbveOrigin(): boolean {
 	if (typeof location === 'undefined') return false;
@@ -41,40 +41,62 @@ function isKbveOrigin(): boolean {
 	);
 }
 
-function startSignInPopup(onToken: (token: string) => void): void {
+interface SignInHandle {
+	cancel: () => void;
+}
+
+function startSignInPopup(
+	signinUrl: string,
+	onToken: (token: string) => void,
+): SignInHandle | null {
 	const popup = window.open(
-		SIGNIN_URL,
+		signinUrl,
 		'kbve_chat_signin',
 		'width=520,height=720,menubar=no,toolbar=no,location=no',
 	);
 	if (!popup) {
-		window.location.href = SIGNIN_URL;
-		return;
+		window.location.href = signinUrl;
+		return null;
 	}
+
+	let cancelled = false;
+	let timerId: number | null = null;
+
+	const cancel = () => {
+		if (cancelled) return;
+		cancelled = true;
+		if (timerId !== null) {
+			window.clearInterval(timerId);
+			timerId = null;
+		}
+		try {
+			if (popup && !popup.closed) popup.close();
+		} catch {
+			/* cross-origin popup, ignore */
+		}
+	};
+
 	const start = Date.now();
-	const interval = window.setInterval(() => {
-		const elapsed = Date.now() - start;
-		if (elapsed > 5 * 60 * 1000) {
-			window.clearInterval(interval);
+	timerId = window.setInterval(() => {
+		if (cancelled) return;
+		if (Date.now() - start > 5 * 60 * 1000) {
+			cancel();
 			return;
 		}
 		const token = readSharedTokenCookie();
 		if (token) {
-			window.clearInterval(interval);
-			try {
-				popup.close();
-			} catch {
-				/* ignore */
-			}
+			cancel();
 			onToken(token);
 			return;
 		}
 		if (popup.closed) {
-			window.clearInterval(interval);
+			cancel();
 			const finalToken = readSharedTokenCookie();
 			if (finalToken) onToken(finalToken);
 		}
 	}, 1200);
+
+	return { cancel };
 }
 
 const STATUS_LABEL: Record<ConnectionStatus, string> = {
@@ -250,13 +272,28 @@ const Feed: React.FC = () => {
 	);
 };
 
-const Composer: React.FC = () => {
+interface ComposerProps {
+	signinUrl?: string;
+}
+
+const Composer: React.FC<ComposerProps> = ({
+	signinUrl = DEFAULT_SIGNIN_URL,
+}) => {
 	const status = useStore($connectionStatus);
 	const canSend = useStore($canSend);
 	const nick = useStore($nick);
 	const avatar = useStore($avatarUrl);
 	const [value, setValue] = useState('');
 	const inputRef = useRef<HTMLInputElement>(null);
+	const signInHandleRef = useRef<SignInHandle | null>(null);
+
+	useEffect(
+		() => () => {
+			signInHandleRef.current?.cancel();
+			signInHandleRef.current = null;
+		},
+		[],
+	);
 
 	const disabled = status !== 'connected' || !canSend;
 
@@ -284,10 +321,12 @@ const Composer: React.FC = () => {
 		const onKbve = isKbveOrigin();
 		const handleSignIn = () => {
 			if (!onKbve) {
-				window.open(SIGNIN_URL, '_blank', 'noopener');
+				window.open(signinUrl, '_blank', 'noopener');
 				return;
 			}
-			startSignInPopup((token) => {
+			signInHandleRef.current?.cancel();
+			signInHandleRef.current = startSignInPopup(signinUrl, (token) => {
+				signInHandleRef.current = null;
 				void reconnectWithToken(token);
 			});
 		};
@@ -377,14 +416,18 @@ const Users: React.FC = () => {
 	);
 };
 
-export const EmbedChat: React.FC = () => (
+export interface EmbedChatProps {
+	signinUrl?: string;
+}
+
+export const EmbedChat: React.FC<EmbedChatProps> = ({ signinUrl }) => (
 	<div className="root">
 		<TopBar />
 		<div className="body">
 			<ChannelRail />
 			<div className="main">
 				<Feed />
-				<Composer />
+				<Composer signinUrl={signinUrl} />
 			</div>
 			<Users />
 		</div>

--- a/apps/irc/astro-irc/src/embed/index.tsx
+++ b/apps/irc/astro-irc/src/embed/index.tsx
@@ -7,24 +7,13 @@ import { connect, disconnect } from './transport';
 import { resetState } from './state';
 
 export interface KbveChatOptions {
-	/** Mount target. Accepts a DOM element or a CSS selector. */
 	el: HTMLElement | string;
-	/** Default channel to auto-join (defaults to "#general"). */
 	channel?: string;
-	/** WebSocket endpoint (defaults to "wss://chat.kbve.com/ws"). */
 	ws?: string;
-	/** "dark" | "light" — defaults to "dark". */
 	theme?: 'dark' | 'light';
-	/**
-	 * Pixel height of the embed shell. Accepts any CSS length string.
-	 * Defaults to "480px". Pass "100%" or "100vh" for full-bleed hosts.
-	 */
 	height?: string;
-	/**
-	 * Optional explicit JWT. If omitted, the embed reads the
-	 * `kbve_session` cross-domain cookie. Empty token = read-only mode.
-	 */
 	token?: string;
+	signinUrl?: string;
 }
 
 interface MountedInstance {
@@ -86,7 +75,7 @@ export function mount(opts: KbveChatOptions): void {
 	const root = createRoot(wrapper);
 	root.render(
 		<StrictMode>
-			<EmbedChat />
+			<EmbedChat signinUrl={opts.signinUrl} />
 		</StrictMode>,
 	);
 
@@ -112,15 +101,6 @@ export function unmount(el: HTMLElement | string): void {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// Auto-discover: scan the page on script load for elements tagged with
-//   <div data-kbve-chat data-channel="..." data-ws="..." data-theme="..." />
-// or any id beginning with "kbve-chat" (kbve-chat, kbve-chat-home,
-// kbve-chat-embed, ...). The id prefix is forgiving because host pages
-// often need multiple mounts on the same page and bare `id="kbve-chat"`
-// can't repeat. Hosts that prefer programmatic control can ignore this
-// and call window.KbveChat.mount({...}) themselves.
-// ---------------------------------------------------------------------------
 function autoMount(): void {
 	const targets = document.querySelectorAll<HTMLElement>(
 		'[data-kbve-chat], [id^="kbve-chat"]',
@@ -134,6 +114,7 @@ function autoMount(): void {
 			theme: (el.dataset.theme as 'dark' | 'light') ?? undefined,
 			height: el.dataset.height,
 			token: el.dataset.token,
+			signinUrl: el.dataset.signinUrl,
 		});
 	}
 }


### PR DESCRIPTION
Closes #11582

## What ships

### 1. Popup interval cleanup on unmount

\`startSignInPopup\` now returns a \`SignInHandle\` with a single \`cancel()\` that clears the polling interval AND closes the popup. \`Composer\` stores the handle in a \`useRef\` and registers a \`useEffect\` cleanup that calls \`cancel()\` on unmount — so navigating away from the host page or remounting the embed mid-signin stops the 1.2s cookie poll immediately, no stale ghost reconnect attempts.

Same \`cancel()\` is called automatically when the popup closes, when the cookie appears, or when the 5min timeout elapses.

### 2. \`data-signin-url\` override

- New optional \`signinUrl\` field on \`KbveChatOptions\` (mount API)
- \`autoMount()\` reads \`el.dataset.signinUrl\`
- Threaded through \`<EmbedChat signinUrl={...} />\` → \`<Composer signinUrl={...} />\`
- Default still \`https://chat.kbve.com/auth/\` (now exported as \`DEFAULT_SIGNIN_URL\`)

Host examples:
\`\`\`html
<!-- Override the OAuth popup target -->
<div id=\"kbve-chat\" data-signin-url=\"https://staging.kbve.com/auth/\"></div>

<!-- Programmatic -->
window.KbveChat.mount({ el, signinUrl: 'https://staging.kbve.com/auth/' });
\`\`\`

Updated \`public/embed/example.html\` with a 5th demo panel that uses \`data-signin-url\`.

## Bundle

215.81 KB → 216.18 KB raw / 67.26 KB → **67.40 KB gz** (+0.1 KB). Stays well under the 80 KB ceiling.

## Acceptance (from #11582)

- [x] Unmount mid-popup → no further \`document.cookie\` reads (interval cleared, ref nulled)
- [x] Popup auto-closes on unmount (defensive \`popup.close()\` in cancel)
- [x] \`data-signin-url\` override honored
- [x] Programmatic \`window.KbveChat.mount({ signinUrl })\` honored
- [x] Bundle stays ≤ 70 KB gz
- [x] \`example.html\` shows the new pattern

## Related

- #11579 — once \`@kbve/laser/chat\` extraction lands, the popup lifecycle code moves into laser; this PR keeps the in-place embed correct in the meantime.