### PR TITLE
test(astro-kbve): Playwright visual regression baselines via toHaveScreenshot

### DIFF
--- a/apps/kbve/astro-kbve/e2e/README.md
+++ b/apps/kbve/astro-kbve/e2e/README.md
@@ -1,0 +1,75 @@
+# astro-kbve e2e
+
+Playwright suite for the astro-kbve app. Runs against the static build under `dist/apps/astro-kbve/` via `python3 -m http.server`.
+
+## Projects
+
+| Project         | Device profile | Notes                     |
+| --------------- | -------------- | ------------------------- |
+| `chromium`      | Desktop Chrome | Default desktop coverage  |
+| `webkit`        | Desktop Safari | UA-specific behaviors     |
+| `mobile-chrome` | Pixel 7        | Touch + mobile viewport   |
+| `mobile-safari` | iPhone 14      | Touch + iOS Safari quirks |
+
+## Run
+
+```sh
+./kbve.sh -nx run astro-kbve:e2e
+```
+
+Or directly:
+
+```sh
+cd apps/kbve/astro-kbve
+pnpm exec playwright test --config=playwright.config.ts
+```
+
+## Visual regression (`toHaveScreenshot`)
+
+Baselines committed under `e2e/__screenshots__/<projectName>/<testFile>/<arg>.png`.
+
+Threshold: `maxDiffPixelRatio: 0.02` (2%) — permissive on first land, tighten as flakes drop.
+
+### Update baselines
+
+After an intentional UI change:
+
+```sh
+cd apps/kbve/astro-kbve
+pnpm exec playwright test --config=playwright.config.ts --update-snapshots
+```
+
+Then commit the regenerated PNGs under `e2e/__screenshots__/`.
+
+For one project at a time:
+
+```sh
+pnpm exec playwright test --project=mobile-safari --update-snapshots
+```
+
+### CI rebase loop
+
+If a PR breaks a screenshot, the CI run uploads a `playwright-report` artifact with the diff image. Two paths forward:
+
+1. The change was unintentional — fix the regression in the PR.
+2. The change was intentional — pull the PR branch, run `--update-snapshots`, commit the new PNGs.
+
+## Auth-mock fixture
+
+`e2e/fixtures/auth-mock.ts` seeds `localStorage['sb-auth-token']` with a synthetic Supabase session before page load, so dashboards that gate on `getSession()` render their authenticated state without hitting the real GoTrue.
+
+```ts
+import {
+	test,
+	expect,
+	mockSupaSession,
+	mockArgoApi,
+} from './fixtures/auth-mock';
+
+test('argo authenticated load', async ({ page }) => {
+	await mockSupaSession(page, { staff: true });
+	await mockArgoApi(page, [{ name: 'example-app' }]);
+	await page.goto('/dashboard/argo/');
+	// ...
+});
+```

--- a/apps/kbve/astro-kbve/e2e/visual.spec.ts
+++ b/apps/kbve/astro-kbve/e2e/visual.spec.ts
@@ -1,0 +1,60 @@
+import {
+	test,
+	expect,
+	mockSupaSession,
+	mockArgoApi,
+} from './fixtures/auth-mock';
+
+test.describe('visual regression — dashboards', () => {
+	test.beforeEach(async ({ page }) => {
+		await mockSupaSession(page, { staff: true });
+		await mockArgoApi(page, [
+			{
+				name: 'app-alpha',
+				project: 'platform',
+				syncStatus: 'Synced',
+				healthStatus: 'Healthy',
+			},
+			{
+				name: 'app-beta',
+				project: 'data',
+				syncStatus: 'OutOfSync',
+				healthStatus: 'Degraded',
+			},
+		]);
+	});
+
+	test('argo dashboard — full page', async ({ page }) => {
+		await page.goto('/dashboard/argo/', { waitUntil: 'load' });
+		await expect(page.locator('button.kbve-argo-row').first()).toBeVisible({
+			timeout: 30_000,
+		});
+		await expect(page).toHaveScreenshot('argo-dashboard.png', {
+			fullPage: true,
+		});
+	});
+
+	test('argo dashboard — row expanded', async ({ page }) => {
+		await page.goto('/dashboard/argo/', { waitUntil: 'load' });
+		const firstRow = page.locator('button.kbve-argo-row').first();
+		await expect(firstRow).toBeVisible({ timeout: 30_000 });
+		await firstRow.click();
+		await expect(firstRow).toHaveAttribute('aria-expanded', 'true');
+		await expect(page).toHaveScreenshot('argo-dashboard-expanded.png', {
+			fullPage: true,
+		});
+	});
+});
+
+test.describe('visual regression — yuki dock', () => {
+	test.beforeEach(async ({ page }) => {
+		await mockSupaSession(page);
+	});
+
+	test('yuki dock — collapsed', async ({ page }) => {
+		await page.goto('/', { waitUntil: 'load' });
+		const dock = page.locator('[data-yuki-dock], #yuki-dock').first();
+		await expect(dock).toBeVisible({ timeout: 30_000 });
+		await expect(dock).toHaveScreenshot('yuki-dock-collapsed.png');
+	});
+});

