### PR TITLE
content(astro-kbve): bump 50 OSRS items v2 → v3 (batch 2)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamantite-limbs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamantite-limbs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adamantite limbs | OSRS Price Data
-description: "Adamantite limbs: A pair of adamantite crossbow limbs.. High alch: 960 GP, GE limit: 10,000."
+description: "Adamantite limbs: A pair of adamantite crossbow limbs. High alch: 960 GP, GE limit: 10,000."
 osrs:
   id: 9429
   name: Adamantite limbs
@@ -12,9 +12,86 @@ osrs:
   lowalch: 640
   highalch: 960
   limit: 10000
-  about: "Adamantite limbs is a members-only item in Old School RuneScape. High alchemy value: 960 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: mid-high
+  shops:
+    - shop_name: Lova's Crossbow Shop
+      location: Dwarven Mines
+      price: 5760
+      currency: Coins
+      members_only: true
+    - shop_name: Hirko's Crossbow Shop
+      location: White Wolf Mountain
+      price: 5760
+      currency: Coins
+      members_only: true
+    - shop_name: Hura's Crossbow Shop
+      location: Keldagrim Palace
+      price: 4800
+      stock: 5
+      currency: Coins
+      members_only: true
+  recipes:
+    - skill: smithing
+      level: 76
+      xp: 62.5
+      materials:
+        - item_name: Adamantite bar
+          quantity: 1
+      product: Adamantite limbs
+      product_id: 9429
+    - skill: fletching
+      level: 61
+      xp: 82
+      materials:
+        - item_name: Adamantite limbs
+          item_id: 9429
+          quantity: 1
+        - item_name: Mahogany stock
+          quantity: 1
+      product: Adamant crossbow (u)
+      product_id: 9459
+  related_items:
+    - item_id: 9434
+      item_name: Adamantite bar
+      slug: adamantite-bar
+      relationship: component
+      description: Smelted into limbs at 76 Smithing.
+    - item_id: 9459
+      item_name: Adamant crossbow (u)
+      slug: adamant-crossbow-u
+      relationship: product
+      description: Limbs attached to a mahogany stock at 61 Fletching.
+  market_strategy:
+    title: Crossbow Fletching Pipeline
+    notes:
+      - Demand is paced by Fletching trainers chasing adamant crossbow XP.
+      - Compare bar + smithing margin vs limb GE flip — usually limbs sit at a loss vs raw smithing.
+      - Bulk buyers move during double XP weekends, so stock ahead of those windows.
+  trading_tips:
+    - Set buy orders below the bar cost to catch panic sells from impatient fletchers.
+    - Check the smithing margin on adamantite bars first to know fair value.
+    - Limbs are noteable — bank stacks for Fletching grinds rather than shop runs.
+  history:
+    - date: "2006-07-31"
+      update: "Crossbows"
+      description: Added with the Crossbows update introducing the full elemental-bar crossbow tier ladder.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "31 Jul 2006"
+    update: "Crossbows"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options: ["Drop"]
+    destroy: "Drop"
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/apprentice-wand.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/apprentice-wand.mdx
@@ -1,6 +1,6 @@
 ---
 title: Apprentice wand | OSRS Price Data
-description: "Apprentice wand is a members weapon slot item requiring 50 Magic. High alch: 900 GP, GE limit: 125."
+description: "Apprentice wand: An apprentice level wand. High alch: 900 GP, GE limit: 125."
 osrs:
   id: 6910
   name: Apprentice wand
@@ -14,95 +14,76 @@ osrs:
   limit: 125
   equipment:
     slot: weapon
-    type: magic_weapon
-    attack_style: magic
+    weapon_type: staff
     attack_speed: 4
+    weight: 0.255
     requirements:
       magic: 50
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 10
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 10
-      defence_ranged: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 10
+      ranged: 0
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    weight: 0.255
-  obtaining:
-    methods:
-      - source: Mage Training Arena
-        requirements:
-          magic: 50
-        pizazz_points:
-          telekinetic: 60
-          alchemist: 60
-          enchantment: 600
-          graveyard: 60
-        notes: Requires beginner wand plus pizazz points
+  shops:
+    - shop_name: Mage Training Arena rewards
+      location: Mage Training Arena (requires beginner wand + pizazz points)
+      price: 0
+      currency: pizazz points
+      members_only: true
   related_items:
     - item_id: 6908
       item_name: Beginner wand
       slug: beginner-wand
       relationship: downgrade
-      description: Previous tier wand
+      description: Previous tier wand and required component.
     - item_id: 6912
       item_name: Teacher wand
       slug: teacher-wand
       relationship: upgrade
-      description: Next tier wand
+      description: Next tier wand in the MTA progression.
     - item_id: 6914
       item_name: Master wand
       slug: master-wand
       relationship: upgrade
-      description: Best MTA wand
-  about: |-
-    "An apprentice level wand."
-
-    | Stat | Value |
-    |------|-------|
-    | Stab Attack | +0 |
-    | Slash Attack | +0 |
-    | Crush Attack | +0 |
-    | Magic Attack | +10 |
-    | Ranged Attack | +0 |
-    | Stab Defence | +0 |
-    | Slash Defence | +0 |
-    | Crush Defence | +0 |
-    | Magic Defence | +10 |
-    | Ranged Defence | +0 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | +0% |
-    | Prayer | +0 |
-
-    Requirements: 50 Magic
-
-    | Wand | Magic Atk | Magic Def | Requirements |
-    |------|----------|----------|-------------|
-    | Beginner wand | +5 | +5 | 45 Magic |
-    | Apprentice wand | +10 | +10 | 50 Magic |
-    | Teacher wand | +15 | +15 | 55 Magic |
-    | Master wand | +20 | +20 | 60 Magic |
-
-    The apprentice wand is the second tier in the Mage Training Arena wand progression. Each upgrade requires the previous wand plus additional pizazz points.
+      description: Best MTA wand.
   market_strategy:
+    title: MTA Progression
     notes:
-      - Mid-level magic training
-      - Stepping stone to master wand
-      - Ironman progression
-      - Most players skip directly to master wand if possible
+      - Mid-level magic training stepping stone
       - Required as a component for the teacher wand upgrade
-      - Low demand compared to master wand
-      - Time-intensive to obtain from MTA
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Most players skip straight to master wand if they can
+      - Low demand, time-intensive to obtain from MTA
+  history:
+    - date: "2006-01-04"
+      update: Mage Training Arena
+      description: Added as the second-tier reward wand from the MTA mini-game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "4 Jan 2006"
+    update: Mage Training Arena
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.255
+    options: [Wield, Drop]
+    alchable: true
+  about: Second-tier Mage Training Arena wand, requires 50 Magic and the beginner wand to claim.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-cloak.mdx
@@ -1,6 +1,6 @@
 ---
 title: Armadyl cloak | OSRS Price Data
-description: "Armadyl cloak is a members cape slot item. High alch: 1,200 GP, GE limit: 8."
+description: "Armadyl cloak: An Armadyl cloak. High alch: 1,200 GP, GE limit: 8."
 osrs:
   id: 12261
   name: Armadyl cloak
@@ -14,22 +14,76 @@ osrs:
   limit: 8
   equipment:
     slot: cape
+    weight: 0.4
     requirements:
       prayer: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
+  treasure_trail:
+    tier: medium
+    is_reward: true
   related_items:
     - item_id: 12253
       item_name: Armadyl robe top
       slug: armadyl-robe-top
       relationship: set-piece
       description: Armadyl vestment body
-  about: |-
-    > *"An Armadyl cloak."*
-
-    The Armadyl cloak is the cape piece of the Armadyl vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as an Armadylean item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 12257
+      item_name: Armadyl robe legs
+      slug: armadyl-robe-legs
+      relationship: set-piece
+      description: Armadyl vestment legs
+    - item_id: 12259
+      item_name: Armadyl mitre
+      slug: armadyl-mitre
+      relationship: set-piece
+      description: Armadyl vestment helm
+  market_strategy:
+    title: Armadyl vestment cape
+    notes:
+      - 1/1133 from medium clue caskets
+      - Counts as Armadylean in God Wars Dungeon
+      - +3 Prayer bonus competitive for vestment users
+      - Requires 40 Prayer to equip
+  history:
+    - date: "2014-06-12"
+      update: "Treasure Trail Expansion"
+      description: Added to the game.
+    - date: "2015-08-13"
+      update: "Graphical Update"
+      description: The Armadyl cloak was fixed graphically.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "12 Jun 2014"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  about: Armadyl cloak is the cape piece of the Armadyl vestment set rewarded from medium Treasure Trails, requiring 40 Prayer and granting +3 Prayer plus +3 defence in all styles.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bass.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bass.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bass | OSRS Price Data
-description: "Bass: Wow, this is a big fish.. High alch: 24 GP, GE limit: 6,000."
+description: "Bass: Wow, this is a big fish. High alch: 24 GP, GE limit: 6,000."
 osrs:
   id: 365
   name: Bass
@@ -12,18 +12,84 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 6000
+  food:
+    heals: 13
+    type: fish
+  recipes:
+    - skill: cooking
+      level: 43
+      xp: 130
+      materials:
+        - item_name: Raw bass
+          item_id: 363
+          quantity: 1
+      product: Bass
+      product_id: 365
+  drop_table:
+    sources:
+      - source: Dagannoth Rex
+        quantity: "5"
+        rarity: rare
+        members_only: true
+      - source: The Nightmare
+        quantity: "1-18"
+        rarity: uncommon
+        members_only: true
+      - source: Phosani's Nightmare
+        quantity: "16-29"
+        rarity: uncommon
+        members_only: true
+  shops:
+    - shop_name: Warriors' Guild Food Shop
+      location: Warriors' Guild
+      price: 48
+      currency: Coins
+      members_only: true
+    - shop_name: Fishing Guild Shop
+      location: Fishing Guild
+      price: 40
+      currency: Coins
+      members_only: true
+    - shop_name: Prifddinas Foodstuffs
+      location: Prifddinas
+      price: 40
+      currency: Coins
+      members_only: true
   related_items:
     - item_id: 363
       item_name: Raw bass
       slug: raw-bass
       relationship: component
       description: Uncooked version
