### PR TITLE
perf+release(kbve-spider): event filters + setting cache + 1Hz short-circuit → bump 0.2.1

### DIFF
--- a/apps/factorio/mods/kbve-spider/changelog.txt
+++ b/apps/factorio/mods/kbve-spider/changelog.txt
@@ -1,4 +1,53 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.2.1
+Date: 2026-06-02
+  Bugfixes:
+    - Eggs now actually hatch. The follow loop and hatch sweep were both registered at
+      on_nth_tick(60); Factorio only keeps one callback per period, so the follow loop was
+      silently replacing the hatch sweep and eggs were frozen at "Hatching… 30s" indefinitely.
+      Both handlers now dispatch from a single 1 Hz registration.
+    - Allies now reliably follow the player. The follow loop only re-issued go_to_location
+      when the ally was more than 4 tiles from the owner, but the command completes at
+      radius 3 — the ally got stuck inside that dead zone. Cadence raised to 1 Hz, rest
+      distance dropped to 2 tiles, distraction switched from by_enemy to by_damage so
+      ambient hostiles don't shred the follow tether.
+    - Spider Eggs no longer body-check the player. Collision box shrunk and collision mask
+      cleared so the egg sits on the ground without blocking foot traffic.
+  Features:
+    - Each hatched ally gets a randomized name (Webby, Charlotte, Aragog, …) floating above
+      it via rendering.draw_text, suffixed with the owner's username so two players can
+      both have a Webby without confusion. Names persist across save/load. The owner's
+      death-alert chat message now reads "Webby died at (X, Y)." instead of generic.
+    - Backfill on on_configuration_changed assigns names + attaches labels to allies that
+      hatched on an older save before this feature existed.
+  Performance:
+    - Ally registry: storage.allies[unit_number] = surface_index, maintained at hatch + death
+      + on_configuration_changed rebuild. Follow loop iterates the registry and resolves
+      entities via game.get_entity_by_unit_number (O(1) in 2.0) instead of calling
+      surface.find_entities_filtered per surface every second.
+    - Sprint + nervous loops now skip surfaces with no connected players (empty planets and
+      dormant space platforms cost a single hashmap lookup per loop firing instead of a
+      full entity scan).
+    - on_entity_damaged + on_entity_died registered with name filters so the callback only
+      fires for kbve-spider / kbve-spider-ally / kbve-spider-egg-entity instead of every
+      damaged or destroyed entity in the game. Largest single saving on combat-heavy ticks.
+    - Runtime mod settings cached at load and refreshed via on_runtime_mod_setting_changed
+      instead of being re-read on every per-tick lookup.
+    - 1 Hz bundled handler short-circuits when both pending_eggs and allies are empty (two
+      hashmap probes per tick on quiet maps).
+  Graphics:
+    - Icon mipmap strips (120×64 = 64 + 32 + 16 + 8) for the spider and the egg so HUD
+      slots + alerts render crisply at every zoom level. All icon-bearing prototypes now
+      declare icon_mipmaps = 4.
+  Modding:
+    - locale/en/kbve-spider.cfg provides proper localized names + descriptions for the
+      mod, all three entities (kbve-spider / kbve-spider-ally / kbve-spider-egg-entity),
+      the spider-egg item, and every mod setting. Tooltips no longer expose raw prototype
+      slugs.
+    - settings.lua exposes runtime knobs (hatch_seconds, sprint_chance, flee_threshold,
+      nervous_pick_count) + startup knobs (sprint_speed_multiplier, ally_max_health).
+    - migrations/ directory scaffolded for future storage-shape changes.
+---------------------------------------------------------------------------------------------------
 Version: 0.2.0
 Date: 2026-06-01
   Features:

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -49,11 +49,28 @@ local SPRINT_TICK_INTERVAL = 180
 local SPRINT_COOLDOWN_TICKS = 600
 local NERVOUS_TICK_INTERVAL = 900
 
