### PR TITLE
content(astro-kbve): bump 100 OSRS items v2 → v3 (batch 5)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-knife-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-knife-p.mdx
@@ -14,19 +14,81 @@ osrs:
   limit: 11000
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
+    weight: 0
     requirements:
       ranged: 30
     attack_bonus:
-      ranged: 12
-    ranged_strength: 14
-  related_items: []
-  about: |-
-    > _"A very sharp adamant knife with a poisoned tip."_
-
-    An adamant knife tipped with basic weapon poison. Requires 30 Ranged. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 15
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 14
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 868
+      item_name: Adamant knife
+      slug: adamant-knife
+      relationship: variant
+      description: Unpoisoned version
+    - item_id: 5660
+      item_name: Adamant knife(p+)
+      slug: adamant-knife-p-plus
+      relationship: upgrade
+      description: Stronger poison tier
+    - item_id: 5667
+      item_name: Adamant knife(p++)
+      slug: adamant-knife-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison tier
+    - item_id: 869
+      item_name: Mithril knife(p)
+      slug: mithril-knife-p
+      relationship: downgrade
+      description: Lower tier knife
+  market_strategy:
+    notes:
+      - Smithing 77 gated supply
+      - Cheap thrown training
+      - Stackable for bulk hold
+      - Poison adds DoT pressure
+  history:
+    - date: "2003-04-14"
+      update: New Throwing Weapons!
+      description: Item released with the new throwing weapons update.
+    - date: "2021-07-21"
+      description: Weapon positioning on female player models adjusted.
+  about: Adamant knife(p) is a one-handed thrown knife tipped with weapon poison, requiring 30 Ranged to wield.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-warhammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-warhammer.mdx
@@ -12,41 +12,100 @@ osrs:
   lowalch: 1648
   highalch: 2472
   limit: 125
+  material:
+    type: adamant
+    tier: mid
   equipment:
     slot: weapon
-    type: warhammer
-    tradeable: true
+    weapon_type: blunt
+    attack_speed: 6
     weight: 2.041
     requirements:
       attack: 30
-    stats:
-      attack_stab: -4
-      attack_slash: -4
-      attack_crush: 35
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 39
+    attack_bonus:
+      stab: -4
+      slash: -4
+      crush: 35
+      magic: -4
+      ranged: -4
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 39
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  recipes:
+    - skill: smithing
+      level: 79
+      xp: 187.5
+      materials:
+        - item_name: Adamantite bar
+          item_id: 2361
+          quantity: 3
+      product: Adamant warhammer
+      product_id: 1345
+      product_quantity: 1
+      facility: Anvil
   related_items:
     - item_id: 1347
       item_name: Rune warhammer
       slug: rune-warhammer
       relationship: upgrade
-      description: Higher tier warhammer
+      description: Higher-tier warhammer
+    - item_id: 1343
+      item_name: Mithril warhammer
+      slug: mithril-warhammer
+      relationship: downgrade
+      description: Lower-tier warhammer
     - item_id: 1430
       item_name: Adamant mace
       slug: adamant-mace
       relationship: alternative
-      description: Alternative crush weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Alternative same-tier crush weapon
+  treasure_trail:
+    tier: medium
+    is_reward: false
+    reward_tiers:
+      - medium
+  history:
+    - date: "2004-03-29"
+      update: RS2 Launch
+      description: Adamant warhammer released with RuneScape 2.
+    - date: "2021-04-01"
+      description: Strength bonus increased from 31 to 39 in the weapon rebalancing pass.
+  about: Adamant warhammer is an F2P two-handed crush weapon used at low to mid combat for crush-weak monsters and as a Bandos door substitute.
+  market_strategy:
+    notes:
+      - Cheap mid-tier crush option below rune warhammer
+      - Required for the medium clue scroll hammer emote
+      - Smithing 79 supply keeps prices near alch
+  trading_tips:
+    - Watch for clue-step demand spikes
+    - Hold stock when adamantite bar prices dip
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.041
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-the-damned-full.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-the-damned-full.mdx
@@ -14,80 +14,80 @@ osrs:
   limit: 8
   equipment:
     slot: neck
-    type: amulet
-    stats:
-      attack_stab: 10
-      attack_slash: 10
-      attack_crush: 10
-      attack_magic: 10
-      attack_ranged: 10
-      strength: 6
-      defence_all: 3
+    weight: 0.1
+    attack_bonus:
+      stab: 10
+      slash: 10
+      crush: 10
+      magic: 10
+      ranged: 10
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
+    other_bonus:
+      melee_strength: 6
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
-  barrows_set_effects:
-    - set: Dharok's
-      bonus: 25% reflect 15% damage
-    - set: Verac's
-      bonus: +7 Prayer bonus
-    - set: Torag's
-      bonus: +1% Def per missing HP
-    - set: Guthan's
-      bonus: Heal up to +10 over max
-    - set: Karil's
-      bonus: 25% double hit (half dmg)
-    - set: Ahrim's
-      bonus: Autocast Ancients, +25% dmg
+  drop_table:
+    sources:
+      - source: Silver shade chest
+        location: Shade Catacombs
+        quantity: "1"
+        rarity: ~1/143
+        members_only: true
+      - source: Gold shade chest
+        location: Shade Catacombs
+        quantity: "1"
+        rarity: ~1/143
+        members_only: true
   related_items:
-    - item_id: 0
-      item_name: Dharok's set
-      slug: dharoks-set
+    - item_name: Dharok's armour set
+      slug: dharoks-armour-set
       relationship: alternative
-      description: Reflect bonus
-    - item_id: 0
-      item_name: Ahrim's set
-      slug: ahrims-set
+      description: Reflect bonus when worn full set
+    - item_name: Ahrim's armour set
+      slug: ahrims-armour-set
       relationship: alternative
-      description: Magic boost
-    - item_id: 0
-      item_name: Shade Catacombs
-      slug: shade-catacombs
-      relationship: component
-      description: Drop source
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +10 |
-    | Slash | +10 |
-    | Crush | +10 |
-    | Magic | +10 |
-    | Ranged | +10 |
-    | Strength | +6 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +3 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +3 |
-
-    | Set | Bonus |
-    |-----|-------|
-    | Dharok's | 25% reflect 15% damage |
-    | Verac's | +7 Prayer bonus |
-    | Torag's | +1% Def per missing HP |
-    | Guthan's | Heal up to +10 over max |
-    | Karil's | 25% double hit (half dmg) |
-    | Ahrim's | Autocast Ancients, +25% dmg |
-
-    Essential for:
-    - Barrows set bonuses
-    - Enhanced Barrows armour
-    - Niche uses
-
-    Unlocks unique Barrows set effects.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Autocast Ancients + 25% damage
+    - item_name: Verac's armour set
+      slug: veracs-armour-set
+      relationship: alternative
+      description: +7 prayer bonus when worn
+  market_strategy:
+    notes:
+      - Tradeable only when undegraded (full charges)
+      - Niche demand from Barrows set-effect users
+      - Low buy limit (8) caps volume
+  history:
+    - date: "2024-10-23"
+      description: Effect now works with Ahrim's during manual casting.
+    - date: "2015-07-02"
+      description: Recoil damage targeting was improved.
+    - date: "2015-01-08"
+      description: Inventory appearance adjusted.
+  about: Amulet of the damned (full) is a members-only neck slot amulet that grants powerful set-specific effects when worn with a full Barrows armour set.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-11-06"
+    update: Amulet of the Damned and CWA
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-crozier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-crozier.mdx
@@ -14,22 +14,68 @@ osrs:
   limit: 8
   equipment:
     slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 0.005
     requirements:
       prayer: 60
+    attack_bonus:
+      stab: 7
+      slash: -1
+      crush: 25
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 10
+      ranged: 0
     other_bonus:
+      melee_strength: 32
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 6
+  treasure_trail:
+    tier: medium
+    is_reward: true
   related_items:
     - item_id: 12201
       item_name: Ancient stole
       slug: ancient-stole
       relationship: set-piece
       description: Ancient vestment neck piece
-  about: |-
-    > *"An Ancient crozier."*
-
-    The Ancient crozier is a weapon slot staff from the Ancient vestment set. It provides a +6 Prayer bonus and requires 60 Prayer to wield. Counts as a Zarosian item in the God Wars Dungeon. Cannot autocast Ancient Magicks despite the name.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Medium clue exclusive reward
+      - Counts as Zarosian in GWD
+      - Cannot autocast Ancient Magicks
+      - Lightest crozier in game
+      - +6 prayer bonus tier
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Item released with the Treasure Trail Expansion update.
+  about: The Ancient crozier is a Zarosian Prayer-themed staff dropped from medium Treasure Trail caskets, requiring 60 Prayer to wield and granting +6 Prayer bonus.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/asyn-remains.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/asyn-remains.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7500
-  about: "Asyn remains is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Asyn Shade
+        combat_level: 100
+        quantity: "1"
+        rarity: always
+        members_only: true
+      - source: Asyn shadow
+        combat_level: 110
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Temple Trekking encounter
+  related_items:
+    - item_id: 3438
+      item_name: Pyre logs
+      slug: pyre-logs
+      relationship: component
+      description: Used with remains on a funeral pyre
+    - item_id: 3444
+      item_name: Shade key
+      slug: shade-key
+      relationship: product
+      description: Cremation reward
+  about: Asyn remains drop from Asyn Shades and Asyn shadows and are burned on funeral pyres during Shades of Mort'ton for Firemaking and Prayer XP.
+  market_strategy:
+    notes:
+      - Steady supply from Shades of Mort'ton runners
+      - Buy limit of 7,500 supports bulk Prayer training
+      - Alch value is sentinel at 1 gp
+      - Demand peaks during Morytania Diary pushes
+  trading_tips:
+    - Watch for Mort'ton minigame XP events
+    - Bulk buy when chest hunters flood the GE
+  history:
+    - date: "2024-07-31"
+      description: Warning added when attempting to burn pyre logs without proper shade remains.
+    - date: "2024-05-08"
+      description: Keys and coins dropped from cremation now despawn after 5 minutes instead of 30 seconds.
+    - date: "2015-03-05"
+      description: Morytania Achievement Diary bonuses now grant a 50% XP boost from cremation with hard/elite tiers completed.
+    - date: "2004-10-18"
+      update: Mortton Shades and Mage Armour
+      description: Asyn remains released with Shades of Mort'ton content.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-18"
+    update: Mortton Shades and Mage Armour
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/banana.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/banana.mdx
@@ -12,9 +12,100 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Banana is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 2
+    type: fruit
+  drop_table:
+    sources:
+      - source: Banana tree (Musa Point, Karamja)
+        quantity: "1"
+        rarity: always
+        members_only: false
+      - source: Banana tree (Ape Atoll)
+        quantity: "1"
+        rarity: always
+        members_only: true
+      - source: Monkey
+        quantity: "1"
+        rarity: common
+        members_only: true
+  shops:
+    - shop_name: Solihib's Food Stall
+      location: Tai Bwo Wannai
+      buy_price: 2
+      sell_price: 1
+      stock: 50
+      members_only: true
+    - shop_name: Wydin's Food Store
+      location: Port Sarim
+      buy_price: 2
+      sell_price: 1
+      stock: 10
+  recipes:
+    - skill: farming
+      level: 33
+      xp: 47.5
+      materials:
+        - item_name: Banana tree seed
+          item_id: 5312
+          quantity: 1
+      product: Banana
+      product_id: 1963
+      product_quantity: 6
+      facility: Fruit tree patch
+      members_only: true
+  related_items:
+    - item_id: 5312
+      item_name: Banana tree seed
+      slug: banana-tree-seed
+      relationship: component
+      description: Grown via Farming for repeatable bananas
+    - item_id: 1973
+      item_name: Sliced banana
+      slug: sliced-banana
+      relationship: product
+      description: Made with a knife
+    - item_id: 2073
+      item_name: Half a pineapple
+      slug: half-a-pineapple
+      relationship: alternative
+      description: Comparable cocktail ingredient
+  farming:
+    farming_level: 33
+    xp: 47.5
+    patch: Fruit tree patch
+    growth_time_minutes: 960
+    protection: 4 baskets of apples (noted)
+  history:
+    - date: "2001-04-06"
+      update: Massive update!
+      description: Banana released as a tropical fruit food item.
+  about: Banana is an F2P fruit picked from trees on Musa Point, Karamja and Ape Atoll, healing 2 Hitpoints per bite.
+  market_strategy:
+    notes:
+      - Almost unlimited supply via Karamja banana trees and Bones to Bananas
+      - Bulk buyers stock for cooking gnomecookery or Monkey Madness needs
+      - Low margin per unit; flips depend on high volume at GE limit
+  trading_tips:
+    - Monitor Bones to Bananas spell costs vs. GE banana price for arbitrage
+    - Stock during quest update launches for surges
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-04-06"
+    update: Massive update!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.028
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-chaps.mdx
@@ -14,6 +14,9 @@ osrs:
   limit: 8
   equipment:
     slot: legs
+    weight: 5
+    requirements:
+      ranged: 70
     attack_bonus:
       stab: 0
       slash: 0
@@ -21,18 +24,19 @@ osrs:
       magic: -4
       ranged: 8
     defence_bonus:
-      stab: 17
-      slash: 20
-      crush: 16
-      magic: 18
-      ranged: 17
+      stab: 31
+      slash: 25
+      crush: 33
+      magic: 28
+      ranged: 31
     other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
+  treasure_trail:
+    tier: hard
+    is_reward: true
   related_items:
     - item_id: 10380
       item_name: Guthix chaps
@@ -55,30 +59,39 @@ osrs:
       slug: black-d-hide-chaps
       relationship: downgrade
       description: Standard version requiring 40 Defence
-  about: |-
-    > *"Bandos blessed dragonhide chaps."*
-
-    | Stat | Blessed | Black D'hide |
-    |------|--------:|-----------:|
-    | Ranged Attack | +8 | +8 |
-    | Stab Defence | +17 | +17 |
-    | Slash Defence | +20 | +20 |
-    | Crush Defence | +16 | +16 |
-    | Magic Defence | +18 | +18 |
-    | Ranged Defence | +17 | +17 |
-    | Prayer | +1 | 0 |
-    | Ranged Req | 70 | 70 |
-    | Defence Req | None | 40 |
-
-    The key advantage: blessed chaps have no Defence requirement, making them ideal for pures and ranged-focused accounts. They also offer a +1 prayer bonus.
   market_strategy:
     notes:
-      - Hard clue exclusive — supply tied to clue completion rates
-      - Popular with 1-Defence pures who need best-in-slot ranged legs
-      - All god variants are functionally identical
-      - Armadyl and Ancient variants tend to have slight premiums
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Hard clue exclusive supply
+      - Popular with 1-Defence pures
+      - All god variants stat-identical
+      - Armadyl and Ancient variants premium
+      - +1 prayer over black d'hide
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Item released with Treasure Trail Expansion.
+    - date: "2021-09-30"
+      description: Removed the 40 Defence requirement during ranged armour rebalance.
+  about: Bandos chaps are blessed dragonhide leg armour from hard clue caskets, requiring 70 Ranged with no Defence requirement and granting +1 Prayer.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/berserker-icon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/berserker-icon.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: null
-  about: "Berserker icon is a members-only item in Old School RuneScape. High alchemy value: 4,800 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - product: Berserker icon
+      skill: Crafting
+      level: 80
+      experience: 400
+      materials:
+        - item_name: Berserker ring
+          quantity: 1
+        - item_name: Chisel
+          quantity: 1
+          tool: true
+      notes: Crafting level is boostable.
+  related_items:
+    - item_id: 6737
+      item_name: Berserker ring
+      slug: berserker-ring
+      relationship: component
+      description: Cut with a chisel to create the icon
+    - item_id: 28281
+      item_name: Ultor vestige
+      slug: ultor-vestige
+      relationship: component
+      description: Combined with the icon and blood runes for an ultor icon
+    - item_id: 28307
+      item_name: Ultor icon
+      slug: ultor-icon
+      relationship: product
+      description: Created from the berserker icon with vestige and blood runes
+    - item_id: 28310
+      item_name: Ultor ring
+      slug: ultor-ring
+      relationship: product
+      description: Final ring crafted from the ultor icon path
+  market_strategy:
+    notes:
+      - Demand tied to ultor ring upgrades
+      - Profit margin shifts with berserker ring price
+      - 80 Crafting gate keeps supply moderate
+      - Slow daily volume — patience on flips
+  history:
+    - date: "2023-07-26"
+      update: Desert Treasure II
+      description: Berserker icon released alongside the Desert Treasure II finale.
+    - date: "2023-08-09"
+      update: Inspect option
+      description: An Inspect option was added to guide players on item usage.
+  about: Berserker icon is a members-only Desert Treasure II reward used in the ultor ring upgrade chain.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-07-26"
+    update: Desert Treasure II
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.002
+    options:
+      - Inspect
+      - Use
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-locks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-locks.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1280
   highalch: 1920
   limit: 8
-  about: "Black locks is a members-only item in Old School RuneScape. High alchemy value: 1,920 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Black chest (Shades of Mort'ton)
+        rarity: 1/63
+        members_only: true
+        notes: Rarity improves to ~1/58 with a ring of wealth equipped.
+  recipes:
+    - product: Black coffin
+      skill: Crafting
+      materials:
+        - item_name: Broken coffin
+          quantity: 1
+        - item_name: Black locks
+          quantity: 1
+      notes: Combined at Dampe in Mort'ton. The "Remove-lock" option reverses the process.
+  related_items:
+    - item_name: Black coffin
+      slug: black-coffin
+      relationship: product
+      description: Coffin upgrade created with Dampe
+    - item_name: Broken coffin
+      slug: broken-coffin
+      relationship: component
+      description: Base coffin Dampe combines with the locks
+    - item_name: Ring of wealth
+      slug: ring-of-wealth
+      relationship: alternative
+      description: Improves the drop rarity from black chests
+  market_strategy:
+    notes:
+      - Shades of Mort'ton runners gate supply
+      - 8 buy limit makes single-flip volume tiny
+      - Black coffin upgrade demand sets the floor
+      - Ring of wealth use thins supply on busy worlds
+  history:
+    - date: "2021-01-27"
+      update: Shades of Mort'ton Rework
+      description: Black locks released as part of the Shades of Mort'ton minigame rework.
+  about: Black locks is a Shades of Mort'ton black chest reward combined with a broken coffin at Dampe to craft a black coffin.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-01-27"
+    update: Shades of Mort'ton Rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody-h3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody-h3.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 1536
   highalch: 2304
   limit: 8
-  about: "Black platebody (h3) is a free-to-play item in Old School RuneScape. High alchemy value: 2,304 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 9.979
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 41
+      slash: 40
+      crush: 30
+      magic: -6
+      ranged: 40
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    is_reward: true
+    tier: easy
+    reward_tiers:
+      - easy
+    rarity: 1/1404
+  related_items:
+    - item_id: 3140
+      item_name: Black platebody
+      slug: black-platebody
+      relationship: variant
+      description: Standard non-trimmed variant
+    - item_id: 7370
+      item_name: Black platebody (h1)
+      slug: black-platebody-h1
+      relationship: variant
+      description: Different heraldic design variant
+  market_strategy:
+    notes:
+      - Easy clue reward at 1/1,404 rarity
+      - Cosmetic free-to-play body slot for clan colours
+      - Buy limit of 8 amplifies price volatility
+      - Demand driven by collection log and aesthetic display
+  history:
+    - date: "2021-04-21"
+      description: The platebody's ranged attack bonus was decreased from -10 to -15.
+    - date: "2019-04-11"
+      description: Released as part of the Treasure Trails Expansion and Easter 2019 update.
+  about: Black platebody (h3) is a free-to-play easy clue reward with a heraldic design and standard black platebody stats.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody.mdx
@@ -12,24 +12,100 @@ osrs:
   lowalch: 1536
   highalch: 2304
   limit: 125
-  item_id: 1125
-  item_type: armor
-  slot: body
-  type: platebody
-  tradeable: true
-  weight: 9.979
-  requirements:
-    defence: 10
-  stats:
-    stab_defence: 41
-    slash_defence: 40
-    crush_defence: 30
-    ranged_defence: 40
+  material:
+    type: black
+    tier: low
+  equipment:
+    slot: body
+    weight: 9.979
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 41
+      slash: 40
+      crush: 30
+      magic: -6
+      ranged: 40
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Horvik's Armour Shop
+      location: Varrock
+      buy_price: 3840
+      sell_price: 1152
+      stock: 0
+    - shop_name: Zenesha's Plate Mail Shop
+      location: East Ardougne
+      buy_price: 3840
+      sell_price: 1152
+      stock: 0
   related_items:
-    - slug: mithril-platebody
-    - slug: black-full-helm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1123
+      item_name: Steel platebody
+      slug: steel-platebody
+      relationship: downgrade
+      description: Lower-tier same defence requirement (Steel)
+    - item_id: 1121
+      item_name: Mithril platebody
+      slug: mithril-platebody
+      relationship: upgrade
+      description: Higher-tier (requires 20 Defence)
+    - item_id: 1165
+      item_name: Black full helm
+      slug: black-full-helm
+      relationship: set-piece
+      description: Matching helm
+    - item_id: 1075
+      item_name: Black platelegs
+      slug: black-platelegs
+      relationship: set-piece
+      description: Matching legs
+    - item_id: 1199
+      item_name: Black kiteshield
+      slug: black-kiteshield
+      relationship: set-piece
+      description: Matching shield
+  history:
+    - date: "2001-01-04"
+      update: Runescape beta is now online!
+      description: Black platebody available since the original RuneScape beta launch.
+  about: Black platebody is an F2P body slot armour requiring 10 Defence, matching white platebody stats minus the prayer bonus.
+  market_strategy:
+    notes:
+      - Cannot be smithed; supply comes from drops and shop restocks
+      - Stable F2P GE staple under 2 Defence equipment
+      - Below alch value, often used for high alching profit
+  trading_tips:
+    - Buy bulk near GE low and high alch for steady margin
+    - Stock dips after F2P PvP events
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-sq-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-sq-shield.mdx
@@ -12,25 +12,89 @@ osrs:
   lowalch: 460
   highalch: 691
   limit: 125
-  item_id: 1179
-  item_type: armor
-  slot: shield
-  type: square_shield
-  tradeable: true
-  weight: 3.628
-  requirements:
-    defence: 10
-  stats:
-    stab_defence: 15
-    slash_defence: 16
-    crush_defence: 14
-    magic_defence: 0
-    ranged_defence: 15
+  material:
+    type: black
+    tier: low
+  equipment:
+    slot: shield
+    weight: 3.628
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 15
+      slash: 16
+      crush: 14
+      magic: 0
+      ranged: 15
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Moss giant
+        combat_level: 42
+        quantity: "1"
+        rarity: 5/128
+        members_only: false
+      - source: Bryophyta
+        combat_level: 128
+        quantity: "1"
+        rarity: 5/128
+        members_only: false
   related_items:
