### PR TITLE
ci(actionlint): gate workflow changes with actionlint + shellcheck (#11599)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+self-hosted-runner:
+    labels:
+        - arc-runner-set
+        - arc-runner-ue
+        - arc-runner-ue-mac
+        - UE5-Mac
+        - UE5-Win
+
+config-variables: null

--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -1,0 +1,99 @@
+name: CI - Actionlint
+
+on:
+    pull_request:
+        branches:
+            - dev
+            - main
+        paths:
+            - '.github/workflows/**'
+            - '.github/actions/**'
+            - '.github/workflows/ci-actionlint.yml'
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+    actionlint:
+        name: actionlint + shellcheck
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Download actionlint
+              id: actionlint
+              run: |
+                  set -euo pipefail
+                  bash <(curl --silent --show-error --fail \
+                      https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+                  echo "bin=$PWD/actionlint" >> "$GITHUB_OUTPUT"
+
+            - name: Verify shellcheck is on PATH
+              run: shellcheck --version
+
+            - name: Run actionlint
+              env:
+                  ACTIONLINT: ${{ steps.actionlint.outputs.bin }}
+              run: |
+                  set -euo pipefail
+                  "$ACTIONLINT" -color -shellcheck 'shellcheck -S error'
+
+    zizmor:
+        name: zizmor (informational)
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        permissions:
+            contents: read
+        continue-on-error: true
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  github-token: ${{ github.token }}
+
+            - name: Run zizmor (offline audits only, informational)
+              run: |
+                  set -euo pipefail
+                  uvx zizmor==1.8.0 --persona=regular --no-online-audits \
+                      --format plain .github/workflows
+
+    track_failure:
+        name: Track Failures
+        if: ${{ always() && contains(needs.*.result, 'failure') }}
+        needs: [actionlint]
+        permissions:
+            issues: write
+            contents: read
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@main
+        with:
+            workflow_name: 'CI - Actionlint'
+            job_name: 'actionlint'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: 'failure'
+
+    track_success:
+        name: Track Success
+        if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        needs: [actionlint]
+        permissions:
+            issues: write
+            contents: read
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@main
+        with:
+            workflow_name: 'CI - Actionlint'
+            job_name: 'actionlint'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: 'success'

--- a/.github/workflows/ci-bevy-game.yml
+++ b/.github/workflows/ci-bevy-game.yml
@@ -182,7 +182,11 @@ jobs:
               id: feats
               run: |
                   FEATS=$(echo '${{ inputs.features }}' | jq -r 'join(",")')
-                  echo "args=$([ -n \"$FEATS\" ] && echo \"--features $FEATS\" || true)" >> "$GITHUB_OUTPUT"
+                  if [ -n "$FEATS" ]; then
+                      echo "args=--features $FEATS" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "args=" >> "$GITHUB_OUTPUT"
+                  fi
             - name: cargo build --release
               working-directory: ${{ inputs.project_path }}
               run: cargo build --release --bin ${{ inputs.app_name }} --target ${{ matrix.target }} ${{ steps.feats.outputs.args }}

--- a/.github/workflows/ci-ue-win-setup.yml
+++ b/.github/workflows/ci-ue-win-setup.yml
@@ -43,6 +43,9 @@ jobs:
     install:
         name: Install on UE5-Win
         runs-on: UE5-Win
+        defaults:
+            run:
+                shell: pwsh
         env:
             FILE_SERVER: http://file-server.angelscript.svc:8080
         steps:

--- a/.github/workflows/ci-ue5-rows.yml
+++ b/.github/workflows/ci-ue5-rows.yml
@@ -11,6 +11,9 @@ on:
             epic_pat:
                 description: 'PAT with access to ghcr.io/epicgames/unreal-engine and game repo (falls back to UNITY_PAT)'
                 required: false
+            UNITY_PAT:
+                description: 'Fallback org-level PAT used when epic_pat is not provided'
+                required: false
     workflow_dispatch:
         inputs:
             shell_path:
@@ -356,7 +359,7 @@ jobs:
     track_failure:
         name: Track Failures
         if: ${{ always() && contains(needs.*.result, 'failure') }}
-        needs: [build, version_gate]
+        needs: [config, build, version_gate]
         permissions:
             issues: write
             contents: read

--- a/.github/workflows/utils-file-alterations.yml
+++ b/.github/workflows/utils-file-alterations.yml
@@ -130,9 +130,6 @@ on:
             laser:
                 description: 'Laser package changed'
                 value: ${{ jobs.alter.outputs.laser }}
-            worker:
-                description: 'Worker changed'
-                value: ${{ jobs.alter.outputs.worker }}
             edge:
                 description: 'Edge functions changed'
                 value: ${{ jobs.alter.outputs.edge }}

--- a/.github/workflows/utils-godot-itch-build-pipeline.yml
+++ b/.github/workflows/utils-godot-itch-build-pipeline.yml
@@ -17,7 +17,6 @@ on:
                 description: 'Godot version to use for the build'
                 required: true
                 type: string
-                default: '4.3'
             export_name:
                 description: 'Export name for the build'
                 required: true

--- a/.github/workflows/utils-unreal-plugin-cicd.yml
+++ b/.github/workflows/utils-unreal-plugin-cicd.yml
@@ -75,9 +75,6 @@ on:
             should_release:
                 description: 'Whether a new release was created'
                 value: ${{ jobs.version-check.outputs.should_release }}
-            build_result:
-                description: 'Build job result'
-                value: ${{ jobs.build.result }}
 
 permissions: {}
 

--- a/.github/workflows/utils-unreal-plugin-win-cicd.yml
+++ b/.github/workflows/utils-unreal-plugin-win-cicd.yml
@@ -76,9 +76,6 @@ on:
             should_release:
                 description: 'Whether a new release was created'
                 value: ${{ jobs.version-check.outputs.should_release }}
-            build_result:
-                description: 'Build job result'
-                value: ${{ jobs.build.result }}
 
 permissions: {}
 
@@ -202,6 +199,9 @@ jobs:
         if: needs.guard.outputs.allowed == 'true'
         runs-on: ${{ inputs.runner }}
         timeout-minutes: ${{ inputs.build_timeout }}
+        defaults:
+            run:
+                shell: pwsh
         permissions:
             contents: read
         steps:


### PR DESCRIPTION
Closes #11599.

## Summary

- Adds `.github/workflows/ci-actionlint.yml` — runs `actionlint` (pinned `v1.7.7`) with the shellcheck plugin (`shellcheck -S error`) on every PR that touches `.github/workflows/**` or `.github/actions/**`. Wires the existing `utils-ci-failure-tracker.yml` for failure/success tracking, matching `ci-security.yml`.
- Adds a second job that runs `zizmor` via `uvx` as `continue-on-error: true` — the stretch security-audit acceptance, informational until the noise floor is known.
- Adds `.github/actionlint.yaml` declaring the repo's self-hosted runner labels (`arc-runner-set`, `arc-runner-ue`, `arc-runner-ue-mac`, `UE5-Win`, `UE5-Mac`) so they stop being flagged as unknown.
- The second acceptance criterion (manifest sync) is already covered by `.github/workflows/ci-manifest-guard.yml`, which runs `astro-kbve:sync:ci-manifest` and diffs `.github/ci-dispatch-manifest.json` on every PR.

## Surgical fixes to keep the gate green on landing

| File | Fix |
|---|---|
| `ci-bevy-game.yml:183` | Replace YAML-escaped `[ -n \"$FEATS\" ]` one-liner with a plain `if` — SC2070 was a real shellcheck bug. |
| `ci-ue-win-setup.yml`, `utils-unreal-plugin-win-cicd.yml` | Declare `defaults.run.shell: pwsh` on the Windows-runner jobs so actionlint stops running shellcheck against PowerShell. |
| `ci-ue5-rows.yml` | Declare the previously-undeclared `UNITY_PAT` workflow_call secret (referenced as the `epic_pat` fallback) and add `config` to `track_failure.needs` so `needs.config.outputs.server_target` resolves. |
| `utils-file-alterations.yml` | Drop the dead `worker` workflow_call output — no `worker` output on the `alter` job, no consumer. |
| `utils-godot-itch-build-pipeline.yml` | Drop `default: '4.3'` on `godot_version` — input is `required: true`, so the default is never used. |
| `utils-unreal-plugin-cicd.yml`, `utils-unreal-plugin-win-cicd.yml` | Drop dead `build_result` workflow_call output — `\${{ jobs.build.result }}` isn't valid as a reusable-workflow output value, and nothing consumes it. |

## Verified locally

- \`actionlint -shellcheck 'shellcheck -S error'\` exits 0 across all 57 workflows after the fixes.
- \`actionlint\` self-lints \`ci-actionlint.yml\` clean.

## Test plan

- [ ] CI - Actionlint job runs on this PR (touches `.github/workflows/**`) and stays green
- [ ] CI - Manifest Guard remains green (untouched, but doc'd here as covering AC#2)
- [ ] Zizmor job runs and posts findings without blocking