### PR TITLE
ci(actionlint): bump zizmor 1.8.0 → 1.25.2 + tolerate non-zero exit

### DIFF
--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -64,9 +64,11 @@ jobs:
 
             - name: Run zizmor (offline audits only, informational)
               run: |
-                  set -euo pipefail
-                  uvx zizmor==1.8.0 --persona=regular --no-online-audits \
-                      --format plain .github/workflows
+                  set -uo pipefail
+                  uvx zizmor==1.25.2 --persona=regular --no-online-audits \
+                      --format plain .github/workflows || \
+                      echo "::notice::zizmor exited non-zero (findings or crash) — informational only, not blocking"
+                  exit 0
 
     track_failure:
         name: Track Failures


### PR DESCRIPTION
## Problem

Post-merge run [#26802909584](https://github.com/KBVE/kbve/actions/runs/26802909584) failed on the zizmor job — zizmor 1.8.0 panicked mid-audit after printing real findings on \`ci-steam-promote.yml\` and \`ci-ue-mac-setup.yml\`:

\`\`\`
Well, this is embarrassing.
zizmor had a problem and crashed. […]
##[error]Process completed with exit code 101.
\`\`\`

The zizmor job is \`continue-on-error: true\` and explicitly labelled \"informational\", but the crash exit code was still surfacing the job as red in the run UI.

## Fix

- **Bump zizmor 1.8.0 → 1.25.2** (current latest PyPI release). 1.8.0 shipped in March; the crash on this repo's mix of self-hosted + Windows workflows was almost certainly already patched upstream by the time the gate landed.
- **Tolerate non-zero exit** — drop \`set -e\` and chain \`|| echo …; exit 0\` so the step exits 0 even when zizmor crashes or reports findings. Findings still print to the job log as before, they just no longer fail the step.

## Test plan

- [ ] CI - Actionlint runs on this PR; the zizmor job exits 0 even if it still reports findings
- [ ] The actionlint job stays green