### PR TITLE
fix(kasm-void): conditional pip --break-system-packages + expand e2e

### DIFF
--- a/packages/docker/kasm-void/Dockerfile
+++ b/packages/docker/kasm-void/Dockerfile
@@ -16,7 +16,12 @@ RUN set -eux; \
         libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libdrm2 libxkbcommon0 \
         libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libgtk-3-0 \
         libasound2 libpango-1.0-0 libcairo2 libcups2 libdbus-1-3 fonts-liberation; \
-    pip3 install --no-cache-dir --break-system-packages websocket-client==1.8.0; \
+    if pip3 install --help 2>&1 | grep -q -- --break-system-packages; then \
+      pip3 install --no-cache-dir --break-system-packages websocket-client==1.8.0; \
+    else \
+      pip3 install --no-cache-dir websocket-client==1.8.0; \
+    fi; \
+    python3 -c 'import websocket, sys; assert websocket.__version__ == "1.8.0", websocket.__version__'; \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \

--- a/packages/docker/kasm-void/project.json
+++ b/packages/docker/kasm-void/project.json
@@ -53,10 +53,23 @@
 			"options": {
 				"commands": [
 					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{.Config.User}}' | grep -q '^1000$' && echo 'PASS: drops to uid 1000'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{.Config.WorkingDir}}' | grep -q '^/home/kasm-user$' && echo 'PASS: workdir is /home/kasm-user'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^CDP_PORT=9222$' && echo 'PASS: CDP_PORT default 9222'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^NAV_SHIM_PORT=9998$' && echo 'PASS: NAV_SHIM_PORT default 9998'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^START_URL=https://kbve.com$' && echo 'PASS: START_URL default kbve.com'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^LAUNCH_CLOAK=1$' && echo 'PASS: LAUNCH_CLOAK default on'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^LAUNCH_DISCORD=1$' && echo 'PASS: LAUNCH_DISCORD default on'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^LAUNCH_NAV_SHIM=1$' && echo 'PASS: LAUNCH_NAV_SHIM default on'",
 					"docker run --rm --entrypoint /opt/cloakbrowser/cloakbrowser ghcr.io/kbve/kasm-void:dev --version && echo 'PASS: cloakbrowser binary runs --version'",
+					"docker run --rm --entrypoint python3 ghcr.io/kbve/kasm-void:dev -c 'import websocket; assert websocket.__version__ == \"1.8.0\", websocket.__version__' && echo 'PASS: websocket-client 1.8.0 importable'",
+					"docker run --rm --entrypoint python3 ghcr.io/kbve/kasm-void:dev -m py_compile /dockerstartup/nav_shim.py && echo 'PASS: nav_shim.py compiles'",
+					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/nav_shim.py && echo 'PASS: nav_shim.py executable'",
+					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/custom_startup.sh && echo 'PASS: custom_startup.sh executable'",
 					"docker run --rm --entrypoint cat ghcr.io/kbve/kasm-void:dev /dockerstartup/custom_startup.sh | grep -q cloak_loop && echo 'PASS: custom_startup.sh has cloak supervisor'",
 					"docker run --rm --entrypoint cat ghcr.io/kbve/kasm-void:dev /dockerstartup/custom_startup.sh | grep -q discord_loop && echo 'PASS: custom_startup.sh has discord supervisor'",
-					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/discord_startup.sh && echo 'PASS: upstream discord startup preserved'"
+					"docker run --rm --entrypoint cat ghcr.io/kbve/kasm-void:dev /dockerstartup/custom_startup.sh | grep -q nav_shim_loop && echo 'PASS: custom_startup.sh has nav_shim supervisor'",
+					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/discord_startup.sh && echo 'PASS: upstream discord startup preserved'",
+					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -f /home/kasm-user/Desktop/cloakbrowser.desktop && echo 'PASS: cloakbrowser.desktop deployed'"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
## Summary
- Root cause of #11643: Jammy base ships pip 22.0.2 which rejects `--break-system-packages` (added pip 23.0.1+). Build exited 2 in `kasm-void:containerx`.
- Detect flag support at build time and dispatch — keeps Noble path working once upstream `kasmweb/discord` bumps.
- Adds build-time `import websocket` + version assertion so a broken pip install fails the image build instead of leaking through to runtime.

## E2E expansion (`packages/docker/kasm-void/project.json`)
- Image WorkingDir = `/home/kasm-user`
- Env defaults: `CDP_PORT=9222`, `NAV_SHIM_PORT=9998`, `START_URL=https://kbve.com`, `LAUNCH_CLOAK/DISCORD/NAV_SHIM=1`
- `websocket-client==1.8.0` importable inside the image
- `nav_shim.py` compiles (`python3 -m py_compile`) and is executable
- `custom_startup.sh` is executable
- `custom_startup.sh` contains `nav_shim_loop` supervisor (parity with existing cloak/discord checks)
- `cloakbrowser.desktop` deployed to `/home/kasm-user/Desktop/`

## Test plan
- [ ] `nx run kasm-void:container` builds clean on Jammy base
- [ ] All 18 e2e assertions pass under `nx run kasm-void:test`
- [ ] CI dev validation green

Closes #11643