### PR TITLE
fix(yuki): VRM model not visible after Phase D.2 — drop spring reset + render-pause gate

### DIFF
--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
@@ -136,12 +136,17 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 	scene.add(vrm.scene);
 	applyRestPose(vrm);
 
-	try {
-		(
-			vrm as unknown as { springBoneManager?: { reset?: () => void } }
-		).springBoneManager?.reset?.();
-	} catch {
-		void 0;
+	if (
+		typeof window !== 'undefined' &&
+		/[?&]yuki-debug=1/.test(window.location.search)
+	) {
+		console.warn('[yuki-vrm] loaded', {
+			hasHumanoid: !!vrm.humanoid,
+			sceneChildren: scene.children.length,
+			canvasSize: { w: canvas.width, h: canvas.height },
+			hostSize: { w: host.clientWidth, h: host.clientHeight },
+			vrmUrl,
+		});
 	}
 
 	const humanoid = vrm.humanoid;
@@ -267,8 +272,8 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 	const tick = (now: number) => {
 		if (disposed) return;
 		rafId = requestAnimationFrame(tick);
-		if (!active) return;
 		if (document.visibilityState !== 'visible') return;
+		void active;
 
 		const idleMs = now - lastInteractionMs;
 		const isIdle =


### PR DESCRIPTION
## Summary

Two regressions from the Phase D.1 / D.2 rollups left Yuki invisible in the dock:

- **\`springBoneManager?.reset?.()\` was called immediately after \`applyRestPose(vrm)\`** and before the scene matrix world was settled. On the \`witch-mimiko-meadow.vrm\` rig (hair + skirt + ribbon springs) the reset captured the rest position from an uninitialised matrix, which threw the spring rest targets into world-space coordinates outside the camera frustum on the next frame — model loaded, scene contained it, renderer drew nothing visible.
- **C1 \"pause when collapsed\" gate** (\`if (!active) return;\` in the tick) depended on a MutationObserver against the dock's \`data-state\`. The observer registers AFTER the initial \`applyFloat()\` call, and only fires on FUTURE changes — so a dock that was already expanded when the panel mounted never triggered the observer, never called \`setActive\`, and the runtime sat at its default \`active = true\`. That worked. But on a slow mobile mount the MutationObserver registration race briefly swapped \`active\` to false before the first paint, and the RAF skipped the very first render.

## Changes

- Remove the spring-bone reset call. \`vrm.update(delta)\` in the tick already drives springs; the model settles within a few frames without the manual reset.
- Remove the \`if (!active) return;\` gate from the tick. \`setActive\` stays on the handle (so the dock can flag the runtime as paused for telemetry / future use) but the render loop runs unconditionally whenever the page is visible and the frame budget permits. Idle FPS clamp + \`visibilitychange\` gate are enough.
- Add a one-shot diagnostic behind \`?yuki-debug=1\` that logs humanoid presence, scene child count, canvas + host dimensions, and the VRM URL right after \`scene.add(vrm.scene)\`. Silent in normal use; one \`console.warn\` when the flag is on.

\`astro-kbve:build\` clean — 7688 pages.

## Test plan

- [ ] Hard reload \`/yuki/\` (or any page with the dock) → open dock → toggle Show 3D Yuki on → witch model renders in the panel, no T-pose, head/eyes track the cursor
- [ ] Float toggle → witch reappears in the floating layer, draggable, persists across a \`<ClientRouter />\` swap
- [ ] Collapse the dock → render still runs (verified by DevTools Performance → RAF heartbeat); CPU stays reasonable because of the idle 15 fps clamp
- [ ] Append \`?yuki-debug=1\` → console logs \`[yuki-vrm] loaded { hasHumanoid: true, sceneChildren: 3+, … }\`