### PR TITLE
chore(ci): bump azure/setup-kubectl v4 -> v5 in ci-dbmate-deploy

### DIFF
--- a/.github/workflows/ci-dbmate-deploy.yml
+++ b/.github/workflows/ci-dbmate-deploy.yml
@@ -63,7 +63,7 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: Install kubectl
-              uses: azure/setup-kubectl@v4
+              uses: azure/setup-kubectl@v5
               with:
                   version: v1.31.0
             - name: Install envsubst
@@ -120,7 +120,7 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: Install kubectl
-              uses: azure/setup-kubectl@v4
+              uses: azure/setup-kubectl@v5
               with:
                   version: v1.31.0
             - name: Install envsubst


### PR DESCRIPTION
## Summary
Resolves dependabot #10808. Only two refs in the repo, both in \`ci-dbmate-deploy.yml\` (validate + prod jobs); both pass just the \`version\` input (\`v1.31.0\`).

## Compatibility
- v4 -> v5 is a runtime bump (Node 20 -> 24). Action input contract is unchanged.
- Pinned kubectl \`v1.31.0\` is unaffected.
- The manual approval gate on the \`kilobase-prod\` environment still guards the prod job's actual \`dbmate up\` — this PR doesn't change that path.

## Follow-up
Close dependabot #10808 after merge.