### PR TITLE
content(astro-kbve): bump 100 OSRS items v2 → v3 (batch 8)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-axe.mdx
@@ -12,39 +12,43 @@ osrs:
   lowalch: 22000
   highalch: 33000
   limit: 40
+  material:
+    type: 3rd-age
+    tier: high
   equipment:
     slot: weapon
-    type: axe
-    attack_style: melee
+    weapon_type: axe
     attack_speed: 5
+    weight: 1.36
     requirements:
       attack: 65
       woodcutting: 61
-    stats:
-      attack_stab: -2
-      attack_slash: 38
-      attack_crush: 32
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 1
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: -2
+      slash: 38
+      crush: 32
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       melee_strength: 42
-      prayer_bonus: 0
-  skilling:
-    skill: woodcutting
-    level: 61
-    speed_modifier: dragon_equivalent
-    special: Functions as dragon axe for woodcutting
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Lumber Up
+    energy: 100
+    description: Boosts the player's Woodcutting level by 3 for 3 minutes; shared with the dragon, infernal, and crystal axes.
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
   related_items:
     - item_id: 12426
       item_name: 3rd age longsword
@@ -65,29 +69,38 @@ osrs:
       item_name: 3rd age pickaxe
       slug: 3rd-age-pickaxe
       relationship: alternative
-      description: 3rd age skilling tool
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Woodcutting Level | 61 |
-    | Speed | Dragon equivalent |
-
-    The 3rd age axe has the same woodcutting speed as a dragon axe. It is compatible with all woodcutting activities that accept the dragon axe.
-
-    The 3rd age axe is a rare skilling tool obtained from Treasure Trails. It requires 61 Woodcutting to use for woodcutting and functions identically to a dragon axe in terms of woodcutting speed.
-
-    3rd age tools are highly sought after due to their extreme rarity and status symbol value. The axe is both a functional woodcutting tool and a prestigious item.
+      description: 3rd age skilling tool counterpart
+  about: "3rd age axe is an extremely rare master Treasure Trail reward (roughly 1/313,168) that requires 65 Attack to wield and 61 Woodcutting to chop trees; it shares the Lumber Up special attack and chops at dragon axe speed."
   market_strategy:
     title: Investment Notes
     notes:
-      - Extremely valuable due to rarity
-      - Functional skilling tool with prestige value
-      - Price fluctuates based on collector demand
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Routinely listed at the Grand Exchange maximum price
+      - Functional skilling tool with prestige and collector value
+      - Verify item authenticity and use trusted middlemen on private trades
+      - Monitor 3rd age set price trends before purchasing
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trails Expansion
+      description: 3rd age axe added as a master Treasure Trails reward.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trails Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-druidic-robe-bottoms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-druidic-robe-bottoms.mdx
@@ -1,6 +1,6 @@
 ---
 title: 3rd age druidic robe bottoms | OSRS Price Data
-description: "3rd age druidic robe bottoms is a members legs slot item requiring 65 Defence. High alch: 120,000 GP, GE limit: 4."
+description: "3rd age druidic robe bottoms is a members legs slot item requiring 65 Prayer. High alch: 120,000 GP, GE limit: 4."
 osrs:
   id: 23339
   name: 3rd age druidic robe bottoms
@@ -12,27 +12,42 @@ osrs:
   lowalch: 80000
   highalch: 120000
   limit: 4
+  material:
+    type: cloth
+    tier: 3rd-age
   equipment:
     slot: legs
-    type: prayer armour
-    attack_style: none
+    weapon_type: none
+    weight: 1.5
     requirements:
-      defence: 65
       prayer: 65
-    stats:
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      prayer_bonus: 6
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Extremely Rare
-        description: Rarest reward from master clue scrolls
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 6
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/313168
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
   related_items:
     - item_id: 23336
       item_name: 3rd age druidic robe top
@@ -49,10 +64,7 @@ osrs:
       slug: 3rd-age-druidic-cloak
       relationship: set-piece
       description: Cape slot of 3rd age druidic set
-  about: |-
-    The 3rd age druidic robe bottoms are part of the 3rd age druidic set, the rarest and most prestigious prayer-focused armour set in Old School RuneScape. They require 65 Defence and 65 Prayer to wear.
-
-    The druidic set is considered one of the most valuable item sets in the game due to its extreme rarity. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
+  about: "The 3rd age druidic robe bottoms are a rare prayer-focused leg slot reward from master clue scrolls, tied for second-highest leg prayer bonus in the game."
   market_strategy:
     title: Investment Notes
     notes:
@@ -62,8 +74,30 @@ osrs:
       - Verify authenticity when trading high-value items
       - Use Grand Exchange for secure trades
       - Consider using trusted middlemen for trades exceeding max cash
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Drop rate roughly 1/313,168 from master reward caskets
+    - Confirm prayer bonus of +6 before trades
+    - Watch for set bundling premium with top, staff, and cloak
+  history:
+    - date: "2019-04-11"
+      description: Added to the game as a master clue scroll reward.
+  properties:
+    release_date: "2019-04-11"
+    update: Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.5
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-druidic-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-druidic-robe-top.mdx
@@ -1,6 +1,6 @@
 ---
 title: 3rd age druidic robe top | OSRS Price Data
-description: "3rd age druidic robe top is a members body slot item requiring 65 Defence. High alch: 120,000 GP, GE limit: 4."
+description: "3rd age druidic robe top is a members body slot item requiring 65 Prayer. High alch: 120,000 GP, GE limit: 4."
 osrs:
   id: 23336
   name: 3rd age druidic robe top
@@ -12,27 +12,36 @@ osrs:
   lowalch: 80000
   highalch: 120000
   limit: 4
+  material:
+    type: 3rd-age
+    tier: high
   equipment:
     slot: body
-    type: prayer armour
-    attack_style: none
+    weight: 1.5
     requirements:
-      defence: 65
       prayer: 65
-    stats:
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      prayer_bonus: 10
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Extremely Rare
-        description: Rarest reward from master clue scrolls
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 8
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
   related_items:
     - item_id: 23339
       item_name: 3rd age druidic robe bottoms
@@ -49,21 +58,37 @@ osrs:
       slug: 3rd-age-druidic-cloak
       relationship: set-piece
       description: Cape slot of 3rd age druidic set
-  about: |-
-    The 3rd age druidic robe top is part of the 3rd age druidic set, the rarest and most prestigious prayer-focused armour set in Old School RuneScape. It requires 65 Defence and 65 Prayer to wear.
-
-    The druidic set is considered one of the most valuable item sets in the game due to its extreme rarity. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
+  about: 3rd age druidic robe top is part of the 3rd age druidic set and is one of the rarest prayer-focused chestpieces in Old School RuneScape; it requires 65 Prayer to wear and is obtained as an extremely rare reward (roughly 1/313,168) from master Treasure Trails clue scroll caskets.
   market_strategy:
     title: Investment Notes
     notes:
-      - Among the most valuable items in OSRS
-      - Extremely rare collector's item
-      - Price driven by wealthy collectors
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Consider using trusted middlemen for trades exceeding max cash
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Among the most valuable tradeable items in OSRS
+      - Extremely rare collector and fashionscape piece
+      - Price driven by wealthy collectors and is often listed at GE maximum
+      - Verify authenticity and use trusted middlemen for trades exceeding max cash
+  history:
+    - date: "2019-04-11"
+      update: Treasure Trails Expansion and Easter 2019
+      description: 3rd age druidic robe top added as a rare master Treasure Trails reward.
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 1.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-robetop.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-robetop.mdx
@@ -14,34 +14,32 @@ osrs:
   limit: 15
   equipment:
     slot: body
-    type: barrows
-    set: Ahrim
-    tradeable: true
-    degradeable: true
-    weight: 4.5
+    weight: 4.535
     requirements:
       defence: 70
       magic: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 30
-      attack_ranged: -10
-      defence_stab: 52
-      defence_slash: 37
-      defence_crush: 63
-      defence_magic: 30
-      defence_ranged: 0
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 30
+      ranged: -10
+    defence_bonus:
+      stab: 52
+      slash: 37
+      crush: 63
+      magic: 30
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 1
       prayer: 0
-  set_effect:
-    name: Blighted Aura
-    pieces_required: 4
-    description: 25% chance to lower opponent's Strength by 5 levels
-    amulet_of_damned: 25% chance to deal 30% extra damage
+  drop_table:
+    sources:
+      - source: Ahrim the Blighted (Barrows)
+        quantity: "1"
+        rarity: "1/392"
   related_items:
     - item_id: 4708
       item_name: Ahrim's hood
@@ -62,48 +60,46 @@ osrs:
       item_name: Ancestral robe top
       slug: ancestral-robe-top
       relationship: upgrade
-      description: Upgrade path
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Stab defence | +52 |
-    | Slash defence | +37 |
-    | Crush defence | +63 |
-    | Magic attack | +30 |
-    | Magic defence | +30 |
-    | Magic damage | +1% |
-    | Ranged attack | -10 |
-    | Requirements | 70 Defence, 70 Magic |
-
-    Blighted Aura:
-    When wearing full Ahrim's equipment (hood, robetop, robeskirt, staff):
-    - Successful magic attacks have 25% chance to lower enemy Strength by 5 levels
-    - Useful for reducing opponent's damage output
-
-    With Amulet of the Damned:
-    - Successful magic attacks have 25% chance to deal 30% extra damage
-
-    Best For:
-    - Magic training (budget option)
-    - Barrows running (ironic but common)
-    - Mid-level magic PvM
-    - Zulrah (budget setup)
-
-    Comparison:
-    - Less magic bonus than Ancestral
-    - Better than Mystic robes
-    - Good defensive stats for magic armor
-
-    - Degrades in combat (15 hours of use)
-    - Repair at Bob in Lumbridge or POH armor stand
-    - Repair cost: ~70k for full set at Bob
+      description: Endgame magic body upgrade
+  charges:
+    duration_hours: 15
+    repair_npc: Bob (Lumbridge)
+    repair_cost_npc: 90000
+    repair_cost_poh: 45450
+    notes: Degrades to 100/75/50/25/0; fully broken until repaired.
+  about: "Magic body from Ahrim the Blighted's Barrows set — +30 magic attack, +1% magic damage, strong defensive stats; degrades over 15 hours of combat and is best worn as part of the full set for the Blighted Aura."
   market_strategy:
     notes:
-      - Budget magic armor option
-      - Often bought as full set
-      - Consider Ancestral for endgame
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Budget magic body before Ancestral
+      - Most demand comes from full-set buyers
+      - Cycle prices with Barrows-loot updates
+      - Watch repair vs flip margins
+  trading_tips:
+    - Bundle with hood + robeskirt + staff for set premium
+    - Pair with Amulet of the Damned listings during DMM events
+  history:
+    - date: "2005-05-09"
+      update: Barrows
+      description: Released as part of the Barrows brothers' equipment set.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 4.535
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    quest_item: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-javelin-p-21324.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-javelin-p-21324.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 168
   highalch: 252
   limit: 7000
-  about: "Amethyst javelin(p++) is a members-only item in Old School RuneScape. High alchemy value: 252 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: amethyst
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: javelin
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 135
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 84
+      xp: 202.5
+      materials:
+        - item_name: Amethyst javelin heads
+          quantity: 15
+        - item_name: Javelin shaft
+          quantity: 15
+      product: Amethyst javelin
+      product_quantity: 15
+      members_only: true
+  related_items:
+    - item_id: 21318
+      item_name: Amethyst javelin
+      slug: amethyst-javelin
+      relationship: variant
+      description: Unpoisoned base javelin before applying Weapon poison++.
+    - item_id: 19484
+      item_name: Dragon javelin(p++)
+      slug: dragon-javelin-p
+      relationship: upgrade
+      description: Stronger javelin tier above amethyst.
+    - item_id: 21326
+      item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: alternative
+      description: Primary launcher used to fire amethyst javelins.
+  about: "Amethyst javelin(p++) is the venom-grade variant of the second-strongest javelin in the game, fired from heavy and light ballistas for high-end ranged damage."
+  market_strategy:
+    notes:
+      - Supply mostly comes from Fletching at level 84 by adding Weapon poison++ to amethyst javelins.
+      - Buy limit of 7,000 per 4 hours sustains medium-scale flips around bossing meta shifts.
+      - Demand spikes when Heavy ballista bossing strategies are popular for venom-friendly content.
+  trading_tips:
+    - Track unpoisoned amethyst javelin price plus Weapon poison++ to size up Fletching profit margins.
+    - Prefer larger limit-sized buys when targeting end-game PvM consumers.
+  history:
+    - date: "2017-06-22"
+      description: Added during the Mining Guild Expansion as the amethyst-tier ballista ammunition.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-06-22"
+    update: Mining Guild Expansion
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ankou-socks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ankou-socks.mdx
@@ -9,12 +9,69 @@ osrs:
   members: true
   icon: Ankou socks.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 4
-  about: "Ankou socks is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.5
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_id: 20104
+      item_name: Ankou mask
+      slug: ankou-mask
+      relationship: set-piece
+      description: Ankou outfit head piece
+    - item_id: 20110
+      item_name: Ankou's leggings
+      slug: ankou-leggings
+      relationship: set-piece
+      description: Ankou outfit legs piece
+    - item_id: 20113
+      item_name: Ankou top
+      slug: ankou-top
+      relationship: set-piece
+      description: Ankou outfit body piece
+    - item_id: 20116
+      item_name: Ankou gloves
+      slug: ankou-gloves
+      relationship: set-piece
+      description: Ankou outfit gloves piece
+  about: "Cosmetic feet slot socks from the Ankou outfit, obtained as a rare reward from Master clue caskets and storable in a costume room."
+  market_strategy:
+    notes:
+      - Master clue scroll cosmetic reward at 1/12,765 per casket
+      - Demand driven by collection log slots and costume room storage
+      - Low daily volume of around 44 units with a 4 per 4 hour buy limit
+  trading_tips:
+    - Buy from clue grinders flipping uncommon set pieces
+    - Pair with the full Ankou set for a higher resale margin
+  history:
+    - date: "2016-07-06"
+      description: Added to the game as a Master clue scroll reward in the Treasure Trail Expansion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antifire-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antifire-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Antifire mix(1) | OSRS Price Data
-description: "Antifire mix(1): One dose of fishy anti-firebreath potion.. High alch: 79 GP, GE limit: 2,000."
+description: "Antifire mix(1): One dose of fishy anti-firebreath potion. High alch: 79 GP, GE limit: 2,000."
 osrs:
   id: 11507
   name: Antifire mix(1)
@@ -12,9 +12,67 @@ osrs:
   lowalch: 52
   highalch: 79
   limit: 2000
-  about: "Antifire mix(1) is a members-only item in Old School RuneScape. High alchemy value: 79 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - description: Provides 3 minutes of dragonfire resistance.
+      - description: Heals 3 Hitpoints when consumed.
+  recipes:
+    - skill: herblore
+      level: 75
+      xp: 26.5
+      materials:
+        - item_name: Antifire potion(1)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      product: Antifire mix(1)
+      product_id: 11507
+      members_only: true
+      notes: "Requires Barbarian Herblore training with Otto Godblessed."
+  related_items:
+    - item_id: 11505
+      item_name: Antifire mix(2)
+      slug: antifire-mix-2
+      relationship: variant
+      description: Two-dose variant
+    - item_id: 2454
+      item_name: Antifire potion(1)
+      slug: antifire-potion-1
+      relationship: component
+      description: Base potion before caviar mix
+  about: "Antifire mix(1) is a one-dose barbarian potion that gives dragonfire resistance while healing 3 Hitpoints on use."
+  market_strategy:
+    notes:
+      - Barbarian potion variant
+      - Niche Herblore mixing recipe
+  trading_tips:
+    - Caviar cost dominates margin
+    - Limited demand outside diary tasks
+  history:
+    - date: "2007-07-03"
+      description: Added alongside Barbarian Training Herblore mixes.
+    - date: "2016-04-15"
+      description: Half-full potions can now be turned into bank placeholders.
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ashes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ashes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ashes | OSRS Price Data
-description: "Ashes: A heap of ashes.. High alch: 1 GP, GE limit: 13,000."
+description: "Ashes: A heap of ashes. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 592
   name: Ashes
@@ -12,13 +12,45 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
+  drop_table:
+    sources:
+      - source: Imp
+        quantity: "1"
+        rarity: 6/128
+      - source: Flesh crawler
+        quantity: "1"
+        rarity: 4/100
+      - source: Killerwatt
+        quantity: "1"
+        rarity: Always
   related_items: []
-  about: |-
-    > _"A pile of ashes."_
-
-    Ashes are a common byproduct of Firemaking. Used in several quests and as a Herblore secondary ingredient. Give 0 Prayer XP if scattered but can be used to make serum 207 and other niche items.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Ashes are a common firemaking byproduct used as a Herblore secondary and in several quests.
+  market_strategy:
+    notes:
+      - Cheap bulk staple for Herblore
+      - Volume far exceeds buy limit on GE
+  trading_tips:
+    - Buy in bulk for serum 207 production
+    - Watch demand spikes around quest releases
+  history:
+    - date: "2001-01-04"
+      description: Added to the game during the RuneScape beta launch.
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-nice-tree.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-nice-tree.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bagged nice tree | OSRS Price Data
-description: "Bagged nice tree: You can plant this in your garden.. High alch: 1,200 GP, GE limit: 10,000."
+description: "Bagged nice tree: You can plant this in your garden. High alch: 1,200 GP, GE limit: 10,000."
 osrs:
   id: 8419
   name: Bagged nice tree
@@ -12,9 +12,55 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 10000
-  about: "Bagged nice tree is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Garden Supplier
+      location: Falador
+      price: 2000
+    - shop_name: Garden Supplier
+      location: Farming Guild
+      price: 2000
+  construction:
+    builds:
+      - hotspot: Garden
+        level: 10
+        xp: 44
+        result: Nice tree
+      - hotspot: Menagerie habitat
+        level: 47
+        xp: 51
+        result: Forest habitat
+      - hotspot: Garden
+        level: 65
+        xp: 474
+        result: Zen theme tree
+  related_items: []
+  about: "Bagged nice tree is a Construction garden plant bought from Garden suppliers, planted for low-level Construction and Farming XP."
+  market_strategy:
+    notes:
+      - Steady Construction supply demand
+      - Shop price floors GE near 2000
+  trading_tips:
+    - Buy from shop for cheaper than GE
+    - Bulk needed for Zen theme upgrades
+  history:
+    - date: "2006-05-31"
+      description: Added with the launch of Construction and Player-Owned Houses.
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/belle-s-folly-tarnished.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/belle-s-folly-tarnished.mdx
@@ -1,6 +1,6 @@
 ---
 title: Belle's folly (tarnished) | OSRS Price Data
-description: "Belle's folly (tarnished): This blade needs some work before it will be useable.. High alch: 27,000 GP."
+description: "Belle's folly (tarnished): This blade needs some work before it will be useable. High alch: 27,000 GP."
 osrs:
   id: 31245
   name: Belle's folly (tarnished)
@@ -12,9 +12,72 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: null
-  about: "Belle's folly (tarnished) is a members-only item in Old School RuneScape. High alchemy value: 27,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: weapon_blank
+    tier: high
+  drop_table:
+    sources:
+      - source: Shellbane Gryphon
+        quantity: "1"
+        rarity: "1/256"
+  recipes:
+    - skill: smithing
+      level: 70
+      xp: 500
+      requirements:
+        smithing: 70
+        quest: Sleeping Giants
+      materials:
+        - item_name: Belle's folly (tarnished)
+          item_id: 31245
+          quantity: 1
+      tools:
+        - Polishing wheel
+      facility: Giants' Foundry
+      product: Belle's folly
+      product_id: 31248
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 31248
+      item_name: Belle's folly
+      slug: belle-s-folly
+      relationship: upgrade
+      description: Polished finished blade
+  about: "Tarnished blade dropped by Shellbane Gryphon; polish at Giants' Foundry with 70 Smithing for Belle's folly."
+  market_strategy:
+    title: Polish-to-flip blank
+    notes:
+      - 1/256 drop from Shellbane Gryphon
+      - 70 Smithing required to polish at Giants' Foundry
+      - Post-Sleeping Giants requirement gates supply
+      - Tracks finished Belle's folly market minus polish XP value
+  trading_tips:
+    - Watch tarnished vs polished spread for craft margin
+    - 500 Smithing XP per polish has minor extra value
+    - Drop rate boost in Feb 2026 expanded supply
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing update as a Shellbane Gryphon drop.
+    - date: "2026-02-04"
+      description: Drop rate buffed from 1/400 to 1/256.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Inspect
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/belle-s-folly.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/belle-s-folly.mdx
@@ -1,6 +1,6 @@
 ---
 title: Belle's folly | OSRS Price Data
-description: "Belle's folly: A well balanced blade adorned with gold.. High alch: 27,000 GP."
+description: "Belle's folly: A well balanced blade adorned with gold. High alch: 27,000 GP."
 osrs:
   id: 31248
   name: Belle's folly
@@ -12,9 +12,89 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: null
-  about: "Belle's folly is a members-only item in Old School RuneScape. High alchemy value: 27,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: weapon
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
+    weight: 1.36
+    requirements:
+      attack: 70
+    attack_bonus:
+      stab: 100
+      slash: 78
+      crush: -3
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+    other_bonus:
+      melee_strength: 102
+  recipes:
+    - skill: smithing
+      level: 70
+      xp: 500
+      requirements:
+        smithing: 70
+        quest: Sleeping Giants
+      materials:
+        - item_name: Belle's folly (tarnished)
+          item_id: 31245
+          quantity: 1
+      tools:
+        - Polishing wheel
+      facility: Giants' Foundry
+      product: Belle's folly
+      product_id: 31248
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 31245
+      item_name: Belle's folly (tarnished)
+      slug: belle-s-folly-tarnished
+      relationship: component
+      description: Tarnished version polished into this blade
+    - item_id: 0
+      item_name: Shellbane Gryphon
+      slug: shellbane-gryphon
+      relationship: alternative
+      description: Source monster for tarnished version
+  about: "Sailing-era stab rapier polished from Belle's folly (tarnished) at the Giants' Foundry polishing wheel."
+  market_strategy:
+    title: Sailing meta weapon
+    notes:
+      - Polish your own tarnished drop for 500 Smithing XP
+      - High alch value of 27,000 supports floor price
+      - No GE buy limit currently listed
+      - Demand tracks Sailing release meta
+  trading_tips:
+    - Compare against rapier-class weapons for margin
+    - Volume thin around release; watch first weeks
+    - Polished cost discount vs buying outright
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing update.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-elegant-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-elegant-shirt.mdx
@@ -12,21 +12,84 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  material:
+    type: cloth
+    tier: cosmetic
   equipment:
     slot: body
-    requirements: {}
+    weapon_type: none
+    weight: 1
+    requirements:
+      none: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
     - item_id: 10402
       item_name: Black elegant legs
       slug: black-elegant-legs
       relationship: set-piece
-      description: Matching elegant legs
-  about: |-
-    > *"A well made elegant men's black shirt."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the black elegant clothing set used for fashionscape and emote clue requirements.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching legs from the black elegant outfit.
+    - item_id: 10404
+      item_name: White elegant blouse
+      slug: white-elegant-blouse
+      relationship: alternative
+      description: Female counterpart in the elegant clothing collection.
+    - item_id: 10396
+      item_name: Red elegant shirt
+      slug: red-elegant-shirt
+      relationship: alternative
+      description: Red colour variant of the same elegant shirt design.
+  about: "Black elegant shirt is a medium clue treasure trail reward worn purely for fashionscape with no combat bonuses."
+  market_strategy:
+    notes:
+      - Supply comes entirely from medium clue caskets at roughly 8 in 18,128 rarity.
+      - Hard buy limit of 4 per 4 hours keeps daily inventory churn low.
+      - Emote clue requirement props up demand among ironmen completing master clues.
+  trading_tips:
+    - Flip in singles around emote clue events when fashionscape demand spikes.
+    - Pair purchases with matching black elegant legs to relist as a set.
+  history:
+    - date: "2006-12-05"
+      description: Added with the Treasure Trails update as a medium clue reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-halberd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-halberd.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 768
   highalch: 1152
   limit: 125
-  about: "Black halberd is a members-only item in Old School RuneScape. High alchemy value: 1,152 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: black
+    tier: low
+  equipment:
+    slot: 2h
+    weapon_type: polearm
+    attack_speed: 7
+    weight: 3.175
+    requirements:
+      attack: 10
+      strength: 5
+    attack_bonus:
+      stab: 19
+      slash: 25
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: 2
+      crush: 3
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 20
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Quartermaster's Stores
+      location: Tyras Camp
+      price: 2496
+      currency: coins
+      members_only: true
+  related_items:
+    - item_id: 3194
+      item_name: Steel halberd
+      slug: steel-halberd
+      relationship: downgrade
+      description: Weaker steel-tier halberd
+    - item_id: 3198
+      item_name: Mithril halberd
+      slug: mithril-halberd
+      relationship: upgrade
+      description: Stronger mithril-tier halberd
+  about: "Black halberd is a members two-handed polearm with a 2 tile reach and 7-tick attack speed, sold by the Quartermaster's Stores in Tyras Camp; unlike the dragon halberd, the Regicide quest is not required to wield it."
+  market_strategy:
+    notes:
+      - Shop price often undercuts the Grand Exchange listing
+      - Niche demand from collectors and pures
+      - Limited daily volume — large flips are slow
+  history:
+    - date: "2004-09-20"
+      update: Halberd Update
+      description: Black halberd released alongside other tier halberds.
+  properties:
+    release_date: "2004-09-20"
+    update: Halberd Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-mask.mdx
@@ -14,85 +14,83 @@ osrs:
   limit: 70
   equipment:
     slot: head
-    type: mask
+    weight: 10
     requirements:
       strength: 20
       defence: 10
-    stats:
-      attack_stab: 3
-      attack_slash: 3
-      attack_crush: 3
-      attack_magic: 3
-      attack_ranged: 3
-  effect:
-    on_task_bonus:
-      accuracy: 16.67
-      damage: 16.67
-      combat_styles:
-        - melee
-    imbue:
-      location: Soul Wars or Nightmare Zone
-      extends_to:
-        - ranged
-        - magic
-      new_requirements:
-        defence: 40
+    attack_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   drop_table:
     sources:
       - source: Cave horror
