### PR TITLE
fix(codegen): gate itemdb-atlas regen behind KBVE_ATLAS_REGEN env var

### DIFF
--- a/packages/data/codegen/gen-itemdb-atlas.mjs
+++ b/packages/data/codegen/gen-itemdb-atlas.mjs
@@ -93,6 +93,13 @@ async function loadItemTile(imgRelPath) {
 }
 
 async function main() {
+	if (process.env.KBVE_ATLAS_REGEN !== '1') {
+		console.log(
+			'[skip] itemdb-atlas regen — set KBVE_ATLAS_REGEN=1 to opt in. Committed atlas PNG + ItemSpriteAtlas.Generated.cs are canonical (sharp/libvips PNG encoding varies per platform).',
+		);
+		return;
+	}
+
 	const records = loadAllMdx();
 	console.log(`Loaded ${records.length} items from MDX`);
 


### PR DESCRIPTION
## Summary

Same shape as #11622 — Unity CI [#26801983437](https://github.com/KBVE/kbve/actions/runs/26801983437) failed every matrix target on a dirty tree, this time a single file:

```
M apps/rareicon/unity-rareicon/Assets/StreamingAssets/itemdb-atlas.png
##[error]Branch is dirty. Refusing to base semantic version on uncommitted changes
```

## Root cause

[gen-itemdb-atlas.mjs](packages/data/codegen/gen-itemdb-atlas.mjs#L125-L135) uses [sharp](https://sharp.pixelplumbing.com/) to composite item icons into a 4096×4096 atlas. sharp wraps libvips, which uses a platform-native PNG encoder. The `darwin-arm64` sharp binary (my Mac) and the `linux-x64` sharp binary (arc-runner image) emit byte-divergent PNG bytes for the same composite + compression level — different filter row choices, slightly different IDAT chunking. CI's sync:itemdb-atlas silently overwrites the committed atlas with subtly-different bytes every run.

Confirmed locally: regen on `origin/main` with darwin-arm64 sharp produces zero diff vs committed bytes. Same as the protoc case.

## Fix

Gate the codegen entirely behind `KBVE_ATLAS_REGEN=1`. CI never regenerates the atlas. Committed `itemdb-atlas.png` + `ItemSpriteAtlas.Generated.cs` slot table stay canonical.

**Why gate both atlas and .cs (not just PNG):** the .cs file maps `ItemId` → atlas slot coords. PNG slot positions must match what the .cs says. Regenerating only the PNG (or only the .cs) under stale conditions ships a build with wrong sprites.

After adding/removing an item MDX, dev opts in:

```sh
KBVE_ATLAS_REGEN=1 nx run astro-kbve:sync:itemdb-atlas
git add apps/rareicon/unity-rareicon/Assets/StreamingAssets/itemdb-atlas.png \
        apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Items/Data/ItemSpriteAtlas.Generated.cs
```

Pairs with #11622 which used the same env-gate pattern for protoc C# regen.

## Test plan

- [ ] Next CI - Unity run shows `[skip] itemdb-atlas regen` in the sync step log
- [ ] `git status` in the Unity build step is clean
- [ ] Build matrix completes without `Branch is dirty`
- [ ] Steam beta upload + auto-dispatch promote chain fires → steam-prod approval gate