-local function setting(name, default)
-	local s = settings.global[name]
-	if not s then return default end
-	return s.value
+-- Runtime mod settings cache. Per-tick lookups through `settings.global[X].value`
+-- are cheap but not free; reading the same six knobs 60× per second adds up on
+-- busy servers. We hydrate once at load and refresh via the runtime-changed
+-- event so the cache stays in sync with admin tweaks without polling.
+local cached_hatch_seconds = 30
+local cached_sprint_chance = 0.45
+local cached_flee_threshold = 0.3
+local cached_nervous_pick = 3
+
+local function rehydrate_runtime_settings()
+	local s_hatch = settings.global["kbve-spider-hatch-seconds"]
+	local s_sprint = settings.global["kbve-spider-sprint-chance"]
+	local s_flee = settings.global["kbve-spider-flee-health-threshold"]
+	local s_nervous = settings.global["kbve-spider-nervous-pick-count"]
+	if s_hatch then cached_hatch_seconds = s_hatch.value end
+	if s_sprint then cached_sprint_chance = s_sprint.value end
+	if s_flee then cached_flee_threshold = s_flee.value end
+	if s_nervous then cached_nervous_pick = s_nervous.value end
 end
+
+script.on_load(rehydrate_runtime_settings)
+script.on_event(defines.events.on_runtime_mod_setting_changed, rehydrate_runtime_settings)
 local NERVOUS_CORPSE = "kbve-spider-corpse-nervous"
 
 -- Map an attacker→spider vector + spider orientation into a hit side.
@@ -82,9 +99,14 @@ local function hit_side(spider_pos, attacker_pos, orientation)
 	end
 end
 