-    - slug: mithril-sq-shield
-    - slug: black-kiteshield
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1191
+      item_name: Mithril sq shield
+      slug: mithril-sq-shield
+      relationship: upgrade
+      description: Higher-tier square shield, requires 20 Defence
+    - item_id: 1195
+      item_name: Adamant sq shield
+      slug: adamant-sq-shield
+      relationship: upgrade
+      description: Stronger metal-tier square shield
+    - item_id: 1191
+      item_name: Black kiteshield
+      slug: black-kiteshield
+      relationship: alternative
+      description: Larger black kiteshield with better defensive stats
+  market_strategy:
+    notes:
+      - Niche shield, mostly alched or used by ironman early game
+      - Supply driven by Moss giant + Bryophyta drops
+      - F2P availability keeps a baseline demand floor
+  history:
+    - date: "2001-12-08"
+      description: Released as part of the original black equipment set.
+    - date: "2004-11-01"
+      description: Received a graphical update between October and November 2004.
+    - date: "2021-04-21"
+      description: Ranged attack bonus increased from -2 to 0 as part of stat normalization.
+  about: Black sq shield is a free-to-play medium square shield requiring 10 Defence; cannot be smithed and drops from Moss giants and Bryophyta.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-12-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-warlock-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-warlock-mix-1.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: null
-  about: "Black warlock mix (1) is a members-only item in Old School RuneScape. High alchemy value: 42 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - description: Boosts Strength by floor(level * 15 / 100) + 4 for a temporary buff.
+      - description: In multicombat areas, up to three nearby players with Accept Aid enabled receive the same boost.
+  recipes:
+    - skill: Hunter
+      members: true
+      materials:
+        - item_name: Black warlock
+          quantity: 1
+        - item_name: Raw hunter meat
+          quantity: 1
+      products:
+        - item_name: Black warlock mix (2)
+          quantity: 1
+      notes: Crafted with a pestle and mortar; takes 3 ticks
+  related_items:
+    - item_id: 29205
+      item_name: Black warlock mix (2)
+      slug: black-warlock-mix-2
+      relationship: variant
+      description: 2-dose version produced by the recipe
+    - item_id: 29203
+      item_name: Black warlock
+      slug: black-warlock
+      relationship: component
+      description: Hunter butterfly base ingredient
+  about: Black warlock mix is a Varlamore hunter butterfly mix that grants a Strength boost and shares the buff with nearby allies in multicombat zones.
+  market_strategy:
+    notes:
+      - Supply tied to Varlamore hunter activity
+      - Strength buff scales with player level
+      - Shareable buff drives party demand
+      - No GE buy limit listed
+  trading_tips:
+    - Stock during Hunter XP events
+    - Watch PvM trip metas that favor shared boosts
+  history:
+    - date: "2024-04-03"
+      description: Group Ironmen corrected to properly share hunter mixes and butterflies with their group.
+    - date: "2024-03-20"
+      update: "Varlamore: Part One"
+      description: Black warlock mix introduced alongside Varlamore hunter content.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-warlock-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-warlock-mix-2.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: null
-  about: "Black warlock mix (2) is a members-only item in Old School RuneScape. High alchemy value: 42 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: Boosts Strength by floor(Strength level × 15 / 100) + 4 — for example +18 at 99 Strength.
+      - description: In multicombat areas, up to three nearby players with Accept Aid on receive the same boost.
+    duration: Single boost per dose.
+  recipes:
+    - product: Black warlock mix (2)
+      skill: Hunter
+      materials:
+        - item_name: Black warlock
+          quantity: 1
+        - item_name: Raw barb-tailed kebbit
+          quantity: 1
+        - item_name: Pestle and mortar
+          quantity: 1
+          tool: true
+      notes: 3-tick craft. Cheapest meat is raw barb-tailed kebbit; recipe currently loses roughly 360 coins per mix.
+  related_items:
+    - item_name: Black warlock
+      slug: black-warlock
+      relationship: component
+      description: Butterfly ingredient
+    - item_name: Raw barb-tailed kebbit
+      slug: raw-barb-tailed-kebbit
+      relationship: component
+      description: Cheapest raw meat used in the mix
+  market_strategy:
+    notes:
+      - Demand follows multicombat group boss meta
+      - Loss-per-mix means players sink supply rather than print
+      - No buy limit — speculative bulk possible
+      - Group iron shareability widens audience
+  history:
+    - date: "2024-03-20"
+      update: Varlamore — Part One
+      description: Black warlock mix released alongside hunter mixes in Varlamore.
+    - date: "2024-04-03"
+      update: Group Ironman sharing
+      description: Group Ironmen can now correctly share hunter mixes and butterflies with their group.
+  about: Black warlock mix (2) is a 2-dose hunter mix that boosts Strength and can share the buff with three nearby allies in multicombat areas.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore — Part One
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-blue-shell-round.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-blue-shell-round.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 13000
-  about: "Blamish blue shell (round) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Bruise blamish snail
+        combat_level: 20
+        quantity: "1"
+        rarity: Always
+        members_only: true
+  recipes:
+    - skill: crafting
+      level: 15
+      xp: 32.5
+      materials:
+        - item_name: Blamish blue shell (round)
+          item_id: 3351
+          quantity: 1
+        - item_name: Chisel
+          quantity: 1
+      product: Bruise blue snelm (round)
+      product_quantity: 1
+  related_items:
+    - item_id: 3349
+      item_name: Blamish blue shell (pointed)
+      slug: blamish-blue-shell-pointed
+      relationship: variant
+      description: Pointed variant used for pointed snelm
+  market_strategy:
+    notes:
+      - Crafted into round bruise blue snelm at level 15 Crafting
+      - Snelms offer minor melee defence for low-level players
+      - Supply gated by bruise blamish snail drops in Mort Myre
+      - Niche cosmetic and Crafting XP item
+  history:
+    - date: "2004-10-14"
+      description: Released as part of the Morytania Expansion update.
+  about: Blamish blue shell (round) is obtained from bruise blamish snails in Mort Myre and crafted with a chisel into a bruise blue snelm (round) at 15 Crafting for 32.5 XP.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-14"
+    update: Morytania Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-essence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-essence.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 500
-  about: "Blood essence is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Nex
+        combat_level: 1001
+        quantity: "1-2"
+        rarity: 1/82
+        members_only: true
+      - source: Spiritual mage (Zaros)
+        combat_level: 182
+        quantity: "1"
+        rarity: 1/128
+        members_only: true
+      - source: Blood reaver
+        combat_level: 174
+        quantity: "1"
+        rarity: 1/128
+        members_only: true
+      - source: Intricate pouch
+        quantity: "1"
+        rarity: 1/200
+        members_only: true
+      - source: Tombs of Amascut
+        combat_level: 0
+        quantity: "1-6"
+        rarity: 3 x 1/27
+        members_only: true
+  related_items:
+    - item_id: 565
+      item_name: Blood rune
+      slug: blood-rune
+      relationship: product
+      description: 50% chance for extra rune while active
+    - item_id: 7936
+      item_name: Pure essence
+      slug: pure-essence
+      relationship: component
+      description: Crafted into blood runes with bonus active
+  market_strategy:
+    notes:
+      - Untradeable once activated
+      - 1,000 bonus runes per activation
+      - Active version is not alchable
+      - Demand tracks blood rune profit
+      - Nex drop pipes most supply
+  history:
+    - date: "2022-01-05"
+      update: "Nex: The Fifth General"
+      description: Released alongside Nex with the Ancient Prison expansion.
+    - date: "2022-01-12"
+      description: Base value halved from 200,000 to 100,000 coins; active version became non-alchemizable.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-01-05"
+    update: "Nex: The Fifth General"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Activate
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  about: Blood essence is a consumable item that grants a 50% chance to craft an extra blood rune for up to 1,000 bonus runes per activation.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-n-tar-snelm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-n-tar-snelm.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Blood'n'tar snelm is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: -1
+    defence_bonus:
+      stab: 7
+      slash: 8
+      crush: 6
+      magic: -1
+      ranged: 7
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Crafting
+      level: 15
+      xp: 32.5
+      output: Blood'n'tar snelm
+      materials:
+        - item_name: Blamish red shell (round)
+          quantity: 1
+        - item_name: Chisel
+          quantity: 1
+  related_items:
+    - item_id: 3327
+      item_name: Myre snelm
+      slug: myre-snelm
+      relationship: variant
+      description: Black snelm variant
+    - item_id: 3331
+      item_name: Bruise blue snelm
+      slug: bruise-blue-snelm
+      relationship: variant
+      description: Blue snelm variant
+    - item_id: 3333
+      item_name: Ochre snelm
+      slug: ochre-snelm
+      relationship: variant
+      description: Yellow snelm variant
+  market_strategy:
+    notes:
+      - Crafted from blamish red shells
+      - Reduces blamish snail damage by 12
+      - Niche early Morytania gear
+      - Round and pointed counterparts exist
+  history:
+    - date: "2004-10-14"
+      update: "Morytania Expansion"
+      description: Released with the Morytania expansion alongside the snail family.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-14"
+    update: "Morytania Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  about: Blood'n'tar snelm is a Crafting-15 head slot helmet made from blamish red shells that reduces blamish snail damage by 12.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-wizard-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-wizard-robe.mdx
@@ -12,39 +12,99 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 125
+  material:
+    type: cloth
+    tier: low
   equipment:
     slot: body
-    type: magic robes
-    tradeable: true
     weight: 0.907
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 3
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 3
-      defence_ranged: 0
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  drop_table:
+    sources:
+      - source: Wizard
+        source_id: 0
+        combat_level: 9
+        quantity: "1"
+        rarity: uncommon
+        members_only: false
+      - source: Reward casket (beginner)
+        source_id: 0
+        combat_level: 0
+        quantity: "1"
+        rarity: varies
+        members_only: true
+      - source: Elaborate lockbox
+        source_id: 0
+        combat_level: 0
+        quantity: "1"
+        rarity: varies
+        members_only: true
+  treasure_trail:
+    tier: beginner
+    is_reward: true
+    reward_tiers:
+      - beginner
   related_items:
     - item_id: 579
       item_name: Blue wizard hat
       slug: blue-wizard-hat
-      relationship: alternative
-      description: Set piece
+      relationship: set-piece
+      description: Wizard set headpiece
     - item_id: 1011
       item_name: Blue wizard robe skirt
       slug: blue-wizard-robe-skirt
-      relationship: alternative
-      description: Set piece
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: set-piece
+      description: Wizard set legs
+  about: Blue wizard robe is a free-to-play body slot magic robe providing magic accuracy and defence.
+  market_strategy:
+    notes:
+      - Cheap F2P magic gear
+      - Common Wizard drop
+      - Beginner clue reward
+      - Set piece with hat and skirt
+      - Low GE buy limit
+  history:
+    - date: "2014-12-10"
+      description: The item was renamed from "Wizard robe" to "Blue wizard robe".
+    - date: "2005-06-13"
+      description: The item was renamed from "Wizards robe" to "Wizard robe".
+    - date: "2001-01-21"
+      description: Blue wizard robe released.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-21"
+    update: Newsletter 1
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bone-club.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bone-club.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 240
   highalch: 360
   limit: 4
-  about: "Bone club is a members-only item in Old School RuneScape. High alchemy value: 360 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: blunt
+    attack_speed: 6
+    weight: 0.907
+    attack_bonus:
+      stab: -4
+      slash: -4
+      crush: 16
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 15
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Cave goblin guard
+        combat_level: 26
+        quantity: "1"
+        rarity: 20/128
+        members_only: true
+      - source: Cave goblin
+        combat_level: 24
+        quantity: "1"
+        rarity: 20/128
+        members_only: true
+  shops:
+    - shop_name: Nardok's Bone Weapons
+      location: Dorgesh-Kaan
+      stock: 10
+      price: 600
+      restock_seconds: 12
+      requirements: Completion of The Lost Tribe
+  related_items:
+    - item_id: 1335
+      item_name: Steel warhammer
+      slug: steel-warhammer
+      relationship: alternative
+      description: Comparable crush bonus, no quest gate
+    - item_id: 5020
+      item_name: Bone spear
+      slug: bone-spear
+      relationship: variant
+      description: Dorgeshuun spear counterpart
+  market_strategy:
+    notes:
+      - Locked behind The Lost Tribe quest
+      - Tiny 4/4hr buy limit chokes supply
+      - Cave goblin drops feed casual flow
+      - F2P-style crush weapon for members
+  history:
+    - date: "2005-05-31"
+      update: "New Appointment in Lumbridge"
+      description: Released alongside The Lost Tribe quest.
+    - date: "2021-07-07"
+      description: Adjusted on-model position so female characters appear to hold it correctly.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-31"
+    update: "New Appointment in Lumbridge"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  about: Bone club is a Dorgeshuun crush weapon sold by Nardok in Dorgesh-Kaan after The Lost Tribe, offering steel-tier crush power with no level requirement.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-axe.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 40
-  about: "Bronze axe is a free-to-play item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: axe
+    attack_speed: 5
+    weight: 1.36
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 0
+      slash: 4
+      crush: 2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 5
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 1
+      xp: 12.5
+      materials:
+        - item_name: Bronze bar
+          quantity: 1
+      product: Bronze axe
+      product_quantity: 1
+      facility: Anvil
+  related_items:
+    - item_id: 1349
+      item_name: Iron axe
+      slug: iron-axe
+      relationship: upgrade
+      description: Next tier woodcutting axe.
+    - item_id: 2349
+      item_name: Bronze bar
+      slug: bronze-bar
+      relationship: component
+      description: Smithed into the axe.
+  market_strategy:
+    notes:
+      - Used by very low-level woodcutters at level 1 Woodcutting.
+      - Smithable for small profit; low volume due to free starter alternatives.
+      - GE limit of 40 caps any flipping strategy.
+  about: Bronze axe is a free-to-play one-handed axe usable from level 1 Attack and Woodcutting, smithable at level 1 Smithing from a single bronze bar.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2005-06-13"
+      description: Examine text corrected from "woodcutters axe" to "woodcutter's axe".
+    - date: "2014-09-01"
+      description: Random event ents removed; axes can no longer break from random events.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-bolts-p-6061.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-bolts-p-6061.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Bronze bolts (p+) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: low
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Bronze bolts
+          item_id: 877
+          quantity: 5
+        - item_name: Weapon poison(+)
+          item_id: 5937
+          quantity: 1
+      description: Apply Weapon poison(+) to 5 bronze bolts to make 5 (p+) bolts
+  related_items:
+    - item_id: 877
+      item_name: Bronze bolts
+      slug: bronze-bolts
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 879
+      item_name: Bronze bolts (p)
+      slug: bronze-bolts-p
+      relationship: variant
+      description: Lower-tier poison variant
+    - item_id: 6062
+      item_name: Bronze bolts (p++)
+      slug: bronze-bolts-p
+      relationship: variant
+      description: Higher-tier poison variant
+  about: Bronze bolts (p+) are extra-strong poisoned bronze crossbow bolts created with Weapon poison(+).
+  market_strategy:
+    notes:
+      - Niche poisoned ammo
+      - Bronze tier rarely used
+      - Members-only via poison application
+      - Stackable ammunition
+  history:
+    - date: "2018-01-04"
+      description: Formatting updated for poison variants.
+    - date: "2006-07-31"
+      description: Graphics updated with crossbow release; renamed from "Bolts" to "Bronze bolts".
+    - date: "2001-01-04"
+      description: Bronze bolts released.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-sword.mdx
@@ -12,26 +12,75 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 125
-  item_id: 1277
-  item_type: equipment
-  slot: weapon
-  type: sword
-  attack_style: stab
-  attack_speed: 4
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 1
-  stats:
-    stab_attack: 4
-    slash_attack: 3
-    crush_attack: -2
-    strength: 5
+  equipment:
+    slot: weapon
+    weapon_type: stab-sword
+    attack_speed: 4
+    weight: 1.814
+    attack_bonus:
+      stab: 4
+      slash: 3
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 5
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 4
+      xp: 12.5
+      materials:
+        - item_name: Bronze bar
+          quantity: 1
+      product: Bronze sword
+      product_id: 1277
+      product_quantity: 1
+  shops:
+    - shop_name: Varrock Swordshop
+      location: Varrock
+      price: 26
+      stock: 5
   related_items:
-    - slug: iron-sword
-    - slug: bronze-scimitar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Iron sword
+      slug: iron-sword
+      relationship: upgrade
+      description: Next-tier sword
+    - item_name: Bronze scimitar
+      slug: bronze-scimitar
+      relationship: alternative
+      description: Same tier, slash weapon
+  history:
+    - date: "2001-01-04"
+      update: RuneScape beta is now online
+      description: Released with the original launch of RuneScape.
+  about: Bronze sword is a free-to-play stab sword smithable at level 4 Smithing from a single bronze bar, used by low-level Attack trainers and starter combatants.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape beta is now online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-of-sand.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-of-sand.mdx
@@ -12,16 +12,6 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  material:
-    type: crafting_ingredient
-    tier: basic
-  sources:
-    - name: Sandpits
-      method: Fill bucket
-    - name: Bert (daily)
-      method: 84 sand after Hand in the Sand quest
-    - name: Sandstone grinder
-      method: Mining sandstone
   recipes:
     - skill: crafting
       level: 1
@@ -42,42 +32,54 @@ osrs:
       item_name: Molten glass
       slug: molten-glass
       relationship: product
-      description: Product
+      description: Smelted product
     - item_id: 1781
       item_name: Soda ash
       slug: soda-ash
       relationship: component
-      description: Partner ingredient
+      description: Partner ingredient for molten glass
     - item_id: 21504
       item_name: Giant seaweed
       slug: giant-seaweed
       relationship: component
-      description: Superglass Make
+      description: Used with sand in Superglass Make
     - item_id: 6971
-      item_name: Sandstone
-      slug: sandstone
+      item_name: Sandstone (10kg)
+      slug: sandstone-10kg
       relationship: component
-      description: Grinder input
-  about: |-
-    | Product | Other Ingredient |
-    |---------|------------------|
-    | Molten glass | Soda ash |
-    | Superglass Make | Giant seaweed |
+      description: Grinder input that yields buckets of sand
   market_strategy:
     notes:
-      - Molten glass production
-      - Sandstone grinder efficient
-      - Bert daily delivery
-      - Molten glass production
-      - Crafting training
-      - Ironman glassblowing
-      - Superglass Make
-      - Bert gives 84 daily (quest)
-      - Sandstone grinder best method
-      - Yanille sandpit close to bank
-      - High volume demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Bert delivers 84 buckets daily after Hand in the Sand quest
+      - Sandstone grinder in Lovakengj produces high-volume supply
+      - Yanille and Zanaris sandpits closest to banks
+      - Demand driven by Crafting glassblowing and Superglass Make
+      - High-volume staple with consistent ironman use
+  history:
+    - date: "2006-03-28"
+      description: Inventory sprite rotated for clarity.
+    - date: "2006-03-22"
+      description: Graphically updated.
+    - date: "2005-08-09"
+      description: '"Empty" option added.'
+    - date: "2002-03-18"
+      description: Released to the game.
+  about: Bucket of sand is the core glass-making ingredient, combined with soda ash at a furnace for 20 Crafting XP to produce molten glass.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.5
+    options:
+      - Empty
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-hat.mdx
@@ -12,9 +12,94 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 150
-  about: "Chef's hat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.907
+    requirements:
+      cooking: 32
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Goblin
+        rarity: common
+      - source: Goblin guard
+        rarity: common
+      - source: Imp
+        rarity: common
+      - source: Pirate
+        rarity: common
+  shops:
+    - shop_name: Fancy Clothes Store
+      location: Varrock
+      price: 2
+      currency: Coins
+      members_only: false
+    - shop_name: Shayzien Styles
+      location: Shayzien
+      price: 2
+      currency: Coins
+      members_only: true
+  recipes:
+    - product: Chef's hat (from Construction)
+      skill: Construction
+      level: 67
+      materials:
+        - item_name: Teak shelves 2
+          quantity: 1
+      notes: Searched from Teak shelves 2 in player-owned houses.
+  related_items:
+    - item_name: Cooks' Guild
+      relationship: alternative
+      description: Required for entry alongside 32 Cooking
+  market_strategy:
+    notes:
+      - Cooks' Guild access keeps demand stable
+      - 150 buy limit supports light flipping
+      - Shop price of 2 coins anchors floor
+      - Frequent monster drop keeps the GE liquid
+  history:
+    - date: "2001-01-04"
+      update: RuneScape launch
+      description: Chef's hat present from the original RuneScape release.
+    - date: "2007-07-17"
+      update: Graphical update
+      description: Chef's hat received a graphical refresh.
+  about: Chef's hat is a free-to-play cosmetic head slot item required alongside 32 Cooking to enter the Cooks' Guild.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chocolate-bomb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chocolate-bomb.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Chocolate bomb is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heal: 15
+    bites: 1
+    notes: Heals 15 hitpoints in a single bite.
+  recipes:
+    - product: Chocolate bomb
+      skill: Cooking
+      level: 42
+      experience: 190
+      materials:
+        - item_name: Gianne dough
+          quantity: 1
+        - item_name: Gnomebowl mould
+          quantity: 1
+          tool: true
+        - item_name: Chocolate bar
+          quantity: 1
+        - item_name: Equa leaf
+          quantity: 1
+        - item_name: Pot of cream
+          quantity: 1
+        - item_name: Chocolate dust
+          quantity: 1
+      notes: Stops burning at level 38 Cooking.
+  shops:
+    - shop_name: Gnome waiters (Grand Tree)
+      location: Grand Tree
+      stock: 3
+      price: 160
+      restock_seconds: 60
+      currency: Coins
+      members_only: true
+  related_items:
+    - item_name: Gianne dough
+      slug: gianne-dough
+      relationship: component
+      description: Base dough for gnome cookery
+    - item_name: Chocolate bar
+      slug: chocolate-bar
+      relationship: component
+      description: Primary chocolate ingredient
+    - item_name: Half made bowl
+      slug: half-made-bowl
+      relationship: component
+      description: Intermediate baked bowl step
+  market_strategy:
+    notes:
+      - Western Provinces Diary keeps steady demand
+      - 6,000 buy limit makes bulk flips viable
+      - Gnome Restaurant minigame consumes supply
+      - 42 Cooking entry attracts skiller crafters
+  history:
+    - date: "2002-12-12"
+      update: Gnome Restaurant
+      description: Chocolate bomb released with the Gnome Restaurant minigame menu.
+  about: Chocolate bomb is a gnome cookery food healing 15 hitpoints, used for the Western Provinces Diary and Gnome Restaurant orders.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Gnome Restaurant
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-bloodied-blows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-bloodied-blows.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: null
   highalch: null
   limit: 50
