### PR TITLE
content(astro-kbve): bump 100 OSRS items v2 → v3 (batch 6)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h4.mdx
@@ -5,16 +5,83 @@ osrs:
   id: 7352
   name: Adamant shield (h4)
   slug: adamant-shield-h4
-  examine: A shield with a heraldic design
+  examine: A shield with a heraldic design.
   members: false
   icon: Adamant shield (h4).png
   value: 5440
   lowalch: 2176
   highalch: 3264
   limit: 70
-  about: "Adamant shield (h4) is a free-to-play item in Old School RuneScape. High alchemy value: 3,264 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: adamant
+    tier: mid
+  equipment:
+    slot: shield
+    weight: 5.896
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 27
+      slash: 31
+      crush: 29
+      magic: -1
+      ranged: 29
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_id: 1199
+      item_name: Adamant kiteshield
+      slug: adamant-kiteshield
+      relationship: variant
+      description: Standard untrimmed adamant kiteshield
+  about: Adamant shield (h4) is a heraldic adamant kiteshield obtained as a reward from medium Treasure Trails, requiring 30 Defence to wield.
+  market_strategy:
+    notes:
+      - Medium clue reward supply
+      - Cosmetic variant of standard adamant kiteshield
+      - Heraldic design adds fashionscape premium
+      - Free-to-play tradeable
+  history:
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -2 to -3.
+    - date: "2014-12-10"
+      description: Renamed from "Adamant shield(h4)" to "Adamant shield (h4)".
+    - date: "2006-03-15"
+      description: Made available to free-to-play players.
+    - date: "2006-02-20"
+      update: Updates, updates and more updates...
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-02-20"
+    update: Updates, updates and more updates...
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 5.896
+    alchable: true
+    destroy: Drop
+    options:
+      - Wear
+      - Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/afro.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/afro.mdx
@@ -1,6 +1,6 @@
 ---
 title: Afro | OSRS Price Data
-description: "Afro: Wild!. High alch: 410 GP, GE limit: 4."
+description: "Afro: Wild! High alch: 410 GP, GE limit: 4."
 osrs:
   id: 12430
   name: Afro
@@ -12,9 +12,65 @@ osrs:
   lowalch: 273
   highalch: 410
   limit: 4
-  about: "Afro is a members-only item in Old School RuneScape. High alchemy value: 410 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_id: 12073
+      item_name: Reward casket (elite)
+      slug: reward-casket-elite
+      relationship: component
+      description: Source casket for the reward
+  market_strategy:
+    notes:
+      - Cosmetic elite clue reward
+      - 1/1275 drop rate from elite caskets
+      - Low buy limit constrains flips
+      - Stored in costume room
+  history:
+    - date: "2014-06-12"
+      description: Item released as an elite Treasure Trail reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: The afro is a cosmetic elite Treasure Trail reward worn in the head slot in Old School RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-bolt-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-bolt-tips.mdx
@@ -1,6 +1,6 @@
 ---
 title: Amethyst bolt tips | OSRS Price Data
-description: "Amethyst bolt tips: Amethyst bolt tips.. High alch: 96 GP, GE limit: 11,000."
+description: "Amethyst bolt tips: Amethyst bolt tips. High alch: 96 GP, GE limit: 11,000."
 osrs:
   id: 21338
   name: Amethyst bolt tips
@@ -13,65 +13,70 @@ osrs:
   highalch: 96
   limit: 11000
   material:
-    type: ammunition_component
-    tradeable: true
-    stackable: true
-    weight: 0
-  creation:
-    method: Crafting
-    requirements:
-      crafting: 83
-    materials:
-      - item_id: 21347
-        item_name: Amethyst
-        quantity: 1
-    product_quantity: 15
-    xp: 60
-  uses:
-    - result_id: 21316
-      result_name: Amethyst broad bolts
+    type: ammunition
+    tier: mid-high
+  recipes:
+    - skill: crafting
+      level: 83
+      xp: 60
       materials:
-        - Broad bolts
-        - Amethyst bolt tips
-      requirements:
-        fletching: 76
-        unlock: Broader fletching
+        - item_name: Amethyst
+          quantity: 1
+      output_quantity: 15
+      notes: Use a chisel on an amethyst gem.
+    - skill: fletching
+      level: 76
       xp: 106
-  market:
-    buy_limit: 11000
-    price_estimate: 202
-    daily_volume: 343000
+      materials:
+        - item_name: Broad bolts
+          quantity: 10
+        - item_name: Amethyst bolt tips
+          quantity: 10
+      output_quantity: 10
+      notes: Requires the Broader fletching unlock; produces amethyst broad bolts.
   related_items:
     - item_id: 21347
       item_name: Amethyst
       slug: amethyst
       relationship: component
-      description: Raw material
+      description: Raw material chiselled into bolt tips
     - item_id: 21318
       item_name: Broad bolts
       slug: broad-bolts
       relationship: component
-      description: Base item
+      description: Base bolts the tips attach to
     - item_id: 21316
       item_name: Amethyst broad bolts
       slug: amethyst-broad-bolts
       relationship: product
-      description: Created item
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ammunition Component |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    | Bolt Created | Materials | Requirements |
-    |--------------|-----------|--------------|
-    | Amethyst broad bolts | Broad bolts + Amethyst bolt tips | 76 Fletching + Broader fletching |
-
-    106 Fletching XP per 10 bolts.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Finished bolts produced via Fletching
+  about: Amethyst bolt tips are stackable members ammunition components chiselled from amethyst at 83 Crafting and attached to broad bolts at 76 Fletching to make amethyst broad bolts.
+  market_strategy:
+    notes:
+      - Steady fletcher and ranger demand
+      - Mining Guild amethyst supply drives price
+      - Broader fletching is a hard requirement on the consumer side
+      - High daily GE volume
+  history:
+    - date: "2017-06-22"
+      update: Mining Guild Expansion
+      description: Added to the game alongside amethyst and amethyst ammunition.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-06-22"
+    update: Mining Guild Expansion
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    alchable: true
+    destroy: Drop
+    options:
+      - Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-defence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-defence.mdx
@@ -14,6 +14,7 @@ osrs:
   limit: 125
   equipment:
     slot: neck
+    weight: 0.01
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,13 +32,11 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements: {}
-    weight: 0.01
   recipes:
     - skill: magic
       level: 27
       xp: 37
-      inputs:
+      materials:
         - item_name: Emerald amulet
           quantity: 1
         - item_name: Cosmic rune
@@ -45,6 +44,7 @@ osrs:
         - item_name: Air rune
           quantity: 3
       output_quantity: 1
+      notes: Lvl-2 Enchant spell on standard spellbook
   related_items:
     - item_id: 1725
       item_name: Amulet of power
@@ -56,39 +56,39 @@ osrs:
       slug: amulet-of-glory
       relationship: upgrade
       description: Superior all-round amulet
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | All styles | +7 |
-
-    Requirements: None | Weight: 0.01 kg
-
-    No attack bonuses of any kind — purely defensive.
-
-    One of the few neck slot items available in F2P that provides defence bonuses. The amulet of power (+6 all attack, +1 all defence, +6 str, +1 prayer) is generally preferred, but the amulet of defence offers +6 more defence per style — making it niche for tanking.
-
-    An Amulet of defence (t) variant exists, obtained from beginner Treasure Trail caskets. This trimmed version is purely cosmetic with identical stats, but trades at a premium for fashionscape.
-
-    The amulet of defence is useful for Wilderness skilling (e.g., black chinchompa hunting, Wilderness Agility Course) where players want cheap defensive stats without risking an expensive amulet.
-
-    | Component | Cost |
-    |-----------|------|
-    | Emerald amulet | ~1,200 GP |
-    | 1 Cosmic rune | ~130 GP |
-    | 3 Air runes | ~15 GP |
-    | Total cost | ~1,345 GP |
-    | GE sell price | ~1,800 GP |
-    | Profit | ~455 GP |
-
-    Enchanting emerald amulets into amulets of defence can be marginally profitable and provides decent Magic XP at low levels.
+    - item_id: 1727
+      item_name: Emerald amulet
+      slug: emerald-amulet
+      relationship: component
+      description: Enchanted into the amulet of defence
+  about: Amulet of defence is a free-to-play neck slot item providing +7 defence across every style, created by casting Lvl-2 Enchant on an emerald amulet at 27 Magic.
   market_strategy:
     notes:
       - Steady F2P demand
       - Enchanting can be marginally profitable
       - (t) variant from beginner clues trades at premium
       - Budget Wilderness risk amulet
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2001-05-24"
+      update: New magic system online!
+      description: Added to the game alongside the new Magic system.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-05-24"
+    update: New magic system online!
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 0.01
+    alchable: true
+    destroy: Drop
+    options:
+      - Wear
+      - Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amylase-crystal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amylase-crystal.mdx
@@ -14,12 +14,20 @@ osrs:
   limit: 11000
   material:
     type: crystal
-    tier: agility
+    tier: mid-high
   shops:
     - shop_name: Grace
       location: Rogues' Den
       currency: Marks of Grace
-      rate: 10 marks = 100 crystals
+      notes: 10 Marks of Grace per 100 crystals (amylase pack)
+    - shop_name: Worm Tongue
+      location: Colossal Wyrm Remains
+      currency: Brimhaven vouchers
+      notes: 60 vouchers per 100 crystals
+    - shop_name: Pirate Jackie the Fruit
+      location: Brimhaven Agility Arena
+      currency: Agility Arena tickets
+      notes: 100 tickets per 100 crystals
   recipes:
     - skill: herblore
       level: 77
@@ -40,37 +48,49 @@ osrs:
       item_name: Super energy(4)
       slug: super-energy-4
       relationship: component
-      description: Stamina base
+      description: Stamina base potion
     - item_id: 12625
       item_name: Stamina potion(4)
       slug: stamina-potion-4
       relationship: product
-      description: End product
+      description: End product brewed with crystals
     - item_id: 21752
       item_name: Ring of endurance
       slug: ring-of-endurance
       relationship: alternative
-      description: Uses staminas
-  about: |-
-    | Potion | Crystals | Herblore Level | XP per crystal |
-    |--------|----------|----------------|----------------|
-    | Stamina potion(4) | 4 | 77 | 25.5 |
+      description: Stamina alternative consuming staminas
+  about: Amylase crystal is a members-only Herblore secondary used to convert super energy potions into stamina potions at level 77.
   market_strategy:
-    profit_formulas:
-      - (Amylase × 100) / 10 = GP per Mark
-      - Stamina(4) - Super energy(4) - (Amylase × 4) = Profit
     notes:
-      - 10 Marks = 100 Amylase crystals
-      - "Calculate:"
-      - Compare to Graceful recoloring value
-      - 4 crystals + Super energy(4) = Stamina(4)
-      - "Calculate:"
-      - Rooftop agility best source
+      - 10 Marks of Grace yield 100 crystals
+      - Compare GP per Mark vs Graceful recoloring value
+      - 4 crystals plus Super energy(4) makes Stamina(4)
+      - Rooftop agility courses are the main supply
       - Marks untradeable, crystals tradeable
-      - Consistent stamina demand
-      - Check GP/Mark vs outfit pieces
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Stamina demand keeps pricing consistent
+  history:
+    - date: "2014-07-10"
+      update: Amylase Tradeable
+      description: Amylase crystals were made tradeable as originally intended.
+    - date: "2014-07-03"
+      update: Stamina Potions
+      description: Initial release alongside stamina potions and the Rogues' Den exchange.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-07-03"
+    update: Stamina Potions
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-kiteshield.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 21760
   highalch: 32640
   limit: 8
-  about: "Bandos kiteshield is a free-to-play item in Old School RuneScape. High alchemy value: 32,640 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    weight: 5.443
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -2
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 46
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_id: 1201
+      item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: variant
+      description: Stock kiteshield with identical defence bonuses
+    - item_id: 12486
+      item_name: Bandos platebody
+      slug: bandos-platebody
+      relationship: set-piece
+      description: Matching Bandos rune body
+    - item_id: 12490
+      item_name: Bandos chestplate
+      slug: bandos-chestplate
+      relationship: alternative
+      description: Higher-tier Bandos armour piece
+    - item_id: 12492
+      item_name: Bandos full helm
+      slug: bandos-full-helm
+      relationship: set-piece
+      description: Matching Bandos rune helm
+  market_strategy:
+    notes:
+      - Cosmetic Bandos trim over rune kiteshield base
+      - Hard clue reward, supply gated by clue solvers
+      - Low GE limit caps flipping volume
+      - Used for costume room set storage
+  about: Bandos kiteshield is a cosmetic rune kiteshield variant in the colours of Bandos, awarded from hard Treasure Trails reward caskets.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-platelegs.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
-  about: "Bandos platelegs is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 9.072
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_id: 1079
+      item_name: Rune platelegs
+      slug: rune-platelegs
+      relationship: alternative
+      description: Standard rune-class legs
+    - item_id: 12476
+      item_name: Bandos full helm
+      slug: bandos-full-helm
+      relationship: set-piece
+      description: Matching Bandos outfit piece
+    - item_id: 12478
+      item_name: Bandos platebody
+      slug: bandos-platebody
+      relationship: set-piece
+      description: Matching Bandos outfit piece
+    - item_id: 12484
+      item_name: Bandos kiteshield
+      slug: bandos-kiteshield
+      relationship: set-piece
+      description: Matching Bandos outfit piece
+  market_strategy:
+    notes:
+      - Rune defence with +1 prayer is a niche edge over plain rune
+      - Hard clue droprate (~1/1,625) controls supply
+      - Bandos aggression suppression in GWD is the keep-set hook
+      - F2P-tradable since 2016, broadens flip pool
+  trading_tips:
+    - Pair flips with other Bandos pieces for set arbitrage
+    - Watch hard clue meta shifts for supply pulses
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Bandos platelegs released as a hard clue scroll reward in the Treasure Trail Expansion.
+    - date: "2016-04-07"
+      update: F2P trade access
+      description: Made available to free-to-play players to trade.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.072
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Bandos platelegs are rune-tier platelegs reskinned in Bandos colours that grant a small Prayer bonus and pacify Bandos followers in the God Wars Dungeon.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-robe-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-robe-legs.mdx
@@ -14,22 +14,67 @@ osrs:
   limit: 8
   equipment:
     slot: legs
+    weight: 2.7
     requirements:
       prayer: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 12265
       item_name: Bandos robe top
       slug: bandos-robe-top
       relationship: set-piece
       description: Bandos vestment body
-  about: |-
-    > *"Leggings from the Bandos Vestments."*
-
-    The Bandos robe legs are the legs piece of the Bandos vestment set. They provide a +5 Prayer bonus and require 20 Prayer to equip. Counts as a Bandosian item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Bandos robe legs is the legs piece of the Bandos vestment set, providing a +5 Prayer bonus and counting as a Bandosian item in the God Wars Dungeon.
+  market_strategy:
+    notes:
+      - Obtained exclusively from easy clue caskets
+      - 1/1,404 rarity from reward casket (easy)
+      - Vestment set demand drives price
+      - Used for fashionscape and GWD
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Added to the game via the Treasure Trail Expansion update.
+    - date: "2014-07-24"
+      description: Vestment robe tops and legs now offer the same prayer bonuses as monk robes.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 2.7
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dagger-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dagger-p.mdx
@@ -12,9 +12,98 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 125
-  about: "Black dagger(p) is a members-only item in Old School RuneScape. High alchemy value: 144 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: black
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: stab-sword
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 10
+      slash: 5
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      melee_strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_id: 1217
+          item_name: Black dagger
+          quantity: 1
+        - item_id: 187
+          item_name: Weapon poison
+          quantity: 1
+      product: Black dagger(p)
+      product_id: 1233
+      notes: Members-only poisoning; instant
+  related_items:
+    - item_id: 1217
+      item_name: Black dagger
+      slug: black-dagger
+      relationship: component
+      description: Unpoisoned base dagger
+    - item_id: 5680
+      item_name: Black dagger(p+)
+      slug: black-dagger-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_id: 5698
+      item_name: Black dagger(p++)
+      slug: black-dagger-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+  about: "Black dagger(p) is a poisoned stab dagger requiring 10 Attack, created by applying weapon poison to a black dagger."
+  market_strategy:
+    notes:
+      - Members-only via poison process
+      - Low-tier PKing dagger
+      - Cheap entry to poison weaponry
+  history:
+    - date: "2001-12-08"
+      update: Equipment Release
+      description: Black dagger added to the game.
+    - date: "2006-08-22"
+      update: Weapon Poison Rename
+      description: Poisoned variants renamed from (+) and (s) to (p+) and (p++).
+    - date: "2021-07-07"
+      update: Female Player Equipment Fix
+      description: Female player equip positioning adjusted.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-12-08"
+    update: Equipment Release
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-flowers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-flowers.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Black flowers is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: slash-sword
+    attack_speed: 4
+    weight: 0.028
+    attack_bonus:
+      stab: -100
+      slash: -100
+      crush: -50
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: -10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  farming:
+    farming_level: 30
+    seed: Mithril seed
+  about: Black flowers are a rare yield from mithril or adamant seeds, functioning as a novelty fun weapon with severe negative combat bonuses.
+  market_strategy:
+    notes:
+      - 2/1,001 chance from mithril or adamant seeds
+      - Single picking opportunity per seed
+      - Fun weapon novelty drives demand
+      - Can be made into imp repellent
+  history:
+    - date: "2004-03-29"
+      description: Added to the game with the RuneScape 2 launch.
+    - date: "2024-04-10"
+      description: Adamant seeds added as a source of black flowers.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-longsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-longsword.mdx
@@ -14,39 +14,84 @@ osrs:
   limit: 125
   equipment:
     slot: weapon
-    type: longsword
-    tradeable: true
+    weapon_type: slash-sword
+    attack_speed: 5
     weight: 1.814
     requirements:
       attack: 10
-    stats:
-      attack_stab: 13
-      attack_slash: 18
-      attack_crush: -2
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 16
+    attack_bonus:
+      stab: 13
+      slash: 18
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 16
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  drop_table:
+    sources:
+      - source: Black Knight
+        combat_level: 33
+        quantity: "1"
+        rarity: rare
+        members_only: false
+      - source: Knight of Saradomin
+        combat_level: 39
+        quantity: "1"
+        rarity: rare
+        members_only: false
   related_items:
     - item_id: 1299
       item_name: Mithril longsword
       slug: mithril-longsword
       relationship: upgrade
       description: Higher tier longsword
+    - item_id: 1295
+      item_name: Steel longsword
+      slug: steel-longsword
+      relationship: downgrade
+      description: Lower tier longsword
     - item_id: 1283
       item_name: Black scimitar
       slug: black-scimitar
       relationship: alternative
       description: Faster slash alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Black longsword is a free-to-play longsword stronger than steel but weaker than mithril, requiring 10 Attack to wield and cannot be created via Smithing.
+  market_strategy:
+    notes:
+      - F2P mid-tier longsword for 10 Attack
+      - Black Knight Fortress is the main source
+      - High alch outpaces typical GE price
+      - Compare to Black scimitar for slash builds
+  history:
+    - date: "2001-12-08"
+      update: Black Knight Fortress
+      description: Released alongside the Black Knight Fortress and other black equipment.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-12-08"
+    update: Black Knight Fortress
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-shard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-shard.mdx
@@ -12,17 +12,26 @@ osrs:
   lowalch: 80000
   highalch: 120000
   limit: 8
-  item:
-    type: crafting material
-    tradeable: true
-  obtaining:
-    - source: Vyrewatch Sentinels
-      drop_rate: 1/1,500
-    - source: Pickpocket Vyres (82 Thieving)
-      drop_rate: 1/5,000
+  charges:
+    max_charges: 10000
+    consumed_on_depletion: true
+    effect: "20% chance to heal 30% of damage dealt; melee only; ~6% average lifesteal"
+  drop_table:
+    sources:
+      - source: Vyrewatch Sentinel
+        combat_level: 151
+        quantity: "1"
+        rarity: 1/1500
+        members_only: true
+      - source: Vyre (pickpocket)
+        quantity: "1"
+        rarity: 1/5000
+        members_only: true
+        notes: Requires 82 Thieving
   recipes:
     - skill: crafting
       level: 1
+      xp: 0
       materials:
         - item_id: 24777
           item_name: Blood shard
@@ -32,14 +41,6 @@ osrs:
           quantity: 1
       product: Amulet of blood fury
       product_id: 24780
-  effect:
-    charges: 10000
-    consumed_on_depletion: true
-    lifesteal:
-      chance: 20%
-      amount: 30% of damage dealt
-      average: ~6% healing per attack
-      melee_only: true
   related_items:
     - item_id: 6585
       item_name: Amulet of fury