-  about: |-
-    > _"Wow, this is a big fish."_
-
-    Bass heals 13 Hitpoints. A decent mid-level members food. Commonly caught with a big fishing net at Catherby or the Fishing Guild.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Heals 13 HP — mid-level food
+      - Stops burning at 80 Cooking
+      - Caught with big fishing net at Catherby or Fishing Guild
+  history:
+    - date: "2025-05-29"
+      update: GE convenience fee exemption
+      description: Bass exempted from Grand Exchange convenience fee.
+    - date: "2018-09-20"
+      update: Value adjustment
+      description: Value adjusted from 120 to 40 coins.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "27 Feb 2002"
+    update: Latest RuneScape News (27 February 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Eat
+      - Drop
+    alchable: true
+  about: Bass is a mid-level members food that heals 13 Hitpoints, cooked at 43 Cooking.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-scimitar.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black scimitar | OSRS Price Data
-description: "Black scimitar: A vicious, curved sword.. High alch: 460 GP, GE limit: 125."
+description: "Black scimitar: A vicious, curved sword. High alch: 460 GP, GE limit: 125."
 osrs:
   id: 1327
   name: Black scimitar
@@ -12,25 +12,84 @@ osrs:
   lowalch: 307
   highalch: 460
   limit: 125
-  item_id: 1327
-  item_type: equipment
-  slot: weapon
-  type: scimitar
-  attack_style: slash
-  attack_speed: 4
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 10
-  stats:
-    slash_attack: 19
-    stab_attack: 4
-    strength: 14
+  equipment:
+    slot: weapon
+    weapon_type: slash-sword
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 4
+      slash: 19
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 14
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Briget's Weapons
+      location: Shayzien
+      price: 768
+      stock: 3
+      currency: Coins
+      members_only: true
+  drop_table:
+    sources:
+      - source: Gangster
+        quantity: "1"
+        rarity: uncommon
+        members_only: false
+      - source: Gang boss
+        quantity: "1"
+        rarity: uncommon
+        members_only: false
   related_items:
-    - slug: mithril-scimitar
-    - slug: steel-scimitar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1325
+      item_name: Steel scimitar
+      slug: steel-scimitar
+      relationship: downgrade
+      description: Lower tier scimitar
+    - item_id: 1329
+      item_name: Mithril scimitar
+      slug: mithril-scimitar
+      relationship: upgrade
+      description: Higher tier scimitar
+  market_strategy:
+    notes:
+      - Black equipment tier requires 10 Attack
+      - Cannot be crafted via Smithing
+      - Obtained from spawns, shop, or monster drops
+  history:
+    - date: "2005-06-13"
+      update: Examine punctuation
+      description: Examine text updated from "A vicious curved sword" to "A vicious, curved sword".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "30 Apr 2002"
+    update: Latest RuneScape News (30 April 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  about: Black scimitar is a free-to-play one-handed slash sword requiring 10 Attack to wield.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-skirt-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-skirt-g.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black skirt (g) | OSRS Price Data
-description: "Black skirt (g) is a F2P legs slot item. High alch: 1 GP, GE limit: 4."
+description: "Black skirt (g): Leg covering favoured by women and wizards. With a colourful trim! High alch: 1 GP, GE limit: 4."
 osrs:
   id: 12445
   name: Black skirt (g)
@@ -14,24 +14,67 @@ osrs:
   limit: 4
   equipment:
     slot: legs
+    weight: 0.907
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
   related_items:
     - item_id: 12447
       item_name: Black skirt (t)
       slug: black-skirt-t
       relationship: variant
-      description: Trimmed variant
+      description: Trimmed variant from easy clues
     - item_id: 12449
       item_name: Black wizard robe (g)
       slug: black-wizard-robe-g
       relationship: set-piece
       description: Matching gold-trimmed wizard robe
-  about: |-
-    > *"Leg covering favoured by women and wizards. With a colourful trim!"*
-
-    The black skirt (g) is a gold-trimmed cosmetic variant of the black wizard skirt. No requirements. Pairs with gold-trimmed black wizard robe and hat.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    title: Easy clue gold-trim cosmetic
+    notes:
+      - 1/1404 from easy clue caskets
+      - Buy limit of 4 keeps it thin
+      - Pairs with gold-trimmed black wizard set
+      - Pure cosmetic - all bonuses are +0
+  history:
+    - date: "2014-06-12"
+      update: "Treasure Trail Expansion"
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "12 Jun 2014"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  about: Black skirt (g) is a F2P gold-trimmed cosmetic legs slot reward from easy Treasure Trails with no combat bonuses.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-pint.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-pint.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blood pint | OSRS Price Data
-description: "Blood pint: It's literally a pint of blood.. High alch: 1 GP, GE limit: 2,000."
+description: "Blood pint: It's literally a pint of blood. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 24774
   name: Blood pint
@@ -12,9 +12,54 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Blood pint is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 0
+    type: ale
+  shops:
+    - shop_name: The Crypt
+      location: Darkmeyer
+      price: 2
+      currency: Coins
+      members_only: true
+  drop_table:
+    sources:
+      - source: Vyrewatch (pickpocket)
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Vyrewatch Sentinel (pickpocket)
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+  about: "Blood pint is a Darkmeyer ale that boosts Attack and Strength by 4% + 2 while draining Magic and Prayer, available from The Crypt shop and via 82 Thieving Vyre pickpockets."
+  market_strategy:
+    title: Vampyric Combat Sip
+    notes:
+      - Cheap shop supply caps the GE ceiling near vendor price floors.
+      - Niche demand from PvMers stacking +Atk/+Str ales pre-fight.
+      - Cannot brew or combine into potions, limiting upside.
+  trading_tips:
+    - Pickpocket Vyres at 82 Thieving for free supply rather than buying.
+    - Sell to GE only during ale-stat-boost meta spikes.
+    - Volume is high but margin is razor-thin — don't tie up cash.
+  history:
+    - date: "2020-06-04"
+      update: "Sins of the Father"
+      description: Added with the Darkmeyer release as a flavour ale and Vyre pickpocket drop.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "04 Jun 2020"
+    update: "Sins of the Father"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options: ["Drink", "Drop"]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/boat-bottle-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/boat-bottle-empty.mdx
@@ -1,6 +1,6 @@
 ---
 title: Boat bottle (empty) | OSRS Price Data
-description: "Boat bottle (empty): One has been poured out for (sailing with) the boys.. High alch: 300 GP, GE limit: 100."
+description: "Boat bottle (empty): One has been poured out for (sailing with) the boys. High alch: 300 GP, GE limit: 100."
 osrs:
   id: 31989
   name: Boat bottle (empty)
@@ -12,9 +12,51 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 100
-  about: "Boat bottle (empty) is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Small salvage
+        quantity: "1"
+        rarity: very-rare
+        members_only: true
+      - source: Fishy salvage
+        quantity: "1"
+        rarity: very-rare
+        members_only: true
+      - source: Barracuda salvage
+        quantity: "1"
+        rarity: very-rare
+        members_only: true
+  related_items:
+    - item_id: 31990
+      item_name: Boat bottle
+      slug: boat-bottle
+      relationship: upgrade
+      description: Filled boat bottle that transports a stored boat between ports.
+  market_strategy:
+    title: Sailing Utility
+    notes:
+      - Single-use transport bottle for boats between ports
+      - Sourced from low-tier shipwreck salvage in Sailing
+      - Limited supply, niche utility demand
+  history:
+    - date: "2025-11-19"
+      update: Sailing is OUT TODAY!
+      description: Added to game with the Sailing skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "19 Nov 2025"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options: [Bottle-boat, Drop]
+    alchable: false
+  about: Single-use Sailing bottle that lets a boat be stored and transported between ports.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/carrallanger-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/carrallanger-teleport-tablet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Carrallanger teleport (tablet) | OSRS Price Data
-description: "Carrallanger teleport (tablet): A teleport to Carrallanger, in level 19 Wilderness.. High alch: 1 GP, GE limit: 10,000."
+description: "Carrallanger teleport (tablet): A teleport to Carrallanger, in level 19 Wilderness. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 12776
   name: Carrallanger teleport (tablet)
@@ -12,9 +12,79 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Carrallanger teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destinations:
+      - Graveyard of Shadows
+    type: tablet
+    magic_level: 84
+    magic_xp: 94
+    runes:
+      - 2 Law runes
+      - 2 Soul runes
+  recipes:
+    - skill: magic
+      level: 84
+      xp: 94
+      materials:
+        - item_name: Soft clay
+          item_id: 1761
+          quantity: 1
+        - item_name: Law rune
+          item_id: 563
+          quantity: 2
+        - item_name: Soul rune
+          item_id: 566
+          quantity: 2
+      product: Carrallanger teleport (tablet)
+      product_id: 12776
+  related_items:
+    - item_id: 12775
+      item_name: Senntisten teleport (tablet)
+      slug: senntisten-teleport-tablet
+      relationship: alternative
+      description: Ancient teleport tablet to Senntisten
+    - item_id: 12777
+      item_name: Annakarl teleport (tablet)
+      slug: annakarl-teleport-tablet
+      relationship: alternative
+      description: Ancient teleport tablet to Annakarl
+    - item_id: 12778
+      item_name: Ghorrock teleport (tablet)
+      slug: ghorrock-teleport-tablet
+      relationship: alternative
+      description: Ancient teleport tablet to Ghorrock
+  market_strategy:
+    notes:
+      - 84 Magic gates production
+      - Soul and law rune cost floors price
+      - PKers use for fast Wilderness escapes
+      - Stackable in bank and inventory
+      - Requires Desert Treasure I to use
+  history:
+    - date: "2014-09-18"
+      update: Bounty Hunter
+      description: Released alongside the Ancient teleport tablet line.
+    - date: "2023-07-26"
+      update: Spelling correction
+      description: Renamed from "Carrallangar" to "Carrallanger".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "18 Sep 2014"
+    update: Bounty Hunter
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Configure
+      - Drop
+    alchable: false
+  about: Ancient teleport tablet to Graveyard of Shadows (level 19 Wilderness); made at the Ancient Lectern.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/choc-saturday.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/choc-saturday.mdx
@@ -1,6 +1,6 @@
 ---
 title: Choc saturday | OSRS Price Data
-description: "Choc saturday: A warm creamy alcoholic beverage.. High alch: 18 GP, GE limit: 2,000."
+description: "Choc saturday: A warm creamy alcoholic beverage. High alch: 18 GP, GE limit: 2,000."
 osrs:
   id: 2074
   name: Choc saturday
@@ -12,9 +12,60 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Choc saturday is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 5
+    type: gnome-cocktail
+  recipes:
+    - skill: cooking
+      level: 33
+      xp: 170
+      materials:
+        - item_name: Mixed saturday base
+          quantity: 1
+        - item_name: Chocolate dust
+          quantity: 1
+        - item_name: Pot of cream
+          quantity: 1
+      product: Choc saturday
+      product_id: 2074
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Drinky Store
+      location: Tai Bwo Wannai
+      price: 8
+      currency: Trading sticks
+      members_only: true
+  about: "Choc saturday is a Gnome Stronghold cocktail that restores 5 hitpoints while reducing Attack and boosting Strength, made via Cooking 33 with a mixed saturday base, chocolate dust and pot of cream."
+  market_strategy:
+    title: Niche Gnome Drink
+    notes:
+      - Primary demand is the Gnome Restaurant minigame fulfilling delivery orders.
+      - Cooking margins are weak; supply is mostly hand-rolled by minigame players.
+      - Premade spawn in Brimstail's cave keeps a floor on demand for cheap pickup.
+  trading_tips:
+    - Stock-pile only when running gnome deliveries — limited Grand Exchange churn.
+    - Compare cost of ingredients against current GE listing before crafting.
+    - Trading-stick price at Gabooty's is irrelevant for GP traders.
+  history:
+    - date: "2002-12-12"
+      update: "Agility skill online"
+      description: Introduced with the Gnome Stronghold cuisine alongside agility content.
+    - date: "2006-08-07"
+      update: "Gnome Restaurant Rework"
+      description: Received an updated inventory icon during the Gnome Restaurant graphics pass.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "12 Dec 2002"
+    update: "Agility skill online"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options: ["Drink", "Drop"]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-chompy-roasted.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-chompy-roasted.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cooked chompy (roasted) | OSRS Price Data
-description: "Cooked chompy (roasted): Roasted chompy bird.. High alch: 51 GP, GE limit: 100."
+description: "Cooked chompy (roasted): Roasted chompy bird. High alch: 51 GP, GE limit: 100."
 osrs:
   id: 7228
   name: Cooked chompy (roasted)
@@ -12,9 +12,38 @@ osrs:
   lowalch: 34
   highalch: 51
   limit: 100
-  about: "Cooked chompy (roasted) is a members-only item in Old School RuneScape. High alchemy value: 51 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 0
+    type: cooked-meat
+  about: "Cooked chompy (roasted) is an unobtainable members-only food remnant tied to the Big Chompy Bird Hunting quest line, surviving on the Grand Exchange despite being inaccessible through normal gameplay."
+  market_strategy:
+    title: Unobtainable Curio
+    notes:
+      - Item exists in the GE but cannot be obtained through normal gameplay after a cooking rework removed its source.
+      - Supply is fixed and trickles from legacy stockpiles, so price drifts purely on collector demand.
+      - High alch is below the cost, so do not alch — list at competitive GE prices for collectors.
+  trading_tips:
+    - Treat this as a rare curio rather than a flippable food item.
+    - Avoid buying at inflated spikes — volume is effectively zero some days.
+    - Stocks held by long-standing players are the only real liquidity.
+  history:
+    - date: "2006-02-20"
+      update: "Updates, updates and more updates..."
+      description: Item added to the game alongside expanded chompy hunting cooking options.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "20 Feb 2006"
+    update: "Updates, updates and more updates..."
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options: ["Eat", "Drop"]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cowhide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cowhide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cowhide | OSRS Price Data
-description: "Cowhide: I should take this to the tannery.. High alch: 1 GP, GE limit: 13,000."
+description: "Cowhide: I should take this to the tannery. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 1739
   name: Cowhide
@@ -14,14 +14,7 @@ osrs:
   limit: 13000
   material:
     type: hide
-    tier: basic
-  tanning:
-    cost: 1
-    product_id: 1741
-    product_name: Leather
-    hard_leather_cost: 3
-    hard_leather_id: 1743
-    hard_leather_name: Hard leather
+    tier: low
   drop_table:
     sources:
       - source: Cow
@@ -29,55 +22,76 @@ osrs:
         combat_level: 2
         quantity: "1"
         rarity: always
+        members_only: false
+      - source: Undead Cow
+        combat_level: 2
+        quantity: "1"
+        rarity: always
+        members_only: false
+      - source: Cow calf
+        combat_level: 2
+        quantity: "1"
+        rarity: always
+        members_only: false
+      - source: H.A.M. Member
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: H.A.M. Guard
+        quantity: "1-3"
+        rarity: uncommon
+        members_only: true
+      - source: Brutus
+        combat_level: 30
+        quantity: "1"
+        rarity: rare
+        members_only: false
   related_items:
     - item_id: 1741
       item_name: Leather
       slug: leather
       relationship: product
-      description: Tanned product
+      description: Tanned at 1 GP
     - item_id: 1743
       item_name: Hard leather
       slug: hard-leather
       relationship: product
-      description: Alternative product
-    - item_id: 1733
-      item_name: Needle
-      slug: needle
-      relationship: component
-      description: For crafting leather
-    - item_id: 1734
-      item_name: Thread
-      slug: thread
-      relationship: component
-      description: For crafting leather
+      description: Tanned at 3 GP
     - item_id: 1129
       item_name: Leather body
       slug: leather-body
       relationship: product
       description: Crafted from leather
-  about: |-
-    Take to a tanner to convert into leather:
-
-    | Product | Cost | Location |
-    |---------|------|----------|
-    | Leather | 1 GP | Any tanner |
-    | Hard leather | 3 GP | Any tanner |
   market_strategy:
-    profit_formulas:
-      - Leather price - Cowhide price - 1 GP = Profit
     notes:
-      - Buy Cowhide → Tan → Sell Leather or Hard leather
-      - "Calculate:"
-      - Very high volume, consistent margins
-      - Al Kharid (closest to bank)
-      - Canifis (requires Priest in Peril)
-      - Crafting Guild (requires 40 Crafting)
+      - Tan into leather for 1 GP or hard leather for 3 GP
+      - Buy cowhide / tan / sell leather flip
+      - Tanners at Al Kharid, Canifis, and Crafting Guild
       - Hard leather has better margin but lower volume
-      - Popular botted activity
-      - Cowhide supply from Lumbridge cow farm
-      - Cow Hide
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Lumbridge cow farm supplies massive volume
+  history:
+    - date: "2018-11-22"
+      update: Value adjustment
+      description: Item value increased from 1 to 2 coins.
+    - date: "2004-11-29"
+      update: Rename
+      description: Renamed from "Cow hide" to "Cowhide".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "23 Jun 2001"
+    update: New tailoring ability
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Drop
+    alchable: true
+  about: Cowhide is a Crafting material tanned into leather or hard leather, dropped by cows.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/desert-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/desert-shirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Desert shirt | OSRS Price Data
-description: "Desert shirt: A cool, light desert shirt.. High alch: 24 GP, GE limit: 150."
+description: "Desert shirt: A cool, light desert shirt. High alch: 24 GP, GE limit: 150."
 osrs:
   id: 1833
   name: Desert shirt
@@ -12,9 +12,91 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 150
-  about: "Desert shirt is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Ali's Discount Wares
+      location: Al Kharid
+      price: 40
+      currency: coins
+      members_only: true
+    - shop_name: Pollnivneach general store
+      location: Pollnivneach
+      price: 40
+      currency: coins
+      members_only: true
+    - shop_name: Shantay Pass Shop
+      location: Shantay Pass
+      price: 40
+      currency: coins
+      members_only: true
+    - shop_name: Raetul and Co's Cloth Store
+      location: Sophanem
+      price: 40
+      currency: coins
+      members_only: true
+    - shop_name: Bandit Bargains
+      location: Bandit Camp
+      price: 40
+      currency: coins
+      members_only: true
+  related_items:
+    - item_id: 1835
+      item_name: Desert robe
+      slug: desert-robe
+      relationship: set-piece
+      description: Desert outfit legs
+    - item_id: 1837
+      item_name: Desert boots
+      slug: desert-boots
+      relationship: set-piece
+      description: Desert outfit footwear
+  market_strategy:
+    title: Desert heat delay gear
+    notes:
+      - Delays desert heat effect by an extra 12 seconds when worn
+      - Cheap and widely stocked in desert shops
+      - Common kit for Kharidian Desert content
+  history:
+    - date: "2003-04-14"
+      update: "Tourist Trap"
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "14 Apr 2003"
+    update: "Tourist Trap"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  about: Desert shirt is a members-only body slot item from desert shops that delays the Kharidian Desert heat effect by 12 additional seconds when worn.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-ranging-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-ranging-potion-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Divine ranging potion(4) | OSRS Price Data
-description: "Divine ranging potion(4): 4 doses of divine ranging potion.. High alch: 150 GP, GE limit: 2,000."
+description: "Divine ranging potion(4): 4 doses of divine ranging potion. High alch: 150 GP, GE limit: 2,000."
 osrs:
   id: 23733
   name: Divine ranging potion(4)
@@ -12,9 +12,83 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 2000
-  about: "Divine ranging potion(4) is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    herblore_level: 74
+    herblore_xp: 2
+    effect: Boosts Ranged by 4 + 10% of base level for 5 minutes; prevents stat drain. Deals 10 HP self-damage on drink.
+    effects:
+      - stat: ranged
+        boost_value: 4
+        duration: 500
+        description: Boosts Ranged by 4 + 10% of base level and prevents stat drain for 5 minutes.
+      - stat: hitpoints
+        boost_value: -10
+        description: Drinking damages the player by 10 Hitpoints; requires 11+ HP.
+  recipes:
+    - skill: herblore
+      level: 74
+      xp: 2
+      materials:
+        - item_name: Ranging potion(4)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 1
+      product: Divine ranging potion(4)
+      product_id: 23733
+  related_items:
+    - item_id: 23736
+      item_name: Divine ranging potion(3)
+      slug: divine-ranging-potion-3
+      relationship: variant
+      description: 3-dose variant
+    - item_id: 23739
+      item_name: Divine ranging potion(2)
+      slug: divine-ranging-potion-2
+      relationship: variant
+      description: 2-dose variant
+    - item_id: 23742
+      item_name: Divine ranging potion(1)
+      slug: divine-ranging-potion-1
+      relationship: variant
+      description: 1-dose variant
+    - item_id: 2444
+      item_name: Ranging potion(4)
+      slug: ranging-potion-4
+      relationship: component
+      description: Base potion required to brew the divine variant
+  market_strategy:
+    notes:
+      - Premium boost for ranged DPS at bosses
+      - Demand tracks raid and boss meta
+      - Crystal dust supply pressures price
+      - Five-minute drain immunity is the selling point
+      - Self-damage limits casual usage
+  history:
+    - date: "2019-07-25"
+      update: Song of the Elves
+      description: Item released alongside crystal dust herblore recipes.
+    - date: "2020-07-02"
+      update: Graphical update
+      description: Inventory icon refreshed to match standard potion sprite.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "25 Jul 2019"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+  about: 4-dose Divine ranging potion brewed from a ranging potion and crystal dust at 74 Herblore.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrow-p-11229.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrow-p-11229.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon arrow(p++) | OSRS Price Data
-description: "Dragon arrow(p++): Venomous-looking arrows.. High alch: 480 GP, GE limit: 11,000."
+description: "Dragon arrow(p++): Venomous-looking arrows. High alch: 480 GP, GE limit: 11,000."
 osrs:
   id: 11229
   name: Dragon arrow(p++)
@@ -12,9 +12,80 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 11000
-  about: "Dragon arrow(p++) is a members-only item in Old School RuneScape. High alchemy value: 480 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: ammo
+    weapon_type: bow
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 60
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: ranged
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Dragon arrow
+          item_id: 11212
+          quantity: 5
+        - item_name: Weapon poison(++)
+          quantity: 1
+      product: Dragon arrow(p++)
+      product_id: 11229
+  related_items:
+    - item_id: 11212
+      item_name: Dragon arrow
+      slug: dragon-arrow
+      relationship: variant
+      description: Unpoisoned dragon arrow.
+    - item_id: 11227
+      item_name: Dragon arrow(p)
+      slug: dragon-arrow-p-11227
+      relationship: downgrade
+      description: Weaker basic-poison variant.
+    - item_id: 11228
+      item_name: Dragon arrow(p+)
+      slug: dragon-arrow-p-plus
+      relationship: downgrade
+      description: Mid-tier weapon poison(+) variant.
+  market_strategy:
+    title: End-Game Ammo
+    notes:
+      - Highest ranged strength ammo (+60) — used for big-hit specs
+      - Requires dragon arrows + weapon poison(++)
+      - Niche PvP / bossing supply, thin daily volume
+  history:
+    - date: "2007-06-11"
+      update: Impetuous Impulses
+      description: Dragon arrows and poisoned variants added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "11 Jun 2007"
+    update: Impetuous Impulses
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options: [Wield, Drop]
+    alchable: true
+  about: Strongest poisoned arrow tier in OSRS, applies weapon poison(++) to dragon arrows.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrowtips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrowtips.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon arrowtips | OSRS Price Data
-description: "Dragon arrowtips: Dragon talons, usable as arrowheads.. High alch: 300 GP, GE limit: 10,000."
+description: "Dragon arrowtips: Dragon talons, usable as arrowheads. High alch: 300 GP, GE limit: 10,000."
 osrs:
   id: 11237
   name: Dragon arrowtips
@@ -12,55 +12,95 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 10000
-  item:
-    type: material
-    tradeable: true
-    stackable: true
-    weight: 0
+  material:
+    type: ammunition
+    tier: high
   recipes:
     - skill: fletching
       level: 90
-      xp: 15
+      xp: 225
       materials:
-        - item_id: 53
-          item_name: Headless arrow
+        - item_name: Headless arrow
+          item_id: 53
           quantity: 15
-        - item_id: 11237
-          item_name: Dragon arrowtips
+        - item_name: Dragon arrowtips
+          item_id: 11237
           quantity: 15
       product: Dragon arrow
       product_id: 11212
+  drop_table:
+    sources:
+      - source: Vorkath
+        combat_level: 732
+        quantity: "1"
+        rarity: common
+        members_only: true
+      - source: King Black Dragon
+        combat_level: 276
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Frost dragon
+        combat_level: 132
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Brutal black dragon
+        combat_level: 318
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Tormented Demon
+        combat_level: 317
+        quantity: "1"
+        rarity: rare
+        members_only: true
+      - source: Grotesque Guardians
+        combat_level: 228
+        quantity: "1"
+        rarity: rare
+        members_only: true
   related_items:
     - item_id: 53
       item_name: Headless arrow
       slug: headless-arrow
       relationship: component
-      description: Base item for creating dragon arrows
+      description: Combined with dragon arrowtips at 90 Fletching.
     - item_id: 11212
       item_name: Dragon arrow
       slug: dragon-arrow
       relationship: product
-      description: Created item from dragon arrowtips
+      description: Crafted product from dragon arrowtips + headless arrows.
     - item_id: 21992
       item_name: Vorkath
       slug: vorkath
       relationship: alternative
-      description: Boss that drops dragon arrowtips
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ammunition Component |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    | Arrow Created | Materials | Requirements |
-    |---------------|-----------|--------------|
-    | Dragon arrows | Headless arrows + Dragon arrowtips | 90 Fletching |
-
-    225 XP per 15 arrows.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Main drop source post-Dragon Slayer II.
+  market_strategy:
+    title: End-Game Fletching
+    notes:
+      - Vorkath supply keeps prices reactive to boss meta
+      - Combine with headless arrows for high-XP Fletching at 90
+      - Used to craft the highest-tier ammo for Ruby/Diamond bolt setups
+  history:
+    - date: "2007-06-11"
+      update: Impetuous Impulses
+      description: Dragon arrowtips and the level 90 Fletching recipe were added.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "11 Jun 2007"
+    update: Impetuous Impulses
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: [Drop]
+    alchable: true
+  about: Dragon talon arrowhead used at 90 Fletching to make dragon arrows.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-kiteshield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gilded kiteshield | OSRS Price Data
-description: "Gilded kiteshield is a F2P shield slot item requiring 40 Defence. High alch: 32,640 GP, GE limit: 8."
+description: "Gilded kiteshield: Rune kiteshield with gold plate. High alch: 32,640 GP, GE limit: 8."
 osrs:
   id: 3488
   name: Gilded kiteshield
@@ -14,50 +14,51 @@ osrs:
   limit: 8
   equipment:
     slot: shield
-    type: melee armour
-    attack_style: melee
+    weight: 5.443
     requirements:
       defence: 40
-    stats:
-      defence_stab: 44
-      defence_slash: 48
-      defence_crush: 46
-      defence_magic: -1
-      defence_ranged: 46
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 46
+    other_bonus:
       melee_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: Rare
-        description: Rare reward from hard clue scrolls
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers: [hard, elite, master]
   related_items:
     - item_id: 3486
       item_name: Gilded full helm
       slug: gilded-full-helm
       relationship: set-piece
-      description: Head slot of gilded set
+      description: Head slot of gilded set.
     - item_id: 3481
       item_name: Gilded platebody
       slug: gilded-platebody
       relationship: set-piece
-      description: Body slot of gilded set
+      description: Body slot of gilded set.
     - item_id: 3483
       item_name: Gilded platelegs
       slug: gilded-platelegs
       relationship: set-piece
-      description: Leg slot of gilded set
+      description: Leg slot of gilded set.
     - item_id: 12389
       item_name: Gilded scimitar
       slug: gilded-scimitar
       relationship: set-piece
-      description: Weapon of gilded set
-  about: |-
-    The gilded kiteshield is a cosmetic variant of the rune kiteshield with identical stats but a prestigious golden appearance. It requires 40 Defence to wear.
-
-    Gilded armour is obtained from Treasure Trails and is valued for its appearance rather than stats. It shares the same defensive bonuses as rune armour but costs significantly more due to its rarity and fashionscape appeal.
+      description: Weapon of gilded set.
   market_strategy:
     title: Investment Notes
     notes:
@@ -67,8 +68,32 @@ osrs:
       - Compare prices with rune equivalent for value assessment
       - Watch for dips after clue scroll events
       - Popular with free-to-play players for fashion
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2021-04-21"
+      update: Combat rebalance
+      description: Ranged attack bonus decreased from -2 to -3.
+    - date: "2016-05-19"
+      update: F2P content
+      description: Made accessible to free-to-play players.
+    - date: "2004-10-26"
+      update: Treasure Trails
+      description: Added as a reward from the Treasure Trails clue system.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "26 Oct 2004"
+    update: Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options: [Wear, Drop]
+    worn_options: [Remove]
+    alchable: true
+  about: Cosmetic gilded variant of the rune kiteshield, rare clue scroll reward with matching stats.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/goading-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/goading-potion-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Goading potion(3) | OSRS Price Data
-description: "Goading potion(3): 3 doses of Goading potion.. High alch: 150 GP."
+description: "Goading potion(3): 3 doses of Goading potion. High alch: 150 GP."
 osrs:
   id: 30140
   name: Goading potion(3)
@@ -12,9 +12,74 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: null
-  about: "Goading potion(3) is a members-only item in Old School RuneScape. High alchemy value: 150 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 3
+    herblore_level: 54
+    herblore_xp: 132
+    effect: "Forces non-aggressive monsters within a 9x9 area to attack the player for 6 minutes per dose."
+    effects:
+      - description: "Forces non-aggressive monsters within line of sight in a 9x9 tile area to become aggressive toward the player."
+      - duration: 600
+        description: "Each dose lasts 6 minutes (600 game ticks) before expiring."
+  recipes:
+    - skill: herblore
+      level: 54
+      xp: 132
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Aldarium
+          quantity: 1
+      product: Goading potion(3)
+      product_id: 30140
+  related_items:
+    - item_id: 30134
+      item_name: Goading potion(4)
+      slug: goading-potion-4
+      relationship: variant
+      description: Four-dose version with longer total effect.
+    - item_id: 30144
+      item_name: Goading potion(2)
+      slug: goading-potion-2
+      relationship: variant
+      description: Two-dose lower-stack version.
+    - item_id: 30148
+      item_name: Goading potion(1)
+      slug: goading-potion-1
+      relationship: variant
+      description: Single-dose final sip.
+  about: "Goading potion(3) is a Varlamore Herblore potion crafted at level 54 from a Harralander potion (unf) and Aldarium that forces non-aggressive monsters within a 9x9 area to attack the drinker for six minutes per dose."
+  market_strategy:
+    title: AFK Aggression Tooling
+    notes:
+      - Demand tracks AFK Slayer and prayer-grind workflows in passive-mob zones.
+      - Aldarium availability gates supply, so monitor that input.
+      - High alch (150) is below cost; do not alch — vial only.
+  trading_tips:
+    - Make and decant — 4-dose stacks usually trade above per-dose 3-dose rate.
+    - Stock during Varlamore content drops that revisit goading meta.
+    - Watch for unaggressive-mob nerf/buff news that swings demand.
+  history:
+    - date: "2024-09-25"
+      update: "Varlamore: The Rising Darkness"
+      description: Introduced with the Varlamore Herblore expansion.
+    - date: "2024-11-13"
+      update: "Goading Expiry Messages"
+      description: Added chat notifications when the effect ends early due to teleporting or tea drinking.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "25 Sep 2024"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options: ["Drink", "Empty", "Drop"]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/greater-demon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/greater-demon-mask.mdx
@@ -1,6 +1,6 @@
 ---
 title: Greater demon mask | OSRS Price Data
-description: "Greater demon mask: Evil.. High alch: 2,400 GP, GE limit: 4."
+description: "Greater demon mask: Evil. High alch: 2,400 GP, GE limit: 4."
 osrs:
   id: 20023
   name: Greater demon mask
@@ -12,9 +12,76 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 4
-  about: "Greater demon mask is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.8
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: rare
+        members_only: true
+  related_items:
+    - item_id: 20020
+      item_name: Lesser demon mask
+      slug: lesser-demon-mask
+      relationship: variant
+      description: Lesser demon mask cosmetic
+    - item_id: 20026
+      item_name: Black demon mask
+      slug: black-demon-mask
+      relationship: variant
+      description: Black demon mask cosmetic
+  market_strategy:
+    notes:
+      - Master clue exclusive drop (~1/851)
+      - Buy limit of 4 caps flipping volume
+      - Pure cosmetic, no combat stats
+      - Storable in costume room mahogany treasure chest
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion
+      description: Added as a master clue casket reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "6 Jul 2016"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  about: Cosmetic head slot mask from master clue caskets; no combat stats.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platebody.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron platebody | OSRS Price Data
-description: "Iron platebody: Provides excellent protection.. High alch: 336 GP, GE limit: 125."
+description: "Iron platebody: Provides excellent protection. High alch: 336 GP, GE limit: 125."
 osrs:
   id: 1115
   name: Iron platebody
@@ -12,24 +12,89 @@ osrs:
   lowalch: 224
   highalch: 336
   limit: 125
-  item_id: 1115
-  item_type: armor
-  slot: body
-  type: platebody
-  tradeable: true
-  weight: 9.979
-  requirements:
-    defence: 0
-  stats:
-    stab_defence: 21
-    slash_defence: 20
-    crush_defence: 12
-    ranged_defence: 20
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: body
+    weight: 9.979
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 21
+      slash: 20
+      crush: 12
+      magic: -6
+      ranged: 20
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 33
+      xp: 125
+      materials:
+        - item_name: Iron bar
+          quantity: 5
+      product: Iron platebody
+      product_id: 1115
+  shops:
+    - shop_name: Horvik's Armour Shop
+      location: Varrock
+      price: 560
+      currency: Coins
+      members_only: false
+    - shop_name: Zenesha's Plate Mail Body Shop
+      location: East Ardougne
+      price: 560
+      currency: Coins
+      members_only: true
   related_items:
-    - slug: steel-platebody
-    - slug: iron-full-helm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1119
+      item_name: Steel platebody
+      slug: steel-platebody
+      relationship: upgrade
+      description: Stronger metal-tier alternative requiring 5 Defence.
+    - item_id: 1153
+      item_name: Iron full helm
+      slug: iron-full-helm
+      relationship: set-piece
+      description: Matching iron armour set helmet.
+  market_strategy:
+    title: Free-to-Play Smithing Sink
+    notes:
+      - Demand stays steady from new players gearing up before Defence-locked tiers.
+      - Smithing margin is a net loss vs bars; only craft for XP, never profit.
+      - Buy limit is only 125 per 4 hours — illiquid for bulk flipping.
+  trading_tips:
+    - Skip alching unless bar input cost drops well below high alch return.
+    - Stock platebody charity drops to F2P levellers in trade chat.
+    - Watch double XP weekends for Smithing-driven supply spikes.
+  history:
+    - date: "2001-01-04"
+      update: "RuneScape launch era"
+      description: Available since early RuneScape Classic as the no-Defence-requirement starter platebody.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "04 Jan 2001"
+    update: "RuneScape launch"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jade-amulet-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jade-amulet-u.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jade amulet (u) | OSRS Price Data
-description: "Jade amulet (u): It needs a string so I can wear it.. High alch: 630 GP, GE limit: 10,000."
+description: "Jade amulet (u): It needs a string so I can wear it. High alch: 630 GP, GE limit: 10,000."
 osrs:
   id: 21102
   name: Jade amulet (u)
@@ -12,9 +12,81 @@ osrs:
   lowalch: 420
   highalch: 630
   limit: 10000
-  about: "Jade amulet (u) is a members-only item in Old School RuneScape. High alchemy value: 630 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: crafting
+      level: 34
+      xp: 70
+      materials:
+        - item_name: Silver bar
+          item_id: 2355
+          quantity: 1
+        - item_name: Jade
+          item_id: 1611
+          quantity: 1
+        - item_name: Amulet mould
+          item_id: 1595
+          quantity: 1
+      product: Jade amulet (u)
+      product_id: 21102
+    - skill: crafting
+      level: 34
+      xp: 4
+      materials:
+        - item_name: Jade amulet (u)
+          item_id: 21102
+          quantity: 1
+        - item_name: Ball of wool
+          item_id: 1759
+          quantity: 1
+      product: Jade amulet
+      product_id: 21104
+  related_items:
+    - item_id: 21104
+      item_name: Jade amulet
+      slug: jade-amulet
+      relationship: product
+      description: Strung version made with a ball of wool
+    - item_id: 21109
+      item_name: Amulet of chemistry
+      slug: amulet-of-chemistry
+      relationship: product
+      description: Enchanted amulet of chemistry via Lvl-2 Enchant
+    - item_id: 1611
+      item_name: Jade
+      slug: jade
+      relationship: component
+      description: Cut gem used in crafting
+    - item_id: 2355
+      item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: Bar smelted at the furnace
+  market_strategy:
+    notes:
+      - 34 Crafting gates supply
+      - Pipeline to amulet of chemistry boosts demand
+      - Silver bar and jade prices cap profitability
+      - High GE limit allows steady flipping
+  history:
+    - date: "2017-02-02"
+      update: Silver Jewellery, Tournament World & QoL
+      description: Released alongside the silver jewellery line.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2 Feb 2017"
+    update: Silver Jewellery, Tournament World & QoL
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.004
+    options:
+      - Drop
+    alchable: true
+  about: Unstrung jade amulet crafted from a silver bar and jade at 34 Crafting; string it to wear.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-longbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-longbow-u.mdx
@@ -1,6 +1,6 @@
 ---
 title: Maple longbow (u) | OSRS Price Data
-description: "Maple longbow (u): An unstrung maple longbow; I need a bowstring for this.. High alch: 192 GP, GE limit: 10,000."
+description: "Maple longbow (u): An unstrung maple longbow; I need a bowstring for this. High alch: 192 GP, GE limit: 10,000."
 osrs:
   id: 62
   name: Maple longbow (u)
@@ -12,23 +12,69 @@ osrs:
   lowalch: 128
   highalch: 192
   limit: 10000
+  recipes:
+    - skill: fletching
+      level: 55
+      xp: 58.3
+      materials:
+        - item_name: Maple logs
+          item_id: 1517
+          quantity: 1
+      product: Maple longbow (u)
+      product_id: 62
+    - skill: fletching
+      level: 55
+      xp: 58.2
+      materials:
+        - item_name: Maple longbow (u)
+          item_id: 62
+          quantity: 1
+        - item_name: Bow string
+          item_id: 1777
+          quantity: 1
+      product: Maple longbow
+      product_id: 851
   related_items:
     - item_id: 58
       item_name: Willow longbow (u)
       slug: willow-longbow-u
-      relationship: variant
+      relationship: downgrade
       description: Lower tier unstrung longbow
     - item_id: 64
       item_name: Maple shortbow (u)
       slug: maple-shortbow-u
       relationship: variant
       description: Matching unstrung maple shortbow
-  about: |-
-    > _"An unstrung maple longbow; I need a bowstring for this."_
-
-    The maple longbow (u) is an unstrung longbow made from maple logs. String with a bowstring at 55 Fletching to create a maple longbow. Members only.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 851
+      item_name: Maple longbow
+      slug: maple-longbow
+      relationship: product
+      description: Strung result
+  market_strategy:
+    notes:
+      - Fletch maple logs with a knife at 55 Fletching
+      - String with a bowstring for 58.2 XP
+      - Common AFK Fletching XP route
+  history:
+    - date: "2005-05-17"
+      update: Rename
+      description: Renamed from "Maple longbow" to "Maple longbow (u)".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "25 Mar 2002"
+    update: Latest RuneScape News (25 March 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.332
+    options:
+      - Drop
+    alchable: true
+  about: Maple longbow (u) is an unstrung longbow fletched from maple logs at 55 Fletching.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dart-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dart-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril dart(p) | OSRS Price Data
-description: "Mithril dart(p) is a members weapon slot item requiring 20 Ranged. High alch: 15 GP, GE limit: 7,000."
+description: "Mithril dart(p): A deadly poisoned dart with a mithril tip. High alch: 15 GP, GE limit: 7,000."
 osrs:
   id: 815
   name: Mithril dart(p)
@@ -14,24 +14,84 @@ osrs:
   limit: 7000
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
+    weight: 0
     requirements:
       ranged: 20
     attack_bonus:
-      ranged: 8
-    ranged_strength: 9
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 9
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: ranged
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Mithril dart
+          item_id: 808
+          quantity: 5
+        - item_name: Weapon poison
+          quantity: 1
+      product: Mithril dart(p)
+      product_id: 815
   related_items:
-    - item_id: 814
-      item_name: Steel dart (p)
-      slug: steel-dart-p
+    - item_id: 808
+      item_name: Mithril dart
+      slug: mithril-dart
       relationship: variant
-      description: Lower tier poisoned dart
-  about: |-
-    > _"A mithril tipped dart with a poisoned tip."_
-
-    A mithril dart tipped with basic weapon poison. Requires 20 Ranged. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Unpoisoned base dart.
+    - item_id: 814
+      item_name: Steel dart(p)
+      slug: steel-dart-p
+      relationship: downgrade
+      description: Lower-tier poisoned dart.
+    - item_id: 5631
+      item_name: Mithril dart(p+)
+      slug: mithril-dart-p-plus
+      relationship: upgrade
+      description: Stronger weapon poison variant.
+  market_strategy:
+    title: Poisoned Thrown Notes
+    notes:
+      - Mid-tier ranged training projectile with passive poison damage
+      - Supply driven by Fletching alts applying poison in bulk
+      - Niche PvP utility on poisoned attack styles
+  history:
+    - date: "2021-06-30"
+      update: Combat rebalance
+      description: Ranged attack reduced from +8 to 0; ranged strength raised from +7 to +9.
+    - date: "2003-04-14"
+      update: New Throwing Weapons!
+      description: Mithril darts and poisoned variants released.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "14 Apr 2003"
+    update: New Throwing Weapons!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options: [Wield, Drop]
+    alchable: true
+  about: Mithril dart coated with basic weapon poison, requires 20 Ranged to wield.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-knife.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-knife.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril knife | OSRS Price Data
-description: "Mithril knife is a members weapon slot item. High alch: 16 GP, GE limit: 7,000."
+description: "Mithril knife: A finely balanced throwing knife. High alch: 16 GP, GE limit: 7,000."
 osrs:
   id: 866
   name: Mithril knife
@@ -12,24 +12,43 @@ osrs:
   lowalch: 10
   highalch: 16
   limit: 7000
+  material:
+    type: mithril
+    tier: mid
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
+    weapon_type: thrown
     attack_speed: 3
-  requirements:
-    ranged: 20
-  stats:
-    attack:
+    weight: 0.006
+    requirements:
+      ranged: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 11
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 10
-  smithing:
-    level: 52
-    xp: 50
-    method: Mithril bar at anvil
-    bars: 1
-    quantity: 5
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 57
+      xp: 50
+      materials:
+        - item_name: Mithril bar
+          item_id: 2359
+          quantity: 1
+      product: Mithril knife
+      product_id: 866
   related_items:
     - item_id: 2359
       item_name: Mithril bar
@@ -51,16 +70,38 @@ osrs:
       slug: mithril-dart
       relationship: alternative
       description: Alternative thrown weapon
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0.006 kg |
-    | Requirements | 20 Ranged |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Mid-tier thrown weapon for early Ranged
+      - Stackable for easy bank management
+      - Mithril bar price floors profitability
+      - Demand from Slayer training and PKers
+  history:
+    - date: "2003-04-14"
+      update: New Throwing Weapons!
+      description: Released with the throwing knives family.
+    - date: "2021-07-01"
+      update: Female animation fix
+      description: Adjusted weapon positioning on female player characters.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "14 Apr 2003"
+    update: New Throwing Weapons!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  about: Mid-tier mithril throwing knife requiring 20 Ranged; smithed five-per-bar at 57 Smithing.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/old-school-bond.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/old-school-bond.mdx
@@ -1,6 +1,6 @@
 ---
 title: Old school bond | OSRS Price Data
-description: "Old school bond: This bond can be redeemed for membership.. GE limit: 100."
+description: "Old school bond: This bond can be redeemed for membership. GE limit: 100."
 osrs:
   id: 13190
   name: Old school bond
@@ -12,9 +12,51 @@ osrs:
   lowalch: null
   highalch: null
   limit: 100
-  about: "Old school bond is a free-to-play item in Old School RuneScape. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_id: 13192
+      item_name: Old school bond (untradeable)
+      slug: old-school-bond-untradeable
+      relationship: variant
+      description: Pouch-held untradeable form
+  market_strategy:
+    notes:
+      - Real-money pegged item; floor follows Jagex bond store
+      - 14-day membership per bond defines lower bound
+      - Demand spikes on holiday sales and league launches
+      - Used for display name changes and gifting
+      - Pouch capacity raised from 20 to 100 in 2025
+  history:
+    - date: "2015-03-30"
+      update: Membership Bonds & Easter
+      description: Old school bonds released for in-game membership trade.
+    - date: "2025-01-08"
+      update: Bond pouch expansion
+      description: Bond pouch capacity raised from 20 to 100.
+    - date: "2025-04-09"
+      update: Ironman gifting
+      description: Ironmen permitted to gift bonds to other players.
+    - date: "2025-04-23"
+      update: Untradeable conversion
+      description: Untradeable bonds can now be converted using bank coins.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "30 Mar 2015"
+    update: Membership Bonds & Easter
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.003
+    destroy: This object cannot be dropped or destroyed.
+    options:
+      - Redeem
+      - Deposit
+      - Drop
+    alchable: false
+  about: Tradeable bond redeemable for membership days or display name changes.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-bolts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Onyx bolts | OSRS Price Data
-description: "Onyx bolts: Onyx tipped Runite crossbow bolts.. High alch: 8,179 GP, GE limit: 11,000."
+description: "Onyx bolts: Onyx tipped Runite crossbow bolts. High alch: 8,179 GP, GE limit: 11,000."
 osrs:
   id: 9342
   name: Onyx bolts
@@ -12,9 +12,91 @@ osrs:
   lowalch: 5453
   highalch: 8179
   limit: 11000
-  about: "Onyx bolts is a members-only item in Old School RuneScape. High alchemy value: 8,179 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    weight: 0
+    requirements:
+      ranged: 67
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 120
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 73
+      xp: 9.4
+      materials:
+        - item_name: Runite bolts
+          quantity: 10
+        - item_name: Onyx bolt tips
+          quantity: 10
+      product: Onyx bolts
+      product_id: 9342
+  related_items:
+    - item_id: 9237
+      item_name: Onyx bolts (e)
+      slug: onyx-bolts-e
+      relationship: upgrade
+      description: Enchanted via Magic 87 for the Life Leech proc.
+    - item_id: 9189
+      item_name: Onyx bolt tips
+      slug: onyx-bolt-tips
+      relationship: component
+      description: Fletched onto runite bolts to produce onyx bolts.
+    - item_id: 9244
+      item_name: Runite bolts
+      slug: runite-bolts
+      relationship: component
+      description: Base ammo before adding onyx tips.
+  market_strategy:
+    title: Onyx Tip Margin Play
+    notes:
+      - Margin tracks Onyx bolt tip GE vs runite bolt + assembled price.
+      - Demand spikes when raiders prep enchanted (e) bolts for Life Leech.
+      - Wide GE limit (11k) makes this scalable if margin opens.
+  trading_tips:
+    - Watch enchanted onyx bolt margin — usually drives raw onyx pricing.
+    - Bulk-buy when ToB/CoX team prep waves hit during weekends.
+    - Fletcher's source bolt tips below GE during PvM lulls.
+  history:
+    - date: "2006-07-31"
+      update: "Crossbows"
+      description: Added with the Crossbows update introducing gem-tipped runite ammunition.
+    - date: "2007-01-29"
+      update: "Item Value Adjustment"
+      description: Store value increased from 1 to 13,633 coins to reflect high-tier ammo pricing.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "31 Jul 2006"
+    update: "Crossbows"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options: ["Wield", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/opal-bolt-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/opal-bolt-tips.mdx
@@ -1,6 +1,6 @@
 ---
 title: Opal bolt tips | OSRS Price Data
-description: "Opal bolt tips: Opal bolt tips.. High alch: 4 GP, GE limit: 11,000."
+description: "Opal bolt tips: Opal bolt tips. High alch: 4 GP, GE limit: 11,000."
 osrs:
   id: 45
   name: Opal bolt tips
@@ -12,18 +12,61 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 11000
+  material:
+    type: ammunition
+    tier: low
+  recipes:
+    - skill: fletching
+      level: 11
+      xp: 1.5
+      materials:
+        - item_name: Cut opal
+          item_id: 1609
+          quantity: 1
+      product: Opal bolt tips
+      product_id: 45
   related_items:
     - item_id: 46
       item_name: Pearl bolt tips
       slug: pearl-bolt-tips
       relationship: variant
       description: Higher tier bolt tips
-  about: |-
-    > _"Opal bolt tips."_
-
-    Opal bolt tips are members-only Fletching supplies. Attach to bronze bolts at 11 Fletching to create opal bolts. The lowest tier of gem-tipped bolt tips.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 879
+      item_name: Opal bolts
+      slug: opal-bolts
+      relationship: product
+      description: Bronze bolts tipped with opal
+  market_strategy:
+    notes:
+      - Cut opals into 12 tips with chisel (1.5 XP each)
+      - Lowest tier gem bolt tip
+      - Combine with bronze bolts for opal bolts
+  history:
+    - date: "2007-01-16"
+      update: Value adjustment
+      description: Item value reduced from 30 to 7 coins.
+    - date: "2006-07-31"
+      update: Graphic update
+      description: Renamed from "Opal bolttips"; quantity-dependent appearances added.
+    - date: "2004-03-03"
+      update: RS2 Beta
+      description: Added to RuneScape 2 Beta.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "29 Mar 2004"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+  about: Opal bolt tips are a low-tier Fletching supply used to make opal bolts.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/orange-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/orange-sapling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Orange sapling | OSRS Price Data
-description: "Orange sapling: This sapling is ready to be replanted in a fruit tree patch.. High alch: 1 GP, GE limit: 200."
+description: "Orange sapling: This sapling is ready to be replanted in a fruit tree patch. High alch: 1 GP, GE limit: 200."
 osrs:
   id: 5498
   name: Orange sapling
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Orange sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: sapling
+    tier: mid
+  farming:
+    farming_level: 39
+    plant_xp: 35.5
+    harvest_xp: 13.5
+    patch_type: fruit tree
+    growth_time: 960
+  related_items:
+    - item_id: 5284
+      item_name: Orange tree seed
+      slug: orange-tree-seed
+      relationship: component
+      description: Seed planted into a plant pot to grow a sapling
+    - item_id: 5371
+      item_name: Orange seedling
+      slug: orange-seedling
+      relationship: component
+      description: Seedling stage before sapling
+    - item_id: 2108
+      item_name: Orange
+      slug: orange
+      relationship: product
+      description: Harvested fruit from a grown orange tree
+  market_strategy:
+    notes:
+      - 39 Farming gates demand
+      - Saplings shortcut waiting for seed-to-sapling growth
+      - Pairs with watered plant pots farming
+      - Steady demand from fruit tree run players
+      - Tradeable since 2015 GE poll
+  history:
+    - date: "2005-07-11"
+      update: Farming
+      description: Released with the Farming skill; converted from cache "Plant pot" entry.
+    - date: "2015-01-29"
+      update: Tradeable saplings
+      description: Made tradeable on the Grand Exchange after a community poll.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "11 Jul 2005"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: false
+  about: Sapling stage of the Orange tree; replant in a fruit tree patch at 39 Farming.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/plant-cure.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/plant-cure.mdx
@@ -1,6 +1,6 @@
 ---
 title: Plant cure | OSRS Price Data
-description: "Plant cure: Use this on plants to cure disease.. High alch: 24 GP, GE limit: 2,000."
+description: "Plant cure: Use this on plants to cure disease. High alch: 24 GP, GE limit: 2,000."
 osrs:
   id: 6036
   name: Plant cure
@@ -12,9 +12,46 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 2000
-  about: "Plant cure is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Farming shops
+      location: Various farming patches and the Farming Guild
+      price: 40
+      currency: coins
+      members_only: true
+  related_items:
+    - item_id: 6036
+      item_name: Plant cure
+      slug: plant-cure
+      relationship: component
+      description: Combined with rune dust during Garden of Tranquillity for strengthened cure.
+  market_strategy:
+    title: Farming Utility
+    notes:
+      - Cheap shop-bought consumable for diseased crops
+      - Cannot revive dead plants — apply early
+      - Auto-vial-smash on use since 2020 patch
+  history:
+    - date: "2020-08-01"
+      update: Quality of Life
+      description: Plant cure now automatically smashes the vial on use.
+    - date: "2005-07-11"
+      update: Farming
+      description: Added with the Farming skill release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "11 Jul 2005"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options: [Empty, Drop]
+    alchable: true
+  about: Farming consumable used to cure diseased crops before they die.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-mud-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-mud-pie.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw mud pie | OSRS Price Data
-description: "Raw mud pie: Needs to be baked before I can use it.. High alch: 16 GP, GE limit: 13,000."
+description: "Raw mud pie: Needs to be baked before I can use it. High alch: 16 GP, GE limit: 13,000."
 osrs:
   id: 7168
   name: Raw mud pie
@@ -12,9 +12,71 @@ osrs:
   lowalch: 10
   highalch: 16
   limit: 13000
-  about: "Raw mud pie is a members-only item in Old School RuneScape. High alchemy value: 16 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 0
+    type: raw-pie
+  recipes:
+    - skill: cooking
+      level: 29
+      xp: 0
+      materials:
+        - item_name: Part mud pie
+          quantity: 1
+        - item_name: Clay
+          quantity: 1
+      product: Raw mud pie
+      product_id: 7168
+    - skill: cooking
+      level: 29
+      xp: 128
+      materials:
+        - item_name: Raw mud pie
+          item_id: 7168
+          quantity: 1
+      product: Mud pie
+      product_id: 7170
+  related_items:
+    - item_id: 7170
+      item_name: Mud pie
+      slug: mud-pie
+      relationship: product
+      description: Baked result that teleports the consumer to Edgeville.
+    - item_id: 1761
+      item_name: Clay
+      slug: clay
+      relationship: component
+      description: Combined with the water-filled pie shell to assemble the raw pie.
+  market_strategy:
+    title: Pie Crafter Pipeline
+    notes:
+      - Demand tied to Cooking levellers and Edgeville-teleport stockpilers.
+      - Mud pie GE margin determines fair raw-pie ceiling.
+      - 13,000 buy limit makes this scalable for AFK Cooking flips.
+  trading_tips:
+    - Check mud pie price first — raw should sit at materials + small markup.
+    - Source cheap clay during weekend mining-spike weekends.
+    - Stack noted in bank for AFK range cooking sessions.
+  history:
+    - date: "2006-02-20"
+      update: "Updates, updates and more updates..."
+      description: Added with the early mud pie / pie cooking expansion.
+    - date: "2015-03-12"
+      update: "Trade Updates"
+      description: Uncooked pies (including raw mud pie) made tradeable on the Grand Exchange.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "20 Feb 2006"
+    update: "Updates, updates and more updates..."
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options: ["Drop"]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-pyre-fox.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-pyre-fox.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw pyre fox | OSRS Price Data
-description: "Raw pyre fox: I should probably cook this first.. High alch: 1 GP, GE limit: 13,000."
+description: "Raw pyre fox: I should probably cook this first. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 29110
   name: Raw pyre fox
@@ -12,9 +12,77 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Raw pyre fox is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: raw-food
+    tier: mid-high
+  food:
+    heals: 0
+    type: raw-meat
+  drop_table:
+    sources:
+      - source: Pyre fox
+        quantity: "1"
+        rarity: always
+        members_only: true
+      - source: Hunters' loot sack (basic)
+        quantity: "3"
+        rarity: varies
+        members_only: true
+      - source: Hunters' loot sack (adept)
+        quantity: "3"
+        rarity: varies
+        members_only: true
+      - source: Hunters' loot sack (expert)
+        quantity: "3"
+        rarity: varies
+        members_only: true
+      - source: Hunters' loot sack (master)
+        quantity: "3"
+        rarity: varies
+        members_only: true
+  recipes:
+    - skill: Cooking
+      level: 59
+      xp: 154
+      materials:
+        - item_name: Raw pyre fox
+          item_id: 29110
+          quantity: 1
+      product: Cooked pyre fox
+      product_id: 29111
+  related_items:
+    - item_id: 29111
+      item_name: Cooked pyre fox
+      slug: cooked-pyre-fox
+      relationship: product
+      description: Cooked variant healing food
+  market_strategy:
+    title: Varlamore hunter supply
+    notes:
+      - Trapped via 57 Hunter pyre foxes
+      - Tradeable to Soar Leader Pitri for quetzal whistle charges
+      - Cooks into pyre fox at 59 Cooking for 154 XP
+      - Steady supply from hunter trainers
+  history:
+    - date: "2024-03-20"
+      update: "Varlamore: Part One"
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "20 Mar 2024"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Drop
+    alchable: true
+  about: Raw pyre fox is a members-only raw food obtained from pyre foxes that can be cooked into pyre fox at 59 Cooking for 154 XP.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Relicym's mix(1) | OSRS Price Data
-description: "Relicym's mix(1): One dose of fishy Relicym's balm.. High alch: 45 GP, GE limit: 2,000."
+description: "Relicym's mix(1): One dose of fishy Relicym's balm. High alch: 45 GP, GE limit: 2,000."
 osrs:
   id: 11439
   name: Relicym's mix(1)
@@ -12,9 +12,69 @@ osrs:
   lowalch: 30
   highalch: 45
   limit: 2000
-  about: "Relicym's mix(1) is a members-only item in Old School RuneScape. High alchemy value: 45 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    herblore_level: 9
+    herblore_xp: 14
+    effect: Cures disease and restores 3 Hitpoints.
+    effects:
+      - stat: hitpoints
+        boost_value: 3
+        description: Restores 3 Hitpoints on drink.
+      - description: Cures the disease status effect.
+  recipes:
+    - skill: herblore
+      level: 9
+      xp: 14
+      materials:
+        - item_name: Relicym's balm(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      product: Relicym's mix(1)
+      product_id: 11439
+  related_items:
+    - item_id: 11437
+      item_name: Relicym's mix(2)
+      slug: relicym-s-mix-2
+      relationship: variant
+      description: 2-dose variant
+    - item_id: 4844
+      item_name: Relicym's balm(4)
+      slug: relicym-s-balm-4
+      relationship: alternative
+      description: Standard cure-disease potion without HP heal
+  market_strategy:
+    notes:
+      - Barbarian Training niche potion
+      - Doubles as a small heal in low-level PvM
+      - Demand spikes during disease-heavy content
+      - Low Herblore requirement keeps supply steady
+  history:
+    - date: "2007-07-03"
+      update: Barbarian Training
+      description: Released as part of the Barbarian Training Herblore extension.
+    - date: "2016-04-15"
+      update: Bank placeholders
+      description: Half-full potion variants can now be set as bank placeholders.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "3 Jul 2007"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+  about: One-dose Relicym's mix from Barbarian Herblore; cures disease and restores 3 HP.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-endurance-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-endurance-uncharged.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ring of endurance (uncharged) | OSRS Price Data
-description: "Ring of endurance (uncharged) is a members ring slot item. High alch: 38,400 GP, GE limit: 5."
+description: "Ring of endurance (uncharged): I wonder if this ring helps with... High alch: 38,400 GP, GE limit: 5."
 osrs:
   id: 24844
   name: Ring of endurance (uncharged)
@@ -14,72 +14,77 @@ osrs:
   limit: 5
   equipment:
     slot: ring
-    type: utility_ring
+    weight: 0.006
     requirements:
       agility: 70
-  effect:
-    passive_threshold: 500
-    passive_effect: Reduces run energy drain by 15%
-    active_effect: Doubles stamina potion effect duration
-    charges_per_dose: 2
-  charging:
-    material_id: 12625
-    material_name: Stamina potion (4)
-    charges_per_potion: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
     max_charges: 1000
+    repairable: false
   drop_table:
     sources:
       - source: Grand Hallowed Coffin
-        source_id: 0
-        combat_level: 0
         quantity: "1"
-        rarity: 1/200
+        rarity: very-rare
         members_only: true
   related_items:
     - item_id: 12625
-      item_name: Stamina potion
-      slug: stamina-potion
-      relationship: alternative
-      description: Charging material
+      item_name: Stamina potion(4)
+      slug: stamina-potion-4
+      relationship: component
+      description: Charges the ring (40 charges per dose-4 potion)
     - item_id: 24795
       item_name: Strange old lockpick
       slug: strange-old-lockpick
       relationship: alternative
-      description: Sepulchre drop
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | All | +0 |
-
-    Requirements: 70 Agility
-
-    Passive (500+ charges):
-    - Reduces run energy drain by 15%
-    - No charges consumed
-
-    Active:
-    - Doubles stamina potion effect duration
-    - Consumes 2 charges per dose
-
-    | Resource | Charges |
-    |----------|---------|
-    | Stamina potion (4) | 40 |
-    | Max capacity | 1,000 |
-
-    Essential for:
-    - Hallowed Sepulchre
-    - Agility training
-    - Extended running
-    - Any run-heavy content
-
-    Best-in-slot for agility and running.
+      description: Other rare Hallowed Sepulchre drop
   market_strategy:
+    title: Sepulchre BiS utility ring
     notes:
-      - Floor 5 Sepulchre only
-      - Keep charged for passive
-      - Great QoL item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Floor 5 Sepulchre 1/200 drop
+      - Keep above 500 charges for the passive
+      - Doubles stamina potion duration when worn
+      - Best-in-slot QoL for any run-heavy content
+  history:
+    - date: "2020-06-12"
+      update: "Darkmeyer Improvements"
+      description: Added to the game.
+    - date: "2024-07-17"
+      update: "QoL update"
+      description: Stamina potion mixes (Stamina mix) now compatible for charging the ring.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "12 Jun 2020"
+    update: "Darkmeyer Improvements"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  about: Ring of endurance (uncharged) is a 70 Agility ring from the Hallowed Sepulchre that, once filled with stamina potions, reduces run energy drain by 15% above 500 charges and doubles stamina dose duration.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-javelin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-javelin.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune javelin | OSRS Price Data
-description: "Rune javelin is a members ammo slot item with +46 ranged strength requiring 40 Ranged. High alch: 240 GP, GE limit: 11,000."
+description: "Rune javelin: A rune tipped javelin. High alch: 240 GP, GE limit: 11,000."
 osrs:
   id: 830
   name: Rune javelin
@@ -14,6 +14,8 @@ osrs:
   limit: 11000
   equipment:
     slot: ammo
+    weapon_type: thrown
+    weight: 0
     attack_bonus:
       stab: 0
       slash: 0
@@ -28,44 +30,75 @@ osrs:
       ranged: 0
     other_bonus:
       melee_strength: 0
-      ranged_strength: 46
+      ranged_strength: 124
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 40
-    weight: 0.02
+  recipes:
+    - skill: fletching
+      level: 77
+      xp: 187.5
+      materials:
+        - item_name: Rune javelin heads
+          quantity: 15
+        - item_name: Javelin shaft
+          quantity: 15
+      product: Rune javelin
+      product_id: 830
+  shops:
+    - shop_name: Void Knight Archery Store
+      location: Void Knights' Outpost
+      price: 400
+      currency: coins
+      members_only: true
+    - shop_name: Hickton's Archery Emporium
+      location: Catherby
+      price: 520
+      currency: coins
+      members_only: true
+    - shop_name: Oobapohk's Javelin Store
+      location: TzHaar City
+      price: 400
+      currency: coins
+      members_only: true
   related_items:
     - item_id: 21318
       item_name: Amethyst javelin
       slug: amethyst-javelin
       relationship: upgrade
-      description: Higher tier javelin
-  about: |-
-    | Other | Value |
-    |-------|-------|
-    | Ranged Strength | +46 |
-
-    Requirements: 40 Ranged | Weight: 0.02 kg
-
-    Javelins are primarily used with the ballista weapons:
-    - Light ballista — requires 65 Ranged
-    - Heavy ballista — requires 75 Ranged (one of the highest single-hit ranged weapons)
-
-    Rune javelins in a heavy ballista can hit extremely high due to the ballista's slow speed and high max hit, making them popular for PvP KO attempts.
-
-    | Javelin | Ranged Str | Req | Source |
-    |---------|-----------|-----|--------|
-    | Adamant | +36 | 30 | Fletching 71 |
-    | Rune | +46 | 40 | Fletching 77 |
-    | Amethyst | +55 | 50 | Fletching 84 |
-    | Dragon | +60 | 60 | Raids/Zulrah |
+      description: Higher-tier javelin.
+    - item_id: 19484
+      item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: alternative
+      description: End-game launcher for rune+ javelins.
   market_strategy:
+    title: Ballista Ammo
     notes:
-      - Consumed as ammo — steady demand
+      - Consumed as ammo — steady daily demand
       - Used in Heavy ballista PvP specs
-      - Fletching training product
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Fletching training product at 77
+  history:
+    - date: "2016-05-06"
+      update: Ballista
+      description: Rune javelins moved from weapon slot to ammunition slot to fire with ballistae.
+    - date: "2004-03-29"
+      update: RS2 Launched!
+      description: Added permanently to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "29 Mar 2004"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options: [Wield, Drop]
+    alchable: true
+  about: Ballista ammunition fletched from rune javelin heads and shafts.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shade-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shade-robe-top.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shade robe top | OSRS Price Data
-description: "Shade robe top is a F2P body slot item. High alch: 24 GP, GE limit: 125."
+description: "Shade robe top: I feel closer to the gods when I am wearing this. High alch: 24 GP, GE limit: 125."
 osrs:
   id: 546
   name: Shade robe top
@@ -14,21 +14,78 @@ osrs:
   limit: 125
   equipment:
     slot: body
+    weight: 0.907
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
+  drop_table:
+    sources:
+      - source: Shade (level 140)
+        combat_level: 140
+        quantity: "1"
+        rarity: uncommon
+        members_only: false
+      - source: Shade (level 159)
+        combat_level: 159
+        quantity: "1"
+        rarity: uncommon
+        members_only: false
   related_items:
     - item_id: 548
       item_name: Shade robe
       slug: shade-robe
       relationship: set-piece
       description: Matching shade robe legs
-  about: |-
-    > *"I feel closer to the gods when I am wearing this."*
-
-    The shade robe top is a free-to-play body slot item that provides a +5 Prayer bonus. It is dropped by shades and is part of the shade robes set. Despite being dropped by high-level monsters, it has no requirements to equip, making it accessible for low-level prayer builds.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - +5 Prayer bonus with no equip requirements
+      - Free-to-play body slot prayer gear
+      - Dropped by shades at ~32/128 rate
+  history:
+    - date: "2014-12-10"
+      update: Rename
+      description: Renamed from "Shade robe" to "Shade robe top".
+    - date: "2005-04-26"
+      update: Examine update
+      description: Examine text capitalization adjusted.
+    - date: "2004-07-20"
+      update: Rename
+      description: Renamed from "Black robe".
+    - date: "2004-03-29"
+      update: RS2 Launched!
+      description: Made permanently available with RS2 launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "29 Mar 2004"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  about: Shade robe top is a free-to-play body slot item providing +5 Prayer bonus, dropped by shades.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shield-left-half.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shield-left-half.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shield left half | OSRS Price Data
-description: "Shield left half: The left half of a dragon square shield.. High alch: 66,000 GP, GE limit: 50."
+description: "Shield left half: The left half of a dragon square shield. High alch: 66,000 GP, GE limit: 50."
 osrs:
   id: 2366
   name: Shield left half
@@ -12,9 +12,85 @@ osrs:
   lowalch: 44000
   highalch: 66000
   limit: 50
-  about: "Shield left half is a members-only item in Old School RuneScape. High alchemy value: 66,000 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Skotizo
+        combat_level: 321
+        quantity: "1"
+        rarity: rare
+        members_only: true
+      - source: Gorak
+        combat_level: 145
+        quantity: "1"
+        rarity: very-rare
+        members_only: true
+      - source: Intricate pouch
+        quantity: "1"
+        rarity: rare
+        members_only: true
+      - source: Elven Crystal Chest
+        quantity: "1"
+        rarity: rare
+        members_only: true
+      - source: Dark Chest
+        quantity: "1"
+        rarity: very-rare
+        members_only: true
+      - source: Rare drop table
+        quantity: "1"
+        rarity: rare
+        members_only: true
+  recipes:
+    - skill: Smithing
+      level: 60
+      xp: 75
+      materials:
+        - item_name: Shield left half
+          item_id: 2366
+          quantity: 1
+        - item_name: Shield right half
+          item_id: 2368
+          quantity: 1
+      product: Dragon sq shield
+      product_id: 1187
+  related_items:
+    - item_id: 2368
+      item_name: Shield right half
+      slug: shield-right-half
+      relationship: component
+      description: Bought from Siegfried Erkle for 750,000 coins
+    - item_id: 1187
+      item_name: Dragon sq shield
+      slug: dragon-sq-shield
+      relationship: product
+      description: Smithed at 60 Smithing from both halves
+  market_strategy:
+    title: Dragon sq shield component
+    notes:
+      - Combined with right half at 60 Smithing for the Dragon sq shield
+      - Best drop rate from Skotizo (1/100)
+      - Goraks remain the AFK farming spot
+      - Tied tightly to Dragon sq shield demand
+  history:
+    - date: "2003-08-20"
+      update: "Legends' Quest"
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "20 Aug 2003"
+    update: "Legends' Quest"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Drop
+    alchable: true
+  about: Shield left half is a members-only rare drop combined with Shield right half at 60 Smithing to forge the Dragon sq shield.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shorts-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shorts-yellow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shorts (yellow) | OSRS Price Data
-description: "Shorts (yellow): Yellow shorts. Far too small for you.. High alch: 216 GP, GE limit: 150."
+description: "Shorts (yellow): Yellow shorts. Far too small for you. High alch: 216 GP, GE limit: 150."
 osrs:
   id: 5044
   name: Shorts (yellow)
@@ -12,9 +12,60 @@ osrs:
   lowalch: 144
   highalch: 216
   limit: 150
-  about: "Shorts (yellow) is a members-only item in Old School RuneScape. High alchemy value: 216 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 0.1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Agmundi Quality Clothes
+      location: Keldagrim
+      price: 468
+      currency: Coins
+      members_only: true
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania and Etceteria Dungeon
+      price: 360
+      currency: Coins
+      members_only: true
+  market_strategy:
+    notes:
+      - Cosmetic legs slot item with no combat bonuses
+      - Sold by Keldagrim and Miscellania clothing shops
+      - Low buy limit at 150 per 4 hours
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "31 May 2005"
+    update: Keldagrim - The Dwarven City
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  about: Shorts (yellow) is a cosmetic legs slot item sold by clothing shops in Keldagrim and Miscellania.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sinew.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sinew.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sinew | OSRS Price Data
-description: "Sinew: I can use this to make a crossbow string.. High alch: 1 GP, GE limit: 13,000."
+description: "Sinew: I can use this to make a crossbow string. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 9436
   name: Sinew
@@ -12,9 +12,78 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Sinew is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: crafting
+    tier: low
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 3
+      materials:
+        - item_name: Raw beef
+          quantity: 1
+      product: Sinew
+      product_id: 9436
+    - skill: cooking
+      level: 1
+      xp: 3
+      materials:
+        - item_name: Raw bear meat
+          quantity: 1
+      product: Sinew
+      product_id: 9436
+    - skill: crafting
+      level: 10
+      xp: 15
+      materials:
+        - item_name: Damaged monkey tail
+          quantity: 1
+      product: Sinew
+      product_id: 9436
+    - skill: crafting
+      level: 10
+      xp: 15
+      materials:
+        - item_name: Sinew
+          quantity: 1
+      product: Crossbow string
+      product_id: 9438
+  related_items:
+    - item_id: 9438
+      item_name: Crossbow string
+      slug: crossbow-string
+      relationship: product
+      description: Spun from sinew at a spinning wheel for crossbow assembly.
+    - item_id: 2132
+      item_name: Raw beef
+      slug: raw-beef
+      relationship: component
+      description: Cheapest source — cook on a range for 1 sinew.
+  market_strategy:
+    title: Cheap Crafting Supply
+    notes:
+      - Profit by cooking raw beef on a range for sinew + cooking XP
+      - Spin at a wheel for crossbow strings — 15 Crafting XP each
+      - Bulk buy limit 13k makes it ironman-friendly
+  history:
+    - date: "2006-07-31"
+      update: Crossbows
+      description: Added with the new crossbow Crafting/Fletching content.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "31 Jul 2006"
+    update: Crossbows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.002
+    options: [Drop]
+    alchable: true
+  about: Crafting material cooked from meat or knifed from monkey tails, spun into crossbow strings.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-brutal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-brutal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel brutal | OSRS Price Data
-description: "Steel brutal: Blunt steel arrow... ouch.. High alch: 12 GP, GE limit: 11,000."
+description: "Steel brutal: Blunt steel arrow... ouch. High alch: 12 GP, GE limit: 11,000."
 osrs:
   id: 4783
   name: Steel brutal
@@ -12,9 +12,81 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 11000
-  about: "Steel brutal is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: mid
+  equipment:
+    slot: ammo
+    weapon_type: bow
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 19
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Fletching
+      level: 33
+      xp: 30.6
+      materials:
+        - item_name: Flighted ogre arrow
+          quantity: 6
+        - item_name: Steel nails
+          quantity: 6
+      product: Steel brutal
+      product_id: 4783
+  related_items:
+    - item_id: 4825
+      item_name: Ogre composite bow
+      slug: ogre-composite-bow
+      relationship: alternative
+      description: Bow that fires brutal arrows
+    - item_id: 4827
+      item_name: Comp ogre bow
+      slug: comp-ogre-bow
+      relationship: alternative
+      description: Composite ogre bow upgrade
+  market_strategy:
+    title: Chompy hunting ammo
+    notes:
+      - Requires partial Zogre Flesh Eaters completion
+      - Used with ogre bow vs zogres, skogres and chompy birds
+      - Fletched 6-at-a-time from steel nails + flighted ogre arrows
+  history:
+    - date: "2005-05-17"
+      update: "Zogre Flesh Eaters"
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "17 May 2005"
+    update: "Zogre Flesh Eaters"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  about: Steel brutal is a members-only fletched arrow used with ogre and composite ogre bows against zogres, skogres and chompy birds.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dart-p-5637.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dart-p-5637.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel dart(p++) | OSRS Price Data
-description: "Steel dart(p++): A deadly poisoned dart with a steel tip.. High alch: 6 GP, GE limit: 7,000."
+description: "Steel dart(p++): A deadly poisoned dart with a steel tip. High alch: 6 GP, GE limit: 7,000."
 osrs:
   id: 5637
   name: Steel dart(p++)
@@ -12,9 +12,90 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 7000
-  about: "Steel dart(p++) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 3
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Steel dart
+          item_id: 807
+          quantity: 1
+        - item_name: Weapon poison(++)
+          item_id: 5937
+          quantity: 1
+      product: Steel dart(p++)
+      product_id: 5637
+  related_items:
+    - item_id: 807
+      item_name: Steel dart
+      slug: steel-dart
+      relationship: variant
+      description: Unpoisoned base dart
+    - item_id: 5633
+      item_name: Steel dart(p)
+      slug: steel-dart-p
+      relationship: downgrade
+      description: Standard weapon poison variant
+    - item_id: 5635
+      item_name: Steel dart(p+)
+      slug: steel-dart-p-plus
+      relationship: downgrade
+      description: Stronger weapon poison (+)
+  market_strategy:
+    title: Extra-strong poisoned dart
+    notes:
+      - Made by applying weapon poison(++) to a steel dart
+      - Strongest poison variant of the steel dart line
+      - Thrown one-handed weapon, attack speed 3
+      - Niche outside legacy poison setups
+  history:
+    - date: "2003-04-14"
+      update: "New Throwing Weapons"
+      description: Added to the game.
+    - date: "2025-05-29"
+      update: "GE Tax Update"
+      description: Steel darts received exemption from Grand Exchange convenience fees.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "14 Apr 2003"
+    update: "New Throwing Weapons"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  about: Steel dart(p++) is a members-only thrown weapon made by applying extra-strong weapon poison(++) to a steel dart, granting +3 ranged strength.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunlight-antler-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunlight-antler-bolts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sunlight antler bolts | OSRS Price Data
-description: "Sunlight antler bolts: Bolts made from the antlers of a sunlight antelope.. High alch: 18 GP, GE limit: 11,000."
+description: "Sunlight antler bolts: Bolts made from the antlers of a sunlight antelope. High alch: 18 GP, GE limit: 11,000."
 osrs:
   id: 28872
   name: Sunlight antler bolts
@@ -12,9 +12,74 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 11000
-  about: "Sunlight antler bolts is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: mid
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    weight: 0
+    requirements:
+      ranged: 66
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 55
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 62
+      xp: 10
+      materials:
+        - item_name: Sunlight antelope antler
+          quantity: 1
+      product: Sunlight antler bolts
+      product_id: 28872
+  related_items:
+    - item_id: 28862
+      item_name: Hunters' sunlight crossbow
+      slug: hunters-sunlight-crossbow
+      relationship: alternative
+      description: Required crossbow for these bolts
+  market_strategy:
+    notes:
+      - Requires 66 Ranged with hunters' sunlight crossbow
+      - Cannot be poisoned
+      - Compatible with Ava's devices
+      - Massive daily volume from Varlamore content
+  history:
+    - date: "2024-07-31"
+      update: Dizana's quiver fix
+      description: Sunlight crossbow and bolts now function correctly with Dizana's quiver.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "20 Mar 2024"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  about: Sunlight antler bolts are members ammunition fletched from sunlight antelope antlers, used with the hunters' sunlight crossbow.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-def-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-def-mix-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super def. mix(2) | OSRS Price Data
-description: "Super def. mix(2): Two doses of fishy super Defence potion.. High alch: 118 GP, GE limit: 2,000."
+description: "Super def. mix(2): Two doses of fishy super Defence potion. High alch: 118 GP, GE limit: 2,000."
 osrs:
   id: 11497
   name: Super def. mix(2)
@@ -12,9 +12,68 @@ osrs:
   lowalch: 79
   highalch: 118
   limit: 2000
-  about: "Super def. mix(2) is a members-only item in Old School RuneScape. High alchemy value: 118 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    herblore_level: 71
+    herblore_xp: 50
+    effect: Boosts Defence by 5 + 15% of level and heals 6 Hitpoints.
+    effects:
+      - stat: defence
+        boost_value: 5
+        description: Boosts Defence by 5 plus 15% of the player's Defence level.
+      - stat: hitpoints
+        boost_value: 6
+        description: Restores 6 Hitpoints on drink.
+  recipes:
+    - skill: herblore
+      level: 71
+      xp: 50
+      materials:
+        - item_name: Super defence(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      product: Super def. mix(2)
+      product_id: 11497
+  related_items:
+    - item_id: 11499
+      item_name: Super def. mix(1)
+      slug: super-def-mix-1
+      relationship: variant
+      description: One-dose version of the same fishy potion.
+    - item_id: 2443
+      item_name: Super defence(2)
+      slug: super-defence-2
+      relationship: component
+      description: Base potion mixed with caviar to create the fishy mix.
+  market_strategy:
+    title: Barbarian Herblore Notes
+    notes:
+      - Niche supply from 71 Herblore Barbarian training
+      - Heals 6 HP per dose making it a hybrid combat consumable
+      - Margins thin against raw super defence ingredients
+  history:
+    - date: "2016-04-15"
+      update: Bank placeholder support
+      description: Half-full potions became convertible to bank placeholders.
+    - date: "2015-02-26"
+      update: Renaming
+      description: Item renamed from "Sup. def. mix" to "Super def. mix".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "3 Jul 2007"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.075
+    options: [Drink, Empty, Drop]
+    alchable: true
+  about: Two-dose fishy super Defence mix made via Barbarian Herblore.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tall-box-hedge-bagged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tall-box-hedge-bagged.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tall box hedge (bagged) | OSRS Price Data
-description: "Tall box hedge (bagged): You can plant this in your garden.. High alch: 60,000 GP, GE limit: 10,000."
+description: "Tall box hedge (bagged): You can plant this in your garden. High alch: 60,000 GP, GE limit: 10,000."
 osrs:
   id: 8449
   name: Tall box hedge (bagged)
@@ -12,9 +12,54 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 10000
-  about: "Tall box hedge (bagged) is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Garden Supplier
+      location: Falador Park
+      price: 100000
+      currency: Coins
+      members_only: true
+    - shop_name: Garden Supplier
+      location: Farming Guild
+      price: 100000
+      currency: Coins
+      members_only: true
+  construction:
+    construction_level: 80
+    construction_xp: 316
+    room: Formal Garden
+    hotspot: Hedge
+  farming:
+    plant_xp: 316
+    patch_type: hedge
+  about: "Tall box hedge (bagged) is a Construction hedge decoration for the Formal Garden, bought from a Garden Supplier and planted at 80 Construction for 316 Construction XP and 316 Farming XP using a charged watering can."
+  market_strategy:
+    title: POH Cosmetic Demand
+    notes:
+      - Demand is steady from high-level POH decorators chasing formal garden cosmetics.
+      - Cap price near shop value (100k); GE spikes above shop are scalp opportunities.
+      - 10k buy limit allows scale but daily volume is modest.
+  trading_tips:
+    - Source straight from Garden Supplier when GE listings spike above 100k.
+    - Stockpile only if you have a queued Construction project planned.
+    - Watch for Construction skill events that pump POH-decor demand.
+  history:
+    - date: "2006-05-31"
+      update: "Player-Owned Houses"
+      description: Released with the Construction skill and Formal Garden room.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "31 May 2006"
+    update: "Player-Owned Houses"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options: ["Drop"]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-dresser-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-dresser-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teak dresser (flatpack) | OSRS Price Data
-description: "Teak dresser (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Teak dresser (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8602
   name: Teak dresser (flatpack)
@@ -12,9 +12,57 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Teak dresser (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: construction
+      level: 46
+      xp: 181
+      materials:
+        - item_name: Teak plank
+          item_id: 8786
+          quantity: 2
+        - item_name: Molten glass
+          item_id: 1775
+          quantity: 1
+      product: Teak dresser (flatpack)
+      product_id: 8602
+  construction:
+    construction_level: 46
+    construction_xp: 181
+    room: Bedroom
+    hotspot: Dresser
+    flatpack: true
+  related_items:
+    - item_id: 8786
+      item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: Required material
+    - item_id: 1775
+      item_name: Molten glass
+      slug: molten-glass
+      relationship: component
+      description: Required material
+  market_strategy:
+    notes:
+      - Made at steel-framed workbench with hammer and saw
+      - 181 Construction XP per flatpack
+      - Sold to other players for POH dressers
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "31 May 2006"
+    update: PLAYER-OWNED HOUSES!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+  about: Teak dresser (flatpack) is a Construction flatpack for the Bedroom dresser hotspot, made at a steel-framed workbench.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-cape-zero.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-cape-zero.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team cape zero | OSRS Price Data
-description: "Team cape zero is a F2P cape slot item. High alch: 30 GP, GE limit: 4."
+description: "Team cape zero: Ooohhh look at the dirty colours... High alch: 30 GP, GE limit: 4."
 osrs:
   id: 20211
   name: Team cape zero
@@ -14,7 +14,28 @@ osrs:
   limit: 4
   equipment:
     slot: cape
+    weight: 0.453
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
   related_items:
     - item_id: 20214
       item_name: Team cape x
@@ -26,12 +47,36 @@ osrs:
       slug: team-cape-i
       relationship: variant
       description: Team cape i variant
-  about: |-
-    > *"Ooohhh look at the dirty colours..."*
-
-    Team cape zero is a cosmetic cape from easy treasure trails. Unlike regular team capes bought from shops, the treasure trail variants are rarer and cannot be purchased from NPCs. No stats or requirements.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Easy clue exclusive supply (~1/5,616)
+      - Low GE buy limit caps flips
+      - Counts as a team cape for Wilderness Easy Diary
+      - Cosmetic cape with minor defensive bonuses
+      - Storable in costume room cape racks
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion
+      description: Added as an easy clue reward casket drop.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "6 Jul 2016"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  about: Easy clue reward cape with minor defence bonuses; satisfies team-cape diary requirements.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tormented-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tormented-ornament-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tormented ornament kit | OSRS Price Data
-description: "Tormented ornament kit: Use on a tormented bracelet to make it look fancier!. High alch: 3,000 GP, GE limit: 4."
+description: "Tormented ornament kit: Use on a tormented bracelet to make it look fancier! High alch: 3,000 GP, GE limit: 4."
 osrs:
   id: 23348
   name: Tormented ornament kit
@@ -12,9 +12,47 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Tormented ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  treasure_trail:
+    tier: master
+    is_reward: true
+  related_items:
+    - item_id: 19544
+      item_name: Tormented bracelet
+      slug: tormented-bracelet
+      relationship: component
+      description: Bracelet the kit attaches to
+    - item_id: 23349
+      item_name: Tormented bracelet (or)
+      slug: tormented-bracelet-or
+      relationship: product
+      description: Ornamented tormented bracelet
+  market_strategy:
+    title: Master clue cosmetic kit
+    notes:
+      - 1/851 from master clue caskets
+      - Combine with tormented bracelet for the (or) variant
+      - Combined item is untradeable but kit can be detached and resold
+      - Low buy limit (4) keeps prices stable
+  history:
+    - date: "2019-04-11"
+      update: "Treasure Trails Expansion & Easter 2019"
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "11 Apr 2019"
+    update: "Treasure Trails Expansion & Easter 2019"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+  about: Tormented ornament kit is a master clue scroll reward applied to a tormented bracelet to create the cosmetic Tormented bracelet (or).
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-top-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-top-yellow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tribal top (yellow) | OSRS Price Data
-description: "Tribal top (yellow): Local dress.. High alch: 180 GP, GE limit: 150."
+description: "Tribal top (yellow): Local dress. High alch: 180 GP, GE limit: 150."
 osrs:
   id: 6361
   name: Tribal top (yellow)
@@ -12,9 +12,67 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Tribal top (yellow) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      price: 360
+      currency: trading sticks
+      members_only: true
+  related_items:
+    - item_id: 6359
+      item_name: Tribal top (blue)
+      slug: tribal-top-blue
+      relationship: variant
+      description: Blue colour variant
+    - item_id: 6363
+      item_name: Tribal top (red)
+      slug: tribal-top-red
+      relationship: variant
+      description: Red colour variant
+  market_strategy:
+    notes:
+      - Bought with trading sticks, not coins
+      - Karamja gloves 1+ cuts cost to 300 sticks
+      - Niche cosmetic body slot
+      - Tradeable on Grand Exchange
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  about: Cosmetic yellow tribal body sold by Gabooty for 360 trading sticks in Tai Bwo Wannai.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trinket-of-avarice.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trinket-of-avarice.mdx
@@ -8,13 +8,48 @@ osrs:
   examine: A magic rock! This one automatically notes and retrieves drops.
   members: true
   icon: Trinket of avarice.png
-  value: 0
-  lowalch: null
-  highalch: null
+  value: 100000
+  lowalch: 40000
+  highalch: 60000
   limit: null
-  about: Trinket of avarice is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Breach monsters (Deadman Mode)
+        quantity: "1"
+        rarity: rare
+        members_only: true
+  about: "Trinket of avarice is a Deadman Mode-exclusive auto-loot trinket that notes and retrieves monster drops, prioritising looting bags and including a value filter and automatic bone pickup."
+  market_strategy:
+    title: Deadman Mode Loot Engine
+    notes:
+      - Restricted to Deadman world 345 and seasonal events, so off-season prices crater.
+      - Demand peaks during DMM tournament prep and early-season rushes.
+      - Single rare drop from breach monsters keeps supply throttled.
+  trading_tips:
+    - Time buys for pre-tournament announcement windows.
+    - Combine with looting bag and value filter for max ROI farming sessions.
+    - Resale liquidity is poor outside live DMM events.
+  history:
+    - date: "2026-01-21"
+      update: "Deadman Mode: Apocalypse"
+      description: Added as a breach monster drop with value filter and auto-noting behaviour.
+    - date: "2026-02-12"
+      update: "DMM Quality of Life"
+      description: Trinket now automatically loots bones and stacks noted drops when the looting bag is full.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "21 Jan 2026"
+    update: "Deadman Mode: Apocalypse"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options: ["Activate", "Configure", "Drop"]
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-comp-bow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-comp-bow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Willow comp bow | OSRS Price Data
-description: "Willow comp bow: A powerful bow made from willow wood.. High alch: 180 GP, GE limit: 8."
+description: "Willow comp bow: A powerful bow made from willow wood. High alch: 180 GP, GE limit: 8."
 osrs:
   id: 10280
   name: Willow comp bow
@@ -12,9 +12,72 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 8
-  about: "Willow comp bow is a free-to-play item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: 2h
+    weapon_type: bow
+    attack_speed: 5
+    weight: 1.8
+    requirements:
+      ranged: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 22
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+  related_items:
+    - item_id: 10282
+      item_name: Maple comp bow
+      slug: maple-comp-bow
+      relationship: upgrade
+      description: Higher tier composite bow
+    - item_id: 10280
+      item_name: Willow longbow
+      slug: willow-longbow
+      relationship: alternative
+      description: Fletched alternative at same Ranged requirement
+  market_strategy:
+    title: Easy clue cosmetic bow
+    notes:
+      - Cannot be fletched - clue scroll reward only
+      - 11/3960 from easy clue caskets
+      - Limit of 8 keeps thin supply
+      - Fires up to mithril arrows
+  history:
+    - date: "2006-12-05"
+      update: "Treasure Trails, spiders and sheep"
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "5 Dec 2006"
+    update: "Treasure Trails, spiders and sheep"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.8
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  about: Willow comp bow is a free-to-play two-handed composite bow from easy Treasure Trails, requiring 20 Ranged and firing up to mithril arrows.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-bracelet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zenyte bracelet | OSRS Price Data
-description: "Zenyte bracelet is a members hands slot item. High alch: 120,600 GP, GE limit: 8."
+description: "Zenyte bracelet: A fiery glow emanates from this bracelet. High alch: 120,600 GP, GE limit: 8."
 osrs:
   id: 19532
   name: Zenyte bracelet
@@ -14,7 +14,25 @@ osrs:
   limit: 8
   equipment:
     slot: hands
-    type: bracelet
+    weight: 0.25
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 95
@@ -26,11 +44,29 @@ osrs:
         - item_name: Zenyte
           item_id: 19493
           quantity: 1
+        - item_name: Bracelet mould
+          item_id: 11065
+          quantity: 1
       product: Zenyte bracelet
       product_id: 19532
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
+    - skill: magic
+      level: 93
+      xp: 110
+      materials:
+        - item_name: Zenyte bracelet
+          item_id: 19532
+          quantity: 1
+        - item_name: Cosmic rune
+          item_id: 564
+          quantity: 1
+        - item_name: Soul rune
+          item_id: 566
+          quantity: 20
+        - item_name: Blood rune
+          item_id: 565
+          quantity: 20
+      product: Tormented bracelet
+      product_id: 19544
   related_items:
     - item_id: 19493
       item_name: Zenyte
@@ -41,7 +77,7 @@ osrs:
       item_name: Tormented bracelet
       slug: tormented-bracelet
       relationship: upgrade
-      description: Enchanted version
+      description: Enchanted BiS magic gloves
     - item_id: 19538
       item_name: Zenyte necklace
       slug: zenyte-necklace
@@ -52,26 +88,32 @@ osrs:
       slug: zenyte-amulet
       relationship: alternative
       description: Amulet version
-  about: |-
-    Craft with gold bar and zenyte at a furnace (95 Crafting, 180 XP).
-
-    | Material | Quantity |
-    |----------|----------|
-    | Gold bar | 1 |
-    | Zenyte | 1 |
-
-    No combat bonuses (unenchanted).
-
-    Intermediate Item:
-    - Enchant into Tormented bracelet
-    - Requires Lvl-7 Enchant (93 Magic)
   market_strategy:
     notes:
       - Zenyte from demonic gorillas
-      - Enchant for BiS magic gloves
-      - High crafting requirement
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Enchant to Tormented bracelet (BiS magic gloves)
+      - 95 Crafting requirement gates production
+  history:
+    - date: "2020-09-10"
+      update: Buy limit reduction
+      description: GE buy limit reduced from 10,000 to 8 per day.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "6 May 2016"
+    update: Monkey Madness II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  about: Zenyte bracelet is the unenchanted intermediate crafted at 95 Crafting; enchant for the Tormented bracelet.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Second batch — migrate 50 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Reshape `equipment.stats.*` → `equipment.{attack_bonus,defence_bonus,other_bonus}.*` per the v3 Zod schema.
- Add v3 `properties` block (release_date, update, weight, options, alchable, etc.), `material` classification, structured `drop_table` / `shops` / `recipes` / `treasure_trail` / `teleport` / `farming` / `construction`, condensed single-line `about`, and `history` block from the wiki Changes section.

Validated locally via `astro sync` — content collection compiles clean.

## Items (50)

raw-pyre-fox, steel-brutal, ring-of-endurance-uncharged, willow-comp-bow, black-skirt-g, armadyl-cloak, steel-dart-p-5637, tormented-ornament-kit, desert-shirt, shield-left-half, divine-ranging-potion-4, relicym-s-mix-1, tribal-top-yellow, orange-sapling, team-cape-zero, greater-demon-mask, jade-amulet-u, old-school-bond, mithril-knife, carrallanger-teleport-tablet, super-def-mix-2, boat-bottle-empty, plant-cure, sinew, mithril-dart-p, dragon-arrow-p-11229, apprentice-wand, rune-javelin, dragon-arrowtips, gilded-kiteshield, cooked-chompy-roasted, adamantite-limbs, choc-saturday, iron-platebody, onyx-bolts, blood-pint, raw-mud-pie, trinket-of-avarice, tall-box-hedge-bagged, goading-potion-3, opal-bolt-tips, shorts-yellow, black-scimitar, shade-robe-top, cowhide, maple-longbow-u, bass, zenyte-bracelet, sunlight-antler-bolts, teak-dresser-flatpack.

## Test plan

- [x] `astro sync` clean — content collection schema validates all 50 entries.
- [ ] Smoke-check a few pages on preview (e.g. `/osrs/black-scimitar`, `/osrs/old-school-bond`, `/osrs/goading-potion-3`).
- [ ] CI build green.

## Follow-ups

- ~4223 v2 items remain after this batch lands. Same template applies for the next 50.