### PR TITLE
fix(kbve-spider): spiders no longer freeze; allies follow reliably

### DIFF
--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -259,9 +259,7 @@ script.on_configuration_changed(function()
 	storage.ally_owners = storage.ally_owners or {}
 	storage.ally_names = storage.ally_names or {}
 	storage.ally_nametags = storage.ally_nametags or {}
-	if not storage.allies then
-		rebuild_ally_registry()
-	end
+	rebuild_ally_registry()
 	backfill_nametags()
 	rehydrate_runtime_settings()
 end)
@@ -503,18 +501,23 @@ local function follow_loop()
 				local dx = opos.x - apos.x
 				local dy = opos.y - apos.y
 				local d2 = dx * dx + dy * dy
-				if d2 > FOLLOW_REST_DIST_SQ and d2 < FOLLOW_RADIUS_SQ then
+				if d2 < FOLLOW_RADIUS_SQ then
 					pcall(function()
-						ally.set_command{
-							type = defines.command.go_to_location,
-							destination = { x = opos.x, y = opos.y },
-							-- by_damage = ally engages only when hit, not at every
-							-- ambient enemy. Keeps the follow tether intact while
-							-- the owner is just walking past biter spawners.
-							distraction = defines.distraction.by_damage,
-							radius = FOLLOW_DESTINATION_RADIUS,
-							pathfind_flags = { allow_destroy_friendly_entities = false },
-						}
+						if d2 > FOLLOW_REST_DIST_SQ then
+							ally.set_command{
+								type = defines.command.go_to_location,
+								destination = { x = opos.x, y = opos.y },
+								distraction = defines.distraction.by_damage,
+								radius = FOLLOW_DESTINATION_RADIUS,
+							}
+						elseif not ally.has_command() then
+							ally.set_command{
+								type = defines.command.wander,
+								ticks_to_wait = 240,
+								wander_in_group = false,
+								distraction = defines.distraction.by_damage,
+							}
+						end
 					end)
 				end
 			end
@@ -559,6 +562,7 @@ script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 			local spiders = surface.find_entities_filtered{ name = { SPIDER, SPIDER_ALLY } }
 			local n = #spiders
 			if n > 0 then
+				-- Twitch overlay on 3 random spiders.
 				local picks = math.min(cached_nervous_pick, n)
 				for _ = 1, picks do
 					local s = spiders[math.random(1, n)]
@@ -572,6 +576,31 @@ script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 								position = s.position,
 								direction = s.direction,
 							}
+						end
+					end
+				end
+				-- Idle wander pass: any spider that's not in an attack group and
+				-- has no current command gets a short wander burst so wild biters
+				-- (which aren't tied to a spawner here, so don't get Factorio's
+				-- normal ambient AI) and ally spiders parked near their owner
+				-- don't freeze in place.
+				for i = 1, n do
+					local s = spiders[i]
+					if s.valid then
+						local in_group = false
+						local ok_ug, ug = pcall(function() return s.unit_group end)
+						if ok_ug and ug then in_group = true end
+						if not in_group then
+							pcall(function()
+								if not s.has_command() then
+									s.set_command{
+										type = defines.command.wander,
+										ticks_to_wait = 600,
+										wander_in_group = false,
+										distraction = defines.distraction.by_damage,
+									}
+								end
+							end)
 						end
 					end
 				end


### PR DESCRIPTION
## Symptom

In-game on the 0.2.1 build (not yet on the portal — riding the same version per no-double-bump rule):

1. Allies stop following after the first hop. Owner walks away, ally stays put.
2. All spiders (wild + ally) freeze in place after their current command completes.

## Fixes

### 1. Drop `pathfind_flags` on the follow command

\`\`\`diff
- pathfind_flags = { allow_destroy_friendly_entities = false },
\`\`\`

On the player force the ally's environment is full of friendly entities. With this flag set, the pathfinder reads it as "can't path through anything that would otherwise be destroyed" and gives up — the ally moves on the first follow tick and then can't find a route back. Removing it lets the standard unit pathfinder run.

### 2. Idle-wander when the ally is inside the rest band

When the ally is within `FOLLOW_REST_DIST_SQ` of the owner (≤ 2 tiles) we used to leave it commandless. Now:

\`\`\`lua
elseif not ally.has_command() then
    ally.set_command{
        type = defines.command.wander,
        ticks_to_wait = 240,
        wander_in_group = false,
        distraction = defines.distraction.by_damage,
    }
end
\`\`\`

`has_command()` gate means we only reissue when the previous wander completes, so it's cheap and never overrides the go_to_location command when the owner moves again.

### 3. Wild-spider wander (piggybacks on the 15s nervous loop)

After the existing nervous-overlay pick, the same loop now iterates all spiders + allies on active surfaces and issues `defines.command.wander` (600 ticks, ~10s) to anything that's not in a `unit_group` AND has no current command. **Why:** the wild spider isn't tied to a `unit-spawner` prototype in this mod, so it never receives Factorio's ambient "join a wave" treatment. Without this, `/editor`-spawned and `create_entity`-spawned wild spiders just stand still until something shoots them. Cost is bounded — 1/15s cadence + active-surface gate.

### 4. Unconditional `rebuild_ally_registry()` on mod-config change

Previously skipped when `storage.allies` was non-nil-but-empty. Now runs every time — cheap one-pass `find_entities_filtered` per surface on mod-config change, catches `/editor`-spawned allies and anything that slipped past the hatch path's registry insert.

## Test plan

- [x] `luac -p control.lua` → clean.
- [x] `./kbve.sh -nx kbve-spider:test` → PASS.
- [x] Built + reinstalled locally as the 0.2.1 zip.
- [ ] CI re-runs `kbve-spider:test` clean.
- [ ] Manual: hatch ally → walk 30 tiles → ally trails at ~1 tile lag, never freezes.
- [ ] Manual: stand still → ally wanders nearby every few seconds → feels alive instead of statue.
- [ ] Manual: `/editor` spawn a few wild kbve-spiders far from any base → within 15s they all start wandering instead of standing rigid.