### PR TITLE
harden(kasm-void): HEALTHCHECK + EXPOSE + OCI labels + k8s probes

### DIFF
--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -172,6 +172,21 @@ spec:
                       - name: nav-shim
                         containerPort: 9998
                         protocol: TCP
+                  startupProbe:
+                      httpGet:
+                          path: /healthz
+                          port: 9998
+                      initialDelaySeconds: 30
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 30
+                  readinessProbe:
+                      httpGet:
+                          path: /healthz
+                          port: 9998
+                      periodSeconds: 30
+                      timeoutSeconds: 5
+                      failureThreshold: 3
                   env:
                       - name: KASM_PORT
                         value: '6901'

--- a/packages/docker/kasm-void/Dockerfile
+++ b/packages/docker/kasm-void/Dockerfile
@@ -6,6 +6,12 @@ ARG CLOAK_SHA256=
 ENV CLOAK_HOME=/opt/cloakbrowser \
     CLOAK_BIN=/opt/cloakbrowser/cloakbrowser
 
+LABEL org.opencontainers.image.source="https://github.com/KBVE/kbve" \
+      org.opencontainers.image.description="KASM workspace with Discord + CloakBrowser + URL launcher nav-shim" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="KBVE" \
+      org.opencontainers.image.title="kasm-void"
+
 USER root
 
 RUN set -eux; \
@@ -67,3 +73,9 @@ ENV HOME=/home/kasm-user \
     NAV_SHIM_PORT=9998 \
     CDP_PORT=9222
 WORKDIR /home/kasm-user
+
+EXPOSE 9222 9998
+STOPSIGNAL SIGTERM
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl -fsS "http://127.0.0.1:${NAV_SHIM_PORT:-9998}/healthz" >/dev/null || exit 1