--- a/apps/kbve/astro-kbve/playwright.config.ts
+++ b/apps/kbve/astro-kbve/playwright.config.ts
@@ -12,6 +12,15 @@ export default defineConfig({
 	retries: process.env['CI'] ? 1 : 0,
 	workers: 1,
 	reporter: process.env['CI'] ? 'line' : 'list',
+	snapshotPathTemplate:
+		'{testDir}/__screenshots__/{projectName}/{testFilePath}/{arg}{ext}',
+	expect: {
+		toHaveScreenshot: {
+			maxDiffPixelRatio: 0.02,
+			animations: 'disabled',
+			caret: 'hide',
+		},
+	},
 	use: {
 		trace: 'on-first-retry',
 		baseURL,
@@ -20,6 +29,18 @@ export default defineConfig({
 		{
 			name: 'chromium',
 			use: { ...devices['Desktop Chrome'] },
+		},
+		{
+			name: 'webkit',
+			use: { ...devices['Desktop Safari'] },
+		},
+		{
+			name: 'mobile-chrome',
+			use: { ...devices['Pixel 7'] },
+		},
+		{
+			name: 'mobile-safari',
+			use: { ...devices['iPhone 14'] },
 		},
 	],
 	webServer: {


### PR DESCRIPTION
Closes #11598 — part of tracker #11592.

## Summary
- `playwright.config.ts`:
  - `snapshotPathTemplate` → `e2e/__screenshots__/<projectName>/<testFile>/<arg>.png` (per-project subdirs so cross-UA differences don't churn)
  - `expect.toHaveScreenshot` defaults: `maxDiffPixelRatio: 0.02`, `animations: 'disabled'`, `caret: 'hide'` — permissive on first land
  - Adds `webkit`, `mobile-chrome`, `mobile-safari` projects alongside `chromium`
- `e2e/visual.spec.ts`: Argo dashboard (collapsed + expanded) and Yuki dock baselines
- `e2e/README.md`: projects table, `--update-snapshots` rebase loop, auth-mock fixture usage

## Why
`toHaveScreenshot()` shipped with Playwright but unused. PR #11578's mobile grid-overflow would have been an obvious screenshot diff if a baseline existed.

## Baselines
Not committed in this PR — first post-merge CI run captures them per-project. Contributors then regenerate after intentional UI changes via:

```sh
pnpm exec playwright test --config=apps/kbve/astro-kbve/playwright.config.ts --update-snapshots
```

## Dependencies
- **Requires #11584** — mobile/webkit projects (this PR also includes them, but #11584 lands first)
- **Requires #11585** — Argo row selectors used in visual spec
- **Requires #11586** — `mockSupaSession` + `mockArgoApi` fixtures

⚠️ Will conflict with #11584 (overlapping `playwright.config.ts` edit). Resolve by rebasing this branch on dev after #11584 lands.

## Test plan
- [ ] Rebase on dev after #11584, #11585, #11586 land
- [ ] First run: `pnpm exec playwright test visual.spec.ts --update-snapshots`
- [ ] Commit generated PNGs under `apps/kbve/astro-kbve/e2e/__screenshots__/`
- [ ] CI fails on >2% pixel diff