+local spider_damaged_filter = {
+	{ filter = "name", name = SPIDER },
+	{ filter = "name", name = SPIDER_ALLY, mode = "or" },
+}
+
 script.on_event(defines.events.on_entity_damaged, function(event)
 	local e = event.entity
-	if not (e and e.valid) or not SPIDER_NAMES[e.name] then return end
+	if not (e and e.valid) then return end
 
 	local cause = event.cause
 	local attacker_pos = (cause and cause.valid) and cause.position or e.position
@@ -110,7 +132,7 @@ script.on_event(defines.events.on_entity_damaged, function(event)
 	local key = e.unit_number
 	if cause and cause.valid and key and not storage.fleeing[key] then
 		local health_ratio = e.get_health_ratio() or 1
-		if health_ratio < setting("kbve-spider-flee-health-threshold", 0.3) then
+		if health_ratio < cached_flee_threshold then
 			storage.fleeing[key] = true
 			e.set_command{
 				type = defines.command.flee,
@@ -125,7 +147,13 @@ script.on_event(defines.events.on_entity_damaged, function(event)
 			}
 		end
 	end
-end)
+end, spider_damaged_filter)
+
+local spider_died_filter = {
+	{ filter = "name", name = SPIDER },
+	{ filter = "name", name = SPIDER_ALLY, mode = "or" },
+	{ filter = "name", name = EGG_ENTITY, mode = "or" },
+}
 
 script.on_event(defines.events.on_entity_died, function(event)
 	local e = event.entity
@@ -137,8 +165,6 @@ script.on_event(defines.events.on_entity_died, function(event)
 		end
 		return
 	end
-
-	if not SPIDER_NAMES[e.name] then return end
 
 	-- The prototype already spawned a Death1 corpse via the `corpse` field.
 	-- 50% of the time, layer a Death2 on top for visual variety.
@@ -176,7 +202,7 @@ script.on_event(defines.events.on_entity_died, function(event)
 			end
 		end
 	end
-end)
+end, spider_died_filter)
 
 -- Rebuild the ally registry from the world. Called on first init and on
 -- mod-config changes so save games predating the registry pick it up. After
@@ -203,6 +229,7 @@ script.on_init(function()
 	storage.allies = {}
 	storage.ally_names = {}
 	storage.ally_nametags = {}
+	rehydrate_runtime_settings()
 end)
 
 local function backfill_nametags()
@@ -236,6 +263,7 @@ script.on_configuration_changed(function()
 		rebuild_ally_registry()
 	end
 	backfill_nametags()
+	rehydrate_runtime_settings()
 end)
 
 local function attach_nametag(ally, name, owner_player)
@@ -277,7 +305,7 @@ end
 
 local function track_egg(entity, tick, placer_index)
 	storage.pending_eggs = storage.pending_eggs or {}
-	local hatch_ticks = math.floor(60 * setting("kbve-spider-hatch-seconds", 30))
+	local hatch_ticks = math.floor(60 * cached_hatch_seconds)
 	local render_id = nil
 	local ok, ro = pcall(function()
 		return rendering.draw_text{
@@ -501,8 +529,11 @@ end
 -- inside one function keeps the behavior + saves the overhead of a second
 -- per-tick dispatch.
 script.on_nth_tick(FOLLOW_TICK_INTERVAL, function(event)
-	hatch_sweep(event.tick)
-	follow_loop()
+	local has_eggs = storage.pending_eggs and next(storage.pending_eggs) ~= nil
+	local has_allies = storage.allies and next(storage.allies) ~= nil
+	if not (has_eggs or has_allies) then return end
+	if has_eggs then hatch_sweep(event.tick) end
+	if has_allies then follow_loop() end
 end)
 
 -- Build a set of surface indices that have at least one connected player.
@@ -528,7 +559,7 @@ script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 			local spiders = surface.find_entities_filtered{ name = { SPIDER, SPIDER_ALLY } }
 			local n = #spiders
 			if n > 0 then
-				local picks = math.min(setting("kbve-spider-nervous-pick-count", 3), n)
+				local picks = math.min(cached_nervous_pick, n)
 				for _ = 1, picks do
 					local s = spiders[math.random(1, n)]
 					if s.valid then
@@ -572,7 +603,7 @@ script.on_nth_tick(SPRINT_TICK_INTERVAL, function(event)
 						local in_group = false
 						local ok, ug = pcall(function() return s.unit_group end)
 						if ok and ug then in_group = true end
-						if in_group and math.random() < setting("kbve-spider-sprint-chance", 0.45) then
+						if in_group and math.random() < cached_sprint_chance then
 							surface.create_entity{
 								name = SPRINT_STICKER,
 								position = s.position,

--- a/apps/factorio/mods/kbve-spider/info.json
+++ b/apps/factorio/mods/kbve-spider/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "kbve-spider",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"factorio_version": "2.0",
 	"title": "KBVE Spider",
 	"author": "kbve",


### PR DESCRIPTION
## Summary

Final perf pass on top of #11611, then bumps `info.json::version` to **0.2.1** so the Factorio mod portal CI matrix from #11554 picks it up on the next `agones-factorio` run and auto-publishes.

### Perf wins in this PR

1. **Filtered events** — `on_entity_damaged` + `on_entity_died` now drop non-spider events inside the engine instead of firing the callback per turret-round; biggest single saving on combat-heavy ticks.
2. **Runtime setting cache** — four hot-path settings hydrated into module-locals, refreshed via `on_runtime_mod_setting_changed` (no polling, no per-tick re-reads).
3. **1 Hz short-circuit** — bundled hatch+follow handler returns immediately when both `pending_eggs` and `allies` are empty (two hashmap probes per tick on quiet maps).

### Changelog roll-up (0.2.0 → 0.2.1)

| PR | What |
| --- | --- |
| #11665 | Hatch-tick collision fix — eggs were frozen at "Hatching… 30s" because two PRs registered handlers at `on_nth_tick(60)` |
| #11609 | Ally follow loop fix (rest distance, distraction, cadence) + walkable egg collision |
| #11611 | Registry-driven follow + active-surface gate |
| #11603 | Ally ownership + follow loop + hatch UX + icon mipmaps |
| #11591 | Locale + mod settings + migrations scaffold |
| #11667 | Random nametag above each hatched ally |
| **this** | Event filters + setting cache + 1Hz short-circuit |

Full per-section breakdown lives in `changelog.txt` under `Version: 0.2.1`.

## Test plan

- [x] `luac -p control.lua` → clean.
- [x] `./kbve.sh -nx kbve-spider:test` → PASS (info.json version=0.2.1).
- [ ] CI re-runs `kbve-spider:test` clean.
- [ ] After merge → next `agones-factorio` CI run → `factorio_mod_portal` matrix should publish `kbve-spider 0.2.1` to mods.factorio.com (gate compares info.json against the portal release list, only kbve-spider gets uploaded; kbve is unchanged so it skips).
- [ ] Empty save → no eggs, no allies → `/show-time-usage` → kbve-spider near 0 % per-tick.
- [ ] Runtime setting tweak mid-game → applies on next tick without save/reload.
- [ ] Place egg → hatch → ally trails + nametag visible → kill ally → owner gets named chat alert.