-  about: "Contract of bloodied blows is a members-only item in Old School RuneScape. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Yama
+        combat_level: 1238
+        quantity: "1"
+        rarity: always
+        members_only: true
+      - source: Lesser demon
+        location: Chasm of Fire
+        quantity: "1"
+        rarity: 1/123
+        members_only: true
+      - source: Greater demon
+        location: Chasm of Fire
+        quantity: "1"
+        rarity: 1/81
+        members_only: true
+      - source: Black demon
+        location: Chasm of Fire
+        quantity: "1"
+        rarity: 1/53
+        members_only: true
+      - source: Dossier
+        quantity: "1"
+        rarity: 260/1740
+        members_only: true
+  related_items:
+    - item_name: Yama
+      slug: yama
+      relationship: alternative
+      description: Boss the contract is presented to
+    - item_name: Oathplate chest
+      slug: oathplate-chest
+      relationship: alternative
+      description: Notable Yama reward
+  market_strategy:
+    notes:
+      - Buy limit raised 5 to 50 in the 29 May 2025 rework
+      - Demand tracks Yama profitability and Oathplate prices
+      - Not alchable; rely on price flips only
+  history:
+    - date: "2025-05-29"
+      description: Yama health reduced from 4,125 to 3,000; buy limit increased from 5 to 50; phase transitions adjusted to 75% and 50%; prayer penetration reduced from 10% to 5%; splash immunity removed; demonbane weapons re-enabled.
+    - date: "2025-05-23"
+      description: Wretched Strength bug affecting void flares was corrected.
+    - date: "2025-05-22"
+      description: Contract terms were formally documented.
+  about: Contract of bloodied blows is a Yama-issued contract item used to access the boss, dropped by Chasm of Fire demons and from dossiers.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-05-14"
+    update: Yama the Master of Pacts
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Read
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooking-apple.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooking-apple.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Cooking apple is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: low
+  food:
+    cooking_level: 1
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Cooking apple
+          item_id: 1955
+          quantity: 1
+      description: Used as a base for apple mush, apple pie, raw summer pie
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle
+      stock: 1000
+      price: 1
+    - shop_name: Logava Gricoller's Cooking Supplies
+      location: Hosidius
+      stock: 20
+      price: 1
+    - shop_name: Frenita's Cookery Shop
+      location: Yanille
+      stock: 5
+      price: 1
+  drop_table:
+    sources:
+      - source: Sourhog
+        source_id: 0
+        combat_level: 28
+        quantity: "1"
+        rarity: common
+        members_only: false
+  farming:
+    farming_level: 27
+    notes: Harvested from apple trees
+  related_items:
+    - item_id: 2003
+      item_name: Apple pie
+      slug: apple-pie
+      relationship: product
+      description: Cooking product
+    - item_id: 5984
+      item_name: Cooking apples (basket)
+      slug: cooking-apples-basket
+      relationship: alternative
+      description: Stored in basket
+  about: Cooking apple is a free-to-play food ingredient used in apple pie, apple mush, and summer pie recipes.
+  market_strategy:
+    notes:
+      - Steady demand from cooks
+      - Used in Apple pie recipe
+      - Free-to-play accessible
+      - High GE buy limit
+      - Farmable at apple trees
+  history:
+    - date: "2001-03-17"
+      description: Cooking apple released.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-03-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.085
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dagannoth-hide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dagannoth-hide.mdx
@@ -12,9 +12,94 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 11000
-  about: "Dagannoth hide is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hide
+    tier: mid
+  drop_table:
+    sources:
+      - source: Dagannoth
+        combat_level: 90
+        quantity: "1"
+        rarity: 10/128
+        members_only: true
+        notes: Waterbirth Island dungeon.
+      - source: Dagannoth Rex
+        combat_level: 303
+        quantity: "1"
+        rarity: always
+        members_only: true
+      - source: Dagannoth Supreme
+        combat_level: 303
+        quantity: "1"
+        rarity: always
+        members_only: true
+      - source: Dagannoth Prime
+        combat_level: 303
+        quantity: "1"
+        rarity: always
+        members_only: true
+      - source: Ninja impling
+        combat_level: 28
+        quantity: "3 (noted)"
+        rarity: 1/19
+        members_only: true
+      - source: Ninja impling jar
+        quantity: "3 (noted)"
+        rarity: 1/19
+        members_only: true
+  recipes:
+    - skill: crafting
+      level: 47
+      xp: 84
+      materials:
+        - item_name: Dagannoth hide
+          quantity: 1
+      product: Spined helm
+      product_quantity: 1
+      facility: Fremennik tanner / crafting interface
+      notes: Requires The Fremennik Trials. Body uses 3 hides, legs use 2, helm uses 1.
+  related_items:
+    - item_id: 6151
+      item_name: Spined body
+      slug: spined-body
+      relationship: product
+      description: Crafted from 3 dagannoth hides.
+    - item_id: 6153
+      item_name: Spined chaps
+      slug: spined-chaps
+      relationship: product
+      description: Crafted from 2 dagannoth hides.
+    - item_id: 6157
+      item_name: Spined helm
+      slug: spined-helm
+      relationship: product
+      description: Crafted from 1 dagannoth hide.
+  market_strategy:
+    notes:
+      - Supply comes largely from Dagannoth Kings trips and Waterbirth Island.
+      - The Fremennik Trials is a hard requirement for any crafting use.
+      - Alternative use - exchange with Askeladden for cooked tuna (before quest) or lobster (after).
+  about: Dagannoth hide is a members-only crafting material dropped by dagannoths and the Dagannoth Kings, tanned and stitched into spined ranged armour after completing The Fremennik Trials.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-01"
+    update: "Waterbirth Island"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2005-08-01"
+      update: Waterbirth Island
+      description: Added to game with the Waterbirth Island update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-attack-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-attack-potion-2.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
-  about: "Divine super attack potion(2) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: Boosts Attack by 5 + 15% of the player's current Attack level for 5 minutes.
+      - description: Attack will not naturally drain below the boost amount during the effect duration.
+      - description: Drinking deals 10 Hitpoints damage; requires 11+ Hitpoints to consume.
+  recipes:
+    - skill: herblore
+      level: 70
+      xp: 1
+      materials:
+        - item_name: Super attack(2)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 2
+      product: Divine super attack potion(2)
+      product_id: 23703
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 23700
+      item_name: Divine super attack potion(4)
+      slug: divine-super-attack-potion-4
+      relationship: variant
+      description: 4-dose variant
+    - item_id: 23706
+      item_name: Divine super attack potion(1)
+      slug: divine-super-attack-potion-1
+      relationship: variant
+      description: 1-dose variant
+    - item_id: 2436
+      item_name: Super attack(4)
+      slug: super-attack-4
+      relationship: alternative
+      description: Standard super attack potion
+  history:
+    - date: "2020-07-02"
+      description: The inventory icon was graphically updated to match the look of normal potions.
+  about: Divine super attack potion(2) is a 2-dose Herblore potion that boosts Attack by 5 + 15% of the player's level for 5 minutes, at the cost of 10 Hitpoints per dose.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-07-25"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-full-helm.mdx
@@ -14,16 +14,19 @@ osrs:
   limit: 8
   equipment:
     slot: head
+    weight: 2
+    requirements:
+      defence: 60
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
-      magic: -3
-      ranged: -1
+      magic: -6
+      ranged: -3
     defence_bonus:
       stab: 45
       slash: 48
-      crush: 51
+      crush: 41
       magic: -1
       ranged: 46
     other_bonus:
@@ -31,51 +34,69 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 60
   drop_table:
-    primary_source: Mithril dragon
-    best_drop_rate: 1/32768
     sources:
       - source: Mithril dragon
         combat_level: 304
         quantity: "1"
-        rarity: very rare
-        drop_rate: 1/32768
+        rarity: 1/32768
+        members_only: true
+      - source: Chewed bones
+        quantity: "1"
+        rarity: 1/256
         members_only: true
   related_items:
     - item_id: 1149
       item_name: Dragon med helm
       slug: dragon-med-helm
       relationship: downgrade
-      description: Common dragon helm
+      description: Common dragon helm without rarity premium
     - item_id: 10828
       item_name: Helm of neitiznot
       slug: helm-of-neitiznot
       relationship: alternative
-      description: Better stats with Strength/Prayer bonus
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +45 |
-    | Slash | +48 |
-    | Crush | +51 |
-    | Magic | -1 |
-    | Ranged | +46 |
-
-    Requirements: 60 Defence
-
-    Primarily a fashionscape and collection item:
-    - High Defence stats but no offensive bonuses
-    - Helm of neitiznot is preferred for melee
-    - Status symbol due to extreme rarity
+      description: Cheap alternative with Strength and Prayer bonuses
+    - item_id: 22234
+      item_name: Chewed bones
+      slug: chewed-bones
+      relationship: component
+      description: Mithril dragon drop that converts into the helm
   market_strategy:
     notes:
-      - Extremely rare (1/32,768)
+      - Extremely rare (1/32,768 direct)
       - Price driven by rarity, not utility
-      - Collector's item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Collector status symbol
+      - Chewed bones add 1/8,192 effective rate
+  history:
+    - date: "2007-07-03"
+      update: "Barbarian Training"
+      description: Released as a rare drop from mithril dragons.
+    - date: "2017-07-13"
+      description: Removed from the brutal black dragon drop table.
+    - date: "2018-01-25"
+      description: Spike recolouring from grey to white.
+    - date: "2021-04-21"
+      description: Ranged attack bonus reduced from -2 to -3.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: "Barbarian Training"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  about: Dragon full helm is an extremely rare 1/32,768 mithril dragon drop worn at 60 Defence, prized for status rather than offensive utility.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-gloves.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: null
-  about: "Elven gloves is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: hands
+    weight: 4.535
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Lliann's Wares
+      location: Prifddinas
+      price: 10000
+  related_items:
+    - item_id: 24000
+      item_name: Elven shirt
+      slug: elven-shirt
+      relationship: set-piece
+      description: Matching elven outfit body.
+    - item_id: 24003
+      item_name: Elven legwear
+      slug: elven-legwear
+      relationship: set-piece
+      description: Matching elven outfit legs.
+    - item_id: 24009
+      item_name: Elven boots
+      slug: elven-boots
+      relationship: set-piece
+      description: Matching elven outfit boots.
+  market_strategy:
+    notes:
+      - Cosmetic-only piece; demand is fashionscape-driven.
+      - Supply gated by Prifddinas access (Song of the Elves required to reach the shop).
+      - Notably the heaviest glove slot item in the game at 4.535 kg.
+  about: Elven gloves are members-only cosmetic hand slot armour purchased from Lliann's Wares in Prifddinas after Song of the Elves, with no combat bonuses and the highest weight of any glove in the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-07-25"
+    update: "Song of the Elves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.535
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2019-07-25"
+      update: Song of the Elves
+      description: Added to game with the Song of the Elves quest and Prifddinas city release.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-dragon-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-dragon-bolts-e.mdx
@@ -14,58 +14,84 @@ osrs:
   limit: 11000
   equipment:
     slot: ammo
+    weight: 0
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: 0
       ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      melee_strength: 0
       ranged_strength: 122
+      magic_damage: 0
       prayer: 0
-    requirements: {}
+  special_attack:
+    name: Magical Poison
+    activation_chance: 55%
+    description: 55% chance (54% vs players) to inflict poison starting at 5 damage; +10% activation with Hard Kandarin Diary.
   recipes:
     - skill: magic
       level: 27
       xp: 37
-      inputs:
-        - item_name: Emerald dragon bolts
+      materials:
+        - item_name: Dragon bolts
           quantity: 10
-      output_quantity: 10
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Nature rune
+          quantity: 1
+        - item_name: Air rune
+          quantity: 3
+      product: Emerald dragon bolts (e)
+      product_id: 21942
+      product_quantity: 10
   related_items:
     - item_id: 9241
       item_name: Emerald bolts (e)
       slug: emerald-bolts-e
       relationship: downgrade
-      description: Regular crossbow version
-  about: |-
-    > *"Enchanted Dragon crossbow bolts, tipped with emerald."*
-
-    Emerald dragon bolts (e) carry the Magical Poison enchantment. On a successful hit, there is a 55% chance (54% against players) to inflict poison starting at 5 damage. When triggered, a green gas effect appears below the target. This is one of the highest activation rates among bolt enchantments, making it an extremely reliable way to apply poison without using a poisoned weapon.
-
-    Enchant Crossbow Bolt (Emerald) requires Magic level 27 and grants 37 XP per cast. Each cast enchants 10 bolts at a time.
-
-    | Component | Quantity |
-    |-----------|----------|
-    | Emerald dragon bolts | 10 |
-    | Cosmic rune | 1 |
-    | Nature rune | 1 |
-    | Air rune | 3 |
-
-    | Stat | Dragon (e) | Regular (e) |
-    |------|-----------|-------------|
-    | Ranged Str | +122 | +46 |
-    | Base bolt | Dragon crossbow bolt | Mithril bolt |
-
-    The dragon bolt base provides significantly higher ranged strength while retaining the same high-probability poison enchantment.
+      description: Mithril-based version with +46 ranged strength
+    - item_id: 21932
+      item_name: Dragon bolts
+      slug: dragon-bolts
+      relationship: component
+      description: Unenchanted base bolt
   market_strategy:
     notes:
-      - Highest activation rate of any bolt enchantment (55%)
-      - Poison starts at 5 damage, ticking down over time
+      - Highest activation rate of any bolt enchantment at 55%
+      - Poison starts at 5 damage and ticks down over time
       - Excellent for bosses susceptible to poison
-      - Very cost-effective for sustained PvM
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cost-effective for sustained PvM with dragon crossbows
+      - Demand driven by dragon hunter crossbow and Zaryte crossbow users
+  history:
+    - date: "2018-01-04"
+      description: Released as part of the Dragon Slayer II update.
+  about: Emerald dragon bolts (e) are dragon crossbow bolts enchanted with Magical Poison, granting a 55% chance to inflict poison on hit and +122 ranged strength.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-anti-venom-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-anti-venom-1.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: 2000
-  about: "Extended anti-venom+(1) is a members-only item in Old School RuneScape. High alchemy value: 66 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: high
+  potion:
+    doses: 1
+    effects:
+      - description: Cures venom and poison instantly.
+      - description: Grants poison immunity for approximately 17.7 minutes per dose.
+      - description: Grants venom immunity for approximately 6.3 minutes per dose.
+  recipes:
+    - skill: herblore
+      level: 94
+      xp: 20
+      materials:
+        - item_name: Anti-venom+(1)
+          item_id: 0
+          quantity: 1
+        - item_name: Araxyte venom sack
+          item_id: 0
+          quantity: 1
+      description: Made by adding Araxyte venom sack to Anti-venom+(1)
+  related_items:
+    - item_id: 0
+      item_name: Extended anti-venom+(2)
+      slug: extended-anti-venom-2
+      relationship: variant
+      description: 2-dose variant
+    - item_id: 0
+      item_name: Extended anti-venom+(3)
+      slug: extended-anti-venom-3
+      relationship: variant
+      description: 3-dose variant
+    - item_id: 0
+      item_name: Extended anti-venom+(4)
+      slug: extended-anti-venom-4
+      relationship: variant
+      description: 4-dose variant
+  about: Extended anti-venom+ is the strongest venom potion in OSRS, granting long poison and venom immunity.
+  market_strategy:
+    notes:
+      - Strongest venom protection
+      - Required for Araxxor and high-tier PvM
+      - High Herblore level (94)
+      - Recoloured for distinctiveness
+      - 6.3 minutes venom immunity per dose
+  history:
+    - date: "2024-09-04"
+      description: Extended anti-venom+ now takes precedence when curing poison/venom. Potions were recoloured for distinctiveness from regular anti-venom+.
+    - date: "2024-08-28"
+      description: Extended anti-venom+(1) released with Araxxor.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-08-28"
+    update: Araxxor
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/flax.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/flax.mdx
@@ -14,10 +14,10 @@ osrs:
   limit: 13000
   material:
     type: plant
-    tier: basic
+    tier: low
   recipes:
     - skill: crafting
-      level: 1
+      level: 10
       xp: 15
       materials:
         - item_name: Flax
@@ -27,43 +27,98 @@ osrs:
       product_id: 1777
       product_quantity: 1
       facility: Spinning wheel
+    - skill: magic
+      level: 76
+      xp: 75
+      materials:
+        - item_name: Flax
+          item_id: 1779
+          quantity: 5
+        - item_name: Nature rune
+          quantity: 2
+        - item_name: Astral rune
+          quantity: 1
+        - item_name: Air rune
+          quantity: 5
+      product: Bow string
+      product_id: 1777
+      product_quantity: 5
+      facility: Lunar spell (Spin Flax)
+      notes: Requires 61 Crafting and Lunar spellbook.
+  shops:
+    - shop_name: Dom Onion's Reward Shop
+      location: Yanille
+      price: 75
+    - shop_name: Durrik's Goods
+      location: Deepfin Mine
+      price: 12
+      stock: 10
+      restock_minutes: 1
+  drop_table:
+    sources:
+      - source: Kurask
+        rarity: uncommon
+        members_only: true
+      - source: King kurask
+        rarity: uncommon
+        members_only: true
+      - source: Zulrah
+        rarity: rare
+        members_only: true
+      - source: Baby impling
+        rarity: common
+        members_only: true
   related_items:
     - item_id: 1777
       item_name: Bow string
       slug: bow-string
       relationship: product
-      description: Spun product
+      description: Spun product from flax.
     - item_id: 66
       item_name: Yew longbow (u)
       slug: yew-longbow-u
-      relationship: product
-      description: Uses bow string
+      relationship: alternative
+      description: Strung with bow string into a finished yew longbow.
     - item_id: 64
       item_name: Magic longbow (u)
       slug: magic-longbow-u
-      relationship: product
-      description: Uses bow string
+      relationship: alternative
+      description: Strung with bow string into a finished magic longbow.
     - item_id: 9438
       item_name: Crossbow string
       slug: crossbow-string
       relationship: alternative
-      description: Alternative product (from sinew/roots)
+      description: Alternative bowstring crafted from sinew or roots.
   market_strategy:
     profit_formulas:
-      - Bow string price - Flax price = Profit
+      - Bow string price - Flax price = Crafting profit per spin
     notes:
-      - Buy Flax → Spin → Sell Bow string
-      - "Calculate:"
-      - Classic low-level money maker
-      - Lumbridge Castle (closest to bank with agility shortcut)
-      - Seers' Village (close to flax field)
-      - Crafting Guild (requires 40 Crafting)
-      - Very consistent margins
-      - Good for low-level accounts
-      - High volume item
-      - Flax can be picked for free near Seers' Village
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Classic low-level money maker; buy flax, spin into bow string at level 10 Crafting.
+      - Best banks - Lumbridge Castle (agility shortcut), Seers' Village (close to free flax field), Crafting Guild (40 Crafting).
+      - Lunar Spin Flax at 76 Magic processes 5 flax per cast.
+      - High volume item with consistent margins; supplemented by free Seers' Village picking.
+  about: Flax is a members-only crafting material picked from flax plants across Gielinor or bought from shops, spun into bow string for fletching at level 10 Crafting or via the Lunar Spin Flax spell at 76 Magic.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-25"
+    update: "Spinning wheel content"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2002-03-25"
+      description: Added to game with the introduction of spinning wheels and bow strings.
+    - date: "2026-05-27"
+      description: Updated alongside contemporary OSRS content patches.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-green-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-green-cloak.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik green cloak is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Accoutrements
+      location: Rellekka
+      buy_price: 325
+      sell_price: 175
+      stock: 5
+  related_items:
+    - item_id: 3766
+      item_name: Fremennik blue cloak
+      slug: fremennik-blue-cloak
+      relationship: variant
+      description: Blue colour variant
+    - item_id: 3767
+      item_name: Fremennik grey cloak
+      slug: fremennik-grey-cloak
+      relationship: variant
+      description: Grey colour variant
+    - item_id: 3768
+      item_name: Fremennik yellow cloak
+      slug: fremennik-yellow-cloak
+      relationship: variant
+      description: Yellow colour variant
+  history:
+    - date: "2004-11-02"
+      update: The Fremennik Trials
+      description: Item released alongside The Fremennik Trials quest.
+    - date: "2014-12-10"
+      description: Item renamed from "Fremennik cloak" to "Fremennik green cloak".
+  about: Fremennik green cloak is a members-only cape obtained from Yrsa's Accoutrements in Rellekka after completing The Fremennik Trials quest.
+  market_strategy:
+    notes:
+      - Cheap from Yrsa's Accoutrements for those who finished The Fremennik Trials
+      - Low daily GE limit of 150 keeps flips small
+      - Cosmetic cape with minor defence bonuses
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-11-02"
+    update: The Fremennik Trials
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-pickaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-pickaxe.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 4
-  about: "Gilded pickaxe is a free-to-play item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: pickaxe
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 41
+      mining: 41
+    attack_bonus:
+      stab: 26
+      slash: -2
+      crush: 24
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 29
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    is_reward: true
+    tier: master
+    reward_tiers:
+      - elite
+      - master
+    rarity: 1/13616
+  related_items:
+    - item_id: 1275
+      item_name: Rune pickaxe
+      slug: rune-pickaxe
+      relationship: variant
+      description: Functional equivalent with identical stats and mining rate
+    - item_id: 13243
+      item_name: Dragon pickaxe
+      slug: dragon-pickaxe
+      relationship: upgrade
+      description: Higher-tier pickaxe with special attack
+  market_strategy:
+    notes:
+      - Elite (1/14,663) and master (1/13,616) clue reward
+      - Mines at rune pickaxe rate, purely cosmetic upgrade
+      - Buy limit of 4 amplifies price swings
+      - Storable in costume room treasure chest
+      - Demand driven by completionists and clue grinders
+  history:
+    - date: "2019-04-11"
+      description: Released as part of the Treasure Trails Expansion and Easter 2019 update.
+  about: Gilded pickaxe is an elite and master clue reward cosmetic variant of the rune pickaxe sharing identical mining speed and combat stats.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-necklace.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 180
   highalch: 270
   limit: 18000
-  about: "Gold necklace is a free-to-play item in Old School RuneScape. High alchemy value: 270 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: neck
+    weight: 0.007
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - product: Gold necklace
+      skill: Crafting
+      level: 6
+      xp: 20
+      materials:
+        - item_name: Gold bar
+          quantity: 1
+        - item_name: Necklace mould
+          quantity: 1
+      facility: Furnace
+      notes: Use gold bar on a furnace while carrying a necklace mould.
+  related_items:
+    - item_id: 2355
+      item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: Smelted bar used to craft the necklace
+    - item_id: 1692
+      item_name: Sapphire necklace
+      slug: sapphire-necklace
+      relationship: upgrade
+      description: First gem-tier neck piece, enchantable to games necklace
+    - item_id: 1727
+      item_name: Gold amulet
+      slug: gold-amulet-u
+      relationship: alternative
+      description: Alternative gold jewellery slot
+  market_strategy:
+    notes:
+      - Low-level Crafting training staple
+      - Cannot be enchanted, value capped by alch
+      - High alch profit vs gold bar cost varies with bar price
+  history:
+    - date: "2001-05-08"
+      description: Released with the initial jewellery system.
+    - date: "2007-04-30"
+      update: 24 Carat Update
+      description: Received a graphical update as part of the 24 Carat Update.
+  about: Gold necklace is a free-to-play neck-slot jewellery item crafted from a single gold bar at level 6 Crafting; provides no combat bonuses and cannot be enchanted.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-05-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/granite-maul.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/granite-maul.mdx
@@ -14,88 +14,102 @@ osrs:
   limit: 70
   equipment:
     slot: 2h
