### PR TITLE
fix(kbve-spider): allies follow by tracking character entity, not static position

### DIFF
--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -428,8 +428,8 @@ end
 -- on a different chunk; once back within range the loop picks up again.
 local FOLLOW_TICK_INTERVAL = 60
 local FOLLOW_RADIUS_SQ = 128 * 128   -- keep tracking up to ~128 tiles away
-local FOLLOW_REST_DIST_SQ = 2 * 2    -- already on top of owner → don't churn
-local FOLLOW_DESTINATION_RADIUS = 2  -- ally settles within 2 tiles of owner
+local FOLLOW_REST_DIST_SQ = 6 * 6    -- ally orbits within 6 tiles — pack-like, not heel-clinging
+local FOLLOW_DESTINATION_RADIUS = 5  -- ally settles within 5 tiles of owner
 
 -- Iterates `storage.allies` (maintained at hatch + death + on_init/
 -- on_configuration_changed rebuild) instead of calling
@@ -520,14 +520,14 @@ local function follow_loop()
 								ally.set_command{
 									type = defines.command.go_to_location,
 									destination_entity = target_entity,
-									distraction = defines.distraction.by_damage,
+									distraction = defines.distraction.by_enemy,
 									radius = FOLLOW_DESTINATION_RADIUS,
 								}
 							else
 								ally.set_command{
 									type = defines.command.go_to_location,
 									destination = { x = opos.x, y = opos.y },
-									distraction = defines.distraction.by_damage,
+									distraction = defines.distraction.by_enemy,
 									radius = FOLLOW_DESTINATION_RADIUS,
 								}
 							end
@@ -536,7 +536,7 @@ local function follow_loop()
 								type = defines.command.wander,
 								ticks_to_wait = 240,
 								wander_in_group = false,
-								distraction = defines.distraction.by_damage,
+								distraction = defines.distraction.by_enemy,
 							}
 						end
 					end)

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -504,12 +504,33 @@ local function follow_loop()
 				if d2 < FOLLOW_RADIUS_SQ then
 					pcall(function()
 						if d2 > FOLLOW_REST_DIST_SQ then
-							ally.set_command{
-								type = defines.command.go_to_location,
-								destination = { x = opos.x, y = opos.y },
-								distraction = defines.distraction.by_damage,
-								radius = FOLLOW_DESTINATION_RADIUS,
-							}
+							-- Pass `destination_entity` instead of a static
+							-- `destination` so Factorio's unit AI tracks the
+							-- player as they move. A plain MapPosition makes
+							-- this a one-shot move command — the unit arrives,
+							-- the command completes, and the ally idles even
+							-- though we re-issue every second (each re-issue is
+							-- a *new* one-shot to a stale spot). The character
+							-- entity is the player's body; LuaPlayer.character
+							-- is nil for spectators / editor mode, in which
+							-- case we fall back to a static destination so the
+							-- ally at least catches up to the cursor.
+							local target_entity = owner.character
+							if target_entity and target_entity.valid then
+								ally.set_command{
+									type = defines.command.go_to_location,
+									destination_entity = target_entity,
+									distraction = defines.distraction.by_damage,
+									radius = FOLLOW_DESTINATION_RADIUS,
+								}
+							else
+								ally.set_command{
+									type = defines.command.go_to_location,
+									destination = { x = opos.x, y = opos.y },
+									distraction = defines.distraction.by_damage,
+									radius = FOLLOW_DESTINATION_RADIUS,
+								}
+							end
 						elseif not ally.has_command() then
 							ally.set_command{
 								type = defines.command.wander,


### PR DESCRIPTION
## Symptom

Even after #11679 dropped \`pathfind_flags\` and added the wander fallback, allies still stop after the first hop and never catch up to a moving owner.

## Root cause

\`defines.command.go_to_location\` with \`destination = {x, y}\` is a **one-shot move**. Factorio walks the unit to that exact map position once, marks the command complete, and idles the unit — it does **not** re-pathfind toward a player who has since walked away.

Re-issuing every second on the 1 Hz loop just queues another one-shot to a slightly newer stale spot; the unit reaches the previous spot first and stops before the next command arrives. Net effect: ally jogs to where you were a second ago, freezes, and the loop never catches up because each command "completes" before the next override.

## Fix

Pass \`destination_entity = owner.character\` instead of a static \`destination\`. With an entity reference, the unit AI tracks the moving target continuously and only completes when it's within \`radius\` of the **current** position of the player's body — no second-by-second catch-up needed.

\`\`\`diff
- ally.set_command{
-     type = defines.command.go_to_location,
-     destination = { x = opos.x, y = opos.y },
-     distraction = defines.distraction.by_damage,
-     radius = FOLLOW_DESTINATION_RADIUS,
- }
+ local target_entity = owner.character
+ if target_entity and target_entity.valid then
+     ally.set_command{
+         type = defines.command.go_to_location,
+         destination_entity = target_entity,
+         distraction = defines.distraction.by_damage,
+         radius = FOLLOW_DESTINATION_RADIUS,
+     }
+ else
+     -- spectator / editor mode → no character body to track
+     ally.set_command{
+         type = defines.command.go_to_location,
+         destination = { x = opos.x, y = opos.y },
+         ...
+     }
+ end
\`\`\`

1 Hz re-issue is still in place — covers the case where the command got cleared by damage / target invalidating / etc. The entity reference does the actual continuous tracking.

## Test plan

- [x] \`luac -p control.lua\` clean, \`./kbve.sh -nx kbve-spider:test\` PASS.
- [x] Built + reinstalled locally as the 0.2.1 zip.
- [ ] Manual: hatch ally → walk 50+ tiles → ally trails continuously, no freeze.
- [ ] Manual: stop walking → ally settles within radius + wanders nearby.
- [ ] Manual: \`/editor\` mode → no character → ally falls back to static destination and at least chases the cursor instead of standing still.