### PR TITLE
content(astro-kbve): bump 100 OSRS items v2 → v3 (batch 4)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-amulet.mdx
@@ -12,64 +12,98 @@ osrs:
   lowalch: 20200
   highalch: 30300
   limit: 8
+  material:
+    type: amulet
+    tier: high
   equipment:
     slot: neck
-    type: amulet
-    attack_style: magic
+    weight: 0.003
     requirements:
       magic: 65
-    stats:
-      attack_magic: 15
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 10
-      defence_ranged: 0
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 10
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
       magic_damage: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
   related_items:
     - item_id: 10342
       item_name: 3rd age mage hat
       slug: 3rd-age-mage-hat
       relationship: set-piece
-      description: Head slot of 3rd age mage set
+      description: Head slot of the 3rd age mage set
     - item_id: 10338
       item_name: 3rd age robe top
       slug: 3rd-age-robe-top
       relationship: set-piece
-      description: Body slot of 3rd age mage set
+      description: Body slot of the 3rd age mage set
     - item_id: 10340
       item_name: 3rd age robe
       slug: 3rd-age-robe
       relationship: set-piece
-      description: Leg slot of 3rd age mage set
-  about: |
-    The 3rd age amulet is part of the 3rd age mage set, one of the rarest and most prestigious accessories in Old School RuneScape. It requires 65 Magic to wear and provides excellent magic attack bonus.
-
-    3rd age equipment is highly sought after due to its extreme rarity and status symbol value. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
+      description: Leg slot of the 3rd age mage set
+    - item_name: Occult necklace
+      slug: occult-necklace
+      relationship: alternative
+      description: Mainstream high-end magic amulet with magic damage bonus
   market_strategy:
     title: Investment Notes
     notes:
       - Extremely valuable due to rarity
       - Price fluctuates based on collector demand
       - Consider set value vs individual pieces
+      - Treasure Trails only - supply driven by clue hunters
   trading_tips:
     - Verify authenticity when trading high-value items
     - Use Grand Exchange for secure trades
     - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: 3rd age amulet is a prestigious neck-slot magic amulet from the 3rd age mage set, obtained as a rare reward from hard, elite, and master clue scroll caskets.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails, spiders and sheep
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.003
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2006-12-05"
+      update: Treasure Trails, spiders and sheep
+      description: 3rd age amulet released with the Treasure Trails update.
+    - date: "2014-06-26"
+      update: Game Update
+      description: Item value increased from 20,000 to 50,500 coins.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-range-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-range-top.mdx
@@ -12,60 +12,85 @@ osrs:
   lowalch: 20320
   highalch: 30480
   limit: 8
+  material:
+    type: 3rd age
+    tier: high
   equipment:
     slot: body
-    type: ranged armour
-    attack_style: ranged
+    weight: 4
     requirements:
       ranged: 65
       defence: 45
-    stats:
-      attack_ranged: 30
-      defence_stab: 55
-      defence_slash: 47
-      defence_crush: 62
-      defence_magic: 55
-      defence_ranged: 57
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 30
+    defence_bonus:
+      stab: 55
+      slash: 47
+      crush: 60
+      magic: 60
+      ranged: 55
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
   related_items:
     - item_id: 10334
       item_name: 3rd age range coif
       slug: 3rd-age-range-coif
       relationship: set-piece
-      description: Head slot of 3rd age range set
+      description: Head slot of the 3rd age ranged set
     - item_id: 10332
       item_name: 3rd age range legs
       slug: 3rd-age-range-legs
       relationship: set-piece
-      description: Leg slot of 3rd age range set
+      description: Legs slot of the 3rd age ranged set
     - item_id: 10336
       item_name: 3rd age vambraces
       slug: 3rd-age-vambraces
       relationship: set-piece
-      description: Hands slot of 3rd age range set
-  about: |-
-    The 3rd age range top is part of the 3rd age ranged set, one of the rarest and most prestigious armour sets in Old School RuneScape. It requires 65 Ranged and 45 Defence to wear.
-
-    3rd age equipment is highly sought after due to its extreme rarity and status symbol value. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
+      description: Hands slot of the 3rd age ranged set
   market_strategy:
-    title: Investment Notes
     notes:
-      - One of the most valuable items in OSRS
-      - Price driven by collector demand
-      - Often used as currency for high-value trades
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - One of the rarest and most prestigious ranged armours
+      - Price driven by collector and high-stakes PvP demand
+      - Often used as a unit of currency in high-value trades
+      - Supply is bottlenecked by hard, elite, and master clue completions
+      - Verify trades through the Grand Exchange to avoid scams
+  history:
+    - date: "2014-07-03"
+      description: Shop value increased from 45,000 to 50,800 coins.
+    - date: "2006-12-05"
+      description: Added with the Treasure Trails, spiders and sheep update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails, spiders and sheep
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: 3rd age range top is an ultra-rare prestige body from hard, elite, and master clue caskets requiring 65 Ranged and 45 Defence.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platelegs-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platelegs-t.mdx
@@ -12,27 +12,83 @@ osrs:
   lowalch: 2560
   highalch: 3840
   limit: 8
+  material:
+    type: adamant
+    tier: mid
   equipment:
     slot: legs
+    weight: 10.432
     requirements:
       defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -11
+      ranged: -11
+    defence_bonus:
+      stab: 33
+      slash: 31
+      crush: 29
+      magic: -4
+      ranged: 34
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    is_reward: true
+    tier: medium
   related_items:
     - item_id: 2599
       item_name: Adamant platebody (t)
       slug: adamant-platebody-t
       relationship: set-piece
-      description: Matching trimmed platebody
+      description: Matching trimmed platebody.
     - item_id: 2609
       item_name: Adamant platelegs (g)
       slug: adamant-platelegs-g
       relationship: variant
-      description: Gold-trimmed variant
-  about: |-
-    > *"Adamant platelegs with trim."*
-
-    The adamant platelegs (t) are a trimmed cosmetic variant of standard adamant platelegs. Identical stats, requiring 30 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Gold-trimmed variant from the same clue tier.
+    - item_id: 1073
+      item_name: Adamant platelegs
+      slug: adamant-platelegs
+      relationship: alternative
+      description: Untrimmed Smithing-made counterpart with identical stats.
+  about: Adamant platelegs (t) are a cosmetic medium clue scroll reward sharing stats with normal adamant platelegs and requiring 30 Defence to wear.
+  market_strategy:
+    notes:
+      - Supply gated entirely by medium clue completions
+      - Demand from fashionscape and trimmed set collectors
+      - Thin GE limit (8) makes large fills slow
+  history:
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -7 to -11.
+    - date: "2014-06-12"
+      description: Renamed from "Adam platelegs (t)" to "Adamant platelegs (t)".
+    - date: "2004-05-05"
+      update: Bigger Banks & Treasure Trails
+      description: Adamant platelegs (t) released as a medium clue scroll reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-05-05"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 10.432
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/aranea-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/aranea-boots.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 8
-  about: "Aranea boots is a members-only item in Old School RuneScape. High alchemy value: 90,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: armour
+    tier: high
+  equipment:
+    slot: feet
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 5
+      ranged: 6
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Araxyte
+        combat_level: 96
+        quantity: "1"
+        rarity: 1/4000
+        members_only: true
+        notes: 1/1,600 while on slayer task.
+      - source: Araxyte
+        combat_level: 146
+        quantity: "1"
+        rarity: 1/2000
+        members_only: true
+        notes: 1/800 while on slayer task.
+      - source: Dreadborn Araxyte
+        quantity: "1"
+        rarity: 3/400
+        members_only: true
+  related_items:
+    - item_id: 0
+      item_name: Araxxor
+      slug: araxxor
+      relationship: alternative
+      description: Lair boss for the araxyte family
+    - item_id: 0
+      item_name: Dreadborn Araxyte
+      slug: dreadborn-araxyte
+      relationship: alternative
+      description: Higher rarity drop source
+  about: Aranea boots are feet slot armour dropped by araxytes that negate spider-based attacks every 8 ticks and let the wearer cross webs without a slash weapon.
+  market_strategy:
+    notes:
+      - Araxxor meta drives supply
+      - BiS for low-defence builds with magic and ranged offence
+      - Buy limit 8 throttles flip volume
+      - Slayer task multiplier shapes drop cadence
+  trading_tips:
+    - Track Araxxor and araxyte slayer task rates for supply pulses
+    - Compare against alternative low-defence feet slots
+    - Hold during boss meta updates that affect web mechanics
+  history:
+    - date: "2024-08-28"
+      update: "Araxxor"
+      description: Released as an araxyte drop with the Araxxor boss launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-08-28"
+    update: "Araxxor"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/avantoe-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/avantoe-potion-unf.mdx
@@ -12,16 +12,15 @@ osrs:
   lowalch: 19
   highalch: 28
   limit: 10000
+  material:
+    type: potion
+    tier: mid-high
   potion:
     type: unfinished
     tier: mid-high
-  herblore:
-    level: 50
-    xp: 0
-    method: Add avantoe to vial of water
   recipes:
     - skill: herblore
-      level: 50
+      level: 1
       xp: 0
       materials:
         - item_name: Vial of water
@@ -45,16 +44,6 @@ osrs:
       slug: vial-of-water
       relationship: component
       description: Base liquid
-    - item_id: 2970
-      item_name: Mort myre fungus
-      slug: mort-myre-fungus
-      relationship: component
-      description: Secondary for super energy
-    - item_id: 10111
-      item_name: Kebbit teeth dust
-      slug: kebbit-teeth-dust
-      relationship: component
-      description: Secondary for hunter potion
     - item_id: 3016
       item_name: Super energy(3)
       slug: super-energy-3