-    type: maul
-    attack_style: melee
+    weapon_type: blunt
     attack_speed: 7
+    weight: 4.535
     requirements:
       attack: 50
       strength: 50
-    stats:
-      attack_crush: 81
-      strength: 79
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 81
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 79
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   special_attack:
     name: Quick Smash
     energy: 60
-    energy_ornate: 50
-    effect: Instant attack, resets attack timer
+    description: Performs an instant attack that resets the attack timer; with the ornate handle the cost drops to 50% and multiple specs can stack in one tick.
   drop_table:
     sources:
       - source: Gargoyle
-        source_id: 412
         combat_level: 111
         quantity: "1"
         rarity: 1/256
         members_only: true
       - source: Marble gargoyle
-        source_id: 7407
-        combat_level: 186
+        combat_level: 349
         quantity: "1"
         rarity: 1/256
         members_only: true
       - source: Grotesque Guardians
-        source_id: 7850
         combat_level: 328
         quantity: "1"
-        rarity: 1/256
+        rarity: 1/250
         members_only: true
   related_items:
     - item_id: 12848
       item_name: Granite maul (or)
       slug: granite-maul-or
       relationship: upgrade
-      description: With ornate handle
+      description: Ornate handle variant with 50% spec cost
     - item_id: 12849
       item_name: Granite clamp
       slug: granite-clamp
-      relationship: upgrade
-      description: Cosmetic upgrade
+      relationship: component
+      description: Cosmetic clamp attachment
     - item_id: 11802
       item_name: Armadyl godsword
       slug: armadyl-godsword
       relationship: alternative
-      description: Common combo weapon
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Crush | +81 |
-    | Strength | +79 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 50 Attack, 50 Strength
-
-    Quick Smash (50% with ornate handle, 60% without):
-    - Deals an instant attack
-    - Can stack multiple specs instantly
-    - Resets attack timer
-
-    With ornate handle, can hit 3 specs in one tick.
-
-    Essential for:
-    - PvP (combo specs)
-    - KO potential
-    - Stacking with other specs
-
-    Iconic PvP weapon for instant damage stacking.
+      description: Common spec combo partner
+  about: Granite maul is a two-handed crush weapon dropped by Gargoyles and the Grotesque Guardians, prized for its Quick Smash instant-attack special that enables PvP spec stacking.
   market_strategy:
     notes:
-      - Very cheap base weapon
-      - Ornate handle essential for PvP
-      - Stack with AGS/claws specs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cheap base for the iconic instant-spec setup
+      - Ornate handle adds the meaningful upgrade
+      - Stable Slayer-supply from gargoyle tasks
+      - PvP demand spikes around Wilderness events
+  trading_tips:
+    - Watch for PvP event announcements driving demand
+    - Stockpile during Slayer XP weekends
+  history:
+    - date: "2019-09-05"
+      description: Special attack energy cost raised to 60% for the base granite maul.
+    - date: "2005-02-15"
+      update: Ghosts Ahoy and Slayer Update
+      description: Granite maul released as a Gargoyle drop with the Slayer skill rework.
+    - date: "2005-01-26"
+      description: Item added to the game cache (unobtainable at the time).
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-15"
+    update: Ghosts Ahoy and Slayer Update
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 4.535
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-guam-leaf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-guam-leaf.mdx
@@ -12,18 +12,95 @@ osrs:
   lowalch: 5
   highalch: 7
   limit: 13000
+  material:
+    type: herb
+    tier: low
+  drop_table:
+    sources:
+      - source: Aberrant spectre
+        combat_level: 96
+        quantity: "1-3"
+        rarity: 1/6.6
+        members_only: true
+      - source: Banshee
+        combat_level: 23
+        quantity: "1"
+        rarity: 1/15.1
+        members_only: true
+      - source: Thug
+        combat_level: 10
+        quantity: "1"
+        rarity: 1/21.3
+        members_only: true
+      - source: Fire giant
+        combat_level: 86
+        quantity: "1"
+        rarity: 1/26.9
+        members_only: true
+      - source: Green dragon
+        combat_level: 79
+        quantity: "1"
+        rarity: 1/34.1
+        members_only: true
+  farming:
+    farming_level: 9
+    seed: Guam seed
+    seed_id: 5291
+    patch: Herb patch
+  recipes:
+    - skill: herblore
+      level: 3
+      xp: 2.5
+      materials:
+        - item_name: Grimy guam leaf
+          item_id: 199
+          quantity: 1
+      product: Guam leaf
+      product_id: 249
+      product_quantity: 1
   related_items:
     - item_id: 249
       item_name: Guam leaf
       slug: guam-leaf
       relationship: product
       description: Cleaned version
-  about: |-
-    > _"It needs cleaning."_
-
-    Grimy guam leaf requires 3 Herblore to clean into a guam leaf (2.5 XP). Guam is the lowest-tier herb, used in attack potions and guam potions (unf).
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 5291
+      item_name: Guam seed
+      slug: guam-seed
+      relationship: component
+      description: Plant in herb patch to grow
+  market_strategy:
+    notes:
+      - Lowest-tier herb, cheap and abundant
+      - Used in attack potions (unf)
+      - Cleaning grants 2.5 Herblore XP at level 3
+      - Supply driven by low-level slayer tasks
+      - Farming guam seeds is profitable for ironmen
+  history:
+    - date: "2017-03-09"
+      description: Item's monetary value increased from 1 to 13 coins.
+    - date: "2015-02-26"
+      description: Visual update to differentiate from other grimy herbs; renamed to full name; became tradeable on Grand Exchange; interaction changed from identify to clean.
+    - date: "2013-02-25"
+      description: Renamed from "Grimy guam" to "Herb"; interaction changed from clean to identify.
+    - date: "2013-02-22"
+      description: Renamed from "Herb" to "Grimy guam"; interaction changed from identify to clean.
+  about: Grimy guam leaf requires 3 Herblore to clean into a guam leaf for 2.5 XP; guam is the lowest-tier herb used in attack potions.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-lantadyme.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-lantadyme.mdx
@@ -12,19 +12,50 @@ osrs:
   lowalch: 9
   highalch: 13
   limit: 11000
-  properties:
-    tradeable: true
-    tradeable_ge: true
-    weight: 0.007
+  material:
+    type: herb
+    tier: mid-high
   recipes:
     - skill: herblore
       level: 67
-      xp: 10.5
+      xp: 13.1
       materials:
         - item_name: Grimy lantadyme
           item_id: 2485
           quantity: 1
-      description: Cleaning grimy lantadyme
+      description: Clean to produce Lantadyme
+  drop_table:
+    sources:
+      - source: Banshee
+        source_id: 0
+        combat_level: 23
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Chaos druid
+        source_id: 0
+        combat_level: 13
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Aberrant spectre
+        source_id: 0
+        combat_level: 96
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Fire giant
+        source_id: 0
+        combat_level: 86
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Demonic gorilla
+        source_id: 0
+        combat_level: 275
+        quantity: "1"
+        rarity: common
+        members_only: true
   related_items:
     - item_id: 2481
       item_name: Lantadyme
@@ -41,22 +72,34 @@ osrs:
       slug: magic-potion-4
       relationship: product
       description: Secondary potion use
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Grimy Herb |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-    | Herblore Level | 67 (to clean) |
-
-    Clean to produce lantadyme for Herblore.
-
-    Lantadyme used for:
-    - Antifire
-    - Magic potion
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Grimy lantadyme is a herb requiring 67 Herblore to clean, used to make antifire and magic potions.
+  market_strategy:
+    notes:
+      - High Herblore XP per clean (13.1)
+      - Used for antifire potions
+      - Steady drops from common slayer tasks
+      - Demonic gorilla farms supply
+      - 11k GE buy limit
+  history:
+    - date: "2004-03-29"
+      description: Grimy lantadyme released with RS2 launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: "RS2 Launched!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bolts-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bolts-unf.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Iron bolts (unf) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: low
+  recipes:
+    - product: Iron bolts (unf)
+      skill: Smithing
+      level: 19
+      xp: 25
+      materials:
+        - item_name: Iron bar
+          quantity: 1
+      facility: Anvil
+      notes: Smith one iron bar at an anvil with a hammer to produce 10 unfinished iron bolts.
+    - product: Iron bolts
+      skill: Fletching
+      level: 39
+      xp: 1.5
+      materials:
+        - item_name: Iron bolts (unf)
+          quantity: 1
+        - item_name: Feather
+          quantity: 1
+      facility: Inventory
+      notes: Attach feathers to unfinished iron bolts to produce finished iron bolts; 1.5 Fletching XP per bolt.
+  related_items:
+    - item_id: 2351
+      item_name: Iron bar
+      slug: iron-bar
+      relationship: component
+      description: Smithing input that produces 10 unfinished bolts
+    - item_id: 9140
+      item_name: Iron bolts
+      slug: iron-bolts
+      relationship: product
+      description: Finished bolts after feather attachment
+    - item_id: 9375
+      item_name: Bronze bolts (unf)
+      slug: bronze-bolts-unf
+      relationship: downgrade
+      description: Lower-tier unfinished bolt
+    - item_id: 9378
+      item_name: Steel bolts (unf)
+      slug: steel-bolts-unf
+      relationship: upgrade
+      description: Higher-tier unfinished bolt
+  market_strategy:
+    notes:
+      - Margin driven by iron bar to feathered iron bolt arbitrage
+      - Consistent volume from Fletching trainers
+      - Members-only Smithing + Fletching crossover good
+  history:
+    - date: "2006-07-31"
+      update: Crossbows
+      description: Released as part of the Crossbows update introducing the bolt manufacturing chain.
+  about: Iron bolts (unf) are unfinished crossbow bolts smithed from iron bars; feathered at 39 Fletching to produce finished iron bolts.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-hasta-p-11389.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-hasta-p-11389.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron hasta(p+) | OSRS Price Data
-description: "Iron hasta(p+): A poison-tipped, one-handed iron hasta.. High alch: 54 GP, GE limit: 125."
+description: "Iron hasta(p+): A poison-tipped, one-handed iron hasta. High alch: 54 GP, GE limit: 125."
 osrs:
   id: 11389
   name: Iron hasta(p+)
@@ -12,9 +12,78 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 125
-  about: "Iron hasta(p+) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 8
+      slash: 8
+      crush: 8
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -2
+      slash: -2
+      crush: -2
+      magic: 0
+      ranged: -2
+    other_bonus:
+      melee_strength: 10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 11388
+      item_name: Iron hasta(p)
+      slug: iron-hasta-p-11388
+      relationship: downgrade
+      description: Standard poison tier
+    - item_id: 11390
+      item_name: Iron hasta(p++)
+      slug: iron-hasta-p-11390
+      relationship: upgrade
+      description: Stronger poison tier
+    - item_id: 11367
+      item_name: Iron hasta
+      slug: iron-hasta
+      relationship: variant
+      description: Unpoisoned version
+  market_strategy:
+    notes:
+      - Barbarian Training gated
+      - Niche poisoned spear option
+      - Low GE volume
+      - 4-tick speed since 2021
+  history:
+    - date: "2007-07-03"
+      update: Barbarian Training
+      description: Item released with Barbarian Training miniquest.
+    - date: "2021-04-21"
+      description: Attack speed improved from 5 ticks to 4 ticks.
+  about: Iron hasta(p+) is a one-handed iron hasta coated with poison+, made at a Barbarian anvil after completing Barbarian Training Smithing.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-scimitar.mdx
@@ -12,24 +12,95 @@ osrs:
   lowalch: 44
   highalch: 67
   limit: 125
-  item_id: 1323
-  item_type: equipment
-  slot: weapon
-  type: scimitar
-  attack_style: slash
-  attack_speed: 4
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 1
-  stats:
-    slash_attack: 10
-    strength: 9
+  equipment:
+    slot: weapon
+    weapon_type: slash-sword
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 2
+      slash: 10
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 9
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 20
+      xp: 50
+      materials:
+        - item_name: Iron bar
+          quantity: 2
+      product: Iron scimitar
+      product_quantity: 1
+      facility: Anvil
+  shops:
+    - shop_name: Zeke's Superior Scimitars
+      location: Al Kharid
+      price: 112
+    - shop_name: Daga's Scimitar Smithy
+      location: Ape Atoll
+      price: 112
+    - shop_name: Ranael's Super Skirt Store / Sophanem scimitar shop
+      location: Sophanem
+      price: 168
   related_items:
-    - slug: steel-scimitar
-    - slug: iron-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1321
+      item_name: Steel scimitar
+      slug: steel-scimitar
+      relationship: upgrade
+      description: Next tier scimitar.
+    - item_id: 1325
+      item_name: Bronze scimitar
+      slug: bronze-scimitar
+      relationship: downgrade
+      description: Lower tier scimitar.
+    - item_id: 2351
+      item_name: Iron bar
+      slug: iron-bar
+      relationship: component
+      description: Smithed (2 bars) into the scimitar at level 20 Smithing.
+  market_strategy:
+    notes:
+      - Cheap free-to-play training weapon for new accounts after the bronze scimitar tier.
+      - Shops offer steady supply at fixed prices, capping flip margins.
+      - Smithing it loses gp vs material cost; bought for use, not profit.
+  about: Iron scimitar is a free-to-play one-handed slash sword usable from level 1 Attack, smithed at level 20 Smithing from 2 iron bars and sold by scimitar shops across Gielinor.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2001-01-04"
+      description: Added to game at RuneScape launch.
+    - date: "2005-06-13"
+      description: Examine text punctuation updated.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-dreams.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-dreams.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Jar of dreams is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: The Nightmare
+        combat_level: 814
+        quantity: "1"
+        rarity: 1/2000
+        members_only: true
+      - source: Phosani's Nightmare
+        combat_level: 1024
+        quantity: "1"
+        rarity: 1/4000
+        members_only: true
+  related_items:
+    - item_id: 11139
+      item_name: Jar of darkness
+      slug: jar-of-darkness
+      relationship: variant
+      description: Skotizo boss jar counterpart
+    - item_id: 23956
+      item_name: Jar of decay
+      slug: jar-of-decay
+      relationship: variant
+      description: Vorkath boss jar counterpart
+    - item_id: 25524
+      item_name: Jar of souls
+      slug: jar-of-souls
+      relationship: variant
+      description: Cerberus boss jar counterpart
+  market_strategy:
+    notes:
+      - Rare Nightmare cosmetic drop
+      - Demand driven by collection log
+      - Achievement Gallery display piece
+      - Dream spell easter egg while held
+      - Low buy limit amplifies price swings
+  history:
+    - date: "2020-02-06"
+      update: "The Nightmare of Ashihama"
+      description: Released as a rare drop from The Nightmare boss.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-02-06"
+    update: "The Nightmare of Ashihama"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  about: Jar of dreams is a rare Nightmare drop used as an Achievement Gallery display piece and triggers an easter egg with the Dream lunar spell.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-spirits.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-spirits.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jar of spirits | OSRS Price Data
-description: "Jar of spirits: How does someone jar this?. High alch: 1 GP, GE limit: 4."
+description: "Jar of spirits: How does someone jar this? High alch: 1 GP, GE limit: 4."
 osrs:
   id: 25521
   name: Jar of spirits
@@ -12,9 +12,49 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Jar of spirits is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Phantom Muspah
+        combat_level: 881
+        quantity: "1"
+        rarity: 1/2500
+        members_only: true
+  related_items:
+    - item_id: 25522
+      item_name: Phantom Muspah (boss)
+      slug: phantom-muspah-boss
+      relationship: product
+      description: POH trophy made from this jar
+  market_strategy:
+    notes:
+      - Phantom Muspah rare drop
+      - Used for POH trophy
+      - 1/2500 rate from boss
+      - Collection log slot
+  history:
+    - date: "2023-01-25"
+      update: Phantom Muspah
+      description: Item released alongside the Phantom Muspah boss.
+    - date: "2024-09-25"
+      update: Varlamore
+      description: Inventory icon adjusted.
+  about: The Jar of spirits is a rare drop from the Phantom Muspah used with a mahogany plank to craft a boss trophy in the Achievement Gallery.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-01-25"
+    update: Phantom Muspah
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-leatherskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-leatherskirt.mdx
@@ -14,34 +14,33 @@ osrs:
   limit: 15
   equipment:
     slot: legs
-    type: barrows
-    set: Karil
-    tradeable: true
-    degradeable: true
-    weight: 4.5
+    weight: 5.443
     requirements:
       defence: 70
       ranged: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -10
-      attack_ranged: 17
-      defence_stab: 26
-      defence_slash: 20
-      defence_crush: 28
-      defence_magic: 35
-      defence_ranged: 33
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 17
+    defence_bonus:
+      stab: 26
+      slash: 20
+      crush: 28
+      magic: 35
+      ranged: 33
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  set_effect:
-    name: Tainted Shot
-    pieces_required: 4
-    description: 25% chance to lower opponent's Agility by 20%
-    amulet_of_damned: 25% chance to hit twice (second hit at 50% damage)
+  drop_table:
+    sources:
+      - source: Chest (Barrows)
+        quantity: "1"
+        rarity: 7/2448
+        members_only: true
   related_items:
     - item_id: 4732
       item_name: Karil's coif
@@ -62,31 +61,45 @@ osrs:
       item_name: Armadyl chainskirt
       slug: armadyl-chainskirt
       relationship: upgrade
-      description: Upgrade path
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Ranged attack | +17 |
-    | Stab defence | +26 |
-    | Slash defence | +20 |
-    | Crush defence | +28 |
-    | Magic defence | +35 |
-    | Ranged defence | +33 |
-    | Magic attack | -10 |
-
-    Note: Third highest magic defence for leg slot (+35).
-
-    Tainted Shot:
-    When wearing full Karil's (coif, leathertop, leatherskirt, crossbow):
-    - 25% chance to lower opponent's Agility by 20%
-
-    With Amulet of the Damned:
-    - 25% chance to hit twice (second hit at 50% damage)
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Higher-tier ranged leg slot upgrade
+  market_strategy:
+    notes:
+      - Third-highest magic defence in the leg slot at +35
+      - Degrades over 15 hours of combat; repair at Bob in Lumbridge or POH armour stand
+      - Tainted Shot set effect lowers opponent Agility 20% at 25% rate
+      - Amulet of the Damned grants 25% double-hit chance
+      - Supply tied to Barrows runs and Tombs of Amascut alts
+  history:
+    - date: "2015-04-16"
+      description: Added Check option to view durability.
+    - date: "2014-12-10"
+      description: Renamed from earlier Karil's skirt variants.
+    - date: "2005-05-17"
+      description: Name standardized to "Karil's leatherskirt".
+    - date: "2005-05-09"
+      description: Released as part of the Barrows update.
+  about: Karil's leatherskirt is the legs piece of the Karil the Tainted Barrows set, providing top-tier magic defence and a +17 ranged bonus at 70 Defence and Ranged.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Check
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lantadyme-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lantadyme-potion-unf.mdx
@@ -15,108 +15,116 @@ osrs:
   potion:
     doses: 0
     type: unfinished
-    base_herb: cadantine
-    uses_blood: true
+    base_herb: lantadyme
   recipes:
     - skill: herblore
-      level: 80
-      xp: 155
+      level: 69
+      xp: 0
       materials:
-        - item_name: Cadantine blood potion (unf)
-          item_id: 2483
+        - item_name: Lantadyme
+          item_id: 2481
           quantity: 1
-        - item_name: Wine of zamorak
-          item_id: 245
+        - item_name: Vial of water
+          item_id: 227
           quantity: 1
-      product: Bastion potion (3)
-      product_id: 22461
+      product: Lantadyme potion (unf)
+      product_id: 2483
       product_quantity: 1
       facility: None
       members_only: true
     - skill: herblore
-      level: 80
-      xp: 155
+      level: 69
+      xp: 84
       materials:
-        - item_name: Cadantine blood potion (unf)
+        - item_name: Lantadyme potion (unf)
+          item_id: 2483
+          quantity: 1
+        - item_name: Dragon scale dust
+          item_id: 241
+          quantity: 1
+      product: Antifire potion (3)
+      product_id: 2454
+      product_quantity: 1
+      facility: None
+      members_only: true
+    - skill: herblore
+      level: 76
+      xp: 172.5
+      materials:
+        - item_name: Lantadyme potion (unf)
           item_id: 2483
           quantity: 1
         - item_name: Potato cactus
           item_id: 3138
           quantity: 1
-      product: Battlemage potion (3)
-      product_id: 22449
+      product: Magic potion (3)
+      product_id: 3042
       product_quantity: 1
       facility: None
       members_only: true
   related_items:
-    - item_id: 265
-      item_name: Cadantine
-      slug: cadantine
+    - item_id: 2481
+      item_name: Lantadyme
+      slug: lantadyme
       relationship: component
-      description: Primary herb
-    - item_id: 22446
-      item_name: Vial of blood
-      slug: vial-of-blood
+      description: Primary herb mixed into the vial
+    - item_id: 227
+      item_name: Vial of water
+      slug: vial-of-water
       relationship: component
-      description: Blood component
-    - item_id: 245
-      item_name: Wine of zamorak
-      slug: wine-of-zamorak
+      description: Base container
+    - item_id: 241
+      item_name: Dragon scale dust
+      slug: dragon-scale-dust
       relationship: component
-      description: Bastion secondary
+      description: Secondary for antifire potion
     - item_id: 3138
       item_name: Potato cactus
       slug: potato-cactus
       relationship: component
-      description: Battlemage secondary
-    - item_id: 22461
-      item_name: Bastion potion (4)
-      slug: bastion-potion-4
+      description: Secondary for magic potion
+    - item_id: 2454
+      item_name: Antifire potion (3)
+      slug: antifire-potion-3
       relationship: product
-      description: Ranged/Defence boost
-    - item_id: 22449
-      item_name: Battlemage potion (4)
-      slug: battlemage-potion-4
+      description: Finished antifire potion
+    - item_id: 3042
+      item_name: Magic potion (3)
+      slug: magic-potion-3
       relationship: product
-      description: Magic/Defence boost
-  about: |-
-    Mix Cadantine + Vial of blood.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 80 |
-
-    Add secondary ingredient to create finished potions:
-
-    | Add | Creates | Level | XP |
-    |-----|---------|-------|-----|
-    | Wine of zamorak | Bastion potion (3) | 80 | 155 |
-    | Potato cactus | Battlemage potion (3) | 80 | 155 |
-
-    Boosts Ranged and Defence:
-    - Ranged: +4 to +13 (level dependent)
-    - Defence: +5 to +19 (level dependent)
-
-    Used for:
-    - Raids (CoX, ToB, ToA)
-    - Bossing with ranged
-    - Inferno attempts
-
-    Boosts Magic and Defence:
-    - Magic: +4
-    - Defence: +5 to +19 (level dependent)
-
-    Used for:
-    - Magic-based bossing
-    - Raids support role
-    - Ancient Magicks
+      description: Finished magic potion
+  history:
+    - date: "2004-03-29"
+      update: RS2 Launched!
+      description: Lantadyme potion (unf) released alongside the Herblore update.
+    - date: "2014-05-01"
+      description: Renamed from "Unfinished potion" to "Lantadyme potion (unf)".
+  about: Lantadyme potion (unf) is the unfinished base used to make antifire potion (69 Herblore) and magic potion (76 Herblore).
   market_strategy:
     notes:
