### PR TITLE
content(astro-kbve): bump 100 OSRS items v2 → v3 (batch 3)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrow-p-21336.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrow-p-21336.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 196
   highalch: 294
   limit: 11000
-  about: "Amethyst arrow(p++) is a members-only item in Old School RuneScape. High alchemy value: 294 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: mid-high
+  equipment:
+    slot: ammo
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 55
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Amethyst arrow
+          item_id: 21332
+          quantity: 1
+        - item_name: Weapon poison(++)
+          item_id: 5954
+          quantity: 1
+      product: Amethyst arrow(p++)
+      product_id: 21336
+      product_quantity: 1
+      facility: Inventory
+  related_items:
+    - item_id: 21332
+      item_name: Amethyst arrow
+      slug: amethyst-arrow
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 21334
+      item_name: Amethyst arrow(p+)
+      slug: amethyst-arrow-p-plus
+      relationship: alternative
+      description: Lower poison tier
+    - item_id: 892
+      item_name: Rune arrow
+      slug: rune-arrow
+      relationship: alternative
+      description: Weaker (+49 ranged strength)
+    - item_id: 11212
+      item_name: Dragon arrow
+      slug: dragon-arrow
+      relationship: upgrade
+      description: Stronger (+60 ranged strength)
+  about: Amethyst arrow(p++) is a venomous amethyst-tipped arrow used with magic shortbow or stronger, applying the stronger weapon poison++ effect for boss and high-level Ranged tasks.
+  market_strategy:
+    notes:
+      - Niche poisoned amethyst variant
+      - Magic shortbow and Twisted bow compatible
+      - Demand tied to venom-immune content avoidance
+  history:
+    - date: "2017-06-22"
+      update: Mining Guild Expansion
+      description: Amethyst arrow line introduced.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: 22 June 2017
+    update: Mining Guild Expansion
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory-t6.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory-t6.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 5
-  about: "Amulet of glory (t6) is a members-only item in Old School RuneScape. High alchemy value: 10,575 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: neck
+    weight: 0.01
+    attack_bonus:
+      stab: 10
+      slash: 10
+      crush: 10
+      magic: 10
+      ranged: 10
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
+    other_bonus:
+      melee_strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 3
+  charges:
+    type: teleport
+    base_uses_per_charge: 1
+    notes: Trimmed glory shares the standard glory teleport charge pool (4 at Heroes' Guild fountain, 6 at Fountain of Rune).
+  teleport:
+    destinations:
+      - Edgeville
+      - Karamja
+      - Draynor Village
+      - Al Kharid
+  treasure_trail:
+    tier: hard
+    rarity: "1/1,625 per slot"
+  related_items:
+    - item_id: 1712
+      item_name: Amulet of glory
+      slug: amulet-of-glory
+      relationship: alternative
+      description: Standard untrimmed version
+    - item_id: 19707
+      item_name: Amulet of eternal glory
+      slug: amulet-of-eternal-glory
+      relationship: upgrade
+      description: Infinite-charge variant
+  about: Amulet of glory (t6) is the Hard Treasure Trail trimmed variant of the glory amulet, identical in combat stats to the standard glory but cosmetically distinct and untradeable for ironman trail completion.
+  market_strategy:
+    notes:
+      - Hard Treasure Trail supply only
+      - Fashionscape / collector demand
+      - 5/day GE limit thins flips
+      - High alch floor at 10,575 gp
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 0.01
+    options:
+      - Wear
+      - Rub
+      - Drop
+    worn_options:
+      - Remove
+      - Rub
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anglerfish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anglerfish.mdx
@@ -12,26 +12,15 @@ osrs:
   lowalch: 180
   highalch: 270
   limit: 10000
+  material:
+    type: fish
+    tier: high
   food:
     heals: 22
     cooking_level: 84
     cooking_xp: 230
     burn_level: 99
     special_effect: Can overheal above max HP (outside PvP)
-  cooking:
-    level: 84
-    xp: 230
-    stop_burn_level: 99
-    stop_burn_level_gauntlets: 84
-    raw_item_id: 13439
-    raw_item_name: Raw anglerfish
-    ticks: 4
-  fishing:
-    level: 82
-    xp: 120
-    method: Fishing rod
-    location: Port Piscarilius
-    bait: Sandworms
   recipes:
     - skill: cooking
       level: 84
@@ -64,18 +53,10 @@ osrs:
       slug: saradomin-brew-4
       relationship: alternative
       description: Percentage-based healing
-  about: |-
-    Anglerfish can overheal above max HP (outside PvP):
-
-    | Hitpoints Level | Heal Amount | Max HP |
-    |-----------------|-------------|--------|
-    | 75 | 19 | 94 |
-    | 85 | 20 | 105 |
-    | 93+ | 22 | 115+ |
-    | 99 | 22 | 121 |
+  about: Anglerfish heals up to 22 HP and uniquely overheals above max HP outside PvP, making it a premium pre-fight food for raids, Inferno, and high-end Slayer.
   market_strategy:
     notes:
-      - Buy Raw anglerfish → Cook → Sell
+      - Buy Raw anglerfish, cook, sell
       - 84+ Cooking required, burns until 99 without gauntlets
       - Pre-fight overheal for bosses
       - Inferno attempts
@@ -84,8 +65,31 @@ osrs:
       - Premium price over sharks
       - Essential for difficult PvM
       - Caught at Port Piscarilius (Kourend)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2016-01-07"
+      update: Zeah
+      description: Released with Zeah.
+    - date: "2018-11-01"
+      description: Overheal restricted in Wilderness and PvP areas.
+    - date: "2020-09-01"
+      description: Overheal allowed in Target Worlds outside Wilderness.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: Zeah
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-poison-supermix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-poison-supermix-2.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 86
   highalch: 129
   limit: 2000
-  about: "Anti-poison supermix(2) is a members-only item in Old School RuneScape. High alchemy value: 129 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - skill: Poison
+        description: Grants poison immunity for 6 minutes per dose.
+      - skill: Hitpoints
+        description: Restores 6 Hitpoints per dose.
+  recipes:
+    - skill: Herblore
+      level: 51
+      xp: 35
+      product: Anti-poison supermix(2)
+      quantity: 1
+      requirements: Completion of Barbarian Herblore training with Otto Godblessed.
+      materials:
+        - item_name: Superantipoison(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+  drop_table:
+    sources:
+      - source: Ferocious barbarian spirit
+        combat_level: 166
+        quantity: "1"
+        rarity: rare
+        members_only: true
+      - source: Chewed bones
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+  related_items:
+    - item_id: 11471
+      item_name: Anti-poison supermix(1)
+      slug: anti-poison-supermix-1
+      relationship: downgrade
+      description: One-dose variant
+    - item_id: 2181
+      item_name: Superantipoison(2)
+      slug: superantipoison-2
+      relationship: component
+      description: Base potion for the mix
+    - item_id: 7944
+      item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Fishy ingredient
+  market_strategy:
+    notes:
+      - Niche barbarian herblore product
+      - Combines antipoison with healing
+      - Steady demand from PvM HCIM
+  history:
+    - date: "2016-04-15"
+      description: Half-full potions became bankable as placeholders.
+    - date: "2015-02-26"
+      description: Renamed from "Anti-p supermix" to the full title.
+    - date: "2007-07-03"
+      description: Released with Barbarian Training.
+  about: A two-dose barbarian potion that grants poison immunity for six minutes and heals six Hitpoints per dose, brewed by mixing caviar into superantipoison.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.075
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-3.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 132
   highalch: 198
   limit: 2000
-  about: "Anti-venom(3) is a members-only item in Old School RuneScape. High alchemy value: 198 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid-high
+  potion:
+    doses: 3
+    effects:
+      - description: Instantly cures venom and poison
+      - description: Grants 12 minutes of poison immunity
+      - description: Grants 36-54 seconds of venom immunity
+  recipes:
+    - skill: herblore
+      level: 87
+      xp: 90
+      materials:
+        - item_name: Antidote++(3)
+          item_id: 0
+          quantity: 1
+        - item_name: Zulrah's scales
+          item_id: 12934
+          quantity: 15
+      facility: Inventory
+      members_only: true
+  related_items:
+    - item_id: 12905
+      item_name: Anti-venom(1)
+      slug: anti-venom-1
+      relationship: variant
+      description: Single-dose version
+    - item_id: 12906
+      item_name: Anti-venom(2)
+      slug: anti-venom-2
+      relationship: variant
+      description: Two-dose version
+    - item_id: 12908
+      item_name: Anti-venom(4)
+      slug: anti-venom-4
+      relationship: variant
+      description: Four-dose version
+    - item_id: 12913
+      item_name: Anti-venom+(4)
+      slug: anti-venom-plus-4
+      relationship: upgrade
+      description: Upgrade with torstol at 94 Herblore
+  about: Anti-venom(3) is a three-dose potion that instantly cures venom and poison, providing 12 minutes of poison immunity and short venom immunity.
+  market_strategy:
+    notes:
+      - Required for Zulrah and venom content
+      - Crafted from Antidote++ + Zulrah's scales
+      - 87 Herblore gates supply
+      - Dose decanting affects price across (1)-(4)
+      - Stable demand during venomous boss events
+  history:
+    - date: "2015-01-08"
+      update: Released with Zulrah
+      description: Released with Zulrah
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-01-08"
+    update: Zulrah
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-2-5956.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-2-5956.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 86
   highalch: 129
   limit: 4000
-  about: "Antidote++(2) is a members-only item in Old School RuneScape. High alchemy value: 129 coins. Grand Exchange buy limit: 4,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: Cures poison instantly on drink.
+      - description: Grants 12 minutes of poison immunity per dose.
+      - description: Grants 18-36 seconds of venom immunity per dose; two doses cure active venom.
+  recipes:
+    - skill: herblore
+      level: 79
+      xp: 88.75
+      materials:
+        - item_name: Antidote++(3)
+          item_id: 5954
+          quantity: 1
+      product: Antidote++(2)
+      product_id: 5956
+      product_quantity: 1
+      facility: Inventory
+  related_items:
+    - item_id: 5952
+      item_name: Antidote++(4)
+      slug: antidote-4
+      relationship: upgrade
+      description: Full 4-dose version
+    - item_id: 5954
+      item_name: Antidote++(3)
+      slug: antidote-3
+      relationship: alternative
+      description: 3-dose variant
+    - item_id: 5958
+      item_name: Antidote++(1)
+      slug: antidote-1
+      relationship: downgrade
+      description: Single-dose variant
+  about: Antidote++(2) is a 2-dose members antipoison brewed at 79 Herblore that cures poison, grants 12 minutes of poison immunity per dose, and partially counters venom.
+  market_strategy:
+    notes:
+      - 79 Herblore gates supply
+      - Slayer/PvM demand drives volume
+      - Coconut milk supply caps margins
+      - Used vs Zulrah, Vorkath, venom raids
+  history:
+    - date: "2016-04-07"
+      update: Drinking any kind of antipoison will no longer decrease your poison immunity.
+      description: Drinking any kind of antipoison will no longer decrease your poison immunity.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ape-atoll-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ape-atoll-teleport-tablet.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Ape atoll teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Ape Atoll cave (south of island)
+    type: tablet
+    quest_requirement: Monkey Madness I (to use destination)
+  recipes:
+    - product: Ape atoll teleport (tablet)
+      skill: Magic
+      level: 90
+      xp: 100
+      facility: Arceuus lectern
+      spellbook: Arceuus
+      materials:
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Soul rune
+          quantity: 2
+        - item_name: Blood rune
+          quantity: 2
+        - item_name: Dark essence block
+          quantity: 1
+  related_items:
+    - item_name: Dark essence block
+      relationship: component
+      description: Required for tablet creation
+    - item_name: Law rune
+      relationship: component
+      description: Runecrafting component
+  about: Ape atoll teleport (tablet) is a members-only Arceuus tablet that teleports the user to the cave on the south side of Ape Atoll.
+  market_strategy:
+    notes:
+      - Created via 90 Magic on the Arceuus spellbook
+      - Steady demand from Slayer and questing players
+      - Skips the standard Monkey Madness teleport pathway
+  history:
+    - date: "2016-05-12"
+      description: Released alongside the Necromancy teleport tablets update
+    - date: "2016-05-19"
+      description: Destination moved from Temple of Marimbo
+    - date: "2017-10-12"
+      description: Examine text updated from generic spell description
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-05-12"
+    update: Necromancy Teleport Tablets
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    alchable: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/aquanite-tendon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/aquanite-tendon.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: null
-  about: "Aquanite tendon is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Aquanite
+        combat_level: 145
+        quantity: "1"
+        rarity: 1/750
+        members_only: true
+      - source: Elder Aquanite
+        combat_level: 305
+        quantity: "1"
+        rarity: 3 x 1/750
+        members_only: true
+  recipes:
+    - product: Aquanite hopper
+      skill: Smithing
+      level: 60
+      xp: 350
+      facility: Anvil
+      materials:
+        - item_name: Aquanite tendon
+          quantity: 1
+        - item_name: Mithril bar
+          quantity: 1
+  related_items:
+    - item_name: Aquanite hopper
+      relationship: product
+      description: Crafted from the tendon and a mithril bar
+    - item_name: Mithril bar
+      relationship: component
+      description: Smithing component for the hopper
+  about: Aquanite tendon is a Sailing-era drop from Aquanites in the Ynysdail Cavern, used in Smithing the aquanite hopper; receiving one broadcasts to the cavern chat.
+  market_strategy:
+    notes:
+      - Rare 1/750 floor drop from Aquanite encounters
+      - No Grand Exchange buy limit currently set
+      - Demand tracks aquanite hopper smithing supply
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing launch
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Inspect
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/banana-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/banana-sapling.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Banana sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    farming_level: 33
+    patch: Fruit tree patch
+    plant_xp: 28
+    check_xp: 1750.5
+    harvest_xp: 10.5
+    growth_time_minutes: 960
+    protection_payment: 4 baskets of apples
+    yield: 6 bananas (regrowable)
+  recipes:
+    - skill: Farming
+      output_name: Banana sapling
+      materials:
+        - item_name: Banana seedling
+          quantity: 1
+      tools:
+        - Watering can
+      notes: Water a banana seedling (or use Humidify) and wait one crop cycle.
+  related_items:
+    - item_id: 5371
+      item_name: Banana tree seed
+      slug: banana-tree-seed
+      relationship: component
+      description: Sown into a plant pot to grow the seedling
+    - item_id: 5371
+      item_name: Banana seedling
+      slug: banana-seedling
+      relationship: component
+      description: Watered to become this sapling
+  market_strategy:
+    notes:
+      - Plant in fruit tree patch at 33 Farming
+      - Disease protection paid with 4 baskets of apples
+      - Strong checking XP per sapling
+      - Buy limit 200/4h, cheap GE flip
+  history:
+    - date: "2015-01-29"
+      description: Became tradeable after a Grand Exchange poll.
+    - date: "2005-07-11"
+      description: Released with the Farming update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming Update
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: true
+  about: Banana sapling is a members-only Farming item planted into a fruit tree patch at 33 Farming, grown from a watered banana seedling.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dragonhide-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dragonhide-set.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 70
-  about: "Black dragonhide set is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hide
+    tier: mid-high
+  recipes:
+    - name: Exchange components via Grand Exchange Sets clerk
+      materials:
+        - item_id: 2503
+          item_name: Black d'hide body
+          quantity: 1
+        - item_id: 2497
+          item_name: Black d'hide chaps
+          quantity: 1
+        - item_id: 2491
+          item_name: Black d'hide vambraces
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_id: 2503
+      item_name: Black d'hide body
+      slug: black-d-hide-body
+      relationship: component
+      description: Body slot piece
+    - item_id: 2497
+      item_name: Black d'hide chaps
+      slug: black-d-hide-chaps
+      relationship: component
+      description: Legs slot piece
+    - item_id: 2491
+      item_name: Black d'hide vambraces
+      slug: black-d-hide-vambraces
+      relationship: component
+      description: Hands slot piece
+  about: Black dragonhide set bundles the black d'hide body, chaps, and vambraces into a single tradeable package via the Grand Exchange Sets clerk.
+  market_strategy:
+    notes:
+      - Spread between set and sum of parts is the only edge
+      - Saves bank space when buying ranged gear in bulk
+      - Low GE limit of 70 caps flipping volume
+  history:
+    - date: "2014-12-10"
+      description: Released with the Trading Post update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-12-10"
+    update: The Trading Post
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-knife-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-knife-p.mdx
@@ -14,24 +14,81 @@ osrs:
   limit: 7000
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
+    weight: 0
     requirements:
       ranged: 10
     attack_bonus:
-      ranged: 8
-    ranged_strength: 8
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 10
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 8
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Herblore
+      output_name: Black knife(p)
+      output_quantity: 5
+      materials:
+        - item_name: Black knife
+          quantity: 5
+        - item_name: Weapon poison
+          quantity: 1
   related_items:
     - item_id: 869
       item_name: Black knife
       slug: black-knife
       relationship: variant
       description: Unpoisoned version
-  about: |-
-    > _"A very sharp black knife with a poisoned tip."_
-
-    A black knife tipped with basic weapon poison. Requires 10 Ranged. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 5654
+      item_name: Black knife(p+)
+      slug: black-knife-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_id: 5664
+      item_name: Black knife(p++)
+      slug: black-knife-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+  market_strategy:
+    notes:
+      - Created by applying Weapon poison to 5 black knives
+      - Profitable poison-flip recipe (around 1.1k profit per batch)
+      - Niche 10 Ranged thrown weapon
+      - Poison deals 2-4 damage over time
+  history:
+    - date: "2006-09-20"
+      description: Renamed to Black knife(p) to distinguish from (p+) and (p++) variants.
+    - date: "2005-07-11"
+      description: Released with the Farming update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming Update
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  about: Black knife(p) is a thrown ranged weapon requiring 10 Ranged, made by applying basic weapon poison to five black knives via Herblore.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blade-of-saeldor-inactive.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blade-of-saeldor-inactive.mdx
@@ -14,32 +14,45 @@ osrs:
   limit: 8
   equipment:
     slot: weapon
-    type: sword
-    tradeable: true
-    weight: 1.814
+    weapon_type: slash-sword
     attack_speed: 4
+    weight: 1.814
     requirements:
       attack: 80
-    stats:
-      attack_stab: 55
-      attack_slash: 94
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 89
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  charging:
-    material_name: Crystal shard
+  charges:
+    material: Crystal shard
     charges_per_100_shards: 10000
+    max_charges: 20000
     corrupting_shards: 1000
-    corrupted_tradeable: false
+    note: Inactive form provides no combat bonuses until charged.
+  recipes:
+    - name: Blade of saeldor
+      skill: Smithing
+      level: 82
+      xp: 5000
+      facility: Singing bowl
+      materials:
+        - item_name: Enhanced crystal weapon seed
+          quantity: 1
+        - item_name: Crystal shard
+          quantity: 100
   related_items:
     - item_id: 25879
       item_name: Blade of saeldor (c)
@@ -61,33 +74,33 @@ osrs:
       slug: ghrazi-rapier
       relationship: alternative
       description: Stab alternative weapon
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Slash | +94 |
-    | Stab | +55 |
-    | Strength | +89 |
-
-    Requirements: 80 Attack
-
-    Note: This is the uncharged/inactive version. No combat bonuses until charged with crystal shards.
-
-    Charge with crystal shards to activate:
-    - 100 shards = 10,000 charges
-    - Recharge anytime before running out
-    - Becomes Blade of saeldor (c) when charged
-
-    Use 1,000 crystal shards to make permanently charged:
-    - Never needs recharging
-    - Becomes untradeable
-    - Worth it for consistent use
+  about: Blade of saeldor (inactive) is an elven slash sword crafted from an enhanced crystal weapon seed; it must be charged with crystal shards before it provides combat bonuses.
   market_strategy:
     notes:
       - Enhanced seed from Corrupted Gauntlet
       - Buy inactive, charge yourself for savings
       - Consider corrupting for convenience
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2019-07-25"
+      description: Released with the Song of the Elves update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-07-25"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-of-ethereum-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-of-ethereum-uncharged.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 28800
   highalch: 43200
   limit: 10000
-  about: "Bracelet of ethereum (uncharged) is a members-only item in Old School RuneScape. High alchemy value: 43,200 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: hands
+    weight: 0.25
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    max_charges: 16000
+    charge_item_id: 21820
+    charge_item_name: Revenant ether
+    effect: Reduces revenant damage by 75% and makes revenants tolerant when worn while charged.
+  drop_table:
+    sources:
+      - source: Revenant dragon
+        combat_level: 252
+        quantity: "1"
+        rarity: 1/6.63
+        members_only: true
+      - source: Revenant maledictus
+        combat_level: 200
+        quantity: "1"
+        rarity: 1/6.63
+        members_only: true
+      - source: Revenant knight
+        combat_level: 140
+        quantity: "1"
+        rarity: 1/7.1
+        members_only: true
+  related_items:
+    - item_id: 21816
+      item_name: Bracelet of ethereum
+      slug: bracelet-of-ethereum
+      relationship: upgrade
+      description: Charged (untradeable) variant
+    - item_id: 21820
+      item_name: Revenant ether
+      slug: revenant-ether
+      relationship: component
+      description: Charge currency
+  about: Bracelet of ethereum (uncharged) is a Revenant Caves drop that holds up to 16,000 revenant ether charges to mitigate revenant damage, but becomes untradeable once charged.
+  market_strategy:
+    notes:
+      - Dismantles for 250 ether (small profit floor)
+      - Bulk buyers stockpile for revenant farming alts
+      - Untradeable when charged so flips happen at zero charges only
+  history:
+    - date: "2017-11-23"
+      description: Released alongside Mage Arena II and the Revenant Caves.
+    - date: "2025-03"
+      description: Bank option added for charge management.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-11-23"
+    update: Mage Arena II, Revenant Caves & Deadman Beta
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/brimstone-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/brimstone-ring.mdx
@@ -12,54 +12,69 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 8
+  material:
+    type: jewellery
+    tier: high
   equipment:
     slot: ring
-    type: hybrid
-    stats:
-      attack_stab: 4
-      attack_slash: 4
-      attack_crush: 4
-      attack_magic: 6
-      attack_ranged: 4
-      defence_stab: 4
-      defence_slash: 4
-      defence_crush: 4
-      defence_magic: 6
-      defence_ranged: 4
-      strength: 4
-  effect:
-    magic_penetration: true
-    proc_chance: 25
-    defence_ignore: 10
-    description: 25% chance to ignore 10% of target's magic defence
-  creation:
-    components:
-      - item_id: 22973
-        item_name: Hydra's eye
-      - item_id: 22971
-        item_name: Hydra's fang
-      - item_id: 22969
-        item_name: Hydra's heart
+    weight: 0.004
+    attack_bonus:
+      stab: 4
+      slash: 4
+      crush: 4
+      magic: 6
+      ranged: 4
+    defence_bonus:
+      stab: 4
+      slash: 4
+      crush: 4
+      magic: 6
+      ranged: 4
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Magic Penetration
+    description: 25% chance on magic attacks to reduce the target's defensive roll by 10% for that attack. Single-target only.
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Hydra's eye
+          item_id: 22973
+          quantity: 1
+        - item_name: Hydra's fang
+          item_id: 22971
+          quantity: 1
+        - item_name: Hydra's heart
+          item_id: 22969
+          quantity: 1
+      product: Brimstone ring
+      product_id: 22975
+      product_quantity: 1
+      facility: Inventory
   drop_table:
     sources:
       - source: Alchemical Hydra
         source_id: 8621
         combat_level: 426
-        quantity: 1 (Components)
-        rarity: Rare
-        drop_rate: 1/181 each
+        quantity: "1"
+        rarity: 1/181 per component
         members_only: true
   related_items:
     - item_id: 6737
       item_name: Berserker ring
       slug: berserker-ring
       relationship: alternative
-      description: Pure melee
+      description: Pure melee strength ring
     - item_id: 6731
       item_name: Seers ring
       slug: seers-ring
       relationship: alternative
-      description: Pure magic
+      description: Pure magic accuracy ring
     - item_id: 22973
       item_name: Hydra's eye
       slug: hydras-eye
@@ -75,51 +90,34 @@ osrs:
       slug: hydras-heart
       relationship: component
       description: Creation component
-  about: |-
-    Combine 3 components from Alchemical Hydra:
-    - Hydra's eye
-    - Hydra's fang
-    - Hydra's heart
-
-    All components untradeable. Ring is tradeable after creation.
-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +4 |
-    | Slash | +4 |
-    | Crush | +4 |
-    | Magic | +6 |
-    | Ranged | +4 |
-    | Strength | +4 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +4 |
-    | Slash | +4 |
-    | Crush | +4 |
-    | Magic | +6 |
-    | Ranged | +4 |
-
-    Requirements: None
-
-    Magic Penetration:
-    - 25% chance on magic attacks
-    - Ignores 10% of target's magic defence
-    - Message: "Your attack ignored 10% of your opponent's magic defence."
-
-    BiS hybrid ring for:
-    - Content requiring style switching
-    - Magic-focused bossing
-    - CoX/ToB switches
-
-    Best all-around combat ring.
+  about: Brimstone ring is a tradeable hybrid ring crafted from three Alchemical Hydra components, providing balanced offence/defence and a 25% magic defence ignore proc.
   market_strategy:
     notes:
-      - 95 Slayer for Hydra
-      - All 3 components needed
-      - Great hybrid option
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - 95 Slayer for Hydra gates supply
+      - Three components needed per ring
+      - BiS hybrid ring for style-switching content
+  history:
+    - date: "2019-01-10"
+      update: The Kebos Lowlands
+      description: Released with Alchemical Hydra.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: 10 January 2019
+    update: The Kebos Lowlands
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.004
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broken-dragon-hasta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broken-dragon-hasta.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 24960
   highalch: 37440
   limit: 70
-  about: "Broken dragon hasta is a members-only item in Old School RuneScape. High alchemy value: 37,440 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Brimstone chest
+        quantity: "1"
+        rarity: 1/200
+        members_only: true
+  recipes:
+    - skill: smithing
+      materials:
+        - item_name: Broken dragon hasta
+          item_id: 22963
+          quantity: 1
+      product: Dragon hasta
+      product_id: 11889
+      product_quantity: 1
+      facility: Otto Godblessed (Barbarian Outpost)
+      members_only: true
+      notes: Repaired by Otto; equipping requires Barbarian Smithing completion
+  related_items:
+    - item_id: 11889
+      item_name: Dragon hasta
+      slug: dragon-hasta
+      relationship: product
+      description: Repaired version
+    - item_id: 11924
+      item_name: Brimstone key
+      slug: brimstone-key
+      relationship: component
+      description: Opens the Brimstone chest
+  market_strategy:
+    notes:
+      - Rare Brimstone chest drop at 1/200
+      - Otto Godblessed repairs into Dragon hasta
+      - Repaired weapon requires Barbarian Smithing to equip
+      - Konar slayer task demand drives Brimstone key supply
+  history:
+    - date: "2019-01-17"
+      description: Item value decreased from 200,000 to 62,400 coins.
+    - date: "2019-01-10"
+      description: Released with The Kebos Lowlands update.
+  properties:
+    release_date: "2019-01-10"
+    update: The Kebos Lowlands
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    alchable: true
+  about: Broken dragon hasta is a rare Brimstone chest drop that Otto Godblessed repairs into a Dragon hasta.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broken-dragon-hook.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broken-dragon-hook.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: null
-  about: "Broken dragon hook is a members-only item in Old School RuneScape. High alchemy value: 4,800 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Great White Shark
+        source_id: 0
+        combat_level: 175
+        quantity: "1"
+        rarity: 1/1023
+        members_only: true
+  recipes:
+    - skill: construction
+      level: 78
+      xp: 0
+      materials:
+        - item_name: Broken dragon hook
+          item_id: 31961
+          quantity: 1
+        - item_name: Rosewood plank
+          item_id: 0
+          quantity: 1
+        - item_name: Dragon nails
+          item_id: 0
+          quantity: 1
+        - item_name: Dragon metal sheet
+          item_id: 0
+          quantity: 1
+        - item_name: Rope
+          item_id: 954
+          quantity: 1
+        - item_name: Cupronickel bar
+          item_id: 0
+          quantity: 1
+      facility: Boat (Sailing 86)
+      members_only: true
+  related_items:
+    - item_id: 0
+      item_name: Dragon salvaging hook
+      slug: dragon-salvaging-hook
+      relationship: upgrade
+      description: Repaired hook used on a boat
+  about: Broken dragon hook is a component obtained from Great White Sharks, used to construct a dragon salvaging hook with 86 Sailing and 78 Construction.
+  market_strategy:
+    notes:
+      - Supply tied to Great White Shark kills
+      - Required component for dragon salvaging hook upgrade
+      - 1/1023 drop rate gates supply
+      - Demand from Sailing content players
+  history:
+    - date: "2025-11-05"
+      update: Item added but unobtainable
+      description: Item added but unobtainable
+    - date: "2025-11-19"
+      update: Made obtainable via the Sailing update
+      description: Made obtainable via the Sailing update
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dagger-p-5670.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dagger-p-5670.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 125
-  about: "Bronze dagger(p+) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: stab-sword
+    attack_speed: 4
+    weight: 0.453
+    attack_bonus:
+      stab: 4
+      slash: 2
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      melee_strength: 3
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Apply Weapon poison(+)
+      materials:
+        - item_id: 1205
+          item_name: Bronze dagger
+          quantity: 1
+        - item_id: 5937
+          item_name: Weapon poison(+)
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_id: 1205
+      item_name: Bronze dagger
+      slug: bronze-dagger
+      relationship: component
+      description: Base dagger
+    - item_id: 5937
+      item_name: Weapon poison(+)
+      slug: weapon-poison-plus
+      relationship: component
+      description: Stronger poison
+    - item_id: 5672
+      item_name: Bronze dagger(p++)
+      slug: bronze-dagger-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+  about: Bronze dagger(p+) is a poisoned variant of the bronze dagger applying the stronger Weapon poison(+) effect on stab attacks.
+  market_strategy:
+    notes:
+      - Cheap entry-level poisoned weapon
+      - Limited demand outside of niche poison setups
+      - Profit margin sits on weapon poison(+) cost
+  history:
+    - date: "2006-08-22"
+      description: Poisoned variants renamed to (p), (p+), (p++) notation.
+    - date: "2014-12-10"
+      description: Br'ze dagger(p++) name corrected to Bronze dagger(p++).
+    - date: "2021-07-07"
+      description: Female player weapon positioning adjusted.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-hasta-p-11382.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-hasta-p-11382.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 125
-  about: "Bronze hasta(p+) is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    attack_bonus:
+      stab: 5
+      slash: 5
+      crush: 5
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: -1
+      crush: -1
+      magic: 0
+      ranged: -1
+    other_bonus:
+      melee_strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Bronze hasta
+          item_id: 11378
+          quantity: 1
+        - item_name: Weapon poison(+)
+          item_id: 5937
+          quantity: 1
+      product: Bronze hasta(p+)
+      product_id: 11382
+      product_quantity: 1
+      facility: Inventory
+  related_items:
+    - item_id: 11378
+      item_name: Bronze hasta
+      slug: bronze-hasta
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 11380
+      item_name: Bronze hasta(p)
+      slug: bronze-hasta-p
+      relationship: alternative
+      description: Lower poison tier
+    - item_id: 11384
+      item_name: Bronze hasta(p++)
+      slug: bronze-hasta-p-plus-plus
+      relationship: upgrade
+      description: Higher poison tier
+  about: Bronze hasta(p+) is a one-handed bronze hasta coated with weapon poison(+), made at the Barbarian Outpost after the Barbarian Training miniquest.
+  market_strategy:
+    notes:
+      - Niche poisoned starter spear
+      - Members-only, low buy limit
+      - Demand limited to collectors and irons
+  history:
+    - date: "2007-07-03"
+      update: Barbarian Training
+      description: Released alongside the Barbarian smithing line.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: 3 July 2007
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cabbage-round-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cabbage-round-shield.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 125
-  about: "Cabbage round shield is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    weight: 4.535
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 24
+      slash: 26
+      crush: 22
+      magic: 0
+      ranged: 24
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    rarity: 1/1133
+  related_items:
+    - item_id: 1199
+      item_name: Adamant sq shield
+      slug: adamant-sq-shield
+      relationship: alternative
+      description: Standard adamant shield with identical stats
+  about: Adamant shield shaped like a cabbage from medium clue scrolls, referencing the pre-2005 cabbage model; wielded by the Brassican Mage NPC.
+  market_strategy:
+    notes:
+      - Medium clue exclusive, supply tied to clue completion rates
+      - Novelty cosmetic over identical adamant kiteshield stats
+      - Niche demand from cabbage cosmetic collectors
+      - Buy limit 125 keeps the float thin
+  history:
+    - date: "2016-07-06"
+      update: Released with the Treasure Trail Expansion
+      description: Released with the Treasure Trail Expansion
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.535
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chopped-garlic.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chopped-garlic.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 13000
-  about: "Chopped garlic is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - product: Chopped garlic
+      skill: Cooking
+      facility: Inventory
+      tools:
+        - Knife
+      materials:
+        - item_name: Bowl
+          quantity: 1
+        - item_name: Garlic
+          quantity: 1
+    - product: Spicy sauce
+      skill: Cooking
+      xp: 25
+      facility: Inventory
+      materials:
+        - item_name: Chopped garlic
+          quantity: 1
+        - item_name: Gnome spice
+          quantity: 1
+  related_items:
+    - item_name: Garlic
+      relationship: component
+      description: Raw ingredient chopped into the bowl
+    - item_name: Bowl
+      relationship: component
+      description: Container that holds the chopped garlic
+    - item_name: Spicy sauce
+      relationship: product
+      description: Made with chopped garlic and gnome spice
+  about: Chopped garlic is a Gnome Cooking ingredient produced by using a knife on garlic over a bowl and combined with gnome spice to make spicy sauce.
+  market_strategy:
+    notes:
+      - Cheap raw-garlic + bowl conversion at any cooking level
+      - Buy limit of 13,000 supports large gnome-cooking prep runs
+      - Spicy sauce demand drives the only meaningful pull
+  history:
+    - date: "2006-01-30"
+      description: Released with Runesquares, Harpie Bugs and new potato recipes
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-01-30"
+    update: Runesquares, Harpie Bugs and new potato recipes!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chugging-barrel-disassembled.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chugging-barrel-disassembled.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chugging barrel (disassembled) | OSRS Price Data
-description: "Chugging barrel (disassembled): Can be assembled to consume multiple potions.. High alch: 600 GP, GE limit: 5."
+description: "Chugging barrel (disassembled) is a Mastering Mixology reward that assembles into a multi-potion drinker. High alch: 600 GP, GE limit: 5."
 osrs:
   id: 30002
   name: Chugging barrel (disassembled)
@@ -12,9 +12,47 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 5
-  about: "Chugging barrel (disassembled) is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Mastering Mixology Rewards
+      location: Mastering Mixology minigame
+      currency: Mox/Aga/Lye resin
+      requirements: 17,250 Mox, 14,000 Aga, 18,600 Lye resin
+  related_items:
+    - item_id: 30000
+      item_name: Chugging barrel
+      slug: chugging-barrel
+      relationship: product
+      description: Assembled barrel ready to drink from
+  about: Chugging barrel (disassembled) is the tradeable form of the Mastering Mixology reward; once assembled it pulls potions from bank or potion storage for chugging.
+  market_strategy:
+    notes:
+      - Tradeable only in disassembled state
+      - Assembly costs significant Mox/Aga/Lye resin
+      - Useful for multi-potion content
+  history:
+    - date: "2025-09-24"
+      description: Barrels now pull potions directly from both bank and potion storage with configurable settings.
+    - date: "2024-10-09"
+      description: Fixed scrollbar display issue in configuration interface.
+    - date: "2024-10-02"
+      description: Renamed from Pre-pot device; expanded usable locations; fixed extended anti-venom+ compatibility; adjusted resin costs.
+    - date: "2024-09-25"
+      description: Item added with Varlamore The Rising Darkness update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    weight: 0.453
+    options:
+      - Assemble
+      - Drop
+    alchable: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-tumeken-s-shadow-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-tumeken-s-shadow-uncharged.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: null
-  about: "Corrupted tumeken's shadow (uncharged) is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: 2h
+    weapon_type: powered-staff
+    attack_speed: 5
+    weight: 1.36
+    requirements:
+      magic: 85
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 35
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 20
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  charges:
+    type: soul-rune
+    base_uses_per_charge: 1
+    notes: Functions identically to Tumeken's shadow when charged; the corrupted variant was a Leagues IV reward and is untradeable in standard play.
+  related_items:
+    - item_id: 27277
+      item_name: Tumeken's shadow
+      slug: tumekens-shadow
+      relationship: alternative
+      description: Tradeable original from Tombs of Amascut
+  about: Corrupted Tumeken's shadow (uncharged) is the league/event-variant uncharged powered staff modelled on Tumeken's shadow; equip requires 85 Magic and it triples magic bonuses from worn gear.
+  market_strategy:
+    notes:
+      - Limited GE liquidity (league reward)
+      - Value driven by collector and ironman demand
+      - High alch floor at 150,000
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    weight: 1.36
+    options:
+      - Charge
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dark-kebbit-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dark-kebbit-fur.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 84
   highalch: 126
   limit: 10000
-  about: "Dark kebbit fur is a members-only item in Old School RuneScape. High alchemy value: 126 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hide
+    tier: mid
+  drop_table:
+    sources:
+      - source: Dark kebbit
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Caught via falconry at the Piscatoris falconry area (57 Hunter, 500gp falcon rental)
+  recipes:
+    - skill: crafting
+      materials:
+        - item_name: Dark kebbit fur
+          item_id: 10115
+          quantity: 2
+      product: Gloves of silence
+      product_id: 10075
+      product_quantity: 1
+      facility: Fancy Clothes Store (Varrock) or Hunter Guild
+      members_only: true
+      notes: 600gp tailoring fee
+  related_items:
+    - item_id: 10075
+      item_name: Gloves of silence
+      slug: gloves-of-silence
+      relationship: product
+      description: Two furs make one pair
+  market_strategy:
+    notes:
+      - 57 Hunter falconry gate limits supply
+      - Demand from thieving players seeking gloves of silence
+      - Two furs needed per pair of gloves
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill.
+  properties:
+    release_date: "2006-11-21"
+    update: HUNTER SKILL!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+  about: Dark kebbit fur is a Hunter drop from dark kebbits, used in pairs at the Fancy Clothes Store to craft gloves of silence.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/death-tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/death-tiara.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 40
-  about: "Death tiara is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - product: Death tiara
+      skill: Runecraft
+      level: 1
+      xp: 50
+      facility: Death Altar
+      materials:
+        - item_name: Tiara
+          quantity: 1
+        - item_name: Death talisman
+          quantity: 1
+  related_items:
+    - item_name: Tiara
+      relationship: component
+      description: Base item bound at the altar
+    - item_name: Death talisman
+      relationship: component
+      description: Talisman consumed during binding
+    - item_name: Death rune
+      relationship: alternative
+      description: Crafted at the same altar
+  about: Death tiara binds a tiara to the Death Altar, freeing the inventory slot a death talisman would occupy and granting one-click access to the runecrafting altar.
+  market_strategy:
+    notes:
+      - Cheap to make at Runecraft 1 for 50 xp per binding
+      - Reused as a Master Treasure Trail emote target
+      - Niche demand caps daily volume
+  history:
+    - date: "2005-10-17"
+      description: Released with Mourning's Ends Part II
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-10-17"
+    update: Mourning's Ends Part II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Enter
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-battlemage-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-battlemage-potion-4.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 288
   highalch: 432
   limit: 2000
-  about: "Divine battlemage potion(4) is a members-only item in Old School RuneScape. High alchemy value: 432 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - description: Boosts Magic by +4 levels for 5 minutes.
+      - description: Boosts Defence by +5 plus 15% of base Defence level for 5 minutes.
+      - description: Deals 10 Hitpoints damage on drink; requires 11+ HP to use safely.
+  recipes:
+    - skill: herblore
+      level: 86
+      xp: 80
+      materials:
+        - item_name: Battlemage potion(4)
+          item_id: 22451
+          quantity: 1
+        - item_name: Crystal dust
+          item_id: 23964
+          quantity: 4
+      product: Divine battlemage potion(4)
+      product_id: 24623
+      product_quantity: 1
+      facility: Herblore
+  related_items:
+    - item_id: 22451
+      item_name: Battlemage potion(4)
+      slug: battlemage-potion-4
+      relationship: component
+      description: Base potion combined with crystal dust
+    - item_id: 24617
+      item_name: Divine super attack potion(4)
+      slug: divine-super-attack-potion-4
+      relationship: alternative
+      description: Divine potion variant
+  about: Divine battlemage potion(4) is a members herblore brew that boosts Magic and Defence for 5 minutes without re-stat decay, crafted at 86 Herblore.
+  market_strategy:
+    notes:
+      - 86 Herblore gates supply
+      - PvP/Castle Wars demand drives flips
+      - Crystal dust supply caps margins
+      - Steady GE volume around 8k/day
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-04-30"
+    update: Poll 70 and Bounty Hunter Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.135
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/draconic-visage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/draconic-visage.mdx
@@ -12,72 +12,98 @@ osrs:
   lowalch: 300000
   highalch: 450000
   limit: 5
-  item:
-    type: crafting_material
-    tradeable: true
-    weight: 1.814
-  obtaining:
-    methods:
+  drop_table:
+    sources:
       - source: King Black Dragon
-        drop_rate: 1/5,000
-      - source: Vorkath
-        drop_rate: 1/5,000
-      - source: Black dragon (Wildy Slayer)
-        drop_rate: 1/5,000
+        combat_level: 276
+        quantity: "1"
+        rarity: 1/5000
+        members_only: false
+      - source: Vorkath (post-quest)
+        combat_level: 732
+        quantity: "1"
+        rarity: 1/5000
+        members_only: true
+      - source: Black dragon (Wilderness Slayer)
+        combat_level: 247
+        quantity: "1"
+        rarity: 1/5000
+        members_only: true
       - source: Rune dragon
-        drop_rate: 1/8,000
+        combat_level: 380
+        quantity: "1"
+        rarity: 1/8000
+        members_only: true
       - source: Adamant dragon
-        drop_rate: 1/9,000
-      - source: Most other dragons/wyverns
-        drop_rate: 1/10,000
-  creation:
-    creates:
-      item_id: 11283
-      item_name: Dragonfire shield
-      slug: dragonfire-shield
-    materials: Anti-dragon shield + visage
-    methods:
-      - source: Player
-        requirements:
-          smithing: 90
-        xp: 2000
-      - source: Oziach
-        cost: 1250000
+        combat_level: 338
+        quantity: "1"
+        rarity: 1/9000
+        members_only: true
+      - source: Mithril dragon
+        combat_level: 304
+        quantity: "1"
+        rarity: 1/10000
+        members_only: true
+      - source: Steel dragon
+        combat_level: 246
+        quantity: "1"
+        rarity: 1/10000
+        members_only: true
+  recipes:
+    - product: Dragonfire shield
+      skill: Smithing
+      level: 90
+      xp: 2000
+      facility: Player crafting (boostable)
+      materials:
+        - item_name: Anti-dragon shield
+          quantity: 1
+        - item_name: Draconic visage
+          quantity: 1
+    - product: Dragonfire shield
+      skill: Smithing
+      facility: Oziach (NPC service, requires Dragon Slayer I)
+      materials:
+        - item_name: Anti-dragon shield
+          quantity: 1
+        - item_name: Draconic visage
+          quantity: 1
+        - item_name: Coins
+          quantity: 1250000
   related_items:
-    - item_id: 11283
-      item_name: Dragonfire shield
-      slug: dragonfire-shield
+    - item_name: Dragonfire shield
       relationship: product
-      description: Created shield
-    - item_id: 1540
-      item_name: Anti-dragon shield
-      slug: anti-dragon-shield
+      description: Created by attaching the visage to an anti-dragon shield
+    - item_name: Anti-dragon shield
       relationship: component
-      description: Base material
-    - item_id: 0
-      item_name: Vorkath
-      slug: vorkath
-      relationship: component
-      description: Best source
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 1.814 kg |
-
-    | Item Created | Materials | Method |
-    |--------------|-----------|--------|
-    | Dragonfire shield | Anti-dragon shield + visage | 90 Smithing or Oziach (1.25M) |
-
-    Grants 2,000 Smithing XP when crafted.
+      description: Base shield combined with the visage
+    - item_name: Vorkath
+      relationship: alternative
+      description: Best consistent farm for the visage
+  about: Draconic visage is a rare drop from dragons used to craft the dragonfire shield with an anti-dragon shield at 90 Smithing for 2,000 XP, or via Oziach for 1.25M coins after Dragon Slayer I.
   market_strategy:
     notes:
-      - Vorkath is best consistent source
-      - KBD for early game
-      - Required for Dragon Slayer I
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Vorkath is the most consistent supply source
+      - King Black Dragon offers the easiest early-game route
+      - Dragonfire shield demand drives the long-run floor
+  history:
+    - date: "2007-06-18"
+      description: Released with The Dragonfire Shield update
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-06-18"
+    update: The Dragonfire Shield
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-claws.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-claws.mdx
@@ -14,24 +14,32 @@ osrs:
   limit: 8
   equipment:
     slot: weapon
-    type: claw
-    attack_style: melee
+    weapon_type: claw
     attack_speed: 4
+    weight: 0.9
     requirements:
       attack: 60
-    stats:
-      attack_stab: 41
-      attack_slash: 57
-      attack_crush: -4
-      defence_stab: 13
-      defence_slash: 26
-      defence_crush: 7
-      strength: 56
-    special_attack:
-      name: Slice and Dice
-      energy: 50
-      effect: 4 rapid hits in sequence
-      accuracy_reduction_per_hit: 10
+    attack_bonus:
+      stab: 41
+      slash: 57
+      crush: -4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 13
+      slash: 26
+      crush: 7
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 56
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Slice and Dice
+    energy: 50
+    description: Hits the enemy four times in rapid succession; later hits scale off the previous swing's roll, enabling huge burst damage.
   drop_table:
     sources:
       - source: Tormented Demons
@@ -44,7 +52,7 @@ osrs:
         source_id: 0
         combat_level: 0
         quantity: "1"
-        rarity: Very rare
+        rarity: 3/69
         members_only: true
   related_items:
     - item_id: 13576
@@ -62,37 +70,37 @@ osrs:
       slug: bandos-godsword
       relationship: alternative
       description: Defence draining spec
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Stab attack | +41 |
-    | Slash attack | +57 |
-    | Crush attack | -4 |
-    | Stab defence | +13 |
-    | Slash defence | +26 |
-    | Crush defence | +7 |
-    | Strength | +56 |
-    | Requirements | 60 Attack |
-
-    Slice and Dice (50% energy):
-    - 4 rapid hits in sequence
-    - Each hit has ~10% reduced accuracy
-    - Can deal massive burst damage
-
-    Extremely powerful for PvP and spec-focused PvM.
-
-    BiS spec weapon for:
-    - PvP (combo specs)
-    - ToB Maiden
-    - CoX Tekton
-    - General burst damage
+  about: Dragon claws are a two-handed melee spec weapon from Chambers of Xeric and Tormented Demons whose Slice and Dice special hits four times for potentially massive burst damage.
   market_strategy:
     notes:
       - Tormented Demons are best source
       - Iconic PvP spec weapon
-      - 4 hits can stack huge damage
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Four hits can stack huge damage
+      - BiS spec for PvP combos, ToB Maiden, CoX Tekton, general burst
+      - Buy limit 8 keeps price volatile
+  history:
+    - date: "2017-01-05"
+      update: Released with Chambers of Xeric
+      description: Released with Chambers of Xeric
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-01-05"
+    update: Chambers of Xeric
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.9
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-spear-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-spear-p.mdx
@@ -12,9 +12,114 @@ osrs:
   lowalch: 24960
   highalch: 37440
   limit: 70
-  about: "Dragon spear(p) is a members-only item in Old School RuneScape. High alchemy value: 37,440 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: high
+  equipment:
+    slot: 2h
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 55
+      slash: 55
+      crush: 55
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 5
+      slash: 5
+      crush: 5
+      magic: 5
+      ranged: 5
+    other_bonus:
+      melee_strength: 60
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Shove
+    energy_cost: 25
+    description: Pushes the target back and stuns them for 5 ticks (3 seconds). Cannot stack on already-stunned targets.
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Dragon spear
+          item_id: 1249
+          quantity: 1
+        - item_name: Weapon poison
+          item_id: 187
+          quantity: 1
+      product: Dragon spear(p)
+      product_id: 1263
+      product_quantity: 1
+      facility: Inventory
+  drop_table:
+    sources:
+      - source: Brutal black dragon
+        combat_level: 318
+        quantity: "1"
+        rarity: 1/512
+        members_only: true
+      - source: Gorak
+        combat_level: 145
+        quantity: "1"
+        rarity: 1/325 (Ring of wealth)
+        members_only: true
+  related_items:
+    - item_id: 1249
+      item_name: Dragon spear
+      slug: dragon-spear
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 5716
+      item_name: Dragon spear(p+)
+      slug: dragon-spear-p-plus
+      relationship: alternative
+      description: Higher poison tier
+    - item_id: 5730
+      item_name: Dragon spear(p++)
+      slug: dragon-spear-p-plus-plus
+      relationship: upgrade
+      description: Highest poison tier
+  about: Dragon spear(p) is a poisoned two-handed dragon spear with a Shove special attack that stuns targets, popular for PvP setups and Castle Wars.
+  market_strategy:
+    notes:
+      - Shove special is core PvP utility
+      - Low GE limit pinches supply
+      - Demand tied to PvP and minigame meta
+  history:
+    - date: "2021-04-21"
+      update: Game update
+      description: Attack speed increased from 5 to 4 ticks.
+    - date: "2016-07-28"
+      update: Game update
+      description: Stun effects modified to prevent stacking on stunned targets.
+    - date: "2004-03-29"
+      update: RuneScape 2 launch
+      description: Dragon spear added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: 29 March 2004
+    update: RuneScape 2 launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-stout-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-stout-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dwarven stout(4) | OSRS Price Data
-description: "Dwarven stout(4): This keg contains 4 pints of Dwarven Stout.. High alch: 1 GP, GE limit: 2,000."
+description: "Dwarven stout(4) is a keg containing 4 pints of Dwarven Stout (Mining/Smithing boost). High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5777
   name: Dwarven stout(4)
@@ -12,9 +12,47 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Dwarven stout(4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    type: drink
+    effects:
+      - description: Each pint gives the same effect as drinking a glass of dwarven stout (boosts Mining and Smithing).
+  related_items:
+    - item_id: 5775
+      item_name: Dwarven stout(1)
+      slug: dwarven-stout-1
+      relationship: variant
+      description: Single-pint keg
+    - item_id: 1913
+      item_name: Dwarven stout
+      slug: dwarven-stout
+      relationship: variant
+      description: Single glass form
+  about: Dwarven stout(4) is a 4-pint keg of Dwarven Stout used to temporarily boost Mining and Smithing; partially drunk versions are untradeable.
+  market_strategy:
+    notes:
+      - Full kegs are tradeable on GE
+      - Partial kegs cannot be sold
+      - Boosts Mining and Smithing skill levels
+  history:
+    - date: "2015-02-26"
+      description: Partially drunk versions were made untradeable on the Grand Exchange.
+    - date: "2005-07-11"
+      description: Item added with Farming update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    alchable: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-stout-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-stout-m4.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Dwarven stout(m4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - skill: Mining
+        description: Temporarily boosts Mining by 2 levels.
+      - skill: Smithing
+        description: Temporarily boosts Smithing by 2 levels.
+      - skill: Attack
+        description: Drains Attack by 3 levels.
+      - skill: Strength
+        description: Drains Strength by 2 levels.
+  recipes:
+    - skill: Cooking
+      level: 19
+      xp: 16
+      product: Dwarven stout(m4)
+      quantity: 1
+      requirements: Aged in calquat keg via the brewing process.
+      materials:
+        - item_name: Water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Hammerstone hops
+          quantity: 2
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Calquat keg
+          quantity: 1
+  related_items:
+    - item_id: 1913
+      item_name: Dwarven stout
+      slug: dwarven-stout
+      relationship: downgrade
+      description: Standard non-matured glass
+    - item_id: 5749
+      item_name: Dwarven stout (m)
+      slug: dwarven-stout-m
+      relationship: alternative
+      description: Single-glass matured variant
+    - item_id: 5793
+      item_name: Calquat keg
+      slug: calquat-keg
+      relationship: component
+      description: Container used to brew the keg
+  market_strategy:
+    notes:
+      - Mining and Smithing boost utility
+      - Long brewing cycle limits supply
+      - Keg holds four pints in one slot
+      - Bulk player-stat for Blast Furnace prep
+  history:
+    - date: "2015-02-26"
+      description: Partially consumed versions became untradeable on the Grand Exchange.
+    - date: "2005-10-04"
+      description: Item renamed during cooking and brewing updates.
+    - date: "2005-07-11"
+      description: Released with the Farming skill update.
+  about: A four-pint keg of matured dwarven stout that temporarily boosts Mining and Smithing by two while draining Attack and Strength, brewed via Cooking and the Farming brewing process.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elemental-helmet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elemental-helmet.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 70
-  about: "Elemental helmet is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.113
+    requirements:
+      smithing: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Elemental helmet
+      skill: Smithing
+      level: 20
+      xp: 20
+      facility: Elemental Workshop workbench
+      materials:
+        - item_name: Elemental metal
+          quantity: 1
+        - item_name: Beaten book
+          quantity: 1
+  related_items:
+    - item_name: Elemental metal
+      slug: elemental-metal
+      relationship: component
+      description: Smithed helm material
+    - item_name: Beaten book
+      slug: beaten-book
+      relationship: component
+      description: Required schematic
+    - item_name: Mind helmet
+      slug: mind-helmet
+      relationship: upgrade
+      description: Elemental Workshop III progression
+  about: Elemental helmet is the reward helm from Elemental Workshop II, smithed from elemental metal and offering minor magic defence.
+  market_strategy:
+    notes:
+      - Quest-locked supply
+      - Marginal combat value, mostly trophy
+      - GE limit of 70 caps speculation
+  history:
+    - date: "2006-10-02"
+      description: Released with the Elemental Workshop II quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-10-02"
+    update: Elemental Workshop II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.113
+    options:
+      - Equip
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fancy-hedge-bagged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fancy-hedge-bagged.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 10000
-  about: "Fancy hedge (bagged) is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    level: 72
+    xp: 158
+    farming_xp: 158
+    facility: Formal Garden (player-owned house)
+    materials:
+      - item_name: Fancy hedge (bagged)
+        item_id: 8445
+        quantity: 1
+      - item_name: Watering can
+        quantity: 1
+  shops:
+    - shop_name: Garden Supplier
+      location: Falador Park
+      price: 25000
+    - shop_name: Garden Supplier
+      location: Farming Guild
+      price: 25000
+  related_items:
+    - item_id: 8443
+      item_name: Box hedge (bagged)
+      slug: box-hedge-bagged
+      relationship: downgrade
+      description: Lower-tier formal garden hedge
+    - item_id: 8447
+      item_name: Tall fancy hedge (bagged)
+      slug: tall-fancy-hedge-bagged
+      relationship: upgrade
+      description: Taller variant for formal gardens
+  about: Fancy hedge (bagged) is a members-only decorative garden item planted in the Formal Garden of a player-owned house at Construction level 72.
+  market_strategy:
+    notes:
+      - Niche Construction supply
+      - Decorative use only
+      - Low daily GE volume
+      - 25,000 gp shop price caps demand
+      - Bulk buyers tend to be POH decorators
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 10
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fedora.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fedora.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 4
-  about: "Fedora is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Crazy Archaeologist
+        combat_level: 204
+        quantity: "1"
+        rarity: 1/128
+        members_only: true
+  related_items:
+    - item_id: 12437
+      item_name: 3rd age cloak
+      slug: 3rd-age-cloak
+      relationship: alternative
+      description: Other rare cosmetic
+  market_strategy:
+    notes:
+      - Rare drop from Crazy Archaeologist
+      - Buy limit only 4 per 4 hours
+      - Cosmetic head slot, no combat bonuses
+      - Has Tip emote on right-click
+  history:
+    - date: "2015-08-20"
+      description: Hat rendering corrected on player chathead.
+    - date: "2014-10-30"
+      description: Added ability to right-click and select "Tip" for an emote animation.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-03-27"
+    update: Wilderness Feedback Update
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Tip
+    alchable: true
+  about: Fedora is a rare cosmetic head slot item dropped by the Crazy Archaeologist in the Wilderness.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fine-fish-offcuts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fine-fish-offcuts.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 8000
-  about: "Fine fish offcuts is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 8,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - name: Slice high-level raw fish with a knife
+      cooking_level: 1
+      materials:
+        - item_name: Raw fish (high-level)
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_id: 11522
+      item_name: Fish offcuts
+      slug: fish-offcuts
+      relationship: alternative
+      description: Standard offcuts variant
+    - item_id: 303
+      item_name: Knife
+      slug: knife
+      relationship: component
+      description: Cutting tool
+  about: Fine fish offcuts are stackable bait sliced from high-level raw fish during the Sailing skill, used in rainbow crab traps and deep sea trawling.
+  market_strategy:
+    notes:
+      - Sailing-era utility bait with steady fishing demand
+      - Stackable storage friendly for ironmen
+      - Chum stations on boats produce faster than knife cutting
+  history:
+    - date: "2025-11-05"
+      description: Added to the live game as part of the Sailing release.
+    - date: "2026-03"
+      description: Fletching knife enabled as an alternative cutting tool.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-bench-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-bench-flatpack.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Gilded bench (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    construction_level: 61
+    xp: 1760
+    facility: Bench with vice
+    placement: Dining room or throne room seating space
+  recipes:
+    - name: Gilded bench (flatpack)
+      skill: Construction
+      level: 61
+      xp: 1760
+      facility: Workshop workbench
+      materials:
+        - item_name: Mahogany plank
+          quantity: 4
+        - item_name: Gold leaf
+          quantity: 4
+  related_items:
+    - item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Bench frame material
+    - item_name: Gold leaf
+      slug: gold-leaf
+      relationship: component
+      description: Gilding material
+    - item_name: Gilded bench
+      slug: gilded-bench
+      relationship: product
+      description: Built furniture form
+  about: Gilded bench (flatpack) is a Player-Owned House flatpack assembled at a workshop bench with vice and placed in dining or throne rooms.
+  market_strategy:
+    notes:
+      - Mahogany planks and gold leaf drive cost
+      - Construction skillers supply at a loss
+      - Demand from PoH decorators
+  history:
+    - date: "2006-05-31"
+      description: Released with the Player-Owned Houses update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/glacial-temotli.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/glacial-temotli.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 33200
   highalch: 49800
   limit: 15
-  about: "Glacial temotli is a members-only item in Old School RuneScape. High alchemy value: 49,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: 2h
+    weapon_type: blunt
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 55
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 72
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 64
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 2
+  special_attack:
+    name: Multi-hit
+    description: Rolls two independent hits per attack; against monsters with negative flat armour (e.g. Nagua) each successful hit deals bonus damage.
+  drop_table:
+    sources:
+      - source: Frost Nagua
+        combat_level: 0
+        quantity: "1"
+        rarity: "1/500"
+        members_only: true
+      - source: Amoxliatl
+        combat_level: 0
+        quantity: "1"
+        rarity: "1/100"
+        members_only: true
+  related_items:
+    - item_id: 21902
+      item_name: Dragon claws
+      slug: dragon-claws
+      relationship: alternative
+      description: Comparable two-hit melee weapon
+    - item_id: 28997
+      item_name: Volatile nightmare staff
+      slug: volatile-nightmare-staff
+      relationship: alternative
+      description: Higher-tier multi-hit option (magic)
+  about: Glacial temotli is a 4-tick two-handed crush weapon dropped in the Ruins of Tapoyauik that hits twice per swing, excelling against negative-armour targets like Nagua.
+  market_strategy:
+    notes:
+      - Drop rate caps supply (1/100 to 1/500)
+      - Niche use for Nagua slayer tasks
+      - 15/day GE limit smooths price spikes
+      - Speculative play around new content
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-09-25"
+    update: Varlamore
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gnome-spice.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gnome-spice.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Gnome spice is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Grand Tree Groceries
+      location: The Grand Tree
+      price: 4
+    - shop_name: The Spice Is Right
+      location: Sophanem
+      price: 4
+  related_items:
+    - item_name: Chopped garlic
+      slug: chopped-garlic
+      relationship: product
+      description: Combines into spicy sauce
+    - item_name: Spicy sauce
+      slug: spicy-sauce
+      relationship: product
+      description: Made with gnome spice
+    - item_name: Toad's legs
+      slug: toads-legs
+      relationship: component
+      description: Used together in gnome cuisine
+  about: Gnome spice is Aluft Gianne's secret seasoning, sold by Hudo and used to prepare Gnome Restaurant dishes and spicy sauce.
+  market_strategy:
+    notes:
+      - Shop-stocked at 4 gp
+      - Gnome Restaurant demand limits margin
+      - Stable price floor from infinite stock
+  history:
+    - date: "2002-12-12"
+      description: Released with the Agility skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Agility
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.15
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-tiara.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 10000
-  about: "Gold tiara is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: head
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Craft Gold tiara at a furnace
+      crafting_level: 42
+      crafting_xp: 35
+      materials:
+        - item_id: 2357
+          item_name: Gold bar
+          quantity: 1
+        - item_name: Tiara mould
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_id: 5525
+      item_name: Tiara
+      slug: tiara
+      relationship: alternative
+      description: Silver-tier counterpart
+    - item_id: 2357
+      item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: Smelted material
+  about: Gold tiara is a purely cosmetic head slot item crafted at level 42 Crafting from one gold bar and a tiara mould at any furnace.
+  market_strategy:
+    notes:
+      - High daily volume makes flipping bait viable
+      - Crafted profit is negative, only alch ladder works on bulk
+      - Cosmetic demand floors price above gold bar cost
+  history:
+    - date: "2022-03-23"
+      description: Crafting level raised from 1 to 42, XP cut from 67.5 to 35.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-03-23"
+    update: Guardians of the Rift
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-elegant-skirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-elegant-skirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Green elegant skirt | OSRS Price Data
-description: "Green elegant skirt is a members legs slot item. High alch: 1,200 GP, GE limit: 4."
+description: "Green elegant skirt is a cosmetic Treasure Trails reward (women's variant). High alch: 1,200 GP, GE limit: 4."
 osrs:
   id: 10434
   name: Green elegant skirt
@@ -14,19 +14,62 @@ osrs:
   limit: 4
   equipment:
     slot: legs
-    requirements: {}
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    casket: Reward casket (easy)
+    rarity: 1/2808
   related_items:
     - item_id: 10432
       item_name: Green elegant blouse
       slug: green-elegant-blouse
       relationship: set-piece
       description: Matching elegant blouse
-  about: |-
-    > *"A rather elegant green skirt."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the green elegant clothing set (women's variant). Pairs with the green elegant blouse.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Green elegant skirt is a purely cosmetic easy Treasure Trail reward, women's variant of the green elegant clothing set.
+  market_strategy:
+    notes:
+      - Cosmetic-only legs slot reward
+      - Low buy limit drives price volatility
+      - Pairs with green elegant blouse
+  history:
+    - date: "2014-12"
+      description: Renamed to Green elegant skirt.
+    - date: "2007-06"
+      description: Renamed from Elegant skirt to Green ele' skirt.
+    - date: "2006-12-05"
+      description: Item added with Treasure Trails, spiders and sheep update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails, spiders and sheep
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-ranarr-weed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-ranarr-weed.mdx
@@ -12,16 +12,12 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 11000
-  herb:
-    type: grimy
+  material:
+    type: herb
     tier: mid-high
-  herblore:
-    cleaning_level: 25
-    cleaning_xp: 7.5
-    clean_id: 257
-    clean_name: Ranarr weed
   farming:
-    level: 32
+    farming_level: 32
+    farming_xp: 30.5
     seed_id: 5295
     seed_name: Ranarr seed
   drop_table:
@@ -29,21 +25,31 @@ osrs:
       - source: Aberrant spectre
         source_id: 2927
         combat_level: 96
-        quantity: "1"
-        rarity: common
+        quantity: "1-3"
+        rarity: 1/19.1
         members_only: true
       - source: Chaos druid
         source_id: 181
         combat_level: 13
+        quantity: "1-2"
+        rarity: 1/32.4
+        members_only: true
+      - source: Elder chaos druid
+        combat_level: 129
+        quantity: "1-4"
+        rarity: 1/27.3
+        members_only: true
+      - source: Flesh crawler
+        combat_level: 28
         quantity: "1"
-        rarity: uncommon
+        rarity: 1/33.2
         members_only: true
   related_items:
     - item_id: 257
       item_name: Ranarr weed
       slug: ranarr-weed
       relationship: product
-      description: Cleaned version
+      description: Cleaned version (25 Herblore, 7.5 XP)
     - item_id: 2434
       item_name: Prayer potion(4)
       slug: prayer-potion-4
@@ -59,32 +65,34 @@ osrs:
       slug: ranarr-seed
       relationship: component
       description: Farming seed
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 25 |
-    | XP | 7.5 |
-    | Product | Ranarr weed |
+  about: Grimy ranarr weed is a members-only herb cleaned at level 25 Herblore for 7.5 XP, primarily used to brew prayer potions.
   market_strategy:
-    title: |-
-      - Herb cleaning profit
-      - Ironman accounts
-      - Herblore XP (low)
-      - Prayer potion chain
     notes:
-      - Buy grimy → Clean → Sell
-      - Calculate profit after cleaning
-      - High volume trading
-      - Herb cleaning profit
-      - Ironman accounts
-      - Herblore XP (low)
-      - Prayer potion chain
-      - Often cheaper than clean
+      - Buy grimy clean and resell for spread profit
+      - High demand from Prayer potion brewers
+      - Ironman cleanup XP is small but consistent
+      - Often cheaper than clean ranarr
       - Quick to clean in bank
-      - Check price spread
-      - High demand herb
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Check price spread before flipping
+  history:
+    - date: "2002-02-27"
+      description: Item released.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: RuneScape released to all
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grog.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grog.mdx
@@ -1,6 +1,6 @@
 ---
 title: Grog | OSRS Price Data
-description: "Grog: A murky glass of some sort of drink.. High alch: 1 GP, GE limit: 2,000."
+description: "Grog is a members drink that boosts Strength but drains Attack. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 1915
   name: Grog
@@ -12,9 +12,53 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Grog is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heal: 3
+    type: drink
+    effects:
+      - description: Temporarily boosts Strength by 4% + 1.
+      - description: Drains Attack by 5% + 3.
+  shops:
+    - shop_name: Dead Man's Chest
+      location: Brimhaven
+    - shop_name: The Asp & Snake Bar
+      location: Pollnivneach
+    - shop_name: The Lighthouse Store
+      location: Lighthouse
+    - shop_name: The Pandemonium
+      location: Pandemonium pub
+    - shop_name: The Rolling Tide
+      location: Port Roberts
+  related_items:
+    - item_id: 1917
+      item_name: Beer
+      slug: beer
+      relationship: alternative
+      description: Standard tavern drink
+  about: Grog is a cheap pub drink that heals 3 HP, temporarily boosts Strength and drains Attack; unlike other ales it cannot be brewed.
+  market_strategy:
+    notes:
+      - Pub-only supply, no brewing
+      - Niche strength boost for low-level content
+      - Drains Attack, situational use
+  history:
+    - date: "2002-02-27"
+      description: Item added.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: Latest RuneScape News (27 February 2002)
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-arrow-p-5623.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-arrow-p-5623.mdx
@@ -12,9 +12,97 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Iron arrow(p++) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: low
+  equipment:
+    slot: ammo
+    weapon_type: thrown
+    attack_speed: 1
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 10
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 15
+      xp: 37.5
+      materials:
+        - item_name: Iron arrow
+          item_id: 884
+          quantity: 5
+        - item_name: Weapon poison(++)
+          item_id: 5940
+          quantity: 1
+      product: Iron arrow(p++)
+      product_id: 5623
+      product_quantity: 5
+      facility: None
+      members_only: true
+  related_items:
+    - item_id: 884
+      item_name: Iron arrow
+      slug: iron-arrow
+      relationship: component
+      description: Unpoisoned base arrow
+    - item_id: 5621
+      item_name: Iron arrow(p)
+      slug: iron-arrow-p-5621
+      relationship: downgrade
+      description: Weakest poison variant
+    - item_id: 5622
+      item_name: Iron arrow(p+)
+      slug: iron-arrow-p-5622
+      relationship: downgrade
+      description: Medium poison variant
+    - item_id: 5940
+      item_name: Weapon poison(++)
+      slug: weapon-poison
+      relationship: component
+      description: Poison applied to arrows
+  market_strategy:
+    notes:
+      - Niche poisoned ammunition for low-level ranged content
+      - Members-only despite base iron arrow being F2P
+      - Demand limited compared to higher-tier poisoned arrows
+  history:
+    - date: "2025-05-29"
+      description: Iron arrows exempted from the Grand Exchange convenience fee.
+  properties:
+    release_date: "2002-03-25"
+    update: RuneScape Launch
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  about: Iron arrow(p++) is a poisoned iron arrow created by applying weapon poison(++) to five iron arrows.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bolts-p-9301.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bolts-p-9301.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Iron bolts (p++) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: low
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 46
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Herblore
+      output_name: Iron bolts (p++)
+      output_quantity: 5
+      materials:
+        - item_name: Iron bolts
+          quantity: 5
+        - item_name: Weapon poison++
+          quantity: 1
+  related_items:
+    - item_id: 9140
+      item_name: Iron bolts
+      slug: iron-bolts
+      relationship: variant
+      description: Unpoisoned base bolt
+    - item_id: 9293
+      item_name: Iron bolts (p)
+      slug: iron-bolts-p-9293
+      relationship: variant
+      description: Basic poison version
+    - item_id: 9297
+      item_name: Iron bolts (p+)
+      slug: iron-bolts-p-plus
+      relationship: variant
+      description: Stronger poison version
+  market_strategy:
+    notes:
+      - Tipped with Weapon poison++ for highest poison damage
+      - Crossbow ammo, +46 ranged strength
+      - Low alch profit minimal, value driven by GE flip margins
+      - Useful for PvP poison ticks
+  history:
+    - date: "2018-07-26"
+      description: Naming corrected from Iron bolts(p++) to Iron bolts (p++) with proper spacing.
+    - date: "2006-07-31"
+      description: Released with the Crossbows update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows Update
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  about: Iron bolts (p++) are crossbow ammunition tipped with super weapon poison, providing +46 ranged strength and the strongest poison tier.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-coif-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-coif-0.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 5200
   highalch: 7800
   limit: 15
-  about: "Karil's coif 0 is a members-only item in Old School RuneScape. High alchemy value: 7,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.907
+    requirements:
+      ranged: 70
+      defence: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -1
+      ranged: 7
+    defence_bonus:
+      stab: 6
+      slash: 9
+      crush: 12
+      magic: 6
+      ranged: 10
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Barrows chest (Karil the Tainted)
+        quantity: "1"
+        rarity: 7 x 1/2448
+        members_only: true
+  related_items:
+    - item_name: Karil's leathertop 0
+      relationship: set-piece
+      description: Karil's Barrows armour set
+    - item_name: Karil's leatherskirt 0
+      relationship: set-piece
+      description: Karil's Barrows armour set
+    - item_name: Karil's crossbow
+      relationship: set-piece
+      description: Karil's Barrows weapon
+  about: Karil's coif 0 is the fully degraded form of Karil the Tainted's coif from the Barrows minigame, providing top-tier ranged defence for ranged setups.
+  market_strategy:
+    notes:
+      - Cheapest Karil's coif state due to zero charges
+      - Repaired charges restore the standard ranged headpiece
+      - Supply is tied to Barrows runs and degradation cycles
+  history:
+    - date: "2014-12-10"
+      description: Renamed from "Karils coif" to "Karil's coif"
+    - date: "2015-04-16"
+      description: Check option added to display remaining durability
+    - date: "2015-06-25"
+      description: Ranged attack bonus increased from +3 to +7
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: If you drop this item it will break. Are you sure?
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kharyrll-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kharyrll-teleport-tablet.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Kharyrll teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Canifis
+    spellbook: Ancient Magicks
+    requirements:
+      quest: Desert Treasure I
+    consumed: true
+  recipes:
+    - name: Kharyrll teleport tablet
+      skill: Magic
+      level: 66
+      xp: 76
+      facility: Ancient Lectern
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Blood rune
+          quantity: 1
+  related_items:
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Tablet base
+    - item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: Crafting reagent
+    - item_name: Blood rune
+      slug: blood-rune
+      relationship: component
+      description: Crafting reagent
+  about: Kharyrll teleport tablet teleports the user to Canifis when broken, requiring Desert Treasure I completion.
+  market_strategy:
+    notes:
+      - Supply from house lectern crafters
+      - Demand from Slayer and Morytania travel
+      - Cheap convenience item
+  history:
+    - date: "2014-09-18"
+      description: Released with the Bounty Hunter update.
+    - date: "2020-09-30"
+      description: Players gained the ability to craft these tablets at the Ancient Lectern.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-09-18"
+    update: Bounty Hunter
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-mithril-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-mithril-keel-parts.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 2500
   highalch: 3750
   limit: 100
-  about: "Large mithril keel parts is a members-only item in Old School RuneScape. High alchemy value: 3,750 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: mid
+  recipes:
+    - name: Forge Large mithril keel parts from regular parts
+      smithing_level: 56
+      materials:
+        - item_name: Mithril keel parts
+          quantity: 5
+      output_quantity: 1
+      requirements: Pandemonium quest
+    - name: Combine into a mithril keel for sloops
+      materials:
+        - item_name: Large mithril keel parts
+          quantity: 16
+        - item_name: Lead bar
+          quantity: 5
+      output_quantity: 1
+  related_items:
+    - item_name: Mithril keel parts
+      relationship: component
+      description: Base part smithed into the large variant
+    - item_name: Lead bar
+      relationship: component
+      description: Combined with parts to build sloop keels
+  about: Large mithril keel parts are Sailing components forged from five mithril keel parts each at 56 Smithing, then assembled into mithril sloop keels.
+  market_strategy:
+    notes:
+      - Pandemonium gate constrains the smithing supply
+      - 16 parts plus 5 lead bars per finished sloop keel is the demand driver
+      - Low GE limit of 100 means thin order book
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/linen-icthlarin-s-little-helper.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/linen-icthlarin-s-little-helper.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 15
-  about: "Linen (Icthlarin's Little Helper) is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Raetul and Co's Cloth Store
+      location: Sophanem
+      stock: 14
+      price: 30
+    - shop_name: Raetul and Co's Cloth Store (post Contact!)
+      location: Sophanem
+      stock: 20
+      price: 30
+  related_items:
+    - item_name: Embalming manual
+      relationship: alternative
+      description: Icthlarin's Little Helper quest item
+    - item_name: Bucket of saltwater
+      relationship: alternative
+      description: Mummification reagent
+    - item_name: Canopic jar
+      relationship: alternative
+      description: Quest mummification component
+  about: Linen is a sheet of mummy wrap purchased from Raetul and Co's Cloth Store in Sophanem and used during the Icthlarin's Little Helper quest to wrap the mummy.
+  market_strategy:
+    notes:
+      - Shop floor price of 30 coins caps the buy ceiling
+      - Quest demand keeps a steady stream of buyers
+      - Low GE buy limit (15) discourages bulk flipping
+  history:
+    - date: "2005-04-26"
+      description: Released with the Desert Month Finale
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-04-26"
+    update: Desert Month Finale
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.907
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mind-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mind-rune.mdx
@@ -12,8 +12,9 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 18000
-  rune:
-    type: combat
+  material:
+    type: rune
+    tier: low
   runecraft:
     level: 2
     xp: 5.5
@@ -22,8 +23,14 @@ osrs:
     altar_location: Between Goblin Village and Ice Mountain
     essence_type: any
   shops:
-    - shop_name: Rune shops
-      stock: Unlimited
+    - shop_name: Aubury's Rune Shop
+      location: Varrock
+      price: 17
+    - shop_name: Betty's Magic Emporium
+      location: Port Sarim
+      price: 17
+    - shop_name: Magic Guild Store
+      location: Yanille
       price: 17
   recipes:
     - skill: runecraft
@@ -63,45 +70,38 @@ osrs:
       slug: fire-rune
       relationship: component
       description: Strike spell combo
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Runecraft Level | 2 |
-    | XP per rune | 5.5 |
-    | Runes per essence | 1 (14 at 98) |
-
-    Multipliers (every 14 levels):
-    - Level 14: 2x runes
-    - Level 28: 3x runes
-    - Level 42: 4x runes
-    - Level 56: 5x runes
-    - Level 70: 6x runes
-    - Level 84: 7x runes
-    - Level 98: 8x runes
-
-    | Spell | Mind Runes | Other Runes |
-    |-------|------------|-------------|
-    | Wind Strike | 1 | 1 Air |
-    | Water Strike | 1 | 1 Air, 1 Water |
-    | Earth Strike | 1 | 1 Air, 2 Earth |
-    | Fire Strike | 1 | 2 Air, 3 Fire |
-    | Confuse | 3 | 3 Water, 2 Earth |
-    | Weaken | 3 | 3 Water, 2 Earth |
+  about: Mind rune is a F2P combat rune used for basic missile Strike spells; the cheapest combat rune and a staple of F2P Magic training.
   market_strategy:
     notes:
       - Strike spells only
-      - F2P Magic training
+      - F2P Magic training staple
       - Very low value per rune
-      - F2P Magic training
-      - Early game spellcasting
       - Splash training (low cost)
-      - Ironman accounts
-      - Cheapest combat rune
-      - F2P demand primary driver
-      - High supply from shops
+      - Ironman demand for early Magic
+      - High supply from rune shops
       - Minimal flip potential
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2025-05-29"
+      update: Exempted from Grand Exchange convenience fee.
+      description: Exempted from Grand Exchange convenience fee.
+    - date: "2022-09-14"
+      update: Buy limit increased from 12,000 to 18,000.
+      description: Buy limit increased from 12,000 to 18,000.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape Launch
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-arrow.mdx
@@ -12,30 +12,58 @@ osrs:
   lowalch: 12
   highalch: 19
   limit: 7000
+  material:
+    type: ammunition
+    tier: mid
   equipment:
     slot: ammo
-    type: arrow
-    attack_style: ranged
-  requirements:
-    ranged: 20
-  stats:
-    other:
+    weapon_type: bow
+    weight: 0
+    requirements:
+      ranged: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 22
-  fletching:
-    level: 45
-    xp: 7.5
-    method: Mithril arrowtips + headless arrows
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 45
+      xp: 112.5
+      materials:
+        - item_name: Headless arrow
+          item_id: 53
+          quantity: 15
+        - item_name: Mithril arrowtips
+          item_id: 42
+          quantity: 15
+      product: Mithril arrow
+      product_id: 888
+      product_quantity: 15
+      facility: Inventory
   drop_table:
     sources:
       - source: Ice warrior
         source_id: 145
         combat_level: 57
-        quantity: 5-12
+        quantity: "5-12"
         rarity: common
       - source: Waterfiend
         source_id: 5361
         combat_level: 115
-        quantity: 20-50
+        quantity: "20-50"
         rarity: common
         members_only: true
   shops:
@@ -63,20 +91,30 @@ osrs:
       slug: headless-arrow
       relationship: component
       description: Fletching material
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Ammo |
-    | Type | Arrows |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 20 Ranged |
-
-    Used with any shortbow or longbow.
-
-    Budget training ammunition.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Mithril arrow is a mid-tier F2P arrow used with any shortbow or longbow, granting +22 ranged strength at 20 Ranged for budget training.
+  market_strategy:
+    notes:
+      - Cheap mid-tier training ammo
+      - Fletching supply gates margins
+      - F2P demand keeps floor stable
+      - Bulk flip volume from PvM losses
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-knife-p-5657.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-knife-p-5657.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 10
   highalch: 16
   limit: 7000
-  about: "Mithril knife(p+) is a members-only item in Old School RuneScape. High alchemy value: 16 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 11
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 10
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Apply Weapon poison(+)
+      materials:
+        - item_id: 5654
+          item_name: Mithril knife
+          quantity: 1
+        - item_id: 5937
+          item_name: Weapon poison(+)
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_id: 5654
+      item_name: Mithril knife
+      slug: mithril-knife
+      relationship: component
+      description: Unpoisoned variant
+    - item_id: 5937
+      item_name: Weapon poison(+)
+      slug: weapon-poison-plus
+      relationship: component
+      description: Stronger poison
+    - item_id: 5659
+      item_name: Mithril knife(p++)
+      slug: mithril-knife-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+  about: Mithril knife(p+) is a stackable thrown Ranged weapon coated in Weapon poison(+), requiring 20 Ranged to wield.
+  market_strategy:
+    notes:
+      - Niche poisoned ranged option for budget pures
+      - Profit hinges on weapon poison(+) spread
+      - Stackable so bulk flips are bank-friendly
+  history:
+    - date: "2006-09-20"
+      description: Renamed from (+) and (s) suffixes to (p+) and (p++).
+    - date: "2021-07-07"
+      description: Female player weapon positioning adjusted.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/musketeer-pants.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/musketeer-pants.mdx
@@ -1,6 +1,6 @@
 ---
 title: Musketeer pants | OSRS Price Data
-description: "Musketeer pants: One for all!. High alch: 1,122 GP, GE limit: 4."
+description: "Musketeer pants are a cosmetic elite Treasure Trails reward. High alch: 1,122 GP, GE limit: 4."
 osrs:
   id: 12443
   name: Musketeer pants
@@ -12,9 +12,65 @@ osrs:
   lowalch: 748
   highalch: 1122
   limit: 4
-  about: "Musketeer pants is a members-only item in Old School RuneScape. High alchemy value: 1,122 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 1.814
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    casket: Reward casket (elite)
+    rarity: 1/1275
+  related_items:
+    - item_id: 12441
+      item_name: Musketeer hat
+      slug: musketeer-hat
+      relationship: set-piece
+      description: Matching cosmetic hat
+    - item_id: 12442
+      item_name: Musketeer top
+      slug: musketeer-top
+      relationship: set-piece
+      description: Matching cosmetic top
+  about: Musketeer pants are cosmetic legs from an elite clue scroll reward casket, part of the Musketeer outfit.
+  market_strategy:
+    notes:
+      - Cosmetic-only, no combat bonus
+      - Elite clue exclusive at 1/1275
+      - Storable in costume room treasure chest
+  history:
+    - date: "2014-06-12"
+      description: Item added with Treasure Trail Expansion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/myre-snelm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/myre-snelm.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Myre snelm is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: -1
+    defence_bonus:
+      stab: 7
+      slash: 8
+      crush: 6
+      magic: -1
+      ranged: 7
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Crafting
+      level: 15
+      xp: 32.5
+      materials:
+        - item_name: Blamish myre shell (round)
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+  related_items:
+    - item_id: 3325
+      item_name: Blamish myre shell (round)
+      slug: blamish-myre-shell-round
+      relationship: component
+      description: Crafted from this shell at 15 Crafting
+  market_strategy:
+    notes:
+      - Crafted from blamish myre shells
+      - Cheaper steel medium helm alternative
+      - Reduces snail damage by 4
+      - Useful in Mort Myre swamps
+  history:
+    - date: "2004-10-14"
+      description: Introduced with Morytania expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-14"
+    update: Morytania Expansion
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  about: Myre snelm is a head slot helmet crafted from a blamish myre shell, offering steel medium helm tier defence with no level requirement.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nature-impling-jar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nature-impling-jar.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
-  about: "Nature impling jar is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Nature impling (Puro-Puro / Gielinor)
+        quantity: "1"
+        rarity: hunter capture
+        members_only: true
+  recipes:
+    - product: Nature impling loot
+      skill: Hunter
+      level: 58
+      facility: Empty impling jar capture
+      materials:
+        - item_name: Empty impling jar
+          quantity: 1
+        - item_name: Butterfly net
+          quantity: 1
+  related_items:
+    - item_name: Empty impling jar
+      relationship: component
+      description: Required to capture the nature impling
+    - item_name: Limpwurt seed
+      relationship: alternative
+      description: Common loot from the jar
+    - item_name: Magic logs
+      relationship: alternative
+      description: Common loot from the jar
+    - item_name: Snapdragon seed
+      relationship: alternative
+      description: Rare loot from the jar
+    - item_name: Torstol seed
+      relationship: alternative
+      description: Rare loot from the jar
+  about: Nature impling jar contains a captured nature impling and yields an average 1,742 coin loot of seeds, herbs, magic logs, and occasional rare seeds, with a 10% chance the jar breaks on loot.
+  market_strategy:
+    notes:
+      - Hunter level 58 gates self-supply via Puro-Puro
+      - 1742 gp average loot anchors a fair-value range
+      - 10% jar break rate adds variance to bulk opening
+  history:
+    - date: "2015-03-05"
+      description: Made tradeable on the Grand Exchange
+    - date: "2016-04-21"
+      description: Hard clue scrolls added to the loot table
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-06-11"
+    update: Impetuous Impulses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Loot
+      - Destroy
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pest-control-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pest-control-teleport.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Pest control teleport is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: teleport-scroll
+    tier: low
+  teleport:
+    destination: Void Knights' Outpost
+    spellbook: Treasure trail reward
+  treasure_trail:
+    tier: easy
+    casket: Reward casket (easy)
+    rarity: drop
+  related_items:
+    - item_id: 0
+      item_name: Reward casket (easy)
+      slug: reward-casket-easy
+      relationship: alternative
+      description: Easy clue reward casket
+  about: Pest control teleport is a stackable scroll from easy Treasure Trails that teleports the player to the Void Knights' Outpost on Mos Le'Harmless.
+  market_strategy:
+    notes:
+      - Easy clue mass-supply keeps price near alch
+      - Useful for free Void Knights' Outpost access
+      - Niche utility for irons and corp resupply paths
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Added as an easy clue reward scroll.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: 12 June 2014
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Teleport
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/phoenix-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/phoenix-necklace.mdx
@@ -14,81 +14,82 @@ osrs:
   limit: 10000
   equipment:
     slot: neck
-    type: necklace
-    tradeable: true
     weight: 0.01
-    stats:
-      all: 0
-  creation:
-    method: Enchant Diamond necklace with Lvl-4 Enchant
-    requirements:
-      magic: 57
-    materials:
-      - item_id: 1662
-        item_name: Diamond necklace
-        slug: diamond-necklace
-      - item_id: 564
-        item_name: Cosmic rune
-        quantity: 1
-      - item_id: 557
-        item_name: Earth rune
-        quantity: 10
-  passive_effects:
-    - name: Emergency Heal
-      description: Triggers at 20% HP or below, restores 30% of max HP, clears pending damage, destroys after use
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Enchant Diamond necklace (Lvl-4 Enchant)
+      magic_level: 57
+      magic_xp: 67
+      materials:
+        - item_id: 1662
+          item_name: Diamond necklace
+          quantity: 1
+        - item_id: 564
+          item_name: Cosmic rune
+          quantity: 1
+        - item_id: 557
+          item_name: Earth rune
+          quantity: 10
+      output_quantity: 1
   related_items:
     - item_id: 2570
       item_name: Ring of life
       slug: ring-of-life
       relationship: alternative
-      description: Teleport safety
+      description: Teleport-on-low-HP safety net
     - item_id: 1662
       item_name: Diamond necklace
       slug: diamond-necklace
       relationship: component
-      description: Base item
+      description: Base item before enchanting
     - item_id: 6685
       item_name: Saradomin brew
       slug: saradomin-brew
       relationship: alternative
-      description: Manual healing
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Neck |
-    | Type | Combat Necklace |
-    | Tradeable | Yes |
-    | Weight | 0.01 kg |
-
-    Enchant Diamond necklace with Lvl-4 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 57 |
-    | Cosmic rune | 1 |
-    | Earth rune | 10 |
-
-    All bonuses +0
-
-    Emergency Heal:
-    - Triggers at 20% HP or below
-    - Restores 30% of max HP
-    - Clears pending damage
-    - Destroys after use
-
-    Essential for:
-    - PvP survival
-    - Risky PvM
-    - Hardcore Ironmen
-
-    Auto-heal safety net.
+      description: Manual heal alternative
+  about: Phoenix necklace is a Lvl-4 enchanted diamond necklace that auto-heals 30% max HP when the wearer drops to 20% HP, then breaks.
   market_strategy:
     notes:
-      - Great for HCIM
-      - One-time use
-      - Clears damage queue
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Staple safety item for HCIM and risky PvM
+      - One-time use keeps demand constant
+      - Clears pending damage queue on proc
+  history:
+    - date: "2025-03-26"
+      description: Phoenix proc no longer restores sanity during the Whisperer fight.
+    - date: "2025-05-29"
+      description: Phoenix proc no longer removes the soulflame horn buff.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-04-30"
+    update: 24 Carat Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-boots-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-boots-t3.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: null
-  about: "Raging echoes boots (t3) is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.34
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: League Hall
+      price: 20000
+      currency: League points
+  related_items:
+    - item_id: 30424
+      item_name: Raging echoes hood (t3)
+      slug: raging-echoes-hood-t3
+      relationship: set-piece
+      description: Tier 3 Raging Echoes Relic Hunter set
+    - item_id: 30425
+      item_name: Raging echoes robe top (t3)
+      slug: raging-echoes-robe-top-t3
+      relationship: set-piece
+      description: Tier 3 Raging Echoes Relic Hunter set
+  market_strategy:
+    notes:
+      - Cosmetic only, zero combat bonuses
+      - Purchased with League points from Leagues V reward shop
+      - Storeable in costume room armour case
+      - Part of full Raging Echoes Relic Hunter outfit
+  history:
+    - date: "2025-01-15"
+      description: Released with Leagues V Raging Echoes.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-01-15"
+    update: Leagues V Raging Echoes
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    alchable: false
+  about: Raging echoes boots (t3) are cosmetic-only feet slot boots from the Leagues V Raging Echoes Relic Hunter outfit, purchasable with League points.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-potion-2.mdx
@@ -12,6 +12,22 @@ osrs:
   lowalch: 86
   highalch: 129
   limit: 2000
+  potion:
+    doses: 2
+    effects:
+      - description: Boosts Ranged by 4 + 10% of current Ranged level (rounded down) per dose.
+    skill_boosted: Ranged
+  recipes:
+    - skill: Herblore
+      level: 72
+      xp: 162.5
+      output_name: Ranging potion(3)
+      materials:
+        - item_name: Dwarf weed potion (unf)
+          quantity: 1
+        - item_name: Wine of zamorak
+          quantity: 1
+      notes: 3-dose potions are split/decanted into the 2-dose variant.
   related_items:
     - item_id: 169
       item_name: Ranging potion(3)
@@ -23,12 +39,39 @@ osrs:
       slug: ranging-potion-1
       relationship: variant
       description: 1-dose version
-  about: |-
-    > _"2 doses of ranging potion."_
-
-    A 2-dose ranging potion. Boosts Ranged by 4 + 10% of current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 11951
+      item_name: Divine ranging potion(4)
+      slug: divine-ranging-potion-4
+      relationship: upgrade
+      description: Divine variant with extended duration
+  market_strategy:
+    notes:
+      - Sourced by decanting 3-dose ranging potions
+      - Used at Ranged bosses for accuracy/strength boost
+      - 72 Herblore gate keeps supply tight
+      - Stack alongside imbued heart for higher buffs
+  history:
+    - date: "2004-10-26"
+      description: '"Empty" option added to potions.'
+    - date: "2002-02-27"
+      description: Released into the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+  about: Ranging potion(2) is a 2-dose Herblore potion that boosts Ranged by 4 plus 10% of the player's current Ranged level per dose.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-bird-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-bird-meat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw bird meat | OSRS Price Data
-description: "Raw bird meat: This certainly needs cooking!. High alch: 10 GP, GE limit: 11,000."
+description: "Raw bird meat is a Hunter drop that cooks into roast bird meat. High alch: 10 GP, GE limit: 11,000."
 osrs:
   id: 9978
   name: Raw bird meat
@@ -12,9 +12,93 @@ osrs:
   lowalch: 6
   highalch: 10
   limit: 11000
-  about: "Raw bird meat is a members-only item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: meat
+    tier: low
+  recipes:
+    - skill: Cooking
+      level: 11
+      xp: 62
+      product_id: 9980
+      product_name: Skewered bird meat
+      notes: Requires iron spit; then cook with 20 Firemaking for roast bird meat.
+      materials:
+        - item_id: 9978
+          item_name: Raw bird meat
+          quantity: 1
+        - item_id: 7228
+          item_name: Iron spit
+          quantity: 1
+  drop_table:
+    sources:
+      - source: Crimson Swift
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Hunter level 1, Jungle
+      - source: Golden Warbler
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Hunter level 5, Desert
+      - source: Copper Longtail
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Hunter level 9, Woodland
+      - source: Cerulean Twitch
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Hunter level 11, Snow
+      - source: Tropical Wagtail
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Hunter level 19, Jungle
+      - source: Bird house
+        quantity: "10"
+        rarity: varies
+        members_only: true
+        notes: Bird house trapping, levels 5-89
+  related_items:
+    - item_id: 9980
+      item_name: Skewered bird meat
+      slug: skewered-bird-meat
+      relationship: product
+      description: Skewered with iron spit
+    - item_id: 9982
+      item_name: Roast bird meat
+      slug: roast-bird-meat
+      relationship: product
+      description: Cooked over a fire
+  about: Raw bird meat is a Hunter byproduct from bird snares and bird houses, cooked via iron spit into roast bird meat.
+  market_strategy:
+    notes:
+      - Steady bird house byproduct supply
+      - Low-tier cooking food
+      - Used as familiar food and bird house byproduct
+  history:
+    - date: "2015-03-12"
+      description: Raw bird meat no longer has an Eat option.
+    - date: "2015-02-26"
+      description: Made tradeable on Grand Exchange.
+    - date: "2006-11-21"
+      description: Item added with Hunter skill release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    weight: 0.15
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-halibut.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-halibut.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 15000
-  about: "Raw halibut is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 15,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: fish
+    tier: mid-high
+  fishing:
+    level: 83
+    xp: 195.5
+    method: Trawling net
+    location: Halibut, Shimmering, and Glistening shoals
+    bait: Fine fish offcuts
+  recipes:
+    - skill: cooking
+      level: 83
+      xp: 212.5
+      materials:
+        - item_name: Raw halibut
+          item_id: 32333
+          quantity: 1
+      facility: Fire or range
+      ticks: 4
+      members_only: true
+  related_items:
+    - item_id: 0
+      item_name: Halibut
+      slug: halibut
+      relationship: upgrade
+      description: Cooked variant
+    - item_id: 0
+      item_name: Burnt halibut
+      slug: burnt-halibut
+      relationship: alternative
+      description: Burnt result on cooking failure
+  about: Raw halibut is caught at 83 Fishing using a trawling net during deep sea trawling, then cooked at 83 Cooking for 212.5 XP.
+  market_strategy:
+    notes:
+      - Sailing-era fish, supply scales with trawling activity
+      - Deep sea trawling yields ~1.25M gp/hr
+      - Cooking it converts to halibut at 83 Cooking
+      - Fine fish offcuts increase catch yield
+  history:
+    - date: "2025-06-26"
+      update: Added to Sailing Beta cache
+      description: Added to Sailing Beta cache
+    - date: "2025-07-03"
+      update: Removed from beta cache
+      description: Removed from beta cache
+    - date: "2025-11-19"
+      update: Released live with the Sailing update
+      description: Released live with the Sailing update
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.7
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/redberries.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/redberries.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Redberries is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    farming_level: 10
+    patch: Bush patch
+    plant_xp: 11.5
+    check_xp: 64
+    harvest_xp: 11.5
+  recipes:
+    - skill: Cooking
+      output_name: Redberry pie
+      materials:
+        - item_name: Redberries
+          quantity: 1
+        - item_name: Pie shell
+          quantity: 1
+    - skill: Crafting
+      output_name: Red dye
+      materials:
+        - item_name: Redberries
+          quantity: 2
+  shops:
+    - shop_name: Wydin's Food Store
+      location: Port Sarim
+      price: 2
+    - shop_name: Grum's Gold Exchange
+      location: Port Sarim
+  related_items:
+    - item_id: 5104
+      item_name: Redberry seed
+      slug: redberry-seed
+      relationship: component
+      description: Plant at 10 Farming
+    - item_id: 2325
+      item_name: Redberry pie
+      slug: redberry-pie
+      relationship: product
+      description: Cooked into a pie
+    - item_id: 1763
+      item_name: Red dye
+      slug: red-dye
+      relationship: product
+      description: Crafted into red dye
+  market_strategy:
+    notes:
+      - Cheap quest staple, 27 used across all quests
+      - Used to craft red dye for further dye recipes
+      - Picked from wild bushes south-east of Varrock mine
+      - Stealable from fruit stall at Xeric's Glade (25 Thieving)
+  history:
+    - date: "2001-02-28"
+      description: Released into the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-02-28"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    alchable: true
+  about: Redberries are a F2P quest and cooking staple harvested from bush patches, wild bushes, or shops, used in redberry pies and red dye.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/right-eye-patch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/right-eye-patch.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 150
-  about: "Right eye patch is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.006
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Fancy Dress Shop
+      location: Varrock
+      price: 25
+    - shop_name: Trader Stan's Trading Post
+      location: Various ports
+      price: 25
+  drop_table:
+    sources:
+      - source: Pirate
+        combat_level: 23
+        quantity: "1"
+        rarity: 12/128
+        members_only: false
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Left eye patch
+      slug: left-eye-patch
+      relationship: alternative
+      description: Mirrored variant
+    - item_name: Pirate hat
+      slug: pirate-hat
+      relationship: product
+      description: Combines via Patchy after Cabin Fever
+  about: Right eye patch is a cosmetic head-slot item dropped by pirates and used by Patchy to craft pirate hat-and-patch combinations after Cabin Fever.
+  market_strategy:
+    notes:
+      - Cheap cosmetic with low supply
+      - Holiday and roleplay demand
+      - Treasure Trail easy reward
+  history:
+    - date: "2016-07-06"
+      description: Renamed from "Eye patch" to "Right eye patch".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-the-elements.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-the-elements.mdx
@@ -14,61 +14,78 @@ osrs:
   limit: null
   equipment:
     slot: ring
-    type: utility ring
-    tradeable: true
     weight: 0.01
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  obtaining:
-    - source: Temple Supplies
-      cost: 400 abyssal pearls
-  charging:
+  shops:
+    - shop_name: Guardians of the Rift Reward Shop
+      location: Temple of the Eye
+      currency: abyssal_pearls
+      price: 400
+  charges:
     max_charges: 10000
-    cost_per_charge: 136 gp
-    materials: "1 each: Air, Water, Earth, Fire + Law rune"
-    notes: Becomes untradeable when charged
-  effect:
-    wintertodt: Counts as warm clothing (only ring with this effect)
-    teleports:
-      - Air altar
-      - Water altar
-      - Earth altar
-      - Fire altar
+    cost_per_charge: 139
+    materials_per_charge: "1 air rune + 1 water rune + 1 earth rune + 1 fire rune + 1 law rune"
+    notes: Becomes untradeable once charged; charges tracked per player account
+  teleport:
+    destinations:
+      - South of the Air altar
+      - West of the Water altar
+      - West of the Earth altar
+      - North of the Fire altar
+    notes: Counts as warm clothing at Wintertodt regardless of charge status
   related_items:
     - item_id: 26792
       item_name: Abyssal pearl
       slug: abyssal-pearl
       relationship: component
       description: Currency for purchase
-  about: |-
-    No combat bonuses.
-
-    Wintertodt: Counts as warm clothing (only ring with this effect).
-
-    Teleports: Air, Water, Earth, and Fire altars.
-
-    | Property | Value |
-    |----------|-------|
-    | Max charges | 10,000 |
-    | Cost per charge | 136 gp |
-    | Materials | 1 each: Air, Water, Earth, Fire + Law rune |
-
-    Becomes untradeable when charged.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Only obtained through Guardians of the Rift minigame
+      - Tradeable when uncharged, untradeable once charged
+      - Steady Runecraft minigame demand keeps abyssal pearl supply flowing
+      - Wintertodt warm-clothing perk makes it a popular utility ring
+  history:
+    - date: "2022-03-23"
+      description: Released with the Guardians of the Rift launch.
+  properties:
+    release_date: "2022-03-23"
+    update: Guardians of the Rift
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Rub
+      - Drop
+    worn_options:
+      - Remove
+      - Last Destination
+      - Uncharge
+    alchable: true
+  about: Ring of the elements is a charged utility ring teleporting to all four elemental altars and counting as warm clothing at Wintertodt.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-armour-set.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 58000
   highalch: 87000
   limit: null
-  about: "Rock-shell armour set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_id: 6128
+      item_name: Rock-shell helm
+      slug: rock-shell-helm
+      relationship: component
+      description: Helm piece of the set
+    - item_id: 6129
+      item_name: Rock-shell plate
+      slug: rock-shell-plate
+      relationship: component
+      description: Body piece of the set
+    - item_id: 6130
+      item_name: Rock-shell legs
+      slug: rock-shell-legs
+      relationship: component
+      description: Legs piece of the set
+    - item_id: 6145
+      item_name: Rock-shell gloves
+      slug: rock-shell-gloves
+      relationship: component
+      description: Gloves piece of the set
+    - item_id: 6143
+      item_name: Rock-shell boots
+      slug: rock-shell-boots
+      relationship: component
+      description: Boots piece of the set
+  market_strategy:
+    notes:
+      - Convenience set bundling five Rock-shell pieces
+      - Exchange at the Grand Exchange clerk for the individual pieces
+      - Premium over component value reflects packaging convenience
+  history:
+    - date: "2025-08-20"
+      description: Added to the game with the More Doom Tweaks, Poll 84, and Summer Sweep Up update.
+  properties:
+    release_date: "2025-08-20"
+    update: More Doom Tweaks, Poll 84, & Summer Sweep Up Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
+  about: Rock-shell armour set is a Grand Exchange convenience bundle containing the Rock-shell helm, plate, legs, gloves, and boots.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sandworms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sandworms.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 8000
-  about: "Sandworms is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 8,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Tynan's Fishing Supplies
+      location: Port Piscarilius
+      price: 90
+  related_items:
+    - item_id: 13441
+      item_name: Anglerfish
+      slug: anglerfish
+      relationship: alternative
+      description: Fish caught using sandworm bait
+    - item_id: 952
+      item_name: Spade
+      slug: spade
+      relationship: component
+      description: Required to dig sandworm castings
+    - item_id: 1925
+      item_name: Bucket
+      slug: bucket
+      relationship: component
+      description: Used to collect sandworms from castings
+  market_strategy:
+    notes:
+      - Hunter-level 15 gate keeps supply moderate
+      - Anglerfish bait demand drives flips
+      - Hourly profit 100k-150k from digging
+      - Tynan shop caps ceiling near 90 gp
+  history:
+    - date: "2016-01-07"
+      description: Released with Zeah - Great Kourend.
+  about: Fishing bait dug from sandworm castings at Port Piscarilius with 15 Hunter and used to catch anglerfish with a fishing rod.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: Zeah - Great Kourend
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-dragon-bolts.mdx
@@ -12,9 +12,101 @@ osrs:
   lowalch: 300
   highalch: 450
   limit: 11000
-  about: "Sapphire dragon bolts is a members-only item in Old School RuneScape. High alchemy value: 450 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: mid-high
+  equipment:
+    slot: ammo
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 122
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      ranged: 64
+    weight: 0
+  recipes:
+    - skill: Fletching
+      level: 84
+      xp: 4.7
+      product: Sapphire dragon bolts
+      quantity: 10
+      materials:
+        - item_name: Sapphire bolt tips
+          quantity: 10
+        - item_name: Dragon bolts
+          quantity: 10
+    - skill: Magic
+      level: 7
+      xp: 17.5
+      product: Sapphire dragon bolts (e)
+      quantity: 10
+      requirements: Enchant Crossbow Bolt (Sapphire) spell.
+      materials:
+        - item_name: Sapphire dragon bolts
+          quantity: 10
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Mind rune
+          quantity: 1
+        - item_name: Water rune
+          quantity: 1
+  related_items:
+    - item_id: 21955
+      item_name: Dragon bolts
+      slug: dragon-bolts
+      relationship: component
+      description: Base bolt before tipping
+    - item_id: 9189
+      item_name: Sapphire bolt tips
+      slug: sapphire-bolt-tips
+      relationship: component
+      description: Fletching tip used to craft bolts
+    - item_id: 21964
+      item_name: Sapphire dragon bolts (e)
+      slug: sapphire-dragon-bolts-e
+      relationship: upgrade
+      description: Enchanted Clear Mind variant
+  market_strategy:
+    notes:
+      - High Fletching XP from tipping
+      - Enchanted variant drives prayer-leech meta
+      - Buy limit 11,000 caps flips
+      - Active daily volume keeps spread tight
+  history:
+    - date: "2018-01-04"
+      description: Released with the Dragon Slayer II update.
+  about: Crossbow ammunition requiring 64 Ranged, fletched at 84 Fletching by attaching sapphire bolt tips to dragon bolts and enchantable into the Clear Mind variant.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-glacialis-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-glacialis-mix-1.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: null
-  about: "Sapphire glacialis mix (1) is a members-only item in Old School RuneScape. High alchemy value: 18 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - skill: Defence
+        description: Boosts Defence by floor(level*15/100)+4.
+      - skill: Multicombat
+        description: Shares the boost with up to three nearby players who have Accept Aid enabled.
+  related_items:
+    - item_id: 29199
+      item_name: Sapphire glacialis mix (2)
+      slug: sapphire-glacialis-mix-2
+      relationship: upgrade
+      description: Two-dose variant
+  market_strategy:
+    notes:
+      - Hunter mix demand from Varlamore PvM
+      - Defence boost niche for mid-game bosses
+      - Stack with Accept Aid for group support
+  history:
+    - date: "2024-04-03"
+      description: Group Ironmen can now share hunter mixes and butterflies with their group.
+    - date: "2024-03-20"
+      description: Released with Varlamore - Part One.
+  about: A one-dose hunter mixture made from a jarred sapphire glacialis butterfly that boosts Defence and can be shared with nearby Accept Aid players.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore - Part One
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: 30 coins
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-cloak.mdx
@@ -12,24 +12,89 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 8
+  material:
+    type: vestment
+    tier: mid
   equipment:
     slot: cape
+    weight: 0.4
     requirements:
       prayer: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
+  treasure_trail:
+    tier: medium
+    casket: Reward casket (medium)
+    rarity: 1/1133
   related_items:
     - item_id: 10458
       item_name: Saradomin robe top
       slug: saradomin-robe-top
       relationship: set-piece
       description: Saradomin vestment body
-  about: |-
-    > *"A Saradomin cloak."*
-
-    The Saradomin cloak is the cape piece of the Saradomin vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as a Saradominist item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 10464
+      item_name: Saradomin robe legs
+      slug: saradomin-robe-legs
+      relationship: set-piece
+      description: Saradomin vestment legs
+    - item_id: 10452
+      item_name: Saradomin mitre
+      slug: saradomin-mitre
+      relationship: set-piece
+      description: Saradomin vestment head
+    - item_id: 10440
+      item_name: Saradomin stole
+      slug: saradomin-stole
+      relationship: set-piece
+      description: Saradomin vestment neck
+  about: Saradomin cloak is the cape piece of the Saradomin vestment set, providing a +3 Prayer bonus at 40 Prayer and counting as a Saradominist item in the God Wars Dungeon.
+  market_strategy:
+    notes:
+      - Vestment set piece, demand tied to fashionscape
+      - 1/1133 from medium clues caps supply
+      - +3 prayer cape competes with Ardougne / God capes
+  prayer:
+    bonus: 3
+  history:
+    - date: "2025-04-02"
+      update: Game update
+      description: Playerkit visual appearance adjusted.
+    - date: "2006-12-05"
+      update: Treasure Trails revamp
+      description: Saradomin vestment set added.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: 5 December 2006
+    update: Treasure Trails revamp
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-platelegs.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
-  about: "Saradomin platelegs is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ore
+    tier: high
+  equipment:
+    slot: legs
+    weight: 9.071
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: -11
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    role: reward
+    rarity: 1/1625
+    notes: Reward from hard Treasure Trails reward caskets.
+  related_items:
+    - item_id: 1079
+      item_name: Rune platelegs
+      slug: rune-platelegs
+      relationship: variant
+      description: Plain version without prayer bonus
+    - item_id: 2661
+      item_name: Saradomin chaps
+      slug: saradomin-chaps
+      relationship: alternative
+      description: Ranged-style alternative legs
+    - item_id: 2665
+      item_name: Saradomin plateskirt
+      slug: saradomin-plateskirt
+      relationship: variant
+      description: Skirt variant with same stats
+  market_strategy:
+    notes:
+      - Hard Treasure Trail reward (1/1625 from caskets)
+      - Same defence as rune platelegs plus +1 prayer
+      - F2P-friendly god armour piece
+      - Wearing any Saradomin armour piece pacifies Saradomin followers
+  history:
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -7 to -11.
+    - date: "2014-01-09"
+      description: Added +1 prayer bonus to all god platelegs.
+    - date: "2004-05-05"
+      description: Released into the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  about: Saradomin platelegs are F2P rune-tier legs from hard Treasure Trails, offering rune defence with a +1 prayer bonus.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ship-ticket.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ship-ticket.mdx
@@ -12,13 +12,48 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 18000
-  related_items: []
-  about: |-
-    > _"Take this to the ship captain."_
-
-    A ship ticket is used to travel by ship between Port Sarim and Karamja. Consumed on use. The one-time 30 coin fee is one of the earliest travel costs new players encounter.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  shops:
+    - shop_name: Seravel
+      location: Shilo Village
+      price: 25
+    - shop_name: Captain Shanks
+      location: Port Sarim
+      price: 26
+  drop_table:
+    sources:
+      - source: Barrel (Shaman Caves, Legends' Quest)
+        quantity: "1"
+        rarity: 1/100
+        members_only: true
+  related_items:
+    - item_name: Karamja gloves
+      slug: karamja-gloves
+      relationship: alternative
+      description: Karamja Diary reward replaces ticket need
+  about: Ship ticket grants single passage aboard the Lady of the Waves between Port Sarim and Port Khazard/Shilo Village and is consumed on use.
+  market_strategy:
+    notes:
+      - Shop-priced cheap travel item
+      - Speculation capped by 18k GE limit
+      - Legacy travel option
+  history:
+    - date: "2003-01-27"
+      description: Released with the Shilo Village quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-01-27"
+    update: Shilo Village
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.004
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-resilience.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-resilience.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of resilience | OSRS Price Data
-description: "Sigil of resilience is a members shield slot item requiring 80 Defence. High alch: 6,000 GP, GE limit: 10."
+description: "Sigil of resilience is a Deadman Mode exclusive sigil that accelerates HP restoration. High alch: 6,000 GP, GE limit: 10."
 osrs:
   id: 25991
   name: Sigil of resilience
@@ -12,131 +12,45 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  equipment:
-    slot: shield
-    type: magic shield
-    tradeable: true
-    weight: 0.708
-    requirements:
-      magic: 80
-      defence: 80
-      prayer: 80
-      smithing: 90
-    stats:
-      attack_magic: 25
-      magic_damage_percent: 5
-      defence_stab: 51
-      defence_slash: 52
-      defence_crush: 48
-      defence_magic: 12
-      defence_ranged: 50
-      prayer: 3
-  creation:
-    materials:
-      - item_id: 25985
-        item_name: Elidinis' ward
-        quantity: 1
-      - item_id: 12827
-        item_name: Arcane sigil
-        quantity: 1
-      - item_id: 566
-        item_name: Soul rune
-        quantity: 10000
-    requirements:
-      prayer: 90
-      smithing: 90
-    notes: 90 Prayer and 90 Smithing required. Process cannot be reversed.
-  drop_table:
-    sources:
-      - source: Creation
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: N/A
-        members_only: true
-        notes: Created from Elidinis' ward + Arcane sigil + 10k Soul runes
-  market:
-    buy_limit: 8
-    price_estimate: 550000000
   related_items:
     - item_id: 25985
       item_name: Elidinis' ward
       slug: elidinis-ward
-      relationship: component
-      description: Base ward from ToA
-    - item_id: 12827
-      item_name: Arcane sigil
-      slug: arcane-sigil
-      relationship: component
-      description: From Corporeal Beast
+      relationship: alternative
+      description: ToA magic shield
     - item_id: 12825
       item_name: Arcane spirit shield
       slug: arcane-spirit-shield
       relationship: alternative
-      description: Previous BiS magic shield
-    - item_id: 27255
-      item_name: Menaphite ornament kit
-      slug: menaphite-ornament-kit
-      relationship: alternative
-      description: Cosmetic upgrade kit
-  about: |-
-    Combine at an anvil with 90 Prayer and 90 Smithing:
-    - Elidinis' ward
-    - Arcane sigil
-    - 10,000 soul runes
-
-    Warning: Process cannot be reversed. Components are permanently consumed.
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Elidinis' ward | Tombs of Amascut | ~3.6M |
-    | Arcane sigil | Corporeal Beast | ~100M |
-    | 10,000 Soul runes | GE/RC | ~4.5M |
-
-    | Offense | Value |
-    |---------|-------|
-    | Magic attack | +25 |
-    | Magic damage | +5% |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +51 |
-    | Slash | +52 |
-    | Crush | +48 |
-    | Magic | +12 |
-    | Ranged | +50 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +3 |
-
-    Requirements: 80 Magic, 80 Defence, 80 Prayer
-
-    Best-in-slot magic shield for:
-    - All magic content
-    - Tombs of Amascut
-    - Theatre of Blood
-    - Inferno
-    - Any shield slot magic combat
-
-    Outperforms Arcane spirit shield in every category.
-
-    | Stat | Elidinis' ward (f) | Arcane spirit shield |
-    |------|-------------------|---------------------|
-    | Magic attack | +25 | +20 |
-    | Magic damage | +5% | +0% |
-    | Prayer | +3 | +3 |
-    | Defence | Higher | Lower |
-
-    Can be upgraded with Menaphite ornament kit to create Elidinis' ward (or) - cosmetic only.
+      description: Alternative magic shield
+  about: Sigil of resilience is a Deadman Mode exclusive sigil that accelerates hitpoint restoration depending on the variant (3x Reborn, 10x Apocalypse, 15x Armageddon).
   market_strategy:
     notes:
-      - Requires high skill levels to create
-      - Most expensive shield in game
-      - Essential for max magic setups
-      - Arcane sigil is major cost
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Exclusive to temporary Deadman Mode events
+      - Cannot be obtained in standard live game
+      - Accelerated HP restoration scales by variant
+  history:
+    - date: "2023-08-23"
+      description: Adjusted to provide 10x health restoration rate for Deadman Apocalypse.
+    - date: "2021-08-25"
+      description: Item added with Deadman Reborn update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: false
+    equipable: false
+    stackable: false
+    noteable: false
+    members: true
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-barbarians.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-barbarians.mdx
@@ -12,9 +12,45 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of the barbarians is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Deadman Mode drop table (most monsters)
+        quantity: "1"
+        rarity: rare
+        members_only: true
+  related_items:
+    - item_name: Sigil of the smith
+      relationship: alternative
+      description: Tier 2 Deadman skilling sigil
+    - item_name: Sigil of the hunter
+      relationship: alternative
+      description: Tier 2 Deadman skilling sigil
+  about: Sigil of the barbarians is a Tier 2 Deadman Mode skilling sigil that, once attuned, grants 50% bonus XP in Firemaking, Fishing, Herblore, and Slayer.
+  market_strategy:
+    notes:
+      - Only obtainable during temporary Deadman Mode events
+      - Un-attuned copies are tradeable on the Grand Exchange
+      - Attuning binds the sigil permanently to the account
+  history:
+    - date: "2021-08-25"
+      description: Released with Deadman Reborn
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    update: Deadman Reborn
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-versatility.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-versatility.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of versatility is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Deadman Mode drop table
+        source_id: 0
+        combat_level: 0
+        quantity: "1"
+        rarity: Uncommon
+        members_only: true
+  related_items:
+    - item_id: 0
+      item_name: Attuned sigil of versatility
+      slug: attuned-sigil-of-versatility
+      relationship: upgrade
+      description: Untradeable attuned version after activation
+  about: Tier 2 Deadman Mode utility sigil that lets the holder swap spellbooks instantly outside combat once attuned; only obtainable during seasonal Deadman events.
+  market_strategy:
+    notes:
+      - Supply only flows during Deadman seasons
+      - Untradeable once attuned, gating circulation
+      - Dormant outside Deadman events
+      - Niche flip during event windows
+  history:
+    - date: "2021-08-25"
+      update: Released with Deadman Reborn
+      description: Released with Deadman Reborn
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-helm.mdx
@@ -14,6 +14,10 @@ osrs:
   limit: 70
   equipment:
     slot: head
+    weight: 1.36
+    requirements:
+      defence: 40
+      magic: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,10 +35,31 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 40
-      magic: 40
-    weight: 1.36
+  recipes:
+    - skill: none
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Dagannoth hide
+          item_id: 6155
+          quantity: 1
+        - item_name: Skull piece
+          item_id: 6165
+          quantity: 1
+        - item_name: Coins
+          quantity: 5000
+      product: Skeletal helm
+      product_id: 6137
+      product_quantity: 1
+      facility: Peer the Seer (Rellekka)
+  drop_table:
+    sources:
+      - source: Wallasalki
+        combat_level: 98
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+        notes: Drops skull piece used in helm creation.
   related_items:
     - item_id: 6139
       item_name: Skeletal top
@@ -51,45 +76,31 @@ osrs:
       slug: splitbark-helm
       relationship: alternative
       description: Craftable alternative with similar stats
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +2 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +10 |
-    | Slash | +9 |
-    | Crush | +11 |
-    | Magic | +3 |
-
-    Requirements: 40 Defence, 40 Magic
-
-    | Stat | Skeletal Helm | Splitbark Helm |
-    |------|--------------|----------------|
-    | Magic Atk | +2 | +3 |
-    | Stab Def | +10 | +10 |
-    | Slash Def | +9 | +9 |
-    | Crush Def | +11 | +11 |
-    | Magic Def | +3 | +3 |
-
-    Nearly identical — splitbark has +1 more Magic attack. Skeletal requires Fremennik Trials and DK materials, making splitbark generally easier to obtain.
-
-    The skeletal set is the magic variant of the three Fremennik armour sets:
-    - Rock-shell — melee (Skulgrimen)
-    - Skeletal — magic (Peer the Seer)
-    - Spined — ranged (Sigli the Huntsman)
-
-    All require The Fremennik Trials and dagannoth hides.
-
-    Can be stored in a Costume Room armour case in a Player-owned House as part of the complete skeletal set.
+  about: Skeletal helm is the magic-variant Fremennik head piece requiring 40 Defence / 40 Magic and The Fremennik Trials, assembled by Peer the Seer from a skull piece, dagannoth hide and 5,000 coins.
   market_strategy:
     notes:
-      - Skull pieces from Wallasalki (Waterbirth Island Dungeon)
-      - Rarely used — splitbark is easier to obtain and slightly better
-      - Collector's/fashionscape piece
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Skull pieces from Wallasalki cap supply
+      - Splitbark helm is easier and slightly better
+      - Collector/fashionscape demand only
+      - Quest gate (Fremennik Trials) thins buyers
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-01"
+    update: Waterbirth Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 1.36
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spined-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spined-gloves.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 260
   highalch: 390
   limit: 125
-  about: "Spined gloves is a members-only item in Old School RuneScape. High alchemy value: 390 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: hands
+    weight: 3.175
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Dagannoth
+        combat_level: 88
+        quantity: "1"
+        rarity: 2/128
+        members_only: true
+        notes: Waterbirth Island dagannoth
+  related_items:
+    - item_id: 6133
+      item_name: Spined helm
+      slug: spined-helm
+      relationship: alternative
+      description: Helm piece of Fremennik spined set
+    - item_id: 6135
+      item_name: Spined body
+      slug: spined-body
+      relationship: alternative
+      description: Body piece of Fremennik spined set
+    - item_id: 6137
+      item_name: Spined chaps
+      slug: spined-chaps
+      relationship: alternative
+      description: Legs piece of Fremennik spined set
+    - item_id: 6147
+      item_name: Spined boots
+      slug: spined-boots
+      relationship: alternative
+      description: Boots piece of Fremennik spined set
+  market_strategy:
+    notes:
+      - Direct drop from Waterbirth Island dagannoth at 2/128
+      - Storable in the Costume Room as part of the Spined set
+      - Low daily volume keeps GE price volatile
+  history:
+    - date: "2005-08-01"
+      description: Released with the Waterbirth Island update.
+  properties:
+    release_date: "2005-08-01"
+    update: Waterbirth Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  about: Spined gloves are Fremennik ranged hands armour stitched from spined dagannoth hide, dropped by dagannoths on Waterbirth Island.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/statius-s-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/statius-s-platebody.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 10
-  about: "Statius's platebody is a members-only item in Old School RuneScape. High alchemy value: 300,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    attack_bonus:
+      stab: 2
+      slash: 2
+      crush: 14
+      magic: -38
+      ranged: -17
+    defence_bonus:
+      stab: 102
+      slash: 97
+      crush: 94
+      magic: -16
+      ranged: 105
+    other_bonus:
+      melee_strength: 5
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 3
+    requirements:
+      defence: 78
+    weight: 9.979
+  shops:
+    - shop_name: Bounty Hunter Store
+      location: Edgeville
+      price: 600
+      currency: Bounty Hunter points
+  related_items:
+    - item_id: 22622
+      item_name: Statius's full helm
+      slug: statius-s-full-helm
+      relationship: set-piece
+      description: Matching helm piece
+    - item_id: 22634
+      item_name: Statius's platelegs
+      slug: statius-s-platelegs
+      relationship: set-piece
+      description: Matching legs piece
+    - item_id: 22622
+      item_name: Statius's warhammer
+      slug: statius-s-warhammer
+      relationship: alternative
+      description: Matching crush weapon
+  market_strategy:
+    notes:
+      - Untradeable Bounty Hunter armour
+      - 78 Defence requirement gates wear
+      - Strong crush defence and prayer bonus
+      - Boost from full Statius set bonus
+  history:
+    - date: "2026-03-25"
+      description: Now usable in TzHaar Fight Pit and POH/Clan Hall combat rings.
+    - date: "2024-09-11"
+      description: Enabled in Castle Wars, Clan Wars, and Soul Wars.
+    - date: "2023-06-14"
+      description: Stab and slash attack reduced from +5 to +2, crush increased from +7 to +14, prayer increased from +1 to +3.
+    - date: "2023-05-24"
+      description: Released with the Bounty Hunter rework.
+  about: A heavy Bounty Hunter platebody for 78 Defence with strong melee defence, a +3 prayer bonus, and a set bonus that boosts special-attack accuracy with other Statius gear.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-05-24"
+    update: Bounty Hunter is Back!
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.979
+    options:
+      - Uncharge
+      - Drop
+    worn_options:
+      - Wear
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steamforge-brew.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steamforge-brew.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: null
-  about: "Steamforge brew is a members-only item in Old School RuneScape. High alchemy value: 4 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: beverage
+    tier: low
+  potion:
+    doses: 1
+    effects:
+      - description: Restores 1 Hitpoint
+      - description: Temporarily boosts Mining by 1 level
+      - description: Temporarily boosts Magic by 1 level
+      - description: Reduces Attack by 5% + 2 of current level
+      - description: Reduces Defence by 5% + 2 of current level
+  shops:
+    - shop_name: The Lost Pickaxe
+      location: Cam Torum
+      price: 8
+    - shop_name: Stick Your Ore Inn
+      location: Mistrock, south of Aldarin
+      price: 8
+  related_items:
+    - item_id: 0
+      item_name: Cam Torum
+      slug: cam-torum
+      relationship: alternative
+      description: Source dwarven town in Varlamore
+  about: Steamforge brew is a members-only dwarven beverage from Cam Torum that boosts Mining and Magic by 1 while reducing Attack and Defence.
+  market_strategy:
+    notes:
+      - Sold by Cam Torum dwarven shops with infinite stock
+      - Niche Mining/Magic micro-boost
+      - Low alch value, limited demand
+  history:
+    - date: "2024-03-20"
+      update: Varlamore - Part One
+      description: Introduced with the Cam Torum release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: 20 March 2024
+    update: Varlamore - Part One
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-arrow.mdx
@@ -12,23 +12,51 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 7000
+  material:
+    type: ammunition
+    tier: low
   equipment:
     slot: ammo
-    type: arrow
-    attack_style: ranged
-  requirements:
-    ranged: 5
-  stats:
-    other:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 16
-  fletching:
-    level: 30
-    xp: 5
-    method: Steel arrowtips + headless arrows
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      ranged: 5
+    weight: 0
+  recipes:
+    - skill: Fletching
+      level: 30
+      xp: 5
+      product: Steel arrow
+      quantity: 15
+      materials:
+        - item_name: Steel arrowtips
+          quantity: 15
+        - item_name: Headless arrow
+          quantity: 15
   shops:
     - shop_name: Lowe's Archery Emporium
       location: Varrock
-      price: 32
+      stock: 1000
+      price: 12
+    - shop_name: Brian's Archery Supplies
+      location: Rimmington
+      stock: 1500
+      price: 12
   related_items:
     - item_id: 888
       item_name: Mithril arrow
@@ -50,8 +78,36 @@ osrs:
       slug: headless-arrow
       relationship: component
       description: Fletching material
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - F2P viable ranged ammunition
+      - Steady fletching supply at level 30
+      - Shop-bought from Varrock and Rimmington
+      - Common low-tier ranged training arrow
+  history:
+    - date: "2025-05-29"
+      description: Exempted from Grand Exchange convenience fee.
+    - date: "2002-03-25"
+      description: Released with the original game launch.
+  about: Steel arrows are ranged ammunition with steel heads, fletched at level 30 Fletching or bought from F2P archery shops.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-25"
+    update: Latest RuneScape News
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-mace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-mace.mdx
@@ -12,28 +12,63 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 125
+  material:
+    type: ore
+    tier: low
   equipment:
     slot: weapon
-    type: mace
-    tradeable: true
+    weapon_type: blunt
+    attack_speed: 4
     weight: 1.814
     requirements:
       attack: 5
-    stats:
-      attack_stab: 7
-      attack_slash: -2
-      attack_crush: 13
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 11
+    attack_bonus:
+      stab: 7
+      slash: -2
+      crush: 13
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 11
       ranged_strength: 0
       magic_damage: 0
       prayer: 2
+  recipes:
+    - skill: Smithing
+      level: 32
+      xp: 37.5
+      materials:
+        - item_name: Steel bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Flynn's Mace Market
+      location: Falador
+      price: 225
+    - shop_name: Warrior Guild Armoury
+      location: Burthorpe
+      price: 270
+  treasure_trail:
+    tier: easy
+    role: reward
+    notes: Easy emote clue at Mudskipper Point.
+  drop_table:
+    sources:
+      - source: Cyclops
+        rarity: uncommon
+      - source: Dark warrior
+        rarity: uncommon
+      - source: Skeleton
+        rarity: uncommon
   related_items:
     - item_id: 1426
       item_name: Black mace
@@ -45,8 +80,31 @@ osrs:
       slug: steel-warhammer
       relationship: alternative
       description: Higher strength alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Free-to-play crush weapon
+      - Has +2 prayer bonus, useful for low-level prayer training
+      - Smithing this at 32 loses money vs steel bar cost
+      - Common shop stock
+  history:
+    - date: "2021-04-21"
+      description: Attack speed improved from 5 ticks to 4 ticks per strike.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  about: Steel mace is a F2P crush weapon requiring 5 Attack that offers a small prayer bonus alongside solid crush damage.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-mix-2.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 79
   highalch: 118
   limit: 2000
-  about: "Super antifire mix(2) is a members-only item in Old School RuneScape. High alchemy value: 118 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: Provides 3 minutes of complete dragonfire protection (with antifire shield/dragonfire shield).
+      - description: Restores 6 Hitpoints on drink.
+  recipes:
+    - skill: herblore
+      level: 98
+      xp: 140
+      materials:
+        - item_name: Super antifire potion(2)
+          item_id: 21981
+          quantity: 1
+        - item_name: Caviar
+          item_id: 7588
+          quantity: 1
+      product: Super antifire mix(2)
+      product_id: 21994
+      product_quantity: 1
+      facility: Barbarian Herblore (Otto Godblessed)
+  related_items:
+    - item_id: 21978
+      item_name: Super antifire potion(4)
+      slug: super-antifire-potion-4
+      relationship: alternative
+      description: Standard (non-mix) variant
+    - item_id: 21992
+      item_name: Super antifire mix(1)
+      slug: super-antifire-mix-1
+      relationship: downgrade
+      description: Single-dose variant
+  about: Super antifire mix(2) is a 2-dose Barbarian Herblore brew (98 Herblore) granting 3 minutes of complete dragonfire protection and restoring 6 HP per dose.
+  market_strategy:
+    notes:
+      - 98 Herblore + Barbarian training gates supply
+      - Caviar supply caps margins
+      - Demand spikes for Vorkath / Wyrms
+      - Combat HP heal is the main selling point
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-potion-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-potion-set.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 2000
-  about: "Super potion set is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion-set
+    tier: mid
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Super attack(4)
+          item_id: 2436
+          quantity: 1
+        - item_name: Super strength(4)
+          item_id: 2440
+          quantity: 1
+        - item_name: Super defence(4)
+          item_id: 2442
+          quantity: 1
+      product: Super potion set
+      product_id: 13066
+      product_quantity: 1
+      facility: Grand Exchange
+  related_items:
+    - item_id: 2436
+      item_name: Super attack(4)
+      slug: super-attack-4
+      relationship: component
+      description: Set component
+    - item_id: 2440
+      item_name: Super strength(4)
+      slug: super-strength-4
+      relationship: component
+      description: Set component
+    - item_id: 2442
+      item_name: Super defence(4)
+      slug: super-defence-4
+      relationship: component
+      description: Set component
+  about: Super potion set bundles 4-dose Super attack, Super strength, and Super defence potions into a single tradeable item via the Grand Exchange Sets interface.
+  market_strategy:
+    notes:
+      - Sets-tab arbitrage vs. component pricing
+      - Combine/break flips work when discount/premium opens
+      - 2,000 buy limit gates volume
+  trading_tips:
+    - Watch the spread between set price and sum of components
+    - Use Grand Exchange clerk "Sets" option to combine or break
+  history:
+    - date: "2015-02-26"
+      update: Grand Exchange Sets
+      description: Released alongside the Grand Exchange Sets interface.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: 26 February 2015
+    update: Grand Exchange Sets
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-boots.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: null
-  about: "Swampbark boots is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.907
+    requirements:
+      magic: 50
+      defence: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 4
+      slash: 3
+      crush: 5
+      magic: 4
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Swampbark boots
+      skill: Runecraft
+      level: 42
+      facility: Nature Altar
+      materials:
+        - item_name: Splitbark boots
+          quantity: 1
+        - item_name: Nature rune
+          quantity: 100
+  related_items:
+    - item_name: Splitbark boots
+      slug: splitbark-boots
+      relationship: component
+      description: Base item for swampbark conversion
+    - item_name: Nature rune
+      slug: nature-rune
+      relationship: component
+      description: Conversion reagent
+    - item_name: Runescroll of swampbark
+      slug: runescroll-of-swampbark
+      relationship: upgrade
+      description: Required to learn the craft
+    - item_name: Bloodbark boots
+      slug: bloodbark-boots
+      relationship: alternative
+      description: Higher tier swampbark relative
+  about: Swampbark boots are crafted by binding nature runes into splitbark boots at the Nature Altar and provide hybrid magic defence for level-50 mages.
+  market_strategy:
+    notes:
+      - Negative crafting margin discourages flips
+      - Demand tied to swampbark armour sets
+      - Runecrafters supply incidentally
+  history:
+    - date: "2021-01-27"
+      description: Released with the Shades of Mort'ton rework.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-01-27"
+    update: Shades of Mort'ton rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tarromin-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tarromin-seed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tarromin seed | OSRS Price Data
-description: "Tarromin seed: A tarromin seed - plant in a herb patch.. High alch: 1 GP, GE limit: 600."
+description: "Tarromin seed grows into grimy tarromin at 19 Farming. High alch: 1 GP, GE limit: 600."
 osrs:
   id: 5293
   name: Tarromin seed
@@ -12,19 +12,20 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 600
-  seed:
-    type: herb
+  material:
+    type: seed
     tier: low
   farming:
-    level: 19
-    xp_plant: 16
-    xp_harvest: 18
+    farming_level: 19
+    plant_xp: 16
+    harvest_xp: 18
     growth_time: 80
     patches: 9
-    product_id: 203
+    product_id: 199
     product_name: Grimy tarromin
+    notes: Gardeners will not watch over herb patches; white lily plants do not protect.
   related_items:
-    - item_id: 203
+    - item_id: 199
       item_name: Grimy tarromin
       slug: grimy-tarromin
       relationship: product
@@ -49,28 +50,40 @@ osrs:
       slug: harralander-seed
       relationship: upgrade
       description: Next tier herb seed
-  about: |-
-    Plant in a herb patch to grow Grimy tarromin.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 19 |
-    | Growth time | 80 minutes |
-    | XP (plant) | 16 |
-    | XP (harvest) | 18 per herb |
+  about: Tarromin seed plants in a herb patch to grow grimy tarromin; low-tier herb requiring 19 Farming, used for strength potions and serum 207.
   market_strategy:
     notes:
       - Low-tier herb seed
       - Used for strength potions and serum 207
       - Low profit margin
-      - Ultracompost (essential)
-      - Magic secateurs (10% more yield)
-      - Farming cape (5% more yield)
+      - Ultracompost essential for yield
+      - Magic secateurs add 10% yield
+      - Farming cape adds 5% yield
       - 9 herb patches available
-      - ~10 minute runs, 80 minute regrowth
       - Serum 207 used for Shades of Mort'ton minigame
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2020-01-09"
+      description: Players can dig up healthy patches early; planting XP moved to harvest.
+    - date: "2018-02-08"
+      description: Value changed from 7 to 3 coins.
+    - date: "2005-08"
+      description: Renamed from Herb seed to Tarromin seed.
+    - date: "2005-06-06"
+      description: Item added with Farming skill release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-06-06"
+    update: Farming
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    members: true
+    weight: 0
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teacher-wand.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teacher-wand.mdx
@@ -14,7 +14,11 @@ osrs:
   limit: 70
   equipment:
     slot: weapon
-    type: wand
+    weapon_type: powered-staff
+    attack_speed: 4
+    weight: 0.226
+    requirements:
+      magic: 55
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,22 +36,23 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      magic: 55
-    weight: 0.226
-    attack_speed: 4
-    combat_style: staff
-    autocast: standard
-  shop:
-    currency: pizazz_points
-    cost:
-      telekinetic: 150
-      alchemist: 200
-      enchantment: 1500
-      graveyard: 150
-    requires_item:
-      item_id: 6910
-      item_name: Apprentice wand
+  shops:
+    - shop_name: Mage Training Arena Reward Shop
+      location: Mage Training Arena
+      currency: pizazz_points
+      notes: "Requires Apprentice wand plus 150 Telekinetic, 200 Alchemist, 1500 Enchantment, 150 Graveyard points"
+  recipes:
+    - skill: magic
+      level: 55
+      materials:
+        - item_name: Apprentice wand
+          item_id: 6910
+          quantity: 1
+      product: Teacher wand
+      product_id: 6912
+      product_quantity: 1
+      facility: Mage Training Arena
+      members_only: true
   related_items:
     - item_id: 6908
       item_name: Beginner wand
@@ -69,41 +74,35 @@ osrs:
       slug: kodai-wand
       relationship: upgrade
       description: Best-in-slot wand from Chambers of Xeric
-  about: |-
-    | Stat | Attack | Defence |
-    |------|--------|---------|
-    | Stab | 0 | 0 |
-    | Slash | 0 | 0 |
-    | Crush | 0 | 0 |
-    | Magic | +15 | +15 |
-    | Ranged | 0 | 0 |
-
-    Requirements: 55 Magic | Weight: 0.23 kg | Speed: 4 ticks (2.4s)
-
-    The teacher wand supports Standard Spellbook autocast only. It cannot autocast Ancient Magicks or Arceuus spells. As a one-handed wand, it allows use of a shield or book in the off-hand slot.
-
-    The teacher wand is the third tier in the Mage Training Arena wand progression:
-
-    | Wand | Magic Atk | Magic Def | Req | Notes |
-    |------|----------|----------|-----|-------|
-    | Beginner wand | +5 | +5 | 45 | Entry tier |
-    | Apprentice wand | +10 | +10 | 50 | Required to buy teacher |
-    | Teacher wand | +15 | +15 | 55 | This item |
-    | Master wand | +20 | +20 | 60 | Best MTA wand |
-    | Kodai wand | +28 | +20 | 75 | Best-in-slot, Chambers of Xeric |
-
-    Each wand upgrade adds +5 magic attack and +5 magic defence. The teacher wand sits in the middle of the progression and is often skipped in favour of saving for the master wand.
-
-    The wand progression requires trading in the previous tier plus additional pizazz points at each step. Cumulative point costs increase significantly for higher tiers. Players aiming for the master wand will pass through the teacher wand as an intermediate step.
   market_strategy:
     notes:
-      - High GE value (~1.87M gp) due to time-gated MTA grind
+      - High GE value due to time-gated MTA grind
       - Often purchased as a stepping stone toward master wand
       - Some players buy from GE to skip part of the MTA grind
       - Demand is relatively stable from mid-level mages
       - The one-handed slot makes it useful with mage books and shields
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2006-01-04"
+      description: Released with the Mage Training Arena update.
+  properties:
+    release_date: "2006-01-04"
+    update: Mage Training Arena
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  about: Teacher wand is the third tier in the Mage Training Arena wand progression, providing +15 Magic attack and defence at 55 Magic.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-cape-rack-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-cape-rack-flatpack.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Teak cape rack (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    creates: Teak cape rack
+    room: Costume Room
+    hotspot: Cape rack
+  recipes:
+    - product: Teak cape rack (flatpack)
+      skill: Construction
+      level: 63
+      xp: 360
+      facility: Bench with vice
+      tools:
+        - Saw
+        - Hammer
+      materials:
+        - item_name: Teak plank
+          quantity: 4
+  related_items:
+    - item_name: Teak plank
+      relationship: component
+      description: Construction material
+    - item_name: Oak cape rack (flatpack)
+      relationship: downgrade
+      description: Lower-tier cape rack flatpack
+    - item_name: Mahogany cape rack (flatpack)
+      relationship: upgrade
+      description: Higher-tier cape rack flatpack
+  about: Teak cape rack (flatpack) is a prefabricated cape rack built at a workbench with vice from four teak planks, used to install or upgrade the cape hotspot in a Player-Owned House costume room.
+  market_strategy:
+    notes:
+      - Cheap teak-plank sink for Construction levellers
+      - Buy limit of 500 supports modest bulk flipping
+      - Demand mostly from POH builders and flatpack farmers
+  history:
+    - date: "2006-10-18"
+      description: Released with the Costume Room update
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-10-18"
+    update: Player-Owned House costume room
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-9-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-9-cape.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-9 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.453
+  shops:
+    - shop_name: Simon's Wilderness Cape Shop
+      location: Chaos Temple
+      stock: 100
+      price: 50
+  related_items:
+    - item_id: 4315
+      item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: alternative
+      description: Different team colour variant
+    - item_id: 4329
+      item_name: Team-8 cape
+      slug: team-8-cape
+      relationship: alternative
+      description: Adjacent team colour variant
+    - item_id: 4333
+      item_name: Team-10 cape
+      slug: team-10-cape
+      relationship: alternative
+      description: Adjacent team colour variant
+  market_strategy:
+    notes:
+      - F2P-tradeable PvP identifier cape
+      - Cheap minimap team marker for clan wars
+      - Persistent shop supply caps price
+  history:
+    - date: "2013-05-23"
+      description: Made available to free-to-play players.
+    - date: "2005-02-22"
+      description: Released with Wilderness Capes, and Changes update.
+  about: A cheap F2P team cape that grants minor defensive bonuses and lets allied players identify each other on the minimap during PvP.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-22"
+    update: Wilderness Capes, and Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toad-batta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toad-batta.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Toad batta is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: low
+  food:
+    heals: 12
+    cooking_level: 26
+    cooking_xp: 152
+    burn_level: 38
+    special_effect: Gnome cuisine batta
+  recipes:
+    - skill: cooking
+      level: 26
+      xp: 152
+      materials:
+        - item_name: Half made batta (toad)
+          item_id: 0
+          quantity: 1
+        - item_name: Equa leaves
+          item_id: 2128
+          quantity: 1
+        - item_name: Cheese
+          item_id: 1985
+          quantity: 1
+        - item_name: Toad legs
+          item_id: 2152
+          quantity: 1
+        - item_name: Gnome spice
+          item_id: 2169
+          quantity: 1
+      facility: Cooking range
+      ticks: 4
+      members_only: true
+  shops:
+    - shop_name: Gnome waiters
+      location: Grand Tree
+      price: 120
+      members_only: true
+  related_items:
+    - item_id: 2217
+      item_name: Cheese+tom batta
+      slug: cheese-tom-batta
+      relationship: alternative
+      description: Other gnome batta variant
+    - item_id: 2225
+      item_name: Worm batta
+      slug: worm-batta
+      relationship: alternative
+      description: Other gnome batta variant
+  about: Gnome cuisine batta cooked from a half-made batta with equa leaves, cheese, toad legs, and gnome spice; heals 12 HP and is also served by Grand Tree waiters.
+  market_strategy:
+    notes:
+      - Low-tier gnome food, near-junk alch
+      - Used in gnome cuisine training and minigame
+      - Burns until level 38, capping flipping
+      - Mostly used by Gnome Restaurant runners
+  history:
+    - date: "2002-12-12"
+      update: Released
+      description: Released
+    - date: "2006-08-07"
+      update: Graphical update during Gnome Cuisine update
+      description: Graphical update during Gnome Cuisine update
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Gnome cuisine
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toktz-xil-ak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toktz-xil-ak.mdx
@@ -14,15 +14,17 @@ osrs:
   limit: 70
   equipment:
     slot: weapon
+    weapon_type: stab-sword
+    attack_speed: 4
     attack_bonus:
-      stab: 36
-      slash: 55
+      stab: 47
+      slash: 38
       crush: -2
       magic: 0
       ranged: 0
     defence_bonus:
-      stab: 0
-      slash: 0
+      stab: 2
+      slash: 3
       crush: 0
       magic: 0
       ranged: 0
@@ -33,6 +35,16 @@ osrs:
       prayer: 0
     requirements:
       attack: 60
+    weight: 1.814
+  shops:
+    - shop_name: TzHaar-Hur-Tel's Equipment Store
+      location: Mor Ul Rek
+      price: 60000
+      currency: Tokkul
+    - shop_name: TzHaar-Hur-Zal's Equipment Store
+      location: Mor Ul Rek
+      price: 60000
+      currency: Tokkul
   related_items:
     - item_id: 6525
       item_name: Toktz-xil-ek
@@ -49,20 +61,34 @@ osrs:
       slug: tzhaar-ket-om
       relationship: alternative
       description: Obsidian maul (crush)
-  about: |-
-    Strong 60 Attack weapon:
-    - Benefits from Obsidian armour set effect (+10% accuracy/damage)
-    - Good Strength training weapon
-    - Popular for low-level PvP
-
-    With full Obsidian set + Berserker necklace: Competitive DPS for training.
   market_strategy:
     notes:
       - Tokkul farmable from TzHaar Fight Cave
-      - Popular for Strength training meta
-      - Obsidian set synergy drives demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Popular Strength training meta weapon
+      - Obsidian armour set synergy drives demand
+      - Karamja gloves discount drops cost to 52,000 Tokkul
+  history:
+    - date: "2005-09-19"
+      description: Released with the Fight Pits minigame.
+  about: A 60 Attack obsidian stab sword that swings every 4 ticks and synergises with the obsidian armour set bonus and berserker necklace for strong Strength training.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-09-19"
+    update: Massive minigame - Fight Pits
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tormented-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tormented-bracelet.mdx
@@ -14,12 +14,26 @@ osrs:
   limit: 8
   equipment:
     slot: hands
-    type: bracelet
+    weight: 0.25
     requirements:
       hitpoints: 75
-    stats:
-      attack_magic: 10
-      magic_damage_percent: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 5
+      prayer: 2
   recipes:
     - skill: magic
       level: 93
@@ -63,38 +77,36 @@ osrs:
       slug: barrows-gloves
       relationship: alternative
       description: All-around option
-  about: |-
-    Enchant Zenyte bracelet with Lvl-7 Enchant spell (93 Magic).
-
-    | Material | Quantity |
-    |----------|----------|
-    | Zenyte bracelet | 1 |
-    | Soul rune | 20 |
-    | Blood rune | 20 |
-    | Cosmic rune | 1 |
-
-    | Stat | Value |
-    |------|-------|
-    | Magic attack | +10 |
-    | Magic damage | +5% |
-    | Requirements | 75 Hitpoints |
-
-    PvM:
-    - Best-in-slot magic gloves
-    - Essential for max magic setups
-    - All magic content
-
-    Best For:
-    - Bossing
-    - Bursting/Barraging
-    - Magic DPS
   market_strategy:
     notes:
-      - Zenyte from demonic gorillas
-      - BiS magic hands slot
-      - Only gloves with magic damage
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Zenyte ingredient sourced from demonic gorillas
+      - Best-in-slot magic hands slot
+      - Only gloves offering magic damage bonus
+      - Buy limit of 8 throttles supply against bossing demand
+  history:
+    - date: "2020-09-01"
+      description: Grand Exchange buy limit reduced from 10,000 to 8.
+    - date: "2016-05-06"
+      description: Released with the Monkey Madness II update.
+  properties:
+    release_date: "2016-05-06"
+    update: Monkey Madness II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  about: Tormented bracelet is the best-in-slot magic gloves enchanted from a Zenyte bracelet using Lvl-7 Enchant at 93 Magic.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toy-doll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toy-doll.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 150
-  about: "Toy doll is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - name: Toy doll
+      skill: Crafting
+      level: 18
+      xp: 15
+      facility: Crafting table 3
+      materials:
+        - item_name: Clockwork
+          quantity: 1
+        - item_name: Plank
+          quantity: 1
+  related_items:
+    - item_name: Clockwork
+      slug: clockwork
+      relationship: component
+      description: Mechanism core
+    - item_name: Plank
+      slug: plank
+      relationship: component
+      description: Doll body material
+    - item_name: Toy mouse
+      slug: toy-mouse
+      relationship: alternative
+      description: Alternative clockwork toy
+  about: Toy doll is a clockwork toy crafted at a Crafting table 3 in a player-owned house workshop; releasing it grants the player a small amount of Agility experience when caught.
+  market_strategy:
+    notes:
+      - Crafted from clockwork + plank
+      - Scam-bait in restricted release zones
+      - Limited niche demand
+  history:
+    - date: "2006-05-31"
+      description: Released with the Player-Owned Houses update.
+    - date: "2014-08-14"
+      description: Limited the number of clockwork toys that can be dropped in an area.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wind
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trading-sticks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trading-sticks.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 18000
-  about: "Trading sticks is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      price: 1
+      currency: Coins
+  drop_table:
+    sources:
+      - source: Jogre
+        combat_level: 53
+        quantity: "5-15"
+        rarity: common
+        members_only: true
+      - source: Broodoo victim
+        combat_level: 73
+        quantity: "varies"
+        rarity: common
+        members_only: true
+  related_items:
+    - item_id: 995
+      item_name: Coins
+      slug: coins
+      relationship: alternative
+      description: Standard Gielinor currency
+    - item_id: 6571
+      item_name: Uncut opal
+      slug: uncut-opal
+      relationship: alternative
+      description: Tradeable gem sold to Gabooty for sticks
+  market_strategy:
+    notes:
+      - Karamja-region currency, 1 gp value
+      - Bulk demand for Hardwood Grove access
+      - Earnable via Tai Bwo Wannai Cleanup
+      - Brimhaven Dungeon shortcut sink (5,000)
+  history:
+    - date: "2005-08-09"
+      description: Released with the Tai Bwo Wannai Clean-Up minigame.
+  about: The currency of the jungle village of Tai Bwo Wannai on Karamja, used to enter the Hardwood Grove, bank items through Rionasta, and unlock the Brimhaven Dungeon shortcut.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-hat-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-hat-t3.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 5
-  about: "Twisted hat (t3) is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues Reward Hall
+      currency: league_points
+      price: 10000
+      notes: Tier 3 Twisted Relic Hunter outfit reward
+  related_items:
+    - item_id: 24389
+      item_name: Twisted coat (t3)
+      slug: twisted-coat-t3
+      relationship: alternative
+      description: Body piece of the t3 outfit
+    - item_id: 24391
+      item_name: Twisted trousers (t3)
+      slug: twisted-trousers-t3
+      relationship: alternative
+      description: Legs piece of the t3 outfit
+    - item_id: 24393
+      item_name: Twisted boots (t3)
+      slug: twisted-boots-t3
+      relationship: alternative
+      description: Boots piece of the t3 outfit
+  market_strategy:
+    notes:
+      - Prestige cosmetic from the Twisted League
+      - GE buy limit of 5 keeps supply scarce
+      - Storeable in Costume Room armour case or League hall
+  history:
+    - date: "2020-01-16"
+      description: Made obtainable; value increased to 100,000 coins; made tradeable on GE and banknoteable.
+    - date: "2019-11-14"
+      description: Item added to game.
+  properties:
+    release_date: "2020-01-16"
+    update: Twisted League Reward Shop and Game Improvements
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  about: Twisted hat (t3) is the head piece of the Tier 3 Twisted Relic Hunter cosmetic outfit purchased from the Leagues Reward Shop for 10,000 League points.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tyras-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tyras-helm.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 220
   highalch: 330
   limit: 150
-  about: "Tyras helm is a members-only item in Old School RuneScape. High alchemy value: 330 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.907
+    requirements:
+      defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 9
+      slash: 10
+      crush: 7
+      magic: -1
+      ranged: 9
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Trader Stan's Trading Post
+      location: Various trading posts
+      members_only: true
+  related_items:
+    - item_id: 1153
+      item_name: Steel full helm
+      slug: steel-full-helm
+      relationship: alternative
+      description: Same Defence req with similar stats
+  about: Tyras helm is a members head slot helmet sold by Trader Stan's Trading Post; nearly identical to a steel full helm but offers slightly better ranged defence.
+  market_strategy:
+    notes:
+      - Bought from Trader Stan, supply is steady
+      - Cosmetic appeal as King Tyras guard helm
+      - Niche use at low Defence
+      - Buy limit 150 caps speculation
+  history:
+    - date: "2006-08-22"
+      update: Regicide quest release
+      description: Regicide quest release
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-08-22"
+    update: Regicide
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unfired-pie-dish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unfired-pie-dish.mdx
@@ -14,10 +14,7 @@ osrs:
   limit: 10000
   material:
     type: pottery
-    tier: unfired
-  crafting:
-    level: 7
-    xp: 15
+    tier: low
   recipes:
     - skill: crafting
       level: 7
@@ -52,27 +49,31 @@ osrs:
       slug: pie-dish
       relationship: product
       description: Fired version
-  about: |-
-    | Method | Level | Materials |
-    |--------|-------|-----------|
-    | Potter's wheel | 7 | 1 Soft clay |
-    | XP | 15 | - |
-
-    | Method | Level | XP |
-    |--------|-------|-----|
-    | Pottery oven | 1 | 10 |
-    | Success rate | 100% | - |
+  about: Unfired pie dish is a free-to-play crafting intermediate made from soft clay at a potter's wheel before firing in a pottery oven.
   market_strategy:
     notes:
-      - Pie dish crafting
-      - Cooking skill
-      - F2P accessible
-      - Higher XP than pots
-      - No failure rate for firing
-      - Used in Cooking
-      - F2P accessible
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - F2P accessible crafting product
+      - Used to train Crafting via firing for Pie dish
+      - Soft clay supply gates production
+  history:
+    - date: "2001-05-08"
+      update: RuneScape update
+      description: Item present since early RuneScape.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: 8 May 2001
+    update: RuneScape update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.68
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-magic-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-magic-staff.mdx
@@ -1,6 +1,6 @@
 ---
 title: White magic staff | OSRS Price Data
-description: "White magic staff: A Magical staff.. High alch: 120 GP, GE limit: 125."
+description: "White magic staff is a members one-handed magic staff requiring 10 Attack and completion of Wanted! quest. High alch: 120 GP, GE limit: 125."
 osrs:
   id: 6603
   name: White magic staff
@@ -12,9 +12,74 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 125
-  about: "White magic staff is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 2
+      slash: -1
+      crush: 10
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 10
+      ranged: 0
+    other_bonus:
+      melee_strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: Sir Vyvin's Armour Shop
+      location: White Knights' Castle, Falador
+      stock: 5
+      price: 200
+      currency: coins
+      notes: Requires Noble rank (500 Black Knight kills)
+  related_items:
+    - item_id: 1379
+      item_name: Staff of air
+      slug: staff-of-air
+      relationship: alternative
+      description: Basic elemental staff
+    - item_id: 1383
+      item_name: Staff of water
+      slug: staff-of-water
+      relationship: alternative
+      description: Basic elemental staff
+  about: White magic staff is a one-handed magic staff requiring 10 Attack and completion of the Wanted! quest, autocasting Standard spellbook only.
+  market_strategy:
+    notes:
+      - Locked behind Wanted! quest
+      - Niche prayer bonus +1 staff
+      - Cheap alternative to ancient staff
+  history:
+    - date: "2006-10-11"
+      description: Renamed from Magic staff to White magic staff.
+    - date: "2005-10-17"
+      description: Item added with Wanted! quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-10-17"
+    update: Wanted!
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-shortbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-shortbow.mdx
@@ -14,24 +14,50 @@ osrs:
   limit: 18000
   equipment:
     slot: 2h
-    type: shortbow
-    attack_style: ranged
+    weapon_type: bow
     attack_speed: 4
-  requirements:
-    ranged: 20
-  stats:
-    attack:
+    weight: 1.36
+    requirements:
       ranged: 20
-    other:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 20
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
-    range: 7
-  fletching:
-    level: 35
-    xp: 33.3
-    method: Willow shortbow (u) + bowstring
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 35
+      xp: 33.3
+      materials:
+        - item_name: Willow shortbow (u)
+          item_id: 60
+          quantity: 1
+        - item_name: Bow string
+          item_id: 1777
+          quantity: 1
+      product: Willow shortbow
+      product_id: 849
+      product_quantity: 1
+      facility: None
+      members_only: false
   shops:
     - shop_name: Lowe's Archery Emporium
       location: Varrock
+      price: 200
+    - shop_name: Brian's Archery Supplies
+      location: Rimmington
       price: 200
   related_items:
     - item_id: 853
@@ -54,8 +80,30 @@ osrs:
       slug: bow-string
       relationship: component
       description: Stringing material
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2005-03-29"
+      description: Made available to free-to-play players.
+    - date: "2005-01-26"
+      description: Graphically updated.
+  properties:
+    release_date: "2002-03-25"
+    update: RuneScape Launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  about: Willow shortbow is a free-to-play two-handed ranged weapon requiring 20 Ranged, fletched from a willow shortbow (u) and bow string at 35 Fletching.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wolf-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wolf-cloak.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Wolf cloak is a free-to-play item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    casket: Reward casket (medium)
+    rarity: 1/1133
+  related_items:
+    - item_id: 0
+      item_name: Reward casket (medium)
+      slug: reward-casket-medium
+      relationship: alternative
+      description: Medium clue reward casket
+  about: Wolf cloak is a free-to-play cosmetic cape from medium Treasure Trails that counts as warm clothing in Wintertodt despite no combat bonuses.
+  market_strategy:
+    notes:
+      - F2P accessible via GE
+      - Tiny buy limit constrains flips
+      - Wintertodt warm-clothing utility supports demand
+  history:
+    - date: "2019-04-11"
+      update: Treasure Trails Expansion / Easter 2019
+      description: Added as a medium clue reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: 11 April 2019
+    update: Treasure Trails Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wood-dining-table-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wood-dining-table-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Wood dining table (flatpack) | OSRS Price Data
-description: "Wood dining table (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Wood dining table (flatpack) assembles into a POH wood dining table at 10 Construction. High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8548
   name: Wood dining table (flatpack)
@@ -12,9 +12,59 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Wood dining table (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    level: 10
+    xp: 115
+    facility: Wooden workbench
+    tools:
+      - Hammer
+      - Saw
+  recipes:
+    - skill: Construction
+      level: 10
+      xp: 115
+      facility: Wooden workbench
+      materials:
+        - item_id: 960
+          item_name: Plank
+          quantity: 4
+        - item_id: 1539
+          item_name: Steel nails
+          quantity: 4
+  related_items:
+    - item_id: 960
+      item_name: Plank
+      slug: plank
+      relationship: component
+      description: Construction material
+    - item_id: 1539
+      item_name: Steel nails
+      slug: steel-nails
+      relationship: component
+      description: Construction material
+  about: Wood dining table (flatpack) is a 10 Construction flatpack that assembles into a wood dining table for the POH dining room.
+  market_strategy:
+    notes:
+      - Sold by flatpack maker scrollers
+      - Material cost typically exceeds GE price
+      - Useful for low Construction training routes
+  history:
+    - date: "2006-05-31"
+      description: Item added with Player-Owned Houses update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    weight: 1
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-spoon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-spoon.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 50
-  about: "Wooden spoon is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: stab-sword
+    attack_speed: 4
+    weight: 0.453
+    attack_bonus:
+      stab: 4
+      slash: 5
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Culinaromancer's chest
+      location: Lumbridge Castle basement
+      price: 45
+  related_items:
+    - item_id: 1291
+      item_name: Bronze longsword
+      slug: bronze-longsword
+      relationship: alternative
+      description: Comparable stats
+  about: Wooden spoon is a novelty Recipe for Disaster melee weapon purchased from the Culinaromancer's chest after at least one subquest, with stats similar to a bronze longsword.
+  market_strategy:
+    notes:
+      - Low GE limit of 50 keeps supply thin
+      - Mostly a meme/cosmetic flex weapon
+      - Examine references The Tick superhero
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-03-15"
+    update: Recipe for Disaster
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-robe-top.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Yellow robe top is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Barkers' Haberdashery
+      location: Canifis
+      price: 650
+  related_items:
+    - item_name: Yellow robe bottoms
+      slug: yellow-robe-bottoms
+      relationship: set-piece
+      description: Matching legs
+    - item_name: Red robe top
+      slug: red-robe-top
+      relationship: alternative
+      description: Color variant
+    - item_name: Teal robe top
+      slug: teal-robe-top
+      relationship: alternative
+      description: Color variant
+  about: Yellow robe top is a cosmetic werewolf body garment purchased from Barker in Canifis, part of a five-color robe set.
+  market_strategy:
+    notes:
+      - Cosmetic demand from Canifis roleplay
+      - Shop supply caps upside
+      - Low alch margin
+  history:
+    - date: "2014-12-10"
+      description: Renamed from "Robe top" to "Yellow robe top".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-06-29"
+    update: Priest in Peril
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-coif.mdx
@@ -14,6 +14,10 @@ osrs:
   limit: 8
   equipment:
     slot: head
+    weight: 0.9
+    requirements:
+      ranged: 70
+      defence: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,9 +35,9 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
-      defence: 40
+  treasure_trail:
+    tier: hard
+    rarity: 1/1625
   related_items:
     - item_id: 10382
       item_name: Guthix coif
@@ -55,17 +59,38 @@ osrs:
       slug: ancient-coif
       relationship: variant
       description: God blessed coif variant
-  about: |-
-    > *"A Zamorak blessed dragonhide coif."*
-
-    All blessed coifs share identical stats. They offer a +1 prayer bonus over a standard coif while maintaining the same defensive profile. The choice between god variants is purely cosmetic.
+  about: Zamorak blessed dragonhide coif from hard clue scrolls; identical defensive profile to a standard coif but with a +1 prayer bonus, choice of god is cosmetic.
   market_strategy:
     notes:
-      - Hard clue exclusive — supply tied to clue completion rates
+      - Hard clue exclusive, supply tied to clue completion rates
       - Price differences between gods are cosmetic preference only
       - Armadyl and Ancient tend to command slight premiums
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2006-12-05"
+      update: Released
+      description: Released
+    - date: "2014-03-01"
+      update: Received +1 prayer bonus buff
+      description: Received +1 prayer bonus buff
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: God blessed dragonhide armour
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.9
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Third batch — migrate 100 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Reshape `equipment.stats.*` → `equipment.{attack_bonus,defence_bonus,other_bonus}.*` per the v3 Zod schema.
- Add v3 `properties` block (release_date, update, weight, options, alchable, etc.), `material` classification, structured `drop_table` / `shops` / `recipes` / `treasure_trail` / `teleport` / `farming` / `construction`, condensed single-line `about`, and `history` block (ISO date + description) from the wiki Changes section.

Schema pitfalls fixed (post-agent normalization):
- `relationship` constrained to enum (variant / upgrade / downgrade / component / product / set-piece / alternative)
- `history[].date` quoted ISO `YYYY-MM-DD`, `description` required
- `shops[]` uses `shop_name:` (not `shop:` / `name:`)
- `properties.destroy` is a string, not bool
- `treasure_trail.tier` (singular), not `tiers`

Validated via `astro sync` — content collection passes schema.

## Test plan

- [x] `astro sync` clean — all 100 entries validate.
- [ ] CI build green.
- [ ] Smoke check 3-5 pages on preview (`/osrs/dragon-claws`, `/osrs/blade-of-saeldor-inactive`, `/osrs/anglerfish`, `/osrs/old-school-bond`).

## Follow-ups

- ~4173 v2 items remain after this lands.