### PR TITLE
test(astro-kbve): mobile-safari + webkit + mobile-chrome Playwright projects

### DIFF
--- a/apps/kbve/astro-kbve/playwright.config.ts
+++ b/apps/kbve/astro-kbve/playwright.config.ts
@@ -21,6 +21,18 @@ export default defineConfig({
 			name: 'chromium',
 			use: { ...devices['Desktop Chrome'] },
 		},
+		{
+			name: 'webkit',
+			use: { ...devices['Desktop Safari'] },
+		},
+		{
+			name: 'mobile-chrome',
+			use: { ...devices['Pixel 7'] },
+		},
+		{
+			name: 'mobile-safari',
+			use: { ...devices['iPhone 14'] },
+		},
 	],
 	webServer: {
 		command: `python3 -m http.server ${port} --directory "${distDir}"`,


### PR DESCRIPTION
Closes #11584 — part of tracker #11583.

## Summary
- Adds three Playwright project profiles to `apps/kbve/astro-kbve/playwright.config.ts`:
  - `webkit` (Desktop Safari)
  - `mobile-chrome` (Pixel 7)
  - `mobile-safari` (iPhone 14)
- Existing `chromium` project untouched.

## Why
PR #11578 fixed a mobile-only Argo dashboard bug that the desktop-Chrome-only Playwright suite missed entirely. This adds the device profiles needed for the dashboard e2e (#11585) and visual regression (#11598) work to assert UA-specific behavior.

## Test plan
- [ ] `pnpm exec playwright install webkit chromium` locally before first run
- [ ] `pnpm exec playwright test --config=apps/kbve/astro-kbve/playwright.config.ts` — existing `towerdefense.spec.ts` runs against all 4 projects
- [ ] CI: nx `astro-kbve:e2e` target picks up new projects automatically