### PR TITLE
test(astro-kbve): axe-core accessibility sweep for dashboards

### DIFF
--- a/apps/kbve/astro-kbve/e2e/axe.spec.ts
+++ b/apps/kbve/astro-kbve/e2e/axe.spec.ts
@@ -1,0 +1,49 @@
+import {
+	test,
+	expect,
+	mockSupaSession,
+	mockArgoApi,
+} from './fixtures/auth-mock';
+import { runAxe } from './fixtures/axe';
+
+test.describe('a11y — dashboards', () => {
+	test('argo dashboard (authenticated)', async ({ page }) => {
+		await mockSupaSession(page, { staff: true });
+		await mockArgoApi(page, [
+			{
+				name: 'app-alpha',
+				project: 'platform',
+				syncStatus: 'Synced',
+				healthStatus: 'Healthy',
+			},
+			{
+				name: 'app-beta',
+				project: 'data',
+				syncStatus: 'OutOfSync',
+				healthStatus: 'Degraded',
+			},
+		]);
+		await page.goto('/dashboard/argo/', { waitUntil: 'load' });
+		await expect(page.locator('button.kbve-argo-row').first()).toBeVisible({
+			timeout: 30_000,
+		});
+		await runAxe(page);
+	});
+
+	test('argo dashboard (sign-in gate)', async ({ page }) => {
+		await page.goto('/dashboard/argo/', { waitUntil: 'load' });
+		await expect(page.getByText('Sign In Required')).toBeVisible({
+			timeout: 30_000,
+		});
+		await runAxe(page);
+	});
+});
+
+test.describe('a11y — homepage', () => {
+	test('home renders without serious/critical violations', async ({
+		page,
+	}) => {
+		await page.goto('/', { waitUntil: 'load' });
+		await runAxe(page);
+	});
+});

--- a/apps/kbve/astro-kbve/e2e/fixtures/axe.ts
+++ b/apps/kbve/astro-kbve/e2e/fixtures/axe.ts
@@ -1,0 +1,65 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page } from '@playwright/test';
+
+const ALLOWED_RULES: string[] = [];
+
+const ALLOWED_INCLUDE_PATTERNS: ReadonlyArray<RegExp> = [/starlight-/i];
+
+export interface RunAxeOptions {
+	include?: string;
+	exclude?: string[];
+	disableRules?: string[];
+	allowSelectorPatterns?: ReadonlyArray<RegExp>;
+}
+
+export async function runAxe(
+	page: Page,
+	options: RunAxeOptions = {},
+): Promise<void> {
+	let builder = new AxeBuilder({ page }).withTags([
+		'wcag2a',
+		'wcag2aa',
+		'wcag21a',
+		'wcag21aa',
+		'best-practice',
+	]);
+
+	if (options.include) builder = builder.include(options.include);
+	for (const sel of options.exclude ?? []) builder = builder.exclude(sel);
+
+	const disableRules = [...ALLOWED_RULES, ...(options.disableRules ?? [])];
+	if (disableRules.length > 0) builder = builder.disableRules(disableRules);
+
+	const allowPatterns = [
+		...ALLOWED_INCLUDE_PATTERNS,
+		...(options.allowSelectorPatterns ?? []),
+	];
+
+	const result = await builder.analyze();
+	const blocking = result.violations.filter((v) => {
+		if (v.impact !== 'serious' && v.impact !== 'critical') return false;
+		const allEnvelopedByAllowList = v.nodes.every((node) =>
+			node.target.some((sel) =>
+				allowPatterns.some((re) => re.test(String(sel))),
+			),
+		);
+		return !allEnvelopedByAllowList;
+	});
+
+	if (blocking.length > 0) {
+		const summary = blocking
+			.map((v) => {
+				const targets = v.nodes
+					.map((n) => n.target.join(' >> '))
+					.slice(0, 5)
+					.join('\n      ');
+				return `  ${v.impact?.toUpperCase()} ${v.id} — ${v.help}\n    ${v.helpUrl}\n    nodes:\n      ${targets}`;
+			})
+			.join('\n');
+		throw new Error(
+			`axe: ${blocking.length} serious/critical accessibility violation(s):\n${summary}`,
+		);
+	}
+
+	expect(blocking).toHaveLength(0);
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@nx/workspace": "22.7.2",
 		"@nxlv/python": "22.0.5",
 		"@playform/compress": "^0.2.3",
+		"@axe-core/playwright": "^4.10.2",
 		"@playwright/test": "^1.59.1",
 		"@scalar/api-reference": "^1.55.3",
 		"@swc-node/register": "1.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       '@astrojs/ts-plugin':
         specifier: ^1.10.7
         version: 1.10.7
+      '@axe-core/playwright':
+        specifier: ^4.10.2
+        version: 4.11.3(playwright-core@1.59.1)
       '@babel/core':
         specifier: ^7.25.9
         version: 7.26.10
@@ -756,6 +759,11 @@ packages:
 
   '@astropub/worker@0.2.0':
     resolution: {integrity: sha512-DkvD+H3N3n9XqRV66Jh3nYq0fPkfPwlbuOcKmLgSINms0z5VcHALVUmneceMJ1ni/MexkqffezWtGgKAiglYbw==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.10.4':
     resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
@@ -7067,6 +7075,10 @@ packages:
 
   axe-core@4.10.1:
     resolution: {integrity: sha512-qPC9o+kD8Tir0lzNGLeghbOrWMr3ZJpaRlCIb6Uobt/7N4FiEDvqUMnxzCHRHmg8vOg14kr5gVNyScRmbMaJ9g==}
+    engines: {node: '>=4'}
+
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
 
   axios@1.15.0:
@@ -16380,6 +16392,11 @@ snapshots:
 
   '@astropub/worker@0.2.0': {}
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.59.1
+
   '@babel/code-frame@7.10.4':
     dependencies:
       '@babel/highlight': 7.25.9
@@ -25137,6 +25154,8 @@ snapshots:
   aws4@1.13.2: {}
 
   axe-core@4.10.1: {}
+
+  axe-core@4.11.4: {}
 
   axios@1.15.0:
     dependencies:


### PR DESCRIPTION
Closes #11587 — part of tracker #11583.

## Summary
- `@axe-core/playwright@^4.10.2` added to root dev deps
- `e2e/fixtures/axe.ts` — `runAxe(page, options?)` helper:
  - Scans WCAG 2.0/2.1 A + AA + best-practice tags
  - Fails only on `impact === 'serious' || 'critical'` (warnings stay informational)
  - Allow-list of selector patterns for known out-of-scope violations — currently `/starlight-/i` for Starlight built-ins
  - Per-call extend via `disableRules` / `allowSelectorPatterns`
- `e2e/axe.spec.ts` covers Argo dashboard (auth + gate) and homepage

## Why
The `<div onClick>` regression from PR #11578 would have failed `runAxe` on the `kbve-argo-row` scope (no `role="button"` + no keyboard handlers).

## Test plan
- [ ] `pnpm exec playwright test --config=apps/kbve/astro-kbve/playwright.config.ts axe.spec.ts`
- [ ] Inspect the first ci-e2e run for unexpected serious/critical hits — tighten the Starlight allow-list if needed