### PR TITLE
feat(kbve-kubectl,factorio): rotate-gameserver subcommand + shim loads latest save

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.179",
+			"version": "1.0.180",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",

--- a/apps/agones/factorio/shim/agones-shim.sh
+++ b/apps/agones/factorio/shim/agones-shim.sh
@@ -193,7 +193,17 @@ if [ -n "$FACTORIO_SAVE" ]; then
         START_ARG="--start-server $SAVE_PATH"
         START_DESC="save=${FACTORIO_SAVE}"
     else
-        echo "[agones-shim] WARN FACTORIO_SAVE=${FACTORIO_SAVE} not found at ${SAVE_PATH}, falling back to scenario ${FACTORIO_SCENARIO}"
+        echo "[agones-shim] WARN FACTORIO_SAVE=${FACTORIO_SAVE} not found at ${SAVE_PATH}, falling back to latest save / scenario ${FACTORIO_SCENARIO}"
+    fi
+fi
+if [ "$START_DESC" = "scenario=${FACTORIO_SCENARIO}" ]; then
+    LATEST_SAVE=$(ls -1t "${FACTORIO_SAVES_DIR}"/*.zip 2>/dev/null | head -n 1 || true)
+    if [ -n "$LATEST_SAVE" ] && [ -f "$LATEST_SAVE" ]; then
+        START_ARG="--start-server $LATEST_SAVE"
+        START_DESC="save=$(basename "$LATEST_SAVE")"
+        echo "[agones-shim] resuming from latest save: ${LATEST_SAVE}"
+    else
+        echo "[agones-shim] no save found, starting fresh scenario ${FACTORIO_SCENARIO}"
     fi
 fi
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -42,6 +42,7 @@ Alpine-based kubectl image with a static musl Rust CLI wrapper for KubeVirt VM m
 | `kbve-kubectl info` | Print version and check available tools |
 | `kbve-kubectl run <script>` | Execute a shell script (passthrough to `/bin/sh`) |
 | `kbve-kubectl guest-exec --vm <name> --command <cmd>` | Run a command inside a KubeVirt VM via QEMU Guest Agent |
+| `kbve-kubectl rotate-gameserver --namespace <ns> --gameserver <name>` | Roll an Agones GameServer when its desired image drifts from the running pod image (delete-only; ArgoCD recreates) |
 
 ### Bundled Tools
 
@@ -70,7 +71,7 @@ The image is pinned in three manifests today, all kept in sync by the `deploymen
 |---|---|---|
 | `apps/kube/kubevirt/autologon/job.yaml` | KubeVirt Windows autologon setup | One-shot Job, kubectl + virtctl |
 | `apps/kube/kubevirt/runner/job.yaml` | KubeVirt runner orchestration | One-shot Job, kubectl + virtctl |
-| `apps/kube/agones/factorio/manifests/rotation-cronjob.yaml` | Factorio GameServer image rotator | CronJob every 5 min, compares `gs.spec.image` vs `pod.spec.image`, deletes the GameServer when they drift so ArgoCD selfHeal recreates from the new spec |
+| `apps/kube/agones/factorio/manifests/rotation-cronjob.yaml` | Factorio GameServer image rotator | CronJob every 5 min, invokes `kbve-kubectl rotate-gameserver` to compare `gs.spec.image` vs `pod.spec.image` and delete the GameServer on drift so ArgoCD selfHeal recreates from the new spec |
 
 When a new behavior needs to land across all rotator and KubeVirt jobs (RCON-aware save-flush probes, Agones SDK Health calls, retry-with-backoff, ConfigMap-driven rotation policy), extend the Rust CLI in `apps/vm/kubectl/src/`, bump `version.toml`, and every manifest above auto-bumps via the post-publish sync.
 
@@ -82,4 +83,19 @@ containers:
       image: ghcr.io/kbve/kubectl:0.1.0
       command: ['kbve-kubectl', 'guest-exec']
       args: ['--vm', 'windows-builder', '--command', 'powershell.exe']
+```
+
+GameServer rotator using the Rust CLI directly:
+
+```yaml
+containers:
+    - name: rotator
+      image: ghcr.io/kbve/kubectl:0.1.2
+      command:
+          - kbve-kubectl
+          - rotate-gameserver
+          - --namespace=factorio
+          - --gameserver=factorio
+          - --container=factorio
+          - --delete-timeout=180
 ```

--- a/apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
+++ b/apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
@@ -33,31 +33,12 @@ spec:
                                       - ALL
                               readOnlyRootFilesystem: true
                           command:
-                              - /bin/sh
-                              - -c
-                              - |
-                                  set -euo pipefail
-                                  NS=factorio
-                                  GS=factorio
-                                  desired=$(kubectl -n "$NS" get gs/"$GS" -o jsonpath='{.spec.template.spec.containers[?(@.name=="factorio")].image}' 2>/dev/null || true)
-                                  running=$(kubectl -n "$NS" get pod/"$GS" -o jsonpath='{.spec.containers[?(@.name=="factorio")].image}' 2>/dev/null || true)
-                                  state=$(kubectl -n "$NS" get gs/"$GS" -o jsonpath='{.status.state}' 2>/dev/null || true)
-                                  echo "desired=${desired} running=${running} state=${state}"
-                                  if [ -z "$desired" ] || [ -z "$running" ]; then
-                                    echo "missing gs or pod — nothing to rotate"
-                                    exit 0
-                                  fi
-                                  if [ "$desired" = "$running" ]; then
-                                    echo "images match — no rotation needed"
-                                    exit 0
-                                  fi
-                                  if [ "$state" != "Ready" ] && [ "$state" != "Allocated" ]; then
-                                    echo "gs not Ready/Allocated (state=${state}) — skipping rotate, will retry next tick"
-                                    exit 0
-                                  fi
-                                  echo "image drift detected: ${running} -> ${desired}; rotating"
-                                  kubectl -n "$NS" delete gs/"$GS" --timeout=180s
-                                  echo "delete sent; ArgoCD selfHeal will recreate from ${desired}"
+                              - kbve-kubectl
+                              - rotate-gameserver
+                              - --namespace=factorio
+                              - --gameserver=factorio
+                              - --container=factorio
+                              - --delete-timeout=180
                           resources:
                               requests:
                                   cpu: 25m

--- a/apps/kube/agones/factorio/manifests/rotation-rbac.yaml
+++ b/apps/kube/agones/factorio/manifests/rotation-rbac.yaml
@@ -15,7 +15,7 @@ rules:
       verbs: ['get', 'list']
     - apiGroups: ['agones.dev']
       resources: ['gameservers']
-      verbs: ['get', 'list', 'delete']
+      verbs: ['get', 'list', 'watch', 'delete']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/apps/vm/kubectl-e2e/e2e/kbve-kubectl.spec.ts
+++ b/apps/vm/kubectl-e2e/e2e/kbve-kubectl.spec.ts
@@ -20,6 +20,7 @@ describe('kbve-kubectl CLI', () => {
 		expect(out).toContain('guest-exec');
 		expect(out).toContain('run');
 		expect(out).toContain('info');
+		expect(out).toContain('rotate-gameserver');
 	});
 
 	it('should show version with --version', () => {
@@ -94,6 +95,26 @@ describe('kbve-kubectl CLI', () => {
 		);
 		// Fails on missing kubectl context, not arg parsing
 		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).not.toContain('unrecognized');
+	});
+
+	it('should show subcommand help for rotate-gameserver', () => {
+		const out = dockerExec('kbve-kubectl rotate-gameserver --help');
+		expect(out).toContain('--namespace');
+		expect(out).toContain('--gameserver');
+		expect(out).toContain('--container');
+		expect(out).toContain('--delete-timeout');
+	});
+
+	it('should fail rotate-gameserver with missing required args', () => {
+		const result = dockerExecSafe('kbve-kubectl rotate-gameserver');
+		expect(result.exitCode).not.toBe(0);
+	});
+
+	it('should accept rotate-gameserver flags without arg-parse errors', () => {
+		const result = dockerExecSafe(
+			'kbve-kubectl rotate-gameserver --namespace ns --gameserver gs --container c --delete-timeout 30',
+		);
 		expect(result.stderr).not.toContain('unrecognized');
 	});
 });

--- a/apps/vm/kubectl/src/main.rs
+++ b/apps/vm/kubectl/src/main.rs
@@ -63,6 +63,17 @@ enum Commands {
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
     },
+    /// Roll an Agones GameServer when its desired image drifts from the running pod image
+    RotateGameserver {
+        #[arg(long)]
+        namespace: String,
+        #[arg(long)]
+        gameserver: String,
+        #[arg(long, default_value = "factorio")]
+        container: String,
+        #[arg(long, default_value = "180")]
+        delete_timeout: u64,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -375,6 +386,90 @@ async fn cmd_guest_exec(
     }
 }
 
+async fn cmd_rotate_gameserver(
+    namespace: &str,
+    gameserver: &str,
+    container: &str,
+    delete_timeout: u64,
+) -> ExitCode {
+    let gs_ref = format!("gs/{gameserver}");
+    let pod_ref = format!("pod/{gameserver}");
+    let image_path =
+        format!("{{.spec.template.spec.containers[?(@.name==\"{container}\")].image}}");
+    let pod_image_path = format!("{{.spec.containers[?(@.name==\"{container}\")].image}}");
+
+    let desired = kubectl_output(&[
+        "-n",
+        namespace,
+        "get",
+        &gs_ref,
+        "-o",
+        &format!("jsonpath={image_path}"),
+    ])
+    .await
+    .unwrap_or_default();
+
+    let running = kubectl_output(&[
+        "-n",
+        namespace,
+        "get",
+        &pod_ref,
+        "-o",
+        &format!("jsonpath={pod_image_path}"),
+    ])
+    .await
+    .unwrap_or_default();
+
+    let state = kubectl_output(&[
+        "-n",
+        namespace,
+        "get",
+        &gs_ref,
+        "-o",
+        "jsonpath={.status.state}",
+    ])
+    .await
+    .unwrap_or_default();
+
+    tracing::info!("desired={desired} running={running} state={state}");
+
+    if desired.is_empty() || running.is_empty() {
+        tracing::info!("missing gs or pod — nothing to rotate");
+        return ExitCode::SUCCESS;
+    }
+    if desired == running {
+        tracing::info!("images match — no rotation needed");
+        return ExitCode::SUCCESS;
+    }
+    if state != "Ready" && state != "Allocated" {
+        tracing::info!("gs not Ready/Allocated (state={state}) — skipping rotate");
+        return ExitCode::SUCCESS;
+    }
+
+    tracing::info!("image drift detected: {running} -> {desired}; rotating");
+
+    let timeout_arg = format!("--timeout={delete_timeout}s");
+    match kubectl_output(&[
+        "-n",
+        namespace,
+        "delete",
+        &gs_ref,
+        &timeout_arg,
+        "--ignore-not-found",
+    ])
+    .await
+    {
+        Ok(_) => {
+            tracing::info!("delete sent; ArgoCD selfHeal will recreate from {desired}");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            tracing::error!("delete failed: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -394,5 +489,11 @@ async fn main() -> ExitCode {
             timeout,
             args,
         } => cmd_guest_exec(&vm, &namespace, &command, &args, timeout).await,
+        Commands::RotateGameserver {
+            namespace,
+            gameserver,
+            container,
+            delete_timeout,
+        } => cmd_rotate_gameserver(&namespace, &gameserver, &container, delete_timeout).await,
     }
 }


### PR DESCRIPTION
## Summary

- **`kbve-kubectl rotate-gameserver`** — new Rust subcommand absorbing the inline shell drift-rotation logic from `apps/kube/agones/factorio/manifests/rotation-cronjob.yaml`. The CronJob now invokes `kbve-kubectl rotate-gameserver --namespace=factorio --gameserver=factorio --container=factorio --delete-timeout=180` instead of a 25-line shell heredoc.
- **`watch` verb on `gameservers`** in `rotation-rbac.yaml` so `kubectl delete --timeout` exits cleanly instead of marking the rotator Job as `FailureTarget` while still performing the deletion.
- **Factorio map-reset fix** — `apps/agones/factorio/shim/agones-shim.sh` previously defaulted to `--start-server-load-scenario kbve` on every restart unless `FACTORIO_SAVE` env was set, which silently wiped the world after every successful rotation. Shim now resumes from the newest `*.zip` in `/factorio/saves` and only falls back to a fresh scenario when the PVC is empty.
- **kubectl-e2e** picks up `rotate-gameserver --help` / arg-parse coverage.

## Context

Live verified yesterday on the cluster:
- Drift rotator finally executed (\`bitnami/kubectl\` → \`ghcr.io/kbve/kubectl:0.1.2\` swap landed in #11629)
- Pod successfully rolled \`agones-factorio:0.0.10\` → \`:0.0.12\`
- BUT the new pod started a fresh scenario because the shim ignored the preserved \`/factorio/saves/kbve.zip\` (3MB save from preStop flush)
- Job also showed \`FailureTarget=True\` because the rotator SA lacks the \`watch\` verb \`kubectl delete --timeout\` requires

This PR closes both gaps; \`deployment_yamls\` on \`kubectl.mdx\` already auto-syncs the new image tag into \`rotation-cronjob.yaml\` after the next \`kbve-kubectl\` publish.

## Test plan

- [x] \`cargo check --manifest-path apps/vm/kubectl/Cargo.toml\` clean
- [x] \`cargo clippy --manifest-path apps/vm/kubectl/Cargo.toml -- -D warnings\` clean
- [x] \`astro-kbve:sync:ci-manifest\` regenerated (no kubectl-related diff; one unrelated axum-kbve patch bump rolled in)
- [ ] CI build of \`kbve-kubectl\` image + Factorio image
- [ ] Post-merge: drift rotator picks up the new \`agones-factorio\` tag, kbve.zip survives the cycle