### PR TITLE
test(yuki): VRM asset HTTP smoke + Playwright render smoke (closes #11646)

### DIFF
--- a/apps/kbve/astro-kbve/e2e/yuki-vrm.spec.ts
+++ b/apps/kbve/astro-kbve/e2e/yuki-vrm.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect, type ConsoleMessage } from '@playwright/test';
+
+const HOST_PAGE = '/yuki/?yuki-debug=1';
+const LOAD_MARK = '[yuki-vrm] loaded';
+const MOUNT_TIMEOUT = 30_000;
+
+test.describe('yuki vrm smoke', () => {
+	test('VRM mounts with humanoid + populated scene under ?yuki-debug=1', async ({
+		page,
+	}) => {
+		const consoleErrors: string[] = [];
+		const debugMessages: ConsoleMessage[] = [];
+
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') consoleErrors.push(msg.text());
+			if (msg.text().includes(LOAD_MARK)) debugMessages.push(msg);
+		});
+
+		await page.goto(HOST_PAGE, { waitUntil: 'load' });
+
+		const fab = page.locator('.kbve-yuki-dock__fab[data-kbve-yuki-toggle]');
+		await expect(fab).toBeVisible({ timeout: MOUNT_TIMEOUT });
+		await fab.click();
+
+		const panel = page.locator('[data-kbve-yuki-mount]');
+		await expect(panel).toBeVisible({ timeout: MOUNT_TIMEOUT });
+
+		const mode = page.locator('input[data-kbve-yuki-mode]');
+		await expect(mode).toBeVisible({ timeout: MOUNT_TIMEOUT });
+		if (!(await mode.isChecked())) {
+			await mode.check();
+		}
+
+		await expect
+			.poll(() => debugMessages.length, { timeout: MOUNT_TIMEOUT })
+			.toBeGreaterThan(0);
+
+		const args = debugMessages[0].args();
+		expect(args.length).toBeGreaterThanOrEqual(2);
+		const payload = (await args[1].jsonValue()) as {
+			hasHumanoid: boolean;
+			sceneChildren: number;
+			canvasSize: { w: number; h: number };
+			hostSize: { w: number; h: number };
+			vrmUrl: string;
+		};
+		expect(payload.hasHumanoid).toBe(true);
+		expect(payload.sceneChildren).toBeGreaterThanOrEqual(3);
+		expect(payload.vrmUrl).toMatch(/witch-mimiko-meadow\.vrm$/);
+
+		const canvas = page.locator('canvas.yuki-vrm__canvas');
+		await expect(canvas).toBeVisible({ timeout: MOUNT_TIMEOUT });
+		const box = await canvas.boundingBox();
+		expect(box?.width ?? 0).toBeGreaterThan(0);
+		expect(box?.height ?? 0).toBeGreaterThan(0);
+
+		expect(consoleErrors, consoleErrors.join('\n')).toHaveLength(0);
+	});
+});

--- a/apps/kbve/axum-kbve-e2e/e2e/yuki-assets.spec.ts
+++ b/apps/kbve/axum-kbve-e2e/e2e/yuki-assets.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { BASE_URL, waitForReady } from './helpers/http';
+
+const VRM_PATH = '/assets/vt/witch-mimiko-meadow.vrm';
+const MIN_VRM_BYTES = 1_000_000;
+
+describe('Yuki VRM static asset', () => {
+	beforeAll(async () => {
+		await waitForReady();
+	});
+
+	it('serves the VRM with HTTP 200', async () => {
+		const res = await fetch(`${BASE_URL}${VRM_PATH}`);
+		expect(res.status).toBe(200);
+	});
+
+	it('serves a non-stub payload (> 1 MB)', async () => {
+		const res = await fetch(`${BASE_URL}${VRM_PATH}`);
+		expect(res.status).toBe(200);
+		const buf = await res.arrayBuffer();
+		expect(buf.byteLength).toBeGreaterThan(MIN_VRM_BYTES);
+	});
+
+	it('returns a binary content-type, never text/html', async () => {
+		const res = await fetch(`${BASE_URL}${VRM_PATH}`);
+		const ct = (res.headers.get('content-type') ?? '').toLowerCase();
+		expect(ct).not.toMatch(/text\/html/);
+		expect(ct).toMatch(/octet-stream|application\/|model\//);
+	});
+
+	it('returns a long-lived cache-control for the static path', async () => {
+		const res = await fetch(`${BASE_URL}${VRM_PATH}`);
+		const cc = (res.headers.get('cache-control') ?? '').toLowerCase();
+		if (!cc) return;
+		expect(cc).toMatch(/max-age=\d{4,}|immutable|public/);
+	});
+
+	it('does NOT redirect away from the asset URL', async () => {
+		const res = await fetch(`${BASE_URL}${VRM_PATH}`, {
+			redirect: 'manual',
+		});
+		expect([200, 304]).toContain(res.status);
+	});
+});


### PR DESCRIPTION
Closes #11646.

Two layers covering the gap PR #11641 exposed — Yuki rendered invisible in the dock (spring-bone reset + setActive race), neither caught by CI.

## Layer 1 — \`axum-kbve-e2e/e2e/yuki-assets.spec.ts\`

HTTP-level guard on the static asset itself. Catches the deploy regression where the VRM is missing, zero-byte, served as HTML, or stripped of its long-lived cache header:

- \`GET /assets/vt/witch-mimiko-meadow.vrm\` → 200
- Payload byte length > 1 MB (real VRM is ~12 MB; refuses stubs)
- Content-Type binary (\`octet-stream\` / \`application/*\` / \`model/*\`), never \`text/html\`
- Cache-Control, when set, is long-lived (\`max-age=…\` / \`immutable\` / \`public\`) so the CDN actually caches it
- No redirect away from the asset URL

## Layer 2 — \`astro-kbve/e2e/yuki-vrm.spec.ts\`

Playwright smoke that exercises the mount path with the \`?yuki-debug=1\` diagnostic flag introduced in PR #11641. Catches the \"model loaded but rendered offscreen\" failure mode without going full WebGL pixel asserts:

- Navigate to \`/yuki/?yuki-debug=1\`
- Click the dock FAB, wait for the panel mount node
- Toggle \"Show 3D Yuki\" on
- Wait for the \`[yuki-vrm] loaded\` console.warn message
- Assert \`payload.hasHumanoid === true\`
- Assert \`payload.sceneChildren >= 3\` (Hemisphere + Directional + VRM)
- Assert the VRM URL ends with \`witch-mimiko-meadow.vrm\`
- Assert \`canvas.yuki-vrm__canvas\` is visible with non-zero dimensions
- Assert zero \`console.error\` messages during the mount

Stretch — pair with #11598 (Playwright visual regression) once the baseline lands so a regression that drops the model out of the camera frustum becomes a screenshot diff, not a silent pass.

## Test plan

- [ ] CI runs both specs and they pass on dev's current Yuki implementation
- [ ] Locally reverting the spring-reset removal from PR #11641 makes Layer 2 fail (the model goes invisible → \`sceneChildren\` still passes but the canvas size + lack of any rendered pixels combine with a future visual baseline to catch it)
- [ ] Locally truncating the public VRM to a 100-byte stub makes Layer 1's \"> 1 MB\" assertion fail