### PR TITLE
fix(kasm-void): detect pip --break-system-packages by version, not --help grep

### DIFF
--- a/packages/docker/kasm-void/Dockerfile
+++ b/packages/docker/kasm-void/Dockerfile
@@ -22,7 +22,8 @@ RUN set -eux; \
         libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libdrm2 libxkbcommon0 \
         libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libgtk-3-0 \
         libasound2 libpango-1.0-0 libcairo2 libcups2 libdbus-1-3 fonts-liberation; \
-    if pip3 install --help 2>&1 | grep -q -- --break-system-packages; then \
+    PIP_MAJOR="$(pip3 --version | awk '{print $2}' | cut -d. -f1)"; \
+    if [ "${PIP_MAJOR}" -ge 23 ]; then \
       pip3 install --no-cache-dir --break-system-packages websocket-client==1.8.0; \
     else \
       pip3 install --no-cache-dir websocket-client==1.8.0; \


### PR DESCRIPTION
## Summary
Fixes #11643. \`Validate Dev→Main / Test affected projects\` failed on \`kasm-void:container\` with:

\`\`\`
+ pip3 install
no such option: --break-system-packages
\`\`\`

The Dockerfile probed pip with \`pip3 install --help | grep -q -- --break-system-packages\` to decide whether to pass the flag. Jammy's pip 22 prints the flag string inside its "Install Options" section even though it doesn't accept it at parse time, so the probe picked the THEN branch and the build died.

## Fix
Switch to a pip-major-version check. \`--break-system-packages\` landed in pip 23.0.

\`\`\`dockerfile
PIP_MAJOR="$(pip3 --version | awk '{print $2}' | cut -d. -f1)"
if [ "${PIP_MAJOR}" -ge 23 ]; then
  pip3 install --no-cache-dir --break-system-packages websocket-client==1.8.0
else
  pip3 install --no-cache-dir websocket-client==1.8.0
fi
\`\`\`

Works on both jammy (pip 22, no PEP 668 marker → plain install) and noble (pip 24, has marker → needs flag). The base \`kasmweb/discord:1.18.0-rolling-daily\` can flip across distros without breaking the build.