-      - Blood vials from Theatre of Blood
-      - Often made for personal use rather than profit
-      - Check which finished potion is more profitable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Profitable bulk Herblore intermediate for antifire/magic potions
+      - Demand tied to lantadyme herb supply
+      - High volume from clean lantadyme + vial of water makers
+  trading_tips:
+    - Track antifire and magic potion margins to time bulk flips
+    - Buy clean lantadyme dips and mass-produce unfinished
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-ironwood-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-ironwood-hull-parts.mdx
@@ -5,16 +5,55 @@ osrs:
   id: 32077
   name: Large ironwood hull parts
   slug: large-ironwood-hull-parts
-  examine: Parts for creating an ironwood hull for a boat.
+  examine: Large parts for creating an ironwood hull for a boat.
   members: true
   icon: Large ironwood hull parts.png
   value: 62500
   lowalch: 25000
   highalch: 37500
   limit: 100
-  about: "Large ironwood hull parts is a members-only item in Old School RuneScape. High alchemy value: 37,500 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: construction
+      level: 77
+      xp: 2.5
+      materials:
+        - item_name: Ironwood hull parts
+          quantity: 5
+      product: Large ironwood hull parts
+      product_id: 32077
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_name: Ironwood hull parts
+      slug: ironwood-hull-parts
+      relationship: component
+      description: Smaller component required (5x) for combine
+  market_strategy:
+    notes:
+      - Crafted at Shipwrights' Workbench from 5 smaller ironwood hull parts
+      - Watch combine cost vs GE flip for profit
+      - New Sailing skill item, prices may swing on update cycles
+  history:
+    - date: "2025-11-19"
+      update: Hotfix
+      description: Halved the amount of Construction experience gained from shipwrights' workbenches.
+  about: Large ironwood hull parts is a Sailing-related component crafted at the Shipwrights' Workbench by combining 5 ironwood hull parts at level 77 Construction.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/limpwurt-root.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/limpwurt-root.mdx
@@ -1,6 +1,6 @@
 ---
 title: Limpwurt root | OSRS Price Data
-description: "Limpwurt root: The root of a limpwurt plant.. High alch: 4 GP, GE limit: 13,000."
+description: "Limpwurt root: The root of a limpwurt plant. High alch: 4 GP, GE limit: 13,000."
 osrs:
   id: 225
   name: Limpwurt root
@@ -16,7 +16,7 @@ osrs:
     type: secondary
     tier: mid
   farming:
-    level: 26
+    farming_level: 26
     seed_id: 5100
     seed_name: Limpwurt seed
   drop_table:
@@ -37,6 +37,11 @@ osrs:
         combat_level: 28
         quantity: "1"
         rarity: common
+      - source: Ogress Warrior
+        combat_level: 82
+        quantity: "1"
+        rarity: common
+        members_only: true
   recipes:
     - skill: herblore
       level: 12
@@ -109,16 +114,32 @@ osrs:
       - Super strength demand
       - Farmable ingredient
       - High volume trading
-      - Super strength potions
       - Strength potion production
-      - Teak tree protection (15)
-      - Ironman Herblore
+      - Ironman Herblore staple
       - Farm runs profitable
       - Hill giants drop commonly
-      - Protect teak trees
       - Consistent demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2001-02-05"
