### PR TITLE
content(astro-kbve): bump 200 OSRS items v2 → v3 (batch 7)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-vambraces.mdx
@@ -12,28 +12,36 @@ osrs:
   lowalch: 20200
   highalch: 30300
   limit: 8
+  material:
+    type: 3rd age
+    tier: high
   equipment:
     slot: hands
-    type: ranged armour
-    attack_style: ranged
+    weight: 1
     requirements:
       ranged: 65
-    stats:
-      attack_ranged: 11
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+      defence: 45
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 11
+    defence_bonus:
+      stab: 6
+      slash: 5
+      crush: 7
+      magic: 9
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers: [hard, elite, master]
   related_items:
     - item_id: 10334
       item_name: 3rd age range coif
@@ -50,10 +58,7 @@ osrs:
       slug: 3rd-age-range-legs
       relationship: set-piece
       description: Leg slot of 3rd age range set
-  about: |-
-    The 3rd age vambraces are part of the 3rd age ranged set, one of the rarest and most prestigious armour sets in Old School RuneScape. They require 65 Ranged to wear and provide the best ranged attack bonus of any vambraces.
-
-    3rd age equipment is highly sought after due to its extreme rarity and status symbol value. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
+  about: "3rd age vambraces are an extremely rare reward from hard, elite, and master Treasure Trails, providing the best ranged attack bonus of any vambraces and forming part of the prestigious 3rd age ranger kit."
   market_strategy:
     title: Investment Notes
     notes:
@@ -63,8 +68,28 @@ osrs:
       - Verify authenticity when trading high-value items
       - Use Grand Exchange for secure trades
       - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2006-12-05"
+      update: Treasure Trails, spiders and sheep
+      description: Released as a reward from Treasure Trails.
+    - date: "2014-06-26"
+      description: Item value increased from 15,000 to 50,500 coins.
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails, spiders and sheep
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options: [Drop]
+    worn_options: [Wear]
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-wand.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-wand.mdx
@@ -1,6 +1,6 @@
 ---
 title: 3rd age wand | OSRS Price Data
-description: "3rd age wand is a members weapon slot item requiring 65 Magic. High alch: 90,000 GP, GE limit: 8."
+description: "3rd age wand: an ultra-rare master clue magic weapon with +20 magic attack and +5% magic damage requiring 65 Magic. High alch: 90,000 GP, GE limit: 8."
 osrs:
   id: 12422
   name: 3rd age wand
@@ -14,67 +14,81 @@ osrs:
   limit: 8
   equipment:
     slot: weapon
-    type: wand
-    attack_style: magic
+    weapon_type: powered_staff
     attack_speed: 4
+    weight: 3.175
     requirements:
       magic: 65
-    stats:
-      attack_magic: 20
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 15
-      defence_ranged: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 20
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 20
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
       magic_damage: 5
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - elite
+      - master
   related_items:
     - item_id: 12426
       item_name: 3rd age longsword
       slug: 3rd-age-longsword
       relationship: alternative
-      description: 3rd age melee weapon
+      description: 3rd age melee weapon counterpart.
     - item_id: 12424
       item_name: 3rd age bow
       slug: 3rd-age-bow
       relationship: alternative
-      description: 3rd age ranged weapon
-    - item_id: 20014
-      item_name: 3rd age pickaxe
-      slug: 3rd-age-pickaxe
+      description: 3rd age ranged weapon counterpart.
+    - item_id: 6914
+      item_name: Master wand
+      slug: master-wand
       relationship: alternative
-      description: 3rd age skilling tool
-    - item_id: 20011
-      item_name: 3rd age axe
-      slug: 3rd-age-axe
-      relationship: alternative
-      description: 3rd age skilling tool
-  about: |-
-    The 3rd age wand is a rare magic weapon obtained from Treasure Trails. It requires 65 Magic to wield and can autocast Ancient Magicks and standard spellbook spells.
-
-    3rd age weapons are highly sought after due to their extreme rarity and status symbol value. The wand provides a 5% magic damage bonus, making it useful for combat as well as a status symbol.
+      description: Same +20 magic attack at lower level with autocast support.
+  about: "The 3rd age wand is an ultra-rare elite and master clue magic weapon providing +20 magic attack and a 5% magic damage bonus."
   market_strategy:
     title: Investment Notes
     notes:
-      - Extremely valuable due to rarity
-      - Price fluctuates based on collector demand
-      - More common than druidic but still very rare
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Extreme rarity from elite and master caskets keeps supply minimal.
+      - Status-symbol pricing dominates over combat utility.
+      - Cannot autocast Ancient or Arceuus spellbooks unlike the master wand.
+      - High-value trades should use the Grand Exchange for security.
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Added to game with the 3rd age weapon line.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-bolts.mdx
@@ -26,9 +26,9 @@ osrs:
     level: 61
     materials:
       - item: Adamant bolts (unf)
-        quantity: 1
+        quantity: "1"
       - item: Feathers
-        quantity: 1
+        quantity: "1"
   obtaining:
     fletching: Smith adamantite bars, then fletch with feathers (61 Fletching)
     drops:

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-full-helm-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-full-helm-g.mdx
@@ -14,20 +14,60 @@ osrs:
   limit: 8
   equipment:
     slot: head
+    weight: 3.175
     requirements:
       defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 19
+      slash: 21
+      crush: 16
+      magic: -1
+      ranged: 19
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
     - item_id: 2605
       item_name: Adamant full helm (t)
       slug: adamant-full-helm-t
       relationship: variant
       description: Trimmed variant
-  about: |-
-    > *"Adamant full helm with gold trim."*
-
-    The adamant full helm (g) is a gold-trimmed cosmetic variant of the standard adamant full helm. Identical stats, requiring 30 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Adamant full helm (g) is a gold-trimmed cosmetic variant of the standard adamant full helm, sharing identical 30 Defence requirement and stats while obtainable only from medium clue scroll reward caskets."
+  history:
+    - date: "2004-05-05"
+      description: Released as a medium clue scroll reward in the Bigger Banks & Treasure Trails update.
+  properties:
+    release_date: "2004-05-05"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-seeds.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-seeds.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 18000
-  about: "Adamant seeds is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: utility
+    tier: mid
+  drop_table:
+    - source: Zombie pirate
+      rarity: "8/378"
+      quantity: "1"
+      notes: "Drop rate varies between 8/378 and 8/1260 across zombie pirate types and lockers."
+    - source: Zombie pirate locker
+      rarity: "8/1260"
+      quantity: "1"
+  related_items:
+    - item_name: Mithril seeds
+      slug: mithril-seeds
+      relationship: alternative
+      description: Counterpart seed that forces movement in the opposite direction.
+  about: "Adamant seeds are stackable Wilderness utility seeds dropped by zombie pirates that force the planter one tile east when used, popular for PvP repositioning and flower-planting money-making."
+  market_strategy:
+    notes:
+      - "PvP and Wilderness activity drive demand; zombie pirate participation governs supply."
+  trading_tips:
+    - "Stack pricing follows Wilderness escalations and league seasons; flip around large PvP updates."
+  history:
+    - date: "2024-04-10"
+      description: Released with the Undead Pirates update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-04-10"
+    update: "Undead Pirates"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: [Plant, Drop]
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/air-orb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/air-orb.mdx
@@ -21,10 +21,10 @@ osrs:
     runes:
       - item_name: Air rune
         item_id: 556
-        quantity: 30
+        quantity: "30"
       - item_name: Cosmic rune
         item_id: 564
-        quantity: 3
+        quantity: "3"
     obelisk: Air Obelisk
     location: Edgeville Dungeon (Wilderness)
   recipes:

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrow.mdx
@@ -28,10 +28,10 @@ osrs:
     materials:
       - item_id: 21350
         item_name: Amethyst arrowtips
-        quantity: 15
+        quantity: "15"
       - item_id: 53
         item_name: Headless arrow
-        quantity: 15
+        quantity: "15"
     xp: 202.5
     product_quantity: 15
   market:

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrowtips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrowtips.mdx
@@ -24,7 +24,7 @@ osrs:
     materials:
       - item_id: 21347
         item_name: Amethyst
-        quantity: 1
+        quantity: "1"
     product_quantity: 15
     xp: 60
   uses:

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-broad-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-broad-bolts.mdx
@@ -29,10 +29,10 @@ osrs:
     materials:
       - item_id: 21318
         item_name: Broad bolts
-        quantity: 10
+        quantity: "10"
       - item_id: 21338
         item_name: Amethyst bolt tips
-        quantity: 10
+        quantity: "10"
     xp: 106
   special_effect:
     name: Slayer Requirement

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-dart-p-25857.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-dart-p-25857.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 11000
-  about: "Amethyst dart(p++) is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 28
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 25849
+      item_name: Amethyst dart
+      slug: amethyst-dart
+      relationship: variant
+      description: Unpoisoned base variant
+    - item_id: 811
+      item_name: Rune dart
+      slug: rune-dart
+      relationship: downgrade
+      description: Lower-tier dart (+2 less ranged strength)
+  about: Amethyst dart(p++) is the deadly-poison variant of the amethyst dart — a one-handed thrown weapon with +28 ranged strength, requiring 50 Ranged.
+  market_strategy:
+    notes:
+      - Niche poison-variant supply via Fletching
+      - 90 Fletching gate keeps producer pool small
+      - Demand from PvP and Slayer with deadly poison utility
+  history:
+    - date: "2021-06-30"
+      description: Amethyst darts released as part of Phosani's Nightmare update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-06-30"
+    update: Phosani's Nightmare
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst.mdx
@@ -29,22 +29,22 @@ osrs:
       product_name: Amethyst arrowtips
       crafting_level: 85
       xp: 60
-      quantity: 15
+      quantity: "15"
     - product_id: 21338
       product_name: Amethyst bolt tips
       crafting_level: 83
       xp: 60
-      quantity: 15
+      quantity: "15"
     - product_id: 21352
       product_name: Amethyst javelin heads
       crafting_level: 87
       xp: 60
-      quantity: 5
+      quantity: "5"
     - product_id: 25853
       product_name: Amethyst dart tips
       crafting_level: 89
       xp: 60
-      quantity: 8
+      quantity: "8"
   market:
     buy_limit: 13000
     price_estimate: 1500

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-chemistry.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-chemistry.mdx
@@ -24,9 +24,9 @@ osrs:
       magic: 27
     runes:
       - rune: Cosmic
-        quantity: 1
+        quantity: "1"
       - rune: Air
-        quantity: 3
+        quantity: "3"
   special_effect:
     name: Extra Dose
     description: 5% chance to create 4-dose potion instead of 3-dose

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-strength.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-strength.mdx
@@ -1,6 +1,6 @@
 ---
 title: Amulet of strength | OSRS Price Data
-description: "Amulet of strength is a F2P neck slot item. High alch: 1,215 GP, GE limit: 125."
+description: "Amulet of strength is a F2P neck slot item providing +10 Strength. High alch: 1,215 GP, GE limit: 125."
 osrs:
   id: 1725
   name: Amulet of strength
@@ -12,26 +12,41 @@ osrs:
   lowalch: 810
   highalch: 1215
   limit: 125
+  material:
+    type: ruby
+    tier: low
   equipment:
     slot: neck
-    type: amulet
-    tradeable: true
     weight: 0.01
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 10
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  recipes:
+    - skill: Magic
+      level: 49
+      xp: 59
+      output_quantity: 1
+      materials:
+        - item_name: Ruby amulet
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 5
   related_items:
     - item_id: 1698
       item_name: Ruby amulet
@@ -43,8 +58,34 @@ osrs:
       slug: amulet-of-power
       relationship: alternative
       description: Balanced alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1727
+      item_name: Amulet of magic
+      slug: amulet-of-magic
+      relationship: alternative
+      description: Magic-focused neck slot
+  about: Amulet of strength is an enchanted ruby amulet granting +10 melee strength, a popular F2P melee neck slot option enchanted at 49 Magic.
+  history:
+    - date: "2001-05-24"
+      update: Amulet enchantment
+      description: Amulet of strength introduced as an enchantable ruby amulet.
+  properties:
+    release_date: "2001-05-24"
+    update: Amulet enchantment
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancestral-robe-bottom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancestral-robe-bottom.mdx
@@ -14,67 +14,78 @@ osrs:
   limit: 8
   equipment:
     slot: legs
-    type: mage_armour
+    weight: 1.814
     requirements:
       magic: 75
       defence: 65
-    stats:
-      defence_stab: 27
-      defence_slash: 24
-      defence_crush: 30
-      defence_magic: 20
-      attack_magic: 26
-      magic_damage_percent: 3
-  drop_sources:
-    - name: Chambers of Xeric
-      combat_level: 0
-      drop_rate: rare
-      members_only: true
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 26
+      ranged: -7
+    defence_bonus:
+      stab: 27
+      slash: 24
+      crush: 30
+      magic: 20
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 3
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Chambers of Xeric
+        rarity: rare
+        members_only: true
   related_items:
     - item_id: 21018
       item_name: Ancestral hat
       slug: ancestral-hat
       relationship: set-piece
-      description: Head slot
+      description: Head slot of the set
     - item_id: 21021
       item_name: Ancestral robe top
       slug: ancestral-robe-top
       relationship: set-piece
-      description: Body slot
+      description: Body slot of the set
     - item_id: 4714
       item_name: Ahrim's robeskirt
       slug: ahrims-robeskirt
       relationship: alternative
-      description: Budget option
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Magic attack | +26 |
-    | Magic damage | +3% |
-    | Stab defence | +27 |
-    | Slash defence | +24 |
-    | Crush defence | +30 |
-    | Magic defence | +20 |
-    | Requirements | 75 Magic, 65 Defence |
-
-    Part of the Ancestral robes set:
-    - Ancestral hat (head)
-    - Ancestral robe top (body)
-    - Ancestral robe bottom (legs)
-
-    Total set bonus: +9% magic damage
-
-    PvM:
-    - Best-in-slot mage legs
-    - Essential for max magic DPS
-    - All high-level magic content
+      description: Budget magic legs alternative
+  about: "Ancestral robe bottom is the best-in-slot mage legs in OSRS, providing +26 magic attack, +3% magic damage and strong melee defence; dropped rarely from Chambers of Xeric."
   market_strategy:
     notes:
-      - CoX completions affect supply
-      - Core for mage setups
-      - Cheaper than robe top
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - CoX completions drive supply
+      - Core piece for high-end mage setups
+      - Typically cheaper than the robe top
+  history:
+    - date: "2024-05-29"
+      description: Magic damage bonus increased from 2% to 3%.
+    - date: "2017-01-05"
+      description: Released with the Chambers of Xeric update.
+  properties:
+    release_date: "2017-01-05"
+    update: Chambers of Xeric
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-bracers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-bracers.mdx
@@ -14,6 +14,9 @@ osrs:
   limit: 8
   equipment:
     slot: hands
+    weight: 1
+    requirements:
+      ranged: 70
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,8 +34,11 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 10376
       item_name: Guthix bracers
@@ -55,24 +61,33 @@ osrs:
       slug: black-d-hide-vambraces
       relationship: downgrade
       description: Standard version requiring 40 Defence
-  about: |-
-    > *"Ancient blessed dragonhide vambraces."*
-
-    | Stat | Blessed | Black D'hide |
-    |------|--------:|-----------:|
-    | Ranged Attack | +11 | +11 |
-    | Prayer | +1 | 0 |
-    | Ranged Req | 70 | 70 |
-    | Defence Req | None | 40 |
-
-    No Defence requirement makes these ideal for 1-Defence pures. The +1 prayer bonus is an additional advantage.
+  about: Ancient bracers are a hard clue scroll reward providing best-in-slot ranged glove stats for pures with no Defence requirement and a bonus +1 prayer.
   market_strategy:
     notes:
       - Hard clue exclusive
       - Best-in-slot ranged gloves for pures
       - All god variants are functionally identical
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  history:
+    - date: "2014-06-12"
+      description: Released as a hard clue scroll reward in the Treasure Trail Expansion.
+    - date: "2021-09-22"
+      description: The 40 Defence requirement was removed.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-ceremonial-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-ceremonial-gloves.mdx
@@ -12,9 +12,97 @@ osrs:
   lowalch: 16000
   highalch: 24000
   limit: 8
-  about: "Ancient ceremonial gloves is a members-only item in Old School RuneScape. High alchemy value: 24,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: hands
+    weight: 0.2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Spiritual mage (Zarosian)
+        rarity: 1/640
+        members_only: true
+      - source: Spiritual ranger (Zarosian)
+        rarity: 1/640
+        members_only: true
+      - source: Spiritual warrior (Zarosian)
+        rarity: 1/640
+        members_only: true
+      - source: Blood reaver
+        rarity: 1/640
+        members_only: true
+      - source: Fumus
+        rarity: 1/1000
+        members_only: true
+      - source: Umbra
+        rarity: 1/1000
+        members_only: true
+      - source: Cruor
+        rarity: 1/1000
+        members_only: true
+      - source: Glacies
+        rarity: 1/1000
+        members_only: true
+  related_items:
+    - item_name: Ancient ceremonial mask
+      slug: ancient-ceremonial-mask
+      relationship: set-piece
+      description: Headgear piece of the ancient ceremonial set
+    - item_name: Ancient ceremonial top
+      slug: ancient-ceremonial-top
+      relationship: set-piece
+      description: Body piece of the ancient ceremonial set
+    - item_name: Ancient ceremonial legs
+      slug: ancient-ceremonial-legs
+      relationship: set-piece
+      description: Legs piece of the ancient ceremonial set
+    - item_name: Ancient ceremonial boots
+      slug: ancient-ceremonial-boots
+      relationship: set-piece
+      description: Boots piece of the ancient ceremonial set
+  about: "Ancient ceremonial gloves are a cosmetic hand slot item released on 5 January 2022 alongside the Nex boss update. They provide a +1 prayer bonus with no other combat stats and are part of the five-piece ancient ceremonial robes set worn by followers of Zaros. They are dropped by various Zarosian NPCs in the Ancient Prison portion of the God Wars Dungeon."
+  market_strategy:
+    notes:
+      - Thin market with low buy limit and modest volume
+      - Demand is mostly cosmetic and tied to costume room storage
+      - Watch for full set purchases driving short price spikes
+  history:
+    - date: "2022-01-05"
+      description: Released alongside the Nex boss update with the Ancient Prison expansion
+  properties:
+    release_date: "2022-01-05"
+    update: Nex
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-ceremonial-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-ceremonial-mask.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
-  about: "Ancient ceremonial mask is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: high
+  equipment:
+    slot: head
+    weight: 0.3
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 2
+  drop_table:
+    - source: Spiritual mage (Ancient Prison)
+      rarity: "1/640"
+      quantity: "1"
+    - source: Spiritual ranger (Ancient Prison)
+      rarity: "1/640"
+      quantity: "1"
+    - source: Spiritual warrior (Ancient Prison)
+      rarity: "1/640"
+      quantity: "1"
+    - source: Ancient Prison bosses
+      rarity: "1/1000"
+      quantity: "1"
+  related_items:
+    - item_name: Ancient ceremonial top
+      slug: ancient-ceremonial-top
+      relationship: set-piece
+      description: Body slot piece of the ancient ceremonial set.
+    - item_name: Ancient ceremonial legs
+      slug: ancient-ceremonial-legs
+      relationship: set-piece
+      description: Legs slot piece of the ancient ceremonial set.
+    - item_name: Ancient ceremonial gloves
+      slug: ancient-ceremonial-gloves
+      relationship: set-piece
+      description: Hands slot piece of the ancient ceremonial set.
+    - item_name: Ancient ceremonial boots
+      slug: ancient-ceremonial-boots
+      relationship: set-piece
+      description: Feet slot piece of the ancient ceremonial set.
+  about: "Ancient ceremonial mask is a head slot cosmetic dropped by Ancient Prison NPCs that grants +2 prayer bonus and god protection against Zarosian NPCs, completing the ancient ceremonial robe set."
+  market_strategy:
+    notes:
+      - "Demand is driven by Zaros cosmetic collectors and Nex farmers; the 8 buy limit keeps spreads wide."
+  trading_tips:
+    - "Watch Nex meta and league announcements; cosmetic set demand spikes during transmog content."
+  history:
+    - date: "2021-12-16"
+      description: Added to the game as an unobtainable item.
+    - date: "2022-01-05"
+      description: Made obtainable with the Nex The Fifth General release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-01-05"
+    update: "Nex: The Fifth General"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options: [Wear, Drop]
+    worn_options: [Remove]
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-chaps.mdx
@@ -14,6 +14,9 @@ osrs:
   limit: 8
   equipment:
     slot: legs
+    weight: 5
+    requirements:
+      ranged: 70
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,8 +34,11 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 10380
       item_name: Guthix chaps
@@ -54,31 +60,35 @@ osrs:
       item_name: Black d'hide chaps
       slug: black-d-hide-chaps
       relationship: downgrade
-      description: Standard version requiring 40 Defence
-  about: |-
-    > *"Ancient blessed dragonhide chaps."*
-
-    | Stat | Blessed | Black D'hide |
-    |------|--------:|-----------:|
-    | Ranged Attack | +8 | +8 |
-    | Stab Defence | +17 | +17 |
-    | Slash Defence | +20 | +20 |
-    | Crush Defence | +16 | +16 |
-    | Magic Defence | +18 | +18 |
-    | Ranged Defence | +17 | +17 |
-    | Prayer | +1 | 0 |
-    | Ranged Req | 70 | 70 |
-    | Defence Req | None | 40 |
-
-    The key advantage: blessed chaps have no Defence requirement, making them ideal for pures and ranged-focused accounts. They also offer a +1 prayer bonus.
+      description: Standard version (40 Defence req historically)
+  about: Ancient chaps are the Zaros-blessed dragonhide chaps from hard clue caskets, identical to other god variants and prized by 1-Defence pures for the +1 prayer bonus.
   market_strategy:
     notes:
       - Hard clue exclusive — supply tied to clue completion rates
-      - Popular with 1-Defence pures who need best-in-slot ranged legs
-      - All god variants are functionally identical
-      - Armadyl and Ancient variants tend to have slight premiums
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - All god variants functionally identical; cosmetic premium varies
+      - Pure-friendly best-in-slot ranged legs
+      - 8/4h buy limit keeps the floor stiff
+  history:
+    - date: "2021-09-22"
+      description: The 40 Defence requirement has been removed.
+    - date: "2015-06-18"
+      description: Fixed a stretching issue with void robes and dragonhide chaps while using Zul-andra teleport.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Wear
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-poison-supermix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-poison-supermix-2.mdx
@@ -24,7 +24,7 @@ osrs:
       level: 51
       xp: 35
       product: Anti-poison supermix(2)
-      quantity: 1
+      quantity: "1"
       requirements: Completion of Barbarian Herblore training with Otto Godblessed.
       materials:
         - item_name: Superantipoison(2)

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/arena-book.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/arena-book.mdx
@@ -12,9 +12,37 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Arena book is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Rewards Guardian
+      price: 200
+      currency: Coins
+  related_items:
+    - item_id: 6889
+      item_name: Mage's book
+      slug: mages-book
+      relationship: alternative
+      description: Visually similar book historically used in scams
+  about: "Arena book is a Mage Training Arena lore book purchased from the Rewards Guardian for 200 coins or found on player-owned house bookshelves; historically used in scams due to its resemblance to the Mage's book."
+  history:
+    - date: "2006-01-04"
+      description: Added to the game with the release of the Mage Training Arena.
+  properties:
+    release_date: "2006-01-04"
+    update: Mage Training Arena
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Read
+      - Destroy
+    alchable: true
+    destroy: "Hopefully the Entrance Guardian has another copy!"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-godsword-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-godsword-ornament-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Armadyl godsword ornament kit | OSRS Price Data
-description: "Armadyl godsword ornament kit: Use on an Armadyl godsword to make it look fancier!. High alch: 3,000 GP, GE limit: 4."
+description: "Armadyl godsword ornament kit: Use on an Armadyl godsword to make it look fancier! High alch: 3,000 GP, GE limit: 4."
 osrs:
   id: 20068
   name: Armadyl godsword ornament kit
@@ -12,9 +12,49 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Armadyl godsword ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ornament kit
+    tier: high
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers: [master]
+  related_items:
+    - item_id: 11802
+      item_name: Armadyl godsword
+      slug: armadyl-godsword
+      relationship: component
+      description: Base weapon the kit attaches to
+    - item_id: 20070
+      item_name: Armadyl godsword (or)
+      slug: armadyl-godsword-or
+      relationship: product
+      description: Ornamental result after attaching
+    - item_id: 20072
+      item_name: Bandos godsword ornament kit
+      slug: bandos-godsword-ornament-kit
+      relationship: alternative
+      description: Bandos variant ornament kit
+  about: "Armadyl godsword ornament kit is a cosmetic master clue reward used on an Armadyl godsword to create the ornamented variant. The kit is detachable so the upgrade can be reversed and resold."
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion
+      description: Released as part of the Treasure Trail Expansion update.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options: [Drop]
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-page-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-page-1.mdx
@@ -12,16 +12,14 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 5
-  item:
-    type: god_page
-    god: Armadyl
-    page_number: 1
-    tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite
-        drop_rate: Varies by tier
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
   related_items:
     - item_id: 12618
       item_name: Armadyl page 2
@@ -38,33 +36,30 @@ osrs:
       slug: armadyl-page-4
       relationship: set-piece
       description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Armadyl |
-    | Page | 1 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of law (Armadyl god book) to complete it.
-
-    Requires all 4 pages:
-    - Armadyl page 1
-    - Armadyl page 2
-    - Armadyl page 3
-    - Armadyl page 4
-
-    When complete, the Book of law provides:
-    - +10 ranged attack bonus
-    - Counts as Armadyl item in GWD
-    - Can be illuminated after Horror from the Deep
+  about: "Armadyl page 1 is one of four pages used to complete a damaged Book of law into the Armadyl god book; obtained from Treasure Trails clue rewards."
   market_strategy:
     notes:
       - Collect all 4 pages
       - Best ranged attack god book
       - GWD Armadyl protection
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2014-07-03"
+      description: Released with the Halos, God Books & Stamina update.
+  properties:
+    release_date: "2014-07-03"
+    update: "Halos, God Books & Stamina"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/avantoe-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/avantoe-seed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Avantoe seed | OSRS Price Data
-description: "Avantoe seed: An avantoe seed - plant in a herb patch.. High alch: 4 GP, GE limit: 200."
+description: "Avantoe seed: An avantoe seed - plant in a herb patch. Farming level 50. High alch: 4 GP, GE limit: 200."
 osrs:
   id: 5298
   name: Avantoe seed
@@ -12,65 +12,80 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 200
-  seed:
-    type: herb
-    tier: mid
   farming:
     level: 50
     xp_plant: 54.5
+    xp_check: 0
     xp_harvest: 61.5
-    growth_time: 80
+    growth_time_minutes: 80
     patches: 9
     product_id: 211
     product_name: Grimy avantoe
+  drop_table:
+    - source: Moss giant
+      rarity: 1/235.7
+      quantity: "1"
+    - source: Aberrant spectre
+      rarity: 1/177
+      quantity: "1"
+    - source: Kurask
+      rarity: 1/177
+      quantity: "1"
+    - source: Master Farmer
+      rarity: 1/86
+      quantity: "1"
   related_items:
     - item_id: 211
       item_name: Grimy avantoe
       slug: grimy-avantoe
       relationship: product
-      description: Harvested product
+      description: Harvested herb product
     - item_id: 261
       item_name: Avantoe
       slug: avantoe
       relationship: product
       description: Cleaned herb
-    - item_id: 2446
-      item_name: Superantifire(4)
-      slug: superantifire-4
-      relationship: product
-      description: Made from avantoe
     - item_id: 5297
       item_name: Irit seed
       slug: irit-seed
-      relationship: alternative
+      relationship: downgrade
       description: Lower tier herb seed
     - item_id: 5299
       item_name: Kwuarm seed
       slug: kwuarm-seed
       relationship: upgrade
-      description: Next tier herb seed
-  about: |-
-    Plant in a herb patch to grow Grimy avantoe.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 50 |
-    | Growth time | 80 minutes |
-    | XP (plant) | 54.5 |
-    | XP (harvest) | 61.5 per herb |
+      description: Higher tier herb seed
+  about: "Avantoe seed is a mid-tier herb seed planted in herb patches at Farming level 50, yielding grimy avantoe used in fishing potions and super antifires."
   market_strategy:
     notes:
-      - Mid-tier herb seed
-      - Used for fishing potions and super antifires
-      - Decent profit margin
-      - Ultracompost (essential)
-      - Magic secateurs (10% more yield)
-      - Farming cape (5% more yield)
-      - 9 herb patches available
-      - ~10 minute runs, 80 minute regrowth
-      - Super antifires highly valuable for dragon slaying
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Mid-tier herb seed with steady demand
+      - Drops from Master Farmers and slayer mid-tier mobs
+      - Profitable to farm with ultracompost and magic secateurs
+      - 9 herb patches yield ~10 minute runs every 80 minutes
+  trading_tips:
+    - Buy from Master Farmer flippers in bulk
+    - Hold seeds for off-peak pricing
+  history:
+    - date: "2005-06-06"
+      description: Avantoe seed released with the Farming skill update.
+    - date: "2020-08-13"
+      description: Herb patch model now matches inventory icon and harvesting grants planting XP.
+  properties:
+    release_date: "2005-06-06"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/awakener-s-orb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/awakener-s-orb.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 30000
   highalch: 45000
   limit: 50
-  about: "Awakener's orb is a members-only item in Old School RuneScape. High alchemy value: 45,000 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: consumable
+    tier: high
+  drop_table:
+    sources:
+      - source: Vardorvis
+        combat_level: 571
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/80.6
+        members_only: true
+      - source: Duke Sucellus
+        combat_level: 575
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/48.5
+        members_only: true
+      - source: The Whisperer
+        combat_level: 599
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/34.5
+        members_only: true
+      - source: The Leviathan
+        combat_level: 593
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/53.6
+        members_only: true
+  related_items:
+    - item_id: 28319
+      item_name: Virtus mask
+      slug: virtus-mask
+      relationship: alternative
+      description: Awakened-mode unique drop
+    - item_id: 28307
+      item_name: Ingot
+      slug: ingot
+      relationship: alternative
+      description: Awakened-mode unique drop
+    - item_id: 28278
+      item_name: Vestige
+      slug: vestige
+      relationship: alternative
+      description: Awakened-mode unique drop
+  about: One-time consumable that empowers a Forgotten Four boss to awakened mode for harder fights with boosted unique drop rates.
+  history:
+    - date: "2023-08-03"
+      description: Awakener's orbs have been added to the collection log; orbs obtained before this update will not appear in the log.
+    - date: "2023-07-26"
+      description: Added to the game with Desert Treasure II - The Fallen Empire.
+  properties:
+    release_date: "2023-07-26"
+    update: Desert Treasure II - The Fallen Empire
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-plant-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-plant-3.mdx
@@ -12,9 +12,38 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10000
-  about: "Bagged plant 3 is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    level: 12
+    xp: 100
+  farming:
+    level: 1
+    xp: 100
+  shops:
+    - shop_name: Garden supplier (Falador Park)
+      price: 10000
+      currency: Coins
+    - shop_name: Garden supplier (Farming Guild)
+      price: 10000
+      currency: Coins
+  about: "Bagged plant 3 is a Construction garden item planted with a filled watering can at 12 Construction; yields 100 Construction and 100 Farming XP and grows into Fern, Huge plant, Reeds, or Tall plant."
+  history:
+    - date: "2006-05-31"
+      description: Added to the game with the launch of player-owned houses.
+  properties:
+    release_date: "2006-05-31"
+    update: PLAYER-OWNED HOUSES!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandit-s-brew.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandit-s-brew.mdx
@@ -12,9 +12,45 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 2000
-  about: "Bandit's brew is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - description: "Attack: +1 boost"
+      - description: "Thieving: +1 boost"
+      - description: "Hitpoints: restores 1"
+      - description: "Strength: drains 3 to 7 based on level band"
+      - description: "Defence: drains 3 to 7 based on level band"
+  shops:
+    - shop_name: The Big Heist Lodge
+      location: Bandit Camp, Kharidian Desert
+      price: 650
+      stock: 10
+  about: "Bandit's brew is a members lager sold at the Bandit Camp's Big Heist Lodge that boosts Attack and Thieving by 1 while heavily draining Strength and Defence based on the player's level band."
+  market_strategy:
+    notes:
+      - Limited to shop supply after Desert Treasure progression
+      - Niche utility outside of quest and Thieving boosts
+      - Mid-range high alch margin when cheap
+  history:
+    - date: "2005-04-18"
+      description: Released with the Desert Treasure update.
+  properties:
+    release_date: "2005-04-18"
+    update: Desert Treasure
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-d-hide-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-d-hide-shield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bandos d'hide shield | OSRS Price Data
-description: "Bandos d'hide shield is a members shield slot item requiring 40 Defence. High alch: 17,000 GP, GE limit: 8."
+description: "Bandos d'hide shield: a hard clue blessed dragonhide shield requiring 70 Ranged and 40 Defence with a +1 prayer bonus. High alch: 17,000 GP, GE limit: 8."
 osrs:
   id: 23203
   name: Bandos d'hide shield
@@ -14,78 +14,89 @@ osrs:
   limit: 8
   equipment:
     slot: shield
-    type: ranged armour
-    attack_style: ranged
+    weight: 8
     requirements:
       ranged: 70
       defence: 40
-    stats:
-      attack_stab: -15
-      attack_slash: -15
-      attack_crush: -11
-      attack_magic: -10
-      attack_ranged: 7
-      defence_stab: 21
-      defence_slash: 18
-      defence_crush: 16
-      defence_magic: 15
-      defence_ranged: 14
+    attack_bonus:
+      stab: -15
+      slash: -15
+      crush: -11
+      magic: -10
+      ranged: 7
+    defence_bonus:
+      stab: 21
+      slash: 18
+      crush: 16
+      magic: 15
+      ranged: 14
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
-      prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: Rare
-        description: Reward from hard clue scroll caskets (1/9,750)
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 23191
       item_name: Saradomin d'hide shield
       slug: saradomin-d-hide-shield
       relationship: variant
-      description: Saradomin variant of blessed d'hide shield
+      description: Saradomin-aligned blessed d'hide shield.
     - item_id: 23188
       item_name: Guthix d'hide shield
       slug: guthix-d-hide-shield
       relationship: variant
-      description: Guthix variant of blessed d'hide shield
+      description: Guthix-aligned blessed d'hide shield.
     - item_id: 23194
       item_name: Zamorak d'hide shield
       slug: zamorak-d-hide-shield
       relationship: variant
-      description: Zamorak variant of blessed d'hide shield
+      description: Zamorak-aligned blessed d'hide shield.
     - item_id: 23200
       item_name: Armadyl d'hide shield
       slug: armadyl-d-hide-shield
       relationship: variant
-      description: Armadyl variant of blessed d'hide shield
+      description: Armadyl-aligned blessed d'hide shield.
     - item_id: 23197
       item_name: Ancient d'hide shield
       slug: ancient-d-hide-shield
       relationship: variant
-      description: Ancient variant of blessed d'hide shield
-  about: |-
-    "Bandos blessed wooden shield covered in dragon leather."
-
-    The Bandos d'hide shield is a blessed dragonhide shield aligned with the god Bandos. It requires 70 Ranged and 40 Defence to equip and occupies the shield slot. Like all blessed d'hide shields, it offers solid ranged attack and defensive bonuses along with a +1 prayer bonus that regular dragonhide shields lack.
-
-    All six god d'hide shields share identical combat stats, so the choice between them is purely cosmetic or based on God Wars Dungeon faction protection. The Bandos d'hide shield provides protection from Bandos-aligned NPCs in the God Wars Dungeon, making it useful for General Graardor trips.
-
-    The blessed d'hide shields are comparable to the black d'hide shield but with an added +1 prayer bonus. For players seeking a ranged shield with prayer, these are a strong budget option. The book of law and other god books offer different stat distributions for the shield slot and may be preferred for offensive setups where the ranged attack bonus matters more than defence.
+      description: Ancient-aligned blessed d'hide shield.
+  about: "The Bandos d'hide shield is a Bandos-aligned blessed dragonhide shield from hard clues that adds a +1 prayer bonus over the black d'hide shield."
   market_strategy:
     title: Investment Notes
     notes:
-      - All god d'hide shield variants share the same stats, so price differences are driven by cosmetic demand
-      - Bandos variants are popular due to the god's association with melee combat and the God Wars Dungeon
-      - Supply is tied to hard clue scroll completion rates
-      - Compare prices across all six god variants before buying since stats are identical
-      - Valuable for Bandos protection in the God Wars Dungeon
-      - Buy limit of 8 per 4 hours on the Grand Exchange
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - All six god d'hide shield variants share identical stats so price differences are cosmetic.
+      - Supply tracks hard clue scroll completion rates.
+      - Bandos protection in the God Wars Dungeon adds practical demand.
+      - Tight buy limit of 8 per 4 hours can cause spikes during cosmetic trends.
+  history:
+    - date: "2019-04-11"
+      update: Treasure Trails Expansion and Easter 2019
+      description: Added to game as a hard clue reward.
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/barb-bolttips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/barb-bolttips.mdx
@@ -12,18 +12,62 @@ osrs:
   lowalch: 38
   highalch: 57
   limit: 11000
+  recipes:
+    - name: Attach barb bolt tips to bronze bolts
+      skill: fletching
+      level: 51
+      xp: 0.3
+      materials:
+        - item_id: 877
+          item_name: Bronze bolts
+          quantity: 1
+        - item_id: 47
+          item_name: Barb bolttips
+          quantity: 1
+      product: Barbed bolts
+      product_id: 881
+      product_quantity: 1
+      tools: []
+      members_only: true
   related_items:
     - item_id: 46
       item_name: Pearl bolt tips
       slug: pearl-bolt-tips
       relationship: variant
-      description: Pearl bolt tips
-  about: |-
-    > _"I can make bolts with these."_
-
-    Barb bolttips are members-only Fletching supplies. Attach to bronze bolts at 51 Fletching to create barbed bolts. Unlike gem bolt tips, these are only available from the Ranging Guild or the Grand Exchange — they cannot be crafted from raw materials.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Gem bolt tip alternative
+    - item_id: 881
+      item_name: Barbed bolts
+      slug: barbed-bolts
+      relationship: product
+      description: Bronze bolts + barb bolt tips
+  about: Barb bolttips are members Fletching supplies attached to bronze bolts at 51 Fletching to produce barbed bolts; sourced from the Ranging Guild or the Grand Exchange, never crafted.
+  market_strategy:
+    notes:
+      - Fixed supply via Ranging Guild trade-in
+      - Demand driven by Fletching trainers and barbed bolt pkers
+      - 11,000/4h buy limit keeps bulk flips smooth
+  history:
+    - date: "2006-06-21"
+      description: Item received a graphical update.
+    - date: "2004-03-29"
+      description: Item became permanently available with the RuneScape 2 launch.
+    - date: "2004-03-03"
+      description: Item was added to the RuneScape 2 Beta.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/battlestaff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/battlestaff.mdx
@@ -14,30 +14,41 @@ osrs:
   limit: 11000
   equipment:
     slot: weapon
-    type: staff
-    attack_requirement: 30
-    magic_requirement: 30
-  attack_bonuses:
-    crush: 25
-    magic: 12
-  other_bonuses:
-    strength: 32
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 30
+      magic: 30
+    attack_bonus:
+      stab: 7
+      slash: -1
+      crush: 25
+      magic: 12
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 12
+    other_bonus:
+      melee_strength: 32
   shops:
-    - shop_name: Zaff's Superior Staffs
+    - shop_name: "Zaff's Superior Staffs"
+      location: Varrock
       price: 7000
       currency: Coins
-      stock: Daily
   recipes:
     - skill: crafting
       level: 66
       xp: 137.5
       materials:
-        - item_name: Battlestaff
-          item_id: 1391
+        - item_id: 1391
+          item_name: Battlestaff
           quantity: 1
-        - item_name: Air orb
-          item_id: 573
+        - item_id: 573
+          item_name: Air orb
           quantity: 1
+      tools: []
       product: Air battlestaff
       product_id: 1397
       product_quantity: 1
@@ -47,12 +58,13 @@ osrs:
       level: 54
       xp: 100
       materials:
-        - item_name: Battlestaff
-          item_id: 1391
+        - item_id: 1391
+          item_name: Battlestaff
           quantity: 1
-        - item_name: Water orb
-          item_id: 571
+        - item_id: 571
+          item_name: Water orb
           quantity: 1
+      tools: []
       product: Water battlestaff
       product_id: 1395
       product_quantity: 1
@@ -62,12 +74,13 @@ osrs:
       level: 58
       xp: 112.5
       materials:
-        - item_name: Battlestaff
-          item_id: 1391
+        - item_id: 1391
+          item_name: Battlestaff
           quantity: 1
-        - item_name: Earth orb
-          item_id: 575
+        - item_id: 575
+          item_name: Earth orb
           quantity: 1
+      tools: []
       product: Earth battlestaff
       product_id: 1399
       product_quantity: 1
@@ -77,12 +90,13 @@ osrs:
       level: 62
       xp: 125
       materials:
-        - item_name: Battlestaff
-          item_id: 1391
+        - item_id: 1391
+          item_name: Battlestaff
           quantity: 1
-        - item_name: Fire orb
-          item_id: 569
+        - item_id: 569
+          item_name: Fire orb
           quantity: 1
+      tools: []
       product: Fire battlestaff
       product_id: 1393
       product_quantity: 1
@@ -109,36 +123,44 @@ osrs:
       slug: celastrus-bark
       relationship: component
       description: Fletching material
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Attack requirement | 30 |
-    | Magic requirement | 30 |
-    | Magic attack | +12 |
-    | Crush attack | +25 |
-    | Strength bonus | +32 |
-
-    | Product | Additional Item |
-    |---------|-----------------|
-    | Air battlestaff | Air orb |
-    | Water battlestaff | Water orb |
-    | Earth battlestaff | Earth orb |
-    | Fire battlestaff | Fire orb |
+  about: "Battlestaff is a level 30 magic weapon and the elemental orb base, sold daily by Zaff in Varrock and a staple of high-level Crafting profit."
   market_strategy:
     notes:
       - Attach orbs for profit
       - Daily Zaff stock
       - High Crafting XP
       - Elemental battlestaff crafting
-      - Crafting training
       - Varrock diary reward
-      - Zaff daily stock
-      - Zaff sells discounted (diary)
-      - High Crafting XP per staff
+      - Zaff sells discounted with diary
       - Orb charging profit chain
       - Mystic staff upgrades
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2021-09-22"
+      description: Magic Attack and Defence bonuses of battlestaves were increased from +10 to +12.
+    - date: "2017-02-09"
+      description: Making battlestaves now includes an animation.
+    - date: "2015-12-03"
+      description: Banking fix for noted battlestaff stacks.
+    - date: "2015-03-05"
+      description: Varrock Diary discount system implemented for Zaff daily stock.
+  properties:
+    release_date: "2002-03-18"
+    update: "RuneScape updated (18 March 2002)"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bellator-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bellator-ring.mdx
@@ -28,12 +28,12 @@ osrs:
         item_name: Bellator vestige
       - item_id: 565
         item_name: Blood rune
-        quantity: 500
+        quantity: "500"
     materials:
       - item_name: Chromium ingot
-        quantity: 3
+        quantity: "3"
       - item_name: Ring mould
-        quantity: 1
+        quantity: "1"
     skill_requirements:
       magic: 90
       crafting: 80

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/berserker-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/berserker-necklace.mdx
@@ -14,19 +14,26 @@ osrs:
   limit: 70
   equipment:
     slot: neck
-    type: amulet
-    requirements:
-      none: true
-    stats:
-      attack_all: -10
-      defence_all: -20
-      strength: 7
+    weight: 0.01
+    attack_bonus:
+      stab: -10
+      slash: -10
+      crush: -10
+      magic: -10
+      ranged: -10
+    defence_bonus:
+      stab: -20
+      slash: -20
+      crush: -20
+      magic: -20
+      ranged: -20
+    other_bonus:
+      melee_strength: 7
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
-  effect:
-    obsidian_damage_bonus: 20
-    stacks_with_armor: true
   recipes:
-    - skill: magic
+    - skill: Magic
       level: 87
       xp: 97
       materials:
@@ -42,10 +49,11 @@ osrs:
         - item_name: Cosmic rune
           item_id: 564
           quantity: 1
+      tools:
+        - Standard spellbook
       product: Berserker necklace
       product_id: 11128
       product_quantity: 1
-      facility: None
       members_only: true
   related_items:
     - item_id: 6528
@@ -63,47 +71,31 @@ osrs:
       slug: amulet-of-fury
       relationship: alternative
       description: General alternative
-  about: |-
-    Enchant Onyx necklace with Lvl-6 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 87 (boostable) |
-    | Runes | 20 fire, 20 earth, 1 cosmic |
-
-    | Offense | Value |
-    |---------|-------|
-    | All attack styles | -10 |
-    | Strength | +7 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | -20 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +3 |
-
-    Obsidian Boost:
-    - +20% damage with obsidian melee weapons
-    - Stacks with full obsidian armor (+10%)
-    - Stacks with Slayer helm and Void
-
-    Total with armor: +30% damage bonus!
-
-    Essential for:
-    - Obsidian training setups
-    - TzHaar slayer tasks
-    - Fight Caves with obsidian
-
-    Core item for obsidian weapon builds.
+  about: Berserker necklace is enchanted from an Onyx necklace via Lvl-6 Enchant and grants a +20% damage boost with obsidian melee weapons that stacks with full obsidian armour.
   market_strategy:
     notes:
       - Use with obsidian weapons
       - Negative defences are significant
       - Great for training
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  properties:
+    release_date: "2007-04-30"
+    update: 24 Carat Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  history:
+    - date: "2007-04-30"
+      description: Released in the 24 Carat Update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/berserker-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/berserker-ring.mdx
@@ -14,12 +14,24 @@ osrs:
   limit: 8
   equipment:
     slot: ring
-    type: ring
-    stats:
-      strength: 4
-    imbue:
-      location: Soul Wars/Nightmare Zone
-      imbued_strength: 8
+    weight: 0.004
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   drop_table:
     sources:
       - source: Dagannoth Rex
@@ -29,49 +41,53 @@ osrs:
         rarity: 1/128
         members_only: true
   related_items:
-    - item_id: 6733
-      item_name: Archers ring
+    - item_name: Berserker ring (i)
+      slug: berserker-ring-i
+      relationship: upgrade
+      description: Imbued variant with doubled Strength bonus (+8)
+    - item_name: Archers ring
       slug: archers-ring
       relationship: alternative
-      description: Ranged equivalent
-    - item_id: 6731
-      item_name: Seers ring
+      description: Ranged equivalent dropped by Dagannoth Supreme
+    - item_name: Seers ring
       slug: seers-ring
       relationship: alternative
-      description: Magic equivalent
-    - item_id: 19550
-      item_name: Ring of suffering
+      description: Magic equivalent dropped by Dagannoth Prime
+    - item_name: Ring of suffering
       slug: ring-of-suffering
       relationship: alternative
-      description: Defensive alternative
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Strength | +4 |
-    | Requirements | None |
-
-    Best-in-slot strength bonus ring.
-
-    Imbue at Soul Wars or Nightmare Zone for doubled stats:
-
-    | Stat | Imbued |
-    |------|--------|
-    | Strength | +8 |
-
-    BiS melee ring for:
-    - All melee combat
-    - Bossing
-    - Slayer
-    - Max strength setups
-
-    Imbue is essential - doubles the bonus.
+      description: Defensive alternative ring option
+  about: "Berserker ring is a members-only ring released on 7 November 2005 with the Waterbirth Island update. It grants a +4 Strength bonus and is dropped by Dagannoth Rex at a 1/128 rate, making it the canonical best-in-slot Strength ring for melee. Its imbued variant doubles the Strength bonus to +8 and is obtainable through Nightmare Zone points, Combat Achievements, Soul Wars zeal, or a Scroll of Imbuing."
   market_strategy:
     notes:
-      - DKs are efficient to farm
-      - Imbue immediately
-      - BiS for all melee
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Best-in-slot melee Strength ring with consistent end-game demand
+      - Dagannoth Rex farming supplies the GE; bossing trends move the price
+      - Imbue immediately for melee content since it doubles the bonus
+  trading_tips:
+    - Buy when Dagannoth Rex group-farming events flood supply
+    - Hold for new melee content releases that boost Strength demand
+  history:
+    - date: "2005-11-07"
+      description: Released with the Waterbirth Island update
+  properties:
+    release_date: "2005-11-07"
+    update: Waterbirth Island - deeper, darker, deadlier!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.004
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-brutal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-brutal.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 11000
-  about: "Black brutal is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: ammo
+    weight: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 22
+      magic_damage: 0
+      prayer: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+  related_items:
+    - item_id: 4827
+      item_name: Comp ogre bow
+      slug: comp-ogre-bow
+      relationship: component
+      description: Bow used to fire brutal arrows
+    - item_id: 2883
+      item_name: Ogre bow
+      slug: ogre-bow
+      relationship: alternative
+      description: Basic ogre bow
+    - item_id: 4824
+      item_name: Flighted ogre arrow
+      slug: flighted-ogre-arrow
+      relationship: component
+      description: Base arrow before adding black nails
+  about: "Black-tipped brutal arrow used with an ogre bow or comp ogre bow to hunt zogres, skogres, and chompy birds; created at 38 Fletching from flighted ogre arrows and black nails."
+  recipes:
+    - product_id: 4788
+      product_name: Black brutal
+      skill: Fletching
+      level: 38
+      experience: 39
+      tools:
+        - Hammer
+      materials:
+        - item_id: 4824
+          item_name: Flighted ogre arrow
+          quantity: 6
+        - item_id: 4819
+          item_name: Black nails
+          quantity: 6
+  history:
+    - date: "2005-05-17"
+      description: Added to the game with the Zogre Flesh Eaters quest.
+  properties:
+    release_date: "2005-05-17"
+    update: Zogre Flesh Eaters
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dart-p-5631.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dart-p-5631.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black dart(p+) | OSRS Price Data
-description: "Black dart(p+): A deadly poisoned dart with a black tip.. High alch: 10 GP, GE limit: 7,000."
+description: "Black dart(p+) is a members thrown weapon requiring 10 Ranged, tipped with weapon poison+. High alch: 10 GP, GE limit: 7,000."
 osrs:
   id: 5631
   name: Black dart(p+)
@@ -12,9 +12,66 @@ osrs:
   lowalch: 7
   highalch: 10
   limit: 7000
-  about: "Black dart(p+) is a members-only item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 10
+    attack_bonus:
+      ranged: 6
+  drop_table:
+    - source: Burthorpe soldier
+      level: 48
+      quantity: "1"
+      rarity: 9/128
+  related_items:
+    - item_id: 3093
+      item_name: Black dart
+      slug: black-dart
+      relationship: variant
+      description: Unpoisoned variant of the black dart
+    - item_id: 5628
+      item_name: Black dart(p)
+      slug: black-dart-p-5628
+      relationship: downgrade
+      description: Weaker poison tier tipped with weapon poison
+    - item_id: 5634
+      item_name: Black dart(p++)
+      slug: black-dart-p-5634
+      relationship: upgrade
+      description: Strongest poison tier tipped with weapon poison++
+  about: "The black dart(p+) is a thrown ranged weapon tipped with weapon poison+, requiring 10 Ranged to wield and dropping primarily from Burthorpe soldiers since it cannot be fletched."
+  market_strategy:
+    notes:
+      - "Supply is drop-only from Burthorpe soldiers, so price is sticky relative to other poisoned darts; spikes happen on Death Plateau quest content swings."
+  trading_tips:
+    - "Pair drops from Death Plateau training with bulk listings while the GE buy limit of 7,000 caps a single trader's exposure."
+  history:
+    - date: "2004-08-09"
+      description: "Released in the Death Plateau quest update."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus on black darts was reduced from +7 to 0 on the unpoisoned variant."
+  properties:
+    release_date: "2004-08-09"
+    update: Death Plateau
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody-h4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody-h4.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 1536
   highalch: 2304
   limit: 8
-  about: "Black platebody (h4) is a free-to-play item in Old School RuneScape. High alchemy value: 2,304 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 9.979
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 41
+      slash: 40
+      crush: 30
+      magic: -6
+      ranged: 40
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_id: 23372
+      item_name: Black platebody (h1)
+      slug: black-platebody-h1
+      relationship: variant
+      description: Saradomin heraldic variant
+    - item_id: 3140
+      item_name: Dragon chainbody
+      slug: dragon-chainbody
+      relationship: alternative
+      description: Members chainbody alternative
+  about: Black platebody (h4) is a heraldic black platebody from easy clue caskets — a free-to-play cosmetic for the standard black platebody.
+  market_strategy:
+    notes:
+      - Easy clue casket drop — wide supply, thin spreads
+      - Cosmetic value drives most demand
+      - 8/4h limit caps bulk flipping
+  history:
+    - date: "2021-04-21"
+      description: The platebody's ranged attack bonus has been decreased from -10 to -15.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-shield-h2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-shield-h2.mdx
@@ -5,16 +5,89 @@ osrs:
   id: 7338
   name: Black shield (h2)
   slug: black-shield-h2
-  examine: A shield with a heraldic design
+  examine: A shield with a heraldic design.
   members: false
   icon: Black shield (h2).png
   value: 1632
   lowalch: 652
   highalch: 979
   limit: 70
-  about: "Black shield (h2) is a free-to-play item in Old School RuneScape. High alchemy value: 979 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    weight: 5.443
+    requirements:
+      defence: 10
+    attack_bonus:
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 17
+      slash: 19
+      crush: 18
+      magic: -1
+      ranged: 18
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_id: 1191
+      item_name: Black kiteshield
+      slug: black-kiteshield
+      relationship: alternative
+      description: Identical stats, non-trimmed
+    - item_id: 7336
+      item_name: Black shield (h1)
+      slug: black-shield-h1
+      relationship: variant
+      description: Heraldic variant 1
+    - item_id: 7340
+      item_name: Black shield (h3)
+      slug: black-shield-h3
+      relationship: variant
+      description: Heraldic variant 3
+    - item_id: 7342
+      item_name: Black shield (h4)
+      slug: black-shield-h4
+      relationship: variant
+      description: Heraldic variant 4
+    - item_id: 7344
+      item_name: Black shield (h5)
+      slug: black-shield-h5
+      relationship: variant
+      description: Heraldic variant 5
+  about: "Black shield (h2) is a cosmetic heraldic variant of the black kiteshield with identical combat stats, rewarded from easy Treasure Trails."
+  market_strategy:
+    notes:
+      - Easy clue scroll reward
+      - Identical stats to black kiteshield
+      - Worn for cosmetic heraldry
+  history:
+    - date: "2021-04-14"
+      description: "Ranged defence bonus reduced from -2 to -3."
+    - date: "2015-12-09"
+      description: "Item value decreased from 16,325 to 1,632 coins."
+    - date: "2006-02-20"
+      description: "Item released with the Updates, updates and more updates... update."
+  properties:
+    release_date: "2006-02-20"
+    update: "Updates, updates and more updates..."
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-shield-h4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-shield-h4.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 652
   highalch: 979
   limit: 70
-  about: "Black shield (h4) is a free-to-play item in Old School RuneScape. High alchemy value: 979 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    weight: 5.443
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -1
+      ranged: -3
+    defence_bonus:
+      stab: 17
+      slash: 19
+      crush: 18
+      magic: -1
+      ranged: 18
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  about: Black shield (h4) is a free-to-play heraldic shield obtained from easy Treasure Trail clues that shares identical bonuses with the standard Black kiteshield.
+  history:
+    - date: "2021-04-21"
+      description: Ranged attack bonus reduced from -2 to -3.
+  properties:
+    release_date: "2006-02-20"
+    update: Treasure Trails Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-shield-h5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-shield-h5.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 652
   highalch: 979
   limit: 70
-  about: "Black shield (h5) is a free-to-play item in Old School RuneScape. High alchemy value: 979 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    weight: 5.443
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 17
+      slash: 19
+      crush: 18
+      magic: -1
+      ranged: 18
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_id: 1191
+      item_name: Black kiteshield
+      slug: black-kiteshield
+      relationship: variant
+      description: Base unbranded kiteshield
+    - item_id: 7350
+      item_name: Black shield (h1)
+      slug: black-shield-h1
+      relationship: variant
+      description: Saradomin heraldic variant
+    - item_id: 7352
+      item_name: Black shield (h2)
+      slug: black-shield-h2
+      relationship: variant
+      description: Guthix heraldic variant
+    - item_id: 7354
+      item_name: Black shield (h3)
+      slug: black-shield-h3
+      relationship: variant
+      description: Zamorak heraldic variant
+  about: Heraldic black kiteshield decorated with the H5 design, obtained as a hard clue scroll reward and available in F2P.
+  history:
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -2 to -3.
+    - date: "2014-12-10"
+      description: "Renamed from Black shield(h5) to Black shield (h5)."
+    - date: "2006-05-31"
+      description: "Renamed from Black kiteshield(h) to Black shield(h5)."
+    - date: "2006-03-15"
+      description: Made available to free-to-play players.
+    - date: "2006-02-20"
+      description: Added to the game.
+  properties:
+    release_date: "2006-02-20"
+    update: "Updates, updates and more updates..."
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-skirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-skirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black skirt | OSRS Price Data
-description: "Black skirt: Clothing favoured by women and dark wizards.. High alch: 1 GP, GE limit: 150."
+description: "Black skirt: Clothing favoured by women and dark wizards. F2P legs slot cosmetic. High alch: 1 GP, GE limit: 150."
 osrs:
   id: 1015
   name: Black skirt
@@ -12,9 +12,75 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 150
-  about: "Black skirt is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 0.907
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Thessalia's Fine Clothes"
+      location: Varrock
+      price: 2
+  drop_table:
+    - source: Forgotten Soul
+      rarity: 1/128
+      quantity: "1"
+  related_items:
+    - item_id: 1013
+      item_name: Blue skirt
+      slug: blue-skirt
+      relationship: variant
+      description: Blue colour variant
+    - item_id: 1017
+      item_name: Pink skirt
+      slug: pink-skirt
+      relationship: variant
+      description: Pink colour variant
+  about: "Black skirt is a free-to-play cosmetic legs slot item with no combat bonuses, often paired with a black robe for the dark wizard look."
+  market_strategy:
+    notes:
+      - F2P cosmetic with negligible combat use
+      - Cheap shop alternative at Thessalia's
+      - Low GE volume
+  history:
+    - date: "2001-01-04"
+      description: Black skirt released as part of the initial RuneScape clothing options.
+  properties:
+    release_date: "2001-01-04"
+    update: Original
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-spear-p-5736.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-spear-p-5736.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black spear(p++) | OSRS Price Data
-description: "Black spear(p++): A poisoned black tipped spear.. High alch: 450 GP, GE limit: 8."
+description: "Black spear(p++): a poisoned two-handed black spear requiring 10 Attack, obtained from Shades of Mort'ton or vampyre Juvinates. High alch: 450 GP, GE limit: 8."
 osrs:
   id: 5736
   name: Black spear(p++)
@@ -12,9 +12,80 @@ osrs:
   lowalch: 300
   highalch: 450
   limit: 8
-  about: "Black spear(p++) is a members-only item in Old School RuneScape. High alchemy value: 450 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: black
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 15
+      slash: 15
+      crush: 15
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 16
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 1247
+      item_name: Black spear
+      slug: black-spear
+      relationship: variant
+      description: Unpoisoned base variant of the black spear.
+    - item_id: 5734
+      item_name: Black spear(p)
+      slug: black-spear-p
+      relationship: variant
+      description: Weakly poisoned black spear.
+    - item_id: 5735
+      item_name: Black spear(p+)
+      slug: black-spear-p-5735
+      relationship: variant
+      description: Moderately poisoned black spear.
+  about: "Black spear(p++) is the strongest-poisoned variant of the two-handed black spear, sourced from Shades of Mort'ton chests and vampyre conversion."
+  market_strategy:
+    title: Investment Notes
+    notes:
+      - Supply tied to Shades of Mort'ton chest drops and Juvinate conversions.
+      - Members-only with a tight buy limit of 8 keeps prices volatile.
+      - Strongest poison tier commands a premium over plain and (p)/(p+).
+      - Niche demand from low-tier PvP and showcase loadouts.
+  history:
+    - date: "2005-05-17"
+      update: Shades of Mort'ton
+      description: Added to game alongside the Shades of Mort'ton minigame and vampyre conversion mechanic.
+  properties:
+    release_date: "2005-05-17"
+    update: Shades of Mort'ton
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-talisman.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: null
-  item:
-    type: material
-    tradeable: true
+  material:
+    type: talisman
+    tier: high
   related_items:
     - item_id: 5529
       item_name: Blood tiara
@@ -26,20 +26,31 @@ osrs:
       slug: blood-rune
       relationship: alternative
       description: Crafted product at Blood Altar
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Runecraft Talisman |
-    | Tradeable | Yes |
-    | Weight | 0.015 kg |
-    | Requirements | Sins of the Father |
-
-    Grants access to Blood Altar in Meiyerditch (77 Runecraft).
-
-    Can create blood tiara for headslot access.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Grants access to the Blood Altar in Meiyerditch and can be combined with a tiara to create a blood tiara for hands-free runecrafting access.
+  history:
+    - date: "2022-03-23"
+      description: Made available as a reward from the Guardians of the Rift minigame.
+    - date: "2004-03-29"
+      description: Permanently added at RS2 launch but remained unobtainable.
+    - date: "2003-12-01"
+      description: Added to RuneScape 2 Beta cache.
+  properties:
+    release_date: "2022-03-23"
+    update: Guardians of the Rift
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.015
+    options:
+      - Locate
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-firelighter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-firelighter.mdx
@@ -12,9 +12,36 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 250
-  about: "Blue firelighter is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
+  about: Blue firelighter is a Treasure Trails reward used on logs to make blue logs that burn with a coloured flame and is also consumed in bulk to recolour a Phoenix pet.
+  properties:
+    release_date: "2006-02-20"
+    update: Updates, updates and more updates...
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+  history:
+    - date: "2006-02-20"
+      description: Released as a Treasure Trail reward.
+    - date: "2020-01-29"
+      description: Grand Exchange buy limit increased from 150 to 250 to accommodate the Phoenix recolouring feature.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-partyhat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-partyhat.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 5
-  about: "Blue partyhat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.056
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  about: Blue partyhat is a discontinued cosmetic head slot item originally obtained from Christmas crackers during the 2001 holiday event and later re-released in the 2013 Rare Drops event.
+  properties:
+    release_date: "2001-12-24"
+    update: Christmas Event
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.056
+    options:
+      - Wear
+      - Drop
+    alchable: false
+  history:
+    - date: "2001-12-24"
+      description: Released as a holiday drop from Christmas crackers.
+    - date: "2013-07-04"
+      description: Re-released temporarily during the 2013 Rare Drops event.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-robe-bottoms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-robe-bottoms.mdx
@@ -14,6 +14,29 @@ osrs:
   limit: 150
   equipment:
     slot: legs
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Fine Fashions
+      location: Grand Tree, Tree Gnome Stronghold
+      price: 180
+      stock: 5
   related_items:
     - item_id: 640
       item_name: Blue robe top
@@ -25,12 +48,36 @@ osrs:
       slug: blue-hat
       relationship: set-piece
       description: Matching hat
-  about: |-
-    > _"A pair of blue robe bottoms."_
-
-    Blue robe bottoms are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Blue robe bottoms are a members gnome cosmetic leg covering sold by Rometti at Fine Fashions in the Grand Tree, offering minor crush and slash defence."
+  market_strategy:
+    notes:
+      - Low GE limit keeps prices fashionscape-driven
+      - Shop restock cap limits arbitrage
+      - Primarily cosmetic demand
+  history:
+    - date: "2014-12-10"
+      description: Renamed from 'Robe bottoms' to 'Blue robe bottoms' during The Trading Post update.
+    - date: "2002-12-12"
+      description: Released with the Agility skill launch.
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-of-cloth.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-of-cloth.mdx
@@ -20,13 +20,13 @@ osrs:
     source: Construction Supplies
     common_builds:
       - name: Curtains
-        quantity: 3
+        quantity: "3"
         xp: 225
       - name: Rug
-        quantity: 2
+        quantity: "2"
         xp: 180
       - name: Torn curtains
-        quantity: 3
+        quantity: "3"
         xp: 132
   shop_sources:
     - name: Sawmill operator

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bookcase-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bookcase-flatpack.mdx
@@ -18,10 +18,10 @@ osrs:
     materials:
       - item_id: 960
         item_name: Plank
-        quantity: 4
+        quantity: "4"
       - item_id: 1539
         item_name: Steel nails
-        quantity: 4
+        quantity: "4"
     hotspot: Bookcase space
     room: Parlour
     tools:

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-of-slaughter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-of-slaughter.mdx
@@ -24,9 +24,9 @@ osrs:
       magic: 49
     runes:
       - rune: Cosmic
-        quantity: 1
+        quantity: "1"
       - rune: Fire
-        quantity: 5
+        quantity: "5"
   special_effect:
     name: Slayer Extension
     description: 25% chance to not count kill toward task

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/brine-sabre.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/brine-sabre.mdx
@@ -14,7 +14,11 @@ osrs:
   limit: 8
   equipment:
     slot: weapon
+    weapon_type: slash_sword
     attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 40
     attack_bonus:
       stab: 7
       slash: 47
@@ -32,9 +36,6 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 40
-    weight: 1.814
   special_attack:
     name: Liquify
     energy: 75
@@ -60,48 +61,36 @@ osrs:
       slug: rune-scimitar
       relationship: alternative
       description: F2P slash weapon
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Slash | +47 |
-    | Stab | +7 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +46 |
-
-    Requirements: 40 Attack | Speed: 4 tick (2.4s)
-
-    > *"A salty sword."*
-
-    | Stat | Brine Sabre | Rune Scimitar |
-    |------|-------------|---------------|
-    | Slash | +47 | +45 |
-    | Strength | +46 | +44 |
-    | Price | ~390K | ~15K |
-
-    The brine sabre has +2 higher slash and strength than the rune scimitar, but costs ~25x more. The granite hammer (+56 crush, +49 str) has since surpassed it as best-in-slot for 40 Attack pures.
-
-    Liquify (75% energy):
-    - Doubles accuracy
-    - Boosts Attack, Strength, and Defence by 25% of damage dealt
-    - Only usable underwater — extremely niche
-
-    Rockslug finishing: Can finish off rockslugs without needing a bag of salt. Also works on rocklings automatically.
-
-    Lobstrosities: One of the few weapons that can kill lobstrosities (underwater creatures).
-
-    - Former best-in-slot for 40 Attack pures on members worlds
-    - Now surpassed by granite hammer for pure DPS
-    - Collector's item due to rare, remote source
-    - Niche underwater content
+  about: "Rare slash sword dropped by brine rats below Rellekka; once best-in-slot for 40 Attack pures, now surpassed by the granite hammer."
   market_strategy:
     notes:
       - Extremely low supply (brine rats are rarely killed)
       - Price driven by rarity, not combat utility
       - 40 Attack PvP bracket demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2016-07-28"
+      description: "Killing a rock slug while wielding a brine sabre will now automatically finish it off."
+    - date: "2007-04-10"
+      description: Added to the game as part of Olaf's Quest.
+  properties:
+    release_date: "2007-04-10"
+    update: Olaf's Quest
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-crossbow.mdx
@@ -29,9 +29,9 @@ osrs:
     level: 9
     materials:
       - item: Bronze crossbow (u)
-        quantity: 1
+        quantity: "1"
       - item: Crossbow string
-        quantity: 1
+        quantity: "1"
   obtaining:
     fletching: 9 Fletching with bronze crossbow (u) + crossbow string
     shop: Crossbow Shop, Keldagrim

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dagger-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dagger-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze dagger(p) | OSRS Price Data
-description: "Bronze dagger(p): This dagger is poisoned.. High alch: 6 GP, GE limit: 125."
+description: "Bronze dagger(p): a weakly poisoned bronze dagger usable from level 1 Attack. High alch: 6 GP, GE limit: 125."
 osrs:
   id: 1221
   name: Bronze dagger(p)
@@ -12,9 +12,87 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 125
-  about: "Bronze dagger(p) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 4
+      slash: 2
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      melee_strength: 3
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Poison a bronze dagger
+      skill: Herblore
+      level: 3
+      experience: 0
+      output: Bronze dagger(p)
+      materials:
+        - item_name: Bronze dagger
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      description: Apply weapon poison to a bronze dagger.
+  related_items:
+    - item_id: 1205
+      item_name: Bronze dagger
+      slug: bronze-dagger
+      relationship: variant
+      description: Unpoisoned bronze dagger.
+    - item_id: 1231
+      item_name: Iron dagger(p)
+      slug: iron-dagger-p
+      relationship: upgrade
+      description: Stronger iron-tier poisoned dagger.
+  about: "Bronze dagger(p) is the bottom-tier poisoned dagger, made by applying weapon poison to a bronze dagger and useful only for early Herblore training."
+  market_strategy:
+    title: Investment Notes
+    notes:
+      - Demand is near-zero outside of Herblore poison practice.
+      - Cheaper to alch components individually than buy whole.
+      - Buy limit of 125 per 4 hours is generous for an item with little speculation interest.
+      - Bronze poisoned variants serve as inexpensive cosmetic options.
+  history:
+    - date: "2002-04-11"
+      update: Members release
+      description: Added with the original poisoned weapon line on RuneScape's members launch.
+  properties:
+    release_date: "2002-04-11"
+    update: Members release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-helm-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-helm-g.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bucket helm (g) | OSRS Price Data
-description: "Bucket helm (g): A helm made from a golden bucket.. High alch: 8,400 GP, GE limit: 4."
+description: "Bucket helm (g): a cosmetic helm from master clue scrolls with no combat bonuses or requirements. High alch: 8,400 GP, GE limit: 4."
 osrs:
   id: 20059
   name: Bucket helm (g)
@@ -12,9 +12,69 @@ osrs:
   lowalch: 5600
   highalch: 8400
   limit: 4
-  about: "Bucket helm (g) is a members-only item in Old School RuneScape. High alchemy value: 8,400 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.5
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_id: 19994
+      item_name: Bucket helm
+      slug: bucket-helm
+      relationship: variant
+      description: Standard bucket helm variant from master clues.
+  about: "The bucket helm (g) is a purely cosmetic master clue head slot reward with all-zero bonuses, prized for its golden-bucket meme aesthetic."
+  market_strategy:
+    title: Investment Notes
+    notes:
+      - Master clue exclusivity keeps supply very low.
+      - Strong demand from collection log completionists and meme outfits.
+      - Tight buy limit of 4 per 4 hours amplifies price swings.
+      - Can be stored in a mahogany costume room treasure chest.
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion
+      description: Added to game with the master clue scroll release.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cadantine-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cadantine-potion-unf.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cadantine potion (unf) | OSRS Price Data
-description: "Cadantine potion (unf) is a 4-dose members potion. High alch: 39 GP, GE limit: 10,000."
+description: "Cadantine potion (unf) is a members unfinished potion. High alch: 39 GP, GE limit: 10,000."
 osrs:
   id: 107
   name: Cadantine potion (unf)
@@ -12,13 +12,14 @@ osrs:
   lowalch: 26
   highalch: 39
   limit: 10000
+  material:
+    type: potion
+    tier: high
   potion:
     type: unfinished
     tier: high
-  herblore:
-    level: 66
-    xp: 0
-    method: Add cadantine to vial of water
+    effects:
+      - description: Used as a base for the Super defence potion when combined with white berries.
   recipes:
     - skill: herblore
       level: 66
@@ -30,8 +31,24 @@ osrs:
         - item_name: Cadantine
           item_id: 265
           quantity: 1
+      tools: []
       product: Cadantine potion (unf)
       product_id: 107
+      product_quantity: 1
+      members_only: true
+    - skill: herblore
+      level: 66
+      xp: 150
+      materials:
+        - item_name: Cadantine potion (unf)
+          item_id: 107
+          quantity: 1
+        - item_name: White berries
+          item_id: 239
+          quantity: 1
+      tools: []
+      product: Super defence(3)
+      product_id: 163
       product_quantity: 1
       members_only: true
   related_items:
@@ -39,7 +56,7 @@ osrs:
       item_name: Cadantine
       slug: cadantine
       relationship: component
-      description: Herb ingredient
+      description: Clean herb ingredient
     - item_id: 227
       item_name: Vial of water
       slug: vial-of-water
@@ -50,24 +67,31 @@ osrs:
       slug: white-berries
       relationship: component
       description: Secondary for super defence
-    - item_id: 2442
-      item_name: Super defence(4)
-      slug: super-defence-4
+    - item_id: 163
+      item_name: Super defence(3)
+      slug: super-defence-3
       relationship: product
-      description: Final product
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Unfinished Potion |
-    | Tradeable | Yes |
-    | Weight | 0.056 kg |
-    | Requirements | 66 Herblore |
-
-    Add secondary ingredient to create:
-    - Super defence (+ white berries)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Final product after adding white berries
+  about: "Cadantine potion (unf) is a members herblore intermediate made by adding clean cadantine to a vial of water at level 66 Herblore. Combine with white berries to brew a Super defence(3) for 150 Herblore XP."
+  history:
+    - date: "2002-02-27"
+      description: Released with the herblore system.
+    - date: "2014-01-01"
+      description: Renamed from "Unfinished potion" to "Cadantine potion (unf)".
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options: [Empty, Drop]
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/candle.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/candle.mdx
@@ -12,13 +12,52 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 40
-  related_items: []
-  about: |-
-    > _"A candle."_
-
-    A candle is a members-only light source. Can be lit with a tinderbox (1 Firemaking). Used in quests including Enlightened Journey and Enakhra's Lament. Can be placed in a candle lantern for a safer light source, as an open candle can ignite swamp gas in certain caves.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  shops:
+    - shop_name: Candle Shop
+      location: Catherby
+      price: 3
+    - shop_name: Candle seller's stall
+      location: Lumbridge Swamp
+      price: 1000
+  related_items:
+    - item_id: 33
+      item_name: Candle lantern
+      slug: candle-lantern
+      relationship: upgrade
+      description: Safer lit light source
+    - item_id: 590
+      item_name: Tinderbox
+      slug: tinderbox
+      relationship: component
+      description: Used to light the candle
+  about: "Candle is the lowest-tier Firemaking light source, lit with a tinderbox and used in Enlightened Journey and Enakhra's Lament, though it can ignite swamp gas if carried lit."
+  market_strategy:
+    notes:
+      - Tradeable on the Grand Exchange with a 40 buy limit
+      - Cheapest source is Candle Shop in Catherby at 3 coins
+      - Quest demand keeps a steady low-volume market
+  history:
+    - date: "2002-02-27"
+      description: Released as a basic Firemaking light source.
+    - date: "2005-03-14"
+      description: Extinguish option added and bank note conversion removed.
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    worn_options:
+      - Extinguish
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-delight-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-delight-m4.mdx
@@ -1,20 +1,95 @@
 ---
-title: Chef's delight(m4) | OSRS Price Data
-description: "Chef's delight(m4): This keg contains 4 pints of mature Chef's Delight.. High alch: 1 GP, GE limit: 2,000."
+title: "Chef's delight(m4) | OSRS Price Data"
+description: "Chef's delight(m4): This keg contains 4 pints of mature Chef's Delight. Boosts Cooking by 5+. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5913
-  name: Chef's delight(m4)
+  name: "Chef's delight(m4)"
   slug: chef-s-delight-m4
-  examine: This keg contains 4 pints of mature Chef's Delight.
+  examine: "This keg contains 4 pints of mature Chef's Delight."
   members: true
-  icon: Chef's delight(m4).png
+  icon: "Chef's delight(m4).png"
   value: 1
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Chef's delight(m4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - skill: Cooking
+        amount: 5
+        description: Boosts Cooking level by 5 + 11% of current level.
+      - skill: Attack
+        amount: -1
+        description: Drains Attack and Strength by 1 + 6% of current level (mature).
+      - skill: Hitpoints
+        amount: 1
+        description: Restores 1 hitpoint per dose.
+  recipes:
+    - skill: Cooking
+      level: 54
+      xp: 446
+      tools:
+        - Vat
+        - Fermenting vat
+      materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Chocolate dust
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: The stuff
+          quantity: 1
+  related_items:
+    - item_id: 5911
+      item_name: "Chef's delight(m)"
+      slug: chefs-delight-m
+      relationship: variant
+      description: Single glass mature variant
+    - item_id: 5907
+      item_name: "Chef's delight"
+      slug: chefs-delight
+      relationship: downgrade
+      description: Non-mature version
+    - item_id: 5915
+      item_name: "Chef's delight(m3)"
+      slug: chefs-delight-m3
+      relationship: variant
+      description: 3-dose keg
+  about: "Chef's delight(m4) is a 4-pint keg of mature Chef's Delight ale that boosts Cooking by 5 plus 11% of the player's current level."
+  market_strategy:
+    notes:
+      - Highly profitable Keldagrim brewery output
+      - 4-dose keg most efficient for skill boost stacking
+      - GE supply driven by brewery botters and skill brewers
+      - Used by Cooking pet hunters and Cooking diary tasks
+  trading_tips:
+    - Brew at Keldagrim or Port Phasmatys for max profit
+    - Buy ingredients in bulk during off-peak hours
+  history:
+    - date: "2005-07-11"
+      description: Chef's delight (mature) keg released with the Forgettable Tale of a Drunken Dwarf and the Keldagrim brewery.
+    - date: "2015-09-10"
+      description: Partially consumed kegs became untradeable.
+  properties:
+    release_date: "2005-07-11"
+    update: Forgettable Tale of a Drunken Dwarf
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/clockwork.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/clockwork.mdx
@@ -23,7 +23,7 @@ osrs:
     materials:
       - item: Steel bar
         item_id: 2353
-        quantity: 1
+        quantity: "1"
     facility: Crafting table 2+ in POH workshop
     ticks: 3
   uses:

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-catalyst-acquisition.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-catalyst-acquisition.mdx
@@ -5,16 +5,50 @@ osrs:
   id: 30831
   name: Contract of catalyst acquisition
   slug: contract-of-catalyst-acquisition
-  examine: A contract issued by Yama. Present it to him to discuss some new terms.
+  examine: "A contract issued by Yama. Present it to him to discuss some new terms."
   members: true
   icon: Contract of catalyst acquisition.png
   value: 75000
   lowalch: null
   highalch: null
   limit: 50
-  about: "Contract of catalyst acquisition is a members-only item in Old School RuneScape. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_name: Aether catalyst
+      slug: aether-catalyst
+      relationship: product
+      description: Reward of 2,000 catalysts granted upon defeating contracted Yama
+  about: "Contract of catalyst acquisition is a consumable contract item released on 14 May 2025 with the Yama, Master of Pacts update. Players present the contract to Yama to initiate a harder fight variant; the contract is consumed on use and guarantees 2,000 aether catalysts upon victory."
+  market_strategy:
+    notes:
+      - Demand tracks Yama PvM activity and aether catalyst price
+      - Not alchable so true floor is set by catalyst margins
+      - Buy limit raised to 50 lets flippers scale up
+  history:
+    - date: "2025-05-14"
+      description: Released with the Yama, Master of Pacts update
+    - date: "2025-05-22"
+      description: Proper contract terms text added to interface
+    - date: "2025-05-23"
+      description: Contract terms updated regarding demonbane weapon vulnerability
+    - date: "2025-05-29"
+      description: Buy limit increased from 5 to 50; phase thresholds adjusted and shadow pools removed
+  properties:
+    release_date: "2025-05-14"
+    update: "Yama, the Master of Pacts: Out Today"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Read
+      - Drop
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-glyphic-attenuation.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-glyphic-attenuation.mdx
@@ -12,9 +12,30 @@ osrs:
   lowalch: null
   highalch: null
   limit: 50
-  about: "Contract of glyphic attenuation is a members-only item in Old School RuneScape. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Contract of glyphic attenuation is presented to Yama to enforce melee-only combat for a harder, more lucrative fight against the Master of Pacts."
+  history:
+    - date: "2025-06-11"
+      description: Ruby and diamond bolt effects no longer trigger during this contract to preserve melee-only strategy.
+    - date: "2025-05-29"
+      description: "Grand Exchange limit increased from 5 to 50; Yama health reduced to 2,875; phase thresholds adjusted to 75% and 50%."
+    - date: "2025-05-22"
+      description: Contract terms properly added after launch placeholder text.
+  properties:
+    release_date: "2025-05-14"
+    update: "Yama, the Master of Pacts: Out Today"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Read
+      - Drop
+    alchable: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-harmony-acquisition.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-harmony-acquisition.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: null
   highalch: null
   limit: 50
-  about: "Contract of harmony acquisition is a members-only item in Old School RuneScape. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: boss-key
+    tier: high
+  drop_table:
+    - source: Yama
+      rarity: "13/1740"
+      quantity: "1"
+      notes: "Dropped from dossiers opened after Yama kills."
+  related_items:
+    - item_name: Soulflame horn
+      slug: soulflame-horn
+      relationship: product
+      description: Guaranteed reward from completing Yama with the contract active.
+    - item_name: Dossier
+      slug: dossier
+      relationship: component
+      description: Drop container from Yama that can yield the contract.
+  about: "Contract of harmony acquisition is a Yama-issued challenge contract consumed at the start of a solo encounter to guarantee a soulflame horn drop, dropped from opening Yama dossiers."
+  market_strategy:
+    notes:
+      - "Price tracks soulflame horn demand and Yama clear rates; supply rises as more players push the boss."
+  trading_tips:
+    - "Buy contracts during PvM lulls; sell into spikes when soulflame horn meta strengthens."
+  history:
+    - date: "2025-05-14"
+      description: Released with the Yama, the Master of Pacts update.
+    - date: "2025-05-23"
+      description: Demonbane weapon weakness was temporarily removed from contract fights.
+    - date: "2025-05-29"
+      description: Buy limit increased from 5 to 50, phase thresholds shifted to 75% and 50% HP, and demonbane vulnerability was restored.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-05-14"
+    update: "Yama, the Master of Pacts"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options: [Read, Drop]
+    alchable: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-dark-bow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-dark-bow.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: null
-  about: "Corrupted dark bow is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: bow
+    attack_speed: 6
+    weight: 1.814
+    requirements:
+      ranged: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 95
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Descent of Darkness
+    energy: 55
+    description: Fires two arrows simultaneously with increased accuracy and damage.
+  about: "Corrupted dark bow is a Deadman-event-only variant of the dark bow that trades attack range for faster fire rate, currently unobtainable in the live game."
+  history:
+    - date: "2024-07-17"
+      description: Released alongside Deadman Armageddon and the While Guthix Sleeps updates.
+  properties:
+    release_date: "2024-07-17"
+    update: "Deadman: Armageddon & While Guthix Sleeps Updates"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-volatile-nightmare-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-volatile-nightmare-staff.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: null
-  about: "Corrupted volatile nightmare staff is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: nightmare
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 1.6
+    requirements:
+      magic: 50
+      hitpoints: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 16
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 14
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 15
+      prayer: 0
+  special_attack:
+    name: Volatile Discharge
+    energy: 55
+    description: Fires a volatile blast at the target with a 6-tile range, hitting up to 50% higher than the player's max hit based on Magic level.
+  related_items:
+    - item_id: 24424
+      item_name: Volatile nightmare staff
+      slug: volatile-nightmare-staff
+      relationship: alternative
+      description: Non-corrupted variant with 10-tile special attack range
+  about: "Corrupted volatile nightmare staff is a Deadman Mode variant of the volatile nightmare staff with lowered requirements but a shorter 6-tile special attack range."
+  history:
+    - date: "2024-07-17"
+      description: Released with the Deadman Armageddon and While Guthix Sleeps Updates.
+  properties:
+    release_date: "2024-07-17"
+    update: Deadman Armageddon & While Guthix Sleeps Updates
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.6
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-armour-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-armour-seed.mdx
@@ -12,14 +12,11 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 100
-  item:
-    type: crafting material
-    tradeable: true
-  obtaining:
+  drop_table:
     - source: The Gauntlet
-      drop_rate: 1/120
+      rate: "1/120"
     - source: Corrupted Gauntlet
-      drop_rate: 1/50
+      rate: "1/50"
   recipes:
     - skill: smithing
       level: 70
@@ -30,9 +27,12 @@ osrs:
         - item_id: 23962
           item_name: Crystal shard
           quantity: 50
+      tools:
+        - Singing bowl
       facility: Singing bowl
       product: Crystal helm
       product_id: 23971
+      product_quantity: 1
     - skill: smithing
       level: 72
       materials:
@@ -42,9 +42,12 @@ osrs:
         - item_id: 23962
           item_name: Crystal shard
           quantity: 100
+      tools:
+        - Singing bowl
       facility: Singing bowl
       product: Crystal legs
       product_id: 23979
+      product_quantity: 1
     - skill: smithing
       level: 74
       materials:
@@ -54,9 +57,12 @@ osrs:
         - item_id: 23962
           item_name: Crystal shard
           quantity: 150
+      tools:
+        - Singing bowl
       facility: Singing bowl
       product: Crystal body
       product_id: 23975
+      product_quantity: 1
   related_items:
     - item_id: 23975
       item_name: Crystal body
@@ -73,27 +79,27 @@ osrs:
       slug: crystal-helm
       relationship: product
       description: Created armour piece
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Stackable | No |
-
-    | Item | Seeds | Shards | Smithing/Crafting |
-    |------|-------|--------|-------------------|
-    | Crystal helm | 1 | 50 | 70 |
-    | Crystal legs | 2 | 100 | 72 |
-    | Crystal body | 3 | 150 | 74 |
-
-    Alternative: Exchange for 250 crystal shards.
+  about: "Crystal armour seed is sung at the Singing bowl with crystal shards into Crystal helm, legs, or body; primary source is the Gauntlet and Corrupted Gauntlet."
   market_strategy:
     notes:
       - Farm Corrupted Gauntlet for best rates
       - Use for crystal armour or trade for shards
       - Needed for full crystal set
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  properties:
+    release_date: "2019-07-25"
+    update: "Song of the Elves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cursed-amulet-of-magic.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cursed-amulet-of-magic.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cursed amulet of magic | OSRS Price Data
-description: "Cursed amulet of magic: An cursed amulet of magic.. High alch: 540 GP, GE limit: 125."
+description: "Cursed amulet of magic: An cursed amulet of magic. High alch: 540 GP, GE limit: 125."
 osrs:
   id: 29486
   name: Cursed amulet of magic
@@ -12,9 +12,52 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 125
-  about: "Cursed amulet of magic is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: neck
+    weight: 0.01
+    other_bonus:
+      magic_damage: -80
+  drop_table:
+    sources:
+      - source: Necromancer
+        combat_level: 68
+        quantity: "1"
+        rarity: "1/5"
+        members_only: false
+        notes: "Great Kourend"
+  related_items:
+    - item_id: 1727
+      item_name: Amulet of magic
+      slug: amulet-of-magic
+      relationship: alternative
+      description: Standard amulet of magic
+  about: "Cursed amulet of magic is a neck slot item with an extreme -80% magic damage penalty, used by restricted accounts to apply venom or earn kill credit without dealing meaningful damage."
+  market_strategy:
+    notes:
+      - Dropped 1/5 by Necromancers in Great Kourend
+      - Niche use for venom-only kill credit setups
+      - Free-to-play tradeable
+  history:
+    - date: "2024-05-29"
+      description: "Item released with the Project Rebalance: Combat Changes update."
+  properties:
+    release_date: "2024-05-29"
+    update: "Project Rebalance: Combat Changes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dark-crab.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dark-crab.mdx
@@ -17,20 +17,6 @@ osrs:
     cooking_level: 90
     cooking_xp: 215
     burn_level: 99
-  cooking:
-    level: 90
-    xp: 215
-    stop_burn_level: 99
-    stop_burn_level_gauntlets: 90
-    raw_item_id: 11934
-    raw_item_name: Raw dark crab
-    ticks: 4
-  fishing:
-    level: 85
-    xp: 130
-    method: Lobster pot
-    location: Wilderness Resource Area
-    bait: Dark fishing bait
   recipes:
     - skill: cooking
       level: 90
@@ -39,6 +25,8 @@ osrs:
         - item_name: Raw dark crab
           item_id: 11934
           quantity: 1
+      tools:
+        - Fire or range
       facility: Fire or range
       ticks: 4
       members_only: true
@@ -63,27 +51,39 @@ osrs:
       slug: dark-fishing-bait
       relationship: component
       description: Required bait for fishing
-  about: |-
-    Heals 22 HP - tied for second highest instant heal.
-
-    | Food | Heal | Notes |
-    |------|------|-------|
-    | Dark crab | 22 | Wilderness only fishing |
-    | Manta ray | 22 | No overheal |
-    | Anglerfish | 22 | Has overheal |
+  about: "Dark crab heals 22 HP, tied for second-highest single-consumption instant heal, caught in the Wilderness Resource Area at 85 Fishing and cooked at 90 Cooking."
   market_strategy:
     notes:
-      - Buy Raw dark crab → Cook → Sell
+      - Buy Raw dark crab, cook, sell
       - 90 Cooking required (high barrier)
       - Caught in Wilderness only
       - PKer risk while fishing
       - Premium price for safe cooked version
-      - Elite Wilderness Diary required for best rates
+      - Elite Wilderness Diary boosts catch rate
       - Alternative to manta rays
-      - Wilderness fishing = risky supply
+      - Wilderness fishing means risky supply
       - Price volatile with PvP activity
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2015-03-19"
+      description: Corrected animation when cooking on fire.
+    - date: "2015-03-05"
+      description: Increased catch rate bonus for players with the Elite Wilderness Diary completed.
+  properties:
+    release_date: "2014-03-13"
+    update: "Rejuvenating the Wilderness: More risk, more reward"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Eat
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dark-trousers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dark-trousers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dark trousers | OSRS Price Data
-description: "Dark trousers: Dark tuxedo trousers with white stockings.. High alch: 3,600 GP, GE limit: 4."
+description: "Dark trousers: Dark tuxedo trousers with white stockings. High alch: 3,600 GP, GE limit: 4."
 osrs:
   id: 19964
   name: Dark trousers
@@ -12,9 +12,65 @@ osrs:
   lowalch: 2400
   highalch: 3600
   limit: 4
-  about: "Dark trousers is a members-only item in Old School RuneScape. High alchemy value: 3,600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: mid
+  equipment:
+    slot: legs
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers: [elite]
+  related_items:
+    - item_id: 19961
+      item_name: Dark tuxedo jacket
+      slug: dark-tuxedo-jacket
+      relationship: set-piece
+      description: Matching tuxedo jacket
+    - item_id: 19967
+      item_name: Dark tuxedo shoes
+      slug: dark-tuxedo-shoes
+      relationship: set-piece
+      description: Matching tuxedo shoes
+  about: "Dark trousers are a purely cosmetic legs slot item from the dark tuxedo outfit, dropped at a 1/12,750 rate from elite Treasure Trail reward caskets and storable in the costume room."
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trail Expansion
+      description: Released as part of the Treasure Trail Expansion update.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options: [Drop]
+    worn_options: [Wear]
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/death-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/death-talisman.mdx
@@ -12,34 +12,41 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  item:
-    type: material
-    tradeable: true
+  material:
+    type: runecraft
+    tier: mid
   related_items:
     - item_id: 5541
       item_name: Death tiara
       slug: death-tiara
       relationship: product
-      description: Combined with tiara
+      description: Combined with tiara at Death Altar
     - item_id: 560
       item_name: Death rune
       slug: death-rune
       relationship: alternative
       description: Crafted product at Death Altar
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Runecraft Talisman |
-    | Tradeable | Yes |
-    | Weight | 0.015 kg |
-    | Requirements | Mourning's End Part II |
-
-    Grants access to Death Altar for runecrafting (65 RC).
-
-    Can create death tiara for headslot access.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Death talisman grants entry to the Death Altar for crafting death runes at 65 Runecraft. Obtained after completing Mourning's End Part II or as a drop from dark beasts.
+  history:
+    - date: "2005-10-17"
+      description: Released alongside the Mourning's End Part II update.
+  properties:
+    release_date: "2005-10-17"
+    update: Mourning's End Part II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    quest: "Mourning's End Part II"
+    weight: 0.015
+    options:
+      - Locate
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-bolts-e.mdx
@@ -27,11 +27,11 @@ osrs:
     magic_level: 57
     runes:
       - item_name: Earth rune
-        quantity: 10
+        quantity: "10"
       - item_name: Law rune
-        quantity: 2
+        quantity: "2"
       - item_name: Cosmic rune
-        quantity: 1
+        quantity: "1"
     bolts_per_cast: 10
   related_items:
     - item_id: 9340

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dinh-s-bulwark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dinh-s-bulwark.mdx
@@ -14,33 +14,38 @@ osrs:
   limit: 8
   equipment:
     slot: 2h
-    type: shield
-    tradeable: true
-    weight: 8
+    weapon_type: bulwark
+    attack_speed: 5
+    weight: 30
     requirements:
+      attack: 75
       defence: 75
-    stats:
-      attack_crush: 124
-      stab_def: 106
-      slash_def: 109
-      crush_def: 109
-      ranged_def: 148
-      strength: 38
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 124
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 106
+      slash: 109
+      crush: 109
+      magic: -10
+      ranged: 148
+    other_bonus:
+      melee_strength: 38
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   special_attack:
     name: Shield Bash
     energy: 50
-    effect: Hits up to 10 enemies in 11x11 area, reduces offensive stats by 5%
-    notes:
-      - Primary target receives 2 hits
-      - Other targets receive 1 hit
+    description: "Hits up to 10 enemies in an 11x11 area with 20% increased accuracy and reduces highest offensive stats by 5%."
   drop_table:
     sources:
       - source: Chambers of Xeric
         rate: 3/69
         notes: Ancient chest
-  truemarket:
-    buy_limit: 8
-    price_estimate: 3000000
   related_items:
     - item_id: 12931
       item_name: Serpentine helm
@@ -52,37 +57,38 @@ osrs:
       slug: dragonfire-shield
       relationship: alternative
       description: Alternative shield
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Crush attack | +124 |
-    | Stab defence | +106 |
-    | Slash defence | +109 |
-    | Crush defence | +109 |
-    | Ranged defence | +148 |
-    | Strength | +38 |
-
-    Strongest shield in-game.
-
-    Shield Bash (50% energy):
-    - Hits up to 10 enemies in 11x11 area
-    - Primary target: 2 hits
-    - Other targets: 1 hit
-    - Reduces enemy offensive stats by 5%
-
-    Best For:
-    - Wilderness tank gear (anti-PK)
-    - Multicombat Slayer (dust devils, nechryaels)
-    - Tanking in dangerous situations
-
-    Strategy: Pair with defensive armor for maximum survivability.
+  about: "Dinh's bulwark is the strongest defensive shield in the game, occupying the two-handed slot and offering a Shield Bash multi-target special attack popular for wilderness tank gear and Chambers of Xeric."
   market_strategy:
     notes:
       - Niche but powerful defensive item
       - Popular for wilderness activities
       - Two-handed (no weapon)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2021-12-01"
+      description: Fixed a bug where the special attack's stat drain was not applying correctly.
+    - date: "2021-09-22"
+      description: Attack speed improved, Crush bonus raised to +124 and defensive bonuses adjusted.
+  properties:
+    release_date: "2017-01-05"
+    update: Chambers of Xeric
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 30
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+      - Pummel
+      - Block
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-magic-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-magic-potion-4.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 2000
-  about: "Divine magic potion(4) is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    duration_minutes: 5
+    effects:
+      - description: Boosts Magic level by 4 for 5 minutes.
+      - description: Magic level does not drain below the boosted maximum during the effect.
+      - description: Costs 10 Hitpoints to drink; player must have more than 10 HP.
+  recipes:
+    - skill: herblore
+      level: 78
+      xp: 2
+      materials:
+        - item_name: Magic potion(4)
+          item_id: 3046
+          quantity: 1
+        - item_name: Crystal dust
+          item_id: 23964
+          quantity: 1
+      tools: []
+      ticks: 2
+      members_only: true
+  related_items:
+    - item_id: 23743
+      item_name: Divine magic potion(3)
+      slug: divine-magic-potion-3
+      relationship: downgrade
+      description: 3 dose version
+    - item_id: 23741
+      item_name: Divine magic potion(2)
+      slug: divine-magic-potion-2
+      relationship: downgrade
+      description: 2 dose version
+    - item_id: 23739
+      item_name: Divine magic potion(1)
+      slug: divine-magic-potion-1
+      relationship: downgrade
+      description: 1 dose version
+    - item_id: 3040
+      item_name: Magic potion(4)
+      slug: magic-potion-4
+      relationship: component
+      description: Base potion infused with crystal dust
+  about: "Divine magic potion (4) holds the +4 Magic boost for 5 minutes at the cost of 10 HP per dose, made at 78 Herblore from a magic potion and crystal dust."
+  history:
+    - date: "2020-07-02"
+      description: Inventory icon updated to match standard potion aesthetics.
+    - date: "2019-07-25"
+      description: Released with the Song of the Elves update.
+  properties:
+    release_date: "2019-07-25"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-combat-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-combat-potion-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Divine super combat potion(2) | OSRS Price Data
-description: "Divine super combat potion(2): 2 doses of divine super combat potion.. High alch: 54 GP, GE limit: 2,000."
+description: "Divine super combat potion(2): 2 doses of divine super combat potion. High alch: 54 GP, GE limit: 2,000."
 osrs:
   id: 23691
   name: Divine super combat potion(2)
@@ -12,9 +12,98 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
-  about: "Divine super combat potion(2) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - skill: attack
+        boost: 5
+        percent_boost: 15
+        duration_seconds: 300
+        description: "Boosts Attack by 5 + 15% of level for 5 minutes; level does not drain during effect."
+      - skill: strength
+        boost: 5
+        percent_boost: 15
+        duration_seconds: 300
+        description: "Boosts Strength by 5 + 15% of level for 5 minutes; level does not drain during effect."
+      - skill: defence
+        boost: 5
+        percent_boost: 15
+        duration_seconds: 300
+        description: "Boosts Defence by 5 + 15% of level for 5 minutes; level does not drain during effect."
+      - skill: hitpoints
+        boost: -10
+        duration_seconds: 0
+        description: "Drinking causes 10 Hitpoints damage; cannot drink at 10 HP or lower."
+  recipes:
+    - skill: herblore
+      level: 97
+      xp: 2
+      materials:
+        - item_name: Super combat potion(2)
+          item_id: 12697
+          quantity: 1
+        - item_name: Crystal dust
+          item_id: 23685
+          quantity: 2
+      product: Divine super combat potion(2)
+      product_id: 23691
+      product_quantity: 1
+      facility: None
+      tools:
+        - Pestle and mortar
+      members_only: true
+  related_items:
+    - item_id: 23685
+      item_name: Crystal dust
+      slug: crystal-dust
+      relationship: component
+      description: Made from crushed crystal shards
+    - item_id: 12697
+      item_name: Super combat potion(2)
+      slug: super-combat-potion-2
+      relationship: component
+      description: Base potion
+    - item_id: 23689
+      item_name: Divine super combat potion(4)
+      slug: divine-super-combat-potion-4
+      relationship: variant
+      description: 4-dose variant
+    - item_id: 23693
+      item_name: Divine super combat potion(3)
+      slug: divine-super-combat-potion-3
+      relationship: variant
+      description: 3-dose variant
+    - item_id: 23695
+      item_name: Divine super combat potion(1)
+      slug: divine-super-combat-potion-1
+      relationship: variant
+      description: 1-dose variant
+  about: "Divine super combat potion(2) provides a fixed boost to Attack, Strength, and Defence that does not drain for 5 minutes, at the cost of 10 Hitpoints on drink."
+  market_strategy:
+    notes:
+      - Decanted from higher-dose divine variants
+      - Used in melee combat scenarios where stat-drain prevention matters
+      - Cannot be shared via Boost Potion Share spell
+  history:
+    - date: "2019-07-25"
+      description: "Item released with the Song of the Elves update."
+  properties:
+    release_date: "2019-07-25"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-defence-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-defence-potion-1.mdx
@@ -12,9 +12,38 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 2000
-  about: "Divine super defence potion(1) is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - skill: defence
+        boost: "+5 +15% of Defence level"
+        duration: 300
+        description: Increases Defence level by 5 plus 15% of the player's Defence level for 5 minutes; Defence will not drop below the boosted maximum during this period.
+      - skill: hitpoints
+        boost: "-10"
+        duration: 0
+        description: Drinking deals 10 Hitpoint damage; player must have more than 10 HP to consume.
+  about: "Divine super defence potion(1) sustains a super defence boost for 5 minutes at the cost of 10 HP, popular for sustained tank training and bossing."
+  history:
+    - date: "2020-07-02"
+      description: Inventory icon graphically updated to match the standard potion appearance.
+  properties:
+    release_date: "2019-07-25"
+    update: "Song of the Elves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dodgy-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dodgy-necklace.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dodgy necklace | OSRS Price Data
-description: "Dodgy necklace is a members neck slot item. High alch: 630 GP, GE limit: 10,000."
+description: "Dodgy necklace: Lets you get away with it - sometimes. 25% chance to prevent stun while pickpocketing. High alch: 630 GP, GE limit: 10,000."
 osrs:
   id: 21143
   name: Dodgy necklace
@@ -14,79 +14,93 @@ osrs:
   limit: 10000
   equipment:
     slot: neck
-    type: thieving_necklace
-    tradeable: true
     weight: 0.01
-  creation:
-    method: Enchant Opal necklace with Lvl-1 Enchant
     requirements:
       magic: 7
-    runes:
-      - rune: Cosmic
-        quantity: 1
-      - rune: Water
-        quantity: 1
-  special_effect:
-    name: Stun Prevention
-    description: 25% chance to avoid stun and damage when pickpocketing
-    charges: 10
-    notes:
-      - Works on all pickpocketing
-      - Stacks with Shadow Veil (36.25% total)
-  market:
-    buy_limit: 10000
-    price_estimate: 1592
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    initial: 10
+    description: Each charge prevents stun and damage from a failed pickpocket. The necklace crumbles to dust at 0 charges.
+  recipes:
+    - skill: Magic
+      level: 7
+      xp: 17.5
+      tools: []
+      materials:
+        - item_name: Opal necklace
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Water rune
+          quantity: 1
   related_items:
-    - item_id: 21168
-      item_name: Rogue equipment
-      slug: rogue-equipment
-      relationship: alternative
-      description: Double loot
+    - item_id: 1603
+      item_name: Opal necklace
+      slug: opal-necklace
+      relationship: component
+      description: Unenchanted base
     - item_id: 23049
-      item_name: Shadow veil
+      item_name: Shadow Veil
       slug: shadow-veil
       relationship: alternative
-      description: Stacking protection
+      description: Stacking pickpocket protection (Magic spell)
     - item_id: 13121
-      item_name: Ardougne cloak
-      slug: ardougne-cloak
+      item_name: Ardougne cloak 4
+      slug: ardougne-cloak-4
       relationship: alternative
-      description: Thieving bonus
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Neck |
-    | Type | Thieving Necklace |
-    | Tradeable | Yes |
-    | Weight | 0.01 kg |
-
-    Enchant Opal necklace with Lvl-1 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 7 |
-    | Cosmic rune | 1 |
-    | Water rune | 1 |
-
-    Stun Prevention:
-    - 25% chance to avoid stun/damage
-    - Works on all pickpocketing
-    - 10 charges
-    - Stacks with Shadow Veil (36.25% total)
-
-    Essential for:
-    - All pickpocketing
-    - Ardy Knights
-    - Master Farmers
-
-    Must-have for thieving.
+      description: Pickpocket buff cape
+  about: "Dodgy necklace is an enchanted opal necklace with 10 charges that grants a 25% chance to prevent stun and damage when pickpocketing."
   market_strategy:
     notes:
-      - Very high volume item
-      - Essential for thieving
-      - Stacks with other bonuses
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Extremely high volume thieving consumable
+      - Essential for Ardougne Knight and Master Farmer thieving
+      - Stacks with Shadow Veil for 36.25% combined protection
+      - Profitable to craft via Lvl-1 Enchant
+  trading_tips:
+    - Buy opal necklaces in bulk and self-enchant for profit
+    - Sell in 1k stacks to maintain GE buy limit churn
+  history:
+    - date: "2017-02-02"
+      description: Dodgy necklace released as part of the Thieving update.
+    - date: "2018-04-05"
+      description: Examine text updated, apostrophe removed.
+  properties:
+    release_date: "2017-02-02"
+    update: Thieving Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Remove
+      - Check
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bolts.mdx
@@ -27,9 +27,9 @@ osrs:
       fletching: 84
     materials:
       - item_name: Dragon bolts (unfinished)
-        quantity: 10
+        quantity: "10"
       - item_name: Feathers
-        quantity: 10
+        quantity: "10"
     xp: 12
     notes: Per bolt
   variants:

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-boots.mdx
@@ -14,16 +14,26 @@ osrs:
   limit: 70
   equipment:
     slot: feet
-    type: melee_boots
+    weight: 1
     requirements:
       defence: 60
-    stats:
-      attack_magic: -3
-      attack_ranged: -1
-      strength: 4
-      defence_stab: 16
-      defence_slash: 17
-      defence_crush: 18
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: -1
+    defence_bonus:
+      stab: 16
+      slash: 17
+      crush: 18
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   drop_table:
     sources:
       - source: Spiritual mage
@@ -43,7 +53,7 @@ osrs:
       item_name: Primordial boots
       slug: primordial-boots
       relationship: upgrade
-      description: BiS melee boots (+1 str)
+      description: BiS melee boots (+1 strength)
     - item_id: 21733
       item_name: Guardian boots
       slug: guardian-boots
@@ -54,35 +64,29 @@ osrs:
       slug: bandos-boots
       relationship: alternative
       description: Prayer bonus option
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Magic | -3 |
-    | Ranged | -1 |
-    | Strength | +4 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +16 |
-    | Slash | +17 |
-    | Crush | +18 |
-
-    Requirements: 60 Defence
-
-    Popular melee boots for:
-    - Budget melee setups
-    - All melee combat
-    - Slayer
-    - Mid-game progression
-
-    Budget alternative to Primordial boots (+1 less strength).
+  about: Dragon boots are the third-highest strength melee boots, dropped by Spiritual mages in the God Wars Dungeon and prized as a budget alternative to Primordial boots.
   market_strategy:
     notes:
-      - Very affordable
-      - Spiritual mages are easy
-      - Popular at all levels
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cheap entry-level strength boot
+      - Steady supply from Spiritual mage drops
+      - High demand across mid-game melee setups
+      - Core component for Primordial boots upgrade path
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2013-10-17"
+    update: The God Wars Dungeon has been uncovered!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-crossbow.mdx
@@ -36,10 +36,10 @@ osrs:
     materials:
       - item_id: 21918
         item_name: Dragon limbs
-        quantity: 1
+        quantity: "1"
       - item_id: 21894
         item_name: Magic stock
-        quantity: 1
+        quantity: "1"
     xp: 135
   market:
     buy_limit: 70

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-impling-jar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-impling-jar.mdx
@@ -12,19 +12,6 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
-  item:
-    type: impling jar
-    tradeable: true
-    hunter_level: 83
-    barehand_level: 93
-  loot:
-    average_value: 118190
-    notable_drops:
-      - item_name: Clue scroll (elite)
-        rarity: 1/50
-      - item_name: Dragon dart
-        rarity: 1/19
-        quantity: 100-250
   related_items:
     - item_id: 11260
       item_name: Impling jar
@@ -41,34 +28,36 @@ osrs:
       slug: dragon-dart
       relationship: alternative
       description: Common valuable drop
-  about: |-
-    Notable Drops:
-
-    | Item | Rarity | Quantity |
-    |------|--------|----------|
-    | Elite clue scroll | 1/50 | 1 |
-    | Dragon dart | 1/19 | 100-250 |
-    | Dragon dart tip | 1/19 | 100-350 |
-    | Dragon arrowtips | 1/19 | 100-500 |
-    | Dragon javelin heads | 1/19 | 25-35 |
-    | Dragonstone | 1/19 | 3 |
-    | Dragon bones | 1/19 | 100-300 |
-
-    Average Loot Value: ~118,190 gp
-
-    Elite Clue Farming:
-    - Alternative to skilling for elite clues
-    - 1/50 drop rate per jar
-    - Dragon darts valuable for blowpipe
-
-    Note: Jar cost often exceeds loot value. Primarily used for elite clue farming.
+  about: "Dragon impling jar contains a caught dragon impling; opening yields elite clue scrolls (1/50), dragon darts, dragonstones, and dragon bones, averaging around 156,183 gp of loot per jar."
   market_strategy:
     notes:
       - High price due to Hunter requirement
       - Often not profitable to open without clue
       - Dragon darts bulk value significant
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2007-06-11"
+      description: Added to the game with Impetuous Impulses.
+    - date: "2015-02-27"
+      description: Made tradeable on the Grand Exchange.
+    - date: "2016-04-21"
+      description: Elite clue scrolls added to the drop table.
+  properties:
+    release_date: "2007-06-11"
+    update: Impetuous Impulses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Loot
+      - Destroy
+    alchable: true
+    destroy: "If you drop this it will disappear. Are you sure you want to do this?"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-med-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-med-helm.mdx
@@ -14,16 +14,19 @@ osrs:
   limit: 8
   equipment:
     slot: head
+    weight: 1.36
+    requirements:
+      defence: 60
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: -3
-      ranged: -1
+      ranged: 0
     defence_bonus:
       stab: 33
       slash: 35
-      crush: 36
+      crush: 32
       magic: -1
       ranged: 34
     other_bonus:
@@ -31,8 +34,6 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 60
   drop_table:
     primary_source: King Black Dragon
     best_drop_rate: 1/128
@@ -65,27 +66,34 @@ osrs:
       slug: rune-full-helm
       relationship: downgrade
       description: F2P alternative
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +33 |
-    | Slash | +35 |
-    | Crush | +36 |
-    | Ranged | +34 |
-
-    Requirements: 60 Defence
-
-    Mid-tier melee helm:
-    - Decent Defence stats
-    - No Strength or Prayer bonus
-    - Helm of neitiznot is generally preferred
+  about: "Dragon med helm is a mid-tier melee helm requiring 60 Defence; commonly dropped by the King Black Dragon and rarely outperformed by the Helm of Neitiznot for most slayer use."
   market_strategy:
     notes:
       - Common dragon drop
       - Low value due to better alternatives
       - Entry-level dragon gear
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2002-09-24"
+      description: Added to the game with Tutorial Island update.
+    - date: "2021-04-21"
+      description: Ranged attack bonus improved from -1 to 0.
+  properties:
+    release_date: "2002-09-24"
+    update: Tutorial Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-bolts-e.mdx
@@ -29,11 +29,11 @@ osrs:
     magic_level: 68
     runes:
       - item_name: Earth rune
-        quantity: 15
+        quantity: "15"
       - item_name: Soul rune
-        quantity: 1
+        quantity: "1"
       - item_name: Cosmic rune
-        quantity: 1
+        quantity: "1"
     bolts_per_cast: 10
   related_items:
     - item_id: 9341

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-stout-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-stout-m4.mdx
@@ -28,7 +28,7 @@ osrs:
       level: 19
       xp: 16
       product: Dwarven stout(m4)
-      quantity: 1
+      quantity: "1"
       requirements: Aged in calquat keg via the brewing process.
       materials:
         - item_name: Water

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elemental-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elemental-shield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Elemental shield | OSRS Price Data
-description: "Elemental shield: A magic shield.. High alch: 12 GP, GE limit: 70."
+description: "Elemental shield: A magic shield. High alch: 12 GP, GE limit: 70."
 osrs:
   id: 2890
   name: Elemental shield
@@ -12,9 +12,68 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 70
-  about: "Elemental shield is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    weight: 0.226
+    requirements:
+      defence: 20
+    defence_bonus:
+      magic: 6
+  recipes:
+    - skill: smithing
+      level: 20
+      xp: 20
+      materials:
+        - item_name: Elemental metal
+          item_id: 2892
+          quantity: 1
+      tools:
+        - Hammer
+        - Battered book
+      product: Elemental shield
+      product_id: 2890
+      product_quantity: 1
+      facility: Workbench in Elemental Workshop
+      members_only: true
+      notes: "Created at the workbench during/after Elemental Workshop I."
+  related_items:
+    - item_id: 2898
+      item_name: Mind shield
+      slug: mind-shield
+      relationship: upgrade
+      description: Made after Elemental Workshop II
+    - item_id: 2892
+      item_name: Elemental metal
+      slug: elemental-metal
+      relationship: component
+      description: Smithed material
+  about: "Elemental shield is the reward shield from Elemental Workshop I, providing a small magic defence bonus and capping wyvern icy breath damage at 10 when worn."
+  market_strategy:
+    notes:
+      - Required during Elemental Workshop I
+      - Useful against skeletal and standard wyverns
+      - Outclassed by mind shield once Elemental Workshop II is complete
+  history:
+    - date: "2004-06-02"
+      description: "Item released with the Elemental Workshop I quest."
+  properties:
+    release_date: "2004-06-02"
+    update: Elemental Workshop I
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: true
+    weight: 0.226
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-amulet-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-amulet-u.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 510
   highalch: 765
   limit: 10000
-  about: "Emerald amulet (u) is a free-to-play item in Old School RuneScape. High alchemy value: 765 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: jewellery
+    tier: low
+  related_items:
+    - item_id: 1696
+      item_name: Emerald amulet
+      slug: emerald-amulet
+      relationship: product
+      description: Strung version (with ball of wool)
+    - item_id: 1701
+      item_name: Amulet of defence
+      slug: amulet-of-defence
+      relationship: product
+      description: Enchanted via Lvl-2 Enchant
+    - item_id: 1759
+      item_name: Ball of wool
+      slug: ball-of-wool
+      relationship: component
+      description: Strings the unstrung amulet
+  about: Unstrung emerald amulet crafted from a gold bar and a cut emerald at 31 Crafting; string with a ball of wool to wear, or enchant to make an amulet of defence.
+  recipes:
+    - product_id: 1696
+      product_name: Emerald amulet
+      skill: Crafting
+      level: 1
+      experience: 4
+      tools:
+        - None
+      materials:
+        - item_id: 1677
+          item_name: Emerald amulet (u)
+          quantity: 1
+        - item_id: 1759
+          item_name: Ball of wool
+          quantity: 1
+  history:
+    - date: "2014-12-10"
+      description: Renamed from Emerald amulet to Emerald amulet (u) during The Trading Post update.
+    - date: "2001-05-08"
+      description: Added to the game.
+  properties:
+    release_date: "2001-05-08"
+    update: Runescape updated (8 May 2001)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.004
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-necklace.mdx
@@ -14,17 +14,52 @@ osrs:
   limit: 18000
   equipment:
     slot: neck
+    weight: 0.01
     requirements:
       crafting: 29
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 29
       xp: 60
-      inputs:
-        - item_name: Emerald
-          quantity: 1
+      materials:
         - item_name: Gold bar
           quantity: 1
+        - item_name: Emerald
+          quantity: 1
+        - item_name: Necklace mould
+          quantity: 1
+      tools:
+        - Necklace mould
+      facility: Furnace
+      output_quantity: 1
+    - skill: magic
+      level: 27
+      xp: 37
+      materials:
+        - item_name: Emerald necklace
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Air rune
+          quantity: 3
+      output_item: Binding necklace
       output_quantity: 1
   related_items:
     - item_id: 1656
@@ -37,28 +72,42 @@ osrs:
       slug: ruby-necklace
       relationship: upgrade
       description: Next tier necklace
-  about: |-
-    Crafting (Level 29): Emerald + Gold bar at a furnace with necklace mould (60 XP)
-
-    > *"An emerald necklace."*
-
-    Lvl-2 Enchant (27 Magic): 1 cosmic rune + 3 air runes (37 XP)
-
-    The Binding necklace guarantees 100% success when crafting combination runes (lava, mud, mist, smoke, steam, dust runes). Without it, combination runecrafting has only a ~50% success rate.
-
-    16 charges per necklace — each combination rune craft uses one charge.
-
-    Essential for:
-    - Lava rune crafting (fastest Runecrafting XP method)
-    - Any combination rune crafting
-    - Ironman rune production
+    - item_id: 5521
+      item_name: Binding necklace
+      slug: binding-necklace
+      relationship: product
+      description: Enchanted form used for combination runecrafting
+  about: An emerald necklace crafted from a gold bar and an emerald at level 29 Crafting that turns into a binding necklace when enchanted with Lvl-2 Enchant.
   market_strategy:
     notes:
-      - Extremely high demand — lava rune RC is the fastest XP method
-      - Consumed after 16 charges
+      - Extremely high demand — lava rune runecrafting is the fastest XP method
+      - Binding necklace consumed after 16 charges
       - Enchanting is consistently profitable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2001-05-08"
+      description: Released with early jewellery crafting.
+    - date: "2007-04-30"
+      description: Graphically updated in the 24 Carat Update.
+    - date: "2018-02-22"
+      description: Inventory sprite rotated to distinguish from enchanted jewellery.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-05-08"
+    update: RuneScape updated (8 May 2001)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/energy-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/energy-mix-2.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 28
   highalch: 43
   limit: 2000
-  about: "Energy mix(2) is a members-only item in Old School RuneScape. High alchemy value: 43 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: Restores 10% of run energy per dose
+      - description: Heals 3 Hitpoints per dose
+  recipes:
+    - skill: Herblore
+      level: 29
+      experience: 23
+      materials:
+        - item_name: Energy potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+  related_items:
+    - item_name: Energy mix(1)
+      slug: energy-mix-1
+      relationship: variant
+      description: Single-dose variant
+    - item_name: Energy potion(2)
+      slug: energy-potion-2
+      relationship: component
+      description: Base potion mixed with caviar to create the barbarian mix
+  about: "Energy mix(2) is the two-dose Barbarian Herblore variant of the energy potion, released on 3 July 2007 with the Barbarian Training update. Each dose restores 10% run energy and heals 3 Hitpoints, providing a small combat utility that base energy potions lack. It is made at level 29 Herblore by combining an Energy potion(2) with caviar for 23 experience."
+  market_strategy:
+    notes:
+      - Profit depends on caviar and energy potion(2) input prices
+      - Useful for cheap healing during low-level Barbarian Herblore training
+      - Volume is low; large flips can move the market noticeably
+  history:
+    - date: "2007-07-03"
+      description: Released with the Barbarian Training update
+    - date: "2016-04-01"
+      description: Half-full potions gained bank placeholder functionality
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.075
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-giant-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-giant-head.mdx
@@ -1,11 +1,11 @@
 ---
 title: Ensouled giant head | OSRS Price Data
-description: "Ensouled giant head: The creature's soul is still in here.. High alch: 191 GP, GE limit: 3,000."
+description: "Ensouled giant head: The creature's soul is still in here. High alch: 191 GP, GE limit: 3,000."
 osrs:
   id: 13475
   name: Ensouled giant head
   slug: ensouled-giant-head
-  examine: The creature's soul is still in here.
+  examine: "The creature's soul is still in here."
   members: true
   icon: Ensouled giant head.png
   value: 319
@@ -25,17 +25,34 @@ osrs:
         source_id: 2098
         combat_level: 28
         quantity: "1"
-        rarity: uncommon
+        rarity: "1/25"
         members_only: true
       - source: Moss giant
         source_id: 2090
         combat_level: 42
         quantity: "1"
-        rarity: uncommon
+        rarity: "1/24"
         members_only: true
       - source: Fire giant
         source_id: 2075
         combat_level: 86
+        quantity: "1"
+        rarity: "1/20"
+        members_only: true
+      - source: Ice giant
+        combat_level: 53
+        quantity: "1"
+        rarity: "1/21"
+        members_only: true
+      - source: Obor
+        quantity: "1"
+        rarity: common
+        members_only: false
+      - source: Bryophyta
+        quantity: "1"
+        rarity: common
+        members_only: true
+      - source: Black Knight Titan
         quantity: "1"
         rarity: uncommon
         members_only: true
@@ -55,20 +72,33 @@ osrs:
       slug: ensouled-demon-head
       relationship: upgrade
       description: Higher XP (1,170)
-  about: |-
-    1. Cast Adept Reanimation spell on the head
-    2. Kill the reanimated creature
-    3. Receive Prayer XP
+  about: "Ensouled giant head is reanimated with the Adept Reanimation spell from the Arceuus spellbook, granting 650 Prayer XP when the spawned giant is killed."
   market_strategy:
     notes:
       - Popular Prayer training option
       - Good XP for the price
       - High supply from giant farming
-      - Popular for efficient training
       - Check GP/XP vs bones
       - Hill giants common source
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2016-01-07"
+      description: "Item released with the Zeah update."
+  properties:
+    release_date: "2016-01-07"
+    update: Zeah
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Reanimate
+      - Drop
+    alchable: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-tzhaar-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-tzhaar-head.mdx
@@ -1,20 +1,66 @@
 ---
 title: Ensouled tzhaar head | OSRS Price Data
-description: "Ensouled tzhaar head: The creature's soul is still in here.. High alch: 304 GP, GE limit: 3,000."
+description: "Ensouled tzhaar head: The creature's soul is still in here. High alch: 304 GP."
 osrs:
   id: 13499
   name: Ensouled tzhaar head
   slug: ensouled-tzhaar-head
-  examine: The creature's soul is still in here.
+  examine: "The creature's soul is still in here. I could reanimate it with Expert Reanimation."
   members: true
   icon: Ensouled tzhaar head.png
   value: 507
   lowalch: 202
   highalch: 304
-  limit: 3000
-  about: "Ensouled tzhaar head is a members-only item in Old School RuneScape. High alchemy value: 304 coins. Grand Exchange buy limit: 3,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit: null
+  prayer:
+    reanimation_level: 72
+    reanimation_xp: 1104
+    spellbook: Arceuus
+  drop_table:
+    - source: TzHaar-Ket (level 149)
+      quantity: "1"
+      rarity: 1/35
+    - source: TzHaar-Ket (level 221)
+      quantity: "1"
+      rarity: 1/25
+  related_items:
+    - item_id: 13501
+      item_name: Ensouled kalphite head
+      slug: ensouled-kalphite-head
+      relationship: alternative
+      description: Adept reanimation ensouled head
+    - item_id: 13507
+      item_name: Ensouled abyssal head
+      slug: ensouled-abyssal-head
+      relationship: upgrade
+      description: Master reanimation ensouled head
+  about: A TzHaar-Ket drop reanimated via the Expert Reanimation spell at 72 Magic on the Arceuus spellbook to spawn a Reanimated TzHaar worth 1,104 Prayer XP.
+  market_strategy:
+    notes:
+      - Untradeable — value comes from the Prayer XP yield per cast
+      - Solid mid-tier Arceuus Prayer training on TzHaar-Ket Slayer assignments
+  history:
+    - date: "2016-01-07"
+      description: Released with Zeah — Great Kourend.
+    - date: "2021-04-28"
+      description: Examine text updated.
+    - date: "2022-03-30"
+      description: Ensouled heads can now drop in instanced areas.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: "Zeah: Great Kourend"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eternal-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eternal-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Eternal boots | OSRS Price Data
-description: "Eternal boots is a members feet slot item requiring 60 Magic. High alch: 45,000 GP, GE limit: 15."
+description: "Eternal boots is a members feet slot item requiring 75 Magic and 75 Defence. High alch: 45,000 GP, GE limit: 15."
 osrs:
   id: 13235
   name: Eternal boots
@@ -14,22 +14,23 @@ osrs:
   limit: 15
   equipment:
     slot: feet
-    type: boots
-    attack_style: magic
+    weight: 1.814
     requirements:
-      magic: 60
-      runecraft: 60
-    stats:
-      attack_magic: 8
-      defence_magic: 8
-      defence_stab: 5
-      defence_slash: 5
-      defence_crush: 5
-      defence_ranged: 5
+      magic: 75
+      defence: 75
+    attack_bonus:
+      magic: 8
+    defence_bonus:
+      stab: 5
+      slash: 5
+      crush: 5
+      magic: 8
+      ranged: 5
+    other_bonus:
       magic_damage: 1
   recipes:
-    - skill: crafting
-      level: 1
+    - skill: magic
+      level: 60
       xp: 200
       materials:
         - item_name: Infinity boots
@@ -43,6 +44,7 @@ osrs:
       product_quantity: 1
       facility: None
       members_only: true
+      notes: "Also requires 60 Runecraft; grants 200 Runecraft XP. Boosts not allowed. Irreversible."
   related_items:
     - item_id: 13239
       item_name: Primordial boots
@@ -59,38 +61,38 @@ osrs:
       slug: eternal-crystal
       relationship: component
       description: From Cerberus
-  about: |-
-    Combine Infinity boots + Eternal crystal.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 60 |
-    | Runecraft | 60 |
-    | XP | 200 Magic, 200 Runecraft |
-
-    Process is irreversible.
-
-    | Stat | Value |
-    |------|-------|
-    | Magic attack | +8 |
-    | Magic defence | +8 |
-    | Magic damage | 1% |
-    | All defence | +5 |
-
-    Second-best magic boots (behind Avernic treads)
-
-    BiS magic boots for:
-    - All magic combat
-    - Raids
-    - Bossing
-    - Barrage Slayer
+    - item_id: 6920
+      item_name: Infinity boots
+      slug: infinity-boots
+      relationship: component
+      description: Mage Training Arena reward
+  about: "Eternal boots are the upgraded magic version of infinity boots, made by combining infinity boots with an eternal crystal dropped by Cerberus."
   market_strategy:
     notes:
       - Crystal from Cerberus
       - Infinity boots from MTA or GE
       - Popular for magic setups
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Second-best magic boots behind Avernic treads
+  history:
+    - date: "2015-08-27"
+      description: "Item released with the Cerberus update."
+  properties:
+    release_date: "2015-08-27"
+    update: Cerberus
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/evil-chicken-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/evil-chicken-legs.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Evil chicken legs is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 0.25
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 20440
+      item_name: Evil chicken head
+      slug: evil-chicken-head
+      relationship: set-piece
+      description: Headslot piece of the outfit
+    - item_id: 20444
+      item_name: Evil chicken wings
+      slug: evil-chicken-wings
+      relationship: set-piece
+      description: Capeslot piece of the outfit
+    - item_id: 20446
+      item_name: Evil chicken feet
+      slug: evil-chicken-feet
+      relationship: set-piece
+      description: Bootsslot piece of the outfit
+  about: Cosmetic legs piece of the evil chicken outfit obtained from offering bird's nests at the Woodcutting Guild shrine; provides no combat bonuses.
+  properties:
+    release_date: "2016-07-21"
+    update: Broken Armour & Open Beta
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extreme-energy-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extreme-energy-potion-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extreme energy potion(4) | OSRS Price Data
-description: "Extreme energy potion(4): 4 doses of extreme energy potion.. High alch: 150 GP."
+description: "Extreme energy potion(4) restores 40% run energy per dose for members. High alch: 150 GP."
 osrs:
   id: 31614
   name: Extreme energy potion(4)
@@ -12,9 +12,64 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: null
-  about: "Extreme energy potion(4) is a members-only item in Old School RuneScape. High alchemy value: 150 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - description: Restores 40% of the player's run energy per dose.
+  recipes:
+    - skill: Herblore
+      level: 66
+      xp: 84
+      output_quantity: 1
+      materials:
+        - item_name: Super energy potion(4)
+          quantity: 1
+        - item_name: Yellow fin
+          quantity: 4
+  related_items:
+    - item_id: 31616
+      item_name: Extreme energy potion(3)
+      slug: extreme-energy-potion-3
+      relationship: variant
+      description: 3-dose variant
+    - item_id: 31618
+      item_name: Extreme energy potion(2)
+      slug: extreme-energy-potion-2
+      relationship: variant
+      description: 2-dose variant
+    - item_id: 31620
+      item_name: Extreme energy potion(1)
+      slug: extreme-energy-potion-1
+      relationship: variant
+      description: 1-dose variant
+    - item_id: 3018
+      item_name: Super energy potion(4)
+      slug: super-energy-potion-4
+      relationship: component
+      description: Base potion before brewing
+  about: "Extreme energy potion(4) is a members Herblore potion brewed at level 66 from a super energy potion and yellow fins; each dose restores 40% run energy and cannot be used to make stamina potions."
+  history:
+    - date: "2025-11-19"
+      update: Sailing is OUT TODAY!
+      description: Extreme energy potion released alongside the Sailing skill launch.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fancy-hedge-bagged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fancy-hedge-bagged.mdx
@@ -20,9 +20,9 @@ osrs:
     materials:
       - item_name: Fancy hedge (bagged)
         item_id: 8445
-        quantity: 1
+        quantity: "1"
       - item_name: Watering can
-        quantity: 1
+        quantity: "1"
   shops:
     - shop_name: Garden Supplier
       location: Falador Park

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fire-orb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fire-orb.mdx
@@ -21,10 +21,10 @@ osrs:
     runes:
       - item_name: Fire rune
         item_id: 554
-        quantity: 30
+        quantity: "30"
       - item_name: Cosmic rune
         item_id: 564
-        quantity: 3
+        quantity: "3"
     obelisk: Fire Obelisk
     location: Taverley Dungeon
   recipes:

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fire-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fire-talisman.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Fire talisman is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    primary_source: Fire wizard
+    best_drop_rate: 1/20
+    sources:
+      - source: Fire wizard
+        rarity: common
+        drop_rate: 1/20
+      - source: Dark wizard
+        rarity: uncommon
+      - source: Skeleton
+        rarity: rare
+      - source: Lava dragon
+        rarity: uncommon
+  shops:
+    - shop_name: Temple Supplies
+      location: Temple of the Eye
+      price: 10
+      currency: Abyssal pearls
+  about: Fire talisman is a free-to-play talisman used to enter the Fire altar for crafting fire runes, commonly dropped by fire wizards and other magical foes.
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.015
+    options:
+      - Locate
+      - Drop
+    alchable: true
+  history:
+    - date: "2003-12-01"
+      description: Added to the RuneScape 2 Beta.
+    - date: "2004-03-29"
+      description: Became permanently available with the RS2 launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-giant-krill.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-giant-krill.mdx
@@ -12,9 +12,23 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: null
-  about: "Fish crate (giant krill) is a members-only item in Old School RuneScape. High alchemy value: 3 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Fish crate (giant krill) is a members-only Sailing-era container holding giant krill fish, used to transport hauls back to port for processing."
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Empty
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-potion-2.mdx
@@ -12,23 +12,67 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
+  potion:
+    doses: 2
+    effects:
+      - description: "Fishing: +3 level boost per dose"
+  recipes:
+    - skill: herblore
+      level: 50
+      xp: 112.5
+      materials:
+        - item_name: Avantoe potion (unf)
+          quantity: 1
+        - item_name: Snape grass
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+      facility: Inventory
   related_items:
     - item_id: 151
       item_name: Fishing potion(3)
       slug: fishing-potion-3
       relationship: variant
-      description: 3-dose version
+      description: 3-dose version brewed directly
     - item_id: 155
       item_name: Fishing potion(1)
       slug: fishing-potion-1
       relationship: variant
       description: 1-dose version
-  about: |-
-    > _"2 doses of Fishing potion."_
-
-    A 2-dose fishing potion. Provides a temporary +3 Fishing boost.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Fishing potion(2) is a 2-dose Herblore potion that grants a temporary +3 Fishing boost per dose, brewed at level 50 Herblore from Avantoe potion (unf) and snape grass."
+  market_strategy:
+    notes:
+      - Niche compared to 3- and 4-dose variants
+      - Often created by splitting larger potions
+      - Useful for stew + Heroes' Quest preparation
+  history:
+    - date: "2016-04-15"
+      description: Half-full potions could be turned into bank placeholders.
+    - date: "2004-10-26"
+      description: An 'Empty' option was added.
+    - date: "2004-03-29"
+      description: The 4-dose potion became permanently available with RuneScape 2 launch.
+    - date: "2002-02-27"
+      description: Released with the initial Herblore content.
+  properties:
+    release_date: "2002-02-27"
+    update: Latest RuneScape News (27 February 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/frog-leather-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/frog-leather-boots.mdx
@@ -12,18 +12,25 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 70
+  material:
+    type: frog-leather
+    tier: mid
   equipment:
     slot: feet
+    weight: 1
+    requirements:
+      ranged: 25
+      defence: 25
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
-      magic: 0
+      magic: -8
       ranged: 2
     defence_bonus:
       stab: 1
-      slash: 0
-      crush: 2
+      slash: 1
+      crush: 1
       magic: 0
       ranged: 1
     other_bonus:
@@ -31,10 +38,10 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 25
-      defence: 25
-    weight: 0.8
+  shops:
+    - shop_name: Reldak's Leather Armour
+      location: Dorgesh-Kaan
+      price: 200
   related_items:
     - item_id: 10954
       item_name: Frog-leather body
@@ -50,25 +57,31 @@ osrs:
       item_name: Snakeskin boots
       slug: snakeskin-boots
       relationship: upgrade
-      description: Better ranged boots
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Ranged | +2 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Crush | +2 |
-
-    Requirements: 25 Ranged, 25 Defence | Weight: 0.8 kg
-
-    Frog-leather boots are the lowest-tier dedicated ranged boots. Most players skip directly to snakeskin boots (+3 ranged, 30 Ranged/Defence).
+      description: Better ranged boots at 30 Ranged
+  about: "Frog-leather boots are the lowest-tier dedicated ranged feet armour, sold by Reldak's Leather Armour in Dorgesh-Kaan; most players skip directly to snakeskin boots."
   market_strategy:
     notes:
-      - Very niche item — low demand
-      - Snakeskin boots are nearly always preferred
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Very niche item with low player demand
+      - Snakeskin boots are nearly always preferred at +3 ranged
+  history:
+    - date: "2007-03-20"
+      description: Released with the Dorgesh-Kaan update.
+  properties:
+    release_date: "2007-03-20"
+    update: Dorgesh-Kaan
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fruit-batta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fruit-batta.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fruit batta | OSRS Price Data
-description: "Fruit batta: It actually smells quite good.. High alch: 1 GP, GE limit: 6,000."
+description: "Fruit batta: It actually smells quite good. Heals 11 HP. High alch: 1 GP, GE limit: 6,000."
 osrs:
   id: 2277
   name: Fruit batta
@@ -12,9 +12,71 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Fruit batta is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 11
+    bites: 1
+  recipes:
+    - skill: Cooking
+      level: 25
+      xp: 150
+      tools:
+        - Batta tin
+      materials:
+        - item_name: Gianne dough
+          quantity: 1
+        - item_name: Equa leaves
+          quantity: 4
+        - item_name: Lime chunks
+          quantity: 1
+        - item_name: Orange chunks
+          quantity: 1
+        - item_name: Pineapple chunks
+          quantity: 1
+        - item_name: Gnome spice
+          quantity: 1
+  shops:
+    - shop_name: Hudo Glenfad's Grocery Store
+      location: Grand Tree
+      price: 120
+      stock: 3
+  related_items:
+    - item_id: 2275
+      item_name: Toad batta
+      slug: toad-batta
+      relationship: alternative
+      description: Alternative gnome batta variant
+    - item_id: 2281
+      item_name: Worm batta
+      slug: worm-batta
+      relationship: alternative
+      description: Alternative gnome batta variant
+  about: "Fruit batta is a gnome cooking food that heals 11 hitpoints, made by combining a batta tin with gnome dough, equa leaves, fruit chunks and gnome spice."
+  market_strategy:
+    notes:
+      - Niche gnome cooking item
+      - GE price often inflated due to low supply
+      - Premade version available at the Grand Tree
+      - Used mainly for Gnome Restaurant minigame credit cooking
+  history:
+    - date: "2002-12-12"
+      description: Fruit batta released with The Grand Tree quest and Gnome Stronghold food.
+  properties:
+    release_date: "2002-12-12"
+    update: The Grand Tree
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-four-poster-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-four-poster-flatpack.mdx
@@ -24,13 +24,13 @@ osrs:
     materials:
       - item_name: Mahogany plank
         item_id: 8782
-        quantity: 5
+        quantity: "5"
       - item_name: Bolt of cloth
         item_id: 8790
-        quantity: 2
+        quantity: "2"
       - item_name: Gold leaf
         item_id: 8784
-        quantity: 2
+        quantity: "2"
   recipes:
     - skill: construction
       level: 60

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-platelegs.mdx
@@ -14,25 +14,34 @@ osrs:
   limit: 8
   equipment:
     slot: legs
-    type: melee armour
-    attack_style: melee
+    weapon_type: null
+    weight: 9.071
     requirements:
       defence: 40
-    stats:
-      defence_stab: 51
-      defence_slash: 49
-      defence_crush: 47
-      defence_magic: -4
-      defence_ranged: 49
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
       melee_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: Rare
-        description: Rare reward from hard clue scrolls
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
   related_items:
     - item_id: 3486
       item_name: Gilded full helm
@@ -54,10 +63,7 @@ osrs:
       slug: gilded-scimitar
       relationship: set-piece
       description: Weapon of gilded set
-  about: |-
-    The gilded platelegs are a cosmetic variant of rune platelegs with identical stats but a prestigious golden appearance. They require 40 Defence to wear.
-
-    Gilded armour is obtained from Treasure Trails and is valued for its appearance rather than stats. It shares the same defensive bonuses as rune armour but costs significantly more due to its rarity and fashionscape appeal.
+  about: "Gilded platelegs are a cosmetic gold-plated variant of rune platelegs with identical defensive bonuses and a 40 Defence requirement, obtained only from clue scroll caskets."
   market_strategy:
     title: Investment Notes
     notes:
@@ -67,8 +73,30 @@ osrs:
       - Compare prices with rune equivalent for value assessment
       - Watch for dips after clue scroll events
       - Popular with free-to-play players for fashion
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2004-10-26"
+      description: Released as a treasure trail reward in the Treasure Trails and Changes update.
+    - date: "2021-04-21"
+      description: Ranged attack bonus reduced from -7 to -11.
+  properties:
+    release_date: "2004-10-26"
+    update: Treasure Trails and Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-leaf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-leaf.mdx
@@ -21,13 +21,13 @@ osrs:
     source: Keldagrim Stonemason
     common_builds:
       - name: Gilded decorations
-        quantity: 1
+        quantity: "1"
         xp: 582
       - name: Gilded altar
-        quantity: 4
+        quantity: "4"
         xp: 2230
       - name: Ornate pool
-        quantity: 5
+        quantity: "5"
         xp: 3200
   shop_sources:
     - name: Keldagrim Stonemason

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-ring.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gold ring | OSRS Price Data
-description: "Gold ring: A valuable ring.. High alch: 210 GP, GE limit: 18,000."
+description: "Gold ring is a F2P ring slot item crafted from a gold bar. High alch: 210 GP, GE limit: 18,000."
 osrs:
   id: 1635
   name: Gold ring
@@ -12,9 +12,84 @@ osrs:
   lowalch: 140
   highalch: 210
   limit: 18000
-  about: "Gold ring is a free-to-play item in Old School RuneScape. High alchemy value: 210 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: gold
+    tier: low
+  equipment:
+    slot: ring
+    weight: 0.004
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Crafting
+      level: 5
+      xp: 15
+      output_quantity: 1
+      facility: Furnace
+      tools: [Ring mould]
+      materials:
+        - item_name: Gold bar
+          quantity: 1
+  related_items:
+    - item_id: 2357
+      item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: Crafting material for the ring
+    - item_id: 1592
+      item_name: Ring mould
+      slug: ring-mould
+      relationship: component
+      description: Required mould to cast the ring
+    - item_id: 1637
+      item_name: Sapphire ring
+      slug: sapphire-ring
+      relationship: upgrade
+      description: Gemmed upgrade
+  about: Gold ring is a free-to-play ring crafted at 5 Crafting from a gold bar using a ring mould at a furnace.
+  history:
+    - date: "2001-05-08"
+      update: RuneScape Update
+      description: Gold ring introduced in the May 2001 RuneScape update.
+    - date: "2007-04-30"
+      update: 24 Carat Update
+      description: Gold ring graphically updated.
+    - date: "2018-12-13"
+      update: Christmas Event 2018
+      description: Inventory sprite adjusted during the Christmas 2018 event.
+  properties:
+    release_date: "2001-05-08"
+    update: RuneScape Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.004
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/granite-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/granite-ring.mdx
@@ -15,6 +15,9 @@ osrs:
   equipment:
     slot: ring
     weight: 3
+    requirements:
+      defence: 50
+      strength: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,9 +35,6 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 50
-      strength: 50
   drop_table:
     primary_source: Grotesque Guardians
     best_drop_rate: 2/500
@@ -67,28 +67,34 @@ osrs:
       slug: granite-ring-i
       relationship: upgrade
       description: Imbued version with doubled stats
-  about: |-
-    Best ranged defence ring:
-    - +12 Ranged defence (highest of any ring)
-    - Can be imbued to double all stats
-
-    Imbuing methods:
-    - Nightmare Zone: 500,000 points
-    - Soul Wars: 200 Zeal Tokens
-    - PvP Arena: Scroll of imbuing
-
-    When imbued:
-    - +4 Stab/Slash/Crush defence
-    - -4 Magic defence
-    - +24 Ranged defence
+  about: "Granite ring is the only ring requiring a Defence level to wear, boasting the highest ranged defence bonus of any ring and imbueable for doubled stats."
   market_strategy:
     notes:
       - Niche tanking ring
       - Best for ranged defence specifically
       - Consider imbuing for doubled stats
       - Part of Grotesque Guardian collection
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2025-06-25"
+      description: Ranged defence bonus increased from +8 to +12.
+    - date: "2017-10-26"
+      description: Released with the Grotesque Guardians update.
+  properties:
+    release_date: "2017-10-26"
+    update: Grotesque Guardians
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/granite-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/granite-shield.mdx
@@ -12,8 +12,15 @@ osrs:
   lowalch: 22400
   highalch: 33600
   limit: 70
+  material:
+    type: granite
+    tier: mid-high
   equipment:
     slot: shield
+    weight: 6.803
+    requirements:
+      defence: 50
+      strength: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,10 +38,6 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 50
-      strength: 50
-    weight: 6.803
   drop_table:
     primary_source: Ice troll
     best_drop_rate: 1/128
@@ -62,42 +65,34 @@ osrs:
       slug: granite-legs
       relationship: set-piece
       description: Granite set piece
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +40 |
-    | Slash | +42 |
-    | Crush | +38 |
-    | Ranged | +65 |
-    | Magic | 0 |
-
-    Requirements: 50 Defence, 50 Strength | Weight: 6.8 kg
-
-    | Stat | Granite Shield | Toktz-ket-xil | Rune Kiteshield |
-    |------|---------------|---------------|-----------------|
-    | Stab Def | +40 | +40 | +44 |
-    | Slash Def | +42 | +42 | +48 |
-    | Crush Def | +38 | +38 | +42 |
-    | Ranged Def | +65 | +65 | +46 |
-    | Str Bonus | 0 | +5 | 0 |
-    | Prayer | 0 | 0 | 0 |
-    | Req | 50 Def/Str | 60 Def | 40 Def |
-
-    Statistically identical to the Toktz-ket-xil (obsidian shield) in defensive stats, but the obsidian shield provides +5 Strength bonus and only requires 60 Defence (no Strength req). The granite shield's main advantage is lower level requirements for the ranged defence.
-
-    The granite shield's model bears a resemblance to the island of Gran Canaria in the Canary Islands, which may be an intentional reference to "granite."
-
-    - Best ranged defence shield at 50 Defence
-    - Part of granite fashionscape set
-    - Budget alternative before dragon/crystal shields
-    - No negative Prayer bonus (unlike some alternatives)
+  about: Granite shield is a members shield offering the best ranged defence at 50 Defence, statistically identical defensively to the obsidian shield (Toktz-ket-xil) but without a strength bonus.
   market_strategy:
     notes:
       - Dropped by trolls on Jatizso during The Fremennik Isles
       - GE price near high alch value
       - Low trade volume
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2004-08-09"
+      update: Death Plateau
+      description: Granite shield released alongside the Death Plateau quest line content.
+  properties:
+    release_date: "2004-08-09"
+    update: Death Plateau
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-shield.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 2200
   highalch: 3300
   limit: 125
-  about: "Green d'hide shield is a members-only item in Old School RuneScape. High alchemy value: 3,300 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    weapon_type: shield
+    weight: 8
+    requirements:
+      ranged: 40
+      defence: 40
+    attack_bonus:
+      stab: -15
+      slash: -15
+      crush: -11
+      magic: 0
+      ranged: 4
+    defence_bonus:
+      stab: 14
+      slash: 12
+      crush: 11
+      magic: 9
+      ranged: 11
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Crafting
+      level: 62
+      experience: 124
+      output_quantity: 1
+      tools:
+        - Needle
+        - Thread
+      materials:
+        - item_name: Green dragon leather
+          quantity: 2
+        - item_name: Maple shield
+          quantity: 1
+        - item_name: Steel nails
+          quantity: 15
+  related_items:
+    - item_id: 22281
+      item_name: Blue d'hide shield
+      slug: blue-d-hide-shield
+      relationship: upgrade
+      description: Higher tier Ranged shield
+    - item_id: 1135
+      item_name: Green d'hide body
+      slug: green-d-hide-body
+      relationship: set-piece
+      description: Matching dragonhide body armour
+  about: "Green d'hide shield is a Ranged-focused offhand crafted from two green dragon leather, a maple shield, and steel nails, requiring 40 Ranged and 40 Defence to equip."
+  market_strategy:
+    notes:
+      - Crafted at 62 Crafting; usually a small loss versus GE price
+      - Useful entry-level Ranged shield for mid-level slayer and pking
+      - 125 buy limit keeps flipping margins thin
+  history:
+    - date: "2018-02-01"
+      description: Released alongside the dragonhide shield set.
+  properties:
+    release_date: "2018-02-01"
+    update: Dragonhide Shields
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-dragonhide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-dragonhide.mdx
@@ -15,10 +15,6 @@ osrs:
   material:
     type: hide
     tier: low
-  tanning:
-    cost: 20
-    product_id: 1745
-    product_name: Green dragon leather
   drop_table:
     sources:
       - source: Green dragon
@@ -65,15 +61,7 @@ osrs:
       slug: black-dragonhide
       relationship: alternative
       description: Highest tier
-  about: |-
-    Take to a tanner to convert into Green dragon leather.
-
-    | Cost | Location |
-    |------|----------|
-    | 20 GP | Most tanners (Al Kharid, etc.) |
-    | 45 GP | Canifis tanner |
-
-    Buy Limit: 13,000 per 4 hours
+  about: Take green dragonhide to a tanner (20 GP at most tanners, 45 GP in Canifis) to convert it into green dragon leather for crafting.
   market_strategy:
     title: Full Processing Chain
     steps:
@@ -88,13 +76,33 @@ osrs:
     profit_formulas:
       - Green dragon leather - Green dragonhide - 20 GP = Profit
     notes:
-      - Buy hide → Tan → Sell leather
-      - "Calculate:"
+      - "Buy hide, tan, sell leather"
       - High volume from green dragon killers
       - Green dragons drop both hides and Dragon bones
       - Check combined value vs alternatives
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2018-09-20"
+      description: Item value increased from 20 to 135 coins for ground visibility purposes.
+    - date: "2005-11-14"
+      description: Renamed from Dragonhide to Green dragonhide; examine text updated to specify Green Dragon.
+    - date: "2004-03-29"
+      description: Permanently available at RuneScape 2 launch.
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/greenmans-ale-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/greenmans-ale-m4.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Greenmans ale(m4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - description: Temporarily boosts Cooking by 2 levels
+  related_items:
+    - item_name: Greenmans ale
+      slug: greenmans-ale
+      relationship: variant
+      description: Standard non-mature single-pint variant
+    - item_name: Greenmans ale(m)
+      slug: greenmans-ale-m
+      relationship: variant
+      description: Single-pint mature variant
+  about: "Greenmans ale(m4) is a four-pint keg of mature Greenmans Ale, released on 11 July 2005 with the Farming update. Each pint provides a small Cooking level boost which is useful for marginal Cooking-based content. Kegs must be brewed from grain, hops, and water using brewing vats and aged into the mature form."
+  market_strategy:
+    notes:
+      - Used niche-side for marginal Cooking boost requirements
+      - Partial kegs cannot be sold on GE, only full m4 trades
+      - Brewing supply is the main price driver
+  history:
+    - date: "2005-07-11"
+      description: Released with the Farming update
+    - date: "2005-10-01"
+      description: "Renamed from 'Greenmans ale(n)' to 'Greenmans ale(mn)' for naming clarity"
+    - date: "2015-02-01"
+      description: Partially consumed versions became untradeable on the Grand Exchange
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-kwuarm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-kwuarm.mdx
@@ -12,18 +12,24 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 13000
-  herb:
-    type: grimy
-    tier: mid-high
-  herblore:
-    cleaning_level: 54
-    cleaning_xp: 11.3
-    clean_id: 263
-    clean_name: Kwuarm
+  material:
+    type: grimy-herb
+    tier: mid
+  recipes:
+    - skill: herblore
+      level: 54
+      xp: 11.3
+      materials:
+        - item_name: Grimy kwuarm
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      facility: Inventory
   farming:
     level: 56
-    seed_id: 5299
     seed_name: Kwuarm seed
+    seed_id: 5299
+    patch: Herb
   drop_table:
     sources:
       - source: Aberrant spectre
@@ -33,10 +39,17 @@ osrs:
         rarity: common
         members_only: true
       - source: Nechryael
-        source_id: 1
         combat_level: 115
         quantity: "1"
         rarity: common
+        members_only: true
+      - source: Abyssal demon
+        quantity: "1"
+        rarity: "1/172.5"
+        members_only: true
+      - source: Fire giant
+        quantity: "1"
+        rarity: "1/172.5"
         members_only: true
   related_items:
     - item_id: 263
@@ -59,22 +72,32 @@ osrs:
       slug: kwuarm-seed
       relationship: component
       description: Farming seed
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Grimy Herb |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-    | Herblore Level | 54 (to clean) |
-
-    Clean to produce kwuarm for Herblore.
-
-    Kwuarm used for:
-    - Super strength
-    - Weapon poison
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Grimy kwuarm is a members herb cleaned at level 54 Herblore for 11.3 XP, used to brew super strength potions and weapon poisons."
+  market_strategy:
+    notes:
+      - Steady demand from super strength brewers
+      - Slayer task drops keep supply consistent
+      - Wide buy limit makes it flippable in volume
+  history:
+    - date: "2002-02-27"
+      description: Released with the initial Herblore content.
+  properties:
+    release_date: "2002-02-27"
+    update: Latest RuneScape News (27 February 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guardian-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guardian-boots.mdx
@@ -34,10 +34,10 @@ osrs:
     materials:
       - item_id: 11834
         item_name: Bandos boots
-        quantity: 1
+        quantity: "1"
       - item_id: 21730
         item_name: Black tourmaline core
-        quantity: 1
+        quantity: "1"
     notes: Process is irreversible
   market:
     buy_limit: 8

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-robe-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-robe-legs.mdx
@@ -14,22 +14,68 @@ osrs:
   limit: 8
   equipment:
     slot: legs
+    weight: 2.7
     requirements:
       prayer: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 10462
       item_name: Guthix robe top
       slug: guthix-robe-top
       relationship: set-piece
       description: Guthix vestment body
-  about: |-
-    > *"Leggings from the Guthix Vestments."*
-
-    The Guthix robe legs are the legs piece of the Guthix vestment set. They provide a +5 Prayer bonus and require 20 Prayer to equip. Counts as a Guthixian item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 10464
+      item_name: Guthix mitre
+      slug: guthix-mitre
+      relationship: set-piece
+      description: Guthix vestment head
+    - item_id: 10470
+      item_name: Guthix stole
+      slug: guthix-stole
+      relationship: set-piece
+      description: Guthix vestment cape
+  about: "Guthix robe legs are the leg piece of the Guthix vestment set, dropped from easy clue caskets and granting +5 Prayer at 20 Prayer to wear."
+  history:
+    - date: "2014-07-24"
+      description: Vestment pieces began offering the same prayer bonuses as monk robes.
+    - date: "2006-12-05"
+      description: Released alongside the original Treasure Trails god vestment rewards.
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.7
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ham-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ham-gloves.mdx
@@ -14,7 +14,24 @@ osrs:
   limit: 15
   equipment:
     slot: hands
-    requirements: {}
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   related_items:
     - item_id: 4302
       item_name: Ham hood
@@ -31,12 +48,31 @@ osrs:
       slug: ham-boots
       relationship: set-piece
       description: H.A.M. feet piece
-  about: |-
-    > *"HAM gloves as worn by the Humans Against Monsters group."*
-
-    The ham gloves are the hands piece of the H.A.M. (Humans Against Monsters) robes set. Wearing more pieces reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing. A members-only item with no combat stats.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Ham gloves are the hands piece of the H.A.M. robes set; wearing more pieces reduces ejection chance when caught pickpocketing at the H.A.M. Hideout.
+  market_strategy:
+    notes:
+      - Demand tied to H.A.M. pickpocketing thieves training
+      - Tiny 15/4h buy limit keeps supply tight
+      - Cosmetic value for full H.A.M. uniform collectors
+  history:
+    - date: "2014-12-10"
+      description: Item renamed from Gloves to Ham gloves.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-22"
+    update: Wilderness Capes, and Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hammer.mdx
@@ -12,9 +12,43 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 40
-  about: "Hammer is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: mid
+  shops:
+    - shop_name: General store (Falador)
+      location: Falador
+      price: 1
+      currency: coins
+    - shop_name: General store (Varrock)
+      location: Varrock
+      price: 1
+      currency: coins
+    - shop_name: General store (Lumbridge)
+      location: Lumbridge
+      price: 1
+      currency: coins
+  about: "Hammer is a free-to-play tool used in Smithing on anvils and Construction for crafting furniture, and is required to enter Bandos' stronghold in the God Wars Dungeon."
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: false
+  history:
+    - date: "2001-01-04"
+      description: Released with the Runescape beta launch.
+    - date: "2021-12-01"
+      description: Hammers were exempted from the Grand Exchange convenience fee.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/helm-of-neitiznot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/helm-of-neitiznot.mdx
@@ -14,6 +14,9 @@ osrs:
   limit: 70
   equipment:
     slot: head
+    weight: 2.267
+    requirements:
+      defence: 55
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,8 +34,6 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 3
-    requirements:
-      defence: 55
   related_items:
     - item_id: 24268
       item_name: Neitiznot faceguard
@@ -49,29 +50,29 @@ osrs:
       slug: warrior-helm
       relationship: alternative
       description: Alternative Fremennik helm
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +31 |
-    | Slash | +29 |
-    | Crush | +34 |
-    | Magic | +3 |
-    | Ranged | +30 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +3 |
-    | Prayer | +3 |
-
-    Best free melee helm until Neitiznot faceguard:
-    - Slayer tasks
-    - General PvM
-    - Budget melee setup
-    - PvP (commonly used)
-
-    Upgrade: Attach a Basilisk jaw to create the Neitiznot faceguard.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Helm of neitiznot is a melee head slot helm awarded after completing The Fremennik Isles quest, valued for its +3 prayer and +3 melee strength bonuses without magic or ranged penalties.
+  history:
+    - date: "2007-02-12"
+      description: "'Destroy' option replaced with 'Drop'."
+  properties:
+    release_date: "2007-02-06"
+    update: The Fremennik Isles
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/holy-symbol.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/holy-symbol.mdx
@@ -25,10 +25,10 @@ osrs:
     materials:
       - item_name: Unstrung symbol
         item_id: 1714
-        quantity: 1
+        quantity: "1"
       - item_name: Ball of wool
         item_id: 1759
-        quantity: 1
+        quantity: "1"
   related_items:
     - item_id: 1724
       item_name: Unholy symbol

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hosidius-hood.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hosidius-hood.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Hosidius hood is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_id: 20119
+      item_name: Hosidius scarf
+      slug: hosidius-scarf
+      relationship: set-piece
+      description: Matching scarf from same Treasure Trail set
+  about: "Hosidius hood is a cosmetic head-slot reward from master Treasure Trails with no combat bonuses, dropped at roughly 1/851 from a Reward casket (master)."
+  market_strategy:
+    notes:
+      - Supply driven entirely by master clue completions
+      - GE limit of 4 keeps prices volatile on demand spikes
+      - Purely cosmetic so demand tracks fashionscape trends
+  history:
+    - date: "2019-01-10"
+      description: Renamed from 'Hosidius house hood' to 'Hosidius hood' with examine updated from 'A rare hood from house Hosidius.'
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion (2016)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/huasca-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/huasca-seed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Huasca seed | OSRS Price Data
-description: "Huasca seed: A huasca seed - plant in a herb patch.. High alch: 42 GP, GE limit: 200."
+description: "Huasca seed: A huasca seed - plant in a herb patch. High alch: 42 GP, GE limit: 200."
 osrs:
   id: 30088
   name: Huasca seed
@@ -12,9 +12,47 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 200
-  about: "Huasca seed is a members-only item in Old School RuneScape. High alchemy value: 42 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: seed
+    tier: high
+  farming:
+    farming_level: 65
+    planting_xp: 86.5
+    harvest_xp: 110
+    growth_time_minutes: 80
+    patch_type: Herb patch
+    protection: None - cannot be protected by farmers or white lily
+  related_items:
+    - item_id: 30089
+      item_name: Grimy huasca
+      slug: grimy-huasca
+      relationship: product
+      description: Harvested herb yield
+    - item_id: 30093
+      item_name: Prayer regeneration potion
+      slug: prayer-regeneration-potion
+      relationship: product
+      description: Final potion product
+  about: "Huasca seed is a members-only herb seed planted in a herb patch at level 65 Farming, yielding grimy huasca used to brew prayer regeneration potions."
+  history:
+    - date: "2024-09-25"
+      update: "Varlamore: The Rising Darkness is OUT NOW"
+      description: Released with the Varlamore Rising Darkness expansion.
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness is OUT NOW"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: [Drop]
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hunter-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hunter-potion-4.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 2000
-  about: "Hunter potion(4) is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    type: boost
+    skill: hunter
+    boost_min: 3
+    boost_max: 3
+    boost_formula: "+3"
+    duration: 60
+    effects:
+      - skill: hunter
+        description: Temporarily raises Hunter level by 3.
+  recipes:
+    - name: Mix Hunter potion(4)
+      skill: herblore
+      level: 53
+      xp: 120
+      materials:
+        - item_id: 105
+          item_name: Avantoe potion (unf)
+          quantity: 1
+        - item_id: 10111
+          item_name: Kebbit teeth dust
+          quantity: 1
+      product: Hunter potion(4)
+      product_id: 9998
+      product_quantity: 1
+      tools: []
+      members_only: true
+  related_items:
+    - item_id: 261
+      item_name: Avantoe
+      slug: avantoe
+      relationship: component
+      description: Primary herb
+    - item_id: 10111
+      item_name: Kebbit teeth dust
+      slug: kebbit-teeth-dust
+      relationship: component
+      description: Secondary ingredient
+  about: Hunter potion(4) is a four-dose members potion that raises the Hunter level by 3 for catching higher-tier creatures.
+  market_strategy:
+    notes:
+      - Niche demand spikes during Hunter contracts and rumours
+      - Cheap to mix; flips on margin not volume
+      - Avantoe-tied supply chain
+  history:
+    - date: "2016-04-15"
+      description: Half-full potions could now be turned into bank placeholders.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: HUNTER SKILL!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/initiate-sallet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/initiate-sallet.mdx
@@ -14,17 +14,28 @@ osrs:
   limit: 125
   equipment:
     slot: head
-    type: armour
-    prayer_bonus: 3
+    weapon_type: armour
+    weight: 2.267
     requirements:
       defence: 20
       prayer: 10
-    combat_stats:
-      stab_defence: 14
-      slash_defence: 16
-      crush_defence: 13
-      magic_defence: -1
-      ranged_defence: 15
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 13
+      slash: 14
+      crush: 11
+      magic: -1
+      ranged: 13
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 3
   related_items:
     - item_id: 5575
       item_name: Initiate hauberk
@@ -46,34 +57,38 @@ osrs:
       slug: helm-of-neitiznot
       relationship: alternative
       description: Better melee stats (+3 Prayer)
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Head |
-    | Prayer Bonus | +3 |
-    | Defence Req | 20 |
-    | Prayer Req | 10 |
-
-    - Mid-tier prayer helm
-    - Bridge to Proselyte
-    - Lower requirements than Proselyte
-
-    | Piece | Prayer Bonus |
-    |-------|--------------|
-    | Initiate sallet | +3 |
-    | Initiate hauberk | +6 |
-    | Initiate cuisse | +5 |
-    | Total | +14 |
+  about: "Initiate sallet is a prayer-boosting Temple Knight helm awarded after Recruitment Drive, matching the Helm of Neitiznot's prayer bonus while keeping mithril-tier defences."
   market_strategy:
     notes:
-      - Requires quest completion
-      - Shop purchase only
-      - No GE trading (untradeable)
-      - Must complete Recruitment Drive
-      - Stepping stone to Proselyte
-      - Lower requirements good for pures
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Requires Recruitment Drive completion to purchase from Sir Tiffy Cashien
+      - Tradeable once obtained, with a 125 buy limit
+      - Stepping stone before the Proselyte upgrade
+      - Lower requirements suit pures and mid-level prayer flick setups
+  history:
+    - date: "2005-06-27"
+      description: Released with the Recruitment Drive quest.
+    - date: "2005-10-04"
+      description: Graphically updated alongside the Wanted! quest release.
+    - date: "2006-09-25"
+      description: Renamed from Initiate helm to Initiate sallet.
+    - date: "2021-04-21"
+      description: Ranged attack bonus reduced from -2 to -3.
+  properties:
+    release_date: "2005-06-27"
+    update: Recruitment Drive
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: true
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-halberd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-halberd.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron halberd | OSRS Price Data
-description: "Iron halberd: An iron halberd.. High alch: 168 GP, GE limit: 125."
+description: "Iron halberd: An iron halberd. Two-handed polearm with 2-tile attack range. High alch: 168 GP, GE limit: 125."
 osrs:
   id: 3192
   name: Iron halberd
@@ -12,9 +12,81 @@ osrs:
   lowalch: 112
   highalch: 168
   limit: 125
-  about: "Iron halberd is a members-only item in Old School RuneScape. High alchemy value: 168 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: iron
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: polearm
+    attack_speed: 7
+    weight: 3.175
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 9
+      slash: 12
+      crush: 0
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    - source: Gorak
+      rarity: 1/128
+      quantity: "1"
+  shops:
+    - shop_name: Quartermaster
+      location: Tyras Camp
+      price: 280
+  related_items:
+    - item_id: 3190
+      item_name: Bronze halberd
+      slug: bronze-halberd
+      relationship: downgrade
+      description: Lower tier polearm
+    - item_id: 3194
+      item_name: Steel halberd
+      slug: steel-halberd
+      relationship: upgrade
+      description: Next tier polearm
+  about: "Iron halberd is a two-handed polearm with 2-tile attack range, useful for safespotting. Wielding requires completion of Regicide quest."
+  market_strategy:
+    notes:
+      - Niche polearm with 2-tile attack range
+      - Requires Regicide quest to wield
+      - Mainly purchased for safespotting strategies
+      - Low GE volume due to limited demand
+  history:
+    - date: "2004-09-20"
+      description: Iron halberd released with the Plague City Part 4 / Regicide quest update.
+  properties:
+    release_date: "2004-09-20"
+    update: Regicide
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-javelin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-javelin.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron javelin | OSRS Price Data
-description: "Iron javelin is a members weapon slot item requiring 1 Ranged. High alch: 3 GP, GE limit: 7,000."
+description: "Iron javelin: a stackable ranged ammunition with +42 ranged strength used by ballistas, made via Fletching at level 17. High alch: 3 GP, GE limit: 7,000."
 osrs:
   id: 826
   name: Iron javelin
@@ -12,31 +12,115 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 7000
+  material:
+    type: iron
+    tier: mid
   equipment:
-    slot: weapon
+    slot: ammo
+    weapon_type: thrown
     attack_speed: 6
+    weight: 0
     requirements:
       ranged: 1
     attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 8
-    ranged_strength: 32
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 42
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Fletch iron javelins
+      skill: Fletching
+      level: 17
+      experience: 30
+      output: Iron javelin
+      quantity: "15"
+      materials:
+        - item_name: Iron javelin heads
+          quantity: 15
+        - item_name: Javelin shaft
+          quantity: 15
+      description: Combine iron javelin heads with javelin shafts to fletch 15 javelins.
+  shops:
+    - shop_name: Ranging Guild Ticket Exchange
+      location: Ranging Guild
+      stock: 100
+      price: 7
+      currency: Coins
+      description: Stocked as ranged ammunition for guild members.
+    - shop_name: Void Knight Archery Store
+      location: Void Knights' Outpost
+      stock: 100
+      price: 6
+      currency: Coins
+      description: Cheap source for Void-aligned archers.
+    - shop_name: Oobapohk's Javelin Store
+      location: Tai Bwo Wannai
+      stock: 50
+      price: 6
+      currency: Coins
+      description: Specialty javelin shop in Tai Bwo Wannai.
   related_items:
     - item_id: 825
       item_name: Bronze javelin
       slug: bronze-javelin
-      relationship: variant
-      description: Lower tier javelin
+      relationship: downgrade
+      description: Lower-tier bronze javelin.
     - item_id: 827
       item_name: Steel javelin
       slug: steel-javelin
-      relationship: variant
-      description: Higher tier javelin
-  about: |-
-    > _"An iron tipped javelin."_
-
-    The iron javelin requires 1 Ranged. Higher ranged strength than iron darts but slower attack speed.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: upgrade
+      description: Stronger steel-tier javelin.
+    - item_id: 19484
+      item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: alternative
+      description: Two-handed ballista that fires javelins.
+  about: "The iron javelin is a stackable ballista ammunition with +42 ranged strength, sold by Ranging Guild and Void shops or fletched at level 17."
+  market_strategy:
+    title: Investment Notes
+    notes:
+      - Shop supply at 6-7 coins anchors the price near alch value.
+      - Demand spikes when ballista users restock for boss trips.
+      - Buy limit of 7,000 supports bulk loadouts.
+      - Fletching is unprofitable at current shop prices and used mainly for XP.
+  history:
+    - date: "2004-03-29"
+      update: Throwing Weapons Revamp
+      description: Added to game in the throwing weapons revamp update.
+    - date: "2016-10-06"
+      update: Throwing Weapon Buffs
+      description: Ranged strength bonus reduced from +50 to +42 in a balance pass.
+  properties:
+    release_date: "2004-03-29"
+    update: Throwing Weapons Revamp
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-knife-p-5655.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-knife-p-5655.mdx
@@ -12,9 +12,31 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Iron knife(p+) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    requirements:
+      ranged: 1
+  about: Iron knife(p+) is a stronger-poisoned thrown ranged weapon used as members ammunition with the weapon slot.
+  properties:
+    release_date: "2005-10-25"
+    update: Poisonous Weaponry
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-knife.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-knife.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron knife | OSRS Price Data
-description: "Iron knife is a members weapon slot item. High alch: 1 GP, GE limit: 7,000."
+description: "Iron knife is a members thrown weapon. High alch: 1 GP, GE limit: 7,000."
 osrs:
   id: 863
   name: Iron knife
@@ -12,24 +12,41 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  material:
+    type: iron
+    tier: low
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
+    weapon_type: thrown
     attack_speed: 3
-  requirements:
-    ranged: 1
-  stats:
-    attack:
+    weight: 0.006
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 5
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 4
-  smithing:
-    level: 22
-    xp: 25
-    method: Iron bar at anvil
-    bars: 1
-    quantity: 5
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Smithing
+      level: 22
+      xp: 25
+      output_quantity: 5
+      tools: [Hammer]
+      facility: Anvil
+      materials:
+        - item_name: Iron bar
+          quantity: 1
   related_items:
     - item_id: 2351
       item_name: Iron bar
@@ -51,16 +68,36 @@ osrs:
       slug: iron-dart
       relationship: alternative
       description: Alternative thrown weapon
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0.006 kg |
-    | Requirements | 1 Ranged |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Iron knife is an entry-level members thrown weapon smithed from a single iron bar yielding five knives at level 22 Smithing.
+  history:
+    - date: "2003-04-14"
+      update: New Throwing Weapons!
+      description: Iron knife introduced alongside the new throwing weapons update.
+    - date: "2006-09-20"
+      update: Poison Nomenclature
+      description: Poisoned knife variants standardised to (p), (p+), (p++) naming.
+    - date: "2021-07-07"
+      update: Female Equipment Positioning
+      description: Female model wielding offsets adjusted.
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-logs.mdx
@@ -12,9 +12,28 @@ osrs:
   lowalch: 144
   highalch: 216
   limit: 12000
-  about: "Ironwood logs is a members-only item in Old School RuneScape. High alchemy value: 216 coins. Grand Exchange buy limit: 12,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Ironwood logs are a high-tier Sailing-era log harvested at level 80 Woodcutting and burned at level 80 Firemaking for premium experience rates."
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing skill launch.
+    - date: "2026-05-13"
+      description: Fixed a bug granting excessive Firemaking XP when burning with a shortbow versus a tinderbox.
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jangerberries.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jangerberries.mdx
@@ -68,19 +68,28 @@ osrs:
       slug: snape-grass
       relationship: alternative
       description: Tree protection (10 jangerberries)
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Herblore Secondary |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-
-    Secondary ingredient for:
-    - Combat potion (with harralander potion unf)
-    - Snape grass protection (10 jangerberries)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Jangerberries are a Herblore secondary used to brew Combat potions and as 10x payment to protect papaya/palm trees; harvested from jangerberry bushes at 48 Farming."
+  history:
+    - date: "2002-12-12"
+      description: Added to the game with the launch of the Agility skill.
+    - date: "2004-10-14"
+      description: The 'eat' option was renamed to 'Eat'.
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Eat
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jogre-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jogre-bones.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 3000
-  about: "Jogre bones is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 3,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  prayer:
+    bury_xp: 15
+    altar_xp: 52.5
+  drop_table:
+    sources:
+      - source: Jogre
+        combat_level: 53
+        quantity: "1"
+        rarity: Always
+        members_only: true
+      - source: Jogre
+        combat_level: 58
+        quantity: "1"
+        rarity: Always
+        members_only: true
+  about: "Jogre bones are members-only big bones dropped by Jogres in Karamja, released on 9 August 2004 with the Death Plateau quest update. They grant 15 Prayer experience when buried and up to 52.5 XP when offered at a gilded altar with two burners lit. They are commonly used as a budget alternative to dragon bones for Prayer training."
+  market_strategy:
+    notes:
+      - High buy limit of 3,000 makes bulk Prayer training feasible
+      - Cheaper than dragon bones but lower XP per cast
+      - Prices are tied to Prayer training demand and altar usage
+  history:
+    - date: "2004-08-09"
+      description: Released with the Death Plateau quest update
+    - date: "2018-08-30"
+      description: Ability to light Jogre bones on free-to-play worlds was removed
+  properties:
+    release_date: "2004-08-09"
+    update: Death Plateau
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Bury
+      - Drop
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jumbo-squid.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jumbo-squid.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: null
-  about: "Jumbo squid is a members-only item in Old School RuneScape. High alchemy value: 96 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: mid
+  food:
+    heal: 17
+    skill: Cooking
+    level: 71
+    xp: 180
+  recipes:
+    - name: Cook Raw jumbo squid
+      skill: Cooking
+      level: 71
+      xp: 180
+      output: Jumbo squid
+      output_quantity: 1
+      tools: [Fire]
+      materials:
+        - item_name: Raw jumbo squid
+          quantity: 1
+      notes: "Burn rate decreases with level; stops burning at 98 Cooking, or 96 with elite Kourend & Kebos Diary at Hosidius Kitchen."
+  related_items:
+    - item_name: Raw jumbo squid
+      slug: raw-jumbo-squid
+      relationship: component
+      description: Raw form caught via Sailing-related fishing content.
+    - item_name: Burnt jumbo squid
+      slug: burnt-jumbo-squid
+      relationship: alternative
+      description: Result of failing the cooking attempt.
+  about: "Jumbo squid is a members-only cooked food released with Sailing, healing 17 hitpoints and requiring 71 Cooking to prepare from raw jumbo squid."
+  market_strategy:
+    notes:
+      - "Sailing skill engagement and resource throughput drive supply; raw jumbo squid input cost currently exceeds the cooked sell price."
+  trading_tips:
+    - "Cooking the squid yourself nets the XP but loses gold per cook; watch raw price swings for arbitrage."
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.45
+    options: [Eat, Drop]
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kyatt-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kyatt-top.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 150
-  about: "Kyatt top is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weapon_type: armour
+    weight: 0.226
+    requirements:
+      hunter: 52
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 10
+      slash: 15
+      crush: 19
+      magic: 0
+      ranged: 12
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 10041
+      item_name: Kyatt legs
+      slug: kyatt-legs
+      relationship: set-piece
+      description: Polar Hunter outfit legs
+    - item_id: 10033
+      item_name: Kyatt hat
+      slug: kyatt-hat
+      relationship: set-piece
+      description: Polar Hunter outfit hat
+    - item_id: 10031
+      item_name: Larupia top
+      slug: larupia-top
+      relationship: alternative
+      description: Jungle Hunter equivalent
+    - item_id: 10043
+      item_name: Graahk top
+      slug: graahk-top
+      relationship: alternative
+      description: Desert Hunter equivalent
+  about: "Kyatt top is the polar-region Hunter camouflage chest piece, crafted from kyatt fur and reducing polar Hunter creature damage when worn as part of the full outfit."
+  market_strategy:
+    notes:
+      - Tradeable on the Grand Exchange
+      - Crafted from kyatt fur or bought at Fancy Clothes Store and Hunter Guild
+      - Demand tied to Polar Hunter activity
+      - Best paired with kyatt hat and legs for the full 60% damage reduction
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill update.
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/leather-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/leather-vambraces.mdx
@@ -1,6 +1,6 @@
 ---
 title: Leather vambraces | OSRS Price Data
-description: "Leather vambraces: Better than no armour!. High alch: 10 GP, GE limit: 125."
+description: "Leather vambraces are F2P hands slot armour, the best-in-slot mage gloves for free players. High alch: 10 GP, GE limit: 125."
 osrs:
   id: 1063
   name: Leather vambraces
@@ -12,9 +12,74 @@ osrs:
   lowalch: 7
   highalch: 10
   limit: 125
-  about: "Leather vambraces is a free-to-play item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: leather
+    tier: mid
+  equipment:
+    slot: hands
+    weight: 0.226
+    requirements: {}
+    attack_bonus:
+      ranged: 4
+    defence_bonus:
+      stab: 2
+      slash: 2
+      crush: 1
+  shops:
+    - shop_name: Aaron's Archery Appendages
+      location: Ranging Guild
+      price: 18
+      stock: 10
+  recipes:
+    - skill: Crafting
+      level: 11
+      experience: 22
+      materials:
+        - item_name: Leather
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+  related_items:
+    - item_id: 1099
+      item_name: Spiky vambraces
+      slug: spiky-vambraces
+      relationship: upgrade
+      description: Upgrade made by adding kebbit claws (Crafting 32)
+    - item_id: 1065
+      item_name: Hard leather vambraces
+      slug: hard-leather-vambraces
+      relationship: upgrade
+      description: Stronger hands slot armour crafted from hard leather
+  about: "Leather vambraces are commonly worn as the best-in-slot mage gloves for free-to-play players because they carry no magic penalty while still giving a small ranged attack bonus."
+  market_strategy:
+    notes:
+      - "Bulk demand comes from low-level rangers and F2P mages, so flips run on volume not margin; the GE limit of 125 caps per-cycle profit."
+  trading_tips:
+    - "Restock arbitrage from Aaron's Archery Appendages can undercut the GE; track daily volume around 15k to time large offers."
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 launch."
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/limestone-brick.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/limestone-brick.mdx
@@ -19,7 +19,7 @@ osrs:
     min_level: 1
     common_builds:
       - name: Stone fireplace
-        quantity: 2
+        quantity: "2"
         xp: 40
   recipes:
     - skill: crafting

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/m-treasure-chest-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/m-treasure-chest-flatpack.mdx
@@ -31,7 +31,7 @@ osrs:
           quantity: 2
       output:
         item_name: M. treasure chest (flatpack)
-        quantity: 1
+        quantity: "1"
       notes: Made at the Workshop workbench; requires hammer and saw.
   related_items:
     - item_id: 8782

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-potion-3.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 2000
-  about: "Magic potion(3) is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 3
+    effects:
+      - description: Temporarily boosts Magic level by 4. Boost does not allow equipping armour or weapons above the unboosted Magic level.
+  recipes:
+    - skill: Herblore
+      level: 76
+      xp: 172.5
+      materials:
+        - item_name: Lantadyme potion (unf)
+        - item_name: Potato cactus
+      tools:
+        - Vial of water
+      output: Magic potion(3)
+  related_items:
+    - item_id: 3040
+      item_name: Magic potion(4)
+      slug: magic-potion-4
+      relationship: upgrade
+      description: Four-dose variant
+  about: "Magic potion(3) is a 3-dose potion that temporarily boosts Magic by 4 levels, useful for casting spells slightly above the player's base Magic level."
+  history:
+    - date: "2004-09-07"
+      description: Released with the Situation in the Sands update.
+    - date: "2004-10-26"
+      description: An "Empty" option was added.
+    - date: "2015-10-08"
+      description: The item was recoloured to distinguish it from Ranging potions.
+  properties:
+    release_date: "2004-09-07"
+    update: Situation in the Sands
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-shortbow-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-shortbow-scroll.mdx
@@ -12,9 +12,47 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 10000
-  about: "Magic shortbow scroll is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: ranged
+      level: 1
+      xp: 0
+      materials:
+        - item_id: 861
+          item_name: Magic shortbow
+          quantity: 1
+        - item_id: 12786
+          item_name: Magic shortbow scroll
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_id: 12788
+      item_name: Magic shortbow (i)
+      slug: magic-shortbow-i
+      relationship: product
+      description: Imbued result of using the scroll on a Magic shortbow.
+  about: Magic shortbow scroll is a Bounty Hunter reward used on a Magic shortbow to permanently imbue it, reducing special attack energy cost from 55% to 50% and boosting ranged attack bonus.
+  history:
+    - date: "2014-09-25"
+      description: Examine text corrected to reference the magic shortbow.
+    - date: "2014-09-18"
+      description: Initial release as a Bounty Hunter reward.
+  properties:
+    release_date: "2014-09-18"
+    update: Bounty Hunter
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.002
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-staff.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 125
-  about: "Magic staff is a free-to-play item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2.267
+    attack_bonus:
+      stab: 2
+      slash: -1
+      crush: 10
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 10
+      ranged: 0
+    other_bonus:
+      melee_strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 1391
+      item_name: Staff of air
+      slug: staff-of-air
+      relationship: upgrade
+      description: Elemental staff providing unlimited air runes
+    - item_id: 1387
+      item_name: Staff
+      slug: staff
+      relationship: downgrade
+      description: Plain wooden staff variant
+  about: "Magic staff is a free-to-play one-handed staff with modest melee and magic bonuses, usable for spell autocast from the earliest levels of Magic."
+  market_strategy:
+    notes:
+      - Cheap free-to-play training option
+      - Demand driven by low-level mage trainers
+      - Marginal flip potential due to low GE volume
+  history:
+    - date: "2004-09-14"
+      description: Inventory and equipped graphics were updated.
+    - date: "2001-01-04"
+      description: Released with the RuneScape beta launch.
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-stock.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-stock.mdx
@@ -1,6 +1,6 @@
 ---
 title: Magic stock | OSRS Price Data
-description: "Magic stock: A magic crossbow stock.. High alch: 168 GP, GE limit: 10,000."
+description: "Magic stock: A magic crossbow stock. Fletching 78 to make. High alch: 168 GP, GE limit: 10,000."
 osrs:
   id: 21952
   name: Magic stock
@@ -12,9 +12,60 @@ osrs:
   lowalch: 112
   highalch: 168
   limit: 10000
-  about: "Magic stock is a members-only item in Old School RuneScape. High alchemy value: 168 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: magic
+    tier: mid
+  recipes:
+    - skill: Fletching
+      level: 78
+      xp: 70
+      tools:
+        - Knife
+      materials:
+        - item_name: Magic logs
+          quantity: 1
+  related_items:
+    - item_id: 21902
+      item_name: Dragon crossbow (u)
+      slug: dragon-crossbow-u
+      relationship: product
+      description: Combined with dragon limbs
+    - item_id: 21932
+      item_name: Dragon crossbow
+      slug: dragon-crossbow
+      relationship: product
+      description: Final dragon crossbow
+    - item_id: 9442
+      item_name: Yew stock
+      slug: yew-stock
+      relationship: downgrade
+      description: Lower tier crossbow stock
+  about: "Magic stock is a crossbow stock made by cutting a magic log at Fletching level 78, used to craft the dragon crossbow with dragon limbs."
+  market_strategy:
+    notes:
+      - Niche fletching intermediate for dragon crossbow
+      - GE supply driven by Fletching skillers
+      - Dragon crossbow demand keeps steady volume
+  history:
+    - date: "2018-01-04"
+      description: Magic stock released with Dragon Slayer II and the dragon crossbow.
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magus-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magus-ring.mdx
@@ -28,12 +28,12 @@ osrs:
         item_name: Magus vestige
       - item_id: 565
         item_name: Blood rune
-        quantity: 500
+        quantity: "500"
     materials:
       - item_name: Chromium ingot
-        quantity: 3
+        quantity: "3"
       - item_name: Ring mould
-        quantity: 1
+        quantity: "1"
     skill_requirements:
       magic: 90
       crafting: 80

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/marble-block.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/marble-block.mdx
@@ -21,13 +21,13 @@ osrs:
     source: Keldagrim Stonemason
     common_builds:
       - name: Marble lecterns
-        quantity: 1
+        quantity: "1"
         xp: 700
       - name: Gilded altar
-        quantity: 2
+        quantity: "2"
         xp: 1500
       - name: Ornate pool
-        quantity: 8
+        quantity: "8"
         xp: 3200
   shop_sources:
     - name: Keldagrim Stonemason

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-2h-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-2h-sword.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril 2h sword | OSRS Price Data
-description: "Mithril 2h sword: A two handed sword.. High alch: 1,560 GP, GE limit: 125."
+description: "Mithril 2h sword: A two handed sword. High alch: 1,560 GP, GE limit: 125."
 osrs:
   id: 1315
   name: Mithril 2h sword
@@ -12,9 +12,82 @@ osrs:
   lowalch: 1040
   highalch: 1560
   limit: 125
-  about: "Mithril 2h sword is a free-to-play item in Old School RuneScape. High alchemy value: 1,560 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: 2h
+    weapon_type: two-handed-sword
+    attack_speed: 7
+    weight: 3.175
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: -4
+      slash: 30
+      crush: 24
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    other_bonus:
+      melee_strength: 31
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 64
+      xp: 150
+      materials:
+        - item_name: Mithril bar
+          item_id: 2366
+          quantity: 3
+      tools: [Hammer, Anvil]
+      product: Mithril 2h sword
+      product_id: 1315
+      product_quantity: 1
+      members_only: false
+  related_items:
+    - item_id: 1311
+      item_name: Adamant 2h sword
+      slug: adamant-2h-sword
+      relationship: upgrade
+      description: Higher-tier two-handed sword
+    - item_id: 1309
+      item_name: Steel 2h sword
+      slug: steel-2h-sword
+      relationship: downgrade
+      description: Lower-tier two-handed sword
+  about: "Mithril 2h sword is a free-to-play two-handed slash weapon in Old School RuneScape requiring 20 Attack to wield. Smithed at level 64 from 3 mithril bars for 150 Smithing XP."
+  history:
+    - date: "2001-01-04"
+      update: Runescape beta is now online!
+      description: Released into the game.
+    - date: "2005-05-31"
+      description: Graphical update applied.
+    - date: "2005-08-23"
+      description: Equip animation changed.
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 3.175
+    options: [Drop]
+    worn_options: [Wield]
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-arrow-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-arrow-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril arrow(p) | OSRS Price Data
-description: "Mithril arrow(p) is a members ammo slot item. High alch: 19 GP, GE limit: 7,000."
+description: "Mithril arrow(p): Venomous-looking arrows. Mithril arrows tipped with weapon poison. High alch: 19 GP, GE limit: 7,000."
 osrs:
   id: 889
   name: Mithril arrow(p)
@@ -12,16 +12,86 @@ osrs:
   lowalch: 12
   highalch: 19
   limit: 7000
+  material:
+    type: mithril
+    tier: mid
   equipment:
     slot: ammo
-    ranged_strength: 22
-  related_items: []
-  about: |-
-    > _"Mithril arrows with a poisoned tip."_
-
-    Mithril arrows tipped with basic weapon poison. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 22
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Herblore
+      level: 1
+      tools: []
+      materials:
+        - item_name: Mithril arrow
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+  related_items:
+    - item_id: 888
+      item_name: Mithril arrow
+      slug: mithril-arrow
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 890
+      item_name: Mithril arrow(p+)
+      slug: mithril-arrow-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_id: 891
+      item_name: Mithril arrow(p++)
+      slug: mithril-arrow-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+  about: "Mithril arrow(p) is a poison-tipped mithril arrow with +22 ranged strength that has a chance to poison the target for 2 damage per tick."
+  market_strategy:
+    notes:
+      - Made by applying weapon poison to mithril arrows
+      - Niche ammo for poison strategies
+      - Often cheaper than the unpoisoned variant due to low demand
+  history:
+    - date: "2002-03-25"
+      description: Mithril arrows released with the original Fletching skill update.
+    - date: "2006-08-22"
+      description: Poisoned variants renamed for naming consistency (Mithril arrow(+) became Mithril arrow(p+)).
+  properties:
+    release_date: "2002-03-25"
+    update: Fletching
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts.mdx
@@ -26,9 +26,9 @@ osrs:
     level: 54
     materials:
       - item: Mithril bolts (unf)
-        quantity: 1
+        quantity: "1"
       - item: Feathers
-        quantity: 1
+        quantity: "1"
   obtaining:
     fletching: Attach feathers to mithril bolts (unf) at 54 Fletching
     drops:

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-cannonball.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-cannonball.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 11000
-  about: "Mithril cannonball is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Smithing
+      level: 55
+      xp: 34
+      materials:
+        - item_name: Mithril bar
+          quantity: 1
+      tools:
+        - Ammo mould
+      output_quantity: 4
+      notes: Requires partial completion of Dwarf Cannon.
+    - skill: Smithing
+      level: 55
+      xp: 68
+      materials:
+        - item_name: Mithril bar
+          quantity: 2
+      tools:
+        - Double ammo mould
+      output_quantity: 8
+      notes: Requires Sleeping Giants completion and Giants' Foundry access.
+  about: "Mithril cannonball is members ammunition used by mithril or stronger ship-mounted cannons during Sailing combat encounters."
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing skill launch.
+    - date: "2026-03-18"
+      description: Ranged Strength bonus increased from +48 to +105.
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dart-p-5639.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dart-p-5639.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril dart(p++) | OSRS Price Data
-description: "Mithril dart(p++): A deadly poisoned dart with a mithril tip.. High alch: 15 GP, GE limit: 7,000."
+description: "Mithril dart(p++): A deadly poisoned dart with a mithril tip. 2-tick throwing weapon. High alch: 15 GP, GE limit: 7,000."
 osrs:
   id: 5639
   name: Mithril dart(p++)
@@ -12,9 +12,94 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 7000
-  about: "Mithril dart(p++) is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 2
+    weight: 0
+    requirements:
+      ranged: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 9
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Herblore
+      level: 1
+      tools: []
+      materials:
+        - item_name: Mithril dart
+          quantity: 1
+        - item_name: Super weapon poison
+          quantity: 1
+  related_items:
+    - item_id: 807
+      item_name: Mithril dart
+      slug: mithril-dart
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 5637
+      item_name: Mithril dart(p)
+      slug: mithril-dart-p-5637
+      relationship: downgrade
+      description: Weak poison variant
+    - item_id: 5638
+      item_name: Mithril dart(p+)
+      slug: mithril-dart-p-plus
+      relationship: downgrade
+      description: Medium poison variant
+    - item_id: 811
+      item_name: Adamant dart(p++)
+      slug: adamant-dart-p-plus-plus
+      relationship: upgrade
+      description: Higher tier super-poison dart
+  about: "Mithril dart(p++) is a super-poison-tipped mithril throwing dart with +9 ranged strength and a 2-tick attack speed, used for fast ranged DPS."
+  market_strategy:
+    notes:
+      - Super poison variant of mithril dart
+      - 2-tick attack speed makes them strong filler ammo
+      - Made by applying super weapon poison to mithril darts
+      - GE volume tied to weapon poison supply
+  history:
+    - date: "2003-04-14"
+      description: Mithril darts released with the New Throwing Weapons update.
+    - date: "2021-06-23"
+      description: Ranged attack bonus dropped from +8 to 0, ranged strength increased from +7 to +9.
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dragon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dragon-mask.mdx
@@ -12,9 +12,31 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Mithril dragon mask is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 2.267
+  treasure_trail:
+    tier: elite
+    is_reward: true
+  about: "Mithril dragon mask is a cosmetic head slot reward from elite Treasure Trails, themed after the mithril dragons of the Ancient Cavern."
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-knife-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-knife-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril knife(p) | OSRS Price Data
-description: "Mithril knife(p) is a members weapon slot item requiring 20 Ranged. High alch: 16 GP, GE limit: 7,000."
+description: "Mithril knife(p) is a members thrown weapon requiring 20 Ranged, tipped with weapon poison. High alch: 16 GP, GE limit: 7,000."
 osrs:
   id: 873
   name: Mithril knife(p)
@@ -12,21 +12,77 @@ osrs:
   lowalch: 10
   highalch: 16
   limit: 7000
+  material:
+    type: mithril
+    tier: mid
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
+    weight: 0
     requirements:
       ranged: 20
     attack_bonus:
-      ranged: 9
-    ranged_strength: 9
-  related_items: []
-  about: |-
-    > _"A very sharp mithril knife with a poisoned tip."_
-
-    A mithril knife tipped with basic weapon poison. Requires 20 Ranged. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      ranged: 11
+    other_bonus:
+      ranged_strength: 10
+  recipes:
+    - skill: Smithing
+      level: 57
+      experience: 50
+      materials:
+        - item_name: Mithril bar
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 5
+  related_items:
+    - item_id: 871
+      item_name: Mithril knife
+      slug: mithril-knife
+      relationship: variant
+      description: Unpoisoned variant of the mithril throwing knife
+    - item_id: 5654
+      item_name: Mithril knife(p+)
+      slug: mithril-knife-p
+      relationship: upgrade
+      description: Stronger poison variant tipped with weapon poison+
+    - item_id: 5663
+      item_name: Mithril knife(p++)
+      slug: mithril-knife-p
+      relationship: upgrade
+      description: Strongest poison variant tipped with weapon poison++
+  about: "The mithril knife(p) is a thrown ranged weapon tipped with basic weapon poison, requiring 20 Ranged to wield and dealing a chance of 2-4 poison damage on hit."
+  market_strategy:
+    notes:
+      - "Poisoned thrown knives sell on consumable demand from PKers and low-level rangers; margins are thin so flips need volume and the 7k limit helps."
+  trading_tips:
+    - "Watch the spread between unpoisoned mithril knife and the (p) tier - if the poison premium narrows below the price of weapon poison plus a small fee, buy the poisoned tier directly."
+  history:
+    - date: "2003-04-14"
+      description: "Released as part of the New Throwing Weapons! update."
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-longsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-longsword.mdx
@@ -12,41 +12,93 @@ osrs:
   lowalch: 520
   highalch: 780
   limit: 125
+  material:
+    type: mithril
+    tier: mid
   equipment:
     slot: weapon
-    type: longsword
-    tradeable: true
+    weapon_type: slash_sword
+    attack_speed: 5
     weight: 1.587
     requirements:
       attack: 20
-    stats:
-      attack_stab: 15
-      attack_slash: 20
-      attack_crush: -2
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 22
+    attack_bonus:
+      stab: 15
+      slash: 20
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 22
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  recipes:
+    - skill: smithing
+      level: 56
+      xp: 100
+      materials:
+        - item_name: Mithril bar
+          quantity: 2
+      tools:
+        - Hammer
+      facility: Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Varrock Swordshop
+      location: Varrock
+      price: 1300
+    - shop_name: Warriors' Guild Armoury
+      location: Burthorpe
+      price: 1560
   related_items:
     - item_id: 1301
       item_name: Adamant longsword
       slug: adamant-longsword
       relationship: upgrade
       description: Higher tier longsword
+    - item_id: 1297
+      item_name: Steel longsword
+      slug: steel-longsword
+      relationship: downgrade
+      description: Lower tier longsword
     - item_id: 1329
       item_name: Mithril scimitar
       slug: mithril-scimitar
       relationship: alternative
       description: Faster slash alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: A free-to-play mithril longsword wielded at 20 Attack, smithed from two mithril bars at level 56 Smithing for 100 experience.
+  market_strategy:
+    notes:
+      - Cheap entry F2P longsword, GE price well below shop price
+      - Useful Smithing alch fodder when bar costs are low
+  history:
+    - date: "2001-01-04"
+      description: Released alongside the original Smithing weapon set.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape released
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.587
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-platebody.mdx
@@ -12,25 +12,80 @@ osrs:
   lowalch: 2080
   highalch: 3120
   limit: 125
-  item_id: 1121
-  item_type: armor
-  slot: body
-  type: platebody
-  tradeable: true
-  weight: 8.618
-  requirements:
-    defence: 20
-  stats:
-    stab_defence: 46
-    slash_defence: 44
-    crush_defence: 38
-    magic: -30
-    ranged: -15
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: body
+    weight: 8.618
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 46
+      slash: 44
+      crush: 38
+      magic: -6
+      ranged: 44
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Smithing
+      level: 68
+      experience: 250
+      materials:
+        - item_name: Mithril bar
+          quantity: 5
+      tools:
+        - Hammer
+        - Anvil
   related_items:
-    - slug: adamant-platebody
-    - slug: mithril-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Adamant platebody
+      slug: adamant-platebody
+      relationship: upgrade
+      description: Higher tier platebody armour
+    - item_name: Mithril bar
+      slug: mithril-bar
+      relationship: component
+      description: Smithing material used to create this item
+  about: "Mithril platebody is a free-to-play body slot armour piece in Old School RuneScape requiring level 20 Defence to wear. It is created by Smithing with 5 mithril bars at level 68 Smithing for 250 experience. Despite being free-to-play, it offers solid defensive bonuses against melee combat styles."
+  market_strategy:
+    notes:
+      - Common F2P armour with steady mid-level demand
+      - Smithing it for experience is rarely profitable; the GE is cheaper than bars
+      - Buy when the GE price drops below mithril bar cost for resale margin
+  history:
+    - date: "2001-01-04"
+      description: Released with the original RuneScape beta launch
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -10 to -15
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 8.618
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/monkey-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/monkey-bones.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 3000
-  about: "Monkey bones is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 3,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  prayer:
+    bury_xp: 5
+    altar_xp: 17.5
+    ectofuntus_xp: 20
+    sinister_offering_xp: 15
+  drop_table:
+    sources:
+      - source: Monkey
+        combat_level: 3
+        quantity: "1"
+        rarity: always
+        members_only: false
+  related_items:
+    - item_id: 526
+      item_name: Bones
+      slug: bones
+      relationship: alternative
+      description: Standard bones with 4.5 Prayer XP
+    - item_id: 532
+      item_name: Big bones
+      slug: big-bones
+      relationship: upgrade
+      description: Higher-tier bones giving 15 Prayer XP
+  about: "Monkey bones are a free-to-play bone drop from monkeys that grant 5 Prayer XP when buried, scaling up to 20 XP at the Ectofuntus."
+  market_strategy:
+    notes:
+      - Cheap free-to-play Prayer training material
+      - Niche compared to dragon or ourg bones for XP rate
+      - Limited bulk demand keeps prices low
+  history:
+    - date: "2004-09-14"
+      description: Released with the Tai Bwo Wannai Trio update.
+  properties:
+    release_date: "2004-09-14"
+    update: Tai Bwo Wannai Trio
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.5
+    options:
+      - Bury
+      - Drop
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-hat-light.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-hat-light.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: 70
-  about: "Mystic hat (light) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.453
+    requirements:
+      magic: 40
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  about: Mystic hat (light) is the head piece of the light variant mystic robes set, a popular early-game magic head slot option.
+  history:
+    - date: "2014-12-10"
+      description: Item renamed from 'Mystic hat' to 'Mystic hat (light)'.
+    - date: "2006-01-16"
+      description: Examine text changed from 'A magical hat' to 'A bright magical hat'.
+  properties:
+    release_date: "2005-01-26"
+    update: Mystic Magic
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/necklace-of-passage-5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/necklace-of-passage-5.mdx
@@ -14,72 +14,86 @@ osrs:
   limit: 10000
   equipment:
     slot: neck
-    type: teleport_jewelry
-    tradeable: true
     weight: 0.01
-    charges: 5
-  creation:
-    method: Enchant Jade necklace with Lvl-2 Enchant
-    requirements:
-      magic: 27
-    runes:
-      - rune: Cosmic
-        quantity: 1
-      - rune: Air
-        quantity: 3
-  teleports:
-    - destination: Wizards' Tower
-    - destination: The Outpost
-    - destination: Eagles' Eyrie
-  market:
-    buy_limit: 10000
-    price_estimate: 700
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    max: 5
+    notes: Crumbles to dust when the final charge is consumed.
+  recipes:
+    - name: Enchant Jade necklace (Lvl-2 Enchant)
+      skill: magic
+      level: 27
+      xp: 37
+      materials:
+        - item_id: 1660
+          item_name: Jade necklace
+          quantity: 1
+        - item_id: 564
+          item_name: Cosmic rune
+          quantity: 1
+        - item_id: 556
+          item_name: Air rune
+          quantity: 3
+      product: Necklace of passage(5)
+      product_id: 21146
+      product_quantity: 1
+      tools: []
+      members_only: true
+  teleport:
+    destinations:
+      - Wizards' Tower
+      - The Outpost
+      - Eagles' Eyrie
   related_items:
     - item_id: 3853
       item_name: Games necklace
       slug: games-necklace
       relationship: alternative
-      description: Similar utility
-    - item_id: 1658
+      description: Similar utility teleport necklace
+    - item_id: 1660
       item_name: Jade necklace
       slug: jade-necklace
       relationship: component
-      description: Base item
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Neck |
-    | Type | Teleport Jewelry |
-    | Tradeable | Yes |
-    | Weight | 0.01 kg |
-
-    Enchant Jade necklace with Lvl-2 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 27 |
-    | Cosmic rune | 1 |
-    | Air rune | 3 |
-
-    - Wizards' Tower
-    - The Outpost
-    - Eagles' Eyrie
-
-    Charges: 5 (crumbles when depleted)
-
-    Great for:
-    - Wizards' Tower access
-    - Fairy ring alternatives
-    - Clue scrolls
-
-    Useful teleport necklace.
+      description: Base item before enchanting
+  about: Necklace of passage(5) is an enchanted Jade necklace with 5 charges that teleports to Wizards' Tower, The Outpost, or Eagles' Eyrie before crumbling to dust.
   market_strategy:
     notes:
-      - Good for early game
-      - Wizards' Tower useful
-      - Alternative to fairy rings
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cheap utility teleport for clues and early game
+      - High 10k buy limit keeps it fluid for bulk crafters
+      - Demand tied to Wizards' Tower and Eagles' Eyrie access
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-02-02"
+    update: A Closed Door, A Forbidden Place
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Rub
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ogre-coffin-key.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ogre-coffin-key.mdx
@@ -12,9 +12,25 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 3000
-  about: "Ogre coffin key is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 3,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Ogre coffin key unlocks the coffins inside the Jiggig dungeon, granting access to ogre bones used in Prayer training and Rag and Bone Man."
+  history:
+    - date: "2015-12-10"
+      description: "Examine text updated to clarify location: opens the locked coffins in the cave at Jiggig."
+  properties:
+    release_date: "2005-05-17"
+    update: "Zogre Flesh Eaters"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.055
+    options:
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oil-lantern.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oil-lantern.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 50
   highalch: 75
   limit: 40
-  about: "Oil lantern is a members-only item in Old School RuneScape. High alchemy value: 75 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: tool
+    tier: mid
+  recipes:
+    - name: Fill empty oil lantern
+      skill: Crafting
+      level: 26
+      output: Oil lantern
+      output_quantity: 1
+      tools: []
+      materials:
+        - item_name: Oil lantern (empty)
+          quantity: 1
+        - item_name: Lamp oil
+          quantity: 1
+  drop_table:
+    - source: Cave goblin guard
+      rarity: "20/128"
+      quantity: "1"
+    - source: Cave goblin (guard variant)
+      rarity: "20/128"
+      quantity: "1"
+  shops:
+    - shop_name: Miltog's Lamps
+      location: Dorgesh-Kaan
+      price: 187
+  related_items:
+    - item_name: Oil lamp
+      slug: oil-lamp
+      relationship: alternative
+      description: Lower-tier oil-fuelled light source.
+    - item_name: Candle lantern
+      slug: candle-lantern
+      relationship: alternative
+      description: Candle-powered light source unlocked earlier in Firemaking.
+    - item_name: Bullseye lantern
+      slug: bullseye-lantern
+      relationship: upgrade
+      description: Upgraded oil-fuelled lantern used in higher-level Firemaking content.
+    - item_name: Lamp oil
+      slug: lamp-oil
+      relationship: component
+      description: Fuel required to convert an empty oil lantern into a lit-ready oil lantern.
+  about: "Oil lantern is a level 26 Firemaking light source crafted from an empty oil lantern and lamp oil, also sold by Miltog's Lamps and dropped by cave goblin guards in Dorgesh-Kaan."
+  market_strategy:
+    notes:
+      - "Demand comes from Lumbridge cave content and Dorgesh-Kaan questers; lamp oil supply caps profitability."
+  trading_tips:
+    - "Buy empties cheap, fill with lamp oil, and resell finished lanterns for a tidy margin."
+  history:
+    - date: "2005-03-14"
+      description: Released with the Lumbridge Swamp Caves update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-03-14"
+    update: "Lumbridge Swamp Caves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options: [Drop]
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-bolts-e.mdx
@@ -35,11 +35,11 @@ osrs:
     magic_level: 87
     runes:
       - item_name: Fire rune
-        quantity: 20
+        quantity: "20"
       - item_name: Death rune
-        quantity: 1
+        quantity: "1"
       - item_name: Cosmic rune
-        quantity: 1
+        quantity: "1"
     bolts_per_cast: 10
   related_items:
     - item_id: 9342

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-ring.mdx
@@ -14,19 +14,39 @@ osrs:
   limit: 10000
   equipment:
     slot: ring
+    weight: 0.006
     requirements:
       crafting: 67
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 67
       xp: 115
-      inputs:
+      materials:
         - item_id: 6573
           item_name: Onyx
           quantity: 1
         - item_id: 2357
           item_name: Gold bar
           quantity: 1
+      tools:
+        - Ring mould
       output_quantity: 1
   related_items:
     - item_id: 1645
@@ -39,19 +59,38 @@ osrs:
       slug: zenyte-ring
       relationship: upgrade
       description: Next tier ring (zenyte)
-  about: |-
-    | Input | Skill | Level | XP |
-    |-------|-------|-------|----|
-    | Onyx + Gold bar | Crafting | 67 | 115 |
-
-    Enchant with Lvl-6 Enchant (Magic 87) to create Ring of stone (cosmetic transformation).
+  about: Onyx ring is a high-value ring crafted from an onyx and a gold bar at a furnace, primarily used as the base for the cosmetic Ring of stone.
   market_strategy:
     notes:
       - Onyx is expensive (~2.5M)
       - Ring of stone is cosmetic only
       - Niche crafting XP method
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2018-12-13"
+      description: Inventory sprite adjusted.
+    - date: "2018-02-22"
+      description: Sprite rotated to distinguish from enchanted jewellery.
+    - date: "2005-10-17"
+      description: Value increased from 1 to 201,000 coins.
+  properties:
+    release_date: "2005-10-04"
+    update: TzHaar Fight Caves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/opal-dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/opal-dragon-bolts.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 220
   highalch: 330
   limit: 11000
-  about: "Opal dragon bolts is a members-only item in Old School RuneScape. High alchemy value: 330 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: ammo
+    weight: 0
+    requirements:
+      ranged: 64
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 122
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Fletching
+      level: 84
+      xp: 16
+      materials:
+        - item_name: Dragon bolts
+          quantity: 10
+        - item_name: Opal bolt tips
+          quantity: 10
+      tools: []
+      output_quantity: 10
+  about: "Opal dragon bolts are high-tier crossbow ammunition fletched at level 84, gaining the Lucky Lightning passive when enchanted for use with dragon crossbows."
+  history:
+    - date: "2018-01-04"
+      description: Released alongside Dragon Slayer II.
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/orange-flowers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/orange-flowers.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Orange flowers is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flower
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    weight: 0.028
+    attack_bonus:
+      stab: -100
+      slash: -100
+      crush: -50
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: -10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  farming:
+    seed: Mithril seed
+    notes: Planting mithril or adamant seeds yields a random-colour flower including orange.
+  related_items:
+    - item_id: 299
+      item_name: Mithril seed
+      slug: mithril-seed
+      relationship: component
+      description: Plants random-colour flowers including orange
+  about: "Orange flowers are a posy obtained by planting mithril or adamant seeds. Equippable as a fun weapon with heavy combat penalties; primarily decorative."
+  history:
+    - date: "2004-03-29"
+      description: Released at RuneScape 2 launch.
+    - date: "2014-12-10"
+      description: The item was renamed from "Flowers" to "Orange flowers".
+    - date: "2024-04-10"
+      description: Coloured flowers became obtainable from adamant seeds.
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/orange-salamander.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/orange-salamander.mdx
@@ -1,6 +1,6 @@
 ---
 title: Orange salamander | OSRS Price Data
-description: "Orange salamander: Slightly slimy but kind of cute.. High alch: 60 GP, GE limit: 125."
+description: "Orange salamander: Slightly slimy but kind of cute. High alch: 60 GP, GE limit: 125."
 osrs:
   id: 10146
   name: Orange salamander
@@ -12,9 +12,74 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 125
-  about: "Orange salamander is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: salamander
+    attack_speed: 5
+    weight: 4
+    requirements:
+      attack: 50
+      magic: 50
+      ranged: 50
+    attack_bonus:
+      stab: 0
+      slash: 19
+      crush: 0
+      magic: 0
+      ranged: 29
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 31
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 10149
+      item_name: Red salamander
+      slug: red-salamander
+      relationship: upgrade
+      description: Higher tier two-handed hybrid salamander
+    - item_id: 10147
+      item_name: Swamp lizard
+      slug: swamp-lizard
+      relationship: downgrade
+      description: Lower-level hybrid salamander
+    - item_id: 10148
+      item_name: Black salamander
+      slug: black-salamander
+      relationship: upgrade
+      description: Highest-tier standard salamander
+  about: A live orange salamander caught at 47 Hunter with a small fishing net and rope, used as a hybrid two-handed weapon switchable between Scorch (slash), Flare (ranged), and Blaze (magic).
+  market_strategy:
+    notes:
+      - Steady consumption — escapes from inventory on death and must be replaced
+      - Popular for AFK chinning style training in low-defence dungeons
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Wield
+      - Release
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/papaya-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/papaya-sapling.mdx
@@ -12,9 +12,47 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Papaya sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    level: 57
+    patch_type: Fruit tree
+    growth_time_minutes: 960
+    planting_xp: 72
+    checking_xp: 6146.6
+    harvest_xp: 27
+    yield: 6
+    protection_payment: 10 pineapples
+  related_items:
+    - item_id: 5288
+      item_name: Papaya tree seed
+      slug: papaya-tree-seed
+      relationship: component
+      description: Seed planted in plant pot to grow sapling
+    - item_id: 5972
+      item_name: Papaya fruit
+      slug: papaya-fruit
+      relationship: product
+      description: Harvested fruit from grown tree
+  about: "Papaya sapling is grown from a papaya tree seed planted in a plant pot and is then transplanted into a fruit tree patch at 57 Farming."
+  history:
+    - date: "2015-01-29"
+      description: Saplings of tradeable seeds became Grand Exchange tradeable.
+    - date: "2005-07-11"
+      description: Released with the Farming update.
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/partyhat-specs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/partyhat-specs.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 720
   highalch: 1080
   limit: 4
-  about: "Partyhat & specs is a members-only item in Old School RuneScape. High alchemy value: 1,080 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 1042
+      item_name: Blue partyhat
+      slug: blue-partyhat
+      relationship: component
+      description: Required base hat for assembly
+    - item_id: 10498
+      item_name: Sagacious spectacles
+      slug: sagacious-spectacles
+      relationship: component
+      description: Reward from Treasure Trails combined with the hat
+  about: "Partyhat & specs is a cosmetic head slot item made by combining a blue partyhat with sagacious spectacles via Patchy on Mos Le'Harmless after Cabin Fever; assembly costs 500 coins, disassembly costs 600."
+  history:
+    - date: "2014-06-12"
+      description: Added to the game with the Treasure Trail Expansion update.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pink-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pink-boots.mdx
@@ -1,11 +1,11 @@
 ---
 title: Pink boots | OSRS Price Data
-description: "Pink boots is a members feet slot item. High alch: 120 GP, GE limit: 150."
+description: "Pink boots: a cosmetic gnome-style feet slot item sold by Rometti at the Grand Tree with minimal defensive bonuses. High alch: 120 GP, GE limit: 150."
 osrs:
   id: 626
   name: Pink boots
   slug: pink-boots
-  examine: They're soft, silky and pink.
+  examine: "They're soft, silky and pink."
   members: true
   icon: Pink boots.png
   value: 200
@@ -14,18 +14,82 @@ osrs:
   limit: 150
   equipment:
     slot: feet
+    weight: 0.34
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Rometti's Fine Fashions"
+      location: Grand Tree, Tree Gnome Stronghold
+      stock: 5
+      price: 200
+      currency: Coins
+      description: Gnome tailor shop stocking the pink boots.
   related_items:
     - item_id: 636
       item_name: Pink robe top
       slug: pink-robe-top
       relationship: set-piece
-      description: Matching top
-  about: |-
-    > _"A\"nice\" pair of pink boots."_
-
-    Pink boots are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching pink gnome robe top.
+    - item_id: 638
+      item_name: Pink skirt
+      slug: pink-skirt
+      relationship: set-piece
+      description: Matching pink gnome skirt.
+    - item_id: 657
+      item_name: Pink hat
+      slug: pink-hat
+      relationship: set-piece
+      description: Matching pink gnome hat.
+  about: "Pink boots are a gnome-style feet slot cosmetic from Rometti's Fine Fashions with marginal slash and crush defence."
+  market_strategy:
+    title: Investment Notes
+    notes:
+      - Reliable shop supply keeps the GE price close to value.
+      - Demand driven entirely by fashionscape and gnome-themed outfits.
+      - Buy limit of 150 leaves plenty of room for bulk fashionscape buyers.
+      - Pair with the matching pink robe top, skirt and hat for the full set.
+  history:
+    - date: "2002-12-12"
+      update: Agility skill launch
+      description: Added to game alongside the Agility skill release.
+    - date: "2014-12-10"
+      update: Item rename
+      description: Renamed from "Boots" to "Pink boots" to disambiguate gnome clothing.
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pink-elegant-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pink-elegant-shirt.mdx
@@ -12,21 +12,62 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  material:
+    type: cloth
+    tier: mid
   equipment:
     slot: body
-    requirements: {}
+    weight: 0.1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers: [medium]
   related_items:
     - item_id: 12317
       item_name: Pink elegant legs
       slug: pink-elegant-legs
       relationship: set-piece
       description: Matching elegant legs
-  about: |-
-    > *"A well made elegant men's pink shirt."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the pink elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Pink elegant shirt is a purely cosmetic body slot reward from medium Treasure Trails at a 8/18,128 rate, forming part of the pink elegant clothing set and storable in the costume room."
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Released as part of the Treasure Trail Expansion.
+    - date: "2014-12-01"
+      description: Renamed from "Pink ele' shirt" to "Pink elegant shirt".
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options: [Drop]
+    worn_options: [Wear]
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-bandana-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-bandana-blue.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Pirate bandana (blue) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Dodgy Mike's Second Hand Clothing"
+      location: Mos Le'Harmless
+      price: 100
+      stock: 20
+  related_items:
+    - item_name: Blue bandana eyepatch
+      slug: blue-bandana-eyepatch
+      relationship: product
+      description: "Combined with right eye patch via Patchy (requires Book o' piracy + 500 coins)"
+  about: "Pirate bandana (blue) is a members-only cosmetic head slot item released during the Cabin Fever update on 7 February 2006. It provides no combat bonuses and is sold by Dodgy Mike's Second Hand Clothing on Mos Le'Harmless for 100 coins. Players can combine it with a right eye patch through Patchy to create a blue bandana eyepatch."
+  market_strategy:
+    notes:
+      - Cheap cosmetic head item with limited demand
+      - Used primarily for pirate-themed outfits and the bandana eyepatch combination
+      - Sold directly from Dodgy Mike's shop for 100 coins making it nearly always available
+  history:
+    - date: "2006-02-07"
+      description: Released with the Cabin Fever update
+    - date: "2006-06-13"
+      description: "Renamed from 'Pirate bandanna' to 'Pirate bandana'"
+  properties:
+    release_date: "2006-02-07"
+    update: Cabin Fever
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-bandana-red.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-bandana-red.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Pirate bandana (red) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Dodgy Mike's Second Hand Clothing
+      location: Mos Le'Harmless
+      price: 100
+      currency: coins
+      stock: 20
+  about: "Pirate bandana (red) is a members-only cosmetic head slot item sold by Dodgy Mike on Mos Le'Harmless, primarily used as pirate-themed gear and as a component for the bandana eyepatch."
+  properties:
+    release_date: "2006-02-07"
+    update: Cabin Fever
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  history:
+    - date: "2006-02-07"
+      description: Released with the Cabin Fever quest update.
+    - date: "2006-06-13"
+      description: Renamed from 'Pirate bandanna' to 'Pirate bandana'.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/plain-pizza.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/plain-pizza.mdx
@@ -1,6 +1,6 @@
 ---
 title: Plain pizza | OSRS Price Data
-description: "Plain pizza: A cheese and tomato pizza.. High alch: 24 GP, GE limit: 10,000."
+description: "Plain pizza is a F2P cookable food healing 7 HP per bite. High alch: 24 GP, GE limit: 10,000."
 osrs:
   id: 2289
   name: Plain pizza
@@ -12,9 +12,74 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 10000
-  about: "Plain pizza is a free-to-play item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 14
+    bites: 2
+    heal_per_bite: 7
+  recipes:
+    - skill: Cooking
+      level: 35
+      xp: 143
+      output_quantity: 1
+      facility: Range or oven
+      materials:
+        - item_name: Uncooked pizza
+          quantity: 1
+  related_items:
+    - item_id: 2287
+      item_name: Uncooked pizza
+      slug: uncooked-pizza
+      relationship: component
+      description: Raw ingredient before cooking
+    - item_id: 2291
+      item_name: Meat pizza
+      slug: meat-pizza
+      relationship: upgrade
+      description: Upgraded by adding cooked meat
+    - item_id: 2293
+      item_name: Anchovy pizza
+      slug: anchovy-pizza
+      relationship: upgrade
+      description: Upgraded by adding cooked anchovies
+    - item_id: 2295
+      item_name: Pineapple pizza
+      slug: pineapple-pizza
+      relationship: upgrade
+      description: Upgraded by adding pineapple
+  about: Plain pizza is a two-bite food cooked at 35 Cooking, healing 7 HP per bite and forming the base for stronger pizza variants.
+  history:
+    - date: "2001-06-11"
+      update: New fishing skill and more cooking
+      description: Plain pizza added with the original Cooking expansion update.
+    - date: "2004-03-29"
+      update: RuneScape 2 launch
+      description: Carried over and made permanently available at RS2 launch.
+    - date: "2004-11-17"
+      update: Graphical Update
+      description: Half pizza inventory icon graphically updated.
+    - date: "2015-02-26"
+      update: GE Update
+      description: Half pizza made untradeable on the Grand Exchange.
+    - date: "2015-08-13"
+      update: Quality of Life
+      description: Pizza now remains in the same inventory slot after the first half is eaten.
+  properties:
+    release_date: "2001-06-11"
+    update: New fishing skill and more cooking
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.8
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/polar-kebbit-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/polar-kebbit-fur.mdx
@@ -1,6 +1,6 @@
 ---
 title: Polar kebbit fur | OSRS Price Data
-description: "Polar kebbit fur: A thick fur for a cold climate.. High alch: 6 GP, GE limit: 100."
+description: "Polar kebbit fur: A thick fur for a cold climate. High alch: 6 GP, GE limit: 100."
 osrs:
   id: 10117
   name: Polar kebbit fur
@@ -12,9 +12,68 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 100
-  about: "Polar kebbit fur is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Polar kebbit fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 20
+      facility: Fancy Clothes Store
+      output_item: Polar camo top
+      output_quantity: 1
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Polar kebbit fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 20
+      facility: Fancy Clothes Store
+      output_item: Polar camo legs
+      output_quantity: 1
+  related_items:
+    - item_id: 10067
+      item_name: Polar camo top
+      slug: polar-camo-top
+      relationship: product
+      description: Camouflage top tailored from polar kebbit fur
+    - item_id: 10068
+      item_name: Polar camo legs
+      slug: polar-camo-legs
+      relationship: product
+      description: Camouflage legs tailored from polar kebbit fur
+    - item_id: 10115
+      item_name: Common kebbit fur
+      slug: common-kebbit-fur
+      relationship: alternative
+      description: Lower-tier kebbit fur drop
+  about: A polar kebbit fur tracked and caught with a noose wand in the Rellekka Hunter area, tailored at the Fancy Clothes Store into polar camouflage gear.
+  market_strategy:
+    notes:
+      - Demand from Hunter ironmen needing polar camo gear
+      - Low GE supply — track polar kebbits in Rellekka instead of buying
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pot-of-cornflour.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pot-of-cornflour.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 15
-  about: "Pot of cornflour is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: quest
+    tier: low
+  recipes:
+    - name: Grind Sweetcorn into cornflour
+      skill: Cooking
+      output: Pot of cornflour
+      output_quantity: 1
+      tools: [Windmill]
+      materials:
+        - item_name: Sweetcorn
+          quantity: 1
+        - item_name: Pot
+          quantity: 1
+      notes: "Collected from the basin under the windmill after grinding sweetcorn."
+  related_items:
+    - item_name: Cornflour mixture
+      slug: cornflour-mixture
+      relationship: product
+      description: Combined with milky mixture during Recipe for Disaster.
+    - item_name: Sweetcorn
+      slug: sweetcorn
+      relationship: component
+      description: Raw input ground at a windmill to produce cornflour.
+  about: "Pot of cornflour is a Recipe for Disaster quest item made by grinding sweetcorn at a windmill, used in the Freeing Sir Amik Varze subquest to prepare creme brulee supreme."
+  market_strategy:
+    notes:
+      - "Strictly demanded by Recipe for Disaster questers; supply is constrained by the small 15-per-4-hours buy limit."
+  trading_tips:
+    - "Self-make at a windmill if the GE markup is excessive; the recipe needs no skill levels."
+  history:
+    - date: "2006-03-15"
+      description: Released as part of the Recipe for Disaster quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-03-15"
+    update: "Recipe for Disaster"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 1.36
+    options: [Empty, Drop]
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-veg-batta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-veg-batta.mdx
@@ -12,9 +12,42 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 6000
-  about: "Premade veg batta is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 11
+    edible: true
+  shops:
+    - shop_name: Grand Tree Gnome Waiter
+      price: 120
+      currency: Coins
+      stock: 3
+  related_items:
+    - item_id: 2222
+      item_name: Veg batta
+      slug: veg-batta
+      relationship: variant
+      description: Player-made vegetable batta with identical effect
+  about: "Premade veg batta is a members food item purchased from the gnome waiter at the Grand Tree (stock 3) for 120 coins; restores 11 Hitpoints when eaten."
+  history:
+    - date: "2002-12-12"
+      description: Added to the game with the launch of the Agility skill.
+    - date: "2006-08-07"
+      description: Renamed from 'Vegetable batta' to 'Premade veg batta'.
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-hauberk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-hauberk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Proselyte hauberk | OSRS Price Data
-description: "Proselyte hauberk is a members body slot item requiring 30 Defence. High alch: 7,200 GP, GE limit: 70."
+description: "Proselyte hauberk is a members body slot prayer armour requiring 30 Defence and 20 Prayer. High alch: 7,200 GP, GE limit: 70."
 osrs:
   id: 9674
   name: Proselyte hauberk
@@ -14,66 +14,87 @@ osrs:
   limit: 70
   equipment:
     slot: body
-    type: armour
-    prayer_bonus: 8
+    weight: 8.618
     requirements:
       defence: 30
       prayer: 20
-    combat_stats:
-      stab_defence: 50
-      slash_defence: 54
-      crush_defence: 46
-      magic_defence: -6
-      ranged_defence: 54
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -15
+    defence_bonus:
+      stab: 65
+      slash: 63
+      crush: 55
+      magic: -6
+      ranged: 54
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 8
+  shops:
+    - shop_name: Sir Tiffy Cashien
+      location: Falador Park
+      price: 12000
   related_items:
     - item_id: 9676
       item_name: Proselyte cuisse
       slug: proselyte-cuisse
       relationship: set-piece
-      description: Legs (+6 Prayer)
+      description: Legs piece (+6 Prayer)
     - item_id: 9672
       item_name: Proselyte sallet
       slug: proselyte-sallet
       relationship: set-piece
-      description: Helm (+4 Prayer)
+      description: Helm piece (+4 Prayer)
     - item_id: 5575
       item_name: Initiate hauberk
       slug: initiate-hauberk
       relationship: downgrade
-      description: Lower tier (+6 Prayer)
+      description: Lower tier prayer body (+6 Prayer)
     - item_id: 544
-      item_name: Monk's robe top
+      item_name: "Monk's robe top"
       slug: monks-robe-top
       relationship: downgrade
-      description: No defence (+6 Prayer)
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Body |
-    | Prayer Bonus | +8 |
-    | Defence Req | 30 |
-    | Prayer Req | 20 |
-
-    - Best-in-slot prayer bonus platebody
-    - Slayer tasks with protection prayers
-    - Budget melee gear with prayer bonus
-
-    | Piece | Prayer Bonus |
-    |-------|--------------|
-    | Proselyte sallet | +4 |
-    | Proselyte hauberk | +8 |
-    | Proselyte cuisse | +6 |
-    | Total | +18 |
+      description: No defence prayer top (+6 Prayer)
+  about: "Proselyte hauberk is a best-in-slot tier prayer-bonus platebody requiring 30 Defence and 20 Prayer, purchased from Sir Tiffy after The Slug Menace."
   market_strategy:
     notes:
-      - Requires quest completion
-      - Shop purchase only
-      - No GE trading (untradeable)
-      - Must complete The Slug Menace
-      - Buy from Sir Tiffy for ~8k
-      - Best prayer armour available
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Requires The Slug Menace quest
+      - Shop-bought from Sir Tiffy for ~12k
+      - Best prayer body bonus before Justiciar
+      - Used for slayer tasks with protect prayers
+  trading_tips:
+    - Buy from Sir Tiffy Cashien before selling on GE
+    - GE price typically below shop price
+    - High demand during Slayer-focused leagues
+  history:
+    - date: "2006-09-20"
+      description: Proselyte hauberk released with The Slug Menace quest.
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -10 to -15.
+  properties:
+    release_date: "2006-09-20"
+    update: The Slug Menace
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8.618
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-sallet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-sallet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Proselyte sallet | OSRS Price Data
-description: "Proselyte sallet is a members full_set slot item requiring 30 Defence. High alch: 4,800 GP, GE limit: 70."
+description: "Proselyte sallet is a members head slot item requiring 30 Defence and 20 Prayer. High alch: 4,800 GP, GE limit: 70."
 osrs:
   id: 9672
   name: Proselyte sallet
@@ -12,89 +12,86 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: 70
+  material:
+    type: prayer-armor
+    tier: mid
   equipment:
-    slot: full_set
-    type: prayer_armor
+    slot: head
+    weight: 2.267
     requirements:
       defence: 30
       prayer: 20
-      quest: The Slug Menace
-    stats:
-      defence_stab: 117
-      defence_slash: 115
-      defence_crush: 100
-      defence_magic: -11
-      defence_ranged: 113
-      prayer: 18
-  set_pieces:
-    sallet:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -1
+      ranged: -3
+    defence_bonus:
+      stab: 19
+      slash: 21
+      crush: 16
+      magic: -1
+      ranged: 19
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 4
-      slot: head
-    hauberk:
-      prayer: 8
-      slot: body
-    cuisse:
-      prayer: 6
-      slot: legs
   drop_table:
     sources:
       - source: Sir Tiffy Cashien (Falador Park)
-        source_id: 0
         combat_level: 0
         quantity: "1"
-        rarity: N/A
+        rarity: always
         members_only: true
   related_items:
+    - item_id: 9674
+      item_name: Proselyte hauberk
+      slug: proselyte-hauberk
+      relationship: set-piece
+      description: Body slot piece of the Proselyte set
+    - item_id: 9676
+      item_name: Proselyte cuisse
+      slug: proselyte-cuisse
+      relationship: set-piece
+      description: Legs slot piece of the Proselyte set
     - item_id: 9670
-      item_name: Initiate armour
-      slug: initiate-armour
+      item_name: Initiate sallet
+      slug: initiate-sallet
       relationship: downgrade
-      description: Lower tier
-    - item_id: 23191
-      item_name: Devout boots
-      slug: devout-boots
-      relationship: alternative
-      description: Prayer boots
-    - item_id: 6714
-      item_name: Holy wrench
-      slug: holy-wrench
-      relationship: alternative
-      description: Prayer boost
-  about: |-
-    | Piece | Prayer | Defence |
-    |-------|--------|---------|
-    | Proselyte sallet | +4 | Helm |
-    | Proselyte hauberk | +8 | Body |
-    | Proselyte cuisse/tasset | +6 | Legs |
-    | Total | +18 | |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +117 |
-    | Slash | +115 |
-    | Crush | +100 |
-    | Magic | -11 |
-    | Ranged | +113 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +18 (full set) |
-
-    Requirements: 30 Defence, 20 Prayer
-
-    Essential for:
-    - Protection prayer Slayer
-    - Budget prayer gear
-    - Cannon tasks
-
-    Best prayer bonus armor set.
+      description: Lower tier prayer armour helm
+  about: Proselyte sallet is the head piece of the Proselyte armour set, awarded after The Slug Menace; gives a strong prayer bonus suitable for Slayer and protection prayer training.
   market_strategy:
     notes:
-      - Complete Slug Menace first
-      - ~12K per piece
-      - Great for Slayer
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Requires The Slug Menace quest completion
+      - Sold by Sir Tiffy Cashien in Falador Park
+      - Great for budget prayer setups
+  history:
+    - date: "2006-09-20"
+      update: The Slug Menace
+      description: Proselyte sallet released with The Slug Menace quest.
+    - date: "2021-04-21"
+      update: Equipment Rebalance
+      description: Ranged attack bonus decreased from -2 to -3.
+  properties:
+    release_date: "2006-09-20"
+    update: The Slug Menace
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rabbit-foot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rabbit-foot.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 100
-  about: "Rabbit foot is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: crafting
+    tier: low
+  related_items:
+    - item_id: 10133
+      item_name: Strung rabbit foot
+      slug: strung-rabbit-foot
+      relationship: product
+      description: "Crafted with a ball of wool at 37 Crafting"
+    - item_id: 1759
+      item_name: Ball of wool
+      slug: ball-of-wool
+      relationship: component
+      description: Used to string the rabbit foot
+  about: Used to craft a strung rabbit foot necklace which increases bird egg drop rates while woodcutting and from birdhouse traps.
+  recipes:
+    - product_id: 10133
+      product_name: Strung rabbit foot
+      skill: Crafting
+      level: 37
+      experience: 4
+      tools:
+        - None
+      materials:
+        - item_id: 1759
+          item_name: Ball of wool
+          quantity: 1
+        - item_id: 10134
+          item_name: Rabbit foot
+          quantity: 1
+  history:
+    - date: "2006-11-28"
+      description: Became obtainable; renamed from Thing to Rabbit foot.
+    - date: "2006-11-21"
+      description: Added to the game cache.
+  properties:
+    release_date: "2006-11-28"
+    update: Eagles' Peak
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-hat-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-hat-t3.mdx
@@ -12,9 +12,33 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: null
-  about: "Raging echoes hat (t3) is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.453
+  about: "Raging echoes hat (t3) is the third-tier cosmetic head reward earned from Leagues V Raging Echoes for top-tier task completion."
+  history:
+    - date: "2025-01-15"
+      description: The item is now obtainable.
+    - date: "2024-11-27"
+      description: The item was added to the game.
+  properties:
+    release_date: "2025-01-15"
+    update: "Leagues V: Raging Echoes Rewards Are Here"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-robeskirt-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-robeskirt-t1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raging echoes robeskirt (t1) | OSRS Price Data
-description: "Raging echoes robeskirt (t1): The robes of a Raging Echoes relic hunter."
+description: "Raging echoes robeskirt (t1) is a members cosmetic legs slot item from Leagues V."
 osrs:
   id: 30408
   name: Raging echoes robeskirt (t1)
@@ -12,9 +12,68 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Raging echoes robeskirt (t1) is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues V hub
+      currency: League points
+      price: 1000
+  related_items:
+    - item_id: 30406
+      item_name: Raging echoes hood (t1)
+      slug: raging-echoes-hood-t1
+      relationship: set-piece
+      description: Head piece of the t1 Raging Echoes outfit
+    - item_id: 30410
+      item_name: Raging echoes robe top (t1)
+      slug: raging-echoes-robe-top-t1
+      relationship: set-piece
+      description: Body piece of the t1 Raging Echoes outfit
+  about: "Raging echoes robeskirt (t1) is a cosmetic legs slot piece of the Raging Echoes Relic Hunter outfit, purchased for 1,000 League points during Leagues V."
+  history:
+    - date: "2024-11-27"
+      update: Leagues V Beta
+      description: Item added to the game in preparation for Leagues V.
+    - date: "2025-01-15"
+      update: "Leagues V: Raging Echoes Rewards Are Here"
+      description: Item became obtainable through the Leagues V rewards shop.
+  properties:
+    release_date: "2025-01-15"
+    update: "Leagues V: Raging Echoes Rewards Are Here"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ranger-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ranger-boots.mdx
@@ -12,18 +12,35 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 8
+  material:
+    type: leather
+    tier: high
   equipment:
     slot: feet
-    type: ranged_boots
+    weight: 0.283
     requirements:
       ranged: 40
-    stats:
-      attack_ranged: 8
-      attack_magic: -10
-      defence_stab: 2
-      defence_slash: 3
-      defence_crush: 4
-      defence_magic: 2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 8
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 4
+      magic: 2
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers: [medium]
   drop_table:
     sources:
       - source: Medium clue casket
@@ -36,7 +53,7 @@ osrs:
       item_name: Pegasian boots
       slug: pegasian-boots
       relationship: upgrade
-      description: Upgraded version
+      description: Combined with pegasian crystal for upgraded version
     - item_id: 13229
       item_name: Pegasian crystal
       slug: pegasian-crystal
@@ -47,34 +64,36 @@ osrs:
       slug: blessed-boots
       relationship: alternative
       description: Budget alternative
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged attack | +8 |
-    | Magic attack | -10 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +2 |
-    | Slash | +3 |
-    | Crush | +4 |
-    | Magic | +2 |
-
-    Requirements: 40 Ranged
-
-    BiS ranged boots until Pegasian:
-    - All ranged combat
-    - Slayer
-    - Bossing
-
-    Can upgrade to Pegasian boots.
+  about: "Ranger boots are a medium Treasure Trail reward providing +8 Ranged attack, the best-in-slot ranged boots until Pegasian boots and historically the most valuable medium clue drop."
   market_strategy:
     notes:
       - Farm medium clues
       - Very expensive
       - Required for Pegasian
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2004-05-05"
+      update: Bigger Banks & Treasure Trails
+      description: Released as a Treasure Trail reward.
+    - date: "2004-12-21"
+      description: Graphically updated to distinguish from Fremennik boots.
+    - date: "2005-01-05"
+      description: Recoloured.
+  properties:
+    release_date: "2004-05-05"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.283
+    options: [Drop]
+    worn_options: [Wear]
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rangers-tunic.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rangers-tunic.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rangers' tunic | OSRS Price Data
-description: "Rangers' tunic is a members body slot item requiring 40 Defence. High alch: 7,200 GP, GE limit: 4."
+description: "Rangers' tunic is a members body slot item requiring 40 Ranged. High alch: 7,200 GP, GE limit: 4."
 osrs:
   id: 12596
   name: Rangers' tunic
@@ -14,24 +14,31 @@ osrs:
   limit: 4
   equipment:
     slot: body
-    type: ranged_armour
-    tradeable: true
-    weight: 3.6
+    weight: 3
     requirements:
       ranged: 40
-      defence: 40
-    stats:
-      attack_ranged: 15
-      defence_stab: 36
-      defence_slash: 30
-      defence_crush: 39
-      defence_magic: -10
-      defence_ranged: 36
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard
-        drop_rate: Rare from reward casket
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 15
+    defence_bonus:
+      stab: 6
+      slash: 9
+      crush: 12
+      magic: 6
+      ranged: 6
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
   related_items:
     - item_id: 2581
       item_name: Robin hood hat
@@ -48,46 +55,35 @@ osrs:
       slug: ranger-boots
       relationship: set-piece
       description: Matching boots (medium clue)
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged attack | +15 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +36 |
-    | Slash | +30 |
-    | Crush | +39 |
-    | Magic | -10 |
-    | Ranged | +36 |
-
-    Requirements: 40 Ranged, 40 Defence
-
-    Good ranged body armour:
-    - Hard clue exclusive
-    - Same ranged bonus as black d'hide body
-    - Better defences than d'hide
-    - Fashionscape with ranger set
-
-    | Item | Ranged attack | Defence |
-    |------|---------------|---------|
-    | Rangers' tunic | +15 | Higher |
-    | Black d'hide body | +15 | Lower |
-    | Blessed d'hide body | +15 | Similar |
-
-    Complete the ranger set with:
-    - Robin hood hat (hard clue)
-    - Ranger gloves (master clue)
-    - Ranger boots (medium clue)
-    - Rangers' tights (elite clue)
+  about: "Rangers' tunic is an elite clue exclusive body armour offering the highest ranged attack bonus available without a Defence requirement, popular with 1 Defence pures."
   market_strategy:
     notes:
-      - Hard clue exclusive
+      - Elite clue exclusive
       - Part of ranger outfit
-      - Good stats for fashionscape
+      - Highest ranged attack with no defence req
       - Collection log item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2014-06-26"
+      description: Released as an elite clue scroll reward during the Midsummer Event.
+  properties:
+    release_date: "2014-06-26"
+    update: Midsummer Event
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-manta-ray.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-manta-ray.mdx
@@ -15,20 +15,19 @@ osrs:
   material:
     type: raw_fish
     tier: high
-  fishing:
-    level: 81
-    xp: 46
-    method: Trawler
-    locations:
-      - Fishing Trawler
-  cooking:
-    level: 91
-    xp: 216.2
-    stop_burn_level: 99
-    raw_item_id: 389
-    raw_item_name: Raw manta ray
-    product_id: 391
-    product_name: Manta ray
+  recipes:
+    - skill: cooking
+      level: 91
+      xp: 216.3
+      materials:
+        - item_name: Raw manta ray
+          item_id: 389
+          quantity: 1
+      tools:
+        - Fire or range
+      facility: Fire or range
+      ticks: 4
+      members_only: true
   related_items:
     - item_id: 391
       item_name: Manta ray
@@ -50,18 +49,36 @@ osrs:
       slug: raw-anglerfish
       relationship: alternative
       description: Overheal alternative
+  about: "Raw manta ray is caught at 81 Fishing exclusively from the Fishing Trawler minigame and cooks at 91 Cooking into manta ray for 22 HP heals."
   market_strategy:
     profit_formulas:
-      - Manta ray - Raw manta ray = Cooking profit
+      - Manta ray price minus Raw manta ray price equals cooking profit
     notes:
       - Raw mantas are a valuable Trawler reward
       - Sell raw for profit or cook for XP
-      - "Calculate:"
       - Manta ray (22 HP) vs Shark (20 HP)
       - Higher healing but harder to obtain
       - Often more expensive than sharks
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2018-09-20"
+      description: Value changed from 500 to 200 as part of Deadman mode adjustments.
+    - date: "2003-07-28"
+      description: Released with the Fishing Trawler minigame update.
+  properties:
+    release_date: "2003-07-28"
+    update: Fishing Trawler
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.45
+    options:
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/restore-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/restore-potion-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Restore potion(4) | OSRS Price Data
-description: "Restore potion(4): 4 doses of restore potion.. High alch: 66 GP, GE limit: 2,000."
+description: "Restore potion(4) restores reduced Attack, Strength, Defence, Ranged and Magic levels over four doses. High alch: 66 GP, GE limit: 2,000."
 osrs:
   id: 2430
   name: Restore potion(4)
@@ -12,9 +12,73 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: 2000
-  about: "Restore potion(4) is a members-only item in Old School RuneScape. High alchemy value: 66 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - skill: Attack
+        description: "Restores reduced Attack by floor(level * 3 / 10) + 10."
+      - skill: Strength
+        description: "Restores reduced Strength by floor(level * 3 / 10) + 10."
+      - skill: Defence
+        description: "Restores reduced Defence by floor(level * 3 / 10) + 10."
+      - skill: Ranged
+        description: "Restores reduced Ranged by floor(level * 3 / 10) + 10."
+      - skill: Magic
+        description: "Restores reduced Magic by floor(level * 3 / 10) + 10."
+  recipes:
+    - skill: Herblore
+      level: 22
+      experience: 62.5
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Red spiders' eggs
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      output_item: Restore potion(3)
+  related_items:
+    - item_id: 3024
+      item_name: Super restore(4)
+      slug: super-restore-4
+      relationship: upgrade
+      description: Stronger restore that also covers Prayer
+    - item_id: 2428
+      item_name: Attack potion(4)
+      slug: attack-potion-4
+      relationship: alternative
+      description: Boost rather than restore variant
+  about: "Restore potion(4) is a four-dose Herblore potion that restores temporarily reduced Attack, Strength, Defence, Ranged and Magic levels but does not affect Prayer or boost stats above base."
+  market_strategy:
+    notes:
+      - "Demand cycles with mid-tier PvM and slayer bursts; competition with super restore caps upside but the 2,000 GE limit lets bulk flips clear quickly."
+  trading_tips:
+    - "Watch the unfinished harralander potion plus red spiders' egg spread - if the combined input price drops below the (4) dose GE, buy materials and Herblore to alch instead of flipping."
+  history:
+    - date: "2002-02-27"
+      description: "Released alongside the Herblore skill in the Latest RuneScape News update."
+    - date: "2004-10-26"
+      description: "Empty option added to allow emptying potion doses."
+    - date: "2016-04-15"
+      description: "Half-full potions could now act as bank placeholders."
+  properties:
+    release_date: "2002-02-27"
+    update: Latest RuneScape News (27 February 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-wealth-5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-wealth-5.mdx
@@ -40,7 +40,7 @@ osrs:
       note: Enchant Dragonstone ring
   construction:
     ornate_jewellery_box:
-      quantity: 8
+      quantity: "8"
       level: 91
   related_items:
     - item_id: 2572

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/royal-crown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/royal-crown.mdx
@@ -5,16 +5,73 @@ osrs:
   id: 12397
   name: Royal crown
   slug: royal-crown
-  examine: Who said I'd never be royal?
+  examine: "Who said I'd never be royal?"
   members: true
   icon: Royal crown.png
   value: 6000
   lowalch: 2400
   highalch: 3600
   limit: 4
-  about: "Royal crown is a members-only item in Old School RuneScape. High alchemy value: 3,600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weapon_type: armour
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+  related_items:
+    - item_id: 12393
+      item_name: Royal gown top
+      slug: royal-gown-top
+      relationship: set-piece
+      description: Matching royal outfit top
+    - item_id: 12395
+      item_name: Royal gown bottom
+      slug: royal-gown-bottom
+      relationship: set-piece
+      description: Matching royal outfit bottom
+  about: "Royal crown is a purely cosmetic elite clue scroll head piece that completes the royal outfit obtained from elite Treasure Trail reward caskets."
+  market_strategy:
+    notes:
+      - Reward only from elite reward caskets at 1/1,275 rarity
+      - Tight 4-per-4-hour buy limit means thin liquidity and volatile pricing
+      - Demand is fashionscape only; no combat bonuses
+  history:
+    - date: "2014-06-12"
+      description: Released with the Treasure Trail Expansion.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/royal-gown-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/royal-gown-top.mdx
@@ -1,6 +1,6 @@
 ---
 title: Royal gown top | OSRS Price Data
-description: "Royal gown top: Feeling distinctly ornate.. High alch: 3,000 GP, GE limit: 4."
+description: "Royal gown top: Feeling distinctly ornate. High alch: 3,000 GP, GE limit: 4."
 osrs:
   id: 12393
   name: Royal gown top
@@ -12,9 +12,57 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Royal gown top is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 1.36
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_id: 12395
+      item_name: Royal gown bottom
+      slug: royal-gown-bottom
+      relationship: set-piece
+      description: Legs piece of the royal outfit
+    - item_id: 12397
+      item_name: Royal crown
+      slug: royal-crown
+      relationship: set-piece
+      description: Head piece of the royal outfit
+    - item_id: 12399
+      item_name: Royal sceptre
+      slug: royal-sceptre
+      relationship: set-piece
+      description: Weapon piece of the royal outfit
+  about: "Royal gown top is a cosmetic body slot piece of the royal outfit, awarded from hard Treasure Trails and storable in a costume room treasure chest."
+  market_strategy:
+    notes:
+      - Hard clue scroll reward
+      - Purely cosmetic with no combat bonuses
+      - Storable in costume room treasure chest
+  history:
+    - date: "2014-06-12"
+      description: "Item released with the Treasure Trail Expansion update."
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-bolts-e.mdx
@@ -29,11 +29,11 @@ osrs:
     magic_level: 49
     runes:
       - item_name: Fire rune
-        quantity: 5
+        quantity: "5"
       - item_name: Blood rune
-        quantity: 1
+        quantity: "1"
       - item_name: Cosmic rune
-        quantity: 1
+        quantity: "1"
     bolts_per_cast: 10
   related_items:
     - item_id: 9339

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-bracelet.mdx
@@ -14,18 +14,37 @@ osrs:
   limit: 10000
   equipment:
     slot: hands
-    requirements:
-      crafting: 42
+    weight: 0.25
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 42
       xp: 80
-      inputs:
+      materials:
         - item_name: Ruby
           quantity: 1
         - item_name: Gold bar
           quantity: 1
+      tools:
+        - Bracelet mould
       output_quantity: 1
+      facility: Furnace
   related_items:
     - item_id: 11076
       item_name: Emerald bracelet
@@ -37,24 +56,41 @@ osrs:
       slug: diamond-bracelet
       relationship: upgrade
       description: Next tier bracelet
-  about: |-
-    Crafting (Level 42): Ruby + Gold bar at a furnace with bracelet mould (80 XP)
-
-    > *"A ruby bracelet."*
-
-    Lvl-3 Enchant (49 Magic): 1 cosmic rune + 5 fire runes (59 XP)
-
-    The Inoculation bracelet provides poison immunity until it absorbs 500 total poison damage, then crumbles. Unlike antipoisons which cure existing poison, this prevents poison from being applied. Useful for:
-    - Wilderness activities where re-poisoning is frequent
-    - Budget alternative to antidote++ or serpentine helm
-    - Single charge of prevention vs repeated potion doses
+    - item_id: 11088
+      item_name: Inoculation bracelet
+      slug: inoculation-bracelet
+      relationship: product
+      description: Enchanted Lvl-3 form
+  about: "Ruby bracelet is a members crafting product made from a ruby and gold bar at a furnace at level 42 Crafting; it can be enchanted into the Inoculation bracelet for poison immunity."
   market_strategy:
     notes:
-      - Niche poison immunity item
-      - Most players prefer antipoison potions
-      - Consumed after 500 poison damage absorbed
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Mainly produced for Crafting XP and gold bar processing
+      - Steady demand from Lvl-3 Enchant casters making Inoculation bracelets
+      - GE volume tied to bulk crafters and ironman alts
+  history:
+    - date: "2018-02-22"
+      description: Inventory sprite was rotated to distinguish it from the enchanted variant.
+    - date: "2007-04-30"
+      description: Released with the 24 Carat Update.
+  properties:
+    release_date: "2007-04-30"
+    update: 24 Carat Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-arrow-p-5621.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-arrow-p-5621.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 11000
-  about: "Rune arrow(p+) is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: mid
+  equipment:
+    slot: ammo
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 49
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 49
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Herblore
+      level: 73
+      experience: 0
+      materials:
+        - item_name: Rune arrow
+          quantity: 1
+        - item_name: Extra strong weapon poison
+          quantity: 1
+      tools: []
+  related_items:
+    - item_name: Rune arrow
+      slug: rune-arrow
+      relationship: variant
+      description: Unpoisoned variant of this arrow
+    - item_name: Rune arrow(p)
+      slug: rune-arrow-p-standard
+      relationship: variant
+      description: Standard poison variant
+    - item_name: Rune arrow(p++)
+      slug: rune-arrow-pp
+      relationship: variant
+      description: Super strong poison variant
+  about: "Rune arrow(p+) is the extra-strong-poison variant of the rune arrow, released on 25 March 2002. It carries the same +49 Ranged attack bonus and +49 Ranged strength as the base arrow while applying poison damage on hit. Players create them with Herblore by applying extra strong weapon poison to standard rune arrows."
+  market_strategy:
+    notes:
+      - High GE buy limit supports bulk Slayer and PvM use
+      - Margins versus unpoisoned rune arrows depend on weapon poison(+) costs
+      - Demand is steady from Ranged training and content where poison helps
+  history:
+    - date: "2002-03-25"
+      description: Released alongside the original rune arrow
+    - date: "2006-08-01"
+      description: "Renamed from 'Rune arrow(+)' to 'Rune arrow(p+)' for naming consistency"
+  properties:
+    release_date: "2002-03-25"
+    update: Latest RuneScape News
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-cane.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-cane.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune cane | OSRS Price Data
-description: "Rune cane is a members weapon slot item with +36 melee strength requiring 40 Attack. High alch: 8,640 GP, GE limit: 4."
+description: "Rune cane: a dragonstone-topped crush weapon from hard clue scrolls with +4 prayer and +36 strength requiring 40 Attack. High alch: 8,640 GP, GE limit: 4."
 osrs:
   id: 12379
   name: Rune cane
@@ -12,10 +12,16 @@ osrs:
   lowalch: 5760
   highalch: 8640
   limit: 4
+  material:
+    type: rune
+    tier: mid
   equipment:
     slot: weapon
-    type: spiked
+    weapon_type: spiked
     attack_speed: 5
+    weight: 1.814
+    requirements:
+      attack: 40
     attack_bonus:
       stab: 20
       slash: -2
@@ -33,60 +39,58 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 4
-    requirements:
-      attack: 40
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard
-        drop_rate: 1/1,625
-        description: Rare reward from hard clue scrolls
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 12377
       item_name: Adamant cane
       slug: adamant-cane
       relationship: downgrade
-      description: Lower-tier cane from medium clues
+      description: Lower-tier cane from medium clues.
     - item_id: 12381
       item_name: Dragon cane
       slug: dragon-cane
       relationship: upgrade
-      description: Higher-tier cane from elite clues
+      description: Higher-tier cane from elite clues.
     - item_id: 1333
       item_name: Rune scimitar
       slug: rune-scimitar
       relationship: alternative
-      description: Common rune-tier weapon
-  about: |-
-    > *"A dragonstone topped cane."*
-
-    | Style | Type | Experience |
-    |-------|------|-----------|
-    | Pound | Crush | Attack |
-    | Pummel | Crush | Strength |
-    | Spike | Stab | Shared |
-    | Block | Crush | Defence |
-
-    | Property | Rune Cane | Rune Mace | Rune Scimitar |
-    |----------|-----------|-----------|---------------|
-    | Best Attack | +39 Crush | +36 Crush | +45 Slash |
-    | Strength | +36 | +36 | +44 |
-    | Prayer | +4 | +1 | 0 |
-    | Speed | 5 | 5 | 4 |
-    | Source | Hard clue | Smithing/drops | Smithing/drops |
-
-    The rune cane trades raw DPS for a superior prayer bonus. It is primarily a cosmetic weapon used for fashionscape rather than efficient combat.
+      description: Standard rune-tier slash weapon.
+  about: "The rune cane is a cosmetic crush weapon from hard clues that trades raw DPS for a notable +4 prayer bonus."
   market_strategy:
     title: Investment Notes
     notes:
-      - Hard clue exclusive cosmetic weapon
-      - Prayer bonus makes it a niche option for prayer-focused setups
-      - Primarily valued for fashionscape and collection log
-      - Not efficient for combat compared to rune scimitar
-      - Collection log completionists drive demand
-      - Pairs with other cane-tier items for a gentleman's outfit
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Hard clue exclusive cosmetic weapon with limited supply.
+      - +4 prayer bonus is niche but unique among rune-tier weapons.
+      - Drives collection-log and fashionscape demand.
+      - Buy limit of 4 keeps the GE thin and prone to swings.
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Added to game in the Treasure Trail Expansion update.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platelegs-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platelegs-t.mdx
@@ -12,22 +12,69 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
+  material:
+    type: rune
+    tier: mid
   equipment:
     slot: legs
+    weight: 9.071
     requirements:
       defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 2623
       item_name: Rune platebody (t)
       slug: rune-platebody-t
       relationship: set-piece
       description: Matching trimmed platebody
-  about: |-
-    > *"Rune platelegs with trim."*
-
-    The rune platelegs (t) are a trimmed cosmetic variant of standard rune platelegs. Identical stats, requiring 40 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1079
+      item_name: Rune platelegs
+      slug: rune-platelegs
+      relationship: alternative
+      description: Untrimmed variant with identical stats
+  about: Rune platelegs (t) are a trimmed cosmetic variant of standard rune platelegs obtained from hard clue scroll reward caskets. Stats are identical to the untrimmed variant.
+  history:
+    - date: "2004-05-05"
+      description: Released with the Bigger Banks & Treasure Trails update.
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -7 to -11.
+  properties:
+    release_date: "2004-05-05"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-pouch-note.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-pouch-note.mdx
@@ -12,20 +12,11 @@ osrs:
   lowalch: 84
   highalch: 126
   limit: 40
-  item:
-    type: redeemable note
-    tradeable: true
-    weight: 0
-  obtaining:
-    - source: Last Man Standing shop
-      cost: 75 LMS points
-  effect:
-    description: Exchange at bank for a Rune pouch
-    locations:
-      - Banker
-      - Grand Exchange clerk
-      - Bank booth
-    restrictions: Cannot redeem if you already own a rune pouch
+  shops:
+    - shop_name: Last Man Standing rewards
+      location: Ferox Enclave
+      currency: LMS points
+      stock_quantity: 75
   related_items:
     - item_id: 12791
       item_name: Rune pouch
@@ -37,22 +28,26 @@ osrs:
       slug: divine-rune-pouch
       relationship: alternative
       description: Upgraded version with 4 slots
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Redeemable Note |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-
-    Exchange at bank for a Rune pouch.
-
-    Use on banker, Grand Exchange clerk, or bank booth.
-
-    Cannot redeem if you already own a rune pouch.
-
-    Tradeable workaround since rune pouches themselves are untradeable.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Rune pouch note is a tradeable redeemable note bought from the Last Man Standing rewards shop and exchanged at any bank for a non-tradeable Rune pouch."
+  history:
+    - date: "2020-04-23"
+      description: Released with the Bounty Hunter Returns update.
+  properties:
+    release_date: "2020-04-23"
+    update: Bounty Hunter Returns
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Read
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bolts.mdx
@@ -26,9 +26,9 @@ osrs:
     level: 69
     materials:
       - item: Runite bolts (unf)
-        quantity: 1
+        quantity: "1"
       - item: Feathers
-        quantity: 1
+        quantity: "1"
   obtaining:
     fletching: Attach feathers to runite bolts (unf) at 69 Fletching
     drops:

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/runite-limbs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/runite-limbs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Runite limbs | OSRS Price Data
-description: "Runite limbs: A pair of runite crossbow limbs.. High alch: 9,600 GP, GE limit: 10,000."
+description: "Runite limbs: A pair of runite crossbow limbs. High alch: 9,600 GP, GE limit: 10,000."
 osrs:
   id: 9431
   name: Runite limbs
@@ -12,9 +12,69 @@ osrs:
   lowalch: 6400
   highalch: 9600
   limit: 10000
-  about: "Runite limbs is a members-only item in Old School RuneScape. High alchemy value: 9,600 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: runite
+    tier: mid
+  recipes:
+    - skill: smithing
+      level: 91
+      xp: 75
+      materials:
+        - item_name: Runite bar
+          quantity: 1
+      tools:
+        - Hammer
+      facility: Anvil
+      output_quantity: 1
+    - skill: fletching
+      level: 69
+      xp: 100
+      materials:
+        - item_name: Runite limbs
+          quantity: 1
+        - item_name: Yew stock
+          quantity: 1
+      output_item: Runite crossbow (u)
+      output_quantity: 1
+  related_items:
+    - item_id: 9461
+      item_name: Runite crossbow (u)
+      slug: runite-crossbow-u
+      relationship: product
+      description: Unstrung runite crossbow assembled from yew stock and runite limbs
+    - item_id: 2363
+      item_name: Runite bar
+      slug: runite-bar
+      relationship: component
+      description: Smithed at an anvil into runite limbs
+    - item_id: 9429
+      item_name: Adamantite limbs
+      slug: adamantite-limbs
+      relationship: downgrade
+      description: Lower-tier crossbow limbs
+  about: Runite limbs are smithed from one runite bar at level 91 Smithing and combined with a yew stock to make an unstrung runite crossbow.
+  market_strategy:
+    notes:
+      - High-level crossbow material with steady demand from Fletchers
+      - Smithing at Yanille or Witchaven counts toward Elite Ardougne Diary
+  history:
+    - date: "2006-07-31"
+      description: Introduced with the Crossbows update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/samurai-kasa.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/samurai-kasa.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 70
-  about: "Samurai kasa is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weapon_type: armour
+    weight: 0.6
+    requirements:
+      defence: 35
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 16
+      slash: 17
+      crush: 15
+      magic: 4
+      ranged: 16
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+  related_items:
+    - item_id: 20038
+      item_name: Samurai shirt
+      slug: samurai-shirt
+      relationship: set-piece
+      description: Matching samurai body piece
+    - item_id: 20041
+      item_name: Samurai greaves
+      slug: samurai-greaves
+      relationship: set-piece
+      description: Matching samurai leg piece
+  about: "Samurai kasa is a master Treasure Trail cosmetic head piece offering mithril-tier defence and forming part of the samurai outfit."
+  market_strategy:
+    notes:
+      - Reward only from master clue scroll caskets at 1/851 rarity
+      - 70 buy limit keeps GE swings volatile on fashionscape demand
+      - Storable in the Costume Room treasure chest
+  history:
+    - date: "2016-07-06"
+      description: Released with the Treasure Trail Expansion.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.6
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sanfew-serum-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sanfew-serum-2.mdx
@@ -20,9 +20,16 @@ osrs:
     effects:
       - stat: Prayer
         boost_formula: 4 + floor(level / 4)
-      - stat: Cure poison
+        description: Restores Prayer points
+      - stat: All stats except Hitpoints
+        boost_formula: 4 + floor(level * 0.30)
+        description: Restores reduced stats
+      - stat: Poison
         boost_type: cure
-        description: Cures poison and venom
+        description: Cures poison and venom and grants 6 minutes of poison immunity
+      - stat: Disease
+        boost_type: cure
+        description: Grants 15 minutes of disease immunity
   related_items:
     - item_id: 10925
       item_name: Sanfew serum(4)
@@ -39,14 +46,36 @@ osrs:
       slug: sanfew-serum-1
       relationship: variant
       description: 1-dose version
-  about: 2-dose variant of Sanfew serum.
+  about: 2-dose variant of Sanfew serum that restores Prayer and stats while curing poison/venom and granting disease immunity; created at 65 Herblore.
   market_strategy:
     notes:
       - Compare to 4-dose price
       - Decanting can profit
       - Use decanting NPC in GE
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2007-03-13"
+      description: Added to the game with the Burgh de Rott Ramble quest.
+    - date: "2014-05-01"
+      description: Correctly classified as a potion (not food) for consumption delays.
+    - date: "2016-04-07"
+      description: Drinking antipoison no longer decreases poison immunity.
+  properties:
+    release_date: "2007-03-13"
+    update: Burgh de Rott Ramble
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/santa-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/santa-hat.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 5
-  about: "Santa hat is a free-to-play item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.113
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  about: "Santa hat is a tradeable cosmetic head slot item originally released during the 2002 Christmas event in RuneScape Classic, prized for its rarity and iconic festive appearance."
+  history:
+    - date: "2002-12-25"
+      description: Released during the original Christmas event in RuneScape Classic.
+    - date: "2013-08-02"
+      description: Reintroduced to Old School RuneScape via the Falador Party Room.
+  properties:
+    release_date: "2002-12-25"
+    update: Merry Christmas
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.113
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-dragon-bolts.mdx
@@ -42,7 +42,7 @@ osrs:
       level: 84
       xp: 4.7
       product: Sapphire dragon bolts
-      quantity: 10
+      quantity: "10"
       materials:
         - item_name: Sapphire bolt tips
           quantity: 10
@@ -52,7 +52,7 @@ osrs:
       level: 7
       xp: 17.5
       product: Sapphire dragon bolts (e)
-      quantity: 10
+      quantity: "10"
       requirements: Enchant Crossbow Bolt (Sapphire) spell.
       materials:
         - item_name: Sapphire dragon bolts

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-ring.mdx
@@ -14,20 +14,28 @@ osrs:
   limit: 10000
   equipment:
     slot: ring
+    weight: 0.006
     requirements:
       crafting: 20
   recipes:
     - skill: crafting
       level: 20
       xp: 40
-      inputs:
+      materials:
         - item_id: 1656
           item_name: Sapphire
           quantity: 1
         - item_id: 2357
           item_name: Gold bar
           quantity: 1
-      output_quantity: 1
+      tools:
+        - Furnace
+        - Ring mould
+      product: Sapphire ring
+      product_id: 1637
+      product_quantity: 1
+      facility: Furnace
+      members_only: false
   related_items:
     - item_id: 1639
       item_name: Emerald ring
@@ -38,36 +46,38 @@ osrs:
       item_name: Ring of recoil
       slug: ring-of-recoil
       relationship: upgrade
-      description: Enchanted version (reflects damage)
-  about: |-
-    Crafting (Level 20): Sapphire + Gold bar at a furnace (40 XP)
-
-    > *"A sapphire ring."*
-
-    Lvl-1 Enchant (7 Magic): 1 cosmic rune + 1 water rune (17.5 XP)
-
-    The Ring of recoil reflects 10% of damage taken back to the attacker (up to 40 total damage before breaking). One of the most consumed items in the game — used in:
-    - PvP — extra chip damage on opponents
-    - Zulrah — passive damage during boss fight
-    - Vorkath — consistent damage reflection
-    - AFK training — damage without attacking
-
-    | Ring | Crafting | Gem | Enchant | Enchanted Ring |
-    |------|----------|-----|---------|---------------|
-    | Sapphire ring | 20 | Sapphire | Lvl-1 (7) | Ring of recoil |
-    | Emerald ring | 27 | Emerald | Lvl-2 (27) | Ring of dueling |
-    | Ruby ring | 34 | Ruby | Lvl-3 (49) | Ring of forging |
-    | Diamond ring | 43 | Diamond | Lvl-4 (57) | Ring of life |
-    | Dragonstone ring | 55 | Dragonstone | Lvl-5 (68) | Ring of wealth |
-    | Onyx ring | 67 | Onyx | Lvl-6 (87) | Ring of stone |
-    | Zenyte ring | 89 | Zenyte | Lvl-7 (93) | Ring of suffering |
+      description: Enchanted version that reflects damage
+  about: "Crafted from a sapphire and a gold bar at level 20 Crafting; enchant via Lvl-1 Enchant to make the heavily consumed Ring of recoil."
   market_strategy:
     notes:
-      - Very high volume — ring of recoil is constantly consumed
+      - Very high volume ring of recoil is constantly consumed
       - Enchanting is often profitable
       - Popular Crafting training product
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2018-12-13"
+      description: The item's inventory sprite was adjusted slightly.
+    - date: "2018-02-22"
+      description: The item's inventory sprite was rotated to distinguish it from enchanted jewellery.
+    - date: "2007-04-30"
+      description: The item was graphically updated.
+  properties:
+    release_date: "2001-05-08"
+    update: "Runescape updated (8 May 2001)"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/seasoned-sardine.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/seasoned-sardine.mdx
@@ -12,9 +12,36 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 15
-  about: "Seasoned sardine is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Seasoned sardine is a quest item from Gertrude's Cat, created by combining doogle leaves with a raw sardine; used to calm Fluffs's kittens and has no use after the quest."
+  related_items:
+    - item_id: 327
+      item_name: Sardine
+      slug: sardine
+      relationship: component
+      description: Base fish used to make the seasoned sardine
+    - item_id: 1573
+      item_name: Doogle leaves
+      slug: doogle-leaves
+      relationship: component
+      description: Seasoning ingredient
+  history:
+    - date: "2003-07-28"
+      description: Added to the game with the release of Gertrude's Cat quest.
+  properties:
+    release_date: "2003-07-28"
+    update: New Members Quest Online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.12
+    options:
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/seercull.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/seercull.mdx
@@ -14,8 +14,11 @@ osrs:
   limit: 8
   equipment:
     slot: weapon
-    two_handed: true
+    weapon_type: bow
     attack_speed: 5
+    weight: 1.36
+    requirements:
+      ranged: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -33,13 +36,10 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 50
-    weight: 1.36
   special_attack:
     name: Soulshot
     energy: 100
-    description: Guaranteed hit that lowers opponent's Magic level equal to damage dealt. Damage boosted only by ammunition and visible Ranged level.
+    description: "Guaranteed hit that lowers opponent's Magic level equal to damage dealt. Damage is boosted only by ammunition and visible Ranged level, not by ranged prayers or equipment ranged strength."
   drop_table:
     primary_source: Dagannoth Supreme
     best_drop_rate: 1/128
@@ -61,50 +61,31 @@ osrs:
       slug: dark-bow
       relationship: alternative
       description: Slow but powerful spec bow
-  about: |-
-    | Ranged | Value |
-    |--------|-------|
-    | Ranged Attack | +69 |
-    | Ranged Strength | +0 |
-
-    Requirements: 50 Ranged | Speed: 5 tick (3.0s) | Two-handed
-
-    Fires arrows up to Amethyst arrows (+55 ranged strength).
-
-    Cost: 100% special attack energy | Guaranteed hit
-
-    Lowers opponent's Magic level equal to damage dealt.
-
-    | Factor | Affects Damage? |
-    |--------|----------------|
-    | Ammunition ranged strength | Yes |
-    | Visible Ranged level | Yes |
-    | Ranged prayers (Eagle Eye, Rigour) | No |
-    | Equipment ranged strength | No |
-    | Void Knight bonuses | No |
-    | Salve amulet / Slayer helm | No |
-
-    Key: Magic drain only applies if the target's Magic isn't already reduced. Consecutive uses won't stack.
-
-    "Seer" (mage) + "cull" (kill) = "mage-killer".
-
-    Draining a mage's Magic level prevents spellcasting until they restore. Effective against:
-    - Mage pures
-    - Tribrid switches
-    - Players without super restores
-
-    | Weapon | Speed | Ranged Atk | Special |
-    |--------|-------|------------|---------|
-    | Seercull | 5 tick | +69 | Magic drain (100%) |
-    | Magic shortbow | 4 tick | +69 | 2 rapid shots (55%) |
-    | Dark bow | 8 tick | +95 | +50% damage (55%) |
+  about: Seercull is a two-handed Fremennik bow dropped by Dagannoth Supreme whose Soulshot special attack consumes 100% energy to guarantee a hit that drains the target's Magic level by the damage dealt.
   market_strategy:
     notes:
       - Supply tied to DK farming
       - Niche PvP anti-mage demand
       - Low practical use keeps price modest
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  properties:
+    release_date: "2005-11-07"
+    update: Waterbirth Island - deeper, darker, deadlier!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  history:
+    - date: "2005-11-07"
+      description: Released alongside the Waterbirth Island update with the Dagannoth Kings.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/serpentine-visage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/serpentine-visage.mdx
@@ -32,7 +32,7 @@ osrs:
     dismantle:
       result_id: 12934
       result_name: Zulrah's scales
-      quantity: 20000
+      quantity: "20000"
   related_items:
     - item_id: 0
       item_name: Zulrah

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/serum-207-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/serum-207-4.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 5
   highalch: 8
   limit: 2000
-  about: "Serum 207 (4) is a members-only item in Old School RuneScape. High alchemy value: 8 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - description: Used to cure afflicted Mort'ton villagers and as Sanctity restorer in Shades of Mort'ton minigame.
+  recipes:
+    - skill: Herblore
+      level: 15
+      xp: 50
+      materials:
+        - item_name: Tarromin potion (unf)
+        - item_name: Ashes
+      tools:
+        - Pestle and mortar
+      output: Serum 207 (3)
+  related_items:
+    - item_id: 3410
+      item_name: Serum 208 (4)
+      slug: serum-208-4
+      relationship: upgrade
+      description: Sanctified variant created with sacred oil
+  about: "Serum 207 (4) is a 4-dose potion used in the Shades of Mort'ton minigame. The name comes from ingredient values in Herbi Flax's diary: water (100) + tarromin (94) + ashes (13) = 207."
+  history:
+    - date: "2004-10-18"
+      description: Released with the Mortton Shades and Mage Armour update.
+    - date: "2024-07-31"
+      description: Sanctifying Serum 207 now uses 5% sanctity per dose rather than a flat 20% regardless of dosage.
+  properties:
+    release_date: "2004-10-18"
+    update: Mortton Shades and Mage Armour
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    quest: "Shades of Mort'ton"
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shade-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shade-robe.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shade robe | OSRS Price Data
-description: "Shade robe is a F2P legs slot item. High alch: 18 GP, GE limit: 125."
+description: "Shade robe is a F2P legs slot item dropped by shades, granting +4 Prayer bonus. High alch: 18 GP, GE limit: 125."
 osrs:
   id: 548
   name: Shade robe
@@ -14,21 +14,64 @@ osrs:
   limit: 125
   equipment:
     slot: legs
+    weight: 0.907
     requirements: {}
     other_bonus:
       prayer: 4
+  drop_table:
+    - source: Shade
+      level: 140
+      quantity: "1"
+      rarity: 32/128
+    - source: Shade
+      level: 159
+      quantity: "1"
+      rarity: 32/128
   related_items:
     - item_id: 546
       item_name: Shade robe top
       slug: shade-robe-top
       relationship: set-piece
-      description: Matching shade robe top
-  about: |-
-    > *"If a shade had knees, this would keep them nice and warm."*
-
-    The shade robe is a free-to-play legs slot item that provides a +4 Prayer bonus. It is dropped by shades and is part of the shade robes set. No requirements to equip, making it useful for prayer-focused builds at any level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching shade robe top with prayer bonus
+    - item_id: 542
+      item_name: Monk's robe
+      slug: monks-robe
+      relationship: alternative
+      description: Members alternative with +5 Prayer bonus
+  prayer:
+    bonus: 4
+  about: "The shade robe is a free-to-play legs slot drop from shades that grants a +4 Prayer bonus, slotting between the priest gown (+3) and monk's robe (+5) for budget prayer setups."
+  market_strategy:
+    notes:
+      - "Demand is steady from F2P prayer flickers and ironmen who cannot get monk's robes; supply scales with shade kills so prices climb during Shades of Mort'ton minigame attention."
+  trading_tips:
+    - "Buy when GE volume spikes after minigame rework news and resell into clue scroll and prayer-training cycles."
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 launch."
+    - date: "2004-07-01"
+      description: "Renamed from Black robe to Shade robe."
+    - date: "2004-10-01"
+      description: "Examine text updated to its current form."
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-top-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-top-t3.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Shattered top (t3) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 26452
+      item_name: Shattered hood (t3)
+      slug: shattered-hood-t3
+      relationship: set-piece
+      description: Tier 3 Shattered Relic Hunter outfit hood.
+    - item_id: 26456
+      item_name: Shattered legs (t3)
+      slug: shattered-legs-t3
+      relationship: set-piece
+      description: Tier 3 Shattered Relic Hunter outfit legs.
+    - item_id: 26458
+      item_name: Shattered boots (t3)
+      slug: shattered-boots-t3
+      relationship: set-piece
+      description: Tier 3 Shattered Relic Hunter outfit boots.
+  about: "Shattered top (t3) is the cosmetic body slot piece of the tier 3 Shattered Relic Hunter outfit, purchased from the Leagues Reward Shop for 15,000 League points."
+  history:
+    - date: "2022-03-16"
+      description: Item made obtainable and examine text capitalization corrected.
+  properties:
+    release_date: "2022-03-16"
+    update: "Leagues III: Shattered Relics"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shirt-lilac.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shirt-lilac.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 250
   highalch: 375
   limit: 150
-  about: "Shirt (lilac) is a members-only item in Old School RuneScape. High alchemy value: 375 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: body
+    weight: 0.07
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Agmundi Quality Clothes
+      location: Keldagrim
+      price: 812
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania/Etceteria Dungeon
+      price: 625
+  about: "Shirt (lilac) is a cosmetic dwarven-styled body slot garment sold by clothing merchants in Keldagrim and Miscellania, providing no combat bonuses."
+  market_strategy:
+    notes:
+      - "Cosmetic demand is thin and stable; shop floor at 625 coins caps downside."
+  trading_tips:
+    - "Flip near the shop floor for a small margin; do not over-stock given the low daily volume."
+  history:
+    - date: "2005-05-31"
+      description: Released with the Keldagrim update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-31"
+    update: "Keldagrim"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.07
+    options: [Wear, Drop]
+    worn_options: [Remove]
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sickle-mould.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sickle-mould.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sickle mould | OSRS Price Data
-description: "Sickle mould: Used to make sickles.. High alch: 6 GP, GE limit: 40."
+description: "Sickle mould: Used to make sickles. High alch: 6 GP, GE limit: 40."
 osrs:
   id: 2976
   name: Sickle mould
@@ -12,9 +12,67 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 40
-  about: "Sickle mould is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: crafting
+      level: 18
+      xp: 50
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+        - item_name: Sickle mould
+          quantity: 1
+      tools:
+        - Sickle mould
+      facility: Furnace
+      output_item: Silver sickle
+      output_quantity: 1
+  shops:
+    - shop_name: Dommik's Crafting Store
+      location: Al Kharid
+      price: 10
+    - shop_name: Rommik's Crafty Supplies
+      location: Rimmington
+      price: 10
+    - shop_name: Jamila's Craft Stall
+      location: Sophanem
+      price: 15
+    - shop_name: Rasolo the Wandering Merchant
+      location: South of Baxtorian Falls
+      price: 20
+  related_items:
+    - item_id: 2961
+      item_name: Silver sickle
+      slug: silver-sickle
+      relationship: product
+      description: Cast from a silver bar with this mould
+    - item_id: 2962
+      item_name: Silver sickle (b)
+      slug: silver-sickle-b
+      relationship: product
+      description: Blessed silver sickle used in Nature Spirit and druidic rituals
+  about: A reusable casting mould for silver sickles, available from general crafting shops and required for several Mort Myre Nature Spirit follow-up activities.
+  market_strategy:
+    notes:
+      - Cheap one-time purchase; demand spikes after Nature Spirit completions
+      - Quick alch fodder when bulk-bought from Crafting stalls
+  history:
+    - date: "2004-07-13"
+      description: Released with the Nature Spirit quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-07-13"
+    update: Nature Spirit
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-deft-strikes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-deft-strikes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of deft strikes | OSRS Price Data
-description: "Sigil of deft strikes: A power enhancing sigil not yet attuned to you.. High alch: 6,000 GP, GE limit: 10."
+description: "Sigil of deft strikes: A power enhancing sigil not yet attuned to you. High alch: 0 GP, GE limit: 10."
 osrs:
   id: 26012
   name: Sigil of deft strikes
@@ -8,13 +8,39 @@ osrs:
   examine: A power enhancing sigil not yet attuned to you.
   members: true
   icon: Sigil of deft strikes.png
-  value: 10000
-  lowalch: 4000
-  highalch: 6000
+  value: 1
+  lowalch: 0
+  highalch: 0
   limit: 10
-  about: "Sigil of deft strikes is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: sigil
+    tier: low
+  related_items:
+    - item_id: 26011
+      item_name: Sigil of deft strikes (attuned)
+      slug: sigil-of-deft-strikes-attuned
+      relationship: variant
+      description: Attuned/unlocked version
+  about: "Sigil of deft strikes is a tier 1 Deadman: Reborn combat sigil granting up to 30% increased accuracy in all styles against all monsters. It exists only in temporary Deadman events and cannot be obtained in standard gameplay."
+  history:
+    - date: "2021-08-25"
+      update: "Deadman: Reborn"
+      description: Released as a tier 1 sigil for the Deadman Reborn event.
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options: [Unlock, Inspect, Destroy]
+    alchable: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-alchemaniac.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-alchemaniac.mdx
@@ -12,9 +12,25 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of the alchemaniac is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sigil of the alchemaniac is a tier 1 utility Deadman Mode sigil that, once attuned, automatically recasts High or Low Level Alchemy on item stacks."
+  properties:
+    release_date: "2023-08-23"
+    update: "Deadman: Apocalypse"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: Destroy
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-skiller.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-skiller.mdx
@@ -12,9 +12,32 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 4
-  about: "Sigil of the skiller is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: sigil
+    tier: mid
+  related_items: []
+  about: "Sigil of the skiller is a Tier 3 Deadman Mode sigil that grants 100% increased XP across all skills once attuned. Untradeable after attunement."
+  history:
+    - date: "2021-08-25"
+      description: Released with the Deadman Reborn update.
+  properties:
+    release_date: "2021-08-25"
+    update: Deadman Reborn
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    alchable: true
+    destroy: "You must unattune the Sigil before you can destroy it."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spicy-tomato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spicy-tomato.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 8000
-  about: "Spicy tomato is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 8,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 2
+    cooking_level: 1
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Chopped tomato
+          item_id: 9988
+          quantity: 1
+        - item_name: Gnome spice
+          item_id: 2169
+          quantity: 1
+      tools:
+        - Knife
+      ticks: 0
+      members_only: true
+  related_items:
+    - item_id: 9988
+      item_name: Chopped tomato
+      slug: chopped-tomato
+      relationship: component
+      description: Base ingredient before spicing
+    - item_id: 10034
+      item_name: Carved teak chinchompa
+      slug: carved-teak-chinchompa
+      relationship: alternative
+      description: Chinchompa bait alternative path
+  about: "Spicy tomato is a gnome-cooking dish made by adding gnome spice to a chopped tomato and serves as chinchompa bait, though it heals just 2 HP."
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill update.
+  properties:
+    release_date: "2006-11-21"
+    update: HUNTER SKILL!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Eat
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spotted-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spotted-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Spotted cape | OSRS Price Data
-description: "Spotted cape: A surprisingly aerodynamic cape.. High alch: 240 GP, GE limit: 125."
+description: "Spotted cape: A surprisingly aerodynamic cape. High alch: 240 GP, GE limit: 125."
 osrs:
   id: 10069
   name: Spotted cape
@@ -12,9 +12,78 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 125
-  about: "Spotted cape is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    weight: 0.453
+    requirements:
+      hunter: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: hunter
+      level: 40
+      xp: 0
+      materials:
+        - item_name: Spotted kebbit fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 400
+      facility: Fancy Clothes Store
+      output_quantity: 1
+  related_items:
+    - item_id: 10071
+      item_name: Spottier cape
+      slug: spottier-cape
+      relationship: upgrade
+      description: Higher-tier Hunter cape that reduces weight further
+    - item_id: 10125
+      item_name: Spotted kebbit fur
+      slug: spotted-kebbit-fur
+      relationship: component
+      description: Required fur for tailoring this cape
+  about: A spotted cape stitched at the Fancy Clothes Store from two spotted kebbit furs at 40 Hunter that reduces equipped weight by 2.267 kg.
+  market_strategy:
+    notes:
+      - Useful early-game weight reducer for Agility / runner accounts
+      - Outclassed by the spottier cape but cheaper to craft
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill.
+    - date: "2015-09-10"
+      description: Fixed cape rack storage issues that prevented retrieval.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-bob-the-cat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-bob-the-cat.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 600
   highalch: 900
   limit: 8
-  about: "Staff of bob the cat is a members-only item in Old School RuneScape. High alchemy value: 900 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2
+    attack_bonus:
+      stab: 2
+      slash: -1
+      crush: 10
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 10
+      ranged: 0
+    other_bonus:
+      melee_strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  about: "Staff of bob the cat is a cosmetic one-handed staff released on 11 April 2019 as part of the Treasure Trails expansion and Easter 2019 update. Obtained as a rare reward from easy reward caskets at roughly 1/1,404, it offers +10 Magic and Crush attack bonuses along with +7 Strength and supports standard spellbook autocasting but not Ancient or Arceuus spells."
+  market_strategy:
+    notes:
+      - Buy limit of 8 keeps daily volume thin and price volatile
+      - Demand is largely collector and fashionscape driven
+      - Treasure Trail droprate underpins long term floor price
+  history:
+    - date: "2019-04-11"
+      description: Released as a reward from the Treasure Trails expansion and Easter 2019 event
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-arrow.mdx
@@ -42,7 +42,7 @@ osrs:
       level: 30
       xp: 5
       product: Steel arrow
-      quantity: 15
+      quantity: "15"
       materials:
         - item_name: Steel arrowtips
           quantity: 15

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bolts.mdx
@@ -29,9 +29,9 @@ osrs:
     xp: 3.5
     materials:
       - item: Steel bolts (unf)
-        quantity: 1
+        quantity: "1"
       - item: Feathers
-        quantity: 1
+        quantity: "1"
   obtaining:
     fletching: 46 Fletching with steel bolts (unf) + feathers
     shop: Crossbow Shop, Keldagrim

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-kiteshield-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-kiteshield-g.mdx
@@ -12,22 +12,79 @@ osrs:
   lowalch: 340
   highalch: 510
   limit: 125
+  material:
+    type: steel
+    tier: low
   equipment:
     slot: shield
+    weight: 5.443
     requirements:
       defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -2
+    defence_bonus:
+      stab: 13
+      slash: 15
+      crush: 14
+      magic: -1
+      ranged: 14
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers: [easy]
   related_items:
-    - item_id: 20169
-      item_name: Steel platebody (g)
+    - item_name: Steel kiteshield
+      slug: steel-kiteshield
+      relationship: variant
+      description: Untrimmed base shield with the same combat profile.
+    - item_name: Steel platebody (g)
       slug: steel-platebody-g
       relationship: set-piece
-      description: Matching gold-trimmed platebody
-  about: |-
-    > *"Steel kiteshield with gold trim."*
-
-    The steel kiteshield (g) is a gold-trimmed cosmetic variant of the standard steel kiteshield. Identical stats, requiring 5 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching gold-trimmed platebody.
+    - item_name: Steel platelegs (g)
+      slug: steel-platelegs-g
+      relationship: set-piece
+      description: Matching gold-trimmed platelegs.
+    - item_name: Steel full helm (g)
+      slug: steel-full-helm-g
+      relationship: set-piece
+      description: Matching gold-trimmed full helm.
+  about: "Steel kiteshield (g) is a gold-trimmed easy clue casket reward that mirrors the standard steel kiteshield's bonuses except for a slightly less negative ranged attack penalty."
+  market_strategy:
+    notes:
+      - "Supply is gated by easy clue completion rates; demand is cosmetic-driven for full gold-trimmed sets."
+  trading_tips:
+    - "Stock during clue scroll xp events; sell into Trailblazer or transmog-related hype."
+  history:
+    - date: "2016-07-06"
+      description: Released with the Treasure Trail Expansion.
+    - date: "2020-02-12"
+      description: Backside trimming was added to the shield model.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options: [Wear, Drop]
+    worn_options: [Remove]
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platebody.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel platebody | OSRS Price Data
-description: "Steel platebody: Provides excellent protection.. High alch: 1,200 GP, GE limit: 125."
+description: "Steel platebody is a F2P body slot armour requiring 5 Defence. High alch: 1,200 GP, GE limit: 125."
 osrs:
   id: 1119
   name: Steel platebody
@@ -12,24 +12,86 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 125
-  item_id: 1119
-  item_type: armor
-  slot: body
-  type: platebody
-  tradeable: true
-  weight: 9.979
-  requirements:
-    defence: 5
-  stats:
-    stab_defence: 32
-    slash_defence: 31
-    crush_defence: 24
-    ranged_defence: 31
+  material:
+    type: steel
+    tier: low
+  equipment:
+    slot: body
+    weight: 9.979
+    requirements:
+      defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -15
+    defence_bonus:
+      stab: 32
+      slash: 31
+      crush: 24
+      magic: -6
+      ranged: 31
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Smithing
+      level: 48
+      xp: 187.5
+      output_quantity: 1
+      tools: [Hammer]
+      facility: Anvil
+      materials:
+        - item_name: Steel bar
+          quantity: 5
   related_items:
-    - slug: black-platebody
-    - slug: steel-full-helm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1117
+      item_name: Black platebody
+      slug: black-platebody
+      relationship: alternative
+      description: F2P platebody alternative
+    - item_id: 1127
+      item_name: Mithril platebody
+      slug: mithril-platebody
+      relationship: upgrade
+      description: Higher tier platebody
+    - item_id: 1107
+      item_name: Steel full helm
+      slug: steel-full-helm
+      relationship: set-piece
+      description: Matching steel helm
+  about: Steel platebody is a free-to-play body armour smithed from five steel bars at 48 Smithing, requiring 5 Defence to wear.
+  history:
+    - date: "2001-01-04"
+      update: RuneScape beta launch
+      description: Steel platebody available since the RuneScape beta launch.
+    - date: "2005-03-07"
+      update: Graphical Update
+      description: Platebody model updated graphically.
+    - date: "2021-04-21"
+      update: Equipment Rebalance
+      description: Ranged attack bonus reduced from -10 to -15.
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape beta launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-plateskirt-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-plateskirt-t.mdx
@@ -12,22 +12,61 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 125
+  material:
+    type: steel
+    tier: mid
   equipment:
     slot: legs
+    weight: 8.164
     requirements:
       defence: 5
+    defence_bonus:
+      stab: 17
+      slash: 16
+      crush: 15
+      magic: -4
+      ranged: 16
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 20175
       item_name: Steel plateskirt (g)
       slug: steel-plateskirt-g
       relationship: variant
-      description: Gold-trimmed variant
-  about: |-
-    > *"Steel plateskirt with trim."*
-
-    The steel plateskirt (t) is a trimmed cosmetic variant of the steel plateskirt. Requiring 5 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Gold-trimmed variant of the steel plateskirt
+  about: "The steel plateskirt (t) is a trim-decorated reward from easy Treasure Trails, sharing the same defence bonuses as a plain steel plateskirt but with cosmetic trim and no Smithing recipe."
+  market_strategy:
+    notes:
+      - "Supply is throttled to easy clue caskets, so prices drift with clue volume; flips work best when global clue events spike caskets opened."
+  trading_tips:
+    - "Track easy clue caskets opened on the wiki Grand Exchange data; cosmetic trims thin-trade so post slightly under margin to clear quickly."
+  history:
+    - date: "2016-07-06"
+      description: "Released as part of the Treasure Trail Expansion (2016) update."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus on the plateskirt was decreased from -7 to -11."
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion (2016)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 8.164
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-trimmed-set-lg.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel trimmed set (lg) | OSRS Price Data
-description: "Steel trimmed set (lg): A set containing a full helm, platebody, legs and kiteshield.. High alch: 540 GP, GE limit: 8."
+description: "Steel trimmed set (lg): A set containing a full helm, platebody, legs and kiteshield. High alch: 540 GP, GE limit: 8."
 osrs:
   id: 20376
   name: Steel trimmed set (lg)
@@ -12,9 +12,57 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 8
-  about: "Steel trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_id: 2627
+      item_name: Steel full helm (t)
+      slug: steel-full-helm-t
+      relationship: set-piece
+      description: Helm component of the trimmed set
+    - item_id: 2623
+      item_name: Steel platebody (t)
+      slug: steel-platebody-t
+      relationship: set-piece
+      description: Body component of the trimmed set
+    - item_id: 2625
+      item_name: Steel platelegs (t)
+      slug: steel-platelegs-t
+      relationship: set-piece
+      description: Legs component of the trimmed set
+    - item_id: 2629
+      item_name: Steel kiteshield (t)
+      slug: steel-kiteshield-t
+      relationship: set-piece
+      description: Shield component of the trimmed set
+    - item_id: 20379
+      item_name: Steel trimmed set (sk)
+      slug: steel-trimmed-set-sk
+      relationship: alternative
+      description: Plateskirt variant
+  about: "Steel trimmed set (lg) is a Grand Exchange bundle combining the trimmed steel full helm, platebody, platelegs, and kiteshield into one tradeable item to save bank space."
+  market_strategy:
+    notes:
+      - Assembled via the Grand Exchange Sets option
+      - Useful for moving the full trimmed kit in one tradeable item
+      - Components originate from easy Treasure Trails
+  history:
+    - date: "2016-07-06"
+      description: "Item released with the Treasure Trail Expansion (2016) update."
+  properties:
+    release_date: "2016-07-06"
+    update: "Treasure Trail Expansion (2016)"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stripy-pirate-shirt-red.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stripy-pirate-shirt-red.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Stripy pirate shirt (red) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Dodgy Mike's Second-hand Clothing"
+      location: Mos Le'Harmless
+      stock: 10
+  about: "Stripy pirate shirt (red) is a purely cosmetic body slot item sold by Dodgy Mike on Mos Le'Harmless following the Cabin Fever quest."
+  history:
+    - date: "2006-02-07"
+      description: Released alongside the Cabin Fever quest.
+  properties:
+    release_date: "2006-02-07"
+    update: Cabin Fever
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sun-shine.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sun-shine.mdx
@@ -12,9 +12,44 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: null
-  about: "Sun-shine is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - description: "Boosts Strength by 5% + 1 levels."
+      - description: "Reduces Attack by 4 levels."
+      - description: "Restores 5 Hitpoints on drink."
+  shops:
+    - shop_name: The Lost Pickaxe
+      location: Cam Torum
+      price: 100
+    - shop_name: Stick Your Ore Inn
+      location: Mistrock
+      price: 100
+  about: "Sun-shine is a Varlamore liquor sold in Cam Torum and Mistrock that trades Attack for a Strength boost and restores a small amount of Hitpoints on drink."
+  market_strategy:
+    notes:
+      - Untradeable on the Grand Exchange
+      - Infinite shop stock at 100 coins
+      - Niche use for Strength-focused boosting where Attack penalty is acceptable
+  history:
+    - date: "2024-03-20"
+      description: Released with the Varlamore content update.
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore
+    tradeable: false
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Drink
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-rune.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 18000
-  about: "Sunfire rune is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: low
+  recipes:
+    - name: Craft Sunfire rune
+      skill: Runecraft
+      level: 33
+      xp: 9
+      output: Sunfire rune
+      output_quantity: 1
+      tools: [Chisel]
+      materials:
+        - item_name: Fire rune
+          quantity: 1
+        - item_name: Sunfire splinters
+          quantity: 1
+        - item_name: Pure essence
+          quantity: 1
+      location: Shrine of Ralos
+      notes: "Output doubles at 49 Runecraft and triples at 98 Runecraft."
+  related_items:
+    - item_name: Fire rune
+      slug: fire-rune
+      relationship: alternative
+      description: Standard fire rune that Sunfire rune empowers.
+    - item_name: Sunfire splinters
+      slug: sunfire-splinters
+      relationship: component
+      description: Required material crafted from Sunfire fanatics.
+    - item_name: Searing pages
+      slug: searing-page
+      relationship: product
+      description: 100 Sunfire runes plus a burnt page produce a Searing page for the Tome of fire.
+    - item_name: Tome of fire
+      slug: tome-of-fire
+      relationship: alternative
+      description: Spellbook tome enhanced by Searing pages.
+  about: "Sunfire runes are members-only fire runes empowered by Ralos that guarantee a minimum 10% max hit when used to cast offensive fire spells, introduced with Varlamore Part One."
+  market_strategy:
+    notes:
+      - "Demand follows magic combat use cases; sunfire splinter availability and Shrine of Ralos throughput drive supply."
+  trading_tips:
+    - "Watch Wintertodt and PvM updates that change fire-spell viability, as those spike sunfire rune demand."
+  history:
+    - date: "2024-03-20"
+      description: Released with the Varlamore Part One expansion.
+    - date: "2024-04-03"
+      description: Runecraft experience per rune was doubled from 4.5 to 9.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: [Drop]
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunlight-antelope-antler.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunlight-antelope-antler.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Sunlight antelope antler is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: secondary
+    tier: mid-high
+  recipes:
+    - name: Fletch Sunlight antler bolts
+      skill: Fletching
+      level: 62
+      xp: 10
+      output: Sunlight antler bolts
+      output_quantity: 12
+      tools: [Chisel]
+      materials:
+        - item_name: Sunlight antelope antler
+          quantity: 1
+      notes: "Each antler yields 12 bolts at 10 XP per bolt."
+    - name: Upgrade Hunters' crossbow
+      skill: Fletching
+      level: 74
+      output: Hunters' sunlight crossbow
+      output_quantity: 1
+      tools: [Chisel]
+      materials:
+        - item_name: Hunters' crossbow
+          quantity: 1
+        - item_name: Sunlight antelope antler
+          quantity: 1
+  related_items:
+    - item_name: Sunlight antler bolts
+      slug: sunlight-antler-bolts
+      relationship: product
+      description: Fletched twelve at a time from one antler at 62 Fletching.
+    - item_name: Hunters' sunlight crossbow
+      slug: hunters-sunlight-crossbow
+      relationship: product
+      description: Upgraded hunters' crossbow created with the antler at 74 Fletching.
+  about: "Sunlight antelope antler is a guaranteed drop from sunlight antelopes in the Avium Savannah requiring 72 Hunter, used to fletch sunlight antler bolts or upgrade the hunters' crossbow."
+  market_strategy:
+    notes:
+      - "Supply scales with Hunter training in Varlamore; demand follows hunters' sunlight crossbow and sunlight antler bolt usage."
+  trading_tips:
+    - "Buy in volume during bolt-craft meta windows when ranged setups switch to sunlight antler bolts."
+  history:
+    - date: "2024-03-20"
+      description: Released with the Varlamore Part One expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options: [Drop]
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-attack-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-attack-1.mdx
@@ -12,6 +12,10 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
+  potion:
+    doses: 1
+    effects:
+      - description: "Boosts Attack by floor(level * 0.15) + 5, decaying at 1 point per minute."
   related_items:
     - item_id: 145
       item_name: Super attack(3)
@@ -23,12 +27,26 @@ osrs:
       slug: super-attack-2
       relationship: variant
       description: 2-dose version
-  about: |-
-    > _"1 dose of super Attack potion."_
-
-    A 1-dose super attack potion. Boosts Attack by 5 + 15% of current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Super attack(1) is a single-dose Attack-boosting potion that elevates Attack by 5 plus 15 percent of the current level for melee combat encounters."
+  history:
+    - date: "2002-02-27"
+      description: Released as part of the original Herblore potion set.
+  properties:
+    release_date: "2002-02-27"
+    update: Members release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-strength-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-strength-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super strength(4) | OSRS Price Data
-description: "Super strength(4) is a 3-dose members potion. High alch: 165 GP, GE limit: 2,000."
+description: "Super strength(4) is a 4-dose members potion. High alch: 165 GP, GE limit: 2,000."
 osrs:
   id: 2440
   name: Super strength(4)
@@ -13,31 +13,32 @@ osrs:
   highalch: 165
   limit: 2000
   potion:
-    doses: 3
+    doses: 4
     type: boost
     skill: strength
     boost_min: 5
     boost_max: 19
-    boost_formula: 15% + 5
+    boost_formula: "floor(level * 0.15) + 5"
     duration: 60
-  herblore:
-    level: 55
-    xp: 125
+    effects:
+      - skill: strength
+        description: "Boosts Strength by 5 + 15% of level (max +19); decays 1 per minute, 90s with Preserve."
   recipes:
-    - skill: herblore
+    - name: Mix Super strength(3)
+      skill: herblore
       level: 55
       xp: 125
       materials:
-        - item_name: Kwuarm potion (unf)
-          item_id: 105
+        - item_id: 105
+          item_name: Kwuarm potion (unf)
           quantity: 1
-        - item_name: Limpwurt root
-          item_id: 225
+        - item_id: 225
+          item_name: Limpwurt root
           quantity: 1
       product: Super strength(3)
-      product_id: 2440
+      product_id: 159
       product_quantity: 1
-      facility: None
+      tools: []
       members_only: true
   related_items:
     - item_id: 263
@@ -49,44 +50,50 @@ osrs:
       item_name: Limpwurt root
       slug: limpwurt-root
       relationship: component
-      description: Secondary
+      description: Secondary ingredient
     - item_id: 12695
       item_name: Super combat potion(4)
       slug: super-combat-potion-4
       relationship: product
-      description: Combined potion
+      description: Combined super potion
     - item_id: 115
       item_name: Strength potion(3)
       slug: strength-potion-3
-      relationship: alternative
+      relationship: downgrade
       description: Lower tier
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 55 |
-    | XP | 125 |
-    | Ingredients | Kwuarm + Limpwurt root |
-
-    | Effect | Value |
-    |--------|-------|
-    | Strength boost | +5 to +19 (15% + 5) |
-    | Duration | 60s per level lost |
-    | Preserve prayer | 90s per level lost |
+  about: Super strength(4) is a four-dose members Strength booster and a core ingredient for Super combat potions.
   market_strategy:
     notes:
-      - Super combat ingredient
-      - Standalone strength boost
-      - Very high demand
-      - Super combat production
-      - Melee PvM
-      - Bossing preparation
-      - Slayer tasks
-      - Low buy limit (2,000)
-      - Kwuarm herb
-      - Limpwurt root secondary
-      - Component for super combat
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Super combat ingredient drives steady volume
+      - Tight 2,000/4h buy limit keeps spreads workable
+      - Kwuarm + Limpwurt supply chain dictates price
+      - Standalone bossing/Slayer staple
+  history:
+    - date: "2016-04-15"
+      description: Half-full potions could now be turned into bank placeholders.
+    - date: "2014-08-14"
+      description: Super strength(4) enabled for Super combat potion crafting.
+    - date: "2004-10-26"
+      description: An Empty option was added.
+    - date: "2004-03-29"
+      description: The 4 dose potion became permanently available with the launch of RuneScape 2.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launched!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-paste.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-paste.mdx
@@ -23,7 +23,7 @@ osrs:
           quantity: 1
       output:
         item_name: Swamp paste
-        quantity: 1
+        quantity: "1"
       notes: Cook on a fire only; cannot be made on a range.
   shops:
     - shop_name: Razmire Builders Merchants

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-tar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-tar.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Swamp tar is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: secondary
+    tier: mid
+  recipes:
+    - skill: Herblore
+      level: 19
+      xp: 30
+      materials:
+        - item_name: Guam leaf
+        - item_name: Swamp tar
+      tools:
+        - Pestle and mortar
+      output: Guam tar
+  related_items:
+    - item_id: 10142
+      item_name: Guam tar
+      slug: guam-tar
+      relationship: product
+      description: Salamander ammunition crafted with herbs
+    - item_id: 1929
+      item_name: Swamp paste
+      slug: swamp-paste
+      relationship: product
+      description: Created by combining swamp tar with flour and heating
+  about: Swamp tar is a foul-smelling tar substance obtained from Lumbridge Swamp, Mort Myre Swamp, or Cave Slime drops. It is used to craft herb tar salamander ammunition, swamp paste, and lamp oil.
+  history:
+    - date: "2002-09-09"
+      description: Released with the Sea Slug quest update.
+    - date: "2006-05-02"
+      description: Examine text punctuation corrected from "tar like" to "tar-like".
+    - date: "2015-06-11"
+      description: Game messages added to chat filter.
+  properties:
+    release_date: "2002-09-09"
+    update: Sea Slug
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-weed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-weed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Swamp weed | OSRS Price Data
-description: "Swamp weed: Swamp weed found in the caves near Dorgesh-Kaan.. High alch: 1 GP, GE limit: 13,000."
+description: "Swamp weed: a members herb dropped by cave bugs and molanisks, used to make soda ash and as a Superglass Make ingredient. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 10978
   name: Swamp weed
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Swamp weed is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    - source: Cave bug
+      level: 96
+      quantity: 1-8
+      rarity: Uncommon
+    - source: Molanisk
+      level: 51
+      quantity: 1-8
+      rarity: Uncommon
+    - source: Fishing spot (frogspawn)
+      quantity: "1"
+      rarity: 43/1000
+      description: Caught while fishing for frogspawn at 33 Fishing.
+  recipes:
+    - name: Soda ash
+      skill: Cooking
+      level: 1
+      experience: 0
+      output: Soda ash
+      materials:
+        - item_name: Swamp weed
+          quantity: 1
+      tools:
+        - Range
+      description: Cook swamp weed on a range to produce soda ash.
+    - name: Superglass Make
+      skill: Magic
+      level: 77
+      experience: 78
+      output: Molten glass
+      materials:
+        - item_name: Swamp weed
+          quantity: 1
+        - item_name: Bucket of sand
+          quantity: 1
+      description: Lunar spell that turns swamp weed and sand into molten glass.
+  about: "Swamp weed is a herb-like plant gathered from the Dorgesh-Kaan South Dungeon, used for soda ash, Superglass Make and cave goblin recipes."
+  market_strategy:
+    title: Investment Notes
+    notes:
+      - Demand driven by Superglass Make crafters needing cheap molten glass.
+      - Buy limit of 13,000 per 4 hours keeps prices stable.
+      - Bulk farming via cave bugs and molanisks fuels supply.
+      - Profitable when crafters compete with raw sand/seaweed alternatives.
+  history:
+    - date: "2007-03-20"
+      update: Land of the Goblins
+      description: Added to game with the Dorgesh-Kaan South Dungeon.
+  properties:
+    release_date: "2007-03-20"
+    update: Land of the Goblins
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-gauntlets.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-gauntlets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Swampbark gauntlets | OSRS Price Data
-description: "Swampbark gauntlets: These should protect my hands.. High alch: 6,000 GP."
+description: "Swampbark gauntlets: These should protect my hands. High alch: 6,000 GP."
 osrs:
   id: 25392
   name: Swampbark gauntlets
@@ -12,9 +12,89 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: null
-  about: "Swampbark gauntlets is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: hands
+    weight: 0.907
+    requirements:
+      magic: 50
+      defence: 50
+    attack_bonus:
+      magic: 3
+    defence_bonus:
+      stab: 4
+      slash: 3
+      crush: 5
+      magic: 4
+  recipes:
+    - skill: runecraft
+      level: 42
+      xp: 5
+      materials:
+        - item_name: Splitbark gauntlets
+          item_id: 3845
+          quantity: 1
+        - item_name: Nature rune
+          item_id: 561
+          quantity: 100
+      product: Swampbark gauntlets
+      product_id: 25392
+      product_quantity: 1
+      facility: Nature Altar
+      members_only: true
+      notes: "Requires reading the Runescroll of swampbark first."
+  related_items:
+    - item_id: 3845
+      item_name: Splitbark gauntlets
+      slug: splitbark-gauntlets
+      relationship: component
+      description: Base gauntlets used in recipe
+    - item_id: 25386
+      item_name: Swampbark helm
+      slug: swampbark-helm
+      relationship: set-piece
+      description: Helm slot piece
+    - item_id: 25388
+      item_name: Swampbark body
+      slug: swampbark-body
+      relationship: set-piece
+      description: Body slot piece
+    - item_id: 25390
+      item_name: Swampbark legs
+      slug: swampbark-legs
+      relationship: set-piece
+      description: Legs slot piece
+    - item_id: 25394
+      item_name: Swampbark boots
+      slug: swampbark-boots
+      relationship: set-piece
+      description: Boots slot piece
+  about: "Swampbark gauntlets are reinforced splitbark gauntlets made at the Nature Altar after reading the Runescroll of swampbark; they do not contribute to the full set bind effect."
+  market_strategy:
+    notes:
+      - Created from splitbark gauntlets + 100 nature runes
+      - Niche magic hands option
+      - Gauntlets do not extend bind spell duration
+  history:
+    - date: "2021-01-27"
+      description: "Item released with the Shades of Mort'ton Rework update."
+  properties:
+    release_date: "2021-01-27"
+    update: "Shades of Mort'ton Rework"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-armchair-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-armchair-flatpack.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Teak armchair (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Construction
+      level: 35
+      experience: 180
+      output_quantity: 1
+      tools:
+        - Hammer
+        - Saw
+      materials:
+        - item_name: Teak plank
+          quantity: 2
+      notes: Built at an Oak workbench in a Workshop.
+  construction:
+    level: 35
+    experience: 180
+    hotspot: Chairs
+    room: Parlour
+  related_items:
+    - item_id: 8505
+      item_name: Teak armchair
+      slug: teak-armchair
+      relationship: product
+      description: Built form for the parlour chair hotspot.
+  about: "Teak armchair (flatpack) is a Construction flatpack built from two teak planks at an Oak workbench, ready to be deployed into a player-owned house parlour chair hotspot."
+  market_strategy:
+    notes:
+      - Tradeable on the Grand Exchange
+      - Profitable training is rare; flatpacks are usually consumed for own use
+      - Buy limit of 500 makes bulk POH building feasible
+  history:
+    - date: "2006-05-31"
+      description: Released with the Player-Owned Houses update.
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-hull-parts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teak hull parts | OSRS Price Data
-description: "Teak hull parts: Parts for creating a teak hull for a boat.. High alch: 750 GP, GE limit: 100."
+description: "Teak hull parts are a Sailing crafting component made from 5 teak planks at a shipwrights' workbench. High alch: 750 GP, GE limit: 100."
 osrs:
   id: 32047
   name: Teak hull parts
@@ -12,9 +12,59 @@ osrs:
   lowalch: 500
   highalch: 750
   limit: 100
-  about: "Teak hull parts is a members-only item in Old School RuneScape. High alchemy value: 750 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: teak
+    tier: mid
+  recipes:
+    - skill: Construction
+      level: 23
+      experience: 225
+      materials:
+        - item_name: Teak plank
+          quantity: 5
+      tools:
+        - Shipwrights' workbench
+  related_items:
+    - item_id: 32048
+      item_name: Large teak hull parts
+      slug: large-teak-hull-parts
+      relationship: product
+      description: Five teak hull parts combine into one large teak hull part
+    - item_id: 32049
+      item_name: Teak hull
+      slug: teak-hull
+      relationship: product
+      description: Assembled skiff hull requiring 31 Sailing and 23 Construction
+  construction:
+    level: 23
+    experience: 225
+  about: "Teak hull parts are a Sailing material crafted from five teak planks at a shipwrights' workbench, used to build large teak hull parts and finally a teak skiff hull."
+  market_strategy:
+    notes:
+      - "Plank cost sits well above alch value, so flips rely on Sailing demand cycles rather than alch arbitrage; expect price compression when shipwrights' workbench XP rates rebalance."
+  trading_tips:
+    - "Compare GE price to (5 * teak plank + nails + tar) - if the spread inverts, buy parts instead of crafting them and bank the construction XP gap."
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing skill launch update."
+    - date: "2025-11-19"
+      description: "Hotfix halved Construction experience from shipwrights' workbenches."
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-magic-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-magic-wardrobe-flatpack.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Teak magic wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: teak
+    tier: mid
+  recipes:
+    - skill: construction
+      level: 60
+      xp: 360
+      materials:
+        - item_name: Teak plank
+          quantity: 4
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+      facility: Steel framed workbench
+  related_items:
+    - item_id: 9853
+      item_name: Teak magic wardrobe
+      slug: teak-magic-wardrobe
+      relationship: product
+      description: Built furniture from this flatpack
+  about: "Teak magic wardrobe (flatpack) is a members-only flatpack built at a steel framed workbench with 60 Construction using 4 teak planks for 360 XP."
+  market_strategy:
+    notes:
+      - Niche flatpack with low daily volume
+      - Most players craft on-site rather than buy flatpacks
+      - Profit margin depends on teak plank prices
+  history:
+    - date: "2015-02-26"
+      description: Renamed from 'Teak mw' to 'Teak magic wardrobe' during The Grand Exchange update.
+  properties:
+    release_date: "2006-10-18"
+    update: Player-Owned House Costume Room
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-2-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-2-cape.mdx
@@ -12,9 +12,35 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-2 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    weight: 0.453
+    defence_bonus:
+      slash: 1
+      crush: 1
+      ranged: 2
+  about: "Team-2 cape is one of the original Wilderness team capes worn for clan identification in Wilderness combat and minigames."
+  history:
+    - date: "2013-05-23"
+      description: The item was made available to free-to-play players.
+  properties:
+    release_date: "2005-02-22"
+    update: "Wilderness Capes, and Changes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-26-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-26-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team-26 cape | OSRS Price Data
-description: "Team-26 cape: Ooohhh look at the pretty colours.... High alch: 30 GP, GE limit: 150."
+description: "Team-26 cape is a F2P cape sold by Richard's Wilderness Cape Shop in Edgeville. High alch: 30 GP, GE limit: 150."
 osrs:
   id: 4365
   name: Team-26 cape
@@ -12,9 +12,54 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-26 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    weight: 0.453
+    requirements: {}
+    defence_bonus:
+      crush: 1
+      ranged: 2
+  shops:
+    - shop_name: Richard's Wilderness Cape Shop
+      location: Edgeville
+      price: 50
+      stock: 100
+  related_items:
+    - item_id: 4315
+      item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: Another numbered team cape from Richard's shop
+  about: "The Team-26 cape is one of fifty numbered team capes sold by Richard's Wilderness Cape Shop in Edgeville, used to identify allies during Wilderness team events."
+  market_strategy:
+    notes:
+      - "Shop restock at 30 coins versus a GE high alch of 30 leaves no alch margin; price moves only on cosmetic demand from team-event organizers."
+  trading_tips:
+    - "Pre-buy from Richard before announced clan wars or PvP events when team capes briefly spike on demand; sell quickly because supply is unlimited at the shop."
+  history:
+    - date: "2005-02-22"
+      description: "Released with the Wilderness Capes, and Changes update."
+    - date: "2013-05-23"
+      description: "Made available to free-to-play players."
+  properties:
+    release_date: "2005-02-22"
+    update: Wilderness Capes, and Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thread.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thread.mdx
@@ -177,81 +177,81 @@ osrs:
       skill: crafting
       level: 1
       xp: 13.8
-      quantity: 1
+      quantity: "1"
     - product: Pheasant boots
       skill: crafting
       level: 2
       xp: 15
-      quantity: 1
+      quantity: "1"
     - product: Pheasant cape
       skill: crafting
       level: 2
       xp: 15
-      quantity: 1
+      quantity: "1"
     - product: Pheasant hat
       skill: crafting
       level: 2
       xp: 15
-      quantity: 1
+      quantity: "1"
     - product: Pheasant legs
       skill: crafting
       level: 2
       xp: 15
-      quantity: 1
+      quantity: "1"
     - product: Leather boots
       slug: leather-boots
       skill: crafting
       level: 7
       xp: 16.3
-      quantity: 1
+      quantity: "1"
     - product: Leather cowl
       slug: leather-cowl
       skill: crafting
       level: 9
       xp: 18.5
-      quantity: 1
+      quantity: "1"
     - product: Leather vambraces
       slug: leather-vambraces
       skill: crafting
       level: 11
       xp: 22
-      quantity: 1
+      quantity: "1"
     - product: Leather body
       slug: leather-body
       skill: crafting
       level: 14
       xp: 25
-      quantity: 1
+      quantity: "1"
     - product: Xerician hat
       slug: xerician-hat
       skill: crafting
       level: 14
       xp: 66
-      quantity: 1
+      quantity: "1"
     - product: Xerician robe
       slug: xerician-robe
       skill: crafting
       level: 17
       xp: 88
-      quantity: 1
+      quantity: "1"
     - product: Leather chaps
       slug: leather-chaps
       skill: crafting
       level: 18
       xp: 27
-      quantity: 1
+      quantity: "1"
     - product: Xerician top
       slug: xerician-top
       skill: crafting
       level: 22
       xp: 110
-      quantity: 1
+      quantity: "1"
     - product: Hardleather body
       slug: hardleather-body
       skill: crafting
       level: 28
       xp: 35
-      quantity: 1
+      quantity: "1"
     - product: Small fur pouch
       skill: crafting
       level: 35
@@ -267,43 +267,43 @@ osrs:
       skill: crafting
       level: 38
       xp: 37
-      quantity: 1
+      quantity: "1"
     - product: Yak-hide armour (top)
       slug: yak-hide-armour-top
       skill: crafting
       level: 46
       xp: 32
-      quantity: 1
+      quantity: "1"
     - product: Yak-hide armour (legs)
       slug: yak-hide-armour-legs
       skill: crafting
       level: 43
       xp: 32
-      quantity: 1
+      quantity: "1"
     - product: Snakeskin boots
       slug: snakeskin-boots
       skill: crafting
       level: 45
       xp: 30
-      quantity: 1
+      quantity: "1"
     - product: Snakeskin vambraces
       slug: snakeskin-vambraces
       skill: crafting
       level: 47
       xp: 35
-      quantity: 1
+      quantity: "1"
     - product: Snakeskin bandana
       slug: snakeskin-bandana
       skill: crafting
       level: 48
       xp: 45
-      quantity: 1
+      quantity: "1"
     - product: Clothes pouch
       slug: clothes-pouch
       skill: crafting
       level: 50
       xp: 47
-      quantity: 1
+      quantity: "1"
     - product: Medium fur pouch
       skill: crafting
       level: 50
@@ -314,81 +314,81 @@ osrs:
       skill: crafting
       level: 51
       xp: 50
-      quantity: 1
+      quantity: "1"
     - product: Snakeskin body
       slug: snakeskin-body
       skill: crafting
       level: 53
       xp: 55
-      quantity: 1
+      quantity: "1"
     - product: Green d'hide vambraces
       slug: green-d-hide-vambraces
       skill: crafting
       level: 57
       xp: 62
-      quantity: 1
+      quantity: "1"
     - product: Green d'hide chaps
       slug: green-d-hide-chaps
       skill: crafting
       level: 60
       xp: 124
-      quantity: 1
+      quantity: "1"
     - product: Splitbark boots
       slug: splitbark-boots
       skill: crafting
       level: 60
       xp: 62
-      quantity: 1
+      quantity: "1"
     - product: Splitbark gauntlets
       slug: splitbark-gauntlets
       skill: crafting
       level: 60
       xp: 62
-      quantity: 1
+      quantity: "1"
     - product: Lunar boots
       skill: crafting
       level: 61
       xp: 25
-      quantity: 1
+      quantity: "1"
     - product: Lunar gloves
       skill: crafting
       level: 61
       xp: 25
-      quantity: 1
+      quantity: "1"
     - product: Lunar legs
       skill: crafting
       level: 61
       xp: 30
-      quantity: 1
+      quantity: "1"
     - product: Lunar torso
       skill: crafting
       level: 61
       xp: 35
-      quantity: 1
+      quantity: "1"
     - product: Splitbark helm
       slug: splitbark-helm
       skill: crafting
       level: 61
       xp: 124
-      quantity: 1
+      quantity: "1"
     - product: Splitbark body
       slug: splitbark-body
       skill: crafting
       level: 62
       xp: 248
-      quantity: 1
+      quantity: "1"
     - product: Splitbark legs
       slug: splitbark-legs
       skill: crafting
       level: 62
       xp: 186
-      quantity: 1
+      quantity: "1"
     - product: Green d'hide body
       slug: green-d-hide-body
       skill: crafting
       level: 63
       xp: 186
-      quantity: 1
+      quantity: "1"
     - product: Large fur pouch
       skill: crafting
       level: 65
@@ -404,13 +404,13 @@ osrs:
       skill: crafting
       level: 66
       xp: 70
-      quantity: 1
+      quantity: "1"
     - product: Blue d'hide chaps
       slug: blue-d-hide-chaps
       skill: crafting
       level: 68
       xp: 140
-      quantity: 1
+      quantity: "1"
     - product: Mixed hide cape
       slug: mixed-hide-cape
       skill: crafting
@@ -428,7 +428,7 @@ osrs:
       skill: crafting
       level: 71
       xp: 210
-      quantity: 1
+      quantity: "1"
     - product: Mixed hide legs
       slug: mixed-hide-legs
       skill: crafting
@@ -446,68 +446,68 @@ osrs:
       skill: crafting
       level: 73
       xp: 78
-      quantity: 1
+      quantity: "1"
     - product: Red d'hide chaps
       slug: red-d-hide-chaps
       skill: crafting
       level: 75
       xp: 156
-      quantity: 1
+      quantity: "1"
     - product: Hueycoatl hide coif
       slug: hueycoatl-hide-coif
       skill: crafting
       level: 76
       xp: 190
-      quantity: 1
+      quantity: "1"
     - product: Hueycoatl hide vambraces
       slug: hueycoatl-hide-vambraces
       skill: crafting
       level: 76
       xp: 95
-      quantity: 1
+      quantity: "1"
     - product: Hueycoatl hide chaps
       slug: hueycoatl-hide-chaps
       skill: crafting
       level: 77
       xp: 190
-      quantity: 1
+      quantity: "1"
     - product: Red d'hide body
       slug: red-d-hide-body
       skill: crafting
       level: 77
       xp: 234
-      quantity: 1
+      quantity: "1"
     - product: Hueycoatl hide body
       slug: hueycoatl-hide-body
       skill: crafting
       level: 78
       xp: 285
-      quantity: 1
+      quantity: "1"
     - product: Black d'hide vambraces
       slug: black-d-hide-vambraces
       skill: crafting
       level: 79
       xp: 86
-      quantity: 1
+      quantity: "1"
     - product: Black d'hide chaps
       slug: black-d-hide-chaps
       skill: crafting
       level: 82
       xp: 172
-      quantity: 1
+      quantity: "1"
     - product: Black d'hide body
       slug: black-d-hide-body
       skill: crafting
       level: 84
       xp: 258
-      quantity: 1
+      quantity: "1"
     - product: Robe of elidinis (top)
       skill: none
-      quantity: 1
+      quantity: "1"
       notes: Sewn during Beneath Cursed Sands.
     - product: Robe of elidinis (bottom)
       skill: none
-      quantity: 1
+      quantity: "1"
       notes: Sewn during Beneath Cursed Sands.
   market_strategy:
     title: Bulk crafting consumable

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-amulet.mdx
@@ -46,7 +46,7 @@ osrs:
           quantity: 1
       output:
         item_name: Topaz amulet
-        quantity: 1
+        quantity: "1"
     - skill: Magic
       level: 80
       xp: 0
@@ -61,7 +61,7 @@ osrs:
           quantity: 2
       output:
         item_name: Topaz amulet
-        quantity: 1
+        quantity: "1"
       notes: Lunar Diplomacy required; String Jewellery spell.
   related_items:
     - item_id: 21112

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-dragon-bolts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Topaz dragon bolts | OSRS Price Data
-description: "Topaz dragon bolts: Dragon crossbow bolts, tipped with red topaz.. High alch: 420 GP, GE limit: 11,000."
+description: "Topaz dragon bolts are members dragon crossbow bolts tipped with red topaz. High alch: 420 GP, GE limit: 11,000."
 osrs:
   id: 21961
   name: Topaz dragon bolts
@@ -12,9 +12,79 @@ osrs:
   lowalch: 280
   highalch: 420
   limit: 11000
-  about: "Topaz dragon bolts is a members-only item in Old School RuneScape. High alchemy value: 420 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  equipment:
+    slot: ammo
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 122
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Fletching
+      level: 84
+      xp: 3.9
+      output_quantity: 10
+      materials:
+        - item_name: Dragon bolts
+          quantity: 10
+        - item_name: Topaz bolt tips
+          quantity: 10
+  related_items:
+    - item_id: 21946
+      item_name: Dragon bolts
+      slug: dragon-bolts
+      relationship: component
+      description: Base unfletched dragon bolts
+    - item_id: 9239
+      item_name: Topaz bolt tips
+      slug: topaz-bolt-tips
+      relationship: component
+      description: Bolt tip applied to the dragon bolts
+    - item_id: 21963
+      item_name: "Topaz dragon bolts (e)"
+      slug: topaz-dragon-bolts-e
+      relationship: upgrade
+      description: Enchanted Sunburst variant
+  about: Topaz dragon bolts are tipped dragon bolts fletched at 84 Fletching from 10 dragon bolts and 10 topaz bolt tips, primarily made to enchant into the Sunburst variant.
+  history:
+    - date: "2018-01-04"
+      update: Dragon Slayer II
+      description: Topaz dragon bolts released as part of the Dragon Slayer II content drop.
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-hammers-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-hammers-0.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 64000
   highalch: 96000
   limit: 15
-  about: "Torag's hammers 0 is a members-only item in Old School RuneScape. High alchemy value: 96,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: bludgeon
+    attack_speed: 5
+    weight: 3.628
+    requirements:
+      attack: 70
+      strength: 70
+    attack_bonus:
+      stab: -4
+      slash: -4
+      crush: 85
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 72
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    max_charges: 0
+    notes: "Fully degraded Torag's hammers; recharge at an armour repair stand or Bob's Brilliant Axes to restore charges."
+  drop_table:
+    primary_source: Barrows
+    best_drop_rate: 7/2448
+    sources:
+      - source: Barrows chest
+        rarity: rare
+        drop_rate: 7/2448
+        members_only: true
+  about: "Torag's hammers 0 are the fully degraded form of Torag the Corrupted's twin two-handed crush hammers from the Barrows minigame, requiring 70 Attack and 70 Strength to wield."
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Check
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: "If you drop this item it will break. Are you sure you want to drop it?"
+  history:
+    - date: "2005-05-09"
+      description: Released with the Barrows minigame.
+    - date: "2005-05-17"
+      description: Updated in the Barrows Changes and Other Tweaks patch.
+    - date: "2014-12-10"
+      description: Renamed to include an apostrophe in Torag's.
+    - date: "2015-04-16"
+      description: Added a Check option to inspect durability.
+    - date: "2024-03-20"
+      description: Damage was split into two independent hitsplats.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-banner.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 5
-  about: "Trailblazer banner is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: bladed
+    attack_speed: 4
+    weight: 2.267
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 24154
+      item_name: Trailblazer hood
+      slug: trailblazer-hood
+      relationship: set-piece
+      description: Matching Trailblazer League cosmetic
+  about: Trailblazer banner is a cosmetic one-handed banner from the Leagues II reward shop with a crossbar that recolours to match the wearer's boot palette.
+  market_strategy:
+    notes:
+      - Leagues II reward shop exclusive — fixed supply
+      - Cosmetic-only, no combat utility
+      - Tiny 5/4h buy limit keeps prices premium
+  history:
+    - date: "2021-01-06"
+      description: Released alongside Soul Wars and the 20th Anniversary Event as a Trailblazer League reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-01-06"
+    update: Soul Wars and 20th Anniversary Event
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-top-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-top-brown.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tribal top (brown) | OSRS Price Data
-description: "Tribal top (brown): Local dress.. High alch: 180 GP, GE limit: 150."
+description: "Tribal top (brown) is a members body slot cosmetic sold at Gabooty's in Tai Bwo Wannai. High alch: 180 GP, GE limit: 150."
 osrs:
   id: 6341
   name: Tribal top (brown)
@@ -12,9 +12,59 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Tribal top (brown) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 1
+    requirements: {}
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      price: 360
+      stock: 50
+  related_items:
+    - item_id: 6339
+      item_name: Tribal top (blue)
+      slug: tribal-top-blue
+      relationship: variant
+      description: Blue colour variant of the tribal top
+    - item_id: 6343
+      item_name: Tribal top (pink)
+      slug: tribal-top-pink
+      relationship: variant
+      description: Pink colour variant of the tribal top
+    - item_id: 6345
+      item_name: Tribal top (yellow)
+      slug: tribal-top-yellow
+      relationship: variant
+      description: Yellow colour variant of the tribal top
+  about: "The tribal top (brown) is a Karamja-themed body slot cosmetic sold at Gabooty's Tai Bwo Wannai Cooperative for 360 trading sticks, reduced to 300 with Karamja gloves."
+  market_strategy:
+    notes:
+      - "Trading-stick gating and a magic wardrobe storage option keep demand cosmetic-only; price drifts on roleplay and houseparty trends rather than meta."
+  trading_tips:
+    - "Stock up while running Tai Bwo Wannai Cleanup for trading sticks - convert excess sticks into tops, then list slightly under the prevailing GE price for a slow flip."
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Tai Bwo Wannai Clean-Up update."
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trident-of-the-seas-full.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trident-of-the-seas-full.mdx
@@ -27,15 +27,15 @@ osrs:
     materials:
       - item_id: 560
         item_name: Death rune
-        quantity: 1
+        quantity: "1"
       - item_id: 562
         item_name: Chaos rune
-        quantity: 1
+        quantity: "1"
       - item_id: 554
         item_name: Fire rune
-        quantity: 5
+        quantity: "5"
       - item_name: Coins
-        quantity: 10
+        quantity: "10"
   obtaining:
     methods:
       - source: Kraken (boss)

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ultor-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ultor-ring.mdx
@@ -27,12 +27,12 @@ osrs:
         item_name: Ultor vestige
       - item_id: 565
         item_name: Blood rune
-        quantity: 500
+        quantity: "500"
     materials:
       - item_name: Chromium ingot
-        quantity: 3
+        quantity: "3"
       - item_name: Ring mould
-        quantity: 1
+        quantity: "1"
     skill_requirements:
       magic: 90
       crafting: 80

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ultracompost.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ultracompost.mdx
@@ -30,10 +30,10 @@ osrs:
     materials:
       - item_id: 6034
         item_name: Supercompost
-        quantity: 1
+        quantity: "1"
       - item_id: 21622
         item_name: Volcanic ash
-        quantity: 1
+        quantity: "1"
   market:
     buy_limit: 2000
     price_estimate: 700

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unholy-symbol.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unholy-symbol.mdx
@@ -25,10 +25,10 @@ osrs:
     materials:
       - item_name: Unstrung symbol (Zamorak)
         item_id: 1720
-        quantity: 1
+        quantity: "1"
       - item_name: Ball of wool
         item_id: 1759
-        quantity: 1
+        quantity: "1"
   related_items:
     - item_id: 1718
       item_name: Holy symbol

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/venator-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/venator-ring.mdx
@@ -28,12 +28,12 @@ osrs:
         item_name: Venator vestige
       - item_id: 565
         item_name: Blood rune
-        quantity: 500
+        quantity: "500"
     materials:
       - item_name: Chromium ingot
-        quantity: 3
+        quantity: "3"
       - item_name: Ring mould
-        quantity: 1
+        quantity: "1"
     skill_requirements:
       magic: 90
       crafting: 80

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vial-of-water.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vial-of-water.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vial of water | OSRS Price Data
-description: "Vial of water: A glass vial containing water.. High alch: 1 GP, GE limit: 13,000."
+description: "Vial of water: A glass vial containing water. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 227
   name: Vial of water
@@ -14,7 +14,7 @@ osrs:
   limit: 13000
   material:
     type: container
-    tier: basic
+    tier: low
   shops:
     - shop_name: General stores
       price: 2
@@ -22,22 +22,17 @@ osrs:
     - shop_name: Herblore shops
       price: 2
       currency: Coins
-  uses:
-    - purpose: Unfinished potions
-      skill: herblore
-    - purpose: Soft clay creation
-      skill: crafting
   related_items:
     - item_id: 229
       item_name: Vial
       slug: vial
       relationship: component
-      description: Empty container
+      description: Empty container filled at water source
     - item_id: 1781
       item_name: Soft clay
       slug: soft-clay
       relationship: product
-      description: Alternative use
+      description: Used to create soft clay
     - item_id: 249
       item_name: Grimy guam leaf
       slug: grimy-guam-leaf
@@ -48,11 +43,7 @@ osrs:
       slug: grimy-ranarr-weed
       relationship: component
       description: Herblore partner
-  about: |-
-    | Purpose | Skill |
-    |---------|-------|
-    | Unfinished potions | Herblore |
-    | Soft clay creation | Crafting |
+  about: "Vial of water is the base liquid for nearly every herblore potion in Old School RuneScape. Made by using an empty vial on any water source, then combined with grimy or clean herbs to make unfinished potions."
   market_strategy:
     notes:
       - Base for all potions
@@ -66,8 +57,27 @@ osrs:
       - Fill at any water source
       - Humidify spell efficient
       - Bulk buy for training
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2002-02-27"
+      update: Latest RuneScape News (27 February 2002)
+      description: Released into the game.
+    - date: "2024-01-10"
+      description: Soft clay can now be created with vials of water.
+  properties:
+    release_date: "2002-02-27"
+    update: Latest RuneScape News (27 February 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options: [Empty, Drop]
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vial.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vial.mdx
@@ -30,14 +30,11 @@ osrs:
         - item_name: Molten glass
           item_id: 1775
           quantity: 1
+      tools:
+        - Glassblowing pipe
       product: Vial
       product_id: 229
       product_quantity: 1
-  uses:
-    - purpose: Vial of water
-      skill: N/A
-    - purpose: Potion storage
-      skill: herblore
   related_items:
     - item_id: 227
       item_name: Vial of water
@@ -54,18 +51,7 @@ osrs:
       slug: vial-of-blood
       relationship: variant
       description: Theatre of Blood variant
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Container |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-
-    | Purpose | Method |
-    |---------|--------|
-    | Vial of water | Fill at any water source |
-    | Potion making | Base for all standard potions |
+  about: "Vial is a free-to-play container used as the base for all standard potions in Herblore; can be filled with water at any source and crafted from molten glass at 33 Crafting for 35 XP."
   market_strategy:
     notes:
       - Base container for all potions
@@ -77,8 +63,26 @@ osrs:
       - Buy from shops for 1 gp each
       - Craft from molten glass for XP
       - Fill at any water source
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2002-02-27"
+      description: Added to the game.
+    - date: "2020-05-14"
+      description: Vials can now have water poured into them from buckets and related vessels.
+  properties:
+    release_date: "2002-02-27"
+    update: Latest RuneScape News
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.015
+    options:
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-robe-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-robe-blue.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Villager robe (blue) is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weapon_type: armour
+    weight: 2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      currency: Trading sticks
+      price: 300
+  related_items:
+    - item_id: 6349
+      item_name: Villager sandals (brown)
+      slug: villager-sandals-brown
+      relationship: set-piece
+      description: Matching villager footwear
+  about: "Villager robe (blue) is a cosmetic Karamja leg slot piece bought with trading sticks at Gabooty's cooperative in Tai Bwo Wannai."
+  market_strategy:
+    notes:
+      - Tradeable on the Grand Exchange with a 150 buy limit
+      - Karamja gloves 1+ discount drops shop cost to 250 trading sticks
+      - Demand is cosmetic; price tracks fashionscape interest
+  history:
+    - date: "2005-08-09"
+      description: Released with the Tai Bwo Wannai Clean-Up update.
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-sandals-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-sandals-brown.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Villager sandals (brown) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weapon_type: armour
+    weight: 0.68
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      currency: Trading sticks
+      price: 120
+  related_items:
+    - item_id: 6353
+      item_name: Villager robe (blue)
+      slug: villager-robe-blue
+      relationship: set-piece
+      description: Matching villager leg slot piece
+  about: "Villager sandals (brown) is a cosmetic Karamja foot slot piece bought with trading sticks at Gabooty's cooperative in Tai Bwo Wannai."
+  market_strategy:
+    notes:
+      - Tradeable on the Grand Exchange with a 150 buy limit
+      - Karamja gloves 1+ discount drops shop cost to 100 trading sticks
+      - Cosmetic demand only; no combat utility
+  history:
+    - date: "2005-08-09"
+      description: Released with the Tai Bwo Wannai Clean-Up update.
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.68
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-battleaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-battleaxe.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 499
   highalch: 748
   limit: 125
-  about: "White battleaxe is a members-only item in Old School RuneScape. High alchemy value: 748 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: battleaxe
+    attack_speed: 6
+    weight: 2.721
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: -2
+      slash: 20
+      crush: 15
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    other_bonus:
+      melee_strength: 24
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: White Knights' Armoury
+      location: Falador
+      price: 1248
+      currency: coins
+  about: White battleaxe is a members-only one-handed slash battleaxe sold by the White Knights' Armoury in Falador, requiring 10 Attack and completion of the Wanted! quest to wield.
+  properties:
+    release_date: "2005-10-17"
+    update: Wanted!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wield
+      - Drop
+    alchable: true
+  history:
+    - date: "2005-10-17"
+      description: Released alongside the Wanted! quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-warhammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-warhammer.mdx
@@ -1,20 +1,93 @@
 ---
 title: White warhammer | OSRS Price Data
-description: "White warhammer: I don't think it's intended for joinery.. High alch: 588 GP, GE limit: 125."
+description: "White warhammer: a White Knight crush weapon with a +1 prayer bonus, requiring 10 Attack and purchased from Sir Vyvin. High alch: 588 GP, GE limit: 125."
 osrs:
   id: 6613
   name: White warhammer
   slug: white-warhammer
-  examine: I don't think it's intended for joinery.
+  examine: "I don't think it's intended for joinery."
   members: true
   icon: White warhammer.png
   value: 980
   lowalch: 392
   highalch: 588
   limit: 125
-  about: "White warhammer is a members-only item in Old School RuneScape. High alchemy value: 588 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: white
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: warhammer
+    attack_speed: 6
+    weight: 1.814
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: -4
+      slash: -4
+      crush: 22
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 22
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: Sir Vyvin's Equipment
+      location: White Knights' Castle, Falador
+      stock: 1
+      price: 980
+      currency: Coins
+      description: Requires Master rank in the White Knights to purchase.
+  related_items:
+    - item_id: 1325
+      item_name: Black warhammer
+      slug: black-warhammer
+      relationship: variant
+      description: Comparable black-tier warhammer without the prayer bonus.
+    - item_id: 1335
+      item_name: Rune warhammer
+      slug: rune-warhammer
+      relationship: upgrade
+      description: Stronger rune-tier warhammer.
+  about: "The white warhammer is a White Knight-only crush weapon sold by Sir Vyvin that mirrors the black warhammer with an added +1 prayer bonus."
+  market_strategy:
+    title: Investment Notes
+    notes:
+      - Supply gated behind Master rank in the White Knights (1,300 black knight kills).
+      - Prayer bonus distinguishes it from other low-tier warhammers.
+      - Buy limit of 125 keeps the market accessible for casual buyers.
+      - Primarily collected for fashionscape and White Knight loadouts.
+  history:
+    - date: "2005-10-17"
+      update: White Knight equipment
+      description: Added to game as part of the White Knight reward line.
+  properties:
+    release_date: "2005-10-17"
+    update: White Knight equipment
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-blackjack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-blackjack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Willow blackjack | OSRS Price Data
-description: "Willow blackjack: A handy little club made out of willow.. High alch: 360 GP, GE limit: 125."
+description: "Willow blackjack: A handy little club made out of willow. High alch: 360 GP, GE limit: 125."
 osrs:
   id: 4600
   name: Willow blackjack
@@ -12,9 +12,59 @@ osrs:
   lowalch: 240
   highalch: 360
   limit: 125
-  about: "Willow blackjack is a members-only item in Old School RuneScape. High alchemy value: 360 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: blackjack
+    attack_speed: 4
+    weight: 1.814
+    other_bonus:
+      melee_strength: 8
+  shops:
+    - shop_name: "Ali's Discount Wares"
+      location: Al Kharid
+      stock: 25
+      price: 600
+    - shop_name: Blackjack seller
+      location: Pollnivneach
+      price: 600
+  related_items:
+    - item_id: 4602
+      item_name: Maple blackjack
+      slug: maple-blackjack
+      relationship: upgrade
+      description: Stronger blackjack
+    - item_id: 4598
+      item_name: Oak blackjack
+      slug: oak-blackjack
+      relationship: downgrade
+      description: Weaker blackjack
+  about: "Willow blackjack is a Thieving and crushing weapon used to knock out bandits and Menaphite Thugs in Pollnivneach."
+  market_strategy:
+    notes:
+      - Bought cheaply from Pollnivneach blackjack seller
+      - Used for blackjacking Thieving training
+      - Better strength bonus than oak variant
+  history:
+    - date: "2005-04-04"
+      description: "Item released with the Ali Morrisane and Pollnivneach update."
+  properties:
+    release_date: "2005-04-04"
+    update: Ali Morrisane and Pollnivneach
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-roots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-roots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Willow roots | OSRS Price Data
-description: "Willow roots: The roots of the Willow tree.. High alch: 1 GP, GE limit: 11,000."
+description: "Willow roots: The roots of the Willow tree. High alch: 1 GP, GE limit: 11,000."
 osrs:
   id: 6045
   name: Willow roots
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Willow roots is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    skill_level: 30
+    notes: Dug from the stump of a fully grown willow tree planted in a tree patch. Yields 1–4 roots per harvest.
+  recipes:
+    - skill: crafting
+      level: 10
+      xp: 15
+      materials:
+        - item_name: Willow roots
+          quantity: 1
+      tools:
+        - Spinning wheel
+      output_item: Crossbow string
+      output_quantity: 1
+  related_items:
+    - item_id: 6043
+      item_name: Oak roots
+      slug: oak-roots
+      relationship: downgrade
+      description: Lower-tier tree roots from oak patches
+    - item_id: 6047
+      item_name: Maple roots
+      slug: maple-roots
+      relationship: upgrade
+      description: Higher-tier tree roots from maple patches
+    - item_id: 6034
+      item_name: Supercompost
+      slug: supercompost
+      relationship: product
+      description: Tree roots compost into supercompost in a compost bin
+  about: Willow roots are dug from a chopped willow tree on a tree farming patch and can be spun into crossbow string or composted into supercompost.
+  market_strategy:
+    notes:
+      - Cheap source of crossbow string via spinning wheel
+      - Bulk farmers feed roots into compost bins for supercompost
+  history:
+    - date: "2005-07-11"
+      description: Released with the Farming skill.
+    - date: "2023-06-28"
+      description: Item icon graphically updated.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    alchable: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wrath-tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wrath-tiara.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 40
-  about: "Wrath tiara is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: runecraft
+    tier: mid
+  equipment:
+    slot: head
+    weight: 1
+    requirements:
+      runecraft: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Runecraft
+      level: 1
+      xp: 52.5
+      materials:
+        - item_name: Tiara
+        - item_name: Wrath talisman
+      tools:
+        - Wrath Altar
+      output: Wrath tiara
+  related_items:
+    - item_id: 21807
+      item_name: Wrath talisman
+      slug: wrath-talisman
+      relationship: component
+      description: Combined with tiara at Wrath Altar
+  about: Wrath tiara is a head slot item that allows left-click entry to the Wrath Altar ruins, removing the need to carry a wrath talisman separately.
+  history:
+    - date: "2018-01-04"
+      description: Released with the Dragon Slayer II update.
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wyrm-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wyrm-bones.mdx
@@ -1,6 +1,6 @@
 ---
 title: Wyrm bones | OSRS Price Data
-description: "Wyrm bones: I wonder how Wyrms have bones.... High alch: 96 GP, GE limit: 7,500."
+description: "Wyrm bones: I wonder how Wyrms have bones. High alch: 96 GP, GE limit: 7,500."
 osrs:
   id: 22780
   name: Wyrm bones
@@ -12,9 +12,55 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 7500
-  about: "Wyrm bones is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  prayer:
+    bury_xp: 50
+    altar_xp: 175
+    ectofuntus_xp: 200
+    sinister_offering_xp: 150
+  drop_table:
+    - source: Wyrm
+      quantity: "1"
+      rarity: Always
+    - source: Shadow Wyrm
+      quantity: "1"
+      rarity: Always
+  related_items:
+    - item_id: 22124
+      item_name: Drake bones
+      slug: drake-bones
+      relationship: upgrade
+      description: Higher-tier slayer dragon bones
+    - item_id: 6729
+      item_name: Dagannoth bones
+      slug: dagannoth-bones
+      relationship: alternative
+      description: Comparable mid-tier prayer bones
+  about: Wyrm bones are dropped by wyrms and shadow wyrms in the Karuulm Slayer Dungeon and give 50 Prayer XP per bone when buried or 175 XP on a gilded altar.
+  market_strategy:
+    notes:
+      - Strong prayer training material between dragon and superior dragon bones
+      - Best XP per coin via Chaos Altar / Gilded Altar
+  history:
+    - date: "2019-01-10"
+      description: Released with The Kebos Lowlands expansion.
+    - date: "2019-02-07"
+      description: Prayer experience increased — burying 30 to 50 XP, gilded altar 105 to 175 XP, Ectofuntus 120 to 200 XP.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-01-10"
+    update: The Kebos Lowlands
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.8
+    options:
+      - Bury
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-hat.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Yellow hat is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  about: Yellow hat is a cosmetic head slot item sold from Barkers' Haberdashery in Canifis with minor magic bonuses.
+  history:
+    - date: "2014-12-10"
+      description: Item renamed from 'Hat' to 'Yellow hat' as part of the Trading Post update.
+  properties:
+    release_date: "2004-06-29"
+    update: Werewolf Agility
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yew-bird-house.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yew-bird-house.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 250
-  about: "Yew bird house is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: crafting
+      level: 60
+      xp: 45
+      materials:
+        - item_name: Yew logs
+          item_id: 1515
+          quantity: 1
+        - item_name: Clockwork
+          item_id: 8792
+          quantity: 1
+      tools:
+        - Chisel
+        - Hammer
+      ticks: 2
+      members_only: true
+  related_items:
+    - item_id: 10092
+      item_name: Bird house
+      slug: bird-house
+      relationship: downgrade
+      description: Regular tier bird house
+    - item_id: 9907
+      item_name: Clockwork
+      slug: clockwork
+      relationship: component
+      description: Required clockwork mechanism
+  about: "Yew bird house is a crafted hunter trap used on Fossil Island, requiring 60 Crafting to build and 59 Hunter to set on bird house spaces."
+  history:
+    - date: "2018-01-18"
+      description: Added to the game with the Fossil Island Improvements update.
+  properties:
+    release_date: "2018-01-18"
+    update: Fossil Island Improvements
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-full-helm.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 8
-  about: "Zamorak full helm is a free-to-play item in Old School RuneScape. High alchemy value: 21,120 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 2.721
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_id: 1163
+      item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: variant
+      description: Plain unbranded rune full helm
+    - item_id: 2657
+      item_name: Saradomin full helm
+      slug: saradomin-full-helm
+      relationship: alternative
+      description: Saradomin-branded variant
+    - item_id: 2673
+      item_name: Guthix full helm
+      slug: guthix-full-helm
+      relationship: alternative
+      description: Guthix-branded variant
+  about: Rune full helm decorated with Zamorak's heraldry, obtained from medium clue scroll caskets and offering a +1 Prayer bonus over a regular rune full helm.
+  history:
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -2 to -3.
+    - date: "2004-05-05"
+      description: Added to the game with the Bigger Banks & Treasure Trails update.
+  properties:
+    release_date: "2004-05-05"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-mjolnir.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-mjolnir.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zamorak mjolnir | OSRS Price Data
-description: "Zamorak mjolnir: A Zamorak Mjolnir.. High alch: 375 GP, GE limit: 8."
+description: "Zamorak mjolnir is a two-handed crush weapon obtained from The Enchanted Key miniquest. High alch: 375 GP, GE limit: 8."
 osrs:
   id: 6764
   name: Zamorak mjolnir
@@ -12,9 +12,55 @@ osrs:
   lowalch: 250
   highalch: 375
   limit: 8
-  about: "Zamorak mjolnir is a members-only item in Old School RuneScape. High alchemy value: 375 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: two-handed
+    attack_speed: 6
+    weight: 2.267
+    requirements: {}
+    attack_bonus:
+      crush: 11
+    other_bonus:
+      melee_strength: 14
+  related_items:
+    - item_id: 6762
+      item_name: Saradomin mjolnir
+      slug: saradomin-mjolnir
+      relationship: variant
+      description: Saradomin-aligned variant of the mjolnir
+    - item_id: 6760
+      item_name: Guthix mjolnir
+      slug: guthix-mjolnir
+      relationship: variant
+      description: Guthix-aligned variant of the mjolnir
+  about: "The Zamorak mjolnir is a two-handed crush weapon obtained from The Enchanted Key miniquest; each character can only acquire one because the enchanted key disintegrates after locating every treasure."
+  market_strategy:
+    notes:
+      - "Tiny GE limit of 8 plus miniquest-only supply keeps the market thin; price moves on collector demand rather than meta."
+  trading_tips:
+    - "Bid in the spread overnight to catch impatient sellers; volume is too low for short flips so plan for multi-day holds."
+  history:
+    - date: "2005-11-22"
+      description: "Released alongside the Making History quest and minor changes update."
+  properties:
+    release_date: "2005-11-22"
+    update: Making History and minor changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Seventh batch — migrate 200 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment. Scaled from 100 → 200 per request.
- Worktree-direct authoring; main repo untouched.
- Schema-validated via `astro sync`.

Post-agent normalisation also caught a few pre-existing v3 files with the same patterns (~46 extras). Net 246 files updated:
- `reward_tiers[]` flattened object form → lowercase string list
- `drop_table[].quantity` int → "string" (schema is string union)
- `market_strategy` bare string → `{ notes: [string] }`
- `trading_tips` bare string → `[string]`
- `drop_table[].monster` → `source` (schema field name)
- `material` bare string → `{ type, tier }`
- `lowalch` / `highalch` explicit `null` where missing (schema-required nullable)
- `properties.quest_item` string → bool `true` + `quest: name`

## Test plan

- [x] `astro sync` clean — all entries validate.
- [ ] CI build green.

## Follow-ups

- ~3673 v2 items remain after this batch lands.