--- a/packages/docker/kasm-void/README.md
+++ b/packages/docker/kasm-void/README.md
@@ -2,11 +2,14 @@
 
 KASM workspace image that bundles the upstream `kasmweb/discord` install with
 [CloakBrowser](https://github.com/CloakHQ/CloakBrowser), a stealth Chromium
-fork. Both apps auto-launch on session start and are individually supervised
-— if either crashes or is closed it is respawned by the startup loop.
+fork, plus a small CDP-backed URL launcher (`nav_shim.py`) on port 9998.
+All three components auto-launch on session start and are individually
+supervised — if any crashes or is closed it is respawned by the startup
+loop.
 
 Use case: run Discord inside the KASM session and screenshare the bundled
-browser through Discord's video/stream feature.
+browser through Discord's video/stream feature; remote services drive page
+navigation via the nav-shim HTTP endpoint.
 
 ## Tags
 
@@ -22,19 +25,31 @@ npx nx run kasm-void:test
 
 ## Runtime env
 
-| Variable         | Default             | Notes                                    |
-| ---------------- | ------------------- | ---------------------------------------- |
-| `START_URL`      | `https://kbve.com`  | Launch URL for the cloakbrowser instance |
-| `CLOAK_APP_ARGS` | (chromium defaults) | Override the full cloakbrowser arg list  |
-| `LAUNCH_DISCORD` | `1`                 | Set to `0` to disable Discord supervisor |
-| `LAUNCH_CLOAK`   | `0`/`1`             | Set to `0` to disable browser supervisor |
-| `VNC_PW`         | (k8s secret)        | Provided by the kasm Deployment          |
+| Variable             | Default             | Notes                                                       |
+| -------------------- | ------------------- | ----------------------------------------------------------- |
+| `START_URL`          | `https://kbve.com`  | Launch URL for the cloakbrowser instance                    |
+| `CLOAK_APP_ARGS`     | (chromium defaults) | Override the full cloakbrowser arg list                     |
+| `LAUNCH_DISCORD`     | `1`                 | Set to `0` to disable Discord supervisor                    |
+| `LAUNCH_CLOAK`       | `1`                 | Set to `0` to disable browser supervisor                    |
+| `LAUNCH_NAV_SHIM`    | `1`                 | Set to `0` to disable URL-launcher HTTP supervisor          |
+| `NAV_SHIM_PORT`      | `9998`              | nav-shim HTTP listener port                                 |
+| `CDP_PORT`           | `9222`              | Chromium remote-debugging port (loopback only)              |
+| `URL_LAUNCHER_TOKEN` | (k8s secret)        | Bearer token required by `POST /open`; falls back to VNC_PW |
+| `VNC_PW`             | (k8s secret)        | Provided by the kasm Deployment                             |
+
+## Exposed ports / health
+
+- `9222/tcp` — Chromium CDP (loopback bind via `--remote-debugging-address=127.0.0.1`)
+- `9998/tcp` — nav-shim HTTP (`GET /healthz`, `POST /open`)
+- `HEALTHCHECK` probes `http://127.0.0.1:${NAV_SHIM_PORT}/healthz` so
+  `docker ps` / Kubernetes probes can detect a wedged shim.
 
 ## Crash recovery
 
-`custom_startup.sh` spawns two background supervisors. Each polls `pgrep`
-every 3 seconds and re-launches its app if missing — closing Discord or
-the browser window from the desktop simply triggers a respawn.
+`custom_startup.sh` spawns three background supervisors (`cloak_loop`,
+`discord_loop`, `nav_shim_loop`). Each polls `pgrep` every 3–5 seconds
+and re-launches its app if missing — closing Discord, the browser, or
+killing the shim process simply triggers a respawn.
 
 ## Deployment
 

--- a/packages/docker/kasm-void/project.json
+++ b/packages/docker/kasm-void/project.json
@@ -69,7 +69,13 @@
 					"docker run --rm --entrypoint cat ghcr.io/kbve/kasm-void:dev /dockerstartup/custom_startup.sh | grep -q discord_loop && echo 'PASS: custom_startup.sh has discord supervisor'",
 					"docker run --rm --entrypoint cat ghcr.io/kbve/kasm-void:dev /dockerstartup/custom_startup.sh | grep -q nav_shim_loop && echo 'PASS: custom_startup.sh has nav_shim supervisor'",
 					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/discord_startup.sh && echo 'PASS: upstream discord startup preserved'",
-					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -f /home/kasm-user/Desktop/cloakbrowser.desktop && echo 'PASS: cloakbrowser.desktop deployed'"
+					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -f /home/kasm-user/Desktop/cloakbrowser.desktop && echo 'PASS: cloakbrowser.desktop deployed'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{.Config.Healthcheck.Test}}' | grep -q '/healthz' && echo 'PASS: HEALTHCHECK targets nav_shim /healthz'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range $$k, $$v := .Config.ExposedPorts}}{{$$k}} {{end}}' | grep -q '9222/tcp' && echo 'PASS: CDP port 9222 exposed'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range $$k, $$v := .Config.ExposedPorts}}{{$$k}} {{end}}' | grep -q '9998/tcp' && echo 'PASS: nav-shim port 9998 exposed'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{.Config.StopSignal}}' | grep -q '^SIGTERM$' && echo 'PASS: STOPSIGNAL=SIGTERM'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{index .Config.Labels \"org.opencontainers.image.source\"}}' | grep -q 'github.com/KBVE/kbve' && echo 'PASS: OCI source label set'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{index .Config.Labels \"org.opencontainers.image.title\"}}' | grep -q '^kasm-void$' && echo 'PASS: OCI title label set'"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
## Summary
Follow-on hardening to #11647 on the kasm-void image surface and its k8s wiring. No functional behavior changes for the running session — just better signals for Docker, the registry, supply-chain tools, and Kubernetes.

### Image (\`packages/docker/kasm-void/Dockerfile\`)
- **OCI image labels** — \`org.opencontainers.image.{source,description,licenses,vendor,title}\`. GHCR shows the link back to this repo; SBOM tools get vendor/license metadata.
- **\`EXPOSE 9222 9998\`** — documents the CDP loopback port and the nav-shim listener.
- **\`STOPSIGNAL SIGTERM\`** — explicit so \`docker stop\` never has to guess; supervisors get the chance to drain inside terminationGracePeriodSeconds.
- **\`HEALTHCHECK\`** hits \`http://127.0.0.1:\$NAV_SHIM_PORT/healthz\` every 30s. Catches a wedged shim during local \`docker run\` / \`docker compose\` flows; ignored by k8s (probes below cover that path).

### Deployment (\`apps/kube/kasm/manifest/deployment.yaml\`)
- **\`startupProbe\`** on workspace → \`GET nav-shim/healthz\`, \`failureThreshold: 30 × periodSeconds: 10s\` → 5 minutes of headroom for KASM desktop boot before the kubelet starts the readiness check.
- **\`readinessProbe\`** on the same path so \`kasm-vpn-service\` only sends traffic once the shim is actually accepting connections.
- **No livenessProbe** intentional — workspace is a stateful session; a flapping shim should not nuke the user's running Discord/browser.

### README
Synced env table with \`LAUNCH_NAV_SHIM\`, \`NAV_SHIM_PORT\`, \`CDP_PORT\`, \`URL_LAUNCHER_TOKEN\`. Switched the supervisor blurb from "both apps" → three supervisors. Added a ports/health section.

### E2E
Six new assertions in \`project.json\`:
- \`Config.Healthcheck.Test\` contains \`/healthz\`
- \`Config.ExposedPorts\` contains \`9222/tcp\` and \`9998/tcp\`
- \`Config.StopSignal == SIGTERM\`
- \`org.opencontainers.image.source\` points at this repo
- \`org.opencontainers.image.title == kasm-void\`

## Test plan
- [ ] \`nx run kasm-void:container\` builds clean
- [ ] All 24 e2e assertions pass under \`nx run kasm-void:test\`
- [ ] CI dev validation green
- [ ] After image rollout, \`kubectl describe pod\` on kasm-vpn shows startup + ready transitions on the workspace container