### PR TITLE
feat(relay): drop join/leave + shrink IRC→Discord prefix to [F] tag

### DIFF
--- a/apps/agones/factorio/relay/src/irc_bridge.rs
+++ b/apps/agones/factorio/relay/src/irc_bridge.rs
@@ -176,8 +176,14 @@ fn parse_privmsg(line: &str, expected_channel: &str, self_nick: &str) -> Option<
 
 fn format_for_irc(ev: &GameEvent) -> Option<String> {
     match ev.kind {
-        GameEventKind::Chat | GameEventKind::Join | GameEventKind::Leave => Some(ev.text.clone()),
-        GameEventKind::Command | GameEventKind::Stats => None,
+        GameEventKind::Chat => {
+            let player = ev.player.as_deref().unwrap_or("server");
+            Some(format!("[CHAT] {player}@factorio: {}", ev.text))
+        }
+        GameEventKind::Join
+        | GameEventKind::Leave
+        | GameEventKind::Command
+        | GameEventKind::Stats => None,
     }
 }
 

--- a/apps/agones/factorio/relay/src/log_tail.rs
+++ b/apps/agones/factorio/relay/src/log_tail.rs
@@ -58,24 +58,36 @@ pub async fn run(cfg: Config, tx: Sender<GameEvent>) -> Result<()> {
 
 fn parse_line(line: &str) -> Option<GameEvent> {
     let trimmed = line.trim_end_matches(['\n', '\r']);
-    let kind = if trimmed.contains("[CHAT]") {
-        GameEventKind::Chat
-    } else if trimmed.contains("[JOIN]") {
-        GameEventKind::Join
-    } else if trimmed.contains("[LEAVE]") {
-        GameEventKind::Leave
-    } else if trimmed.contains("[COMMAND]") {
-        GameEventKind::Command
-    } else if trimmed.contains("[STATS]") {
-        GameEventKind::Stats
-    } else {
-        return None;
+
+    let tags = [
+        ("[CHAT]", GameEventKind::Chat),
+        ("[JOIN]", GameEventKind::Join),
+        ("[LEAVE]", GameEventKind::Leave),
+        ("[COMMAND]", GameEventKind::Command),
+        ("[STATS]", GameEventKind::Stats),
+    ];
+    let (tag, kind, tag_idx) = tags
+        .iter()
+        .find_map(|(t, k)| trimmed.find(t).map(|i| (*t, k.clone(), i)))?;
+
+    let after_tag = trimmed[tag_idx + tag.len()..].trim_start();
+
+    let (player, text) = match kind {
+        GameEventKind::Chat => match after_tag.split_once(": ") {
+            Some((p, m)) => (Some(p.to_string()), m.to_string()),
+            None => (None, after_tag.to_string()),
+        },
+        GameEventKind::Join | GameEventKind::Leave => {
+            let player = after_tag.split_whitespace().next().map(str::to_string);
+            (player, after_tag.to_string())
+        }
+        _ => (None, after_tag.to_string()),
     };
 
     Some(GameEvent {
         kind,
-        player: None,
-        text: trimmed.to_string(),
+        player,
+        text,
         raw: trimmed.to_string(),
     })
 }

--- a/apps/discordsh/discordsh-bot/src/discord/relay.rs
+++ b/apps/discordsh/discordsh-bot/src/discord/relay.rs
@@ -92,15 +92,32 @@ fn should_forward_irc(msg: &ChatMessage, target_channel: &str) -> bool {
 fn format_irc_for_discord(msg: &ChatMessage) -> String {
     let sender = sanitize(&msg.sender);
     let content = sanitize(&msg.content);
+    let tag = platform_tag(&msg.platform);
     let head = if sender.is_empty() {
-        "**IRC**".to_owned()
+        format!("**[{tag}]**")
     } else {
-        format!("**IRC \u{2022} {sender}**")
+        format!("**[{tag}] {sender}**")
     };
     if content.is_empty() {
         head
     } else {
         format!("{head}: {content}")
+    }
+}
+
+fn platform_tag(platform: &str) -> String {
+    match platform {
+        "factorio" => "F".to_owned(),
+        "isometric" => "I".to_owned(),
+        "rareicon" => "R".to_owned(),
+        "minecraft" => "M".to_owned(),
+        "system" => "SYS".to_owned(),
+        "irc" => "IRC".to_owned(),
+        other => other
+            .chars()
+            .next()
+            .map(|c| c.to_ascii_uppercase().to_string())
+            .unwrap_or_else(|| "IRC".to_owned()),
     }
 }
 


### PR DESCRIPTION
## Summary
- Factorio relay drops `[JOIN]`/`[LEAVE]`/`[COMMAND]`/`[STATS]` from IRC; only `[CHAT]` propagates
- Factorio chat now leaves the relay as structured `[CHAT] <player>@factorio: <msg>` (parsed cleanly by `bevy_chat::ChatMessage::from_irc_privmsg`)
- discordsh-bot formats IRC messages with a short platform tag: `factorio→F`, `isometric→I`, `rareicon→R`, `minecraft→M`, fallback first-letter

Before: `IRC • factorio-bot: 2026-06-02 07:42:55 [CHAT] h0lybyte: oh`
After: `**[F] h0lybyte**: oh`

## Test plan
- [x] `cargo build -p agones-factorio-relay -p discordsh-bot`
- [x] `cargo test -p agones-factorio-relay -p discordsh-bot --bins` (747 passed)
- [ ] Live verify on Factorio server — chat relays as `[F] <player>`, join/leave silent
- [ ] Verify Discord→IRC direction still works (unchanged path)