+      description: Item released into Old School RuneScape.
+    - date: "2023-02-15"
+      description: Magic secateurs now affect crop yield for limpwurt roots.
+  about: Limpwurt root is a Herblore secondary used in Strength and Super strength potions.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-02-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-sapling.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Mahogany sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    farming_level: 55
+    patch_type: Hardwood tree
+    planting_xp: 63
+    checking_xp: 15720
+    growth_time_minutes: 5120
+    protection: 25 Yanillian hops per growth cycle.
+    notes: Plant a mahogany seed in a filled plant pot with a gardening trowel, water it, then wait one crop cycle for the sapling to sprout.
+  recipes:
+    - product: Mahogany sapling
+      skill: Farming
+      level: 55
+      experience: 63
+      materials:
+        - item_name: Mahogany seed
+          quantity: 1
+        - item_name: Plant pot (filled)
+          quantity: 1
+        - item_name: Gardening trowel
+          quantity: 1
+          tool: true
+        - item_name: Watering can
+          quantity: 1
+          tool: true
+      notes: Watered seedling matures into a sapling within one crop cycle (0–5 minutes).
+  related_items:
+    - item_name: Mahogany seed
+      slug: mahogany-seed
+      relationship: component
+      description: Seed planted in a plant pot to start the sapling
+    - item_name: Mahogany seedling
+      slug: mahogany-seedling
+      relationship: component
+      description: Intermediate stage before watering
+    - item_name: Mahogany tree
+      slug: mahogany-tree
+      relationship: product
+      description: Fully grown hardwood tree from this sapling
+    - item_name: Mahogany logs
+      slug: mahogany-logs
+      relationship: product
+      description: Logs chopped from the grown tree
+  market_strategy:
+    notes:
+      - Hardwood farmers create steady supply
+      - 200 limit makes daily restocks easy
+      - Demand spikes during Construction events
+      - Ultracompost is cheaper than Yanillian hops for disease protection
+  history:
+    - date: "2017-09-07"
+      update: Fossil Island
+      description: Mahogany sapling released alongside the Fossil Island hardwood patches.
+  about: Mahogany sapling is the planted hardwood seedling stage used in Fossil Island hardwood tree patches at 55 Farming.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-09-07"
+    update: Fossil Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-table-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-table-flatpack.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Mahogany table (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    construction_level: 52
+    xp: 840
+    workbench: Steel framed bench
+    description: Built at a steel framed workbench in a player-owned house.
+  recipes:
+    - skill: Construction
+      level: 52
+      xp: 840
+      output: Mahogany table (flatpack)
+      materials:
+        - item_name: Mahogany plank
+          quantity: 6
+        - item_name: Hammer
+          quantity: 1
+        - item_name: Saw
+          quantity: 1
+  related_items:
+    - item_id: 8780
+      item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Six required per flatpack
+    - item_id: 8555
+      item_name: Teak table (flatpack)
+      slug: teak-table-flatpack
+      relationship: downgrade
+      description: Lower-tier dining table flatpack
+  market_strategy:
+    notes:
+      - Construction XP-train method
+      - Negative GE margin vs plank cost
+      - Useful for portable dining hotspots
+      - 500/4hr buy limit caps flips
+  history:
+    - date: "2006-05-31"
+      update: "PLAYER-OWNED HOUSES!"
+      description: Released with the Construction skill and player-owned houses.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: "PLAYER-OWNED HOUSES!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  about: Mahogany table flatpack is a Construction 52 build that produces a portable dining table hotspot using six mahogany planks for 840 XP.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts-p-9296.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts-p-9296.mdx
@@ -12,9 +12,96 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 11000
-  about: "Mithril bolts (p+) is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: mid
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    attack_speed: 6
+    weight: 0
+    requirements:
+      ranged: 36
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 82
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Stronger poison coating
+    description: Applies a stronger poison effect than the standard (p) variant when fired at a target.
+  recipes:
+    - product: Mithril bolts (p+)
+      skill: Herblore
+      level: 73
+      xp: 0
+      materials:
+        - item_name: Mithril bolts
+          quantity: 1
+        - item_name: Weapon poison(+)
+          quantity: 1
+      facility: Inventory
+      notes: Apply weapon poison(+) to unpoisoned mithril bolts.
+  related_items:
+    - item_id: 9142
+      item_name: Mithril bolts
+      slug: mithril-bolts
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 9287
+      item_name: Mithril bolts (p)
+      slug: mithril-bolts-p-9287
+      relationship: downgrade
+      description: Standard poison variant
+    - item_id: 9306
+      item_name: Mithril bolts (p++)
+      slug: mithril-bolts-p-9306
+      relationship: upgrade
+      description: Strongest poison variant
+  market_strategy:
+    notes:
+      - Mid-tier poisoned crossbow bolt for 36+ Ranged
+      - Margin driven by weapon poison(+) cost vs unpoisoned mithril bolts
+      - Volume driven by Herblore training and PvP loadouts
+  history:
+    - date: "2006-07-31"
+      update: Crossbows
+      description: Released as part of the Crossbows update with the rest of the bolt tier system.
+    - date: "2007-01-16"
+      description: Value of unpoisoned mithril bolts decreased from 48 to 20 around this window; poison variants adjusted in sync.
+    - date: "2018-01-04"
+      description: Naming convention standardized to add a space in poisoned variants.
+  about: Mithril bolts (p+) are members-only poisoned mithril crossbow bolts requiring 36 Ranged, created by applying weapon poison(+) to unpoisoned mithril bolts.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-nails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-nails.mdx
@@ -14,15 +14,7 @@ osrs:
   limit: 13000
   material:
     type: nails
-    tier: mithril
-  smithing:
-    level: 54
-    xp: 50
-    bars: 1
-    nails_per_bar: 15
-  construction:
-    bend_rate: Low
-    min_level: 1
+    tier: mid-high
   recipes:
     - skill: smithing
       level: 54
@@ -34,51 +26,57 @@ osrs:
       product: Mithril nails
       product_id: 4822
       product_quantity: 15
+      facility: Anvil
   related_items:
     - item_id: 2359
       item_name: Mithril bar
       slug: mithril-bar
       relationship: component
-      description: Smelting material
+      description: Smithed into 15 nails per bar at level 54
     - item_id: 1539
       item_name: Steel nails
       slug: steel-nails
       relationship: downgrade
-      description: Higher bend rate
+      description: Cheaper, higher bend rate
     - item_id: 4823
       item_name: Adamantite nails
       slug: adamantite-nails
       relationship: upgrade
-      description: Lower bend rate
+      description: Lower bend rate, higher tier
     - item_id: 960
       item_name: Plank
       slug: plank
       relationship: component
-      description: Used with planks
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Bend rate | Low |
-    | Construction level | 1+ |
-    | Used with | Planks |
-
-    Good option for Construction with low bend rate.
-
-    | Nails | Bend Rate | Shop Price |
-    |-------|-----------|------------|
-    | Bronze | Highest | 1 GP |
-    | Iron | High | 2 GP |
-    | Steel | Medium | 5 GP |
-    | Mithril | Low | 10 GP |
-    | Adamantite | Very Low | 25 GP |
-    | Rune | Never bends | 100 GP |
+      description: Paired with planks for Construction
+  history:
+    - date: "2005-05-17"
+      update: Zogre Flesh Eaters
+      description: Mithril nails introduced alongside the Zogre Flesh Eaters quest update.
+  about: Mithril nails are smithed at level 54 (15 per bar, 50 XP) and used in Construction with a low bend rate.
   market_strategy:
     notes:
-      - Good balance of cost and reliability
-      - Rarely bends during construction
-      - More expensive than steel but saves time
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Smithing 54+ players supply consistently via mithril bars
+      - Construction demand from mid-game POH builders
+      - Lower bend rate than steel makes these popular for furniture
+  trading_tips:
+    - Buy at GE during weekend dips; bend rate keeps demand steady
+    - Sell in 100-1000 unit lots to active Construction players
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-17"
+    update: Zogre Flesh Eaters
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-moth-item.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-moth-item.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 125
-  about: "Moonlight moth (item) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Hunter (Butterfly net)
+        quantity: "1"
+        rarity: common
+        members_only: true
+        notes: Caught with butterfly net and butterfly jar at level 75 Hunter; barehanded at level 85 Hunter in Varlamore.
+  prayer:
+    notes:
+      - Restores 22 Prayer points when released from butterfly jar.
+      - Shareable with up to 3 nearby players in multi-combat zones if Accept Aid is enabled.
+      - Cannot be shared on Group Ironman accounts.
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Moonlight moth (item)
+          quantity: 1
+        - item_name: Raw hunter meat
+          quantity: 1
+      product: Moonlight moth mix
+      product_quantity: 1
+      facility: Pestle and mortar
+  market_strategy:
+    notes:
+      - Hunted in Varlamore butterfly netting; supply driven by 75+ Hunter players.
+      - Prayer restore niche makes it useful for low-cost PvM trips.
+      - Pestle-and-mortar combine creates moonlight moth mix variants.
+  about: Moonlight moth (item) is a members-only Hunter catch from Varlamore that restores 22 Prayer points when released and can be combined with raw hunter meat to make moonlight moth mix.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Inventory icon adjusted"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Release
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  history:
+    - date: "2024-03-20"
+      update: Perilous Moons
+      description: Added to game with the release of Varlamore Hunter content.
+    - date: "2024-09-25"
+      description: Inventory icon adjusted.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-shortbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-shortbow.mdx
@@ -14,24 +14,50 @@ osrs:
   limit: 18000
   equipment:
     slot: 2h
-    type: shortbow
-    attack_style: ranged
+    weapon_type: bow
     attack_speed: 4
-  requirements:
-    ranged: 5
-  stats:
-    attack:
+    weight: 1.814
+    requirements:
+      ranged: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 14
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
-    range: 7
-  fletching:
-    level: 20
-    xp: 16.5
-    method: Oak shortbow (u) + bowstring
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 20
+      xp: 16.5
+      materials:
+        - item_name: Oak shortbow (u)
+          item_id: 54
+          quantity: 1
+        - item_name: Bow string
+          item_id: 1777
+          quantity: 1
+      product: Oak shortbow
+      product_id: 843
+      product_quantity: 1
+      facility: None
+      members_only: false
   shops:
     - shop_name: Lowe's Archery Emporium
       location: Varrock
+      price: 100
+    - shop_name: Brian's Archery Supplies
+      location: Rimmington
       price: 100
   related_items:
     - item_id: 849
@@ -54,8 +80,36 @@ osrs:
       slug: bow-string
       relationship: component
       description: Stringing material
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - F2P low-level ranged weapon
+      - Fletching 20 product
+      - Stable shop supply at 100 gp
+      - Common training intermediate
+  history:
+    - date: "2002-03-25"
+      description: Item released into RuneScape.
+    - date: "2005-01-26"
+      description: Inventory and equipped sprite graphically updated.
+  about: The oak shortbow is a free-to-play two-handed ranged weapon strung from oak shortbow (u) and a bowstring at Fletching 20.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oathplate-chest.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oathplate-chest.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 240000
   highalch: 360000
   limit: null
-  about: "Oathplate chest is a members-only item in Old School RuneScape. High alchemy value: 360,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 9.979
+    requirements:
+      defence: 78
+    attack_bonus:
+      stab: 0
+      slash: 16
+      crush: 0
+      magic: -16
+      ranged: -18
+    defence_bonus:
+      stab: 105
+      slash: 128
+      crush: 100
+      magic: -5
+      ranged: 112
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 83
+      xp: 2000
+      materials:
+        - item_name: Infernal plate
+          quantity: 9
+      product: Oathplate chest
+      product_id: 30753
+      product_quantity: 1
+      members_only: true
+  drop_table:
+    sources:
+      - source: Yama
+        combat_level: 1238
+        quantity: "1"
+        rarity: 1/600
+        members_only: true
+      - source: Forgotten lockbox
+        quantity: "1"
+        rarity: 1/403
+        members_only: true
+  related_items:
+    - item_name: Oathplate helm
+      slug: oathplate-helm
+      relationship: set-piece
+      description: Helm component
+    - item_name: Oathplate legs
+      slug: oathplate-legs
+      relationship: set-piece
+      description: Legs component
+    - item_name: Infernal plate
+      slug: infernal-plate
+      relationship: component
+      description: Smithing material
+  history:
+    - date: "2025-05-22"
+      description: Players can now smelt oathplate armour pieces into 50 oathplate shards using the Ancient Forge.
+    - date: "2025-05-16"
+      update: Hotfix
+      description: Infernal plates requirement for crafting was increased from 7 to 9.
+  about: Oathplate chest is a high-tier body armour requiring 78 Defence, smithed at 83 Smithing from 9 Infernal plates or obtained as a rare Yama drop.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-05-14"
+    update: Yama the Master of Pacts
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.979
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/orange-chunks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/orange-chunks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Orange chunks | OSRS Price Data
-description: "Orange chunks: Fresh chunks of orange.. High alch: 1 GP, GE limit: 13,000."
+description: "Orange chunks: Fresh chunks of orange. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 2110
   name: Orange chunks
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Orange chunks is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: secondary
+    tier: low
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Orange
+          item_id: 2108
+          quantity: 1
+        - item_name: Knife
+          item_id: 946
+          quantity: 1
+      product: Orange chunks
+      product_id: 2110
+      product_quantity: 1
+      facility: None
+      members_only: true
+  related_items:
+    - item_id: 2108
+      item_name: Orange
+      slug: orange
+      relationship: component
+      description: Diced with a knife to produce chunks
+    - item_id: 2112
+      item_name: Fruit batta
+      slug: fruit-batta
+      relationship: product
+      description: Gnome cooking dish
+    - item_id: 2113
+      item_name: Blurberry Special
+      slug: blurberry-special
+      relationship: product
+      description: Gnome cocktail ingredient
+  market_strategy:
+    notes:
+      - Gnome cooking secondary
+      - Diced from oranges
+      - Low margin per craft
+      - Used in fruit batta
+      - Blurberry Special component
+  history:
+    - date: "2002-12-12"
+      update: Agility skill release
+      description: Item released alongside the Agility skill update.
+  about: Orange chunks are a gnome cooking ingredient made by dicing an orange with a knife.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.09
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pearl-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pearl-bolts-e.mdx
@@ -12,13 +12,50 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 11000
+  material:
+    type: ammunition
+    tier: mid
   equipment:
     slot: ammo
-    other_bonus:
-      ranged_strength: 48
+    weapon_type: crossbow
+    attack_speed: 6
+    weight: 0
     requirements:
       ranged: 1
-    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 48
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Sea Curse
+    description: 6% proc (6.6% with Kandarin Hard Diary) deals bonus water damage equal to 1/20 of Ranged level (1/15 vs fiery enemies); negated by water staff, amplified by fire staff. Bonus applies even if base attack misses.
+  recipes:
+    - product: Pearl bolts (e)
+      skill: Magic
+      level: 24
+      xp: 29.5
+      materials:
+        - item_name: Pearl bolts
+          quantity: 10
+        - item_name: Water rune
+          quantity: 2
+        - item_name: Cosmic rune
+          quantity: 1
+      facility: Inventory
+      notes: Cast Enchant Crossbow Bolt (Pearl) to enchant 10 pearl bolts per cast (~3 ticks).
   related_items:
     - item_id: 9236
       item_name: Opal bolts (e)
@@ -30,21 +67,45 @@ osrs:
       slug: topaz-bolts-e
       relationship: upgrade
       description: Next tier enchanted bolt
-  about: |-
-    | Other | Value |
-    |-------|-------|
-    | Ranged Strength | +48 |
-
-    Proc chance: 6% (6.6% with Kandarin hard diary)
-
-    On activation, deals extra water-based damage. Damage is increased against fire-based enemies (fire giants, fire elementals, etc.) but negated entirely against targets wielding a water staff.
+    - item_id: 880
+      item_name: Pearl bolts
+      slug: pearl-bolts
+      relationship: component
+      description: Unenchanted base bolts
   market_strategy:
     notes:
       - Effective against fire-type monsters
       - Cheap mid-tier enchanted bolt
       - Niche PvM use
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2006-07-31"
+      update: Crossbows
+      description: Released as part of the Crossbows update.
+    - date: "2007-06-18"
+      description: Item value increased from 1 to 15 coins.
+    - date: "2015-03-05"
+      description: Kandarin headgear 3 introduced a 10% activation boost to enchanted bolt special effects.
+    - date: "2015-04-16"
+      description: Hard Kandarin Diary completion made the +10% enchanted bolt activation permanent without requiring the headgear equipped.
+  about: Pearl bolts (e) are enchanted Sea Curse bolts that proc bonus water damage scaling with Ranged level; especially strong against fiery enemies and negated by water staves.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pie-shell.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pie-shell.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 13000
-  about: "Pie shell is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Cooking
+      level: 1
+      xp: 0
+      output: Pie shell
+      materials:
+        - item_name: Pastry dough
+          quantity: 1
+        - item_name: Pie dish
+          quantity: 1
+  related_items:
+    - item_id: 2321
+      item_name: Redberry pie
+      slug: redberry-pie
+      relationship: product
+      description: Filled with redberries
+    - item_id: 2327
+      item_name: Meat pie
+      slug: meat-pie
+      relationship: product
+      description: Filled with cooked meat
+    - item_id: 2323
+      item_name: Apple pie
+      slug: apple-pie
+      relationship: product
+      description: Filled with cooking apples
+    - item_id: 1953
+      item_name: Pie dish
+      slug: pie-dish
+      relationship: component
+      description: Required vessel for the shell
+  market_strategy:
+    notes:
+      - High 13k buy limit, thin margins
+      - Bulk supply for pie crafters
+      - F2P-accessible cooking baseline
+      - No XP gain on creation
+  history:
+    - date: "2001-03-17"
+      description: Released as the universal pie base.
+    - date: "2015-02-26"
+      description: Temporarily blocked from the Grand Exchange.
+    - date: "2015-02-27"
+      description: Re-enabled for Grand Exchange trading as a bugfix.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-03-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.25
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  about: Pie shell is the universal Cooking base made by combining pastry dough with a pie dish, ready to receive any pie filling.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pink-headband.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pink-headband.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 4
-  about: "Pink headband is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.04
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    clue_type: emote
+    notes: Required for the Panic emote clue south of the Blighted Volcano bridge alongside a Guthix crozier.
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        notes: Demonic Pacts League reward.
+        rarity: 1/1133
+        members_only: true
+  related_items:
+    - item_name: Headband (set)
+      relationship: set-piece
+      description: One of eight headband colour variants
+    - item_name: Guthix crozier
+      slug: guthix-crozier
+      relationship: component
+      description: Paired with the headband for the Panic emote clue step
+  market_strategy:
+    notes:
+      - Clue step demand drives all flow
+      - Buy limit of 4 caps single-flip volume
+      - League reward casket pulls supply during events
+      - Costume room storage reduces resale velocity
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Pink headband released as part of the Treasure Trail expansion cosmetic line.
+  about: Pink headband is a cosmetic hard-clue Treasure Trails reward used for the Panic emote step south of the Blighted Volcano bridge.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-fr-blast.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-fr-blast.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Premade fr' blast is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 9
+    type: cocktail
+  shops:
+    - shop_name: Blurberry Bar
+      location: Grand Tree
+      buy_price: 30
+      sell_price: 18
+      stock: 10
+      restock_seconds: 60
+    - shop_name: Blurberry Bar
+      location: Gnome Stronghold (east of Gnomeball)
+      buy_price: 30
+      sell_price: 18
+      stock: 10
+      restock_seconds: 60
+  related_items:
+    - item_id: 2084
+      item_name: Fruit blast
+      slug: fruit-blast
+      relationship: alternative
+      description: Player-mixed cocktail equivalent
+  history:
+    - date: "2002-12-12"
+      update: Agility skill online
+      description: Premade Fruit Blast released alongside the Gnome Restaurant minigame.
+    - date: "2006-08-07"
+      description: Renamed from "Fruit blast" to "Premade fr' blast" with a graphical update.
+  about: Premade fr' blast is a Gnome Restaurant cocktail bought from Blurberry Bar that heals 9 Hitpoints when drunk.
+  market_strategy:
+    notes:
+      - Always available from Blurberry Bar at 30 coins
+      - Cheap members food alternative for early bossing or skilling
+      - Low GE turnover compared to monkfish or sharks
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.45
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-ttl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-ttl.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 6000
-  about: "Premade ttl is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heal_amount: 15
+    edible: true
+  shops:
+    - shop_name: Gnome Waiter
+      location: Grand Tree
+      price: 160
+      stock: 3
+      restock_time: 1 minute
+    - shop_name: Gianne's Restaurant
+      location: Demonic Pacts League
+      price: 160
+  related_items:
+    - item_id: 2152
+      item_name: Tangled toads' legs
+      slug: tangled-toads-legs
+      relationship: variant
+      description: Player-cooked version of the gnome dish
+  about: Premade Tangled Toads Legs is a gnome bowl-food item sold by the Gnome Waiter at the Grand Tree that heals 15 hitpoints when eaten.
+  market_strategy:
+    notes:
+      - Predictable shop price of 160 gp
+      - High buy limit supports bulk flipping
+      - Demand from gnome restaurant tasks and ironman starts
+      - Alch value below shop price
+  trading_tips:
+    - Stockpile before gnome restaurant XP events
+    - Resell to lazy mid-game pkers needing cheap food
+  history:
+    - date: "2006-08-07"
+      description: Item renamed from "Tangled toad's legs" to "Premade ttl".
+    - date: "2002-12-12"
+      update: Agility skill online
+      description: Premade ttl released alongside Gnome Restaurant content.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill online
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-graahk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-graahk.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Raw graahk is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    cooking_level: 41
+    cooking_xp: 124
+    notes:
+      - Cooked into graahk; failed attempts yield burnt large beast
+      - Cooking unlock requires completing 25 Hunters' Rumours
+  drop_table:
+    sources:
+      - source: Horned graahk
+        rarity: always
+        quantity: "1"
+        members_only: true
+        notes: Hunted in Karamja (Demonic Pacts League region) at 41 Hunter.
+  recipes:
+    - product: Graahk
+      skill: Cooking
+      level: 41
+      xp: 124
+      materials:
+        - item_name: Raw graahk
+          quantity: 1
+      facility: Fire / Range
+      notes: Requires completion of 25 Hunters' Rumours to unlock cooking.
+  related_items:
+    - item_id: 29121
+      item_name: Graahk
+      slug: graahk
+      relationship: product
+      description: Cooked version of the raw meat
+    - item_id: 29117
+      item_name: Raw kyatt
+      slug: raw-kyatt
+      relationship: alternative
+      description: Alternative raw big-game meat from Varlamore Hunter
+    - item_id: 29115
+      item_name: Raw larupia
+      slug: raw-larupia
+      relationship: alternative
+      description: Alternative raw big-game meat from Varlamore Hunter
+  market_strategy:
+    notes:
+      - Supply gated by 41 Hunter + Hunters' Rumours unlock
+      - Used as Cooking training food and herblore secondary base
+      - Margin tied to cooked graahk demand
+  history:
+    - date: "2024-03-20"
+      update: Varlamore Part One
+      description: Released with the Varlamore Part One update as part of the new big-game Hunter loop.
+  about: Raw graahk is a members-only big-game raw meat obtained from hunting horned graahks at 41 Hunter and cooked into graahk at 41 Cooking.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore Part One
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-swordtip-squid.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-swordtip-squid.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: null
-  about: "Raw swordtip squid is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Lantern harpoon fishing spot
+        quantity: "1"
+        rarity: common
+        members_only: true
+  recipes:
+    - skill: Cooking
+      level: 56
+      xp: 150
+      output: Swordtip squid
+      materials:
+        - item_name: Raw swordtip squid
+          quantity: 1
+    - skill: Herblore
+      level: 1
+      xp: 0
+      output: Squid paste
+      materials:
+        - item_name: Raw swordtip squid
+          quantity: 1
+  related_items:
+    - item_id: 31555
+      item_name: Swordtip squid
+      slug: swordtip-squid
+      relationship: product
+      description: Cooked version healing 15 HP
+    - item_id: 31557
+      item_name: Squid paste
+      slug: squid-paste
+      relationship: product
+      description: Herblore ingredient made by crushing
+  market_strategy:
+    notes:
+      - Lantern harpoon at 52 Fishing
+      - Cooking at 56 yields 150 XP
+      - Supply tied to Sailing engagement
+      - 1/1024 chance for squid beaks bycatch
+  history:
+    - date: "2025-06-26"
+      description: Added to Sailing Beta cache.
+    - date: "2025-07-03"
+      description: Removed when Sailing Beta ended.
+    - date: "2025-08-14"
+      description: Model updated during Sailing Stress Test.
+    - date: "2025-11-19"
+      update: "Sailing"
+      description: Released alongside the Sailing skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.45
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  about: Raw swordtip squid is fished via lantern harpooning at 52 Fishing and cooked at 56 Cooking into food that heals 15 Hitpoints.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/restore-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/restore-potion-1.mdx
@@ -12,6 +12,23 @@ osrs:
   lowalch: 17
   highalch: 26
   limit: 2000
+  potion:
+    doses: 1
+    effects:
+      - description: Restores reduced Attack, Strength, Defence, Ranged, and Magic by 10 + 30% of base level per skill.
+      - description: Does not restore Prayer or boost stats above base level.
+  recipes:
+    - skill: Herblore
+      level: 22
+      members: true
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Red spiders' eggs
+          quantity: 1
+      products:
+        - item_name: Restore potion(3)
+          quantity: 1
   related_items:
     - item_id: 127
       item_name: Restore potion(3)
@@ -23,12 +40,43 @@ osrs:
       slug: restore-potion-2
       relationship: variant
       description: 2-dose version
-  about: |-
-    > _"1 dose of restore potion."_
-
-    A 1-dose restore potion. Restores reduced combat stats by 10 + 30% of max level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 133
+      item_name: Restore potion(4)
+      slug: restore-potion-4
+      relationship: variant
+      description: 4-dose version
+  about: A 1-dose restore potion that restores reduced combat stats by 10 plus 30 percent of the max level for Attack, Strength, Defence, Ranged, and Magic.
+  market_strategy:
+    notes:
+      - Outclassed by Super restore in mid/late game
+      - Steady low-level Herblore training supply
+      - Cheap alch fodder when overstocked
+      - Decanters convert doses across the (1)/(2)/(3)/(4) tiers
+  trading_tips:
+    - Watch Herblore XP events for supply surges
+    - Buy in bulk when GE price dips below alch
+  history:
+    - date: "2004-10-26"
+      description: '"Empty" option added to the potion.'
+    - date: "2002-02-27"
+      description: Restore potion released with the original Herblore content.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/riyl-remains.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/riyl-remains.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7500
-  about: "Riyl remains is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: remains
+    tier: mid
+  drop_table:
+    sources:
+      - source: Riyl shade
+        combat_level: 80
+        quantity: "1"
+        rarity: Always
+        members_only: true
+      - source: Riyl shadow
+        combat_level: 80
+        quantity: "1"
+        rarity: Always
+        members_only: true
+        location: Temple Trekking
+  related_items:
+    - item_id: 3398
+      item_name: Loar remains
+      slug: loar-remains
+      relationship: downgrade
+      description: Lower-tier shade remains
+    - item_id: 3402
+      item_name: Asyn remains
+      slug: asyn-remains
+      relationship: upgrade
+      description: Higher-tier shade remains
+    - item_id: 3404
+      item_name: Fiyr remains
+      slug: fiyr-remains
+      relationship: upgrade
+      description: Highest-tier shade remains
+  market_strategy:
+    notes:
+      - Used in Shades of Mort'ton minigame for Firemaking and Prayer XP
+      - Cremation grants shade keys for tier-locked loot rooms
+      - 50% XP boost with Hard/Elite Morytania Diary completion
+      - Demand driven by ironman key-running and pyre log XP rates
+      - 79% chance for shade keys, 21% chance for 600-700 coins on cremation
+  history:
+    - date: "2024-07-31"
+      description: Warning added when attempting pyre logs without appropriate remains.
+    - date: "2024-05-08"
+      description: Despawn timer increased to 5 minutes; other players cannot take items during this period.
+    - date: "2015-03-05"
+      description: Achievement Diary bonuses added (50% XP boost with Hard/Elite Morytania completion).
+    - date: "2004-10-18"
+      description: Released as part of the Mort'ton Shades and Mage Armour update.
+  about: Riyl remains are the third-tier shade drop, cremated on pyre logs at Mort'ton for Firemaking and Prayer XP and a chance at shade keys.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-18"
+    update: Mort'ton Shades and Mage Armour
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rock-hammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rock-hammer.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 40
-  about: "Rock hammer is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: tool
+    tier: mid
+  shops:
+    - shop_name: Slayer Equipment
+      location: Burthorpe
+      stock: 50
+      price: 500
+    - shop_name: Slayer Equipment
+      location: Draynor Village
+      stock: 50
+      price: 500
+    - shop_name: Slayer Equipment
+      location: Edgeville
+      stock: 50
+      price: 500
+    - shop_name: Slayer Equipment
+      location: Canifis
+      stock: 50
+      price: 500
+    - shop_name: Slayer Equipment
+      location: Edgeville Dungeon
+      stock: 50
+      price: 500
+    - shop_name: Slayer Equipment
+      location: Zanaris
+      stock: 50
+      price: 500
+    - shop_name: Slayer Equipment
+      location: Mount Karuulm
+      stock: 50
+      price: 500
+    - shop_name: Slayer Equipment
+      location: Tree Gnome Stronghold
+      stock: 50
+      price: 500
+    - shop_name: Slayer Equipment
+      location: Shilo Village
+      stock: 50
+      price: 500
+  related_items:
+    - item_id: 21742
+      item_name: Granite hammer
+      slug: granite-hammer
+      relationship: upgrade
+      description: Combat-capable upgrade
+  about: Rock hammer is a Slayer tool used to finish gargoyles at or below 10 HP unless Gargoyle Smasher is unlocked.
+  market_strategy:
+    notes:
+      - Required for gargoyle Slayer task
+      - Cheap shop alternative (500 gp)
+      - Low GE buy limit
+      - Reusable tool
+      - Granite hammer upgrade exists
+  history:
+    - date: "2005-01-26"
+      description: Rock hammer released with the Slayer skill.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-01-26"
+    update: "Slayer Skill"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rosewood-repair-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rosewood-repair-kit.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 13000
-  about: "Rosewood repair kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Veiled kraken
+        combat_level: 210
+        quantity: "1"
+        rarity: 1/272
+        members_only: true
+  recipes:
+    - skill: construction
+      level: 92
+      xp: 330
+      materials:
+        - item_name: Rosewood plank
+          quantity: 1
+        - item_name: Dragon nails
+          quantity: 5
+        - item_name: Swamp paste
+          quantity: 5
+      product: Rosewood repair kit
+      product_id: 31982
+      product_quantity: 3
+      facility: Shipwrights' workbench
+  related_items:
+    - item_id: 31980
+      item_name: Rosewood plank
+      slug: rosewood-plank
+      relationship: component
+      description: Primary crafting input
+    - item_id: 31978
+      item_name: Dragon nails
+      slug: dragon-nails
+      relationship: component
+      description: Crafting input
+    - item_id: 1975
+      item_name: Swamp paste
+      slug: swamp-paste
+      relationship: component
+      description: Crafting input
+  market_strategy:
+    notes:
+      - Sailing high-tier repair kit, gated behind 92 Construction
+      - Material cost approximately 59,786 coins per kit (cost divided by 3)
+      - Veiled kraken drop offers alternative supply for non-builders
+      - Demand tied to Sailing skill engagement and boat upkeep
+  history:
+    - date: "2025-11-19"
+      description: Construction XP from Sailing workbenches halved.
+    - date: "2025-11-05"
+      description: Item added with the Sailing release; initially unobtainable.
+  about: Rosewood repair kit is a high-tier Sailing repair item made at the shipwrights' workbench at 92 Construction or dropped by veiled krakens.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Apply
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-crossbow.mdx
@@ -12,41 +12,70 @@ osrs:
   lowalch: 6480
   highalch: 9720
   limit: 70
+  material:
+    type: metal
+    tier: mid-high
   equipment:
-    slot: 2h
-    type: crossbow
-    attack_style: ranged
-    attack_speed: 5
+    slot: weapon
+    weapon_type: crossbow
+    attack_speed: 6
+    weight: 6
     requirements:
       ranged: 61
-    stats:
-      attack_ranged: 90
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 90
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 69
+      xp: 50
+      materials:
+        - item_name: Runite crossbow (u)
+          item_id: 9454
+          quantity: 1
+        - item_name: Crossbow string
+          item_id: 9438
+          quantity: 1
+      description: String unfinished runite crossbow
   drop_table:
     sources:
       - source: Kree'arra
         source_id: 3162
         combat_level: 580
         quantity: "1"
-        rarity: 1/127
+        rarity: 8/127
         members_only: true
       - source: Crazy Archaeologist
         source_id: 6618
         combat_level: 204
         quantity: "1"
-        rarity: 2/128
+        rarity: 5/128
         members_only: true
-      - source: Elite clue casket
+      - source: Reward casket (elite)
         source_id: 0
         combat_level: 0
         quantity: "1"
         rarity: 1/32.3
         members_only: true
-      - source: Fletching (69)
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: N/A
-        members_only: true
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
   related_items:
     - item_id: 11785
       item_name: Armadyl crossbow
@@ -63,31 +92,39 @@ osrs:
       slug: zaryte-crossbow
       relationship: upgrade
       description: BiS crossbow
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged attack | +90 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 61 Ranged
-
-    Popular mid-game crossbow for:
-    - Fight Caves
-    - Early bossing
-    - Slayer tasks
-    - Budget ranged option
-
-    Can use all bolt types up to runite/dragon.
+  about: Rune crossbow is a members one-handed crossbow requiring 61 Ranged, the popular mid-game choice before ACB or ZCB.
   market_strategy:
     notes:
-      - Very affordable
-      - Good stepping stone
-      - Upgrade to ACB/ZCB later
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Very affordable mid-game
+      - Good stepping stone to ACB and ZCB
+      - Used at Fight Caves and early bossing
+      - Accepts up to runite and dragon bolts
+      - Available via Fletching at 69
+  history:
+    - date: "2015-09-24"
+      description: Crossbows can now be made with a boosted Fletching level.
+    - date: "2014-12-10"
+      description: Item renamed from Rune c'bow to Rune crossbow.
+    - date: "2006-07-31"
+      description: Rune crossbow released.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/samurai-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/samurai-boots.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 1800
   highalch: 2700
   limit: 70
-  about: "Samurai boots is a members-only item in Old School RuneScape. High alchemy value: 2,700 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.95
+    requirements:
+      defence: 35
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 11
+      slash: 12
+      crush: 13
+      magic: 1
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    is_reward: true
+    tier: master
+    reward_tiers:
+      - master
+    rarity: 1/851
+  related_items:
+    - item_id: 20041
+      item_name: Samurai kasa
+      slug: samurai-kasa
+      relationship: set-piece
+      description: Head slot set piece
+    - item_id: 20043
+      item_name: Samurai shirt
+      slug: samurai-shirt
+      relationship: set-piece
+      description: Body slot set piece
+    - item_id: 20045
+      item_name: Samurai greaves
+      slug: samurai-greaves
+      relationship: set-piece
+      description: Legs slot set piece
+    - item_id: 20049
+      item_name: Samurai gloves
+      slug: samurai-gloves
+      relationship: set-piece
+      description: Hands slot set piece
+  market_strategy:
+    notes:
+      - Master clue reward at 1/851 rarity
+      - Cosmetic feet slot storable in costume room
+      - Low buy limit of 70 amplifies short-term volatility
+      - Demand driven by collection log and cosmetic transmog
+  history:
+    - date: "2016-07-06"
+      description: Released as part of the Treasure Trail Expansion update.
+  about: Samurai boots are a master clue reward feet slot cosmetic granting modest melee defence bonuses at 35 Defence.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.95
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sandstone-1kg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sandstone-1kg.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 100
-  about: "Sandstone (1kg) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: sandstone
+    tier: low
+  drop_table:
+    sources:
+      - source: Sandstone rocks (Bandit Camp Quarry)
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Requires 35 Mining
+      - source: Sandstone rocks (Necropolis mine)
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Requires 35 Mining
+      - source: Sandstone rocks (Cape Conch mine)
+        quantity: "1"
+        rarity: always
+        members_only: true
+        notes: Requires 35 Mining
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Sandstone (1kg)
+          item_id: 6971
+          quantity: 1
+        - item_name: Bucket
+          item_id: 1925
+          quantity: 1
+      product: Bucket of sand
+      product_id: 1783
+      product_quantity: 1
+      facility: Sandstorm grinder
+      members_only: true
+      notes: Costs 50 coins at the grinder
+  related_items:
+    - item_id: 6973
+      item_name: Sandstone (2kg)
+      slug: sandstone-2kg
+      relationship: variant
+      description: Heavier chunk variant
+    - item_id: 6975
+      item_name: Sandstone (5kg)
+      slug: sandstone-5kg
+      relationship: variant
+      description: Larger chunk variant
+    - item_id: 6977
+      item_name: Sandstone (10kg)
+      slug: sandstone-10kg
+      relationship: variant
+      description: Largest chunk variant
+    - item_id: 1783
+      item_name: Bucket of sand
+      slug: bucket-of-sand
+      relationship: product
+      description: Made by grinding sandstone at the Sandstorm grinder
+  history:
+    - date: "2006-01-23"
+      update: Enakhra's Lament
+      description: Sandstone released with the Enakhra's Lament quest update.
+    - date: "2015-04-30"
+      description: Varrock armour mining bonuses applied to sandstone mining.
+  about: Sandstone (1kg) is a members-only mining drop from Bandit Camp Quarry, Necropolis, and Cape Conch, ground into buckets of sand at the Sandstorm grinder.
+  market_strategy:
+    notes:
+      - Very small GE limit caps flipping at 100 per 4 hours
+      - Niche supply for grinder users avoiding sand buckets
+      - Alch value is 0, no high alch profit floor
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-01-23"
+    update: Enakhra's Lament
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-glacialis-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-glacialis-mix-2.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: null
-  about: "Sapphire glacialis mix (2) is a members-only item in Old School RuneScape. High alchemy value: 18 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid
+  potion:
+    doses: 2
+    effects:
+      - description: Boosts Defence by floor(level x 15/100) + 4, ranging from +4 (levels 1-6) to +18 (levels 94-99).
+  recipes:
+    - skill: hunter
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Jarred sapphire glacialis
+          item_id: 0
+          quantity: 1
+        - item_name: Raw hunter meat
+          item_id: 0
+          quantity: 1
+      description: Combined with pestle and mortar in 3 ticks
+  related_items:
+    - item_id: 0
+      item_name: Sapphire glacialis mix (1)
+      slug: sapphire-glacialis-mix-1
+      relationship: variant
+      description: 1-dose variant
+  about: Sapphire glacialis mix is a 2-dose Defence-boosting hunter mix introduced with the Varlamore Part One update.
+  market_strategy:
+    notes:
+      - Niche Defence boost potion
+      - Made from Varlamore hunting
+      - Not GE listed (limit null)
+      - 2-dose variant
+  history:
+    - date: "2024-04-03"
+      description: Group Ironmen can now correctly share hunter mixes and butterflies with their group.
+    - date: "2024-03-20"
+      description: Sapphire glacialis mix (2) released with Varlamore Part One.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-page-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-page-3.mdx
@@ -12,16 +12,18 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 5
-  item:
-    type: god_page
-    god: Saradomin
-    page_number: 3
-    tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy/Medium/Hard/Elite
-        drop_rate: Varies by tier
+  material:
+    type: god-page
+    tier: mid
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
   related_items:
     - item_id: 3827
       item_name: Saradomin page 1
@@ -38,23 +40,38 @@ osrs:
       slug: saradomin-page-4
       relationship: set-piece
       description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Saradomin |
-    | Page | 3 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of wisdom (Saradomin god book) to complete it.
-
-    Requires all 4 pages:
-    - Saradomin page 1
-    - Saradomin page 2
-    - Saradomin page 3
-    - Saradomin page 4
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Saradomin page 3 is one of four pages combined to form the Saradomin god book of wisdom.
+  market_strategy:
+    notes:
+      - Clue scroll reward
+      - Combine all 4 pages for god book
+      - Low GE buy limit (5)
+      - Steady demand for god book completion
+  history:
+    - date: "2019-01-24"
+      description: Inventory model received graphical updates to match holy book coloring.
+    - date: "2006-07-11"
+      description: Item renamed from "Torn page 3(s)" to "Saradomin page 3".
+    - date: "2004-11-29"
+      description: Item renamed from "Torn page 3" to "Torn page 3(s)".
+    - date: "2004-11-17"
+      description: Saradomin page 3 released with Horror From The Deep.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-11-17"
+    update: "Horror From The Deep"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/secateurs-blade.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/secateurs-blade.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: null
-  about: "Secateurs blade is a members-only item in Old School RuneScape. High alchemy value: 600 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: smithing
+      level: 35
+      xp: 0
+      materials:
+        - item_name: Secateurs blade
+          item_id: 28159
+          quantity: 1
+        - item_name: Iron bar
+          item_id: 2351
+          quantity: 1
+      product: Secateurs attachment
+      product_id: 28160
+      product_quantity: 50
+      facility: Forestry Shop crafting station
+      members_only: true
+  shops:
+    - shop_name: Forestry Shop
+      location: Forestry locations
+      buy_price: 420
+      sell_price: 0
+      stock: 50
+      currency: Anima-infused bark
+  related_items:
+    - item_id: 28160
+      item_name: Secateurs attachment
+      slug: secateurs-attachment
+      relationship: product
+      description: Crafted with an iron bar (50 attachments per blade)
+    - item_id: 2351
+      item_name: Iron bar
+      slug: iron-bar
+      relationship: component
+      description: Required to craft the attachment
+    - item_id: 28140
+      item_name: Anima-infused bark
+      slug: anima-infused-bark
+      relationship: component
+      description: Forestry currency used to purchase the blade
+  history:
+    - date: "2023-06-28"
+      update: "Forestry: The Way of the Forester - Part One"
+      description: Secateurs blade released with the Forestry update.
+  about: Secateurs blade is a Forestry shop ingredient combined with an iron bar at level 35 Woodcutting and Smithing to make 50 secateurs attachments.
+  market_strategy:
+    notes:
+      - Forestry shop supply via anima-infused bark gives steady availability
+      - Bottlenecked by anima-infused bark grind, so GE price runs well above alch
+      - Useful for Forestry farmers stocking secateurs attachments
+  trading_tips:
+    - Compare anima-infused bark cost vs. GE flip margin
+    - Watch for Forestry update spikes in demand
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-06-28"
+    update: "Forestry: The Way of the Forester - Part One"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Craft
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shark-paint.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shark-paint.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Shark paint is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Port task
+        notes: Rolled at a 1/36 rate upon completing a port task.
+        rarity: 1/36
+        members_only: true
+  recipes:
+    - product: Merchant's paint
+      skill: Sailing
+      notes: Exchange shark, angler's, inky, salvor's, and Barracuda paints to Trader Stan for merchant's paint.
+      materials:
+        - item_name: Shark paint
+          quantity: 1
+        - item_name: Angler's paint
+          quantity: 1
+        - item_name: Inky paint
+          quantity: 1
+        - item_name: Salvor's paint
+          quantity: 1
+        - item_name: Barracuda paint
+          quantity: 1
+  related_items:
+    - item_name: Merchant's paint
+      slug: merchant-s-paint
+      relationship: product
+      description: Traded to Trader Stan with the full paint set
+    - item_name: Skiff
+      slug: skiff
+      relationship: alternative
+      description: Recolour target — one paint per skiff
+    - item_name: Sloop
+      slug: sloop
+      relationship: alternative
+      description: Recolour target — two paints per sloop
+  market_strategy:
+    notes:
+      - Supply gated by Sailing port task volume
+      - Cosmetic demand from Sailing decorators
+      - Part of the merchant's paint full-set sink
+      - Buy limit not enforced — speculative inventory possible
+  history:
+    - date: "2025-11-19"
+      update: Sailing is OUT TODAY!
+      description: Shark paint released with the Sailing launch.
+    - date: "2025-11-26"
+      update: Typo fix
+      description: Corrected the receipt message from "recieved" to "received".
+  about: Shark paint is a cosmetic Sailing reward used to recolour skiffs and sloops or trade in to Trader Stan for merchant's paint.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-barrows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-barrows.mdx
@@ -12,9 +12,38 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of barrows is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: sigil
+    tier: high
+  about: Sigil of barrows is a Deadman Mode sigil granting +40% Barrows weapon accuracy and preventing Barrows gear degradation except on death or drop.
+  market_strategy:
+    notes:
+      - Deadman Mode exclusive
+      - Currently unobtainable in live game
+      - Untradeable on GE
+      - Duplicates sold via Deadman's skull
+      - Adds amulet of the damned effects
+  history:
+    - date: "2021-08-25"
+      description: Sigil of barrows released with Deadman Reborn.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: "You must unattune the Sigil before you can destroy it."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-elves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-elves.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of the elves is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Deadman Mode drop table
+        quantity: "1"
+        rarity: varies
+        members_only: true
+        notes: Dropped by most monsters during Deadman events
+  related_items:
+    - item_id: 26088
+      item_name: Sigil of the elves (attuned)
+      slug: sigil-of-the-elves-attuned
+      relationship: variant
+      description: Attuned form that grants the XP bonus
+  about: "Sigil of the elves is a tier 2 Deadman: Reborn skilling sigil that grants 50 percent more XP in Agility, Fletching, Hunter, and Farming once attuned."
+  market_strategy:
+    notes:
+      - Only tradable while un-attuned
+      - Supply tied to Deadman event cycles
+      - Attuning permanently removes from the market
+      - Limit of 8 keeps liquidity tight
+  trading_tips:
+    - Stock during Deadman event windows
+    - Sell to skillers chasing Agility/Hunter goals
+  history:
+    - date: "2021-08-25"
+      update: "Deadman: Reborn"
+      description: Sigil of the elves released as a tier 2 skilling sigil during the Deadman:Reborn event.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    alchable: true
+    destroy: Destroy
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silver-locks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silver-locks.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 7680
   highalch: 11520
   limit: 8
-  about: "Silver locks is a members-only item in Old School RuneScape. High alchemy value: 11,520 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Silver chest (Shades of Mort'ton)
+        quantity: "1"
+        rarity: 1/63
+        members_only: true
+        notes: Drop rate varies 1/63 to 1/57 by chest tier; improved with ring of wealth
+  recipes:
+    - skill: Crafting
+      members: true
+      materials:
+        - item_name: Silver locks
+          quantity: 1
+        - item_name: Broken coffin
+          quantity: 1
+      products:
+        - item_name: Silver coffin
+          quantity: 1
+      notes: Performed by Dampe; reversible via Remove-lock
+  related_items:
+    - item_id: 25433
+      item_name: Broken coffin
+      slug: broken-coffin
+      relationship: component
+      description: Coffin upgraded with silver locks
+    - item_id: 25443
+      item_name: Silver coffin
+      slug: silver-coffin
+      relationship: product
+      description: Final upgraded coffin
+  about: Silver locks are a Shades of Mort'ton silver chest reward used by Dampe to upgrade a broken coffin into a silver coffin.
+  market_strategy:
+    notes:
+      - Supply gated by silver chest drop rates
+      - Ring of wealth improves drop odds
+      - Limit of 8 keeps the market thin
+      - Demand tied to coffin upgrade meta
+  trading_tips:
+    - Track Shades of Mort'ton popularity for supply shifts
+    - Flip during minigame XP events
+  history:
+    - date: "2021-01-27"
+      update: Shades of Mort'ton Rework
+      description: Silver locks added as a silver chest reward in the reworked Shades of Mort'ton minigame.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-01-27"
+    update: Shades of Mort'ton Rework
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/splitbark-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/splitbark-helm.mdx
@@ -14,6 +14,10 @@ osrs:
   limit: 70
   equipment:
     slot: head
+    weight: 0.907
+    requirements:
+      magic: 40
+      defence: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,81 +35,64 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      magic: 40
-      defence: 40
-    weight: 0.907
   recipes:
     - skill: crafting
       level: 61
       xp: 124
-      inputs:
+      materials:
         - item_name: Bark
           quantity: 2
         - item_name: Fine cloth
           quantity: 2
-      output_quantity: 1
+        - item_name: Thread
+          quantity: 1
+      product: Splitbark helm
+      product_quantity: 1
+      facility: Wizard Jalarast (Wizards' Tower) or crafting interface
+      notes: Wizard Jalarast charges an additional 6,000 coins per helm.
   related_items:
     - item_id: 3387
       item_name: Splitbark body
       slug: splitbark-body
       relationship: set-piece
-      description: Matching body piece
+      description: Matching body piece in the splitbark set.
     - item_id: 3389
       item_name: Splitbark legs
       slug: splitbark-legs
       relationship: set-piece
-      description: Matching leg piece
+      description: Matching leg piece in the splitbark set.
     - item_id: 4091
       item_name: Mystic robe top
       slug: mystic-robe-top
       relationship: alternative
-      description: Higher magic bonus, no defence
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +3 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +10 |
-    | Slash | +9 |
-    | Crush | +11 |
-    | Magic | +3 |
-
-    Requirements: 40 Magic, 40 Defence
-
-    - Bark: Obtained from Hollow Trees in the Haunted Woods (east of Canifis). Requires a knife. Each tree gives 1 bark.
-    - Fine cloth: Obtained from the Shades of Mort'ton minigame by burning remains on pyres and looting the chest.
-
-    | Stat | Splitbark Helm | Mystic Hat |
-    |------|---------------|------------|
-    | Magic Atk | +3 | +4 |
-    | Stab Def | +10 | 0 |
-    | Slash Def | +9 | 0 |
-    | Crush Def | +11 | 0 |
-    | Magic Def | +3 | +4 |
-
-    Trades 1 Magic attack for significant melee defence. Better for hybrid setups where you expect melee hits.
-
-    - Swampbark helm: Requires Nature Spirit quest. Adds prayer-boosting effects to Earth spells.
-    - Bloodbark helm: Requires A Taste of Hope quest. Adds blood spell healing effects.
-
-    | Stat | Total |
-    |------|-------|
-    | Magic Atk | +20 |
-    | Stab Def | +68 |
-    | Slash Def | +55 |
-    | Crush Def | +78 |
-    | Magic Def | +28 |
-    | Materials | 9 bark + 9 fine cloth |
+      description: Higher magic attack but no melee defence.
   market_strategy:
     notes:
-      - Material sourcing is the bottleneck (fine cloth from Shades of Mort'ton)
-      - Craftable for XP and slight profit
-      - Niche hybrid demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Fine cloth from Shades of Mort'ton is the supply bottleneck.
+      - Niche hybrid demand; trades 1 Magic attack for sizeable melee defence vs Mystic hat.
+      - Craftable for XP at 61 Crafting; small loss after material costs.
+  about: Splitbark helm is a members-only head slot hybrid armour piece requiring 40 Magic and 40 Defence, crafted from bark and fine cloth and offering both melee defence and a magic attack bonus.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2004-10-18"
+      description: Added to game.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-potion-2.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Stamina potion(2) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: Restores 20% of run energy per dose on use.
+      - description: Reduces run energy depletion by 70% for 2 minutes (duration does not stack; additional doses reset the timer).
+      - description: Run energy orb changes from yellow to orange while the effect is active.
+  recipes:
+    - skill: herblore
+      level: 77
+      xp: 25.5
+      materials:
+        - item_name: Super energy potion
+          quantity: 1
+        - item_name: Amylase crystal
+          quantity: 1
+      product: Stamina potion(4)
+      product_quantity: 1
+      facility: Mixing
+      notes: Each amylase crystal added to a 4-dose super energy potion produces a 4-dose stamina potion; lower-dose variants are obtained by decanting or drinking doses.
+  related_items:
+    - item_id: 12625
+      item_name: Stamina potion(4)
+      slug: stamina-potion-4
+      relationship: variant
+      description: Full 4-dose variant.
+    - item_id: 12627
+      item_name: Stamina potion(3)
+      slug: stamina-potion-3
+      relationship: variant
+      description: 3-dose variant.
+    - item_id: 12631
+      item_name: Stamina potion(1)
+      slug: stamina-potion-1
+      relationship: variant
+      description: 1-dose variant.
+    - item_id: 12409
+      item_name: Amylase crystal
+      slug: amylase-crystal
+      relationship: component
+      description: Required to upgrade super energy potion into stamina potion.
+  market_strategy:
+    notes:
+      - Decant-and-resell pressure ties the 2-dose price closely to the 4-dose price per dose.
+      - High demand from questing, Blast Furnace, Herbiboar, runecrafting, agility, and Theatre of Blood trips.
+      - Amylase crystal supply (Blast Furnace points) anchors long-term price.
+  about: Stamina potion(2) is a members-only 2-dose potion that restores 20% run energy per dose and halves run energy depletion (70% reduction) for 2 minutes, brewed at level 77 Herblore by combining a super energy potion with an amylase crystal.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2014-07-03"
+      description: Added to game alongside the stamina potion family.
+    - date: "2026-05-26"
+      description: Updated alongside contemporary OSRS content patches.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bolts-p-9295.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bolts-p-9295.mdx
@@ -12,9 +12,96 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 11000
-  about: "Steel bolts (p+) is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: low
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    attack_speed: 6
+    weight: 0
+    requirements:
+      ranged: 23
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 64
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Stronger poison coating
+    description: Applies a stronger poison effect than standard (p) variant on the target when fired.
+  recipes:
+    - product: Steel bolts (p+)
+      skill: Herblore
+      level: 73
+      xp: 0
+      materials:
+        - item_name: Steel bolts
+          quantity: 1
+        - item_name: Weapon poison(+)
+          quantity: 1
+      facility: Inventory
+      notes: Apply weapon poison(+) to unpoisoned steel bolts.
+  related_items:
+    - item_id: 9140
+      item_name: Steel bolts
+      slug: steel-bolts
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 9286
+      item_name: Steel bolts (p)
+      slug: steel-bolts-p-9286
+      relationship: downgrade
+      description: Standard poison variant
+    - item_id: 9305
+      item_name: Steel bolts (p++)
+      slug: steel-bolts-p-9305
+      relationship: upgrade
+      description: Strongest poison variant
+  market_strategy:
+    notes:
+      - Niche poison-tier bolt for early-Ranged players
+      - Profit margin tied to weapon poison(+) supply
+      - Volume driven by Herblore training and PvP loadouts
+  history:
+    - date: "2006-07-31"
+      update: Crossbows
+      description: Released as part of the Crossbows update with the rest of the bolt tier system.
+    - date: "2007-01-16"
+      description: Value adjusted; poisoned bolt variants raised from 1 to 8 coins around this window.
+    - date: "2018-01-04"
+      description: Naming convention adjusted to add a space in poisoned variants (e.g. "Steel bolts (p+)").
+  about: Steel bolts (p+) are members-only poisoned crossbow bolts requiring 23 Ranged, created by applying weapon poison(+) to standard steel bolts.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/strength-amulet-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/strength-amulet-t.mdx
@@ -14,21 +14,71 @@ osrs:
   limit: 5
   equipment:
     slot: neck
-    requirements: {}
+    weight: 0.01
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
       melee_strength: 10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    is_reward: true
+    tier: medium
+    rarity: 10/3410
+    source: Reward casket (medium)
   related_items:
     - item_id: 1725
       item_name: Amulet of strength
       slug: amulet-of-strength
       relationship: variant
-      description: Standard (untrimmed) version
-  about: |-
-    > *"An enchanted ruby amulet."*
-
-    The strength amulet (t) is a trimmed cosmetic variant of the amulet of strength. Identical +10 melee strength bonus with no requirements. F2P item. Popular with pures for fashionscape while training melee.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Standard untrimmed version with identical stats
+  about: The strength amulet (t) is a trimmed cosmetic variant of the amulet of strength obtained as a medium clue reward, offering +10 melee strength with no requirements.
+  market_strategy:
+    notes:
+      - Supply only from medium clue rewards
+      - Buy limit of 5 keeps the market thin
+      - Demand driven by fashionscape and pures
+      - Identical stats to base amulet keep ceiling capped
+  trading_tips:
+    - Flip alongside medium clue release events
+    - Watch for streamer fashionscape boosts
+  history:
+    - date: "2014-12-10"
+      description: Renamed from "Strength amulet(t)" to "Strength amulet (t)".
+    - date: "2006-12-12"
+      description: Renamed from "Amulet of strength" to "Strength amulet(t)".
+    - date: "2006-12-05"
+      update: Treasure Trails, spiders and sheep
+      description: Item released as a Treasure Trails reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails, spiders and sheep
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-fanatic-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-fanatic-armour-set.mdx
@@ -12,9 +12,45 @@ osrs:
   lowalch: 22000
   highalch: 33000
   limit: null
-  about: "Sunfire fanatic armour set is a members-only item in Old School RuneScape. High alchemy value: 33,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_name: Sunfire fanatic helm
+      slug: sunfire-fanatic-helm
+      relationship: set-piece
+      description: Helm component
+    - item_name: Sunfire fanatic cuirass
+      slug: sunfire-fanatic-cuirass
+      relationship: set-piece
+      description: Body component
+    - item_name: Sunfire fanatic chausses
+      slug: sunfire-fanatic-chausses
+      relationship: set-piece
+      description: Legs component
+  market_strategy:
+    notes:
+      - Assembled via the Grand Exchange clerk's Sets interface
+      - Trades as a single bundle for easy resale of full set
+      - Watch premium vs individual piece total for arb opportunities
+  history:
+    - date: "2024-03-20"
+      update: Varlamore Part One
+      description: Released with the Sunfire fanatic armour as part of Varlamore Part One.
+  about: Sunfire fanatic armour set bundles the Sunfire fanatic helm, cuirass, and chausses for trading as one item via the Grand Exchange Sets interface.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore Part One
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-hunter-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-hunter-potion-3.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: null
-  about: "Super hunter potion(3) is a members-only item in Old School RuneScape. High alchemy value: 102 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 3
+    effects:
+      - description: Boosts Hunter level by +6.
+    duration: Single boost, no persistent duration.
+  recipes:
+    - product: Super hunter potion(3)
+      skill: Herblore
+      level: 67
+      experience: 154
+      materials:
+        - item_name: Pillar potion (unf)
+          quantity: 1
+        - item_name: Crab paste
+          quantity: 1
+      notes: Creating this potion currently nets a loss of around 74 coins before GE tax.
+  related_items:
+    - item_id: 31626
+      item_name: Super hunter potion(1)
+      slug: super-hunter-potion-1
+      relationship: variant
+      description: 1-dose variant
+    - item_id: 31627
+      item_name: Super hunter potion(2)
+      slug: super-hunter-potion-2
+      relationship: variant
+      description: 2-dose variant
+    - item_id: 31631
+      item_name: Super hunter potion(4)
+      slug: super-hunter-potion-4
+      relationship: variant
+      description: 4-dose variant
+    - item_name: Pillar potion (unf)
+      slug: pillar-potion-unf
+      relationship: component
+      description: Unfinished base potion used in the recipe
+    - item_name: Crab paste
+      slug: crab-paste
+      relationship: component
+      description: Secondary ingredient
+  market_strategy:
+    notes:
+      - 67 Herblore gate limits supply scaling
+      - Pillar potion (unf) supply caps daily output
+      - Hunter boost niche — flippers watch Sailing demand
+      - Loss-per-mix means GE flips dominate over crafting
+  history:
+    - date: "2025-11-19"
+      update: Sailing is OUT TODAY!
+      description: Super hunter potion released with the Sailing launch.
+  about: Super hunter potion(3) is a 67 Herblore potion that boosts Hunter by +6 doses, brewed from a pillar potion (unf) and crab paste.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-strength-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-strength-1.mdx
@@ -12,6 +12,13 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: 2000
+  potion:
+    doses: 1
+    type: combat
+    base_herb: kwuarm
+    effects:
+      - description: "Boosts Strength by 5 + 15% of current Strength level (floored)."
+      - description: "Effect decays at 1 level per minute, or 1 level per 90 seconds with the Preserve prayer active."
   related_items:
     - item_id: 157
       item_name: Super strength(3)
@@ -23,12 +30,48 @@ osrs:
       slug: super-strength-2
       relationship: variant
       description: 2-dose version
-  about: |-
-    > _"1 dose of super Strength potion."_
-
-    A 1-dose super strength potion. Boosts Strength by 5 + 15% of current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 163
+      item_name: Vial
+      slug: vial
+      relationship: component
+      description: Empty container left after drinking the last dose
+    - item_id: 219
+      item_name: Kwuarm potion (unf)
+      slug: kwuarm-potion-unf
+      relationship: component
+      description: Unfinished base before adding limpwurt root
+  history:
+    - date: "2002-02-27"
+      description: Super strength potions released alongside the Herblore skill expansion.
+    - date: "2004-10-26"
+      description: '"Empty" option added.'
+  about: Super strength(1) is the single-dose form of the super strength potion, providing a Strength boost of 5 + 15% of the player's level.
+  market_strategy:
+    notes:
+      - Often sold by raiders trimming inventory doses
+      - Decanters convert single doses into 3- or 4-dose flasks for profit
+      - Limited demand vs. 4-dose; thinner spread
+  trading_tips:
+    - Combine 1-doses into 4-doses via decanting NPCs
+    - Watch limpwurt root and kwuarm supply
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: Herblore expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tan-cavalier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tan-cavalier.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 4
-  about: "Tan cavalier is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.08
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    is_reward: true
+    tier: hard
+    rarity: 1/1625
+    source: Reward casket (hard)
+  related_items:
+    - item_id: 2641
+      item_name: Dark cavalier
+      slug: dark-cavalier
+      relationship: variant
+      description: Alternate cavalier colour
+    - item_id: 2643
+      item_name: Black cavalier
+      slug: black-cavalier
+      relationship: variant
+      description: Alternate cavalier colour
+  about: Tan cavalier is a cosmetic head slot hat rewarded from hard clue caskets, storable in the costume room and providing no combat bonuses.
+  market_strategy:
+    notes:
+      - Pure cosmetic from hard clues
+      - Low buy limit keeps prices spiky
+      - Costume room storage reduces circulating supply
+      - Variants compete for fashionscape demand
+  trading_tips:
+    - Buy after hard clue XP events flood supply
+    - Sell during streamer fashionscape trends
+  history:
+    - date: "2005-05-31"
+      description: Renamed from "Brown cavalier" to "Tan cavalier".
+    - date: "2005-05-17"
+      description: Renamed from "Cavalier" to "Brown cavalier".
+    - date: "2004-05-05"
+      update: Bigger Banks & Treasure Trails
+      description: Tan cavalier released as a Treasure Trails reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-05-05"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-17-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-17-cape.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-17 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 0
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Neil's Wilderness Cape Shop
+      location: Bandit Camp, Wilderness
+      stock: 100
+      price: 50
+      restock_seconds: 60
+  related_items:
+    - item_id: 4329
+      item_name: Team-8 cape
+      slug: team-8-cape
+      relationship: variant
+      description: Yellow team cape variant
+    - item_id: 4365
+      item_name: Team-26 cape
+      slug: team-26-cape
+      relationship: variant
+      description: Sibling team cape from the 50-cape set
+  market_strategy:
+    notes:
+      - F2P available since 2013
+      - Stable shop floor at 50 gp
+      - Cosmetic with negligible defence bonus
+      - Collectible across the 50-cape set
+  history:
+    - date: "2005-02-22"
+      description: Released as part of the team cape collection.
+    - date: "2013-05-23"
+      description: Made available to free-to-play players.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  about: Team-17 cape is one of fifty numbered team capes used for clan identification, sold by Neil's Wilderness Cape Shop in the Bandit Camp.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trinket-of-fortuity-inactive.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trinket-of-fortuity-inactive.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trinket of fortuity (inactive) | OSRS Price Data
-description: Trinket of fortuity (inactive) is a members-only OSRS item.
+description: Trinket of fortuity (inactive) is a members-only OSRS item from Deadman Mode breach bosses.
 osrs:
   id: 33047
   name: Trinket of fortuity (inactive)
@@ -8,13 +8,68 @@ osrs:
   examine: A magic rock! This one increases the chance of obtaining rare items when active.
   members: true
   icon: Trinket of fortuity (inactive).png
-  value: 0
-  lowalch: null
-  highalch: null
+  value: 100000
+  lowalch: 40000
+  highalch: 60000
   limit: null
-  about: Trinket of fortuity (inactive) is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  charges:
+    activation_cost: 50000000
+    notes: Charging with 50,000,000 coins activates the trinket (10,000,000 in Deadman Annihilation). Active version grants +100% drop rate at bosses and forces a 7-second skull-style teleport timer.
+  drop_table:
+    sources:
+      - source: Dagannoth Rex (breach)
+        rarity: 1/9576
+        members_only: true
+      - source: King Black Dragon (breach)
+        rarity: 1/9576
+        members_only: true
+      - source: Kree'arra (breach)
+        rarity: 1/9576
+        members_only: true
+      - source: TzTok-Jad (breach)
+        rarity: 1/9576
+        members_only: true
+      - source: Other breach monsters
+        rarity: 1/9576
+        members_only: true
+        notes: Shared 1/9,576 rate across 40+ breach bosses.
+  related_items:
+    - item_id: 33050
+      item_name: Trinket of fortuity
+      slug: trinket-of-fortuity
+      relationship: upgrade
+      description: Active version after charging with coins
+  market_strategy:
+    notes:
+      - Deadman-mode exclusive — liquidity tied to seasonal events
+      - 50M activation cost anchors floor pricing
+      - Breach boss rarity keeps supply scarce
+      - Annihilation discount changes seasonal demand curves
+  history:
+    - date: "2026-01-21"
+      update: Deadman Mode release
+      description: Trinket of fortuity (inactive) released for Deadman Mode on world 345 and event windows.
+    - date: "2026-02-11"
+      update: Teleport timer fix
+      description: Prevented bypassing the active teleport timer via looting bag storage and clarified the skull-style timer behaviour.
+  about: Trinket of fortuity (inactive) is a Deadman Mode breach boss drop charged with coins to activate a +100% boss drop rate buff.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2026-01-21"
+    update: Deadman Mode
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Charge
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncooked-berry-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncooked-berry-pie.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 13000
-  about: "Uncooked berry pie is a free-to-play item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: cooking
+      level: 10
+      xp: 0
+      materials:
+        - item_name: Pie shell
+          quantity: 1
+        - item_name: Redberries
+          quantity: 1
+      product: Uncooked berry pie
+      product_id: 2321
+      product_quantity: 1
+  related_items:
+    - item_name: Redberry pie
+      slug: redberry-pie
+      relationship: product
+      description: Cooked product
+    - item_name: Pie shell
+      slug: pie-shell
+      relationship: component
+      description: Required base
+    - item_name: Redberries
+      slug: redberries
+      relationship: component
+      description: Filling ingredient
+  history:
+    - date: "2015-03-12"
+      description: Uncooked pies can now be traded on the Grand Exchange.
+    - date: "2015-02-26"
+      description: The item was made untradeable on the Trading Post/Grand Exchange.
+  about: Uncooked berry pie is a free-to-play Cooking intermediate made at level 10 from a pie shell and redberries, baked into a redberry pie.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-03-17"
+    update: This weeks update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unstrung-heavy-ballista.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unstrung-heavy-ballista.mdx
@@ -1,6 +1,6 @@
 ---
 title: Unstrung heavy ballista | OSRS Price Data
-description: "Unstrung heavy ballista: Needs a suitably simian rope.. High alch: 30,000 GP, GE limit: 8."
+description: "Unstrung heavy ballista: Needs a suitably simian rope. High alch: 30,000 GP, GE limit: 8."
 osrs:
   id: 19607
   name: Unstrung heavy ballista
@@ -12,9 +12,89 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
-  about: "Unstrung heavy ballista is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: fletching
+      level: 72
+      xp: 30
+      materials:
+        - item_name: Incomplete heavy ballista
+          item_id: 19601
+          quantity: 1
+        - item_name: Ballista spring
+          item_id: 19595
+          quantity: 1
+      product: Unstrung heavy ballista
+      product_id: 19607
+      product_quantity: 1
+      facility: None
+      members_only: true
+    - skill: fletching
+      level: 72
+      xp: 600
+      materials:
+        - item_name: Unstrung heavy ballista
+          item_id: 19607
+          quantity: 1
+        - item_name: Monkey tail
+          item_id: 19613
+          quantity: 1
+      product: Heavy ballista
+      product_id: 19481
+      product_quantity: 1
+      facility: None
+      members_only: true
+  related_items:
+    - item_id: 19481
+      item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: upgrade
+      description: Strung functional ballista
+    - item_id: 19601
+      item_name: Incomplete heavy ballista
+      slug: incomplete-heavy-ballista
+      relationship: component
+      description: Pre-assembly stage
+    - item_id: 19595
+      item_name: Ballista spring
+      slug: ballista-spring
+      relationship: component
+      description: Required spring component
+    - item_id: 19613
+      item_name: Monkey tail
+      slug: monkey-tail
+      relationship: component
+      description: Stringing material for the ballista
+  market_strategy:
+    notes:
+      - Monkey Madness II gated supply
+      - Cheaper than strung ballista
+      - Final step requires monkey tail
+      - Fletching 72 to assemble
+      - Niche Ironman crafting demand
+  history:
+    - date: "2016-05-06"
+      update: Monkey Madness II
+      description: Item released alongside Monkey Madness II.
+    - date: "2017-10-19"
+      update: Halloween 2017 & Make-All
+      description: Inventory sprite adjusted.
+  about: The unstrung heavy ballista is the penultimate step in crafting a heavy ballista, requiring a monkey tail to complete.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-05-06"
+    update: Monkey Madness II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 5.75
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/water-orb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/water-orb.mdx
@@ -1,6 +1,6 @@
 ---
 title: Water orb | OSRS Price Data
-description: "Water orb: A magic glowing orb.. High alch: 180 GP, GE limit: 11,000."
+description: "Water orb: A magic glowing orb. High alch: 180 GP, GE limit: 11,000."
 osrs:
   id: 571
   name: Water orb
@@ -12,37 +12,43 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 11000
-  item:
-    type: material
-    tradeable: true
+  material:
+    type: secondary
+    tier: mid
   recipes:
     - skill: magic
       level: 56
       xp: 66
       materials:
-        - item_id: 567
-          item_name: Unpowered orb
+        - item_name: Unpowered orb
+          item_id: 567
           quantity: 1
-        - item_id: 555
-          item_name: Water rune
+        - item_name: Water rune
+          item_id: 555
           quantity: 30
-        - item_id: 564
-          item_name: Cosmic rune
+        - item_name: Cosmic rune
+          item_id: 564
           quantity: 3
       product: Water orb
       product_id: 571
+      product_quantity: 1
+      facility: Obelisk of Water
+      members_only: true
     - skill: crafting
-      level: 66
+      level: 54
       xp: 100
       materials:
-        - item_id: 571
-          item_name: Water orb
+        - item_name: Water orb
+          item_id: 571
           quantity: 1
-        - item_id: 1391
-          item_name: Battlestaff
+        - item_name: Battlestaff
+          item_id: 1391
           quantity: 1
       product: Water battlestaff
       product_id: 1395
+      product_quantity: 1
+      facility: None
+      members_only: true
   related_items:
     - item_id: 567
       item_name: Unpowered orb
@@ -59,17 +65,36 @@ osrs:
       slug: cosmic-rune
       relationship: component
       description: Required rune for charging
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 0.453 kg |
-
-    Combine with battlestaff (66 Crafting) to create water battlestaff.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Magic 56 production gate
+      - Water battlestaff intermediate
+      - Profitable charge spell
+      - Steady daily volume
+      - Limit raised to 11k in 2020
+  history:
+    - date: "2002-03-18"
+      description: Item released into RuneScape.
+    - date: "2015-03-05"
+      description: Continuous orb charging enabled without diary tasks.
+    - date: "2020-09-09"
+      description: Grand Exchange buy limit raised from 10,000 to 11,000.
+  about: The water orb is a magic-charged crafting material made at the Obelisk of Water and combined with a battlestaff to create a water battlestaff.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-dark-bow-paint.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-dark-bow-paint.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "White dark bow paint is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Justine's stuff for the Last Man Standing
+      location: Last Man Standing lobby
+      price: 25
+      currency: Last Man Standing points
+  related_items:
+    - item_id: 11235
+      item_name: Dark bow
+      slug: dark-bow
+      relationship: component
+      description: Base bow recolored by this paint
+    - item_id: 12765
+      item_name: Dark bow (white)
+      slug: dark-bow-white
+      relationship: product
+      description: Resulting recolored dark bow
+  about: White dark bow paint is a cosmetic item used to recolor a dark bow white, purchased from Justine's shop in the Last Man Standing lobby for 25 LMS points.
+  market_strategy:
+    notes:
+      - Sourced only from Last Man Standing points
+      - Cosmetic recolor, no combat impact
+      - Limited supply tied to LMS engagement
+      - Buy limit of 4 throttles flips
+  trading_tips:
+    - Watch LMS participation patches for supply shifts
+    - Price spikes when cosmetic dark bows trend in PvP
+  history:
+    - date: "2014-09-18"
+      update: Bounty Hunter
+      description: Item released alongside the Bounty Hunter update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-09-18"
+    update: Bounty Hunter
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-mace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-mace.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 172
   highalch: 259
   limit: 125
-  about: "White mace is a members-only item in Old School RuneScape. High alchemy value: 259 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: blunt
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 8
+      slash: -2
+      crush: 16
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 13
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 3
+  shops:
+    - shop_name: White Knight Armoury (Sir Vyvin)
+      location: White Knights' Castle, Falador
+      price: 432
+      notes: Requires Noble rank (500 Black Knight kills) and completion of Wanted!.
+  related_items:
+    - item_id: 1422
+      item_name: Black mace
+      slug: black-mace
+      relationship: alternative
+      description: Same melee bonuses without the +3 prayer.
+    - item_id: 6603
+      item_name: White warhammer
+      slug: white-warhammer
+      relationship: set-piece
+      description: Other White Knight crush weapon.
+    - item_id: 6631
+      item_name: White sq shield
+      slug: white-sq-shield
+      relationship: set-piece
+      description: White Knight off-hand shield.
+  market_strategy:
+    notes:
+      - Wanted! quest and Noble rank gate supply; mainly bought for the +3 prayer bonus over the black mace.
+      - Attack speed buffed to 4 ticks in April 2021, making it competitive with low-level scimitars for crush.
+      - Niche prayer-bonus PvP / training tool; volume is low.
+  about: White mace is a members-only one-handed crush weapon requiring 10 Attack and Wanted! completion, purchased from Sir Vyvin at Noble rank and notable for its +3 prayer bonus over the otherwise-identical black mace.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-10-17"
+    update: "Wanted!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2005-10-17"
+      update: Wanted!
+      description: Added to game alongside the Wanted! quest and White Knight Armoury.
+    - date: "2021-04-21"
+      description: Attack speed improved from 5 ticks to 4 ticks as part of weapon rebalance.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-sq-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-sq-shield.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 460
   highalch: 691
   limit: 125
-  about: "White sq shield is a members-only item in Old School RuneScape. High alchemy value: 691 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    weight: 3.628
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 15
+      slash: 16
+      crush: 14
+      magic: 0
+      ranged: 15
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: White Knight Armoury (Sir Vyvin)
+      location: White Knights' Castle, Falador
+      price: 1152
+      notes: Requires Page rank (300 Black Knight kills) and completion of Wanted!.
+  related_items:
+    - item_id: 1175
+      item_name: Black sq shield
+      slug: black-sq-shield
+      relationship: alternative
+      description: Same defence bonuses without the +1 prayer.
+    - item_id: 6601
+      item_name: White mace
+      slug: white-mace
+      relationship: set-piece
+      description: Matching White Knight crush weapon.
+  market_strategy:
+    notes:
+      - Wanted! quest + Page rank gate supply; +1 prayer differentiates from black sq shield.
+      - Ranged defence buffed to 0 in April 2021 (from -2), modest fashionscape lift.
+      - Low volume; mostly bought for prayer trips or completionist sets.
+  about: White sq shield is a members-only shield requiring 10 Defence and Wanted! completion, purchased from Sir Vyvin at Page rank and notable for its +1 prayer bonus over the otherwise-identical black sq shield.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-10-17"
+    update: "Wanted!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2005-10-17"
+      update: Wanted!
+      description: Added to game alongside the Wanted! quest and White Knight Armoury.
+    - date: "2021-04-21"
+      description: Ranged attack bonus increased from -2 to 0.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-pyre-logs.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 11000
-  about: "Willow pyre logs is a members-only item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: log
+    tier: low
+  recipes:
+    - product: Willow pyre logs
+      skill: Firemaking
+      level: 35
+      xp: 100
+      materials:
+        - item_name: Willow logs
+          quantity: 1
+        - item_name: Sacred oil (3)
+          quantity: 1
+      facility: Inventory
+      notes: Use sacred oil on willow logs; flat 5 Firemaking XP per dose applied.
+  prayer:
+    notes:
+      - Burned at Mort'ton funeral pyres with shade remains to grant Prayer XP
+      - Loar remains 33.5 XP, Phrin 46 XP, Riyl 61 XP on willow pyre
+      - Higher Prayer XP than regular pyre logs, gated by 35 Firemaking
+  related_items:
+    - item_id: 1519
+      item_name: Willow logs
+      slug: willow-logs
+      relationship: component
+      description: Base log soaked in sacred oil
+    - item_id: 3438
+      item_name: Pyre logs
+      slug: pyre-logs
+      relationship: downgrade
+      description: Regular log version, lower Firemaking requirement
+    - item_id: 3444
+      item_name: Maple pyre logs
+      slug: maple-pyre-logs
+      relationship: upgrade
+      description: Next-tier pyre log with higher Prayer XP
+  market_strategy:
+    notes:
+      - Demand driven by Shades of Mort'ton Prayer training
+      - Cheaper alternative to higher-tier pyre logs
+      - Supply tied to willow log + sacred oil availability
+  history:
+    - date: "2004-10-18"
+      update: Shades of Mort'ton
+      description: Released alongside the Shades of Mort'ton minigame.
+    - date: "2015-01-22"
+      description: Firemaking XP standardized regardless of click order on sacred oil application.
+    - date: "2024-07-31"
+      description: Make-All menu added; Firemaking XP from sacred oil set to a flat 5 XP per dose.
+  about: Willow pyre logs are willow logs soaked in sacred oil, used at Mort'ton funeral pyres to grant elevated Prayer XP from shade remains.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-18"
+    update: Shades of Mort'ton
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/xerician-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/xerician-hat.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 125
-  about: "Xerician hat is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.2
+    requirements:
+      defence: 10
+      magic: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 14
+      xp: 66
+      materials:
+        - item_name: Xerician fabric
+          quantity: 3
+        - item_name: Thread
+          quantity: 1
+      product: Xerician hat
+      product_id: 13385
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_name: Xerician top
+      slug: xerician-top
+      relationship: set-piece
+      description: Body component of set
+    - item_name: Xerician robe
+      slug: xerician-robe
+      relationship: set-piece
+      description: Legs component of set
+    - item_name: Xerician fabric
+      slug: xerician-fabric
+      relationship: component
+      description: Crafting material
+  market_strategy:
+    notes:
+      - Stats match gnome hats, Canifis hats, ghostly hood, Fremennik hat
+      - Crafted from Xerician fabric at level 14 Crafting
+      - Low alch margin; flip mostly on fabric cost swings
+  history:
+    - date: "2016-01-07"
+      update: Zeah Great Kourend
+      description: Released with the Great Kourend expansion.
+  about: Xerician hat is a low-level magic hat requiring 10 Defence and 20 Magic, crafted at level 14 Crafting from 3 Xerician fabric and one thread.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: Zeah Great Kourend
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yanillian-hops.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yanillian-hops.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 11000
-  about: "Yanillian hops is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    farming_level: 16
+    seed: Yanillian seed
+    patch: Hops
+    growth_time_minutes: 50
+    description: Grown from a Yanillian seed in a hops patch.
+  recipes:
+    - skill: Cooking
+      level: 34
+      xp: 314
+      output: Wizard's mind bomb
+      materials:
+        - item_name: Yanillian hops
+          quantity: 4
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Water
+          quantity: 2
+        - item_name: Ale yeast
+          quantity: 1
+  shops:
+    - shop_name: Vanessa's Farming Shop
+      location: Catherby
+      stock: 0
+      price: 7
+    - shop_name: Richard's Farming Shop
+      location: North of East Ardougne
+      stock: 0
+      price: 7
+    - shop_name: Sarah's Farming Shop
+      location: South Falador Farm
+      stock: 0
+      price: 7
+    - shop_name: Alice's Farming Shop
+      location: Alice's farm
+      stock: 0
+      price: 7
+  related_items:
+    - item_id: 5994
+      item_name: Hammerstone hops
+      slug: hammerstone-hops
+      relationship: variant
+      description: Lower-tier hops variety
+    - item_id: 5996
+      item_name: Asgarnian hops
+      slug: asgarnian-hops
+      relationship: variant
+      description: Mid-tier hops variety
+    - item_id: 6000
+      item_name: Krandorian hops
+      slug: krandorian-hops
+      relationship: variant
+      description: Higher-tier hops variety
+    - item_id: 6002
+      item_name: Wildblood hops
+      slug: wildblood-hops
+      relationship: variant
+      description: Highest-tier hops variety
+  market_strategy:
+    notes:
+      - Wizard's Mind Bomb is the staple sink
+      - Mahogany tree protection costs 25
+      - 11k buy limit absorbs farm flips
+      - Farming shops never run out
+  history:
+    - date: "2005-07-11"
+      update: "Farming"
+      description: Released with the Farming skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: "Farming"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  about: Yanillian hops are the mid-tier hops harvested from a Yanillian seed at 16 Farming, used to brew Wizard's Mind Bomb and pay mahogany tree protection.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yew-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yew-logs.mdx
@@ -15,14 +15,6 @@ osrs:
   material:
     type: log
     tier: mid-high
-  woodcutting:
-    level: 60
-    xp: 175
-    locations:
-      - Woodcutting Guild
-      - Edgeville
-      - Seers' Village
-      - Varrock Palace
   recipes:
     - skill: fletching
       level: 65
@@ -45,7 +37,7 @@ osrs:
       product_id: 66
       product_quantity: 1
     - skill: fletching
-      level: 72
+      level: 69
       xp: 50
       materials:
         - item_name: Yew logs
@@ -55,6 +47,34 @@ osrs:
       product_id: 9446
       product_quantity: 1
       members_only: true
+    - skill: fletching
+      level: 72
+      xp: 150
+      materials:
+        - item_name: Yew logs
+          item_id: 1515
+          quantity: 2
+      product: Yew shield
+      product_quantity: 1
+      members_only: true
+    - skill: fletching
+      level: 60
+      xp: 25
+      materials:
+        - item_name: Yew logs
+          item_id: 1515
+          quantity: 1
+      product: Yew arrow shafts
+      product_quantity: 75
+    - skill: firemaking
+      level: 60
+      xp: 202.5
+      materials:
+        - item_name: Yew logs
+          item_id: 1515
+          quantity: 1
+      product: Ashes
+      product_quantity: 1
   related_items:
     - item_id: 66
       item_name: Yew longbow (u)
@@ -86,10 +106,6 @@ osrs:
       slug: magic-logs
       relationship: alternative
       description: Higher tier logs
-  about: |
-    Yew logs is a free-to-play item in Old School RuneScape. It is one of the most popular logs for fletching and high alchemy money-making methods.
-
-    Yew trees require level 60 Woodcutting to chop and are found at several locations including the Woodcutting Guild, Edgeville, Seers' Village, and Varrock Palace.
   market_strategy:
     title: Yew Longbow (u) Processing
     steps:
@@ -112,8 +128,26 @@ osrs:
     - High volume item with consistent demand
     - Compare GE price to high alchemy value (768 GP for longbow)
     - Watch for price dips during double XP or bot ban waves
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2005-07-11"
+      update: Farming
+      description: The item was graphically updated with the release of Farming.
+  about: Yew logs is a free-to-play log obtained by chopping yew trees at level 60 Woodcutting, widely used for fletching yew bows and high alchemy money-making.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-s-grapes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-s-grapes.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 11000
-  about: "Zamorak's grapes is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    farming_level: 36
+    notes:
+      - Picked from vines at the Hosidius vinery while carrying Bologa's blessing
+      - One blessing is consumed per grape harvested
+  recipes:
+    - product: Wine of Zamorak
+      skill: Cooking
+      level: 65
+      xp: 200
+      materials:
+        - item_name: Zamorak's grapes
+          quantity: 1
+        - item_name: Jug of water
+          quantity: 1
+      facility: Inventory
+      notes: Success rate scales from ~50% at 65 Cooking to 100% at 98 Cooking; failures produce jug of bad wine.
+  related_items:
+    - item_id: 245
+      item_name: Wine of Zamorak
+      slug: wine-of-zamorak
+      relationship: product
+      description: Cooked product used in high-level Herblore potions
+    - item_id: 1937
+      item_name: Grapes
+      slug: grapes
+      relationship: alternative
+      description: Standard grapes used in regular wine making
+    - item_id: 20755
+      item_name: Bologa's blessing
+      slug: bologa-s-blessing
+      relationship: component
+      description: Required to harvest from the Hosidius vinery
+  market_strategy:
+    notes:
+      - Supply gated by 36 Farming + Hosidius access
+      - Demand driven by Wine of Zamorak ingredient for Herblore
+      - Margin tied to Wine of Zamorak resale at 65+ Cooking
+  history:
+    - date: "2016-09-29"
+      update: Duel Arena Improvements
+      description: Released alongside the Duel Arena Improvements update.
+    - date: "2023-03-01"
+      description: Wine of Zamorak success rate floor improved at level 65 and capped at 100% by level 98 (previously 99).
+  about: Zamorak's grapes are members-only vinery grapes harvested in Hosidius using Bologa's blessing and cooked into Wine of Zamorak at 65 Cooking.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-09-29"
+    update: Duel Arena Improvements
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zombie-pirate-key.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zombie-pirate-key.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 250
-  about: "Zombie pirate key is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Zombie pirate
+        combat_level: 22
+        quantity: "1"
+        rarity: 1/24
+        members_only: true
+        notes: Drop rate hotfixed from 1/50 to 1/24 on 2024-04-12; Wilderness Chaos Temple.
+      - source: Zombie pirate
+        combat_level: 28
+        quantity: "1"
+        rarity: 1/24
+        members_only: true
+        notes: Wilderness Chaos Temple.
+      - source: Zombie pirate
+        combat_level: 34
+        quantity: "1"
+        rarity: 1/24
+        members_only: true
+        notes: Wilderness Chaos Temple.
+  related_items:
+    - item_id: 29447
+      item_name: Teleport anchoring scroll
+      slug: teleport-anchoring-scroll
+      relationship: product
+      description: Locker reward with increased rate vs base drop table
+    - item_id: 29445
+      item_name: Pirate hook
+      slug: pirate-hook
+      relationship: alternative
+      description: Other zombie pirate themed reward
+  market_strategy:
+    notes:
+      - Always lost on PvP death and unprotectable
+      - Demand driven by doubled loot vs killing zombie pirates direct
+      - Supply tied to Wilderness Chaos Temple zombie pirate kills
+  history:
+    - date: "2024-04-10"
+      update: Undead Pirates, Colosseum Changes & more!
+      description: Released with the Undead Pirates content update.
+    - date: "2024-04-12"
+      description: Hotfix increased drop rate from 1/50 to 1/24.
+  about: Zombie pirate key is a Wilderness drop from zombie pirates at the Chaos Temple that opens lockers on a nearby shipwreck for doubled loot and increased teleport anchoring scroll rates.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-04-10"
+    update: Undead Pirates, Colosseum Changes & more!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Fifth batch — migrate 100 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Worktree-direct authoring; main repo untouched.
- Schema-validated via `astro sync`.

Post-agent normalisation:
- `treasure_trail.tier` required singular field (added where reward-only items omitted it)
- Lowercased capitalised tier enum values (`Beginner` → `beginner`, etc.)
- Quoted `about:` strings containing unescaped colons (`Deadman: Reborn` etc.)

## Test plan

- [x] `astro sync` clean — all 100 entries validate.
- [ ] CI build green.
- [ ] Smoke check a few pages on preview.

## Follow-ups

- ~3973 v2 items remain after this batch lands.