### PR TITLE
fix(kbve-spider): eggs never hatch — collapse duplicate on_nth_tick(60)

### DIFF
--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -260,11 +260,11 @@ script.on_event(defines.events.on_robot_mined_entity, function(event)
 	drop_pending(event.entity)
 end, egg_filter)
 
-script.on_nth_tick(60, function(event)
+local function hatch_sweep(tick)
 	if not storage.pending_eggs then return end
 	storage.ally_owners = storage.ally_owners or {}
 	for unit_number, info in pairs(storage.pending_eggs) do
-		if event.tick >= info.tick_due then
+		if tick >= info.tick_due then
 			local surface = game.surfaces[info.surface_index]
 			if surface then
 				local eggs = surface.find_entities_filtered{
@@ -299,13 +299,13 @@ script.on_nth_tick(60, function(event)
 			end
 			storage.pending_eggs[unit_number] = nil
 		else
-			local remaining = math.max(0, math.ceil((info.tick_due - event.tick) / 60))
+			local remaining = math.max(0, math.ceil((info.tick_due - tick) / 60))
 			if info.render_id and info.render_id.valid then
 				info.render_id.text = string.format("Hatching… %ds", remaining)
 			end
 		end
 	end
-end)
+end
 
 -- Follow loop: re-issued every second so the ally tracks the owner smoothly
 -- even when the owner is moving. We re-issue UNCONDITIONALLY (modulo the
@@ -408,7 +408,16 @@ local function follow_loop()
 	end
 end
 
-script.on_nth_tick(FOLLOW_TICK_INTERVAL, follow_loop)
+-- One 1 Hz handler. Factorio's script.on_nth_tick(n, fn) only allows a
+-- single callback per period — registering twice silently replaces the
+-- first registration, which previously stranded the hatch sweep when the
+-- follow loop was bumped to 60-tick cadence. Bundling both call sites
+-- inside one function keeps the behavior + saves the overhead of a second
+-- per-tick dispatch.
+script.on_nth_tick(FOLLOW_TICK_INTERVAL, function(event)
+	hatch_sweep(event.tick)
+	follow_loop()
+end)
 
 -- Build a set of surface indices that have at least one connected player.
 -- Sprint + nervous AI runs only on these surfaces — there's no value in


### PR DESCRIPTION
## Symptom

Player places a Spider Egg. Floating "Hatching… 30s" text appears above it and **never ticks down**. After 30+ seconds the egg is still sitting there, no ally ever spawns.

## Root cause

\`script.on_nth_tick(n, fn)\` in Factorio's runtime API only keeps **one** callback per period — calling it twice silently replaces the first. Two PRs each registered an `on_nth_tick(60, …)`:

| PR | Handler | Cadence at registration |
| --- | --- | --- |
| #11603 | hatch sweep (decrement countdown + spawn ally on expiry) | `on_nth_tick(60, …)` |
| #11609 | follow loop (bumped from 120 → 60 ticks to fix the stall) | `on_nth_tick(60, …)` ← **wins, overwrites #11603's hatch sweep** |

After #11609 merged the hatch sweep stopped dispatching. The follow loop alone didn't read or progress `storage.pending_eggs`, so eggs sat in the registry indefinitely and the floating text stayed frozen.

## Fix

Lift the hatch sweep into a `hatch_sweep(tick)` local function and dispatch both from a single `on_nth_tick(FOLLOW_TICK_INTERVAL, …)`:

\`\`\`lua
script.on_nth_tick(FOLLOW_TICK_INTERVAL, function(event)
    hatch_sweep(event.tick)
    follow_loop()
end)
\`\`\`

Identical behavior to the original design, single registration, no logic changes elsewhere. Saves one nth-tick dispatch slot per tick as a side bonus.

## Test plan

- [x] \`luac -p control.lua\` clean.
- [x] \`./kbve.sh -nx kbve-spider:test\` → PASS.
- [ ] Manual: place egg → countdown ticks down 30 → 0 → puff + ally spawns. Ally follows owner.
- [ ] Manual: place egg, mine it before hatch → countdown clears, item returns. Place again → hatches normally.