### PR TITLE
ci(actionlint): bump pin 1.7.7 → 1.7.12 to drop stale 10-input cap (closes #11636)

### DIFF
--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -33,7 +33,7 @@ jobs:
               run: |
                   set -euo pipefail
                   bash <(curl --silent --show-error --fail \
-                      https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+                      https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
                   echo "bin=$PWD/actionlint" >> "$GITHUB_OUTPUT"
 
             - name: Verify shellcheck is on PATH


### PR DESCRIPTION
Closes #11636.

## Summary

The CI - Actionlint gate landed in #11634 pinned to actionlint v1.7.7. That version still enforces the legacy "workflow_dispatch supports at most 10 inputs" rule, which fired on the first PR after the gate landed (#11636) against these existing workflows:

| Workflow | Inputs |
|---|---|
| \`ci-godot.yml\` | 13 |
| \`ci-publish.yml\` | 13 |
| \`ci-unity.yml\` | 16 |
| \`ci-unreal-game.yml\` | 14 |

GitHub's runtime accepts >10 \`workflow_dispatch\` inputs in practice (these workflows have been dispatchable all along), and newer actionlint releases drop the cap. The cleanest fix is to ride the upstream relaxation rather than churn each workflow's dispatch surface.

This bumps the actionlint pin (and the URL the install script is sourced from) v1.7.7 → v1.7.12.

## Verified

- \`actionlint -shellcheck 'shellcheck -S error'\` exits 0 across all workflows on v1.7.12 locally.
- No new diagnostics introduced by v1.7.12 in this repo.

## Test plan

- [ ] CI - Actionlint job runs on this PR and stays green
- [ ] #11636's failure tracker auto-closes after a green run