@@ -51,28 +52,34 @@ osrs:
       slug: amulet-of-blood-fury
       relationship: product
       description: Created lifesteal amulet
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Stackable | No |
-
-    Combine with Amulet of fury to create Amulet of blood fury.
-
-    Charges: 10,000 per shard (consumed when depleted).
-
-    Melee Lifesteal:
-    - 20% chance to heal 30% of damage dealt
-    - ~6% average lifesteal
-    - Only works with melee
+  about: "Blood shard combines with an Amulet of fury to create an Amulet of blood fury, granting 10,000 charges of melee lifesteal."
   market_strategy:
     notes:
       - Great for melee sustain
       - Consumes shard on depletion
       - Farm Vyres in Darkmeyer
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - High demand among PvM players
+      - Single-use crafting consumable
+  history:
+    - date: "2020-06-04"
+      update: Darkmeyer
+      description: Blood shard introduced as a rare drop from Vyrewatch Sentinels and Vyre pickpocketing.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-06-04"
+    update: Darkmeyer
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-helm-broken.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-helm-broken.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
-  about: "Blue moon helm (broken) is a members-only item in Old School RuneScape. High alchemy value: 61,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.453
+    requirements:
+      magic: 75
+      defence: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 29023
+      item_name: Blue moon helm
+      slug: blue-moon-helm
+      relationship: upgrade
+      description: Repaired wearable version
+    - item_id: 29066
+      item_name: Blue moon chestplate (broken)
+      slug: blue-moon-chestplate-broken
+      relationship: set-piece
+      description: Broken body slot of the set
+    - item_id: 29068
+      item_name: Blue moon tassets (broken)
+      slug: blue-moon-tassets-broken
+      relationship: set-piece
+      description: Broken legs slot of the set
+  about: Blue moon helm (broken) is the degraded form of the Blue moon helm, repaired by Bob in Lumbridge or Dunstan in Burthorpe for 1.5M coins or via an armour stand.
+  market_strategy:
+    notes:
+      - Repair price floors broken vs whole price
+      - Self-repair at armour stand discounts cost
+      - Tradeable while broken, untradeable when fixed
+      - Varlamore hybrid magic helm tier
+  history:
+    - date: "2024-05-29"
+      update: Moon Armour Buff
+      description: Magic damage bonus increased from 0% to 1%.
+    - date: "2024-04-24"
+      update: Weight Adjustment
+      description: Weight decreased from 0.907 kg to 0.453 kg.
+    - date: "2024-03-20"
+      update: "Varlamore: Part One"
+      description: Released as part of the Moons of Peril boss reward set.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bone-fragments.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bone-fragments.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bone fragments | OSRS Price Data
-description: "Bone fragments: Ground down bone fragments.. High alch: 1 GP, GE limit: 500."
+description: "Bone fragments: Ground down bone fragments. High alch: 1 GP, GE limit: 500."
 osrs:
   id: 25139
   name: Bone fragments
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 500
-  about: "Bone fragments is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bone
+    tier: low
+  charges:
+    target_item: Skull sceptre (i)
+    notes: One bone fragment grants one charge to the imbued skull sceptre.
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Skull sceptre
+          quantity: 1
+      output_quantity: 14
+      notes: Use a chisel on skull sceptre components; output scales up with Varrock Diary tiers.
+  related_items:
+    - item_id: 9013
+      item_name: Skull sceptre
+      slug: skull-sceptre
+      relationship: component
+      description: Chiselled into bone fragments
+    - item_id: 25140
+      item_name: Skull sceptre (i)
+      slug: skull-sceptre-i
+      relationship: upgrade
+      description: Imbued sceptre charged by bone fragments
+  about: Bone fragments are tradeable consumables created by chiselling Stronghold of Security skull sceptre components, each fragment recharging one cast of the imbued skull sceptre.
+  market_strategy:
+    notes:
+      - Stronghold of Security farming gates supply
+      - Demand follows imbued skull sceptre usage
+      - Higher Varrock Diary tiers boost fragment yields
+      - Free-to-play accessible
+  history:
+    - date: "2025-04-28"
+      description: Grand Exchange buy limit increased from 100 to 500.
+    - date: "2020-11-18"
+      update: More Poll 73 Updates & Leagues Changes
+      description: Added to the game alongside the imbued skull sceptre.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-11-18"
+    update: More Poll 73 Updates & Leagues Changes
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    members: false
+    quest_item: false
+    weight: 0
+    alchable: false
+    destroy: Drop
+    options:
+      - Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bookcase-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bookcase-flatpack.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Bookcase (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    construction_level: 4
+    xp: 115
+    materials:
+      - item_id: 960
+        item_name: Plank
+        quantity: 4
+      - item_id: 1539
+        item_name: Steel nails
+        quantity: 4
+    hotspot: Bookcase space
+    room: Parlour
+    tools:
+      - Hammer
+      - Saw
+    notes: Built at a Wooden workbench in a player-owned house workshop.
+  recipes:
+    - skill: construction
+      level: 4
+      xp: 115
+      materials:
+        - item_id: 960
+          item_name: Plank
+          quantity: 4
+        - item_id: 1539
+          item_name: Steel nails
+          quantity: 4
+      product: Bookcase (flatpack)
+      product_id: 8510
+  related_items:
+    - item_id: 960
+      item_name: Plank
+      slug: plank
+      relationship: component
+      description: Base material
+    - item_id: 1539
+      item_name: Steel nails
+      slug: steel-nails
+      relationship: component
+      description: Fasteners required for assembly
+  about: "Bookcase (flatpack) is a pre-built Construction flatpack assembled at a Wooden workbench from 4 planks and 4 steel nails."
+  market_strategy:
+    notes:
+      - Used in Parlour, Quest Hall and Study rooms
+      - Cheap entry-level Construction XP item
+      - Sold to other players for low-level XP gains
+  history:
+    - date: "2006-05-31"
+      update: Player-Owned Houses
+      description: Bookcase (flatpack) released alongside the Construction skill.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bowl-wig.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bowl-wig.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bowl wig | OSRS Price Data
-description: "Bowl wig: The bowl wig.. High alch: 1 GP, GE limit: 4."
+description: "Bowl wig: The bowl wig. High alch: 0 GP, GE limit: 4."
 osrs:
   id: 20110
   name: Bowl wig
@@ -9,12 +9,68 @@ osrs:
   members: true
   icon: Bowl wig.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: 0
+  highalch: 0
   limit: 4
-  about: "Bowl wig is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_id: 19836
+      item_name: Reward casket (master)
+      slug: reward-casket-master
+      relationship: component
+      description: Source casket for the reward
+  market_strategy:
+    notes:
+      - Cosmetic master clue reward
+      - 1/851 drop rate from master caskets
+      - Mod Ronan inside-joke item
+      - Costume room storable
+  history:
+    - date: "2016-07-06"
+      description: Item released as part of the Treasure Trail Expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
+  about: The bowl wig is a cosmetic master Treasure Trail reward worn in the head slot in Old School RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze dart | OSRS Price Data
-description: "Bronze dart is a members weapon slot item. High alch: 1 GP, GE limit: 7,000."
+description: "Bronze dart: A deadly throwing dart with a bronze tip. High alch: 1 GP, GE limit: 7,000."
 osrs:
   id: 806
   name: Bronze dart
@@ -12,23 +12,49 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  material:
+    type: metal
+    tier: low
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
+    weapon_type: thrown
     attack_speed: 3
-  requirements:
-    ranged: 1
-  stats:
-    attack:
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 0
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 1
-  fletching:
-    level: 1
-    xp: 1.8
-    method: Attach feathers to bronze dart tips
-    quest: Tourist Trap
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 10
+      xp: 1.8
+      materials:
+        - item_name: Bronze dart tip
+          item_id: 819
+          quantity: 1
+        - item_name: Feather
+          item_id: 314
+          quantity: 1
+      product: Bronze dart
+      product_id: 806
+      product_quantity: 1
+      facility: Inventory
+      members_only: true
   related_items:
     - item_id: 819
       item_name: Bronze dart tip
@@ -50,16 +76,38 @@ osrs:
       slug: toxic-blowpipe
       relationship: alternative
       description: Uses darts as ammo
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon/Ammo |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 1 Ranged |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Fastest-tier thrown weapon
+      - Tourist Trap unlocks fletching
+      - Tiny strength bonus only
+      - High volume PKer ammo class
+  history:
+    - date: "2003-04-14"
+      description: Item released as the starter thrown weapon.
+    - date: "2021-06-30"
+      description: Ranged attack bonus reduced from +3 to +0.
+    - date: "2025-05-29"
+      description: Exempted from Grand Exchange convenience fees.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
+  about: Bronze dart is a members one-handed thrown weapon requiring 1 Ranged and fletched from bronze dart tips and feathers in Old School RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cabbage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cabbage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cabbage | OSRS Price Data
-description: "Cabbage: Yuck I don't like cabbage.. High alch: 1 GP, GE limit: 6,000."
+description: "Cabbage: Yuck I don't like cabbage. High alch: 1 GP, GE limit: 6,000."
 osrs:
   id: 1965
   name: Cabbage
@@ -12,17 +12,30 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  produce:
-    type: allotment
-    tier: low
+  food:
+    heals: 1
+    eat_message: You eat the cabbage. Yuck!
   farming:
     seed_id: 5324
     seed_name: Cabbage seed
-    level: 7
+    farming_level: 7
     xp_plant: 10
     xp_harvest: 11.5
     growth_time: 40
     patches: 8
+  shops:
+    - shop_name: Grand Tree Groceries
+      location: Grand Tree
+      stock: 10
+      price: 1
+    - shop_name: Food Store
+      location: Port Sarim
+      stock: 3
+      price: 1
+    - shop_name: Cook (Blue Moon Inn)
+      location: Varrock
+      price: 1
+      notes: Unlimited stock
   related_items:
     - item_id: 5324
       item_name: Cabbage seed
@@ -39,28 +52,39 @@ osrs:
       slug: tomato
       relationship: alternative
       description: Alternative allotment produce
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 7 |
-    | Growth time | 40 minutes |
-    | XP (plant) | 10 |
-    | XP (harvest) | 11.5 per cabbage |
-
-    - Protection payment for onion seeds
-    - Used in cooking recipes
-    - Draynor Manor cabbage is special (Black Knight's Fortress quest)
+  about: Cabbage is a free-to-play allotment crop that heals 1 hitpoint when eaten, grown from cabbage seeds at 7 Farming and used as a Farming protection payment for onion seeds.
   market_strategy:
-    title: Ironman Notes
     notes:
       - Low-tier crop
       - Very low value
       - Good for early farming training
-      - Easy to obtain
       - Required for some quests
-      - Good early farming crop
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Draynor Manor cabbage has a unique role in Black Knights' Fortress
+  history:
+    - date: "2005-07-11"
+      description: Graphically updated with the release of Farming.
+    - date: "2005-04-18"
+      description: Graphically updated with the release of Desert Treasure.
+    - date: "2001-01-04"
+      update: Runescape beta is now online!
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    alchable: false
+    destroy: Drop
+    options:
+      - Eat
+      - Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cadantine-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cadantine-seed.mdx
@@ -12,11 +12,11 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 200
-  seed:
+  material:
     type: herb
     tier: high
   farming:
-    level: 67
+    farming_level: 67
     xp_plant: 106.5
     xp_harvest: 120
     growth_time: 80
@@ -28,7 +28,7 @@ osrs:
       item_name: Grimy cadantine
       slug: grimy-cadantine
       relationship: product
-      description: Harvested product
+      description: Harvested grimy herb
     - item_id: 265
       item_name: Cadantine
       slug: cadantine
@@ -38,26 +38,18 @@ osrs:
       item_name: Super defence(4)
       slug: super-defence-4
       relationship: product
-      description: Made from cadantine
+      description: Potion made from cadantine
     - item_id: 5300
       item_name: Snapdragon seed
       slug: snapdragon-seed
       relationship: alternative
-      description: Lower tier herb seed
+      description: Lower-tier herb seed
     - item_id: 5302
       item_name: Lantadyme seed
       slug: lantadyme-seed
       relationship: upgrade
-      description: Next tier herb seed
-  about: |-
-    Plant in a herb patch to grow Grimy cadantine.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 67 |
-    | Growth time | 80 minutes |
-    | XP (plant) | 106.5 |
-    | XP (harvest) | 120 per herb |
+      description: Next-tier herb seed
+  about: "Cadantine seed is a tier-67 herb seed yielding grimy cadantine, the main ingredient for Super defence potions."
   market_strategy:
     notes:
       - High-tier herb seed
@@ -69,8 +61,35 @@ osrs:
       - 9 herb patches available
       - ~10 minute runs, 80 minute regrowth
       - Super defence essential for PvM
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2005-08-09"
+      update: Farming
+      description: Herb seed introduced with the Farming skill.
+    - date: "2005-08-23"
+      update: Farming Tweaks
+      description: Renamed from generic Herb seed to Cadantine seed.
+    - date: "2018-02-08"
+      update: Ground Visibility
+      description: Value reduced from 64 to 7 coins to improve ground visibility.
+    - date: "2020-01-09"
+      update: Farming XP Rework
+      description: Plant XP is now awarded on harvest instead of planting.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-09"
+    update: Farming
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/calquat-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/calquat-sapling.mdx
@@ -5,16 +5,90 @@ osrs:
   id: 5503
   name: Calquat sapling
   slug: calquat-sapling
-  examine: This sapling is ready to be replanted in a Calquat Tree patch.
+  examine: This sapling is ready to be replanted in a Calquat tree patch.
   members: true
   icon: Calquat sapling.png
   value: 1
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Calquat sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    farming_level: 72
+    plant_xp: 129.5
+    check_health_xp: 12096
+    harvest_xp: 48.5
+    patch_type: Calquat
+    growth_time_minutes: 1280
+    protection_payment: 8 poison ivy berries (noted)
+    patch_locations:
+      - Tai Bwo Wannai Village
+      - The Summer Shore
+      - Kastori
+  recipes:
+    - skill: farming
+      level: 72
+      xp: 27
+      materials:
+        - item_name: Calquat seed
+          item_id: 5284
+          quantity: 1
+        - item_name: Plant pot (filled)
+          item_id: 5354
+          quantity: 1
+      product: Calquat seedling
+      product_id: 5502
+      product_quantity: 1
+      facility: Gardening trowel + water
+      members_only: true
+  related_items:
+    - item_id: 5284
+      item_name: Calquat seed
+      slug: calquat-seed
+      relationship: component
+      description: Seed planted in a plant pot
+    - item_id: 5502
+      item_name: Calquat seedling
+      slug: calquat-seedling
+      relationship: component
+      description: Watered seedling matures into the sapling
+    - item_id: 5980
+      item_name: Calquat fruit
+      slug: calquat-fruit
+      relationship: product
+      description: Harvested from the grown tree
+  about: Calquat sapling is a members-only Farming item planted in a Calquat tree patch at level 72 to grow Calquat fruits used in Karamja gloves and brewing.
+  market_strategy:
+    notes:
+      - Only one patch grants daily Calquat yield
+      - Buy seeds, save XP by planting saplings
+      - Karamja Diary fruit demand sustains use
+      - Saplings tradeable since 2015 update
+  history:
+    - date: "2019-01-10"
+      update: Examine Polish
+      description: Examine text slightly modified.
+    - date: "2015-01-29"
+      update: Tradeable Saplings
+      description: Saplings from tradeable seeds became tradeable.
+    - date: "2005-07-11"
+      update: Farming Skill
+      description: Item released alongside the Farming skill and Calquat tree patch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming Skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/carved-teak-magic-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/carved-teak-magic-wardrobe-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Carved teak magic wardrobe (flatpack) | OSRS Price Data
-description: "Carved teak magic wardrobe (flatpack): Carved teak magic wardrobe.. High alch: 6 GP, GE limit: 500."
+description: "Carved teak magic wardrobe (flatpack): Carved teak magic wardrobe. High alch: 6 GP, GE limit: 500."
 osrs:
   id: 9855
   name: Carved teak magic wardrobe (flatpack)
@@ -12,9 +12,64 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Carved teak magic wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: construction
+      level: 69
+      xp: 540
+      materials:
+        - item_name: Teak plank
+          item_id: 8780
+          quantity: 6
+      product: Carved teak magic wardrobe (flatpack)
+      product_id: 9855
+      product_quantity: 1
+      facility: Workbench (player-owned house workshop)
+  construction:
+    construction_level: 69
+    xp: 540
+    notes: Assembled in the Costume Room's Magic wardrobe space.
+  related_items:
+    - item_id: 8780
+      item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: Material (×6) for the flatpack
+    - item_id: 9853
+      item_name: Teak magic wardrobe (flatpack)
+      slug: teak-magic-wardrobe-flatpack
+      relationship: downgrade
+      description: Lower tier teak wardrobe variant
+  about: "Carved teak magic wardrobe (flatpack) is a Construction 69 workbench product crafted from 6 teak planks for the player-owned house Costume Room."
+  market_strategy:
+    notes:
+      - Construction 69 + 6 teak planks per flatpack
+      - 540 XP per build, useful for ironman XP routes
+      - GE buy limit 500 per 4 hours
+      - High alch only 6 GP, alching is unprofitable
+      - Demand driven by POH Costume Room builders
+  history:
+    - date: "2006-10-18"
+      update: Construction release
+      description: Carved teak magic wardrobe flatpack added with the Construction skill launch.
+    - date: "2015-02-26"
+      update: Renaming
+      description: Renamed from Carved teak mw to full name with the Grand Exchange update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-10-18"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1.0
+    options:
+      - Build
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/civitas-illa-fortis-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/civitas-illa-fortis-teleport.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Civitas illa fortis teleport is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Civitas illa Fortis
+    type: tablet
+    consumable: true
+  recipes:
+    - skill: Magic
+      level: 54
+      xp: 64
+      facility: Spellbook (Standard)
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 1
+        - item_name: Law rune
+          quantity: 2
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 1761
+      item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Tablet base
+    - item_id: 563
+      item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: Casting cost (x2)
+  market_strategy:
+    notes:
+      - Magic 54 + Twilight's Promise gates the cast
+      - Player-made tablet, supply tied to runecrafting/teleport flippers
+      - Quick access to Varlamore for hunter/herblore/agility runs
+  trading_tips:
+    - Watch demand around Varlamore content releases
+    - Stack against alternate Varlamore travel (Quetzal, fairy ring CIQ)
+  history:
+    - date: "2024-03-20"
+      update: Varlamore - Part One
+      description: Civitas illa Fortis teleport spell and tablet released alongside Varlamore Part One.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore - Part One
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Break
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Civitas illa fortis teleport is a Magic 54 tablet that teleports the player to Civitas illa Fortis in Varlamore.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-dashing-kebbit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-dashing-kebbit.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 6000
-  about: "Cooked dashing kebbit is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 23
+    description: "Heals 13 Hitpoints immediately, then 10 more after a 7-tick delay (4.2s) which also restores 10 run energy."
+  recipes:
+    - product_name: Cooked dashing kebbit
+      skill: Cooking
+      cooking_level: 82
+      experience: 215
+      facility: Cooking range
+      materials:
+        - item_name: Raw dashing kebbit
+          quantity: 1
+  related_items:
+    - item_id: 29132
+      item_name: Raw dashing kebbit
+      slug: raw-dashing-kebbit
+      relationship: component
+      description: Uncooked source meat for the dish
+  market_strategy:
+    notes:
+      - Premium food driven by Hunter Guild participants needing 50 Rumours
+      - High Cooking requirement keeps the supply pool small
+      - Doubles as run-energy restore for endgame movement
+  history:
+    - date: "2024-03-20"
+      update: "Varlamore: Part One"
+      description: Cooked dashing kebbit released with the Varlamore Hunter Guild update.
+    - date: "2026-05-13"
+      update: Sailing Changes and Gem Bag Expansion
+      description: Inventory icon graphically updated.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: "Cooked dashing kebbit is a members-only food prepared at 82 Cooking from raw dashing kebbit, healing 23 Hitpoints in two ticks and restoring 10 run energy on the secondary heal."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/demon-feet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/demon-feet.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Demon feet is a free-to-play item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: beginner
+    is_reward: true
+    reward_tiers:
+      - beginner
+  related_items:
+    - item_id: 23288
+      item_name: Demon head
+      slug: demon-head
+      relationship: set-piece
+      description: Cosmetic demon outfit piece
+    - item_id: 23291
+      item_name: Demon torso
+      slug: demon-torso
+      relationship: set-piece
+      description: Cosmetic demon outfit piece
+    - item_id: 23297
+      item_name: Demon hands
+      slug: demon-hands
+      relationship: set-piece
+      description: Cosmetic demon outfit piece
+    - item_id: 23300
+      item_name: Demon legs
+      slug: demon-legs
+      relationship: set-piece
+      description: Cosmetic demon outfit piece
+  market_strategy:
+    notes:
+      - Cosmetic only, no combat use
+      - Buy limit of 4 makes flips capital-bound
+      - Counts as warm clothing at Wintertodt
+  trading_tips:
+    - Demand tracks fashionscape and Wintertodt fits
+    - Treasure-room storage shrinks public supply
+  history:
+    - date: "2019-04-11"
+      update: Treasure Trails Expansion and Easter 2019
+      description: Demon feet introduced as a beginner clue casket reward in the Treasure Trails Expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Demon feet is a cosmetic feet-slot reward from beginner Treasure Trail caskets that counts as warm clothing at Wintertodt.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-bastion-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-bastion-potion-3.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 216
   highalch: 324
   limit: 2000
-  about: "Divine bastion potion(3) is a members-only item in Old School RuneScape. High alchemy value: 324 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    duration_minutes: 5
+    effects:
+      - description: "Boosts Ranged by 4 + 10% of the player's current Ranged level."
+      - description: "Boosts Defence by 5 + 15% of the player's current Defence level."
+      - description: "Prevents the boosted Ranged and Defence stats from draining below the potion's maximum boost while active."
+      - description: "Inflicts 10 Hitpoints damage when consumed, requiring the player to have at least 11 HP."
+  recipes:
+    - product_name: Divine bastion potion(3)
+      skill: Herblore
+      herblore_level: 86
+      experience: 1.5
+      materials:
+        - item_name: Bastion potion(3)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 3
+  related_items:
+    - item_id: 24634
+      item_name: Divine bastion potion(4)
+      slug: divine-bastion-potion-4
+      relationship: variant
+      description: Four-dose variant
+    - item_id: 24642
+      item_name: Divine bastion potion(2)
+      slug: divine-bastion-potion-2
+      relationship: variant
+      description: Two-dose variant
+    - item_id: 24646
+      item_name: Divine bastion potion(1)
+      slug: divine-bastion-potion-1
+      relationship: variant
+      description: One-dose variant
+    - item_id: 22461
+      item_name: Bastion potion(3)
+      slug: bastion-potion-3
+      relationship: component
+      description: Base bastion potion combined with crystal dust
+    - item_id: 23964
+      item_name: Crystal dust
+      slug: crystal-dust
+      relationship: component
+      description: Crushed crystal shard ingredient
+  market_strategy:
+    notes:
+      - Used by Ranged PvMers wanting boosted defence without stat drain
+      - Crystal shard supply ties price to Prifddinas activities
+      - Per-dose cost falls when bought as (4)-dose and decanted
+  history:
+    - date: "2020-04-30"
+      update: Poll 70
+      description: Divine bastion potion introduced as part of the divine potion rework giving Ranged and Defence boosts with no stat decay.
+    - date: "2020-07-02"
+      description: Inventory icon graphically updated to match the standardised potion sprite style.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-04-30"
+    update: Poll 70
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: "Divine bastion potion(3) is a members-only three-dose Herblore potion that locks in Ranged and Defence boosts for five minutes at the cost of 10 Hitpoints per consumption."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-cane.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-cane.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon cane | OSRS Price Data
-description: "Dragon cane: An onyx topped cane.. High alch: 18,000 GP, GE limit: 4."
+description: "Dragon cane: An onyx topped cane. High alch: 18,000 GP, GE limit: 4."
 osrs:
   id: 12373
   name: Dragon cane
@@ -12,9 +12,84 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 4
-  about: "Dragon cane is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: polestaff
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 40
+      slash: -2
+      crush: 60
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 55
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 5
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_id: 11770
+      item_name: Reward casket (elite)
+      slug: reward-casket-elite
+      relationship: component
+      description: Source casket for the dragon cane
+    - item_id: 6562
+      item_name: Onyx
+      slug: onyx
+      relationship: component
+      description: Onyx tops the cane in lore and design
+    - item_id: 11924
+      item_name: Dragon thrownaxe
+      slug: dragon-thrownaxe
+      relationship: alternative
+      description: Other dragon weapons without special attacks
+  about: "Dragon cane is an elite Treasure Trails one-handed polestaff requiring 60 Attack, granting +60 crush, +55 strength and +5 prayer with no special attack."
+  market_strategy:
+    notes:
+      - Elite clue reward at 1/1,275 from elite caskets
+      - Buy limit 4 per 4 hours keeps prices volatile
+      - 60 Attack required, polestaff combat options
+      - Prayer bonus 5 enables ironman prayer training niche
+      - High alch 18,000 GP rarely beats GE price
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Dragon cane added as part of the Treasure Trail Expansion update.
+    - date: "2015-09-03"
+      update: Polygon adjustment
+      description: Model polygon count adjusted for performance.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dart-p-11234.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dart-p-11234.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 11000
-  about: "Dragon dart(p++) is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 2
+    weight: 0
+    requirements:
+      ranged: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 35
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Dragon dart
+          quantity: 1
+        - item_name: Weapon poison++
+          quantity: 1
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 11230
+      item_name: Dragon dart
+      slug: dragon-dart
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 11232
+      item_name: Dragon dart(p)
+      slug: dragon-dart-p-11232
+      relationship: variant
+      description: Standard poison variant
+    - item_id: 11233
+      item_name: Dragon dart(p+)
+      slug: dragon-dart-p-11233
+      relationship: variant
+      description: Stronger poison variant
+  about: Dragon dart(p++) is the strongest poison variant of the dragon dart, a thrown weapon requiring 60 Ranged with +35 ranged strength.
+  market_strategy:
+    notes:
+      - 60 Ranged required
+      - Top-tier thrown weapon
+      - Loaded into toxic blowpipe by some
+      - Strongest poison tier extends DoT
+  history:
+    - date: "2007-06-11"
+      description: Added to the game.
+    - date: "2021-06-01"
+      description: Ranged attack bonus reduced to 0; ranged strength increased to 35.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-06-11"
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-spear-p-5730.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-spear-p-5730.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 24960
   highalch: 37440
   limit: 70
-  about: "Dragon spear(p++) is a members-only item in Old School RuneScape. High alchemy value: 37,440 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  equipment:
+    slot: 2h
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 55
+      slash: 55
+      crush: 55
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 5
+      slash: 5
+      crush: 5
+      magic: 5
+      ranged: 5
+    other_bonus:
+      melee_strength: 60
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Shove
+    energy_cost: 25
+    description: "Pushes the target back and stuns them for 5 ticks (3 seconds). Cannot stun already-stunned targets and is ineffective against large multi-tile creatures."
+  related_items:
+    - item_id: 1249
+      item_name: Dragon spear
+      slug: dragon-spear
+      relationship: variant
+      description: Unpoisoned base variant
+    - item_id: 5716
+      item_name: Dragon spear(p)
+      slug: dragon-spear-p
+      relationship: variant
+      description: Lower poison tier
+    - item_id: 5730
+      item_name: Dragon spear(p+)
+      slug: dragon-spear-p-plus
+      relationship: variant
+      description: Mid poison tier
+    - item_id: 11716
+      item_name: Zamorakian spear
+      slug: zamorakian-spear
+      relationship: upgrade
+      description: Stronger spear with same shove special
+  market_strategy:
+    notes:
+      - Highest poison tier of the dragon spear line
+      - Demand driven by PvP shove special attack
+      - Stocks consumed in deep wilderness PKing
+      - Niche use against poison-immune targets via stun lock
+  history:
+    - date: "2004-03-29"
+      update: RuneScape 2 launch
+      description: Dragon spear line introduced with the RS2 launch update.
+    - date: "2016-07-28"
+      description: Stun stacking mechanics adjusted to prevent indefinite stun-locking of opponents.
+    - date: "2021-04-21"
+      description: Attack speed improved from 5 ticks to 4 ticks, bringing it in line with other spears.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2 launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: "Dragon spear(p++) is a members-only two-handed spear in Old School RuneScape, the strongest poison variant of the dragon spear with a Shove special attack used widely for PvP stuns."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/drunk-dragon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/drunk-dragon.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Drunk dragon is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 5
+    boost: "+5% +2 Strength, -2 to -3 Attack"
+  recipes:
+    - skill: Cooking
+      level: 32
+      xp: 160
+      materials:
+        - item_name: Vodka
+          quantity: 1
+        - item_name: Gin
+          quantity: 1
+        - item_name: Dwellberries
+          quantity: 1
+        - item_name: Pineapple chunks
+          quantity: 1
+        - item_name: Pot of cream
+          quantity: 1
+        - item_name: Cocktail glass
+          quantity: 1
+      output_quantity: 1
+      members_only: true
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Drinky Store
+      location: Tai Bwo Wannai
+      currency: Trading sticks
+  related_items:
+    - item_id: 2025
+      item_name: Vodka
+      slug: vodka
+      relationship: component
+      description: Cocktail ingredient
+    - item_id: 2019
+      item_name: Gin
+      slug: gin
+      relationship: component
+      description: Cocktail ingredient
+    - item_id: 2126
+      item_name: Dwellberries
+      slug: dwellberries
+      relationship: component
+      description: Cocktail ingredient
+  market_strategy:
+    notes:
+      - Niche Cooking product, low GE flow
+      - Gnome cocktail demand from Gnome Restaurant minigame
+      - Strength boost competes with combat potions
+  trading_tips:
+    - Watch Tai Bwo Wannai trading stick conversion arbitrage
+    - Stockpile during Gnome Restaurant grinds
+  history:
+    - date: "2002-12-12"
+      update: Agility skill release
+      description: Drunk dragon added as a gnome cocktail with the Agility skill launch.
+    - date: "2006-08-07"
+      update: Gnome Restaurant rework
+      description: Graphics updated alongside the Gnome Restaurant minigame rework.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Drunk dragon is a gnome cocktail made at Cooking 32 that heals 5 and boosts Strength while lowering Attack.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/echo-virtus-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/echo-virtus-ornament-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Echo virtus ornament kit | OSRS Price Data
-description: "Echo virtus ornament kit: Used on Virtus robes to decorate them in the style of Leagues V: Raging Echoes.. High alch: 3,000 GP."
+description: "Echo virtus ornament kit: Used on Virtus robes to decorate them in the style of Leagues V: Raging Echoes. High alch: 3,000 GP."
 osrs:
   id: 30443
   name: Echo virtus ornament kit
@@ -12,9 +12,58 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: null
-  about: "Echo virtus ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Lumbridge Castle
+      currency: League Points
+      price: 8000
+      notes: Pack of 3 kits
+  related_items:
+    - item_id: 26241
+      item_name: Virtus mask
+      slug: virtus-mask
+      relationship: component
+      description: Decorated when kit is applied
+    - item_id: 26243
+      item_name: Virtus robe top
+      slug: virtus-robe-top
+      relationship: component
+      description: Decorated when kit is applied
+    - item_id: 26245
+      item_name: Virtus robe bottom
+      slug: virtus-robe-bottom
+      relationship: component
+      description: Decorated when kit is applied
+  about: "Echo virtus ornament kit is a Leagues V: Raging Echoes cosmetic kit applied to Virtus robes; the process is reversible, returning both the item and kit."
+  market_strategy:
+    notes:
+      - Limited supply tied to Leagues V reward shop
+      - Reversible application protects underlying Virtus value
+      - Strong fashionscape demand among Virtus owners
+      - No GE buy limit listed
+  history:
+    - date: "2025-01-15"
+      update: "Leagues V: Raging Echoes Rewards"
+      description: Item became obtainable from the Leagues Reward Shop.
+    - date: "2024-11-27"
+      description: Item added to the game cache.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-01-15"
+    update: "Leagues V: Raging Echoes Rewards Are Here"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    alchable: false
+    destroy: Drop
+    options:
+      - Use
+      - Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elysian-sigil.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elysian-sigil.mdx
@@ -12,60 +12,73 @@ osrs:
   lowalch: 300000
   highalch: 450000
   limit: 5
-  item:
-    type: sigil
-    tradeable: true
-    weight: 3
-  obtaining:
-    methods:
+  drop_table:
+    sources:
       - source: Corporeal Beast
-        drop_rate: 1/4,095
-        note: Rarest sigil drop
-  creation:
-    creates:
-      item_id: 12817
-      item_name: Elysian spirit shield
-      slug: elysian-spirit-shield
-    method: Combine with Blessed spirit shield
-    requirements:
-      prayer: 90
-      smithing: 85
-    alternative: Pay Abbot Langley 1,500,000 gp
-  created_effect:
-    name: Divine Protection
-    description: 70% chance to reduce incoming damage by 25%
+        combat_level: 785
+        quantity: "1"
+        rarity: 1/4095
+        members_only: true
+  recipes:
+    - skill: smithing
+      level: 85
+      xp: 1800
+      materials:
+        - item_name: Blessed spirit shield
+          item_id: 12831
+          quantity: 1
+        - item_name: Elysian sigil
+          item_id: 12819
+          quantity: 1
+      product: Elysian spirit shield
+      product_id: 12817
+      product_quantity: 1
+      members_only: true
+      notes: Also requires 90 Prayer. Alternative — pay Abbot Langley 1,500,000 coins to assemble.
   related_items:
-    - item_id: 0
-      item_name: Corporeal Beast
-      slug: corporeal-beast
-      relationship: component
-      description: Source
     - item_id: 12817
       item_name: Elysian spirit shield
       slug: elysian-spirit-shield
       relationship: product
-      description: Created item
+      description: Combine with blessed spirit shield to create
     - item_id: 12831
       item_name: Blessed spirit shield
       slug: blessed-spirit-shield
       relationship: component
-      description: Required material
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Sigil |
-    | Tradeable | Yes |
-    | Weight | 3 kg |
-
-    | Item Created | Materials | Requirements |
-    |--------------|-----------|--------------|
-    | Elysian spirit shield | Elysian sigil + Blessed spirit shield | 90 Prayer, 85 Smithing |
-
-    Alternatively, pay Abbot Langley 1,500,000 gp.
-
-    Elysian Spirit Shield: 70% chance to reduce incoming damage by 25%.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Base shield required for assembly
+    - item_id: 12821
+      item_name: Spectral sigil
+      slug: spectral-sigil
+      relationship: alternative
+      description: Sister sigil from Corporeal Beast
+    - item_id: 12825
+      item_name: Arcane sigil
+      slug: arcane-sigil
+      relationship: alternative
+      description: Sister sigil from Corporeal Beast
+  market_strategy:
+    notes:
+      - Rarest Corporeal Beast sigil drop
+      - High-end PvM shield investment
+      - Low GE limit constrains flipping
+      - Demand tied to Corp Beast team activity
+  about: Elysian sigil is the rarest sigil dropped by the Corporeal Beast and is combined with a blessed spirit shield to create the Elysian spirit shield.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-10-16"
+    update: Corporeal Beast
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enchant-onyx.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enchant-onyx.mdx
@@ -1,6 +1,6 @@
 ---
 title: Enchant onyx | OSRS Price Data
-description: "Enchant onyx: A tablet containing a magic spell.. High alch: 1 GP, GE limit: 10,000."
+description: "Enchant onyx: A tablet containing a magic spell. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 8021
   name: Enchant onyx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Enchant onyx is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: construction
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 20
+        - item_name: Fire rune
+          quantity: 20
+      output_quantity: 1
+      notes: Created at a Mahogany demon lectern in a player-owned house Study.
+  related_items:
+    - item_id: 6571
+      item_name: Onyx
+      slug: onyx
+      relationship: component
+      description: Gem enchanted when the tablet is broken
+    - item_id: 1761
+      item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Base for the tablet
+  about: Enchant onyx is a magic tablet that casts Lvl-6 Enchant on an onyx without requiring runes, made at a Mahogany demon lectern and granting 72.8 Magic XP when broken.
+  market_strategy:
+    notes:
+      - Saves runes for high-level enchanters
+      - Construction product profitable when onyx jewellery is in demand
+      - Stackable tablets travel well for skilling
+      - Members-only consumer good
+  history:
+    - date: "2018-03-01"
+      description: The "Break" left-click option was removed and replaced with an "Info" right-click option.
+    - date: "2006-05-31"
+      update: PLAYER-OWNED HOUSES!
+      description: Added to the game with the release of Construction.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: PLAYER-OWNED HOUSES!
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    alchable: false
+    destroy: Drop
+    options:
+      - Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/energy-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/energy-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Energy potion(1) | OSRS Price Data
-description: "Energy potion(1): 1 dose of energy potion.. High alch: 21 GP, GE limit: 2,000."
+description: "Energy potion(1): 1 dose of energy potion. High alch: 21 GP, GE limit: 2,000."
 osrs:
   id: 3014
   name: Energy potion(1)
@@ -12,9 +12,77 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 2000
-  about: "Energy potion(1) is a free-to-play item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    herblore_level: 26
+    herblore_xp: 67.5
+    effect: Restores 10% of run energy
+    effects:
+      - description: Restores 10% of the player's run energy
+  recipes:
+    - skill: Herblore
+      level: 26
+      xp: 67.5
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Chocolate dust
+          quantity: 1
+      output_quantity: 1
+      output_item: Energy potion(3)
+  related_items:
+    - item_name: Energy potion(4)
+      slug: energy-potion-4
+      relationship: variant
+      description: 4-dose version
+    - item_name: Energy potion(3)
+      slug: energy-potion-3
+      relationship: variant
+      description: 3-dose version
+    - item_name: Energy potion(2)
+      slug: energy-potion-2
+      relationship: variant
+      description: 2-dose version
+    - item_name: Super energy(4)
+      slug: super-energy-4
+      relationship: upgrade
+      description: Restores more run energy per dose
+  market_strategy:
+    notes:
+      - F2P tradeable potion since 2017
+      - Compare 1-dose vs 4-dose for decant flips
+      - 2000/4h buy limit
+  history:
+    - date: "2004-09-01"
+      update: Herblore Additions
+      description: Item released with the Herblore additions update.
+    - date: "2004-10-26"
+      description: '"Empty" option added.'
+    - date: "2016-04-15"
+      description: Half-full potions became bankable.
+    - date: "2017-03-09"
+      description: Made available to free-to-play players.
+    - date: "2025-05-29"
+      description: Exempted from the Grand Exchange convenience fee.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-09-01"
+    update: Herblore Additions
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Energy potion(1) is a free-to-play 1-dose potion that restores 10% of run energy, made at 26 Herblore.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-horror-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-horror-head.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 161
   highalch: 241
   limit: 7500
-  about: "Ensouled horror head is a members-only item in Old School RuneScape. High alchemy value: 241 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Cave horror
+        combat_level: 80
+        quantity: "1"
+        rarity: 1/30
+        members_only: true
+      - source: Jungle horror
+        combat_level: 70
+        quantity: "1"
+        rarity: 1/40
+        members_only: true
+      - source: Cave abomination
+        combat_level: 206
+        quantity: "1"
+        rarity: always
+        members_only: true
+  prayer:
+    xp_reanimation: 832
+    reanimation_spell: Adept Reanimation
+    spellbook: Arceuus
+    magic_level: 41
+  related_items:
+    - item_id: 13483
+      item_name: Ensouled bear head
+      slug: ensouled-bear-head
+      relationship: alternative
+      description: Lower-tier reanimation head
+    - item_id: 13491
+      item_name: Ensouled kalphite head
+      slug: ensouled-kalphite-head
+      relationship: alternative
+      description: Adjacent-tier reanimation head
+    - item_id: 565
+      item_name: Blood rune
+      slug: blood-rune
+      relationship: component
+      description: Adept reanimation rune cost component
+  market_strategy:
+    notes:
+      - Steady Arceuus Prayer XP source
+      - Supply gated by cave horror tasks
+      - Buy limit allows bulk training stock
+      - Reanimated horror also gives Slayer XP toward jungle tasks
+  about: Ensouled horror head is dropped by cave horrors, jungle horrors, and cave abominations and can be reanimated with the Arceuus spellbook for Prayer experience.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: "Zeah: Great Kourend"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ent-branch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ent-branch.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ent branch | OSRS Price Data
-description: "Ent branch: A branch from an ent.. High alch: 132 GP."
+description: "Ent branch: A branch from an ent. High alch: 132 GP."
 osrs:
   id: 31032
   name: Ent branch
@@ -12,9 +12,68 @@ osrs:
   lowalch: 88
   highalch: 132
   limit: null
-  about: "Ent branch is a members-only item in Old School RuneScape. High alchemy value: 132 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Vale Totems (vale offerings)
+        rarity: common
+        members_only: true
+      - source: Vale Research Exchange (20 research points)
+        rarity: always
+        members_only: true
+  recipes:
+    - skill: fletching
+      materials:
+        - item_name: Ent branch
+          item_id: 31032
+          quantity: 1
+      product: Atlatl dart shafts
+      product_quantity: 100
+      facility: Knife
+    - skill: construction
+      materials:
+        - item_name: Ent branch
+          item_id: 31032
+          quantity: 5
+      product: Greenman statue
+      facility: Player-owned house
+  related_items:
+    - item_id: 31030
+      item_name: Atlatl dart shaft
+      slug: atlatl-dart-shaft
+      relationship: product
+      description: Fletched 100 per ent branch
+    - item_id: 31028
+      item_name: Greenman statue
+      slug: greenman-statue
+      relationship: product
+      description: Decorative POH construction product
+  about: "Ent branch is a stackable Varlamore drop from Vale Totems used to fletch atlatl dart shafts and craft greenman statues."
+  market_strategy:
+    notes:
+      - Common Vale Totems output drives bulk supply
+      - Stackable, no GE buy limit listed
+      - 100 atlatl dart shafts per branch make it an essential fletching input
+      - Vale Research Exchange offers 20-point fixed price floor
+      - Greenman decor demand from POH builders adds steady sink
+  history:
+    - date: "2025-07-23"
+      update: Varlamore - The Final Dawn
+      description: Ent branch added with the Varlamore final expansion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-07-23"
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0.0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/expeditious-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/expeditious-bracelet.mdx
@@ -14,73 +14,102 @@ osrs:
   limit: 15000
   equipment:
     slot: hands
-    type: slayer_bracelet
-    tradeable: true
-    weight: 0.007
-    charges: 30
-  creation:
-    method: Enchant Opal bracelet with Lvl-1 Enchant
+    weight: 0.25
     requirements:
       magic: 7
-    runes:
-      - rune: Cosmic
-        quantity: 1
-      - rune: Water
-        quantity: 1
-  special_effect:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    maximum: 30
+    description: Each bracelet holds 30 charges; one charge is consumed per qualifying slayer kill, with a 25% chance that kill counts as two toward the task without bonus XP.
+  special_attack:
     name: Slayer Acceleration
-    description: 25% chance for kill to count as 2 kills
-    charges: 30
-    notes:
-      - No extra XP granted
-  market:
-    buy_limit: 15000
-    price_estimate: 1600
+    description: 25% chance for a kill to count as two toward the current slayer task; no extra Slayer XP awarded. Elite combat achievement gives 10% chance to fully recharge instead of breaking.
+  recipes:
+    - skill: magic
+      level: 7
+      xp: 17.5
+      materials:
+        - item_name: Opal bracelet
+          item_id: 11072
+          quantity: 1
+        - item_name: Cosmic rune
+          item_id: 564
+          quantity: 1
+        - item_name: Water rune
+          item_id: 555
+          quantity: 1
+      product: Expeditious bracelet
+      product_id: 21177
+      product_quantity: 1
+      facility: Lvl-1 Enchant
+      members_only: true
   related_items:
     - item_id: 21183
       item_name: Bracelet of slaughter
       slug: bracelet-of-slaughter
       relationship: alternative
-      description: Task extending
+      description: Slayer task extending bracelet
     - item_id: 11866
       item_name: Slayer ring
       slug: slayer-ring
       relationship: alternative
-      description: Teleports
+      description: Slayer monster teleports
     - item_id: 11072
       item_name: Opal bracelet
       slug: opal-bracelet
       relationship: component
-      description: Base item
-  about: |-
-    Enchant Opal bracelet with Lvl-1 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 7 |
-    | Cosmic rune | 1 |
-    | Water rune | 1 |
-
-    All bonuses +0
-
-    Slayer Acceleration:
-    - 25% chance for kill to count as 2
-    - No extra XP granted
-    - 30 charges
-
-    Essential for:
-    - Skipping bad tasks
-    - Point boosting
-    - Task block alternatives
-
-    Speeds through unwanted tasks.
+      description: Enchanted to create the bracelet
+  about: Expeditious bracelet is a members-only enchanted opal bracelet that gives a 25% chance per slayer kill to count as two, useful for skipping unwanted tasks faster.
   market_strategy:
     notes:
-      - Very cheap to use
-      - Good for point tasks
-      - Combine with slaughter
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cheap consumable for slayer point farming
+      - Combine with Bracelet of slaughter for big tasks
+      - Elite CA unlocks 10% full-recharge chance
+      - Charges Slayer count divided by 5 estimate
+  history:
+    - date: "2024-09-04"
+      update: Slayer Partner Points Fix
+      description: Adjusted to ensure correct Slayer points when using with a partner.
+    - date: "2017-02-02"
+      update: Slayer Bracelets
+      description: Released alongside the bracelet of slaughter.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-02-02"
+    update: Slayer Bracelets
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Check
+      - Break
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fancy-teak-dresser-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fancy-teak-dresser-flatpack.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Fancy teak dresser (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Construction
+      level: 56
+      xp: 182
+      facility: Steel framed workbench
+      tools:
+        - Hammer
+        - Saw
+      materials:
+        - item_name: Teak plank
+          quantity: 2
+        - item_name: Molten glass
+          quantity: 2
+      output_quantity: 1
+      members_only: true
+  construction:
+    construction_level: 56
+    construction_xp: 182
+    hotspot: Dresser space
+    room: Bedroom
+  related_items:
+    - item_id: 8780
+      item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: Primary material
+    - item_id: 1775
+      item_name: Molten glass
+      slug: molten-glass
+      relationship: component
+      description: Secondary material
+  market_strategy:
+    notes:
+      - Construction flatpack demand from Mahogany Homes / training
+      - Capped buy limit of 500 throttles bulk supply
+      - Profitable to alch only at extreme price collapse
+  trading_tips:
+    - Stack alongside other teak/mahogany flatpacks
+    - Check vs raw teak plank price when flipping
+  history:
+    - date: "2006-05-31"
+      update: Player-Owned Houses!
+      description: Fancy teak dresser (flatpack) added with the Construction skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Build
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Fancy teak dresser (flatpack) is a Construction flatpack assembled into a bedroom dresser inside a player-owned house.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-robe.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Fremennik robe is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Accoutrements
+      location: Rellekka
+      stock: 5
+      price: 650
+      members_only: true
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania
+      stock: 5
+      price: 500
+      members_only: true
+  about: Fremennik robe is a body slot clothing item sold in Rellekka after completing The Fremennik Trials, offering minor slash and crush defence.
+  market_strategy:
+    notes:
+      - Sold by Yrsa for 650 coins in Rellekka
+      - Requires The Fremennik Trials
+      - Cosmetic Fremennik fashion
+      - Low GE volume
+  history:
+    - date: "2004-11-02"
+      description: Added to the game with The Fremennik Trials quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-11-02"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/granite-500g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/granite-500g.mdx
@@ -12,9 +12,45 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 100
-  about: "Granite (500g) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_id: 6981
+      item_name: Granite (2kg)
+      slug: granite-2kg
+      relationship: variant
+      description: 2kg granite chunk
+    - item_id: 6983
+      item_name: Granite (5kg)
+      slug: granite-5kg
+      relationship: variant
+      description: 5kg granite chunk
+  market_strategy:
+    notes:
+      - Mined at 45 Mining from granite rocks
+      - Found at Bandit Camp Quarry, Necropolis, Cape Conch
+      - Desert heat protection required for Bandit Camp
+      - 50 Mining XP per chunk
+      - Used in construction and stonemasonry
+  history:
+    - date: "2006-01-23"
+      description: Added to the game with the Desert Treasure update.
+    - date: "2006-01-30"
+      description: Items renamed from Granite (tiny/small/medium) to Granite (500g/2kg/5kg).
+  about: Granite (500g) is a small mined granite chunk obtained at 45 Mining from rocks in the Bandit Camp Quarry and other desert sites.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-01-23"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grape-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grape-seed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Grape seed | OSRS Price Data
-description: "Grape seed: A grape seed for growing in a vinery.. High alch: 44 GP, GE limit: 200."
+description: "Grape seed: A grape seed for growing in a vinery. High alch: 44 GP, GE limit: 200."
 osrs:
   id: 13657
   name: Grape seed
@@ -12,9 +12,57 @@ osrs:
   lowalch: 29
   highalch: 44
   limit: 200
-  about: "Grape seed is a members-only item in Old School RuneScape. High alchemy value: 44 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    farming_level: 36
+    patch_type: Vine patch
+    location: Hosidius Vinery
+    growth_time_minutes: 35
+    growth_cycles: 7
+    plant_xp: 31.5
+    check_health_xp: 625
+    harvest_xp: 40
+    seeds_per_planting: 1
+    notes: Soil must be treated with saltpetre using a gardening trowel before planting. Compost is not accepted. Patches receive free protection from Gallow.
+  shops:
+    - shop_name: Tithe Farm Reward Shop
+      location: Hosidius
+      base_price: 2
+      currency: Tithe Farm points
+  related_items:
+    - item_name: Grapes
+      slug: grapes
+      relationship: product
+      description: Harvested from a mature vine patch
+    - item_name: Saltpetre
+      slug: saltpetre
+      relationship: component
+      description: Required to treat vine patch soil before planting
+  market_strategy:
+    notes:
+      - Supply gated behind Tithe Farm points (2 per seed)
+      - 36 Farming requirement keeps demand niche
+      - Yields scale with Farming level
+  history:
+    - date: "2016-02-25"
+      description: Item released with the Grapes and PvP poll features.
+    - date: "2019-10-31"
+      description: 'Attempting to plant grape seeds in incorrect patches now shows: "You can only plant grape seeds in a vine patch."'
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-02-25"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Grape seed is a members farming seed planted in the Hosidius vinery at 36 Farming to grow grapes.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-boots.mdx
@@ -14,18 +14,81 @@ osrs:
   limit: 150
   equipment:
     slot: feet
+    weight: 0.34
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Rometti's Fine Fashions
+      location: Grand Tree, Tree Gnome Stronghold
+      currency: Coins
+      price: 200
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 638
       item_name: Green robe top
       slug: green-robe-top
       relationship: set-piece
-      description: Matching top
-  about: |-
-    > _"A pair of green boots."_
-
-    Green boots are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching gnome robe top
+    - item_id: 630
+      item_name: Blue boots
+      slug: blue-boots
+      relationship: alternative
+      description: Recoloured gnome boots variant
+    - item_id: 632
+      item_name: Red boots
+      slug: red-boots
+      relationship: alternative
+      description: Recoloured gnome boots variant
+  about: Green boots are members-only cosmetic gnome footwear sold by Rometti's Fine Fashions and rewarded from Easy clue scrolls, with negligible combat stats.
+  market_strategy:
+    notes:
+      - Cosmetic fashionscape item
+      - Easy clue casket reward floor
+      - Limited buy of 150 per 4 hours
+      - Shop price 200 caps GE downside
+  history:
+    - date: "2014-12-10"
+      update: Item Rename
+      description: Item renamed from Boots to Green boots.
+    - date: "2002-12-12"
+      update: Agility Online
+      description: Released with the Agility Online update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Agility Online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-torstol.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-torstol.mdx
@@ -12,30 +12,49 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 11000
-  herb:
-    type: grimy
-    tier: highest
-  herblore:
-    cleaning_level: 75
-    cleaning_xp: 15
-    clean_id: 269
-    clean_name: Torstol
+  material:
+    type: herb
+    tier: high
   farming:
-    level: 85
-    seed_id: 5309
+    farming_level: 85
+    seed_id: 5304
     seed_name: Torstol seed
+    plant_xp: 25
+    harvest_xp: 224.5
+  recipes:
+    - skill: Herblore
+      level: 75
+      xp: 15
+      materials:
+        - item_name: Grimy torstol
+          quantity: 1
+      output_quantity: 1
+      output_item: Torstol
+      members_only: true
   drop_table:
     sources:
+      - source: Kalphite Queen
+        source_id: 963
+        combat_level: 333
+        quantity: "25 (noted)"
+        rarity: uncommon
+        members_only: true
+      - source: Scorpia
+        source_id: 7811
+        combat_level: 225
+        quantity: "10-15 (noted)"
+        rarity: uncommon
+        members_only: true
       - source: Zulrah
         source_id: 2042
         combat_level: 725
-        quantity: 10-20 (noted)
+        quantity: "10-20 (noted)"
         rarity: uncommon
         members_only: true
       - source: Cerberus
         source_id: 5862
         combat_level: 318
-        quantity: 5-15 (noted)
+        quantity: "5-15 (noted)"
         rarity: uncommon
         members_only: true
   related_items:
@@ -43,39 +62,51 @@ osrs:
       item_name: Torstol
       slug: torstol
       relationship: product
-      description: Cleaned version
+      description: Cleaned form
     - item_id: 111
       item_name: Torstol potion (unf)
       slug: torstol-potion-unf
       relationship: product
       description: Unfinished potion
+    - item_id: 5304
+      item_name: Torstol seed
+      slug: torstol-seed
+      relationship: component
+      description: Farming seed
     - item_id: 2450
       item_name: Zamorak brew(4)
       slug: zamorak-brew-4
       relationship: product
       description: Primary end product
-    - item_id: 5309
-      item_name: Torstol seed
-      slug: torstol-seed
-      relationship: component
-      description: Farming seed
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Grimy Herb |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-    | Herblore Level | 75 (to clean) |
-
-    Clean to produce torstol for Herblore.
-
-    Torstol used for:
-    - Zamorak brew
-    - Overload (in raids)
-    - Antivenom+
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Top-tier herb supply hard-gated by 85 Farming
+      - Demand pinned to Zamorak brew and super combat
+      - Boss noted-drop streams smooth supply
+  trading_tips:
+    - Track vs clean torstol spread for 75 Herblore cleaning flip
+    - Watch Raids/herb-running cycles for demand spikes
+  history:
+    - date: "2002-12-12"
+      update: RuneScape 2 launch herb pool
+      description: Grimy torstol added as the highest-level Herblore herb.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Grimy torstol is the highest-level grimy herb, cleaned at Herblore 75 for use in Zamorak brews and overloads.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/holy-sandals.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/holy-sandals.mdx
@@ -14,70 +14,78 @@ osrs:
   limit: 4
   equipment:
     slot: feet
-    type: boots
-    tradeable: true
-    weight: 1
+    weight: 0.5
     requirements:
       prayer: 31
-    stats:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Medium
-        drop_rate: 1/1,133 from reward casket
-  effects:
-    - name: God Wars Protection
-      description: Counts as a Saradomin item, prevents Saradomin faction aggression in GWD
-  upgrades:
-    - item_name: Devout boots
-      materials: Holy sandals + Drake's tooth
-      bonus: +5 prayer
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
     - item_id: 23037
       item_name: Devout boots
       slug: devout-boots
       relationship: upgrade
-      description: Upgraded version (+5 prayer)
+      description: Upgraded prayer footwear (+5 prayer)
     - item_id: 22983
       item_name: Drake's tooth
       slug: drakes-tooth
       relationship: component
-      description: Upgrade material
+      description: Material used to craft Devout boots
     - item_id: 2577
       item_name: Ranger boots
       slug: ranger-boots
       relationship: alternative
-      description: Same clue tier
+      description: Same clue tier ranged equivalent
     - item_id: 2579
       item_name: Wizard boots
       slug: wizard-boots
       relationship: alternative
-      description: Magic equivalent
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Prayer | +3 |
-
-    God Wars Protection:
-    - Counts as a Saradomin item
-    - Prevents Saradomin faction aggression in GWD
-
-    Combine with Drake's tooth to create Devout boots:
-    - Increases prayer bonus to +5
-    - Requires completion of upgrade process
-
-    Best prayer bonus boots option:
-    - Slayer tasks with prayer
-    - GWD as Saradomin item
-    - Budget option before Devout boots
+      description: Magic equivalent boots
   market_strategy:
     notes:
-      - Medium clue reward
-      - Upgrade to Devout when affordable
-      - Saradomin item utility adds value
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Medium clue casket reward
+      - Saradomin item for GWD aggression skips
+      - Stepping stone toward Devout boots
+      - Buy limit 4 caps daily flips
+  about: Holy sandals are members feet slot boots awarded from medium Treasure Trails reward caskets, count as a Saradomin item, and serve as the base for Devout boots.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-26"
+    update: Midsummer Event
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/huasca.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/huasca.mdx
@@ -1,6 +1,6 @@
 ---
 title: Huasca | OSRS Price Data
-description: "Huasca: A powerful herb.. High alch: 45 GP."
+description: "Huasca: A powerful herb. High alch: 45 GP."
 osrs:
   id: 30097
   name: Huasca
@@ -12,9 +12,86 @@ osrs:
   lowalch: 30
   highalch: 45
   limit: null
-  about: "Huasca is a members-only item in Old School RuneScape. High alchemy value: 45 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: herb
+    tier: high
+  farming:
+    farming_level: 65
+    seed: Huasca seed
+    notes: Grow huasca herbs in herb patches with a huasca seed.
+  recipes:
+    - skill: herblore
+      level: 58
+      xp: 11.8
+      materials:
+        - item_name: Grimy huasca
+          item_id: 30095
+          quantity: 1
+      product: Huasca
+      product_id: 30097
+      product_quantity: 1
+      facility: Inventory (clean herb)
+    - skill: herblore
+      materials:
+        - item_name: Huasca
+          item_id: 30097
+          quantity: 1
+        - item_name: Vial of water
+          item_id: 227
+          quantity: 1
+      product: Huasca potion (unf)
+      facility: Inventory
+  related_items:
+    - item_id: 30095
+      item_name: Grimy huasca
+      slug: grimy-huasca
+      relationship: downgrade
+      description: Uncleaned form of the herb
+    - item_id: 30093
+      item_name: Huasca seed
+      slug: huasca-seed
+      relationship: component
+      description: Farming seed for huasca
+    - item_id: 30099
+      item_name: Huasca potion (unf)
+      slug: huasca-potion-unf
+      relationship: product
+      description: Unfinished potion crafted from clean huasca
+    - item_id: 30103
+      item_name: Prayer regeneration potion
+      slug: prayer-regeneration-potion
+      relationship: product
+      description: Restores 66 prayer points over 8 minutes
+  about: "Huasca is a Herblore 58 clean herb from Varlamore used to brew prayer regeneration potions and aga paste, sourced from grimy huasca or huasca seeds."
+  market_strategy:
+    notes:
+      - Cleaning grimy huasca grants 11.8 Herblore XP at level 58
+      - Prayer regeneration potion (with aldarium) is the main demand driver
+      - Aga paste at Herblore 60 adds a secondary sink
+      - Zahur can clean and unf-process huasca for a fee
+      - GE supply scales with huasca seed farming output
+  history:
+    - date: "2024-09-25"
+      update: Varlamore - The Rising Darkness
+      description: Huasca herb added with the Varlamore second-content drop.
+    - date: "2025-01-08"
+      update: Zahur processing
+      description: Zahur can now process huasca into huasca potion (unf).
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-09-25"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/infernal-plate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/infernal-plate.mdx
@@ -1,6 +1,6 @@
 ---
 title: Infernal plate | OSRS Price Data
-description: "Infernal plate: Metal from infernus, waiting to be shaped at an anvil.. High alch: 12 GP."
+description: "Infernal plate: Metal from infernus, waiting to be shaped at an anvil. High alch: 12 GP."
 osrs:
   id: 30864
   name: Infernal plate
@@ -12,9 +12,78 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Infernal plate is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ore
+    tier: high
+  recipes:
+    - skill: Smithing
+      level: 83
+      xp: 2000
+      materials:
+        - item_name: Infernal plate
+          quantity: 9
+      output_quantity: 1
+      output_item: Oathplate chest
+      facility: Anvil
+    - skill: Smithing
+      level: 83
+      xp: 2000
+      materials:
+        - item_name: Infernal plate
+          quantity: 9
+      output_quantity: 1
+      output_item: Oathplate helm
+      facility: Anvil
+    - skill: Smithing
+      level: 83
+      xp: 2000
+      materials:
+        - item_name: Infernal plate
+          quantity: 9
+      output_quantity: 1
+      output_item: Oathplate legs
+      facility: Anvil
+  related_items:
+    - item_name: Oathplate chest
+      slug: oathplate-chest
+      relationship: product
+      description: Created from 9 infernal plates at 83 Smithing
+    - item_name: Oathplate helm
+      slug: oathplate-helm
+      relationship: product
+      description: Created from 9 infernal plates at 83 Smithing
+    - item_name: Oathplate legs
+      slug: oathplate-legs
+      relationship: product
+      description: Created from 9 infernal plates at 83 Smithing
+  market_strategy:
+    notes:
+      - High Smithing requirement (83) restricts demand
+      - Stackable smithing material
+      - Demand tied to Oathplate armor crafting
+  history:
+    - date: "2025-05-14"
+      update: "Yama, the Master of Pacts: Out Today"
+      description: Item released with the Yama boss update.
+    - date: "2025-05-22"
+      description: Infernal plates can now be traded.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-05-14"
+    update: "Yama, the Master of Pacts: Out Today"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Infernal plate is a members-only smithing material used to craft Oathplate armor at 83 Smithing.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/inquisitor-s-great-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/inquisitor-s-great-helm.mdx
@@ -1,97 +1,101 @@
 ---
 title: Inquisitor's great helm | OSRS Price Data
-description: "Inquisitor's great helm is a members legs slot item requiring 70 Defence. High alch: 300,000 GP, GE limit: 8."
+description: "Inquisitor's great helm is a members head slot item requiring 30 Defence and 70 Strength. High alch: 300,000 GP, GE limit: 8."
 osrs:
   id: 24419
   name: Inquisitor's great helm
   slug: inquisitor-s-great-helm
-  examine: The great helmet of the turncloak Justiciar.
+  examine: The great helmet of the turncloak justiciar.
   members: true
   icon: Inquisitor's great helm.png
   value: 500000
   lowalch: 200000
   highalch: 300000
   limit: 8
+  material:
+    type: metal
+    tier: high
   equipment:
-    slot: legs
-    type: crystal_armor
-    attack_style: ranged
+    slot: head
+    weight: 2.721
     requirements:
-      ranged: 70
-      defence: 70
-    stats:
-      defence_stab: 32
-      defence_slash: 24
-      defence_crush: 48
-      defence_magic: -4
-      defence_ranged: 36
-    degradeable: true
-    tradeable: false
-  set_bonus:
-    with_item: Bow of faerdhinen
-    per_piece_accuracy: 3
-    per_piece_damage: 6
-    full_set_accuracy: 15
-    full_set_damage: 30
-  recipes:
-    - skill: crafting
-      level: 70
-      xp: 0
-      materials:
-        - item_name: Crystal armour seed
-          item_id: 23956
-          quantity: 1
-        - item_name: Crystal shard
-          item_id: 23962
-          quantity: 1500
-      product: Crystal legs
-      product_id: 24419
-      product_quantity: 1
-      facility: Singing bowl
-      members_only: true
+      defence: 30
+      strength: 70
+    attack_bonus:
+      stab: -2
+      slash: -2
+      crush: 8
+      magic: -5
+      ranged: -5
+    defence_bonus:
+      stab: 19
+      slash: 10
+      crush: 21
+      magic: 0
+      ranged: 12
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  drop_table:
+    sources:
+      - source: The Nightmare
+        combat_level: 814
+        quantity: "1"
+        rarity: 1/420
+        members_only: true
+      - source: Phosani's Nightmare
+        combat_level: 1024
+        quantity: "1"
+        rarity: 1/700
+        members_only: true
   related_items:
-    - item_id: 25865
-      item_name: Bow of faerdhinen
-      slug: bow-of-faerdhinen
-      relationship: component
-      description: Crystal bow
-    - item_id: 24421
-      item_name: Crystal body
-      slug: crystal-body
-      relationship: alternative
-      description: Body slot
     - item_id: 24417
-      item_name: Crystal helm
-      slug: crystal-helm
-      relationship: alternative
-      description: Helm slot
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +0 |
-    | Stab defence | +32 |
-    | Slash defence | +24 |
-    | Crush defence | +48 |
-    | Magic defence | -4 |
-    | Ranged defence | +36 |
-    | Requirements | 70 Ranged, Defence |
-
-    With Bow of faerdhinen:
-    - Each piece: +3% accuracy, +6% damage
-    - Full set: +15% accuracy, +30% damage
-
-    BiS for Bow of faerdhinen builds:
-    - Inferno
-    - Fight Caves
-    - Slayer
-    - General ranged combat
+      item_name: Inquisitor's hauberk
+      slug: inquisitor-s-hauberk
+      relationship: set-piece
+      description: Body slot set piece
+    - item_id: 24421
+      item_name: Inquisitor's plateskirt
+      slug: inquisitor-s-plateskirt
+      relationship: set-piece
+      description: Legs slot set piece
+    - item_id: 24423
+      item_name: Inquisitor's mace
+      slug: inquisitor-s-mace
+      relationship: set-piece
+      description: Crush weapon paired with the set
   market_strategy:
     notes:
-      - Crystal seeds from Gauntlet
-      - Best with corrupted bow
-      - Shards from Prifddinas
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Crush-focused tank helm
+      - Nightmare boss drop pool
+      - High wealth-storage value
+      - Synergises with Inquisitor's mace
+  history:
+    - date: "2020-02-06"
+      description: Item released as part of The Nightmare boss drops.
+    - date: "2024-05-29"
+      description: Set effect tripled when wielding Inquisitor's mace.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-02-06"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Inquisitor's great helm is a members crush-focused tank helm dropped by The Nightmare in Old School RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bolts-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bolts-p.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Iron bolts (p) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: low
+  equipment:
+    slot: ammo
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 46
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Iron bolts
+          quantity: 5
+        - item_name: Weapon poison
+          quantity: 1
+      output_quantity: 5
+      members_only: true
+  related_items:
+    - item_id: 9140
+      item_name: Iron bolts
+      slug: iron-bolts
+      relationship: component
+      description: Unpoisoned base bolts
+    - item_id: 175
+      item_name: Weapon poison
+      slug: weapon-poison
+      relationship: component
+      description: Standard weapon poison
+    - item_id: 9293
+      item_name: Iron bolts (p+)
+      slug: iron-bolts-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_id: 9299
+      item_name: Iron bolts (p++)
+      slug: iron-bolts-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+  market_strategy:
+    notes:
+      - Tiny per-unit alch, value pure GE flip
+      - Poison gates out gem-tipped bolt enhancement
+      - 11k buy limit gives decent flip volume
+  trading_tips:
+    - Track spread vs base iron bolts + weapon poison cost
+    - Watch low-level slayer/PvM bolt consumption cycles
+  history:
+    - date: "2006-07-31"
+      update: Crossbows
+      description: Iron bolts (p) released with the Crossbows update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Iron bolts (p) are poison-tipped iron crossbow bolts crafted by combining iron bolts with weapon poison.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bolts.mdx
@@ -12,38 +12,101 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  item_id: 9140
-  type: ammunition
-  tradeable: true
-  weight: 0
-  buy_limit: 7000
+  material:
+    type: ammunition
+    tier: low
   equipment:
     slot: ammo
-    type: bolts
+    weapon_type: crossbow
+    weight: 0
     requirements:
       ranged: 26
-    stats:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 46
-  fletching:
-    level: 39
-    xp: 1.5
-    materials:
-      - item: Iron bolts (unf)
-        quantity: 1
-      - item: Feathers
-        quantity: 1
-  obtaining:
-    fletching: 39 Fletching with iron bolts (unf) + feathers
-    shop: Crossbow Shop, Keldagrim
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Daryl's Ranging Surplus
+      location: Shayzien
+      stock: 1500
+      base_price: 2
+  recipes:
+    - skill: Fletching
+      level: 39
+      xp: 1.5
+      materials:
+        - item_name: Iron bolts (unf)
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      output_quantity: 10
   related_items:
-    - slug: steel-bolts
-      name: Steel bolts
-      relation: upgrade
-    - slug: iron-crossbow
-      name: Iron crossbow
-      relation: compatible_weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Bronze bolts
+      slug: bronze-bolts
+      relationship: downgrade
+      description: Lower-tier crossbow bolt
+    - item_name: Steel bolts
+      slug: steel-bolts
+      relationship: upgrade
+      description: Next-tier crossbow bolt
+    - item_name: Iron bolts (unf)
+      slug: iron-bolts-unf
+      relationship: component
+      description: Unfinished bolt fletched with feathers
+    - item_name: Iron crossbow
+      slug: iron-crossbow
+      relationship: alternative
+      description: Compatible crossbow weapon
+    - item_name: Iron bolts (p)
+      slug: iron-bolts-p
+      relationship: variant
+      description: Poisoned version
+  market_strategy:
+    notes:
+      - 26 Ranged requirement keeps mid-game demand steady
+      - Daryl's Ranging Surplus stocks 1,500 at 2 coins
+      - Stackable ammunition with 7000/4h buy limit
+  history:
+    - date: "2006-07-31"
+      update: Crossbows
+      description: Item released with the Crossbows update.
+    - date: "2007-01-16"
+      description: Unpoisoned value decreased from 12 to 2 coins.
+    - date: "2018-01-04"
+      description: Poison variant naming standardised with spacing.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Iron bolts are a members ammunition stackable requiring 26 Ranged, fletched at 39 from iron bolts (unf) and feathers.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-crossbow.mdx
@@ -14,48 +14,90 @@ osrs:
   limit: 125
   equipment:
     slot: weapon
-    type: crossbow
-    tradeable: true
+    weapon_type: crossbow
+    attack_speed: 6
     weight: 4
     requirements:
       ranged: 26
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 42
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 42
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    attack_range: 7
   recipes:
     - skill: fletching
       level: 39
+      xp: 88
       materials:
         - item_name: Iron crossbow (u)
+          item_id: 9455
           quantity: 1
         - item_name: Crossbow string
+          item_id: 9438
           quantity: 1
+      product: Iron crossbow
+      product_id: 9177
+      product_quantity: 1
+      members_only: true
   related_items:
     - item_id: 9179
       item_name: Steel crossbow
       slug: steel-crossbow
       relationship: upgrade
-      description: Next tier crossbow
+      description: Next-tier crossbow
+    - item_id: 837
+      item_name: Crossbow
+      slug: crossbow
+      relationship: downgrade
+      description: Bronze-tier crossbow predecessor
     - item_id: 9140
       item_name: Iron bolts
       slug: iron-bolts
       relationship: alternative
-      description: Compatible ammo
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Tier-matched bolts
+    - item_id: 9455
+      item_name: Iron crossbow (u)
+      slug: iron-crossbow-u
+      relationship: component
+      description: Unstrung Fletching intermediate
+  market_strategy:
+    notes:
+      - Fletching ingredient demand drives supply
+      - Cheap mid-tier crossbow for low Ranged accounts
+      - Low margin per unit but high turnover
+      - Loses to bronze-bolt + Karil's setups in PvM
+  about: Iron crossbow is a one-handed members crossbow requiring 26 Ranged to wield and is fletched from an iron crossbow (u) and a crossbow string at level 39 Fletching for 88 experience.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-full-helm.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron full helm | OSRS Price Data
-description: "Iron full helm: A full face helmet.. High alch: 92 GP, GE limit: 125."
+description: "Iron full helm: A full face helmet. High alch: 92 GP, GE limit: 125."
 osrs:
   id: 1153
   name: Iron full helm
@@ -12,24 +12,79 @@ osrs:
   lowalch: 61
   highalch: 92
   limit: 125
-  item_id: 1153
-  item_type: armor
-  slot: head
-  type: full_helm
-  tradeable: true
-  weight: 2.721
-  requirements:
-    defence: 0
-  stats:
-    stab_defence: 6
-    slash_defence: 7
-    crush_defence: 5
-    ranged_defence: 6
+  material:
+    type: iron
+    tier: low
+  equipment:
+    slot: head
+    weight: 2.721
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 6
+      slash: 7
+      crush: 5
+      magic: -1
+      ranged: 6
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 22
+      xp: 50
+      materials:
+        - item_name: Iron bar
+          quantity: 2
+      output_quantity: 1
+      notes: Smith on an anvil with a hammer.
   related_items:
-    - slug: steel-full-helm
-    - slug: iron-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1155
+      item_name: Steel full helm
+      slug: steel-full-helm
+      relationship: upgrade
+      description: Next tier of full helm
+    - item_id: 1115
+      item_name: Iron platebody
+      slug: iron-platebody
+      relationship: set-piece
+      description: Matching iron body armour
+  about: Iron full helm is a free-to-play head slot item smithed from 2 iron bars at 22 Smithing, providing low-tier melee defence and prayer-neutral stats.
+  market_strategy:
+    notes:
+      - High daily volume on the GE
+      - Common low-level F2P starter armour
+      - Smithing recipe operates at a loss
+      - Useful for early ironman defence training
+  history:
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -2 to -3.
+    - date: "2001-01-04"
+      update: Runescape beta is now online!
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    alchable: true
+    destroy: Drop
+    options:
+      - Wear
+      - Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-blowpipe-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-blowpipe-empty.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ironwood blowpipe (empty) | OSRS Price Data
-description: "Ironwood blowpipe (empty): Breath powered dart delivering system with a hint of ironwood.. High alch: 2,160 GP, GE limit: 8."
+description: "Ironwood blowpipe (empty): Breath powered dart delivering system with a hint of ironwood. High alch: 2,160 GP, GE limit: 8."
 osrs:
   id: 31581
   name: Ironwood blowpipe (empty)
@@ -12,9 +12,81 @@ osrs:
   lowalch: 1440
   highalch: 2160
   limit: 8
-  about: "Ironwood blowpipe (empty) is a members-only item in Old School RuneScape. High alchemy value: 2,160 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: 2h
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0.3
+    requirements:
+      ranged: 55
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 16
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 4
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Fletching
+      level: 72
+      xp: 170
+      materials:
+        - item_name: Ironwood logs
+          quantity: 2
+        - item_name: Squid beak
+          quantity: 1
+        - item_name: Knife
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Toxic blowpipe
+      slug: toxic-blowpipe
+      relationship: alternative
+      description: Higher-tier blowpipe variant
+    - item_name: Ironwood blowpipe
+      slug: ironwood-blowpipe
+      relationship: variant
+      description: Charged state of this weapon
+  market_strategy:
+    notes:
+      - Released with Sailing update
+      - Ranged 55 requirement keeps mid-game demand strong
+      - Fletching 72 supply gates the item
+      - Tracks ironwood log and squid beak input prices
+  history:
+    - date: "2025-11-19"
+      update: Sailing
+      description: Item released with the Sailing update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Ironwood blowpipe (empty) is a members two-handed thrown weapon fletched at 72 from ironwood logs and squid beak, requiring 55 Ranged to wield.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-coif.mdx
@@ -1,6 +1,6 @@
 ---
 title: Karil's coif | OSRS Price Data
-description: "Karil's coif is a members head slot item requiring 70 Defence. High alch: 7,800 GP, GE limit: 15."
+description: "Karil's coif is a members head slot item requiring 70 Defence and 70 Ranged. High alch: 7,800 GP, GE limit: 15."
 osrs:
   id: 4732
   name: Karil's coif
@@ -14,34 +14,38 @@ osrs:
   limit: 15
   equipment:
     slot: head
-    type: barrows
-    set: Karil
-    tradeable: true
-    degradeable: true
-    weight: 0.9
+    weight: 0.907
     requirements:
       defence: 70
       ranged: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 7
-      defence_stab: 6
-      defence_slash: 9
-      defence_crush: 12
-      defence_magic: 6
-      defence_ranged: 10
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -1
+      ranged: 7
+    defence_bonus:
+      stab: 6
+      slash: 9
+      crush: 12
+      magic: 6
+      ranged: 10
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  set_effect:
-    name: Tainted Shot
-    pieces_required: 4
-    description: 25% chance to lower opponent's Agility by 20%
-    amulet_of_damned: 25% chance to hit twice (second hit at 50% damage)
+  drop_table:
+    sources:
+      - source: Karil the Tainted
+        combat_level: 98
+        quantity: "1"
+        rarity: 1/2448
+        members_only: true
+      - source: Barrows chest
+        quantity: "1"
+        rarity: 1/2448
+        members_only: true
   related_items:
     - item_id: 4736
       item_name: Karil's leathertop
@@ -62,28 +66,39 @@ osrs:
       item_name: Armadyl helmet
       slug: armadyl-helmet
       relationship: upgrade
-      description: Upgrade path
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Ranged attack | +7 |
-    | Stab defence | +6 |
-    | Slash defence | +9 |
-    | Crush defence | +12 |
-    | Magic defence | +6 |
-    | Ranged defence | +10 |
-
-    Tainted Shot:
-    When wearing full Karil's (coif, leathertop, leatherskirt, crossbow):
-    - 25% chance to lower opponent's Agility by 20%
-
-    With Amulet of the Damned:
-    - 25% chance to hit twice (second hit at 50% damage)
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Higher tier ranged helm
+  market_strategy:
+    notes:
+      - Cheap entry barrows ranged helm
+      - 15 hours of combat per charge
+      - Repairs at Bob or POH stand
+      - Drops broken from chest
+  history:
+    - date: "2005-05-09"
+      description: Item released with the Barrows minigame.
+    - date: "2015-06-25"
+      description: Ranged attack bonus increased from +3 to +7.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Remove
+      - Check
+    alchable: true
+    destroy: Drop
+  about: "Karil's coif is the members head piece of Karil the Tainted's barrows set, degrading over 15 hours of combat in Old School RuneScape."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kitchen-knife.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kitchen-knife.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: 50
-  about: "Kitchen knife is a members-only item in Old School RuneScape. High alchemy value: 4,800 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: stab-sword
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 25
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 24
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle Cellar
+      stock: 1
+      price: 10400
+      members_only: true
+      notes: Requires 8 Recipe for Disaster subquests complete to wield; 8,320 gp with Lumbridge & Draynor Diary discount.
+  related_items:
+    - item_id: 946
+      item_name: Knife
+      slug: knife
+      relationship: alternative
+      description: Standard skilling knife with no combat use
+    - item_id: 5680
+      item_name: Rune dagger
+      slug: rune-dagger
+      relationship: alternative
+      description: Tier-equivalent dagger that can be poisoned
+  market_strategy:
+    notes:
+      - Recipe for Disaster quest unlock gates demand
+      - Rune-tier stab without poison support
+      - Low GE limit caps flipping volume
+      - Mostly cosmetic / completionist purchase
+  about: Kitchen knife is a melee stab weapon sold from the Culinaromancer's Chest after completing eight Recipe for Disaster subquests, mirroring rune dagger stats without the poison option.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-03-15"
+    update: "Hundredth Quest - Recipe for Disaster!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/leaping-salmon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/leaping-salmon.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Leaping salmon is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Barbarian fishing
+        quantity: "1"
+        rarity: common
+        members_only: true
+  related_items:
+    - item_id: 11328
+      item_name: Leaping trout
+      slug: leaping-trout
+      relationship: alternative
+      description: Lower-tier barbarian fish
+    - item_id: 11332
+      item_name: Leaping sturgeon
+      slug: leaping-sturgeon
+      relationship: upgrade
+      description: Higher-tier barbarian fish
+    - item_id: 11324
+      item_name: Roe
+      slug: roe
+      relationship: product
+      description: Yielded when gutted with a knife
+    - item_id: 11334
+      item_name: Fish offcuts
+      slug: fish-offcuts
+      relationship: product
+      description: Yielded when gutted with a knife
+  market_strategy:
+    notes:
+      - Barbarian fishing supply gated by 58 Fishing
+      - Cuts to roe/caviar for cooking demand
+      - Consumed for Strength/Agility XP at Otto's Grotto
+      - Buy-limit 13,000 keeps volume thin
+  trading_tips:
+    - Bulk for cuts to roe/caviar pipelines
+    - Watch league/event spikes on barbarian training
+  history:
+    - date: "2007-07-03"
+      update: Barbarian Training
+      description: Leaping salmon released as a Barbarian fishing catch at Otto's Grotto.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Leaping salmon is a barbarian Fishing catch used to harvest roe and fish offcuts in Old School RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lesser-demon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lesser-demon-mask.mdx
@@ -1,6 +1,6 @@
 ---
 title: Lesser demon mask | OSRS Price Data
-description: "Lesser demon mask: Evil.. High alch: 2,400 GP, GE limit: 4."
+description: "Lesser demon mask: Evil. High alch: 2,400 GP, GE limit: 4."
 osrs:
   id: 20020
   name: Lesser demon mask
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 4
-  about: "Lesser demon mask is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.8
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_id: 19929
+      item_name: Greater demon mask
+      slug: greater-demon-mask
+      relationship: variant
+      description: Larger cosmetic demon mask
+    - item_id: 19725
+      item_name: Black demon mask
+      slug: black-demon-mask
+      relationship: variant
+      description: Black-variant cosmetic demon mask
+  about: Lesser demon mask is a purely cosmetic head slot item rewarded from master Treasure Trail caskets at roughly 1/851, storable in a costume room mahogany treasure chest.
+  market_strategy:
+    notes:
+      - Tight master clue supply with a 4-per-4-hours limit
+      - Fashionscape demand outpaces drop rate
+      - Storable in a mahogany treasure chest
+      - High alch is a price floor at 2,400 GP
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion
+      description: Added to the master Treasure Trail reward pool.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.8
+    alchable: true
+    destroy: Drop
+    options:
+      - Wear
+      - Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/light-tuxedo-jacket.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/light-tuxedo-jacket.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Light tuxedo jacket is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_id: 19967
+      item_name: Light tuxedo cuffs
+      slug: light-tuxedo-cuffs
+      relationship: set-piece
+      description: Light tuxedo outfit cuffs
+    - item_id: 19970
+      item_name: Light trousers
+      slug: light-trousers
+      relationship: set-piece
+      description: Light tuxedo outfit trousers
+    - item_id: 19976
+      item_name: Light tuxedo shoes
+      slug: light-tuxedo-shoes
+      relationship: set-piece
+      description: Light tuxedo outfit shoes
+    - item_id: 19979
+      item_name: Light bow tie
+      slug: light-bow-tie
+      relationship: set-piece
+      description: Light tuxedo outfit bow tie
+  market_strategy:
+    notes:
+      - Pure cosmetic, demand driven by fashionscape
+      - Elite clue droprate (~1/12,750) makes supply scarce
+      - Costume storage shrinks circulating float
+  trading_tips:
+    - Watch elite clue meta and bot waves for supply pulses
+    - Set-piece arbitrage via GE clerk set buyout
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion
+      description: Light tuxedo jacket added as an elite clue scroll reward in the Treasure Trail Expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Light tuxedo jacket is a cosmetic body-slot piece of the light tuxedo outfit rewarded from elite Treasure Trail caskets.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-roots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-roots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Maple roots | OSRS Price Data
-description: "Maple roots: The roots of the Maple tree.. High alch: 1 GP, GE limit: 11,000."
+description: "Maple roots: The roots of the Maple tree. High alch: 1 GP, GE limit: 11,000."
 osrs:
   id: 6047
   name: Maple roots
@@ -12,9 +12,72 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Maple roots is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Vale offerings (Vale Totems)
+        rarity: common
+        members_only: true
+  farming:
+    farming_level: 45
+    seed: Maple seed
+    notes: Grow a maple tree then chop and dig the stump to obtain roots.
+  recipes:
+    - skill: crafting
+      level: 10
+      xp: 15
+      materials:
+        - item_name: Maple roots
+          item_id: 6047
+          quantity: 1
+      product: Crossbow string
+      product_quantity: 1
+      facility: Spinning wheel
+  related_items:
+    - item_id: 5316
+      item_name: Maple seed
+      slug: maple-seed
+      relationship: component
+      description: Seed planted to obtain roots
+    - item_id: 1517
+      item_name: Maple logs
+      slug: maple-logs
+      relationship: alternative
+      description: Logs from the same maple tree
+    - item_id: 21486
+      item_name: Supercompost
+      slug: supercompost
+      relationship: product
+      description: Roots can be added to a compost bin
+  about: "Maple roots are obtained by digging up a chopped maple tree planted via Farming or by completing Vale offerings in Vale Totems."
+  market_strategy:
+    notes:
+      - Members-only Farming and Vale Totems byproduct
+      - Used for crossbow strings (Crafting 10, 15 XP)
+      - Compost bin input for supercompost batches
+      - GE limit 11,000 per 4 hours allows bulk turnover
+      - Supply scales with maple seed farming popularity
+  history:
+    - date: "2005-07-11"
+      update: Release
+      description: Maple roots added with the introduction of the Farming skill.
+    - date: "2023-06-28"
+      update: Graphical update
+      description: Item icon refreshed with modernised artwork.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/marrentill-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/marrentill-potion-unf.mdx
@@ -15,10 +15,6 @@ osrs:
   potion:
     type: unfinished
     tier: basic
-  herblore:
-    level: 5
-    xp: 0
-    method: Add marrentill to vial of water
   recipes:
     - skill: herblore
       level: 5
@@ -32,6 +28,20 @@ osrs:
           quantity: 1
       product: Marrentill potion (unf)
       product_id: 93
+      product_quantity: 1
+      members_only: true
+    - skill: herblore
+      level: 5
+      xp: 37.5
+      materials:
+        - item_name: Marrentill potion (unf)
+          item_id: 93
+          quantity: 1
+        - item_name: Unicorn horn dust
+          item_id: 235
+          quantity: 1
+      product: Antipoison(3)
+      product_id: 175
       product_quantity: 1
       members_only: true
   related_items:
@@ -49,27 +59,35 @@ osrs:
       item_name: Unicorn horn dust
       slug: unicorn-horn-dust
       relationship: component
-      description: Secondary for antipoison
+      description: Secondary used to finish antipoison
     - item_id: 175
       item_name: Antipoison(3)
       slug: antipoison-3
       relationship: product
-      description: Cures poison
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Unfinished Potion |
-    | Tradeable | Yes |
-    | Weight | 0.056 kg |
-    | Requirements | 5 Herblore |
-
-    Add secondary ingredient to create:
-    - Antipoison (+ unicorn horn dust)
-
-    Essential early-game potion for poison protection.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Finished antipoison potion
+  market_strategy:
+    notes:
+      - Cleaning + brewing supply chain item
+      - Demand tracks early-game Herblore training
+      - Empty option allows quick vial recovery
+      - Antipoison floor sets price ceiling
+  about: Marrentill potion (unf) is a 4-dose unfinished potion made by adding a marrentill herb to a vial of water at level 5 Herblore and is the base for antipoison.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mith-grapple-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mith-grapple-unf.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 19
   highalch: 28
   limit: 11000
-  about: "Mith grapple (unf) is a members-only item in Old School RuneScape. High alchemy value: 28 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Fletching
+      level: 59
+      xp: 11
+      materials:
+        - item_name: Mith grapple tip
+          quantity: 1
+        - item_name: Mithril bolts
+          quantity: 1
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 9419
+      item_name: Mith grapple
+      slug: mith-grapple
+      relationship: product
+      description: Finished grapple after attaching rope
+  market_strategy:
+    notes:
+      - Intermediate fletching product
+      - Made at 59 Fletching for 11 XP
+      - Attach rope to complete the grapple
+      - Used for agility shortcuts
+  history:
+    - date: "2006-07-31"
+      description: Added to the game.
+    - date: "2006-08-15"
+      description: Value increased from 0 to 48 coins.
+  about: Mith grapple (unf) is an intermediate Fletching product made by attaching a mith grapple tip to a mithril bolt at 59 Fletching.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-chainbody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-chainbody.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril chainbody | OSRS Price Data
-description: "Mithril chainbody: A series of connected metal rings.. High alch: 1,170 GP, GE limit: 125."
+description: "Mithril chainbody: A series of connected metal rings. High alch: 1,170 GP, GE limit: 125."
 osrs:
   id: 1109
   name: Mithril chainbody
@@ -12,25 +12,113 @@ osrs:
   lowalch: 780
   highalch: 1170
   limit: 125
-  item_id: 1109
-  item_type: armor
-  slot: body
-  type: chainbody
-  tradeable: true
-  weight: 5.896
-  requirements:
-    defence: 20
-  stats:
-    stab_defence: 25
-    slash_defence: 35
-    crush_defence: 42
-    magic_defence: -3
-    ranged_defence: 27
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: body
+    weight: 5.896
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: 0
+    defence_bonus:
+      stab: 25
+      slash: 35
+      crush: 42
+      magic: -3
+      ranged: 27
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 61
+      xp: 150
+      materials:
+        - item_name: Mithril bar
+          item_id: 2359
+          quantity: 3
+      product: Mithril chainbody
+      product_id: 1109
+      product_quantity: 1
+      facility: Anvil
+  shops:
+    - shop_name: Horvik's Armour Shop
+      location: Varrock
+    - shop_name: Wayne's Chains - Chainmail Specialist
+      location: Falador
+    - shop_name: Skulgrimen's Battle Gear
+      location: Jatizso
+    - shop_name: Hild's Wares
+      location: Keldagrim
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  drop_table:
+    sources:
+      - source: Various mithril-tier monster drops
+        rarity: varies
+        members_only: false
   related_items:
-    - slug: adamant-chainbody
-    - slug: mithril-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 2359
+      item_name: Mithril bar
+      slug: mithril-bar
+      relationship: component
+      description: Smithing material (×3)
+    - item_id: 1121
+      item_name: Mithril platebody
+      slug: mithril-platebody
+      relationship: upgrade
+      description: Stronger mithril body slot armour
+    - item_id: 1105
+      item_name: Adamant chainbody
+      slug: adamant-chainbody
+      relationship: upgrade
+      description: Next tier chainbody
+    - item_id: 1103
+      item_name: Steel chainbody
+      slug: steel-chainbody
+      relationship: downgrade
+      description: Previous tier chainbody
+  about: "Mithril chainbody is a free-to-play body slot armour requiring 20 Defence, smithed from 3 mithril bars at Smithing 61."
+  market_strategy:
+    notes:
+      - F2P 20 Defence body slot armour
+      - Smithed from 3 mithril bars at Smithing 61 for 150 XP
+      - GE limit 125 per 4 hours
+      - Stocked by multiple armour shops, suppressing price spikes
+      - High alch 1,170 GP rarely profitable vs bar costs
+  history:
+    - date: "2001-01-04"
+      update: Release
+      description: Mithril chainbody added as part of the original armour line-up.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 5.896
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-hasta-p-11403.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-hasta-p-11403.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 338
   highalch: 507
   limit: 125
-  about: "Mithril hasta(p+) is a members-only item in Old School RuneScape. High alchemy value: 507 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 17
+      slash: 17
+      crush: 17
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -5
+      slash: 0
+      crush: -4
+      magic: 0
+      ranged: -5
+    other_bonus:
+      melee_strength: 18
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Mithril hasta
+          quantity: 1
+        - item_name: Weapon poison+
+          quantity: 1
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 11391
+      item_name: Mithril hasta
+      slug: mithril-hasta
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 11401
+      item_name: Mithril hasta(p)
+      slug: mithril-hasta-p-11401
+      relationship: variant
+      description: Standard poison variant
+    - item_id: 11405
+      item_name: Mithril hasta(p++)
+      slug: mithril-hasta-p-11405
+      relationship: variant
+      description: Strongest poison variant
+  about: Mithril hasta(p+) is a one-handed Barbarian Training spear variant poisoned with weapon poison+, requiring 20 Attack and completion of the miniquest to wield.
+  market_strategy:
+    notes:
+      - Requires Barbarian Training miniquest
+      - 20 Attack and completion to wield
+      - Poison+ tier improves damage over time
+      - 4-tick attack speed after 2021 buff
+  history:
+    - date: "2007-07-03"
+      description: Added to the game with Barbarian Training.
+    - date: "2021-04-01"
+      description: Attack speed improved from 5 ticks to 4 ticks.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-mace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-mace.mdx
@@ -12,28 +12,58 @@ osrs:
   lowalch: 234
   highalch: 351
   limit: 125
+  material:
+    type: mithril
+    tier: mid
   equipment:
     slot: weapon
-    type: mace
-    tradeable: true
+    weapon_type: spiked
+    attack_speed: 4
     weight: 1.587
     requirements:
       attack: 20
-    stats:
-      attack_stab: 11
-      attack_slash: -2
-      attack_crush: 18
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 16
+    attack_bonus:
+      stab: 11
+      slash: -2
+      crush: 18
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 16
       ranged_strength: 0
       magic_damage: 0
       prayer: 3
+  recipes:
+    - skill: smithing
+      level: 52
+      xp: 50
+      materials:
+        - item_name: Mithril bar
+          quantity: 1
+      output_quantity: 1
+      notes: Smith on an anvil with a hammer.
+  shops:
+    - shop_name: Warrior Guild Armoury
+      location: Burthorpe
+      price: 702
+    - shop_name: Flynn's Mace Market
+      location: Falador
+      price: 585
+    - shop_name: Briget's Weapons
+      location: Shayzien
+      price: 585
+    - shop_name: Iwan's Maces
+      location: Prifddinas
+      price: 585
+    - shop_name: Spike's Spikes
+      location: Outer Fortis
+      price: 760
   related_items:
     - item_id: 1430
       item_name: Adamant mace
@@ -45,8 +75,41 @@ osrs:
       slug: mithril-warhammer
       relationship: alternative
       description: Higher strength alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 2436
+      item_name: Mithril bar
+      slug: mithril-bar
+      relationship: component
+      description: Smithed into the mace
+  about: Mithril mace is a free-to-play crush mace requiring 20 Attack, smithed from a single mithril bar at 52 Smithing and granting +3 prayer alongside +16 strength.
+  market_strategy:
+    notes:
+      - Cheaper than GE value via Falador shop runs
+      - Niche +3 prayer bonus for low-level prayer trips
+      - Limited F2P demand outside ironmen
+      - Smithing recipe operates at a loss
+  history:
+    - date: "2021-04-21"
+      description: Attack speed decreased from 5 (every 3.0 seconds) to 4 (every 2.4 seconds).
+    - date: "2001-01-04"
+      update: Runescape beta is now online!
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 1.587
+    alchable: true
+    destroy: Drop
+    options:
+      - Wield
+      - Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-trimmed-set-lg.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril trimmed set (lg) | OSRS Price Data
-description: "Mithril trimmed set (lg): A set containing a full helm, platebody, legs and kiteshield.. High alch: 3,000 GP, GE limit: 8."
+description: "Mithril trimmed set (lg): A set containing a full helm, platebody, legs and kiteshield. High alch: 3,000 GP, GE limit: 8."
 osrs:
   id: 13004
   name: Mithril trimmed set (lg)
@@ -12,9 +12,63 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
-  about: "Mithril trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Grand Exchange (Sets)
+      location: Varrock
+      notes: Bundled via the Grand Exchange clerk Sets interface.
+  related_items:
+    - item_id: 12283
+      item_name: Mithril full helm (t)
+      slug: mithril-full-helm-t
+      relationship: component
+      description: Trimmed helm bundled in the set
+    - item_id: 12281
+      item_name: Mithril platebody (t)
+      slug: mithril-platebody-t
+      relationship: component
+      description: Trimmed platebody bundled in the set
+    - item_id: 12285
+      item_name: Mithril platelegs (t)
+      slug: mithril-platelegs-t
+      relationship: component
+      description: Trimmed legs bundled in the set
+    - item_id: 12289
+      item_name: Mithril kiteshield (t)
+      slug: mithril-kiteshield-t
+      relationship: component
+      description: Trimmed kiteshield bundled in the set
+    - item_id: 13005
+      item_name: Mithril trimmed set (sk)
+      slug: mithril-trimmed-set-sk
+      relationship: alternative
+      description: Skirt variant of the trimmed set
+  about: "Mithril trimmed set (lg) bundles four trimmed mithril pieces (full helm, platebody, platelegs, kiteshield) into a single tradeable package via the Grand Exchange clerk."
+  market_strategy:
+    notes:
+      - Bundles four trimmed mithril pieces to save bank space
+      - Compare bundle GE price vs sum of individual pieces for arbitrage
+      - F2P tradeable cosmetic set, no combat advantage over plain mithril
+      - GE limit 8 per 4 hours throttles arbitrage volume
+      - Use sets-interface to unpack or repack as supply shifts
+  history:
+    - date: "2015-02-26"
+      update: The Grand Exchange
+      description: Set added when the Grand Exchange clerk's Sets interface was introduced.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 6.0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-warhammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-warhammer.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril warhammer | OSRS Price Data
-description: "Mithril warhammer is a F2P weapon slot item requiring 20 Attack. High alch: 996 GP, GE limit: 125."
+description: "Mithril warhammer is a F2P weapon slot item requiring 20 Strength. High alch: 996 GP, GE limit: 125."
 osrs:
   id: 1343
   name: Mithril warhammer
@@ -12,41 +12,106 @@ osrs:
   lowalch: 664
   highalch: 996
   limit: 125
+  material:
+    type: mithril
+    tier: mid
   equipment:
     slot: weapon
-    type: warhammer
-    tradeable: true
+    weapon_type: blunt
+    attack_speed: 6
     weight: 1.587
     requirements:
-      attack: 20
-    stats:
-      attack_stab: -4
-      attack_slash: -4
-      attack_crush: 25
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 27
+      strength: 20
+    attack_bonus:
+      stab: -4
+      slash: -4
+      crush: 25
+      magic: -4
+      ranged: -4
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 27
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  recipes:
+    - product_name: Mithril warhammer
+      skill: Smithing
+      smithing_level: 59
+      experience: 150
+      materials:
+        - item_name: Mithril bar
+          quantity: 3
+  shops:
+    - shop_name: Skulgrimen's Battle Gear
+      location: Rellekka
+    - shop_name: Vigr's Warhammers
+      location: Keldagrim
+    - shop_name: Mount Karuulm Weapon Shop
+      location: Mount Karuulm
+    - shop_name: Cam Torum Blacksmith
+      location: Cam Torum
+  drop_table:
+    sources:
+      - source: Ice troll
+        rarity: uncommon
+        members_only: true
+      - source: Dagannoth Rex
+        combat_level: 303
+        rarity: uncommon
+        members_only: true
   related_items:
     - item_id: 1345
       item_name: Adamant warhammer
       slug: adamant-warhammer
       relationship: upgrade
       description: Higher tier warhammer
+    - item_id: 1341
+      item_name: Steel warhammer
+      slug: steel-warhammer
+      relationship: downgrade
+      description: Lower tier warhammer
     - item_id: 1428
       item_name: Mithril mace
       slug: mithril-mace
       relationship: alternative
-      description: Alternative crush weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: One-tick faster mithril crush weapon
+  market_strategy:
+    notes:
+      - F2P legal but rarely used in mainstream PvM
+      - Smithing supply unprofitable at current bar prices
+      - Most demand is Smithing XP and Slayer tasks needing crush
+  history:
+    - date: "2004-03-29"
+      update: RuneScape 2 launch
+      description: Mithril warhammer added to the F2P warhammer line.
+    - date: "2021-04-21"
+      description: Requirement changed from 20 Attack to 20 Strength and strength bonus increased from +20 to +27.
+    - date: "2021-07-07"
+      description: Female player equipment positioning adjusted.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2 launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.587
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: "Mithril warhammer is a free-to-play one-handed crush weapon requiring 20 Strength, smithed from three mithril bars and stocked by warhammer shops across Gielinor."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mixed hide boots | OSRS Price Data
-description: "Mixed hide boots: Made from the hide of a few different creatures.. High alch: 2,400 GP."
+description: "Mixed hide boots: Made from the hide of a few different creatures. High alch: 2,400 GP."
 osrs:
   id: 29286
   name: Mixed hide boots
@@ -12,9 +12,103 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: null
-  about: "Mixed hide boots is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hide
+    tier: mid-high
+  equipment:
+    slot: feet
+    weight: 2
+    requirements:
+      ranged: 60
+      defence: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 5
+    defence_bonus:
+      stab: 4
+      slash: 5
+      crush: 6
+      magic: 3
+      ranged: 3
+    other_bonus:
+      melee_strength: 2
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 69
+      xp: 75
+      materials:
+        - item_name: Mixed hide base
+          item_id: 29280
+          quantity: 1
+        - item_name: Sunlight antelope fur
+          item_id: 28367
+          quantity: 1
+        - item_name: Needle
+          item_id: 1733
+          quantity: 1
+        - item_name: Thread
+          item_id: 1734
+          quantity: 1
+      product: Mixed hide boots
+      product_id: 29286
+      product_quantity: 1
+      facility: Inventory
+      members_only: true
+  related_items:
+    - item_id: 29280
+      item_name: Mixed hide base
+      slug: mixed-hide-base
+      relationship: component
+      description: Crafting base material
+    - item_id: 28367
+      item_name: Sunlight antelope fur
+      slug: sunlight-antelope-fur
+      relationship: component
+      description: Crafting material
+    - item_id: 29284
+      item_name: Mixed hide top
+      slug: mixed-hide-top
+      relationship: set-piece
+      description: Body slot set piece
+    - item_id: 29282
+      item_name: Mixed hide legs
+      slug: mixed-hide-legs
+      relationship: set-piece
+      description: Legs slot set piece
+  market_strategy:
+    notes:
+      - Crafted at 69 with Hunter Guild help
+      - Hybrid melee-ranged stats
+      - Healthy daily volume
+      - Strength bonus suits mid-game
+  history:
+    - date: "2024-03-20"
+      description: Item released with Varlamore Part One.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
+  about: Mixed hide boots are members hybrid feet armour crafted at 69 Crafting from a mixed hide base and sunlight antelope fur in Old School RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-lava-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-lava-staff.mdx
@@ -14,7 +14,12 @@ osrs:
   limit: 8
   equipment:
     slot: weapon
+    weapon_type: staff
     attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 40
+      magic: 40
     attack_bonus:
       stab: 10
       slash: -1
@@ -32,62 +37,61 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 40
-      magic: 40
-    weight: 2.267
+  recipes:
+    - product_name: Mystic lava staff
+      skill: Magic
+      facility: Thormac (Sorcerer's Tower, after Scorpion Catcher)
+      materials:
+        - item_name: Lava battlestaff
+          quantity: 1
+        - item_name: Coins
+          quantity: 40000
   related_items:
     - item_id: 3053
       item_name: Lava battlestaff
       slug: lava-battlestaff
       relationship: component
-      description: Base staff for upgrade
+      description: Base staff turned into the mystic variant by Thormac
     - item_id: 6563
       item_name: Mystic mud staff
       slug: mystic-mud-staff
       relationship: alternative
-      description: Water+Earth combination
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +14 |
-    | Crush | +40 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +14 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +50 |
-
-    Requirements: 40 Attack, 40 Magic
-
-    Provides unlimited earth and fire runes simultaneously:
-    - Lvl-6 Enchant (Onyx) — saves earth + fire runes
-    - Superheat Item — saves fire runes with earth covered
-    - Shadow Veil (Arceuus) — requires earth + fire runes
-    - Fire spells — saves fire runes with earth as backup
-    - Autocast with standard spellbook
-
-    A Lava staff upgrade kit (from Master Treasure Trails) can be applied for a cosmetic variant. Purely visual — no stat changes.
-
-    | Feature | Mystic Lava | Mystic Mud |
-    |---------|-------------|------------|
-    | Elements | Earth + Fire | Water + Earth |
-    | Base staff cost | ~10K | ~35K+ |
-    | Best for | Superheat, Enchant | Barrage, Lunar |
-    | Buy limit | 8/4h | 8/4h |
-
-    Both are combination mystic staves with identical combat stats. The mud staff is more expensive and generally more useful for endgame content.
+      description: Water+Earth combination mystic staff
+    - item_id: 6562
+      item_name: Mystic steam staff
+      slug: mystic-steam-staff
+      relationship: alternative
+      description: Water+Fire combination mystic staff
   market_strategy:
     notes:
-      - Lava battlestaff is cheap and common
-      - Thormac cost varies with Kandarin diary tier
-      - Cosmetic upgrade kit available from Master clues
-      - Less demand than mystic mud staff
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Lava battlestaff supply is cheap and steady
+      - Thormac upgrade fee drops with Hard and Elite Kandarin diary
+      - Cosmetic Lava staff upgrade kit (Master clues) leaves stats unchanged
+      - Less demand than mystic mud staff for endgame Magic content
+  history:
+    - date: "2004-09-07"
+      update: Situation in the Sands
+      description: Mystic lava staff added as a combination staff providing unlimited earth and fire runes.
+    - date: "2021-09-22"
+      description: Magic attack and defence bonuses increased from +10 to +14.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-09-07"
+    update: Situation in the Sands
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: "Mystic lava staff is a members-only one-handed staff that supplies unlimited earth and fire runes, providing strong crush damage, +14 magic and standard-spellbook autocast."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/narwhal-horn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/narwhal-horn.mdx
@@ -1,20 +1,73 @@
 ---
 title: Narwhal horn | OSRS Price Data
-description: "Narwhal horn: A sharp horn for such a gentle creature.. High alch: 4,800 GP."
+description: "Narwhal horn: The sharp horn of a narwhal. High alch: 4,800 GP."
 osrs:
   id: 31954
   name: Narwhal horn
   slug: narwhal-horn
-  examine: A sharp horn for such a gentle creature.
+  examine: The sharp horn of a narwhal.
   members: true
   icon: Narwhal horn.png
   value: 8000
   lowalch: 3200
   highalch: 4800
   limit: null
-  about: "Narwhal horn is a members-only item in Old School RuneScape. High alchemy value: 4,800 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Narwhal
+        combat_level: 111
+        quantity: "1"
+        rarity: 1/20
+        members_only: true
+  recipes:
+    - skill: crafting
+      level: 51
+      xp: 73
+      materials:
+        - item_name: Narwhal horn
+          item_id: 31954
+          quantity: 1
+        - item_name: Chisel
+          item_id: 1755
+          quantity: 1
+      product: Narwhal horn knife
+      product_quantity: 1
+      facility: Inventory
+      members_only: true
+  related_items:
+    - item_id: 1755
+      item_name: Chisel
+      slug: chisel
+      relationship: component
+      description: Tool used to shape the horn
+  market_strategy:
+    notes:
+      - Sailing-era narwhal drop
+      - Shapes into untradeable knife
+      - High alch covers cost floor
+      - Demand tied to Crafting trainers
+  history:
+    - date: "2025-11-05"
+      description: Item added to game data but unobtainable.
+    - date: "2025-11-19"
+      description: Became obtainable with the Sailing launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1.5
+    options:
+      - Inspect
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Narwhal horn is a members Sailing drop from narwhals that can be carved into a narwhal horn knife at 51 Crafting in Old School RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nature-tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nature-tiara.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 40
-  about: "Nature tiara is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: runecraft
+      level: 1
+      xp: 45
+      materials:
+        - item_name: Tiara
+          item_id: 5525
+          quantity: 1
+        - item_name: Nature talisman
+          item_id: 1462
+          quantity: 1
+      product: Nature tiara
+      product_id: 5541
+      product_quantity: 1
+      members_only: true
+      notes: Combine at the Nature Altar.
+  related_items:
+    - item_id: 5525
+      item_name: Tiara
+      slug: tiara
+      relationship: component
+      description: Base tiara required for crafting
+    - item_id: 1462
+      item_name: Nature talisman
+      slug: nature-talisman
+      relationship: component
+      description: Talisman bound to create the tiara
+    - item_id: 561
+      item_name: Nature rune
+      slug: nature-rune
+      relationship: product
+      description: Rune crafted at the same altar
+  teleport:
+    destination: Nature Altar
+    type: Altar access (worn)
+    notes: Left-click the mysterious ruins while worn to enter without holding a nature talisman.
+  market_strategy:
+    notes:
+      - Created at a loss vs raw materials
+      - Useful for nature rune crafters freeing inventory slot
+      - Low GE limit constrains flipping
+      - Demand stable from RC trainers
+  about: Nature tiara is a head slot item crafted at the Nature Altar from a tiara and a nature talisman, granting talisman-free altar access while worn.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-06-13"
+    update: RuneCraft
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/opal-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/opal-bolts-e.mdx
@@ -12,42 +12,98 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 11000
+  material:
+    type: ammunition
+    tier: low
   equipment:
     slot: ammo
-    other_bonus:
-      ranged_strength: 14
+    weight: 0
     requirements:
       ranged: 1
-    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 14
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Lucky Lightning
+    description: "Lightning strike deals extra damage equal to 10% of visible Ranged level (rounded down); 5% activation chance, 5.5% with Kandarin hard diary."
+    proc_chance: "5%"
+  recipes:
+    - skill: magic
+      level: 4
+      xp: 9
+      materials:
+        - item_id: 879
+          item_name: Opal bolts
+          quantity: 10
+        - item_id: 556
+          item_name: Air rune
+          quantity: 2
+        - item_id: 564
+          item_name: Cosmic rune
+          quantity: 1
+      product: Opal bolts (e)
+      product_id: 9236
+      notes: Cast Enchant Crossbow Bolt (Opal); yields 10 per cast.
   related_items:
+    - item_id: 879
+      item_name: Opal bolts
+      slug: opal-bolts
+      relationship: component
+      description: Unenchanted base bolt
     - item_id: 9238
       item_name: Pearl bolts (e)
       slug: pearl-bolts-e
       relationship: upgrade
-      description: Next tier enchanted bolt
-  about: |-
-    | Other | Value |
-    |-------|-------|
-    | Ranged Strength | +14 |
-
-    Proc chance: 5% (5.5% with Kandarin hard diary)
-
-    On activation, a lightning strike deals extra damage equal to 10% of your visible Ranged level (rounded down). At 99 Ranged, this adds up to 9 extra damage.
-
-    | Bolt | Ranged Str | Effect | Proc % |
-    |------|-----------|--------|--------|
-    | Opal (e) | +14 | Lucky Lightning (+10% Rng dmg) | 5% |
-    | Pearl (e) | +48 | Sea Curse (extra vs fire enemies) | 6% |
-    | Topaz (e) | +66 | Down to Earth (-1 Magic) | 4% |
-    | Sapphire (e) | +83 | Clear Mind (drain Prayer) | 5% |
-    | Emerald (e) | +85 | Magical Poison (5 poison) | 54% |
+      description: Next-tier enchanted bolt
+  about: "Opal bolts (e) are the lowest-tier enchanted gem bolts, providing +14 ranged strength and a 5% Lucky Lightning proc dealing 10% bonus Ranged damage."
   market_strategy:
     notes:
       - Lowest tier enchanted bolt
       - Cheap to enchant for Magic XP
       - Rarely used in practice — higher tier bolts preferred
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2006-07-31"
+      update: Crossbows
+      description: Opal bolts (e) released alongside the Crossbows expansion.
+    - date: "2015-03-05"
+      update: Kandarin Headgear
+      description: Kandarin headgear added a +10% proc bonus for gem bolt effects.
+    - date: "2015-04-16"
+      update: Kandarin Diary Update
+      description: Hard diary completion grants the proc bonus permanently without wearing the headgear.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-potion-1.mdx
@@ -18,8 +18,24 @@ osrs:
     herblore_xp: 87.5
     effect: Restores 7-31 Prayer points based on Prayer level
     effects:
-      - stat: Prayer
-        boost_formula: 7 + floor(level / 4)
+      - description: Restores 7 + floor(Prayer level / 4) prayer points per dose
+      - description: With Holy wrench/Prayer cape/Ring of the gods (i) restores 7 + floor(Prayer level * 27 / 100) prayer points
+  shops:
+    - shop_name: Chest (Theatre of Blood)
+      location: Theatre of Blood
+      base_price: 2
+      members_only: true
+  recipes:
+    - skill: Herblore
+      level: 38
+      xp: 87.5
+      materials:
+        - item_name: Ranarr potion (unf)
+          quantity: 1
+        - item_name: Snape grass
+          quantity: 1
+      output_quantity: 1
+      output_item: Prayer potion(3)
   related_items:
     - item_id: 2434
       item_name: Prayer potion(4)
@@ -41,14 +57,43 @@ osrs:
       slug: super-restore-4
       relationship: upgrade
       description: Also restores stats
-  about: 1-dose variant of Prayer potion.
   market_strategy:
     notes:
-      - Compare to 4-dose price
-      - Decanting can profit
-      - Use decanting NPC in GE
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Compare to 4-dose price for decanting profit
+      - Decanting NPC in GE
+      - Lowest dose variant, often the cheapest per-dose option
+  trading_tips:
+    - Watch 1-dose vs 4-dose price gap for decant arbitrage
+    - 2000/4h buy limit allows steady flipping
+  history:
+    - date: "2002-02-27"
+      description: Item released with the original Prayer potion launch.
+    - date: "2004-03-09"
+      description: 4-dose variant added to RS2 Beta.
+    - date: "2004-03-29"
+      description: 4-dose variant permanently available with RS2 launch.
+    - date: "2004-10-26"
+      description: '"Empty" option added.'
+    - date: "2016-04-15"
+      description: Half-full potions convertible to bank placeholders.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: 1-dose variant of Prayer potion, restores prayer points scaling with Prayer level.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-garden-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-garden-pie.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 13000
-  about: "Raw garden pie is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    type: raw
+    cookable: true
+  recipes:
+    - skill: cooking
+      level: 34
+      xp: 138
+      materials:
+        - item_name: Raw garden pie
+          item_id: 7176
+          quantity: 1
+      product: Garden pie
+      product_id: 7178
+      product_quantity: 1
+      members_only: true
+      notes: Cooked on a range; can produce a burnt pie below the no-burn threshold.
+    - skill: cooking
+      level: 34
+      xp: 0
+      materials:
+        - item_name: Part garden pie
+          item_id: 7174
+          quantity: 1
+        - item_name: Cabbage
+          item_id: 1965
+          quantity: 1
+      product: Raw garden pie
+      product_id: 7176
+      product_quantity: 1
+      members_only: true
+      notes: Final assembly step before cooking.
+  related_items:
+    - item_id: 7178
+      item_name: Garden pie
+      slug: garden-pie
+      relationship: product
+      description: Cooked result
+    - item_id: 7174
+      item_name: Part garden pie
+      slug: part-garden-pie
+      relationship: component
+      description: Pre-cabbage assembly stage
+    - item_id: 1965
+      item_name: Cabbage
+      slug: cabbage
+      relationship: component
+      description: Final filling ingredient
+    - item_id: 2313
+      item_name: Pie dish
+      slug: pie-dish
+      relationship: component
+      description: Base container
+  market_strategy:
+    notes:
+      - Farming Guild + Cooking training feeder
+      - Cabbage supply gates production
+      - Cooks to 138 XP per pie
+      - Useful for restoring Farming level
+  about: Raw garden pie is the uncooked stage of the garden pie, assembled from a part garden pie and a cabbage and cooked at level 34 Cooking for 138 experience.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-02-20"
+    update: "Updates, updates and more updates..."
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-ugthanki-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-ugthanki-meat.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Raw ugthanki meat is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - product_name: Ugthanki meat
+      skill: Cooking
+      cooking_level: 1
+      experience: 40
+      materials:
+        - item_name: Raw ugthanki meat
+          quantity: 1
+  drop_table:
+    sources:
+      - source: Ugthanki
+        combat_level: 42
+        quantity: "1"
+        rarity: always
+        members_only: true
+  related_items:
+    - item_id: 1861
+      item_name: Ugthanki meat
+      slug: ugthanki-meat
+      relationship: product
+      description: Cooked form of raw ugthanki meat
+    - item_id: 1885
+      item_name: Ugthanki kebab
+      slug: ugthanki-kebab
+      relationship: product
+      description: Kebab made from cooked ugthanki meat
+  market_strategy:
+    notes:
+      - Supply tied to camel hunting in the Kharidian Desert
+      - Used in ugthanki kebab recipes for healing food
+      - Burn rate stays non-trivial even at high Cooking levels
+  history:
+    - date: "2003-04-14"
+      update: Tourist Trap Quest Online!
+      description: Raw ugthanki meat introduced alongside the Tourist Trap quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: Tourist Trap Quest Online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: "Raw ugthanki meat is a members-only food ingredient dropped by Ugthankis in the Kharidian Desert, cookable at level 1 Cooking for 40 XP and used in ugthanki kebab recipes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-body.mdx
@@ -12,19 +12,32 @@ osrs:
   lowalch: 4492
   highalch: 6738
   limit: 70
+  material:
+    type: hide
+    tier: mid-high
   equipment:
     slot: body
-    type: ranged_armour
-    ranged_requirement: 60
-    defence_requirement: 40
-  attack_bonuses:
-    ranged: 25
-  defence_bonuses:
-    ranged: 48
-    magic: 40
-  crafting:
-    level: 77
-    xp: 234
+    weight: 6.803
+    requirements:
+      ranged: 60
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 25
+    defence_bonus:
+      stab: 26
+      slash: 34
+      crush: 36
+      magic: 36
+      ranged: 45
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 77
@@ -46,58 +59,69 @@ osrs:
       item_name: Red dragonhide
       slug: red-dragonhide
       relationship: component
-      description: Raw material
+      description: Raw hide material
     - item_id: 2507
       item_name: Red dragon leather
       slug: red-dragon-leather
       relationship: component
-      description: Tanned hide
+      description: Tanned hide for crafting
     - item_id: 2495
       item_name: Red d'hide chaps
       slug: red-dhide-chaps
-      relationship: alternative
-      description: Matching legs
+      relationship: set-piece
+      description: Matching legs slot
     - item_id: 2489
       item_name: Red d'hide vambraces
       slug: red-dhide-vambraces
-      relationship: alternative
-      description: Matching gloves
+      relationship: set-piece
+      description: Matching gloves slot
     - item_id: 2499
       item_name: Blue d'hide body
       slug: blue-dhide-body
-      relationship: alternative
-      description: Lower tier body
+      relationship: downgrade
+      description: Lower tier dragonhide body
     - item_id: 2503
       item_name: Black d'hide body
       slug: black-dhide-body
-      relationship: alternative
-      description: Higher tier body
-  about: |-
-    | Method | Level | Materials |
-    |--------|-------|-----------|
-    | Crafting | 77 | 3 Red dragon leather |
-    | XP | 234 | - |
-
-    | Stat | Value |
-    |------|-------|
-    | Ranged requirement | 60 |
-    | Defence requirement | 40 |
-    | Ranged attack | +25 |
-    | Ranged defence | +48 |
-    | Magic defence | +40 |
+      relationship: upgrade
+      description: Higher tier dragonhide body
+  about: Red d'hide body is a members-only ranged armour requiring 60 Ranged and 40 Defence, crafted from 3 red dragon leather at 77 Crafting for 234 XP.
   market_strategy:
     notes:
-      - Third dragonhide body tier
-      - Members only
-      - Popular crafting item
-      - Crafting training (234 XP)
-      - High-level ranged armor
-      - Wilderness risk gear
-      - 3 leather per body
-      - Good XP for level
-      - Second best d'hide body
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Crafted for steady 234 XP per body
+      - Third highest dragonhide body tier
+      - 70 buy limit floors flips
+      - Wilderness risk gear staple
+  history:
+    - date: "2021-09-22"
+      update: Defence Rebalance
+      description: Defence bonuses significantly reduced across all damage types.
+    - date: "2006-01-23"
+      update: Item Rename
+      description: Renamed from Dragonhide body to Red d'hide body.
+    - date: "2005-06-22"
+      update: Graphical Update
+      description: Item model updated.
+    - date: "2004-03-29"
+      update: RuneScape 2 Launch
+      description: Released with the RS2 launch alongside other dragonhide armour.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2 Launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rum-red.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rum-red.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rum (red) | OSRS Price Data
-description: "Rum (red): Alcohol in the loosest sense of the word.. High alch: 120 GP."
+description: "Rum (red): Alcohol in the loosest sense of the word. High alch: 120 GP."
 osrs:
   id: 8940
   name: Rum (red)
@@ -12,9 +12,50 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: null
-  about: "Rum (red) is a members-only item in Old School RuneScape. High alchemy value: 120 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Honest Jimmy's
+      location: Mos Le'Harmless (Trouble Brewing lobby)
+      price: 20
+      currency: Pieces of eight
+  related_items:
+    - item_id: 8939
+      item_name: Rum (blue)
+      slug: rum-blue
+      relationship: alternative
+      description: Opposing team variant
+    - item_id: 8888
+      item_name: Pieces of eight
+      slug: pieces-of-eight
+      relationship: component
+      description: Currency used to purchase
+  market_strategy:
+    notes:
+      - One-shot Trouble Brewing teleport
+      - Bought with pieces of eight only
+      - Limited use outside the minigame
+      - Tradeable since 2026 buff
+  history:
+    - date: "2006-07-04"
+      description: Item released with the Trouble Brewing minigame.
+    - date: "2026-02-04"
+      description: Became tradeable on the Grand Exchange and base value raised from 2 to 200 coins.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-04"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.003
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: "Rum (red) is a members Trouble Brewing reward that teleports the drinker back to the minigame lobby in Old School RuneScape."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-armour-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-armour-set-lg.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 30000
   highalch: 45000
   limit: 8
-  about: "Rune armour set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 45,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_id: 1163
+      item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: set-piece
+      description: Helmet included in the set
+    - item_id: 1127
+      item_name: Rune platebody
+      slug: rune-platebody
+      relationship: set-piece
+      description: Body armour included in the set
+    - item_id: 1079
+      item_name: Rune platelegs
+      slug: rune-platelegs
+      relationship: set-piece
+      description: Leg armour included in the set
+    - item_id: 1201
+      item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: set-piece
+      description: Shield included in the set
+    - item_id: 13025
+      item_name: Rune armour set (sk)
+      slug: rune-armour-set-sk
+      relationship: alternative
+      description: Skirt variant of the rune armour set
+  about: "Rune armour set (lg) bundles full helm, platebody, platelegs and kiteshield into one Grand Exchange Sets package for convenient bank storage."
+  market_strategy:
+    notes:
+      - Convenience premium over individual pieces
+      - Useful for bank space savings
+      - Exchange via Grand Exchange Sets interface
+      - Popular among ironmen for gifting transfers
+  history:
+    - date: "2015-02-26"
+      update: Grand Exchange Sets
+      description: Rune armour set (lg) added to the Grand Exchange Sets interface.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-02-26"
+    update: Grand Exchange Sets
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune platebody | OSRS Price Data
-description: "Rune platebody is a F2P body slot item requiring 40 Defence. High alch: 39,000 GP, GE limit: 70."
+description: "Rune platebody: Provides excellent protection. High alch: 39,000 GP, GE limit: 70."
 osrs:
   id: 1127
   name: Rune platebody
@@ -12,15 +12,20 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 70
+  material:
+    type: rune
+    tier: high
   equipment:
     slot: body
     weight: 9.979
+    requirements:
+      defence: 40
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: -30
-      ranged: 0
+      ranged: -15
     defence_bonus:
       stab: 82
       slash: 80
@@ -32,15 +37,6 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 40
-  smithing:
-    level: 99
-    xp: 375
-    bars_required: 5
-  alch:
-    high: 39000
-    low: 26000
   recipes:
     - skill: smithing
       level: 99
@@ -53,48 +49,69 @@ osrs:
       product_id: 1127
       product_quantity: 1
       facility: Anvil
+  drop_table:
+    sources:
+      - source: Treasure Trails
+        rarity: varies
+        members_only: false
+      - source: Various monster drops
+        rarity: varies
+        members_only: false
   related_items:
     - item_id: 2363
       item_name: Runite bar
       slug: runite-bar
       relationship: component
-      description: Raw material (×5)
+      description: Smithing material (×5)
     - item_id: 1079
       item_name: Rune platelegs
       slug: rune-platelegs
       relationship: set-piece
-      description: Alternative rune armor
-    - item_id: 1319
-      item_name: Rune 2h sword
-      slug: rune-2h-sword
+      description: Matching rune armor leg piece
+    - item_id: 1093
+      item_name: Rune plateskirt
+      slug: rune-plateskirt
       relationship: alternative
-      description: Alternative alch item
+      description: Skirt variant for legs slot
     - item_id: 561
       item_name: Nature rune
       slug: nature-rune
       relationship: component
-      description: For High Alchemy
-  about: |-
-    | Alch Type | Value |
-    |-----------|-------|
-    | High Alch | 39,000 GP |
-    | Low Alch | 26,000 GP |
+      description: Required for High Alchemy
+  about: "Rune platebody is a free-to-play body slot armor in Old School RuneScape requiring 40 Defence and Dragon Slayer I completion to equip."
   market_strategy:
-    profit_formulas:
-      - 39,000 - Rune platebody price - Nature rune = Profit
-      - 39,000 - (5 × Runite bar price) - Nature rune
     notes:
-      - "High Alch value: **39,000 GP**"
-      - "Calculate:"
-      - One of the highest alch value items
-      - "Cost: 5 Runite bars"
-      - "Revenue: 39,000 GP (alch) or GE price"
-      - "Compare:"
-      - "Buy limit: 8 per 4 hours (low limit!)"
-      - Dragon Slayer 1 completion required to equip
-      - Popular PvM drop - check drop sources for supply
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - High alch value 39,000 GP makes it a popular alching target
+      - Smithing requires 99 level and 5 runite bars per body
+      - Dragon Slayer I quest required to equip
+      - Buy limit of 70 per 4 hours constrains alchemy throughput
+      - Compare bar cost vs GE price to determine smithing profit
+      - Popular PvM drop from rune-tier mobs sustains supply
+  history:
+    - date: "2001-09-23"
+      update: Release
+      description: Rune platebody added to Old School RuneScape as part of the initial rune armor set.
+    - date: "2021-04-21"
+      update: Combat bonus rebalance
+      description: Ranged attack bonus decreased from -10 to -15.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-09-23"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-page-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-page-2.mdx
@@ -12,16 +12,15 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 5
-  item:
-    type: god_page
-    god: Saradomin
-    page_number: 2
-    tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy/Medium/Hard/Elite
-        drop_rate: Varies by tier
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
   related_items:
     - item_id: 3827
       item_name: Saradomin page 1
@@ -38,23 +37,40 @@ osrs:
       slug: saradomin-page-4
       relationship: set-piece
       description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Saradomin |
-    | Page | 2 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of wisdom (Saradomin god book) to complete it.
-
-    Requires all 4 pages:
-    - Saradomin page 1
-    - Saradomin page 2
-    - Saradomin page 3
-    - Saradomin page 4
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 3839
+      item_name: Holy book
+      slug: holy-book
+      relationship: product
+      description: Completed Saradomin god book
+  market_strategy:
+    notes:
+      - Tiny 5/4h buy limit makes price volatile
+      - Demand tracks god book completion runs
+      - Supply only via clue caskets, no PvM faucet
+  trading_tips:
+    - Flip alongside other Saradomin pages for set arbitrage
+    - Watch GE clerk page-set buyout pricing
+  history:
+    - date: "2004-11-17"
+      update: Horror From The Deep
+      description: Saradomin page 2 added as part of the god books introduced with Horror From The Deep.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-11-17"
+    update: Horror From The Deep
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Saradomin page 2 is one of four pages combined with the holy book to complete the Saradomin god book.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-hood-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-hood-t3.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Shattered hood (t3) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  about: Shattered hood (t3) is the head piece of the tier 3 Shattered Relic Hunter cosmetic set, purchased for 15,000 League points during the Shattered Relics League.
+  market_strategy:
+    notes:
+      - Shattered Relics League cosmetic
+      - 15,000 League points from reward shop
+      - Stored in costume room armor case
+      - Purely cosmetic, +0 bonuses
+  history:
+    - date: "2022-01-19"
+      description: Added to the game.
+    - date: "2022-03-16"
+      description: Made obtainable via the Shattered Relics League reward shop.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-01-19"
+    update: Shattered Relics League
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-top-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-top-t1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shattered top (t1) | OSRS Price Data
-description: "Shattered top (t1): The shirt of a Shattered Relic Hunter.. High alch: 9,000 GP."
+description: "Shattered top (t1): The shirt of a Shattered Relic Hunter. High alch: 9,000 GP."
 osrs:
   id: 26430
   name: Shattered top (t1)
@@ -12,9 +12,81 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Shattered top (t1) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: League hub
+      base_price: 1000
+      currency: League points
+  related_items:
+    - item_name: Shattered hood (t1)
+      slug: shattered-hood-t1
+      relationship: set-piece
+      description: Same tier 1 cosmetic set
+    - item_name: Shattered trousers (t1)
+      slug: shattered-trousers-t1
+      relationship: set-piece
+      description: Same tier 1 cosmetic set
+    - item_name: Shattered boots (t1)
+      slug: shattered-boots-t1
+      relationship: set-piece
+      description: Same tier 1 cosmetic set
+    - item_name: Shattered top (t2)
+      slug: shattered-top-t2
+      relationship: upgrade
+      description: Tier 2 cosmetic upgrade
+    - item_name: Shattered top (t3)
+      slug: shattered-top-t3
+      relationship: upgrade
+      description: Tier 3 cosmetic upgrade
+  market_strategy:
+    notes:
+      - Cosmetic-only with zero combat bonuses
+      - Supply capped by Leagues reward shop sales
+      - Storable in costume room armour case as part of complete outfit
+  history:
+    - date: "2022-03-16"
+      update: "PvP Arena: Rewards Beta"
+      description: Item released as part of the Shattered Relics League tier 1 cosmetic outfit.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-03-16"
+    update: "PvP Arena: Rewards Beta"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Shattered top (t1) is a members cosmetic body slot reward from the Shattered Relics League, purchasable for 1,000 League points.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shirt-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shirt-brown.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shirt (brown) | OSRS Price Data
-description: "Shirt (brown): Tiny!. High alch: 270 GP, GE limit: 150."
+description: "Shirt (brown): Tiny! High alch: 270 GP, GE limit: 150."
 osrs:
   id: 5030
   name: Shirt (brown)
@@ -12,9 +12,68 @@ osrs:
   lowalch: 180
   highalch: 270
   limit: 150
-  about: "Shirt (brown) is a members-only item in Old School RuneScape. High alchemy value: 270 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.07
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Vermundi's Clothes Stall
+      location: Keldagrim Palace
+      base_price: 585
+  related_items:
+    - item_name: Shirt (lilac)
+      slug: shirt-lilac
+      relationship: variant
+      description: Dwarven shirt colour variant
+    - item_name: Shirt (yellow)
+      slug: shirt-yellow
+      relationship: variant
+      description: Dwarven shirt colour variant
+  market_strategy:
+    notes:
+      - Cosmetic body slot from Vermundi's stall
+      - Supply limited to Keldagrim shop stock
+      - 150/4h buy limit
+  history:
+    - date: "2005-05-31"
+      update: Keldagrim - The Dwarven City
+      description: Item released with the Keldagrim city update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-31"
+    update: Keldagrim - The Dwarven City
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.07
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Shirt (brown) is a members cosmetic body slot item sold by Vermundi's Clothes Stall in Keldagrim.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-resistance.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-resistance.mdx
@@ -8,13 +8,55 @@ osrs:
   examine: A power enhancing sigil not yet attuned to you.
   members: true
   icon: Sigil of resistance.png
-  value: 10000
+  value: 1
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of resistance is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  special_attack:
+    name: Resistance
+    description: "All attacks from monsters deal 25% less damage; does not stack with Sigil of Titanium."
+  drop_table:
+    sources:
+      - source: Deadman Mode monsters
+        quantity: "1"
+        rarity: rare
+        members_only: true
+        notes: Historic drop during temporary Deadman events; unobtainable in the live game.
+  related_items:
+    - item_id: 28490
+      item_name: Sigil of resistance
+      slug: sigil-of-resistance
+      relationship: variant
+      description: Attuned form unlocked via the Deadman skull shop
+  about: "Sigil of resistance is a Deadman: Reborn skill sigil granting 25% incoming damage reduction; obtainable only during temporary Deadman events."
+  market_strategy:
+    notes:
+      - Exclusive to Deadman Mode events
+      - Currently unobtainable in the live game
+      - Attune permanently via the Deadman skull shop
+      - Duplicate sigils sell back to the skull shop
+  history:
+    - date: "2023-08-23"
+      update: "Deadman: Reborn"
+      description: Sigil of resistance introduced as a power-enhancing sigil for Deadman Mode.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-08-23"
+    update: "Deadman: Reborn"
+    tradeable: false
+    equipable: false
+    stackable: false
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: Destroy
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-stamina.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-stamina.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of stamina is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Deadman Mode drop table (most monsters)
+        quantity: "1"
+        rarity: rare
+        members_only: true
+  related_items:
+    - item_id: 26044
+      item_name: Sigil of supreme stamina
+      slug: sigil-of-supreme-stamina
+      relationship: upgrade
+      description: Tier-2 stamina sigil
+    - item_id: 26020
+      item_name: Sigil of the menacing mage
+      slug: sigil-of-the-menacing-mage
+      relationship: alternative
+      description: Alternate Deadman power sigil
+  market_strategy:
+    notes:
+      - Only available during seasonal Deadman events
+      - Attuning makes it permanently untradeable
+      - Stamina effect saves run energy potion slots
+      - Buy limit small; spikes around event launches
+  about: "Sigil of stamina: a Deadman Mode reward that grants permanent stamina potion effects while attuned during the event."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    alchable: true
+    destroy: Destroy
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-infernal-chef.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-infernal-chef.mdx
@@ -12,9 +12,34 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of the infernal chef is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_id: 28503
+      item_name: Sigil of the infernal chef (attuned)
+      slug: sigil-of-the-infernal-chef-attuned
+      relationship: product
+      description: Activated form bound to the player
+  history:
+    - date: "2023-08-23"
+      update: "Deadman: Apocalypse"
+      description: Sigil of the infernal chef introduced as part of the Deadman Mode seasonal sigil pool.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-08-23"
+    update: "Deadman: Apocalypse"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: Destroy
+  about: "Sigil of the infernal chef is a Deadman Mode sigil that, once attuned, gives a chance to instantly cook fish caught while Fishing and awards Cooking XP regardless of level requirements."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spicy-sauce.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spicy-sauce.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 3
   highalch: 5
   limit: 13000
-  about: "Spicy sauce is a members-only item in Old School RuneScape. High alchemy value: 5 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 2
+  recipes:
+    - product_name: Spicy sauce
+      skill: Cooking
+      cooking_level: 9
+      experience: 25
+      materials:
+        - item_name: Chopped garlic
+          quantity: 1
+        - item_name: Gnome spice
+          quantity: 1
+  related_items:
+    - item_id: 7062
+      item_name: Chopped garlic
+      slug: chopped-garlic
+      relationship: component
+      description: Garlic ingredient prepared for the sauce
+    - item_id: 2169
+      item_name: Gnome spice
+      slug: gnome-spice
+      relationship: component
+      description: Spice ingredient bought from Gnome cooks
+    - item_id: 7062
+      item_name: Chilli con carne
+      slug: chilli-con-carne
+      relationship: product
+      description: Combined with minced meat to make chilli con carne
+    - item_id: 7054
+      item_name: Chilli potato
+      slug: chilli-potato
+      relationship: product
+      description: Downstream Gnome cooking dish using spicy sauce
+  market_strategy:
+    notes:
+      - Used in chilli con carne and chilli potato recipes
+      - GE supply driven by Gnome Restaurant minigame players
+      - Per-portion yield is small so volume is steady but low
+  history:
+    - date: "2006-01-30"
+      update: Runesquares, Harpie Bugs and new potato recipes!
+      description: Spicy sauce added with the Gnome cooking expansion that introduced new potato dishes.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-01-30"
+    update: Runesquares, Harpie Bugs and new potato recipes!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: "Spicy sauce is a members-only Cooking ingredient made by combining chopped garlic with gnome spice, used in chilli con carne and chilli potato recipes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-claws.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-claws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel claws | OSRS Price Data
-description: "Steel claws: A set of fighting claws.. High alch: 105 GP, GE limit: 125."
+description: "Steel claws: A set of fighting claws. High alch: 105 GP, GE limit: 125."
 osrs:
   id: 3097
   name: Steel claws
@@ -12,9 +12,99 @@ osrs:
   lowalch: 70
   highalch: 105
   limit: 125
-  about: "Steel claws is a members-only item in Old School RuneScape. High alchemy value: 105 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: claw
+    attack_speed: 4
+    weight: 0.907
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 8
+      slash: 11
+      crush: -4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 3
+      slash: 6
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 43
+      xp: 75
+      materials:
+        - item_name: Steel bar
+          item_id: 2353
+          quantity: 2
+      product: Steel claws
+      product_id: 3097
+      product_quantity: 1
+      facility: Anvil
+      members_only: true
+  shops:
+    - shop_name: Martin Thwait's Lost and Found
+      location: Rogues' Den
+      price: 175
+  related_items:
+    - item_id: 3095
+      item_name: Bronze claws
+      slug: bronze-claws
+      relationship: downgrade
+      description: Lower tier claws
+    - item_id: 3096
+      item_name: Iron claws
+      slug: iron-claws
+      relationship: downgrade
+      description: Lower tier claws
+    - item_id: 3098
+      item_name: Black claws
+      slug: black-claws
+      relationship: upgrade
+      description: Higher tier claws
+    - item_id: 3099
+      item_name: Mithril claws
+      slug: mithril-claws
+      relationship: upgrade
+      description: Higher tier claws
+  market_strategy:
+    notes:
+      - Smithed from 2 steel bars at 43 Smithing
+      - Niche claw weapon class
+      - Low demand outside cosmetics
+      - Mostly held by collectors
+  history:
+    - date: "2004-08-09"
+      description: Item released alongside the rest of the claw weapon class.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-08-09"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Steel claws are a members-only two-handed claw weapon requiring 5 Attack to wield in Old School RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-crossbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-crossbow-u.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 130
   highalch: 196
   limit: 10000
-  about: "Steel crossbow (u) is a members-only item in Old School RuneScape. High alchemy value: 196 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: low
+  recipes:
+    - skill: fletching
+      level: 46
+      xp: 54
+      materials:
+        - item_id: 9442
+          item_name: Teak stock
+          quantity: 1
+        - item_id: 9425
+          item_name: Steel limbs
+          quantity: 1
+      product: Steel crossbow (u)
+      product_id: 9459
+    - skill: fletching
+      level: 46
+      xp: 27
+      materials:
+        - item_id: 9459
+          item_name: Steel crossbow (u)
+          quantity: 1
+        - item_id: 9438
+          item_name: Crossbow string
+          quantity: 1
+      product: Steel crossbow
+      product_id: 9177
+  related_items:
+    - item_id: 9442
+      item_name: Teak stock
+      slug: teak-stock
+      relationship: component
+      description: Crossbow stock material
+    - item_id: 9425
+      item_name: Steel limbs
+      slug: steel-limbs
+      relationship: component
+      description: Crossbow limbs material
+    - item_id: 9177
+      item_name: Steel crossbow
+      slug: steel-crossbow
+      relationship: product
+      description: Strung result of the unfinished crossbow
+  about: "Steel crossbow (u) is an unfinished crossbow made at 46 Fletching by attaching steel limbs to a teak stock; string it to produce a steel crossbow."
+  market_strategy:
+    notes:
+      - Mid-Fletching XP intermediate item
+      - Limited demand due to crossbow tier
+      - Most players make and string in sequence
+  history:
+    - date: "2006-07-31"
+      update: Crossbows
+      description: Steel crossbow (u) released as part of the Crossbows update.
+    - date: "2021-07-07"
+      update: Animation Fix
+      description: Female stringing animation adjusted so the crossbow is held correctly.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-hasta-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-hasta-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel hasta(p) | OSRS Price Data
-description: "Steel hasta(p): A poison-tipped, one-handed steel hasta.. High alch: 195 GP, GE limit: 125."
+description: "Steel hasta(p): A poison-tipped, one-handed steel hasta. High alch: 195 GP, GE limit: 125."
 osrs:
   id: 11393
   name: Steel hasta(p)
@@ -12,9 +12,95 @@ osrs:
   lowalch: 130
   highalch: 195
   limit: 125
-  about: "Steel hasta(p) is a members-only item in Old School RuneScape. High alchemy value: 195 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ore
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 12
+      slash: 12
+      crush: 12
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -3
+      slash: -3
+      crush: -3
+      magic: 0
+      ranged: -3
+    other_bonus:
+      melee_strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    poison: true
+    notes: Applies regular weapon poison on hit
+  recipes:
+    - skill: Herblore
+      level: 1
+      materials:
+        - item_name: Steel hasta
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Steel hasta
+      slug: steel-hasta
+      relationship: variant
+      description: Unpoisoned base spear
+    - item_name: Steel hasta(p+)
+      slug: steel-hasta-p-plus
+      relationship: upgrade
+      description: Stronger weapon poison
+    - item_name: Steel hasta(p++)
+      slug: steel-hasta-p-plus-plus
+      relationship: upgrade
+      description: Strongest standard weapon poison
+    - item_name: Steel hasta(kp)
+      slug: steel-hasta-kp
+      relationship: variant
+      description: Karambwan poison variant
+  market_strategy:
+    notes:
+      - Barbarian smithing alternative to a basic spear
+      - Same stats as steel hasta with poison applied
+      - Profitable poison-application target via weapon poison
+  history:
+    - date: "2007-07-03"
+      update: Barbarian Training
+      description: Item released with the Barbarian training update.
+    - date: "2021-04-21"
+      description: Attack speed improved from 5 ticks to 4 ticks.
+    - date: "2021-07-07"
+      description: Female player equipment positioning adjusted.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: Steel hasta(p) is a poison-applied one-handed spear created via Barbarian Smithing and weapon poison, requiring 5 Attack to wield.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-kiteshield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel kiteshield | OSRS Price Data
-description: "Steel kiteshield: A large metal shield.. High alch: 510 GP, GE limit: 125."
+description: "Steel kiteshield: A large metal shield. High alch: 510 GP, GE limit: 125."
 osrs:
   id: 1193
   name: Steel kiteshield
@@ -12,24 +12,114 @@ osrs:
   lowalch: 340
   highalch: 510
   limit: 125
-  item_id: 1193
-  item_type: armor
-  slot: shield
-  type: kiteshield
-  tradeable: true
-  weight: 5.443
-  requirements:
-    defence: 5
-  stats:
-    stab_defence: 13
-    slash_defence: 15
-    crush_defence: 14
-    ranged_defence: 14
+  material:
+    type: ore
+    tier: low
+  equipment:
+    slot: shield
+    weight: 5.443
+    requirements:
+      defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 13
+      slash: 15
+      crush: 14
+      magic: -1
+      ranged: 14
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Cassie's Shield Shop
+      location: Falador
+      base_price: 850
+    - shop_name: Seddu's Adventurer's Store
+      location: Nardah
+      stock: 1
+      base_price: 807
+    - shop_name: Shields of Mistrock
+      location: Mistrock
+      stock: 3
+      base_price: 850
+    - shop_name: Elder Blunn's Spear and Shield Stall
+      location: The Summer Shore
+      stock: 4
+      base_price: 850
+  drop_table:
+    sources:
+      - source: Dagannoth Rex
+        combat_level: 303
+        quantity: "1"
+        rarity: 17/128
+        members_only: true
+      - source: Moss giant
+        combat_level: 48
+        quantity: "1"
+        rarity: 1/128
+        members_only: false
+  recipes:
+    - skill: Smithing
+      level: 42
+      xp: 112.5
+      materials:
+        - item_name: Steel bar
+          quantity: 3
+      facility: Anvil
+      tools: [Hammer]
+      output_quantity: 1
   related_items:
-    - slug: black-kiteshield
-    - slug: steel-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Black kiteshield
+      slug: black-kiteshield
+      relationship: downgrade
+      description: Weaker tier
+    - item_name: Mithril kiteshield
+      slug: mithril-kiteshield
+      relationship: upgrade
+      description: Stronger tier
+    - item_name: Steel platebody
+      slug: steel-platebody
+      relationship: set-piece
+      description: Same metal tier body armor
+  market_strategy:
+    notes:
+      - Common drop from low-level monsters
+      - Smithing target item at level 42
+      - Stock available from multiple shops
+      - Defence 5 requirement makes it accessible
+  history:
+    - date: "2001-01-04"
+      update: Runescape beta is now online
+      description: Item released with the launch of the RuneScape beta.
+    - date: "2004-05-05"
+      description: Graphical update applied.
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -2 to -3.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Steel kiteshield is a free-to-play shield requiring 5 Defence to wield, smithed at level 42 from 3 steel bars.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-sword.mdx
@@ -12,26 +12,95 @@ osrs:
   lowalch: 130
   highalch: 195
   limit: 125
-  item_id: 1281
-  item_type: equipment
-  slot: weapon
-  type: sword
-  attack_style: stab
-  attack_speed: 4
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 5
-  stats:
-    stab_attack: 11
-    slash_attack: 8
-    crush_attack: -2
-    strength: 12
+  material:
+    type: steel
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: stab-sword
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 11
+      slash: 8
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 34
+      xp: 37.5
+      materials:
+        - item_id: 2353
+          item_name: Steel bar
+          quantity: 1
+      product: Steel sword
+      product_id: 1281
+  shops:
+    - shop_name: Varrock Swordshop
+      location: Varrock
+      price: 325
+    - shop_name: Warriors' Guild Armoury
+      location: Warriors' Guild
+      price: 390
   related_items:
-    - slug: black-sword
-    - slug: steel-scimitar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1283
+      item_name: Black sword
+      slug: black-sword
+      relationship: downgrade
+      description: Lower-tier sword
+    - item_id: 1285
+      item_name: Mithril sword
+      slug: mithril-sword
+      relationship: upgrade
+      description: Higher-tier sword
+    - item_id: 1325
+      item_name: Steel scimitar
+      slug: steel-scimitar
+      relationship: alternative
+      description: Slash-focused steel weapon
+  about: "Steel sword is a free-to-play stab sword requiring 5 Attack to wield, smithable at 34 Smithing from 1 steel bar."
+  market_strategy:
+    notes:
+      - Common F2P low-level weapon
+      - Smithing produces a net loss vs bar cost
+      - Sold in basic sword shops
+  history:
+    - date: "2001-01-04"
+      update: RuneScape beta
+      description: Steel sword released as part of the original RuneScape weapon roster.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape beta
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/strength-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/strength-potion-3.mdx
@@ -12,6 +12,28 @@ osrs:
   lowalch: 5
   highalch: 7
   limit: 2000
+  potion:
+    doses: 3
+    effects:
+      - description: Boosts Strength by 3 + 10% of current level (rounded down)
+      - description: Boost decays 1 point per minute (90 seconds with Preserve)
+  recipes:
+    - skill: Herblore
+      level: 12
+      xp: 50
+      materials:
+        - item_name: Tarromin potion (unf)
+          quantity: 1
+        - item_name: Limpwurt root
+          quantity: 1
+      output_quantity: 1
+      members_only: true
+  shops:
+    - shop_name: Warriors' Guild Potion Shop
+      location: Warriors' Guild
+      stock: 10
+      price: 15
+      members_only: true
   related_items:
     - item_id: 117
       item_name: Strength potion(2)
@@ -23,12 +45,33 @@ osrs:
       slug: strength-potion-1
       relationship: variant
       description: 1-dose version
-  about: |-
-    > _"3 doses of Strength potion."_
-
-    The strength potion boosts Strength by 3 + 10% of current level (rounded down). Available to both F2P and members, though Herblore brewing is members-only. The Apothecary can make a 4-dose version using limpwurt root, red spiders' eggs, and 5 coins.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Strength potion(3) provides a Strength boost of 3 + 10% of current level, available to both F2P and members though Herblore brewing is members-only.
+  market_strategy:
+    notes:
+      - F2P tradeable, broad market
+      - Used by F2P combat trainers
+      - Herblore 12 to brew
+      - Limpwurt root + tarromin recipe
+  history:
+    - date: "2001-02-05"
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-02-05"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teal-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teal-robe-top.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teal robe top | OSRS Price Data
-description: "Teal robe top: Some fine werewolf clothing.. High alch: 300 GP, GE limit: 150."
+description: "Teal robe top: Some fine werewolf clothing. High alch: 300 GP, GE limit: 150."
 osrs:
   id: 2926
   name: Teal robe top
@@ -12,9 +12,84 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Teal robe top is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Barkers' Haberdashery
+      location: Canifis
+      price: 650
+  related_items:
+    - item_id: 2924
+      item_name: Teal hat
+      slug: teal-hat
+      relationship: set-piece
+      description: Matching head slot piece
+    - item_id: 2928
+      item_name: Teal robe bottoms
+      slug: teal-robe-bottoms
+      relationship: set-piece
+      description: Matching legs slot piece
+    - item_id: 2918
+      item_name: Red robe top
+      slug: red-robe-top
+      relationship: alternative
+      description: Different colour variant
+    - item_id: 2920
+      item_name: Yellow robe top
+      slug: yellow-robe-top
+      relationship: alternative
+      description: Different colour variant
+  about: "Teal robe top is a members-only body slot cosmetic sold by Barker in Canifis as part of a five-colour werewolf robe collection."
+  market_strategy:
+    notes:
+      - Sold by Barker's Haberdashery in Canifis at 650 GP base
+      - Cosmetic-only, no combat use
+      - GE limit 150 per 4 hours
+      - Part of a matching teal werewolf outfit
+      - Demand driven by fashionscape collectors
+  history:
+    - date: "2004-06-29"
+      update: Priest in Peril
+      description: Added with the Priest in Peril quest update making Morytania accessible.
+    - date: "2014-12-10"
+      update: Renaming
+      description: Renamed from Robe top to Teal robe top to disambiguate from other coloured robes.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-bulwark-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-bulwark-ornament-kit.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: null
-  about: "Trailblazer reloaded bulwark ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Main game (post Leagues IV)
+      currency: League Points
+      price: 10000
+      notes: 10,000 League Points during Leagues IV claim window
+  related_items:
+    - item_id: 21015
+      item_name: Dinh's bulwark
+      slug: dinhs-bulwark
+      relationship: component
+      description: Shield this ornament kit reskins
+    - item_id: 28685
+      item_name: Dinh's blazing bulwark
+      slug: dinhs-blazing-bulwark
+      relationship: product
+      description: Resulting reskinned shield (reversible)
+  about: "Trailblazer reloaded bulwark ornament kit is a Leagues IV reward used on Dinh's Bulwark to create Dinh's Blazing Bulwark, a reversible cosmetic reskin."
+  market_strategy:
+    notes:
+      - No GE buy limit pads turnover
+      - Cannot be high alched
+      - Cosmetic, reversible reskin holds value
+      - Demand spikes with Bulwark meta
+  history:
+    - date: "2023-11-29"
+      update: Leagues IV Reward Shop
+      description: Item became obtainable from the Leagues Reward Shop.
+    - date: "2023-11-15"
+      update: Game Addition
+      description: Item added to the game files.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-11-29"
+    update: Leagues IV Reward Shop
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-relic-hunter-t3-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-relic-hunter-t3-armour-set.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: null
-  about: "Trailblazer reloaded relic hunter (t3) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_id: 28771
+      item_name: Trailblazer reloaded headband (t3)
+      slug: trailblazer-reloaded-headband-t3
+      relationship: set-piece
+      description: Head piece bundled in the set
+    - item_id: 28773
+      item_name: Trailblazer reloaded top (t3)
+      slug: trailblazer-reloaded-top-t3
+      relationship: set-piece
+      description: Body piece bundled in the set
+    - item_id: 28775
+      item_name: Trailblazer reloaded trousers (t3)
+      slug: trailblazer-reloaded-trousers-t3
+      relationship: set-piece
+      description: Legs piece bundled in the set
+    - item_id: 28777
+      item_name: Trailblazer reloaded boots (t3)
+      slug: trailblazer-reloaded-boots-t3
+      relationship: set-piece
+      description: Feet piece bundled in the set
+  market_strategy:
+    notes:
+      - Convenience bundle made via the Grand Exchange Sets option
+      - Premium asked over component sum reflects packing convenience
+      - Resale supply tied to Leagues IV cosmetic demand
+  history:
+    - date: "2023-11-22"
+      update: Chambers of Xeric Changes
+      description: Trailblazer reloaded relic hunter (t3) armour set added as a Grand Exchange bundle alongside Leagues IV reward cosmetics.
+    - date: "2023-11-29"
+      description: Initial release typo "Strailblazer" corrected on the item name.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-11-22"
+    update: Chambers of Xeric Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
+  about: "Trailblazer reloaded relic hunter (t3) armour set is a members-only Grand Exchange bundle holding the Trailblazer Reloaded headband, top, trousers and boots (t3) Leagues IV cosmetics."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncooked-dragonfruit-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncooked-dragonfruit-pie.mdx
@@ -1,6 +1,6 @@
 ---
 title: Uncooked dragonfruit pie | OSRS Price Data
-description: "Uncooked dragonfruit pie: This would be much tastier cooked.. High alch: 24 GP, GE limit: 10,000."
+description: "Uncooked dragonfruit pie: This would be much tastier cooked. High alch: 24 GP, GE limit: 10,000."
 osrs:
   id: 22789
   name: Uncooked dragonfruit pie
@@ -12,9 +12,75 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 10000
-  about: "Uncooked dragonfruit pie is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: cooking
+      level: 73
+      xp: 0
+      materials:
+        - item_name: Dragonfruit
+          item_id: 21769
+          quantity: 1
+        - item_name: Pie shell
+          item_id: 2315
+          quantity: 1
+      product: Uncooked dragonfruit pie
+      product_id: 22789
+      product_quantity: 1
+      facility: Inventory
+      members_only: true
+    - skill: cooking
+      level: 73
+      xp: 220
+      materials:
+        - item_name: Uncooked dragonfruit pie
+          item_id: 22789
+          quantity: 1
+      product: Dragonfruit pie
+      product_id: 22791
+      product_quantity: 1
+      facility: Range
+      members_only: true
+  related_items:
+    - item_id: 21769
+      item_name: Dragonfruit
+      slug: dragonfruit
+      relationship: component
+      description: Cooking ingredient
+    - item_id: 2315
+      item_name: Pie shell
+      slug: pie-shell
+      relationship: component
+      description: Pie base
+    - item_id: 22791
+      item_name: Dragonfruit pie
+      slug: dragonfruit-pie
+      relationship: product
+      description: Cooked result
+  market_strategy:
+    notes:
+      - Step before high-end Cooking pies
+      - 73 Cooking gate limits suppliers
+      - Bakeable for 220 XP at 73 Cooking
+      - Steady demand for skillers
+  history:
+    - date: "2019-01-10"
+      description: Item released with The Kebos Lowlands update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  about: Uncooked dragonfruit pie is a members Cooking intermediate combining a dragonfruit with a pie shell, baked into a dragonfruit pie at 73 Cooking in Old School RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ursine-chainmace-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ursine-chainmace-u.mdx
@@ -12,9 +12,105 @@ osrs:
   lowalch: 70000
   highalch: 105000
   limit: 8
-  about: "Ursine chainmace (u) is a members-only item in Old School RuneScape. High alchemy value: 105,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: spiked
+    attack_speed: 4
+    weight: 2
+    requirements:
+      attack: 70
+    attack_bonus:
+      stab: 53
+      slash: -2
+      crush: 71
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 74
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 2
+  special_attack:
+    name: Bear Down
+    energy_cost: 50
+    description: Doubles accuracy against the target's slash defence; on hit deals 20 damage over 6 seconds, prevents running for 3.6 seconds and drains 20 Agility. Charged variant only.
+  recipes:
+    - skill: smithing
+      level: 85
+      xp: 0
+      materials:
+        - item_name: Viggora's chainmace (u)
+          item_id: 22542
+          quantity: 1
+        - item_name: Claws of Callisto
+          item_id: 27667
+          quantity: 1
+      product: Ursine chainmace (u)
+      product_id: 27657
+      product_quantity: 1
+      facility: Player or Andros Mai (500,000 coin fee)
+      members_only: true
+  related_items:
+    - item_id: 22542
+      item_name: Viggora's chainmace (u)
+      slug: viggoras-chainmace-u
+      relationship: component
+      description: Base wilderness weapon upgraded with claws
+    - item_id: 27667
+      item_name: Claws of Callisto
+      slug: claws-of-callisto
+      relationship: component
+      description: Rare drop from Callisto used to corrupt the chainmace
+    - item_id: 27659
+      item_name: Ursine chainmace
+      slug: ursine-chainmace
+      relationship: upgrade
+      description: Charged version activated with revenant ether
+  about: Ursine chainmace (u) is the uncharged form of the corrupted chainmace, crafted from Viggora's chainmace plus Claws of Callisto at 85 Smithing and the best Wilderness melee weapon when charged.
+  market_strategy:
+    notes:
+      - Charged variant melee BiS for Wilderness PvM
+      - Ether bank deep ties price to revenant supply
+      - 8 per 4 hour buy limit caps liquidity
+      - Andros Mai 500k coin fee for assembly
+  history:
+    - date: "2025-12-17"
+      update: Charge Notification
+      description: Updated the charge notification message for the chainmace.
+    - date: "2023-05-03"
+      update: Ether Prompt
+      description: Added prompts asking for the amount of revenant ether to apply.
+    - date: "2023-02-08"
+      update: Wilderness Boss Polish
+      description: Fixed special attack damage and effect avoidance against Callisto, Venenatis and Vet'ion.
+    - date: "2023-01-25"
+      update: Wilderness Boss Rework
+      description: Released alongside the Wilderness Boss Rework as a corrupted upgrade.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-01-25"
+    update: Wilderness Boss Rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wield
+      - Dismantle
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vulnerability-charm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vulnerability-charm.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vulnerability charm | OSRS Price Data
-description: "Vulnerability charm: A magical, helpful charm.. High alch: 6,000 GP."
+description: "Vulnerability charm: A magical, helpful charm. High alch: 60,000 GP."
 osrs:
   id: 30685
   name: Vulnerability charm
@@ -8,13 +8,55 @@ osrs:
   examine: A magical, helpful charm.
   members: true
   icon: Vulnerability charm.png
-  value: 10000
-  lowalch: 4000
-  highalch: 6000
+  value: 100000
+  lowalch: 40000
+  highalch: 60000
   limit: null
-  about: "Vulnerability charm is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Breach bosses (Deadman Mode world 345)
+        rarity: varies
+        members_only: true
+      - source: Monsters combat level 200+ (Deadman Mode world 345)
+        rarity: varies
+        members_only: true
+  related_items:
+    - item_id: 4434
+      item_name: Vulnerability
+      slug: vulnerability
+      relationship: alternative
+      description: Standard spellbook curse with similar theme
+  about: "Vulnerability charm is a Deadman Reborn relic that boosts accuracy by 50%, multiplies thrall max hits by 5, and reduces incoming damage by 25% while held in inventory."
+  market_strategy:
+    notes:
+      - Deadman Mode world 345 exclusive drop source
+      - Held in inventory to apply effects, not worn
+      - High alch jumped to 60,000 after the value buff
+      - No GE buy limit listed
+      - Demand scales with Deadman season activity
+  history:
+    - date: "2025-03-12"
+      update: Deadman Reborn release
+      description: Vulnerability charm added with the Deadman Reborn game mode launch.
+    - date: "2026-01-21"
+      update: Value rebalance
+      description: Base value increased from 10,000 to 100,000 coins, raising high alch to 60,000.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-03-12"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1.0
+    options:
+      - Inspect
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wood-camo-top-equipped.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wood-camo-top-equipped.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Wood camo top (equipped) is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.226
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 10
+      slash: 15
+      crush: 19
+      magic: 0
+      ranged: 12
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - product_name: Wood camo top
+      skill: Crafting
+      facility: Fancy Clothes Store, Hunter Guild, or Seamstress (Prifddinas)
+      materials:
+        - item_name: Common kebbit fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 20
+  related_items:
+    - item_id: 10053
+      item_name: Wood camo legs
+      slug: wood-camo-legs
+      relationship: set-piece
+      description: Matching legs slot of the Woodland camouflage set
+  market_strategy:
+    notes:
+      - Cosmetic camouflage with negligible market depth
+      - Worn variant entry, distinct ID from inventory item
+      - Weight reduction perk benefits Hunter runs in wooded areas
+  history:
+    - date: "2006-11-21"
+      update: Hunter skill launch
+      description: Wood camo top released alongside the Hunter skill.
+    - date: "2024-03-20"
+      update: "Varlamore: The Hunter Guild"
+      description: Worn version now reduces equipped weight by 3 kg.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter skill launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  about: "Wood camo top (equipped) is a members-only body slot camouflage garment in Old School RuneScape, providing defensive bonuses and a -3 kg equipped weight perk for woodland Hunter activity."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/xerician-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/xerician-robe.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 125
-  about: "Xerician robe is a members-only item in Old School RuneScape. High alchemy value: 42 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 0.18
+    requirements:
+      defence: 10
+      magic: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 7
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 17
+      xp: 88
+      materials:
+        - item_id: 13383
+          item_name: Xerician fabric
+          quantity: 4
+        - item_id: 1734
+          item_name: Thread
+          quantity: 1
+      product: Xerician robe
+      product_id: 13389
+  related_items:
+    - item_id: 13383
+      item_name: Xerician fabric
+      slug: xerician-fabric
+      relationship: component
+      description: Material used in crafting
+    - item_id: 13385
+      item_name: Xerician hat
+      slug: xerician-hat
+      relationship: set-piece
+      description: Matching head slot piece
+    - item_id: 13387
+      item_name: Xerician top
+      slug: xerician-top
+      relationship: set-piece
+      description: Matching body slot piece
+  about: "Xerician robe is a leg-slot magic garment crafted from 4 Xerician fabric and thread at 17 Crafting, requiring 10 Defence and 20 Magic to wear."
+  market_strategy:
+    notes:
+      - Entry-tier magic legwear
+      - Crafting from fabric yields modest profit
+      - Often used in early Kourend questing
+  history:
+    - date: "2016-01-07"
+      update: "Zeah: Great Kourend"
+      description: Xerician robe released alongside the Great Kourend update.
+    - date: "2021-09-22"
+      update: Wilderness & Equipment Rebalance
+      description: Magic attack bonus reduced from +8 to +4.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: "Zeah: Great Kourend"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.18
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-crozier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-crozier.mdx
@@ -14,22 +14,65 @@ osrs:
   limit: 8
   equipment:
     slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2
     requirements:
       prayer: 60
+    attack_bonus:
+      stab: 7
+      slash: -1
+      crush: 25
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 10
+      ranged: 0
     other_bonus:
+      melee_strength: 32
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 6
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 10474
       item_name: Zamorak stole
       slug: zamorak-stole
       relationship: set-piece
       description: Zamorak vestment neck piece
-  about: |-
-    > *"A Zamorak crozier."*
-
-    The Zamorak crozier is a weapon slot staff from the Zamorak vestment set. It provides a +6 Prayer bonus and requires 60 Prayer to wield. Counts as a Zamorakian item in the God Wars Dungeon. Primarily used for prayer bonus and fashionscape.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Zamorak crozier is a weapon-slot staff from the Zamorak vestment set, providing a +6 Prayer bonus and counting as a Zamorakian item in the God Wars Dungeon.
+  market_strategy:
+    notes:
+      - 1/1,625 from hard clue caskets
+      - Hard clue source, easy costume room slot
+      - Vestment set fashionscape demand
+      - +6 Prayer bonus competes with other croziers
+  history:
+    - date: "2006-12-05"
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zogre-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zogre-bones.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 3000
-  about: "Zogre bones is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 3,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bone
+    tier: low
+  prayer:
+    xp_bury: 22.5
+    xp_scatter: 22.5
+  drop_table:
+    sources:
+      - source: Zogre
+        combat_level: 44
+        quantity: "1"
+        rarity: always
+        members_only: true
+      - source: Skogre
+        combat_level: 44
+        quantity: "1"
+        rarity: always
+        members_only: true
+      - source: Slash Bash
+        combat_level: 111
+        quantity: "2"
+        rarity: always
+        members_only: true
+      - source: Ogre coffin (Thieving)
+        quantity: "1"
+        rarity: 64/128
+        members_only: true
+  related_items:
+    - item_id: 526
+      item_name: Bones
+      slug: bones
+      relationship: downgrade
+      description: Standard low tier bones
+    - item_id: 4830
+      item_name: Ogre bones
+      slug: ogre-bones
+      relationship: alternative
+      description: Sibling ogre bones from regular ogres
+    - item_id: 6818
+      item_name: Babydragon bones
+      slug: babydragon-bones
+      relationship: upgrade
+      description: Higher tier prayer bones
+  about: Zogre bones are members-only bones unlocked through Zogre Flesh Eaters, dropped by Zogres, Skogres and Slash Bash, giving 22.5 Prayer XP per bury or scatter.
+  market_strategy:
+    notes:
+      - Unlocked behind Zogre Flesh Eaters quest
+      - 22.5 Prayer XP matches regular ogre bones
+      - 3000 buy limit suits big sinkers
+      - Slash Bash drops two per kill
+  history:
+    - date: "2005-05-17"
+      update: Zogre Flesh Eaters
+      description: Released with the Zogre Flesh Eaters quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-17"
+    update: Zogre Flesh Eaters
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Bury
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Sixth batch — migrate 100 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Worktree-direct authoring; main repo untouched.
- Schema-validated via `astro sync`.

Post-agent normalisation:
- `properties.release_date` string-quoted (YAML date object → ISO string)
- `recipes[].tools` normalised to array shape

## Test plan

- [x] `astro sync` clean — all 100 entries validate.
- [ ] CI build green.

## Follow-ups

- ~3873 v2 items remain after this batch lands.