-        source_id: 3210
-        combat_level: 80
         quantity: "1"
         rarity: 1/512
-        members_only: true
+  charges:
+    max_charges: 10
+    effect: Lowers enemy Defence by 2 + 7% with 1/10 activation chance
+  about: "Black mask is a head slot melee-only mask dropped by Cave horrors that grants a 16.67% accuracy and damage boost vs the player's current Slayer task, and forms the base for the Slayer helmet."
+  market_strategy:
+    notes:
+      - Cave horrors require 58 Slayer and Cabin Fever to access
+      - Imbue immediately at Nightmare Zone, Soul Wars or Emir's Arena
+      - Combine into Slayer helmet at 55 Crafting
+  trading_tips:
+    - Imbued version extends bonus to Ranged and Magic
+    - Salve amulet effects do not stack with on-task bonus
+  history:
+    - date: "2006-07-04"
+      description: Released alongside Cave horrors and the Cabin Fever quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-04"
+    update: Cabin Fever
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: Cabin Fever
+    weight: 10
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   related_items:
     - item_id: 11864
       item_name: Slayer helmet
       slug: slayer-helmet
       relationship: upgrade
-      description: Upgraded form
-    - item_id: 4081
-      item_name: Salve amulet
-      slug: salve-amulet
-      relationship: alternative
-      description: Undead bonus (doesn't stack)
+      description: Combined upgraded form
     - item_id: 11865
       item_name: Slayer helmet (i)
       slug: slayer-helmet-i
       relationship: upgrade
-      description: Imbued version
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Stab attack | +3 |
-    | Slash attack | +3 |
-    | Crush attack | +3 |
-    | Magic attack | +3 |
-    | Ranged attack | +3 |
-    | Requirements | 20 Strength, 10 Defence (imbued: 40 Def) |
-
-    Required for Slayer helmet.
-
-    When on task:
-    - +16.67% accuracy and damage vs assigned monster
-
-    Must be imbued for full effect.
-
-    Imbue at Soul Wars or Nightmare Zone:
-    - Extends bonus to Magic and Ranged
-    - Requires 40 Defence when imbued
-
-    Essential for:
-    - All Slayer tasks
-    - Slayer helm upgrade
-    - Salve amulet doesn't stack
-  market_strategy:
-    notes:
-      - Cave horrors require Cabin Fever
-      - Imbue immediately
-      - Combine into Slayer helm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Imbued variant
+    - item_id: 4081
+      item_name: Salve amulet
+      slug: salve-amulet
+      relationship: alternative
+      description: Undead-only bonus, does not stack
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-ancient-ice-sack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-ancient-ice-sack.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 15000
-  about: "Blighted ancient ice sack is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 15,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Ferox Enclave
+      currency: Last Man Standing point
+      price: 1
+    - shop_name: Soul Wars Reward Shop
+      location: Edgeville
+      currency: Zeal Token
+      price: 10
+  drop_table:
+    sources:
+      - source: Chaos Elemental
+        quantity: "1-10"
+        rarity: 1/11
+      - source: Revenant
+        quantity: "1-10"
+        rarity: 1/24
+  related_items: []
+  about: "Blighted ancient ice sack lets the Ancient Magicks user cast any ice spell without runes in PvP areas like the Wilderness and Soul Wars."
+  market_strategy:
+    notes:
+      - PvP supply driven by Wilderness drops
+      - Demand swings with PvP events
+  trading_tips:
+    - Bulk buy before Wilderness updates
+    - Compare to barrage cast cost per kill
+  history:
+    - date: "2020-04-23"
+      description: Released alongside the Bounty Hunter Returns update, replacing the prior single-spell sack.
+    - date: "2024-11-01"
+      description: Use locations expanded to include Ferox Enclave and Mage Arena bank.
+  properties:
+    release_date: "2020-04-23"
+    update: Bounty Hunter Returns
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-snare-sack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-snare-sack.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Blighted snare sack is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Justine's stuff for the Last Man Standing
+      location: Ferox Enclave
+      currency: Last Man Standing points
+      sell_price: 1
+    - shop_name: Soul Wars Reward Shop
+      location: Ferox Enclave
+      currency: Zeal Tokens
+      sell_price: 10
+  related_items:
+    - item_id: 24617
+      item_name: Blighted entangle sack
+      slug: blighted-entangle-sack
+      relationship: alternative
+      description: Successor sack that absorbed snare functionality after the 2023 merge.
+    - item_id: 24614
+      item_name: Blighted bind sack
+      slug: blighted-bind-sack
+      relationship: variant
+      description: Lower-tier Wilderness entanglement sack.
+    - item_id: 24623
+      item_name: Blighted wave sack
+      slug: blighted-wave-sack
+      relationship: variant
+      description: Wilderness combat spell sack in the same Blighted line.
+  about: "Blighted snare sack let players cast Snare in the Wilderness without runes, sold at LMS and Soul Wars reward shops; merged into the Blighted entangle sack on 20 September 2023."
+  market_strategy:
+    notes:
+      - Untradeable after acquisition; not a Grand Exchange item.
+      - Buy in bulk from Justine's shop with LMS points before Wilderness PK trips.
+      - Stack effectively replaced by the Blighted entangle sack since the 2023 merge.
+  trading_tips:
+    - Stock up only if you actively PK on the standard spellbook in the Wilderness.
+    - Prefer the entangle sack for current content - snare sacks are legacy stock.
+  history:
+    - date: "2020-04-23"
+      description: Introduced with the Bounty Hunter Returns update as a Wilderness-only Snare casting sack.
+    - date: "2023-09-20"
+      description: Functionality merged into the Blighted entangle sack alongside other blighted spell sacks.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-04-23"
+    update: Bounty Hunter Returns
+    tradeable: false
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-rune.mdx
@@ -12,15 +12,9 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 25000
-  rune:
-    type: combat
-  runecraft:
-    level: 77
-    xp: 23.8
-    altar: Dark Altar
-    altar_location: Arceuus (Zeah)
-    essence_type: dark
-    method: Dark essence fragments
+  material:
+    type: rune
+    tier: high
   recipes:
     - skill: runecraft
       level: 77
@@ -29,17 +23,44 @@ osrs:
         - item_name: Dark essence fragments
           item_id: 7938
           quantity: 1
+      tools:
+        - Dark altar (Arceuus)
       product: Blood rune
       product_id: 565
-      product_quantity: 1
-      facility: Dark altar (Arceuus)
-      members_only: true
+    - skill: runecraft
+      level: 77
+      xp: 10.5
+      materials:
+        - item_name: Pure essence
+          item_id: 7936
+          quantity: 1
+        - item_name: Blood talisman
+          item_id: 5516
+          quantity: 1
+      tools:
+        - True Blood Altar (Morytania)
+      product: Blood rune
+      product_id: 565
+    - skill: runecraft
+      level: 77
+      xp: 15.7
+      materials:
+        - item_name: Daeyalt essence
+          item_id: 24704
+          quantity: 1
+        - item_name: Blood talisman
+          item_id: 5516
+          quantity: 1
+      tools:
+        - True Blood Altar (Morytania)
+      product: Blood rune
+      product_id: 565
   related_items:
     - item_id: 560
       item_name: Death rune
       slug: death-rune
       relationship: alternative
-      description: Paired for barrages
+      description: Paired for Ancient barrage spells
     - item_id: 22325
       item_name: Scythe of vitur
       slug: scythe-of-vitur
@@ -54,38 +75,52 @@ osrs:
       item_name: Dark essence fragments
       slug: dark-essence-fragments
       relationship: component
-      description: Crafting material
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Runecraft Level | 77 |
-    | Method | Dark altar (Arceuus) |
-    | XP per rune | 23.8 |
-
-    Note: Cannot be crafted at true Blood Altar without special requirements.
-
-    | Spell | Blood Runes | Effect |
-    |-------|-------------|--------|
-    | Fire Wave | 1 | Standard combat |
-    | Blood Rush | 2 | Ancient heal |
-    | Blood Burst | 4 | Ancient AoE heal |
-    | Blood Barrage | 4 | Best Ancient heal |
-    | Heal Group | 3 | Lunar healing |
+      description: Arceuus Dark altar crafting material
+    - item_id: 5516
+      item_name: Blood talisman
+      slug: blood-talisman
+      relationship: component
+      description: Required for True Blood Altar runecrafting
+  about: "High-level Runecraft rune (77+) used for Ancient Magicks combat, healing spells, and charging Scythe of vitur / Sanguinesti staff — Dark Altar at Arceuus is the dominant production method."
   market_strategy:
+    title: Blood rune flip & flow
     notes:
-      - Dark essence fragments → Blood runes
-      - ~1.5m GP/hr at 77+ RC
-      - AFK profitable method
-      - Ancient Magicks combat
-      - Scythe of vitur charges
-      - Sanguinesti staff charges
-      - High-level PvM
-      - Scythe uses 3 per swing
-      - Sanguinesti uses 3 per attack
-      - ToB gear creates massive sink
-      - Price correlates with raid popularity
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Dark essence fragments yield ~1.5M GP/hr at 77+ Runecraft
+      - Scythe + Sanguinesti charging creates massive sink
+      - Price correlates with raid (ToB) popularity
+      - Ancient Magicks barrages keep demand consistent
+      - True Blood Altar (Sins of the Father) gives more GP/h after quest
+    profit_formulas:
+      - "GP/hr ≈ (runes per hour) × (GE price − essence cost)"
+  trading_tips:
+    - Stockpile during ToB resets when price dips
+    - Watch DMM seasonal demand for sustain spikes
+  history:
+    - date: "2019-12-19"
+      update: Sins of the Father
+      description: Quest released, unlocking the True Blood Altar in Morytania for blood rune crafting.
+    - date: "2017-09-14"
+      update: Arceuus Favour Rework
+      description: Dark Altar at Arceuus enabled blood rune crafting via dark essence fragments.
+    - date: "2002-03-18"
+      update: Ancient Magicks
+      description: Released with the Ancient Magicks spellbook.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-18"
+    update: Ancient Magicks
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    quest_item: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-dragon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-dragon-mask.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Blue dragon mask is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 2.267
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  about: "Blue dragon mask is a purely cosmetic head slot item obtained as a hard Treasure Trail reward, part of the chromatic dragon mask family released in the Treasure Trail Expansion."
+  market_strategy:
+    notes:
+      - Cosmetic-only; demand driven by fashionscape
+      - Hard clue exclusive; supply tied to clue completion rate
+      - Storable in costume room treasure chest
+  history:
+    - date: "2014-06-12"
+      description: Added as a hard Treasure Trail reward with the Treasure Trail Expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_id: 12518
+      item_name: Green dragon mask
+      slug: green-dragon-mask
+      relationship: alternative
+      description: Other chromatic mask
+    - item_id: 12522
+      item_name: Red dragon mask
+      slug: red-dragon-mask
+      relationship: alternative
+      description: Other chromatic mask
+    - item_id: 12524
+      item_name: Black dragon mask
+      slug: black-dragon-mask
+      relationship: alternative
+      description: Other chromatic mask
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-headband.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-headband.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 4
-  about: "Blue headband is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: cosmetic
+  equipment:
+    slot: head
+    weight: 0.04
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Red headband
+      slug: red-headband
+      relationship: variant
+      description: Alternative colour variant
+    - item_name: Brown headband
+      slug: brown-headband
+      relationship: variant
+      description: Alternative colour variant
+    - item_name: Black headband
+      slug: black-headband
+      relationship: variant
+      description: Alternative colour variant
+  about: The blue headband is a cosmetic head-slot item obtained from easy Treasure Trail rewards, offering no combat bonuses but a distinctive minimalist look.
+  market_strategy:
+    notes:
+      - Cosmetic-only with low supply from clue scrolls
+      - "Buy limit: 4 per 4 hours"
+      - Price floats with fashionscape demand
+  trading_tips:
+    - Treat as a flip target rather than a daily trade
+    - Watch for clue meta updates that change supply
+  history:
+    - date: "2014-06-12"
+      description: Blue headband released with the Treasure Trail Expansion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-of-cloth.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-of-cloth.mdx
@@ -16,74 +16,91 @@ osrs:
     type: construction
     tier: basic
   construction:
-    cost: 650
-    source: Construction Supplies
-    common_builds:
-      - name: Curtains
-        quantity: "3"
-        xp: 225
-      - name: Rug
-        quantity: "2"
-        xp: 180
-      - name: Torn curtains
-        quantity: "3"
-        xp: 132
-  shop_sources:
-    - name: Sawmill operator
-      location: Various sawmills
+    common_uses:
+      - Curtains
+      - Rugs
+      - Beds
+      - Bell-pulls
+      - Tapestries
+  shops:
+    - shop_name: Construction supplies
+      location: Sawmill
       price: 650
-      stock: 10
-    - name: Construction Supplies (Mahogany Homes)
-      location: Various cities
+      stock: 1000
+      currency: coins
+      members_only: true
+    - shop_name: Construction supplies
+      location: Woodcutting Guild
       price: 650
-      stock: 10
+      stock: 1000
+      currency: coins
+      members_only: true
+    - shop_name: Construction supplies
+      location: Prifddinas
+      price: 650
+      stock: 1000
+      currency: coins
+      members_only: true
+    - shop_name: Construction supplies
+      location: Auburnvale
+      price: 650
+      stock: 1000
+      currency: coins
+      members_only: true
   related_items:
     - item_id: 8786
       item_name: Marble block
       slug: marble-block
       relationship: alternative
-      description: Premium material
+      description: Premium Construction material
     - item_id: 8784
       item_name: Gold leaf
       slug: gold-leaf
       relationship: alternative
-      description: Premium decoration
+      description: Premium Construction decoration
     - item_id: 8778
       item_name: Oak plank
       slug: oak-plank
       relationship: component
-      description: Used together
+      description: Often used together for furniture
     - item_id: 1759
       item_name: Ball of wool
       slug: ball-of-wool
       relationship: alternative
-      description: Crafting material
-  about: |-
-    | Furniture | Bolts of Cloth | Level | XP |
-    |-----------|----------------|-------|-----|
-    | Torn curtains | 3 | 2 | 132 |
-    | Curtains | 3 | 18 | 225 |
-    | Rug | 2 | 13 | 180 |
-    | Opulent rug | 4 | 65 | 360 |
-    | Bell-pull | 1 | 37 | 120 |
-    | Tapestry | 4 | 36 | 290 |
-
-    Common Uses:
-    - Decorating bedrooms, parlours, and dining rooms
-    - Required for servant call bell-pulls
-    - Rugs and curtains in various rooms
-
-    - Plank - Basic construction
-    - Oak plank - Common training
-    - Steel nails - Some furniture requires nails
+      description: Crafting cloth alternative
+  about: Bolt of cloth is a Construction material used in many bedroom, parlour, and dining-room furniture builds, and is purchased from Construction supply shops for 650 coins.
   market_strategy:
     notes:
-      - Cheap at 650 GP from shops
-      - Low demand item - usually at GE minimum
-      - Buy from sawmill when building in bulk
-      - Used for Mahogany Homes contracts occasionally
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cheap at 650 GP from Construction supplies
+      - Usually trades close to shop price on the Grand Exchange
+      - Buy from sawmill when building furniture in bulk
+      - Occasional demand from Mahogany Homes contracts
+  trading_tips:
+    - Buy from shops before listing on the Grand Exchange
+    - Stock heavily before player-owned house meta updates
+  history:
+    - date: "2006-05-31"
+      description: Bolt of cloth added with the player-owned houses update.
+    - date: "2006-06-13"
+      description: Item received a graphical update.
+    - date: "2006-07-04"
+      description: Item renamed from "Cloth" to "Bolt of cloth".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: PLAYER-OWNED HOUSES!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-2h-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-2h-sword.mdx
@@ -12,28 +12,44 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 125
+  about: "Bronze 2h sword is the weakest two-handed sword in OSRS, smithable at level 14 Smithing from 3 bronze bars."
+  material:
+    type: Bronze
+    tier: low
   equipment:
     slot: 2h
-    type: two-handed sword
-    tradeable: true
+    weapon_type: two_handed_sword
+    attack_speed: 7
     weight: 3.628
     requirements:
       attack: 1
-    stats:
-      attack_stab: -4
-      attack_slash: 9
-      attack_crush: 8
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: -4
+      slash: 9
+      crush: 8
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    other_bonus:
       strength: 10
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  recipes:
+    - skill: Smithing
+      level: 14
+      xp: 37.5
+      materials:
+        - item_name: Bronze bar
+          quantity: 3
+      tools:
+        - Hammer
+        - Anvil
   related_items:
     - item_id: 1309
       item_name: Iron 2h sword
@@ -45,8 +61,34 @@ osrs:
       slug: bronze-longsword
       relationship: alternative
       description: One-handed alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  properties:
+    release_date: "2001-01-04"
+    update: "RuneScape Launch"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  market_strategy:
+    notes:
+      - "High daily volume (~6,607) makes flips fast at thin margins."
+      - "GE price ~134 gp vs 48 gp high alch; never alch."
+  trading_tips:
+    - "Cheap Smithing XP source at level 14 (37.5 xp per sword)."
+    - "Free strength bonus +10 makes it a budget low-level training weapon."
+  history:
+    - date: "2001-01-04"
+      description: "Released with the launch of RuneScape Classic."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-bolts-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-bolts-unf.mdx
@@ -9,12 +9,75 @@ osrs:
   members: true
   icon: Bronze bolts (unf) 5.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 13000
-  about: "Bronze bolts (unf) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: bronze
+  recipes:
+    - skill: Smithing
+      level: 3
+      xp: 12.5
+      materials:
+        - item_name: Bronze bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output:
+        item_name: Bronze bolts (unf)
+        quantity: 10
+    - skill: Fletching
+      level: 9
+      xp: 5
+      materials:
+        - item_name: Bronze bolts (unf)
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      output:
+        item_name: Bronze bolts
+        quantity: 10
+  related_items:
+    - item_id: 2349
+      item_name: Bronze bar
+      slug: bronze-bar
+      relationship: component
+      description: Material smithed into unfinished bolts
+    - item_id: 877
+      item_name: Bronze bolts
+      slug: bronze-bolts
+      relationship: product
+      description: Finished bolts after attaching feathers
+  about: "Entry-tier unfinished crossbow bolts smithed from a bronze bar, completed by attaching feathers via Fletching for low-level training XP."
+  market_strategy:
+    notes:
+      - Primary use is low-level Fletching XP via feather attachment
+      - 13,000 buy limit and ~35k daily volume keep the market liquid
+      - Not alchable so margins live entirely in the GE spread
+  trading_tips:
+    - Stack with cheap feathers during Fletching XP events
+    - Watch bronze bar price floors since they cap profitable spreads
+  history:
+    - date: "2006-07-31"
+      description: Added to the game with the Crossbows update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-plateskirt-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-plateskirt-t.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 4
-  about: "Bronze plateskirt (t) is a free-to-play item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Bronze plateskirt (t) is a trimmed cosmetic variant of the bronze plateskirt obtained from easy Treasure Trail clue scrolls."
+  material:
+    type: Bronze
+    tier: low
+  equipment:
+    slot: legs
+    weight: 8.164
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 8
+      slash: 7
+      crush: 6
+      magic: -4
+      ranged: 7
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 8.164
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  related_items:
+    - item_id: 1089
+      item_name: Bronze plateskirt
+      slug: bronze-plateskirt
+      relationship: variant
+      description: Standard untrimmed version with identical stats
+    - item_id: 12221
+      item_name: Bronze plateskirt (g)
+      slug: bronze-plateskirt-g
+      relationship: variant
+      description: Gold-trimmed cosmetic variant
+  market_strategy:
+    notes:
+      - "Low daily volume (~33 trades); illiquid clue cosmetic."
+      - "Buy limit of 4 keeps supply tight despite low demand."
+  trading_tips:
+    - "Cosmetic only; price driven by fashionscape collectors."
+    - "1/1,404 from easy clue caskets; expect slow flips."
+  history:
+    - date: "2021-04-21"
+      description: "Ranged attack bonus reduced from -7 to -11."
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-scimitar.mdx
@@ -12,24 +12,92 @@ osrs:
   lowalch: 12
   highalch: 19
   limit: 125
-  item_id: 1321
-  item_type: equipment
-  slot: weapon
-  type: scimitar
-  attack_style: slash
-  attack_speed: 4
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 1
-  stats:
-    slash_attack: 7
-    strength: 6
+  material:
+    type: bronze
+    tier: tier_1
+  equipment:
+    slot: weapon
+    weapon_type: slash_sword
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 1
+      slash: 7
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 5
+      xp: 25
+      materials:
+        - item_name: Bronze bar
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      product: Bronze scimitar
+      members_only: false
   related_items:
-    - slug: iron-scimitar
-    - slug: bronze-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Iron scimitar
+      slug: iron-scimitar
+      relationship: upgrade
+      description: Next metal tier scimitar
+    - item_name: Bronze bar
+      slug: bronze-bar
+      relationship: component
+      description: Smelting material for the scimitar
+    - item_name: Bronze longsword
+      slug: bronze-longsword
+      relationship: alternative
+      description: Bronze tier longsword alternative
+  about: The bronze scimitar is the lowest-tier scimitar, smithed from 2 bronze bars at 5 Smithing for 25 experience and wielded with 1 Attack.
+  market_strategy:
+    notes:
+      - Cheap entry-level slash weapon
+      - Low Grand Exchange volume
+      - "Buy limit: 125 per 4 hours"
+      - Smithing supply usually exceeds demand
+  trading_tips:
+    - Use as Smithing XP material rather than a flip target
+    - Compare against iron scimitar for early Attack training value
+  history:
+    - date: "2001-01-04"
+      description: Bronze scimitar added with the RuneScape beta launch.
+    - date: "2005-06-13"
+      description: Examine text updated for punctuation.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape beta is now online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bryophyta-s-essence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bryophyta-s-essence.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 2800
   highalch: 4200
   limit: 100
-  about: "Bryophyta's essence is a free-to-play item in Old School RuneScape. High alchemy value: 4,200 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: boss drop
+    tier: bryophyta
+  recipes:
+    - skill: crafting
+      level: 62
+      materials:
+        - item_name: Battlestaff
+          quantity: 1
+        - item_name: Bryophyta's essence
+          quantity: 1
+      tools:
+        - Hands
+      product: "Bryophyta's staff (uncharged)"
+  drop_table:
+    sources:
+      - source: Bryophyta
+        quantity: "1"
+        rarity: 1/118
+      - source: Moss giant
+        quantity: "1"
+        rarity: 1/15488
+  related_items:
+    - item_id: 22368
+      item_name: Bryophyta's staff (uncharged)
+      slug: bryophyta-s-staff-uncharged
+      relationship: product
+      description: Infused battlestaff created with the essence.
+    - item_id: 22370
+      item_name: Bryophyta's staff
+      slug: bryophyta-s-staff
+      relationship: product
+      description: Charged form of the Bryophyta staff used in combat.
+    - item_id: 1391
+      item_name: Battlestaff
+      slug: battlestaff
+      relationship: component
+      description: Required base item to infuse with the essence.
+  about: "Bryophyta's essence is a rare drop from the F2P-accessible Bryophyta boss in Varrock Sewers used at 62 Crafting to infuse a battlestaff into Bryophyta's staff."
+  market_strategy:
+    notes:
+      - Buy limit of 100 keeps the market manageable for flippers.
+      - Demand spikes when Bryophyta's staff trends in low-level magic content.
+      - F2P accessibility broadens the buyer pool versus members-only essences.
+  trading_tips:
+    - Track Bryophyta kill rate metas to anticipate supply increases.
+    - Spike on splash mage training advice that mentions Bryophyta's staff.
+    - Compare cost-per-cast versus alternative low-tier magic weapons.
+  history:
+    - date: "2018-05-03"
+      description: Added to the game as part of the Bryophyta boss release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-05-03"
+    update: "Bryophyta"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-sapling.mdx
@@ -9,12 +9,71 @@ osrs:
   members: true
   icon: Camphor sapling.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: null
-  about: "Camphor sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Camphor sapling is a hardwood tree sapling planted in hardwood patches at 66 Farming for 17,840 XP on check-health."
+  farming:
+    skill: Farming
+    level: 66
+    plant_xp: 88
+    check_xp: 17840
+    growth_minutes: 5120
+    patch: Hardwood tree
+    protection: 10 white berries
+  recipes:
+    - skill: Farming
+      level: 66
+      xp: 88
+      materials:
+        - item_name: Camphor seed
+          quantity: 1
+        - item_name: Plant pot (filled)
+          quantity: 1
+      tools:
+        - Gardening trowel
+        - Watering can
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: false
+  related_items:
+    - item_id: 31500
+      item_name: Camphor seed
+      slug: camphor-seed
+      relationship: component
+      description: Seed germinated into the sapling
+    - item_id: 31501
+      item_name: Camphor seedling
+      slug: camphor-seedling
+      relationship: component
+      description: Intermediate growth stage before sapling
+    - item_id: 31503
+      item_name: Camphor tree
+      slug: camphor-tree
+      relationship: product
+      description: Final mature hardwood tree
+  market_strategy:
+    notes:
+      - "GE price ~6,511 gp with ~6,929 daily volume; modest hardwood demand."
+      - "Watch Sailing update cycles for spikes in hardwood farming activity."
+  trading_tips:
+    - "Buy seeds and germinate for cheaper saplings if you have a farming bot setup."
+    - "Pay 10 white berries to the gardener to protect mature trees from disease."
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chitin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chitin.mdx
@@ -9,12 +9,88 @@ osrs:
   members: true
   icon: Chitin.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: null
-  about: "Chitin is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Dagannoth Rex (Deadman)
+        quantity: "1"
+        rarity: "1/2"
+      - source: Dagannoth Prime (Deadman)
+        quantity: "1"
+        rarity: "1/2"
+      - source: Dagannoth Supreme (Deadman)
+        quantity: "1"
+        rarity: "1/2"
+      - source: General Graardor (Deadman)
+        quantity: "1"
+        rarity: "1/2"
+      - source: K'ril Tsutsaroth (Deadman)
+        quantity: "1"
+        rarity: "1/2"
+      - source: Kree'arra (Deadman)
+        quantity: "1"
+        rarity: "1/2"
+      - source: Commander Zilyana (Deadman)
+        quantity: "1"
+        rarity: "1/2"
+      - source: TzTok-Jad (Deadman)
+        quantity: "1"
+        rarity: "1/2"
+      - source: Cerberus (Deadman)
+        quantity: "1"
+        rarity: "1/2"
+      - source: Vardorvis (Deadman)
+        quantity: "1"
+        rarity: "1/2"
+  recipes:
+    - skill: herblore
+      level: 83
+      xp: 125
+      materials:
+        - item_name: Super combat potion(4)
+          item_id: 12695
+          quantity: 1
+        - item_name: Chitin
+          item_id: 29643
+          quantity: 1
+      tools:
+        - Vial
+      product: Blighted super combat potion(4)
+      product_id: 29647
+  related_items:
+    - item_id: 29647
+      item_name: Blighted super combat potion(4)
+      slug: blighted-super-combat-potion-4
+      relationship: product
+      description: Crafted using chitin in Deadman mode
+  about: "Deadman Mode crafting material dropped at 1/2 from most breach bosses; combine with 4-dose super combat / ranging / magic potions at 83 Herblore for 125 XP to create blighted overloads."
+  market_strategy:
+    notes:
+      - Deadman Mode exclusive — no main-game market
+      - Stockpile for blighted overload crafting
+      - Burn through Slayer / boss tasks for supply
+  history:
+    - date: "2024-07-17"
+      update: "Deadman: Armageddon & While Guthix Sleeps Updates"
+      description: Released alongside the Deadman Armageddon launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-07-17"
+    update: "Deadman: Armageddon"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.01
+    options:
+      - Drop
+    alchable: false
+    quest_item: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/combat-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/combat-mix-2.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 42
   highalch: 63
   limit: 2000
-  about: "Combat mix(2) is a members-only item in Old School RuneScape. High alchemy value: 63 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: "Boosts Attack by 3 + 10% of base Attack level"
+      - description: "Boosts Strength by 3 + 10% of base Strength level"
+      - description: "Heals 3 Hitpoints per dose"
+  recipes:
+    - skill: Herblore
+      level: 40
+      xp: 28
+      materials:
+        - item_name: Caviar
+          quantity: 1
+        - item_name: Combat potion(2)
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      requirements:
+        - Barbarian Herblore training with Otto Godblessed
+  related_items:
+    - item_id: 11443
+      item_name: Combat mix(1)
+      slug: combat-mix-1
+      relationship: variant
+      description: 1-dose version
+    - item_id: 9741
+      item_name: Combat potion(2)
+      slug: combat-potion-2
+      relationship: component
+      description: Base potion before mixing
+  about: "Two-dose fishy combat potion that boosts Attack and Strength while healing three Hitpoints per sip, brewed via Barbarian Herblore."
+  market_strategy:
+    notes:
+      - Niche Barbarian Herblore consumable competing with super combat doses
+      - Demand spikes for fishy variants that double as light healing
+      - 2,000 buy limit keeps small-time flipping liquid
+  trading_tips:
+    - Watch caviar price swings since they drive the input cost
+    - Flip alongside Combat potion(2) when raw inputs are cheap
+  history:
+    - date: "2007-07-03"
+      description: Added to the game with the Barbarian Training update.
+    - date: "2016-04-15"
+      description: Half-full potions became convertible to bank placeholders.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/condensed-gold.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/condensed-gold.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 3200000
   highalch: 4800000
   limit: null
-  about: "Condensed gold is a members-only item in Old School RuneScape. High alchemy value: 4,800,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: construction material
+    tier: gold sink
+  shops:
+    - shop_name: "Stonemason"
+      location: Keldagrim
+      price: 10400000
+    - shop_name: "Metla"
+      location: Stonecutter Outpost
+      price: 10400000
+  construction:
+    level: 47
+    experience: 11144
+    product: Gold sink
+  recipes:
+    - skill: construction
+      level: 47
+      experience: 11144
+      materials:
+        - item_name: Condensed gold
+          quantity: 10
+        - item_name: Mahogany plank
+          quantity: 5
+        - item_name: Gold leaf
+          quantity: 5
+      tools:
+        - Hammer
+        - Saw
+      product: Gold sink (player-owned house kitchen)
+  related_items:
+    - item_id: 8784
+      item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Required alongside condensed gold when building the kitchen gold sink.
+    - item_id: 8784
+      item_name: Gold leaf
+      slug: gold-leaf
+      relationship: component
+      description: Required alongside condensed gold when building the kitchen gold sink.
+  about: "Condensed gold is a high-value Construction material sold by the Keldagrim Stonemason and Metla, used as the core ingredient for the player-owned house kitchen gold sink."
+  market_strategy:
+    notes:
+      - Shop price rises with bulk purchases, creating soft ceiling pressure on flips.
+      - Demand tracks Construction training and gold sink build orders.
+      - No buy limit removes flipping volume restrictions but exposes traders to whale moves.
+  trading_tips:
+    - Buy from the Keldagrim Stonemason when GE price drifts above shop ceiling.
+    - Watch Construction XP rates for shifts that change gold sink demand.
+    - Treat as a quasi-bond-tier asset; price is anchored to in-game shop supply.
+  history:
+    - date: "2021-11-24"
+      description: Added to the game with the Android Beta and Gold Sink Changes update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-11-24"
+    update: Android Beta and Gold Sink Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-t-bone-steak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-t-bone-steak.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 6000
-  about: "Cooked t-bone steak is a free-to-play item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Cooked t-bone steak is a food item that restores 9 Hitpoints and grants a +2 Strength boost when eaten."
+  properties:
+    release_date: "2026-02-25"
+    update: "Cow Boss is Out Today!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.34
+    options:
+      - Eat
+      - Drop
+    alchable: true
+  food:
+    heals: 9
+    bites: 1
+  recipes:
+    - skill: Cooking
+      level: 13
+      xp: 90
+      materials:
+        - item_name: Raw t-bone steak
+          quantity: 1
+      tools:
+        - Cooking range
+  related_items:
+    - item_id: 33107
+      item_name: Raw t-bone steak
+      slug: raw-t-bone-steak
+      relationship: component
+      description: Raw ingredient used in Cooking
+    - item_id: 33111
+      item_name: Burnt t-bone steak
+      slug: burnt-t-bone-steak
+      relationship: alternative
+      description: Failure result when cooking
+  market_strategy:
+    notes:
+      - "Cost ~79 coins to cook vs ~66 GE price; flipping is unprofitable after tax."
+      - "Best value as a food source for mid-level F2P training."
+  trading_tips:
+    - "Buy raw steaks below cooked price for Cooking XP profit."
+    - "Strength boost makes it useful for low-level slayer or pures."
+  history:
+    - date: "2026-02-25"
+      description: "Released alongside the Brutus boss in the Cow Boss update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crier-coat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crier-coat.mdx
@@ -5,16 +5,78 @@ osrs:
   id: 20240
   name: Crier coat
   slug: crier-coat
-  examine: Don't shoot the messenger!
+  examine: "Don't shoot the messenger!"
   members: true
   icon: Crier coat.png
   value: 5000
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Crier coat is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Crier coat is a cosmetic body piece of the Crier outfit obtained from medium Treasure Trail reward caskets."
+  equipment:
+    slot: body
+    weight: 0.001
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  properties:
+    release_date: "2016-07-06"
+    update: "Treasure Trail Expansion (2016)"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  related_items:
+    - item_id: 20242
+      item_name: Crier hat
+      slug: crier-hat
+      relationship: set-piece
+      description: Headpiece of the Crier outfit
+    - item_id: 20244
+      item_name: Crier bell
+      slug: crier-bell
+      relationship: set-piece
+      description: Hand-held bell of the Crier outfit
+  market_strategy:
+    notes:
+      - "GE price (~2,888 gp) sits below high alch (3,000 gp); borderline alch."
+      - "Buy limit of 4 + low daily volume (~83) keeps supply thin."
+  trading_tips:
+    - "Purely cosmetic; price driven by fashionscape and clue completionists."
+    - "Costume room storage; UIM can't retrieve individual pieces until full set is stored."
+  history:
+    - date: "2016-07-06"
+      description: "Released with the 2016 Treasure Trail Expansion."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crossbow-string.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crossbow-string.mdx
@@ -9,12 +9,79 @@ osrs:
   members: true
   icon: Crossbow string.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 11000
-  about: "Crossbow string is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: string
+    tier: basic
+  recipes:
+    - skill: crafting
+      level: 10
+      xp: 15
+      materials:
+        - item_name: Sinew
+          quantity: 1
+      tools:
+        - Spinning wheel
+      product: Crossbow string
+      members_only: true
+    - skill: crafting
+      level: 10
+      xp: 15
+      materials:
+        - item_name: Tree roots
+          quantity: 1
+      tools:
+        - Spinning wheel
+      product: Crossbow string
+      members_only: true
+  related_items:
+    - item_name: Sinew
+      slug: sinew
+      relationship: component
+      description: Material option for stringing
+    - item_name: Bronze crossbow
+      slug: bronze-crossbow
+      relationship: product
+      description: Crossbow made by stringing with a string
+    - item_name: Dragon crossbow
+      slug: dragon-crossbow
+      relationship: product
+      description: Highest-tier crossbow built from this string
+    - item_name: Bow string
+      slug: bow-string
+      relationship: alternative
+      description: Equivalent string for shortbows and longbows
+  about: Crossbow strings are spun at 10 Crafting from sinew or tree roots and used to fletch every crossbow from bronze through dragon.
+  market_strategy:
+    notes:
+      - "Buy limit: 11,000 per 4 hours"
+      - Cheap supply from tree-root farming
+      - High volume for crossbow fletchers
+      - Often more profitable to fletch from roots than buy outright
+  trading_tips:
+    - Track sinew and root prices for spinning profit margins
+    - Stock heavily before crossbow flipping flips
+  history:
+    - date: "2006-07-31"
+      description: Crossbow string introduced with the Crossbows update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.002
+    options:
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dagannoth-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dagannoth-bones.mdx
@@ -12,11 +12,9 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 7500
-  item_id: 6729
-  type: bones
-  tradeable: true
-  weight: 1.5
-  buy_limit: 7500
+  material:
+    type: bones
+    tier: high
   prayer:
     xp_bury: 125
     xp_gilded: 437.5
@@ -26,41 +24,71 @@ osrs:
   drop_table:
     sources:
       - source: Dagannoth Rex
-        rate: Always
+        source_id: 2882
+        combat_level: 303
+        quantity: "1"
+        rarity: always
         members_only: true
       - source: Dagannoth Prime
-        rate: Always
+        source_id: 2883
+        combat_level: 303
+        quantity: "1"
+        rarity: always
         members_only: true
       - source: Dagannoth Supreme
-        rate: Always
+        source_id: 2881
+        combat_level: 303
+        quantity: "1"
+        rarity: always
         members_only: true
   related_items:
-    - slug: dragon-bones
-      name: Dragon bones
-      relation: alternative
-    - slug: superior-dragon-bones
-      name: Superior dragon bones
-      relation: higher_tier
-    - slug: dagannoth-kings
-      name: Dagannoth Kings
-      relation: drop_source
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Bones |
-    | Tradeable | Yes |
-    | Weight | 1.5 kg |
-    | Prayer XP | 125 (buried) |
-
-    Prayer training: Bury for 125 XP.
-
-    Enhanced methods:
-    - Gilded/Chaos altar: 437.5 XP
-    - Ectofuntus: 500 XP
-    - Sinister Offering: 375 XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Dragon bones
+      slug: dragon-bones
+      relationship: alternative
+      description: Common Prayer training bones with same XP
+    - item_name: Superior dragon bones
+      slug: superior-dragon-bones
+      relationship: upgrade
+      description: Higher Prayer XP per bone
+    - item_name: Dagannoth Kings
+      slug: dagannoth-kings
+      relationship: alternative
+      description: Boss source for dagannoth bones
+  about: Dagannoth bones are dropped by the three Dagannoth Kings and grant 125 Prayer experience when buried, or up to 500 XP at the Ectofuntus.
+  market_strategy:
+    notes:
+      - "Buy limit: 7,500 per 4 hours"
+      - Supply driven by Dagannoth Kings hunters
+      - Gilded altar produces 437.5 XP per bone
+      - Chaos altar yields 50% bone-save chance
+      - Compare GP per Prayer XP against dragon bones
+  trading_tips:
+    - Buy during Dagannoth Kings trip resets when supply spikes
+    - Watch dragon bones spread for substitution effect
+  history:
+    - date: "2005-11-07"
+      description: Dagannoth bones added with the Waterbirth Island update.
+    - date: "2015-03-05"
+      description: Automatically noted when obtained after completing the Fremennik Elite Diary.
+    - date: "2018-02-08"
+      description: Item value changed from 1 to 150 coins for ground visibility.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-11-07"
+    update: Waterbirth Island - deeper, darker, deadlier!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.5
+    options:
+      - Bury
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/defence-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/defence-mix-2.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
-  about: "Defence mix(2) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: "Boosts Defence level by 3 + floor(Defence level / 10) — up to +12 at 90+."
+      - description: "Heals 6 Hitpoints per dose consumed."
+  recipes:
+    - skill: herblore
+      level: 33
+      xp: 25
+      materials:
+        - item_name: Defence potion(2)
+          item_id: 135
+          quantity: 1
+        - item_name: Caviar
+          item_id: 11326
+          quantity: 1
+      tools:
+        - Otto Godblessed (Barbarian Herblore)
+      product: Defence mix(2)
+      product_id: 11457
+  related_items:
+    - item_id: 11458
+      item_name: Defence mix(1)
+      slug: defence-mix-1
+      relationship: variant
+      description: Single-dose variant
+    - item_id: 135
+      item_name: Defence potion(2)
+      slug: defence-potion-2
+      relationship: component
+      description: Base potion before adding caviar
+    - item_id: 11326
+      item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Fish ingredient added via Barbarian Herblore
+  about: "Two-dose Barbarian Herblore Defence mix — boosts Defence and heals 6 HP per sip; made at 33 Herblore for 25 XP after unlocking Barbarian training."
+  market_strategy:
+    notes:
+      - Barbarian Herblore niche product
+      - Low GE volume — slow flip
+      - Healing-on-sip useful for combat skillers
+  history:
+    - date: "2007-07-03"
+      update: Barbarian Training
+      description: Released alongside the Barbarian Herblore training unlock from Otto Godblessed.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.075
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    quest_item: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-javelin-p-19490.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-javelin-p-19490.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 180
   highalch: 270
   limit: 11000
-  about: "Dragon javelin(p++) is a members-only item in Old School RuneScape. High alchemy value: 270 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: dragon
+  equipment:
+    slot: ammo
+    weapon_type: javelin
+    attack_speed: 7
+    weight: 0
+    requirements:
+      ranged: 70
+    other_bonus:
+      ranged_strength: 150
+  related_items:
+    - item_id: 19484
+      item_name: Dragon javelin
+      slug: dragon-javelin
+      relationship: variant
+      description: Unpoisoned variant
+    - item_id: 19486
+      item_name: Dragon javelin(p)
+      slug: dragon-javelin-p
+      relationship: variant
+      description: Light poison variant
+    - item_id: 19488
+      item_name: Dragon javelin(p+)
+      slug: dragon-javelin-p-plus
+      relationship: variant
+      description: Stronger poison variant
+    - item_id: 19481
+      item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: component
+      description: Ballista that fires the javelins
+  about: "Highly-poisoned dragon javelin ammo for the Heavy ballista, providing +150 Ranged Strength and stacking damage-over-time on hit."
+  market_strategy:
+    notes:
+      - Premier Heavy ballista ammo for PvP and high-tier Ranged DPS
+      - Requires 92 Fletching to craft which keeps supply Fletching-gated
+      - Buy limit of 11,000 supports active PvP restocking
+  trading_tips:
+    - Watch PvP meta cycles since javelin demand spikes with ballista use
+    - Compare to dragon javelin(p+) for the cheapest stack of poison procs
+  history:
+    - date: "2016-05-06"
+      description: Added to the game with the Monkey Madness II update.
+    - date: "2016-10-31"
+      description: Ranged Strength bonus reduced from +175 to +150 after Void synergy issues.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-05-06"
+    update: Monkey Madness II
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-knife.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-knife.mdx
@@ -12,61 +12,85 @@ osrs:
   lowalch: 66
   highalch: 100
   limit: 11000
+  material:
+    type: dragon
+    tier: dragon
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
+    weapon_type: thrown
     attack_speed: 3
-  requirements:
-    ranged: 60
-  stats:
-    attack:
+    weight: 0.006
+    requirements:
+      ranged: 60
+    attack_bonus:
       ranged: 28
-    other:
+    other_bonus:
       ranged_strength: 30
   special_attack:
-    name: Draconic Puncture
+    name: Duality
     energy: 25
-    description: Two rapid attacks with 5% increased accuracy
-  obtaining:
-    - source: Hydra
-      location: Karuulm Slayer Dungeon
-      members_only: true
-    - source: Alchemical Hydra
-      location: Karuulm Slayer Dungeon
-      members_only: true
+    description: Throws two knives with independent accuracy and damage rolls.
+  drop_table:
+    sources:
+      - source: Wyrm
+        quantity: "1"
+        rarity: 1/2000
+      - source: Drake
+        quantity: "1"
+        rarity: 1/2000
+      - source: Hydra
+        quantity: "1"
+        rarity: 1/2000
+      - source: Alchemical Hydra
+        quantity: "1"
+        rarity: 1/2000
   related_items:
     - item_id: 868
       item_name: Rune knife
       slug: rune-knife
       relationship: downgrade
-      description: Lower tier knife
+      description: Lower tier throwing knife
     - item_id: 22806
       item_name: Dragon knife (p++)
       slug: dragon-knife-p++
       relationship: variant
-      description: Poisoned version
+      description: Poisoned variant
     - item_id: 11230
       item_name: Dragon dart
       slug: dragon-dart
       relationship: alternative
       description: Alternative dragon thrown
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0.006 kg |
-    | Requirements | 60 Ranged |
-
-    Draconic Puncture:
-    - 25% special energy
-    - Two rapid attacks
-    - 5% increased accuracy per hit
-    - Popular for PvP combos
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Dragon-tier throwing knife dropped by Kebos slayer creatures, with a Duality special that fires two independent knives for 25% energy."
+  market_strategy:
+    notes:
+      - Top-tier thrown weapon for PvP combos and burst Ranged DPS
+      - Steady drop supply from Wyrms, Drakes, and Hydras at 1/2,000
+      - High volume but price is sensitive to PvP meta shifts
+  trading_tips:
+    - Buy on PvE meta dips and resell when Bounty Hunter cycles back
+    - Compare to dragon dart pricing for the cheapest spec spam loadout
+  history:
+    - date: "2019-01-10"
+      description: Added to the game with The Kebos Lowlands update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-01-10"
+    update: The Kebos Lowlands
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-bear-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-bear-head.mdx
@@ -5,7 +5,7 @@ osrs:
   id: 13463
   name: Ensouled bear head
   slug: ensouled-bear-head
-  examine: The creature's soul is still in here.
+  examine: "The creature's soul is still in here. I could reanimate it with Basic Reanimation."
   members: true
   icon: Ensouled bear head.png
   value: 260
@@ -14,25 +14,25 @@ osrs:
   limit: 3000
   material:
     type: ensouled_head
-    tier: basic
+    tier: low
   prayer:
     xp_reanimate: 480
-    magic_level: 3
+    magic_level: 16
     spell: Basic Reanimation
   drop_table:
     sources:
-      - source: Bear
-        source_id: 106
-        combat_level: 21
+      - source: Black bear
         quantity: "1"
-        rarity: uncommon
-        members_only: true
+        rarity: "1/25"
       - source: Grizzly bear
-        source_id: 105
-        combat_level: 21
         quantity: "1"
-        rarity: uncommon
-        members_only: true
+        rarity: "1/25"
+      - source: Grizzly bear cub
+        quantity: "1"
+        rarity: "1/25"
+      - source: Bear cub
+        quantity: "1"
+        rarity: "1/25"
   related_items:
     - item_id: 13454
       item_name: Ensouled imp head
@@ -49,19 +49,39 @@ osrs:
       slug: ensouled-demon-head
       relationship: upgrade
       description: Higher XP (1,170)
-  about: |-
-    1. Cast Basic Reanimation spell on the head
-    2. Kill the reanimated creature
-    3. Receive Prayer XP
+  about: "Cast Basic Reanimation on the head, then kill the reanimated creature to gain 480 Prayer XP — budget early-game Prayer training option."
   market_strategy:
     notes:
       - Budget Prayer training option
-      - Decent early game XP
-      - Not commonly traded
-      - Bears easy to kill
-      - Consider giant heads instead
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Decent early-game XP
+      - Bears are easy to kill for supply
+      - Consider giant heads for better XP/hr
+  history:
+    - date: "2022-03-30"
+      update: Guardians of the Rift Improvements
+      description: Ensouled heads can now drop in instanced areas.
+    - date: "2021-04-28"
+      update: Arceuus Spellbook Beta and A Kingdom Divided Preparation
+      description: Examine text was slightly changed from the previous version.
+    - date: "2016-01-07"
+      update: "Zeah: Great Kourend"
+      description: Item added to the game with the Arceuus reanimation spellbook.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: "Zeah: Great Kourend"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    quest_item: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-kalphite-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-kalphite-head.mdx
@@ -44,30 +44,50 @@ osrs:
       item_name: Ensouled troll head
       slug: ensouled-troll-head
       relationship: downgrade
-      description: Lower XP (780)
+      description: Lower Prayer XP (780)
     - item_id: 13493
       item_name: Ensouled dagannoth head
       slug: ensouled-dagannoth-head
       relationship: upgrade
-      description: Higher XP (936)
+      description: Higher Prayer XP (936)
     - item_id: 13502
       item_name: Ensouled demon head
       slug: ensouled-demon-head
       relationship: upgrade
-      description: Higher XP (1,170)
-  about: |-
-    1. Cast Expert Reanimation spell on the head
-    2. Kill the reanimated creature
-    3. Receive Prayer XP
+      description: Higher Prayer XP (1,170)
+  about: The ensouled kalphite head is reanimated using the Expert Reanimation spell at 72 Magic, then killing the resulting monster grants 884 Prayer experience.
   market_strategy:
     notes:
-      - Good Prayer XP
-      - Supply from kalphite tasks
-      - Kalphite tasks provide supply
-      - Higher magic requirement
-      - Decent GP/XP ratio
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Good Prayer XP per cast
+      - Supply from Kalphite Slayer tasks
+      - Higher magic requirement than mid-tier ensouled heads
+      - Decent GP/XP ratio for mid-game Prayer training
+  trading_tips:
+    - Buy in bulk during Kalphite Slayer task weeks
+    - Compare GP per Prayer XP against dagannoth and bloodveld heads
+  history:
+    - date: "2016-01-07"
+      description: Ensouled kalphite head released with the Zeah Great Kourend update.
+    - date: "2021-04-28"
+      description: Examine text slightly adjusted.
+    - date: "2022-03-30"
+      description: Ensouled heads can now drop in instanced areas.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: "Zeah: Great Kourend"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-troll-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-troll-head.mdx
@@ -5,7 +5,7 @@ osrs:
   id: 13484
   name: Ensouled troll head
   slug: ensouled-troll-head
-  examine: The creature's soul is still in here.
+  examine: "The creature's soul is still in here. I could reanimate it with Adept Reanimation."
   members: true
   icon: Ensouled troll head.png
   value: 384
@@ -14,25 +14,34 @@ osrs:
   limit: 7500
   material:
     type: ensouled_head
-    tier: adept
+    tier: mid
   prayer:
     xp_reanimate: 780
     magic_level: 41
     spell: Adept Reanimation
   drop_table:
     sources:
-      - source: Troll
-        source_id: 1106
-        combat_level: 75
+      - source: Ice troll grunt
         quantity: "1"
-        rarity: uncommon
-        members_only: true
+        rarity: "1/20"
+      - source: Ice troll runt
+        quantity: "1"
+        rarity: "1/20"
+      - source: Ice troll male
+        quantity: "1"
+        rarity: "1/20"
+      - source: Ice troll female
+        quantity: "1"
+        rarity: "1/20"
       - source: Mountain troll
-        source_id: 937
-        combat_level: 69
         quantity: "1"
-        rarity: uncommon
-        members_only: true
+        rarity: "1/45"
+      - source: Troll (general)
+        quantity: "1"
+        rarity: "1/45"
+      - source: Fremennik salvage activity
+        quantity: "1"
+        rarity: "50/2670"
   related_items:
     - item_id: 13475
       item_name: Ensouled giant head
@@ -49,19 +58,35 @@ osrs:
       slug: ensouled-demon-head
       relationship: upgrade
       description: Higher XP (1,170)
-  about: |-
-    1. Cast Adept Reanimation spell on the head
-    2. Kill the reanimated creature
-    3. Receive Prayer XP
+  about: "Cast Adept Reanimation (41 Magic) on the head, then kill the reanimated troll for 780 Prayer XP; sourced from troll Slayer tasks."
   market_strategy:
     notes:
-      - Decent Prayer XP
-      - Medium supply from Slayer
-      - Troll tasks provide supply
-      - Compare GP/XP to alternatives
-      - Mid-level Prayer training
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Mid-tier Prayer training option
+      - Troll Slayer tasks keep supply steady
+      - Compare GP/XP vs dragon and bigger heads
+  history:
+    - date: "2022-03-30"
+      update: Guardians of the Rift Improvements
+      description: Ensouled heads can now drop in instanced areas.
+    - date: "2016-01-07"
+      update: "Zeah: Great Kourend"
+      description: Added with the Arceuus reanimation spellbook.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: "Zeah: Great Kourend"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    quest_item: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/felling-axe-handle.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/felling-axe-handle.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: null
-  about: "Felling axe handle is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: special
+  shops:
+    - shop_name: Forestry Shop
+      location: Forestry events
+      currency: Anima-infused bark
+      sell_price: 10000
+      notes: Also requires 500 noted oak logs alongside the bark cost.
+  recipes:
+    - skill: smithing
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Felling axe handle
+          item_id: 28177
+          quantity: 1
+        - item_name: Bronze axe
+          quantity: 1
+      product: Bronze felling axe
+      product_quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      members_only: true
+      notes: Any base axe (bronze through crystal) can be combined; transformation is irreversible.
+  related_items:
+    - item_id: 28184
+      item_name: Bronze felling axe
+      slug: bronze-felling-axe
+      relationship: product
+      description: Lowest-tier felling axe produced with the handle.
+    - item_id: 28196
+      item_name: Dragon felling axe
+      slug: dragon-felling-axe
+      relationship: product
+      description: Dragon-tier felling axe crafted via the handle.
+    - item_id: 28202
+      item_name: Crystal felling axe
+      slug: crystal-felling-axe
+      relationship: product
+      description: Crystal-tier felling axe crafted via the handle.
+  about: "Felling axe handle combines with any regular axe at an anvil to permanently convert it into the matching felling axe used in Forestry group woodcutting."
+  market_strategy:
+    notes:
+      - Supply gated behind Forestry Shop trades that cost 10,000 anima-infused bark and 500 noted oak logs.
+      - No Grand Exchange buy limit removes throughput caps for resellers.
+      - Demand follows Forestry meta - spikes when felling axe tiers are favoured for group woodcutting.
+  trading_tips:
+    - Compare GE price against anima-infused bark spot value to spot resale arbitrage.
+    - Stockpile for new Forestry content releases when handle demand temporarily outruns supply.
+  history:
+    - date: "2023-06-28"
+      description: Initially added as an unobtainable placeholder during the first Forestry update.
+    - date: "2023-10-25"
+      description: Became tradeable with Forestry Part Two, with revised name and 5,000 coin base value.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-10-25"
+    update: "Forestry: Part Two"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fiendish-ashes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fiendish-ashes.mdx
@@ -9,8 +9,8 @@ osrs:
   members: false
   icon: Fiendish ashes.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 3000
   material:
     type: ashes
@@ -36,32 +36,55 @@ osrs:
       item_name: Vile ashes
       slug: vile-ashes
       relationship: upgrade
-      description: Higher XP (25 base)
+      description: Higher Prayer XP per scatter
     - item_id: 25772
       item_name: Malicious ashes
       slug: malicious-ashes
       relationship: upgrade
-      description: Higher XP (65 base)
+      description: Higher Prayer XP per scatter
     - item_id: 25775
       item_name: Abyssal ashes
       slug: abyssal-ashes
       relationship: upgrade
-      description: Higher XP (85 base)
+      description: Higher Prayer XP per scatter
     - item_id: 25778
       item_name: Infernal ashes
       slug: infernal-ashes
       relationship: upgrade
-      description: Highest XP (110 base)
+      description: Highest Prayer XP per scatter
+  about: Fiendish ashes are the lowest tier of demonic ashes used for Prayer training via scattering or the Demonic Offering spell.
   market_strategy:
     notes:
       - Lowest tier of demonic ashes
-      - High supply from imp farming
+      - High supply from imp farming in free-to-play
       - Low value but consistent demand
-      - Entry-level ashes for Prayer
-      - Demonic Offering triples XP
-      - Compare GP/XP to higher tiers
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Entry-level ashes for early Prayer training
+      - Demonic Offering triples Prayer XP per cast
+  trading_tips:
+    - Compare GP per Prayer XP to higher tier ashes
+    - Buy in bulk during imp farming events
+  history:
+    - date: "2021-06-16"
+      description: Fiendish ashes released with the A Kingdom Divided update.
+    - date: "2021-06-23"
+      description: Fiendish ashes are now available as drops from monsters in free-to-play worlds.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-06-16"
+    update: A Kingdom Divided
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.056
+    options:
+      - Scatter
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fly-fishing-rod.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fly-fishing-rod.mdx
@@ -12,18 +12,65 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 40
+  shops:
+    - shop_name: Gerrant's Fishy Business
+      location: Port Sarim
+      price: 5
+      stock: 5
+      currency: coins
+      members_only: false
+    - shop_name: Fernahei's Fishing Hut
+      location: Shilo Village
+      price: 5
+      currency: coins
+      members_only: true
+    - shop_name: Fremennik Fish Monger
+      location: Rellekka
+      price: 6
+      currency: coins
+      members_only: true
+    - shop_name: Fishing Guild Shop
+      location: Fishing Guild
+      price: 5
+      currency: coins
+      members_only: true
   related_items:
     - item_id: 307
       item_name: Fishing rod
       slug: fishing-rod
       relationship: variant
-      description: For sardines and herring
-  about: |-
-    > _"Useful for catching salmon or trout."_
-
-    The fly fishing rod is used with feathers at lure/bait fishing spots to catch trout (20 Fishing) and salmon (30 Fishing). The most popular early-game Fishing training method.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Used with bait for sardines and herring
+    - item_id: 311
+      item_name: Harpoon
+      slug: harpoon
+      relationship: alternative
+      description: Tool for tuna and swordfish
+  about: The fly fishing rod is used with feathers at lure or bait fishing spots to catch raw trout at 20 Fishing, raw salmon at 30 Fishing, and raw rainbow fish at 38 Fishing; it is one of the most popular early game Fishing training tools and is available from several fishing shops across Gielinor.
+  market_strategy:
+    notes:
+      - Always in demand for early Fishing training
+      - Cheaper to buy from shops than the Grand Exchange in most cases
+      - Bulk flipping margin is small but volume is steady
+  history:
+    - date: "2001-06-11"
+      description: Fly fishing rod added with the launch of the Fishing skill.
+    - date: "2021-07-07"
+      description: Rod positioning adjusted for female player fishing animations.
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    weight: 1.36
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/frozen-tear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/frozen-tear.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 13000
-  about: "Frozen tear is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Frozen tear is a stackable drop used to charge the Pendant of Ates; each tear grants one teleport charge."
+  drop_table:
+    sources:
+      - source: Brutal blue dragon
+        quantity: "1"
+        rarity: "1/32"
+      - source: Blue dragon
+        quantity: "1"
+        rarity: "1/100"
+      - source: Icefiend
+        quantity: "1"
+        rarity: "1/150"
+      - source: Frost crab
+        quantity: "1"
+        rarity: "1/90"
+  charges:
+    item: Pendant of Ates
+    per_charge: 1
+    full_restore: 100
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+  related_items:
+    - item_id: 29893
+      item_name: Pendant of Ates (inert)
+      slug: pendant-of-ates-inert
+      relationship: product
+      description: Inert pendant; dismantle for 100 tears
+    - item_id: 29897
+      item_name: Pendant of Ates
+      slug: pendant-of-ates
+      relationship: product
+      description: Charged teleport pendant powered by frozen tears
+  market_strategy:
+    notes:
+      - "Very high volume (~174k daily); deep liquidity for bulk pendant charging."
+      - "GE price (~293 gp) sits just under high alch (300 gp); marginal alch profit on tax-free sources."
+  trading_tips:
+    - "Bulk buy when pendant demand spikes (post-update or DT2 grinds)."
+    - "Brutal blue dragons (1/32) are the most efficient farming source."
+  history:
+    - date: "2024-09-25"
+      description: "Released with the Varlamore: The Rising Darkness update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/giant-seaweed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/giant-seaweed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Giant seaweed | OSRS Price Data
-description: "Giant seaweed: Seaweed of large size.. High alch: 1 GP, GE limit: 11,000."
+description: "Giant seaweed: Seaweed of large size. High alch: 1 GP, GE limit: 11,000."
 osrs:
   id: 21504
   name: Giant seaweed
@@ -15,35 +15,55 @@ osrs:
   material:
     type: farming_produce
     tier: high
-    tradeable: true
-    stackable: true
-    weight: 0
   farming:
     level: 23
+    seed_id: 21490
+    seed_name: Seaweed spore
     location: Fossil Island seaweed patch
-    yield_min: 3
-    yield_max: 30
     growth_time_minutes: 40
-  uses:
-    - method: Cooking
+    planting_xp: 19
+    harvest_xp: 21
+    yield_min: 3
+  recipes:
+    - skill: cooking
+      materials:
+        - item_name: Giant seaweed
+          item_id: 21504
+          quantity: 1
+      tools:
+        - Fire or range
+      product: Soda ash
       product_id: 1781
-      product_name: Soda ash
       product_quantity: 6
-    - method: Superglass Make
-      requirements:
-        magic: 77
-        spellbook: Lunar
-      product_id: 1775
-      product_name: Molten glass
-      product_quantity: 6
+      members_only: true
+    - skill: magic
+      level: 77
       xp: 78
-      runes:
-        - 2 Astral
-        - 6 Fire
-        - 10 Air
-  market:
-    buy_limit: 11000
-    price_estimate: 130
+      spell: Superglass Make
+      spellbook: Lunar
+      materials:
+        - item_name: Giant seaweed
+          item_id: 21504
+          quantity: 1
+        - item_name: Bucket of sand
+          item_id: 1783
+          quantity: 1
+        - item_name: Astral rune
+          item_id: 9075
+          quantity: 2
+        - item_name: Fire rune
+          item_id: 554
+          quantity: 6
+        - item_name: Air rune
+          item_id: 556
+          quantity: 10
+      tools: []
+      product: Molten glass
+      product_id: 1775
+      product_quantity: 6
+      members_only: true
+  drop_table:
+    sources: []
   related_items:
     - item_id: 21490
       item_name: Seaweed spore
@@ -65,26 +85,41 @@ osrs:
       slug: bucket-of-sand
       relationship: alternative
       description: Superglass partner
-  about: |-
-    | Product | Method |
-    |---------|--------|
-    | Soda ash (6) | Cooking |
-    | Superglass Make | 77 Magic, Lunar |
+  about: Giant seaweed is a Fossil Island farming crop used to produce soda ash and molten glass via Superglass Make.
   market_strategy:
+    title: Glass production demand
     notes:
-      - Best method for molten glass
-      - Underwater farming
-      - High volume demand
-      - Superglass Make spell
-      - Crafting training
-      - Molten glass production
-      - Ironman essentials
-      - 2 patches on Fossil Island
-      - Use seaweed spores
-      - Superglass Make gives bonus glass
-      - Very AFK farming
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Best raw material for Superglass Make
+      - Underwater farming patches on Fossil Island
+      - Use seaweed spores to plant
+      - Superglass Make yields 6 molten glass per seaweed
+      - Very AFK farming activity
+      - High demand from crafters and ironmen
+  trading_tips:
+    - Buy during off-peak hours for resale to glassmakers
+    - Stockpile before bond price spikes
+    - 11,000 buy limit allows bulk operations
+  history:
+    - date: "2017-09-07"
+      description: Released with the Fossil Island expansion.
+    - date: "2023-07-12"
+      description: Item received a graphical update.
+  properties:
+    release_date: "2017-09-07"
+    update: Fossil Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-boots.mdx
@@ -12,9 +12,103 @@ osrs:
   lowalch: 5000
   highalch: 7500
   limit: 8
-  about: "Gilded boots is a members-only item in Old School RuneScape. High alchemy value: 7,500 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: gilded armour
+    tier: rune
+  equipment:
+    slot: feet
+    weight: 1.36
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 12
+      slash: 13
+      crush: 14
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 2
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Elite Treasure Trails
+        quantity: "1"
+        rarity: 1/14662.5
+      - source: Master Treasure Trails
+        quantity: "1"
+        rarity: 1/13616
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+      - master
+  related_items:
+    - item_id: 4131
+      item_name: Rune boots
+      slug: rune-boots
+      relationship: variant
+      description: Standard rune boots with identical combat stats.
+    - item_id: 3486
+      item_name: Gilded full helm
+      slug: gilded-full-helm
+      relationship: set-piece
+      description: Head slot of the gilded armour set.
+    - item_id: 3481
+      item_name: Gilded platebody
+      slug: gilded-platebody
+      relationship: set-piece
+      description: Body slot of the gilded armour set.
+    - item_id: 3483
+      item_name: Gilded platelegs
+      slug: gilded-platelegs
+      relationship: set-piece
+      description: Leg slot of the gilded armour set.
+    - item_id: 3488
+      item_name: Gilded kiteshield
+      slug: gilded-kiteshield
+      relationship: set-piece
+      description: Shield slot of the gilded armour set.
+  about: "Gilded boots are a cosmetic feet-slot reward from Elite and Master clue scrolls that share rune boot stats but require 40 Defence to wear."
+  market_strategy:
+    notes:
+      - Price driven by fashionscape demand rather than combat utility.
+      - Drop rates are extremely rare so supply growth is slow.
+      - Buy limit of 8 keeps the market thin and price-volatile.
+      - Storeable in costume room treasure chest once the matching clue interface is opened.
+  trading_tips:
+    - Track Elite and Master clue meta changes for supply pressure.
+    - Compare against other gilded set pieces for fashionscape rotation value.
+    - Avoid panic selling during short-lived clue scroll events.
+  history:
+    - date: "2014-06-12"
+      description: Added to the game as an Elite and Master clue scroll reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-platebody.mdx
@@ -12,63 +12,111 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
+  material:
+    type: gilded armour
+    tier: rune
   equipment:
     slot: body
-    type: melee armour
-    attack_style: melee
+    weight: 9.979
     requirements:
       defence: 40
-    stats:
-      defence_stab: 82
-      defence_slash: 80
-      defence_crush: 72
-      defence_magic: -6
-      defence_ranged: 80
-      melee_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: Rare
-        description: Rare reward from hard clue scrolls
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 82
+      slash: 80
+      crush: 72
+      magic: -6
+      ranged: 80
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Hard Treasure Trails
+        quantity: "1"
+        rarity: 1/35750
+      - source: Elite Treasure Trails
+        quantity: "1"
+        rarity: 1/32257.5
+      - source: Master Treasure Trails
+        quantity: "1"
+        rarity: 1/149776
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
   related_items:
     - item_id: 3486
       item_name: Gilded full helm
       slug: gilded-full-helm
       relationship: set-piece
-      description: Head slot of gilded set
+      description: Head slot of the gilded armour set.
     - item_id: 3483
       item_name: Gilded platelegs
       slug: gilded-platelegs
       relationship: set-piece
-      description: Leg slot of gilded set
+      description: Leg slot of the gilded armour set.
+    - item_id: 3485
+      item_name: Gilded plateskirt
+      slug: gilded-plateskirt
+      relationship: set-piece
+      description: Skirt alternative for the gilded set.
     - item_id: 3488
       item_name: Gilded kiteshield
       slug: gilded-kiteshield
       relationship: set-piece
-      description: Shield slot of gilded set
-    - item_id: 12389
-      item_name: Gilded scimitar
-      slug: gilded-scimitar
-      relationship: set-piece
-      description: Weapon of gilded set
-  about: |-
-    The gilded platebody is a cosmetic variant of the rune platebody with identical stats but a prestigious golden appearance. It requires 40 Defence to wear.
-
-    Gilded armour is obtained from Treasure Trails and is valued for its appearance rather than stats. It shares the same defensive bonuses as rune armour but costs significantly more due to its rarity and fashionscape appeal.
+      description: Shield slot of the gilded armour set.
+    - item_id: 1127
+      item_name: Rune platebody
+      slug: rune-platebody
+      relationship: variant
+      description: Standard rune platebody with identical combat stats.
+  about: "Gilded platebody is a cosmetic body-slot reward from clue scrolls that mirrors rune platebody stats and requires 40 Defence plus Dragon Slayer I."
   market_strategy:
-    title: Investment Notes
     notes:
-      - Price driven by cosmetic demand
-      - Popular for fashionscape and showing off
-      - More accessible than 3rd age but still valuable
-      - Compare prices with rune equivalent for value assessment
-      - Watch for dips after clue scroll events
-      - Popular with free-to-play players for fashion
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Price driven by cosmetic and fashionscape demand.
+      - More accessible than 3rd age while still carrying a premium look.
+      - Buy limit of 8 keeps the market thin and price-volatile.
+      - Watch for dips after clue scroll events flood supply.
+  trading_tips:
+    - Compare against rune platebody as a price-to-prestige benchmark.
+    - Free-to-play accessibility broadens the buyer base versus members-only gilded gear.
+    - Stockpile during clue droughts before broadcast-worthy clue events.
+  history:
+    - date: "2004-10-26"
+      description: Added to the game with the Treasure Trails update.
+    - date: "2016-05-05"
+      description: Became available to free-to-play players.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-26"
+    update: Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    quest: "Dragon Slayer I"
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/granite-hammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/granite-hammer.mdx
@@ -12,12 +12,17 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
+  material:
+    type: granite
+    tier: high
   equipment:
     slot: weapon
-    weapon_type: hammer
+    weapon_type: blunt
     weight: 5
     attack_speed: 4
-    attack_range: 1
+    requirements:
+      attack: 50
+      strength: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -35,26 +40,16 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 50
-      strength: 50
   special_attack:
     name: Hammer Blow
     energy: 60
-    description: Deals 10% more damage with 50% increased accuracy
-    damage_modifier: 1.1
+    description: "Costs 60% special energy: 50% increased accuracy with a guaranteed minimum damage of 5, except against immune NPCs."
     accuracy_modifier: 1.5
   drop_table:
-    primary_source: Grotesque Guardians
-    best_drop_rate: 2/750
     sources:
       - source: Grotesque Guardians
-        source_id: 7851
-        combat_level: 228
         quantity: "1"
-        rarity: rare
-        drop_rate: 2/750
-        members_only: true
+        rarity: 2/750
   related_items:
     - item_id: 21736
       item_name: Granite gloves
@@ -76,29 +71,38 @@ osrs:
       slug: granite-maul
       relationship: alternative
       description: Different granite weapon
-  about: |-
-    Special properties:
-    - Acts as rock hammer (auto-finishes Gargoyles)
-    - 30% damage and accuracy bonus vs golems
-    - 4-tick attack speed (same as scimitar)
-
-    Special attack - Hammer Blow:
-    - 60% special energy
-    - 10% increased damage
-    - 50% increased accuracy
-
-    Combat comparison:
-    - Lower DPS than Dragon scimitar
-    - Useful for Gargoyle tasks
-    - Convenient for finishing blows
+  about: "Granite hammer is a one-handed crush weapon dropped by Grotesque Guardians; it acts as a rock hammer for Gargoyle finishers, has a 4-tick attack speed, and its Hammer Blow special attack costs 60% energy for a guaranteed minimum 5 damage with 50% accuracy bonus."
   market_strategy:
     notes:
-      - Quality of life for Gargoyle tasks
-      - Saves inventory space (no rock hammer)
-      - Niche PvM use for golem creatures
-      - Part of Grotesque Guardian collection
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Quality of life for Gargoyle slayer tasks
+      - Saves an inventory slot vs carrying a rock hammer
+      - Niche PvM use against golem-type creatures with Golembane
+      - Part of the Grotesque Guardian unique drop collection
+  history:
+    - date: "2017-10-26"
+      update: Grotesque Guardians
+      description: Granite hammer added as a unique drop from the Grotesque Guardians slayer boss.
+    - date: "2025-08-27"
+      description: Gained a 30% Golembane damage bonus against golem-type creatures, stacking multiplicatively with slayer helmet bonuses.
+  properties:
+    release_date: "2017-10-26"
+    update: Grotesque Guardians
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 5
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/greenman-s-ale-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/greenman-s-ale-flatpack.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Greenman's ale (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: construction
+      level: 26
+      xp: 184
+      materials:
+        - item_name: Oak plank
+          item_id: 8778
+          quantity: 3
+        - item_name: Greenman's ale
+          item_id: 1909
+          quantity: 8
+      tools:
+        - Hammer
+        - Saw
+      product: Greenman's ale (flatpack)
+      product_id: 8522
+  related_items:
+    - item_id: 1909
+      item_name: Greenman's ale
+      slug: greenmans-ale
+      relationship: component
+      description: Source ale used in the flatpack
+    - item_id: 8778
+      item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: Construction plank required for assembly
+  about: "Greenman's ale (flatpack) is a flatpacked Greenman's barrel built at an Oak workbench in a player-owned house Workshop, requiring level 26 Construction; the resulting flatpack can be placed in the Kitchen Barrel hotspot or sold on the Grand Exchange."
+  market_strategy:
+    notes:
+      - Profitable Construction-to-GE flip when oak planks are cheap
+      - Buy limit of 500 caps short term flipping per 4 hours
+      - Low daily volume means large batches sell slowly
+  history:
+    - date: "2006-05-31"
+      update: Player-Owned Houses
+      description: Greenman's ale (flatpack) added with the Player-Owned Houses update.
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/greenman-s-ale-m.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/greenman-s-ale-m.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Greenman's ale(m) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: beer
+    tier: mature
+  potion:
+    effects:
+      - description: "Boosts Herblore by 2 levels."
+      - description: "Drains Attack by 2 levels."
+      - description: "Drains Strength by 2 levels."
+      - description: "Restores 2 Hitpoints."
+  recipes:
+    - skill: cooking
+      level: 29
+      experience: 281
+      materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Harralander
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Beer glass
+          quantity: 8
+      tools:
+        - Brewing vat
+      product: Greenman's ale(m)
+  related_items:
+    - item_id: 1909
+      item_name: Greenman's ale
+      slug: greenman-s-ale
+      relationship: variant
+      description: Standard non-mature version of the brew.
+    - item_id: 5741
+      item_name: Harralander
+      slug: harralander
+      relationship: component
+      description: Key herb used during brewing.
+  about: "Greenman's ale(m) is a mature ale brewed at Cooking level 29 that gives a temporary +2 Herblore boost in exchange for Attack and Strength drains."
+  market_strategy:
+    notes:
+      - Demand spikes around Herblore boost requirements for high-level potion mixing.
+      - 5% maturation chance (64% with the stuff) limits supply per brewing batch.
+      - Buy limit of 2,000 supports mid-volume flipping during Herblore content updates.
+  trading_tips:
+    - Stockpile before major Herblore boosts are needed for clue scrolls or quests.
+    - Price tracks Herblore boost meta and DIY ironman brewing rates.
+    - Mature variant carries a premium over the regular Greenman's ale.
+  history:
+    - date: "2005-07-11"
+      description: Added to the game with the Farming update as a mature ale brewing reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-harralander.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-harralander.mdx
@@ -1,6 +1,6 @@
 ---
 title: Grimy harralander | OSRS Price Data
-description: "Grimy harralander: It needs cleaning.. High alch: 9 GP, GE limit: 13,000."
+description: "Grimy harralander: It needs cleaning. High alch: 9 GP, GE limit: 13,000."
 osrs:
   id: 205
   name: Grimy harralander
@@ -12,8 +12,8 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 13000
-  herb:
-    type: grimy
+  material:
+    type: grimy_herb
     tier: low
   herblore:
     cleaning_level: 20
@@ -27,16 +27,20 @@ osrs:
   drop_table:
     sources:
       - source: Chaos druid
-        source_id: 181
-        combat_level: 13
         quantity: "1"
-        rarity: common
-        members_only: true
+        rarity: "1/25.4"
+      - source: Banshee
+        quantity: "1"
+        rarity: "1/34.4"
+      - source: Fire giant
+        quantity: "1"
+        rarity: "1/61.6"
+      - source: Green dragon
+        quantity: "1"
+        rarity: "1/78"
       - source: Master Farmer
-        source_id: 5730
         quantity: "1"
         rarity: rare
-        members_only: true
   related_items:
     - item_id: 255
       item_name: Harralander
@@ -52,29 +56,48 @@ osrs:
       item_name: Energy potion(4)
       slug: energy-potion-4
       relationship: product
-      description: End product
+      description: End potion product
     - item_id: 5294
       item_name: Harralander seed
       slug: harralander-seed
       relationship: component
       description: Farming seed
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Grimy Herb |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-    | Herblore Level | 20 (to clean) |
-
-    Clean to produce harralander for Herblore.
-
-    Harralander used for:
-    - Compost potion
-    - Restore potion
-    - Energy potion
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Mid-tier grimy herb cleaned at 20 Herblore for 6.3 XP into harralander, used in compost, restore, and energy potions.
+  market_strategy:
+    title: Herb cleaning margin
+    notes:
+      - Clean from grimy to clean version for instant profit
+      - Bulk Chaos druid drops feed the supply
+      - Master Farmer pickpocketing alternative source
+      - Steady demand from Herblore trainers
+  trading_tips:
+    - Watch grimy vs clean spread for cleaning profit
+    - Buy during raid metas dropping potion demand
+    - 13,000 buy limit per 4 hours
+  history:
+    - date: "2002-02-27"
+      description: Item released with Old School RuneScape launch herbs.
+    - date: "2015-01-01"
+      description: Graphic updated to better distinguish from other grimy herbs.
+    - date: "2017-01-01"
+      description: Shop value increased from 1 to 16 coins.
+  properties:
+    release_date: "2002-02-27"
+    update: Herblore
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guam-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guam-seed.mdx
@@ -9,11 +9,11 @@ osrs:
   members: true
   icon: Guam seed 5.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 600
-  seed:
-    type: herb
+  material:
+    type: herb-seed
     tier: low
   farming:
     level: 9
@@ -28,44 +28,50 @@ osrs:
       item_name: Grimy guam leaf
       slug: grimy-guam-leaf
       relationship: product
-      description: Harvested product
+      description: Harvested grimy herb
     - item_id: 249
       item_name: Guam leaf
       slug: guam-leaf
       relationship: product
-      description: Cleaned herb
+      description: Cleaned herb after grimy
     - item_id: 91
       item_name: Attack potion(4)
       slug: attack-potion-4
       relationship: product
-      description: Made from guam
+      description: Final Herblore potion using guam
     - item_id: 5292
       item_name: Marrentill seed
       slug: marrentill-seed
       relationship: upgrade
       description: Next tier herb seed
-  about: |-
-    Plant in a herb patch to grow Grimy guam leaf.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 9 |
-    | Growth time | 80 minutes |
-    | XP (plant) | 11 |
-    | XP (harvest) | 12.5 per herb |
+  about: "Entry-tier herb seed planted in herb patches to grow Grimy guam leaf, supporting beginner Farming and low-level Herblore potions."
   market_strategy:
     notes:
-      - Beginner herb seed for new farmers
-      - Low value but good for learning herb runs
-      - Used in many low-level potions
-      - Ultracompost (essential)
-      - Magic secateurs (10% more yield)
-      - Farming cape (5% more yield)
-      - 9 herb patches available
-      - ~10 minute runs, 80 minute regrowth
-      - Good for ironman accounts starting out
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Beginner herb seed primarily used by new farmers and Ironmen
+      - Magic secateurs and Farming cape boost yield per patch
+      - Demand stays moderate due to abundant seed drops and ~80 minute regrowth
+  trading_tips:
+    - Buy in bulk when Master Farmer thieving output floods supply
+    - Pair with low-tier potion runs to lock in Herblore XP value
+  history:
+    - date: "2005-06-06"
+      description: Added to the game as part of the Farming skill release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-06-06"
+    update: Farming Skill
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/halloween-mask-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/halloween-mask-set.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 5
-  about: "Halloween mask set is a free-to-play item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: holiday
+  related_items:
+    - item_id: 1057
+      item_name: Red halloween mask
+      slug: red-halloween-mask
+      relationship: component
+      description: Red mask packaged inside the set.
+    - item_id: 1053
+      item_name: Green halloween mask
+      slug: green-halloween-mask
+      relationship: component
+      description: Green mask packaged inside the set.
+    - item_id: 1055
+      item_name: Blue halloween mask
+      slug: blue-halloween-mask
+      relationship: component
+      description: Blue mask packaged inside the set.
+  about: "Halloween mask set bundles the red, green and blue Halloween masks together, awarded as noted set drops during multiple Halloween holiday events."
+  market_strategy:
+    notes:
+      - Supply is fixed - issued only during specific Halloween events from 2015 onwards.
+      - Buy limit of 5 per 4 hours keeps the set thin on the Grand Exchange.
+      - Set trades at a premium to the sum of individual masks during low-supply windows.
+  trading_tips:
+    - Track each mask price individually to spot arbitrage versus opening the set.
+    - Hold during off-season; events that drop sets can compress the premium temporarily.
+  history:
+    - date: "2015-03-19"
+      description: Introduced with the Boss Pets, Sets, Chat & More update.
+    - date: "2015-10-29"
+      description: First awarded as noted reward during the 2015 Halloween event.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-03-19"
+    update: Boss Pets, Sets, Chat & More
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ham-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ham-robe.mdx
@@ -5,38 +5,95 @@ osrs:
   id: 4300
   name: Ham robe
   slug: ham-robe
-  examine: The label says 'Vivid Crimson', but it looks pink to me!
+  examine: "The label says 'Vivid Crimson', but it looks pink to me!"
   members: true
   icon: Ham robe.png
   value: 75
   lowalch: 30
   highalch: 45
   limit: 15
+  material:
+    type: cloth
+    tier: low
   equipment:
     slot: legs
-    requirements: {}
+    weapon_type: none
+    weight: 0.907
+    requirements:
+      none: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: H.A.M. Member (pickpocket)
+        thieving_level: 15
+        quantity: "1"
+        rarity: uncommon
+      - source: H.A.M. Guard
+        quantity: "1"
+        rarity: uncommon
   related_items:
     - item_id: 4302
       item_name: Ham hood
       slug: ham-hood
       relationship: set-piece
-      description: H.A.M. head piece
+      description: H.A.M. head piece in the same robe set.
     - item_id: 4298
       item_name: Ham shirt
       slug: ham-shirt
       relationship: set-piece
-      description: H.A.M. body piece
+      description: H.A.M. body piece worn with the robe.
     - item_id: 4304
       item_name: Ham cloak
       slug: ham-cloak
       relationship: set-piece
-      description: H.A.M. cape piece
-  about: |-
-    > *"The label says 'Vivid Crimson', but it looks pink to me!"*
-
-    The ham robe is the legs piece of the H.A.M. (Humans Against Monsters) robes set. Wearing more pieces reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing. A members-only item with no combat stats.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: H.A.M. cape piece completing the disguise.
+  about: "Ham robe is the legs piece of the H.A.M. uniform; wearing more set pieces lowers the ejection chance when pickpocketing inside the Hideout."
+  market_strategy:
+    notes:
+      - Supply driven by pickpocket and H.A.M. Guard drops alongside Death to the Dorgeshuun rewards.
+      - Buy limit of 15 per 4 hours keeps margins thin and inventory turnover slow.
+      - Demand jumps from ironmen building the full H.A.M. ejection-reduction set.
+  trading_tips:
+    - Bundle with hood, shirt and cloak to resell as a complete H.A.M. set.
+    - Stay below high alch when bidding so worst-case losses are capped.
+  history:
+    - date: "2005-02-22"
+      description: Released with the Wilderness Capes, and Changes update as part of the H.A.M. outfit.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-22"
+    update: Wilderness Capes, and Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-crossbow-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-crossbow-0.mdx
@@ -1,6 +1,6 @@
 ---
 title: Karil's crossbow 0 | OSRS Price Data
-description: "Karil's crossbow 0: Karil the Tainted's repeating crossbow.. High alch: 96,000 GP, GE limit: 15."
+description: "Karil's crossbow 0: Karil the Tainted's repeating crossbow. High alch: 96,000 GP, GE limit: 15."
 osrs:
   id: 4938
   name: Karil's crossbow 0
@@ -12,9 +12,102 @@ osrs:
   lowalch: 64000
   highalch: 96000
   limit: 15
-  about: "Karil's crossbow 0 is a members-only item in Old School RuneScape. High alchemy value: 96,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: barrows_equipment
+    tier: high
+  equipment:
+    slot: 2h
+    weapon_type: crossbow
+    attack_speed: 4
+    weight: 3.628
+    requirements:
+      ranged: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 84
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      ranged_strength: 0
+  charges:
+    type: degradation
+    current: 0
+    max: 1
+    repair_cost: 100000
+    notes: Fully degraded; repair at NPC armour stand for up to 100,000 GP based on Smithing level.
+  drop_table:
+    sources:
+      - source: Barrows chest
+        quantity: "1"
+        rarity: "1/2448"
+  related_items:
+    - item_id: 4734
+      item_name: Karil's crossbow
+      slug: karil-s-crossbow
+      relationship: variant
+      description: Fully repaired version
+    - item_id: 4940
+      item_name: Karil's crossbow 25
+      slug: karil-s-crossbow-25
+      relationship: variant
+      description: Partially degraded version
+    - item_id: 4942
+      item_name: Karil's crossbow 50
+      slug: karil-s-crossbow-50
+      relationship: variant
+      description: Partially degraded version
+    - item_id: 4944
+      item_name: Karil's crossbow 75
+      slug: karil-s-crossbow-75
+      relationship: variant
+      description: Partially degraded version
+    - item_id: 4736
+      item_name: Karil's crossbow (broken)
+      slug: karil-s-crossbow-broken
+      relationship: variant
+      description: Fully broken state
+  about: Fully degraded Karil's repeating crossbow with 0 charges; requires NPC or armour-stand repair before reuse.
+  market_strategy:
+    title: Karil's repair flip
+    notes:
+      - Buy at 0 charges discount and repair via POH armour stand
+      - 100,000 GP NPC repair caps full cost
+      - Demand tracks Barrows set ranged meta
+      - GE limit of only 15 per 4 hours
+  trading_tips:
+    - Watch fully-charged Karil's price as upper bound
+    - Use 70+ Smithing for cheaper armour stand repair
+    - Light daily volume — expect overnight fills
+  history:
+    - date: "2005-05-09"
+      description: Released with the Barrows update.
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Check
+      - Remove
+    alchable: true
+    destroy: "If you drop this item it will break. Are you sure you want to drop it?"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kourend-castle-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kourend-castle-teleport-tablet.mdx
@@ -9,12 +9,79 @@ osrs:
   members: true
   icon: Kourend castle teleport (tablet).png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: null
-  about: "Kourend castle teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: teleport_tablet
+    tier: basic
+  teleport:
+    destination: Kourend Castle courtyard
+    type: tablet
+    requirements: Completion of Client of Kourend
+  recipes:
+    - skill: magic
+      level: 48
+      xp: 58
+      materials:
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Water rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 1
+        - item_name: Soft clay
+          quantity: 1
+      tools:
+        - Teak lectern
+        - Mahogany lectern
+        - Marble lectern
+      product: Kourend castle teleport (tablet)
+      members_only: true
+  related_items:
+    - item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: Required rune for making the tablet
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Required base material
+    - item_name: Civitas illa fortis teleport (tablet)
+      slug: civitas-illa-fortis-teleport-tablet
+      relationship: alternative
+      description: Similar regional teleport tablet
+  about: The Kourend castle teleport tablet is a single-use teleport to the Kourend Castle courtyard, crafted at a player-owned house lectern after completing Client of Kourend.
+  market_strategy:
+    notes:
+      - Cheap utility teleport with niche demand
+      - Useful for Slayer tasks and farming runs around Kourend
+      - Supply driven by Construction profit flippers
+  trading_tips:
+    - Stock up during Construction training spikes
+    - Check Mahogany Homes activity for supply changes
+  history:
+    - date: "2024-01-10"
+      description: Kourend castle teleport tablet introduced with the Children of the Sun update.
+    - date: "2025-05-29"
+      description: Standard teleport tablets exempted from the Grand Exchange convenience fee.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-01-10"
+    update: Children of the Sun
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lava-scale-shard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lava-scale-shard.mdx
@@ -12,62 +12,88 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 11000
-  item:
+  material:
     type: herblore secondary
-    tradeable: true
-    weight: 0
+    tier: lava scale
   recipes:
     - skill: herblore
       level: 84
       materials:
-        - item_id: 2454
-          item_name: Antifire potion
+        - item_name: Antifire potion
           quantity: 1
-        - item_id: 11994
-          item_name: Lava scale shard
+        - item_name: Lava scale shard
           quantity: 1
-      product: Extended antifire
-      product_id: 11951
+      tools:
+        - Hands
+      product: Extended antifire (per dose)
     - skill: herblore
       level: 98
       materials:
-        - item_id: 21978
-          item_name: Super antifire
+        - item_name: Super antifire potion
           quantity: 1
-        - item_id: 11994
-          item_name: Lava scale shard
+        - item_name: Lava scale shard
           quantity: 1
-      product: Extended super antifire
-      product_id: 22209
+      tools:
+        - Hands
+      product: Extended super antifire (per dose)
+  drop_table:
+    sources:
+      - source: Lava scale (pestle and mortar)
+        quantity: "1"
+        rarity: Always (3-6 shards)
+      - source: Infernal eel (hammer)
+        quantity: "1"
+        rarity: 1/8.75 (1-5 shards)
   related_items:
     - item_id: 11992
       item_name: Lava scale
       slug: lava-scale
       relationship: component
-      description: Raw material ground into shards
+      description: Raw scale ground with a pestle and mortar to produce shards.
     - item_id: 11951
       item_name: Extended antifire
       slug: extended-antifire
       relationship: product
-      description: Primary potion created with shards
+      description: Primary potion created with shards at 84 Herblore.
+    - item_id: 22209
+      item_name: Extended super antifire
+      slug: extended-super-antifire
+      relationship: product
+      description: High-end potion created with shards at 98 Herblore.
     - item_id: 21357
       item_name: Infernal eel
       slug: infernal-eel
       relationship: alternative
-      description: Alternative source for shards
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Herblore Secondary |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-
-    Secondary ingredient for:
-    - Extended antifire (with antifire potion)
-    - Extended super antifire (with super antifire)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Alternative source for shards via hammer cracking.
+  about: "Lava scale shard is a Herblore secondary produced by grinding lava scales or cracking infernal eels, used per dose for extended antifire potions at 84 Herblore and extended super antifire at 98."
+  market_strategy:
+    notes:
+      - Buy limit of 11,000 enables large-volume flipping.
+      - Demand tracks Vorkath and dragon slayer Herblore consumption.
+      - Hard Wilderness Diary boosts yield by 50%, increasing supply over time.
+  trading_tips:
+    - Stockpile before raid metas that boost extended antifire usage.
+    - Watch lava dragon and brutal black dragon kill trends for supply pressure.
+    - Compare against infernal eel cooking margins for break-even calculations.
+  history:
+    - date: "2014-03-27"
+      description: Added to the game alongside extended antifire potions.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-03-27"
+    update: Extended Antifires
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lily-of-the-sands.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lily-of-the-sands.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 13000
-  about: "Lily of the sands is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Tombs of Amascut reward chest
+        quantity: "1-46 (noted)"
+        rarity: "3 x 1/27"
+  recipes:
+    - skill: herblore
+      level: 88
+      xp: 200
+      materials:
+        - item_name: Lily of the sands
+          item_id: 27272
+          quantity: 1
+        - item_name: Dwarf weed potion (unf)
+          item_id: 119
+          quantity: 1
+      tools:
+        - Vial
+      product: Menaphite remedy(3)
+      product_id: 27279
+  related_items:
+    - item_id: 27279
+      item_name: Menaphite remedy(3)
+      slug: menaphite-remedy-3
+      relationship: product
+      description: Herblore product (88 Herblore, 200 XP)
+    - item_id: 27281
+      item_name: Menaphite remedy(4)
+      slug: menaphite-remedy-4
+      relationship: product
+      description: Four-dose variant of the remedy
+  about: "Tombs of Amascut secondary used at 88 Herblore (200 XP) with unfinished dwarf weed potion to make Menaphite remedy — the standard restore + heal potion for ToA scaling."
+  market_strategy:
+    notes:
+      - Supply tied to ToA completion rate
+      - Demand from late-game Herblore training
+      - Tracks Menaphite remedy price closely
+      - Watch raid balance patches
+  trading_tips:
+    - Buy after ToA nerfs when chest yields drop
+    - Sell during XP boost events (Bonus XP / Leagues)
+  history:
+    - date: "2025-04-30"
+      update: Reagent Pouch Fix
+      description: Lily of the sands is now correctly used from the reagent pouch when making Menaphite remedies.
+    - date: "2022-08-24"
+      update: Tombs of Amascut
+      description: Released with the Tombs of Amascut raid as a chest reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-08-24"
+    update: Tombs of Amascut
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.003
+    options:
+      - Drop
+    alchable: true
+    quest_item: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-longbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-longbow.mdx
@@ -12,9 +12,16 @@ osrs:
   lowalch: 1024
   highalch: 1536
   limit: 18000
+  material:
+    type: bow
+    tier: high
   equipment:
     slot: weapon
+    weapon_type: bow
+    attack_speed: 6
     weight: 1.814
+    requirements:
+      ranged: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,27 +39,22 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 50
-    attack_speed: 6
+  special_attack:
+    name: Powershot
+    description: Increased accuracy and damage on a single shot.
   recipes:
     - skill: fletching
       level: 85
       xp: 91.5
       materials:
         - item_name: Magic longbow (u)
-          item_id: 64
           quantity: 1
         - item_name: Bow string
-          item_id: 1777
           quantity: 1
+      tools:
+        - Knife
       product: Magic longbow
-      product_id: 859
-      product_quantity: 1
       members_only: true
-  alchemy:
-    high: 1536
-    low: 1024
   related_items:
     - item_id: 64
       item_name: Magic longbow (u)
@@ -69,48 +71,47 @@ osrs:
       slug: bow-string
       relationship: component
       description: Required for stringing
-    - item_id: 561
-      item_name: Nature rune
-      slug: nature-rune
-      relationship: component
-      description: For High Alchemy
     - item_id: 855
       item_name: Yew longbow
       slug: yew-longbow
-      relationship: alternative
+      relationship: downgrade
       description: Lower tier alternative
-  about: |-
-    String a Magic longbow (u) with a Bow string.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Fletching Level | 85 |
-    | XP gained | 91.5 |
-
-    | Alch Type | Value |
-    |-----------|-------|
-    | High Alch | 1,536 GP |
-    | Low Alch | 1,024 GP |
+  about: The magic longbow is a two-handed bow that requires 50 Ranged to wield and is fletched by stringing a magic longbow (u) at 85 Fletching for 91.5 experience.
   market_strategy:
-    title: Full Processing Chain
-    steps:
-      - order: 1
-        action: Magic logs → Magic longbow (u) → Magic longbow → High Alch
-      - order: 2
-        action: "Total cost: Magic log + Bow string + Nature rune"
-      - order: 3
-        action: "Revenue: 1,536 GP"
-    profit_formulas:
-      - 1,536 - Magic longbow price - Nature rune price = Profit
     notes:
-      - "High Alch value: **1,536 GP**"
-      - "Calculate:"
+      - "High Alch value: 1,536 GP"
       - Higher profit per alch than yew longbows
       - "Buy limit: 18,000 per 4 hours"
       - Less competition than yew longbows
       - Good for high-level fletchers
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Buy magic logs and bow string in bulk for fletching margins
+    - Check daily volume before flipping
+    - Compare alch profit against nature rune price
+  history:
+    - date: "2002-03-25"
+      description: Magic longbow added to the game.
+    - date: "2004-06-14"
+      description: The item was given a special attack, Powershot.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-25"
+    update: Latest RuneScape News
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-string.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-string.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Magic string is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: crafting material
+    tier: magic
+  recipes:
+    - skill: crafting
+      level: 19
+      experience: 30
+      materials:
+        - item_name: Magic root
+          quantity: 1
+      tools:
+        - Spinning wheel
+      product: Magic string
+    - skill: crafting
+      level: 50
+      materials:
+        - item_name: Emerald amulet (u)
+          quantity: 1
+        - item_name: Magic string
+          quantity: 1
+      tools:
+        - Hands
+      product: Pre-nature amulet
+  related_items:
+    - item_id: 6037
+      item_name: Magic root
+      slug: magic-root
+      relationship: component
+      description: Spun on a spinning wheel to create magic string.
+    - item_id: 1673
+      item_name: Emerald amulet (u)
+      slug: emerald-amulet-u
+      relationship: component
+      description: Combined with magic string to make the pre-nature amulet.
+    - item_id: 6040
+      item_name: Amulet of nature
+      slug: amulet-of-nature
+      relationship: product
+      description: Enchanted final form of the pre-nature amulet.
+  about: "Magic string is a members-only Crafting material spun from a magic root on a spinning wheel at level 19 Crafting, granting 30 experience."
+  market_strategy:
+    notes:
+      - Demand driven by amulet of nature crafting for farming patch notifications.
+      - Supply tied to Woodcutting magic tree availability and magic root drops.
+      - Buy limit of 11,000 makes it suitable for high-volume flipping.
+      - Profit margin tracks the gap between magic root cost and finished amulet price.
+  trading_tips:
+    - Watch magic root prices to anticipate magic string supply shifts.
+    - Most profitable when batched with amulet of nature production for crafting XP.
+    - Stockpile during low-demand periods before farming content updates.
+  history:
+    - date: "2005-07-11"
+      description: Added to the game with the Farming update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.014
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-toy-box-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-toy-box-flatpack.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Mahogany toy box (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: high
+  construction:
+    level: 86
+    xp: 280
+    builds: Mahogany toy box (costume room)
+  recipes:
+    - skill: construction
+      level: 86
+      xp: 280
+      materials:
+        - item_name: Mahogany plank
+          item_id: 8782
+          quantity: 2
+      product: Mahogany toy box (flatpack)
+      product_id: 9851
+      product_quantity: 1
+      tools:
+        - Hammer
+        - Saw
+      notes: Crafted at a workbench with lathe inside a Player-owned House workshop.
+      members_only: true
+  related_items:
+    - item_id: 8782
+      item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Required material for crafting the flatpack.
+    - item_id: 9853
+      item_name: Magical cape rack (flatpack)
+      slug: magical-cape-rack-flatpack
+      relationship: alternative
+      description: Higher-tier costume room flatpack on the same workbench.
+    - item_id: 9849
+      item_name: Toy box (flatpack)
+      slug: toy-box-flatpack
+      relationship: downgrade
+      description: Teak-tier costume room toy box flatpack.
+  about: "Mahogany toy box (flatpack) is crafted at 86 Construction from 2 mahogany planks on a workbench with lathe and assembles into the costume room toy box."
+  market_strategy:
+    notes:
+      - Supply comes from high-level Construction players bulk-making flatpacks for XP.
+      - Buy limit of 500 per 4 hours suits mid-volume flips.
+      - Demand grows with costume room build-outs and Construction goals around 80-90.
+  trading_tips:
+    - Compare against mahogany plank cost to spot favourable buyout windows.
+    - List into builder bursts when Construction Sundays or DXP drive flatpack consumption.
+  history:
+    - date: "2006-10-18"
+      description: Added alongside the Costume Room player-owned house update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-10-18"
+    update: Costume Room
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/meat-pizza.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/meat-pizza.mdx
@@ -12,9 +12,96 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 10000
-  about: "Meat pizza is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: low
+  food:
+    heals: 16
+    bites: 2
+    bite_heal: 8
+    consume_ticks: 2
+  recipes:
+    - skill: cooking
+      level: 45
+      xp: 26
+      materials:
+        - item_name: Plain pizza
+          item_id: 2289
+          quantity: 1
+        - item_name: Cooked meat
+          item_id: 2142
+          quantity: 1
+      product: Meat pizza
+      product_id: 2293
+      product_quantity: 1
+      notes: Cooked chicken substitutes for cooked meat with identical results.
+    - skill: cooking
+      level: 45
+      xp: 26
+      materials:
+        - item_name: Plain pizza
+          item_id: 2289
+          quantity: 1
+        - item_name: Cooked chicken
+          item_id: 2140
+          quantity: 1
+      product: Meat pizza
+      product_id: 2293
+      product_quantity: 1
+  related_items:
+    - item_id: 2289
+      item_name: Plain pizza
+      slug: plain-pizza
+      relationship: component
+      description: Base pizza topped to make a meat pizza.
+    - item_id: 2295
+      item_name: 1/2 meat pizza
+      slug: half-meat-pizza
+      relationship: variant
+      description: Half-eaten remnant after the first bite.
+    - item_id: 2297
+      item_name: Anchovy pizza
+      slug: anchovy-pizza
+      relationship: alternative
+      description: Same cooking tree, lower healing tier.
+    - item_id: 2301
+      item_name: Pineapple pizza
+      slug: pineapple-pizza
+      relationship: upgrade
+      description: Higher-tier pizza built from the same plain base.
+  about: "Meat pizza is a free-to-play two-bite food made at 45 Cooking from a plain pizza topped with cooked meat or chicken, healing 16 hitpoints total."
+  market_strategy:
+    notes:
+      - Supply comes from F2P cooks topping plain pizzas at 45 Cooking.
+      - Buy limit of 10,000 per 4 hours supports bulk midgame food flipping.
+      - Demand stays niche compared to monkfish or sharks since pineapple pizza dominates the line.
+  trading_tips:
+    - Watch plain pizza and cooked meat spreads to time profitable cook-ups.
+    - Stack against pineapple pizza margins before committing to bulk pizza production.
+  history:
+    - date: "2001-06-11"
+      description: Added with the new fishing skill and more cooking update.
+    - date: "2014-12-15"
+      description: Pizza halves became recombinable into a full pizza again.
+    - date: "2015-02-09"
+      description: Half-eaten pizzas became untradeable on the Grand Exchange.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-06-11"
+    update: New fishing skill and more cooking
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.9
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-red-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-red-hat.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 150
-  about: "Menaphite red hat is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic clothing
+    tier: menaphite
+  equipment:
+    slot: head
+    weight: 0.005
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Ali's Discount Wares"
+      location: Al Kharid
+      price: 35
+  related_items:
+    - item_id: 6402
+      item_name: Menaphite red top
+      slug: menaphite-red-top
+      relationship: set-piece
+      description: Torso piece of the red Menaphite outfit.
+    - item_id: 6404
+      item_name: Menaphite red robe
+      slug: menaphite-red-robe
+      relationship: set-piece
+      description: Robe piece of the red Menaphite outfit.
+    - item_id: 6406
+      item_name: Menaphite red kilt
+      slug: menaphite-red-kilt
+      relationship: set-piece
+      description: Kilt piece of the red Menaphite outfit.
+    - item_id: 6392
+      item_name: Menaphite purple hat
+      slug: menaphite-purple-hat
+      relationship: variant
+      description: Purple-coloured variant of the same hat.
+  about: "Menaphite red hat is a cosmetic head-slot item sold by Ali's Discount Wares that adds 12 seconds of desert heat resistance for desert travel."
+  market_strategy:
+    notes:
+      - Steady shop supply at 35 coins caps how high the GE price can climb.
+      - Demand driven by fashionscape and quest-related desert outfits.
+      - Buy limit of 150 makes flipping easy but margins thin.
+  trading_tips:
+    - Flip the gap between shop price and GE price during fashionscape trends.
+    - Pairs well with full red Menaphite outfit listings.
+    - Useful filler for desert quest playthroughs to delay heat damage.
+  history:
+    - date: "2005-08-15"
+      description: Added to the game with the Rogue Trader miniquest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-15"
+    update: Rogue Trader
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-seeds.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-seeds.mdx
@@ -12,13 +12,67 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 18000
-  related_items: []
-  about: |-
-    > _"Magical seeds in a mithril case."_
-
-    Mithril seeds force the player one tile when planted, growing into random flowers. Used in PvP to move while frozen. Can also be used to grief Hunter and Firemaking spots by blocking tile placement.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  drop_table:
+    sources:
+      - source: Master Farmer (Pickpocket)
+        quantity: "1"
+        rarity: common
+      - source: Martin the Master Gardener (Pickpocket)
+        quantity: "1"
+        rarity: common
+      - source: Hard clue scroll casket
+        quantity: "5"
+        rarity: uncommon
+  shops:
+    - shop_name: Shop of Useful Items
+      location: Legends' Guild
+      price: 300
+      stock: 6
+      currency: Coins
+      members_only: true
+  related_items:
+    - item_id: 5096
+      item_name: Marigold seed
+      slug: marigold-seed
+      relationship: alternative
+      description: Real flower-patch seed alternative
+  about: "Plant to force one tile of movement (cycling N/E/S/W) and grow a random colour flower — abused in PvP to escape freezes and to grief Hunter and Firemaking spots."
+  market_strategy:
+    notes:
+      - Steady Pickpocket Master Farmer supply
+      - Niche PvP demand (escape-freeze trick)
+      - Bulk flips around DMM and Leagues
+      - Quest reward (40 seeds) from Waterfall Quest
+  history:
+    - date: "2021-01-13"
+      update: Deadman Reborn
+      description: Re-enabled planting in banks and Grand Exchange on Deadman worlds.
+    - date: "2016-04-07"
+      update: Elemental Workshop Fixes
+      description: Can no longer be planted in the upper level of the Elemental Workshop.
+    - date: "2013-03-18"
+      update: Mithril Seed Plant Update
+      description: Flowers planted from seeds now always grow as mixed flowers to remove gambling exploits.
+    - date: "2002-09-24"
+      update: Tutorial Island
+      description: Item added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-09-24"
+    update: Tutorial Island
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    weight: 0
+    options:
+      - Plant
+      - Drop
+    alchable: true
+    quest_item: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/morrigan-s-leather-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/morrigan-s-leather-chaps.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 10
-  about: "Morrigan's leather chaps is a members-only item in Old School RuneScape. High alchemy value: 300,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: leather
+    tier: high
+  equipment:
+    slot: legs
+    weight: 5.443
+    requirements:
+      defence: 78
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 23
+    defence_bonus:
+      stab: 18
+      slash: 15
+      crush: 20
+      magic: 46
+      ranged: 22
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 6
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Morrigan's leather body
+      slug: morrigan-s-leather-body
+      relationship: set-piece
+      description: Body slot of the Morrigan's ranged set
+    - item_name: Morrigan's coif
+      slug: morrigan-s-coif
+      relationship: set-piece
+      description: Head slot of the Morrigan's ranged set
+    - item_name: Karil's leathertop
+      slug: karil-s-leathertop
+      relationship: alternative
+      description: Comparable ranged armour from Barrows
+  about: "Morrigan's leather chaps are powerful PvP-focused ranged leg armour requiring 78 Defence, obtained as a Bounty Hunter reward."
+  market_strategy:
+    notes:
+      - Supply driven by Bounty Hunter rewards
+      - High value PvP gear with niche demand
+      - "Buy limit: 10 per 4 hours"
+      - Price sensitive to Bounty Hunter meta changes
+  trading_tips:
+    - Monitor Bounty Hunter update notes for supply shifts
+    - Consider charges and degradation before reselling
+  history:
+    - date: "2026-03-25"
+      description: Bounty Hunter rewards can now be used within the TzHaar Fight Pit and both the player-owned house and Clan Hall combat rings.
+    - date: "2025-01-29"
+      description: Defence bonuses reduced across stab, slash, crush, and ranged slots.
+    - date: "2024-09-11"
+      description: Made usable in Castle Wars, Clan Wars, and Soul Wars.
+    - date: "2023-05-04"
+      description: Ranged strength bonus increased from 0 to 6.
+    - date: "2023-05-24"
+      description: Re-released with the relaunch of Bounty Hunter.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-05-24"
+    update: "Bounty Hunter is Back!"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Uncharge
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mushroom-spore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mushroom-spore.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 34
   highalch: 51
   limit: 200
-  about: "Mushroom spore is a members-only item in Old School RuneScape. High alchemy value: 51 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: farming seed
+    tier: mushroom
+  farming:
+    level: 53
+    planting_experience: 61.5
+    harvest_experience: 57.7
+    patch: Mushroom patch
+    location: West of Canifis
+    growth_time_minutes: 240
+    yield: 6
+    product: Bittercap mushroom
+  related_items:
+    - item_id: 6004
+      item_name: Bittercap mushroom
+      slug: bittercap-mushroom
+      relationship: product
+      description: Harvested mushroom grown from planting the spore.
+    - item_id: 22881
+      item_name: Attas seed
+      slug: attas-seed
+      relationship: alternative
+      description: Anima patch herb that increases adjacent farming yields.
+  about: "Mushroom spore is a Farming planting material that grows into bittercap mushrooms in the Mort Myre patch at level 53 Farming over four hours."
+  market_strategy:
+    notes:
+      - Demand tracks bittercap mushroom usage in Herblore and quest steps.
+      - Master Farmer pickpocketing supply keeps GE price suppressed.
+      - Buy limit of 200 supports moderate-volume flipping.
+  trading_tips:
+    - Stockpile before farming buffs or new mushroom-based recipes are released.
+    - Compare against bittercap mushroom price to project planter profit.
+    - Watch Master Farmer thieving meta shifts for supply pressure changes.
+  history:
+    - date: "2005-06-06"
+      description: Added to the game with the Seeds, Bankspace and Advisors update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-06-06"
+    update: Seeds, Bankspace and Advisors
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-boots-dark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-boots-dark.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 70
-  about: "Mystic boots (dark) is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Mystic boots (dark) are the dark variant of the mystic boots, a magical footwear set dropped by Infernal Mages and Malevolent Mages."
+  equipment:
+    slot: feet
+    weight: 0.453
+    requirements:
+      magic: 40
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Infernal Mage
+        quantity: "1"
+        rarity: "1/512"
+      - source: Malevolent Mage
+        quantity: "1"
+        rarity: "3/512"
+  properties:
+    release_date: "2005-01-26"
+    update: "Slayer Skill"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  related_items:
+    - item_id: 4097
+      item_name: Mystic boots
+      slug: mystic-boots
+      relationship: variant
+      description: Blue mystic boots variant with identical stats
+    - item_id: 4117
+      item_name: Mystic boots (light)
+      slug: mystic-boots-light
+      relationship: variant
+      description: Light variant of the mystic boots
+    - item_id: 23054
+      item_name: Mystic boots (dusk)
+      slug: mystic-boots-dusk
+      relationship: variant
+      description: Dusk variant of the mystic boots
+  market_strategy:
+    notes:
+      - "GE price (~83k) sits well above high alch (~6k); never alch these."
+      - "Steady Infernal Mage Slayer task supply keeps prices stable."
+  trading_tips:
+    - "Identical stats to standard mystic boots; price reflects cosmetic preference."
+    - "Pair with the rest of the dark mystic set for fashionscape value."
+  history:
+    - date: "2014-12-10"
+      description: "Renamed from Mystic boots to Mystic boots (dark)."
+    - date: "2006-01-16"
+      description: "Examine text changed to 'Dark magical boots'."
+    - date: "2005-01-26"
+      description: "Released with the Slayer skill update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/navy-cavalier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/navy-cavalier.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 4
-  about: "Navy cavalier is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.08
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_id: 12321
+      item_name: Black cavalier
+      slug: black-cavalier
+      relationship: variant
+      description: Black-colored cavalier variant
+    - item_id: 12323
+      item_name: Red cavalier
+      slug: red-cavalier
+      relationship: variant
+      description: Red-colored cavalier variant
+    - item_id: 12327
+      item_name: Pink cavalier
+      slug: pink-cavalier
+      relationship: variant
+      description: Pink-colored cavalier variant
+    - item_id: 12329
+      item_name: White cavalier
+      slug: white-cavalier
+      relationship: variant
+      description: White-colored cavalier variant
+  about: "Cosmetic head-slot hat obtained as a hard Treasure Trails reward (1/1625 from caskets); the examine references The Three Musketeers."
+  market_strategy:
+    notes:
+      - Hard-clue reward exclusive
+      - Cosmetic only — no combat bonuses
+      - Demand driven by fashionscape collectors
+      - Costume-room storable
+  trading_tips:
+    - Flip on volume spikes around Leagues / clue scroll updates
+    - Compare full cavalier set prices before listing
+  history:
+    - date: "2014-06-12"
+      update: Treasure Trail Expansion
+      description: Added to the game as a hard clue scroll reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 0.08
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    quest_item: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-toy-box-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-toy-box-flatpack.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak toy box (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: oak
+    tier: oak
+  construction:
+    level: 50
+    xp: 120
+    room: Costume Room
+    hotspot: Toy box
+  recipes:
+    - skill: Construction
+      level: 50
+      xp: 120
+      materials:
+        - item_name: Oak plank
+          quantity: 2
+      tools:
+        - Hammer
+        - Saw
+      requirements:
+        - Steel framed workbench in a Workshop
+      output:
+        item_name: Oak toy box (flatpack)
+        quantity: 1
+  related_items:
+    - item_id: 8778
+      item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: Plank used to build the flatpack
+    - item_id: 9851
+      item_name: Teak toy box (flatpack)
+      slug: teak-toy-box-flatpack
+      relationship: upgrade
+      description: Teak-tier variant
+    - item_id: 9853
+      item_name: Mahogany toy box (flatpack)
+      slug: mahogany-toy-box-flatpack
+      relationship: upgrade
+      description: Mahogany-tier variant
+  about: "Oak-tier Construction flatpack built at a steel framed workbench from two oak planks and placed in the Costume Room toy box hotspot."
+  market_strategy:
+    notes:
+      - Low-margin Construction levelling output with thin daily volume
+      - 500 buy limit accommodates costume room hotspot demand bursts
+      - Net profit per craft is negative once oak plank costs are paid
+  trading_tips:
+    - Sell into Construction XP events when plank prices spike demand
+    - Avoid mass production unless oak planks are deeply undercut
+  history:
+    - date: "2006-10-18"
+      description: Added with the Player-Owned House Costume Room update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-10-18"
+    update: Costume Room
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/purple-dye.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/purple-dye.mdx
@@ -1,6 +1,6 @@
 ---
 title: Purple dye | OSRS Price Data
-description: "Purple dye: A little bottle of purple dye.. High alch: 3 GP, GE limit: 150."
+description: "Purple dye: A little bottle of purple dye. High alch: 3 GP, GE limit: 150."
 osrs:
   id: 1773
   name: Purple dye
@@ -12,9 +12,70 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 150
-  about: "Purple dye is a free-to-play item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dye
+    tier: low
+  recipes:
+    - skill: crafting
+      materials:
+        - item_name: Blue dye
+          item_id: 1767
+          quantity: 1
+        - item_name: Red dye
+          item_id: 1763
+          quantity: 1
+      tools: []
+      product: Purple dye
+      product_id: 1773
+      product_quantity: 1
+      members_only: false
+  shops:
+    - shop_name: Lletya Seamstress
+      location: Lletya
+      price: 6
+      members_only: true
+  related_items:
+    - item_id: 1767
+      item_name: Blue dye
+      slug: blue-dye
+      relationship: component
+      description: Combined with red dye
+    - item_id: 1763
+      item_name: Red dye
+      slug: red-dye
+      relationship: component
+      description: Combined with blue dye
+  about: Free-to-play dye made by combining blue and red dye; used in capes, dyed oranges and several quests including Ghosts Ahoy.
+  market_strategy:
+    title: Quest item demand
+    notes:
+      - Combine cheap red and blue dyes for a single bottle
+      - Used in Ghosts Ahoy and other quests
+      - 150 GE buy limit caps bulk plays
+      - Spawns in East Ardougne and Hosidius chapel
+  trading_tips:
+    - Pick from spawn points for free supply
+    - Demand spikes during quest cape grinds
+    - Compare combine cost vs GE price for arbitrage
+  history:
+    - date: "2001-12-08"
+      description: Released with the original Crafting skill content.
+  properties:
+    release_date: "2001-12-08"
+    update: Crafting skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-dragon-leather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-dragon-leather.mdx
@@ -14,68 +14,109 @@ osrs:
   limit: 11000
   material:
     type: leather
-    tier: high
-  tanning:
-    cost: 20
-    source_id: 1749
-    source_name: Red dragonhide
-  crafting_products:
+    tier: red
+  recipes:
+    - product: Red dragon leather
+      skill: Crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Red dragonhide
+          quantity: 1
+      tools:
+        - Tanner
     - product: Red d'hide vambraces
-      product_id: 2489
+      skill: Crafting
       level: 73
       xp: 78
-      leather: 1
+      materials:
+        - item_name: Red dragon leather
+          quantity: 1
+      tools:
+        - Needle
+        - Thread
     - product: Red d'hide chaps
-      product_id: 2495
+      skill: Crafting
       level: 75
       xp: 156
-      leather: 2
+      materials:
+        - item_name: Red dragon leather
+          quantity: 2
+      tools:
+        - Needle
+        - Thread
     - product: Red d'hide shield
-      product_id: 24370
+      skill: Crafting
       level: 76
       xp: 156
-      leather: 2
+      materials:
+        - item_name: Red dragon leather
+          quantity: 2
+      tools:
+        - Needle
+        - Thread
     - product: Red d'hide body
-      product_id: 2501
+      skill: Crafting
       level: 77
       xp: 234
-      leather: 3
+      materials:
+        - item_name: Red dragon leather
+          quantity: 3
+      tools:
+        - Needle
+        - Thread
+  about: "Red dragon leather is the second-best dragon leather tier, tanned from red dragonhide for 20 coins and crafted into the full red d'hide armour set at 73-77 Crafting."
+  market_strategy:
+    notes:
+      - Second-best dragonhide leather behind black
+      - Tan Leather spell at 78 Magic processes 5 hides per cast
+      - Crafting profit margin tight; volume play
+      - Steady demand from crafters training 73-77
+  trading_tips:
+    - Buy red dragonhide and pay 20 gp tanner fee per leather
+    - Watch d'hide body demand for crafting bot supply spikes
+  history:
+    - date: "2004-03-29"
+      description: Released with RuneScape 2 launch.
+    - date: "2005-11-01"
+      description: Renamed from Dragon leather to Red dragon leather for clarification.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
   related_items:
     - item_id: 1749
       item_name: Red dragonhide
       slug: red-dragonhide
       relationship: component
-      description: Raw material
+      description: Raw material before tanning
     - item_id: 2501
       item_name: Red d'hide body
       slug: red-dhide-body
       relationship: product
-      description: Main product
+      description: Main armour product
     - item_id: 2509
       item_name: Black dragon leather
       slug: black-dragon-leather
-      relationship: alternative
-      description: Higher tier
+      relationship: upgrade
+      description: Higher tier leather
     - item_id: 2505
       item_name: Blue dragon leather
       slug: blue-dragon-leather
-      relationship: alternative
-      description: Lower tier
-  market_strategy:
-    notes:
-      - Second-best dragonhide
-      - Good Crafting XP
-      - Tan Leather profit
-      - Crafting training
-      - D'hide armor production
-      - Tan Leather spell
-      - Ironman progression
-      - Tan Leather spell efficient
-      - 20 GP tanner fee
-      - Red dragons drop hide
-      - Step below black
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: downgrade
+      description: Lower tier leather
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-salamander.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-salamander.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 125
-  about: "Red salamander is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: 2h
+    weapon_type: salamander
+    attack_speed: 5
+    weight: 4
+    requirements:
+      attack: 60
+      ranged: 60
+      magic: 60
+    attack_bonus:
+      stab: 0
+      slash: 37
+      crush: 0
+      magic: 0
+      ranged: 47
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  about: "Red salamander is a Hunter-caught three-style weapon usable with Slash, Ranged or Magic attack styles, consuming Tarromin tar ammo per cast."
+  market_strategy:
+    notes:
+      - Cheap and effective for ranged or magic training at 60+
+      - Live creature; runs off corpse if unprotected on death
+      - Caught at 59 Hunter via net traps
+  trading_tips:
+    - Stock tarromin tar in bulk before training sessions
+    - Useful for safespotting through diagonals and fences
+  history:
+    - date: "2006-11-21"
+      description: Released as part of the Hunter skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter skill release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_id: 10146
+      item_name: Orange salamander
+      slug: orange-salamander
+      relationship: downgrade
+      description: Lower-level salamander
+    - item_id: 10149
+      item_name: Black salamander
+      slug: black-salamander
+      relationship: upgrade
+      description: Higher-tier salamander
+    - item_id: 590
+      item_name: Tinderbox
+      slug: tinderbox
+      relationship: component
+      description: Required to make tarromin tar
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rock-climbing-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rock-climbing-boots.mdx
@@ -11,10 +11,44 @@ osrs:
   value: 1
   lowalch: 1
   highalch: 1
-  limit: 0
-  about: "Rock-climbing boots is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit: null
+  material:
+    type: joke item
+    tier: novelty
+  related_items:
+    - item_id: 3105
+      item_name: Climbing boots
+      slug: climbing-boots
+      relationship: alternative
+      description: Functional climbing boots sold by Tenzing on Death Plateau.
+  about: "Rock-climbing boots is an unobtainable members-only joke item parodying the climbing boots rebrand controversy from RuneScape 3."
+  market_strategy:
+    notes:
+      - Listed on the Grand Exchange but not actively obtainable in-game.
+      - Buy limit of 0 means no trading volume occurs.
+      - Treated as a collector curiosity, not an investment.
+  trading_tips:
+    - Do not attempt to flip; the item cannot be acquired through gameplay.
+    - Useful only as a historical reference to OSRS Grand Exchange jokes.
+  history:
+    - date: "2015-02-26"
+      description: Added to the game alongside the Grand Exchange update as an unobtainable joke item.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-02-26"
+    update: The Grand Exchange
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rolling-pin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rolling-pin.mdx
@@ -5,16 +5,73 @@ osrs:
   id: 7445
   name: Rolling pin
   slug: rolling-pin
-  examine: That's how I roll!
+  examine: "That's how I roll!"
   members: true
   icon: Rolling pin.png
   value: 14400
   lowalch: 5760
   highalch: 8640
   limit: 50
-  about: "Rolling pin is a members-only item in Old School RuneScape. High alchemy value: 8,640 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: rune
+  equipment:
+    slot: weapon
+    weapon_type: crush
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      attack: 40
+      quests: Recipe for Disaster (7 subquests for wielding)
+    attack_bonus:
+      stab: 20
+      crush: 39
+    other_bonus:
+      strength: 36
+      prayer: 4
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle basement
+      stock: 0
+      price: 18720
+  related_items:
+    - item_id: 1432
+      item_name: Rune mace
+      slug: rune-mace
+      relationship: alternative
+      description: Standard rune-tier mace with identical stats
+  about: "Rune-tier crush weapon shaped like a rolling pin, sold by the Culinaromancer's Chest after six Recipe for Disaster subquests and used in an Elite emote clue step."
+  market_strategy:
+    notes:
+      - Niche melee novelty mirroring Rune mace stats with a unique skin
+      - Required for an Elite Treasure Trails emote clue at the Lava Maze Dungeon
+      - Buy limit of 50 keeps supply tight despite low daily volume
+  trading_tips:
+    - Stock before Elite clue events and emote-step content updates
+    - Compare to current Rune mace price for arbitrage on novelty premium
+  history:
+    - date: "2006-03-15"
+      description: Added to the game with the Recipe for Disaster quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-03-15"
+    update: Recipe for Disaster
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: Recipe for Disaster (6 subquests to buy, 7 to wield)
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-helm-h3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-helm-h3.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 70
-  about: "Rune helm (h3) is a free-to-play item in Old School RuneScape. High alchemy value: 21,120 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Rune helm (h3) is a heraldic rune full helm cosmetic obtained from hard and elite Treasure Trail clue scrolls."
+  material:
+    type: Rune
+    tier: mid-high
+  equipment:
+    slot: head
+    weight: 2.721
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+  properties:
+    release_date: "2006-12-05"
+    update: "Treasure Trails Update"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  related_items:
+    - item_id: 1163
+      item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: variant
+      description: Standard rune full helm with identical defensive stats
+    - item_id: 10286
+      item_name: Rune helm (h1)
+      slug: rune-helm-h1
+      relationship: variant
+      description: Asgarnia heraldic variant
+    - item_id: 10288
+      item_name: Rune helm (h2)
+      slug: rune-helm-h2
+      relationship: variant
+      description: Dorgeshuun heraldic variant
+  market_strategy:
+    notes:
+      - "Trades well below high alch (~20,611 GE vs 21,120 alch) — alch profit when uncovered."
+      - "Heraldic design appeals to fashionscape and clue completionists."
+  trading_tips:
+    - "Same defensive stats as rune full helm; price premium is cosmetic only."
+    - "Hard and elite caskets feed supply; flips depend on clue activity."
+  history:
+    - date: "2021-04-21"
+      description: "Ranged attack bonus reduced from -2 to -3."
+    - date: "2006-12-05"
+      description: "Released with the Treasure Trails update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sandwich-lady-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sandwich-lady-hat.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 4
-  about: "Sandwich lady hat is a free-to-play item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.907
+  treasure_trail:
+    tier: beginner
+    is_reward: true
+    reward_tiers:
+      - beginner
+  related_items:
+    - item_id: 23315
+      item_name: Sandwich lady top
+      slug: sandwich-lady-top
+      relationship: set-piece
+      description: Sandwich lady outfit body piece
+    - item_id: 23318
+      item_name: Sandwich lady bottoms
+      slug: sandwich-lady-bottoms
+      relationship: set-piece
+      description: Sandwich lady outfit legs piece
+  about: "Free-to-play cosmetic head hat from the Sandwich lady outfit, dropped from Beginner clue caskets at a 1/360 rate."
+  market_strategy:
+    notes:
+      - Beginner clue reward with steady demand from cosmetic collectors
+      - F2P accessible which broadens the buyer pool
+      - 4 per 4 hour buy limit caps fast accumulation
+  trading_tips:
+    - Stock when Beginner clue meta dips and prices soften
+    - Pair the full Sandwich lady set for a margin on bulk sales
+  history:
+    - date: "2019-04-11"
+      description: Added with the Treasure Trails Expansion and Easter 2019 update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-relics-void-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-relics-void-ornament-kit.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 5
-  about: "Shattered relics void ornament kit is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Lumbridge Castle
+      price: 6500
+      currency: League Points
+      members_only: true
+  related_items:
+    - item_id: 11665
+      item_name: Void knight top
+      slug: void-knight-top
+      relationship: component
+      description: Compatible cosmetic target
+    - item_id: 11676
+      item_name: Void knight robe
+      slug: void-knight-robe
+      relationship: component
+      description: Compatible cosmetic target
+    - item_id: 8842
+      item_name: Void knight gloves
+      slug: void-knight-gloves
+      relationship: component
+      description: Compatible cosmetic target
+    - item_id: 11663
+      item_name: Void melee helm
+      slug: void-melee-helm
+      relationship: component
+      description: Compatible cosmetic target
+    - item_id: 11664
+      item_name: Void mage helm
+      slug: void-mage-helm
+      relationship: component
+      description: Compatible cosmetic target
+    - item_id: 11675
+      item_name: Void ranger helm
+      slug: void-ranger-helm
+      relationship: component
+      description: Compatible cosmetic target
+  about: "Cosmetic kit themed to Leagues III - Shattered Relics; applies a recolour to the six Void Knight pieces (three helmets, top, robe, gloves) and is purchased from the Leagues Reward Shop for 6,500 League Points."
+  market_strategy:
+    notes:
+      - Pure cosmetic — fashion-driven price
+      - Limited Leagues supply windows
+      - Long-term hold candidate
+      - Compare other Leagues ornament kits before flipping
+  trading_tips:
+    - List ahead of Leagues IV/V announcements for nostalgia premium
+    - Watch GE volume — daily turnover is thin
+  history:
+    - date: "2022-03-16"
+      update: "PvP Arena: Rewards Beta"
+      description: Public release of the Leagues III reward shop, including the void ornament kit.
+    - date: "2022-01-19"
+      update: "Leagues III: Shattered Relics"
+      description: Added to the game alongside the Shattered Relics league.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-01-19"
+    update: "Leagues III: Shattered Relics"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.1
+    options:
+      - Drop
+    alchable: true
+    quest_item: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-hoarding.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-hoarding.mdx
@@ -8,13 +8,39 @@ osrs:
   examine: A power enhancing sigil not yet attuned to you.
   members: true
   icon: Sigil of hoarding.png
-  value: 10000
+  value: 1
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of hoarding is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sigil of hoarding is a tier 1 Deadman Mode skilling sigil that grants a permanent multiplier (typically 5x) to reward points earned from many minigames and activities such as Barbarian Assault, Tempoross, Mastering Mixology, Mage Training Arena, Wintertodt, and Guardians of the Rift; it is obtained only during active Deadman Mode events and is not currently available in the live game."
+  related_items:
+    - item_id: 28482
+      item_name: Attuned sigil of hoarding
+      slug: attuned-sigil-of-hoarding
+      relationship: upgrade
+      description: Attuned form unlocked on the active character
+  history:
+    - date: "2023-08-23"
+      update: Deadman Apocalypse
+      description: Sigil of hoarding introduced as a tier 1 skilling sigil during the Deadman Apocalypse event.
+  properties:
+    release_date: "2023-08-23"
+    update: Deadman Apocalypse
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    weight: 0.4
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-porcupine.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-porcupine.mdx
@@ -12,9 +12,41 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of the porcupine is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sigil of the porcupine is a Deadman Mode damage recoil sigil that reflects damage to attackers when activated."
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: "You will lose this item permanently. You can get another from a Deadman Mode event."
+  related_items:
+    - item_id: 26063
+      item_name: Sigil of the porcupine
+      slug: sigil-of-the-porcupine
+      relationship: variant
+      description: Damage recoil sigil from Deadman Mode events
+  market_strategy:
+    notes:
+      - "Only obtainable during temporary Deadman Mode events; not available in the live game."
+      - "Duplicates can be sold via the deadman's skull during Deadman: Annihilation."
+  trading_tips:
+    - "Reflects damage to attackers; higher world tiers deal more recoil per hit."
+    - "Stack with other Deadman sigils for PvP survivability."
+  history:
+    - date: "2021-08-25"
+      description: "Released with the Deadman: Reborn event."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spectral-spirit-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spectral-spirit-shield.mdx
@@ -12,43 +12,54 @@ osrs:
   lowalch: 800000
   highalch: 1200000
   limit: 8
+  material:
+    type: ethereal
+    tier: spirit-shield
   equipment:
     slot: shield
-    type: magic_shield
+    weapon_type: none
+    weight: 2
     requirements:
       defence: 75
       magic: 65
       prayer: 70
-    stats:
-      attack_magic: 0
-      defence_stab: 53
-      defence_slash: 55
-      defence_crush: 73
-      defence_magic: 30
-      defence_ranged: 52
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 53
+      slash: 55
+      crush: 73
+      magic: 30
+      ranged: 52
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
-  effect:
-    prayer_protection:
-      drain_reduction: 50
-      pvm_only: true
-      works_against:
-        - Cerberus ghosts
-        - K'ril smash
   recipes:
     - skill: smithing
       level: 85
-      xp: 0
+      xp: 1800
       materials:
-        - item_id: 12823
-          item_name: Spectral sigil
+        - item_name: Spectral sigil
           quantity: 1
-        - item_id: 12831
-          item_name: Blessed spirit shield
+        - item_name: Blessed spirit shield
           quantity: 1
+      tools:
+        - Hammer
       product: Spectral spirit shield
       product_id: 12821
       facility: Anvil
       members_only: true
+  drop_table:
+    sources:
+      - source: Corporeal Beast
+        quantity: "1"
+        rarity: 1/1024
   related_items:
     - item_id: 12825
       item_name: Arcane spirit shield
@@ -65,50 +76,41 @@ osrs:
       slug: spectral-sigil
       relationship: component
       description: From Corp
-  about: |-
-    Attach Spectral sigil to Blessed spirit shield.
-
-    | Method | Requirements |
-    |--------|--------------|
-    | Smithing | 90 Prayer, 85 Smithing |
-    | Abbot Langley | 1.5M gp fee |
-
-    | Offense | Value |
-    |---------|-------|
-    | Magic attack | +0 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +53 |
-    | Slash | +55 |
-    | Crush | +73 |
-    | Magic | +30 |
-    | Ranged | +52 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +3 |
-
-    Requirements: 75 Defence, 65 Magic, 70 Prayer
-
-    Prayer Protection:
-    - 50% reduction to prayer-draining attacks (PvM only)
-    - Works on Cerberus ghosts, K'ril smash
-    - Does NOT work in PvP
-
-    Essential for:
-    - Cerberus (reduces ghost prayer drain)
-    - K'ril Tsutsaroth
-    - Prayer-draining content
-
-    Niche but powerful for specific bosses.
+    - item_id: 12831
+      item_name: Blessed spirit shield
+      slug: blessed-spirit-shield
+      relationship: component
+      description: Base shield
+  about: "Spectral spirit shield is a high-tier shield made by attaching the spectral sigil to a blessed spirit shield, giving 50% reduction to most PvM prayer-draining attacks."
   market_strategy:
     notes:
       - Sigil from Corporeal Beast
       - Essential for Cerberus
       - Cheapest spirit shield
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Price tied to Corp loot supply
+    - Compare to Arcane and Elysian premium
+    - Verify charges and item id before trade
+  history:
+    - date: "2014-10-16"
+      description: Released alongside the Corporeal Beast update.
+  properties:
+    release_date: "2014-10-16"
+    update: Corporeal Beast
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spiked-manacles.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spiked-manacles.mdx
@@ -5,7 +5,7 @@ osrs:
   id: 23389
   name: Spiked manacles
   slug: spiked-manacles
-  examine: Some very spikey metal bands, better make sure I don't cut myself while walking.
+  examine: "Some very spikey metal bands, better make sure I don't cut myself while walking."
   members: true
   icon: Spiked manacles.png
   value: 2500
@@ -15,6 +15,8 @@ osrs:
   equipment:
     slot: feet
     weight: 3
+    requirements:
+      defence: 1
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,52 +34,64 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Medium
-        drop_rate: 1/1,133
-        description: Rare reward from medium clue scrolls
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  about: "Spiked manacles are medium clue feet slot armour with no requirements that tie aranea boots for the best strength bonus among unrestricted footwear, matching dragon boots without the 60 Defence requirement."
+  market_strategy:
+    notes:
+      - Best-in-slot strength boots for 1-Defence pures
+      - Medium clue exclusive with consistent demand from the pure community
+      - No alternative matches the strength bonus without a Defence requirement
+      - Price tracks pure PvP meta demand
+  trading_tips:
+    - Pair with other no-requirement strength gear
+    - Medium clues complete fast, keeping supply steady
+  history:
+    - date: "2019-04-11"
+      description: Released as part of the Treasure Trails Expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   related_items:
     - item_id: 11840
       item_name: Dragon boots
       slug: dragon-boots
       relationship: alternative
-      description: Best melee boots for mains (+4 str, requires 60 Defence)
+      description: Same strength bonus with 60 Defence req
     - item_id: 13239
       item_name: Primordial boots
       slug: primordial-boots
       relationship: upgrade
-      description: Best-in-slot melee boots (+5 str, requires 75 Defence)
+      description: Best-in-slot melee boots (+5 str, 75 Defence)
     - item_id: 4131
       item_name: Rune boots
       slug: rune-boots
       relationship: alternative
-      description: Alternative boots for pures (+2 str, no requirements)
-  about: |-
-    > *"Some very spikey metal bands, better make sure I don't cut myself while walking."*
-
-    | Property | Spiked Manacles | Rune Boots | Dragon Boots | Primordial Boots |
-    |----------|----------------|------------|--------------|-----------------|
-    | Melee Strength | +4 | +2 | +4 | +5 |
-    | Defence Req | None | None | 60 | 75 |
-    | Magic Attack | -3 | 0 | 0 | 0 |
-    | Magic Defence | -4 | 0 | 0 | 0 |
-    | Source | Medium clue | Nechryael | Spiritual mages | Dragon boots + Primordial crystal |
-
-    Spiked manacles match dragon boots in strength bonus while having no Defence requirement, making them essential for pure builds. The trade-off is negative magic attack and defence bonuses and zero defensive stats.
-  market_strategy:
-    title: Investment Notes
-    notes:
-      - Best-in-slot strength boots for 1-Defence pures
-      - Medium clue exclusive with consistent demand from pure community
-      - No alternative provides the same strength bonus without Defence requirements
-      - Essential purchase for any melee pure build
-      - Price is driven by pure PvP meta demand
-      - Consider pairing with other no-requirement strength gear
-      - Medium clues are relatively fast to complete, keeping supply steady
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: No requirement alternative (+2 str)
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/split-log.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/split-log.mdx
@@ -1,6 +1,6 @@
 ---
 title: Split log | OSRS Price Data
-description: "Split log: Used to repair bridges.. High alch: 54 GP, GE limit: 11,000."
+description: "Split log: Used to repair bridges. High alch: 54 GP, GE limit: 11,000."
 osrs:
   id: 10812
   name: Split log
@@ -12,9 +12,61 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 11000
-  about: "Split log is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: log
+    tier: low
+  recipes:
+    - skill: woodcutting
+      level: 56
+      xp: 5
+      materials:
+        - item_name: Arctic pine logs
+          item_id: 10810
+          quantity: 1
+      tools:
+        - Woodcutting stump
+      product: Split log
+      product_id: 10812
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 10810
+      item_name: Arctic pine logs
+      slug: arctic-pine-logs
+      relationship: component
+      description: Source log for splitting
+  about: Quest item produced from arctic pine logs at a woodcutting stump; used to repair the bridge during The Fremennik Isles.
+  market_strategy:
+    title: Quest support demand
+    notes:
+      - Required for The Fremennik Isles quest bridge repair
+      - Produced at woodcutting stump from arctic pine logs at 56 WC
+      - 11,000 GE buy limit allows bulk speculation
+      - Minor passive Woodcutting XP gain
+  trading_tips:
+    - Quest item — sticky demand from new players
+    - Buy raw arctic pine logs for arbitrage
+    - Daily volume light; expect slow flips
+  history:
+    - date: "2007-02-06"
+      description: Released with The Fremennik Isles quest update.
+  properties:
+    release_date: "2007-02-06"
+    update: The Fremennik Isles
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    quest: The Fremennik Isles
+    weight: 1.814
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/splitbark-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/splitbark-body.mdx
@@ -12,8 +12,15 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 70
+  material:
+    type: splitbark
+    tier: mid
   equipment:
     slot: body
+    weight: 4.535
+    requirements:
+      magic: 40
+      defence: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,28 +38,29 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      magic: 40
-      defence: 40
-    weight: 4.535
   recipes:
     - skill: crafting
       level: 62
       xp: 248
-      inputs:
+      materials:
         - item_name: Bark
+          item_id: 3239
           quantity: 4
         - item_name: Fine cloth
+          item_id: 3470
           quantity: 4
-      output_quantity: 1
+        - item_name: Thread
+          item_id: 1734
+          quantity: 1
+      tools:
+        - Needle
+      product: Splitbark body
+      product_id: 3387
   drop_table:
     sources:
       - source: Chaos Fanatic
-        combat_level: 202
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/128
-        members_only: true
+        rarity: 5/128
   related_items:
     - item_id: 3385
       item_name: Splitbark helm
@@ -64,43 +72,37 @@ osrs:
       slug: splitbark-legs
       relationship: set-piece
       description: Matching leg piece
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +10 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +36 |
-    | Slash | +26 |
-    | Crush | +42 |
-    | Magic | +15 |
-
-    Requirements: 40 Magic, 40 Defence
-
-    | Stat | Splitbark Body | Mystic Robe Top |
-    |------|---------------|-----------------|
-    | Magic Atk | +10 | +20 |
-    | Stab Def | +36 | 0 |
-    | Slash Def | +26 | 0 |
-    | Crush Def | +42 | 0 |
-    | Magic Def | +15 | +20 |
-
-    Half the magic attack bonus of mystic, but provides substantial melee defence. The body piece shows the largest stat trade-off in the set — 10 less magic attack for +36/+26/+42 melee defence.
-
-    - Bark: Hollow Trees in the Haunted Woods (east of Canifis)
-    - Fine cloth: Shades of Mort'ton minigame — burn shade remains on pyres
-    - The body requires the most materials of any splitbark piece (4 bark + 4 fine cloth)
-
-    - Swampbark body: Earth spell prayer effect variant
-    - Bloodbark body: Blood spell healing effect variant
+  about: Splitbark body is a hybrid magic and melee chestplate that requires 40 Magic and 40 Defence; it offers substantial stab, slash, crush, and magic defence at the cost of magic attack compared to mystic robes, and is crafted from bark and fine cloth at 62 Crafting.
   market_strategy:
     notes:
-      - Chaos Fanatic is a Wilderness boss — PvP risk for drops
-      - Material-intensive to craft (4+4)
-      - Niche hybrid and fashionscape demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Chaos Fanatic is a Wilderness boss so drops carry PvP risk
+      - Crafting recipe is material intensive (4 bark + 4 fine cloth)
+      - Niche hybrid and fashionscape demand keeps daily volume low
+  history:
+    - date: "2004-10-18"
+      description: Splitbark body added with the Splitbark armour update.
+    - date: "2004-10-26"
+      description: Graphical update applied.
+    - date: "2006-05-31"
+      description: Inventory sprite rotated.
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 4.535
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-fanatic-chausses.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-fanatic-chausses.mdx
@@ -14,9 +14,10 @@ osrs:
   limit: null
   equipment:
     slot: legs
-    type: melee_prayer
-    tradeable: true
-    weight: 5
+    weight: 7.711
+    requirements:
+      defence: 40
+      prayer: 60
     attack_bonus:
       stab: 0
       slash: 0
@@ -34,88 +35,64 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 8
-    requirements:
-      prayer: 60
-      defence: 40
-  set_effect:
-    name: Sunfire Fanatic
-    pieces:
-      - Sunfire fanatic helm
-      - Sunfire fanatic cuirass
-      - Sunfire fanatic chausses
-    description: Best-in-slot prayer bonus armor set
   drop_table:
-    primary_source: Fortis Colosseum
-    best_drop_rate: 1/24.47
     sources:
       - source: Fortis Colosseum
         quantity: "1"
-        rarity: uncommon
-        drop_rate: 1/24.47 (full completion)
-        members_only: true
-  market:
-    buy_limit: 8
-    price_estimate: 1800000
+        rarity: 1/24.47
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  about: "Sunfire fanatic chausses are the best-in-slot prayer bonus legs, dropped from the Fortis Colosseum and also obtainable as an Elite Treasure Trail reward."
+  market_strategy:
+    notes:
+      - Mid-priced piece in the Sunfire fanatic set
+      - Strong defence stats matching rune platelegs
+      - Pairs well with rest of the set for max prayer bonus
+      - Stable demand from PvM and prayer-heavy content
+  trading_tips:
+    - Watch Colosseum drop rate updates for supply shifts
+    - Full set demand spikes on Inferno or ToB releases
+  history:
+    - date: "2024-03-20"
+      description: Released as part of the Varlamore Fortis Colosseum update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore - The Final Dawn
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 7.711
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   related_items:
     - item_id: 28933
       item_name: Sunfire fanatic helm
       slug: sunfire-fanatic-helm
       relationship: set-piece
-      description: Head piece
+      description: Head piece of the Sunfire fanatic set
     - item_id: 28936
       item_name: Sunfire fanatic cuirass
       slug: sunfire-fanatic-cuirass
       relationship: set-piece
-      description: Body piece
-  about: |-
-    ### Defensive Bonuses
-    | Defence Type | Bonus |
-    |--------------|-------|
-    | Stab | +51 |
-    | Slash | +49 |
-    | Crush | +47 |
-    | Magic | -4 |
-    | Ranged | +49 |
-
-    ### Other Bonuses
-    | Stat | Bonus |
-    |------|-------|
-    | Magic Attack | -4 |
-    | Ranged Attack | -11 |
-    | Prayer | +8 |
-
-    The Sunfire Fanatic set provides the best-in-slot prayer bonus when worn together:
-
-    Full Set Pieces:
-    - Sunfire fanatic helm (+6 Prayer)
-    - Sunfire fanatic cuirass (+10 Prayer)
-    - Sunfire fanatic chausses (+8 Prayer)
-
-    Total Set Prayer Bonus: +24
-
-    The chausses contribute a substantial +8 prayer bonus, making them the second-highest prayer bonus piece in the set.
-
-    Best uses for the Sunfire fanatic chausses:
-
-    - Inferno: Essential for prayer management
-    - Fight Caves: Extended Jad attempts
-    - GWD: Reduced prayer potion usage
-    - Cox/TOB: Prayer preservation in raids
-    - General PvM: Efficient for prayer-heavy content
-
-    Comparison to Proselyte:
-    - Proselyte cuisse: +6 Prayer
-    - Sunfire fanatic chausses: +8 Prayer (+2 more)
-    - Much better defensive stats than Proselyte
-  market_strategy:
-    notes:
-      - Mid-priced piece in the set
-      - Good balance of prayer and defence
-      - Pairs well with other prayer gear
-      - Consider full set for maximum efficiency
-      - Stable demand from PvM community
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Body piece of the Sunfire fanatic set
+    - item_id: 9472
+      item_name: Proselyte cuisse
+      slug: proselyte-cuisse
+      relationship: alternative
+      description: Cheaper prayer legs alternative
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-plank.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-plank.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teak plank | OSRS Price Data
-description: "Teak plank: A plank of fine teak.. High alch: 300 GP, GE limit: 13,000."
+description: "Teak plank: A plank of fine teak. High alch: 300 GP, GE limit: 13,000."
 osrs:
   id: 8780
   name: Teak plank
@@ -18,28 +18,24 @@ osrs:
   construction:
     xp_per_plank: 90
     min_level: 35
-    common_builds:
-      - name: Teak garden benches
-        planks: 6
-        xp: 540
-      - name: Teak dining tables
-        planks: 4
-        xp: 360
   recipes:
     - skill: construction
       materials:
         - item_name: Teak logs
           item_id: 6333
           quantity: 1
+      tools:
+        - Coins (500)
+      facility: Sawmill
       product: Teak plank
       product_id: 8780
       product_quantity: 1
-      facility: Sawmill
       cost: 500
       members_only: true
     - skill: magic
       level: 86
       xp: 90
+      spell: Plank Make
       materials:
         - item_name: Teak logs
           item_id: 6333
@@ -53,12 +49,12 @@ osrs:
         - item_name: Earth rune
           item_id: 557
           quantity: 15
+      tools: []
       product: Teak plank
       product_id: 8780
       product_quantity: 1
       cost: 350
       members_only: true
-      spell: Plank Make
   related_items:
     - item_id: 6333
       item_name: Teak logs
@@ -85,32 +81,38 @@ osrs:
       slug: nature-rune
       relationship: component
       description: For Plank Make
-  about: |-
-    | XP per plank | 90 |
-    |--------------|-----|
-    | Mythical cape rack | ~180 XP per plank |
-    | Buy limit | 13,000 per 4 hours |
-    | Min Construction level | 35 |
-
-    Best XP methods:
-    - Teak garden benches (6 planks, 540 XP)
-    - Mahogany Homes contracts (efficient XP)
-    - Teak dining tables (4 planks, 360 XP)
+  about: Mid-tier Construction plank giving 90 XP each, produced by paying the Sawmill 500 GP or casting Plank Make at 86 Magic.
   market_strategy:
-    profit_formulas:
-      - Teak plank price - Teak log price - 500 GP = Profit
+    title: Construction training feedstock
     notes:
-      - Buy Teak logs → Sawmill → Sell planks
-      - "Calculate:"
-      - 86 Magic required
-      - Only 350 GP per plank (saves 150 GP vs sawmill)
-      - Good middle ground between oak and mahogany
-      - Better XP/GP ratio than mahogany
-      - Cheaper than mahogany planks
-      - Popular for efficient Construction training
-      - Mythical cape rack is meta method
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Buy Teak logs and convert at Sawmill for resale margin
+      - Plank Make spell saves 150 GP per plank at 86 Magic
+      - Better XP per GP ratio than mahogany planks
+      - Mythical cape rack is current XP meta
+      - Strong demand from Mahogany Homes contracts
+  trading_tips:
+    - Watch teak log to plank spread for sawmill arbitrage
+    - Stockpile before Construction skill events
+    - 13,000 GE buy limit per 4 hours
+  history:
+    - date: "2006-05-31"
+      description: Released with the Construction skill and player-owned houses update.
+  properties:
+    release_date: "2006-05-31"
+    update: Construction
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-36-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-36-cape.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-36 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Richard's Wilderness Cape Shop
+      location: Edgeville
+      price: 50
+      stock: 100
+      currency: coins
+      members_only: false
+  related_items:
+    - item_id: 4383
+      item_name: Team-35 cape
+      slug: team-35-cape
+      relationship: variant
+      description: Adjacent numbered team cape
+    - item_id: 4387
+      item_name: Team-37 cape
+      slug: team-37-cape
+      relationship: variant
+      description: Adjacent numbered team cape
+  about: "Team-36 cape is one of fifty numbered team capes sold by Richard at the Wilderness Cape Shop in Edgeville for 50 coins; players wearing matching team capes appear as blue dots on each other's minimaps and gain right-click attack protection against same-team players."
+  market_strategy:
+    notes:
+      - Steady free-to-play demand from team minigames and clue clues
+      - Shop price of 50gp acts as a hard floor
+      - Bulk lots flip slowly because daily volume is low
+  history:
+    - date: "2005-02-22"
+      description: Team-36 cape added with the team capes update.
+    - date: "2013-05-23"
+      description: Item made available to free-to-play players.
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-6-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-6-cape.mdx
@@ -5,16 +5,85 @@ osrs:
   id: 4325
   name: Team-6 cape
   slug: team-6-cape
-  examine: Ooohhh look at the pretty colours...
+  examine: "Ooohhh look at the pretty colours..."
   members: false
   icon: Team-6 cape.png
   value: 50
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-6 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Team-6 cape is a free-to-play team cape that makes matching players appear as blue dots on the minimap."
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Richard's Wilderness Cape Shop"
+      location: Edgeville
+      stock: 100
+      price: 50
+  properties:
+    release_date: "2005-02-22"
+    update: "Wilderness Capes, and Changes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  related_items:
+    - item_id: 4315
+      item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: Alternate team cape colour
+    - item_id: 4323
+      item_name: Team-5 cape
+      slug: team-5-cape
+      relationship: variant
+      description: Alternate team cape colour
+    - item_id: 4327
+      item_name: Team-7 cape
+      slug: team-7-cape
+      relationship: variant
+      description: Alternate team cape colour
+  market_strategy:
+    notes:
+      - "GE price (~101 gp) tracks shop cost; minimal arbitrage."
+      - "Buy in bulk from Richard at 50 gp and flip on the GE for small margins."
+  trading_tips:
+    - "Identifies teammates on the minimap and changes attack option to right-click."
+    - "Cheap clan/team identifier; bulk shop buyout > 100 capes possible across worlds."
+  history:
+    - date: "2013-05-23"
+      description: "Made available to free-to-play players."
+    - date: "2005-02-22"
+      description: "Released with the Wilderness Capes update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thammaron-s-sceptre-au.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thammaron-s-sceptre-au.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 48000
   highalch: 72000
   limit: 8
-  about: "Thammaron's sceptre (au) is a members-only item in Old School RuneScape. High alchemy value: 72,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      magic: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 20
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    material: Revenant ether
+    initial_activation: 1000
+    max_charges: 17000
+    hourly_usage: 1200
+  about: "Thammaron's sceptre (au) is the autocasting variant that lets players cast standard spellbook and Ancient Magicks offensive spells, and grants a 50% magic accuracy and damage boost against NPCs in the Wilderness while charged with revenant ether."
+  market_strategy:
+    notes:
+      - Wilderness-focused magic weapon for revenant hunting and PvM
+      - Initial activation requires 1000 revenant ether
+      - Effect stacks with Slayer helmet (i) and Salve amulet variants
+      - Swap option toggles between sceptre and autocast forms
+  history:
+    - date: "2023-02-08"
+      description: Released as part of the Wilderness Boss rework alongside revenant rework updates.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-02-08"
+    update: Wilderness Boss Rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Swap
+      - Uncharge
+    worn_options:
+      - Swap
+      - Uncharge
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_id: 27787
+      item_name: Thammaron's sceptre
+      slug: thammaron-s-sceptre
+      relationship: variant
+      description: Powered staff form
+    - item_id: 21796
+      item_name: Revenant ether
+      slug: revenant-ether
+      relationship: component
+      description: Required charging material
+    - item_id: 11791
+      item_name: Staff of the dead
+      slug: staff-of-the-dead
+      relationship: alternative
+      description: Alternative magic staff
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-bracelet.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 600
   highalch: 900
   limit: 10000
-  about: "Topaz bracelet is a members-only item in Old School RuneScape. High alchemy value: 900 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: jewellery
+    tier: silver
+  equipment:
+    slot: hands
+    weight: 0.25
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - product: Topaz bracelet
+      skill: Crafting
+      level: 38
+      xp: 75
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+        - item_name: Red topaz
+          quantity: 1
+      tools:
+        - Bracelet mould
+        - Furnace
+  about: "Topaz bracelet is the entry-level silver gem bracelet, crafted at 38 Crafting from a silver bar and red topaz, and enchanted into a bracelet of slaughter via Lvl-3 Enchant."
+  market_strategy:
+    notes:
+      - Crafting profitable rarely; mostly a stepping stone to bracelet of slaughter
+      - Enchanted form (slaughter) is the demand driver
+      - High alch loses gp at most prices
+  trading_tips:
+    - Watch slaughter bracelet demand for slayer training spikes
+    - Buy silver bar plus red topaz under bracelet price for craft profit
+  history:
+    - date: "2017-02-02"
+      description: Added with the Zeah expansion gem update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-02-02"
+    update: Zeah Gem Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_id: 21133
+      item_name: Bracelet of slaughter
+      slug: bracelet-of-slaughter
+      relationship: upgrade
+      description: Enchanted form via Lvl-3 Enchant
+    - item_id: 1746
+      item_name: Red topaz
+      slug: red-topaz
+      relationship: component
+      description: Gem used in crafting
+    - item_id: 2355
+      item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: Metal used in crafting
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tumeken-s-shadow-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tumeken-s-shadow-uncharged.mdx
@@ -14,35 +14,73 @@ osrs:
   limit: 8
   equipment:
     slot: 2h
-    type: powered_staff
-    attack_style: magic
+    weapon_type: powered_staff
     attack_speed: 5
-    attack_range: 8
+    weight: 4
     requirements:
       magic: 85
-    stats:
-      attack_magic: 35
-      defence_magic: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 35
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 20
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 1
-    degradeable: true
-  effect:
-    magic_multiplier: 3
-    magic_multiplier_toa: 4
-    damage_cap: 100
-  charging:
-    material_id: 566
-    material_name: Soul rune
+  charges:
+    material: Soul rune + Chaos rune
     soul_per_cast: 2
     chaos_per_cast: 5
     max_charges: 20000
   drop_table:
     sources:
       - source: Tombs of Amascut
-        source_id: 11751
-        combat_level: 0
         quantity: "1"
         rarity: 1/24
-        members_only: true
+  about: "Tumeken's shadow is a tier-90 powered staff dropped from Tombs of Amascut that triples worn magic attack and magic damage bonuses (quadruples inside ToA), capped at 100% magic damage."
+  market_strategy:
+    notes:
+      - Second most expensive weapon in the game
+      - Requires good magic gear to maximise the triple multiplier
+      - Charging cost is significant per hour
+      - Does not multiply Void or Salve amulet bonuses
+  trading_tips:
+    - Charge in bank; full charge cost approximates 18.7M coins
+    - Uncharging refunds all runes invested
+  history:
+    - date: "2022-08-24"
+      description: Released alongside the Tombs of Amascut raid.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-08-24"
+    update: Tombs of Amascut
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Wield
+      - Charge
+      - Uncharge
+      - Check
+    worn_options:
+      - Check
+      - Uncharge
+    alchable: true
+    destroy: "Drop"
   related_items:
     - item_id: 566
       item_name: Soul rune
@@ -58,53 +96,12 @@ osrs:
       item_name: Sanguinesti staff
       slug: sanguinesti-staff
       relationship: alternative
-      description: Budget alternative
-    - item_id: 21018
-      item_name: Ancestral robe top
-      slug: ancestral-robe-top
-      relationship: component
-      description: BiS magic armor
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Magic attack | +35 |
-    | Magic defence | +20 |
-    | Prayer | +1 |
-    | Attack speed | 5 tick (3.0s) |
-    | Range | 8 tiles |
-    | Requirements | 85 Magic |
-
-    Magic Bonus Tripling:
-    - Multiplies magic attack bonus by 3x
-    - Multiplies magic damage by 3x
-    - Cap: 100% magic damage bonus
-    - Inside ToA: multiplier increases to 4x
-
-    Does NOT multiply:
-    - Void Knight equipment
-    - Salve amulet variants
-
-    | Resource | Per Cast | Cost |
-    |----------|----------|------|
-    | Soul rune | 2 | - |
-    | Chaos rune | 5 | - |
-    | Total | - | ~935 gp |
-
-    - Max charges: 20,000
-    - Full charge: ~18.7M gp
-    - Hourly cost: ~1.1M gp
-
-    Best-in-slot magic weapon for:
-    - Tombs of Amascut
-    - Theatre of Blood (some rooms)
-    - Any magic-focused bossing
-  market_strategy:
-    notes:
-      - Second most expensive weapon
-      - Requires good magic gear to maximize
-      - Charging costs significant
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Budget magic powered staff alternative
+    - item_id: 27275
+      item_name: Tumeken's shadow
+      slug: tumeken-s-shadow
+      relationship: variant
+      description: Charged form
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unlit-bug-lantern.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unlit-bug-lantern.mdx
@@ -1,6 +1,6 @@
 ---
 title: Unlit bug lantern | OSRS Price Data
-description: "Unlit bug lantern: A lantern to aid attacking Harpie bugs.. High alch: 78 GP, GE limit: 40."
+description: "Unlit bug lantern: A lantern to aid attacking Harpie bugs. High alch: 78 GP, GE limit: 40."
 osrs:
   id: 7051
   name: Unlit bug lantern
@@ -12,9 +12,67 @@ osrs:
   lowalch: 52
   highalch: 78
   limit: 40
-  about: "Unlit bug lantern is a members-only item in Old School RuneScape. High alchemy value: 78 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: slayer_equipment
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: bladed
+    attack_speed: 6
+    weight: 2.267
+    requirements:
+      slayer: 33
+      firemaking: 33
+  shops:
+    - shop_name: Slayer Equipment
+      location: Burthorpe, Draynor, Edgeville, Canifis, Zanaris, Mount Karuulm and others
+      price: 130
+      members_only: true
+  related_items:
+    - item_id: 7053
+      item_name: Lit bug lantern
+      slug: lit-bug-lantern
+      relationship: variant
+      description: Lit version used in combat
+    - item_id: 590
+      item_name: Tinderbox
+      slug: tinderbox
+      relationship: component
+      description: Required to light the lantern
+  about: Slayer equipment required to fight Harpie Bug Swarms; light with a tinderbox to convert into the lit bug lantern.
+  market_strategy:
+    title: Slayer task pickup
+    notes:
+      - 130 GP fixed shop price floor
+      - 40 GE buy limit per 4 hours
+      - Demand tracks Harpie Bug Swarm task assignments
+      - Lit version also counts as Wintertodt warm clothing
+  trading_tips:
+    - Buy from Slayer shop and flip at GE markup
+    - Steady but thin daily volume
+    - Stock during low slayer master pricing windows
+  history:
+    - date: "2006-01-30"
+      description: Released with the Eagles' Peak / Harpie Bug Swarm slayer content.
+  properties:
+    release_date: "2006-01-30"
+    update: Slayer expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/venator-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/venator-ring.mdx
@@ -12,39 +12,59 @@ osrs:
   lowalch: 56000
   highalch: 84000
   limit: null
+  material:
+    type: chromium
+    tier: ancient-ring
   equipment:
     slot: ring
-    type: ranged
+    weapon_type: none
+    weight: 0.012
     requirements:
-      quest: The Leviathan kill
-    stats:
-      attack_ranged: 10
-      ranged_strength: 2
-  creation:
-    components:
-      - item_id: 28271
-        item_name: Archer icon
-      - item_id: 28289
-        item_name: Venator vestige
-      - item_id: 565
-        item_name: Blood rune
-        quantity: "500"
-    materials:
-      - item_name: Chromium ingot
-        quantity: "3"
-      - item_name: Ring mould
-        quantity: "1"
-    skill_requirements:
       magic: 90
       crafting: 80
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 10
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 2
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 80
+      xp: 2500
+      materials:
+        - item_name: Archer icon
+          quantity: 1
+        - item_name: Venator vestige
+          quantity: 1
+        - item_name: Chromium ingot
+          quantity: 3
+        - item_name: Ring mould
+          quantity: 1
+        - item_name: Blood rune
+          quantity: 500
+      tools:
+        - Furnace
+      product: Venator ring
+      product_id: 28310
+      members_only: true
+      notes: "Requires Magic 90 (boostable) and completion of Desert Treasure II."
   drop_table:
     sources:
       - source: The Leviathan
-        source_id: 12214
-        combat_level: 800
-        quantity: 1 (Venator vestige)
-        rarity: Rare
-        members_only: true
+        quantity: "1"
+        rarity: 1/96
   related_items:
     - item_id: 11771
       item_name: Archers ring (i)
@@ -61,36 +81,37 @@ osrs:
       slug: venator-vestige
       relationship: component
       description: From The Leviathan
-  about: |-
-    1. Combine Archer icon + Venator vestige + 500 blood runes
-    2. Craft at furnace with 3 chromium ingots + ring mould
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 90 (boostable) |
-    | Crafting | 80 (boostable) |
-    | Kill The Leviathan | 1 time |
-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged | +10 |
-    | Ranged Strength | +2 |
-
-    Requirements: The Leviathan kill
-
-    BiS for:
-    - All ranged combat
-    - Maximum ranged DPS
-    - Raids
-
-    Only ring with ranged strength bonus.
+  about: "Venator ring is the best-in-slot ranged ring crafted from a Venator vestige dropped by The Leviathan, providing the only ring ranged strength bonus."
   market_strategy:
     notes:
       - Vestige from The Leviathan
       - Cannot be imbued
       - DT2 content
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Watch vestige drop rate news
+    - Compare to Magus and Bellator pricing
+    - Verify equip requirement before purchase
+  history:
+    - date: "2023-07-26"
+      description: Released with the Desert Treasure II rewards update.
+  properties:
+    release_date: "2023-07-26"
+    update: Desert Treasure II - The Fallen Empire
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: Desert Treasure II - The Fallen Empire
+    weight: 0.012
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-beret.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-beret.mdx
@@ -12,21 +12,78 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 4
+  material:
+    type: cloth
+    tier: cosmetic
   equipment:
     slot: head
-    requirements: {}
+    weapon_type: none
+    weight: 0.04
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 2635
       item_name: Black beret
       slug: black-beret
       relationship: variant
       description: Black colour variant
-  about: |-
-    > *"Parlez-vous francais?"*
-
-    The white beret is a purely cosmetic head slot item from easy treasure trails. No combat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "White beret is a cosmetic head slot reward from easy clue scrolls with no combat bonuses."
+  market_strategy:
+    notes:
+      - Cosmetic clue scroll reward
+      - Demand driven by fashionscape
+  trading_tips:
+    - Low GE limit, plan trades carefully
+    - Price stays elevated above alch
+  history:
+    - date: "2004-05-05"
+      description: Released as part of the Bigger Banks & Treasure Trails update.
+    - date: "2005-05-17"
+      description: Renamed from Berret/Beret to White beret.
+  properties:
+    release_date: "2004-05-05"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-berries.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-berries.mdx
@@ -19,6 +19,7 @@ osrs:
     level: 59
     seed_id: 5105
     seed_name: Whiteberry seed
+    patch: Bush
   drop_table:
     sources:
       - source: Kurask
@@ -30,7 +31,7 @@ osrs:
       - source: Corporeal Beast
         source_id: 319
         combat_level: 785
-        quantity: 100-340 (noted)
+        quantity: "100-340 (noted)"
         rarity: uncommon
         members_only: true
   recipes:
@@ -67,37 +68,50 @@ osrs:
       item_name: Cadantine
       slug: cadantine
       relationship: component
-      description: Super defence herb
+      description: Super defence herb paired with white berries.
     - item_id: 2442
       item_name: Super defence(4)
       slug: super-defence-4
       relationship: product
-      description: Primary end product
+      description: Primary endgame product using white berries.
     - item_id: 5105
       item_name: Whiteberry seed
       slug: whiteberry-seed
       relationship: component
-      description: Farming source
+      description: Farming source for self-sustaining supply.
     - item_id: 133
       item_name: Defence potion(3)
       slug: defence-potion-3
       relationship: product
-      description: Basic product
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Herblore Secondary |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-
-    Secondary ingredient for:
-    - Defence potion (with ranarr potion unf)
-    - Super defence (with cadantine potion unf)
-
-    Also usable as supercompost material.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Low-level Herblore output using ranarr unf and white berries.
+  about: "White berries are a Herblore secondary used in Defence and Super defence potions, also feeding supercompost and Hand in the Sand quest progress."
+  market_strategy:
+    notes:
+      - Supply combines Farming harvests at 59 Farming and Kurask Slayer task loot.
+      - Buy limit of 13,000 per 4 hours sustains bulk Herblore mixing.
+      - Demand stays steady from Super defence potion brewing for PvP and ironmen.
+  trading_tips:
+    - Watch the Super defence margin to decide between flipping berries or mixing potions.
+    - Bundle whiteberry seed buys when planting alongside the berry resell loop.
+  history:
+    - date: "2002-02-27"
+      description: Added with the early Herblore expansion in the original RuneScape update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: RuneScape News
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-boots.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 230
   highalch: 345
   limit: 125
-  about: "White boots is a members-only item in Old School RuneScape. High alchemy value: 345 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: white
+  equipment:
+    slot: feet
+    weight: 1.36
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: -1
+    defence_bonus:
+      stab: 7
+      slash: 8
+      crush: 9
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: Sir Vyvin (Adept rank)
+      location: White Knights' Castle, Falador
+      notes: Requires Adept rank in White Knight faction
+  about: "White boots are the cheapest prayer-bonus boots in the game, sold by Sir Vyvin after reaching Adept rank with the White Knights."
+  market_strategy:
+    notes:
+      - Cheapest +1 prayer footwear
+      - Cannot be smithed
+      - Storable in costume room armour case
+  trading_tips:
+    - Budget option for early prayer setups
+    - Supply driven by Adept rank White Knight players
+  history:
+    - date: "2005-10-17"
+      description: Added in the Wanted! quest update with full White Knight equipment set.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-10-17"
+    update: Wanted!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: Wanted!
+    weight: 1.36
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_id: 4129
+      item_name: Rune boots
+      slug: rune-boots
+      relationship: alternative
+      description: Higher tier non-prayer boots
+    - item_id: 2581
+      item_name: Ranger boots
+      slug: ranger-boots
+      relationship: alternative
+      description: Ranged-focused boots
+    - item_id: 6107
+      item_name: White full helm
+      slug: white-full-helm
+      relationship: set-piece
+      description: Other White Knight equipment
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-claws.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-claws.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 144
   highalch: 216
   limit: 125
-  about: "White claws is a members-only item in Old School RuneScape. High alchemy value: 216 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: white
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: claws
+    attack_speed: 4
+    weight: 0.907
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 10
+      slash: 14
+      crush: -4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 4
+      slash: 7
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 14
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: Sir Vyvin
+      location: White Knights' Castle
+      currency: Coins
+      sell_price: 360
+      notes: Sold only after reaching Master rank with 1,300 black knight kills.
+  related_items:
+    - item_id: 3095
+      item_name: Black claws
+      slug: black-claws
+      relationship: alternative
+      description: Black-tier claw counterpart with similar stats.
+    - item_id: 6585
+      item_name: Amulet of fury
+      slug: amulet-of-fury
+      relationship: alternative
+      description: Common neck-slot pairing for melee weapon setups.
+    - item_id: 13652
+      item_name: Dragon claws
+      slug: dragon-claws
+      relationship: upgrade
+      description: Far stronger claw weapon used at endgame.
+  about: "White claws are White Knight-tier melee claws requiring 10 Attack with +14 slash bonus and a rare +1 Prayer bonus among mid-game weapons."
+  market_strategy:
+    notes:
+      - Supply trickles from Master-rank White Knights selling Sir Vyvin's stock.
+      - Buy limit of 125 per 4 hours pairs with the very low daily volume of around 2 trades.
+      - Demand is mostly collector or fashionscape; combat use is dominated by stronger claws.
+  trading_tips:
+    - List with patience - thin order book means sales can take hours to fill.
+    - Compare against black claws to estimate fair midgame claw spread.
+  history:
+    - date: "2005-10-17"
+      description: Released alongside the Wanted! quest update enabling White Knight rank purchases.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-10-17"
+    update: "Wanted!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-longbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-longbow.mdx
@@ -12,27 +12,52 @@ osrs:
   lowalch: 128
   highalch: 192
   limit: 18000
+  material:
+    type: wood
+    tier: willow
   equipment:
     slot: 2h
-    type: longbow
-    attack_style: ranged
+    weapon_type: bow
     attack_speed: 6
-  requirements:
-    ranged: 20
-  stats:
-    attack:
+    weight: 1.814
+    requirements:
       ranged: 20
-    other:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 20
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 0
-    range: 9
-  fletching:
-    level: 40
-    xp: 41.5
-    method: Willow longbow (u) + bowstring
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 40
+      xp: 41.5
+      materials:
+        - item_name: Willow longbow (u)
+          quantity: 1
+        - item_name: Bow string
+          quantity: 1
+      tools:
+        - None
+      product: Willow longbow
+      product_id: 847
+      members_only: false
   shops:
     - shop_name: Lowe's Archery Emporium
       location: Varrock
-      price: 320
+    - shop_name: Lletya Archery Shop
+      location: Lletya
   related_items:
     - item_id: 851
       item_name: Maple longbow
@@ -54,8 +79,37 @@ osrs:
       slug: bow-string
       relationship: component
       description: Stringing material
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: A free-to-play willow longbow used by mid-level rangers, fletched at 40 Fletching by stringing a willow longbow (u).
+  market_strategy:
+    notes:
+      - Common Fletching training output
+      - Loses small gp per craft vs materials
+      - Stable F2P demand
+  trading_tips:
+    - Free-to-play tradable, ample volume
+    - Check material cost vs GE for fletching profit
+  history:
+    - date: "2002-03-25"
+      description: Added to the game.
+    - date: "2005-03-29"
+      description: Made available to free-to-play players.
+  properties:
+    release_date: "2002-03-25"
+    update: Bows and Arrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wyvern-visage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wyvern-visage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Wyvern visage | OSRS Price Data
-description: "Wyvern visage: It looks like this could be attached to a shield somehow.. High alch: 450,000 GP, GE limit: 5."
+description: "Wyvern visage: It looks like this could be attached to a shield somehow. High alch: 450,000 GP, GE limit: 5."
 osrs:
   id: 21637
   name: Wyvern visage
@@ -14,29 +14,42 @@ osrs:
   limit: 5
   material:
     type: visage
-    tradeable: true
-    weight: 0.907
+    tier: high
   drop_table:
     sources:
       - source: Ancient wyvern
-        rate: 1/10,000
+        quantity: "1"
+        rarity: "1/10000"
       - source: Long-tailed wyvern
-        rate: 1/10,000
+        quantity: "1"
+        rarity: "1/12000"
       - source: Spitting wyvern
-        rate: 1/10,000
+        quantity: "1"
+        rarity: "1/12000"
       - source: Taloned wyvern
-        rate: 1/12,000
-  uses:
-    - result_id: 21634
-      result_name: Ancient wyvern shield
-      method: Combine with elemental shield at Strange Machine
-      location: House on the Hill
+        quantity: "1"
+        rarity: "1/12000"
+  recipes:
+    - skill: smithing
+      level: 66
+      xp: 2000
       requirements:
         magic: 66
         smithing: 66
-  market:
-    buy_limit: 5
-    price_estimate: 25500000
+      materials:
+        - item_name: Wyvern visage
+          item_id: 21637
+          quantity: 1
+        - item_name: Elemental shield
+          item_id: 2890
+          quantity: 1
+      tools:
+        - Hammer
+      facility: Strange Machine (House on the Hill)
+      product: Ancient wyvern shield
+      product_id: 21634
+      product_quantity: 1
+      members_only: true
   related_items:
     - item_id: 21634
       item_name: Ancient wyvern shield
@@ -52,27 +65,43 @@ osrs:
       item_name: Skeletal visage
       slug: skeletal-visage
       relationship: alternative
-      description: Similar drop
+      description: Similar boss drop
     - item_id: 11286
       item_name: Draconic visage
       slug: draconic-visage
       relationship: alternative
-      description: Similar drop
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A (Material) |
-    | Type | Boss Drop |
-    | Tradeable | Yes |
-    | Weight | 0.907 kg |
-
-    Combine with an elemental shield at the Strange Machine (House on the Hill).
-
-    Requirements: 66 Magic and 66 Smithing.
-
-    Creates: Ancient wyvern shield
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Similar boss drop
+  about: Rare drop from Fossil Island wyverns; combine with an elemental shield at the Strange Machine to craft an Ancient wyvern shield.
+  market_strategy:
+    title: Boss drop investment
+    notes:
+      - Very low GE buy limit of 5
+      - Rare 1/10,000 to 1/12,000 drop rates
+      - High demand from shield crafters
+      - Long-term price trend tracks Ancient wyvern shield
+  trading_tips:
+    - Flip on low GE limit with margin patience
+    - Watch Cold War / wyvern slayer task popularity
+    - Combine yourself rather than flipping if costs align
+  history:
+    - date: "2017-09-07"
+      description: Added to game as a rare drop from Fossil Island wyverns.
+  properties:
+    release_date: "2017-09-07"
+    update: Fossil Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-brew-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-brew-3.mdx
@@ -12,6 +12,28 @@ osrs:
   lowalch: 70
   highalch: 105
   limit: 2000
+  potion:
+    doses: 3
+    effects:
+      - description: "Boosts Attack by 2 + 20% of base Attack level"
+      - description: "Boosts Strength by 2 + 12% of base Strength level"
+      - description: "Restores 10% of current Prayer points"
+      - description: "Drains Defence by 2 + 10% of current Defence level"
+      - description: "Drains 12% of current Hitpoints (minimum 1 HP remaining)"
+  recipes:
+    - skill: Herblore
+      level: 78
+      xp: 175
+      materials:
+        - item_name: Torstol potion (unf)
+          quantity: 1
+        - item_name: Jangerberries
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output:
+        item_name: Zamorak brew(3)
+        quantity: 1
   related_items:
     - item_id: 191
       item_name: Zamorak brew(2)
@@ -23,12 +45,48 @@ osrs:
       slug: zamorak-brew-1
       relationship: variant
       description: 1-dose version
-  about: |-
-    > _"3 doses of Zamorak brew."_
-
-    The Zamorak brew boosts Attack and Strength while draining Defence and Hitpoints. Also restores approximately 10% of Prayer. A high-risk, high-reward potion used in advanced PvM and PvP.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 2454
+      item_name: Torstol potion (unf)
+      slug: torstol-potion-unf
+      relationship: component
+      description: Unfinished base potion
+    - item_id: 247
+      item_name: Jangerberries
+      slug: jangerberries
+      relationship: component
+      description: Secondary ingredient
+  about: "Three-dose Zamorak brew that boosts Attack and Strength while draining Defence and Hitpoints, restoring ~10% Prayer per sip for risky PvM and PvP use."
+  market_strategy:
+    notes:
+      - Staple at Corporeal Beast for outsized Attack boost over super combats
+      - Doubles as budget Prayer restoration on Ironman Slayer tasks
+      - 2,000 buy limit and steady ingredient costs keep prices stable
+  trading_tips:
+    - Watch torstol and jangerberries swings to gauge production margins
+    - Stock ahead of Corp mass events and Inferno meta cycles
+  history:
+    - date: "2002-12-12"
+      description: Added to the game.
+    - date: "2014-01-23"
+      description: 1-dose version updated to restore Prayer points like other doses.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Herblore Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorakian-hasta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorakian-hasta.mdx
@@ -12,33 +12,52 @@ osrs:
   lowalch: 120000
   highalch: 180000
   limit: 8
+  material:
+    type: metal
+    tier: zamorakian
   equipment:
     slot: weapon
-    type: stab_weapon
-    tradeable: true
+    weapon_type: spear
+    attack_speed: 4
     weight: 3
     requirements:
       attack: 70
-      quest: Barbarian Training
-    stats:
-      attack_stab: 85
-      attack_slash: 65
-      attack_crush: 65
+    attack_bonus:
+      stab: 85
+      slash: 65
+      crush: 65
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 13
+      slash: 13
+      crush: 12
+      magic: 0
+      ranged: 13
+    other_bonus:
       strength: 75
-      defence_stab: 13
-      defence_slash: 13
-      defence_ranged: 13
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 2
   special_attack:
     name: Shove
     energy: 25
-    description: Stuns and pushes opponent, 3 second disable
-  creation:
-    method: Take Zamorakian spear to Otto Godblessed
-    cost: 300000
-    diary_discount:
-      diary: Elite Kandarin Diary
-      cost: 150000
+    description: "Pushes opponent back and stuns them for three seconds; shared with the Dragon and Zamorakian spear."
+  recipes:
+    - skill: none
+      level: 0
+      xp: 0
+      materials:
+        - item_name: Zamorakian spear
+          quantity: 1
+        - item_name: Coins
+          quantity: 300000
+      tools: []
+      product: Zamorakian hasta
+      product_id: 11889
+      facility: Otto Godblessed
+      members_only: true
+      notes: "Cost reduced to 150,000 coins with the Elite Kandarin Diary completed."
   related_items:
     - item_id: 11824
       item_name: Zamorakian spear
@@ -55,38 +74,34 @@ osrs:
       slug: hydras-claw
       relationship: component
       description: Upgrade material
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Stab | +85 |
-    | Slash | +65 |
-    | Crush | +65 |
-    | Strength | +75 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Stab | +13 |
-    | Slash | +13 |
-    | Ranged | +13 |
-
-    | Other | Bonus |
-    |-------|-------|
-    | Prayer | +2 |
-
-    Shove (25% energy)
-    - Stuns and pushes opponent
-    - 3 second disable
-
-    - One-handed (can use shield/defender)
-    - Third best stab weapon
-    - Cannot be poisoned
-
-    Used for:
-    - General stab combat
-    - DHL upgrade base
-    - Budget stab weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Zamorakian hasta is a one-handed stab spear converted from the Zamorakian spear by Otto Godblessed, allowing shield use while keeping the Shove special attack."
+  market_strategy:
+    notes:
+      - Conversion sink burns gp at Otto
+      - Tied to Zamorakian spear supply from K'ril
+  trading_tips:
+    - Elite Kandarin Diary halves conversion cost
+    - Compare to DHL for slayer setups
+  history:
+    - date: "2014-01-09"
+      description: Released as a one-handed Zamorakian spear variant.
+  properties:
+    release_date: "2014-01-09"
+    update: God Wars Dungeon Improvements
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zulrah-s-scales.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zulrah-s-scales.mdx
@@ -14,16 +14,15 @@ osrs:
   limit: 30000
   material:
     type: scale
-    tier: zulrah
+    tier: mid-high
   drop_table:
-    primary_source: Zulrah
     sources:
       - source: Zulrah
-        source_id: 2042
-        combat_level: 725
-        quantity: 100-299
-        rarity: common
-        members_only: true
+        quantity: "100-299"
+        rarity: Always
+      - source: Zulrah
+        quantity: "500"
+        rarity: 2/249
   charges:
     toxic_blowpipe:
       per_use: 0.33
@@ -34,6 +33,9 @@ osrs:
     trident_of_the_swamp:
       per_use: 1
       max_charges: 2500
+    toxic_staff_of_the_dead:
+      per_use: 1
+      max_charges: 11000
   recipes:
     - skill: herblore
       level: 87
@@ -45,53 +47,59 @@ osrs:
         - item_name: Zulrah's scales
           item_id: 12934
           quantity: 20
+      tools:
+        - Vial
       product: Anti-venom(4)
       product_id: 12905
-      product_quantity: 1
-      members_only: true
   related_items:
     - item_id: 12924
       item_name: Toxic blowpipe
       slug: toxic-blowpipe
       relationship: alternative
-      description: Primary consumer
+      description: Primary consumer of scales
     - item_id: 12931
       item_name: Serpentine helm
       slug: serpentine-helm
       relationship: alternative
-      description: Defense use
+      description: Charged for venom immunity
     - item_id: 12899
       item_name: Trident of the swamp
       slug: trident-of-the-swamp
       relationship: alternative
-      description: Magic use
+      description: Magic weapon charged with scales
     - item_id: 12905
       item_name: Anti-venom(4)
       slug: anti-venom-4
       relationship: product
-      description: Herblore product
-  about: |-
-    | Item | Scales per charge | Max charges |
-    |------|-------------------|-------------|
-    | Toxic blowpipe | 1 per 3 shots | 16,383 |
-    | Serpentine helm | 1 per hit taken | 11,000 |
-    | Trident of the swamp | 1 per cast | 2,500 |
-    | Toxic staff of the dead | 1 per cast | 11,000 |
+      description: Herblore product brewed with scales
+  about: "Zulrah's scales are a stackable members consumable dropped in piles of 100-299 (and rarely 500) by Zulrah; they charge the toxic blowpipe, serpentine helm, trident of the swamp, and toxic staff of the dead, and are an ingredient for anti-venom potions at 87 Herblore."
   market_strategy:
     notes:
-      - High volume consumable
-      - Price tied to Zulrah popularity
-      - Blowpipe nerfs affected demand
-      - Toxic blowpipe users
-      - Serpentine helm charges
-      - Swamp trident users
-      - Anti-venom production
-      - Price correlates with raids activity
-      - Blowpipe still popular post-nerf
-      - Check GP/scale for gear choices
-      - Sacred eel fishing for ironmen
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - High volume consumable tied to Zulrah popularity
+      - Blowpipe nerfs and rework history affect long term demand
+      - Always check GP per scale across blowpipe, helm, and trident charges
+      - Anti-venom production absorbs excess supply at higher Herblore
+      - Sacred eel fishing is the ironman alternative source
+  history:
+    - date: "2015-01-08"
+      update: Zulrah
+      description: Zulrah's scales added as a guaranteed drop from the Zulrah boss fight.
+  properties:
+    release_date: "2015-01-08"
+    update: Zulrah
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Eighth batch — migrate 100 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Worktree-direct authoring; main repo untouched.
- Schema-validated via `astro sync`.

Post-agent normalisation: `material.tier` numeric values mapped to enum string (`low|mid|mid-high|high`).

## Test plan

- [x] `astro sync` clean — all 100 entries validate.
- [ ] CI build green.

## Follow-ups

- ~3573 v2 items remain after this batch lands.