@@ -70,23 +59,31 @@ osrs:
       slug: fishing-potion-3
       relationship: product
       description: Boosts fishing
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Unfinished Potion |
-    | Tradeable | Yes |
-    | Weight | 0.056 kg |
-    | Requirements | 50 Herblore |
-
-    Add secondary ingredient to create:
-    - Super energy potion (+ mort myre fungus)
-    - Hunter potion (+ kebbit teeth dust)
-    - Fishing potion (+ snape grass)
-
-    Popular for super energy production.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2016-04-15"
+      description: Item became usable as a bank placeholder.
+    - date: "2014-05-01"
+      description: Renamed from "Unfinished potion" to "Avantoe potion (unf)".
+    - date: "2004-10-26"
+      description: '"Empty" option added.'
+  about: Avantoe potion (unf) is a members unfinished potion made by adding avantoe to a vial of water, used as the base for fishing, super energy, and hunter potions.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: RuneScape News (27 February 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bag-of-salt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bag-of-salt.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 8000
-  about: "Bag of salt is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 8,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: slayer-supply
+    tier: low
+  shops:
+    - shop_name: Slayer Equipment
+      location: Edgeville
+      stock: 5000
+      sells_for: 10
+      restock_time: 3
+    - shop_name: Slayer Equipment
+      location: Canifis
+      stock: 5000
+      sells_for: 10
+      restock_time: 3
+    - shop_name: Slayer Equipment
+      location: Morytania Slayer Tower
+      stock: 5000
+      sells_for: 10
+      restock_time: 3
+    - shop_name: Slayer Equipment
+      location: Shilo Village
+      stock: 5000
+      sells_for: 10
+      restock_time: 3
+    - shop_name: Slayer Equipment
+      location: Zanaris
+      stock: 5000
+      sells_for: 10
+      restock_time: 3
+    - shop_name: Slayer Equipment
+      location: Nardah
+      stock: 5000
+      sells_for: 10
+      restock_time: 3
+  related_items:
+    - item_id: 1714
+      item_name: Rockslug
+      slug: rockslug
+      relationship: alternative
+      description: Slayer monster requiring bag of salt finisher
+    - item_id: 1734
+      item_name: Slayer's staff
+      slug: slayers-staff
+      relationship: alternative
+      description: Slayer equipment purchased from same shops
+  about: Bag of salt is a Slayer supply used to finish off rockslugs at low HP and a required item during Icthlarin's Little Helper.
+  market_strategy:
+    notes:
+      - Shops sell at 10 gp with deep stock
+      - GE flips driven by alch and quest demand
+      - Rockslug slayer tasks spike usage
+      - Icthlarin's Little Helper quest creates one-off demand
+  history:
+    - date: "2005-01-26"
+      update: Slayer Skill
+      description: Item released with the Slayer skill.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-01-26"
+    update: Slayer Skill
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/battlemage-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/battlemage-potion-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Battlemage potion(3) | OSRS Price Data
-description: "Battlemage potion(3): 3 doses of Battlemage potion.. High alch: 162 GP, GE limit: 2,000."
+description: "Battlemage potion(3): 3 doses of Battlemage potion. High alch: 162 GP, GE limit: 2,000."
 osrs:
   id: 22452
   name: Battlemage potion(3)
@@ -12,9 +12,84 @@ osrs:
   lowalch: 108
   highalch: 162
   limit: 2000
-  about: "Battlemage potion(3) is a members-only item in Old School RuneScape. High alchemy value: 162 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: high
+  potion:
+    doses: 3
+    effects:
+      - description: Boosts Magic level by 4.
+      - description: Boosts Defence level by 5 + 15% of player's Defence level.
+      - description: Defence boost decays by 1 every minute (90 seconds with Preserve prayer).
+  recipes:
+    - skill: herblore
+      level: 80
+      xp: 155
+      materials:
+        - item_name: Cadantine blood potion (unf)
+          quantity: 1
+        - item_name: Potato cactus
+          quantity: 1
+      facility: None
+      members_only: true
+  related_items:
+    - item_name: Battlemage potion(4)
+      slug: battlemage-potion-4
+      relationship: upgrade
+      description: Four-dose variant
+    - item_name: Battlemage potion(2)
+      slug: battlemage-potion-2
+      relationship: downgrade
+      description: Two-dose variant
+    - item_name: Battlemage potion(1)
+      slug: battlemage-potion-1
+      relationship: downgrade
+      description: One-dose variant
+    - item_name: Cadantine blood potion (unf)
+      slug: cadantine-blood-potion-unf
+      relationship: component
+      description: Required unfinished base potion
+    - item_name: Potato cactus
+      slug: potato-cactus
+      relationship: component
+      description: Secondary ingredient
+    - item_name: Bastion potion(3)
+      slug: bastion-potion-3
+      relationship: alternative
+      description: Ranged-focused sibling potion
+  market_strategy:
+    notes:
+      - Niche PvM consumable - mostly used at Theatre of Blood and ToA
+      - Profit margin tracks Cadantine and Potato cactus prices
+      - Often cheaper to make from scratch vs buying assembled potions
+      - 80 Herblore gate limits supply
+  about: Battlemage potion(3) is a three-dose Herblore potion that boosts Magic by 4 and provides a scaling Defence boost, used in high-level PvM encounters.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-06-07"
+    update: Theatre of Blood
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2018-06-07"
+      update: Theatre of Blood
+      description: Battlemage potion released alongside the Theatre of Blood raid.
+    - date: "2019-08-01"
+      update: Game Update
+      description: Inventory ordering standardised with other combat potions.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-knife-p-5658.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-knife-p-5658.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 7
   highalch: 10
   limit: 7000
-  about: "Black knife(p+) is a members-only item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: black
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 10
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 8
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 13
+      xp: 0
+      materials:
+        - item_name: Black knife
+          item_id: 869
+          quantity: 1
+        - item_name: Weapon poison(+)
+          item_id: 5937
+          quantity: 1
+      product: Black knife(p+)
+      product_id: 5658
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 869
+      item_name: Black knife
+      slug: black-knife
+      relationship: variant
+      description: Unpoisoned base knife
+    - item_id: 870
+      item_name: Black knife(p)
+      slug: black-knife-p-870
+      relationship: downgrade
+      description: Basic poison variant
+    - item_id: 5662
+      item_name: Black knife(p++)
+      slug: black-knife-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+  history:
+    - date: "2021-07-07"
+      description: Female player equipment positioning adjusted.
+    - date: "2006-09-20"
+      description: Poison variants renamed from "+" notation to "(p+)" and "(p++)" format.
+    - date: "2003-04-14"
+      update: New Throwing Weapons!
+      description: Black knife(p+) released with the thrown weapons update.
+  about: Black knife(p+) is a thrown black knife coated in stronger weapon poison(+), requiring 10 Ranged and inflicting an upgraded poison effect on hit.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-skirt-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-skirt-t.mdx
@@ -14,24 +14,68 @@ osrs:
   limit: 4
   equipment:
     slot: legs
-    requirements: {}
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    is_reward: true
+    tier: easy
+    drop_rate: 1/1404
   related_items:
     - item_id: 12445
       item_name: Black skirt (g)
       slug: black-skirt-g
       relationship: variant
-      description: Gold-trimmed variant
+      description: Gold-trimmed variant from the same clue tier.
     - item_id: 12451
       item_name: Black wizard robe (t)
       slug: black-wizard-robe-t
       relationship: set-piece
-      description: Matching trimmed wizard robe
-  about: |-
-    > *"Leg covering favoured by women and wizards. With a colourful trim!"*
-
-    The black skirt (t) is a trimmed cosmetic variant of the black wizard skirt. No requirements.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching trimmed wizard robe.
+  about: Black skirt (t) is a purely cosmetic easy clue scroll reward with no combat bonuses and no equip requirements, part of the trimmed black wizard set.
+  market_strategy:
+    notes:
+      - Supply comes entirely from easy clue caskets
+      - 4 per 4-hour buy limit keeps fills slow
+      - Fashionscape demand drives price well above alch value
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Black skirt (t) introduced as an easy clue scroll reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-d-hide-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-d-hide-shield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blue d'hide shield | OSRS Price Data
-description: "Blue d'hide shield: A solid yew shield covered in blue dragon leather.. High alch: 4,500 GP, GE limit: 125."
+description: "Blue d'hide shield: A solid yew shield covered in blue dragon leather. High alch: 4,500 GP, GE limit: 125."
 osrs:
   id: 22278
   name: Blue d'hide shield
@@ -12,9 +12,98 @@ osrs:
   lowalch: 3000
   highalch: 4500
   limit: 125
-  about: "Blue d'hide shield is a members-only item in Old School RuneScape. High alchemy value: 4,500 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragonhide_shield
+    tier: mid
+  equipment:
+    slot: shield
+    weight: 8
+    requirements:
+      defence: 40
+      ranged: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 16
+      slash: 14
+      crush: 12
+      magic: 12
+      ranged: 12
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 69
+      xp: 140
+      materials:
+        - item_name: Blue dragon leather
+          quantity: 2
+        - item_name: Yew shield
+          quantity: 1
+        - item_name: Mithril nails
+          quantity: 15
+      facility: Hammer
+      ticks: 5
+      members_only: true
+  related_items:
+    - item_name: Green d'hide shield
+      slug: green-d-hide-shield
+      relationship: downgrade
+      description: Lower-tier dragonhide shield
+    - item_name: Red d'hide shield
+      slug: red-d-hide-shield
+      relationship: upgrade
+      description: Higher-tier dragonhide shield
+    - item_name: Black d'hide shield
+      slug: black-d-hide-shield
+      relationship: upgrade
+      description: Highest-tier dragonhide shield
+    - item_name: Yew shield
+      slug: yew-shield
+      relationship: component
+      description: Required base shield for crafting
+    - item_name: Blue dragon leather
+      slug: blue-dragon-leather
+      relationship: component
+      description: Crafted from cured blue dragonhide
+  market_strategy:
+    notes:
+      - Crafted item, supply driven by Crafting trainers
+      - Generally trades below high-alch value
+      - Useful budget shield for mid-tier ranged or melee setups
+      - Requires 40 Defence and 50 Ranged to equip
+  about: Blue d'hide shield is a members-only shield-slot item in Old School RuneScape, crafted from a yew shield, two blue dragon leathers, and mithril nails at 69 Crafting.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-02-01"
+    update: Leather Shields and Tournament Worlds
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2018-02-01"
+      update: Leather Shields and Tournament Worlds
+      description: Blue d'hide shield released as part of the Leather Shields update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-elegant-skirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-elegant-skirt.mdx
@@ -12,21 +12,69 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  material:
+    type: cloth
+    tier: mid
   equipment:
     slot: legs
-    requirements: {}
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    is_reward: true
+    tier: easy
   related_items:
     - item_id: 10428
       item_name: Blue elegant blouse
       slug: blue-elegant-blouse
       relationship: set-piece
       description: Matching elegant blouse
-  about: |-
-    > *"A rather elegant blue skirt."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the blue elegant clothing set (women's variant). Pairs with the blue elegant blouse.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Blue elegant skirt is a cosmetic Easy Treasure Trail reward worn in the legs slot with no combat bonuses.
+  market_strategy:
+    notes:
+      - Easy clue scroll reward (~1/2808 from caskets)
+      - Purely cosmetic, no combat stats
+      - Set bonus only when worn with matching blouse
+  history:
+    - date: "2014-12-10"
+      description: Renamed from "Blue ele' skirt" to "Blue elegant skirt".
+    - date: "2006-12-05"
+      update: Treasure Trails, spiders and sheep
+      description: Blue elegant skirt added as an Easy Treasure Trail reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails, spiders and sheep
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-tassets.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-tassets.mdx
@@ -12,9 +12,15 @@ osrs:
   lowalch: 115964
   highalch: 173946
   limit: 15
+  material:
+    type: blue-moon
+    tier: high
   equipment:
     slot: legs
     weight: 1.36
+    requirements:
+      magic: 75
+      defence: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,11 +38,13 @@ osrs:
       ranged_strength: 0
       magic_damage: 1
       prayer: 0
-    requirements:
-      magic: 75
-      defence: 50
-    degradable: true
-    charges: 3000
+  charges:
+    initial: 3000
+    drain_rate: 1 charge per 54 seconds of combat
+    duration: ~45 hours of combat
+    repair_npc_cost: 1500000
+    repair_smithing_cost: 757500
+    repair_smithing_level: 99
   drop_table:
     primary_source: Lunar Chest (Neypotzli)
     best_drop_rate: 1/224
@@ -51,40 +59,49 @@ osrs:
       item_name: Blue moon spear
       slug: blue-moon-spear
       relationship: set-piece
-      description: Weapon for Frostweaver set effect
+      description: Weapon for the Frostweaver set effect.
     - item_id: 29019
       item_name: Blue moon helm
       slug: blue-moon-helm
       relationship: set-piece
-      description: Helm in set
+      description: Helm in the Blue moon set.
     - item_id: 29013
       item_name: Blue moon chestplate
       slug: blue-moon-chestplate
       relationship: set-piece
-      description: Body armour in set
-  about: |-
-    When wearing the full Blue moon armour set with the Blue moon spear:
-    - Frostweaver: After casting a bind spell, 20% chance for next melee attack to be unaffected by action delays
-
-    | Property | Value |
-    |----------|-------|
-    | Total charges | 3,000 |
-    | Charge rate | 1 per 54 seconds |
-    | Combat duration | ~45 hours |
-    | NPC repair cost | 1,500,000 coins |
-    | Repair at 99 Smithing | 757,500 coins |
-
-    Magic-melee hybrid legs for Blue moon builds:
-    - +22 magic attack
-    - +1 strength bonus
-    - +1% magic damage
+      description: Body armour in the Blue moon set.
+  about: Blue moon tassets are magic-melee hybrid legs from the Lunar Chest that anchor the Frostweaver set, giving 20% chance after a bind spell that the Blue moon spear's next melee swing ignores action delays.
   market_strategy:
     notes:
-      - Essential for Blue moon builds
-      - Good magic defence
-      - Factor in repair costs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Essential for Blue moon hybrid builds
+      - Strong magic defence and +1% magic damage
+      - Factor 1.5M repair cost into long-term price floor
+  history:
+    - date: "2024-05-29"
+      description: Magic damage bonus increased from 0% to 1%.
+    - date: "2024-04-24"
+      description: Weight reduced from 8 kg to 1.36 kg.
+    - date: "2024-03-20"
+      update: Varlamore; Part One
+      description: Blue moon tassets released as part of the Blue moon armour set.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore; Part One
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bone-dagger-p-8876.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bone-dagger-p-8876.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 70
-  about: "Bone dagger (p+) is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bone
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: stab-sword
+    attack_speed: 4
+    weight: 0.453
+    attack_bonus:
+      stab: 5
+      slash: 3
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Backstab
+    energy_cost: 75
+    description: Guarantees a hit as long as the target has not been damaged previously, and lowers the target's Defence by the damage dealt.
+  recipes:
+    - name: Poison bone dagger
+      skill: none
+      level: 1
+      xp: 0
+      output_quantity: 1
+      materials:
+        - item_name: Bone dagger (p)
+          quantity: 1
+        - item_name: Weapon poison(+)
+          quantity: 1
+      facility: none
+      members: true
+      notes: Apply weapon poison(+) to a bone dagger (p) to upgrade it to the (p+) variant.
+  related_items:
+    - item_name: Bone dagger
+      slug: bone-dagger
+      relationship: variant
+      description: Unpoisoned base variant of the bone dagger.
+    - item_name: Bone dagger (p)
+      slug: bone-dagger-p
+      relationship: variant
+      description: Standard poisoned variant of the bone dagger.
+    - item_name: Bone dagger (p++)
+      slug: bone-dagger-p-plus-plus
+      relationship: upgrade
+      description: Stronger poisoned variant inflicting heavier damage over time.
+  about: Bone dagger (p+) is the enhanced poisoned variant of the Dorgeshuun bone dagger, sold by Nardok and prized for its Backstab special attack used in PvM hit-checks.
+  market_strategy:
+    notes:
+      - Backstab is used to land guaranteed first hits on bosses such as Kephri and Duke Sucellus.
+      - Poison potency drives most of the premium over the unpoisoned dagger.
+      - Cheaper than (p++) while keeping the same special attack damage.
+  history:
+    - date: "2025-08-06"
+      update: PvM update
+      description: Backstab now guarantees a hit on the first attack against Kephri, Duke Sucellus, Phantom Muspah, and Doom of Mokhaiotl.
+    - date: "2006-06-21"
+      update: Death to the Dorgeshuun
+      description: Bone dagger and its poisoned variants released with the Death to the Dorgeshuun quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-06-21"
+    update: Death to the Dorgeshuun
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bones.mdx
@@ -14,7 +14,7 @@ osrs:
   limit: 3000
   material:
     type: bone
-    tier: basic
+    tier: low
   prayer:
     xp_bury: 4.5
     xp_gilded_altar: 15.75
@@ -66,8 +66,28 @@ osrs:
       - Very low value per bone
       - High volume but low profit potential
       - Better to collect Big bones instead
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2001-01-04"
+      update: RuneScape beta launch
+      description: Item added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape beta launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.5
+    options:
+      - Bury
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Bones are the lowest-tier Prayer training material in Old School RuneScape, dropped by almost every low-level monster and used for bury/altar XP.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/book-of-darkness-page-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/book-of-darkness-page-set.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 3000
   highalch: 4500
   limit: 5
-  about: "Book of darkness page set is a members-only item in Old School RuneScape. High alchemy value: 4,500 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: page set
+    tier: mid
+  recipes:
+    - skill: none
+      level: 1
+      xp: 0
+      materials:
+        - item_id: 11341
+          item_name: Ancient page 1
+          quantity: 1
+        - item_id: 11342
+          item_name: Ancient page 2
+          quantity: 1
+        - item_id: 11343
+          item_name: Ancient page 3
+          quantity: 1
+        - item_id: 11344
+          item_name: Ancient page 4
+          quantity: 1
+      product: Book of darkness page set
+      product_id: 13159
+  related_items:
+    - item_id: 11341
+      item_name: Ancient page 1
+      slug: ancient-page-1
+      relationship: component
+      description: First page combined into the set
+    - item_id: 11342
+      item_name: Ancient page 2
+      slug: ancient-page-2
+      relationship: component
+      description: Second page combined into the set
+    - item_id: 11343
+      item_name: Ancient page 3
+      slug: ancient-page-3
+      relationship: component
+      description: Third page combined into the set
+    - item_id: 11344
+      item_name: Ancient page 4
+      slug: ancient-page-4
+      relationship: component
+      description: Fourth page combined into the set
+  market_strategy:
+    notes:
+      - Created through the Grand Exchange sets exchange option
+      - Set premium fluctuates with completion log demand
+      - Flips between individual pages and the packed set for arbitrage
+      - Buy limit of 5 restricts large-scale flipping
+  history:
+    - date: "2015-03-26"
+      description: God page sets are now noted when packed.
+    - date: "2015-03-19"
+      description: Added with the Boss Pets, Sets, Chat & More update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-03-19"
+    update: "Boss Pets, Sets, Chat & More"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Book of darkness page set is a GE sets-stall bundle that packs all four Ancient pages into a single tradeable item.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bounty-supply-crate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bounty-supply-crate.mdx
@@ -5,16 +5,83 @@ osrs:
   id: 30576
   name: Bounty supply crate
   slug: bounty-supply-crate
-  examine: A crate full of supplies.
+  examine: A special crate that can be filled with supplies.
   members: true
   icon: Bounty supply crate (unobtainable item).png
   value: 10000
   lowalch: 4000
   highalch: 6000
   limit: null
-  about: "Bounty supply crate is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: container
+    tier: mid
+  recipes:
+    - skill: other
+      materials:
+        - item_name: Blighted super restore(4)
+          quantity: 1
+        - item_name: Blighted karambwan
+          quantity: 2
+        - item_name: Coins
+          quantity: 1000
+        - item_name: Blighted anglerfish or blighted manta ray
+          quantity: 8
+      product: Bounty supply crate
+      product_id: 30576
+      product_quantity: 1
+      members_only: true
+      notes: Filled at the Bounty Hunter lobby crate object in Daimon's Crater; yields either the anglerfish or manta ray variant.
+  related_items:
+    - item_id: 0
+      item_name: Bounty supply crate (anglerfish)
+      slug: bounty-supply-crate-anglerfish
+      relationship: variant
+      description: Anglerfish-filled variant
+    - item_id: 0
+      item_name: Bounty supply crate (manta ray)
+      slug: bounty-supply-crate-manta-ray
+      relationship: variant
+      description: Manta ray-filled variant
+    - item_id: 0
+      item_name: Blighted anglerfish
+      slug: blighted-anglerfish
+      relationship: component
+      description: Food filling option
+    - item_id: 0
+      item_name: Blighted manta ray
+      slug: blighted-manta-ray
+      relationship: component
+      description: Food filling option
+  about: Bounty supply crate is a Bounty Hunter container assembled in Daimon's Crater lobby from blighted supplies to bank a bounty supply pack of anglerfish or manta ray.
+  market_strategy:
+    notes:
+      - Wilderness PvP supply convenience item
+      - Demand follows Bounty Hunter activity
+      - Variants gate which food is inside
+  trading_tips:
+    - Track blighted food prices for cost basis
+    - Compare against raw blighted food banking time
+  history:
+    - date: "2025-01-29"
+      update: "Bounty Hunter Changes, Collection Log Updates & Emote Improvements"
+      description: Introduced alongside Bounty Hunter quality-of-life rework.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-01-29"
+    update: "Bounty Hunter Changes, Collection Log Updates & Emote Improvements"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Take manta ray
+      - Take anglerfish
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-bolts-p-6062.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-bolts-p-6062.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze bolts (p++) | OSRS Price Data
-description: "Bronze bolts (p++): Super poisoned bronze bolts.. High alch: 1 GP, GE limit: 11,000."
+description: "Bronze bolts (p++): Super poisoned bronze bolts. High alch: 1 GP, GE limit: 11,000."
 osrs:
   id: 6062
   name: Bronze bolts (p++)
@@ -12,9 +12,92 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Bronze bolts (p++) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammo
+    tier: low
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 10
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: none
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Bronze bolts
+          quantity: 1
+        - item_name: Weapon poison++
+          quantity: 1
+      facility: Apply poison
+      members_only: true
+  related_items:
+    - item_name: Bronze bolts
+      slug: bronze-bolts
+      relationship: component
+      description: Unpoisoned base bolt
+    - item_name: Bronze bolts (p)
+      slug: bronze-bolts-p
+      relationship: variant
+      description: Standard poison variant
+    - item_name: Bronze bolts (p+)
+      slug: bronze-bolts-p-plus
+      relationship: variant
+      description: Mid-tier poison variant
+    - item_name: Weapon poison++
+      slug: weapon-poison-plus-plus
+      relationship: component
+      description: Required to apply super poison
+  market_strategy:
+    notes:
+      - Strongest poison tier for bronze bolts
+      - Niche use due to weak base damage of bronze
+      - Often crafted by Herblore trainers for the +20 poison effect
+      - Low volume - prefer broad bolts for serious ranged training
+  about: Bronze bolts (p++) are super-poisoned bronze crossbow bolts created by applying weapon poison++ to a regular bronze bolt.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-11-28"
+    update: Slayer Update
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2005-11-28"
+      update: Slayer Update
+      description: Super-poisoned bolt variants introduced alongside weapon poison++.
+    - date: "2018-01-04"
+      update: Game Update
+      description: Item name reformatted from "Bronze bolts(p++)" to "Bronze bolts (p++)" with added space.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-brutal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-brutal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze brutal | OSRS Price Data
-description: "Bronze brutal: Blunt bronze arrow... ouch.. High alch: 3 GP, GE limit: 11,000."
+description: "Bronze brutal: Blunt bronze arrow... ouch. High alch: 3 GP, GE limit: 11,000."
 osrs:
   id: 4773
   name: Bronze brutal
@@ -12,9 +12,107 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 11000
-  about: "Bronze brutal is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammo
+    tier: low
+  equipment:
+    slot: ammo
+    weapon_type: bow
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 11
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 7
+      xp: 8.4
+      materials:
+        - item_name: Flighted ogre arrow
+          quantity: 6
+        - item_name: Bronze nails
+          quantity: 6
+      facility: Hammer
+      members_only: true
+  shops:
+    - shop_name: Hickton's Archery Emporium
+      location: Catherby
+      price: 12
+    - shop_name: Dargaud's Bow and Arrows
+      location: Ranging Guild
+      price: 12
+    - shop_name: Uglug's Stuffsies
+      location: Jiggig
+      price: 12
+  related_items:
+    - item_name: Flighted ogre arrow
+      slug: flighted-ogre-arrow
+      relationship: component
+      description: Base shaft required for fletching brutals
+    - item_name: Bronze nails
+      slug: bronze-nails
+      relationship: component
+      description: Required arrow head material
+    - item_name: Iron brutal
+      slug: iron-brutal
+      relationship: upgrade
+      description: Higher-tier ogre brutal arrow
+    - item_name: Steel brutal
+      slug: steel-brutal
+      relationship: upgrade
+      description: Mid-tier ogre brutal arrow
+    - item_name: Ogre bow
+      slug: ogre-bow
+      relationship: alternative
+      description: Required bow to fire brutal arrows
+    - item_name: Comp ogre bow
+      slug: comp-ogre-bow
+      relationship: alternative
+      description: Upgraded ogre bow compatible with brutals
+  market_strategy:
+    notes:
+      - Niche ammo - only ogre and comp ogre bows can fire brutals
+      - Primarily used for chompy bird hunting and Zogre Flesh Eaters content
+      - Requires partial completion of Zogre Flesh Eaters quest
+      - Limited demand outside of chompy hunter title grinding
+  about: Bronze brutal is a tier-one ogre arrow used with the ogre bow or comp ogre bow, fletched from flighted ogre arrows and bronze nails at 7 Fletching after partial completion of Zogre Flesh Eaters.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-17"
+    update: Zogre Flesh Eaters
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2005-05-17"
+      update: Zogre Flesh Eaters
+      description: Bronze brutal released as part of the Zogre Flesh Eaters quest update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-full-helm-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-full-helm-g.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 19
   highalch: 28
   limit: 4
-  about: "Bronze full helm (g) is a free-to-play item in Old School RuneScape. High alchemy value: 28 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: low
+  equipment:
+    slot: head
+    weight: 2.721
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -1
+      ranged: -3
+    defence_bonus:
+      stab: 4
+      slash: 5
+      crush: 3
+      magic: -1
+      ranged: 4
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+  related_items:
+    - item_id: 1155
+      item_name: Bronze full helm
+      slug: bronze-full-helm
+      relationship: variant
+      description: Untrimmed base helm
+    - item_id: 12213
+      item_name: Bronze full helm (t)
+      slug: bronze-full-helm-t
+      relationship: variant
+      description: Trimmed (t) cosmetic counterpart
+  market_strategy:
+    notes:
+      - Cosmetic trim with identical defence to base helm
+      - Tiny buy limit keeps GE prices volatile
+      - Driven by easy clue scroll completions
+      - Popular collection log target for newer accounts
+  history:
+    - date: "2021-04-21"
+      description: Ranged attack bonus reduced from -2 to -3.
+    - date: "2014-06-12"
+      description: Added with the Treasure Trail Expansion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Bronze full helm (g) is a gold-trimmed cosmetic helmet from easy clue scroll caskets with the same defence as the base helm.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-pickaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-pickaxe.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 40
-  about: "Bronze pickaxe is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: pickaxe
+    attack_speed: 5
+    weight: 2.267
+    attack_bonus:
+      stab: 4
+      slash: -2
+      crush: 2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 5
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Bob's Brilliant Axes
+      location: Lumbridge
+      stock: 5
+      price: 1
+    - shop_name: Nurmof's Pickaxe Shop
+      location: Dwarven Mines
+      stock: 6
+      price: 1
+    - shop_name: Yarsul's Prodigious Pickaxes
+      location: Mining Guild
+      stock: 6
+      price: 1
+  related_items:
+    - item_id: 1267
+      item_name: Iron pickaxe
+      slug: iron-pickaxe
+      relationship: upgrade
+      description: Faster mining tier
+    - item_id: 1273
+      item_name: Steel pickaxe
+      slug: steel-pickaxe
+      relationship: upgrade
+      description: Mid-tier pickaxe
+  market_strategy:
+    notes:
+      - Starter pickaxe given to new accounts
+      - Shop stock keeps prices floored
+      - F2P availability suppresses GE flips
+      - Low buy limit limits bulk movement
+      - Demand mostly from ironmen and noobs
+  history:
+    - date: "2022-05-04"
+      update: F2P Mining Rebalance
+      description: Pickaxes no longer randomly accelerate Mining by one tick on free-to-play worlds.
+    - date: "2014-03-13"
+      description: Random acceleration bug fixed across all pickaxes on F2P.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Bronze pickaxe is the entry-level pickaxe given to new players during the Mining tutorial.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-platebody.mdx
@@ -12,24 +12,86 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 125
-  item_id: 1117
-  item_type: armor
-  slot: body
-  type: platebody
-  tradeable: true
-  weight: 9.979
-  requirements:
-    defence: 0
-  stats:
-    stab_defence: 15
-    slash_defence: 14
-    crush_defence: 9
-    ranged_defence: 14
+  material:
+    type: bronze
+    tier: low
+  equipment:
+    slot: body
+    weight: 9.979
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 15
+      slash: 14
+      crush: 9
+      magic: -6
+      ranged: 14
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 18
+      xp: 62.5
+      materials:
+        - item_name: Bronze bar
+          item_id: 2349
+          quantity: 5
+      product: Bronze platebody
+      product_id: 1117
+      product_quantity: 1
+      tool: Hammer
+      facility: Anvil
   related_items:
-    - slug: iron-platebody
-    - slug: bronze-full-helm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1115
+      item_name: Iron platebody
+      slug: iron-platebody
+      relationship: upgrade
+      description: Next smithing tier platebody
+    - item_id: 1155
+      item_name: Bronze full helm
+      slug: bronze-full-helm
+      relationship: set-piece
+      description: Matching bronze armour piece
+  about: Bronze platebody is the cheapest tier of platebody, smithed at level 18 from 5 bronze bars.
+  market_strategy:
+    notes:
+      - Smithing target item at level 18
+      - Almost always loss-making to smith for cash
+      - GE price typically below high alch
+      - Steady low-level player demand
+  history:
+    - date: "2001-01-04"
+      update: RuneScape beta launch
+      description: Item released with the RuneScape beta.
+    - date: "2005-03-07"
+      description: Item received a graphical update.
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -10 to -15.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape beta launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/burnt-page.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/burnt-page.mdx
@@ -1,6 +1,6 @@
 ---
 title: Burnt page | OSRS Price Data
-description: "Burnt page: It's still warm to the touch.. High alch: 120 GP, GE limit: 11,000."
+description: "Burnt page: It's still warm to the touch. High alch: 120 GP, GE limit: 11,000."
 osrs:
   id: 20718
   name: Burnt page
@@ -14,57 +14,70 @@ osrs:
   limit: 11000
   material:
     type: charging_material
-    tradeable: true
-    stackable: true
-    weight: 0
+    tier: mid
+  charges:
+    target_item: Tome of fire
+    charges_per_unit: 20
   drop_table:
     sources:
       - source: Wintertodt reward cart
-        notes: Random drop
-      - source: Book of Eternal Flame
-        notes: Desiccated pages + 50 Runecraft
+        notes: Random drop from Wintertodt supply crates
       - source: Ignisia exchange
-        notes: 250 for empty Tome of fire
-  uses:
-    - target_id: 20714
-      target_name: Tome of fire
-      effect: 20 charges per page
-    - target_id: 28920
-      target_name: Searing page
-      effect: Converts with 100 sunfire runes per page
-  market:
-    buy_limit: 11000
-    price_estimate: 5600
+        notes: Exchange 250 burnt pages for an empty Tome of fire
+      - source: Book of Eternal Flame
+        notes: Created from desiccated pages at 50 Runecraft
   related_items:
-    - item_id: 20704
-      item_name: Wintertodt
+    - item_name: Wintertodt
       slug: wintertodt
-      relationship: component
-      description: Source minigame
-    - item_id: 20714
-      item_name: Tome of fire
+      relationship: alternative
+      description: Source minigame for burnt pages
+    - item_name: Tome of fire
       slug: tome-of-fire
       relationship: product
-      description: Charging target
-    - item_id: 28920
-      item_name: Searing page
+      description: Item charged using burnt pages
+    - item_name: Searing page
       slug: searing-page
       relationship: upgrade
-      description: Upgraded version
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Charging Material |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    | Use | Effect |
-    |-----|--------|
-    | Tome of fire | 20 charges per page |
-    | Searing page conversion | 100 sunfire runes per page |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Upgraded version made from burnt pages plus sunfire runes
+    - item_name: Tome of water
+      slug: tome-of-water
+      relationship: alternative
+      description: Soaked pages serve the same function for water spells
+  market_strategy:
+    notes:
+      - Supply driven by Wintertodt firemaking trainers
+      - Required to charge Tome of fire for magic training
+      - 20 charges per page, 100 sunfire runes per searing page conversion
+      - Volume scales with Wintertodt popularity
+  about: Burnt page is a Wintertodt drop used to charge the Tome of fire (20 charges per page) and to craft searing pages.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-09-08"
+    update: The Wintertodt
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Read
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2016-09-08"
+      update: The Wintertodt
+      description: Burnt page released with the Wintertodt minigame as a reward from supply crates.
+    - date: "2018-01-11"
+      update: Game Update
+      description: Players may exchange empty Tome of fire to Ignisia for 100 burnt pages.
+    - date: "2020-04-08"
+      update: Game Update
+      description: Exchange rate increased to 250 pages per tome; Wintertodt unique items now exchange for additional pages and crate drop rate increased by 50%.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cavalier-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cavalier-mask.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 150
-  about: "Cavalier mask is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: head
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: other
+      materials:
+        - item_name: Black cavalier
+          quantity: 1
+        - item_name: Highwayman mask
+          quantity: 1
+        - item_name: Coins
+          quantity: 500
+      product: Cavalier mask
+      product_id: 11280
+      product_quantity: 1
+      members_only: true
+      notes: Combined by Patchy on Mos Le'Harmless for 500 coins; disassembly costs 600 coins.
+  treasure_trail:
+    is_reward: true
+    tier: hard
+    notes: Assembled from a black cavalier (hard clue reward) and highwayman mask (easy clue reward).
+  related_items:
+    - item_id: 0
+      item_name: Black cavalier
+      slug: black-cavalier
+      relationship: component
+      description: Hard clue scroll reward component
+    - item_id: 2631
+      item_name: Highwayman mask
+      slug: highwayman-mask
+      relationship: component
+      description: Easy clue scroll reward component
+  about: Cavalier mask is a cosmetic head slot item assembled by Patchy on Mos Le'Harmless from a black cavalier and highwayman mask.
+  market_strategy:
+    notes:
+      - Niche cosmetic with limited demand
+      - Margin set by component clue rewards
+      - Low daily volume requires patience
+  trading_tips:
+    - Compare component prices vs combined mask
+    - Watch clue scroll meta and Treasure Trails updates
+  history:
+    - date: "2007-06-18"
+      update: "Game Improvements"
+      description: Released as a cosmetic combined headgear from clue scroll rewards.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-06-18"
+    update: "Game Improvements"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chasm-teleport-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chasm-teleport-scroll.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: null
-  about: "Chasm teleport scroll is a members-only item in Old School RuneScape. High alchemy value: 6 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Bottom of the Chasm of Fire near the Voice of Yama
+    type: scroll
+    consumed: true
+  drop_table:
+    sources:
+      - source: Yama
+        combat_level: 1238
+        quantity: "6"
+        rarity: 4/95.11
+        members_only: true
+      - source: Dossier
+        quantity: 15-18
+        rarity: 1/15
+        members_only: true
+        notes: Tertiary drop bundle from Yama
+  related_items:
+    - item_id: 0
+      item_name: Yama
+      slug: yama
+      relationship: component
+      description: Boss drop source
+    - item_id: 0
+      item_name: Chasm of Fire
+      slug: chasm-of-fire
+      relationship: alternative
+      description: Teleport destination
+  about: Chasm teleport scroll is a stackable members teleport scroll dropped by Yama that warps the holder to the bottom of the Chasm of Fire.
+  market_strategy:
+    notes:
+      - Supply gated by Yama boss popularity
+      - High alch value far below GE price
+      - Convenience teleport for repeat Yama trips
+      - Stackable, easy to bank
+  trading_tips:
+    - Track Yama boss meta shifts that affect kills per hour
+    - Compare against alternative Chasm of Fire access methods
+  history:
+    - date: "2025-05-14"
+      update: "Yama, the Master of Pacts"
+      description: Item released with the Yama boss launch.
+    - date: "2025-05-29"
+      description: Teleport destination adjusted to land players by the Voice of Yama on the lowest level instead of near the Chasm exit on the uppermost level.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-05-14"
+    update: "Yama, the Master of Pacts"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Teleport
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/choc-ice.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/choc-ice.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 6000
-  about: "Choc-ice is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: low
+  food:
+    heals: 7
+    effects:
+      - description: Automatically eaten during desert heat to cool the player and offset thirst.
+      - description: Waterskins take priority over choc-ices when both are in inventory.
+  shops:
+    - shop_name: Rok's Chocs Box
+      location: Nardah
+      stock: 30
+      price: 30
+      restock_seconds: 30
+  drop_table:
+    sources:
+      - source: Karamel
+        combat_level: 110
+        quantity: "1"
+        rarity: common
+        members_only: true
+  related_items:
+    - item_id: 1973
+      item_name: Chocolate bar
+      slug: chocolate-bar
+      relationship: alternative
+      description: Standard chocolate food source
+  market_strategy:
+    notes:
+      - Niche utility in the Kharidian Desert
+      - Heals 7 plus desert cooling effect
+      - Bulk demand from desert questers and Pyramid Plunder runners
+      - Cheap shop supply caps upside
+      - Stable low-volume listing
+  history:
+    - date: "2005-12-05"
+      description: Released alongside the Contact! quest and Nardah shop expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-12-05"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Choc-ice is a desert-friendly food that doubles as a coolant against Kharidian heat damage.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cleaning-cloth.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cleaning-cloth.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cleaning cloth | OSRS Price Data
-description: "Cleaning cloth: A spirit soaked piece of silk which can be used to remove poison.. High alch: 36 GP, GE limit: 40."
+description: "Cleaning cloth: A spirit soaked piece of silk which can be used to remove poison. High alch: 36 GP, GE limit: 40."
 osrs:
   id: 3188
   name: Cleaning cloth
@@ -12,9 +12,64 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 40
-  about: "Cleaning cloth is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  shops:
+    - shop_name: Tamayu's Spear Stall
+      location: Tai Bwo Wannai
+      price: 60
+      quantity_in_stock: 5
+      restock_time: 100
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Silk
+          item_id: 950
+          quantity: 1
+        - item_name: Karamjan rum
+          item_id: 431
+          quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 950
+      item_name: Silk
+      slug: silk
+      relationship: component
+      description: Base material for the cloth
+    - item_id: 431
+      item_name: Karamjan rum
+      slug: karamjan-rum
+      relationship: component
+      description: Combine with silk to produce the cloth
+  about: Cleaning cloth is a spirit-soaked silk used to remove poison from weapons and clean cosmetic recolours from abyssal whips and dark bows; obtained from Tamayu's Spear Stall after Tai Bwo Wannai Trio.
+  market_strategy:
+    notes:
+      - Small 40 buy limit caps arbitrage
+      - Demand spikes when whip/dark bow recolours trend
+      - Quest-locked shop limits supply
+  history:
+    - date: "2004-09-14"
+      update: Tai Bwo Wannai Trio
+      description: Cleaning cloth added with the Tai Bwo Wannai Trio quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-09-14"
+    update: Tai Bwo Wannai Trio
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-weapon-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-weapon-seed.mdx
@@ -12,13 +12,10 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 70
-  properties:
-    tradeable: true
-    tradeable_ge: true
-    weight: 0.014
+  material:
+    type: crystal
+    tier: high
   drop_table:
-    primary_source: Corrupted Gauntlet
-    best_drop_rate: 1/50
     sources:
       - source: The Gauntlet
         source_id: 0
@@ -34,51 +31,97 @@ osrs:
         rarity: uncommon
         drop_rate: 1/50
         members_only: true
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Ferox Enclave
+      sells_for: 12
+      currency: Last Man Standing points
+  recipes:
+    - skill: smithing
+      level: 78
+      xp: 0
+      materials:
+        - item_name: Crystal weapon seed
+          item_id: 4207
+          quantity: 1
+        - item_name: Crystal shard
+          item_id: 23962
+          quantity: 40
+      product: Crystal bow
+      product_id: 23864
+      product_quantity: 1
+      tool: Singing bowl
+      members_only: true
+    - skill: crafting
+      level: 78
+      xp: 0
+      materials:
+        - item_name: Crystal weapon seed
+          item_id: 4207
+          quantity: 1
+        - item_name: Crystal shard
+          item_id: 23962
+          quantity: 40
+      product: Crystal halberd
+      product_id: 23987
+      product_quantity: 1
+      tool: Singing bowl
+      members_only: true
   related_items:
     - item_id: 23864
       item_name: Crystal bow
       slug: crystal-bow
       relationship: product
-      description: Created weapon
+      description: Sung crystal bow weapon
     - item_id: 23866
       item_name: Crystal shield
       slug: crystal-shield
       relationship: product
-      description: Created shield
+      description: Sung crystal shield
     - item_id: 23987
       item_name: Crystal halberd
       slug: crystal-halberd
       relationship: product
-      description: Created weapon (requires diary)
+      description: Sung crystal halberd (Hard Western Provinces Diary)
     - item_id: 23757
       item_name: Enhanced crystal weapon seed
       slug: enhanced-crystal-weapon-seed
       relationship: upgrade
-      description: For Blade of Saeldor and Bow of Faerdhinen
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Seed |
-    | Tradeable | Yes |
-    | Weight | 0.014 kg |
-
-    Creates crystal weapons:
-    - Crystal bow
-    - Crystal shield
-    - Crystal halberd (requires Hard Western Provinces Diary)
-
-    Via Singing Bowl (78 Smithing/Crafting): 40 crystal shards per weapon.
-
-    Via Ilfeen: 150K-900K gp (no skill req).
-
-    Can exchange for 10 crystal shards or crystal acorn.
+      description: Upgraded seed for Blade of Saeldor and Bow of Faerdhinen
+  about: Crystal weapon seed is a Gauntlet drop sung into Crystal bows, shields, or halberds via the Singing Bowl (or via Ilfeen for gp).
   market_strategy:
     notes:
-      - Farm Corrupted Gauntlet
+      - Corrupted Gauntlet is the primary supply at 1/50
+      - Price tracks Enhanced seed demand
       - Cheaper than enhanced seed
-      - Good for ironmen
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Solid ironman crafting path
+      - LMS shop offers an alternate point-sink supply
+  history:
+    - date: "2005-02-07"
+      update: Roving Elves
+      description: Item released with the Roving Elves quest.
+    - date: "2005-06-22"
+      description: Initial graphical update.
+    - date: "2015-03-05"
+      description: Halberd enchantment added, requiring the Hard Western Provinces Diary.
+    - date: "2019-07-25"
+      description: Graphically updated and renamed from "Crystal seed".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-07"
+    update: Roving Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.014
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/desert-camo-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/desert-camo-top.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Desert camo top is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: body
+    weight: -3
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 10
+      slash: 15
+      crush: 19
+      magic: 0
+      ranged: 12
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Fancy Clothes Store
+      location: Varrock
+      sells_for: 20
+      notes: Trade 2 desert devil furs plus 20 coins
+    - shop_name: Hunter Guild Shop
+      location: Hunter Guild
+      sells_for: 20
+      notes: Pellem; trade 2 desert devil furs plus 20 coins
+    - shop_name: Seamstress
+      location: Prifddinas
+      sells_for: 20
+      notes: Trade 2 desert devil furs plus 20 coins
+  related_items:
+    - item_id: 10063
+      item_name: Desert camo legs
+      slug: desert-camo-legs
+      relationship: set-piece
+      description: Matching desert camouflage legs
+    - item_id: 10069
+      item_name: Polar camo top
+      slug: polar-camo-top
+      relationship: variant
+      description: Polar biome camouflage top
+    - item_id: 10065
+      item_name: Woodland camo top
+      slug: woodland-camo-top
+      relationship: variant
+      description: Woodland biome camouflage top
+  about: Desert camo top is a body slot camouflage shirt purchased with 2 desert devil furs and 20 coins; the camo affix is flavour text and does not influence Hunter traps.
+  market_strategy:
+    notes:
+      - Not tradeable on Grand Exchange
+      - Purchase price requires desert devil furs
+      - 2024 weight reduction (-3 kg) revived demand
+      - Useful as a passive weight-reducing body
+  history:
+    - date: "2006-11-21"
+      update: Hunter
+      description: Item released with the Hunter skill update.
+    - date: "2024-03-20"
+      description: Now reduces worn weight by 3 kg.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter
+    tradeable: false
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: -3
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/desert-devil-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/desert-devil-fur.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 6
   highalch: 10
   limit: 10000
-  about: "Desert devil fur is a members-only item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: fur
+    tier: low
+  drop_table:
+    sources:
+      - source: Desert devil
+        quantity: "1"
+        rarity: always
+        members_only: true
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Desert devil fur
+          item_id: 10123
+          quantity: 2
+        - item_name: Coins
+          item_id: 995
+          quantity: 20
+      product: Desert camo legs
+      product_id: 10067
+      product_quantity: 1
+      members_only: true
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Desert devil fur
+          item_id: 10123
+          quantity: 2
+        - item_name: Coins
+          item_id: 995
+          quantity: 20
+      product: Desert camo top
+      product_id: 10065
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 10067
+      item_name: Desert camo legs
+      slug: desert-camo-legs
+      relationship: product
+      description: Made from 2 desert devil furs
+    - item_id: 10065
+      item_name: Desert camo top
+      slug: desert-camo-top
+      relationship: product
+      description: Made from 2 desert devil furs
+  history:
+    - date: "2006-11-21"
+      update: HUNTER SKILL!
+      description: Desert devil fur added with the Hunter skill release.
+  about: Desert devil fur is a sandy coloured kebbit fur obtained from hunting desert devils at level 13 Hunter, used by the Fancy Clothes Store to craft desert camo gear.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: HUNTER SKILL!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/desert-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/desert-robe.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 150
-  about: "Desert robe is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: legs
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Ali Morrisane
+      location: Pollnivneach
+      currency: Coins
+      members_only: true
+  related_items:
+    - item_id: 1833
+      item_name: Desert shirt
+      slug: desert-shirt
+      relationship: set-piece
+      description: Matching top half of the desert outfit
+    - item_id: 1837
+      item_name: Desert boots
+      slug: desert-boots
+      relationship: set-piece
+      description: Matching boots for desert travel
+  history:
+    - date: "2003-04-14"
+      update: Tourist Trap Quest Online!
+      description: Desert robe released with the Tourist Trap quest.
+  about: Desert robe is a light leg covering worn for protection from desert heat, delaying the drain effect by 12 extra seconds when equipped.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: Tourist Trap Quest Online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-javelin-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-javelin-p.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 180
   highalch: 270
   limit: 11000
-  about: "Dragon javelin(p) is a members-only item in Old School RuneScape. High alchemy value: 270 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: thrown
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 150
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 92
+      xp: 225
+      materials:
+        - item_name: Dragon javelin
+          item_id: 825
+          quantity: 15
+        - item_name: Weapon poison
+          item_id: 187
+          quantity: 1
+      product: Dragon javelin(p)
+      product_id: 19486
+      product_quantity: 15
+      members_only: true
+  related_items:
+    - item_id: 825
+      item_name: Dragon javelin
+      slug: dragon-javelin
+      relationship: variant
+      description: Unpoisoned base javelin
+    - item_id: 19488
+      item_name: Dragon javelin(p+)
+      slug: dragon-javelin-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_id: 19490
+      item_name: Dragon javelin(p++)
+      slug: dragon-javelin-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+    - item_id: 11959
+      item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: alternative
+      description: Required weapon to use javelins
+  history:
+    - date: "2016-10-31"
+      update: Hotfix
+      description: Ranged Strength bonus decreased from +175 to +150.
+    - date: "2016-05-06"
+      update: Monkey Madness II
+      description: Dragon javelin(p) added to the game.
+  about: Dragon javelin(p) is a poisoned dragon javelin fired from the heavy ballista, dealing strong ranged damage plus poison effect.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-05-06"
+    update: Monkey Madness II
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-scimitar-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-scimitar-ornament-kit.mdx
@@ -12,60 +12,68 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  item:
-    type: ornament_kit
-    tradeable: true
-    target_item: Dragon scimitar
-    target_id: 4587
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Master
-        drop_rate: Rare from reward casket
+  material:
+    type: ornament-kit
+    tier: high
+  treasure_trail:
+    is_reward: true
+    tier: elite
+    drop_rate: 1/1275
+  recipes:
+    - skill: smithing
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Dragon scimitar
+          item_id: 4587
+          quantity: 1
+        - item_name: Dragon scimitar ornament kit
+          item_id: 20002
+          quantity: 1
+      product: Dragon scimitar (or)
+      product_id: 20000
+      product_quantity: 1
+      members_only: true
   related_items:
     - item_id: 4587
       item_name: Dragon scimitar
       slug: dragon-scimitar
-      relationship: product
-      description: Base item to upgrade
+      relationship: component
+      description: Base weapon the kit attaches to
     - item_id: 20000
       item_name: Dragon scimitar (or)
       slug: dragon-scimitar-or
       relationship: product
-      description: Ornamented version
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ornament Kit |
-    | Target | Dragon scimitar |
-    | Tradeable | Yes |
-
-    Use on a Dragon scimitar to create a Dragon scimitar (or).
-
-    The ornament kit:
-    - Adds gold trim to the scimitar
-    - Purely cosmetic change
-    - Does not affect stats
-    - Can be reverted
-
-    Materials:
-    - Dragon scimitar
-    - Dragon scimitar ornament kit
-
-    Result:
-    - Dragon scimitar (or) - gold trimmed version
-
-    The ornamented scimitar can be reverted to return:
-    - Dragon scimitar
-    - Dragon scimitar ornament kit
+      description: Ornamented version after kit applied
+  about: Dragon scimitar ornament kit is an elite clue reward applied to a Dragon scimitar to create the cosmetic-only Dragon scimitar (or); reversible to return both pieces.
   market_strategy:
     notes:
-      - Master clue exclusive
-      - Popular weapon upgrade
-      - Fashionscape item
-      - Collection log item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Elite clue exclusive supply
+      - Pure cosmetic, no stat change
+      - Fashionscape and collection log demand
+      - Tiny GE buy limit (4) makes price volatile
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion
+      description: Item released with the 2016 Treasure Trail Expansion.
+    - date: "2017-06-08"
+      description: The item was graphically updated.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/drift-net.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/drift-net.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 600
-  about: "Drift net is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: net
+    tier: low
+  recipes:
+    - skill: crafting
+      level: 26
+      xp: 55
+      materials:
+        - item_name: Jute fibre
+          item_id: 5931
+          quantity: 2
+      product: Drift net
+      product_id: 21652
+      product_quantity: 1
+      facility: Loom
+      members_only: true
+  related_items:
+    - item_id: 5931
+      item_name: Jute fibre
+      slug: jute-fibre
+      relationship: component
+      description: Crafted into drift nets at a loom
+    - item_id: 21347
+      item_name: Numulite
+      slug: numulite
+      relationship: alternative
+      description: Common Fossil Island drift-fishing reward currency
+  market_strategy:
+    notes:
+      - Single-use net consumed per shoal sequence
+      - Drift fishing burns 80-110 nets per hour
+      - Loom crafting at 26 Crafting yields steady supply
+      - GE limit lifted to 600 in 2020 to ease bottlenecks
+      - Demand peaks during Fishing or Hunter grinds
+  history:
+    - date: "2020-09-10"
+      description: Grand Exchange buy limit increased from 100 to 600.
+    - date: "2017-09-07"
+      update: Fossil Island
+      description: Released with the Fossil Island update for drift-net fishing.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-09-07"
+    update: Fossil Island
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Drift net is a Fossil Island consumable used in drift-net fishing for combined Fishing and Hunter experience.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-moon-chestplate-broken.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-moon-chestplate-broken.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 116004
   highalch: 174006
   limit: 15
-  about: "Eclipse moon chestplate (broken) is a members-only item in Old School RuneScape. High alchemy value: 174,006 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: moon-armour
+    tier: mid-high
+  charges:
+    description: Degrades from the standard Eclipse moon chestplate through extended combat use; repair restores full charges.
+    repair_cost: 1500000
+    repair_npc: Lumbridge armour repair NPCs
+    self_repair_discount: Up to 50% off with 99 Smithing on an armour stand (~757,500 coins).
+  related_items:
+    - item_id: 29039
+      item_name: Eclipse moon chestplate
+      slug: eclipse-moon-chestplate
+      relationship: variant
+      description: Active form restored after repair
+    - item_id: 29047
+      item_name: Eclipse moon helm (broken)
+      slug: eclipse-moon-helm-broken
+      relationship: set-piece
+      description: Matching broken helm
+    - item_id: 29051
+      item_name: Eclipse moon tassets (broken)
+      slug: eclipse-moon-tassets-broken
+      relationship: set-piece
+      description: Matching broken tassets
+    - item_id: 29024
+      item_name: Eclipse atlatl
+      slug: eclipse-atlatl
+      relationship: alternative
+      description: Set weapon dropped from the Lunar Chest
+  market_strategy:
+    notes:
+      - Broken variant trades at a discount to active piece
+      - Repair fee anchors the floor price
+      - Players flip broken stock to reroll fresh repairs
+      - Limited supply from Lunar Chest pulls
+      - 99 Smithing armour stand routes save 50%
+  history:
+    - date: "2024-04-24"
+      description: Weight reduced from 12 kg to 3 kg.
+    - date: "2024-03-20"
+      update: Varlamore - Part One
+      description: Released as the degraded form of the Eclipse moon chestplate.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore - Part One
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+      - Check
+    alchable: true
+    destroy: Drop
+  about: Eclipse moon chestplate (broken) is the fully degraded form of the Eclipse moon chestplate and must be repaired before it can be worn again.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-marlin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-marlin.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 250
-  about: "Fish crate (marlin) is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: container
+    tier: mid
+  recipes:
+    - skill: fishing
+      materials:
+        - item_name: Fish crate (empty)
+          quantity: 1
+        - item_name: Raw marlin
+          quantity: 10
+      product: Fish crate (marlin)
+      product_id: 32383
+      product_quantity: 1
+      members_only: true
+      notes: Created by emptying a trawling net containing at least 10 raw marlin while an empty fish crate sits in the cargo hold.
+  related_items:
+    - item_id: 0
+      item_name: Fish crate (empty)
+      slug: fish-crate-empty
+      relationship: component
+      description: Empty crate base
+    - item_id: 0
+      item_name: Raw marlin
+      slug: raw-marlin
+      relationship: component
+      description: Marlin filling
+    - item_id: 0
+      item_name: Camphor crate
+      slug: camphor-crate
+      relationship: downgrade
+      description: Fallback received if emptied outside a bank
+  about: Fish crate (marlin) is a Sailing-era container packed with raw marlin; it must be emptied at a bank or it reverts to a camphor crate without the ice cooler.
+  market_strategy:
+    notes:
+      - Sailing supply chain item, gated by trawling RNG
+      - Buy limit 250 caps bulk arbitrage
+      - Tradeable bulk-marlin shortcut for cooks
+  trading_tips:
+    - Compare marlin spot price to crate price for arbitrage
+    - Always empty inside a bank to preserve the crate
+    - Watch Sailing meta updates for supply swings
+  history:
+    - date: "2025-11-19"
+      update: "Sailing"
+      description: Released as part of the Sailing skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-kilt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-kilt.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 24000
   highalch: 36000
   limit: 8
+  material:
+    type: leather
+    tier: mid
   equipment:
     slot: legs
     weight: 3
@@ -32,12 +35,9 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Elite
-        drop_rate: 1/1,275
-        description: Rare reward from elite clue scrolls
+  treasure_trail:
+    tier: elite
+    is_reward: true
   related_items:
     - item_id: 4087
       item_name: Rune platelegs
@@ -53,32 +53,35 @@ osrs:
       item_name: Bandos tassets
       slug: bandos-tassets
       relationship: upgrade
-      description: Best-in-slot melee legs (+2 str, requires 65 Defence)
-  about: |-
-    > *"A kilt worn by the mightiest of Fremennik warriors."*
-
-    | Property | Fremennik Kilt | Bandos Tassets | Obsidian Platelegs |
-    |----------|---------------|----------------|-------------------|
-    | Melee Strength | +1 | +2 | +1 |
-    | Stab Defence | +11 | +71 | +50 |
-    | Slash Defence | +10 | +63 | +48 |
-    | Crush Defence | +10 | +66 | +52 |
-    | Defence Req | None | 65 | 60 |
-    | Source | Elite clue | General Graardor | TzHaar shops |
-
-    The Fremennik kilt is the only legs-slot item with a strength bonus and no requirements, making it valuable for pures and restricted accounts.
+      description: Best-in-slot melee legs (+2 strength, 65 Defence)
   market_strategy:
-    title: Investment Notes
     notes:
-      - Elite clue exclusive with niche demand from pure community
-      - Only no-requirement legs with a strength bonus
-      - Shares +1 strength with obsidian platelegs but needs no Defence level
-      - Essential for melee pures seeking maximum strength bonus
-      - Pair with spiked manacles for a no-requirement strength gear setup
-      - Elite clues are slower to complete, keeping supply limited
-      - Price driven by the pure PvP community
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Only no-requirement legs slot with a strength bonus
+      - Pure PvP demand drives the bulk of the price
+      - Elite clue caskets are slow to farm, capping supply
+      - Pairs well with spiked manacles for no-requirement strength setups
+      - Shares +1 strength with obsidian platelegs without needing 60 Defence
+  history:
+    - date: "2019-04-11"
+      description: Added with the Treasure Trails Expansion alongside the Easter 2019 update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Fremennik kilt is an elite clue reward and the only legs slot item with a strength bonus and no level requirements.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-skirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-skirt.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Fremennik skirt is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: legs
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Shoe Store
+      location: Rellekka
+      sells_for: 650
+      buys_for: 350
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania Dungeon
+      sells_for: 500
+      buys_for: 275
+  related_items:
+    - item_id: 3791
+      item_name: Fremennik shirt
+      slug: fremennik-shirt
+      relationship: set-piece
+      description: Matching Fremennik outfit top
+    - item_id: 3793
+      item_name: Fremennik boots
+      slug: fremennik-boots
+      relationship: set-piece
+      description: Matching Fremennik outfit boots
+  about: Fremennik skirt is a green skirt purchased from Yrsa or the Miscellania Clothes Shop after completing The Fremennik Trials.
+  market_strategy:
+    notes:
+      - Fixed shop supply caps demand spikes
+      - Fashionscape collectors drive price
+      - Cheap to stock from Yrsa post-quest
+      - Low alch margin keeps floor near shop value
+  history:
+    - date: "2004-11-02"
+      update: The Fremennik Trials
+      description: Item released with the Fremennik Trials quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-11-02"
+    update: The Fremennik Trials
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/frog-slippers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/frog-slippers.mdx
@@ -1,20 +1,88 @@
 ---
 title: Frog slippers | OSRS Price Data
-description: "Frog slippers: Cute frog slippers.. High alch: 600 GP, GE limit: 4."
+description: "Frog slippers: Cute frog slippers. High alch: 600 GP, GE limit: 4."
 osrs:
   id: 23288
   name: Frog slippers
   slug: frog-slippers
   examine: Cute frog slippers.
-  members: false
+  members: true
   icon: Frog slippers.png
   value: 1000
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Frog slippers is a free-to-play item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic_armour
+    tier: low
+  equipment:
+    slot: feet
+    weight: 0.2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: beginner
+    is_reward: true
+    rarity: 1/360
+  related_items:
+    - item_name: Reward casket (beginner)
+      slug: reward-casket-beginner
+      relationship: component
+      description: Source casket for the frog slippers drop
+    - item_name: Bunny feet
+      slug: bunny-feet
+      relationship: alternative
+      description: Cosmetic feet slot from holiday event
+    - item_name: Frog mask
+      slug: frog-mask
+      relationship: alternative
+      description: Themed cosmetic head slot
+  market_strategy:
+    notes:
+      - Cosmetic only - zero combat bonuses
+      - Counts as warm clothing at Wintertodt
+      - Low buy limit (4) keeps supply tight
+      - Storable in costume room treasure chest
+  about: Frog slippers are a cosmetic feet-slot reward from beginner-tier Treasure Trails caskets that count as warm clothing at the Wintertodt.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2019-04-11"
+      update: Treasure Trails Expansion and Easter 2019
+      description: Frog slippers added as a beginner clue reward during the Treasure Trails expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-armour-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-armour-set-lg.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Gilded armour set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: high
+  related_items:
+    - item_id: 3486
+      item_name: Gilded full helm
+      slug: gilded-full-helm
+      relationship: component
+      description: Set piece
+    - item_id: 3481
+      item_name: Gilded platebody
+      slug: gilded-platebody
+      relationship: component
+      description: Set piece
+    - item_id: 3483
+      item_name: Gilded platelegs
+      slug: gilded-platelegs
+      relationship: component
+      description: Set piece
+    - item_id: 3488
+      item_name: Gilded kiteshield
+      slug: gilded-kiteshield
+      relationship: component
+      description: Set piece
+    - item_id: 13037
+      item_name: Gilded armour set (sk)
+      slug: gilded-armour-set-sk
+      relationship: variant
+      description: Skirt variant of the set
+  shops:
+    - shop_name: Grand Exchange
+      location: Varrock
+      price: 80000
+  market_strategy:
+    notes:
+      - Container item for the four gilded armour pieces
+      - Trade via Grand Exchange set conversion
+      - Useful for buying/selling all four pieces atomically
+      - Cosmetic Treasure Trail loot, high alch value
+      - Free-to-play accessible since 2016
+      - Compare set price vs sum of individual pieces for arbitrage
+  history:
+    - date: "2015-02-26"
+      update: The Grand Exchange
+      description: Item added to the game as part of Grand Exchange set conversion.
+    - date: "2016-05-19"
+      update: Sand Crabs & Soul Bearers
+      description: Made available to free-to-play players.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-02-26"
+    update: The Grand Exchange
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Gilded armour set (lg) is a free-to-play Grand Exchange container holding the four gilded armour pieces (full helm, platebody, platelegs, kiteshield) for atomic trading.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-armour-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-armour-set-sk.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Gilded armour set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: armour_set
+    tier: high
+  recipes:
+    - skill: other
+      materials:
+        - item_name: Gilded full helm
+          quantity: 1
+        - item_name: Gilded platebody
+          quantity: 1
+        - item_name: Gilded plateskirt
+          quantity: 1
+        - item_name: Gilded kiteshield
+          quantity: 1
+      product: Gilded armour set (sk)
+      product_id: 13038
+      product_quantity: 1
+      members_only: false
+      notes: Assembled via the Grand Exchange clerk's "Sets" interface.
+  related_items:
+    - item_id: 3486
+      item_name: Gilded full helm
+      slug: gilded-full-helm
+      relationship: set-piece
+      description: Helm component
+    - item_id: 3481
+      item_name: Gilded platebody
+      slug: gilded-platebody
+      relationship: set-piece
+      description: Platebody component
+    - item_id: 3485
+      item_name: Gilded plateskirt
+      slug: gilded-plateskirt
+      relationship: set-piece
+      description: Plateskirt component
+    - item_id: 3488
+      item_name: Gilded kiteshield
+      slug: gilded-kiteshield
+      relationship: set-piece
+      description: Kiteshield component
+  about: Gilded armour set (sk) bundles a gilded full helm, platebody, plateskirt, and kiteshield through the Grand Exchange Sets interface for one-click trading.
+  market_strategy:
+    notes:
+      - Convenience bundle for cosmetic gilded gear
+      - Margin tracks individual gilded component prices
+      - GE buy limit 8 gates flip volume
+      - High-value flip with long settle times
+  trading_tips:
+    - Compare set price vs sum of components for arbitrage
+    - Sets clerk has no fee, only GE tax applies on sale
+    - Watch clue scroll loot tables for supply pulses
+  history:
+    - date: "2016-05-19"
+      description: Made accessible to free-to-play players.
+    - date: "2015-02-26"
+      update: "The Grand Exchange"
+      description: Added with the Grand Exchange sets interface.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-02-26"
+    update: "The Grand Exchange"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-four-poster-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-four-poster-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gilded four-poster (flatpack) | OSRS Price Data
-description: "Gilded four-poster (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Gilded four-poster (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8588
   name: Gilded four-poster (flatpack)
@@ -12,9 +12,86 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Gilded four-poster (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flatpack
+    tier: high
+  construction:
+    construction_level: 60
+    xp: 1330
+    hotspot: Bed space
+    room: Bedroom
+    flatpack: true
+    materials:
+      - item_name: Mahogany plank
+        item_id: 8782
+        quantity: 5
+      - item_name: Bolt of cloth
+        item_id: 8790
+        quantity: 2
+      - item_name: Gold leaf
+        item_id: 8784
+        quantity: 2
+  recipes:
+    - skill: construction
+      level: 60
+      xp: 1330
+      materials:
+        - item_name: Mahogany plank
+          item_id: 8782
+          quantity: 5
+        - item_name: Bolt of cloth
+          item_id: 8790
+          quantity: 2
+        - item_name: Gold leaf
+          item_id: 8784
+          quantity: 2
+      ticks: 5
+      members_only: true
+      tools:
+        - Hammer
+        - Saw
+  related_items:
+    - item_id: 8782
+      item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: 5 required to build
+    - item_id: 8790
+      item_name: Bolt of cloth
+      slug: bolt-of-cloth
+      relationship: component
+      description: 2 required to build
+    - item_id: 8784
+      item_name: Gold leaf
+      slug: gold-leaf
+      relationship: component
+      description: 2 required to build
+  about: Gilded four-poster (flatpack) is a Construction flatpack built at a workshop bench at 60 Construction for 1,330 XP, placed in the Bedroom bed hotspot.
+  market_strategy:
+    notes:
+      - Builders make at sawmill bench then sell on GE
+      - Net loss versus material cost - convenience premium
+      - Demand driven by Construction trainers skipping bench trips
+  history:
+    - date: "2006-05-31"
+      update: PLAYER-OWNED HOUSES!
+      description: Gilded four-poster flatpack added with the Construction skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: PLAYER-OWNED HOUSES!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-avantoe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-avantoe.mdx
@@ -12,16 +12,20 @@ osrs:
   lowalch: 7
   highalch: 10
   limit: 13000
-  herb:
-    type: clean
+  material:
+    type: herb
     tier: mid
-  herblore:
-    cleaning_level: 48
-    cleaning_xp: 10
+  potion:
+    skill: herblore
+    level: 48
+    xp: 10
+    effects:
+      - description: Cleans into Avantoe, used in Fishing potion, Hunter potion, and Super energy mixtures.
   farming:
-    level: 50
-    seed_id: 5298
+    farming_level: 50
     seed_name: Avantoe seed
+    seed_id: 5298
+    patch_type: herb
   drop_table:
     sources:
       - source: Aberrant spectre
@@ -31,6 +35,18 @@ osrs:
         rarity: common
         members_only: true
   recipes:
+    - skill: herblore
+      level: 48
+      xp: 10
+      materials:
+        - item_name: Grimy avantoe
+          item_id: 211
+          quantity: 1
+      product: Avantoe
+      product_id: 261
+      product_quantity: 1
+      facility: None
+      members_only: true
     - skill: herblore
       level: 50
       xp: 112.5
@@ -62,51 +78,53 @@ osrs:
       facility: None
       members_only: true
   related_items:
-    - item_id: 3022
-      item_name: Super energy(3)
-      slug: super-energy-3
+    - item_id: 261
+      item_name: Avantoe
+      slug: avantoe
       relationship: product
-      description: Main product
-    - item_id: 2970
-      item_name: Mort myre fungus
-      slug: mort-myre-fungus
-      relationship: component
-      description: Secondary
-    - item_id: 12625
-      item_name: Stamina potion(4)
-      slug: stamina-potion-4
-      relationship: product
-      description: Upgraded product
+      description: Cleaned form of the herb
     - item_id: 5298
       item_name: Avantoe seed
       slug: avantoe-seed
       relationship: component
-      description: Farming seed
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 48 |
-    | XP | 10 |
-    | Product | Avantoe (clean) |
+      description: Farming seed used to grow the herb
+    - item_id: 3022
+      item_name: Super energy(3)
+      slug: super-energy-3
+      relationship: product
+      description: Downstream Herblore product
+    - item_id: 2970
+      item_name: Mort myre fungus
+      slug: mort-myre-fungus
+      relationship: component
+      description: Secondary for Super energy production
   market_strategy:
-    title: |-
-      - Super energy production
-      - Stamina potion chain
-      - Moderate value
     notes:
-      - Super energy production
-      - Stamina potion chain
-      - Moderate value
-      - Super energy potions
-      - Stamina potion production
-      - Hunter potions
-      - Ironman accounts
-      - Farm runs profitable
-      - 50 Farming required
-      - Essential for stamina chain
-      - Mid-tier pricing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Mid-tier herb backing Super energy and Stamina chains
+      - Steady drop supply from Slayer tasks
+      - Farming runs profitable at 50 Farming
+      - Strong consistent demand from PvMers
+      - Ironman accounts widen the buy book
+  history:
+    - date: "2002-02-27"
+      description: Released alongside the Herblore skill rework.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Grimy avantoe is the uncleaned form of Avantoe, requiring level 48 Herblore to clean for 10 XP.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-marrentill.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-marrentill.mdx
@@ -1,6 +1,6 @@
 ---
 title: Grimy marrentill | OSRS Price Data
-description: "Grimy marrentill: It needs cleaning.. High alch: 8 GP, GE limit: 13,000."
+description: "Grimy marrentill: It needs cleaning. High alch: 8 GP, GE limit: 13,000."
 osrs:
   id: 201
   name: Grimy marrentill
@@ -12,18 +12,85 @@ osrs:
   lowalch: 5
   highalch: 8
   limit: 13000
+  material:
+    type: herb
+    tier: low
+  drop_table:
+    sources:
+      - source: Aberrant spectre
+        combat_level: 96
+        quantity: "1"
+        rarity: 1/8.8
+        members_only: true
+      - source: Elder Chaos druid
+        combat_level: 129
+        quantity: "1"
+        rarity: 1/12.5
+        members_only: true
+      - source: Deviant spectre
+        combat_level: 169
+        quantity: "1"
+        rarity: 1/14.8
+        members_only: true
+  farming:
+    farming_level: 14
+    seed_item: Marrentill seed
+    seed_item_id: 5292
+    grow_time_minutes: 80
+    cleaning:
+      herblore_level: 5
+      xp: 3.8
+  recipes:
+    - skill: herblore
+      level: 5
+      xp: 3.8
+      materials:
+        - item_name: Grimy marrentill
+          item_id: 201
+          quantity: 1
+      output_item: Marrentill
+      output_item_id: 251
+      members_only: true
   related_items:
     - item_id: 251
       item_name: Marrentill
       slug: marrentill
       relationship: product
       description: Cleaned version
-  about: |-
-    > _"It needs cleaning."_
-
-    Grimy marrentill requires 5 Herblore to clean (3.8 XP). Used in antipoison potions and as incense on the Incense Burner in a Player-Owned House.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 5292
+      item_name: Marrentill seed
+      slug: marrentill-seed
+      relationship: component
+      description: Farmable seed source
+  about: Grimy marrentill is the uncleaned form of marrentill, cleaned at 5 Herblore for 3.8 XP and used in antipoison potions and POH incense burners.
+  market_strategy:
+    notes:
+      - Bulk supply from Slayer (Aberrant/Deviant spectres)
+      - Low alch margin - flips on volume
+      - Farmable from Marrentill seeds at 14 Farming
+  history:
+    - date: "2017-03-09"
+      description: Value raised from 1 to 14 coins.
+    - date: "2015-02-24"
+      description: Made tradeable on the Grand Exchange with a "Clean" option replacing "Identify".
+    - date: "2002-02-27"
+      description: Grimy marrentill added as part of the original Herblore herb set.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guam-tar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guam-tar.mdx
@@ -12,9 +12,99 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Guam tar is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 5
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 16
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 19
+      xp: 30
+      materials:
+        - item_name: Swamp tar
+          item_id: 1939
+          quantity: 15
+        - item_name: Guam leaf
+          item_id: 249
+          quantity: 1
+      product: Guam tar
+      product_id: 10142
+      product_quantity: 15
+      members_only: true
+      tool: Pestle and mortar
+      notes: Using ground guam instead of a guam leaf produces a small profit.
+  related_items:
+    - item_id: 249
+      item_name: Guam leaf
+      slug: guam-leaf
+      relationship: component
+      description: Clean herb ingredient
+    - item_id: 1939
+      item_name: Swamp tar
+      slug: swamp-tar
+      relationship: component
+      description: Tar base produced from Hunter
+    - item_id: 0
+      item_name: Swamp lizard
+      slug: swamp-lizard
+      relationship: alternative
+      description: Hunter creature this tar fuels and baits
+  about: Guam tar is ammunition for swamp lizards and an optional Hunter bait that boosts catch rate by roughly 3%, made at 19 Herblore from a guam leaf and 15 swamp tar.
+  market_strategy:
+    notes:
+      - Hunter and slayer demand for swamp lizards
+      - Ground guam route beats leaf route for profit
+      - Buy limit 7,000 supports bulk Hunter trips
+  trading_tips:
+    - Compare ground guam vs leaf cost when herbloring
+    - Watch swamp tar Hunter supply prices
+    - Stable low-value bulk staple
+  history:
+    - date: "2007-06-04"
+      description: '"Use" and "Wield" options were switched, so Wield is now left-click.'
+    - date: "2006-11-21"
+      update: "Hunter Skill"
+      description: Released with the Hunter skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: "Hunter Skill"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-d-hide-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-d-hide-body.mdx
@@ -12,35 +12,36 @@ osrs:
   lowalch: 5200
   highalch: 7800
   limit: 8
+  material:
+    type: dragonhide
+    tier: mid-high
   equipment:
     slot: body
-    type: ranged armour
-    attack_style: ranged
+    weight: 6
     requirements:
       ranged: 70
       defence: 40
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -15
-      attack_ranged: 30
-      defence_stab: 55
-      defence_slash: 47
-      defence_crush: 60
-      defence_magic: 50
-      defence_ranged: 55
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 30
+    defence_bonus:
+      stab: 55
+      slash: 47
+      crush: 60
+      magic: 50
+      ranged: 55
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
-      prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: 1/1,625
-        description: Reward from hard clue scroll caskets
+      prayer: 1
+  treasure_trail:
+    is_reward: true
+    tier: hard
+    drop_rate: 1/1625
   related_items:
     - item_id: 10370
       item_name: Zamorak d'hide body
@@ -67,36 +68,39 @@ osrs:
       slug: black-d-hide-body
       relationship: downgrade
       description: Standard black dragonhide body with lower defensive stats and no prayer bonus
-  about: |-
-    The Guthix d'hide body is a blessed dragonhide body armour aligned with Guthix, the god of balance. It is one of six blessed d'hide body variants obtainable from hard clue scrolls, each representing a different god in the RuneScape pantheon.
-
-    All blessed d'hide bodies share identical combat stats, making the choice between them purely cosmetic. They are a direct upgrade over the Black d'hide body, offering significantly higher defensive bonuses and a +1 prayer bonus while requiring the same 70 Ranged and 40 Defence to equip.
-
-    | Stat | Blessed (All Gods) | Black D'hide Body |
-    |------|--------------------:|------------------:|
-    | Ranged Attack | +30 | +30 |
-    | Magic Attack | -15 | -15 |
-    | Stab Defence | +55 | +30 |
-    | Slash Defence | +47 | +38 |
-    | Crush Defence | +60 | +45 |
-    | Magic Defence | +50 | +45 |
-    | Ranged Defence | +55 | +50 |
-    | Prayer | +1 | +0 |
-    | Ranged Req | 70 | 70 |
-    | Defence Req | 40 | 40 |
-
-    The blessed variants provide substantially better defensive bonuses across the board, with the largest improvements in stab defence (+25), crush defence (+15), and ranged defence (+5). The +1 prayer bonus is a further advantage that no standard dragonhide body offers. Since the requirements are identical, blessed d'hide bodies are a strict upgrade over the black d'hide body.
+  about: Guthix d'hide body is a hard clue reward blessed dragonhide body sharing identical stats with the other five god variants; a strict upgrade over Black d'hide body at the same 70 Ranged / 40 Defence requirements.
   market_strategy:
-    title: Investment Notes
     notes:
-      - All six blessed d'hide bodies are functionally identical, so prices are driven by cosmetic preference and supply
-      - Guthix d'hide tends to be moderately priced among the blessed variants
-      - Prices are closely tied to the volume of hard clue scrolls being completed by the player base
-      - Compare prices across all six blessed variants before buying, as the cheapest one offers the same stats
-      - Hard clue scroll farming events or updates can temporarily increase supply and lower prices
-      - Consider buying during periods of high clue scroll activity for better deals
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - All six blessed bodies share identical stats, so price is driven by cosmetic preference
+      - Compare every blessed variant before buying the cheapest copy
+      - Supply is gated by hard clue completion rate
+      - Clue activity spikes tend to soften prices
+  history:
+    - date: "2006-12-05"
+      update: Treasure Trails
+      description: Item released as a hard clue reward.
+    - date: "2014-03-06"
+      description: Prayer bonus increased to +1.
+    - date: "2020-04-15"
+      description: Renamed from "Guthix dragonhide body" to "Guthix d'hide body" for consistency.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-mitre.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-mitre.mdx
@@ -12,30 +12,78 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
+  material:
+    type: vestment
+    tier: mid
   equipment:
     slot: head
+    weight: 0.3
     requirements:
       prayer: 40
       magic: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Medium
-        description: Reward from medium clue scrolls
+  treasure_trail:
+    tier: medium
+    is_reward: true
   related_items:
     - item_id: 10452
       item_name: Guthix robe top
       slug: guthix-robe-top
       relationship: set-piece
-      description: Guthix vestment body piece
-  about: |-
-    > *"A Guthix mitre."*
-
-    The Guthix mitre is a head slot item from the Guthix vestment set. It provides a +5 Prayer bonus and requires 40 Prayer and 40 Magic to equip. As a Guthixian item, it provides protection in the God Wars Dungeon. Offers one of the higher prayer bonuses for the head slot while also providing modest magic bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Body slot of the Guthix vestment set
+    - item_id: 10456
+      item_name: Guthix robe legs
+      slug: guthix-robe-legs
+      relationship: set-piece
+      description: Legs slot of the Guthix vestment set
+    - item_id: 10440
+      item_name: Saradomin mitre
+      slug: saradomin-mitre
+      relationship: alternative
+      description: Saradominist counterpart with identical stats
+  market_strategy:
+    notes:
+      - One of the highest prayer bonuses for the head slot
+      - Useful for prayer-heavy bossing setups
+      - Provides protection in the God Wars Dungeon Guthix area
+      - Supply is steady from medium clue completions
+  history:
+    - date: "2006-12-05"
+      description: Added with the Treasure Trails update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Guthix mitre is a head slot vestment from medium clues offering +5 prayer and +4 magic bonuses for prayer-heavy setups.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/harralander-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/harralander-potion-unf.mdx
@@ -12,13 +12,16 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 10000
+  material:
+    type: unfinished_potion
+    tier: mid
   potion:
     type: unfinished
-    tier: mid
-  herblore:
-    level: 22
-    xp: 0
-    method: Add harralander to vial of water
+    doses: 0
+    effects:
+      - description: Base for Restore potion(3) when combined with red spiders' eggs (22 Herblore, 62.5 XP).
+      - description: Base for Energy potion(3) when combined with chocolate dust (26 Herblore, 67.5 XP).
+      - description: Base for Combat potion(3) when combined with goat horn dust (36 Herblore, 84 XP).
   recipes:
     - skill: herblore
       level: 22
@@ -39,49 +42,60 @@ osrs:
       item_name: Harralander
       slug: harralander
       relationship: component
-      description: Herb ingredient
+      description: Cleaned herb ingredient
     - item_id: 227
       item_name: Vial of water
       slug: vial-of-water
       relationship: component
       description: Base liquid
-    - item_id: 223
-      item_name: Red spiders' eggs
-      slug: red-spiders-eggs
-      relationship: component
-      description: Secondary for restore
     - item_id: 127
       item_name: Restore potion(3)
       slug: restore-potion-3
       relationship: product
-      description: Restores stats
+      description: Stat restore made with red spiders' eggs
     - item_id: 3008
       item_name: Energy potion(3)
       slug: energy-potion-3
       relationship: product
-      description: Restores run energy
-    - item_id: 3024
+      description: Run energy restore made with chocolate dust
+    - item_id: 9741
       item_name: Combat potion(3)
       slug: combat-potion-3
       relationship: product
-      description: Boosts attack and strength
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Unfinished Potion |
-    | Tradeable | Yes |
-    | Weight | 0.056 kg |
-    | Requirements | 22 Herblore |
-
-    Add secondary ingredient to create:
-    - Restore potion (+ red spiders' eggs)
-    - Energy potion (+ chocolate dust)
-    - Combat potion (+ goat horn dust)
-
-    Versatile unfinished potion with multiple uses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Attack and strength boost made with goat horn dust
+  about: Harralander potion (unf) is the unfinished base made from a clean harralander and vial of water at 22 Herblore; combine with secondary ingredients for restore, energy, or combat potions.
+  market_strategy:
+    notes:
+      - High-volume Herblore staple
+      - Margin tracks harralander and vial-of-water prices
+      - Buy limit 10,000 supports bulk crafting
+  trading_tips:
+    - Compare harralander + vial cost vs unf price for crafting profit
+    - Bulk supply for combat potion makers
+    - Watch herb runs and farming output cadence
+  history:
+    - date: "2014-05-01"
+      description: Renamed from "Unfinished potion" to "Harralander potion (unf)" when herb-named variants were introduced.
+    - date: "2004-10-26"
+      description: '"Empty" option added.'
+    - date: "2002-02-27"
+      description: Released alongside the original Herblore content.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/holy-elixir.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/holy-elixir.mdx
@@ -12,53 +12,79 @@ osrs:
   lowalch: 300000
   highalch: 450000
   limit: 5
-  item:
+  material:
     type: crafting_material
-    tradeable: true
-    weight: 2
-  obtaining:
-    methods:
+    tier: high
+  drop_table:
+    sources:
       - source: Corporeal Beast
-        drop_rate: 3/512 (~1/171)
-  creation:
-    creates:
-      item_id: 12831
-      item_name: Blessed spirit shield
-      slug: blessed-spirit-shield
-    method: Combine with Spirit shield
-    requirements:
-      prayer: 85
-    note: Blessed spirit shield can then be combined with sigils
+        combat_level: 785
+        quantity: "1"
+        rarity: 3/512
+        members_only: true
+  recipes:
+    - skill: prayer
+      level: 85
+      xp: 0
+      materials:
+        - item_name: Spirit shield
+          item_id: 12829
+          quantity: 1
+        - item_name: Holy elixir
+          item_id: 12833
+          quantity: 1
+      product: Blessed spirit shield
+      product_id: 12831
+      product_quantity: 1
+      members_only: true
+      notes: Blessed spirit shield can then be combined with sigils to make spectral, arcane, elysian, or divine spirit shields.
   related_items:
-    - item_id: 0
-      item_name: Corporeal Beast
-      slug: corporeal-beast
-      relationship: component
-      description: Source
     - item_id: 12829
       item_name: Spirit shield
       slug: spirit-shield
       relationship: component
-      description: Required material
+      description: Required base shield
     - item_id: 12831
       item_name: Blessed spirit shield
       slug: blessed-spirit-shield
       relationship: product
-      description: Created item
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 2 kg |
-
-    | Item Created | Materials | Requirements |
-    |--------------|-----------|--------------|
-    | Blessed spirit shield | Spirit shield + Holy elixir | 85 Prayer |
-
-    Blessed spirit shield can then be combined with sigils.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Product created when combined with spirit shield
+    - item_id: 0
+      item_name: Corporeal Beast
+      slug: corporeal-beast
+      relationship: alternative
+      description: Drop source
+  about: Holy elixir is a rare drop from the Corporeal Beast used at 85 Prayer to bless a spirit shield into a blessed spirit shield, the base for all sigil-tier spirit shields.
+  market_strategy:
+    notes:
+      - Supply gated by Corporeal Beast kill rates
+      - Demand from blessed spirit shield production
+      - Buy limit 5 makes flips slow
+      - Long-term hold against shield meta shifts
+  trading_tips:
+    - Watch Corp Beast popularity for supply pulses
+    - Track blessed spirit shield and sigil prices in tandem
+    - Patient flipper item due to thin volume
+  history:
+    - date: "2014-10-16"
+      update: "Corporeal Beast"
+      description: Released alongside the Corporeal Beast as a tradeable rare drop used to bless spirit shields.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-10-16"
+    update: "Corporeal Beast"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/inquisitor-s-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/inquisitor-s-plateskirt.mdx
@@ -12,77 +12,94 @@ osrs:
   lowalch: 300000
   highalch: 450000
   limit: 8
+  material:
+    type: inquisitor
+    tier: high
   equipment:
     slot: legs
-    type: melee armour
-    tradeable: true
+    weapon_type: unarmed
     weight: 9.071
     requirements:
-      strength: 70
       defence: 30
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 49
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 2
+      strength: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 12
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 42
+      slash: 30
+      crush: 49
+      magic: 0
+      ranged: 22
+    other_bonus:
+      melee_strength: 2
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  obtaining:
-    - source: The Nightmare
-      drop_rate: 1/420
-    - source: Phosani's Nightmare
-      drop_rate: 1/700
-  set_bonus:
-    name: Inquisitor's Set
-    per_piece: +0.5% accuracy and damage (crush style)
-    full_set: +2.5% accuracy and damage
-    full_set_with_mace: +7.5% accuracy and damage
+  drop_table:
+    sources:
+      - source: The Nightmare
+        source_id: 9416
+        combat_level: 814
+        quantity: "1"
+        rarity: 1/420
+        members_only: true
+      - source: Phosani's Nightmare
+        source_id: 11153
+        combat_level: 1024
+        quantity: "1"
+        rarity: 1/700
+        members_only: true
   related_items:
     - item_id: 24417
       item_name: Inquisitor's mace
       slug: inquisitors-mace
-      relationship: alternative
-      description: Set weapon for maximum bonus
+      relationship: set-piece
+      description: Set weapon for the +7.5% full bonus
     - item_id: 24420
       item_name: Inquisitor's hauberk
       slug: inquisitors-hauberk
-      relationship: alternative
-      description: Set body piece
+      relationship: set-piece
+      description: Body slot member of the set
     - item_id: 24419
       item_name: Inquisitor's great helm
       slug: inquisitors-great-helm
-      relationship: alternative
-      description: Set helm piece
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Strength | +2 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Crush | +49 |
-
-    Crush Bonus:
-    - +0.5% accuracy and damage (crush style)
-    - +2.5% with full set
-    - +7.5% with full set + mace
-
-    BiS for:
-    - Crush-focused setups
-    - Tekton
-    - Cerberus
-
-    Part of Inquisitor set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: set-piece
+      description: Helm slot member of the set
+  market_strategy:
+    notes:
+      - BiS legs for crush damage at Tekton and Cerberus
+      - Set bonus stacks each crush attack
+      - 70 Strength gates the equip
+      - Long-cycle Nightmare drop keeps supply tight
+      - Mid-tier piece relative to hauberk and helm
+  history:
+    - date: "2020-02-06"
+      update: The Nightmare of Ashihama
+      description: Released as a possible drop from The Nightmare.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-02-06"
+    update: The Nightmare of Ashihama
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Inquisitor's plateskirt is a Nightmare-drop legs piece that boosts crush accuracy and damage when worn with the Inquisitor's set.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-knife-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-knife-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron knife(p) | OSRS Price Data
-description: "Iron knife(p) is a members weapon slot item requiring 1 Ranged. High alch: 1 GP, GE limit: 7,000."
+description: "Iron knife(p) is a members thrown weapon. High alch: 1 GP, GE limit: 7,000."
 osrs:
   id: 871
   name: Iron knife(p)
@@ -12,21 +12,90 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  material:
+    type: iron
+    tier: low
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
-    requirements:
-      ranged: 1
+    weight: 0
     attack_bonus:
-      ranged: 4
-    ranged_strength: 3
-  related_items: []
-  about: |-
-    > _"A very sharp iron knife with a poisoned tip."_
-
-    An iron knife tipped with basic weapon poison. Requires 1 Ranged. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 5
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 4
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 3
+      xp: 0
+      materials:
+        - item_name: Iron knife
+          item_id: 863
+          quantity: 1
+        - item_name: Weapon poison
+          item_id: 187
+          quantity: 1
+      product: Iron knife(p)
+      product_id: 871
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 863
+      item_name: Iron knife
+      slug: iron-knife
+      relationship: variant
+      description: Unpoisoned base knife
+    - item_id: 5654
+      item_name: Iron knife(p+)
+      slug: iron-knife-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_id: 5660
+      item_name: Iron knife(p++)
+      slug: iron-knife-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+  history:
+    - date: "2021-07-07"
+      description: Female player equipment positioning adjusted.
+    - date: "2006-09-20"
+      description: Poison naming convention standardised across thrown weapons.
+    - date: "2003-04-14"
+      update: New Throwing Weapons!
+      description: Iron knife(p) released alongside the thrown weapons update.
+  about: Iron knife(p) is a thrown iron knife coated in basic weapon poison, dealing standard ranged damage plus a small poison effect against the target.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kebab.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kebab.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Kebab is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: low
+  food:
+    heals: 3
+    effects:
+      - description: "1/32 chance: heals 7 + 24% Hitpoints and boosts melee stats by 2"
+      - description: "8/32 chance: heals 6 + 14% Hitpoints"
+      - description: "20/32 chance: heals 3 + 7% Hitpoints"
+      - description: "1/32 chance: drains a random skill by 3"
+      - description: "1/32 chance: drains melee stats by 3 and random skill by 4"
+  shops:
+    - shop_name: Karim's Kebab Shop
+      location: Al Kharid
+      price: 1
+    - shop_name: Kjut's Kebabs
+      location: Keldagrim
+      price: 1
+    - shop_name: Ali the Kebab seller
+      location: Pollnivneach
+      price: 3
+  related_items:
+    - item_id: 1965
+      item_name: Cabbage
+      slug: cabbage
+      relationship: alternative
+      description: Free heal alternative
+    - item_id: 1891
+      item_name: Meat pie
+      slug: meat-pie
+      relationship: alternative
+      description: Comparable F2P food
+  market_strategy:
+    notes:
+      - Cheap supply from Al Kharid and Keldagrim shops
+      - Random healing makes it niche for stat-boost gambles
+      - Heavy buy-limit absorbs demand spikes from random events
+      - F2P friendly food source
+  history:
+    - date: "2007-07-17"
+      description: Kebabs can no longer reduce Hitpoints; adverse effects target other skills instead.
+    - date: "2001-01-21"
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-21"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Kebab is an F2P food item that grants variable healing with a small chance of boosting melee or draining stats.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kebbit-teeth.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kebbit-teeth.mdx
@@ -1,6 +1,6 @@
 ---
 title: Kebbit teeth | OSRS Price Data
-description: "Kebbit teeth: A kebbit-sized set of dentures.. High alch: 96 GP, GE limit: 10,000."
+description: "Kebbit teeth: A kebbit-sized set of dentures. High alch: 96 GP, GE limit: 10,000."
 osrs:
   id: 10109
   name: Kebbit teeth
@@ -12,9 +12,67 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 10000
-  about: "Kebbit teeth is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hunter
+    tier: mid
+  drop_table:
+    sources:
+      - source: Sabre-toothed kebbit
+        combat_level: 0
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Deadfall trap at 51 Hunter
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Kebbit teeth
+          item_id: 10109
+          quantity: 1
+        - item_name: Pestle and mortar
+          item_id: 233
+          quantity: 1
+      members_only: true
+      output_item: Kebbit teeth dust
+  related_items:
+    - item_id: 10111
+      item_name: Kebbit teeth dust
+      slug: kebbit-teeth-dust
+      relationship: product
+      description: Ground form, used in Hunter potions
+    - item_id: 10000
+      item_name: Hunter potion(4)
+      slug: hunter-potion-4
+      relationship: product
+      description: Final Herblore product using the dust
+  about: Kebbit teeth are dropped by Sabre-toothed kebbits trapped via deadfall at 51 Hunter, then ground with a pestle and mortar into Kebbit teeth dust for Hunter potions.
+  market_strategy:
+    notes:
+      - Supply gated by 51 Hunter Sabre-toothed kebbit trapping
+      - Demand driven by Hunter potion Herblore training
+      - Steady price floor around alch value
+  history:
+    - date: "2006-11-21"
+      update: HUNTER SKILL!
+      description: Kebbit teeth introduced with the Hunter skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: HUNTER SKILL!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/keg-of-beer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/keg-of-beer.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 2000
-  about: "Keg of beer is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: container
+    tier: mid
+  food:
+    type: drink
+    edible: true
+  drop_table:
+    sources:
+      - source: Black Guard
+        combat_level: 48
+        quantity: "1"
+        rarity: 4/128
+        members_only: true
+      - source: Warrior (Rellekka)
+        combat_level: 48
+        quantity: "1"
+        rarity: 4/128
+        members_only: true
+      - source: Black Guard Berserker
+        combat_level: 66
+        quantity: "1"
+        rarity: 4/128
+        members_only: true
+      - source: Market Guard
+        combat_level: 48
+        quantity: "1"
+        rarity: 4/128
+        members_only: true
+      - source: Dagannoth (Waterbirth Island)
+        combat_level: 88
+        quantity: "1"
+        rarity: 2/128
+        members_only: true
+      - source: Dagannoth (Waterbirth Island)
+        combat_level: 90
+        quantity: "1"
+        rarity: 2/128
+        members_only: true
+  shops:
+    - shop_name: Rasolo the Wandering Merchant
+      location: South of Baxtorian Falls
+      sell_price: 500
+      buy_price: 25
+      currency: Coins
+      members_only: true
+    - shop_name: Rellekka Longhall Bar
+      location: Rellekka
+      sell_price: 325
+      buy_price: 175
+      currency: Coins
+      members_only: true
+  history:
+    - date: "2004-11-02"
+      update: The Fremennik Trials
+      description: Keg of beer added to the game.
+  about: Keg of beer is a members-only barrel of beer from The Fremennik Trials, used to deliver large quantities of alcohol in one container.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-11-02"
+    update: The Fremennik Trials
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 20
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-dragon-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-dragon-keel-parts.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 75000
   highalch: 112500
   limit: 100
-  about: "Large dragon keel parts is a members-only item in Old School RuneScape. High alchemy value: 112,500 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon-metal
+    tier: high
+  recipes:
+    - name: Forge large dragon keel parts
+      skill: smithing
+      level: 94
+      xp: 500
+      output_quantity: 1
+      materials:
+        - item_name: Dragon keel parts
+          quantity: 2
+        - item_name: Hammer
+          quantity: 1
+      facility: Dragon forge
+      members: true
+      notes: Requires completion of Dragon Slayer II and Pandemonium to use the Dragon forge.
+  drop_table:
+    sources:
+      - source: Vampyre kraken
+        combat_level: 211
+        quantity: "1"
+        rarity: 1/1024
+        members_only: true
+      - source: Armoured kraken
+        combat_level: 180
+        quantity: "1"
+        rarity: 1/1280
+        members_only: true
+      - source: Veiled kraken
+        combat_level: 210
+        quantity: "1"
+        rarity: 1/2100
+        members_only: true
+      - source: Great white shark
+        combat_level: 175
+        quantity: "1"
+        rarity: 1/6138
+        members_only: true
+  related_items:
+    - item_name: Dragon keel parts
+      slug: dragon-keel-parts
+      relationship: component
+      description: Two standard dragon keel parts smelt into one large dragon keel part.
+    - item_name: Dragon metal sheet
+      slug: dragon-metal-sheet
+      relationship: component
+      description: Upstream material used to manufacture dragon keel parts.
+  about: Large dragon keel parts are a high-tier Sailing material smithed at the Dragon forge from two dragon keel parts, used to construct dragon sloop keels.
+  market_strategy:
+    notes:
+      - 94 Smithing plus Dragon Slayer II and Pandemonium gate supply tightly.
+      - Sloop keels demand sixteen parts each, sustaining steady buy pressure.
+      - Drop sources are deep-sea bosses with low rates - shop liquidity is driven by smithers.
+  history:
+    - date: "2025-11-19"
+      update: Sailing is OUT TODAY!
+      description: Released with the Sailing skill launch as a dragon-tier keel component.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/larupia-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/larupia-top.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Larupia top is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: fur
+    tier: low
+  equipment:
+    slot: body
+    weight: 0.226
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 10
+      slash: 15
+      crush: 19
+      magic: 0
+      ranged: 12
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Tailor larupia top
+      skill: none
+      level: 1
+      xp: 0
+      output_quantity: 1
+      materials:
+        - item_name: Larupia fur
+          quantity: 1
+        - item_name: Coins
+          quantity: 100
+      facility: Fancy Clothes Store
+      members: true
+      notes: Bring larupia fur and 100 coins to the Fancy Clothes Store tailor (Varrock), Hunter Guild, or Prifddinas Seamstress.
+  related_items:
+    - item_name: Larupia fur
+      slug: larupia-fur
+      relationship: component
+      description: Tailor a larupia fur to produce the larupia top.
+    - item_name: Larupia legs
+      slug: larupia-legs
+      relationship: set-piece
+      description: Legs piece of the larupia hunter outfit.
+    - item_name: Larupia hat
+      slug: larupia-hat
+      relationship: set-piece
+      description: Head piece of the larupia hunter outfit.
+  about: Larupia top is the body piece of the larupia hunter outfit, providing a camouflage bonus for tracking larupia and similar woodland prey.
+  market_strategy:
+    notes:
+      - Supply depends on hunter players selling spare furs.
+      - Wearing the full larupia set improves hunting catch rates for several creatures.
+      - Tatty larupia fur recipe is a cheaper path to flipping for profit.
+  history:
+    - date: "2006-11-21"
+      update: Hunter Skill
+      description: Released as part of the Hunter skill launch alongside the larupia hunter outfit.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter Skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lassar-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lassar-teleport-tablet.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Lassar teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: teleport tablet
+    tier: mid
+  teleport:
+    destination: Ice Mountain
+    type: ancient
+    requirements:
+      quest: Desert Treasure I
+  recipes:
+    - skill: magic
+      level: 72
+      xp: 82
+      materials:
+        - item_id: 1761
+          item_name: Soft clay
+          quantity: 1
+        - item_id: 563
+          item_name: Law rune
+          quantity: 2
+        - item_id: 555
+          item_name: Water rune
+          quantity: 4
+      product: Lassar teleport (tablet)
+      product_id: 12780
+  related_items:
+    - item_id: 12779
+      item_name: Paddewwa teleport (tablet)
+      slug: paddewwa-teleport-tablet
+      relationship: alternative
+      description: Lower-level Ancient teleport tablet
+    - item_id: 12781
+      item_name: Dareeyak teleport (tablet)
+      slug: dareeyak-teleport-tablet
+      relationship: alternative
+      description: Higher-level Ancient teleport tablet
+  market_strategy:
+    notes:
+      - Useful for Ice Mountain quick access without Magic level
+      - Bypasses Ancient spellbook requirement for use
+      - Crafted at the ancient lectern in the Ancient Pyramid
+      - Steady casual demand from quest helpers and skillers
+  history:
+    - date: "2020-04-15"
+      description: Players gained the ability to craft Ancient Magicks teleport tablets at the ancient lectern.
+    - date: "2014-09-18"
+      description: Added with the Bounty Hunter update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-09-18"
+    update: Bounty Hunter
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    alchable: false
+    destroy: Drop
+  about: Lassar teleport (tablet) is an Ancient Magicks tablet that teleports the user to Ice Mountain after completing Desert Treasure I.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/limestone-brick.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/limestone-brick.mdx
@@ -14,11 +14,7 @@ osrs:
   limit: 10000
   material:
     type: construction
-    tier: basic
-  crafting:
-    level: 12
-    xp: 6
-    tool: Chisel
+    tier: low
   construction:
     min_level: 1
     common_builds:
@@ -53,27 +49,40 @@ osrs:
       slug: chisel
       relationship: alternative
       description: Required tool
-  about: |-
-    | Furniture | Bricks | Level | XP |
-    |-----------|--------|-------|-----|
-    | Stone fireplace | 2 | 33 | 40 |
-    | Limestone attack stone | 3 | 59 | 200 |
-
-    Budget Construction:
-    - Cheaper alternative to marble blocks
-    - Used for basic stone furniture
-    - Lower XP than premium materials
   market_strategy:
     profit_formulas:
       - Brick price - Limestone price = Profit
     notes:
-      - Buy limestone, craft into bricks, sell
-      - "Calculate:"
+      - Buy limestone, craft into bricks, sell at margin
       - Low demand construction material
       - Marble blocks preferred for high-level builds
       - Useful for Ironman construction
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Stable supply from chisel craft
+      - GE limit 10,000 per 4 hours supports bulk flips
+  history:
+    - date: "2004-10-18"
+      update: Mortton Shades and Mage Armour
+      description: Item added to the game.
+    - date: "2005-03-21"
+      update: Game update
+      description: Received a graphical update and examine corrected from "lime stone" to "limestone".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-18"
+    update: Mortton Shades and Mage Armour
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Limestone brick is a chiselled limestone used in basic Construction furniture and budget builds.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/m-treasure-chest-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/m-treasure-chest-flatpack.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "M. treasure chest (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mahogany
+    tier: mid-high
+  construction:
+    construction_level: 84
+    xp: 280
+    hotspot: Treasure chest space
+    room: Costume Room
+    location: Workbench (Workshop)
+    builds: Mahogany treasure chest
+  recipes:
+    - skill: Construction
+      level: 84
+      xp: 280
+      materials:
+        - item_name: Mahogany plank
+          quantity: 2
+      output:
+        item_name: M. treasure chest (flatpack)
+        quantity: 1
+      notes: Made at the Workshop workbench; requires hammer and saw.
+  related_items:
+    - item_id: 8782
+      item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Sole construction material for the flatpack.
+    - item_id: 9863
+      item_name: T. treasure chest (flatpack)
+      slug: t-treasure-chest-flatpack
+      relationship: downgrade
+      description: Teak-tier predecessor flatpack.
+  about: M. treasure chest (flatpack) is a portable mahogany furniture pack that lets a player skip the level-84 Construction requirement when placing a mahogany treasure chest into the Costume Room of a player-owned house.
+  market_strategy:
+    notes:
+      - Demand from POH owners under level 84 Construction
+      - Profit margin currently negative on mahogany plank cost
+      - 500 GE buy limit keeps flips small and frequent
+  history:
+    - date: "2006-10-18"
+      description: M. treasure chest (flatpack) introduced as part of the Costume Room update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dagger-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dagger-p.mdx
@@ -12,9 +12,94 @@ osrs:
   lowalch: 130
   highalch: 195
   limit: 125
-  about: "Mithril dagger(p) is a members-only item in Old School RuneScape. High alchemy value: 195 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: stab-sword
+    attack_speed: 4
+    weight: 0.396
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 11
+      slash: 5
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      melee_strength: 10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Mithril dagger
+          item_id: 1209
+          quantity: 1
+        - item_name: Weapon poison
+          item_id: 187
+          quantity: 1
+      product: Mithril dagger(p)
+      product_id: 1225
+      product_quantity: 1
+  related_items:
+    - item_id: 1209
+      item_name: Mithril dagger
+      slug: mithril-dagger
+      relationship: variant
+      description: Unpoisoned base dagger
+    - item_id: 5680
+      item_name: Mithril dagger(p+)
+      slug: mithril-dagger-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_id: 5686
+      item_name: Mithril dagger(p++)
+      slug: mithril-dagger-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+  about: Mithril dagger(p) is a poisoned mithril stab sword created by applying weapon poison to a mithril dagger; requires 20 Attack to wield.
+  market_strategy:
+    notes:
+      - Cheap entry-level poisoned weapon
+      - Poison adds little over base dagger price
+      - Low alch margin from mithril bar route
+      - Limited PvM use; PKers prefer higher tiers
+  history:
+    - date: "2001-01-04"
+      update: RuneScape beta launch
+      description: Item released with the RuneScape beta.
+    - date: "2006-08-22"
+      description: Poison variants renamed from "(+)" and "(s)" suffixes to "(p+)" and "(p++)" respectively.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape beta launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.396
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-full-helm-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-full-helm-t.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 572
   highalch: 858
   limit: 8
-  about: "Mithril full helm (t) is a free-to-play item in Old School RuneScape. High alchemy value: 858 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: head
+    weight: 2.267
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 13
+      slash: 14
+      crush: 11
+      magic: -1
+      ranged: 13
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    is_reward: true
+    tier: medium
+  related_items:
+    - item_id: 1149
+      item_name: Mithril full helm
+      slug: mithril-full-helm
+      relationship: variant
+      description: Untrimmed base item
+    - item_id: 12291
+      item_name: Mithril full helm (g)
+      slug: mithril-full-helm-g
+      relationship: variant
+      description: Gold-trimmed cosmetic variant
+  market_strategy:
+    notes:
+      - Cosmetic medium clue reward
+      - Identical stats to plain mithril full helm
+      - Low supply, rare medium clue drop (1/1133)
+      - Demand from collectors and trim ironmen
+      - Alchable for 858 GP
+      - Compare with gold-trim variant for valuation
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Item added to the game as a medium clue reward.
+    - date: "2021-04-21"
+      update: Game update
+      description: Ranged attack bonus decreased from -2 to -3.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Mithril full helm (t) is a trimmed cosmetic medium clue reward identical in stats to the regular mithril full helm.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-hasta-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-hasta-p.mdx
@@ -12,9 +12,98 @@ osrs:
   lowalch: 338
   highalch: 507
   limit: 125
-  about: "Mithril hasta(p) is a members-only item in Old School RuneScape. High alchemy value: 507 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 17
+      slash: 17
+      crush: 17
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -5
+      slash: -5
+      crush: -4
+      magic: 0
+      ranged: -5
+    other_bonus:
+      melee_strength: 18
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 55
+      xp: 100
+      materials:
+        - item_name: Mithril bar
+          item_id: 2359
+          quantity: 1
+        - item_name: Maple logs
+          item_id: 1517
+          quantity: 1
+      product: Mithril hasta
+      product_id: 11392
+      product_quantity: 1
+      tool: Hammer at Barbarian anvil
+  related_items:
+    - item_id: 11392
+      item_name: Mithril hasta
+      slug: mithril-hasta
+      relationship: variant
+      description: Unpoisoned base hasta
+    - item_id: 11401
+      item_name: Mithril hasta(p+)
+      slug: mithril-hasta-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_id: 11402
+      item_name: Mithril hasta(p++)
+      slug: mithril-hasta-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison tier
+  market_strategy:
+    notes:
+      - Barbarian Smithing miniquest required to wield
+      - 4-tick spear attack speed since 2021
+      - Cheap entry-tier poison spear
+      - Smithing 55 craft recipe undercut by GE supply
+      - GE limit 125 per 4 hours
+      - Niche demand outside Barbarian content
+  history:
+    - date: "2007-07-03"
+      update: Barbarian Training
+      description: Item added to the game with Barbarian hastas.
+    - date: "2021-04-21"
+      update: Game update
+      description: Attack speed improved from 5 ticks to 4 ticks.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: Drop
+  about: Mithril hasta(p) is a low-tier poisoned spear from the Barbarian Smithing miniquest, wielded at 20 Attack with a 4-tick speed.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-set-lg.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril set (lg) | OSRS Price Data
-description: "Mithril set (lg): A set containing a full helm, platebody, legs and kiteshield.. High alch: 3,000 GP, GE limit: 8."
+description: "Mithril set (lg): A set containing a full helm, platebody, legs and kiteshield. High alch: 3,000 GP, GE limit: 8."
 osrs:
   id: 13000
   name: Mithril set (lg)
@@ -12,9 +12,61 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
-  about: "Mithril set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: low
+  related_items:
+    - item_id: 1147
+      item_name: Mithril full helm
+      slug: mithril-full-helm
+      relationship: component
+      description: Head slot piece
+    - item_id: 1121
+      item_name: Mithril platebody
+      slug: mithril-platebody
+      relationship: component
+      description: Body slot piece
+    - item_id: 1071
+      item_name: Mithril platelegs
+      slug: mithril-platelegs
+      relationship: component
+      description: Legs slot piece
+    - item_id: 1199
+      item_name: Mithril kiteshield
+      slug: mithril-kiteshield
+      relationship: component
+      description: Shield slot piece
+    - item_id: 13001
+      item_name: Mithril set (sk)
+      slug: mithril-set-sk
+      relationship: variant
+      description: Skirt variant of the set
+  about: Mithril set (lg) is a free-to-play armour set bundle of full helm, platebody, platelegs and kiteshield acquired via the Grand Exchange Sets tab.
+  market_strategy:
+    notes:
+      - Bundled via Grand Exchange Sets tab to save bank space
+      - Free-to-play accessible
+      - Component swap arbitrage when set vs pieces diverge
+  history:
+    - date: "2015-02-26"
+      update: The Grand Exchange
+      description: Mithril set (lg) added with the Grand Exchange Sets tab launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-02-26"
+    update: The Grand Exchange
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mole-skin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mole-skin.mdx
@@ -12,46 +12,79 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 50
-  item_id: 7418
-  type: boss_drop
-  tradeable: true
-  weight: 0.001
-  buy_limit: 50
-  obtaining:
-    primary:
-      source: Giant Mole
-      location: Beneath Falador Park
-      quantity: 1-3 per kill
-      diary_bonus: Noted with Falador Hard Diary
-  usage:
-    exchange:
-      npc: Wyson the gardener
-      location: Falador Park
-      product: Bird nest
-      rate: 1:1
+  material:
+    type: hide
+    tier: low
+  drop_table:
+    sources:
+      - source: Giant Mole
+        combat_level: 230
+        quantity: "1-3"
+        rarity: always
+        members_only: true
+        notes: Drops noted with the Falador Hard Diary completed.
+  recipes:
+    - name: Exchange for bird nest
+      skill: none
+      level: 1
+      xp: 0
+      output_quantity: 1
+      materials:
+        - item_name: Mole skin
+          quantity: 1
+        - item_name: Mole claw
+          quantity: 1
+      facility: Falador Park
+      members: true
+      notes: Wyson the gardener exchanges one mole skin and one mole claw for a seed-bearing bird nest.
   related_items:
-    - slug: mole-claw
-      name: Mole claw
-      relation: also_dropped
-    - slug: bird-nest
-      name: Bird nest
-      relation: exchange_reward
-    - slug: giant-mole
-      name: Giant Mole
-      relation: drop_source
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Boss Drop |
-    | Tradeable | Yes |
-    | Weight | 0.001 kg |
-
-    Trade to Wyson the gardener (Falador Park) for bird nests.
-
-    Exchange rate: 1 mole skin = 1 bird nest
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Mole claw
+      slug: mole-claw
+      relationship: alternative
+      description: Companion drop from Giant Mole used alongside skins at Wyson.
+    - item_name: Bird nest
+      slug: bird-nest
+      relationship: product
+      description: Reward bird nest obtained by trading mole parts to Wyson the gardener.
+    - item_name: Baby mole
+      slug: baby-mole
+      relationship: alternative
+      description: Giant Mole pet; mole skin reverts Baby mole-rat back to Baby mole.
+  about: Mole skin is the trademark Giant Mole drop, exchanged with Wyson the gardener in Falador Park for seed-bearing bird nests.
+  market_strategy:
+    notes:
+      - Buy limit of 50 caps single-trader flips - rely on volume, not size.
+      - Bird nest seed pool drives most of the GE demand from herb and allotment farmers.
+      - Falador Hard Diary noted drops keep supply ticking from veteran mole hunters.
+  history:
+    - date: "2021-04-07"
+      update: Game update
+      description: Adding mole skins to a Baby mole-rat reverts the pet to its Baby mole form.
+    - date: "2016-02-18"
+      update: Game update
+      description: Wyson's bird nest exchange seed pool was improved with more useful allotments and herbs.
+    - date: "2015-03-05"
+      update: Falador Diary
+      description: Falador Hard Diary added; Giant Mole drops become noted for completers.
+    - date: "2006-03-07"
+      update: Canoeing, Zygomites and a Mole!
+      description: Mole skin released alongside the Giant Mole boss in Falador Park.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-03-07"
+    update: Canoeing, Zygomites and a Mole!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/moonclan-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/moonclan-teleport-tablet.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Moonclan teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: tablet
+    tier: low
+  recipes:
+    - name: Make Moonclan teleport tablet
+      skill: magic
+      level: 69
+      xp: 66
+      output_quantity: 1
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 2
+        - item_name: Astral rune
+          quantity: 2
+      facility: Lunar Lectern
+      members: true
+      notes: Requires Lunar spellbook active; crafted at the Lunar Lectern on Lunar Isle.
+  teleport:
+    destination: Lunar Isle village gate
+    type: tablet
+    requirements:
+      quests:
+        - Lunar Diplomacy
+    notes: Requires having visited Lunar Isle during the Lunar Diplomacy quest.
+  related_items:
+    - item_name: Ourania teleport
+      slug: ourania-teleport
+      relationship: alternative
+      description: Lunar spellbook teleport tablet to the Ourania altar.
+    - item_name: Waterbirth teleport
+      slug: waterbirth-teleport
+      relationship: alternative
+      description: Lunar spellbook teleport tablet to Waterbirth Island.
+    - item_name: Catherby teleport
+      slug: catherby-teleport
+      relationship: alternative
+      description: Lunar spellbook teleport tablet to Catherby.
+    - item_name: Fishing guild teleport
+      slug: fishing-guild-teleport
+      relationship: alternative
+      description: Lunar spellbook teleport tablet to the Fishing Guild.
+  about: Moonclan teleport (tablet) is a Lunar spellbook tablet that breaks to teleport the user to the gate of the Moonclan village on Lunar Isle.
+  market_strategy:
+    notes:
+      - High buy limit (10,000) supports bulk flipping at thin margins.
+      - Steady tablet farmer supply keeps the GE price near material cost.
+      - Lunar spellbook switchers buy in bulk to skip Magic skill requirement gating.
+  history:
+    - date: "2020-10-14"
+      update: Game update
+      description: Grand Exchange buy limit increased from 100 to 10,000.
+    - date: "2020-10-07"
+      update: Game update
+      description: Made tradeable on the Grand Exchange.
+    - date: "2020-09-30"
+      update: Last Poll 72 Updates
+      description: Released alongside the broader Lunar spellbook tablet update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-09-30"
+    update: Last Poll 72 Updates
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-magic-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-magic-wardrobe-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Oak magic wardrobe (flatpack) | OSRS Price Data
-description: "Oak magic wardrobe (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Oak magic wardrobe (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 9852
   name: Oak magic wardrobe (flatpack)
@@ -12,9 +12,72 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak magic wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flatpack
+    tier: low
+  construction:
+    level: 42
+    xp: 240
+    facility: Steel framed workbench
+    builds: Oak magic wardrobe
+  recipes:
+    - skill: construction
+      level: 42
+      xp: 240
+      materials:
+        - item_name: Oak plank
+          quantity: 4
+      facility: Steel framed workbench
+      ticks: 5
+      members_only: true
+  related_items:
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: Required building material
+    - item_name: Oak magic wardrobe
+      slug: oak-magic-wardrobe
+      relationship: product
+      description: Costume room furniture built from the flatpack
+    - item_name: Teak magic wardrobe (flatpack)
+      slug: teak-magic-wardrobe-flatpack
+      relationship: upgrade
+      description: Higher-tier costume room flatpack
+    - item_name: Mahogany magic wardrobe (flatpack)
+      slug: mahogany-magic-wardrobe-flatpack
+      relationship: upgrade
+      description: Highest-tier costume room flatpack
+  market_strategy:
+    notes:
+      - Construction training and ironman supply staple
+      - Sold for trivial coin compared to plank cost
+      - Used to skip POH carpentry steps for costume room storage
+      - Buy limit 500 keeps mass training accessible
+  about: Oak magic wardrobe (flatpack) is a Construction flatpack made from 4 oak planks at the steel framed workbench, used to build an Oak magic wardrobe in a Costume Room.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-10-18"
+    update: Player-Owned House Costume Room
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2006-10-18"
+      update: Player-Owned House Costume Room
+      description: Oak magic wardrobe flatpack released alongside the Costume Room.
+    - date: "2015-02-26"
+      update: Grand Exchange update
+      description: Item renamed from "Oak mage wardrobe" to "Oak magic wardrobe".
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/orange-dye.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/orange-dye.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 150
-  about: "Orange dye is a free-to-play item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dye
+    tier: low
+  recipes:
+    - name: Mix orange dye
+      skill: none
+      level: 1
+      xp: 0
+      output_quantity: 1
+      materials:
+        - item_name: Red dye
+          quantity: 1
+        - item_name: Yellow dye
+          quantity: 1
+      facility: none
+      members: false
+      notes: Use red dye on yellow dye (or vice versa) to combine into orange dye.
+  shops:
+    - shop_name: Lletya Seamstress
+      location: Lletya
+      price: 6
+    - shop_name: Guinevere's Dyes
+      location: Prifddinas
+      price: 6
+    - shop_name: Dyes to Die For
+      location: Tal Teklan
+      price: 6
+    - shop_name: Durrik's Goods
+      location: Deepfin Mine
+      price: 12
+  related_items:
+    - item_name: Red dye
+      slug: red-dye
+      relationship: component
+      description: Combine with yellow dye to create orange dye.
+    - item_name: Yellow dye
+      slug: yellow-dye
+      relationship: component
+      description: Combine with red dye to create orange dye.
+    - item_name: Orange cape
+      slug: orange-cape
+      relationship: product
+      description: Use orange dye on a regular cape to produce an orange cape.
+    - item_name: Orange goblin mail
+      slug: orange-goblin-mail
+      relationship: product
+      description: Used during Goblin Diplomacy to colour goblin mail orange.
+  about: Orange dye is a free-to-play crafting reagent made by combining red and yellow dye, used in Goblin Diplomacy, Ghosts Ahoy, and to recolour capes and balloons.
+  market_strategy:
+    notes:
+      - Cheaper to mix from red and yellow dyes when GE prices skew low.
+      - Demand spikes during seasonal cape colouring events.
+      - Quest demand from Goblin Diplomacy and Ghosts Ahoy supports steady volume.
+  history:
+    - date: "2001-05-08"
+      update: RuneScape updated
+      description: Orange dye released alongside the initial dye recipe system.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-05-08"
+    update: RuneScape updated
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: true
+    weight: 0.02
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pearl-dragon-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pearl-dragon-bolts-e.mdx
@@ -12,58 +12,89 @@ osrs:
   lowalch: 272
   highalch: 408
   limit: 11000
+  material:
+    type: dragon
+    tier: high
   equipment:
     slot: ammo
+    weight: 0
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: 0
       ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      melee_strength: 0
       ranged_strength: 122
+      magic_damage: 0
       prayer: 0
-    requirements: {}
+  special_attack:
+    name: Sea Curse
+    description: Water bolt strike dealing extra damage equal to 1/15 of Ranged level against fiery targets and 1/20 against others; negated by water staves. 6% activation (6.6% with Hard Kandarin Diary).
+    activation_chance: 6
   recipes:
     - skill: magic
       level: 24
       xp: 29.5
-      inputs:
+      materials:
         - item_name: Pearl dragon bolts
+          item_id: 21932
           quantity: 10
-      output_quantity: 10
+        - item_name: Cosmic rune
+          item_id: 564
+          quantity: 1
+        - item_name: Water rune
+          item_id: 555
+          quantity: 2
+      members_only: true
   related_items:
+    - item_id: 21932
+      item_name: Pearl dragon bolts
+      slug: pearl-dragon-bolts
+      relationship: component
+      description: Unenchanted base bolts
     - item_id: 9238
       item_name: Pearl bolts (e)
       slug: pearl-bolts-e
       relationship: downgrade
       description: Regular crossbow version
-  about: |-
-    > *"Enchanted Dragon crossbow bolts, tipped with pearl."*
-
-    Pearl dragon bolts (e) carry the Sea Curse enchantment. On activation, a mighty bolt of water strikes the opponent. The effect deals extra damage equal to 1/15 of the attacker's visible Ranged level against fiery targets (fire-based monsters, players wielding fire staves or fire capes) and 1/20 against all other targets. The effect is negated if the target is wielding a water staff. This makes pearl bolts particularly effective against fire-themed enemies.
-
-    Enchant Crossbow Bolt (Pearl) requires Magic level 24 and grants 29.5 XP per cast. Each cast enchants 10 bolts at a time.
-
-    | Component | Quantity |
-    |-----------|----------|
-    | Pearl dragon bolts | 10 |
-    | Cosmic rune | 1 |
-    | Water rune | 2 |
-
-    | Stat | Dragon (e) | Regular (e) |
-    |------|-----------|-------------|
-    | Ranged Str | +122 | +48 |
-    | Base bolt | Dragon crossbow bolt | Iron bolt |
-
-    The dragon bolt base provides substantially higher ranged strength over the regular pearl bolt variant.
+  about: Pearl dragon bolts (e) are dragon crossbow bolts tipped with pearl and enchanted with Sea Curse, dealing bonus water damage versus fiery targets.
   market_strategy:
     notes:
       - Extra effective against fire-themed monsters and fire staff/cape users
       - Negated by water staves in PvP
       - Mid-low tier enchant requirement (Magic 24)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Highest ranged strength pearl bolt variant
+  history:
+    - date: "2018-01-04"
+      update: Dragon Slayer II
+      description: Pearl dragon bolts (e) introduced with Dragon Slayer II quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-bandana-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-bandana-brown.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Pirate bandana (brown) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Dodgy Mike's Second Hand Clothing
+      location: Mos Le'Harmless
+      price: 100
+  related_items:
+    - item_id: 7124
+      item_name: Bandana eyepatch (brown)
+      slug: bandana-eyepatch-brown
+      relationship: product
+      description: Combine with an eye patch for a single-slot piece.
+    - item_id: 7130
+      item_name: Pirate bandana (red)
+      slug: pirate-bandana-red
+      relationship: variant
+      description: Red recolour from the same set.
+    - item_id: 7132
+      item_name: Pirate bandana (blue)
+      slug: pirate-bandana-blue
+      relationship: variant
+      description: Blue recolour from the same set.
+    - item_id: 7134
+      item_name: Pirate bandana (white)
+      slug: pirate-bandana-white
+      relationship: variant
+      description: White recolour from the same set.
+  about: Pirate bandana (brown) is a cosmetic head-slot item sold on Mos Le'Harmless after Cabin Fever, providing no combat bonuses and combinable with an eye patch into a bandana eyepatch.
+  market_strategy:
+    notes:
+      - Steady fashionscape demand keeps price above shop value
+      - 150 GE buy limit caps bulk flipping
+      - Combine demand for bandana eyepatch tightens supply
+  history:
+    - date: "2006-06-13"
+      description: Item renamed from "Pirate bandanna" to "Pirate bandana".
+    - date: "2006-02-07"
+      update: Cabin Fever
+      description: Pirate bandana (brown) introduced with the Cabin Fever quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-02-07"
+    update: Cabin Fever
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/purple-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/purple-gloves.mdx
@@ -12,9 +12,100 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Purple gloves is a free-to-play item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: hands
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Barker's Haberdashery
+      location: Canifis
+      price: 650
+  drop_table:
+    sources:
+      - source: Crawling Hand
+        rarity: 1/64
+        quantity: "1"
+        members_only: true
+      - source: Crushing Hand
+        rarity: 3/64
+        quantity: "1"
+        members_only: true
+  treasure_trail:
+    is_reward: true
+    tier: medium
+  related_items:
+    - item_name: Grey gloves
+      slug: grey-gloves
+      relationship: variant
+      description: Grey colour variant from Barker's Haberdashery.
+    - item_name: Red gloves
+      slug: red-gloves
+      relationship: variant
+      description: Red colour variant from Barker's Haberdashery.
+    - item_name: Yellow gloves
+      slug: yellow-gloves
+      relationship: variant
+      description: Yellow colour variant from Barker's Haberdashery.
+    - item_name: Teal gloves
+      slug: teal-gloves
+      relationship: variant
+      description: Teal colour variant from Barker's Haberdashery.
+  about: Purple gloves are a cosmetic hand slot item sold at Barker's Haberdashery in Canifis, matching the purple Canifis robe set and dropped by Crawling Hands.
+  market_strategy:
+    notes:
+      - Demand is largely cosmetic; matched with purple robe set for fashionscape.
+      - Medium clue emote step reward keeps supply ticking.
+      - Crawling Hand Slayer tasks supply consistent drops.
+  history:
+    - date: "2014-12-10"
+      update: Game update
+      description: Renamed from "Gloves" to "Purple gloves" for clarity with the other colour variants.
+    - date: "2004-07-20"
+      update: Game update
+      description: Made available to free-to-play players.
+    - date: "2004-07-13"
+      update: Game update
+      description: Briefly switched to members-only before reverting.
+    - date: "2004-06-29"
+      update: Priest in Peril
+      description: Released with the Priest in Peril quest update alongside Canifis robe sets.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-06-29"
+    update: Priest in Peril
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-boots-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-boots-t1.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Raging echoes boots (t1) is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: feet
+    weight: 0.34
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 30404
+      item_name: Raging echoes helm (t1)
+      slug: raging-echoes-helm-t1
+      relationship: set-piece
+      description: Matching tier 1 helm
+    - item_id: 30406
+      item_name: Raging echoes top (t1)
+      slug: raging-echoes-top-t1
+      relationship: set-piece
+      description: Matching tier 1 top
+    - item_id: 30408
+      item_name: Raging echoes legs (t1)
+      slug: raging-echoes-legs-t1
+      relationship: set-piece
+      description: Matching tier 1 legs
+    - item_id: 30412
+      item_name: Raging echoes gloves (t1)
+      slug: raging-echoes-gloves-t1
+      relationship: set-piece
+      description: Matching tier 1 gloves
+  history:
+    - date: "2025-01-15"
+      update: "Leagues V: Raging Echoes Rewards Are Here"
+      description: Item became obtainable from the Leagues Reward Shop.
+    - date: "2024-11-27"
+      update: "Leagues V: Raging Echoes OUT NOW!"
+      description: Item added to the game with the Leagues V launch.
+  about: Raging echoes boots (t1) are tier 1 cosmetic foot armour from the Leagues V reward shop, purchased with 1,000 League points as part of the Raging Echoes outfit.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-11-27"
+    update: "Leagues V: Raging Echoes OUT NOW!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-top-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-top-t1.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Raging echoes top (t1) is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: body
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 30408
+      item_name: Raging echoes legs (t1)
+      slug: raging-echoes-legs-t1
+      relationship: set-piece
+      description: Legs slot of the tier 1 Relic Hunter outfit
+    - item_id: 30404
+      item_name: Raging echoes hood (t1)
+      slug: raging-echoes-hood-t1
+      relationship: set-piece
+      description: Head slot of the tier 1 Relic Hunter outfit
+  market_strategy:
+    notes:
+      - Cosmetic-only with zero combat bonuses
+      - Supply tied to Leagues V participation
+      - Storable in costume room armour case
+      - Demand driven by completionist collectors
+  history:
+    - date: "2025-01-15"
+      description: Item became obtainable through Leagues V reward shop.
+    - date: "2024-11-27"
+      description: Added to the game ahead of Leagues V launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-01-15"
+    update: "Leagues V: Raging Echoes Rewards Are Here"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    alchable: false
+    destroy: Drop
+  about: Raging echoes top (t1) is the tier 1 cosmetic body of the Leagues V Relic Hunter outfit with no combat bonuses.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rope.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rope.mdx
@@ -12,13 +12,72 @@ osrs:
   lowalch: 7
   highalch: 10
   limit: 250
-  related_items: []
-  about: |-
-    > _"A coil of rope."_
-
-    Rope is used in numerous quests and activities. Required for tying things, crossing obstacles, and many quest objectives. One of the most commonly needed quest items in the game.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  material:
+    type: quest material
+    tier: low
+  recipes:
+    - skill: crafting
+      level: 30
+      xp: 50
+      materials:
+        - item_id: 10814
+          item_name: Yak-hair
+          quantity: 1
+      product: Rope
+      product_id: 954
+  shops:
+    - shop_name: Ned's Handmade Rope
+      location: Draynor Village
+      price: 18
+      stock: 30
+    - shop_name: Aemad's Adventuring Supplies
+      location: Ardougne
+      price: 23
+      stock: 20
+    - shop_name: Khazard General Store
+      location: Port Khazard
+      price: 25
+      stock: 30
+    - shop_name: Martin Thwait's Lost and Found
+      location: Rogues' Den
+      price: 18
+      stock: 50
+  related_items:
+    - item_id: 1759
+      item_name: Ball of wool
+      slug: ball-of-wool
+      relationship: component
+      description: Used by Ned to make rope (4 balls of wool)
+    - item_id: 10814
+      item_name: Yak-hair
+      slug: yak-hair
+      relationship: component
+      description: Spun on a spinning wheel to craft rope
+  market_strategy:
+    notes:
+      - Heavy quest demand keeps a constant baseline buy volume
+      - Best F2P source is Ned's shop in Draynor Village
+      - Tempoross rewards free rope inventories for members
+      - Buy limit of 250 caps speculative flips
+  history:
+    - date: "2001-02-28"
+      description: Added with the "Yet another new quest, and new options menu" update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-02-28"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Rope is a low-cost F2P quest staple sold at Ned's shop in Draynor Village and required by dozens of quests and obstacles.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-essence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-essence.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 20000
-  item:
-    type: material
-    tradeable: true
+  material:
+    type: runecrafting
+    tier: low
   recipes:
     - skill: runecraft
       level: 1
@@ -23,35 +23,63 @@ osrs:
         - item_id: 1436
           item_name: Rune essence
           quantity: 1
-      product: Elemental runes
-      product_id: 0
+      product: Air rune
+      product_id: 556
+  drop_table:
+    sources:
+      - source: Catablepon
+        quantity: "1"
+        rarity: common
+        members_only: true
+      - source: Minotaur
+        quantity: "1"
+        rarity: common
+        members_only: false
+      - source: Ankou
+        quantity: "1"
+        rarity: common
+        members_only: true
   related_items:
     - item_id: 7936
       item_name: Pure essence
       slug: pure-essence
       relationship: upgrade
-      description: Members upgrade for more rune types
+      description: Members-only upgrade usable for all rune types
     - item_id: 556
       item_name: Air rune
       slug: air-rune
       relationship: product
-      description: Crafted product
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Runecraft Material |
-    | Tradeable | Yes |
-    | Weight | 0.002 kg |
-    | Requirements | Rune Mysteries quest |
-
-    Used to craft elemental runes (air, water, earth, fire).
-
-    Free-to-play runecrafting material.
-
-    Members get pure essence at 30+ Mining instead.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Crafted product at the Air Altar
+  market_strategy:
+    notes:
+      - F2P-only crafting input now that members use pure essence
+      - Steady demand from low-level runecrafters
+      - Buy limit of 20,000 supports bulk training
+      - Price floor stays near alch value
+  history:
+    - date: "2022-03-23"
+      description: Examine text changed from "An uncharged Rune Stone" to "An unimbued rune."
+    - date: "2006-04-20"
+      description: Inventory sprite updated alongside the release of pure essence.
+    - date: "2004-03-29"
+      description: Became permanently available with the RS2 launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 launch
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 0.002
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Rune essence is the basic Runecraft material used by free players to craft low-level elemental and catalytic runes.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-hasta-p-11417.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-hasta-p-11417.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 8320
   highalch: 12480
   limit: 70
-  about: "Rune hasta(p+) is a members-only item in Old School RuneScape. High alchemy value: 12,480 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 36
+      slash: 36
+      crush: 36
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -10
+      slash: -10
+      crush: -9
+      magic: 0
+      ranged: -10
+    other_bonus:
+      melee_strength: 42
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 11415
+      item_name: Rune hasta
+      slug: rune-hasta
+      relationship: variant
+      description: Unpoisoned base hasta
+    - item_id: 11416
+      item_name: Rune hasta(p)
+      slug: rune-hasta-p
+      relationship: variant
+      description: Weaker poison variant
+    - item_id: 11418
+      item_name: Rune hasta(p++)
+      slug: rune-hasta-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison tier
+  market_strategy:
+    notes:
+      - Barbarian Smithing miniquest required to wield
+      - 4-tick spear attack speed (since 2021 buff)
+      - Poison++ damage stacks on hit
+      - Limited PvM niche, low supply
+      - Alchable for 12,480 GP
+      - Compare with regular rune spear for value
+  history:
+    - date: "2007-07-03"
+      update: Barbarian Training
+      description: Item added to the game with Barbarian hastas.
+    - date: "2021-04-21"
+      update: Game update
+      description: Attack speed improved from 5 ticks to 4 ticks.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: Drop
+  about: Rune hasta(p+) is a strong-poison variant of the Barbarian-Smithing rune hasta with a 4-tick spear attack speed.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-helm-h1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-helm-h1.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 70
-  about: "Rune helm (h1) is a free-to-play item in Old School RuneScape. High alchemy value: 21,120 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune-metal
+    tier: high
+  equipment:
+    slot: head
+    weight: 2.721
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    is_reward: true
+    tier: hard
+    reward_tiers:
+      - hard
+      - elite
+  related_items:
+    - item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: variant
+      description: Base rune full helm without a heraldic crest.
+    - item_name: Rune helm (h2)
+      slug: rune-helm-h2
+      relationship: variant
+      description: Alternate heraldic colour variant.
+    - item_name: Rune helm (h3)
+      slug: rune-helm-h3
+      relationship: variant
+      description: Alternate heraldic colour variant.
+    - item_name: Rune helm (h4)
+      slug: rune-helm-h4
+      relationship: variant
+      description: Alternate heraldic colour variant.
+    - item_name: Rune helm (h5)
+      slug: rune-helm-h5
+      relationship: variant
+      description: Alternate heraldic colour variant.
+  about: Rune helm (h1) is a heraldic cosmetic rune full helm with identical stats to the standard rune full helm, awarded from hard and elite Treasure Trails.
+  market_strategy:
+    notes:
+      - Stats mirror the rune full helm; value is purely cosmetic crest demand.
+      - Hard and elite clue completions cap supply each rotation.
+      - Worn with matching rune heraldic kiteshield for fashionscape sets.
+  history:
+    - date: "2021-04-21"
+      update: Game update
+      description: Ranged attack bonus reduced from -2 to -3 to align with other rune full helms.
+    - date: "2006-12-05"
+      update: Treasure Trails, spiders and sheep
+      description: Released as a clue scroll reward with the heraldic helm series.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails, spiders and sheep
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-scimitar.mdx
@@ -12,24 +12,108 @@ osrs:
   lowalch: 10240
   highalch: 15360
   limit: 70
-  item_id: 1333
-  item_type: equipment
-  slot: weapon
-  type: scimitar
-  attack_style: slash
-  attack_speed: 4
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 40
-  stats:
-    slash_attack: 45
-    strength: 44
+  material:
+    type: rune
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: slash-sword
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 7
+      slash: 45
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 44
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Fire giant
+        combat_level: 86
+        quantity: "1"
+        rarity: 1/128
+        members_only: true
+      - source: Zamorak warrior
+        combat_level: 57
+        quantity: "1"
+        rarity: 1/50
+        members_only: true
+  shops:
+    - shop_name: Iorwerth's Arms
+      location: Prifddinas
+      price: 38400
+  recipes:
+    - skill: smithing
+      level: 90
+      xp: 150
+      materials:
+        - item_name: Runite bar
+          item_id: 2363
+          quantity: 2
+      product: Rune scimitar
+      product_id: 1333
+      product_quantity: 1
+      tool: Hammer at anvil
   related_items:
-    - slug: dragon-scimitar
-    - slug: runite-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 4587
+      item_name: Dragon scimitar
+      slug: dragon-scimitar
+      relationship: upgrade
+      description: Members upgrade with special attack
+    - item_id: 2363
+      item_name: Runite bar
+      slug: runite-bar
+      relationship: component
+      description: Raw smithing material
+    - item_id: 1323
+      item_name: Adamant scimitar
+      slug: adamant-scimitar
+      relationship: downgrade
+      description: Lower tier alternative
+  market_strategy:
+    notes:
+      - Strongest scimitar in F2P
+      - Second-strongest scimitar overall behind Dragon scimitar
+      - Crafting from runite bars is unprofitable; GE flips preferred
+      - High supply from Fire giant and Zamorak warrior drops
+      - GE limit 70 per 4 hours
+      - Alchable for 15,360 GP, decent F2P money-making baseline
+  history:
+    - date: "2001-08-13"
+      update: Wilderness
+      description: Item added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-08-13"
+    update: Wilderness
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: Drop
+  about: Rune scimitar is a 40-Attack one-handed slash sword, the strongest scimitar available in free-to-play and a staple F2P weapon.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-spear-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-spear-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune spear(p) | OSRS Price Data
-description: "Rune spear(p): A poisoned rune tipped spear.. High alch: 12,480 GP, GE limit: 70."
+description: "Rune spear(p): A poisoned rune tipped spear. High alch: 12,480 GP, GE limit: 70."
 osrs:
   id: 1261
   name: Rune spear(p)
@@ -12,9 +12,111 @@ osrs:
   lowalch: 8320
   highalch: 12480
   limit: 70
-  about: "Rune spear(p) is a members-only item in Old School RuneScape. High alchemy value: 12,480 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: spear
+    tier: mid-high
+  equipment:
+    slot: 2h
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 36
+      slash: 36
+      crush: 36
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 42
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: none
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Rune spear
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      facility: Apply poison
+      members_only: true
+  shops:
+    - shop_name: Mount Karuulm Weapon Shop
+      location: Mount Karuulm
+      price: 20800
+  related_items:
+    - item_name: Rune spear
+      slug: rune-spear
+      relationship: component
+      description: Unpoisoned base spear
+    - item_name: Rune spear(p+)
+      slug: rune-spear-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_name: Rune spear(p++)
+      slug: rune-spear-p-plus-plus
+      relationship: upgrade
+      description: Super-poison variant
+    - item_name: Rune spear(kp)
+      slug: rune-spear-kp
+      relationship: variant
+      description: Karambwan-poisoned variant
+    - item_name: Dragon spear(p)
+      slug: dragon-spear-p
+      relationship: upgrade
+      description: Higher-tier poisoned spear
+    - item_name: Weapon poison
+      slug: weapon-poison
+      relationship: component
+      description: Required to apply poison
+  market_strategy:
+    notes:
+      - Niche PvP and Corporeal Beast specialty weapon
+      - Spears bypass shields - useful at Corporeal Beast
+      - Poison variant adds early-fight chip damage
+      - Supply driven by Karuulm shop and Mithril dragon drops
+      - Buy limit 70 keeps it inexpensive vs dragon spear
+  about: Rune spear(p) is a poisoned two-handed rune spear with 4-tick attack speed, requiring 40 Attack to wield and dealing standard poison stacks on hit.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2003-04-14"
+      update: New Throwing Weapons!
+      description: Rune spear and poisoned variants released.
+    - date: "2006-08-22"
+      update: Game Update
+      description: Poisoned variants renamed from "Rune spear(+)" to "Rune spear(p+)" for consistency.
+    - date: "2021-04-21"
+      update: Weapon Rebalance
+      description: Attack speed improved from 5 ticks to 4 ticks.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-amulet-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-amulet-u.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 10000
-  about: "Sapphire amulet (u) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: jewellery
+    tier: low
+  recipes:
+    - skill: crafting
+      level: 24
+      xp: 65
+      materials:
+        - item_name: Sapphire
+          item_id: 1607
+          quantity: 1
+        - item_name: Gold bar
+          item_id: 2357
+          quantity: 1
+      product: Sapphire amulet (u)
+      product_id: 1675
+      product_quantity: 1
+      members_only: false
+      tool: Amulet mould
+  related_items:
+    - item_id: 1607
+      item_name: Sapphire
+      slug: sapphire
+      relationship: component
+      description: Cut gem required for crafting
+    - item_id: 2357
+      item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: Smelted bar required for crafting
+    - item_id: 1694
+      item_name: Sapphire amulet
+      slug: sapphire-amulet
+      relationship: upgrade
+      description: Strung version made by adding ball of wool
+    - item_id: 1727
+      item_name: Amulet of magic
+      slug: amulet-of-magic
+      relationship: upgrade
+      description: Enchanted form via Lvl-1 Enchant
+  about: Sapphire amulet (u) is the unstrung amulet crafted from a sapphire and gold bar at 24 Crafting; add a ball of wool to string it.
+  market_strategy:
+    notes:
+      - F2P crafting staple at low levels
+      - Demand driven by Lvl-1 Enchant + amulet of magic
+      - Gold bar and sapphire prices set the floor
+      - High volume, low margin
+  trading_tips:
+    - Watch sapphire and gold bar markets for arbitrage
+    - Buy in bulk near alch value as a price floor
+    - Common Crafting XP path for 24+
+  history:
+    - date: "2014-12-10"
+      description: Renamed from "Sapphire amulet" to "Sapphire amulet (u)" to disambiguate from the strung version.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-05-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.004
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-hood-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-hood-t2.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Shattered hood (t2) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: mid
+  equipment:
+    slot: head
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Shattered Relics League
+      price: 3000
+      currency: League points
+      notes: Purchased for 3,000 League points during the Shattered Relics League event.
+  related_items:
+    - item_name: Shattered hood (t1)
+      slug: shattered-hood-t1
+      relationship: downgrade
+      description: Tier 1 version of the Shattered Relic Hunter hood.
+    - item_name: Shattered hood (t3)
+      slug: shattered-hood-t3
+      relationship: upgrade
+      description: Tier 3 version of the Shattered Relic Hunter hood.
+    - item_name: Shattered top (t2)
+      slug: shattered-top-t2
+      relationship: set-piece
+      description: Matching tier 2 top of the Shattered Relic Hunter outfit.
+    - item_name: Shattered trousers (t2)
+      slug: shattered-trousers-t2
+      relationship: set-piece
+      description: Matching tier 2 trousers of the Shattered Relic Hunter outfit.
+    - item_name: Shattered boots (t2)
+      slug: shattered-boots-t2
+      relationship: set-piece
+      description: Matching tier 2 boots of the Shattered Relic Hunter outfit.
+  about: Shattered hood (t2) is the tier 2 cosmetic head piece of the Shattered Relic Hunter outfit, awarded during the Shattered Relics League for 3,000 League points.
+  market_strategy:
+    notes:
+      - Strictly cosmetic with no combat bonuses.
+      - Supply is fixed to the original League release window; rarity drives the high GE price.
+      - Stored in costume room armour case or displayed on the league hall outfit stand.
+  history:
+    - date: "2022-03-16"
+      update: PvP Arena - Rewards Beta
+      description: Became obtainable on live servers following the league reward sync.
+    - date: "2022-01-19"
+      update: Shattered Relics League
+      description: Item added to the game alongside the Shattered Relics League outfit set.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-01-19"
+    update: Shattered Relics League
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-mobility.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-mobility.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of mobility is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: sigil
+    tier: mid
+  drop_table:
+    sources:
+      - source: Deadman Mode monster drop table
+        quantity: "1"
+        rarity: very rare
+        members_only: true
+        notes: Drops from most monsters while playing in temporary Deadman Mode events.
+  related_items:
+    - item_name: Sigil of consistency
+      slug: sigil-of-consistency
+      relationship: alternative
+      description: Companion Deadman Mode utility sigil with a different attunement effect.
+    - item_name: Sigil of stamina
+      slug: sigil-of-stamina
+      relationship: alternative
+      description: Stamina-themed Deadman Mode utility sigil.
+  about: Sigil of mobility is a tier 1 utility Deadman Mode sigil that, once attuned, removes rune and XP costs from teleports, only obtainable during temporary Deadman events.
+  market_strategy:
+    notes:
+      - Only obtainable during Deadman Mode events - supply is limited to event windows.
+      - Reduces logistics overhead on alts that teleport frequently during ranked play.
+      - Stack with stamina-style sigils to free up gear slots in PvP setups.
+  history:
+    - date: "2021-08-25"
+      update: Deadman - Reborn
+      description: Released with the Deadman - Reborn event as a utility sigil that nullifies teleport rune and XP costs once attuned.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    update: Deadman - Reborn
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Destroy
+    alchable: false
+    destroy: Destroy
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-revoked-limitation.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-revoked-limitation.mdx
@@ -12,9 +12,45 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: null
-  about: "Sigil of revoked limitation is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Deadman skull shop
+      location: Deadman Mode
+      price: 1
+      currency: Deadman's skull
+      notes: Tier 2 utility unlock; duplicates can be sold back.
+  related_items:
+    - item_id: 13576
+      item_name: Bracelet of ethereum
+      slug: bracelet-of-ethereum
+      relationship: alternative
+      description: Standard-mode counter to revenant weapons outside Wilderness.
+  about: Sigil of revoked limitation is a Deadman Mode tier-2 utility sigil that, once attuned, removes the Wilderness restriction on revenant weapon accuracy and damage bonuses so they apply to NPCs anywhere.
+  market_strategy:
+    notes:
+      - Exclusive to temporary Deadman events; not on the live Grand Exchange
+      - Earlier untradeable drop versions cycled with Deadman drop tables
+      - Multiple permanent sigils can stack across an account
+  history:
+    - date: "2024-07-17"
+      update: Deadman; Armageddon & While Guthix Sleeps
+      description: Sigil of revoked limitation introduced as a Deadman Mode permanent utility unlock.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-07-17"
+    update: Deadman; Armageddon & While Guthix Sleeps
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Unlock
+      - Inspect
+    alchable: false
+    destroy: Destroy
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snakeskin-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snakeskin-body.mdx
@@ -12,8 +12,15 @@ osrs:
   lowalch: 500
   highalch: 750
   limit: 125
+  material:
+    type: snakeskin
+    tier: mid
   equipment:
     slot: body
+    weight: 6.803
+    requirements:
+      ranged: 30
+      defence: 30
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,20 +38,21 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 30
-      defence: 30
-    weight: 6.803
   recipes:
     - skill: crafting
       level: 53
       xp: 55
-      inputs:
+      materials:
         - item_name: Snakeskin
+          item_id: 6287
           quantity: 15
         - item_name: Thread
+          item_id: 1734
           quantity: 1
-      output_quantity: 1
+        - item_name: Needle
+          item_id: 1733
+          quantity: 1
+      members_only: true
   related_items:
     - item_id: 6324
       item_name: Snakeskin chaps
@@ -61,43 +69,40 @@ osrs:
       slug: green-dhide-body
       relationship: upgrade
       description: 40 Ranged body upgrade
-  about: |-
-    | Ranged | Value |
-    |--------|-------|
-    | Ranged Attack | +12 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +25 |
-    | Slash | +28 |
-    | Crush | +32 |
-    | Magic | +15 |
-    | Ranged | +35 |
-
-    Requirements: 30 Ranged, 30 Defence
-
-    | Stat | Snakeskin Body | Studded Body | Green D'hide Body |
-    |------|---------------|--------------|-------------------|
-    | Ranged Atk | +12 | +8 | +15 |
-    | Stab Def | +25 | +22 | +40 |
-    | Magic Def | +15 | +4 | +20 |
-    | Req | 30 Rng/Def | 20 Rng/Def | 40 Rng/Def |
-
-    Bridges the gap between studded leather (20 Ranged) and green d'hide (40 Ranged). Notable for its +15 Magic defence at only 30 Defence.
-
-    Requires 15 snakeskin — the most material-intensive piece in the snakeskin set. Snakeskin is cheap on the GE (~50 GP each), making the body cost under 1,000 GP in materials.
-
-    - Mid-tier ranged body for 30 Def bracket
-    - Popular with ironmen leveling through ranged tiers
-    - Crafting training product (53-57 range)
-    - Niche for 30 Def pures in PvP
+    - item_id: 6287
+      item_name: Snakeskin
+      slug: snakeskin
+      relationship: component
+      description: Material (15 required)
+  about: Snakeskin body is a mid-tier ranged body bridging studded leather and green d'hide, crafted from 15 snakeskins at 53 Crafting and notable for +15 Magic defence at only 30 Defence.
   market_strategy:
     notes:
-      - Low demand — green d'hide body preferred at 40+
+      - Low demand - green d'hide body preferred at 40+
       - Crafting training byproduct
       - Niche for 30 Def bracket builds
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2005-08-09"
+      update: Tai Bwo Wannai Clean-Up
+      description: Snakeskin body released with the Tai Bwo Wannai Clean-Up update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snape-grass.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snape-grass.mdx
@@ -16,7 +16,7 @@ osrs:
     type: secondary
     tier: mid
   farming:
-    level: 61
+    farming_level: 61
     seed_id: 22879
     seed_name: Snape grass seed
   recipes:
@@ -69,13 +69,7 @@ osrs:
       slug: avantoe
       relationship: component
       description: Fishing potion herb
-  about: |-
-    Secondary ingredient for potions:
-
-    | Potion | Herb | Herblore Level |
-    |--------|------|----------------|
-    | Prayer potion | Ranarr weed | 38 |
-    | Fishing potion | Avantoe | 50 |
+  about: Snape grass is a herblore secondary used for prayer potions and fishing potions; farmable at level 61 and yielding supercompost when composted.
   market_strategy:
     notes:
       - Grow Snape grass seed at 61 Farming
@@ -88,8 +82,26 @@ osrs:
       - Waterbirth collection popular
       - Fossil Island farming patches
       - Check seed vs grass prices
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2002-02-27"
+      description: Item released.
+    - date: "2020-08-26"
+      description: Composting snape grass now yields supercompost instead of normal compost.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-balance.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-balance.mdx
@@ -12,9 +12,100 @@ osrs:
   lowalch: 400001
   highalch: 600002
   limit: null
-  about: "Staff of balance is a members-only item in Old School RuneScape. High alchemy value: 600,002 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: staff
+    tier: high
+  equipment:
+    slot: 2h
+    weapon_type: staff
+    attack_speed: 4
+    weight: 1.5
+    requirements:
+      attack: 75
+      magic: 75
+    attack_bonus:
+      stab: 55
+      slash: 70
+      crush: 0
+      magic: 17
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 3
+      magic: 17
+      ranged: 0
+    other_bonus:
+      melee_strength: 72
+      ranged_strength: 0
+      magic_damage: 15
+      prayer: 0
+  special_attack:
+    name: Power of Death
+    energy_cost: 100
+    description: Halves opponent melee damage for one minute and stacks with Protect from Melee.
+  recipes:
+    - skill: none
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Staff of the dead
+          item_id: 11791
+          quantity: 1
+        - item_name: Guthixian icon
+          item_id: 24141
+          quantity: 1
+      product: Staff of balance
+      product_id: 24144
+      product_quantity: 1
+      facility: Chasm of Tears (Juna)
+      members_only: true
+  related_items:
+    - item_id: 11791
+      item_name: Staff of the dead
+      slug: staff-of-the-dead
+      relationship: component
+      description: Base staff combined with the Guthixian icon
+    - item_id: 24141
+      item_name: Guthixian icon
+      slug: guthixian-icon
+      relationship: component
+      description: Song of the Elves reward used in conversion
+    - item_id: 22296
+      item_name: Staff of light
+      slug: staff-of-light
+      relationship: alternative
+      description: Sibling sceptre with passive magic defence
+  market_strategy:
+    notes:
+      - Conversion is irreversible which sinks supply
+      - 75 Attack and 75 Magic gate the weapon
+      - High-level PvM staff with PvP utility
+      - Listing dominated by long-term holders
+      - Special attack adds niche tank value
+  history:
+    - date: "2019-08-29"
+      update: Song of the Elves
+      description: Released as a combination of the staff of the dead and Guthixian icon at Juna.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-08-29"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1.5
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Staff of balance combines the staff of the dead with the Guthixian icon, granting Guthix-aligned Magic damage and a defensive special attack.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-potion-4.mdx
@@ -12,16 +12,19 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 2000
+  material:
+    type: potion
+    tier: mid-high
   potion:
     doses: 4
     herblore_level: 77
-    herblore_xp: 102
+    herblore_xp: 25.5
     effect: Restores 20% run energy and reduces drain by 70% for 2 minutes
     effects:
       - stat: Run energy
         boost_value: 20
         boost_type: percentage
-        description: Restores 20% run energy
+        description: Restores 20% run energy per dose
       - stat: Run energy drain
         boost_value: -70
         boost_type: percentage
@@ -29,7 +32,7 @@ osrs:
   recipes:
     - skill: herblore
       level: 77
-      xp: 102
+      xp: 25.5
       materials:
         - item_name: Super energy(4)
           item_id: 3016
@@ -39,6 +42,10 @@ osrs:
           quantity: 4
       ticks: 2
       members_only: true
+  shops:
+    - shop_name: Chest (Theatre of Blood)
+      location: Theatre of Blood
+      price: 0
   related_items:
     - item_id: 3016
       item_name: Super energy(4)
@@ -65,29 +72,39 @@ osrs:
       slug: stamina-potion-3
       relationship: variant
       description: 3-dose version
-  about: |-
-    Per dose:
-    - Restores: 20% run energy
-    - Reduces: Run energy drain by 70% for 2 minutes
-    - Effect resets (doesn't stack) with additional doses
-
-    Essential for:
-    - Runecrafting (especially blood/soul runes)
-    - Agility training
-    - Raids (constant running)
-    - Hunter (tracking)
-    - General efficiency
+  about: Stamina potion(4) is a 4-dose members Herblore potion that restores 20% run energy and reduces drain by 70% for 2 minutes.
   market_strategy:
     profit_formulas:
-      - Stamina(4) - Super energy(4) - (Amylase × 4) = Profit
+      - Stamina(4) - Super energy(4) - (Amylase x 4) = Profit
     notes:
       - Buy Super energy(4) + 4 Amylase crystal
       - Make Stamina potion(4)
-      - "Calculate:"
       - Marks of grace from Rooftop Agility (10 marks = 100 crystals)
       - Controls stamina potion supply
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2025-01-08"
+      description: Players can now begin crafting stamina potions without canceling movement.
+    - date: "2014-07-03"
+      update: Halos, God Books & Stamina
+      description: Stamina potion released.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-07-03"
+    update: Halos, God Books & Stamina
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-full-helm.mdx
@@ -12,24 +12,98 @@ osrs:
   lowalch: 220
   highalch: 330
   limit: 125
-  item_id: 1157
-  item_type: armor
-  slot: head
-  type: full_helm
-  tradeable: true
-  weight: 2.721
-  requirements:
-    defence: 5
-  stats:
-    stab_defence: 9
-    slash_defence: 10
-    crush_defence: 7
-    ranged_defence: 9
+  material:
+    type: steel
+    tier: low
+  equipment:
+    slot: head
+    weight: 2.721
+    requirements:
+      defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -1
+      ranged: -1
+    defence_bonus:
+      stab: 9
+      slash: 10
+      crush: 7
+      magic: -1
+      ranged: 9
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 37
+      xp: 75
+      materials:
+        - item_name: Steel bar
+          item_id: 2353
+          quantity: 2
+      product: Steel full helm
+      product_id: 1157
+      product_quantity: 1
+      members_only: false
+  shops:
+    - shop_name: Helmet Shop
+      location: Barbarian Village
+      sell_price: 550
+      buy_price: 330
+      currency: Coins
+      members_only: false
+    - shop_name: Thurid's Brain Buckets
+      location: Sunset Coast
+      sell_price: 715
+      buy_price: 220
+      currency: Coins
+      members_only: true
   related_items:
-    - slug: black-full-helm
-    - slug: steel-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1155
+      item_name: Steel med helm
+      slug: steel-med-helm
+      relationship: downgrade
+      description: Cheaper medium-helm steel variant
+    - item_id: 1153
+      item_name: Iron full helm
+      slug: iron-full-helm
+      relationship: downgrade
+      description: Lower-tier iron full helm
+    - item_id: 1159
+      item_name: Mithril full helm
+      slug: mithril-full-helm
+      relationship: upgrade
+      description: Higher-tier mithril full helm
+  history:
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -2 to -3.
+    - date: "2001-01-04"
+      update: Runescape beta is now online!
+      description: Steel full helm available since launch.
+  about: Steel full helm is a free-to-play head slot armour smithed from 2 steel bars at 37 Smithing, offering solid early-game defence with a 5 Defence requirement.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-gold-trimmed-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-gold-trimmed-set-sk.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 8
-  about: "Steel gold-trimmed set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: low
+  treasure_trail:
+    tier: easy
+    is_reward: false
+    reward_tiers:
+      - easy
+  related_items:
+    - item_id: 2587
+      item_name: Steel full helm (g)
+      slug: steel-full-helm-g
+      relationship: component
+      description: Helm piece of the set
+    - item_id: 2589
+      item_name: Steel platebody (g)
+      slug: steel-platebody-g
+      relationship: component
+      description: Platebody piece of the set
+    - item_id: 3477
+      item_name: Steel plateskirt (g)
+      slug: steel-plateskirt-g
+      relationship: component
+      description: Plateskirt piece of the set
+    - item_id: 2591
+      item_name: Steel kiteshield (g)
+      slug: steel-kiteshield-g
+      relationship: component
+      description: Kiteshield piece of the set
+  market_strategy:
+    notes:
+      - Pure cosmetic set tradeable via Grand Exchange Sets clerk
+      - Component sum frequently outpaces set price
+      - F2P bank-saver bundle
+      - Low buy limit caps flips
+      - Discounted when paired vs piece-by-piece
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion
+      description: Released as a Grand Exchange set bundling the four steel gold-trimmed (sk) pieces.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Steel gold-trimmed set (sk) bundles the helm, platebody, plateskirt, and kiteshield gold-trimmed Steel pieces for compact Grand Exchange trading.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stony-basalt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stony-basalt.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 10000
-  about: "Stony basalt is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: teleport
+    tier: mid
+  teleport:
+    destination: Troll Stronghold
+    consumable: true
+    requirements:
+      quest: Making Friends with My Arm
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Basalt
+          item_id: 22596
+          quantity: 1
+        - item_name: Urt salt
+          item_id: 22583
+          quantity: 3
+        - item_name: Te salt
+          item_id: 22585
+          quantity: 1
+      product: Stony basalt
+      product_id: 22601
+      product_quantity: 1
+      facility: None
+      members_only: true
+  related_items:
+    - item_id: 22596
+      item_name: Basalt
+      slug: basalt
+      relationship: component
+      description: Base rock used to craft the teleport
+    - item_id: 22583
+      item_name: Urt salt
+      slug: urt-salt
+      relationship: component
+      description: Reagent x3
+    - item_id: 22585
+      item_name: Te salt
+      slug: te-salt
+      relationship: component
+      description: Reagent x1
+  market_strategy:
+    notes:
+      - Consumed on use which keeps demand constant
+      - Crafting requires Weiss salt mining + quest gate
+      - Buy-limit-friendly bulk stack price
+      - Convenient teleport for Troll Stronghold tasks
+      - Salt rune cost dictates floor price
+  history:
+    - date: "2025-12-01"
+      description: Added left-click toggle and right-click destination menu between Stronghold entrances.
+    - date: "2018-09-06"
+      description: Released with Making Friends with My Arm.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-09-06"
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Rub
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Stony basalt is a single-use teleport stone crafted from basalt and Weiss salts that delivers the user to the Troll Stronghold.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/strength-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/strength-mix-1.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 2000
-  about: "Strength mix(1) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: low
+  potion:
+    doses: 1
+    effects:
+      - description: Boosts Strength by 3 + 10% of level
+      - description: Restores 3 Hitpoints on drink
+  recipes:
+    - skill: herblore
+      level: 14
+      xp: 17
+      materials:
+        - item_name: Strength potion(2)
+          item_id: 115
+          quantity: 1
+        - item_name: Caviar
+          item_id: 11451
+          quantity: 1
+      product: Strength mix(1)
+      product_id: 11441
+      product_quantity: 2
+  related_items:
+    - item_id: 11443
+      item_name: Strength mix(2)
+      slug: strength-mix-2
+      relationship: upgrade
+      description: Two-dose version
+    - item_id: 113
+      item_name: Strength potion(4)
+      slug: strength-potion-4
+      relationship: alternative
+      description: Non-mix four-dose strength potion
+    - item_id: 11451
+      item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Mix additive
+  market_strategy:
+    notes:
+      - Requires Barbarian Training to make
+      - Restores 3 HP on drink, useful in low-level PvM
+      - Niche demand outside Barbarian content
+      - Caviar makes the higher-XP variant
+      - Mix potions cannot be decanted at NPCs
+      - GE limit 2,000 per 4 hours
+  history:
+    - date: "2007-07-03"
+      update: Barbarian Training
+      description: Item added to the game with Barbarian Herblore mixes.
+    - date: "2016-04-15"
+      update: QoL
+      description: Half-full potions could now be turned into bank placeholders.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Strength mix(1) is a one-dose Barbarian Herblore mix that boosts Strength and restores 3 Hitpoints on drink.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-paste.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-paste.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 13000
-  about: "Swamp paste is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Cooking
+      level: 1
+      xp: 2
+      materials:
+        - item_name: Swamp tar
+          quantity: 1
+        - item_name: Pot of flour
+          quantity: 1
+      output:
+        item_name: Swamp paste
+        quantity: 1
+      notes: Cook on a fire only; cannot be made on a range.
+  shops:
+    - shop_name: Razmire Builders Merchants
+      location: Mort'ton
+      stock: 1000
+      price: 31
+    - shop_name: Khazard General Store
+      location: Port Khazard
+      stock: 5000
+      price: 42
+    - shop_name: Trader Stan's Trading Post
+      location: Various (21 locations)
+      stock: 30
+      price: 75
+  related_items:
+    - item_id: 1939
+      item_name: Swamp tar
+      slug: swamp-tar
+      relationship: component
+      description: Combined with flour to form raw swamp paste.
+    - item_id: 1933
+      item_name: Pot of flour
+      slug: pot-of-flour
+      relationship: component
+      description: Second component of swamp paste.
+  about: Swamp paste is a stackable members' utility item cooked from swamp tar and flour, used to repair leaks and boats across multiple quests, craft Construction repair kits, and fix damage in the Fishing Trawler minigame.
+  market_strategy:
+    notes:
+      - Razmire is the cheapest steady supply at 31 gp
+      - Stack-friendly so quest runners and Trawlers buy in bulk
+      - Construction repair kits act as a long-term demand floor
+  history:
+    - date: "2003-12-09"
+      description: Swamp paste became stackable.
+    - date: "2006-05-02"
+      description: Minor examine text punctuation update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-09-09"
+    update: Sea Slug
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-25-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-25-cape.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-25 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Edward's Wilderness Cape Shop
+      location: Rogues' Castle
+      price: 50
+      sells_for: 30
+      restock: 100 per minute
+  related_items:
+    - item_id: 4315
+      item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: Different team number variant
+    - item_id: 4329
+      item_name: Team-8 cape
+      slug: team-8-cape
+      relationship: variant
+      description: Different team number variant
+  market_strategy:
+    notes:
+      - Sold by Edward at Rogues' Castle for 50 gp
+      - Players wearing matching capes appear as blue minimap dots
+      - Niche PvP/team-tag usage
+      - Stock recovers 100 per minute, plentiful supply
+      - F2P accessible since 2013
+      - Limited collector demand
+  history:
+    - date: "2005-02-22"
+      update: Wilderness Capes, and Changes
+      description: Item added to the game.
+    - date: "2013-05-23"
+      update: Game update
+      description: Made available to free-to-play players.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-22"
+    update: Wilderness Capes, and Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Team-25 cape is one of fifty numbered team capes sold from the Wilderness cape shop, used to tag PvP allies on the minimap.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teasing-stick.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teasing-stick.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 40
-  about: "Teasing stick is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hunter
+    tier: low
+  shops:
+    - shop_name: Nardah Hunter Shop
+      location: Nardah
+      stock: 5
+      price: 60
+    - shop_name: Aleck's Hunter Emporium
+      location: Yanille
+      stock: 5
+      price: 60
+    - shop_name: Imia's Supplies
+      location: Hunter Guild
+      stock: 5
+      price: 60
+  related_items:
+    - item_id: 10092
+      item_name: Hunters' spear
+      slug: hunters-spear
+      relationship: alternative
+      description: Equippable substitute that frees the inventory slot
+  market_strategy:
+    notes:
+      - Required for falconry-style hunter techniques
+      - Three shops keep effective supply uncapped
+      - Low GE buy limit kills bulk flipping
+      - Replaceable by Hunters' spear for inventory savings
+      - Marginal arbitrage between shop and GE
+  history:
+    - date: "2006-11-21"
+      update: Hunter
+      description: Released with the Hunter skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Teasing stick is a Hunter tool used to poke larupia, graahk, kyatt, and antelope into pitfall traps.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-amulet.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 500
   highalch: 750
   limit: 10000
-  about: "Topaz amulet is a members-only item in Old School RuneScape. High alchemy value: 750 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: silver
+    tier: mid
+  equipment:
+    slot: neck
+    weight: 0.007
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Crafting
+      level: 1
+      xp: 4
+      materials:
+        - item_name: Topaz amulet (u)
+          quantity: 1
+        - item_name: Ball of wool
+          quantity: 1
+      output:
+        item_name: Topaz amulet
+        quantity: 1
+    - skill: Magic
+      level: 80
+      xp: 0
+      materials:
+        - item_name: Topaz amulet (u)
+          quantity: 1
+        - item_name: Water rune
+          quantity: 5
+        - item_name: Earth rune
+          quantity: 10
+        - item_name: Astral rune
+          quantity: 2
+      output:
+        item_name: Topaz amulet
+        quantity: 1
+      notes: Lunar Diplomacy required; String Jewellery spell.
+  related_items:
+    - item_id: 21112
+      item_name: Topaz amulet (u)
+      slug: topaz-amulet-u
+      relationship: component
+      description: Unstrung base used in stringing.
+    - item_id: 21116
+      item_name: Burning amulet
+      slug: burning-amulet
+      relationship: upgrade
+      description: Enchanted form via Lvl-5 Enchant.
+  about: Topaz amulet is the unenchanted neck-slot product made by stringing a topaz amulet (u) with a ball of wool, primarily used as a base for the Burning amulet enchantment.
+  market_strategy:
+    notes:
+      - Demand driven by Burning amulet enchanters
+      - Stringing margin tracks wool + topaz amulet (u) prices
+      - String Jewellery spell competes with manual stringing
+  history:
+    - date: "2017-02-16"
+      description: Inventory sprite rotated so unenchanted silver jewellery now uses non-standard angles.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-02-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trousers-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trousers-blue.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 300
   highalch: 450
   limit: 150
-  about: "Trousers (blue) is a members-only item in Old School RuneScape. High alchemy value: 450 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Agmundi Quality Clothes
+      location: Keldagrim
+      price: 975
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania
+      price: 750
+  related_items:
+    - item_id: 5038
+      item_name: Trousers (green)
+      slug: trousers-green
+      relationship: variant
+      description: Green dwarven trousers recolour.
+    - item_id: 5042
+      item_name: Trousers (purple)
+      slug: trousers-purple
+      relationship: variant
+      description: Purple dwarven trousers recolour.
+  about: Trousers (blue) are cosmetic dwarven legwear sold in Keldagrim and Miscellania, providing no combat bonuses.
+  market_strategy:
+    notes:
+      - Shops keep a hard ceiling near 975 gp
+      - Fashionscape demand modest; thin liquidity
+      - 150 GE buy limit fine for casual flips
+  history:
+    - date: "2005-07-26"
+      description: Examine text updated from "These look pretty heavy." to "A pair of long dwarven trousers... long for dwarves, of course."
+    - date: "2005-05-31"
+      description: Trousers (blue) released as Keldagrim dwarven clothing.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tuna-potato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tuna-potato.mdx
@@ -12,14 +12,11 @@ osrs:
   lowalch: 45
   highalch: 67
   limit: 13000
+  material:
+    type: food
+    tier: high
   food:
     heals: 22
-    cooking_level: 68
-    cooking_xp: 309.5
-  cooking:
-    level: 68
-    xp: 309.5
-    ticks: 4
   recipes:
     - skill: cooking
       level: 68
@@ -39,72 +36,72 @@ osrs:
       item_name: Potato with butter
       slug: potato-with-butter
       relationship: component
-      description: Base potato
+      description: Base potato component
     - item_id: 7068
       item_name: Tuna and corn
       slug: tuna-and-corn
       relationship: component
-      description: Filling ingredient
+      description: Filling component
     - item_id: 361
       item_name: Tuna
       slug: tuna
       relationship: component
-      description: Tuna source
+      description: Tuna source ingredient
     - item_id: 5988
       item_name: Sweetcorn
       slug: sweetcorn
       relationship: component
-      description: Corn source
+      description: Corn source ingredient
     - item_id: 391
       item_name: Manta ray
       slug: manta-ray
       relationship: alternative
-      description: Same healing (22 HP)
+      description: Same 22 HP healing food
     - item_id: 11936
       item_name: Dark crab
       slug: dark-crab
       relationship: alternative
-      description: Same healing (22 HP)
+      description: Same 22 HP healing food
     - item_id: 13441
       item_name: Anglerfish
       slug: anglerfish
       relationship: alternative
-      description: Overheal food (up to 22 HP)
+      description: Overheal food up to 22 HP
     - item_id: 385
       item_name: Shark
       slug: shark
       relationship: alternative
-      description: Lower tier food (20 HP)
-  about: |-
-    Combine tuna and corn with a potato with butter.
-
-    Full Recipe Chain:
-    1. Bake a potato on a range/fire
-    2. Add butter to make potato with butter
-    3. Combine cooked tuna with cooked sweetcorn to make tuna and corn
-    4. Add tuna and corn to the potato with butter
-
-    | Effect | Value |
-    |--------|-------|
-    | Healing | 22 Hitpoints |
-
-    Tuna potato is one of the highest instant-healing foods:
-    - Tied with manta ray, dark crab, anglerfish, and bluefin at 22 HP
-    - Single-bite consumption
-    - Complex to make (many preparation steps)
+      description: Lower tier food at 20 HP
   market_strategy:
     notes:
-      - Complex recipe = potential profit margins
-      - Requires multiple intermediate items
-      - Calculate full material costs vs sell price
-      - Same healing as manta ray and dark crab
-      - Heavier weight (0.5 kg) than alternatives
-      - Most complex preparation of any 22 HP food
-      - Low trade volume due to complex creation
+      - Complex recipe creates potential profit margins from component flipping
+      - Same healing as manta ray and dark crab but heavier at 0.5 kg
+      - Low trade volume due to multi-step preparation
       - Ironman accounts may make these for efficient food
-      - Consider component flipping instead of full recipe
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Consider component flipping instead of full recipe assembly
+  about: Tuna potato is a high-end members food that heals 22 Hitpoints, made at level 68 Cooking by combining a potato with butter and tuna and corn.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-01-30"
+    update: Runesquares, Harpie Bugs and new potato recipes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2006-01-30"
+      update: Runesquares, Harpie Bugs and new potato recipes
+      description: Tuna potato released as part of the new potato recipes update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tzhaar-ket-em.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tzhaar-ket-em.mdx
@@ -12,9 +12,94 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 70
-  about: "Tzhaar-ket-em is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: obsidian
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: blunt
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 62
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 56
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: TzHaar-Ket
+        combat_level: 149
+        quantity: "1"
+        rarity: rare
+        members_only: true
+  shops:
+    - shop_name: TzHaar-Hur-Zal's Equipment Store
+      location: Mor Ul Rek
+      price: 37500
+  related_items:
+    - item_id: 6528
+      item_name: Tzhaar-ket-om
+      slug: tzhaar-ket-om
+      relationship: upgrade
+      description: Two-handed obsidian maul variant
+    - item_id: 1434
+      item_name: Dragon mace
+      slug: dragon-mace
+      relationship: alternative
+      description: Comparable melee mace tier
+    - item_id: 11128
+      item_name: Berserker necklace
+      slug: berserker-necklace
+      relationship: alternative
+      description: Provides 20% damage boost with obsidian weapons
+  market_strategy:
+    notes:
+      - Strongest non-special obsidian mace
+      - 20% boost with Berserker necklace
+      - Obsidian armour set bonus stacks (+10% melee accuracy/strength)
+      - Niche use vs dragon mace (no special attack)
+      - Sold by TzHaar shop in Tokkul or coins
+      - GE limit 70 per 4 hours
+  history:
+    - date: "2005-09-19"
+      update: Massive minigame - Fight Pits
+      description: Item added to the game with the TzHaar city.
+    - date: "2021-04-28"
+      update: Game update
+      description: Attack speed reverted to 5 ticks after temporary 4-tick adjustment.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-09-19"
+    update: Massive minigame - Fight Pits
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: Drop
+  about: Tzhaar-ket-em is an obsidian one-handed mace requiring 60 Attack, slightly stronger than the dragon mace but without a special attack.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-helm.mdx
@@ -12,34 +12,38 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
+  material:
+    type: barrows
+    tier: high
   equipment:
     slot: head
-    type: barrows
-    set: Verac
-    tradeable: true
-    degradeable: true
-    weight: 2.7
+    weight: 1.36
     requirements:
       defence: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -6
-      attack_ranged: 0
-      defence_stab: 55
-      defence_slash: 58
-      defence_crush: 54
-      defence_magic: 0
-      defence_ranged: 56
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 55
+      slash: 58
+      crush: 54
+      magic: 0
+      ranged: 56
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 3
-  set_effect:
-    name: Defiler
-    pieces_required: 4
-    description: 25% chance to ignore target's Defence and Protection prayers
+  special_attack:
+    name: Defiler (set effect)
+    description: While wearing the full Verac's set, attacks have a 25% chance to ignore the target's Defence and Protection prayers.
+    activation_chance: 25
+  charges:
+    max_charges: 15
+    description: Degrades after 15 hours of combat. Repair at Bob in Lumbridge (60,000 gp) or POH armour stand for reduced cost scaling with Smithing.
   related_items:
     - item_id: 4757
       item_name: Verac's brassard
@@ -56,38 +60,40 @@ osrs:
       slug: veracs-flail
       relationship: set-piece
       description: Weapon set piece
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Stab defence | +55 |
-    | Slash defence | +58 |
-    | Crush defence | +54 |
-    | Magic defence | +0 |
-    | Ranged defence | +56 |
-    | Prayer | +3 |
-    | Magic attack | -6 |
-
-    Note: Only Barrows helm with prayer bonus (+3).
-
-    Defiler:
-    When wearing full Verac's (helm, brassard, plateskirt, flail):
-    - 25% chance to ignore target's Defence and Protection prayers
-    - Hits through Protect from Melee
-
-    Best For:
-    - Prayer bonus helm option
-    - Corporeal Beast (with set)
-    - Kalphite Queen
-    - PvP against prayer users
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
+  about: Verac's helm is the head piece of Verac the Defiled's Barrows set, the only Barrows helm with a Prayer bonus, contributing to the Defiler set effect that bypasses Defence and Protection prayers.
   market_strategy:
     notes:
-      - Prayer bonus unique among Barrows
-      - Full set used at Corp
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Prayer bonus unique among Barrows helms
+      - Full set used at Corporeal Beast
+      - Repair cost scales with Smithing level at POH armour stand
+  history:
+    - date: "2015-04-16"
+      description: Added "Check" option for viewing remaining durability.
+    - date: "2014-12-10"
+      description: Renamed from "Veracs helm" to "Verac's helm".
+    - date: "2005-05-09"
+      update: Barrows
+      description: Verac's helm released with the Barrows update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: If you drop this item it will break. Are you sure you want to drop it?
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-armband-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-armband-brown.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 150
-  about: "Villager armband (brown) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: hands
+    weight: 0.68
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      price: 180
+      currency: Trading sticks
+      notes: 150 trading sticks while wearing Karamja gloves 1 or better.
+  related_items:
+    - item_id: 6349
+      item_name: Villager armband (yellow)
+      slug: villager-armband-yellow
+      relationship: variant
+      description: Yellow recolour from the same shop.
+    - item_id: 6351
+      item_name: Villager armband (blue)
+      slug: villager-armband-blue
+      relationship: variant
+      description: Blue recolour from the same shop.
+    - item_id: 6353
+      item_name: Villager armband (pink)
+      slug: villager-armband-pink
+      relationship: variant
+      description: Pink recolour from the same shop.
+  about: Villager armband (brown) is a cosmetic hands-slot item bought from Gabooty's Cooperative in Tai Bwo Wannai for trading sticks, providing no combat bonuses.
+  market_strategy:
+    notes:
+      - Shop price acts as a price ceiling for the brown variant
+      - Karamja gloves discount drops effective cost to 150 sticks
+      - Fashionscape demand thin but steady from Tai Bwo Wannai sets
+  history:
+    - date: "2005-09-12"
+      description: Examine text changed from "A brightly coloured cream arm band." to "A brown armband, as worn by the Tai Bwo Wannai locals."
+    - date: "2005-08-09"
+      update: Tai Bwo Wannai Clean-Up
+      description: Villager armband (brown) released with the Tai Bwo Wannai Clean-Up update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.68
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-sandals-pink.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-sandals-pink.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Villager sandals (pink) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: feet
+    weight: 0.68
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      sells_for: 120
+      currency: Trading sticks
+  related_items:
+    - item_id: 6373
+      item_name: Villager robe (pink)
+      slug: villager-robe-pink
+      relationship: set-piece
+      description: Matching pink villager robe
+    - item_id: 6375
+      item_name: Villager hat (pink)
+      slug: villager-hat-pink
+      relationship: set-piece
+      description: Matching pink villager hat
+  about: Villager sandals (pink) are feet slot cosmetic footwear bought from Gabooty's Tai Bwo Wannai Cooperative for 120 trading sticks (100 with Karamja gloves).
+  market_strategy:
+    notes:
+      - Trading-stick shop sets a hard supply floor
+      - Karamja gloves 1+ discount supports merchant flips
+      - Fashionscape collectors and quest completionists drive price
+      - Low buy limit keeps spikes possible
+  history:
+    - date: "2005-08-09"
+      update: Tai Bwo Wannai Clean-Up
+      description: Item released with the Tai Bwo Wannai Clean-Up update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.68
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wyrmling-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wyrmling-bones.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 3000
-  about: "Wyrmling bones is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 3,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bones
+    tier: mid-high
+  prayer:
+    xp_bury: 21
+  drop_table:
+    sources:
+      - source: Wyrmling
+        combat_level: 55
+        quantity: "1"
+        rarity: always
+        members_only: true
+      - source: Lunar Chest
+        quantity: "42-54 (noted)"
+        rarity: 6 x 1/30
+        members_only: true
+  related_items:
+    - item_id: 532
+      item_name: Bones
+      slug: bones
+      relationship: alternative
+      description: Standard low-tier bones (4.5 XP)
+    - item_id: 25849
+      item_name: Wyrm bones
+      slug: wyrm-bones
+      relationship: upgrade
+      description: Stronger wyrm bones (50 XP)
+  history:
+    - date: "2024-03-20"
+      update: Varlamore Part One
+      description: Wyrmling bones added with the Lunar Chest content.
+  about: Wyrmling bones are dropped by wyrmlings in Varlamore and give 21 Prayer experience when buried, offering solid mid-tier Prayer training.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore Part One
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Bury
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Fourth batch — migrate 100 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Worktree-direct authoring this round (agents wrote straight to `kbve-osrs-v3-batch-4`, main repo untouched).
- Schema-clean on first `astro sync` — pitfall checklist from batches 1-3 fully internalized by the agents:
  - `relationship` constrained to enum
  - `history[].date` quoted ISO + required `description`
  - `shops[].shop_name` first key (no `shop:` / `name:`)
  - `properties.destroy` as string
  - `treasure_trail.tier` singular
  - skill requirement levels ≥1 (omitted if zero)
  - `recipes[].materials[].item_name` (not `item:`)
  - `potion.effects[]` as objects with `description:`

## Test plan

- [x] `astro sync` clean — all 100 entries validate.
- [ ] CI build green.
- [ ] Smoke check 3-5 pages on preview (`/osrs/dragon-claws` analogue, `/osrs/staff-of-balance`, `/osrs/blue-moon-tassets`, `/osrs/verac-s-helm`, `/osrs/tuna-potato`).

## Follow-ups

- ~4073 v2 items remain after this batch lands.