### PR TITLE
fix(ci-steam-promote): translate to_branch=default → empty betakey for Steam public branch

### DIFF
--- a/.github/workflows/ci-steam-promote.yml
+++ b/.github/workflows/ci-steam-promote.yml
@@ -115,7 +115,15 @@ jobs:
                     DESC="$DESC ($APP_LABEL)"
                   fi
 
-                  echo "::notice::Setting app=$APP_ID build=$BUILD_ID live on branch=$TO_BRANCH"
+                  # Steam's public/default branch has no betakey of its own —
+                  # the API expects an empty string. `default` / `public` are
+                  # operator-friendly synonyms; both map to empty here.
+                  BETAKEY="$TO_BRANCH"
+                  if [ "$BETAKEY" = "default" ] || [ "$BETAKEY" = "public" ]; then
+                    BETAKEY=""
+                  fi
+
+                  echo "::notice::Setting app=$APP_ID build=$BUILD_ID live on branch=${BETAKEY:-<default/public>}"
 
                   HTTP_BODY=$(mktemp)
                   HTTP_CODE=$(curl -sS -o "$HTTP_BODY" -w '%{http_code}' \
@@ -123,7 +131,7 @@ jobs:
                     --data-urlencode "key=$STEAM_WEBAPI_KEY" \
                     --data-urlencode "appid=$APP_ID" \
                     --data-urlencode "buildid=$BUILD_ID" \
-                    --data-urlencode "betakey=$TO_BRANCH" \
+                    --data-urlencode "betakey=$BETAKEY" \
                     --data-urlencode "description=$DESC")
 
                   echo "HTTP $HTTP_CODE"


### PR DESCRIPTION
## Summary

Unity build [#26804496989](https://github.com/KBVE/kbve/actions/runs/26804496989) succeeded ✅ (deterministic codegen fix from #11659 means tree is clean). Auto-dispatched promotion [#26808319253](https://github.com/KBVE/kbve/actions/runs/26808319253) then failed at the SetAppBuildLive call:

```
HTTP 200
{"response":{"result":2,"message":"unknown beta branch for appID 3791950"}}
```

## Root cause

Steam Partner Web API's [`ISteamApps/SetAppBuildLive`](https://partner.steamgames.com/doc/webapi/ISteamApps#SetAppBuildLive) treats the public/default branch as `betakey=""` (empty string). Per Valve's docs, the betakey parameter is _"required, may be empty string for default branch"_.

The manifest declares `promote_to_branch: default` for the demo app, and [ci-steam-promote.yml:126](.github/workflows/ci-steam-promote.yml#L126) passed the literal string `default` as betakey. Steam doesn't have a beta named `default` — its result=2 = "Fail" with that message.

## Fix

Translate operator-friendly synonyms `default` and `public` → empty `betakey` before the curl call. Named beta branches (`playtest`, `qa`, `beta`, etc.) pass through unchanged.

```bash
BETAKEY="$TO_BRANCH"
if [ "$BETAKEY" = "default" ] || [ "$BETAKEY" = "public" ]; then
  BETAKEY=""
fi
```

Notice log still surfaces `<default/public>` so the UI shows what was actually targeted.

No manifest changes needed — `promote_to_branch: default` stays as-is and continues to mean "ship to the public branch".

## Test plan

- [ ] Manual `gh workflow run ci-steam-promote.yml -f app_id=3791950 -f build_id=<existing> -f to_branch=default` succeeds, returns `result=OK`
- [ ] Re-trigger the failed promote ([#26808319253](https://github.com/KBVE/kbve/actions/runs/26808319253)) via dispatch, confirm HTTP 200 + `result=OK`
- [ ] Steam install + verify the demo on the default branch reflects the new BuildID