### PR TITLE
content(astro-kbve): bump 200 OSRS items v2 → v3 (batch 9)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-dart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-dart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adamant dart | OSRS Price Data
-description: "Adamant dart is a members weapon slot item. High alch: 39 GP, GE limit: 11,000."
+description: "Adamant dart is a members thrown ranged weapon. High alch: 39 GP, GE limit: 11,000."
 osrs:
   id: 810
   name: Adamant dart
@@ -12,67 +12,106 @@ osrs:
   lowalch: 26
   highalch: 39
   limit: 11000
+  material:
+    type: adamant
+    tier: mid
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
+    weapon_type: thrown
     attack_speed: 3
-  requirements:
-    ranged: 30
-  stats:
-    attack:
+    weight: 0
+    requirements:
+      ranged: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 0
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 17
-  fletching:
-    level: 67
-    xp: 15
-    method: Attach feathers to adamant dart tips
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Fletching
+      level: 67
+      xp: 15
+      output_quantity: 10
+      materials:
+        - item_name: Adamant dart tip
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      tools: []
+      notes: "Attach feathers to adamant dart tips."
   drop_table:
     sources:
       - source: Dagannoth Supreme
-        source_id: 2265
-        combat_level: 303
-        quantity: 25-75
+        quantity: "1"
         rarity: common
-        members_only: true
       - source: Brutal blue dragon
-        source_id: 7273
-        combat_level: 271
-        quantity: 7-13
+        quantity: "1"
         rarity: common
-        members_only: true
   related_items:
     - item_id: 823
       item_name: Adamant dart tip
       slug: adamant-dart-tip
       relationship: component
-      description: Fletching material
+      description: Fletching material used to make adamant darts.
     - item_id: 314
       item_name: Feather
       slug: feather
       relationship: component
-      description: Fletching material
+      description: Required to fletch darts.
     - item_id: 811
       item_name: Rune dart
       slug: rune-dart
       relationship: upgrade
-      description: Higher tier
+      description: Higher tier thrown dart.
     - item_id: 809
       item_name: Mithril dart
       slug: mithril-dart
       relationship: downgrade
-      description: Lower tier
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon/Ammo |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 30 Ranged |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Lower tier thrown dart.
+  about: "Adamant dart is a members thrown ranged weapon requiring 30 Ranged to wield, fletched at level 67 Fletching."
+  market_strategy:
+    notes:
+      - Bulk-flipped by mid-game rangers
+      - GE limit 11,000 supports large flips
+      - Tied to fletching profit margins
+  trading_tips:
+    - Watch adamant dart tip prices for fletching arbitrage
+    - Stable consumable demand from PvM/Slayer
+  history:
+    - date: "2003-04-14"
+      description: "Released with the New Throwing Weapons update."
+    - date: "2021-06-30"
+      description: "Ranged attack bonus decreased from +11 to 0; ranged strength increased from +10 to +17."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: "New Throwing Weapons!"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-h5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-h5.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 6656
   highalch: 9984
   limit: 8
-  about: "Adamant platebody (h5) is a free-to-play item in Old School RuneScape. High alchemy value: 9,984 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: adamant
+    tier: mid
+  equipment:
+    slot: body
+    weight: 11.339
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 65
+      slash: 63
+      crush: 55
+      magic: -6
+      ranged: 63
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_id: 1119
+      item_name: Adamant platebody
+      slug: adamant-platebody
+      relationship: variant
+      description: Base adamant platebody without heraldry
+  about: "Adamant platebody (h5) is a heraldic variant obtained from medium clue reward caskets, sharing identical stats to the regular adamant platebody."
+  market_strategy:
+    notes:
+      - Cosmetic heraldic variant of standard adamant platebody
+      - Low buy limit makes flipping slow
+      - Obtained only from medium clue rewards
+  trading_tips:
+    - Stats match the regular adamant platebody
+    - Stored in costume room treasure chest
+  history:
+    - date: "2019-04-11"
+      description: Released as part of the Treasure Trails Expansion and Easter 2019 update.
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -10 to -15.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 11.339
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adamant platebody (t) | OSRS Price Data
-description: "Adamant platebody (t) is a F2P body slot item requiring 30 Defence. High alch: 9,984 GP, GE limit: 8."
+description: "Adamant platebody (t) is a F2P body slot reward from medium clues requiring 30 Defence. High alch: 9,984 GP, GE limit: 8."
 osrs:
   id: 2599
   name: Adamant platebody (t)
@@ -12,33 +12,83 @@ osrs:
   lowalch: 6656
   highalch: 9984
   limit: 8
+  material:
+    type: adamantite
+    tier: mid
   equipment:
     slot: body
     requirements:
       defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     defence_bonus:
       stab: 65
       slash: 63
       crush: 55
       magic: -6
       ranged: 63
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
     - item_id: 2601
       item_name: Adamant platelegs (t)
       slug: adamant-platelegs-t
       relationship: set-piece
-      description: Matching trimmed platelegs
+      description: Matching trimmed platelegs.
+    - item_id: 2603
+      item_name: Adamant kiteshield (t)
+      slug: adamant-kiteshield-t
+      relationship: set-piece
+      description: Matching trimmed kiteshield.
+    - item_id: 2605
+      item_name: Adamant full helm (t)
+      slug: adamant-full-helm-t
+      relationship: set-piece
+      description: Matching trimmed full helm.
     - item_id: 2607
       item_name: Adamant platebody (g)
       slug: adamant-platebody-g
       relationship: variant
-      description: Gold-trimmed variant
-  about: |-
-    > *"Adamant platebody with trim."*
-
-    The adamant platebody (t) is a trimmed cosmetic variant of the standard adamant platebody. Identical stats, requiring 30 Defence. Cannot be made through Smithing — clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Gold-trimmed cosmetic variant.
+  about: "Adamant platebody (t) is a cosmetic trimmed platebody from medium clue scroll rewards with identical stats to the standard adamant platebody."
+  market_strategy:
+    notes:
+      - Identical combat stats to base adamant platebody — premium is purely cosmetic
+      - Tight 8/4h buy limit keeps trimmed clue cosmetics thin
+  history:
+    - date: "2004-05-05"
+      description: Released alongside the Bigger Banks and Treasure Trails update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-05-05"
+    update: "Bigger Banks & Treasure Trails"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 11.339
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-sword.mdx
@@ -12,26 +12,76 @@ osrs:
   lowalch: 832
   highalch: 1248
   limit: 125
-  item_id: 1287
-  item_type: equipment
-  slot: weapon
-  type: sword
-  attack_style: stab
-  attack_speed: 4
-  tradeable: true
-  weight: 2.041
-  requirements:
-    attack: 30
-  stats:
-    stab_attack: 23
-    slash_attack: 18
-    crush_attack: -2
-    strength: 24
+  material:
+    type: adamant
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
+    weight: 2.041
+    requirements:
+      attack: 30
+    attack_bonus:
+      stab: 23
+      slash: 18
+      crush: -2
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 1
+    other_bonus:
+      strength: 24
+  shops:
+    - shop_name: Varrock Swordshop
+      price: 2080
+    - shop_name: Warrior Guild Armoury
+      price: 2496
+    - shop_name: Quality Weapons Shop
+      location: Keldagrim
+      price: 2704
+    - shop_name: Briget's Weapons
+      location: Shayzien
+      price: 2080
+    - shop_name: Cam Torum Blacksmith
+      price: 2080
   related_items:
-    - slug: rune-sword
-    - slug: adamant-scimitar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Rune sword
+      slug: rune-sword
+      relationship: upgrade
+      description: Higher-tier sword
+    - item_name: Adamant scimitar
+      slug: adamant-scimitar
+      relationship: alternative
+      description: Faster slash weapon at the same tier
+  about: "Adamant sword is a free-to-play stab weapon requiring 30 Attack to wield. Crafted at 74 Smithing or sold by sword shops across the world."
+  market_strategy:
+    notes:
+      - Free-to-play stab weapon at 30 Attack
+      - Outclassed by scimitar for training due to slash attack speed
+      - Common smithing product at 74 Smithing
+  history:
+    - date: "2001-01-04"
+      description: Released with the RuneScape beta launch.
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.041
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-trimmed-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-trimmed-set-sk.mdx
@@ -12,9 +12,42 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: 8
-  about: "Adamant trimmed set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 4,800 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: adamant
+    tier: mid
+  related_items:
+    - item_name: Adamant full helm (t)
+      relationship: set-piece
+      description: Part of the set
+    - item_name: Adamant platebody (t)
+      relationship: set-piece
+      description: Part of the set
+    - item_name: Adamant plateskirt (t)
+      relationship: set-piece
+      description: Part of the set
+    - item_name: Adamant kiteshield (t)
+      relationship: set-piece
+      description: Part of the set
+  about: "Adamant trimmed set (sk) bundles the trimmed adamant helm, platebody, skirt, and kiteshield for compact bank storage."
+  history:
+    - date: "2015-02-26"
+      description: Released with the Grand Exchange item set update.
+  properties:
+    release_date: "2015-02-26"
+    update: Grand Exchange
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/aldarium.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/aldarium.mdx
@@ -1,6 +1,6 @@
 ---
 title: Aldarium | OSRS Price Data
-description: "Aldarium: A special alchemical ingredient used for creating potions.. High alch: 60 GP, GE limit: 13,000."
+description: "Aldarium: A special alchemical ingredient used for creating potions. High alch: 60 GP, GE limit: 13,000."
 osrs:
   id: 29993
   name: Aldarium
@@ -12,9 +12,74 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 13000
-  about: "Aldarium is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Mixology Rewards
+      location: Alchemical Society headquarters
+      quantity: 0
+      notes: "Infinite stock; costs 80 Mox + 60 Aga + 90 Lye resin per Aldarium."
+  recipes:
+    - skill: herblore
+      level: 54
+      xp: 132
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Aldarium
+          quantity: 1
+      tools: []
+      output_item: Goading potion(3)
+      output_quantity: 1
+    - skill: herblore
+      level: 58
+      xp: 132
+      materials:
+        - item_name: Huasca potion (unf)
+          quantity: 1
+        - item_name: Aldarium
+          quantity: 1
+      tools: []
+      output_item: Prayer regeneration potion(3)
+      output_quantity: 1
+  related_items:
+    - item_id: 30000
+      item_name: Mox resin
+      slug: mox-resin
+      relationship: component
+      description: One of the resins spent at the Mixology Rewards shop.
+    - item_id: 30001
+      item_name: Aga resin
+      slug: aga-resin
+      relationship: component
+      description: One of the resins spent at the Mixology Rewards shop.
+    - item_id: 30002
+      item_name: Lye resin
+      slug: lye-resin
+      relationship: component
+      description: One of the resins spent at the Mixology Rewards shop.
+  about: "Aldarium is a Herblore ingredient bought from the Mixology Rewards shop with resins, used to brew Goading and Prayer regeneration potions."
+  market_strategy:
+    notes:
+      - Demand tracks Goading and Prayer regen potion meta usage
+      - Resin supply via Mastering Mixology caps practical supply
+  history:
+    - date: "2024-09-25"
+      description: Released alongside Varlamore - The Rising Darkness and the Mastering Mixology minigame.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrowtips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrowtips.mdx
@@ -14,70 +14,56 @@ osrs:
   limit: 10000
   material:
     type: ammunition_component
-    tradeable: true
-    stackable: true
-    weight: 0
-  creation:
-    method: Crafting
-    requirements:
-      crafting: 85
-    materials:
-      - item_id: 21347
-        item_name: Amethyst
-        quantity: "1"
-    product_quantity: 15
-    xp: 60
-  uses:
-    - result_id: 21326
-      result_name: Amethyst arrows
+    tier: mid-high
+  recipes:
+    - product_name: Amethyst arrowtips
+      skill: Crafting
+      level: 85
+      xp: 60
+      output_quantity: 15
       materials:
-        - Headless arrows
-        - Amethyst arrowtips
-      requirements:
-        fletching: 82
-      xp: 202.5
-  money_making:
-    gp_per_hour: 638000
-    activity: Cutting amethyst arrowtips
-    requirements:
-      crafting: 85
-  market:
-    buy_limit: 10000
-    price_estimate: 245
-    daily_volume: 17800000
+        - item_name: Amethyst
+          quantity: "1"
+      tools:
+        - Chisel
   related_items:
-    - item_id: 21347
-      item_name: Amethyst
+    - item_name: Amethyst
       slug: amethyst
       relationship: component
-      description: Raw material
-    - item_id: 53
-      item_name: Headless arrow
+      description: Raw material chiselled to make tips
+    - item_name: Headless arrow
       slug: headless-arrow
       relationship: component
-      description: Base item
-    - item_id: 21326
-      item_name: Amethyst arrow
+      description: Combined with tips to make amethyst arrows
+    - item_name: Amethyst arrow
       slug: amethyst-arrow
       relationship: product
-      description: Created item
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ammunition Component |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    | Arrow Created | Materials | Requirements |
-    |---------------|-----------|--------------|
-    | Amethyst arrows | Headless arrows + Amethyst arrowtips | 82 Fletching |
-
-    202.5 Fletching XP per 15 arrows.
-
-    ~638K gp/hr profit cutting amethyst arrowtips at 85 Crafting.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Final fletched arrow product
+  about: "Amethyst arrowtips are crafted from amethyst at 85 Crafting and attached to headless arrows for amethyst arrows at 82 Fletching."
+  market_strategy:
+    notes:
+      - Tip price tracks amethyst gem supply from Mining Guild
+      - 10,000 buy limit accommodates large fletching orders
+      - Profit margins thin once 2% GE tax is applied
+  history:
+    - date: "2017-06-22"
+      description: Added with the Mining Guild expansion update.
+  properties:
+    release_date: "2017-06-22"
+    update: "Mining Guild Expansion"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anchovies.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anchovies.mdx
@@ -12,23 +12,57 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 15000
+  food:
+    heals: 1
+    type: fish
+  recipes:
+    - skill: Cooking
+      level: 1
+      xp: 30
+      materials:
+        - item_name: Raw anchovies
+          quantity: 1
+      tools:
+        - Cooking range or fire
   related_items:
-    - item_id: 315
-      item_name: Shrimps
+    - item_name: Shrimps
       slug: shrimps
-      relationship: variant
-      description: Another net-caught fish
-    - item_id: 321
-      item_name: Raw anchovies
+      relationship: alternative
+      description: Other entry-level net-caught fish
+    - item_name: Raw anchovies
       slug: raw-anchovies
       relationship: component
       description: Uncooked version
-  about: |-
-    > _"Some nicely cooked anchovies."_
-
-    Anchovies heal 1 Hitpoint. Caught with a small fishing net at 15 Fishing. Despite low healing, they're useful as an ingredient for anchovy pizza.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Anchovy pizza
+      slug: anchovy-pizza
+      relationship: product
+      description: Pizza recipe using cooked anchovies
+  about: "Anchovies are a free-to-play cooked fish that heal 1 Hitpoint. Cooked at level 1 Cooking for 30 XP and stop burning at level 34 (level 31 on the Lumbridge range with Cook's Assistant complete)."
+  market_strategy:
+    notes:
+      - Healing too low for combat, mainly a Cooking training and pizza ingredient
+      - Stops burning at level 34 Cooking, or 31 on Lumbridge range
+      - Used in anchovy pizza recipe
+  history:
+    - date: "2001-06-11"
+      description: Released with the new Fishing skill and Cooking expansion.
+  properties:
+    release_date: "2001-06-11"
+    update: New fishing skill and more cooking
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.1
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-effigy.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-effigy.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 3200000
   highalch: 4800000
   limit: 250
-  about: "Ancient effigy is a members-only item in Old School RuneScape. High alchemy value: 4,800,000 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Revenant imp
+        quantity: "1"
+        rarity: Rare
+      - source: Revenant goblin
+        quantity: "1"
+        rarity: Rare
+      - source: Revenant pyrefiend
+        quantity: "1"
+        rarity: Rare
+      - source: Revenant hobgoblin
+        quantity: "1"
+        rarity: Rare
+      - source: Revenant cyclops
+        quantity: "1"
+        rarity: Rare
+      - source: Revenant hellhound
+        quantity: "1"
+        rarity: Rare
+      - source: Revenant demon
+        quantity: "1"
+        rarity: Rare
+      - source: Revenant ork
+        quantity: "1"
+        rarity: Rare
+      - source: Revenant dark beast
+        quantity: "1"
+        rarity: Rare
+      - source: Revenant knight
+        quantity: "1"
+        rarity: Rare
+      - source: Revenant dragon
+        quantity: "1"
+        rarity: Rare
+      - source: Bounty Crate
+        quantity: "1"
+        rarity: 4/1000
+  related_items:
+    - item_name: Bracelet of ethereum
+      slug: bracelet-of-ethereum
+      relationship: alternative
+      description: Other always-lost-on-death revenant item
+    - item_name: Revenant ether
+      slug: revenant-ether
+      relationship: product
+      description: Effigy can be chiselled into 16,000 revenant ether
+  about: "Ancient effigy is a high-value drop from revenants and Bounty Crates that can be exchanged with the Emblem Trader for 8,000,000 coins or chiselled into 16,000 revenant ether."
+  market_strategy:
+    notes:
+      - Effigy sells for a fixed 8,000,000 to the Emblem Trader so GE price is anchored just below that ceiling
+      - 16,000 revenant ether per effigy gives a second valuation route to compare against
+  trading_tips:
+    - Compare GE price to Emblem Trader payout minus GE tax before flipping
+    - Always lost on death even if alone in inventory; do not carry while risking PvP
+  history:
+    - date: "2018-02-08"
+      update: Revenant Caves
+      description: Added to the game.
+    - date: "2025-07"
+      description: Chiselling an effigy now produces 16,000 revenant ether.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-02-08"
+    update: Revenant Caves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-hilt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-hilt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ancient hilt | OSRS Price Data
-description: "Ancient hilt: Brimming with potential.. High alch: 300,000 GP."
+description: "Ancient hilt: Brimming with potential. High alch: 300,000 GP."
 osrs:
   id: 26370
   name: Ancient hilt
@@ -12,54 +12,69 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: null
-  item:
-    type: crafting material
-    tradeable: true
-    weight: 2.5
-  obtaining:
-    - source: Nex
-      drop_rate: 1/516
+  material:
+    type: godsword-hilt
+    tier: high
+  drop_table:
+    sources:
+      - source: Nex
+        quantity: "1"
+        rarity: 1/516
   recipes:
-    - materials:
-        - item_id: 26370
-          item_name: Ancient hilt
-          quantity: 1
+    - product: Ancient godsword
+      product_id: 26233
+      skill: None
+      level: 0
+      experience: 0
+      materials:
         - item_id: 11690
           item_name: Godsword blade
           quantity: 1
-      product: Ancient godsword
-      product_id: 26233
-      notes: No skill requirements
+        - item_id: 26370
+          item_name: Ancient hilt
+          quantity: 1
+      tools: []
+      notes: No skill requirements to combine.
   related_items:
     - item_id: 11690
       item_name: Godsword blade
       slug: godsword-blade
       relationship: component
-      description: Base component for godsword
+      description: Base component combined with the hilt.
     - item_id: 26233
       item_name: Ancient godsword
       slug: ancient-godsword
       relationship: product
-      description: Created healing spec weapon
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 2.5 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Ancient godsword | Godsword blade + Ancient hilt |
-
-    No skill requirements.
+      description: Created two-handed godsword with the Blood Sacrifice special attack.
+  about: "Ancient hilt is the rare Nex drop combined with a godsword blade to forge the Ancient godsword, the highest-value hilt thanks to the blade's healing spec."
   market_strategy:
     notes:
-      - Farm Nex
-      - Most valuable hilt
-      - Unique blood spec
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Supply is gated by Nex spawns; price tracks PvM popularity.
+      - Spec utility on the finished godsword sustains long-term demand.
+  trading_tips:
+    - Buy hilts during Nex content lulls and assemble during PvM hype.
+    - Track godsword blade price to time arbitrage windows.
+  history:
+    - date: "2021-12-16"
+      description: Item added to the game data but not yet obtainable.
+    - date: "2022-01-05"
+      description: "Became obtainable as a Nex drop with the Nex: The Fifth General update."
+  properties:
+    release_date: "2022-01-05"
+    update: "Nex: The Fifth General"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.5
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-page-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-page-2.mdx
@@ -1,54 +1,69 @@
 ---
 title: Ancient page 2 | OSRS Price Data
-description: "Ancient page 2: This seems to have been torn from a book.... High alch: 240 GP, GE limit: 5."
+description: "Ancient page 2: This seems to have been torn from a book... High alch: 240 GP, GE limit: 5."
 osrs:
   id: 12622
   name: Ancient page 2
   slug: ancient-page-2
-  examine: This seems to have been torn from a book...
+  examine: "This seems to have been torn from a book..."
   members: true
   icon: Ancient page 2.png
   value: 400
   lowalch: 160
   highalch: 240
   limit: 5
-  item:
-    type: god_page
-    god: Ancient
-    page_number: 2
-    tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite
-        drop_rate: Varies by tier
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
   related_items:
     - item_id: 12621
       item_name: Ancient page 1
       slug: ancient-page-1
       relationship: set-piece
-      description: Page 1 of 4
+      description: Page 1 of 4 of the Book of darkness.
     - item_id: 12623
       item_name: Ancient page 3
       slug: ancient-page-3
       relationship: set-piece
-      description: Page 3 of 4
+      description: Page 3 of 4 of the Book of darkness.
     - item_id: 12624
       item_name: Ancient page 4
       slug: ancient-page-4
       relationship: set-piece
-      description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Ancient (Zaros) |
-    | Page | 2 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of darkness (Ancient god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Page 4 of 4 of the Book of darkness.
+    - item_id: 3839
+      item_name: Book of darkness
+      slug: book-of-darkness
+      relationship: product
+      description: Completed Ancient (Zaros) god book assembled from all four pages.
+  about: "Ancient page 2 is a Zaros-themed clue scroll reward used with the other three pages to complete the Book of darkness."
+  market_strategy:
+    notes:
+      - Tiny 5/4h buy limit makes the page price spiky
+      - Demand follows Hard/Elite/Master clue popularity and god book restorations
+  history:
+    - date: "2014-07-03"
+      description: Released alongside the Halos, God Books and Stamina update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-07-03"
+    update: "Halos, God Books & Stamina"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-statuette.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-statuette.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ancient statuette | OSRS Price Data
-description: "Ancient statuette: A mysterious artifact of ancient times, of substantial value to emblem traders.. High alch: 1,200,000 GP, GE limit: 250."
+description: "Ancient statuette: a mysterious artifact of ancient times, of substantial value to emblem traders. High alch: 1,200,000 GP, GE limit: 250."
 osrs:
   id: 21813
   name: Ancient statuette
@@ -12,9 +12,53 @@ osrs:
   lowalch: 800000
   highalch: 1200000
   limit: 250
-  about: "Ancient statuette is a members-only item in Old School RuneScape. High alchemy value: 1,200,000 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Revenant dragon
+        quantity: "1"
+        rarity: 1/4000
+      - source: Revenant knight
+        quantity: "1"
+        rarity: 1/4000
+      - source: Bounty crate
+        quantity: "1"
+        rarity: 15/1000
+  about: "Ancient statuette is a high-value Revenant Caves drop and bounty crate reward, chiselable into 4,000 revenant ether and treated as a tradeable wealth carrier in the Wilderness."
+  market_strategy:
+    notes:
+      - Wealth carrier dropped on death pre-2018 rework
+      - 9 July 2025 chisel conversion into 4,000 revenant ether sets a price floor
+  trading_tips:
+    - Track revenant ether price for arbitrage versus chisel output
+    - Demand spikes during Wilderness updates and double XP events
+  history:
+    - date: "2025-07-09"
+      description: Can now be chiseled into 4,000 revenant ether.
+    - date: "2020-09-10"
+      description: Grand Exchange buy limit reduced from 18,000 to 250.
+    - date: "2018-03-01"
+      description: Now always dropped on death regardless of protect-item.
+    - date: "2018-02-08"
+      description: Graphical redesign and examine text updated.
+    - date: "2017-11-23"
+      description: Released alongside the Mage Arena II and Revenant Caves update.
+  properties:
+    release_date: "2017-11-23"
+    update: "Mage Arena II, Revenant Caves & Deadman Beta"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Chisel
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ankou-s-leggings.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ankou-s-leggings.mdx
@@ -9,12 +9,95 @@ osrs:
   members: true
   icon: Ankou's leggings.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 4
-  about: "Ankou's leggings is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.5
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/12765
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_id: 20101
+      item_name: Ankou mask
+      slug: ankou-mask
+      relationship: set-piece
+      description: Matching Ankou outfit head piece
+    - item_id: 20102
+      item_name: Ankou's top
+      slug: ankou-s-top
+      relationship: set-piece
+      description: Matching Ankou outfit body piece
+    - item_id: 20103
+      item_name: Ankou gloves
+      slug: ankou-gloves
+      relationship: set-piece
+      description: Matching Ankou outfit gloves piece
+    - item_id: 20105
+      item_name: Ankou socks
+      slug: ankou-socks
+      relationship: set-piece
+      description: Matching Ankou outfit feet piece
+  about: "Ankou's leggings are a cosmetic master Treasure Trail reward with no combat bonuses, dropped at 1/12,765 from a reward casket (master) and storable in a costume room mahogany treasure chest."
+  market_strategy:
+    notes:
+      - Master clue cosmetic, extreme rarity drives high GE price
+      - Not alchable; value comes from collector demand
+      - Low daily volume (around 60); use limit orders
+  trading_tips:
+    - Track Ankou outfit set premium when listing
+    - Master clue completion price floor moves with clue meta
+  history:
+    - date: "2016-07-06"
+      description: Released with the Treasure Trail Expansion update.
+    - date: "2019-10-31"
+      description: Renamed during a consistency adjustment pass.
+    - date: "2020-06-04"
+      description: Name reverted to Ankou's leggings.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-3-12915.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-3-12915.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 133
   highalch: 199
   limit: 2000
-  about: "Anti-venom+(3) is a members-only item in Old School RuneScape. High alchemy value: 199 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 3
+    effects:
+      - description: "Instantly cures venom and poison"
+      - description: "Grants approximately 3.6 minutes of venom immunity"
+      - description: "Grants 15 minutes of poison immunity"
+  related_items:
+    - item_id: 12913
+      item_name: "Anti-venom+(4)"
+      slug: anti-venom-4
+      relationship: variant
+      description: Full 4-dose version
+    - item_id: 12917
+      item_name: "Anti-venom+(2)"
+      slug: anti-venom-2
+      relationship: variant
+      description: 2-dose variant
+    - item_id: 12919
+      item_name: "Anti-venom+(1)"
+      slug: anti-venom-1
+      relationship: variant
+      description: 1-dose variant
+    - item_id: 12905
+      item_name: "Anti-venom(4)"
+      slug: anti-venom-4-12905
+      relationship: component
+      description: Base potion used in recipe
+    - item_id: 269
+      item_name: Torstol
+      slug: torstol
+      relationship: component
+      description: Secondary ingredient
+  about: "Anti-venom+(3) is a 3-dose potion that instantly cures venom and poison while granting prolonged immunity. Made at Herblore level 94 by combining anti-venom(4) with torstol or an unfinished torstol potion."
+  market_strategy:
+    notes:
+      - Required for Zulrah and other venom encounters
+      - High Herblore requirement limits supply
+      - Doses split GE pricing
+  trading_tips:
+    - Track Zulrah popularity for demand signals
+    - Decanting between dose sizes can yield margin
+  history:
+    - date: "2015-01-08"
+      description: Released with the Zulrah update.
+    - date: "2022-11-16"
+      description: Recipe now accepts unfinished torstol potions as a substitute for torstol.
+  properties:
+    release_date: "2015-01-08"
+    update: Zulrah
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-4.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 144
   highalch: 216
   limit: 4000
-  about: "Antidote+(4) is a members-only item in Old School RuneScape. High alchemy value: 216 coins. Grand Exchange buy limit: 4,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - description: Cures poison on consumption.
+      - description: Grants 9 minutes of poison immunity per dose.
+      - description: Two doses reduce venom to poison then cure it.
+  recipes:
+    - skill: Herblore
+      level: 68
+      xp: 155
+      materials:
+        - item_name: Toadflax (clean)
+          quantity: 1
+        - item_name: Coconut milk
+          quantity: 1
+        - item_name: Yew roots
+          quantity: 1
+      tools:
+        - Vial
+  related_items:
+    - item_id: 5945
+      item_name: Antidote+(3)
+      slug: antidote-3
+      relationship: variant
+      description: 3-dose vial
+    - item_id: 5947
+      item_name: Antidote+(2)
+      slug: antidote-2
+      relationship: variant
+      description: 2-dose vial
+    - item_id: 5949
+      item_name: Antidote+(1)
+      slug: antidote-1
+      relationship: variant
+      description: 1-dose vial
+    - item_id: 5952
+      item_name: Antidote++(4)
+      slug: antidote-pp-4
+      relationship: upgrade
+      description: Longer immunity variant
+  about: "Antidote+(4) is a 4-dose extra strong antipoison brewed at 68 Herblore that cures poison and grants 9 minutes of immunity per dose."
+  market_strategy:
+    notes:
+      - Made at 68 Herblore for 155 xp
+      - Brewed using coconut milk for 4 doses
+      - Buy limit 4,000 per 4 hours
+      - Two doses cure venom
+  trading_tips:
+    - Coconut milk inflates batch yield to 4 doses
+    - Pre-2016 antipoisons reset immunity timers
+  history:
+    - date: "2005-07-11"
+      description: Released with the Farming update.
+    - date: "2016-04-07"
+      description: Drinking antipoisons no longer shortens existing immunity.
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-chestplate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-chestplate.mdx
@@ -1,6 +1,6 @@
 ---
 title: Armadyl chestplate | OSRS Price Data
-description: "Armadyl chestplate is a members legs slot item requiring 70 Defence. High alch: 174,000 GP, GE limit: 8."
+description: "Armadyl chestplate is a members body slot armour requiring 70 Ranged and 70 Defence. High alch: 174,000 GP, GE limit: 8."
 osrs:
   id: 11828
   name: Armadyl chestplate
@@ -12,68 +12,83 @@ osrs:
   lowalch: 116000
   highalch: 174000
   limit: 8
+  material:
+    type: armadyl
+    tier: high
   equipment:
-    slot: legs
-    type: ranged_armour
+    slot: body
+    weapon_type: armour
+    weight: 4
     requirements:
       ranged: 70
       defence: 70
-    stats:
-      attack_ranged: 20
-      defence_stab: 32
-      defence_slash: 26
-      defence_crush: 34
-      defence_magic: 40
-      defence_ranged: 33
+    attack_bonus:
+      stab: -7
+      slash: -7
+      crush: -7
+      magic: -15
+      ranged: 33
+    defence_bonus:
+      stab: 56
+      slash: 48
+      crush: 61
+      magic: 70
+      ranged: 57
+    other_bonus:
+      prayer: 1
+      ranged_strength: 0
   drop_table:
     sources:
       - source: Kree'arra
-        source_id: 3162
-        combat_level: 580
         quantity: "1"
         rarity: 1/381
-        members_only: true
   related_items:
-    - item_id: 11826
-      item_name: Armadyl chestplate
-      slug: armadyl-chestplate
-      relationship: alternative
-      description: Body armor
-    - item_id: 27235
-      item_name: Masori chaps (f)
-      slug: masori-chaps-f
-      relationship: upgrade
-      description: Upgrade path
-    - item_id: 11824
-      item_name: Armadyl helmet
+    - item_name: Armadyl chainskirt
+      slug: armadyl-chainskirt
+      relationship: set-piece
+      description: Matching legs slot piece
+    - item_name: Armadyl helmet
       slug: armadyl-helmet
-      relationship: alternative
-      description: Helm slot
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +20 |
-    | Stab defence | +32 |
-    | Slash defence | +26 |
-    | Crush defence | +34 |
-    | Magic defence | +40 |
-    | Ranged defence | +33 |
-    | Requirements | 70 Ranged, Defence |
-
-    Best-in-slot ranged legs (until Masori).
-
-    BiS ranged legs for:
-    - All ranged combat
-    - Bossing
-    - Slayer
-    - Required for Masori (f) upgrade
+      relationship: set-piece
+      description: Matching helm slot piece
+    - item_name: Masori body (f)
+      slug: masori-body-f
+      relationship: upgrade
+      description: Higher-tier ranged body
+  about: "Armadyl chestplate is a high-tier ranged body slot piece dropped by Kree'arra at 1/381. It needs 70 Ranged and 70 Defence to equip and is part of the Armadyl ranged set."
   market_strategy:
     notes:
-      - GWD is popular grind
-      - Required for Masori chaps (f)
-      - Good defensive stats
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - GWD Kree'arra grind is popular for the drop
+      - Used as a Masori body (f) upgrade component
+      - Strong defensive bonuses across the board
+  history:
+    - date: "2017-01-01"
+      description: Graphic update showing less skin on male players.
+    - date: "2014-07-01"
+      description: Female model updated to cover both shoulders.
+    - date: "2014-01-01"
+      description: Item value increased from 60,000 to 290,000 coins.
+    - date: "2013-10-17"
+      description: Released with the God Wars Dungeon.
+  properties:
+    release_date: "2013-10-17"
+    update: The God Wars Dungeon has been uncovered!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-bracers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-bracers.mdx
@@ -12,14 +12,17 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 8
+  material:
+    type: blessed dragonhide
+    tier: high
   equipment:
     slot: hands
+    weight: 1
+    requirements:
+      ranged: 70
     attack_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
-      magic: 0
       ranged: 11
+      magic: -10
     defence_bonus:
       stab: 6
       slash: 5
@@ -27,52 +30,69 @@ osrs:
       magic: 6
       ranged: 8
     other_bonus:
-      melee_strength: 0
-      ranged_strength: 0
-      magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 10376
       item_name: Guthix bracers
       slug: guthix-bracers
       relationship: variant
+      description: Guthix-aligned variant with identical stats
     - item_id: 10368
       item_name: Zamorak bracers
       slug: zamorak-bracers
       relationship: variant
+      description: Zamorak-aligned variant with identical stats
     - item_id: 12506
       item_name: Armadyl bracers
       slug: armadyl-bracers
       relationship: variant
+      description: Armadyl-aligned variant with identical stats
     - item_id: 12490
       item_name: Ancient bracers
       slug: ancient-bracers
       relationship: variant
+      description: Ancient-aligned variant with identical stats
     - item_id: 2491
       item_name: Black d'hide vambraces
       slug: black-d-hide-vambraces
       relationship: downgrade
       description: Standard version requiring 40 Defence
-  about: |-
-    > *"Bandos blessed dragonhide vambraces."*
-
-    | Stat | Blessed | Black D'hide |
-    |------|--------:|-----------:|
-    | Ranged Attack | +11 | +11 |
-    | Prayer | +1 | 0 |
-    | Ranged Req | 70 | 70 |
-    | Defence Req | None | 40 |
-
-    No Defence requirement makes these ideal for 1-Defence pures. The +1 prayer bonus is an additional advantage.
+  about: "Bandos bracers are Bandos-blessed dragonhide vambraces requiring 70 Ranged and rewarded from Hard Treasure Trails at a rate of 1/1,625; no Defence requirement makes them best-in-slot ranged gloves for 1-Defence pures and they grant Bandosian protection in the God Wars Dungeon."
   market_strategy:
     notes:
       - Hard clue exclusive
-      - Best-in-slot ranged gloves for pures
-      - All god variants are functionally identical
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Best-in-slot ranged gloves for pures because they bypass Defence requirements
+      - All god-blessed bracers (Bandos, Saradomin, Zamorak, Guthix, Armadyl, Ancient) are functionally identical
+  trading_tips:
+    - Watch Bandos-themed demand cycles around God Wars updates
+    - Storable in costume room treasure chest, reducing live supply
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trail Expansion update, added to the Hard clue reward pool."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/barrel-of-demonic-tallow-full.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/barrel-of-demonic-tallow-full.mdx
@@ -1,20 +1,66 @@
 ---
 title: Barrel of demonic tallow (full) | OSRS Price Data
-description: "Barrel of demonic tallow (full): Somebody's been avoiding their cardio.... High alch: 300 GP."
+description: "Barrel of demonic tallow (full): Somebody's been avoiding their cardio... High alch: 300 GP."
 osrs:
   id: 30795
   name: Barrel of demonic tallow (full)
   slug: barrel-of-demonic-tallow-full
-  examine: Somebody's been avoiding their cardio...
+  examine: "Somebody's been avoiding their cardio..."
   members: true
   icon: Barrel of demonic tallow (full).png
   value: 500
   lowalch: 200
   highalch: 300
   limit: null
-  about: "Barrel of demonic tallow (full) is a members-only item in Old School RuneScape. High alchemy value: 300 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: barrel
+    tier: mid
+  drop_table:
+    sources:
+      - source: Yama
+        quantity: "1"
+        rarity: 5/95
+  related_items:
+    - item_name: Demonic tallow
+      slug: demonic-tallow
+      relationship: product
+      description: Yielded when the full barrel is emptied.
+    - item_name: Barrel of demonic tallow
+      slug: barrel-of-demonic-tallow
+      relationship: variant
+      description: Partially emptied untradeable version of the barrel.
+  about: "Barrel of demonic tallow (full) is a Yama drop that empties into 100 demonic tallow when opened in a bank."
+  market_strategy:
+    notes:
+      - Full barrels stay tradeable; partial barrels become untradeable.
+      - Demand pivots on Hallowed Sepulchre and ritual content using tallow.
+      - Yama remains the only source, supply ties to boss attention.
+  trading_tips:
+    - Always empty in-bank to keep the partial as personal supply.
+    - Sell full barrels while Yama receives meta updates for premium prices.
+  history:
+    - date: "2025-05-14"
+      description: Released with the Yama, the Master of Pacts update.
+    - date: "2025-05-29"
+      description: Players gained the ability to empty barrels directly inside the bank.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-05-14"
+    update: "Yama, the Master of Pacts"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bellator-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bellator-ring.mdx
@@ -12,39 +12,42 @@ osrs:
   lowalch: 56000
   highalch: 84000
   limit: null
+  material:
+    type: chromium
+    tier: high
   equipment:
     slot: ring
-    type: melee
+    weapon_type: unarmed
     requirements:
-      quest: The Whisperer kill
-    stats:
-      attack_slash: 20
+      attack: 1
+    attack_bonus:
+      slash: 20
+    defence_bonus: {}
+    other_bonus:
       strength: 6
-  creation:
-    components:
-      - item_id: 28275
-        item_name: Warrior icon
-      - item_id: 28292
-        item_name: Bellator vestige
-      - item_id: 565
-        item_name: Blood rune
-        quantity: "500"
-    materials:
-      - item_name: Chromium ingot
-        quantity: "3"
-      - item_name: Ring mould
-        quantity: "1"
-    skill_requirements:
-      magic: 90
-      crafting: 80
+  recipes:
+    - materials:
+        - item_name: Warrior icon
+          quantity: "1"
+        - item_name: Bellator vestige
+          quantity: "1"
+        - item_name: Blood rune
+          quantity: "500"
+        - item_name: Chromium ingot
+          quantity: "3"
+        - item_name: Ring mould
+          quantity: "1"
+      tools:
+        - Furnace
+      skill: Crafting
+      level: 80
+      experience: 2500
+      output_quantity: 1
   drop_table:
     sources:
       - source: The Whisperer
-        source_id: 12204
-        combat_level: 600
-        quantity: 1 (Bellator vestige)
+        quantity: "1"
         rarity: Rare
-        members_only: true
   related_items:
     - item_id: 28307
       item_name: Ultor ring
@@ -61,36 +64,33 @@ osrs:
       slug: bellator-vestige
       relationship: component
       description: From The Whisperer
-  about: |-
-    1. Combine Warrior icon + Bellator vestige + 500 blood runes
-    2. Craft at furnace with 3 chromium ingots + ring mould
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 90 (boostable) |
-    | Crafting | 80 (boostable) |
-    | Kill The Whisperer | 1 time |
-
-    | Offense | Value |
-    |---------|-------|
-    | Slash | +20 |
-    | Strength | +6 |
-
-    Requirements: The Whisperer kill
-
-    BiS for:
-    - Slash accuracy builds
-    - High-def targets
-    - Accuracy-focused combat
-
-    Highest slash attack bonus ring.
+  about: "Bellator ring is a high-tier melee ring from Desert Treasure II with the highest slash attack bonus of any ring."
   market_strategy:
     notes:
       - Vestige from The Whisperer
       - Cannot be imbued
       - DT2 content
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2023-07-26"
+      description: Released with the Desert Treasure II update.
+  properties:
+    release_date: "2023-07-26"
+    update: Desert Treasure II - The Fallen Empire
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.012
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bird-house.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bird-house.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 250
-  about: "Bird house is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - product: Bird house
+      skill: Crafting
+      level: 5
+      xp: 15
+      tools:
+        - Hammer
+        - Chisel
+      materials:
+        - item_name: Logs
+          quantity: 1
+        - item_name: Clockwork
+          quantity: 1
+  related_items:
+    - item_id: 21514
+      item_name: Oak bird house
+      slug: oak-bird-house
+      relationship: upgrade
+      description: Higher-tier oak bird house variant
+    - item_id: 21516
+      item_name: Willow bird house
+      slug: willow-bird-house
+      relationship: upgrade
+      description: Higher-tier willow variant
+    - item_id: 11065
+      item_name: Clockwork
+      slug: clockwork
+      relationship: component
+      description: Required component, returned on dismantle
+  about: "Bird house is the basic Fossil Island trap built at 5 Crafting that, when placed and seeded, passively gathers feathers, raw bird meat, and nests over about 50 minutes."
+  market_strategy:
+    notes:
+      - Crafted cheaply from logs and a returned clockwork
+      - Demand from passive hunter trainers
+      - Mostly self-supplied; GE flips are slim
+  trading_tips:
+    - Clockwork is reused; only logs are spent per cycle
+    - Strung rabbit foot boosts ring/egg nest odds
+  history:
+    - date: "2017-09-07"
+      description: Released with the Fossil Island update.
+    - date: "2025-02-12"
+      description: Added an option to automatically dismantle and rebuild bird houses.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-09-07"
+    update: Fossil Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-cape.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 150
-  about: "Black cape is a free-to-play item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cape
+    tier: low
+  equipment:
+    slot: cape
+    weight: 0.453
+    defence_bonus:
+      slash: 1
+      crush: 1
+      ranged: 2
+  shops:
+    - shop_name: "Barker's Haberdashery"
+      location: Canifis
+      price: 9
+    - shop_name: Shayzien Styles
+      location: Shayzien
+      price: 7
+  related_items:
+    - item_name: Red cape
+      slug: red-cape
+      relationship: variant
+      description: Red colour variant of the basic cape
+    - item_name: Blue cape
+      slug: blue-cape
+      relationship: variant
+      description: Blue colour variant of the basic cape
+    - item_name: Green cape
+      slug: green-cape
+      relationship: variant
+      description: Green colour variant of the basic cape
+  about: "Black cape is a cheap F2P cape slot item often used as starter gear or for fashionscape colour-matching."
+  market_strategy:
+    notes:
+      - Steady demand from low-level F2P players
+      - Shop supply caps price near alch value
+      - 150 buy limit prevents large speculative buys
+  history:
+    - date: "2001-01-21"
+      description: Released as part of the original RuneScape Classic capes.
+    - date: "2014-12-10"
+      description: Item renamed from Cape to Black cape to clarify the colour variant.
+  properties:
+    release_date: "2001-01-21"
+    update: "RuneScape Classic"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-d-hide-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-d-hide-chaps.mdx
@@ -12,19 +12,30 @@ osrs:
   lowalch: 2488
   highalch: 3732
   limit: 70
+  material:
+    type: dragonhide
+    tier: high
   equipment:
     slot: legs
-    type: ranged_armour
-    ranged_requirement: 70
-    defence_requirement: 40
-  attack_bonuses:
-    ranged: 17
-  defence_bonuses:
-    ranged: 30
-    magic: 28
-  crafting:
-    level: 82
-    xp: 172
+    requirements:
+      ranged: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 17
+    defence_bonus:
+      stab: 18
+      slash: 20
+      crush: 26
+      magic: 23
+      ranged: 26
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 82
@@ -36,6 +47,8 @@ osrs:
         - item_name: Thread
           item_id: 1734
           quantity: 1
+      tools:
+        - Needle
       product: Black d'hide chaps
       product_id: 2497
       product_quantity: 1
@@ -55,46 +68,55 @@ osrs:
     - item_id: 2503
       item_name: Black d'hide body
       slug: black-dhide-body
-      relationship: alternative
+      relationship: set-piece
       description: Matching body
     - item_id: 2491
       item_name: Black d'hide vambraces
       slug: black-dhide-vambraces
-      relationship: alternative
-      description: Matching gloves
+      relationship: set-piece
+      description: Matching vambraces
     - item_id: 2495
       item_name: Red d'hide chaps
       slug: red-dhide-chaps
-      relationship: alternative
+      relationship: downgrade
       description: Lower tier chaps
-  about: |-
-    | Method | Level | Materials |
-    |--------|-------|-----------|
-    | Crafting | 82 | 2 Black dragon leather |
-    | XP | 172 | - |
-
-    | Stat | Value |
-    |------|-------|
-    | Ranged requirement | 70 |
-    | Defence requirement | 40 |
-    | Ranged attack | +17 |
-    | Ranged defence | +30 |
-    | Magic defence | +28 |
+  about: "Black d'hide chaps are the highest-tier standard dragonhide legs in OSRS, requiring 70 Ranged. Crafted at 82 Crafting from 2 black dragon leather. Popular Ranged training and Wilderness risk gear."
   market_strategy:
     notes:
       - Highest tier standard d'hide legs
-      - Popular for Ranged training
-      - Wilderness risk gear
-      - Ranged training
-      - Wilderness activities
-      - Budget Ranged gear
-      - PvP risk gear
+      - Popular Ranged training gear
       - Low buy limit (70)
-      - 2 leather per chaps
-      - Popular risk gear
-      - Best non-degradable ranged legs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Wilderness PvP risk gear
+      - Crafting demand from black dragon leather supply
+  trading_tips:
+    - Watch Hydra and Colossal Hydra drop supply
+    - Crafter margin tied to black dragon leather price
+  history:
+    - date: "2004-03-29"
+      description: Released with RuneScape 2.
+    - date: "2006-01-09"
+      description: Renamed from Dragonhide chaps to Black d'hide chaps.
+    - date: "2021-09-29"
+      description: Defence bonuses reduced in the ranged armour rebalance.
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dagger.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black dagger | OSRS Price Data
-description: "Black dagger: A vicious black dagger.. High alch: 144 GP, GE limit: 125."
+description: "Black dagger: A vicious black dagger. High alch: 144 GP, GE limit: 125."
 osrs:
   id: 1217
   name: Black dagger
@@ -12,26 +12,78 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 125
-  item_id: 1217
-  item_type: equipment
-  slot: weapon
-  type: dagger
-  attack_style: stab
-  attack_speed: 4
-  tradeable: true
-  weight: 0.453
-  requirements:
-    attack: 10
-  stats:
-    stab_attack: 10
-    slash_attack: 5
-    crush_attack: -4
-    strength: 7
+  material:
+    type: black
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 10
+      slash: 5
+      crush: -4
+      magic: 1
+    other_bonus:
+      melee_strength: 7
+  drop_table:
+    sources:
+      - source: Cyclops
+        quantity: "1"
+        rarity: Uncommon
+      - source: Spiritual warrior
+        quantity: "1"
+        rarity: Uncommon
+      - source: Chaos druid warrior
+        quantity: "1"
+        rarity: Uncommon
+  shops:
+    - shop_name: Varrock Swordshop
+      location: Varrock
+    - shop_name: Warriors' Guild Armoury
+      location: Warriors' Guild
   related_items:
-    - slug: mithril-dagger
-    - slug: black-sword
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1215
+      item_name: Mithril dagger
+      slug: mithril-dagger
+      relationship: upgrade
+      description: Next tier dagger with higher stab attack
+    - item_id: 1219
+      item_name: Black dagger(p)
+      slug: black-dagger-p
+      relationship: variant
+      description: Poisoned version coated in weapon poison
+    - item_id: 1550
+      item_name: Black sword
+      slug: black-sword
+      relationship: alternative
+      description: Same-tier one-handed sword
+  about: "Black dagger is a F2P-tradeable dagger requiring 10 Attack to wield, dropped by cyclopes, spiritual warriors, and chaos druid warriors, and sold in Varrock's Swordshop and the Warriors' Guild Armoury."
+  properties:
+    release_date: "2001-12-08"
+    update: "RuneScape Classic"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2001-12-08"
+      description: "Released as part of the original RuneScape Classic equipment set."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-nails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-nails.mdx
@@ -12,9 +12,31 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 13000
-  about: "Black nails is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: black
+    tier: low
+  about: "Black nails cannot be player-smithed and are gathered from ogre coffins, Tarn's Lair zombies, or quest rubble for Construction and black brutal arrows."
+  history:
+    - date: "2005-05-17"
+      description: Released with the Zogre Flesh Eaters quest.
+    - date: "2005-07-05"
+      description: Value increased from 0 to 12 coins with the Magic Carpet Ride update.
+  properties:
+    release_date: "2005-05-17"
+    update: Zogre Flesh Eaters
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody-h1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody-h1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black platebody (h1) | OSRS Price Data
-description: "Black platebody (h1): Black plate body with a heraldic design.. High alch: 2,304 GP, GE limit: 8."
+description: "Black platebody (h1): Black plate body with a heraldic design. High alch: 2,304 GP, GE limit: 8."
 osrs:
   id: 23366
   name: Black platebody (h1)
@@ -12,9 +12,95 @@ osrs:
   lowalch: 1536
   highalch: 2304
   limit: 8
-  about: "Black platebody (h1) is a free-to-play item in Old School RuneScape. High alchemy value: 2,304 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: armour
+    tier: low
+  equipment:
+    slot: body
+    weapon_type: melee
+    weight: 9.979
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -15
+    defence_bonus:
+      stab: 41
+      slash: 40
+      crush: 30
+      magic: -6
+      ranged: 40
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_id: 23369
+      item_name: Black platebody (h2)
+      slug: black-platebody-h2
+      relationship: variant
+      description: Heraldic black platebody variant (h2).
+    - item_id: 23372
+      item_name: Black platebody (h3)
+      slug: black-platebody-h3
+      relationship: variant
+      description: Heraldic black platebody variant (h3).
+    - item_id: 23375
+      item_name: Black platebody (h4)
+      slug: black-platebody-h4
+      relationship: variant
+      description: Heraldic black platebody variant (h4).
+    - item_id: 23378
+      item_name: Black platebody (h5)
+      slug: black-platebody-h5
+      relationship: variant
+      description: Heraldic black platebody variant (h5).
+    - item_id: 3140
+      item_name: Black platebody
+      slug: black-platebody
+      relationship: alternative
+      description: Standard non-heraldic version with identical stats.
+  about: Cosmetic heraldic variant of the black platebody dropped from easy clue caskets; shares stats with the standard black platebody.
+  market_strategy:
+    notes:
+      - Supply tracks easy clue completion rates
+      - Heraldic cosmetics see steady collector demand
+  trading_tips:
+    - Watch each h-variant individually; prices diverge based on crest popularity
+    - High alch margin can be profitable during scroll farming meta shifts
+  history:
+    - date: "2019-04-11"
+      description: Released with the Treasure Trails Expansion and Easter 2019 update.
+    - date: "2021-04-21"
+      description: Ranged attack bonus reduced from -10 to -15.
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-shield-h3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-shield-h3.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 652
   highalch: 979
   limit: 70
-  about: "Black shield (h3) is a free-to-play item in Old School RuneScape. High alchemy value: 979 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: black
+    tier: low
+  equipment:
+    slot: shield
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 17
+      slash: 19
+      crush: 18
+      magic: -1
+      ranged: 18
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 5.443
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_id: 1195
+      item_name: Black kiteshield
+      slug: black-kiteshield
+      relationship: alternative
+      description: Same stats, no heraldic design
+  about: Heraldic black kiteshield variant with identical combat stats to a standard black kiteshield; obtained from easy Treasure Trail reward caskets at 1/1,404 and storable in the costume room treasure chest.
+  market_strategy:
+    notes:
+      - Easy clue cosmetic; cosmetic premium over plain kiteshield
+      - Free-to-play tradeable
+      - Buy limit 70; thin volume
+  trading_tips:
+    - Track easy clue casket output during clue weeks
+    - Cosmetic demand peaks around fashionscape events
+  history:
+    - date: "2006-02-20"
+      description: Released with heraldic shields.
+    - date: "2006-03-01"
+      description: Made available to free players.
+    - date: "2006-05-01"
+      description: Renamed from Black kiteshield(h).
+    - date: "2014-12-01"
+      description: Name formatting standardised.
+    - date: "2021-04-01"
+      description: Ranged defence bonus reduced from -2 to -3.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-02-20"
+    update: Heraldic shields
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-spear-p-5734.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-spear-p-5734.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black spear(p+) | OSRS Price Data
-description: "Black spear(p+): A poisoned black tipped spear.. High alch: 450 GP, GE limit: 8."
+description: "Black spear(p+): a poisoned black tipped spear. High alch: 450 GP, GE limit: 8."
 osrs:
   id: 5734
   name: Black spear(p+)
@@ -12,9 +12,81 @@ osrs:
   lowalch: 300
   highalch: 450
   limit: 8
-  about: "Black spear(p+) is a members-only item in Old School RuneScape. High alchemy value: 450 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: black
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 15
+      slash: 15
+      crush: 15
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 16
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 5730
+      item_name: Black spear
+      slug: black-spear
+      relationship: alternative
+      description: Unpoisoned variant
+    - item_id: 5732
+      item_name: Black spear(p)
+      slug: black-spear-p-base
+      relationship: downgrade
+      description: Weaker poison variant
+    - item_id: 5736
+      item_name: Black spear(kp)
+      slug: black-spear-kp
+      relationship: alternative
+      description: Karambwan poison variant
+  about: "Black spear(p+) is a two-handed members weapon coated in extra-strength poison, requiring 10 Attack and dealing stab/slash/crush damage in melee."
+  market_strategy:
+    notes:
+      - Niche poison variant of the black spear
+      - 21 April 2021 speed buff to 4 ticks improved viability
+  trading_tips:
+    - Thin volume, list near alch value for slow fills
+    - Watch for poison sigil meta usage at low-defence bosses
+  history:
+    - date: "2021-04-21"
+      description: Attack speed increased from 5 ticks to 4 ticks.
+    - date: "2005-05-17"
+      description: Released alongside the Barrows Changes and Other Tweaks update.
+  properties:
+    release_date: "2005-05-17"
+    update: Barrows Changes and Other Tweaks
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-unicorn-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-unicorn-mask.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Black unicorn mask is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_id: 20265
+      item_name: Black unicorn mask
+      slug: black-unicorn-mask
+      relationship: set-piece
+      description: Part of the unicorn mask cosmetic line
+  about: "Black unicorn mask is a cosmetic head slot item rewarded from medium-tier Treasure Trails. It provides no combat bonuses and is storable in the costume room treasure chest."
+  market_strategy:
+    notes:
+      - Cosmetic-only treasure trail reward
+      - Low buy limit (4)
+      - Storable in costume room
+  trading_tips:
+    - Watch for clue-running supply spikes
+    - Premium driven by cosmetic demand
+  history:
+    - date: "2016-07-06"
+      description: Released as part of the Treasure Trail Expansion.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-red-shell-pointed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-red-shell-pointed.mdx
@@ -12,9 +12,42 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 13000
-  about: "Blamish red shell (pointed) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Blood Blamish Snail
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - materials:
+        - item_name: Blamish red shell (pointed)
+          quantity: "1"
+      tools:
+        - Chisel
+      skill: Crafting
+      level: 15
+      experience: 32.5
+      output_quantity: 1
+      output_item: Pointed blood'n'tar snelm
+  about: "Blamish red shell (pointed) is dropped by pointed-shell Blood Blamish Snails and can be chiselled into a pointed blood'n'tar snelm."
+  history:
+    - date: "2004-10-14"
+      description: Released with the Morytania expansion.
+  properties:
+    release_date: "2004-10-14"
+    update: Morytania
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-bind-sack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-bind-sack.mdx
@@ -1,20 +1,71 @@
 ---
 title: Blighted bind sack | OSRS Price Data
-description: "Blighted bind sack: Enough power for a Bind, blighted so it can be used only in the Wilderness.. High alch: 1 GP, GE limit: 10,000."
+description: "Blighted bind sack: Enough power for a Bind, blighted so it can be used only in the Wilderness. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 24609
   name: Blighted bind sack
   slug: blighted-bind-sack
-  examine: Enough power for a Bind, blighted so it can be used only in the Wilderness.
+  examine: "Enough power for a Bind, blighted so it can be used only in the Wilderness."
   members: true
   icon: Blighted bind sack.png
   value: 1
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Blighted bind sack is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: blighted spell sack
+    tier: low
+  shops:
+    - shop_name: "Justine's stuff for the Last Man Standing"
+      location: Ferox Enclave
+      price: 1
+      currency: Last Man Standing points
+      quantity: 300
+    - shop_name: Soul Wars Reward Shop
+      location: Soul Wars
+      price: 10
+      currency: Zeal Tokens
+      quantity: 300
+  related_items:
+    - item_name: Blighted entangle sack
+      slug: blighted-entangle-sack
+      relationship: upgrade
+      description: Successor sack covering both Bind and Entangle after the 2023 rework.
+    - item_name: Blighted snare sack
+      slug: blighted-snare-sack
+      relationship: alternative
+      description: Equivalent blighted sack for the Snare spell.
+  about: "Blighted bind sack let players cast Bind in the Wilderness without runes until it was rolled into the blighted entangle sack on 20 September 2023."
+  market_strategy:
+    notes:
+      - Removed in September 2023, only legacy stacks remain.
+      - Functionality merged into blighted entangle sack.
+      - No active supply, treat as historical only.
+  trading_tips:
+    - Only relevant for legacy inventories; do not flip.
+  history:
+    - date: "2020-04-23"
+      description: Released as part of the blighted Wilderness spell sacks lineup.
+    - date: "2023-09-20"
+      description: Removed from the game with bind functionality folded into the blighted entangle sack.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-04-23"
+    update: "Blighted Wilderness Supplies"
+    tradeable: false
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Cast
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-helm-broken.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-helm-broken.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blood moon helm (broken) | OSRS Price Data
-description: "Blood moon helm (broken): The helm of the Blood Moon.. High alch: 61,800 GP, GE limit: 15."
+description: "Blood moon helm (broken): The helm of the Blood Moon. High alch: 61,800 GP, GE limit: 15."
 osrs:
   id: 29073
   name: Blood moon helm (broken)
@@ -12,9 +12,55 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
-  about: "Blood moon helm (broken) is a members-only item in Old School RuneScape. High alchemy value: 61,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: blood moon
+    tier: high
+  related_items:
+    - item_id: 29024
+      item_name: Blood moon helm
+      slug: blood-moon-helm
+      relationship: variant
+      description: Charged, usable form repaired from broken state
+    - item_id: 29027
+      item_name: Blood moon chestplate
+      slug: blood-moon-chestplate
+      relationship: set-piece
+      description: Body slot piece of the Blood Moon armour set
+    - item_id: 29030
+      item_name: Blood moon tassets
+      slug: blood-moon-tassets
+      relationship: set-piece
+      description: Legs slot piece of the Blood Moon armour set
+  about: "Blood moon helm (broken) is the depleted form of the Blood moon helm, dropped by the Lunar Chest in Neypotzli at a rate of 1/224. Repair it at an armour stand or with an NPC to restore 3,000 charges."
+  market_strategy:
+    notes:
+      - Drops fully broken from the Lunar Chest; high alch value of 61,800 props up the floor
+      - Players flip broken vs repaired states based on Smithing repair cost vs NPC repair
+      - GE limit of 15 per 4 hours throttles bulk repair flipping
+  trading_tips:
+    - Compare Smithing repair cost (757,500 at 99 Smithing) to NPC repair (1,500,000) before flipping
+    - Watch for Blood Moon meta shifts that increase demand for Bloodrager set pieces
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Repair
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2024-03-20"
+      description: "Released as part of the Varlamore: Part One update, dropped fully broken from the Lunar Chest."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-dragon-leather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-dragon-leather.mdx
@@ -5,7 +5,7 @@ osrs:
   id: 2505
   name: Blue dragon leather
   slug: blue-dragon-leather
-  examine: It's a piece of prepared blue dragonhide.
+  examine: "It's a piece of prepared blue dragonhide."
   members: true
   icon: Blue dragon leather.png
   value: 70
@@ -15,31 +15,43 @@ osrs:
   material:
     type: leather
     tier: mid
-  tanning:
-    cost: 20
-    source_id: 1751
-    source_name: Blue dragonhide
-  crafting_products:
-    - product: Blue d'hide vambraces
-      product_id: 2487
+  recipes:
+    - skill: Crafting
       level: 66
       xp: 70
-      leather: 1
-    - product: Blue d'hide chaps
-      product_id: 2493
+      materials:
+        - item_name: Blue dragon leather
+          quantity: 1
+      tools:
+        - Needle
+        - Thread
+    - skill: Crafting
       level: 68
       xp: 140
-      leather: 2
-    - product: Blue d'hide shield
-      product_id: 24373
+      materials:
+        - item_name: Blue dragon leather
+          quantity: 2
+      tools:
+        - Needle
+        - Thread
+    - skill: Crafting
       level: 69
       xp: 140
-      leather: 2
-    - product: Blue d'hide body
-      product_id: 2499
+      materials:
+        - item_name: Blue dragon leather
+          quantity: 2
+      tools:
+        - Needle
+        - Thread
+    - skill: Crafting
       level: 71
       xp: 210
-      leather: 3
+      materials:
+        - item_name: Blue dragon leather
+          quantity: 3
+      tools:
+        - Needle
+        - Thread
   related_items:
     - item_id: 1751
       item_name: Blue dragonhide
@@ -61,21 +73,34 @@ osrs:
       slug: green-dragon-leather
       relationship: alternative
       description: Lower tier
+  about: "Blue dragon leather is mid-tier dragonhide tanned for 20 coins and used in Crafting to make vambraces, chaps, shields, and bodies between levels 66 and 71."
   market_strategy:
     notes:
-      - Mid-tier dragonhide
-      - F2P armor accessible
-      - High volume trading
-      - Crafting training
-      - Blue d'hide production
-      - Tan Leather profit
-      - F2P ranged gear
-      - Tan Leather spell efficient
-      - Blue dragons very common
-      - Popular training leather
-      - F2P bodies usable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Tan at 20 coins (45 in Canifis)
+      - Mid-tier crafting feedstock
+      - High volume turnover
+      - Buy limit 13,000 per 4 hours
+  history:
+    - date: "2004-03-29"
+      description: Released with the RS2 launch.
+    - date: "2015-01-01"
+      description: Renamed to Blue dragon leather (from Blue d-leather).
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launched
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-elegant-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-elegant-legs.mdx
@@ -14,19 +14,68 @@ osrs:
   limit: 4
   equipment:
     slot: legs
+    weight: 1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 10408
       item_name: Blue elegant shirt
       slug: blue-elegant-shirt
       relationship: set-piece
-      description: Matching elegant shirt
-  about: |-
-    > *"A rather elegant pair of men's blue pantaloons."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the blue elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching elegant shirt.
+  about: "Blue elegant legs is a purely cosmetic easy clue treasure trail reward forming half of the blue elegant gentlemen's set."
+  market_strategy:
+    notes:
+      - Supply is limited to easy clue completions, supporting a premium over alch value.
+      - Low daily volume makes pricing reactive to a few large orders.
+  trading_tips:
+    - List near the high alch value floor when accumulating sets.
+    - Pair with the matching shirt to flip as a full set.
+  history:
+    - date: "2006-12-05"
+      description: Added to the game as an easy clue reward.
+    - date: "2014-12-10"
+      description: Renamed from Blue ele' legs to Blue elegant legs.
+  properties:
+    release_date: "2006-12-05"
+    update: "Treasure Trails, spiders and sheep"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-hat.mdx
@@ -14,18 +14,63 @@ osrs:
   limit: 150
   equipment:
     slot: head
+    weapon_type: none
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    requirements: {}
+  shops:
+    - shop_name: Fine Fashions
+      location: Tree Gnome Stronghold
+      price: 160
+    - shop_name: Rasolo the Wandering Merchant
+      location: Baxtorian Falls
+      price: 320
   related_items:
     - item_id: 640
       item_name: Blue robe top
       slug: blue-robe-top
       relationship: set-piece
-      description: Matching top
-  about: |-
-    > _"A blue hat."_
-
-    The blue hat is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching blue robe top from the gnome clothing set.
+  about: The blue hat is a cosmetic gnome clothing head piece offering a small magic attack and defence bonus.
+  history:
+    - date: "2014-12-10"
+      description: Renamed from Hat to Blue hat alongside the Trading Post update.
+    - date: "2002-12-12"
+      description: Released with the Agility skill online update.
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bob-s-black-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bob-s-black-shirt.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Bob's black shirt is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_id: 10320
+      item_name: "Bob's red shirt"
+      slug: bob-s-red-shirt
+      relationship: variant
+      description: Red variant
+    - item_id: 10324
+      item_name: "Bob's blue shirt"
+      slug: bob-s-blue-shirt
+      relationship: variant
+      description: Blue variant
+    - item_id: 10326
+      item_name: "Bob's green shirt"
+      slug: bob-s-green-shirt
+      relationship: variant
+      description: Green variant
+    - item_id: 10328
+      item_name: "Bob's purple shirt"
+      slug: bob-s-purple-shirt
+      relationship: variant
+      description: Purple variant
+  about: "Bob's black shirt is a cosmetic body slot reward from easy-tier Treasure Trails featuring Bob the Jagex Cat. It provides no combat bonuses and can be stored in the costume room treasure chest."
+  market_strategy:
+    notes:
+      - Cosmetic clue reward
+      - Low buy limit (4)
+      - High GE price vs low alch value
+  trading_tips:
+    - Cosmetic collector demand drives price
+    - Hold during clue scroll surge events
+  history:
+    - date: "2006-12-05"
+      description: "Released alongside the Treasure Trails, spiders and sheep update."
+  properties:
+    release_date: "2006-12-05"
+    update: "Treasure Trails, spiders and sheep"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bob-s-purple-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bob-s-purple-shirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bob's purple shirt | OSRS Price Data
-description: "Bob's purple shirt: 'Bob says: Keep your computer keylogger free and virus scanned.'. High alch: 1 GP, GE limit: 4."
+description: "Bob's purple shirt: 'Bob says: Keep your computer keylogger free and virus scanned.' High alch: 1 GP, GE limit: 4."
 osrs:
   id: 10324
   name: Bob's purple shirt
@@ -12,9 +12,85 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Bob's purple shirt is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_id: 10318
+      item_name: Bob's red shirt
+      slug: bob-s-red-shirt
+      relationship: variant
+      description: Red variant of the same cosmetic shirt.
+    - item_id: 10320
+      item_name: Bob's blue shirt
+      slug: bob-s-blue-shirt
+      relationship: variant
+      description: Blue variant.
+    - item_id: 10322
+      item_name: Bob's green shirt
+      slug: bob-s-green-shirt
+      relationship: variant
+      description: Green variant.
+    - item_id: 10326
+      item_name: Bob's black shirt
+      slug: bob-s-black-shirt
+      relationship: variant
+      description: Black variant.
+  about: "Bob's purple shirt is one of five cosmetic body-slot easy clue rewards bearing the Jagex Bob security tagline, storable in the costume room."
+  market_strategy:
+    notes:
+      - Steady novelty demand from clue scroll completionists.
+      - Daily volume hovers in the dozens, so listings move slowly.
+  trading_tips:
+    - List around the average GE price; do not undercut aggressively as supply is thin.
+    - Bundle the full set of Bob's shirts for collectors.
+  history:
+    - date: "2006-12-05"
+      description: Added to the game as an easy clue reward.
+    - date: "2014-12-10"
+      description: Renamed from Bob shirt to Bob's purple shirt.
+  properties:
+    release_date: "2006-12-05"
+    update: "Treasure Trails, spiders and sheep"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-rack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-rack.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 11000
-  about: "Bolt rack is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    attack_speed: 4
+    weight: 0
+    requirements:
+      ranged: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 55
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Barrows reward chest
+        quantity: "1"
+        rarity: Common
+  shops:
+    - shop_name: "Ak-Haranu's Exotic Items"
+      location: Port Phasmatys
+      price: 39
+    - shop_name: Last Man Standing Store
+      location: LMS lobby
+      price: Points
+  related_items:
+    - item_id: 4734
+      item_name: "Karil's crossbow"
+      slug: karil-s-crossbow
+      relationship: component
+      description: Exclusive crossbow that fires bolt racks
+  about: "Bolt racks are ammunition exclusive to Karil's crossbow, dropped through the Barrows reward chest and available from select shops; always consumed and never recovered via Ava's devices."
+  market_strategy:
+    notes:
+      - Barrows runs drive bulk supply
+      - Consumable for Karil's crossbow only
+      - Ava's devices do not recover them
+  trading_tips:
+    - Buy during high Barrows activity windows for the cheapest stocks
+    - Price pressure increases when LMS or PvP events spike
+  history:
+    - date: "2005-05-09"
+      description: Released alongside the Barrows update.
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/book-of-war-page-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/book-of-war-page-set.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 3000
   highalch: 4500
   limit: 5
-  about: "Book of war page set is a members-only item in Old School RuneScape. High alchemy value: 4,500 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: grand_exchange_set
+    tier: mid
+  recipes:
+    - product_name: Book of war page set
+      skill: Grand Exchange
+      level: 1
+      xp: 0
+      output_quantity: 1
+      materials:
+        - item_name: Bandos page 1
+          quantity: "1"
+        - item_name: Bandos page 2
+          quantity: "1"
+        - item_name: Bandos page 3
+          quantity: "1"
+        - item_name: Bandos page 4
+          quantity: "1"
+      tools:
+        - Grand Exchange clerk
+  related_items:
+    - item_name: Bandos page 1
+      slug: bandos-page-1
+      relationship: component
+      description: First page of the Book of War
+    - item_name: Bandos page 2
+      slug: bandos-page-2
+      relationship: component
+      description: Second page of the Book of War
+    - item_name: Bandos page 3
+      slug: bandos-page-3
+      relationship: component
+      description: Third page of the Book of War
+    - item_name: Bandos page 4
+      slug: bandos-page-4
+      relationship: component
+      description: Fourth page of the Book of War
+    - item_name: Book of war
+      slug: book-of-war
+      relationship: product
+      description: Assembled prayer book read for Bandos
+  about: "Book of war page set bundles the four Bandos pages used to assemble the Book of war Prayer book."
+  market_strategy:
+    notes:
+      - Compare set price against summed individual page cost before buying
+      - 5 buy limit constrains large rebuild trades
+      - Useful when individual pages are illiquid on the GE
+  history:
+    - date: "2015-03-19"
+      description: Released with the Boss Pets, Sets, Chat & More update.
+    - date: "2015-03-26"
+      description: God page sets became noteable when packed for easier bank storage.
+  properties:
+    release_date: "2015-03-19"
+    update: "Boss Pets, Sets, Chat & More"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bounty-supply-crate-anglerfish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bounty-supply-crate-anglerfish.mdx
@@ -12,9 +12,40 @@ osrs:
   lowalch: null
   highalch: null
   limit: 100
-  about: "Bounty supply crate (anglerfish) is a members-only item in Old School RuneScape. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: Bounty supply crate (anglerfish) packages blighted Bounty Hunter supplies and can only be opened inside the Bounty Hunter Worlds wilderness minigame.
+  recipes:
+    - skill: none
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Blighted super restore(4)
+          quantity: 1
+        - item_name: Blighted karambwan
+          quantity: 2
+        - item_name: Coins
+          quantity: 1000
+      tools: []
+      output_quantity: 1
+  history:
+    - date: "2025-01-29"
+      description: Released with the Bounty Hunter Changes, Collection Log Updates and Emote Improvements update.
+  properties:
+    release_date: "2025-01-29"
+    update: Bounty Hunter Changes, Collection Log Updates & Emote Improvements
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Open
+      - Drop
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-arrow-p-5616.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-arrow-p-5616.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Bronze arrow(p+) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: ammo
+    weapon_type: arrow
+    weight: 0
+    other_bonus:
+      ranged_strength: 7
+  recipes:
+    - skill: Herblore
+      materials:
+        - item_name: Bronze arrow
+          quantity: 1
+        - item_name: Extra strong poison
+          quantity: 1
+      tools: []
+  related_items:
+    - item_id: 882
+      item_name: Bronze arrow
+      slug: bronze-arrow
+      relationship: component
+      description: Unpoisoned variant
+    - item_id: 884
+      item_name: Iron arrow(p+)
+      slug: iron-arrow-p
+      relationship: upgrade
+      description: Higher tier poisoned arrow
+  about: "Bronze arrow(p+) is a poisoned ammo arrow dealing extra venomous damage on hit and used with bows of all tiers up to adamant."
+  market_strategy:
+    notes:
+      - Low-tier poisoned ammunition
+      - Stackable training resource
+      - Buy limit 7,000 per 4 hours
+  history:
+    - date: "2001-01-04"
+      description: Original bronze arrow line released with RuneScape beta launch.
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape beta
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dart-p-5635.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dart-p-5635.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Bronze dart(p++) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 1
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Bronze dart
+      slug: bronze-dart
+      relationship: variant
+      description: Unpoisoned version
+    - item_name: Bronze dart(p)
+      slug: bronze-dart-p
+      relationship: variant
+      description: Weak poison variant
+    - item_name: Bronze dart(p+)
+      slug: bronze-dart-plus
+      relationship: variant
+      description: Stronger poison variant
+    - item_name: Weapon poison++
+      slug: weapon-poison-plus-plus
+      relationship: component
+      description: Used to upgrade darts to (p++)
+  about: "Bronze dart(p++) is a deadly-poisoned bronze throwing dart equipped in the weapon slot, usable from Ranged level 1."
+  market_strategy:
+    notes:
+      - Poison upgrade tier is mostly cosmetic for low-tier darts so demand is thin
+      - Margin opportunity sits in the gap between unpoisoned darts plus weapon poison++ versus the (p++) price
+  trading_tips:
+    - Watch the unpoisoned bronze dart price plus weapon poison++ as the synthesis cost reference
+    - Daily volume is low; size orders accordingly
+  history:
+    - date: "2003-04-14"
+      update: New Throwing Weapons
+      description: Added to the game.
+    - date: "2021-06-30"
+      description: Ranged attack bonus reduced from +3 to 0.
+    - date: "2025-05-29"
+      description: Exempted from the Grand Exchange convenience fee.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dart-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dart-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze dart(p) | OSRS Price Data
-description: "Bronze dart(p) is a members weapon slot item. High alch: 1 GP, GE limit: 7,000."
+description: "Bronze dart(p): A deadly poisoned dart with a bronze tip. High alch: 1 GP, GE limit: 7,000."
 osrs:
   id: 812
   name: Bronze dart(p)
@@ -12,24 +12,82 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  material:
+    type: bronze
+    tier: low
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
-    attack_bonus:
-      ranged: 3
-    ranged_strength: 1
+    weight: 0
+    other_bonus:
+      ranged_strength: 1
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Bronze dart
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      tools: []
+      product: Bronze dart(p)
+      product_quantity: 1
+      members_only: true
   related_items:
+    - item_id: 806
+      item_name: Bronze dart
+      slug: bronze-dart
+      relationship: component
+      description: Unpoisoned base dart.
     - item_id: 813
-      item_name: Iron dart (p)
+      item_name: Bronze dart(p+)
+      slug: bronze-dart-p-plus
+      relationship: upgrade
+      description: Stronger poisoned variant using weapon poison(+).
+    - item_id: 814
+      item_name: Bronze dart(p++)
+      slug: bronze-dart-p-plus-plus
+      relationship: upgrade
+      description: Strongest poisoned variant using weapon poison(++).
+    - item_id: 807
+      item_name: Iron dart(p)
       slug: iron-dart-p
       relationship: variant
-      description: Higher tier poisoned dart
-  about: |-
-    > _"A bronze tipped dart with a poisoned tip."_
-
-    A bronze dart tipped with basic weapon poison. No Ranged requirement. Poison deals 2-4 damage over time. Cheap and effective for poisoning enemies in early-game.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Higher tier poisoned dart.
+  about: "Bronze dart(p) is the poisoned form of the entry-level bronze throwing dart, requiring no Ranged level to wield and inflicting basic weapon poison on hit."
+  market_strategy:
+    notes:
+      - Entry-tier poisoned thrown weapon with no Ranged requirement.
+      - Poison ticks add 2-4 damage over time.
+      - GE limit 7,000 per 4 hours.
+  trading_tips:
+    - Compare bronze dart + weapon poison cost vs (p) dart price for arbitrage.
+    - Demand is niche — bulk orders only when training new accounts.
+  history:
+    - date: "2003-04-14"
+      description: "Released with the New Throwing Weapons update."
+    - date: "2021-06-30"
+      description: "Ranged Attack bonus reduced from +3 to 0 (matches base bronze dart change)."
+    - date: "2025-05-29"
+      description: "Exempted from Grand Exchange convenience fees."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-knife-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-knife-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze knife(p) | OSRS Price Data
-description: "Bronze knife(p) is a members weapon slot item. High alch: 1 GP, GE limit: 7,000."
+description: "Bronze knife(p): A finely balanced throwing knife coated in weapon poison. High alch: 1 GP, GE limit: 7,000."
 osrs:
   id: 870
   name: Bronze knife(p)
@@ -12,19 +12,71 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  material:
+    type: bronze
+    tier: low
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
+    weight: 0
     attack_bonus:
       ranged: 3
-    ranged_strength: 2
-  related_items: []
-  about: |-
-    > _"A very sharp\"bronze\" knife with a poisoned tip."_
-
-    A bronze knife tipped with basic weapon poison. No Ranged requirement. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    other_bonus:
+      ranged_strength: 2
+  recipes:
+    - skill: Herblore
+      materials:
+        - item_name: Bronze knife
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      tools: []
+      output: Bronze knife(p)
+  related_items:
+    - item_id: 864
+      item_name: Bronze knife
+      slug: bronze-knife
+      relationship: variant
+      description: Unpoisoned base form
+    - item_id: 5654
+      item_name: Bronze knife(p+)
+      slug: bronze-knife-p-plus
+      relationship: upgrade
+      description: Coated in extra-strength weapon poison(+)
+    - item_id: 5660
+      item_name: Bronze knife(p++)
+      slug: bronze-knife-p-plus-plus
+      relationship: upgrade
+      description: Coated in super-strength weapon poison(++)
+    - item_id: 868
+      item_name: Iron knife(p)
+      slug: iron-knife-p
+      relationship: upgrade
+      description: Next tier poisoned throwing knife
+  about: "Bronze knife(p) is a thrown weapon coated in standard weapon poison, dealing 2-4 damage over time on a successful hit; created by using weapon poison on a Bronze knife with no Herblore level requirement."
+  properties:
+    release_date: "2003-04-14"
+    update: "Member's Update - Herblore (Members)"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2003-04-14"
+      description: "Released as part of the Herblore skill launch, poisoned variants of throwing knives became available."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-locks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-locks.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 8
-  about: "Bronze locks is a members-only item in Old School RuneScape. High alchemy value: 480 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Bronze chest (red)
+        quantity: "1"
+        rarity: 1/63
+      - source: Bronze chest (brown)
+        quantity: "1"
+        rarity: 1/63
+      - source: Bronze chest (crimson)
+        quantity: "1"
+        rarity: 1/63
+      - source: Bronze chest (black)
+        quantity: "1"
+        rarity: 1/63
+      - source: Bronze chest (purple)
+        quantity: "1"
+        rarity: 1/59
+  related_items:
+    - item_id: 25441
+      item_name: Broken coffin
+      slug: broken-coffin
+      relationship: component
+      description: Combined with bronze locks via Dampe to make a bronze coffin
+    - item_id: 25443
+      item_name: Bronze coffin
+      slug: bronze-coffin
+      relationship: product
+      description: Bronze locks + broken coffin combined at Dampe
+  about: "Shades of Mort'ton bronze chest reward; combined with a broken coffin via Dampe to assemble a bronze coffin, and the process is reversible through the coffin's Remove-lock option."
+  market_strategy:
+    notes:
+      - Bronze chest drop with ring of wealth boost
+      - Buy limit 8; thin volume (around 9/day)
+      - Demand tied to shade coffin construction
+  trading_tips:
+    - Watch coffin assembly demand spikes after Shades reworks
+    - Limit 8 keeps spreads wide; price carefully
+  history:
+    - date: "2021-01-27"
+      description: Released with the Shades of Mort'ton rework.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-01-27"
+    update: Shades of Mort'ton rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-platelegs-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-platelegs-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze platelegs (t) | OSRS Price Data
-description: "Bronze platelegs (t): Bronze platelegs with trim.. High alch: 48 GP, GE limit: 4."
+description: "Bronze platelegs (t): Bronze platelegs with trim. High alch: 48 GP, GE limit: 4."
 osrs:
   id: 12217
   name: Bronze platelegs (t)
@@ -12,9 +12,83 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 4
-  about: "Bronze platelegs (t) is a free-to-play item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: low
+  equipment:
+    slot: legs
+    weapon_type: none
+    weight: 9.071
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 8
+      slash: 7
+      crush: 6
+      magic: -4
+      ranged: 7
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_id: 1075
+      item_name: Bronze platelegs
+      slug: bronze-platelegs
+      relationship: variant
+      description: Untrimmed bronze platelegs with identical stats.
+    - item_id: 12219
+      item_name: Bronze platelegs (g)
+      slug: bronze-platelegs-g
+      relationship: variant
+      description: Gold-trimmed cosmetic variant.
+  about: "Bronze platelegs (t) is a free-to-play cosmetic trimmed variant of bronze platelegs obtained only from easy Treasure Trail reward caskets."
+  market_strategy:
+    notes:
+      - Cosmetic-only; demand driven by fashionscape and collectors.
+      - GE buy limit is only 4 per 4 hours.
+  trading_tips:
+    - Watch supply spikes after easy clue completions.
+    - List at margin above untrimmed bronze platelegs.
+  history:
+    - date: "2014-06-12"
+      description: Released as part of the Treasure Trail Expansion update.
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -7 to -11.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/brown-toy-horsey.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/brown-toy-horsey.mdx
@@ -1,6 +1,6 @@
 ---
 title: Brown toy horsey | OSRS Price Data
-description: "Brown toy horsey: A brown toy horse.. High alch: 60 GP, GE limit: 150."
+description: "Brown toy horsey: a brown toy horse. High alch: 60 GP, GE limit: 150."
 osrs:
   id: 2520
   name: Brown toy horsey
@@ -12,9 +12,41 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Brown toy horsey is a free-to-play item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Brown toy horsey is a free-to-play novelty item used during Forgettable Tale of a Drunken Dwarf to barter a Kelda seed from a rowdy dwarf."
+  market_strategy:
+    notes:
+      - Quest-driven demand from Forgettable Tale chains
+      - Low-volume novelty item
+  trading_tips:
+    - Buy near alch floor and slow-flip during weekend quest surges
+    - Stack with related toy horsey colours for resellers
+  history:
+    - date: "2014-12-18"
+      description: Fixed a typo on toy horse.
+    - date: "2014-12-10"
+      description: "Item renamed from Toy horsey to Brown toy horsey."
+    - date: "2013-03-18"
+      description: 'Forced speech locked to "Just say neigh to gambling!" replacing the prior randomised phrases.'
+    - date: "2004-04-01"
+      description: Released alongside the RuneScape chat improved update.
+  properties:
+    release_date: "2004-04-01"
+    update: "RuneScape chat improved!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    quest: "Forgettable Tale of a Drunken Dwarf"
+    weight: 0.05
+    options:
+      - Play-with
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/burning-claws.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/burning-claws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Burning claws | OSRS Price Data
-description: "Burning claws: Torn from the hands of ancient demons.. High alch: 480,000 GP, GE limit: 8."
+description: "Burning claws: Torn from the hands of ancient demons. High alch: 480,000 GP, GE limit: 8."
 osrs:
   id: 29577
   name: Burning claws
@@ -12,9 +12,81 @@ osrs:
   lowalch: 320000
   highalch: 480000
   limit: 8
-  about: "Burning claws is a members-only item in Old School RuneScape. High alchemy value: 480,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: demonic
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: claws
+    attack_speed: 4
+    weight: 0.907
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 43
+      slash: 54
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 3
+      slash: 6
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 32
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    description: "Burning barrage drains 30% special attack energy and hits the target three times in quick succession, with each hit able to apply a burn dealing 10 damage over 40 ticks."
+  drop_table:
+    sources:
+      - source: Tormented Demon
+        quantity: "1"
+        rarity: 1/1000
+  related_items:
+    - item_id: 30916
+      item_name: Emberlight
+      slug: emberlight
+      relationship: upgrade
+      description: Upgraded weapon made by combining two burning claws.
+    - item_id: 30912
+      item_name: Scorching bow
+      slug: scorching-bow
+      relationship: alternative
+      description: Alternative Tormented Demon weapon for Ranged.
+  about: "Burning claws are a rare drop from Tormented Demons used to build Emberlight; their special attack Burning barrage stacks burn damage over 40 ticks."
+  market_strategy:
+    notes:
+      - Two are required to make Emberlight, so pricing tracks Emberlight demand.
+      - High GE value paired with an 8-limit means each flip carries large absolute exposure.
+  trading_tips:
+    - Pair purchases in twos to enable an Emberlight craft if margin closes.
+    - Watch Tormented Demon nerf or buff news before opening large positions.
+  history:
+    - date: "2024-07-10"
+      description: Released as part of the While Guthix Sleeps quest update.
+  properties:
+    release_date: "2024-07-10"
+    update: While Guthix Sleeps
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cactus-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cactus-seed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cactus seed | OSRS Price Data
-description: "Cactus seed: A Cactus seed - plant in a cactus patch.. High alch: 59 GP, GE limit: 200."
+description: "Cactus seed: A Cactus seed - plant in a cactus patch. High alch: 59 GP, GE limit: 200."
 osrs:
   id: 5280
   name: Cactus seed
@@ -12,9 +12,62 @@ osrs:
   lowalch: 39
   highalch: 59
   limit: 200
-  about: "Cactus seed is a members-only item in Old School RuneScape. High alchemy value: 59 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    skill_level: 55
+    plant_xp: 66.5
+    check_xp: 374
+    harvest_xp: 25
+    growth_time_minutes: 560
+    patch_type: Cactus patch
+    protection_payment: 6 cadava berries
+    produces: Cactus spine
+  drop_table:
+    sources:
+      - source: Aberrant spectre
+        quantity: "1"
+        rarity: "1/76.5"
+      - source: Moss giant
+        quantity: "1"
+        rarity: "1/319.4"
+      - source: Master Farmer (pickpocket)
+        quantity: "1"
+        rarity: "1/1230"
+      - source: Ice giant
+        quantity: "1"
+        rarity: Uncommon
+      - source: Cave horror
+        quantity: "1"
+        rarity: Uncommon
+  related_items:
+    - item_name: Cactus spine
+      relationship: product
+      description: Harvested from a grown cactus.
+  about: "Cactus seed is planted in a cactus patch at 55 Farming, taking around 9 hours 20 minutes to grow before yielding cactus spines used in Herblore."
+  market_strategy:
+    notes:
+      - Low GE limit of 200 per 4 hours restricts bulk farming
+      - Supply driven by Master Farmer pickpocketing and aberrant spectre drops
+      - Cactus spine demand is tied to weapon poison Herblore use
+  history:
+    - date: "2005-06-06"
+      description: Released as part of the Farming skill expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-06-06"
+    update: Farming skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/calcified-moth.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/calcified-moth.mdx
@@ -1,6 +1,6 @@
 ---
 title: Calcified moth | OSRS Price Data
-description: "Calcified moth: A fossilised moth infused with dwarven magic.. GE limit: 100."
+description: "Calcified moth: a fossilised moth infused with dwarven magic that teleports the user to Cam Torum. GE limit: 100."
 osrs:
   id: 29090
   name: Calcified moth
@@ -12,9 +12,52 @@ osrs:
   lowalch: null
   highalch: null
   limit: 100
-  about: "Calcified moth is a members-only item in Old School RuneScape. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Cam Torum
+    type: single-use
+    wilderness_limit: 20
+  recipes:
+    - skill: smithing
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Calcified deposit
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      product: Calcified moth
+      product_quantity: 1
+      members_only: true
+      notes: 1/4 chance per deposit
+  about: "Calcified moth is a single-use teleport to Cam Torum produced by smithing calcified deposits and requires partial Perilous Moons progress to activate."
+  market_strategy:
+    notes:
+      - Output of calcified deposit smithing rolls
+      - Demand tied to Cam Torum convenience teleports
+  trading_tips:
+    - Buy in bulk during off-peak hours for slayer/skilling trips
+    - Track Perilous Moons popularity for demand shifts
+  history:
+    - date: "2024-03-20"
+      description: Released as part of the Varlamore Part One update.
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Crush
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/celastrus-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/celastrus-sapling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Celastrus sapling | OSRS Price Data
-description: "Celastrus sapling: This sapling is ready to be replanted in a Celastrus patch.. High alch: 1 GP, GE limit: 100."
+description: "Celastrus sapling: ready to be replanted in a Celastrus patch. Members-only. GE limit: 100."
 osrs:
   id: 22856
   name: Celastrus sapling
@@ -9,12 +9,59 @@ osrs:
   members: true
   icon: Celastrus sapling.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 100
-  about: "Celastrus sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    patch: Celastrus patch
+    level: 85
+    plant_xp: 200
+    check_xp: 14130
+    harvest_xp: 23.5
+    growth_minutes: 800
+    protection: 8 potato cacti
+  recipes:
+    - skill: farming
+      level: 85
+      xp: 200
+      materials:
+        - item_name: Celastrus seedling (w)
+          quantity: 1
+        - item_name: Plant pot
+          quantity: 1
+      tools:
+        - Watering can
+      product: Celastrus sapling
+      product_quantity: 1
+      members_only: true
+  about: "Celastrus sapling is a members-only Farming item produced by watering a celastrus seedling, ready to be planted in the Farming Guild celastrus patch at 85 Farming."
+  market_strategy:
+    notes:
+      - Bought by players skipping the seedling grow tick
+      - Demand tied to celastrus bark price for Battlestaves
+  trading_tips:
+    - Margins thin compared to raw seeds
+    - List near GE mid-price for fastest fills
+  history:
+    - date: "2019-01-10"
+      description: Released as part of The Kebos Lowlands update.
+  properties:
+    release_date: "2019-01-10"
+    update: The Kebos Lowlands
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Check-health
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-delight-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-delight-4.mdx
@@ -1,20 +1,84 @@
 ---
-title: Chef's delight(4) | OSRS Price Data
+title: "Chef's delight(4) | OSRS Price Data"
 description: "Chef's delight(4): This keg contains 4 pints of Chef's Delight.. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5833
-  name: Chef's delight(4)
+  name: "Chef's delight(4)"
   slug: chef-s-delight-4
   examine: This keg contains 4 pints of Chef's Delight.
   members: true
-  icon: Chef's delight(4).png
+  icon: "Chef's delight(4).png"
   value: 1
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Chef's delight(4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: Boosts Cooking by 1-5 levels per pint while lowering Attack and Strength by 2-3.
+      - description: Restores roughly 1-10% run energy depending on pint.
+  recipes:
+    - skill: cooking
+      level: 54
+      xp: 446
+      materials:
+        - item_name: The stuff
+          quantity: 2
+        - item_name: Chocolate bar
+          quantity: 2
+        - item_name: Pot of cream
+          quantity: 4
+        - item_name: Beer barrel
+          quantity: 1
+      output_quantity: 2
+      tools:
+        - Brewing vat
+        - Calquat keg
+  related_items:
+    - item_id: 5831
+      item_name: "Chef's delight(3)"
+      slug: chef-s-delight-3
+      relationship: variant
+      description: Three-pint version of the keg
+    - item_id: 5829
+      item_name: "Chef's delight(2)"
+      slug: chef-s-delight-2
+      relationship: variant
+      description: Two-pint version of the keg
+    - item_id: 5827
+      item_name: "Chef's delight(1)"
+      slug: chef-s-delight-1
+      relationship: variant
+      description: One-pint version of the keg
+  about: "Four-pint keg of Chef's Delight brewed at 54 Cooking; each pint temporarily boosts Cooking while reducing Attack and Strength."
+  market_strategy:
+    notes:
+      - Brewed via the Keldagrim brewery vat
+      - Used as a Cooking boost for tougher recipes
+      - Partial kegs cannot be traded after sipping
+  trading_tips:
+    - Buy during brewing event windows when supply peaks
+    - Useful as a Cooking boost stockpile for new high-level food updates
+  history:
+    - date: "2005-07-11"
+      description: Released with the Farming update.
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-delight-m.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-delight-m.mdx
@@ -1,20 +1,80 @@
 ---
 title: Chef's delight(m) | OSRS Price Data
-description: "Chef's delight(m): This looks a good deal stronger than normal Chef's Delight.. High alch: 1 GP, GE limit: 2,000."
+description: "Chef's delight(m): This looks a good deal stronger than normal Chef's Delight. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5757
   name: Chef's delight(m)
   slug: chef-s-delight-m
-  examine: This looks a good deal stronger than normal Chef's Delight.
+  examine: "This looks a good deal stronger than normal Chef's Delight."
   members: true
   icon: Chef's delight(m).png
   value: 2
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Chef's delight(m) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: beer
+    tier: low
+  potion:
+    effects:
+      - description: "Restores 2 Hitpoints per pint."
+      - description: "Boosts Cooking by 5% + 2 levels."
+      - description: "Drains Attack by 5% + 3 levels."
+      - description: "Drains Strength by 5% + 3 levels."
+  recipes:
+    - skill: Cooking
+      level: 54
+      materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Chocolate dust
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Beer glass
+          quantity: 8
+      tools:
+        - Brewery vat
+        - Calquat keg
+      product: Chef's delight(m)
+      notes: "Matured variant of Chef's Delight from the Keldagrim brewery; takes multiple days to ferment."
+  related_items:
+    - item_name: Chef's delight
+      slug: chef-s-delight
+      relationship: alternative
+      description: Standard non-matured Cooking-boost beer.
+  about: "Chef's delight(m) is the matured Keldagrim brew that grants a stronger Cooking boost than its standard counterpart at the cost of melee stats."
+  market_strategy:
+    notes:
+      - Matured beers come from random brewery aging, supply is thin.
+      - Cooking trainers buy in bulk for level boosts on stews and gauntlets.
+      - High GE price relative to alch value is purely demand driven.
+  trading_tips:
+    - Drip-feed sells; market is shallow and shifts on small volume.
+    - Buy below 30k when supply spikes after brewery cycles.
+  history:
+    - date: "2005-07-11"
+      description: Released as part of the Farming update brewery content.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: "Farming"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/climbing-boots-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/climbing-boots-g.mdx
@@ -12,63 +12,64 @@ osrs:
   lowalch: 30000
   highalch: 45000
   limit: 4
+  material:
+    type: boots
+    tier: mid-high
   equipment:
     slot: feet
-    type: boots
-    tradeable: true
-    weight: 0.7
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 2
-      defence_stab: 0
-      defence_slash: 1
-      defence_crush: 1
+    weight: 0.34
+    requirements:
+      death-plateau: 1
+    attack_bonus:
+      crush: 2
+    defence_bonus:
+      slash: 1
+      crush: 1
+    other_bonus:
       strength: 2
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Medium
-        drop_rate: Rare from reward casket
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 3105
-      item_name: Climbing boots
+    - item_name: Climbing boots
       slug: climbing-boots
       relationship: downgrade
-      description: Non-gilded version
-    - item_id: 2577
-      item_name: Ranger boots
+      description: Non-trimmed version sold by Tenzing
+    - item_name: Ranger boots
       slug: ranger-boots
       relationship: alternative
-      description: Same clue tier
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Crush attack | +2 |
-    | Slash defence | +1 |
-    | Crush defence | +1 |
-    | Strength | +2 |
-
-    Same stats as regular climbing boots but with gold trim cosmetic.
-
-    | Property | Climbing boots | Climbing boots (g) |
-    |----------|---------------|-------------------|
-    | Stats | Same | Same |
-    | Appearance | Normal | Gold trimmed |
-    | Source | Purchase | Medium clue |
-
-    Cosmetic upgrade to climbing boots:
-    - Same +2 strength bonus
-    - Fashionscape item
-    - Collection log item
+      description: Same medium clue tier cosmetic
+  about: "Climbing boots (g) are a gold-trimmed cosmetic variant of climbing boots obtained as a rare medium Treasure Trail reward."
   market_strategy:
     notes:
-      - Medium clue exclusive
-      - Purely cosmetic upgrade
-      - Collection log hunters
-      - Identical stats to regular version
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Supply gated by medium clue completions and 4 buy limit
+      - Demand from fashionscape and collection log hunters
+      - Death Plateau quest required to equip both versions
+  history:
+    - date: "2019-04-11"
+      description: Released with the Treasure Trails Expansion and Easter 2019 update.
+    - date: "2019-04-18"
+      description: Received a graphical update to match other gold-trimmed items.
+  properties:
+    release_date: "2019-04-11"
+    update: "Treasure Trails Expansion and Easter 2019"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: Death Plateau
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cocktail-guide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cocktail-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cocktail guide | OSRS Price Data
-description: "Cocktail guide: A book on tree gnome cocktails.. High alch: 1 GP, GE limit: 15."
+description: "Cocktail guide: a book on tree gnome cocktails. High alch: 1 GP, GE limit: 15."
 osrs:
   id: 2023
   name: Cocktail guide
@@ -12,9 +12,47 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Cocktail guide is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Blurberry's Bar
+      location: Grand Tree
+      stock: 5
+      price: 4
+    - shop_name: Heckel Funch's Bar
+      location: Grand Tree
+      stock: 5
+      price: 4
+    - shop_name: Rasolo the Wandering Merchant
+      location: South of Baxtorian Falls
+      stock: 1
+      price: 4
+  about: "Cocktail guide is a members reference book containing the seven tree gnome cocktail recipes used in the Gnome Restaurant minigame and player-mixed cocktails."
+  market_strategy:
+    notes:
+      - Cheap shop-floor item with thin GE demand
+      - Mostly bought to unlock cocktail mixing references
+  trading_tips:
+    - Slow flips near alch value for collectors only
+    - Player-owned house bookcase removes most demand
+  history:
+    - date: "2002-12-12"
+      description: Released alongside the Agility skill online update.
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.51
+    options:
+      - Read
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/common-tench.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/common-tench.mdx
@@ -12,9 +12,47 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Common tench is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: raw_fish
+    tier: low
+  related_items:
+    - item_name: Cormorant's glove
+      slug: cormorants-glove
+      relationship: component
+      description: Required glove for aerial fishing
+    - item_name: Greater siren
+      slug: greater-siren
+      relationship: alternative
+      description: Higher-tier aerial fishing catch
+    - item_name: Bluegill
+      slug: bluegill
+      relationship: alternative
+      description: Alternative aerial fishing catch
+  about: "Common tench is the entry-level aerial fishing catch on Molch Island, requiring 56 Fishing and 51 Hunter with a Cormorant's glove."
+  market_strategy:
+    notes:
+      - Bulk supply from aerial fishing keeps price near alch value
+      - 13,000 buy limit supports mass trade for slow Hunter XP
+      - Demand mainly from collectors and aerial fishing herblore offhand
+  history:
+    - date: "2019-01-10"
+      description: Released with The Kebos Lowlands update introducing aerial fishing.
+  properties:
+    release_date: "2019-01-10"
+    update: "The Kebos Lowlands"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/comp-ogre-bow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/comp-ogre-bow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Comp ogre bow | OSRS Price Data
-description: "Comp ogre bow: A composite ogre bow.. High alch: 108 GP, GE limit: 70."
+description: "Comp ogre bow is a members composite ogre bow requiring 30 Ranged and partial Zogre Flesh Eaters progress. High alch: 108 GP, GE limit: 70."
 osrs:
   id: 4827
   name: Comp ogre bow
@@ -12,9 +12,104 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 70
-  about: "Comp ogre bow is a members-only item in Old School RuneScape. High alchemy value: 108 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: bow
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      ranged: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 38
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Fletching
+      level: 30
+      xp: 45
+      output_quantity: 1
+      materials:
+        - item_name: Achey tree logs
+          quantity: 1
+        - item_name: Wolf bones
+          quantity: 1
+        - item_name: Bow string
+          quantity: 1
+      tools:
+        - Knife
+      notes: "Carve achey tree logs into an unstrung comp bow, attach wolf bones for the composite frame, then string it."
+  shops:
+    - shop_name: Hickton's Archery Emporium
+      location: Catherby
+      currency: coins
+    - shop_name: Dargaud's Bow and Arrows
+      location: Ranging Guild
+      currency: coins
+    - shop_name: Uglug's Stuffsies
+      location: Jiggig
+      currency: coins
+  related_items:
+    - item_id: 4825
+      item_name: Ogre bow
+      slug: ogre-bow
+      relationship: variant
+      description: Standard non-composite ogre bow.
+    - item_id: 4839
+      item_name: Ogre arrow
+      slug: ogre-arrow
+      relationship: component
+      description: Required ammunition for ogre bows.
+    - item_id: 4773
+      item_name: Brutal arrow
+      slug: brutal-arrow
+      relationship: component
+      description: Alternative ammunition for ogre bows.
+  about: "Comp ogre bow is the only composite bow craftable via Fletching; it fires ogre and brutal arrows and tracks Chompy bird kills up to 100,000 notches."
+  market_strategy:
+    notes:
+      - Demand tied to Chompy bird hunting and capes
+      - GE price well above high alch
+      - Buy limit 70 supports modest flips
+  trading_tips:
+    - Wolf bone supply gates fletching profit
+    - Check Big Chompy Bird Hunting quest demand surges
+  history:
+    - date: "2005-05-17"
+      description: "Released as part of the Zogre Flesh Eaters update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-17"
+    update: "Zogre Flesh Eaters"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: "Zogre Flesh Eaters"
+    weight: 1.814
+    options:
+      - Wield
+      - Check
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-familiar-acquisition.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-familiar-acquisition.mdx
@@ -12,9 +12,43 @@ osrs:
   lowalch: null
   highalch: null
   limit: 50
-  about: "Contract of familiar acquisition is a members-only item in Old School RuneScape. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_name: Yami familiar
+      slug: yami-familiar
+      relationship: product
+      description: Pet reward from a contracted Yama fight
+  about: "Contract of familiar acquisition is presented to Yama to start a harder version of his fight, giving a 1/100 chance at the Yami familiar (25x the base rate). The contract is consumed on use but returned if the player succeeds."
+  market_strategy:
+    notes:
+      - Buy limit raised to 50 on 29 May 2025
+      - 1/100 Yami chance after 4 June 2025 buff
+      - Duo partners share the contract benefit unless one is an ironman
+  history:
+    - date: "2025-06-04"
+      description: Yami drop rate increased from 1/250 to 1/100; duo partners both benefit from the contract.
+    - date: "2025-05-29"
+      description: Buy limit increased from 5 to 50; phase transitions adjusted; void flares spawn with reduced health in duos.
+    - date: "2025-05-22"
+      description: Contract terms properly documented.
+    - date: "2025-05-14"
+      description: Released with Yama, the Master of Pacts.
+  properties:
+    release_date: "2025-05-14"
+    update: "Yama, the Master of Pacts: Out Today"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Read
+      - Drop
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-chompy.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-chompy.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 52
   highalch: 78
   limit: 6000
-  about: "Cooked chompy is a members-only item in Old School RuneScape. High alchemy value: 78 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 10
+    bites: 1
+  recipes:
+    - skill: cooking
+      level: 30
+      xp: 100
+      materials:
+        - item_name: Skewered chompy
+          item_id: 2876
+          quantity: 1
+      tools:
+        - Any fire or range
+      product: Cooked chompy
+      product_id: 2878
+      product_quantity: 1
+      facility: Fire or range
+      members_only: true
+  related_items:
+    - item_id: 2876
+      item_name: Skewered chompy
+      slug: skewered-chompy
+      relationship: component
+      description: Raw skewered chompy used for cooking
+    - item_id: 2877
+      item_name: Chompy
+      slug: chompy
+      relationship: component
+      description: Raw chompy bird meat
+  about: "Cooked chompy heals 10 Hitpoints and is created by cooking a skewered chompy at level 30 Cooking, granting 100 XP. The heavy 10 kg weight makes hunting near Castle Wars practical."
+  market_strategy:
+    notes:
+      - Heaviest food tied with cooked jubbly
+      - Cooked by chompy hunters
+      - Niche use due to weight
+  trading_tips:
+    - Supply driven by chompy hunter activity
+    - Limited demand outside Big Chompy Bird Hunting content
+  history:
+    - date: "2004-05-18"
+      description: Released with the Big Chompy Bird Hunting update.
+    - date: "2005-06-06"
+      description: Item value increased from 10 to 130 coins.
+  properties:
+    release_date: "2004-05-18"
+    update: Big Chompy Bird Hunting
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Big Chompy Bird Hunting
+    weight: 10
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-2h-axe-inactive.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-2h-axe-inactive.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 208000
   highalch: 312000
   limit: null
-  about: "Crystal 2h axe (inactive) is a free-to-play item in Old School RuneScape. High alchemy value: 312,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Uncharged crystal two-handed woodcutting axe; requires crystal shards to reactivate before use."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dark-tuxedo-shoes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dark-tuxedo-shoes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dark tuxedo shoes | OSRS Price Data
-description: "Dark tuxedo shoes: Dark shoes to match your dark tuxedo.. High alch: 1,800 GP, GE limit: 4."
+description: "Dark tuxedo shoes: Dark shoes to match your dark tuxedo. High alch: 1,800 GP, GE limit: 4."
 osrs:
   id: 19967
   name: Dark tuxedo shoes
@@ -12,9 +12,84 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 4
-  about: "Dark tuxedo shoes is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weapon_type: cosmetic
+    weight: 0.5
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_id: 19961
+      item_name: Dark tuxedo jacket
+      slug: dark-tuxedo-jacket
+      relationship: set-piece
+      description: Body piece of the dark tuxedo outfit.
+    - item_id: 19964
+      item_name: Dark trousers
+      slug: dark-trousers
+      relationship: set-piece
+      description: Legs piece of the dark tuxedo outfit.
+    - item_id: 19958
+      item_name: Dark bow tie
+      slug: dark-bow-tie
+      relationship: set-piece
+      description: Neck piece of the dark tuxedo outfit.
+    - item_id: 19970
+      item_name: Dark tuxedo cuffs
+      slug: dark-tuxedo-cuffs
+      relationship: set-piece
+      description: Hands piece of the dark tuxedo outfit.
+  about: Cosmetic feet slot piece of the Dark Tuxedo outfit obtained from elite clue caskets; storable in the costume room treasure chest.
+  market_strategy:
+    notes:
+      - Supply is limited to elite clue completions
+      - Collector demand keeps price well above alch value
+  trading_tips:
+    - Watch each tuxedo piece individually - shoes lag jacket pricing
+    - Spike sell around bot ban waves that clear cheap supply
+  history:
+    - date: "2016-07-06"
+      description: Released with the Treasure Trail Expansion update.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/defence-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/defence-potion-4.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
-  about: "Defence potion(4) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - description: "Boosts Defence by 3 + 10% of current Defence level (rounded down)."
+      - description: "Boost decays at 1 point per minute, or 90 seconds with the Preserve prayer."
+  recipes:
+    - skill: Herblore
+      level: 30
+      xp: 75
+      materials:
+        - item_name: Ranarr potion (unf)
+          quantity: 1
+        - item_name: White berries
+          quantity: 1
+      tools: []
+  drop_table:
+    sources:
+      - source: Abyssal demon
+        quantity: "1"
+        rarity: 1/128
+      - source: Black demon
+        quantity: "1"
+        rarity: 1/128
+      - source: Young impling jar
+        quantity: "1"
+        rarity: 1/100
+  related_items:
+    - item_name: Defence potion(3)
+      slug: defence-potion-3
+      relationship: variant
+      description: Three-dose variant
+    - item_name: Defence potion(2)
+      slug: defence-potion-2
+      relationship: variant
+      description: Two-dose variant
+    - item_name: Defence potion(1)
+      slug: defence-potion-1
+      relationship: variant
+      description: Single-dose variant
+  about: "Defence potion(4) holds four doses that each boost Defence by 3 + 10% of the current level. Brewed at 30 Herblore from a ranarr potion (unf) and white berries for 75 XP."
+  market_strategy:
+    notes:
+      - Cheap Herblore training product
+      - Limited combat use vs Super defence
+      - Drops from demons and young impling jars
+  history:
+    - date: "2004-10-26"
+      description: An "Empty" option was added.
+    - date: "2004-03-29"
+      description: The 4-dose potion became permanently available with the RuneScape 2 launch.
+    - date: "2002-02-27"
+      description: Released with Herblore-era potion content.
+  properties:
+    release_date: "2002-02-27"
+    update: Latest RuneScape News (27 February 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/demon-tear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/demon-tear.mdx
@@ -1,6 +1,6 @@
 ---
 title: Demon tear | OSRS Price Data
-description: "Demon tear: A strange glowing tear.. High alch: 300 GP, GE limit: 13,000."
+description: "Demon tear: A strange glowing tear. High alch: 300 GP, GE limit: 13,000."
 osrs:
   id: 31111
   name: Demon tear
@@ -12,9 +12,47 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 13000
-  about: "Demon tear is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Doom of Mokhaiotl
+        quantity: "1"
+        rarity: 7/104 (100-300 per drop)
+      - source: Doom of Mokhaiotl (guaranteed)
+        quantity: "1"
+        rarity: 50 guaranteed per kill
+      - source: Infected roots
+        quantity: "1"
+        rarity: 15/17 at 80+ Woodcutting
+      - source: Eye of Ayak (dismantle)
+        quantity: "1"
+        rarity: 10,000 per dismantle
+  about: "Demon tear is a stackable upgrade material introduced with the Varlamore: The Final Dawn update, used to enhance the Eye of Ayak and craft Confliction gauntlets and Avernic treads variants."
+  market_strategy:
+    notes:
+      - Primary sink is Avernic treads upgrades (4,000 per upgrade) and Confliction gauntlets (10,000).
+      - Total of 22,000 tears needed for full Avernic treads + Confliction gauntlets.
+      - GE buy limit 13,000 per 4 hours supports bulk acquisition.
+  trading_tips:
+    - Watch Doom of Mokhaiotl player counts to forecast supply.
+    - Demand spikes whenever a new sink is announced for the tears.
+  history:
+    - date: "2025-07-23"
+      description: "Released with the Varlamore: The Final Dawn update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-07-23"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-combat-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-combat-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Divine super combat potion(1) | OSRS Price Data
-description: "Divine super combat potion(1): 1 dose of divine super combat potion.. High alch: 24 GP, GE limit: 2,000."
+description: "Divine super combat potion(1): 1 dose of divine super combat potion. High alch: 24 GP, GE limit: 2,000."
 osrs:
   id: 23694
   name: Divine super combat potion(1)
@@ -12,96 +12,76 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 2000
-  item:
-    type: potion
-    tradeable: true
-    doses: 4
-  effect:
-    divine_boost:
-      skills:
-        - Attack
-        - Strength
-        - Defence
-      formula: floor(level * 0.15) + 5
-      duration_seconds: 300
-      no_decay: true
-      self_damage: 10
+  potion:
+    doses: 1
+    effects:
+      - description: "Boosts Attack, Strength, and Defence by 5 + 15% of the player's level for 5 minutes."
+      - description: "Boosted stats do not decay during the 5-minute duration."
+      - description: "Drinking inflicts 10 hitpoints of damage; requires more than 10 HP to drink."
   recipes:
-    - skill: herblore
+    - skill: Herblore
       level: 97
-      xp: 2
+      xp: 0.5
+      tools:
+        - Pestle and mortar
       materials:
-        - item_id: 12695
-          item_name: Super combat potion (4)
+        - item_name: Super combat potion(1)
           quantity: 1
-        - item_id: 23964
-          item_name: Crystal dust
-          quantity: 4
-      product: Divine super combat potion (4)
-      product_id: 23694
-      facility: N/A
-      members_only: true
+        - item_name: Crystal dust
+          quantity: 1
+      product: Divine super combat potion(1)
   related_items:
+    - item_id: 23685
+      item_name: Divine super combat potion(4)
+      slug: divine-super-combat-potion-4
+      relationship: variant
+      description: 4-dose variant of the same potion.
     - item_id: 12695
-      item_name: Super combat potion
-      slug: super-combat-potion
+      item_name: Super combat potion(4)
+      slug: super-combat-potion-4
       relationship: component
-      description: Base potion
+      description: Base potion used to brew the divine variant.
     - item_id: 23964
       item_name: Crystal dust
       slug: crystal-dust
       relationship: component
-      description: From crystal shards
+      description: Made by grinding a crystal shard.
     - item_id: 23733
-      item_name: Divine ranging potion
-      slug: divine-ranging-potion
+      item_name: Divine ranging potion(1)
+      slug: divine-ranging-potion-1
       relationship: alternative
-      description: Ranged version
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Potion |
-    | Tradeable | Yes |
-    | Weight | 0.035 kg (4-dose) |
-
-    Combine Super combat potion + Crystal dust.
-
-    | Component | Amount (4-dose) |
-    |-----------|-----------------|
-    | Super combat (4) | 1 |
-    | Crystal dust | 4 |
-
-    Herblore: 97
-    XP: 2
-
-    Boosts Attack, Strength, and Defence for 5 minutes.
-
-    | Level | Boost |
-    |-------|-------|
-    | 1-6 | +5 |
-    | 80-86 | +17 |
-    | 94-99 | +19 |
-
-    Formula: ⌊Level × 15%⌋ + 5
-
-    NO DECAY for 5 minutes!
-
-    Damage: Deals 10 HP damage on drink.
-
-    BiS for:
-    - ToB
-    - CoX
-    - High-level bossing
-    - Any 5+ minute fight
-
-    Non-draining boost is massive DPS increase.
+      description: Ranged equivalent that boosts Ranged.
+  about: "Divine super combat potion(1) is a 1-dose stat booster brewed at 97 Herblore that locks Attack, Strength, and Defence boosts for five minutes at the cost of ten hitpoints."
   market_strategy:
     notes:
-      - Crystal dust from Prifddinas
-      - Worth the 10 HP cost
-      - Essential for raids
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Crystal dust supply comes from Prifddinas crystal shards.
+      - Buyers prefer 4-dose pricing; 1-dose typically trades at a discount per dose.
+  trading_tips:
+    - Decant into higher doses for better margins.
+    - Demand spikes around raid resets and DMM events.
+  history:
+    - date: "2019-07-25"
+      description: Released alongside the Song of the Elves quest.
+    - date: "2020-07-02"
+      description: Graphically updated for inventory consistency with standard potions.
+  properties:
+    release_date: "2019-07-25"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-defence-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-defence-potion-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Divine super defence potion(3) | OSRS Price Data
-description: "Divine super defence potion(3): 3 doses of divine super defence potion.. High alch: 102 GP, GE limit: 2,000."
+description: "Divine super defence potion(3): 3 doses of divine super defence potion. High alch: 102 GP, GE limit: 2,000."
 osrs:
   id: 23724
   name: Divine super defence potion(3)
@@ -12,9 +12,73 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 2000
-  about: "Divine super defence potion(3) is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 3
+    effects:
+      - description: "Boosts Defence by 5 + 15% of the player's Defence level"
+      - description: "Prevents Defence from draining below the boost cap for 5 minutes"
+      - description: "Deals 10 hitpoints damage on consumption; player must have more than 10 HP to drink"
+  recipes:
+    - skill: Herblore
+      level: 70
+      xp: 1.5
+      materials:
+        - item_name: Super defence(3)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 1
+      tools: []
+      output_item: Divine super defence potion(3)
+      output_quantity: 1
+  related_items:
+    - item_name: Divine super defence potion(1)
+      relationship: variant
+      description: 1-dose version.
+    - item_name: Divine super defence potion(2)
+      relationship: variant
+      description: 2-dose version.
+    - item_name: Divine super defence potion(4)
+      relationship: variant
+      description: 4-dose version.
+    - item_name: Super defence(3)
+      relationship: component
+      description: Base potion combined with crystal dust.
+    - item_name: Crystal dust
+      relationship: component
+      description: Required ingredient unlocked through Song of the Elves.
+  about: "Divine super defence potion(3) is a divine Herblore variant that holds the super defence boost for five minutes at the cost of 10 hitpoints on drink, requiring 70 Herblore to brew."
+  market_strategy:
+    notes:
+      - Crystal dust supply gates production
+      - 5-minute sustain favours boss trips and PvM setups
+      - Lower demand than divine bastion / battlemage potions
+  trading_tips:
+    - Watch the spread vs. super defence(3) + crystal dust input cost
+    - Margin compresses during Song of the Elves events
+  history:
+    - date: "2019-07-25"
+      description: Released with the Song of the Elves update.
+    - date: "2020-07-02"
+      description: Inventory icon graphically updated to match standard potion sprites.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-07-25"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-chainbody-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-chainbody-ornament-kit.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Dragon chainbody ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/1275
+  related_items:
+    - item_id: 3140
+      item_name: Dragon chainbody
+      slug: dragon-chainbody
+      relationship: component
+      description: Base chainbody the kit ornaments
+    - item_id: 12535
+      item_name: Dragon chainbody (g)
+      slug: dragon-chainbody-g
+      relationship: product
+      description: Resulting gilded ornamented chainbody
+  about: "Elite Treasure Trails ornament reward that gilds a Dragon chainbody into Dragon chainbody (g); the gilded form is untradeable but the kit can be detached and resold."
+  market_strategy:
+    notes:
+      - Strict 4-per-4-hour GE buy limit caps bulk
+      - Drop rate is 1/1275 from elite reward caskets
+      - Untradeable once applied unless detached
+  trading_tips:
+    - Flip during elite clue completion surges
+    - Stock when cosmetic announcements drive cosmetic demand
+  history:
+    - date: "2014-06-12"
+      description: Released with the Treasure Trail expansion.
+    - date: "2018-01-25"
+      description: Received a graphical update.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dart-p-11233.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dart-p-11233.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon dart(p+) | OSRS Price Data
-description: "Dragon dart(p+): A deadly poisoned dart with a dragon tip.. High alch: 300 GP, GE limit: 11,000."
+description: "Dragon dart(p+) is a members enhanced-poison thrown weapon requiring 60 Ranged. High alch: 300 GP, GE limit: 11,000."
 osrs:
   id: 11233
   name: Dragon dart(p+)
@@ -12,9 +12,96 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 11000
-  about: "Dragon dart(p+) is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 35
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Herblore
+      level: 73
+      xp: 0
+      output_quantity: 1
+      materials:
+        - item_name: Dragon dart
+          quantity: 1
+        - item_name: Weapon poison(+)
+          quantity: 1
+      tools: []
+      notes: "Use Weapon poison(+) on a dragon dart to make a Dragon dart(p+)."
+  related_items:
+    - item_id: 11230
+      item_name: Dragon dart
+      slug: dragon-dart
+      relationship: variant
+      description: Unpoisoned dragon dart base.
+    - item_id: 11232
+      item_name: Dragon dart(p)
+      slug: dragon-dart-p
+      relationship: downgrade
+      description: Standard-poison dragon dart.
+    - item_id: 11234
+      item_name: Dragon dart(p++)
+      slug: dragon-dart-pp
+      relationship: upgrade
+      description: Extra-strong poison dragon dart.
+    - item_id: 11231
+      item_name: Dragon dart tip
+      slug: dragon-dart-tip
+      relationship: component
+      description: Fletching base for the dart.
+  about: "Dragon dart(p+) is the second-tier poisoned dragon throwing dart, dealing +35 ranged strength and applying enhanced poison damage on hit."
+  market_strategy:
+    notes:
+      - Slight premium over unpoisoned dragon darts
+      - GE limit 11,000 enables bulk flipping
+      - Weapon poison(+) supply gates the spread
+  trading_tips:
+    - Monitor unpoisoned dragon dart prices for poison arbitrage
+    - Demand peaks around poison-immune-light boss content
+  history:
+    - date: "2007-06-11"
+      description: "Released with the Impetuous Impulses update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-06-11"
+    update: "Impetuous Impulses"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hasta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hasta.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon hasta | OSRS Price Data
-description: "Dragon hasta is a members shield slot item requiring 75 Defence. High alch: 37,440 GP, GE limit: 70."
+description: "Dragon hasta is a members weapon slot item requiring 60 Attack. High alch: 37,440 GP, GE limit: 70."
 osrs:
   id: 22731
   name: Dragon hasta
@@ -12,92 +12,79 @@ osrs:
   lowalch: 24960
   highalch: 37440
   limit: 70
+  material:
+    type: dragon
+    tier: high
   equipment:
-    slot: shield
-    type: shield
-    attack_style: melee
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
     requirements:
-      defence: 75
-    stats:
-      defence_stab: 20
-      defence_slash: 25
-      defence_crush: 22
-      defence_ranged: 22
-      strength: 7
-    degradeable: true
-    max_charges: 50
-  effect:
-    dragonfire_protection: true
-    wyvern_protection: partial
-    dragonfire_blast: true
-    blast_damage: 25
-    blast_range: 10
-  recipes:
-    - skill: smithing
-      level: 90
-      xp: 2000
-      materials:
-        - item_name: Anti-dragon shield
-          item_id: 1540
-          quantity: 1
-        - item_name: Draconic visage
-          item_id: 11286
-          quantity: 1
-      product: Dragonfire shield
-      product_id: 11284
-      product_quantity: 1
-      facility: Anvil
-      members_only: true
+      attack: 60
+    attack_bonus:
+      stab: 55
+      slash: 55
+      crush: 55
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -15
+      slash: -15
+      crush: -12
+      magic: 0
+      ranged: -15
+    other_bonus:
+      strength: 60
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Unleash
+    energy_cost: 50
+    description: "Scales with energy used: 5% accuracy and 2.5% damage boost per 5% spec energy; ignores Protect from Melee."
   related_items:
-    - item_id: 11286
-      item_name: Draconic visage
-      slug: draconic-visage
-      relationship: component
-      description: Drop from dragons
-    - item_id: 1540
-      item_name: Anti-dragon shield
-      slug: anti-dragon-shield
-      relationship: component
-      description: Base shield
-    - item_id: 22003
-      item_name: Dragonfire ward
-      slug: dragonfire-ward
+    - item_id: 11716
+      item_name: Dragon spear
+      slug: dragon-spear
+      relationship: variant
+      description: Two-handed dragon spear counterpart
+    - item_id: 11889
+      item_name: Zamorakian hasta
+      slug: zamorakian-hasta
       relationship: alternative
-      description: Ranged alternative
-  about: |-
-    Combine Anti-dragon shield + Draconic visage:
-
-    | Method | Requirements | XP |
-    |--------|--------------|-----|
-    | Smithing | 90 Smithing + anvil + hammer | 2,000 |
-    | Oziach (NPC) | Dragon Slayer I + 1,250,000 gp | None |
-
-    | Stat | Uncharged | Charged (+50) |
-    |------|-----------|---------------|
-    | Stab defence | +20 | +70 |
-    | Slash defence | +25 | +75 |
-    | Crush defence | +22 | +72 |
-    | Ranged defence | +22 | +72 |
-    | Strength | +7 | +7 |
-
-    Dragonfire Protection:
-    - Same protection as anti-dragon shield
-    - Partial wyvern breath protection
-
-    Dragonfire Blast (right-click activate):
-    - Deals up to 25 damage
-    - Uses 1 charge
-    - 10-tile range
-    - ~2 minute cooldown
-
-    Charges from absorbing dragonfire attacks (max 50 charges).
+      description: Stronger god-tier one-handed hasta
+  about: "One-handed dragon hasta retrieved from the brimstone chest in broken form and repaired free of charge by Otto Godblessed; requires 60 Attack to wield."
   market_strategy:
     notes:
-      - Visage is the expensive component
-      - Required for some high-level dragon content
-      - Consider Dragonfire ward for ranged
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Brimstone chest is the only source, so supply is rare drop driven
+      - Repair via Otto Godblessed costs nothing
+      - Pure spear slot weapon with potent Unleash spec
+  trading_tips:
+    - Watch chest rate posts for supply spikes
+    - Position around Inferno/grandmaster PvM updates that demand spec weapons
+  history:
+    - date: "2019-01-10"
+      description: Released as a brimstone chest reward.
+  properties:
+    release_date: "2019-01-10"
+    update: Brimstone Chest
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-metal-shard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-metal-shard.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon metal shard | OSRS Price Data
-description: "Dragon metal shard: A badly damaged shard of dragon metal.. High alch: 720,000 GP, GE limit: 50."
+description: "Dragon metal shard: A badly damaged shard of dragon metal. High alch: 720,000 GP, GE limit: 50."
 osrs:
   id: 22097
   name: Dragon metal shard
@@ -12,9 +12,94 @@ osrs:
   lowalch: 480000
   highalch: 720000
   limit: 50
-  about: "Dragon metal shard is a members-only item in Old School RuneScape. High alchemy value: 720,000 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: smithing-component
+    tier: high
+  shops:
+    - shop_name: Myths' Guild Armoury
+      location: Myths' Guild basement
+      price: 1800000
+  recipes:
+    - name: Dragon kiteshield
+      skill: Smithing
+      level: 75
+      xp: 1000
+      materials:
+        - item_name: Dragon metal shard
+          quantity: 1
+        - item_name: Dragon metal slice
+          quantity: 1
+        - item_name: Dragon sq shield
+          quantity: 1
+      tools:
+        - Anvil
+        - Hammer
+      notes: Requires Dragon Slayer II completion.
+    - name: Dragon platebody
+      skill: Smithing
+      level: 90
+      xp: 2000
+      materials:
+        - item_name: Dragon metal shard
+          quantity: 1
+        - item_name: Dragon metal lump
+          quantity: 1
+        - item_name: Dragon chainbody
+          quantity: 1
+      tools:
+        - Anvil
+        - Hammer
+      notes: Requires Dragon Slayer II completion.
+  related_items:
+    - item_id: 22103
+      item_name: Dragon metal lump
+      slug: dragon-metal-lump
+      relationship: alternative
+      description: Companion smithing material for the dragon platebody.
+    - item_id: 22100
+      item_name: Dragon metal slice
+      slug: dragon-metal-slice
+      relationship: alternative
+      description: Companion smithing material for the dragon kiteshield.
+    - item_id: 1187
+      item_name: Dragon sq shield
+      slug: dragon-sq-shield
+      relationship: component
+      description: Base shield used in the dragon kiteshield recipe.
+    - item_id: 3140
+      item_name: Dragon chainbody
+      slug: dragon-chainbody
+      relationship: component
+      description: Base armour used in the dragon platebody recipe.
+  about: Smithing component bought from the Myths' Guild Armoury after Dragon Slayer II; used to craft the dragon kiteshield and dragon platebody.
+  market_strategy:
+    notes:
+      - Supply is gated behind Dragon Slayer II + Myths' Guild shop
+      - Demand spikes when high-level Smithing becomes more profitable
+  trading_tips:
+    - Margin between shop price and GE flips fast - check before bulk buying
+    - Pair purchases with companion lump or slice to flip as kits
+  history:
+    - date: "2018-01-04"
+      description: Released with the Dragon Slayer II update.
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Dragon Slayer II
+    weight: 2.721
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-sq-shield-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-sq-shield-ornament-kit.mdx
@@ -12,60 +12,67 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  item:
+  material:
     type: ornament_kit
-    tradeable: true
-    target_item: Dragon sq shield
-    target_id: 1187
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Elite
-        drop_rate: Rare from reward casket
+    tier: high
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/1275
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  recipes:
+    - skill: Cosmetic
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Dragon sq shield
+          quantity: 1
+        - item_name: Dragon sq shield ornament kit
+          quantity: 1
+      tools: []
   related_items:
-    - item_id: 1187
-      item_name: Dragon sq shield
+    - item_name: Dragon sq shield
       slug: dragon-sq-shield
+      relationship: component
+      description: Base shield to upgrade
+    - item_name: Dragon sq shield (g)
+      slug: dragon-sq-shield-g
       relationship: product
-      description: Base item to upgrade
-    - item_id: 12420
-      item_name: Dragon sq shield (or)
-      slug: dragon-sq-shield-or
-      relationship: product
-      description: Ornamented version
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ornament Kit |
-    | Target | Dragon sq shield |
-    | Tradeable | Yes |
-
-    Use on a Dragon sq shield to create a Dragon sq shield (or).
-
-    The ornament kit:
-    - Adds gold trim to the shield
-    - Purely cosmetic change
-    - Does not affect stats
-    - Can be reverted
-
-    Materials:
-    - Dragon sq shield
-    - Dragon sq shield ornament kit
-
-    Result:
-    - Dragon sq shield (or) - gold trimmed version
-
-    The ornamented shield can be reverted to return:
-    - Dragon sq shield
-    - Dragon sq shield ornament kit
+      description: Gold-trimmed ornamented version
+  about: "Dragon sq shield ornament kit is an elite Treasure Trails reward that applies a cosmetic gold trim to a Dragon sq shield. The combined shield is untradeable but the kit can be removed and traded again."
   market_strategy:
     notes:
-      - Elite clue exclusive
-      - Cosmetic upgrade only
-      - Popular fashionscape item
+      - Elite clue exclusive at 1/1,275
+      - Cosmetic upgrade with no stat changes
+      - Detachable kit, ornamented shield is untradeable
       - Collection log item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2018-01-25"
+      description: Visual update applied during the Barbarian Assault Ranged Rework patch.
+    - date: "2014-06-12"
+      description: Released with the Treasure Trail Expansion.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-amulet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragonstone amulet | OSRS Price Data
-description: "Dragonstone amulet is a members neck slot item. High alch: 10,575 GP, GE limit: 10,000."
+description: "Dragonstone amulet is a members neck slot item enchantable into the Amulet of glory. High alch: 10,575 GP, GE limit: 10,000."
 osrs:
   id: 1702
   name: Dragonstone amulet
@@ -12,55 +12,103 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 10000
+  material:
+    type: gold
+    tier: high
   equipment:
     slot: neck
     requirements:
       crafting: 80
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 80
       xp: 150
-      inputs:
-        - item_name: Dragonstone
-          quantity: 1
+      materials:
         - item_name: Gold bar
           quantity: 1
+        - item_name: Dragonstone
+          quantity: 1
+        - item_name: Amulet mould
+          quantity: 1
+      tools:
+        - Furnace
+      output_item: Dragonstone amulet (unstrung)
+      output_quantity: 1
+    - skill: crafting
+      level: 1
+      xp: 4
+      materials:
+        - item_name: Dragonstone amulet (unstrung)
+          quantity: 1
+        - item_name: Ball of wool
+          quantity: 1
+      tools: []
+      output_item: Dragonstone amulet
       output_quantity: 1
   related_items:
     - item_id: 1700
       item_name: Diamond amulet
       slug: diamond-amulet
       relationship: downgrade
-      description: Previous tier amulet
+      description: Previous-tier gem amulet.
     - item_id: 6581
       item_name: Onyx amulet
       slug: onyx-amulet
       relationship: upgrade
-      description: Next tier amulet
+      description: Higher-tier gem amulet.
     - item_id: 1704
       item_name: Amulet of glory
       slug: amulet-of-glory
-      relationship: upgrade
-      description: Enchanted version (teleports + bonuses)
-  about: |-
-    Crafting (Level 80): Dragonstone + Gold bar at a furnace with amulet mould (150 XP). String with ball of wool.
-
-    > *"A dragonstone amulet."*
-
-    Lvl-5 Enchant (68 Magic): 1 cosmic rune + 15 earth runes + 15 water runes (78 XP)
-
-    The Amulet of glory is one of the most widely used amulets:
-    - +10 to all attack styles, +3 to all defence, +6 Strength, +3 Prayer
-    - 4 teleport charges (Edgeville, Karamja, Draynor, Al Kharid)
-    - Recharge at the Fountain of Heroes or Fountain of Rune (wilderness)
-    - Increases gem chance from gem rocks
+      relationship: product
+      description: "Enchanted form via Lvl-5 Enchant: teleports + combat bonuses."
+  about: "Dragonstone amulet is a Crafting product enchanted via Lvl-5 Enchant into the Amulet of glory, one of the most-used neck slot items in the game."
   market_strategy:
     notes:
-      - Glory is one of the most used amulets — steady demand
-      - Enchanting is often profitable
-      - Dragonstone cost drives the price
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Glory demand keeps a steady enchant-flip funnel through this base
+      - Dragonstone gem cost is the dominant input — track gem pricing together
+      - Watch DKS / dragon implings supply spikes that crash dragonstone
+  trading_tips:
+    - Buy in bulk before Crafting bonus weekends when enchanters arbitrage
+    - Compare GE margin to making your own dragonstone from rough gems
+  history:
+    - date: "2002-02-27"
+      description: Released alongside the Members beta launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: "Members release"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-bolts.mdx
@@ -12,21 +12,44 @@ osrs:
   lowalch: 386
   highalch: 580
   limit: 11000
+  material:
+    type: runite
+    tier: high
   equipment:
     slot: ammo
-    stats:
+    weapon_type: crossbow
+    attack_speed: 6
+    weight: 0
+    requirements:
+      ranged: 64
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 117
-    requirements: {}
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: fletching
       level: 71
       xp: 82
-      inputs:
+      materials:
         - item_name: Runite bolts
           quantity: 10
         - item_name: Dragonstone bolt tips
           quantity: 10
       output_quantity: 10
+      tools: []
   related_items:
     - item_id: 9244
       item_name: Dragonstone bolts (e)
@@ -43,33 +66,37 @@ osrs:
       slug: dragonstone-bolt-tips
       relationship: component
       description: Gem tips used in creation
-  about: |-
-    > *"Dragonstone tipped Runite crossbow bolts."*
-
-    | Bonus | Value |
-    |-------|-------|
-    | Ranged Strength | +117 |
-    | All other bonuses | +0 |
-
-    | Detail | Value |
-    |--------|-------|
-    | Skill | Fletching |
-    | Level | 71 |
-    | XP | 82 (per 10 bolts) |
-    | Inputs | 10 Runite bolts + 10 Dragonstone bolt tips |
-    | Output | 10 Dragonstone bolts |
-
-    Dragonstone bolt tips are crafted by using a chisel on a cut dragonstone, requiring 71 Crafting.
-
-    Dragonstone bolts can be enchanted into Dragonstone bolts (e) using the Enchant Crossbow Bolt spell at level 68 Magic. The enchanted version has the Dragon's Breath special effect, which has a chance to inflict a dragonfire hit on the target. This effect does not work against targets that are immune to dragonfire.
+  about: "Dragonstone tipped Runite crossbow bolts fletched at 71 Fletching from Runite bolts and Dragonstone bolt tips for 82 XP per set of 10; the enchanted variant carries the Dragon's Breath special."
   market_strategy:
     notes:
       - High-tier crossbow bolt with strong ranged strength
       - Enchanted version used for its Dragon's Breath spec
       - Dragonstone bolt tips can also come from dragon implings
       - Members only item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Buy bolt tips from dragon implings to undercut GE supply
+    - Enchant for resale margin when DS bolts (e) demand spikes
+  history:
+    - date: "2006-07-31"
+      description: Released with the Crossbows update.
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragonstone boots | OSRS Price Data
-description: "Dragonstone boots: A stylish pair of rune boots inlaid with dragonstones.. High alch: 7,500 GP."
+description: "Dragonstone boots: A stylish pair of rune boots inlaid with dragonstones. High alch: 7,500 GP."
 osrs:
   id: 24043
   name: Dragonstone boots
@@ -12,9 +12,83 @@ osrs:
   lowalch: 5000
   highalch: 7500
   limit: null
-  about: "Dragonstone boots is a members-only item in Old School RuneScape. High alchemy value: 7,500 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragonstone-rune
+    tier: high
+  equipment:
+    slot: feet
+    weight: 1.36
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: -1
+    defence_bonus:
+      stab: 12
+      slash: 13
+      crush: 14
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 2
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Elven Crystal Chest
+        quantity: "1"
+        rarity: 1/2500
+  related_items:
+    - item_id: 24039
+      item_name: Dragonstone full helm
+      slug: dragonstone-full-helm
+      relationship: set-piece
+      description: Matching full helm.
+    - item_id: 24041
+      item_name: Dragonstone platebody
+      slug: dragonstone-platebody
+      relationship: set-piece
+      description: Matching platebody.
+    - item_id: 24037
+      item_name: Dragonstone platelegs
+      slug: dragonstone-platelegs
+      relationship: set-piece
+      description: Matching platelegs.
+  about: "Dragonstone boots are a high-tier melee foot slot reward from the Elven Crystal Chest in Prifddinas, sharing rune-tier defences with a small Strength bonus."
+  market_strategy:
+    notes:
+      - Supply is gated by Crystal Chest runs, supporting strong long-term value.
+      - Most demand comes from cosmetic set collectors rather than pure DPS upgraders.
+  trading_tips:
+    - Snipe undercut listings during Crystal Chest grind weekends.
+    - Buy in tandem with the rest of the Dragonstone armour set for resale.
+  history:
+    - date: "2019-07-25"
+      description: Added with the release of Song of the Elves and the Elven Crystal Chest rewards.
+  properties:
+    release_date: "2019-07-25"
+    update: "Song of the Elves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: Song of the Elves
+    weight: 1.36
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-dragon-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-dragon-bolts-e.mdx
@@ -5,7 +5,7 @@ osrs:
   id: 21948
   name: Dragonstone dragon bolts (e)
   slug: dragonstone-dragon-bolts-e
-  examine: Enchanted Dragon crossbow bolts, tipped with dragonstone. Double dragon!
+  examine: "Enchanted Dragon crossbow bolts, tipped with dragonstone. Double dragon!"
   members: true
   icon: Dragonstone dragon bolts (e) 5.png
   value: 1150
@@ -14,59 +14,91 @@ osrs:
   limit: 11000
   equipment:
     slot: ammo
+    weapon_type: crossbow
+    weight: 0
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: 0
       ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      strength: 0
       ranged_strength: 122
+      magic_damage: 0
       prayer: 0
-    requirements: {}
+  special_attack:
+    name: "Dragon's Breath"
+    description: "6% chance on hit to deal bonus dragonfire damage equal to 20% of the attacker's visible Ranged level (22% with Zaryte crossbow passive)."
   recipes:
-    - skill: magic
+    - skill: Magic
       level: 68
       xp: 78
-      inputs:
+      materials:
         - item_name: Dragonstone dragon bolts
           quantity: 10
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Soul rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 15
+      tools: []
+      output_item: Dragonstone dragon bolts (e)
       output_quantity: 10
   related_items:
-    - item_id: 9244
-      item_name: Dragonstone bolts (e)
-      slug: dragonstone-bolts-e
+    - item_name: Dragonstone dragon bolts
+      relationship: component
+      description: Unenchanted base bolt.
+    - item_name: Dragonstone bolts (e)
       relationship: downgrade
-      description: Regular crossbow version
-  about: |-
-    > *"Enchanted Dragon crossbow bolts, tipped with dragonstone. Double dragon!"*
-
-    Dragonstone dragon bolts (e) carry the Dragon's Breath enchantment. On a successful hit, there is a 6% chance to trigger a dragonfire attack on the target, dealing extra damage equal to 20% of the attacker's visible Ranged level (rounded down). When used with the Zaryte crossbow passive effect, this bonus increases to 22%. The dragonfire effect can be mitigated by anti-dragon shields and antifire potions, making it less effective against prepared targets.
-
-    Enchant Crossbow Bolt (Dragonstone) requires Magic level 68 and grants 78 XP per cast. Each cast enchants 10 bolts at a time.
-
-    | Component | Quantity |
-    |-----------|----------|
-    | Dragonstone dragon bolts | 10 |
-    | Cosmic rune | 1 |
-    | Soul rune | 1 |
-    | Earth rune | 15 |
-
-    | Stat | Dragon (e) | Regular (e) |
-    |------|-----------|-------------|
-    | Ranged Str | +122 | +117 |
-    | Base bolt | Dragon crossbow bolt | Runite bolt |
-
-    While both variants have similar ranged strength, the dragon bolt base still provides a modest edge.
+      description: Runite-base equivalent with +117 ranged strength.
+    - item_name: Dragon crossbow
+      relationship: alternative
+      description: Common crossbow used to fire these bolts.
+    - item_name: Zaryte crossbow
+      relationship: upgrade
+      description: Boosts the special effect chance and damage.
+  about: "Dragonstone dragon bolts (e) are enchanted dragon-tipped bolts that trigger Dragon's Breath at a 6% rate for bonus dragonfire damage, with +122 ranged strength making them a top all-round PvM bolt."
   market_strategy:
     notes:
-      - One of the best all-around bolt enchantments for PvM
-      - Enhanced by Zaryte crossbow passive (22% instead of 20%)
-      - Can be mitigated by anti-dragon shields and antifire potions
-      - High Magic requirement (68) but excellent XP per cast
-      - Most commonly used enchanted dragon bolt
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - One of the strongest all-round bolt enchantments for PvM
+      - Enhanced by the Zaryte crossbow passive (22% instead of 20%)
+      - Mitigated by anti-dragon shields and antifire potions
+      - 68 Magic gate keeps fresh supply scarce
+      - Most commonly used enchanted dragon bolt variant
+  trading_tips:
+    - Margin from buying base dragon bolts and enchanting in bulk is reliable
+    - Watch the spread on soul rune costs after farming events
+  history:
+    - date: "2018-01-04"
+      description: Released as part of the Dragon Slayer II update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-platelegs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragonstone platelegs | OSRS Price Data
-description: "Dragonstone platelegs: A stylish pair of rune platelegs inlaid with dragonstones.. High alch: 38,400 GP."
+description: "Dragonstone platelegs is a free-to-play rune-tier legs slot armour inlaid with dragonstones. High alch: 38,400 GP."
 osrs:
   id: 24040
   name: Dragonstone platelegs
@@ -12,9 +12,96 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: null
-  about: "Dragonstone platelegs is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: high
+  equipment:
+    slot: legs
+    weight: 9.071
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Elven Crystal Chest
+        quantity: "1"
+        rarity: rare
+  related_items:
+    - item_id: 24034
+      item_name: Dragonstone full helm
+      slug: dragonstone-full-helm
+      relationship: set-piece
+      description: Matching helm of the dragonstone armour set.
+    - item_id: 24037
+      item_name: Dragonstone platebody
+      slug: dragonstone-platebody
+      relationship: set-piece
+      description: Matching body of the dragonstone armour set.
+    - item_id: 24043
+      item_name: Dragonstone boots
+      slug: dragonstone-boots
+      relationship: set-piece
+      description: Matching boots of the dragonstone armour set.
+    - item_id: 24046
+      item_name: Dragonstone gauntlets
+      slug: dragonstone-gauntlets
+      relationship: set-piece
+      description: Matching gauntlets of the dragonstone armour set.
+    - item_id: 1079
+      item_name: Rune platelegs
+      slug: rune-platelegs
+      relationship: alternative
+      description: Standard non-dragonstone rune platelegs.
+  about: "Dragonstone platelegs are obtained as a rare reward from the Elven Crystal Chest in Prifddinas and share rune-tier defence with a fashionscape premium."
+  market_strategy:
+    notes:
+      - Supply gated entirely by Elven Crystal Chest rolls
+      - High GE price reflects fashion and set-completion demand
+      - No GE buy limit aids large arbitrage flips
+  trading_tips:
+    - Watch Song of the Elves chest reset metas for supply spikes
+    - Compare against full dragonstone set premium for piece arbitrage
+  history:
+    - date: "2019-07-25"
+      description: "Released as part of Song of the Elves."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus decreased from -7 to -11."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-07-25"
+    update: "Song of the Elves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    quest: "Song of the Elves"
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-top-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-top-yellow.mdx
@@ -6,15 +6,63 @@ osrs:
   name: Elven top (yellow)
   slug: elven-top-yellow
   examine: Clothing from the elven city of Prifddinas.
-  members: false
+  members: true
   icon: Elven top (yellow).png
   value: 5000
   lowalch: 2000
   highalch: 3000
   limit: null
-  about: "Elven top (yellow) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.907
+  shops:
+    - shop_name: "Lliann's Wares"
+      location: Prifddinas
+      price: 5000
+      stock: 100
+  related_items:
+    - item_name: Elven top (white)
+      slug: elven-top-white
+      relationship: variant
+      description: White colour variant
+    - item_name: Elven legwear (yellow)
+      slug: elven-legwear-yellow
+      relationship: set-piece
+      description: Matching legwear
+    - item_name: Elven gloves (yellow)
+      slug: elven-gloves-yellow
+      relationship: set-piece
+      description: Matching gloves
+    - item_name: Elven boots (yellow)
+      slug: elven-boots-yellow
+      relationship: set-piece
+      description: Matching boots
+  about: "Elven top (yellow) is a cosmetic body slot garment sold by Lliann's Wares in Prifddinas after Song of the Elves."
+  market_strategy:
+    notes:
+      - Cosmetic fashionscape demand only
+      - Easily restocked from Lliann's Wares at 5,000 gp
+      - Limited daily volume keeps spreads wide
+  history:
+    - date: "2019-07-25"
+      description: Added with the Song of the Elves quest and Prifddinas update.
+  properties:
+    release_date: "2019-07-25"
+    update: "Song of the Elves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-dragon-bolts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Emerald dragon bolts | OSRS Price Data
-description: "Emerald dragon bolts: Dragon crossbow bolts, tipped with emerald.. High alch: 480 GP, GE limit: 11,000."
+description: "Emerald dragon bolts: Dragon crossbow bolts, tipped with emerald. High alch: 480 GP, GE limit: 11,000."
 osrs:
   id: 21965
   name: Emerald dragon bolts
@@ -12,9 +12,93 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 11000
-  about: "Emerald dragon bolts is a members-only item in Old School RuneScape. High alchemy value: 480 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon-bolt
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    weight: 0
+    requirements:
+      ranged: 64
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 122
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - product: Emerald dragon bolts
+      product_id: 21965
+      skill: Fletching
+      level: 84
+      experience: 5.5
+      materials:
+        - item_id: 21905
+          item_name: Dragon bolts
+          quantity: 1
+        - item_id: 9192
+          item_name: Emerald bolt tips
+          quantity: 1
+      tools: []
+      notes: "Use emerald bolt tips on dragon bolts; xp granted is per bolt."
+  related_items:
+    - item_id: 21905
+      item_name: Dragon bolts
+      slug: dragon-bolts
+      relationship: component
+      description: Base unenchanted dragon crossbow bolts.
+    - item_id: 9192
+      item_name: Emerald bolt tips
+      slug: emerald-bolt-tips
+      relationship: component
+      description: Emerald tip attached to the bolt.
+    - item_id: 21967
+      item_name: Emerald dragon bolts (e)
+      slug: emerald-dragon-bolts-e
+      relationship: upgrade
+      description: Enchanted variant unlocking the Magical Poison proc.
+  about: "Emerald dragon bolts are 64 Ranged crossbow ammunition that fletchers can tip and the Magic skill can enchant into the proc-laden (e) version."
+  market_strategy:
+    notes:
+      - Demand follows enchant-and-flip Magic XP cycles.
+      - Buy limit of 11,000 supports large daily flips when emerald tips dip.
+  trading_tips:
+    - Track emerald bolt tip price against the enchanted variant for arbitrage.
+    - Bulk produce at GE price floor during Fletching grinds.
+  history:
+    - date: "2018-01-04"
+      description: Added to the game with the Dragon Slayer II update.
+  properties:
+    release_date: "2018-01-04"
+    update: "Dragon Slayer II"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/falador-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/falador-teleport-tablet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Falador teleport (tablet) | OSRS Price Data
-description: "Falador teleport (tablet): A teleport to Falador.. High alch: 1 GP, GE limit: 15,000."
+description: "Falador teleport (tablet): A teleport to Falador. High alch: 1 GP, GE limit: 15,000."
 osrs:
   id: 8009
   name: Falador teleport (tablet)
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15000
-  about: "Falador teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Falador
+    type: Tablet
+  recipes:
+    - product: Falador teleport (tablet)
+      product_id: 8009
+      skill: Magic
+      level: 37
+      experience: 48
+      materials:
+        - item_id: 563
+          item_name: Law rune
+          quantity: 1
+        - item_id: 556
+          item_name: Air rune
+          quantity: 3
+        - item_id: 555
+          item_name: Water rune
+          quantity: 1
+        - item_id: 1761
+          item_name: Soft clay
+          quantity: 1
+      tools:
+        - Eagle lectern
+      notes: Crafted at a player-owned house lectern.
+  about: "Falador teleport tablet is a members-only one-click teleport item created at a lectern in a player-owned house, requiring 37 Magic and granting 48 experience."
+  market_strategy:
+    notes:
+      - Standard teleport tablets were exempted from the Grand Exchange convenience fee in May 2025.
+      - Steady consumer demand keeps daily volume in the hundreds of thousands.
+  trading_tips:
+    - Bulk produce when law rune prices dip for the best margin.
+    - List slightly above material cost for fast sales.
+  history:
+    - date: "2006-05-31"
+      description: Added to the game with the Player-Owned Houses update.
+    - date: "2025-05-29"
+      description: Exempted from the Grand Exchange convenience fee.
+  properties:
+    release_date: "2006-05-31"
+    update: "PLAYER-OWNED HOUSES!"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/feldip-weasel-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/feldip-weasel-fur.mdx
@@ -12,9 +12,45 @@ osrs:
   lowalch: 5
   highalch: 8
   limit: 10000
-  about: "Feldip weasel fur is a members-only item in Old School RuneScape. High alchemy value: 8 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Feldip weasel
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Jungle camo top
+      slug: jungle-camo-top
+      relationship: product
+      description: Crafted from Feldip weasel fur at the Varrock tailor
+    - item_name: Jungle camo legs
+      slug: jungle-camo-legs
+      relationship: product
+      description: Crafted from Feldip weasel fur at the Varrock tailor
+  about: "Feldip weasel fur is caught from Feldip weasels in Feldip Hills using a tracking trap and 7 Hunter. Two furs plus 20 coins per piece are exchanged at the Varrock tailor for jungle camouflage clothing."
+  market_strategy:
+    notes:
+      - Requires 7 Hunter to capture
+      - Used at Varrock tailor for jungle camo gear (2 furs + 20 coins each)
+      - Camo gear is weight-reducing only, no Hunter bonus
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill.
+  properties:
+    release_date: "2006-11-21"
+    update: HUNTER SKILL!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-beige-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-beige-shirt.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik beige shirt is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Yrsa's Accoutrements"
+      location: Rellekka
+      price: 325
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania and Etceteria Dungeon
+      price: 250
+  related_items:
+    - item_id: 3765
+      item_name: Fremennik blue shirt
+      slug: fremennik-blue-shirt
+      relationship: variant
+      description: Blue colour variant
+    - item_id: 3767
+      item_name: Fremennik red shirt
+      slug: fremennik-red-shirt
+      relationship: variant
+      description: Red colour variant
+    - item_id: 3769
+      item_name: Fremennik brown shirt
+      slug: fremennik-brown-shirt
+      relationship: variant
+      description: Brown colour variant
+    - item_id: 3773
+      item_name: Fremennik grey shirt
+      slug: fremennik-grey-shirt
+      relationship: variant
+      description: Grey colour variant
+  about: "Fremennik beige shirt is a Fremennik-themed body slot item sold by Yrsa's shop in Rellekka and the Miscellanian Clothes Shop. Released with The Fremennik Trials, it provides minor slash and crush defence."
+  market_strategy:
+    notes:
+      - Quest cosmetic supply
+      - Fixed shop availability stabilises supply
+      - Niche fashionscape demand
+  trading_tips:
+    - Shop floor sets price ceiling
+    - Hold during Fremennik content updates
+  history:
+    - date: "2004-11-02"
+      description: Released with The Fremennik Trials quest.
+    - date: "2005-01-17"
+      description: Graphical update applied.
+    - date: "2014-12-10"
+      description: Renamed from Fremennik shirt to Fremennik beige shirt.
+  properties:
+    release_date: "2004-11-02"
+    update: The Fremennik Trials
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: The Fremennik Trials
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-cyan-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-cyan-cloak.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik cyan cloak is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    weight: 0.453
+    requirements:
+      quest: The Fremennik Trials
+    defence_bonus:
+      slash: 1
+      crush: 1
+      ranged: 2
+  shops:
+    - shop_name: Yrsa's Accoutrements
+      location: Rellekka
+      price: 325
+      stock: 5
+  related_items:
+    - item_id: 3757
+      item_name: Fremennik cloak
+      slug: fremennik-cloak
+      relationship: alternative
+      description: Brown variant
+    - item_id: 3761
+      item_name: Fremennik green cloak
+      slug: fremennik-green-cloak
+      relationship: alternative
+      description: Green variant
+  about: "Fremennik cyan cloak is a cape sold by Yrsa's Accoutrements in Rellekka after completing The Fremennik Trials."
+  market_strategy:
+    notes:
+      - Shop stocks 5 at 325 coins
+      - Restocks every minute
+      - GE buy limit 150
+      - Requires Fremennik Trials
+  history:
+    - date: "2004-11-02"
+      description: Released with The Fremennik Trials update.
+    - date: "2014-12-10"
+      description: Renamed from Fremennik cloak to Fremennik cyan cloak.
+  properties:
+    release_date: "2004-11-02"
+    update: The Fremennik Trials
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/garden-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/garden-pie.mdx
@@ -12,9 +12,33 @@ osrs:
   lowalch: 9
   highalch: 14
   limit: 10000
-  about: "Garden pie is a members-only item in Old School RuneScape. High alchemy value: 14 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 12
+    bites: 2
+    boost: "+3 Farming"
+  about: "Garden pie restores 12 hitpoints over two bites and grants a temporary +3 Farming level boost."
+  history:
+    - date: "2006-02-20"
+      description: Released with the Updates, updates and more updates update.
+    - date: "2015-02-26"
+      description: Partially-eaten version became untradeable on the Grand Exchange.
+  properties:
+    release_date: "2006-02-20"
+    update: "Updates, updates and more updates..."
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gardening-trowel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gardening-trowel.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 40
-  about: "Gardening trowel is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    role: Required tool to fill plant pots with earth and to plant tree seeds in plant pots.
+  shops:
+    - shop_name: Heskel's Farming Store
+      location: Falador
+      price: 12
+    - shop_name: Sarah's Farming Shop
+      location: North Ardougne
+      price: 12
+    - shop_name: Farming Guild stock
+      location: Farming Guild
+      price: 12
+    - shop_name: Catherby farming sellers
+      location: Catherby
+      price: 12
+  about: "Essential Farming tool used to fill plant pots with earth before planting tree seeds; stocked across most farming shops for 12 coins and exempt from GE convenience fees."
+  market_strategy:
+    notes:
+      - Shop-stocked at unlimited stock; rarely worth GE flipping
+      - High alch of 7 coins is below value, never alch
+      - Exempt from GE convenience fees since 2021
+  trading_tips:
+    - Buy direct from any farming shop for 12 gp
+    - Bank a noted stack for tree runs to skip shop trips
+  history:
+    - date: "2005-06-06"
+      description: Added to the game cache ahead of the Farming release.
+    - date: "2005-07-11"
+      description: Made obtainable with Farming; examine set and value raised from 3 to 12 coins.
+    - date: "2021-12-09"
+      description: Exempted from Grand Exchange convenience fees.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-scimitar.mdx
@@ -12,69 +12,82 @@ osrs:
   lowalch: 10240
   highalch: 15360
   limit: 8
+  material:
+    type: scimitar
+    tier: high
   equipment:
     slot: weapon
-    type: scimitar
-    attack_style: melee
+    weapon_type: slash_sword
     attack_speed: 4
+    weight: 1.814
     requirements:
       attack: 40
-    stats:
-      attack_stab: 7
-      attack_slash: 45
-      attack_crush: -2
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 1
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      melee_strength: 44
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Elite
-        rarity: Rare
-        description: Rare reward from elite clue scrolls
+    attack_bonus:
+      stab: 7
+      slash: 45
+      crush: -2
+    defence_bonus:
+      slash: 1
+    other_bonus:
+      strength: 44
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+      - master
   related_items:
-    - item_id: 3486
-      item_name: Gilded full helm
+    - item_name: Rune scimitar
+      slug: rune-scimitar
+      relationship: alternative
+      description: Identical stats without gilded cosmetic
+    - item_name: Gilded full helm
       slug: gilded-full-helm
       relationship: set-piece
-      description: Head slot of gilded set
-    - item_id: 3481
-      item_name: Gilded platebody
+      description: Head slot of the gilded set
+    - item_name: Gilded platebody
       slug: gilded-platebody
       relationship: set-piece
-      description: Body slot of gilded set
-    - item_id: 3483
-      item_name: Gilded platelegs
+      description: Body slot of the gilded set
+    - item_name: Gilded platelegs
       slug: gilded-platelegs
       relationship: set-piece
-      description: Leg slot of gilded set
-    - item_id: 3488
-      item_name: Gilded kiteshield
+      description: Leg slot of the gilded set
+    - item_name: Gilded kiteshield
       slug: gilded-kiteshield
       relationship: set-piece
-      description: Shield slot of gilded set
-  about: |-
-    The gilded scimitar is a cosmetic variant of the rune scimitar with identical stats but a prestigious golden appearance. It requires 40 Attack to wield.
-
-    Gilded weapons are obtained from Treasure Trails and are valued for their appearance rather than stats. The gilded scimitar shares the same offensive bonuses as a rune scimitar but costs significantly more due to its rarity and fashionscape appeal.
+      description: Shield slot of the gilded set
+  about: "Gilded scimitar is a cosmetic rune scimitar variant requiring 40 Attack, dropped from elite and master clue caskets."
   market_strategy:
-    title: Investment Notes
     notes:
-      - Price driven by cosmetic demand
-      - Popular for fashionscape and showing off
-      - Great for free-to-play pking fashion
-      - Compare prices with rune equivalent for value assessment
-      - Watch for dips after clue scroll events
-      - Popular with free-to-play players for fashion
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Price driven entirely by fashionscape demand
+      - Buy limit of 8 amplifies short-term squeezes
+      - F2P availability since 2016 widens collector base
+      - Watch dips after large clue scroll events flood supply
+  history:
+    - date: "2014-06-12"
+      description: Released with the Treasure Trail Expansion update.
+    - date: "2016-05-19"
+      description: Made available to free-to-play players.
+    - date: "2019-04-11"
+      description: Became storable in the costume room treasure chest.
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/graahk-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/graahk-legs.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 150
-  about: "Graahk legs is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: fur
+    tier: mid
+  equipment:
+    slot: legs
+    requirements:
+      hunter: 38
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -7
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: 0
+      ranged: 10
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.226
+  recipes:
+    - skill: Hunter
+      level: 38
+      xp: 0
+      materials:
+        - item_name: Graahk fur
+          quantity: 1
+        - item_name: Coins
+          quantity: 150
+      tools: []
+      output_quantity: 1
+      notes: Tailored by an NPC tailor in Varrock, Hunter Guild, or Prifddinas; tatty graahk fur also works.
+  related_items:
+    - item_id: 10045
+      item_name: Graahk headdress
+      slug: graahk-headdress
+      relationship: set-piece
+      description: Matching graahk hunter head piece
+    - item_id: 10043
+      item_name: Graahk top
+      slug: graahk-top
+      relationship: set-piece
+      description: Matching graahk hunter body piece
+  about: "Hunter camouflage leg armour for jungle and desert regions, tailored from one graahk fur and 150 coins; requires 38 Hunter to wear and grants jungle camouflage when paired with the rest of the set."
+  market_strategy:
+    notes:
+      - Demand tracks Hunter training and Aerial Fishing prep
+      - Tailoring from tatty fur is cheaper margin
+      - Buy limit 150; bulk flipping viable
+  trading_tips:
+    - Stock during Hunter double XP events
+    - Watch graahk fur supply for entry timing
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/granite-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/granite-legs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Granite legs | OSRS Price Data
-description: "Granite legs is a members legs slot item requiring 50 Defence. High alch: 39,600 GP, GE limit: 70."
+description: "Granite legs is a members legs slot item requiring 50 Defence and 50 Strength. High alch: 39,600 GP, GE limit: 70."
 osrs:
   id: 6809
   name: Granite legs
@@ -12,8 +12,15 @@ osrs:
   lowalch: 26400
   highalch: 39600
   limit: 70
+  material:
+    type: granite
+    tier: mid
   equipment:
     slot: legs
+    weight: 15.875
+    requirements:
+      defence: 50
+      strength: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,72 +38,58 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 50
-      strength: 50
-    weight: 15.875
   drop_table:
-    primary_source: Skeletal Wyvern
-    best_drop_rate: 1/512
     sources:
       - source: Skeletal Wyvern
-        combat_level: 140
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/512
-        members_only: true
+        rarity: 1/512
   related_items:
     - item_id: 10589
       item_name: Granite helm
       slug: granite-helm
       relationship: set-piece
-      description: Granite set piece
+      description: Granite set helm piece
     - item_id: 3122
       item_name: Granite shield
       slug: granite-shield
       relationship: set-piece
-      description: Granite set piece
+      description: Granite set shield piece
     - item_id: 4087
       item_name: Dragon platelegs
       slug: dragon-platelegs
       relationship: upgrade
-      description: 60 Def alternative
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +43 |
-    | Slash | +45 |
-    | Crush | +41 |
-    | Ranged | +68 |
-    | Magic | -4 |
-
-    Requirements: 50 Defence, 50 Strength | Weight: 15.9 kg
-
-    | Stat | Granite Legs | Rune Platelegs | Dragon Platelegs |
-    |------|-------------|----------------|------------------|
-    | Stab Def | +43 | +51 | +68 |
-    | Slash Def | +45 | +49 | +66 |
-    | Crush Def | +41 | +47 | +63 |
-    | Ranged Def | +68 | +45 | +65 |
-    | Magic | -4 | -21 | -4 |
-    | Weight | 15.9 kg | 9.1 kg | 9.1 kg |
-
-    Notably provides superior ranged defence (+68) compared to rune platelegs (+45), but has lower melee defence stats. The heavy weight of 15.9 kg significantly impacts run energy.
-
-    The -31 Magic attack penalty makes granite legs popular for splashing — providing 10 more negative magic than rune platelegs (-21). This helps players intentionally miss spells for AFK Magic XP.
-
-    - Best ranged defence legs at 50 Defence
-    - Popular for splash training (high negative magic)
-    - Used in some Dagannoth Kings guides for ranged defence
-    - Budget option before dragon platelegs
-    - Part of granite fashionscape set
+      description: 60 Defence alternative
+  about: "Granite legs are heavy members leg armour from Skeletal Wyverns with class-leading ranged defence at 50 Defence, balanced by a 15.9 kg weight and a steep -31 magic attack penalty."
   market_strategy:
     notes:
-      - Only obtainable from Skeletal Wyverns (72 Slayer)
-      - GE price near high alch value
-      - Heavy item (15.9 kg) — significant run energy impact
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Only obtainable from Skeletal Wyverns at 72 Slayer
+      - Price hovers near high alch as a borderline alch target
+      - Heavy 15.9 kg weight discourages bulk inventory use
+  trading_tips:
+    - Buy near alch floor and flip into splash-training demand
+    - Monitor Slayer task popularity for supply spikes
+  history:
+    - date: "2005-12-12"
+      description: Released alongside the Champions, Wyverns and Granite update.
+  properties:
+    release_date: "2005-12-12"
+    update: Champions, Wyverns and Granite
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 15.875
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grapes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grapes.mdx
@@ -9,12 +9,87 @@ osrs:
   members: false
   icon: Grapes.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 20000
-  about: "Grapes is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 20,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle basement
+      price: 1
+      stock: 10
+    - shop_name: Faustus' Fruit and Veg
+      location: Aldarin
+      price: 1
+      stock: 5
+  drop_table:
+    sources:
+      - source: Kalphite Queen
+        quantity: "1"
+        rarity: 5/126 (noted 100)
+      - source: Thermonuclear smoke devil
+        quantity: "1"
+        rarity: 1/107 (noted 100)
+      - source: Zulrah
+        quantity: "1"
+        rarity: 6/249 (noted 250)
+      - source: Vorkath
+        quantity: "1"
+        rarity: 5/150 (noted 250-300)
+      - source: Goblin variants
+        quantity: "1"
+        rarity: 1/128
+  recipes:
+    - product: Jug of wine
+      skill: Cooking
+      level: 35
+      xp: 200
+      tools: []
+      materials:
+        - item_name: Jug of water
+          quantity: 1
+        - item_name: Grapes
+          quantity: 1
+  related_items:
+    - item_id: 1937
+      item_name: Jug of water
+      slug: jug-of-water
+      relationship: component
+      description: Combined with grapes to make unfermented wine
+    - item_id: 1993
+      item_name: Jug of wine
+      slug: jug-of-wine
+      relationship: product
+      description: Crafted from grapes and a jug of water
+  about: "Grapes are used to make jugs of wine at 35 Cooking for 200 XP and are required for the Monkey Madness II quest."
+  market_strategy:
+    notes:
+      - Cheap shop-buyable component for wine training
+      - Massive GE buy limit suits bulk purchase
+      - Often dropped noted from bossing
+  trading_tips:
+    - Shop-buyable at 1 coin
+    - Bulk farm via Culinaromancer's Chest
+  history:
+    - date: "2001-03-17"
+      description: Item released in this week's update.
+    - date: "2020-09-10"
+      description: Grand Exchange buy limit increased from 13,000 to 20,000 units.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-03-17"
+    update: This week's update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.25
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-elegant-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-elegant-legs.mdx
@@ -5,7 +5,7 @@ osrs:
   id: 10414
   name: Green elegant legs
   slug: green-elegant-legs
-  examine: A rather elegant pair of men's green pantaloons.
+  examine: "A rather elegant pair of men's green pantaloons."
   members: true
   icon: Green elegant legs.png
   value: 2000
@@ -14,19 +14,73 @@ osrs:
   limit: 4
   equipment:
     slot: legs
+    weight: 1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: "1/2808"
   related_items:
-    - item_id: 10412
-      item_name: Green elegant shirt
-      slug: green-elegant-shirt
+    - item_name: Green elegant shirt
       relationship: set-piece
-      description: Matching elegant shirt
-  about: |-
-    > *"A rather elegant pair of men's green pantaloons."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the green elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching elegant shirt for male characters.
+    - item_name: Green elegant blouse
+      relationship: alternative
+      description: Female equivalent top piece.
+    - item_name: Green elegant skirt
+      relationship: alternative
+      description: Female legs equivalent.
+  about: "Green elegant legs is a purely cosmetic Easy Treasure Trail reward, dropped from reward caskets at a 1/2,808 rate and part of the green elegant clothing set."
+  market_strategy:
+    notes:
+      - Tiny buy limit of 4 per 4 hours suits long-term flipping only
+      - Demand driven by cosmetic costume room collectors
+      - Supply tied to Easy Treasure Trail completions
+  history:
+    - date: "2006-12-05"
+      description: Released with the Treasure Trails, spiders and sheep update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails, spiders and sheep
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grid-master-tabard-b.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grid-master-tabard-b.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Grid master tabard (b) is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weapon_type: cosmetic
+    weight: 0.3
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Events Reward Shop
+      location: Varrock Square
+      price: 750
+      currency: Event points
+  related_items:
+    - item_id: 31180
+      item_name: Grid master tabard
+      slug: grid-master-tabard
+      relationship: variant
+      description: Standard variant of the same cosmetic tabard.
+    - item_id: 31182
+      item_name: Grid master tabard (g)
+      slug: grid-master-tabard-g
+      relationship: variant
+      description: Gold variant of the cosmetic tabard.
+    - item_id: 31186
+      item_name: Grid master tabard (p)
+      slug: grid-master-tabard-p
+      relationship: variant
+      description: Purple variant of the cosmetic tabard.
+    - item_id: 31188
+      item_name: Grid master swords and emblem (b)
+      slug: grid-master-swords-and-emblem-b
+      relationship: set-piece
+      description: Matching shield/emblem piece for the (b) variant set.
+  about: Cosmetic blue Grid Master tabard bought from the Events Reward Shop for 750 event points; storable in costume room armour cases.
+  market_strategy:
+    notes:
+      - Supply is limited to event point spenders
+      - Ultimate Ironman two-piece storage rule limits resale velocity
+  trading_tips:
+    - Watch event resets - tabard prices dip when new participants flood the GE
+    - Pair flips with the matching swords and emblem (b) piece
+  history:
+    - date: "2025-10-15"
+      description: Released alongside the Grid Master event launch.
+  properties:
+    release_date: "2025-10-15"
+    update: "Grid Master - Out Today!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-dwarf-weed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-dwarf-weed.mdx
@@ -12,18 +12,14 @@ osrs:
   lowalch: 9
   highalch: 14
   limit: 11000
-  herb:
-    type: grimy
+  material:
+    type: grimy-herb
     tier: high
-  herblore:
-    cleaning_level: 70
-    cleaning_xp: 13.8
-    clean_id: 267
-    clean_name: Dwarf weed
   farming:
     level: 79
     seed_id: 5303
     seed_name: Dwarf weed seed
+    xp_per_harvest: 192
   drop_table:
     sources:
       - source: Aberrant spectre
@@ -35,6 +31,14 @@ osrs:
       - source: Gargoyle
         source_id: 412
         combat_level: 111
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Abyssal Sire
+        quantity: "1"
+        rarity: common
+        members_only: true
+      - source: Demonic gorilla
         quantity: "1"
         rarity: uncommon
         members_only: true
@@ -59,22 +63,35 @@ osrs:
       slug: dwarf-weed-seed
       relationship: component
       description: Farming seed
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Grimy Herb |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-    | Herblore Level | 70 (to clean) |
-
-    Clean to produce dwarf weed for Herblore.
-
-    Dwarf weed used for:
-    - Ranging potion
-    - Combat potion
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Grimy dwarf weed is the uncleaned form of dwarf weed, requiring 70 Herblore to clean for 13.8 XP. Primarily used to make ranging potions. Farmed at level 79 or dropped by slayer monsters."
+  market_strategy:
+    notes:
+      - High volume herblore staple
+      - Ranging potion supply chain
+      - Steady slayer drop supply
+      - 11,000 buy limit supports bulk trades
+  trading_tips:
+    - Track ranging potion demand for price signal
+    - Cleaning margin vs cleaned dwarf weed
+  history:
+    - date: "2002-02-27"
+      description: Released with RuneScape 2.
+  properties:
+    release_date: "2002-02-27"
+    update: Herblore release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-helm-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-helm-0.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthan's helm 0 | OSRS Price Data
-description: "Guthan's helm 0: Guthan the Infested's helm.. High alch: 61,800 GP, GE limit: 15."
+description: "Guthan's helm 0: Guthan the Infested's helm. High alch: 61,800 GP, GE limit: 15."
 osrs:
   id: 4908
   name: Guthan's helm 0
@@ -12,9 +12,81 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
-  about: "Guthan's helm 0 is a members-only item in Old School RuneScape. High alchemy value: 61,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: barrows
+    tier: high
+  equipment:
+    slot: head
+    weapon_type: armour
+    weight: 2.721
+    requirements:
+      defence: 70
+    attack_bonus:
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 55
+      slash: 58
+      crush: 54
+      magic: -1
+      ranged: 62
+  related_items:
+    - item_id: 4724
+      item_name: Guthan's helm
+      slug: guthan-s-helm
+      relationship: variant
+      description: Fully charged version with 15 hours of combat durability.
+    - item_id: 4910
+      item_name: Guthan's platebody 0
+      slug: guthan-s-platebody-0
+      relationship: set-piece
+      description: Uncharged platebody piece of the Guthan's set.
+    - item_id: 4912
+      item_name: Guthan's chainskirt 0
+      slug: guthan-s-chainskirt-0
+      relationship: set-piece
+      description: Uncharged legwear piece of the Guthan's set.
+    - item_id: 4914
+      item_name: Guthan's warspear 0
+      slug: guthan-s-warspear-0
+      relationship: set-piece
+      description: Uncharged warspear piece of the Guthan's set.
+  about: "Guthan's helm 0 is the fully-degraded helm from Guthan the Infested's Barrows set, broken and unable to be worn until repaired with coins at an armour stand."
+  market_strategy:
+    notes:
+      - Cheaper than the charged variant — repair cost determines net price.
+      - Used as a low-cost entry to the Guthan's healing set effect.
+      - Low GE limit (15) makes flipping illiquid.
+  trading_tips:
+    - Compare repair cost vs charged helm GE price for arbitrage.
+    - Spread orders across multiple GE slots given the 15-per-4h limit.
+  history:
+    - date: "2005-05-09"
+      description: "Released with the Barrows update."
+    - date: "2014-12-10"
+      description: "Renamed from 'Guthans helm' to 'Guthan's helm'."
+    - date: "2015-04-16"
+      description: "Added a Check option to display remaining durability."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: "If you drop this item it will break. Are you sure you want to drop it?"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/haemostatic-dressing-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/haemostatic-dressing-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Haemostatic dressing (3) | OSRS Price Data
-description: "Haemostatic dressing (3): 3 applications of haemostatic dressing.. High alch: 150 GP."
+description: "Haemostatic dressing (3) is a members herblore dressing that cures bleed status. High alch: 150 GP."
 osrs:
   id: 31593
   name: Haemostatic dressing (3)
@@ -12,9 +12,59 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: null
-  about: "Haemostatic dressing (3) is a members-only item in Old School RuneScape. High alchemy value: 150 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 3
+    effects:
+      - description: "Cures the bleed status effect when applied."
+      - description: "Restores 5 Hitpoints if bleeding was active at the time of use."
+  related_items:
+    - item_id: 31591
+      item_name: Haemostatic dressing (1)
+      slug: haemostatic-dressing-1
+      relationship: variant
+      description: Single-use dressing.
+    - item_id: 31592
+      item_name: Haemostatic dressing (2)
+      slug: haemostatic-dressing-2
+      relationship: variant
+      description: Two-application dressing.
+    - item_id: 31594
+      item_name: Haemostatic dressing (4)
+      slug: haemostatic-dressing-4
+      relationship: variant
+      description: Four-application dressing (full).
+  about: "Haemostatic dressing (3) is a three-application herblore dressing that cures bleed and restores 5 HP when applied during a bleed."
+  market_strategy:
+    notes:
+      - Mid-dose variant typically flips against the (4) dose
+      - Demand follows Sailing combat encounters
+      - No GE buy limit makes bulk flips viable
+  trading_tips:
+    - 'Decant strategy: combine doses into (4) for thinner-margin resale'
+    - Watch herblore secondary prices around updates
+  history:
+    - date: "2025-11-05"
+      description: "Added to the game (initially unobtainable)."
+    - date: "2025-11-19"
+      description: "Released with the Sailing launch update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Apply
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/heavy-frame.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/heavy-frame.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
-  about: "Heavy frame is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Demonic gorilla
+        quantity: "1"
+        rarity: 1/1500
+      - source: Tortured gorilla
+        quantity: "1"
+        rarity: 1/15000
+  recipes:
+    - product: Incomplete heavy ballista
+      skill: Fletching
+      level: 72
+      xp: 30
+      tools: []
+      materials:
+        - item_name: Heavy frame
+          quantity: 1
+        - item_name: Ballista limbs
+          quantity: 1
+  related_items:
+    - item_id: 19592
+      item_name: Ballista limbs
+      slug: ballista-limbs
+      relationship: component
+      description: Combined with the heavy frame at 72 Fletching
+    - item_id: 19478
+      item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: product
+      description: End product after assembling all ballista parts
+    - item_id: 19590
+      item_name: Light frame
+      slug: light-frame
+      relationship: alternative
+      description: Lighter ballista frame variant
+  about: "Heavy frame is a rare Demonic gorilla drop used at 72 Fletching to build the incomplete heavy ballista, requiring Monkey Madness II."
+  market_strategy:
+    notes:
+      - Locked behind Monkey Madness II grind
+      - Demand from heavy ballista crafters
+      - Buy limit of 8 keeps spread wide
+  trading_tips:
+    - Pairs 1:1 with ballista limbs
+    - Demonic gorilla farming is the main supply
+  history:
+    - date: "2016-05-06"
+      description: Released with Monkey Madness II.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-05-06"
+    update: Monkey Madness II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Monkey Madness II
+    weight: 5.25
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hemp-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hemp-seed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hemp seed | OSRS Price Data
-description: "Hemp seed: A hemp plant seed - plant in a hops patch.. High alch: 3 GP, GE limit: 2,000."
+description: "Hemp seed: A hemp plant seed - plant in a hops patch. High alch: 3 GP, GE limit: 2,000."
 osrs:
   id: 31543
   name: Hemp seed
@@ -12,9 +12,89 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 2000
-  about: "Hemp seed is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: seed
+    tier: low
+  farming:
+    level: 37
+    patch: Hops patch
+    seeds_per_patch: 3
+    growth_time: 80
+    plant_xp: 33
+    harvest_xp: 37
+    protection_payment: 6 flax
+  drop_table:
+    sources:
+      - source: Albatross
+        quantity: "1"
+        rarity: Varies
+      - source: Osprey
+        quantity: "1"
+        rarity: Varies
+      - source: Frigatebird
+        quantity: "1"
+        rarity: Varies
+      - source: Narwhal
+        quantity: "1"
+        rarity: Varies
+      - source: Tern
+        quantity: "1"
+        rarity: Varies
+      - source: Orca
+        quantity: "1"
+        rarity: Varies
+      - source: Butterfly ray
+        quantity: "1"
+        rarity: Varies
+      - source: Eagle ray
+        quantity: "1"
+        rarity: Varies
+      - source: Barracuda
+        quantity: "1"
+        rarity: Varies
+      - source: Large salvage
+        quantity: "1"
+        rarity: Varies
+  related_items:
+    - item_id: 5992
+      item_name: Jute seed
+      slug: jute-seed
+      relationship: alternative
+      description: Another hops patch seed used for Farming training.
+    - item_id: 5990
+      item_name: Hammerstone seed
+      slug: hammerstone-seed
+      relationship: alternative
+      description: Low-level hops patch seed.
+  about: Sailing-era hops patch seed planted at 37 Farming for Farming experience; dropped by various sailing encounters.
+  market_strategy:
+    notes:
+      - Supply tracks Sailing encounter and salvage farming
+      - Demand is driven by 37+ Farming trainers running hops patches
+  trading_tips:
+    - Buy when sailing meta floods the GE with seeds
+    - Stockpile around farming bonus events for spike sells
+  history:
+    - date: "2025-11-19"
+      description: Released alongside the Sailing skill expansion.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Plant
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/holy-wraps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/holy-wraps.mdx
@@ -14,55 +14,61 @@ osrs:
   limit: 4
   equipment:
     slot: hands
-    type: gloves
-    tradeable: true
-    weight: 0.05
+    weight: 0.5
     requirements:
       prayer: 31
-    stats:
+    other_bonus:
       prayer: 3
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Master
-        drop_rate: Rare from reward casket
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/1275
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
   related_items:
     - item_id: 19994
       item_name: Ranger gloves
       slug: ranger-gloves
       relationship: alternative
-      description: Ranged gloves from master clues
+      description: Ranged gloves from elite clues
     - item_id: 12598
       item_name: Holy sandals
       slug: holy-sandals
       relationship: set-piece
       description: Matching prayer boots
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Prayer | +3 |
-
-    Requirements: 31 Prayer
-
-    Best prayer bonus gloves in game:
-    - +3 prayer bonus
-    - Master clue exclusive
-    - Saradomin-aligned item
-    - BiS for prayer setups
-
-    | Item | Prayer Bonus |
-    |------|--------------|
-    | Holy wraps | +3 |
-    | Barrows gloves | 0 |
-    | Combat bracelet | +1 |
+  about: "Holy wraps are gloves dropped from elite reward caskets at a 1/1,275 rate and grant the highest prayer bonus available for the hands slot."
   market_strategy:
     notes:
-      - Master clue exclusive
+      - Elite clue exclusive
       - BiS prayer gloves
-      - Part of prayer outfit
-      - Collection log item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Saradomin item in GWD and Hallowed Sepulchre
+      - Buy limit 4 per 4 hours
+  history:
+    - date: "2016-07-06"
+      description: Released with the Treasure Trail Expansion update.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hosidius-scarf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hosidius-scarf.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hosidius scarf | OSRS Price Data
-description: "Hosidius scarf: A green scarf adorned with an ornamental leaf.. High alch: 6,000 GP, GE limit: 4."
+description: "Hosidius scarf: A green scarf adorned with an ornamental leaf. High alch: 6,000 GP, GE limit: 4."
 osrs:
   id: 19946
   name: Hosidius scarf
@@ -12,9 +12,85 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Hosidius scarf is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: neck
+    weight: 0.5
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_id: 19943
+      item_name: Lovakengj scarf
+      slug: lovakengj-scarf
+      relationship: variant
+      description: Lovakengj house scarf variant.
+    - item_id: 19949
+      item_name: Piscarilius scarf
+      slug: piscarilius-scarf
+      relationship: variant
+      description: Piscarilius house scarf variant.
+    - item_id: 19952
+      item_name: Shayzien scarf
+      slug: shayzien-scarf
+      relationship: variant
+      description: Shayzien house scarf variant.
+    - item_id: 19955
+      item_name: Arceuus scarf
+      slug: arceuus-scarf
+      relationship: variant
+      description: Arceuus house scarf variant.
+  about: "Hosidius scarf is a cosmetic elite clue neck reward representing the Hosidius region, with no favour or skill requirement to wear."
+  market_strategy:
+    notes:
+      - Supply is gated by elite clue completion rates, supporting a healthy premium over alch.
+      - House scarves attract Zeah completionists building full collections.
+  trading_tips:
+    - Compare against other house scarves; demand rotates with content updates.
+    - Hold during elite clue droughts to capture price spikes.
+  history:
+    - date: "2016-07-06"
+      description: Added to the game with the Treasure Trail Expansion update.
+    - date: "2019-01-10"
+      description: Renamed from Hosidius house scarf to Hosidius scarf.
+  properties:
+    release_date: "2016-07-06"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/initiate-hauberk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/initiate-hauberk.mdx
@@ -12,19 +12,39 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 125
+  material:
+    type: blessed
+    tier: mid
   equipment:
     slot: body
-    type: armour
-    prayer_bonus: 6
     requirements:
       defence: 20
       prayer: 10
-    combat_stats:
-      stab_defence: 40
-      slash_defence: 44
-      crush_defence: 38
-      magic_defence: -6
-      ranged_defence: 44
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 46
+      slash: 44
+      crush: 38
+      magic: -6
+      ranged: 44
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 6
+    weight: 8.618
+  shops:
+    - shop_name: Initiate Temple Knight Armoury
+      location: Falador Park
+      price: 10000
+    - shop_name: Proselyte Temple Knight Armoury
+      location: Falador Park
+      price: 10000
   related_items:
     - item_id: 5576
       item_name: Initiate cuisse
@@ -46,34 +66,45 @@ osrs:
       slug: monks-robe-top
       relationship: downgrade
       description: No defence (+6 Prayer)
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Body |
-    | Prayer Bonus | +6 |
-    | Defence Req | 20 |
-    | Prayer Req | 10 |
-
-    - Mid-tier prayer armour
-    - Bridge to Proselyte
-    - Lower requirements than Proselyte
-
-    | Piece | Prayer Bonus |
-    |-------|--------------|
-    | Initiate sallet | +3 |
-    | Initiate hauberk | +6 |
-    | Initiate cuisse | +5 |
-    | Total | +14 |
+  about: Mid-tier prayer body armour locked behind Recruitment Drive, bridging Monk's robe top and Proselyte with mithril platebody defence plus a +6 prayer bonus.
   market_strategy:
     notes:
-      - Requires quest completion
-      - Shop purchase only
-      - No GE trading (untradeable)
-      - Must complete Recruitment Drive
+      - Requires Recruitment Drive completion
+      - Shop purchase from Sir Tiffy in Falador Park
       - Stepping stone to Proselyte
-      - Lower requirements good for pures
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Lower combat requirements suit pures
+  trading_tips:
+    - GE flips usually anchor near shop price
+    - Demand spikes with prayer training meta and pure builds
+  history:
+    - date: "2005-06-27"
+      description: Released with the Recruitment Drive quest.
+    - date: "2005-10-17"
+      description: Graphical updates rolled in with the Wanted! quest release.
+    - date: "2006-09-20"
+      description: Renamed from Initiate platemail.
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -10 to -15.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-06-27"
+    update: Recruitment Drive
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: Recruitment Drive
+    weight: 8.618
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-cannonball.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-cannonball.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron cannonball | OSRS Price Data
-description: "Iron cannonball: Ammo suited for a boat's cannon.. High alch: 2 GP, GE limit: 11,000."
+description: "Iron cannonball: Ammo suited for a boat's cannon. High alch: 2 GP, GE limit: 11,000."
 osrs:
   id: 31908
   name: Iron cannonball
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Iron cannonball is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: iron
+    tier: low
+  related_items:
+    - item_id: 31909
+      item_name: Iron chainshot cannonball
+      slug: iron-chainshot-cannonball
+      relationship: variant
+      description: Specialized chainshot variant for boat cannons.
+    - item_id: 31910
+      item_name: Iron incendiary cannonball
+      slug: iron-incendiary-cannonball
+      relationship: variant
+      description: Specialized incendiary variant for boat cannons.
+  recipes:
+    - skill: smithing
+      level: 20
+      xp: 17
+      materials:
+        - item_name: Iron bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      product: Iron cannonball
+      product_quantity: 4
+      members_only: true
+  about: "Iron cannonball is stackable boat-cannon ammunition smithed from iron bars at 20 Smithing, used for ship combat during the Sailing skill."
+  market_strategy:
+    notes:
+      - Smith from iron bars (1 bar = 4 cannonballs, or 2 bars = 8 with a double mould).
+      - High-volume consumable for Sailing combat content.
+      - GE buy limit 11,000 per 4 hours.
+  trading_tips:
+    - Watch iron bar GE price vs cannonball price for smithing profit margins.
+    - Bulk-buy during off-peak hours to stock ship voyages.
+  history:
+    - date: "2025-11-19"
+      description: "Released as part of the Sailing skill update."
+    - date: "2026-03-18"
+      description: "Ranged Strength bonus increased from +10 to +56."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-keel-parts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron keel parts | OSRS Price Data
-description: "Iron keel parts: Parts for creating an iron keel for a boat.. High alch: 75 GP, GE limit: 100."
+description: "Iron keel parts: Parts for creating an iron keel for a boat. High alch: 75 GP, GE limit: 100."
 osrs:
   id: 32002
   name: Iron keel parts
@@ -12,9 +12,58 @@ osrs:
   lowalch: 50
   highalch: 75
   limit: 100
-  about: "Iron keel parts is a members-only item in Old School RuneScape. High alchemy value: 75 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: iron
+    tier: low
+  recipes:
+    - skill: Smithing
+      level: 22
+      xp: 125
+      materials:
+        - item_name: Iron bar
+          quantity: 5
+      tools:
+        - Hammer
+        - Anvil
+      output: Iron keel parts
+  related_items:
+    - item_id: 32000
+      item_name: Bronze keel parts
+      slug: bronze-keel-parts
+      relationship: downgrade
+      description: Lower-tier keel parts variant
+    - item_id: 32004
+      item_name: Steel keel parts
+      slug: steel-keel-parts
+      relationship: upgrade
+      description: Next tier keel parts variant
+    - item_id: 2351
+      item_name: Iron bar
+      slug: iron-bar
+      relationship: component
+      description: Bar smelted from iron ore used in the recipe
+  about: "Iron keel parts are Sailing-era shipbuilding components smithed at Smithing 22 from 5 iron bars (125 xp); ten parts combine via Construction 17 and Sailing 22 into an iron keel for skiffs, and large iron keel parts (5 regular parts each) build sloops."
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing skill launch as part of the shipbuilding component pool."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platelegs-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platelegs-t.mdx
@@ -1,20 +1,97 @@
 ---
 title: Iron platelegs (t) | OSRS Price Data
-description: "Iron platelegs (t): Iron platelegs with trim.. High alch: 168 GP, GE limit: 4."
+description: "Iron platelegs (t): Iron platelegs with trim. High alch: 168 GP, GE limit: 4."
 osrs:
   id: 12227
   name: Iron platelegs (t)
   slug: iron-platelegs-t
-  examine: Iron platelegs with trim.
+  examine: "Iron platelegs with trim."
   members: false
   icon: Iron platelegs (t).png
   value: 280
   lowalch: 112
   highalch: 168
   limit: 4
-  about: "Iron platelegs (t) is a free-to-play item in Old School RuneScape. High alchemy value: 168 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: trimmed armour
+    tier: low
+  equipment:
+    slot: legs
+    weapon_type: none
+    weight: 9.071
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: -4
+      ranged: 10
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Iron platelegs
+      slug: iron-platelegs
+      relationship: alternative
+      description: Untrimmed counterpart with identical combat stats.
+    - item_name: Iron platelegs (g)
+      slug: iron-platelegs-g
+      relationship: alternative
+      description: Gold-trimmed cosmetic alternative from easy caskets.
+    - item_name: Iron platebody (t)
+      slug: iron-platebody-t
+      relationship: set-piece
+      description: Matching body slot of the trimmed iron set.
+  about: "Iron platelegs (t) are a cosmetic trimmed legs slot reward from easy Treasure Trails with the same combat stats as standard iron platelegs."
+  market_strategy:
+    notes:
+      - Pure cosmetic value drives the price spread over plain iron legs.
+      - Easy clue completion is the only injection of supply.
+      - Storable in a POH costume room treasure chest.
+  trading_tips:
+    - Margin against the matching trim set for cosmetic bundle plays.
+    - Buy in dips after large easy clue casket events or DMM weekends.
+  history:
+    - date: "2014-06-12"
+      description: Released with the Treasure Trail Expansion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ixcoztic-white.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ixcoztic-white.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: null
-  about: "Ixcoztic white is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 16
+    type: drink
+  potion:
+    doses: 1
+    effects:
+      - description: "Restores 16 Hitpoints."
+      - description: "Boosts Farming by 1 level."
+      - description: "Drains Attack by 5 levels and Herblore by 1 level."
+  shops:
+    - shop_name: Moonrise Wines
+      location: Aldarin
+      price: 100
+      stock: 20
+  about: "Ixcoztic white is an Aldarin wine sold at Moonrise Wines for 100 coins. Drinking it restores 16 Hitpoints, boosts Farming by 1, and drains Attack by 5 and Herblore by 1."
+  market_strategy:
+    notes:
+      - Sold at Moonrise Wines in Aldarin, restock 20
+      - Niche Farming +1 boost
+      - Attack and Herblore drains limit combat use
+  history:
+    - date: "2024-09-25"
+      description: Released with Varlamore - The Rising Darkness.
+  properties:
+    release_date: "2024-09-25"
+    update: Varlamore - The Rising Darkness
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jade-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jade-ring.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jade ring | OSRS Price Data
-description: "Jade ring: A valuable ring.. High alch: 765 GP, GE limit: 10,000."
+description: "Jade ring: A valuable ring. High alch: 765 GP, GE limit: 10,000."
 osrs:
   id: 21084
   name: Jade ring
@@ -12,9 +12,64 @@ osrs:
   lowalch: 510
   highalch: 765
   limit: 10000
-  about: "Jade ring is a members-only item in Old School RuneScape. High alchemy value: 765 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: ring
+    requirements:
+      crafting: 13
+  recipes:
+    - skill: Crafting
+      level: 13
+      xp: 32
+      materials:
+        - item_name: Jade
+          quantity: 1
+        - item_name: Silver bar
+          quantity: 1
+      tools:
+        - Ring mould
+        - Furnace
+      output: Jade ring
+  related_items:
+    - item_id: 21100
+      item_name: Ring of returning
+      slug: ring-of-returning
+      relationship: upgrade
+      description: Enchanted form via Lvl-2 Enchant (Magic 27)
+    - item_id: 1611
+      item_name: Jade
+      slug: jade
+      relationship: component
+      description: Cut gem used to craft the ring
+    - item_id: 2355
+      item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: Bar smelted from silver ore, used in the recipe
+  about: "Jade ring is a silver ring crafted at Crafting level 13 from one jade and one silver bar using a ring mould at a furnace, granting 32 Crafting experience and acting as the base for the Ring of returning enchantment."
+  properties:
+    release_date: "2017-02-02"
+    update: "Silver Jewellery, Tournament World & QoL"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2017-02-02"
+      description: "Released with the Silver Jewellery, Tournament World & QoL update."
+    - date: "2017-02-16"
+      description: "Inventory sprite was rotated so unenchanted silver jewellery now uses non-standard angles."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-souls.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-souls.mdx
@@ -1,56 +1,67 @@
 ---
 title: Jar of souls | OSRS Price Data
-description: "Jar of souls: This may be of use for a certain person.. High alch: 1 GP, GE limit: 4."
+description: "Jar of souls: This may be of use for a certain person. High alch: 1 GP, GE limit: 4."
 osrs:
   id: 13245
   name: Jar of souls
   slug: jar-of-souls
-  examine: This may be of use for a certain person.
+  examine: "This may be of use for a certain person."
   members: true
   icon: Jar of souls.png
   value: 1
   lowalch: 1
   highalch: 1
   limit: 4
-  item:
-    type: jar
-    tradeable: true
-    weight: 0.02
-  obtaining:
-    methods:
+  material:
+    type: boss jar
+    tier: mid-high
+  drop_table:
+    sources:
       - source: Cerberus
-        drop_rate: 1/2,000
-  usage:
-    description: Decoration for Achievement Gallery boss lair display
-    requirements: Defeating Cerberus at least once to place
-    cosmetic: true
+        quantity: "1"
+        rarity: 1/2000
   related_items:
-    - item_id: 0
-      item_name: Jar of miasma
-      slug: jar-of-miasma
+    - item_name: Hellpuppy
+      slug: hellpuppy
       relationship: alternative
-      description: Similar jar drop
-    - item_id: 0
-      item_name: Hellhound champion scroll
-      slug: hellhound-champion-scroll
+      description: Cerberus pet drop sharing the same boss drop table.
+    - item_name: Smouldering stone
+      slug: smouldering-stone
       relationship: alternative
-      description: Cerberus area drop
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Jar |
-    | Tradeable | Yes |
-    | Weight | 0.02 kg |
-    | Requirements | None |
-
-    Decoration for Achievement Gallery boss lair display.
-
-    Requires defeating Cerberus at least once to place.
-
-    Cosmetic/collectible item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Cerberus unique used to create primordial, pegasian, and eternal boots.
+    - item_name: Jar of stone
+      slug: jar-of-stone
+      relationship: alternative
+      description: Similar collectible boss jar from the General Graardor drop table.
+  about: "Jar of souls is a Cerberus collectible jar that places a boss-lair display of Cerberus inside a player-owned house Achievement Gallery."
+  market_strategy:
+    notes:
+      - Pure collectible, no combat utility.
+      - Supply tracks Cerberus task popularity and Slayer meta.
+      - Buy limit of 4 keeps daily volume low.
+  trading_tips:
+    - Hold for long-term appreciation as Slayer collectibles climb over time.
+    - Buy after league or DMM events drain market supply.
+  history:
+    - date: "2015-08-27"
+      description: Released with the Cerberus boss update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-08-27"
+    update: "Cerberus"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-swamp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-swamp.mdx
@@ -1,56 +1,58 @@
 ---
 title: Jar of swamp | OSRS Price Data
-description: "Jar of swamp: This is my Swamp!. High alch: 1 GP, GE limit: 4."
+description: "Jar of swamp: This is my Swamp! High alch: 1 GP, GE limit: 4."
 osrs:
   id: 12936
   name: Jar of swamp
   slug: jar-of-swamp
-  examine: This is my Swamp!
+  examine: "This is my Swamp!"
   members: true
   icon: Jar of swamp.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 4
-  item:
-    type: jar
-    tradeable: true
-    weight: 0.02
-  obtaining:
-    methods:
+  drop_table:
+    sources:
       - source: Zulrah
-        drop_rate: 1/3,000
-  usage:
-    description: Decoration for Achievement Gallery boss lair display
-    requirements: Defeating Zulrah at least once to place
-    cosmetic: true
+        quantity: "1"
+        rarity: 1/3000
   related_items:
     - item_id: 12934
       item_name: Zulrah's scales
       slug: zulrahs-scales
       relationship: alternative
-      description: Common drop
+      description: Common drop from Zulrah used for the Trident family.
     - item_id: 12927
       item_name: Serpentine visage
       slug: serpentine-visage
       relationship: alternative
-      description: Rare drop
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Jar |
-    | Tradeable | Yes |
-    | Weight | 0.02 kg |
-    | Requirements | None |
-
-    Decoration for Achievement Gallery boss lair display.
-
-    Requires defeating Zulrah at least once to place.
-
-    Cosmetic/collectible item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Rare unique drop used to craft the Serpentine helm.
+  about: "Jar of swamp is an ultra-rare Zulrah drop used as the boss-lair display piece in the Achievement Gallery."
+  market_strategy:
+    notes:
+      - Tiny 4/4h buy limit keeps the price spiky
+      - Demand is driven by Achievement Gallery collectors, not gear meta
+  history:
+    - date: "2015-01-08"
+      description: Released alongside Zulrah - The Solo Snake Boss.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-01-08"
+    update: "Zulrah - The Solo Snake Boss"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Open
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jungle-camo-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jungle-camo-legs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jungle camo legs | OSRS Price Data
-description: "Jungle camo legs: These should make me harder to spot in jungle areas.. High alch: 12 GP."
+description: "Jungle camo legs: These should make me harder to spot in jungle areas. High alch: 12 GP."
 osrs:
   id: 10059
   name: Jungle camo legs
@@ -12,9 +12,94 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Jungle camo legs is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weapon_type: none
+    weight: 0.226
+    requirements:
+      hunter: 4
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -7
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: 0
+      ranged: 10
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Fancy Clothes Store
+      location: Varrock
+      cost: 20
+      currency: coins
+    - shop_name: Hunter Guild Store
+      location: Hunter Guild
+      cost: 20
+      currency: coins
+    - shop_name: Seamstress
+      location: Prifddinas
+      cost: 20
+      currency: coins
+  recipes:
+    - skill: Purchase
+      tools: []
+      materials:
+        - item_name: Feldip weasel fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 20
+      product: Jungle camo legs
+  related_items:
+    - item_id: 10057
+      item_name: Jungle camo top
+      slug: jungle-camo-top
+      relationship: set-piece
+      description: Matching torso piece of the jungle camo set.
+    - item_id: 10061
+      item_name: Desert camo legs
+      slug: desert-camo-legs
+      relationship: variant
+      description: Desert biome camo legs variant.
+  about: "Jungle camo legs are members-only Hunter clothing that improves catch rate in jungle Hunter areas and reduces carried weight by 2 kg when worn."
+  market_strategy:
+    notes:
+      - Crafted cheaply from feldip weasel furs and resold for Hunter convenience.
+      - GE supply is thin; flips depend on Hunter player demand.
+  trading_tips:
+    - Pair with Jungle camo top for full-set sales.
+    - Stock up before new Hunter content releases.
+  history:
+    - date: "2006-11-21"
+      description: Released alongside the Hunter skill.
+    - date: "2024-03-20"
+      description: Updated to reduce carried weight by 2 kg when equipped.
+  properties:
+    release_date: "2006-11-21"
+    update: "HUNTER SKILL!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-adamant-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-adamant-keel-parts.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 6250
   highalch: 9375
   limit: 100
-  about: "Large adamant keel parts is a members-only item in Old School RuneScape. High alchemy value: 9,375 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: adamant
+    tier: mid
+  recipes:
+    - product: Large adamant keel parts
+      skill: Smithing
+      level: 74
+      xp: 5
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_name: Adamant keel parts
+          quantity: 5
+  related_items:
+    - item_id: 32030
+      item_name: Adamant keel parts
+      slug: adamant-keel-parts
+      relationship: component
+      description: Five combine to make large adamant keel parts
+    - item_id: 32034
+      item_name: Large adamant keel
+      slug: large-adamant-keel
+      relationship: product
+      description: Built from sixteen large keel parts for Sloop construction
+  about: "Large adamant keel parts are a Smithing 74 Sailing component crafted from five adamant keel parts, required for building a Sloop's adamant keel."
+  market_strategy:
+    notes:
+      - Sailing-update bottleneck for adamant keels
+      - Recipe consumes 5 adamant keel parts each
+      - Margins follow adamant bar prices
+  trading_tips:
+    - Profitable when adamant keel parts spread is thin
+    - 16 required per large adamant keel
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Pandemonium
+    weight: 4.0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-iron-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-iron-keel-parts.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 250
   highalch: 375
   limit: 100
-  about: "Large iron keel parts is a members-only item in Old School RuneScape. High alchemy value: 375 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: iron
+    tier: low
+  recipes:
+    - skill: smithing
+      level: 22
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_name: Iron keel parts
+          item_id: 32022
+          quantity: 5
+      product: Large iron keel parts
+      product_id: 32023
+      members_only: true
+  related_items:
+    - item_name: Iron keel parts
+      slug: iron-keel-parts
+      relationship: component
+      description: Smaller part smithed up into large iron keel parts
+    - item_name: Iron bar
+      slug: iron-bar
+      relationship: component
+      description: Raw material; 400 iron bars make one full keel
+    - item_name: Iron keel
+      slug: iron-keel
+      relationship: product
+      description: Sailing keel assembled from 16 large iron keel parts
+  about: "Large iron keel parts are a Sailing/Smithing component made at level 22 Smithing from 5 iron keel parts and used to assemble iron keels for sloops."
+  market_strategy:
+    notes:
+      - Demand is anchored to Sailing keel construction so volume tracks the post-Pandemonium meta
+      - Cost basis is 100 iron bars per stack of 5 large parts; compare against GE price for craft-vs-buy
+  trading_tips:
+    - Check current iron bar price against GE price for large parts before smithing
+    - 16 large parts per keel; size orders to match a clean keel run
+  history:
+    - date: "2025-11-19"
+      update: Sailing is OUT TODAY!
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    quest: Pandemonium
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/leather-cowl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/leather-cowl.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 9
   highalch: 14
   limit: 125
-  about: "Leather cowl is a free-to-play item in Old School RuneScape. High alchemy value: 14 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: leather
+    tier: low
+  equipment:
+    slot: head
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 1
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 4
+      magic: 2
+      ranged: 3
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.907
+  drop_table:
+    sources:
+      - source: Reward casket (beginner)
+        quantity: "1"
+        rarity: 11/492
+  treasure_trail:
+    tier: beginner
+    is_reward: true
+    reward_tiers:
+      - beginner
+  shops:
+    - shop_name: Aaron's Archery Appendages
+      location: Ranging Guild
+      price: 24
+  recipes:
+    - skill: Crafting
+      level: 9
+      xp: 18.5
+      materials:
+        - item_name: Leather
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+      notes: Costume needle also works.
+  about: "Entry-level F2P ranged head slot armour with a +1 ranged attack bonus, crafted from leather and thread at 9 Crafting for 18.5 experience."
+  market_strategy:
+    notes:
+      - Free-to-play crafting target for early Crafting XP
+      - Beginner clue reward boosts inflow
+      - High alch loses to vendor value
+  trading_tips:
+    - GE price tends to track leather supply
+    - Buy in bulk during Crafting double XP windows
+  history:
+    - date: "2003-12-01"
+      description: Initially added during the RS2 Beta.
+    - date: "2004-03-29"
+      description: Made permanent at the RS2 launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lime.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lime.mdx
@@ -12,9 +12,24 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Lime is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: Lime is a fresh fruit used in Gnome Cuisine recipes and obtainable from groceries, fruit stalls, and gnome drops.
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-fancy-dress-box-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-fancy-dress-box-flatpack.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Mahogany fancy dress box (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mahogany
+    tier: high
+  construction:
+    level: 80
+    xp: 280
+    facility: Bench with vice
+  recipes:
+    - skill: construction
+      level: 80
+      xp: 280
+      tools:
+        - Hammer
+        - Saw
+      materials:
+        - item_name: Mahogany plank
+          item_id: 8782
+          quantity: 2
+      product: Mahogany fancy dress box (flatpack)
+      product_id: 9867
+      members_only: true
+  related_items:
+    - item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Material used to build the flatpack
+    - item_name: Teak fancy dress box (flatpack)
+      slug: teak-fancy-dress-box-flatpack
+      relationship: downgrade
+      description: Lower-tier costume room dress box
+  about: Mahogany fancy dress box flatpack is built on a bench with a vice and installed in the costume room space of a player-owned house.
+  market_strategy:
+    notes:
+      - Producing the flatpack from raw mahogany planks is typically a small loss after GE tax
+      - Demand is driven by player-owned house decoration so volume is thin
+  trading_tips:
+    - Compare GE price against the cost of two mahogany planks before crafting for profit
+    - Use it to consume excess mahogany planks while still earning Construction XP
+  history:
+    - date: "2006-10-18"
+      update: Player-Owned House Costume Room
+      description: Added to the game.
+    - date: "2015-02-26"
+      description: Renamed from Mahogany fdb to its full name.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-10-18"
+    update: Player-Owned House Costume Room
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-shortbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-shortbow.mdx
@@ -12,23 +12,30 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 18000
+  material:
+    type: wood
+    tier: mid
   equipment:
     slot: 2h
-    type: shortbow
-    attack_style: ranged
+    weapon_type: shortbow
     attack_speed: 4
-  requirements:
-    ranged: 30
-  stats:
-    attack:
+    weight: 1.36
+    requirements:
+      ranged: 30
+    attack_bonus:
       ranged: 29
-    other:
+    other_bonus:
       ranged_strength: 0
-    range: 7
-  fletching:
-    level: 50
-    xp: 50
-    method: Maple shortbow (u) + bowstring
+  recipes:
+    - skill: Fletching
+      level: 50
+      xp: 50
+      materials:
+        - item_name: Maple shortbow (u)
+          quantity: 1
+        - item_name: Bow string
+          quantity: 1
+      tools: []
   shops:
     - shop_name: Lowe's Archery Emporium
       location: Varrock
@@ -54,8 +61,37 @@ osrs:
       slug: bow-string
       relationship: component
       description: Stringing material
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Maple shortbow is a free-to-play two-handed bow fletched at level 50 and the strongest bow available to F2P, accepting arrows up to adamant."
+  market_strategy:
+    notes:
+      - BiS F2P bow
+      - Crafted at 50 Fletching for 50 xp
+      - Buy limit 18,000 per 4 hours
+      - Sold by Lowe's Archery Emporium
+  history:
+    - date: "2002-03-25"
+      description: Released as a members-only shortbow.
+    - date: "2005-03-29"
+      description: Made available to free-to-play players.
+  properties:
+    release_date: "2002-03-25"
+    update: Maple shortbow release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/marble-block.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/marble-block.mdx
@@ -1,6 +1,6 @@
 ---
 title: Marble block | OSRS Price Data
-description: "Marble block: A beautifully carved marble block.. High alch: 150,000 GP, GE limit: 11,000."
+description: "Marble block: A beautifully carved marble block. High alch: 150,000 GP, GE limit: 11,000."
 osrs:
   id: 8786
   name: Marble block
@@ -14,69 +14,78 @@ osrs:
   limit: 11000
   material:
     type: construction
-    tier: premium
+    tier: high
   construction:
     min_level: 50
-    cost: 325000
-    source: Keldagrim Stonemason
     common_builds:
-      - name: Marble lecterns
+      - name: Marble lectern
         quantity: "1"
         xp: 700
       - name: Gilded altar
         quantity: "2"
         xp: 1500
-      - name: Ornate pool
+      - name: Ornate rejuvenation pool
         quantity: "8"
         xp: 3200
-  shop_sources:
-    - name: Keldagrim Stonemason
+  shops:
+    - shop_name: Stonemason
+      location: Keldagrim
       price: 325000
-    - name: Stonecutter Supplies
+    - shop_name: Stonecutter Supplies
+      location: Stonecutter Outpost
       price: 325000
   related_items:
     - item_id: 8784
       item_name: Gold leaf
       slug: gold-leaf
       relationship: alternative
-      description: Another premium material
+      description: Premium construction material used alongside marble.
     - item_id: 8790
       item_name: Bolt of cloth
       slug: bolt-of-cloth
       relationship: alternative
-      description: Decoration material
+      description: Decoration material for POH furniture.
     - item_id: 8782
       item_name: Mahogany plank
       slug: mahogany-plank
       relationship: component
-      description: Often used together
+      description: Frequently used in the same high-tier builds.
     - item_id: 3420
       item_name: Limestone brick
       slug: limestone-brick
       relationship: alternative
-      description: Budget stone option
-  about: |-
-    | Furniture | Marble Blocks | Level | XP |
-    |-----------|---------------|-------|-----|
-    | Marble fireplace | 1 | 63 | 500 |
-    | Gilded decoration | 2 | 75 | 1020 |
-    | Gilded altar | 2 | 75 | 2230 |
-    | Ornate rejuvenation pool | 8 | 90 | 3200 |
-    | Spirit tree & fairy ring | 1 | 95 | 2500 |
-
-    Key POH Builds:
-    - Gilded altar (75 Construction) - Best Prayer training in POH
-    - Ornate pool (90 Construction) - Full stat restore
-    - Occult altar (90 Construction) - Spellbook swapping
+      description: Budget stone option for early Construction.
+  about: High-tier Construction stone bought from the Keldagrim Stonemason or Stonecutter Outpost; used in gilded altars and ornate pools.
   market_strategy:
     notes:
-      - "Gilded altar: 650,000 GP (2 blocks)"
-      - "Ornate pool: 2,600,000 GP (8 blocks)"
+      - "Gilded altar: 650,000 GP per build (2 blocks)"
+      - "Ornate pool: 2,600,000 GP per build (8 blocks)"
       - Buy in bulk to save trips to Keldagrim
       - Most builds also require Gold leaf
       - High Construction level unlocks best features
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Margin tracks GE versus 325,000 shop price - watch for clips
+    - Stockpile before bonus XP weekends when Construction demand spikes
+  history:
+    - date: "2006-05-31"
+      description: Released with the Player-Owned Houses update.
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 13.607
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mask-of-ranul.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mask-of-ranul.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 70
-  about: "Mask of ranul is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mask
+    tier: mid
+  equipment:
+    slot: head
+    weight: 0.35
+    attack_bonus:
+      magic: 2
+    defence_bonus:
+      magic: 2
+  drop_table:
+    sources:
+      - source: Undead Druid
+        quantity: "1"
+        rarity: 1/1000
+  related_items:
+    - item_name: Wizard hat
+      slug: wizard-hat
+      relationship: alternative
+      description: Comparable magic head slot with similar stats
+  about: "Mask of ranul is a magic head slot drop from Undead Druids in Forthos Dungeon that triggers Chosen Aluinus' appearance at Shipwreck Cove."
+  market_strategy:
+    notes:
+      - Drop rate of 1/1,000 keeps supply consistent from Undead Druid slayer tasks
+      - Buy limit of 70 caps speculative spikes
+      - Demand driven by cosmetic flavour interaction with Chosen Aluinus
+  history:
+    - date: "2019-07-04"
+      description: Added with the Forthos Dungeon update.
+  properties:
+    release_date: "2019-07-04"
+    update: "Forthos Dungeon"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/masori-armour-set-f.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/masori-armour-set-f.mdx
@@ -1,20 +1,62 @@
 ---
 title: Masori armour set (f) | OSRS Price Data
-description: "Masori armour set (f): A set containing a Masori mask (f), Masori body (f), Masori chaps (f). High alch: 87,000 GP, GE limit: 5."
+description: "Masori armour set (f): a Grand Exchange set containing fortified Masori mask, body, and chaps. High alch: 87,000 GP, GE limit: 5."
 osrs:
   id: 27355
   name: Masori armour set (f)
   slug: masori-armour-set-f
-  examine: A set containing a Masori mask (f), Masori body (f), Masori chaps (f)
+  examine: "A set containing a Masori mask (f), Masori body (f), Masori chaps (f)"
   members: true
   icon: Masori armour set (f).png
   value: 145000
   lowalch: 58000
   highalch: 87000
   limit: 5
-  about: "Masori armour set (f) is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_id: 27238
+      item_name: Masori mask (f)
+      slug: masori-mask-f
+      relationship: component
+      description: Fortified mask included in the set
+    - item_id: 27241
+      item_name: Masori body (f)
+      slug: masori-body-f
+      relationship: component
+      description: Fortified body included in the set
+    - item_id: 27244
+      item_name: Masori chaps (f)
+      slug: masori-chaps-f
+      relationship: component
+      description: Fortified chaps included in the set
+  about: "Masori armour set (f) is a Grand Exchange placeholder bundle that exchanges into fortified Masori mask, body, and chaps for one-click bulk trading of the BiS ranged set."
+  market_strategy:
+    notes:
+      - GE set convenience wrapper, no other use
+      - Trades versus combined piece value with small premium
+      - Buy limit of 5 caps daily flipping volume
+  trading_tips:
+    - Monitor combined piece pricing for arbitrage entries
+    - Premium widens during high TOA invocation meta demand
+  history:
+    - date: "2022-08-24"
+      description: Released as part of the Tombs of Amascut raid update.
+  properties:
+    release_date: "2022-08-24"
+    update: Tombs of Amascut
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/masori-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/masori-body.mdx
@@ -1,6 +1,6 @@
 ---
 title: Masori body | OSRS Price Data
-description: "Masori body is a members legs slot item requiring 30 Defence. High alch: 720,000 GP, GE limit: 8."
+description: "Masori body is a members body slot item requiring 80 Ranged and 30 Defence. High alch: 720,000 GP, GE limit: 8."
 osrs:
   id: 27229
   name: Masori body
@@ -12,91 +12,97 @@ osrs:
   lowalch: 480000
   highalch: 720000
   limit: 8
+  material:
+    type: masori
+    tier: high
   equipment:
-    slot: legs
-    type: masori_armor
-    attack_style: ranged
+    slot: body
+    weight: 8
     requirements:
       ranged: 80
       defence: 30
-    stats:
-      attack_ranged: 22
-      attack_magic: -4
-      defence_ranged: 6
-      ranged_strength: 2
-  set_bonus:
-    with_full_set: true
-    regular_damage: 10
-    fortified_damage: 12.5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 43
+    defence_bonus:
+      stab: 37
+      slash: 35
+      crush: 38
+      magic: 25
+      ranged: 33
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 4
+      magic_damage: 0
+      prayer: 0
   drop_table:
     sources:
       - source: Tombs of Amascut
-        source_id: 11751
-        combat_level: 0
         quantity: "1"
-        rarity: 1/48 at 150 invocation
-        members_only: true
+        rarity: 2/24
   recipes:
     - skill: crafting
       level: 90
       xp: 0
       materials:
-        - item_name: Masori chaps
-          item_id: 27229
+        - item_name: Masori body
           quantity: 1
-        - item_name: Armadyl chainskirt
-          item_id: 11828
-          quantity: 1
-      product: Masori chaps (f)
-      product_id: 27238
+        - item_name: Armadylean plate
+          quantity: 4
+      tools: []
+      product: Masori body (f)
       product_quantity: 1
-      facility: None
       members_only: true
   related_items:
-    - item_id: 27226
-      item_name: Masori body
-      slug: masori-body
-      relationship: alternative
-      description: Body armor
+    - item_id: 27238
+      item_name: Masori body (f)
+      slug: masori-body-f
+      relationship: upgrade
+      description: Fortified version crafted with Armadylean plates
     - item_id: 27232
       item_name: Masori mask
       slug: masori-mask
-      relationship: alternative
-      description: Helm slot
-    - item_id: 11828
-      item_name: Armadyl chainskirt
-      slug: armadyl-chainskirt
-      relationship: component
-      description: Used for fortifying
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +22 |
-    | Magic attack | -4 |
-    | Ranged defence | +6 |
-    | Ranged strength | +2 |
-    | Requirements | 80 Ranged, 30 Defence |
-
-    With full Masori armor (fortified):
-    - +12.5% ranged damage bonus
-
-    With regular Masori:
-    - +10% ranged damage bonus
-
-    BiS ranged leg armor for:
-    - All ranged combat
-    - Raids
-    - Bossing
-    - Slayer
-
-    Fortified version requires Armadyl chainskirt.
+      relationship: set-piece
+      description: Helm slot set piece
+    - item_id: 27235
+      item_name: Masori chaps
+      slug: masori-chaps
+      relationship: set-piece
+      description: Legs slot set piece
+  about: "Masori body is best-in-slot ranged body armour obtained from the Tombs of Amascut, requiring 80 Ranged and 30 Defence to equip."
   market_strategy:
     notes:
-      - Regular from ToA
-      - Fortify with Armadyl piece
-      - Set bonus is massive DPS increase
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Obtained from Tombs of Amascut reward chest
+      - Fortify with 4 Armadylean plates for the (f) version
+      - High-end BiS ranged gear with significant capital requirement
+  trading_tips:
+    - Watch ToA invocation meta shifts that affect supply
+    - Track fortified premium versus raw piece price
+  history:
+    - date: "2022-08-24"
+      description: Released as part of the Tombs of Amascut raid update.
+  properties:
+    release_date: "2022-08-24"
+    update: Tombs of Amascut
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/masori-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/masori-mask.mdx
@@ -1,6 +1,6 @@
 ---
 title: Masori mask | OSRS Price Data
-description: "Masori mask is a members body slot item requiring 30 Defence. High alch: 480,000 GP, GE limit: 8."
+description: "Masori mask: An ancient mask once worn by a powerful ranger. High alch: 480,000 GP, GE limit: 8."
 osrs:
   id: 27226
   name: Masori mask
@@ -12,91 +12,89 @@ osrs:
   lowalch: 320000
   highalch: 480000
   limit: 8
+  material:
+    type: masori
+    tier: high
   equipment:
-    slot: body
-    type: masori_armor
-    attack_style: ranged
+    slot: head
+    weapon_type: armour
+    weight: 1
     requirements:
       ranged: 80
       defence: 30
-    stats:
-      attack_ranged: 30
-      attack_magic: -6
-      defence_ranged: 8
+    attack_bonus:
+      magic: -1
+      ranged: 12
+    defence_bonus:
+      stab: 3
+      slash: 4
+      crush: 3
+      magic: 6
+      ranged: 4
+    other_bonus:
       ranged_strength: 2
-  set_bonus:
-    with_full_set: true
-    regular_damage: 10
-    fortified_damage: 12.5
   drop_table:
     sources:
       - source: Tombs of Amascut
-        source_id: 11751
-        combat_level: 0
         quantity: "1"
-        rarity: 1/48 at 150 invocation
-        members_only: true
+        rarity: 2/24
   recipes:
     - skill: crafting
       level: 90
       xp: 0
       materials:
-        - item_name: Masori body
-          item_id: 27226
+        - item_name: Masori mask
           quantity: 1
-        - item_name: Armadyl chestplate
-          item_id: 11826
+        - item_name: Armadylean plate
           quantity: 1
-      product: Masori body (f)
-      product_id: 27235
+      tools: []
+      product: Masori mask (f)
       product_quantity: 1
-      facility: None
       members_only: true
   related_items:
+    - item_id: 27235
+      item_name: Masori mask (f)
+      slug: masori-mask-f
+      relationship: upgrade
+      description: Fortified variant requiring 80 Defence and an Armadylean plate.
     - item_id: 27229
+      item_name: Masori body
+      slug: masori-body
+      relationship: set-piece
+      description: Body slot of the Masori armour set.
+    - item_id: 27232
       item_name: Masori chaps
       slug: masori-chaps
-      relationship: alternative
-      description: Leg armor
-    - item_id: 27232
-      item_name: Masori mask
-      slug: masori-mask
-      relationship: alternative
-      description: Helm slot
-    - item_id: 11826
-      item_name: Armadyl chestplate
-      slug: armadyl-chestplate
-      relationship: component
-      description: Used for fortifying
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +30 |
-    | Magic attack | -6 |
-    | Ranged defence | +8 |
-    | Ranged strength | +2 |
-    | Requirements | 80 Ranged, 30 Defence |
-
-    With full Masori armor (fortified):
-    - +12.5% ranged damage bonus
-
-    With regular Masori:
-    - +10% ranged damage bonus
-
-    BiS ranged body armor for:
-    - All ranged combat
-    - Raids
-    - Bossing
-    - Slayer
-
-    Fortified version requires Armadyl chestplate.
+      relationship: set-piece
+      description: Leg slot of the Masori armour set.
+  about: "Masori mask is the head-slot piece of the Masori ranged armour set, dropped from the Tombs of Amascut raid and upgradable to a fortified version with an Armadylean plate."
   market_strategy:
     notes:
-      - Regular from ToA
-      - Fortify with Armadyl piece
-      - Set bonus is massive DPS increase
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Obtained only as a ToA drop (2/24 from the chest).
+      - Fortification is one-way and bumps Defence requirement to 80.
+      - Low GE limit (8) — illiquid for short-term flipping.
+  trading_tips:
+    - Track ToA participation trends to anticipate supply.
+    - Watch Armadylean plate prices when fortified variant demand spikes.
+  history:
+    - date: "2022-08-24"
+      description: "Released as part of the Tombs of Amascut update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-08-24"
+    update: Tombs of Amascut
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-remedy-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-remedy-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Menaphite remedy(2) | OSRS Price Data
-description: "Menaphite remedy(2): 2 doses of Menaphite remedy.. High alch: 66 GP."
+description: "Menaphite remedy(2): 2 doses of Menaphite remedy. High alch: 66 GP."
 osrs:
   id: 27208
   name: Menaphite remedy(2)
@@ -12,9 +12,73 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: null
-  about: "Menaphite remedy(2) is a members-only item in Old School RuneScape. High alchemy value: 66 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: "Restores 6 + 16% of each combat stat (excluding Prayer) every 15 seconds for 5 minutes."
+      - description: "Negates Saradomin brew stat drains for the duration."
+      - description: "Removes divine potion effects so they decay normally instead of resetting on expiry."
+  recipes:
+    - skill: herblore
+      level: 88
+      xp: 200
+      materials:
+        - item_name: Unfinished dwarf weed potion
+          quantity: 1
+        - item_name: Lily of the sands
+          quantity: 1
+      tools:
+        - Vial
+      product: Menaphite remedy(4)
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 27204
+      item_name: Menaphite remedy(4)
+      slug: menaphite-remedy-4
+      relationship: variant
+      description: 4-dose version of the same potion.
+    - item_id: 27206
+      item_name: Menaphite remedy(3)
+      slug: menaphite-remedy-3
+      relationship: variant
+      description: 3-dose version of the same potion.
+    - item_id: 27210
+      item_name: Menaphite remedy(1)
+      slug: menaphite-remedy-1
+      relationship: variant
+      description: 1-dose version of the same potion.
+  about: "Menaphite remedy(2) is a 2-dose stat-renewal potion made at 88 Herblore that gradually restores combat stats and counters Saradomin brew drains."
+  market_strategy:
+    notes:
+      - Made at 88 Herblore from unfinished dwarf weed potion and lily of the sands.
+      - Decants down from 4-dose; price tracks per-dose value of (4).
+      - No explicit GE limit reported on this dose variant.
+  trading_tips:
+    - Compare per-dose price vs Menaphite remedy(4) to spot decanting margin.
+    - Demand spikes around Brew-heavy bossing trips (Nex, ToB, ToA).
+  history:
+    - date: "2022-08-24"
+      description: "Released as part of the Tombs of Amascut update."
+    - date: "2025-04-30"
+      description: "Lily of the sands now correctly draws from the reagent pouch when brewing."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-08-24"
+    update: Tombs of Amascut
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/merchant-s-paint.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/merchant-s-paint.mdx
@@ -1,6 +1,6 @@
 ---
 title: Merchant's paint | OSRS Price Data
-description: "Merchant's paint: A vibrant gold paint. This might look good on a boat.. High alch: 1 GP."
+description: "Merchant's paint: A vibrant gold paint. This might look good on a boat. High alch: 1 GP."
 osrs:
   id: 32110
   name: Merchant's paint
@@ -12,9 +12,83 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Merchant's paint is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - product: Merchant's paint
+      product_id: 32110
+      skill: Sailing
+      level: 25
+      experience: 0
+      materials:
+        - item_id: 32100
+          item_name: Shark paint
+          quantity: 1
+        - item_id: 32102
+          item_name: Inky paint
+          quantity: 1
+        - item_id: 32104
+          item_name: Barracuda paint
+          quantity: 1
+        - item_id: 32106
+          item_name: Salvor's paint
+          quantity: 1
+        - item_id: 32108
+          item_name: Angler's paint
+          quantity: 1
+      tools: []
+      notes: "Talk to Trader Stan while holding all five tradeable paints to receive a Merchant's paint."
+  related_items:
+    - item_id: 32100
+      item_name: Shark paint
+      slug: shark-paint
+      relationship: component
+      description: One of the five paints traded in.
+    - item_id: 32102
+      item_name: Inky paint
+      slug: inky-paint
+      relationship: component
+      description: One of the five paints traded in.
+    - item_id: 32104
+      item_name: Barracuda paint
+      slug: barracuda-paint
+      relationship: component
+      description: One of the five paints traded in.
+    - item_id: 32106
+      item_name: Salvor's paint
+      slug: salvor-s-paint
+      relationship: component
+      description: One of the five paints traded in.
+    - item_id: 32108
+      item_name: Angler's paint
+      slug: angler-s-paint
+      relationship: component
+      description: One of the five paints traded in.
+  about: "Merchant's paint is a prestige Sailing boat recolour earned by handing Trader Stan every standard paint at once and applied via the Shipyard schematics board with 25 Sailing and 20 Construction."
+  market_strategy:
+    notes:
+      - Supply requires consuming roughly 22M coins of base paints, anchoring a steep floor.
+      - High-end Sailing cosmetics collectors are the primary buyer pool.
+  trading_tips:
+    - Margin opportunities open when one of the five base paints crashes below trend.
+    - Treat as a luxury hold rather than a high-volume flip.
+  history:
+    - date: "2025-11-19"
+      description: Added with the launch of the Sailing skill.
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/metztonalli-white.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/metztonalli-white.mdx
@@ -12,9 +12,43 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: null
-  about: "Metztonalli white is a members-only item in Old School RuneScape. High alchemy value: 300 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 16
+    effect: "Boosts Runecraft by 1 level while reducing Attack by 5 and Firemaking by 1."
+  shops:
+    - shop_name: The Flaming Arrow
+      location: Civitas illa Fortis
+      price: 500
+    - shop_name: Moonrise Wines
+      location: Civitas illa Fortis
+      price: 500
+    - shop_name: Sunlight's Sanctum
+      location: Civitas illa Fortis
+      price: 500
+    - shop_name: The King's Inn
+      location: Aldarin
+      price: 500
+  about: Metztonalli white is a Varlamore Aldarin White wine that restores 16 hitpoints, boosts Runecraft, and lightly drains Attack and Firemaking.
+  history:
+    - date: "2024-09-25"
+      description: Released with the Varlamore The Rising Darkness update.
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness is OUT NOW"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mind-altar-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mind-altar-teleport-tablet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mind altar teleport (tablet) | OSRS Price Data
-description: "Mind altar teleport (tablet): A teleport to the Mind Altar.. High alch: 1 GP, GE limit: 10,000."
+description: "Mind altar teleport (tablet): A teleport to the Mind Altar. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 19617
   name: Mind altar teleport (tablet)
@@ -12,9 +12,56 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Mind altar teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Mind Altar entrance
+    type: tablet
+  recipes:
+    - skill: magic
+      level: 28
+      xp: 22
+      materials:
+        - item_name: Law rune
+          quantity: 1
+        - item_name: Mind rune
+          quantity: 2
+        - item_name: Dark essence block
+          quantity: 1
+      tools:
+        - Lectern
+      product: Mind altar teleport (tablet)
+      product_quantity: 1
+      facility: Arceuus spellbook
+      members_only: true
+  about: "Mind altar teleport tablet is a one-use teleport made on the Arceuus spellbook that drops the player at the entrance to the Mind Altar between Ice Mountain and Goblin Village."
+  market_strategy:
+    notes:
+      - Made at 28 Magic on the Arceuus spellbook for 22 XP per cast.
+      - Useful for free-to-play and runecrafting routes to the Mind Altar.
+      - GE limit 10,000 per 4 hours.
+  trading_tips:
+    - Compare law/mind/dark essence costs vs tablet GE price for profit.
+    - Stack tablets for bulk laws or runecrafting trips.
+  history:
+    - date: "2016-05-12"
+      description: "Released as part of the teleport tablet expansion."
+    - date: "2017-10-12"
+      description: "Examine text updated from 'A tablet containing a magic spell.' to the current text."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-05-12"
+    update: Teleport tablet expansion
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    alchable: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mind-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mind-shield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mind shield | OSRS Price Data
-description: "Mind shield: A magic shield.. High alch: 1,800 GP, GE limit: 70."
+description: "Mind shield is a members magic shield crafted via Elemental Workshop II. High alch: 1,800 GP, GE limit: 70."
 osrs:
   id: 9731
   name: Mind shield
@@ -12,9 +12,84 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 70
-  about: "Mind shield is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    weight: 0.226
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 9
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Smithing
+      level: 30
+      xp: 30
+      output_quantity: 1
+      materials:
+        - item_name: Primed mind bar
+          quantity: 1
+        - item_name: Slashed book
+          quantity: 1
+      tools:
+        - Hammer
+      notes: "Use the workbench inside the Elemental Workshop II to forge the shield."
+  related_items:
+    - item_id: 2890
+      item_name: Elemental shield
+      slug: elemental-shield
+      relationship: downgrade
+      description: Base elemental shield from Elemental Workshop I.
+    - item_id: 9729
+      item_name: Mind helmet
+      slug: mind-helmet
+      relationship: set-piece
+      description: Matching Elemental Workshop II helm.
+  about: "Mind shield is crafted at the Elemental Workshop II workbench and reduces max damage from wyvern icy breath attacks to 10."
+  market_strategy:
+    notes:
+      - Demand follows skeletal and ancient wyvern slayer tasks
+      - GE price runs well above high alch
+      - Buy limit 70 keeps thin daily volume manageable
+  trading_tips:
+    - Watch wyvern task popularity and slayer streamer events
+    - Pairs with mind helmet for Elemental Workshop II fashionscape demand
+  history:
+    - date: "2006-10-02"
+      description: "Released with the Elemental Workshop II quest update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-10-02"
+    update: "Elemental Workshop II"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: "Elemental Workshop II"
+    weight: 0.226
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mind-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mind-talisman.mdx
@@ -1,20 +1,93 @@
 ---
 title: Mind talisman | OSRS Price Data
-description: "Mind talisman: A mysterious power emanates from the talisman.... High alch: 2 GP, GE limit: 11,000."
+description: "Mind talisman: A mysterious power emanates from the talisman... High alch: 2 GP, GE limit: 11,000."
 osrs:
   id: 1448
   name: Mind talisman
   slug: mind-talisman
-  examine: A mysterious power emanates from the talisman...
+  examine: "A mysterious power emanates from the talisman..."
   members: false
   icon: Mind talisman.png
   value: 4
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Mind talisman is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Imp
+        quantity: "1"
+        rarity: 7/128
+      - source: Wizard
+        quantity: "1"
+        rarity: Common
+      - source: Essence impling
+        quantity: "1"
+        rarity: Common
+      - source: Abyssal creatures
+        quantity: "1"
+        rarity: Common
+      - source: Dagannoth Kings
+        quantity: "1"
+        rarity: Uncommon
+  shops:
+    - shop_name: Temple Supplies (Temple of the Eye)
+      currency: Abyssal pearl
+      price: 10
+  recipes:
+    - skill: runecraft
+      level: 1
+      xp: 27.5
+      materials:
+        - item_name: Mind talisman
+          quantity: 1
+        - item_name: Tiara
+          quantity: 1
+      tools: []
+      product: Mind tiara
+      product_quantity: 1
+      facility: Mind Altar
+      members_only: false
+  related_items:
+    - item_id: 5527
+      item_name: Mind tiara
+      slug: mind-tiara
+      relationship: product
+      description: Wearable tiara that replaces the talisman.
+    - item_id: 558
+      item_name: Mind rune
+      slug: mind-rune
+      relationship: product
+      description: Rune crafted at the Mind Altar.
+  about: "Mind talisman provides access to the Mind Altar between Ice Mountain and Goblin Village, and combines with a tiara to produce a Mind tiara needed for the Easy Falador Diary."
+  market_strategy:
+    notes:
+      - Steady free-to-play demand from runecrafting and Easy Falador Diary.
+      - Imps drop at 7/128 — a primary supply source.
+      - Temple Supplies sells for 10 Abyssal pearls.
+  trading_tips:
+    - High daily volume (~65k) — tight margins, scale with quantity.
+    - Spikes around new f2p content or diary refreshes.
+  history:
+    - date: "2003-12-01"
+      description: "Added to the RuneScape 2 Beta."
+    - date: "2004-03-29"
+      description: "Permanently available with the RS2 launch."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: "RuneScape 2 launch"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.015
+    options:
+      - Locate
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-gold-trimmed-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-gold-trimmed-set-sk.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
-  about: "Mithril gold-trimmed set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: mid
+  related_items:
+    - item_id: 12283
+      item_name: Mithril full helm (g)
+      slug: mithril-full-helm-g
+      relationship: set-piece
+      description: Helm component
+    - item_id: 12281
+      item_name: Mithril platebody (g)
+      slug: mithril-platebody-g
+      relationship: set-piece
+      description: Platebody component
+    - item_id: 12285
+      item_name: Mithril plateskirt (g)
+      slug: mithril-plateskirt-g
+      relationship: set-piece
+      description: Skirt component
+    - item_id: 12287
+      item_name: Mithril kiteshield (g)
+      slug: mithril-kiteshield-g
+      relationship: set-piece
+      description: Kiteshield component
+  about: "Mithril gold-trimmed set (sk) bundles a gold-trimmed mithril full helm, platebody, plateskirt and kiteshield via the Grand Exchange Sets option."
+  market_strategy:
+    notes:
+      - Exchanged via GE clerk Sets option
+      - Components sum cheaper than set
+      - F2P bank space saver
+      - Buy limit 8 per 4 hours
+  history:
+    - date: "2015-02-26"
+      description: Released alongside the Grand Exchange Sets option.
+  properties:
+    release_date: "2015-02-26"
+    update: Grand Exchange Sets
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-halberd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-halberd.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril halberd | OSRS Price Data
-description: "Mithril halberd: A mithril halberd.. High alch: 1,560 GP, GE limit: 125."
+description: "Mithril halberd: A mithril halberd. High alch: 1,560 GP, GE limit: 125."
 osrs:
   id: 3198
   name: Mithril halberd
@@ -12,9 +12,77 @@ osrs:
   lowalch: 1040
   highalch: 1560
   limit: 125
-  about: "Mithril halberd is a members-only item in Old School RuneScape. High alchemy value: 1,560 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Mithril
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: halberd
+    attack_speed: 7
+    weight: 2.721
+    requirements:
+      attack: 20
+      strength: 10
+    attack_bonus:
+      stab: 22
+      slash: 28
+      crush: 0
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: 2
+      crush: 4
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 29
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Quartermaster
+      location: Tyras Camp
+      price: 3380
+      members: true
+  related_items:
+    - item_name: Steel halberd
+      relationship: downgrade
+      description: Lower-tier halberd.
+    - item_name: Adamant halberd
+      relationship: upgrade
+      description: Higher-tier halberd.
+  about: "Mithril halberd is a two-handed polearm requiring 20 Attack, sold by the Quartermaster at Tyras Camp. Its 2-tile reach is the defining feature for safespotting melee monsters."
+  market_strategy:
+    notes:
+      - Reached only after Regicide grants access to Tyras Camp
+      - 2-tile reach allows melee training while safespotted
+      - Buy limit of 125 per 4 hours caps flipping volume
+  trading_tips:
+    - Stock up via the Quartermaster when the GE price is above 3,380 coins
+    - Watch for spikes after Regicide quest guide promotion
+  history:
+    - date: "2004-09-20"
+      description: Released with the Plague City Part 4 update introducing halberds.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-09-20"
+    update: Plague City Part 4
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-platebody-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-platebody-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril platebody (t) | OSRS Price Data
-description: "Mithril platebody (t): Mithril platebody with trim.. High alch: 3,120 GP, GE limit: 8."
+description: "Mithril platebody (t) is a free-to-play trimmed body armour from medium treasure trails. High alch: 3,120 GP, GE limit: 8."
 osrs:
   id: 12287
   name: Mithril platebody (t)
@@ -12,9 +12,80 @@ osrs:
   lowalch: 2080
   highalch: 3120
   limit: 8
-  about: "Mithril platebody (t) is a free-to-play item in Old School RuneScape. High alchemy value: 3,120 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: body
+    weight: 8.618
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 46
+      slash: 44
+      crush: 38
+      magic: -6
+      ranged: 44
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_id: 1121
+      item_name: Mithril platebody
+      slug: mithril-platebody
+      relationship: variant
+      description: Standard untrimmed mithril platebody.
+    - item_id: 12283
+      item_name: Mithril platebody (g)
+      slug: mithril-platebody-g
+      relationship: variant
+      description: Gold-trimmed cosmetic variant.
+  about: "Mithril platebody (t) is a trimmed cosmetic version of the mithril platebody obtained as a medium treasure trail reward."
+  market_strategy:
+    notes:
+      - Pure cosmetic value over standard mithril platebody
+      - Limited supply from medium clue rewards
+      - Buy limit 8 restricts large flips
+  trading_tips:
+    - Compare against god-themed mithril variants for fashionscape demand
+    - Volume is thin; use limit orders
+  history:
+    - date: "2014-06-12"
+      description: "Released in the Treasure Trail Expansion update."
+    - date: "2021-04-01"
+      description: "Ranged attack bonus decreased from -10 to -15."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 8.618
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-plateskirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril plateskirt | OSRS Price Data
-description: "Mithril plateskirt: Designer leg protection.. High alch: 1,560 GP, GE limit: 125."
+description: "Mithril plateskirt: Designer leg protection. High alch: 1,560 GP, GE limit: 125."
 osrs:
   id: 1085
   name: Mithril plateskirt
@@ -12,9 +12,85 @@ osrs:
   lowalch: 1040
   highalch: 1560
   limit: 125
-  about: "Mithril plateskirt is a free-to-play item in Old School RuneScape. High alchemy value: 1,560 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: legs
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 24
+      slash: 22
+      crush: 20
+      magic: -4
+      ranged: 22
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 66
+      xp: 150
+      materials:
+        - item_name: Mithril bar
+          quantity: 3
+      tools:
+        - Hammer
+        - Anvil
+      output_item: Mithril plateskirt
+      output_quantity: 1
+  related_items:
+    - item_id: 1071
+      item_name: Mithril platelegs
+      slug: mithril-platelegs
+      relationship: variant
+      description: Male leg-slot equivalent with identical stats.
+    - item_id: 1085
+      item_name: Mithril chainbody
+      slug: mithril-chainbody
+      relationship: set-piece
+      description: Lower-tier chain body piece often paired for partial sets.
+    - item_id: 1101
+      item_name: Mithril platebody
+      slug: mithril-platebody
+      relationship: set-piece
+      description: Matching torso for the full mithril armour set.
+  about: "Mithril plateskirt is a F2P leg-slot mithril armour piece smithable at 66 Smithing and worn from 20 Defence."
+  market_strategy:
+    notes:
+      - Common F2P trainer pickup — steady alch and turnover
+      - Smithing margin usually negative; flip rather than craft
+  history:
+    - date: "2001-02-13"
+      description: Released with the launch of RuneScape, retained in OSRS at 2013 rollback.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-02-13"
+    update: "RuneScape release"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 7.257
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mole-slippers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mole-slippers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mole slippers | OSRS Price Data
-description: "Mole slippers: Cute mole slippers.. High alch: 600 GP, GE limit: 4."
+description: "Mole slippers: Cute mole slippers. High alch: 600 GP, GE limit: 4."
 osrs:
   id: 23285
   name: Mole slippers
@@ -12,9 +12,73 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Mole slippers is a free-to-play item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.2
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: beginner
+    is_reward: true
+    reward_tiers:
+      - beginner
+  related_items:
+    - item_id: 23283
+      item_name: Holy sandals
+      slug: holy-sandals
+      relationship: component
+      description: Combined with mole slippers to create holy moleys.
+    - item_id: 23287
+      item_name: Holy moleys
+      slug: holy-moleys
+      relationship: product
+      description: Result of combining mole slippers with holy sandals.
+  about: "Mole slippers are a cosmetic beginner clue reward that count as warm clothing during Wintertodt and combine with holy sandals to form holy moleys."
+  market_strategy:
+    notes:
+      - Demand is driven by warm clothing seekers and joke set collectors.
+      - Buy limit of 4 keeps individual flips small but reliable.
+  trading_tips:
+    - Pair with holy sandals when building inventory for holy moleys flips.
+    - Buy near alch value during clue droughts for long-term holds.
+  history:
+    - date: "2019-04-11"
+      description: Added to the game as a beginner clue reward.
+  properties:
+    release_date: "2019-04-11"
+    update: "Treasure Trails Expansion and Easter 2019"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-antelope-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-antelope-fur.mdx
@@ -12,9 +12,26 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 18000
-  about: "Moonlight antelope fur is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: Moonlight antelope fur is a guaranteed Hunter drop from moonlight antelopes in Varlamore and is currently used primarily as vendor stock.
+  history:
+    - date: "2024-03-20"
+      description: Released as part of Varlamore Part One.
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/morrigan-s-coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/morrigan-s-coif.mdx
@@ -1,20 +1,99 @@
 ---
 title: Morrigan's coif | OSRS Price Data
-description: "Morrigan's coif: A powerful coif.. High alch: 150,000 GP, GE limit: 10."
+description: "Morrigan's coif: A powerful coif. High alch: 150,000 GP, GE limit: 10."
 osrs:
   id: 22638
   name: Morrigan's coif
   slug: morrigan-s-coif
-  examine: A powerful coif.
+  examine: "A powerful coif."
   members: true
   icon: Morrigan's coif.png
   value: 250000
   lowalch: 100000
   highalch: 150000
   limit: 10
-  about: "Morrigan's coif is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bounty hunter armour
+    tier: high
+  equipment:
+    slot: head
+    weapon_type: none
+    weight: 0.907
+    requirements:
+      defence: 78
+      ranged: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -5
+      ranged: 13
+    defence_bonus:
+      stab: 8
+      slash: 11
+      crush: 14
+      magic: 8
+      ranged: 12
+    other_bonus:
+      strength: 0
+      ranged_strength: 4
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Bounty Hunter Store
+      location: Edgeville
+      price: 400
+      currency: Bounty Hunter points
+      quantity: 1
+  charges:
+    max_charges: 5000000
+  related_items:
+    - item_name: Morrigan's leather body
+      slug: morrigan-s-leather-body
+      relationship: set-piece
+      description: Body slot piece of Morrigan's ranged PvP set.
+    - item_name: Morrigan's leather chaps
+      slug: morrigan-s-leather-chaps
+      relationship: set-piece
+      description: Legs slot piece of Morrigan's ranged PvP set.
+    - item_name: Morrigan's throwing axe
+      slug: morrigan-s-throwing-axe
+      relationship: set-piece
+      description: Special-attack ammo paired with the Morrigan set.
+  about: "Morrigan's coif is the Bounty Hunter head slot piece of Morrigan's PvP ranged set, purchased for 400 BH points and activated with 5M coins."
+  market_strategy:
+    notes:
+      - Untradeable after activation, activation requires 5M coins.
+      - Demand limited to PvP locations that allow PvP-only gear.
+      - Full set effect grants +15% ranged special attack accuracy.
+  trading_tips:
+    - Buy only if you actively play Bounty Hunter or PvP minigames.
+    - Untradeable status makes flipping post-activation impossible.
+  history:
+    - date: "2023-04-05"
+      description: Ranged strength bonus increased from +0 to +4.
+    - date: "2023-05-24"
+      description: Released with the Bounty Hunter is Back! update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-05-24"
+    update: "Bounty Hunter is Back!"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Uncharge
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mottled-eel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mottled-eel.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Mottled eel is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 0
+  drop_table:
+    sources:
+      - source: Aerial fishing (Molch island)
+        quantity: "1"
+        rarity: Common
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 20
+      tools:
+        - Knife
+      materials:
+        - item_name: Mottled eel
+          item_id: 22832
+          quantity: 1
+      product: Fish offcuts
+      product_id: 22836
+      members_only: true
+  related_items:
+    - item_name: Cormorant's glove
+      slug: cormorants-glove
+      relationship: component
+      description: Required tool for aerial fishing
+    - item_name: Fish offcuts
+      slug: fish-offcuts
+      relationship: product
+      description: Made by cutting mottled eel with a knife
+    - item_name: Cooked mottled eel
+      slug: cooked-mottled-eel
+      relationship: product
+      description: Cooked variant used as food
+  about: "Mottled eel is an aerial fishing catch from Molch island that can be cut with a knife for stackable fish offcuts, granting 20 Cooking XP per cut."
+  market_strategy:
+    notes:
+      - Aerial fishing supply is steady so price moves track Hunter and Fishing meta demand
+      - Most volume flows through fish offcuts so check that derivative price first
+  trading_tips:
+    - Bulk buy when offcut demand spikes during boss prep periods
+    - Watch GE volume for sudden drops if aerial fishing meta cools
+  history:
+    - date: "2019-01-10"
+      update: The Kebos Lowlands
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-01-10"
+    update: The Kebos Lowlands
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mushroom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mushroom.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 15
   highalch: 22
   limit: 11000
-  about: "Mushroom is a members-only item in Old School RuneScape. High alchemy value: 22 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    level: 53
+    seed_id: 5282
+    seed_name: Mushroom spore
+    xp_per_harvest: 58
+    growth_time_minutes: 240
+  related_items:
+    - item_id: 5282
+      item_name: Mushroom spore
+      slug: mushroom-spore
+      relationship: component
+      description: Seed used at the Canifis mushroom patch
+    - item_id: 7080
+      item_name: Mushroom potato
+      slug: mushroom-potato
+      relationship: product
+      description: Cooking use
+    - item_id: 7082
+      item_name: Fried mushrooms
+      slug: fried-mushrooms
+      relationship: product
+      description: Cooking use
+  about: "Mushroom (Bittercap) is a Farming product grown at the Canifis patch from level 53. Used in fairy ring construction, supercompost, Whiteberry farmer payment, fried mushrooms, and Hard Morytania Diary tasks."
+  market_strategy:
+    notes:
+      - Steady farming supply
+      - Multi-use across Farming, Cooking, Construction
+      - High GE limit (11,000)
+  trading_tips:
+    - Bulk sourced from Canifis patch growers
+    - Sulliuscep alternative source on Fossil Island
+  history:
+    - date: "2005-07-11"
+      description: Released with the Farming update.
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-armchair-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-armchair-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Oak armchair (flatpack) | OSRS Price Data
-description: "Oak armchair (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Oak armchair (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8504
   name: Oak armchair (flatpack)
@@ -12,9 +12,61 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak armchair (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: oak
+    tier: low
+  recipes:
+    - skill: construction
+      level: 26
+      xp: 180
+      materials:
+        - item_name: Oak plank
+          quantity: 3
+      tools:
+        - Hammer
+        - Saw
+      output_item: Oak armchair (flatpack)
+      output_quantity: 1
+      notes: "Built at an Oak workbench in the Workshop of a player-owned house."
+  construction:
+    level: 26
+    xp: 180
+    notes: "Flatpack version is built at an Oak workbench (Workshop) and placed in the Parlour/Quest Hall chair hotspots."
+  related_items:
+    - item_id: 8500
+      item_name: Wooden armchair (flatpack)
+      slug: wooden-armchair-flatpack
+      relationship: downgrade
+      description: Lower-tier wooden chair flatpack.
+    - item_id: 8508
+      item_name: Teak armchair (flatpack)
+      slug: teak-armchair-flatpack
+      relationship: upgrade
+      description: Higher-tier teak chair flatpack.
+  about: "Oak armchair (flatpack) is a Construction flatpack built at an Oak workbench and placed in chair hotspots of player-owned houses."
+  market_strategy:
+    notes:
+      - Bulk-bought by Construction trainers furnishing budget POH layouts
+      - Margin vs raw oak plank cost usually negative — flip, do not craft
+  history:
+    - date: "2006-05-31"
+      description: Released alongside the Player-Owned Houses update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: "Player-Owned Houses"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/obsidian-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/obsidian-cape.mdx
@@ -12,77 +12,106 @@ osrs:
   lowalch: 24000
   highalch: 36000
   limit: 70
-  item_id: 6568
-  type: equipment
   equipment:
     slot: cape
-    type: melee_cape
-    tradeable: true
-    weight: 0.9
-    buy_limit: 70
-    requirements:
-      skills: []
-    stats:
-      defence_stab: 9
-      defence_slash: 9
-      defence_crush: 9
-      defence_magic: 9
-      defence_ranged: 9
-  obtaining:
-    drops:
-      - source: TzHaar-Ket
-        combat_level: 149/221
-        rate: 1/512
-      - source: TzHaar-Xil
-        combat_level: 133
-        rate: 1/2,048
-      - source: TzHaar-Mej
-        combat_level: 103
-        rate: 1/4,096
-    shop:
-      name: TzHaar-Hur-Tel's Equipment Store
+    weight: 1.814
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 9
+      slash: 9
+      crush: 9
+      magic: 9
+      ranged: 9
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: TzHaar-Ket (149)
+        quantity: "1"
+        rarity: 1/512
+      - source: TzHaar-Ket (221)
+        quantity: "1"
+        rarity: 1/512
+      - source: TzHaar-Xil (133)
+        quantity: "1"
+        rarity: 1/2048
+      - source: TzHaar-Mej (103)
+        quantity: "1"
+        rarity: 1/4096
+  shops:
+    - shop_name: TzHaar-Hur-Tel's Equipment Store
+      location: Mor Ul Rek
+      price: 90000
+      currency: Tokkul
+      discount_price: 78000
+      discount_requirement: Karamja gloves
+    - shop_name: TzHaar-Hur-Zal's Equipment Store
       location: Mor Ul Rek
       price: 90000
       currency: Tokkul
       discount_price: 78000
       discount_requirement: Karamja gloves
   related_items:
-    - slug: fire-cape
-      name: Fire cape
-      relation: upgrade
-    - slug: infernal-cape
-      name: Infernal cape
-      relation: best_upgrade
-    - slug: obsidian-platebody
-      name: Obsidian platebody
-      relation: set_piece
-    - slug: toktz-ket-xil
-      name: Toktz-ket-xil
-      relation: obsidian_shield
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Stab defence | +9 |
-    | Slash defence | +9 |
-    | Crush defence | +9 |
-    | Magic defence | +9 |
-    | Ranged defence | +9 |
-
-    Best For:
-    - Pre-Fire cape option
-    - No skill requirements
-    - Budget defensive cape
-
-    Upgrade Path:
-    - Fire cape - Fight Caves reward (+4 str)
-    - Infernal cape - Inferno reward (+8 str)
+    - item_id: 6570
+      item_name: Fire cape
+      slug: fire-cape
+      relationship: upgrade
+      description: Fight Caves reward with +4 strength
+    - item_id: 21295
+      item_name: Infernal cape
+      slug: infernal-cape
+      relationship: upgrade
+      description: Inferno reward with +8 strength
+    - item_id: 21301
+      item_name: Obsidian platebody
+      slug: obsidian-platebody
+      relationship: set-piece
+      description: Member of the obsidian armour set
+    - item_id: 6524
+      item_name: Toktz-ket-xil
+      slug: toktz-ket-xil
+      relationship: alternative
+      description: Obsidian shield from the same shop
+  about: "Obsidian cape is the unrequired pre-Fire cape defensive cape with +9 to every defence style, sold for 90,000 Tokkul at the TzHaar equipment shops."
   market_strategy:
     notes:
-      - Popular for F2P-style builds
-      - No requirements makes it accessible
-      - Farm TzHaar for Tokkul if patient
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Popular for F2P-style and Tokkul farming builds
+      - No skill requirements widens the buyer pool
+      - Supply driven by TzHaar drops and Tokkul exchange
+  trading_tips:
+    - Wear Karamja gloves for the 78,000 Tokkul discount
+    - Cheaper than fire cape but lacks offensive bonus
+  history:
+    - date: "2005-10-04"
+      description: Released with the TzHaar Fight Caves update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-10-04"
+    update: TzHaar Fight Caves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ochre-snelm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ochre-snelm.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Ochre snelm is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 2
+    attack_bonus:
+      magic: -3
+      ranged: -1
+    defence_bonus:
+      stab: 7
+      slash: 8
+      crush: 6
+  recipes:
+    - skill: Crafting
+      level: 15
+      xp: 32.5
+      materials:
+        - item_name: Blamish ochre shell (round)
+          quantity: 1
+      tools:
+        - Chisel
+  related_items:
+    - item_id: 3325
+      item_name: Blamish ochre shell (round)
+      slug: blamish-ochre-shell-round
+      relationship: component
+      description: Crafting material
+    - item_id: 3333
+      item_name: Ochre snelm (pointed)
+      slug: ochre-snelm-pointed
+      relationship: alternative
+      description: Pointed shell variant
+  about: "Ochre snelm is a snail shell helmet crafted from a blamish ochre shell at level 15 Crafting; reduces damage from snails by 4."
+  market_strategy:
+    notes:
+      - Crafted at 15 Crafting for 32.5 xp
+      - Reduces snail damage by 4
+      - Comparable to steel med helm
+      - GE buy limit 150
+  history:
+    - date: "2004-10-14"
+      description: Released with the Morytania expansion.
+  properties:
+    release_date: "2004-10-14"
+    update: Morytania
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onion.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onion.mdx
@@ -12,17 +12,30 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  produce:
-    type: allotment
-    tier: lowest
+  food:
+    heal_amount: 1
+    edible: true
   farming:
-    seed_id: 5319
     seed_name: Onion seed
     level: 5
     xp_plant: 9.5
     xp_harvest: 10.5
     growth_time: 40
     patches: 8
+  shops:
+    - shop_name: Grand Tree Groceries
+      location: Grand Tree
+      price: 3
+      stock: 10
+  recipes:
+    - product: Yellow dye
+      skill: Crafting
+      level: 1
+      xp: 0
+      tools: []
+      materials:
+        - item_name: Onion
+          quantity: 2
   related_items:
     - item_id: 5319
       item_name: Onion seed
@@ -39,28 +52,38 @@ osrs:
       slug: cabbage
       relationship: alternative
       description: Alternative allotment produce
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 5 |
-    | Growth time | 40 minutes |
-    | XP (plant) | 9.5 |
-    | XP (harvest) | 10.5 per onion |
-
-    - Ingredient in various cooking recipes
-    - Used in several quests
-    - Protection payment for potato seeds
+  about: "Onions are a free-to-play allotment crop grown at 5 Farming, used in cooking recipes, yellow dye, and many quests."
   market_strategy:
-    title: Ironman Notes
     notes:
-      - Low-tier crop
-      - Very low value
-      - Good for early farming training
-      - Easy to obtain
-      - Required for some quests
-      - Good early farming crop
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Low-tier crop, very low value
+      - Good early Farming training
+      - Easy to obtain via spawns or shops
+      - Required for several quests
+  trading_tips:
+    - Stock-buyable from grocery shops
+    - Field spawns at Rimmington and Hosidius
+  history:
+    - date: "2001-02-28"
+      description: Item released.
+    - date: "2005-07-11"
+      description: An 'Eat' option was added following the Farming update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-02-28"
+    update: Onion (initial release)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.15
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-dragon-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-dragon-bolts-e.mdx
@@ -14,60 +14,80 @@ osrs:
   limit: 11000
   equipment:
     slot: ammo
+    weapon_type: crossbow
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: 0
       ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      strength: 0
       ranged_strength: 122
+      magic_damage: 0
       prayer: 0
-    requirements: {}
+    requirements:
+      ranged: 1
+  special_attack:
+    description: "Life Leech: deals 20% extra damage and heals the attacker for 25% of the damage dealt. Activation chance 11% PvM / 10% PvP (12.1%/11% with hard Kandarin Diary). Does not work on undead monsters."
   recipes:
     - skill: magic
       level: 87
       xp: 97
-      inputs:
+      materials:
         - item_name: Onyx dragon bolts
           quantity: 10
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Death rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 20
+      tools: []
       output_quantity: 10
   related_items:
     - item_id: 9245
       item_name: Onyx bolts (e)
       slug: onyx-bolts-e
-      relationship: downgrade
-      description: Regular crossbow version
-  about: |-
-    > *"Enchanted Dragon crossbow bolts, tipped with onyx."*
-
-    Onyx dragon bolts (e) carry the Life Leech enchantment. On activation, the attack deals 20% extra damage and the attacker is healed for 25% of the total damage dealt. The activation chance is 11% in PvM and 10% in PvP (12.1% and 11% respectively with the hard Kandarin Diary completed). This effect does not work on undead monsters. Life Leech provides both offensive and sustain benefits, making it one of the most powerful bolt enchantments in the game.
-
-    Enchant Crossbow Bolt (Onyx) requires Magic level 87 and grants 97 XP per cast. Each cast enchants 10 bolts at a time.
-
-    | Component | Quantity |
-    |-----------|----------|
-    | Onyx dragon bolts | 10 |
-    | Cosmic rune | 1 |
-    | Death rune | 1 |
-    | Fire rune | 20 |
-
-    | Stat | Dragon (e) | Regular (e) |
-    |------|-----------|-------------|
-    | Ranged Str | +122 | +120 |
-    | Base bolt | Dragon crossbow bolt | Runite bolt |
-
-    Both variants have very similar ranged strength, but the dragon bolt base provides a slight edge.
+      relationship: alternative
+      description: Regular runite crossbow bolt version with the same Life Leech enchantment.
+  about: Onyx dragon bolts (e) carry the Life Leech enchantment and offer +122 ranged strength, making them one of the strongest enchanted bolt options for sustain-heavy PvM.
   market_strategy:
     notes:
-      - Highest tier bolt enchantment (Magic 87)
+      - Highest tier bolt enchantment (Magic 87 required)
       - Most expensive enchanted dragon bolt variant
-      - 20% extra damage + 25% healing on proc
+      - 20% extra damage plus 25% healing on proc
       - Does not work on undead monsters
       - Best for sustain-heavy PvM encounters
-      - Often used alongside dragonstone dragon bolts (e) as a switch
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Often paired with dragonstone dragon bolts (e) as a switch
+  history:
+    - date: "2018-01-04"
+      description: Released as part of the Dragon Slayer II update.
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pearl-bolt-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pearl-bolt-tips.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pearl bolt tips | OSRS Price Data
-description: "Pearl bolt tips: Pearl bolt tips.. High alch: 7 GP, GE limit: 11,000."
+description: "Pearl bolt tips: Pearl bolt tips. High alch: 7 GP, GE limit: 11,000."
 osrs:
   id: 46
   name: Pearl bolt tips
@@ -12,23 +12,85 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 11000
+  material:
+    type: pearl
+    tier: low
+  recipes:
+    - skill: Fletching
+      level: 41
+      xp: 3.2
+      tools:
+        - Chisel
+      materials:
+        - item_name: Oyster pearl
+          quantity: 1
+      product: Pearl bolt tips
+    - skill: Fletching
+      level: 41
+      xp: 3.2
+      tools:
+        - Chisel
+      materials:
+        - item_name: Oyster pearls
+          quantity: 1
+      product: Pearl bolt tips
+    - skill: Fletching
+      level: 41
+      xp: 3.2
+      tools: []
+      materials:
+        - item_name: Iron bolts
+          quantity: 10
+        - item_name: Pearl bolt tips
+          quantity: 10
+      product: Pearl bolts
   related_items:
     - item_id: 45
       item_name: Opal bolt tips
       slug: opal-bolt-tips
-      relationship: variant
-      description: Lower tier bolt tips
+      relationship: downgrade
+      description: Lower tier gem bolt tip.
     - item_id: 47
-      item_name: Barb bolttips
-      slug: barb-bolttips
-      relationship: variant
-      description: Barbed bolt tips
-  about: |-
-    > _"Pearl bolt tips."_
-
-    Pearl bolt tips are members-only Fletching supplies. Attach to iron bolts at 41 Fletching to create pearl bolts. Pearl bolts can be enchanted to create pearl bolts (e) which have a special effect against fiery creatures.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      item_name: Red topaz bolt tips
+      slug: red-topaz-bolt-tips
+      relationship: upgrade
+      description: Higher tier gem bolt tip.
+    - item_id: 880
+      item_name: Pearl bolts
+      slug: pearl-bolts
+      relationship: product
+      description: Iron bolts tipped with these pearl bolt tips.
+  about: "Pearl bolt tips are members Fletching supplies cut from oyster pearls; attached to iron bolts at 41 Fletching to create pearl bolts."
+  market_strategy:
+    notes:
+      - High daily volume; flips rely on tight margins.
+      - Profit is generally better when crafted from single oyster pearls than oyster pearls (multi).
+  trading_tips:
+    - Bulk orders fill quickly given the 11,000 GE limit.
+    - Monitor pearl bolts (e) demand to predict tip pricing.
+  history:
+    - date: "2002-09-09"
+      description: Released as part of the Sea Slug quest update.
+    - date: "2006-07-31"
+      description: Graphically updated, renamed from Pearl bolttips, value reduced from 56 to 40, appearance varies by stack size.
+    - date: "2007-01-29"
+      description: Value decreased from 40 to 12 coins.
+  properties:
+    release_date: "2002-09-09"
+    update: Sea Slug
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pink-elegant-skirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pink-elegant-skirt.mdx
@@ -15,18 +15,73 @@ osrs:
   equipment:
     slot: legs
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.1
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/18128
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
     - item_id: 12339
       item_name: Pink elegant blouse
       slug: pink-elegant-blouse
       relationship: set-piece
-      description: Matching elegant blouse
-  about: |-
-    > *"A rather elegant pink skirt."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the pink elegant clothing set (women's variant). Pairs with the pink elegant blouse.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching elegant blouse top
+  about: "Cosmetic medium Treasure Trail reward with no combat bonuses; pairs with the pink elegant blouse and is storable in a costume room treasure chest."
+  market_strategy:
+    notes:
+      - Medium clue cosmetic at 1/18,128 rarity
+      - Low daily volume (around 33); use limit orders
+      - Value tied to clue meta and fashionscape demand
+  trading_tips:
+    - Track set price alongside the blouse for flipping margin
+    - Spread widens after clue rework patches
+  history:
+    - date: "2014-06-12"
+      description: Released with the Treasure Trail Expansion update.
+    - date: "2014-12-10"
+      description: "Renamed from Pink ele' skirt to Pink elegant skirt."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-s-hook.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-s-hook.mdx
@@ -1,20 +1,99 @@
 ---
 title: Pirate's hook | OSRS Price Data
-description: "Pirate's hook: You should see the shark.... High alch: 53 GP, GE limit: 4."
+description: "Pirate's hook: You should see the shark... High alch: 53 GP, GE limit: 4."
 osrs:
   id: 2997
   name: Pirate's hook
   slug: pirate-s-hook
-  examine: You should see the shark...
+  examine: "You should see the shark..."
   members: true
   icon: Pirate's hook.png
   value: 89
   lowalch: 35
   highalch: 53
   limit: 4
-  about: "Pirate's hook is a members-only item in Old School RuneScape. High alchemy value: 53 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: unarmed
+    weight: 0.3
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 5
+      crush: 3
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Pirate Jackie the Fruit's Hideout
+      location: Brimhaven Agility Arena
+      price: 800
+      currency: Brimhaven vouchers
+  recipes:
+    - name: Crabclaw hook
+      skill: None
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Pirate's hook
+          quantity: 1
+        - item_name: Crab claw
+          quantity: 1
+        - item_name: Coins
+          quantity: 500
+      tools: []
+      notes: Patchy on Mos Le'Harmless combines the hook and claw after Cabin Fever.
+  related_items:
+    - item_id: 7551
+      item_name: Crabclaw hook
+      slug: crabclaw-hook
+      relationship: upgrade
+      description: Combined hook+claw variant from Patchy.
+    - item_id: 2995
+      item_name: Pirate bandana (red)
+      slug: pirate-bandana-red
+      relationship: alternative
+      description: Another Brimhaven Agility Arena pirate cosmetic.
+  about: Cosmetic glove-slot hook bought from Pirate Jackie the Fruit with Brimhaven vouchers; combinable with a crab claw via Patchy after Cabin Fever.
+  market_strategy:
+    notes:
+      - Voucher cost gates supply from Brimhaven Agility Arena
+      - Elite Karamja Diary reduces ticket grind time
+  trading_tips:
+    - Buy when voucher farmers offload bulk stock after diary updates
+    - Pair flips with the crabclaw hook for upgrade demand
+  history:
+    - date: "2004-07-27"
+      description: Released with the Agility, Potions and Parties! update.
+  properties:
+    release_date: "2004-07-27"
+    update: Agility, Potions and Parties!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/potato-cactus-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/potato-cactus-seed.mdx
@@ -12,9 +12,43 @@ osrs:
   lowalch: 56
   highalch: 84
   limit: 200
-  about: "Potato cactus seed is a members-only item in Old School RuneScape. High alchemy value: 84 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    level: 64
+    patch: Cactus patch
+    growth_time_minutes: 70
+    planting_xp: 68
+    checking_xp: 230
+    harvesting_xp: 68
+    payment: 8 snape grass
+  about: "Members-only farming seed planted at 64 Farming in a cactus patch; yields potato cactus used in Herblore."
+  market_strategy:
+    notes:
+      - Source via master farmer pickpocketing at 38 Thieving
+      - Seed packs from farming contracts supply steady inventory
+      - Limited buy quota of 200 caps bulk plays
+  trading_tips:
+    - Restock when GE listings dry up after seed-pack flushes
+    - Pair with snape grass to immediately farm-plant on flips
+  history:
+    - date: "2019-01-10"
+      description: Released with The Kebos Lowlands update.
+  properties:
+    release_date: "2019-01-10"
+    update: The Kebos Lowlands
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/potato-with-butter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/potato-with-butter.mdx
@@ -1,6 +1,6 @@
 ---
 title: Potato with butter | OSRS Price Data
-description: "Potato with butter: A baked potato with butter.. High alch: 4 GP, GE limit: 13,000."
+description: "Potato with butter: A baked potato with butter. High alch: 4 GP, GE limit: 13,000."
 osrs:
   id: 6703
   name: Potato with butter
@@ -12,9 +12,70 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 13000
-  about: "Potato with butter is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 14
+    edible: true
+  recipes:
+    - skill: Cooking
+      level: 39
+      xp: 40
+      materials:
+        - item_name: Baked potato
+          quantity: 1
+        - item_name: Pat of butter
+          quantity: 1
+      tools: []
+      output_item: Potato with butter
+      output_quantity: 1
+      notes: Pat of not garlic butter can substitute for pat of butter.
+  related_items:
+    - item_name: Baked potato
+      relationship: component
+      description: Required base item.
+    - item_name: Chilli potato
+      relationship: alternative
+      description: Higher-level baked potato variant.
+    - item_name: Potato with cheese
+      relationship: alternative
+      description: Cheese-topped baked potato.
+    - item_name: Egg potato
+      relationship: alternative
+      description: Egg-topped baked potato.
+    - item_name: Mushroom potato
+      relationship: alternative
+      description: Mushroom-topped baked potato.
+    - item_name: Tuna potato
+      relationship: alternative
+      description: Top-tier baked potato variant.
+  about: "Potato with butter heals 14 hitpoints in one bite and is made by combining a baked potato with a pat of butter at 39 Cooking for 40 XP."
+  market_strategy:
+    notes:
+      - Cheap mid-tier healing food useful for Cooking training
+      - Inputs (baked potato and pat of butter) typically cost more than the output
+      - Demand spike when butter floods the GE
+  history:
+    - date: "2005-10-24"
+      description: Released alongside the Mogres, Lizards, Pet Fish, Potions and Potatoes update.
+    - date: "2006-01-30"
+      description: Shop value updated from 0 to 8 coins.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-10-24"
+    update: "Mogres, Lizards, Pet Fish, Potions and Potatoes!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pyre-logs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pyre logs | OSRS Price Data
-description: "Pyre logs: Logs prepared with sacred oil for a funeral pyre.. High alch: 4 GP, GE limit: 11,000."
+description: "Pyre logs: Logs prepared with sacred oil for a funeral pyre. High alch: 4 GP, GE limit: 11,000."
 osrs:
   id: 3438
   name: Pyre logs
@@ -12,9 +12,60 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 11000
-  about: "Pyre logs is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Firemaking
+      level: 1
+      xp: 10
+      materials:
+        - item_name: Logs
+          quantity: 1
+        - item_name: Sacred oil(2)
+          quantity: 1
+      tools: []
+      output: Pyre logs
+  related_items:
+    - item_id: 3440
+      item_name: Oak pyre logs
+      slug: oak-pyre-logs
+      relationship: upgrade
+      description: Higher-tier pyre log
+    - item_id: 3442
+      item_name: Willow pyre logs
+      slug: willow-pyre-logs
+      relationship: upgrade
+      description: Willow-tier pyre log
+    - item_id: 1511
+      item_name: Logs
+      slug: logs
+      relationship: component
+      description: Base log used in the recipe
+    - item_id: 3436
+      item_name: Sacred oil(2)
+      slug: sacred-oil-2
+      relationship: component
+      description: Sacred oil applied to soak the logs
+  about: "Pyre logs are regular logs soaked in sacred oil(2), produced at Firemaking 1 for 10 xp and burned at Mort'ton funeral pyres (Firemaking 5) to cremate Loar and Phrin shade remains for 50 Firemaking xp plus Prayer xp."
+  properties:
+    release_date: "2004-10-18"
+    update: "Mortton Shades and Mage Armour"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2004-10-18"
+      description: "Released with the Mortton Shades and Mage Armour update introducing Shades of Mort'ton."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-kyatt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-kyatt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw kyatt | OSRS Price Data
-description: "Raw kyatt: I should probably cook this first.. High alch: 1 GP, GE limit: 13,000."
+description: "Raw kyatt: I should probably cook this first. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 29125
   name: Raw kyatt
@@ -12,9 +12,74 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Raw kyatt is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 0
+    edible: false
+  recipes:
+    - skill: Cooking
+      level: 51
+      xp: 143
+      materials:
+        - item_name: Raw kyatt
+          quantity: 1
+      tools:
+        - Fire or range
+      output_item: Cooked kyatt
+      output_quantity: 1
+      notes: "Requires 25 Hunters' Rumours completion. Burns into Burnt large beast on failure."
+  drop_table:
+    sources:
+      - source: Sabre-toothed kyatt
+        quantity: "1"
+        rarity: Always
+      - source: Hunters' loot sack (basic)
+        quantity: "1"
+        rarity: Common
+      - source: Hunters' loot sack (adept)
+        quantity: "1"
+        rarity: Common
+      - source: Hunters' loot sack (expert)
+        quantity: "1"
+        rarity: Common
+      - source: Hunters' loot sack (master)
+        quantity: "1"
+        rarity: Common
+      - source: Hunters' loot sack (supplies)
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - item_name: Cooked kyatt
+      relationship: product
+      description: Cooked version produced at 51 Cooking.
+    - item_name: Burnt large beast
+      relationship: alternative
+      description: Failure product when cooking raw kyatt.
+  about: "Raw kyatt is hunted from sabre-toothed kyatts in Varlamore and cooked at level 51 Cooking for 143 XP. Used as a herblore ingredient and to recharge quetzal whistle charges via Soar Leader Pitri."
+  market_strategy:
+    notes:
+      - Steady supply from Hunter training in Varlamore
+      - Ingredient for six Herblore potion mixes
+      - Used as currency for quetzal whistle charges
+  history:
+    - date: "2024-03-20"
+      description: Released with the Varlamore Part One update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-slimy-eel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-slimy-eel.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw slimy eel | OSRS Price Data
-description: "Raw slimy eel: A slime covered eel - yuck!. High alch: 1 GP, GE limit: 13,000."
+description: "Raw slimy eel: A slime covered eel - yuck! High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 3379
   name: Raw slimy eel
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Raw slimy eel is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Cooking
+      level: 28
+      xp: 95
+      materials:
+        - item_name: Raw slimy eel
+          quantity: 1
+      tools:
+        - Fire or range
+      output_item: Slimy eel
+      output_quantity: 1
+      notes: Burns into Burnt eel on failure.
+    - skill: Fishing
+      level: 28
+      xp: 80
+      materials:
+        - item_name: Fishing bait
+          quantity: 1
+      tools:
+        - Fishing rod
+      output_item: Raw slimy eel
+      output_quantity: 1
+      notes: 80 XP from swamp caves/dungeons, 65 XP in Mort Myre Swamp.
+  related_items:
+    - item_name: Slimy eel
+      relationship: product
+      description: Cooked version at 28 Cooking.
+    - item_name: Burnt eel
+      relationship: alternative
+      description: Failure product when cooking.
+  about: "Raw slimy eel is fished at 28 Fishing from Mort Myre Swamp, Dorgesh-Kaan, the Lumbridge Swamp Caves, or the Ruins of Camdozaal, and cooked at 28 Cooking for 95 XP."
+  market_strategy:
+    notes:
+      - Steady supply from Mort Myre and Lumbridge Swamp Caves fishers
+      - Low alch value caps downside; flipping depends on cook spread
+      - Buy limit of 13,000 supports bulk arbitrage
+  history:
+    - date: "2004-10-14"
+      description: Released as part of the Morytania expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-14"
+    update: Morytania expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-yellowfin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-yellowfin.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw yellowfin | OSRS Price Data
-description: "Raw yellowfin: I should try cooking this.. High alch: 102 GP, GE limit: 15,000."
+description: "Raw yellowfin: I should try cooking this. High alch: 102 GP, GE limit: 15,000."
 osrs:
   id: 32325
   name: Raw yellowfin
@@ -12,9 +12,59 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 15000
-  about: "Raw yellowfin is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 15,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    raw: true
+    cook_level: 79
+    cook_xp: 200
+    cooked_item: Yellowfin
+    burnt_item: Burnt yellowfin
+  recipes:
+    - skill: Cooking
+      level: 79
+      xp: 200
+      materials:
+        - item_name: Raw yellowfin
+          quantity: 1
+      tools:
+        - Range
+      output: Yellowfin
+  related_items:
+    - item_name: Yellowfin
+      slug: yellowfin
+      relationship: product
+      description: Cooked form (Cooking 79, 200 xp)
+    - item_name: Yellow fin
+      slug: yellow-fin
+      relationship: product
+      description: Herblore secondary obtained by cutting the raw fish with a knife
+    - item_name: Burnt yellowfin
+      slug: burnt-yellowfin
+      relationship: variant
+      description: Failure result when cooking
+  about: "Raw yellowfin is a Sailing-era fish caught at Fishing 79 from yellowfin, shimmering, and glistening shoals; cooked at Cooking 79 for 200 xp or sliced with a knife into the Herblore secondary Yellow fin."
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.7
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing skill launch."
+    - date: "2026-05-13"
+      description: "Inventory sprite graphically updated for enhanced vibrancy."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-boots.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Red boots is a free-to-play item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.34
+    defence_bonus:
+      slash: 1
+      crush: 1
+  shops:
+    - shop_name: Barkers' Haberdashery
+      location: Canifis
+      price: 650
+      stock: 5
+  related_items:
+    - item_id: 2900
+      item_name: Grey boots
+      slug: grey-boots
+      relationship: alternative
+      description: Grey variant
+    - item_id: 2906
+      item_name: Yellow boots
+      slug: yellow-boots
+      relationship: alternative
+      description: Yellow variant
+    - item_id: 2908
+      item_name: Teal boots
+      slug: teal-boots
+      relationship: alternative
+      description: Teal variant
+    - item_id: 2910
+      item_name: Purple boots
+      slug: purple-boots
+      relationship: alternative
+      description: Purple variant
+  about: "Red boots are cosmetic feet slot footwear sold by Barkers' Haberdashery in Canifis with stats matching leather boots."
+  market_strategy:
+    notes:
+      - Sold at 650 coins in Canifis
+      - Cosmetic; matches leather boots stats
+      - GE buy limit 150
+  history:
+    - date: "2004-06-29"
+      description: Released with the Priest in Peril quest update.
+    - date: "2023-03-22"
+      description: Converted from members-only to free-to-play.
+  properties:
+    release_date: "2004-06-29"
+    update: Priest in Peril
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-firelighter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-firelighter.mdx
@@ -1,6 +1,6 @@
 ---
 title: Red firelighter | OSRS Price Data
-description: "Red firelighter: Makes firelighting a lot easier.. High alch: 9 GP, GE limit: 250."
+description: "Red firelighter: Makes firelighting a lot easier. High alch: 9 GP, GE limit: 250."
 osrs:
   id: 7329
   name: Red firelighter
@@ -12,9 +12,70 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 250
-  about: "Red firelighter is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/161.5
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/130
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/100
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/85
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+  related_items:
+    - item_id: 7330
+      item_name: Green firelighter
+      slug: green-firelighter
+      relationship: variant
+      description: Green coloured firelighter variant.
+    - item_id: 7331
+      item_name: Blue firelighter
+      slug: blue-firelighter
+      relationship: variant
+      description: Blue coloured firelighter variant.
+  about: "Red firelighter is a members-only stackable item used with logs to create red-coloured campfires; obtained from Treasure Trails reward caskets."
+  market_strategy:
+    notes:
+      - Demand peaks during holiday events and recolour-related quests.
+      - GE limit increased from 150 to 250 on 29 January 2020.
+  trading_tips:
+    - Stack pricing closely with Green and Blue variants.
+    - Bulk buyers usually flip in lots of 250 due to GE limit.
+  history:
+    - date: "2006-02-20"
+      description: Released alongside the Updates, updates and more updates patch.
+    - date: "2020-01-29"
+      description: GE buy limit increased from 150 to 250; 250 firelighters could revert a recoloured Phoenix pet.
+    - date: "2024-10-23"
+      description: Red firelighters no longer required to revert a Phoenix pet to default red colouring.
+  properties:
+    release_date: "2006-02-20"
+    update: "Updates, updates and more updates..."
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "N/A"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-halloween-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-halloween-mask.mdx
@@ -1,20 +1,85 @@
 ---
 title: Red halloween mask | OSRS Price Data
-description: "Red halloween mask: Aaaarrrghhh ... I'm a monster.. High alch: 9 GP, GE limit: 5."
+description: "Red halloween mask: Aaaarrrghhh ... I'm a monster. High alch: 9 GP, GE limit: 5."
 osrs:
   id: 1057
   name: Red halloween mask
   slug: red-halloween-mask
-  examine: Aaaarrrghhh ... I'm a monster.
+  examine: "Aaaarrrghhh ... I'm a monster."
   members: false
   icon: Red halloween mask.png
   value: 15
   lowalch: 6
   highalch: 9
   limit: 5
-  about: "Red halloween mask is a free-to-play item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weapon_type: none
+    weight: 0.34
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 1053
+      item_name: Green halloween mask
+      slug: green-halloween-mask
+      relationship: variant
+      description: Green coloured halloween mask variant.
+    - item_id: 1055
+      item_name: Blue halloween mask
+      slug: blue-halloween-mask
+      relationship: variant
+      description: Blue coloured halloween mask variant.
+  about: "Red halloween mask is a cosmetic rare originally distributed during the 2002 Halloween event and the 2013 Rare Drops event; one of three halloween mask colours."
+  market_strategy:
+    notes:
+      - Strict GE buy limit of 5 keeps supply thin.
+      - Long-term holder asset; pricing tied to player base growth.
+  trading_tips:
+    - Watch all three colours together; spreads narrow during seasonal hype.
+    - Avoid impulsive flips; thin supply means wide spreads.
+  history:
+    - date: "2002-10-31"
+      description: Released during the 2002 Halloween holiday event.
+    - date: "2005-05-17"
+      description: Renamed from Halloween mask to Red h'ween mask; examine text capitalisation corrected.
+    - date: "2013-06-17"
+      description: Redistributed during the 2013 Rare Drops event through 24 June 2013.
+    - date: "2015-02-26"
+      description: Renamed from Red h'ween mask to Red halloween mask.
+  properties:
+    release_date: "2002-10-31"
+    update: 2002 Hallowe'en event
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-topaz.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-topaz.mdx
@@ -1,6 +1,6 @@
 ---
 title: Red topaz | OSRS Price Data
-description: "Red topaz: A semi precious stone.. High alch: 120 GP, GE limit: 11,000."
+description: "Red topaz: A semi precious stone. High alch: 120 GP, GE limit: 11,000."
 osrs:
   id: 1613
   name: Red topaz
@@ -12,9 +12,72 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 11000
-  about: "Red topaz is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: gem
+    tier: mid
+  recipes:
+    - skill: Crafting
+      level: 16
+      xp: 25
+      tools:
+        - Chisel
+      materials:
+        - item_name: Uncut red topaz
+          quantity: 1
+      product: Red topaz
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      cost: 200
+      currency: Trading sticks
+  related_items:
+    - item_id: 1629
+      item_name: Uncut red topaz
+      slug: uncut-red-topaz
+      relationship: component
+      description: Uncut form cut with a chisel into a red topaz.
+    - item_id: 1611
+      item_name: Jade
+      slug: jade
+      relationship: downgrade
+      description: Lower tier semi-precious gem.
+    - item_id: 1615
+      item_name: Dragonstone
+      slug: dragonstone
+      relationship: upgrade
+      description: Higher tier gem.
+    - item_id: 47
+      item_name: Red topaz bolt tips
+      slug: red-topaz-bolt-tips
+      relationship: product
+      description: Bolt tips cut from red topaz with a chisel.
+  about: "Red topaz is a members semi-precious gem cut from uncut red topaz at 16 Crafting; primarily used to fletch red topaz bolt tips and machetes."
+  market_strategy:
+    notes:
+      - High daily volume keeps flips fast.
+      - Pricing closely tracks oyster pearl and bolt tip demand.
+  trading_tips:
+    - Convert to red topaz bolt tips when the bolt tip margin is favourable.
+    - Stockpile during Shilo Village quest pushes when supply increases.
+  history:
+    - date: "2003-01-27"
+      description: Released alongside the Shilo Village quest going online.
+  properties:
+    release_date: "2003-01-27"
+    update: Shilo Village
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.002
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-legs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rock-shell legs | OSRS Price Data
-description: "Rock-shell legs is a members legs slot item requiring 40 Defence. High alch: 38,400 GP, GE limit: 70."
+description: "Rock-shell legs is a members legs slot armour requiring 40 Defence and The Fremennik Trials. High alch: 38,400 GP, GE limit: 70."
 osrs:
   id: 6130
   name: Rock-shell legs
@@ -14,6 +14,9 @@ osrs:
   limit: 70
   equipment:
     slot: legs
+    weight: 9.071
+    requirements:
+      defence: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,60 +34,66 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 40
-    weight: 9.071
   drop_table:
     sources:
       - source: Dagannoth Rex
-        combat_level: 303
         quantity: "1"
         rarity: uncommon
-        drop_rate: 1/128
-        members_only: true
+  shops:
+    - shop_name: Skulgrimen's Battle Gear
+      location: Rellekka
+      stock: 0
+      price: 7500
+      currency: coins
+      notes: "Crafted on demand for 7,500 coins using 2 Dagannoth hides and 1 Rock-shell chunk."
   related_items:
     - item_id: 6128
       item_name: Rock-shell helm
       slug: rock-shell-helm
       relationship: set-piece
-      description: Matching helm piece
+      description: Matching helm of the rock-shell set.
     - item_id: 6129
       item_name: Rock-shell plate
       slug: rock-shell-plate
       relationship: set-piece
-      description: Matching body piece
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +51 |
-    | Slash | +49 |
-    | Crush | +47 |
-    | Ranged | +49 |
-    | Magic | -4 |
-
-    Requirements: 40 Defence | Weight: 9.1 kg
-
-    | Stat | Rock-shell Legs | Rune Platelegs |
-    |------|----------------|----------------|
-    | Stab Def | +51 | +51 |
-    | Slash Def | +49 | +49 |
-    | Crush Def | +47 | +47 |
-    | Ranged Def | +49 | +45 |
-    | Magic | -4 | -21 |
-
-    Identical melee defence to rune platelegs with +4 more ranged defence and significantly less magic penalty (-4 vs -21). Like the rock-shell plate, this is slightly superior to its rune counterpart.
-
-    Rex (melee DK) drops the legs at 1/128. Players farming all three DKs will accumulate these passively alongside other rock-shell and skeletal pieces.
-
-    Storable in a Costume Room armour case as part of the complete rock-shell set.
+      description: Matching body of the rock-shell set.
+    - item_id: 1079
+      item_name: Rune platelegs
+      slug: rune-platelegs
+      relationship: alternative
+      description: Comparable melee tier with weaker ranged defence.
+  about: "Rock-shell legs offer identical melee defence to rune platelegs with +4 more ranged defence and a far smaller magic penalty."
   market_strategy:
     notes:
-      - GE price near high alch value
-      - Dagannoth Rex drop (passive from DK farming)
-      - Slight upgrade over rune platelegs for ranged defence
-      - Moderate trade volume
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - GE price hovers near high-alch value
+      - Passive supply from Dagannoth Kings runs
+      - Strong ranged-defence niche vs rune platelegs
+  trading_tips:
+    - Monitor Dagannoth Rex weekly drop rates for supply spikes
+    - Buy full rock-shell sets when discounted vs piece prices
+  history:
+    - date: "2005-08-01"
+      description: "Released with the Waterbirth Island / Dagannoth Kings update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-01"
+    update: "Waterbirth Island"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: "The Fremennik Trials"
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-brutal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-brutal.mdx
@@ -1,20 +1,89 @@
 ---
 title: Rune brutal | OSRS Price Data
-description: "Rune brutal: Blunt rune arrow... ouch.. High alch: 270 GP, GE limit: 11,000."
+description: "Rune brutal: Blunt rune arrow... ouch. High alch: 270 GP, GE limit: 11,000."
 osrs:
   id: 4803
   name: Rune brutal
   slug: rune-brutal
-  examine: Blunt rune arrow... ouch.
+  examine: "Blunt rune arrow... ouch."
   members: true
   icon: Rune brutal 5.png
   value: 450
   lowalch: 180
   highalch: 270
   limit: 11000
-  about: "Rune brutal is a members-only item in Old School RuneScape. High alchemy value: 270 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: arrow
+    weight: 0
+    other_bonus:
+      ranged_strength: 60
+  recipes:
+    - skill: fletching
+      level: 77
+      xp: 12.5
+      materials:
+        - item_name: Flighted ogre arrow
+          quantity: 1
+        - item_name: Rune nails
+          quantity: 1
+      tools:
+        - Chisel
+      product: Rune brutal
+      product_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 4773
+      item_name: Bronze brutal
+      slug: bronze-brutal
+      relationship: variant
+      description: Lowest tier brutal arrow.
+    - item_id: 4783
+      item_name: Iron brutal
+      slug: iron-brutal
+      relationship: variant
+      description: Tier 2 brutal arrow.
+    - item_id: 4793
+      item_name: Steel brutal
+      slug: steel-brutal
+      relationship: variant
+      description: Tier 3 brutal arrow.
+    - item_id: 10033
+      item_name: Comp ogre bow
+      slug: comp-ogre-bow
+      relationship: component
+      description: Required to wield brutal arrows.
+  about: "Rune brutal is the highest-tier brutal arrow, fletched at 77 Fletching from flighted ogre arrows and rune nails for use with the composite ogre bow against zogres, skogres, and chompy birds."
+  market_strategy:
+    notes:
+      - Niche demand from Zogre Flesh Eaters-related content and chompy hunting.
+      - Best ranged strength among brutal arrows (+60).
+      - Requires partial completion of Zogre Flesh Eaters to fletch or wield.
+  trading_tips:
+    - Track rune nail and flighted ogre arrow GE prices for fletching margin.
+    - Demand is event/diary-driven; avoid long holds outside of clue/diary cycles.
+  history:
+    - date: "2005-05-17"
+      description: "Released as part of the Zogre Flesh Eaters update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-17"
+    update: Zogre Flesh Eaters
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-spear.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 8320
   highalch: 12480
   limit: 70
-  about: "Rune spear is a members-only item in Old School RuneScape. High alchemy value: 12,480 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    attack_bonus:
+      stab: 36
+      slash: 36
+      crush: 36
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 42
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      attack: 40
+  drop_table:
+    sources:
+      - source: Mithril dragon
+        quantity: "1"
+        rarity: rare
+      - source: Brutal black dragon
+        quantity: "1"
+        rarity: rare
+      - source: Brutal red dragon
+        quantity: "1"
+        rarity: rare
+      - source: Basilisk knight
+        quantity: "1"
+        rarity: rare
+      - source: Rare drop table
+        quantity: "1"
+        rarity: rare
+  about: Rune spear is a two-handed runite spear with equal stab, slash, and crush attack bonuses, popular for training melee against creatures weak to a specific style.
+  history:
+    - date: "2021-04-21"
+      description: Attack speed increased from 5 ticks to 4 ticks.
+    - date: "2003-04-14"
+      description: Released with the New Throwing Weapons update.
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sacred-oil-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sacred-oil-2.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 30
   highalch: 45
   limit: 2000
-  about: "Sacred oil(2) is a members-only item in Old School RuneScape. High alchemy value: 45 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: Used on regular logs to create pyre logs for cremating shade remains
+      - description: Grants 5 Firemaking experience per dose consumed when creating pyre logs
+  related_items:
+    - item_name: Sacred oil(1)
+      slug: sacred-oil-1
+      relationship: variant
+      description: 1-dose variant
+    - item_name: Sacred oil(3)
+      slug: sacred-oil-3
+      relationship: variant
+      description: 3-dose variant
+    - item_name: Sacred oil(4)
+      slug: sacred-oil-4
+      relationship: variant
+      description: 4-dose variant
+    - item_name: Olive oil(4)
+      slug: olive-oil-4
+      relationship: component
+      description: Refined into sacred oil at the Flamtaer fire altar
+    - item_name: Pyre logs
+      slug: pyre-logs
+      relationship: product
+      description: Created by applying sacred oil to regular logs
+  about: "Sacred oil(2) is a two-dose vial used in the Shades of Mort'ton minigame to create pyre logs for cremating shade remains."
+  market_strategy:
+    notes:
+      - Demand tracks Shades of Mort'ton activity and pyre log production
+      - Compare price per dose across (1)/(2)/(3)/(4) variants to pick the cheapest dose source
+  trading_tips:
+    - Check the per-dose ratio against sacred oil(4) before bulk buying
+    - Daily volume is moderate; large orders need patience
+  history:
+    - date: "2004-10-18"
+      update: Shades of Mort'ton
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-18"
+    update: Shades of Mort'ton
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/scrambled-egg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/scrambled-egg.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 13000
-  about: "Scrambled egg is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 5
+  recipes:
+    - skill: cooking
+      level: 13
+      xp: 50
+      tools:
+        - Bowl
+        - Range
+      materials:
+        - item_name: Egg
+          item_id: 1944
+          quantity: 1
+        - item_name: Bowl
+          item_id: 1923
+          quantity: 1
+      product: Scrambled egg
+      product_id: 7078
+      members_only: true
+      burn_stop_level: 48
+  related_items:
+    - item_name: Egg
+      slug: egg
+      relationship: component
+      description: Cooking ingredient
+    - item_name: Bowl
+      slug: bowl
+      relationship: component
+      description: Required container
+    - item_name: Egg and tomato
+      slug: egg-and-tomato
+      relationship: product
+      description: Combine with tomato at Cooking 23 for a potato topping
+  about: "Scrambled egg is a members-only Cooking food that heals 5 Hitpoints and is made by cooking an egg in a bowl on a range at level 13 Cooking."
+  market_strategy:
+    notes:
+      - Low heal-per-coin compared with mainstream food so demand is niche
+      - Small per-cook XP profit versus raw eggs can flip in either direction
+  trading_tips:
+    - Watch the spread vs Egg price; thin GE volume makes flipping slow
+    - Stops burning at 48 Cooking so XP is reliable for low-level cooks
+  history:
+    - date: "2006-01-30"
+      update: Runesquares, Harpie Bugs and new potato recipes!
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-01-30"
+    update: Runesquares, Harpie Bugs and new potato recipes!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-relic-hunter-t1-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-relic-hunter-t1-armour-set.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: null
-  about: "Shattered relic hunter (t1) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: armour set
+    tier: high
+  related_items:
+    - item_name: Shattered hood (t1)
+      slug: shattered-hood-t1
+      relationship: set-piece
+      description: Head slot component of the set.
+    - item_name: Shattered top (t1)
+      slug: shattered-top-t1
+      relationship: set-piece
+      description: Body slot component of the set.
+    - item_name: Shattered trousers (t1)
+      slug: shattered-trousers-t1
+      relationship: set-piece
+      description: Legs slot component of the set.
+    - item_name: Shattered boots (t1)
+      slug: shattered-boots-t1
+      relationship: set-piece
+      description: Feet slot component of the set.
+  about: "Shattered relic hunter (t1) armour set bundles the four T1 Shattered Relics League cosmetic pieces for convenient Grand Exchange trading."
+  market_strategy:
+    notes:
+      - Convenience bundle for the four T1 Shattered pieces.
+      - Compare set price vs sum of individual pieces before exchanging.
+      - Daily volume is very thin, expect slow fills.
+  trading_tips:
+    - Buy the set when it trades below the sum of its components.
+    - Sell as components when the parts trade richer than the bundle.
+  history:
+    - date: "2022-01-19"
+      description: Item added to game with the Shattered Relics League conclusion rewards.
+    - date: "2022-03-16"
+      description: Became obtainable via the Grand Exchange alongside the PvP Arena rewards beta.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-03-16"
+    update: "PvP Arena: Rewards Beta"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shorts-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shorts-blue.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 156
   highalch: 234
   limit: 150
-  about: "Shorts (blue) is a members-only item in Old School RuneScape. High alchemy value: 234 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 0.1
+  shops:
+    - shop_name: Agmundi Quality Clothes
+      location: Keldagrim
+      price: 507
+      stock: 3
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania
+      price: 390
+      stock: 3
+  related_items:
+    - item_id: 5048
+      item_name: Shorts (red)
+      slug: shorts-red
+      relationship: alternative
+      description: Red variant
+    - item_id: 5044
+      item_name: Shorts (white)
+      slug: shorts-white
+      relationship: alternative
+      description: White variant
+  about: "Shorts (blue) are dwarven-style cosmetic leg slot apparel sold in Keldagrim and Miscellania with no combat bonuses."
+  market_strategy:
+    notes:
+      - Stocked in Keldagrim and Miscellania
+      - 21-second restocks
+      - GE buy limit 150
+      - Cosmetic only
+  history:
+    - date: "2005-05-31"
+      description: Released with the Keldagrim - The Dwarven City update.
+  properties:
+    release_date: "2005-05-31"
+    update: Keldagrim - The Dwarven City
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-bloodhound.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-bloodhound.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of the bloodhound is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Most monsters (Deadman Mode events)
+        quantity: "1"
+        rarity: Rare
+  treasure_trail:
+    tier: master
+    is_reward: false
+  related_items:
+    - item_name: Reward casket (master)
+      slug: reward-casket-master
+      relationship: product
+      description: 75% chance to be returned when completing a clue step while sigil is attuned
+  about: "Sigil of the bloodhound is a tier 2 utility sigil exclusive to Deadman Mode events that grants a 75% chance for any-tier clue rewards to return the casket on completion."
+  market_strategy:
+    notes:
+      - Only available during Deadman Mode events so price discovery only matters in-season
+      - Un-attuned version is tradeable on the Grand Exchange; attuned version is character-bound
+  trading_tips:
+    - Buy un-attuned during the event window; resale outside Deadman is impossible
+    - Confirm event payout values before bidding against the 1 coin base value
+  history:
+    - date: "2023-08-23"
+      update: Deadman Apocalypse - Friday 25th August
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-08-23"
+    update: Deadman Apocalypse - Friday 25th August
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: Destroy
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-ruthless-ranger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-ruthless-ranger.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of the ruthless ranger | OSRS Price Data
-description: "Sigil of the ruthless ranger: A power enhancing sigil not yet attuned to you.. High alch: 12,000 GP, GE limit: 8."
+description: "Sigil of the ruthless ranger is a Deadman Mode power-enhancing sigil. High alch: 12,000 GP, GE limit: 8."
 osrs:
   id: 26072
   name: Sigil of the ruthless ranger
@@ -12,9 +12,44 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of the ruthless ranger is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - item_id: 26071
+      item_name: Sigil of the ruthless ranger (attuned)
+      slug: sigil-of-the-ruthless-ranger-attuned
+      relationship: variant
+      description: Attuned, character-bound version of the sigil.
+  about: "Sigil of the ruthless ranger is a Deadman Mode sigil that gives ranged attacks a 15% chance to cripple target movement."
+  market_strategy:
+    notes:
+      - Only tradeable during specific Deadman events
+      - GE limit 8 keeps liquidity thin
+      - Demand spikes during Deadman seasons
+  trading_tips:
+    - Track Deadman tournament announcements before flipping
+    - Attuning permanently binds the sigil so resale ends
+  history:
+    - date: "2021-08-25"
+      description: "Released as part of Deadman: Reborn."
+    - date: "2023-08-16"
+      description: "Returned as a Deadman: Apocalypse skull shop reward."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+    worn_options: []
+    alchable: false
+    destroy: "You can reclaim this from a reward chest during Deadman events."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bolts-p-9299.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bolts-p-9299.mdx
@@ -12,9 +12,94 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 11000
-  about: "Silver bolts (p+) is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: silver
+    tier: low
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    attack_speed: 1
+    weight: 0
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 36
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - product: Silver bolts (p+)
+      skill: Fletching
+      level: 73
+      xp: 0
+      tools: []
+      materials:
+        - item_name: Silver bolts
+          quantity: 10
+        - item_name: Weapon poison(+)
+          quantity: 1
+  related_items:
+    - item_id: 9286
+      item_name: Silver bolts
+      slug: silver-bolts
+      relationship: variant
+      description: Unpoisoned base bolt
+    - item_id: 9298
+      item_name: Silver bolts (p)
+      slug: silver-bolts-p
+      relationship: variant
+      description: Weaker poison variant
+    - item_id: 9300
+      item_name: Silver bolts (p++)
+      slug: silver-bolts-pp
+      relationship: upgrade
+      description: Strongest poison variant
+  about: "Silver bolts (p+) are silver crossbow bolts coated in weapon poison(+) that deal extra damage to undead and apply poison on hit."
+  market_strategy:
+    notes:
+      - Niche use against undead and Slayer tasks
+      - Margins track weapon poison(+) supply
+      - Volume is small versus mainstream bolt types
+  trading_tips:
+    - Apply weapon poison(+) at 73 Fletching for free
+    - Decant variants between (p), (p+), and (p++) for arbitrage
+  history:
+    - date: "2006-07-31"
+      description: Released with the Crossbows update.
+    - date: "2007-01-01"
+      description: Unpoisoned bolt values lowered from 30 to 5 coins while poisoned variants rose from 1 to 5 coins.
+    - date: "2018-01-01"
+      description: Naming standardised with proper spacing for (p+) and (p++) variants.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Skeletal boots | OSRS Price Data
-description: "Skeletal boots: Some finely crafted Fremennik boots, made from the bones of a wallasalki.. High alch: 390 GP, GE limit: 125."
+description: "Skeletal boots: Some finely crafted Fremennik boots, made from the bones of a wallasalki. High alch: 390 GP, GE limit: 125."
 osrs:
   id: 6147
   name: Skeletal boots
@@ -12,9 +12,81 @@ osrs:
   lowalch: 260
   highalch: 390
   limit: 125
-  about: "Skeletal boots is a members-only item in Old School RuneScape. High alchemy value: 390 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bone
+    tier: mid
+  equipment:
+    slot: feet
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Wallasalki
+        quantity: "1"
+        rarity: 2/128
+  related_items:
+    - item_id: 6145
+      item_name: Skeletal helm
+      slug: skeletal-helm
+      relationship: set-piece
+      description: Helmet of the skeletal Fremennik set.
+    - item_id: 6143
+      item_name: Skeletal top
+      slug: skeletal-top
+      relationship: set-piece
+      description: Body piece of the skeletal Fremennik set.
+    - item_id: 6141
+      item_name: Skeletal bottoms
+      slug: skeletal-bottoms
+      relationship: set-piece
+      description: Legs of the skeletal Fremennik set.
+    - item_id: 6149
+      item_name: Skeletal gloves
+      slug: skeletal-gloves
+      relationship: set-piece
+      description: Gloves of the skeletal Fremennik set.
+  about: "Skeletal boots are a Fremennik foot slot drop from wallasalkis on Waterbirth Island, part of the skeletal armour set with mage-friendly footwear bonuses."
+  market_strategy:
+    notes:
+      - Tight 125 buy limit creates persistent supply scarcity
+      - Demand spikes whenever mage-friendly set cosmetics trend
+  history:
+    - date: "2005-08-01"
+      description: Released alongside the Waterbirth Island update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-01"
+    update: "Waterbirth Island"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/slayer-s-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/slayer-s-staff.mdx
@@ -14,8 +14,12 @@ osrs:
   limit: 70
   equipment:
     slot: weapon
-    type: staff
-    attack_speed: 5
+    weapon_type: staff
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      magic: 50
+      slayer: 55
     attack_bonus:
       stab: 7
       slash: -1
@@ -33,15 +37,9 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      magic: 50
-      slayer: 55
-  properties:
-    tradeable: true
-    tradeable_ge: true
-    weight: 1.814
-  shop_source:
-    - name: Slayer Masters
+  shops:
+    - shop_name: Slayer Equipment
+      location: Slayer Masters
       cost: 21000
       currency: coins
   related_items:
@@ -49,39 +47,47 @@ osrs:
       item_name: Slayer's staff (e)
       slug: slayers-staff-e
       relationship: upgrade
-      description: Enchanted version with +15% magic damage
+      description: Enchanted variant with +15% magic damage on Slayer tasks.
     - item_id: 21257
       item_name: Slayer's enchantment
       slug: slayers-enchantment
       relationship: component
-      description: Upgrade material
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Stab | +7 |
-    | Slash | -1 |
-    | Crush | +25 |
-    | Magic | +12 |
-    | Strength | +35 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Stab | +2 |
-    | Slash | +3 |
-    | Crush | +1 |
-    | Magic | +10 |
-
-    Autocasts: Magic Dart, Crumble Undead, Arceuus spells, Wave and Surge spells.
-
-    Required for Magic Dart against turoth and kurask.
-
-    | Item | Requirements |
-    |------|--------------|
-    | Slayer's staff (e) | 75 Magic, Slayer's enchantment |
-
-    Enchanted version has 2,500 charges, +15% magic damage.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Used to enchant the staff into Slayer's staff (e).
+    - item_id: 4166
+      item_name: Mystic smoke staff
+      slug: mystic-smoke-staff
+      relationship: alternative
+      description: Alternative one-handed magic staff with melee bonuses.
+  about: "Slayer's staff is a members magic staff sold by Slayer Masters; it is the only weapon that can autocast Magic Dart against Turoth and Kurask."
+  market_strategy:
+    notes:
+      - Shop price 21,000 coins anchors a floor for arbitrage from Slayer Masters.
+      - Demand tracks Slayer task popularity and Magic Dart use.
+  trading_tips:
+    - Buy from Slayer Masters at 21,000 coins and resell on GE when margin opens.
+    - Consider upgrading to Slayer's staff (e) for personal Slayer use rather than reselling.
+  history:
+    - date: "2005-01-26"
+      description: Released as part of the Slayer skill update.
+  properties:
+    release_date: "2005-01-26"
+    update: Slayer skill released
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snakeskin-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snakeskin-vambraces.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 173
   highalch: 260
   limit: 125
-  about: "Snakeskin vambraces is a members-only item in Old School RuneScape. High alchemy value: 260 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: snakeskin
+    tier: mid
+  equipment:
+    slot: hands
+    weapon_type: none
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -5
+      ranged: 6
+    defence_bonus:
+      stab: 2
+      slash: 2
+      crush: 2
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      ranged: 30
+      defence: 30
+  recipes:
+    - skill: crafting
+      level: 47
+      xp: 35
+      materials:
+        - item_name: Snakeskin
+          quantity: 8
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+  about: Snakeskin vambraces are mid-tier ranged hand armour crafted from snakeskins, providing a small ranged attack bonus and modest melee defence.
+  history:
+    - date: "2014-12-10"
+      description: Item renamed from Snakeskin v'brace to Snakeskin vambraces.
+    - date: "2005-08-09"
+      description: Released as part of Tai Bwo Wannai Clean-Up.
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snapdragon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snapdragon.mdx
@@ -12,12 +12,12 @@ osrs:
   lowalch: 23
   highalch: 35
   limit: 11000
-  herb:
-    type: clean
+  material:
+    type: herb
     tier: high
   farming:
-    level: 67
-    xp: 141
+    level: 62
+    xp: 98.5
     growth_time: 80
     seed_id: 5300
     seed_name: Snapdragon seed
@@ -30,6 +30,8 @@ osrs:
     - skill: herblore
       level: 63
       xp: 142.5
+      tools:
+        - Pestle and mortar
       materials:
         - item_name: Snapdragon
           item_id: 3000
@@ -41,53 +43,59 @@ osrs:
       product_id: 3026
       members_only: true
   related_items:
-    - item_id: 3051
-      item_name: Grimy snapdragon
+    - item_name: Grimy snapdragon
       slug: grimy-snapdragon
-      relationship: component
+      relationship: variant
       description: Uncleaned version
-    - item_id: 5300
-      item_name: Snapdragon seed
+    - item_name: Snapdragon seed
       slug: snapdragon-seed
       relationship: component
-      description: For farming
-    - item_id: 223
-      item_name: Red spiders' eggs
+      description: Seed used to grow the herb at Farming 62
+    - item_name: Red spiders' eggs
       slug: red-spiders-eggs
       relationship: component
-      description: Secondary ingredient
-    - item_id: 3024
-      item_name: Super restore(4)
+      description: Secondary ingredient for super restore
+    - item_name: Super restore(4)
       slug: super-restore-4
       relationship: product
-      description: Final product
-    - item_id: 257
-      item_name: Ranarr weed
+      description: Final super restore potion
+    - item_name: Ranarr weed
       slug: ranarr-weed
       relationship: alternative
-      description: Alternative herb for prayer pots
+      description: Alternative herb for prayer potions
+  about: "Snapdragon is a high-tier herb cleaned at Herblore 59 and combined with red spiders' eggs at Herblore 63 to make super restore potions."
   market_strategy:
-    steps:
-      - order: 1
-        action: Buy Grimy snapdragon or clean Snapdragon
-      - order: 2
-        action: Buy Red spiders' eggs
-      - order: 3
-        action: Make Super restore(4)
-      - order: 4
-        action: "Calculate: `Super restore price - Snapdragon price - Red spiders' eggs - Vial = Profit`"
-    profit_formulas:
-      - Super restore price - Snapdragon price - Red spiders' eggs - Vial = Profit
+    title: Clean and brew flow
     notes:
-      - Buy grimy → Clean (3 XP) → Sell clean
-      - Check margin between grimy and clean
-      - Snapdragon seed (67 Farming)
-      - Profitable alternative to ranarr
-      - Super restores essential for raids
-      - Paired with Sara brews (3:1 ratio)
-      - Universal stat recovery potion
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Buy grimy snapdragon, clean for 11.8 XP, sell clean for the spread
+      - Pair with red spiders' eggs to make super restore(3) at Herblore 63
+      - Super restore demand from raids props up the floor on snapdragon prices
+      - Snapdragon seed at Farming 62 is the long-term supply source for ironmen
+      - 'Profit formula: super restore price - snapdragon price - red spiders'' eggs - vial'
+  trading_tips:
+    - Watch the grimy-to-clean margin daily; cleaning is near-instant for the spread
+    - Universal stat recovery means demand is sticky across PvM content
+    - Often paired with Saradomin brews at a 3:1 ratio in raid kits
+  history:
+    - date: "2004-07-27"
+      update: Agility, Potions and Parties!
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-07-27"
+    update: Agility, Potions and Parties!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spined-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spined-body.mdx
@@ -12,8 +12,14 @@ osrs:
   lowalch: 3120
   highalch: 4680
   limit: 70
+  material:
+    type: hide
+    tier: mid
   equipment:
     slot: body
+    requirements:
+      defence: 40
+      ranged: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,18 +37,12 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 40
-      ranged: 40
     weight: 6.803
   drop_table:
     sources:
       - source: Dagannoth Supreme
-        combat_level: 303
         quantity: "1"
-        rarity: uncommon
-        drop_rate: 1/128
-        members_only: true
+        rarity: 1/128
   related_items:
     - item_id: 6131
       item_name: Spined helm
@@ -58,44 +58,39 @@ osrs:
       item_name: Green d'hide body
       slug: green-dhide-body
       relationship: alternative
-      description: Easier to obtain, no Def req
-  about: |-
-    | Ranged | Value |
-    |--------|-------|
-    | Ranged Attack | +15 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +40 |
-    | Slash | +32 |
-    | Crush | +45 |
-    | Magic | +20 |
-    | Ranged | +40 |
-
-    Requirements: 40 Defence, 40 Ranged
-
-    | Stat | Spined Body | Green D'hide Body |
-    |------|------------|-------------------|
-    | Ranged Atk | +15 | +15 |
-    | Stab Def | +40 | +40 |
-    | Slash Def | +32 | +34 |
-    | Crush Def | +45 | +38 |
-    | Magic Def | +20 | +20 |
-    | Ranged Def | +40 | +40 |
-    | Req | 40 Def + 40 Rng | 40 Rng |
-
-    Very similar stats to green d'hide body — slightly better crush defence (+45 vs +38) but slightly worse slash defence. The spined body requires 40 Defence in addition to 40 Ranged, making green d'hide more accessible.
-
-    Supreme (ranged DK) drops the spined body at 1/128. Players farming all three DKs will accumulate these passively.
-
-    Storable in a Costume Room armour case as part of the complete spined set.
+      description: Easier to obtain, no Defence requirement
+  about: "Fremennik ranged body with stats close to green d'hide body and slightly better crush defence; drops from Dagannoth Supreme at 1/128 or crafted by Sigli the Huntsman from three dagannoth hides plus a flattened hide and 10,000 coins."
   market_strategy:
     notes:
-      - Dagannoth Supreme drop (passive from DK farming)
-      - Green d'hide body is generally preferred (no Def req)
-      - Low trade volume
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Dagannoth Supreme drop, passive supply from DK trips
+      - Green d'hide body usually preferred (no Defence req)
+      - Low trade volume; rely on limit orders
+  trading_tips:
+    - Trade volume thin, set wide spreads
+    - Watch The Fremennik Trials completion supply pulses
+  history:
+    - date: "2005-08-01"
+      description: Released with the Waterbirth Island update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-01"
+    update: Waterbirth Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: The Fremennik Trials
+    weight: 6.803
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dart-tip.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dart-tip.mdx
@@ -12,6 +12,30 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 13000
+  material:
+    type: steel
+    tier: low
+  recipes:
+    - skill: smithing
+      level: 34
+      xp: 37.5
+      materials:
+        - item_name: Steel bar
+          quantity: 1
+      output_quantity: 10
+      tools:
+        - Hammer
+        - Anvil
+    - skill: fletching
+      level: 37
+      xp: 75
+      materials:
+        - item_name: Steel dart tip
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      output_quantity: 10
+      tools: []
   related_items:
     - item_id: 820
       item_name: Iron dart tip
@@ -23,12 +47,41 @@ osrs:
       slug: mithril-dart-tip
       relationship: variant
       description: Higher tier dart tip
-  about: |-
-    > _"Can be used to make steel darts."_
-
-    Steel dart tips are used with feathers at 37 Fletching to create steel darts (7.5 XP each). One bar makes 10 tips.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 807
+      item_name: Steel dart
+      slug: steel-dart
+      relationship: product
+      description: Finished throwing weapon
+  about: "Smithed at 34 Smithing after Tourist Trap from a steel bar into 10 tips; attached to feathers at 37 Fletching to create steel darts."
+  market_strategy:
+    notes:
+      - Tourist Trap completion gates production
+      - Bulk profit from smithing tips for daily flips
+      - Pairs with feathers for Fletching XP runs
+  trading_tips:
+    - Smith tips when steel bar prices dip
+    - Stock during Fletching XP events
+  history:
+    - date: "2003-04-14"
+      description: Released alongside the New Throwing Weapons update.
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Tourist Trap
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-keel-parts.mdx
@@ -12,9 +12,40 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 100
-  about: "Steel keel parts is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: mid
+  recipes:
+    - materials:
+        - item_name: Steel bar
+          quantity: "5"
+      tools:
+        - Anvil
+        - Hammer
+      skill: Smithing
+      level: 38
+      experience: 187.5
+      output_quantity: 1
+  about: "Steel keel parts are smithed from 5 steel bars and used in Sailing to build skiff keels or upgrade into larger sloop keel parts."
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing skill update.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platebody-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platebody-t.mdx
@@ -12,10 +12,35 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 125
+  material:
+    type: steel
+    tier: low
   equipment:
     slot: body
     requirements:
       defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 32
+      slash: 31
+      crush: 24
+      magic: -6
+      ranged: 31
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 20187
       item_name: Steel platelegs (t)
@@ -27,12 +52,44 @@ osrs:
       slug: steel-platebody-g
       relationship: variant
       description: Gold-trimmed variant
-  about: |-
-    > *"Steel platebody with trim."*
-
-    The steel platebody (t) is a trimmed cosmetic variant of the standard steel platebody. Identical stats, requiring 5 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1119
+      item_name: Steel platebody
+      slug: steel-platebody
+      relationship: variant
+      description: Standard untrimmed version
+  about: "Steel platebody (t) is a trimmed cosmetic variant of the standard steel platebody, requiring 5 Defence. Identical stats to the untrimmed version. Easy-tier Treasure Trail exclusive."
+  market_strategy:
+    notes:
+      - Easy clue cosmetic
+      - Identical stats to plain steel platebody
+      - Storable in costume room
+  trading_tips:
+    - Supply tied to easy clue completions
+    - Premium driven by cosmetic demand
+  history:
+    - date: "2016-07-06"
+      description: Released as part of the Treasure Trail Expansion.
+    - date: "2021-04-21"
+      description: Ranged attack penalty adjusted in armour rebalance.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platelegs-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platelegs-t.mdx
@@ -12,22 +12,75 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 125
+  material:
+    type: steel
+    tier: low
   equipment:
     slot: legs
+    weight: 9.071
     requirements:
       defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -4
+      ranged: -11
+    defence_bonus:
+      stab: 17
+      slash: 16
+      crush: 15
+      magic: -4
+      ranged: 16
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 20184
       item_name: Steel platebody (t)
       slug: steel-platebody-t
       relationship: set-piece
       description: Matching trimmed platebody
-  about: |-
-    > *"Steel platelegs with trim."*
-
-    The steel platelegs (t) are a trimmed cosmetic variant of standard steel platelegs. Identical stats, requiring 5 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Steel platelegs (t) is a trimmed cosmetic variant of standard steel platelegs obtained from easy clue scroll caskets. Identical stats, requiring 5 Defence."
+  market_strategy:
+    notes:
+      - Easy clue exclusive cosmetic
+      - Identical stats to standard steel platelegs
+      - Storable in costume room as part of steel trimmed set
+  trading_tips:
+    - Price near high alch floor
+    - Demand driven by fashionscape collectors
+  history:
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased from -7 to -11 as part of equipment rebalancing.
+    - date: "2016-07-06"
+      description: Item released as part of the Treasure Trail Expansion update.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-trimmed-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-trimmed-set-sk.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 8
-  about: "Steel trimmed set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: low
+  related_items:
+    - item_id: 20182
+      item_name: Steel full helm (t)
+      slug: steel-full-helm-t
+      relationship: set-piece
+      description: Helmet component
+    - item_id: 20184
+      item_name: Steel platebody (t)
+      slug: steel-platebody-t
+      relationship: set-piece
+      description: Body component
+    - item_id: 20186
+      item_name: Steel plateskirt (t)
+      slug: steel-plateskirt-t
+      relationship: set-piece
+      description: Legs component
+    - item_id: 20188
+      item_name: Steel kiteshield (t)
+      slug: steel-kiteshield-t
+      relationship: set-piece
+      description: Shield component
+  about: "Steel trimmed set (sk) bundles the steel full helm (t), platebody (t), plateskirt (t), and kiteshield (t) via the Grand Exchange Sets interface. Useful for free-to-play bank management."
+  market_strategy:
+    notes:
+      - Bank-space convenience bundle
+      - Free-to-play accessible
+      - Low daily volume
+      - Created via Grand Exchange clerk Sets interface
+  trading_tips:
+    - Buy individual pieces from clue rewards to assemble
+    - Arbitrage opportunity vs component sum
+  history:
+    - date: "2016-07-06"
+      description: Released as part of the Treasure Trail Expansion.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stew.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stew.mdx
@@ -1,20 +1,69 @@
 ---
 title: Stew | OSRS Price Data
-description: "Stew: It's a meat and potato stew.. High alch: 12 GP, GE limit: 10,000."
+description: "Stew: It's a meat and potato stew. High alch: 12 GP, GE limit: 10,000."
 osrs:
   id: 2003
   name: Stew
   slug: stew
-  examine: It's a meat and potato stew.
+  examine: "It's a meat and potato stew."
   members: false
   icon: Stew.png
   value: 20
   lowalch: 8
   highalch: 12
   limit: 10000
-  about: "Stew is a free-to-play item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 11
+    edible: true
+  recipes:
+    - skill: Cooking
+      level: 25
+      xp: 117
+      materials:
+        - item_name: Uncooked stew
+          quantity: 1
+      tools:
+        - Range
+      output_item: Stew
+      output_quantity: 1
+      notes: Stops burning at level 58 (or 54 on the Lumbridge range).
+  related_items:
+    - item_name: Uncooked stew
+      relationship: component
+      description: Raw input cooked into stew.
+    - item_name: Burnt stew
+      relationship: alternative
+      description: Failure product when cooking stew.
+    - item_name: Spicy stew
+      relationship: upgrade
+      description: Enhanced variant brewed from stew and spice.
+  about: "Stew is a free-to-play meal that heals 11 hitpoints, cooked from an uncooked stew at 25 Cooking for 117 XP and used in Recipe for Disaster (Evil Dave) and The Queen of Thieves."
+  market_strategy:
+    notes:
+      - Driven by Recipe for Disaster and Queen of Thieves prep
+      - Easy 117 XP per cook for low-level Cooking training
+      - Inputs and outputs frequently flip due to quest demand
+  history:
+    - date: "2001-06-11"
+      description: Released with the Fishing skill and additional Cooking content.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-06-11"
+    update: New fishing skill and more cooking
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 1.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/studded-body-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/studded-body-g.mdx
@@ -1,22 +1,39 @@
 ---
 title: Studded body (g) | OSRS Price Data
-description: "Studded body (g) is a F2P body slot item requiring 20 Defence. High alch: 510 GP, GE limit: 8."
+description: "Studded body (g): Those studs should provide a bit more protection. Nice trim too! High alch: 510 GP, GE limit: 8."
 osrs:
   id: 7362
   name: Studded body (g)
   slug: studded-body-g
-  examine: Those studs should provide a bit more protection. Nice trim too!
+  examine: "Those studs should provide a bit more protection. Nice trim too!"
   members: false
   icon: Studded body (g).png
   value: 850
   lowalch: 340
   highalch: 510
   limit: 8
+  material:
+    type: studded leather
+    tier: low
   equipment:
     slot: body
+    weight: 5.443
     requirements:
       ranged: 20
       defence: 20
+    attack_bonus:
+      ranged: 8
+    defence_bonus:
+      stab: 18
+      slash: 25
+      crush: 22
+      magic: 8
+      ranged: 25
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 7366
       item_name: Studded chaps (g)
@@ -27,13 +44,43 @@ osrs:
       item_name: Studded body (t)
       slug: studded-body-t
       relationship: variant
-      description: Trimmed variant
-  about: |-
-    > *"Those studs should provide a bit more protection. Nice trim too!"*
-
-    The studded body (g) is a gold-trimmed cosmetic variant of the studded body. Identical stats, requiring 20 Ranged and 20 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Black-trimmed variant
+    - item_id: 1133
+      item_name: Studded body
+      slug: studded-body
+      relationship: variant
+      description: Standard untrimmed version with identical stats
+  about: "Studded body (g) is a gold-trimmed cosmetic variant of the studded body rewarded from Easy clue scrolls at a rate of 1/1,404; identical stats to the base studded body, requiring 20 Ranged and 20 Defence."
+  market_strategy:
+    notes:
+      - Easy clue exclusive cosmetic — supply tracks clue scroll completion rates
+      - GE buy limit of 8 per 4 hours throttles flipping
+      - Stored in the costume room treasure chest as part of the gold-trimmed studded leather set
+  trading_tips:
+    - Pair with Studded chaps (g) for the full set listing premium
+    - F2P-tradeable but member-only obtainable, watch for F2P pure demand
+  properties:
+    release_date: "2006-02-20"
+    update: "Easter Event & Clue Scroll Update"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2006-02-20"
+      description: "Released as part of the Treasure Trail Easy clue reward pool."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super antifire potion(1) | OSRS Price Data
-description: "Super antifire potion(1): 1 dose of super anti-firebreath potion.. High alch: 408 GP, GE limit: 2,000."
+description: "Super antifire potion(1): 1 dose of super anti-firebreath potion. High alch: 408 GP, GE limit: 2,000."
 osrs:
   id: 21987
   name: Super antifire potion(1)
@@ -12,9 +12,75 @@ osrs:
   lowalch: 272
   highalch: 408
   limit: 2000
-  about: "Super antifire potion(1) is a members-only item in Old School RuneScape. High alchemy value: 408 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - description: Grants complete immunity to standard dragonfire for three minutes.
+      - description: Partially blocks stronger dragonfire from King Black Dragon, Galvek, and Vorkath.
+      - description: Requires having started Dragon Slayer I to drink.
+  recipes:
+    - product: Super antifire potion(1)
+      product_id: 21987
+      skill: Herblore
+      level: 92
+      experience: 32.5
+      materials:
+        - item_id: 2454
+          item_name: Antifire potion(4)
+          quantity: 1
+        - item_id: 22418
+          item_name: Crushed superior dragon bones
+          quantity: 1
+      tools: []
+      notes: Brewing a full dose-4 antifire potion before splitting yields a four-dose super antifire totalling 130 XP.
+  related_items:
+    - item_id: 21981
+      item_name: Super antifire potion(4)
+      slug: super-antifire-potion-4
+      relationship: variant
+      description: Four-dose version.
+    - item_id: 21983
+      item_name: Super antifire potion(3)
+      slug: super-antifire-potion-3
+      relationship: variant
+      description: Three-dose version.
+    - item_id: 21985
+      item_name: Super antifire potion(2)
+      slug: super-antifire-potion-2
+      relationship: variant
+      description: Two-dose version.
+  about: "Super antifire potion(1) is the single-dose form of the high-tier antifire potion unlocked through Dragon Slayer II, granting full immunity to standard dragonfire for three minutes."
+  market_strategy:
+    notes:
+      - Demand spikes around dragon slayer training spikes and Vorkath grinds.
+      - Single doses are typically the cheapest per-dose form when crafters split (4) doses.
+  trading_tips:
+    - Buy single doses near the per-dose discount and combine for personal use.
+    - Sell to consumers during late-game PvM hype windows.
+  history:
+    - date: "2018-01-04"
+      description: Released with the Dragon Slayer II update.
+    - date: "2018-01-25"
+      description: Duration extended from two to three minutes and lava scale shard upgrade path added.
+  properties:
+    release_date: "2018-01-04"
+    update: "Dragon Slayer II"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Dragon Slayer II
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-hunter-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-hunter-potion-1.mdx
@@ -12,9 +12,42 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: null
-  about: "Super hunter potion(1) is a members-only item in Old School RuneScape. High alchemy value: 24 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Boosts Hunter level by +6 for a single dose."
+  recipes:
+    - skill: herblore
+      level: 67
+      xp: 154
+      materials:
+        - item_name: Pillar potion (unf)
+          quantity: 1
+        - item_name: Crab paste
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  about: Super hunter potion(1) is a single-dose Herblore potion that boosts the Hunter skill by 6 levels.
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing skill launch update.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-hunter-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-hunter-potion-4.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: null
-  about: "Super hunter potion(4) is a members-only item in Old School RuneScape. High alchemy value: 150 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: Boosts Hunter level by 6 stages on use.
+      - description: Standard four-dose potion; each sip consumes one dose.
+  recipes:
+    - skill: Herblore
+      level: 67
+      xp: 154
+      materials:
+        - item_name: Pillar potion (unf)
+          quantity: 1
+        - item_name: Crab paste
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+      notes: Produces a Super hunter potion(3); requires four mixes to bank a full (4) dose.
+  about: "Four-dose Herblore potion that grants a +6 visible Hunter boost, mixed at level 67 Herblore from a pillar potion (unf) and crab paste for 154 experience."
+  market_strategy:
+    notes:
+      - Released alongside Sailing on 19 Nov 2025
+      - Crab paste supply tied to Sailing fishing nodes
+      - Pillar potion (unf) is the price driver
+  trading_tips:
+    - Buy doses in (4) and split via decanter for arbitrage
+    - Watch crab paste GE supply during Hunter event weeks
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super restore mix(1) | OSRS Price Data
-description: "Super restore mix(1): One dose of fishy super restore potion.. High alch: 72 GP, GE limit: 2,000."
+description: "Super restore mix(1) is a members one-dose barbarian-mixed super restore. High alch: 72 GP, GE limit: 2,000."
 osrs:
   id: 11495
   name: Super restore mix(1)
@@ -12,9 +12,75 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 2000
-  about: "Super restore mix(1) is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - description: "Restores Prayer points by 8 + 25% of the player's Prayer level."
+      - description: "Restores all other lowered stats (except Hitpoints) by 8 + 25% of their base level."
+      - description: "Heals 3 Hitpoints due to its barbarian-mix fish base."
+  recipes:
+    - skill: Herblore
+      level: 67
+      xp: 41.7
+      output_quantity: 1
+      materials:
+        - item_name: Super restore(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      notes: "Barbarian Herblore training (Recipe for Disaster sub-quest) required."
+  related_items:
+    - item_id: 11497
+      item_name: Super restore mix(2)
+      slug: super-restore-mix-2
+      relationship: variant
+      description: Two-dose barbarian mix variant.
+    - item_id: 3026
+      item_name: Super restore(4)
+      slug: super-restore-4
+      relationship: alternative
+      description: Standard non-mixed super restore.
+    - item_id: 7318
+      item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Barbarian-mix secondary ingredient.
+  about: "Super restore mix(1) is a one-dose Barbarian Herblore mix that restores Prayer and stats while healing 3 Hitpoints on drink."
+  market_strategy:
+    notes:
+      - Caviar supply drives the mix premium
+      - Low-dose variant moves slower than the (2) dose
+      - GE buy limit 2,000 supports steady flips
+  trading_tips:
+    - Decant (1) doses into (2) doses or split (2) → (1) based on premium
+    - Tracks Barbarian Herblore training demand
+  history:
+    - date: "2007-07-03"
+      description: "Released as part of the Barbarian Training update."
+    - date: "2015-02-26"
+      description: "Renamed from 'Sup. restore mix' to 'Super restore mix'."
+    - date: "2016-04-15"
+      description: "Half-full potions can now be converted into bank placeholders."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: "Barbarian Training"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/superantipoison-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/superantipoison-3.mdx
@@ -12,6 +12,22 @@ osrs:
   lowalch: 115
   highalch: 172
   limit: 2000
+  potion:
+    doses: 3
+    effects:
+      - description: Cures poison and grants 6 minutes of poison immunity per dose.
+      - description: Two doses cure venom by stepping it down to poison then clearing it.
+  recipes:
+    - product: Superantipoison(3)
+      skill: Herblore
+      level: 48
+      xp: 106.3
+      tools: []
+      materials:
+        - item_name: Irit potion (unf)
+          quantity: 1
+        - item_name: Unicorn horn dust
+          quantity: 1
   related_items:
     - item_id: 183
       item_name: Superantipoison(2)
@@ -23,12 +39,43 @@ osrs:
       slug: superantipoison-1
       relationship: variant
       description: 1-dose version
-  about: |-
-    > _"3 doses of super antipoison potion."_
-
-    The superantipoison cures poison and grants 6 minutes of poison immunity per dose. Two doses cure venom. A significant upgrade over regular antipoison.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 2448
+      item_name: Antidote+
+      slug: antidote-plus
+      relationship: upgrade
+      description: Longer-lasting poison protection
+  about: "Superantipoison(3) cures poison and grants six minutes of poison immunity per dose, with two doses required to clear venom."
+  market_strategy:
+    notes:
+      - Mid-tier poison defence consumable
+      - Demand spikes for venom-heavy bosses
+      - Brewed at 48 Herblore from irit potion (unf)
+  trading_tips:
+    - Decant between 1, 2, 3, and 4-dose variants for arbitrage
+    - Often cheaper to brew than buy on the GE
+  history:
+    - date: "2002-02-27"
+      description: Item released.
+    - date: "2004-03-29"
+      description: 4-dose variant introduced with RuneScape 2.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: Herblore launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/superattack-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/superattack-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Superattack mix(1) | OSRS Price Data
-description: "Superattack mix(1): One dose of fishy super Attack potion.. High alch: 54 GP, GE limit: 2,000."
+description: "Superattack mix(1): One dose of fishy super Attack potion. High alch: 54 GP, GE limit: 2,000."
 osrs:
   id: 11471
   name: Superattack mix(1)
@@ -12,9 +12,68 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
-  about: "Superattack mix(1) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: barbarian potion
+    tier: low
+  potion:
+    effects:
+      - description: "Boosts Attack by 5 + 15% of current level."
+      - description: "Restores 6 Hitpoints on consumption."
+  recipes:
+    - skill: Herblore
+      level: 47
+      experience: 33
+      materials:
+        - item_name: Super attack(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      product: Superattack mix(1)
+      notes: "Barbarian Herblore mix; requires Barbarian Training."
+  food:
+    heals: 6
+    type: potion mix
+  related_items:
+    - item_name: Superattack mix(2)
+      slug: superattack-mix-2
+      relationship: variant
+      description: Two-dose variant of the same mix.
+    - item_name: Super attack(2)
+      slug: super-attack-2
+      relationship: component
+      description: Base super attack potion used to brew the mix.
+  about: "Superattack mix(1) is a Barbarian Herblore variant of the super attack potion that adds a small heal alongside the attack boost."
+  market_strategy:
+    notes:
+      - Low volume potion, primarily used by Barbarian Herblore trainers.
+      - Compare against Super attack(2) plus caviar input cost for arbitrage.
+      - Daily limit of 2,000 leaves plenty of room for bulk plays.
+  trading_tips:
+    - Margin flips work best during caviar supply dips.
+    - Bulk buyers usually undercut alch values, expect thin spreads.
+  history:
+    - date: "2007-07-03"
+      description: Released with the Barbarian Training update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: "Barbarian Training"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/te-salt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/te-salt.mdx
@@ -12,9 +12,26 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Te salt is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Te salt is a red salt from Making Friends with My Arm used in salt-burning rituals for skill boosts."
+  history:
+    - date: "2018-09-06"
+      description: Released with the Making Friends With My Arm update.
+  properties:
+    release_date: "2018-09-06"
+    update: Making Friends With My Arm
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-27-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-27-cape.mdx
@@ -12,9 +12,41 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-27 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    weapon_type: unarmed
+    requirements:
+      attack: 1
+    attack_bonus: {}
+    defence_bonus:
+      slash: 1
+      crush: 1
+      ranged: 2
+    other_bonus: {}
+  about: "Team-27 cape is a free-to-play team cape used to identify teammates on the minimap."
+  history:
+    - date: "2005-02-22"
+      description: Released with the Wilderness Capes update.
+    - date: "2013-05-23"
+      description: Item became accessible to free-to-play players.
+  properties:
+    release_date: "2005-02-22"
+    update: Wilderness Capes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thorny-hedge-bagged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thorny-hedge-bagged.mdx
@@ -1,6 +1,6 @@
 ---
 title: Thorny hedge (bagged) | OSRS Price Data
-description: "Thorny hedge (bagged): You can plant this in your garden.. High alch: 3,000 GP, GE limit: 10,000."
+description: "Thorny hedge (bagged): You can plant this in your garden. High alch: 3,000 GP, GE limit: 10,000."
 osrs:
   id: 8437
   name: Thorny hedge (bagged)
@@ -12,9 +12,47 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 10000
-  about: "Thorny hedge (bagged) is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Garden Centre (Falador Park)
+      location: Falador Park
+      quantity: 20
+      price: 5000
+    - shop_name: Garden Centre (Farming Guild)
+      location: Farming Guild
+      quantity: 20
+      price: 5000
+  farming:
+    level: 1
+    xp: 72
+    notes: "Plant in formal garden patch; requires Construction 56 and a filled watering can. 70 Farming required to uproot."
+  construction:
+    level: 56
+    xp: 72
+    notes: "Used in formal garden hotspots in player-owned houses."
+  about: "Thorny hedge (bagged) is a members-only farming/construction item used to plant decorative thorny hedges in formal garden hotspots of player-owned houses."
+  market_strategy:
+    notes:
+      - Niche POH cosmetic with modest GE turnover
+      - Bought in bulk by Construction trainers furnishing formal gardens
+  history:
+    - date: "2006-05-31"
+      description: Released alongside the Player-Owned Houses update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: "PLAYER-OWNED HOUSES!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tinderbox.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tinderbox.mdx
@@ -12,13 +12,27 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 40
+  about: The tinderbox is an essential tool used to ignite logs for Firemaking and to light candles, lanterns, and quest-related light sources.
   related_items: []
-  about: |-
-    > _"Useful for lighting fires."_
-
-    The tinderbox is used to light fires with logs (1 Firemaking) and light various light sources. One of the most essential tools in the game. Can be stored in a tool belt equivalent.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2001-01-04"
+      description: Added to the game when RuneScape Beta launched.
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toad-crunchies.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toad-crunchies.mdx
@@ -1,6 +1,6 @@
 ---
 title: Toad crunchies | OSRS Price Data
-description: "Toad crunchies: It actually smells quite good.. High alch: 1 GP, GE limit: 6,000."
+description: "Toad crunchies: It actually smells quite good. High alch: 1 GP, GE limit: 6,000."
 osrs:
   id: 2217
   name: Toad crunchies
@@ -12,9 +12,67 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Toad crunchies is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 8
+    edible: true
+  recipes:
+    - skill: Cooking
+      level: 10
+      xp: 100
+      materials:
+        - item_name: Unfinished crunchy (toad)
+          quantity: 1
+      tools:
+        - Range
+      output_item: Toad crunchies
+      output_quantity: 1
+      notes: "Stops burning at level 38. Gnome cooking chain starts from Gianne dough + crunchy tray."
+  related_items:
+    - item_name: Gianne dough
+      relationship: component
+      description: Base dough for the crunchy chain.
+    - item_name: Crunchy tray
+      relationship: component
+      description: Tray that shapes raw crunchies.
+    - item_name: Toad's legs
+      relationship: component
+      description: Added with gnome spice to form half-made crunchies.
+    - item_name: Equa leaves
+      relationship: component
+      description: Finishing ingredient after cooking.
+    - item_name: Worm crunchies
+      relationship: alternative
+      description: Sibling gnome crunchy variant.
+    - item_name: Spicy crunchies
+      relationship: alternative
+      description: Sibling gnome crunchy variant.
+  about: "Toad crunchies is a Gnome Restaurant snack that heals 8 hitpoints, cooked at level 10 Cooking for 100 XP after a multi-step gnome cooking chain."
+  market_strategy:
+    notes:
+      - Used in the Gnome Restaurant minigame
+      - Multi-step gnome cooking chain caps supply
+      - GE price often well above alch values due to minigame demand
+  history:
+    - date: "2002-12-12"
+      description: Released alongside the Agility skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-bolts-e.mdx
@@ -12,13 +12,33 @@ osrs:
   lowalch: 9
   highalch: 14
   limit: 11000
+  material:
+    type: red topaz
+    tier: mid
   equipment:
     slot: ammo
-    other_bonus:
-      ranged_strength: 66
+    weapon_type: bolt
+    weight: 0
     requirements:
       ranged: 1
-    weight: 0
+    other_bonus:
+      ranged_strength: 66
+  special_attack:
+    name: Down to Earth
+    description: "4% chance (4.4% with Hard Kandarin Diary) on a successful hit in PvP to lower the target's Magic level by 1."
+  recipes:
+    - skill: Magic
+      level: 29
+      xp: 33
+      materials:
+        - item_name: Topaz bolts
+          quantity: 10
+        - item_name: Fire rune
+          quantity: 2
+        - item_name: Cosmic rune
+          quantity: 1
+      tools: []
+      output: Topaz bolts (e)
   related_items:
     - item_id: 9238
       item_name: Pearl bolts (e)
@@ -30,23 +50,42 @@ osrs:
       slug: sapphire-bolts-e
       relationship: upgrade
       description: Next tier enchanted bolt
-  about: |-
-    | Other | Value |
-    |-------|-------|
-    | Ranged Strength | +66 |
-
-    Proc chance: 4% (4.4% with Kandarin hard diary)
-
-    On activation, reduces the target's Magic level by 1. Useful in PvP to gradually lower an opponent's Magic level, reducing their magic defence and splash chance.
-
-    Topaz bolts are niche in PvP — stacking Magic drains can make targets more vulnerable to binds and magic attacks. However, the low 4% proc rate limits their effectiveness.
+    - item_id: 9237
+      item_name: Topaz bolts
+      slug: topaz-bolts
+      relationship: component
+      description: Unenchanted base bolt
+  about: "Topaz bolts (e) are red topaz-tipped steel crossbow bolts enchanted with Lvl-3 Enchant (Magic 29, 33 xp per cast of 10) that proc the Down to Earth effect — a 4% chance (4.4% with Hard Kandarin Diary) to lower the target's Magic level by 1 in PvP."
   market_strategy:
     notes:
       - Niche PvP bolt for Magic drain
-      - Low proc rate limits usefulness
-      - Cheap to enchant
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Low 4% proc rate limits PvE usefulness
+      - Cheap to enchant; supply tracks Topaz bolt + cosmic rune prices
+  trading_tips:
+    - Enchant in bulk when topaz bolts and cosmic runes are both cheap
+    - Watch for PvP meta shifts that increase Magic-drain bolt demand
+  properties:
+    release_date: "2006-07-31"
+    update: "Bolt Enchant Spells"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2006-07-31"
+      description: "Released alongside bolt enchant spells, adding enchanted gem-tipped bolt variants."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-platelegs-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-platelegs-0.mdx
@@ -1,20 +1,93 @@
 ---
 title: Torag's platelegs 0 | OSRS Price Data
-description: "Torag's platelegs 0: Torag the Corrupted's plate leg armour.. High alch: 165,000 GP, GE limit: 15."
+description: "Torag's platelegs 0: Torag the Corrupted's plate leg armour. High alch: 165,000 GP, GE limit: 15."
 osrs:
   id: 4974
   name: Torag's platelegs 0
   slug: torag-s-platelegs-0
-  examine: Torag the Corrupted's plate leg armour.
+  examine: "Torag the Corrupted's plate leg armour."
   members: true
   icon: Torag's platelegs 0.png
   value: 275000
   lowalch: 110000
   highalch: 165000
   limit: 15
-  about: "Torag's platelegs 0 is a members-only item in Old School RuneScape. High alchemy value: 165,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: barrows armour
+    tier: high
+  equipment:
+    slot: legs
+    weapon_type: none
+    weight: 9.071
+    requirements:
+      defence: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 85
+      slash: 82
+      crush: 83
+      magic: -4
+      ranged: 92
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Barrows chest
+        quantity: "1"
+        rarity: 1/2448
+  related_items:
+    - item_name: Torag's platelegs 25
+      slug: torag-s-platelegs-25
+      relationship: variant
+      description: Partially degraded charge state of the same legs.
+    - item_name: Torag's platelegs 100
+      slug: torag-s-platelegs-100
+      relationship: variant
+      description: Fully repaired charge state of the same legs.
+    - item_name: Torag's platebody 0
+      slug: torag-s-platebody-0
+      relationship: set-piece
+      description: Matching body slot piece for Torag's set effect.
+  about: "Torag's platelegs are the legs slot of Torag the Corrupted's Barrows set, equipped at 70 Defence and degraded to broken state."
+  market_strategy:
+    notes:
+      - Fully degraded variant traded for repair at NPCs or POH armour stand.
+      - Wears the same as charged versions but cannot be equipped until repaired.
+      - Price tracks the cost of repair plus expected resale of charged legs.
+  trading_tips:
+    - Buy 0 charge variants when undercut below repair-cost spread.
+    - 99 Smithing players save ~40k per repair vs NPC pricing.
+  history:
+    - date: "2005-05-09"
+      description: Released with the Barrows minigame update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    update: "Barrows"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "If you drop this item it will break. Are you sure?"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torva-platebody-damaged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torva-platebody-damaged.mdx
@@ -1,86 +1,89 @@
 ---
 title: Torva platebody (damaged) | OSRS Price Data
-description: "Torva platebody (damaged): An ancient warrior's platebody.. High alch: 360,000 GP, GE limit: 8."
+description: "Torva platebody (damaged): An ancient warrior's platebody. High alch: 360,000 GP, GE limit: 8."
 osrs:
   id: 26378
   name: Torva platebody (damaged)
   slug: torva-platebody-damaged
-  examine: An ancient warrior's platebody.
+  examine: "An ancient warrior's platebody."
   members: true
   icon: Torva platebody (damaged).png
   value: 600000
   lowalch: 240000
   highalch: 360000
   limit: 8
-  item:
+  material:
     type: damaged armour
-    tradeable: true
-    weight: 9.525
-  obtaining:
-    - source: Nex
-      drop_rate: 1/43 per unique roll
-      notes: Requires Bandos chestplate to repair
+    tier: high
+  drop_table:
+    sources:
+      - source: Nex
+        quantity: "1"
+        rarity: 1/258
   recipes:
-    - skill: none
-      level: 0
+    - skill: Smithing
+      level: 90
+      experience: 2250
       materials:
-        - item_id: 26378
-          item_name: Torva platebody (damaged)
+        - item_name: Torva platebody (damaged)
           quantity: 1
-        - item_id: 11832
-          item_name: Bandos chestplate
+        - item_name: Bandos chestplate
           quantity: 1
+      tools:
+        - Hammer
+        - Anvil
       product: Torva platebody
-      product_id: 26384
-      notes: No skill requirements
+      notes: "Bandos chestplate is consumed in the process."
   related_items:
-    - item_id: 11832
-      item_name: Bandos chestplate
+    - item_name: Bandos chestplate
       slug: bandos-chestplate
       relationship: component
-      description: Required to repair
-    - item_id: 26384
-      item_name: Torva platebody
+      description: Consumed component required to restore the platebody.
+    - item_name: Torva platebody
       slug: torva-platebody
       relationship: product
-      description: Repaired BiS melee body
-    - item_id: 26376
-      item_name: Torva full helm (damaged)
+      description: Restored best-in-slot melee body produced from this damaged piece.
+    - item_name: Torva full helm (damaged)
       slug: torva-full-helm-damaged
       relationship: alternative
-      description: Damaged helm from Nex
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Damaged Armour |
-    | Tradeable | Yes |
-    | Weight | 9.525 kg |
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Torva platebody (damaged) | Nex | ~290M |
-    | Bandos chestplate | God Wars Dungeon | ~15M |
-
-    No skill requirements to combine the items.
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Torva platebody | Damaged piece + Bandos chestplate |
-
-    Warning: Bandos chestplate is permanently consumed.
-
-    Part of the Torva armour set, which provides:
-    - Best-in-slot melee stats
-    - +4 HP boost (body piece)
-    - +16 total HP with full set
+      description: Damaged head slot drop from Nex.
+    - item_name: Torva platelegs (damaged)
+      slug: torva-platelegs-damaged
+      relationship: alternative
+      description: Damaged legs slot drop from Nex.
+  about: "Damaged Torva platebody drops from Nex and combines with a Bandos chestplate at 90 Smithing to restore the best-in-slot Torva platebody."
   market_strategy:
     notes:
-      - Nex exclusive drop
-      - BCP consumed in repair
-      - Creates BiS melee body
-      - Second most valuable Nex unique
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Nex exclusive drop with a 1/258 unique rate.
+      - Restoration requires 90 Smithing and consumes a Bandos chestplate.
+      - Track the spread between damaged and restored pieces plus the BCP cost.
+  trading_tips:
+    - Buy damaged when restored price minus BCP minus tax exceeds the damaged ask.
+    - Skippers without 90 Smithing should flip the restored variant directly.
+  history:
+    - date: "2022-01-05"
+      description: "Released with the Nex: The Fifth General update."
+    - date: "2023-08-03"
+      description: Received a graphical rework alongside the wider Torva set refresh.
+    - date: "2023-08-16"
+      description: Back design lowered to better conceal the neck.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-01-05"
+    update: "Nex: The Fifth General"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 9.979
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toy-mouse.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toy-mouse.mdx
@@ -1,6 +1,6 @@
 ---
 title: Toy mouse | OSRS Price Data
-description: "Toy mouse: Nice bit of crafting!. High alch: 6 GP, GE limit: 150."
+description: "Toy mouse: Nice bit of crafting! High alch: 6 GP, GE limit: 150."
 osrs:
   id: 7767
   name: Toy mouse
@@ -12,9 +12,65 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 150
-  about: "Toy mouse is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: clockwork
+    tier: low
+  recipes:
+    - skill: crafting
+      level: 33
+      xp: 15
+      materials:
+        - item_name: Clockwork
+          quantity: 1
+        - item_name: Plank
+          quantity: 1
+      tools: []
+      output_item: Toy mouse
+      output_quantity: 1
+      notes: "Built at the Crafting table 4 in a player-owned house Workshop (requires 42 Construction)."
+  related_items:
+    - item_id: 8792
+      item_name: Clockwork
+      slug: clockwork
+      relationship: component
+      description: Crafting table input made at any POH crafting table from a steel bar.
+    - item_id: 960
+      item_name: Plank
+      slug: plank
+      relationship: component
+      description: Regular plank used as the wooden body of the toy.
+    - item_id: 7765
+      item_name: Toy cat
+      slug: toy-cat
+      relationship: alternative
+      description: Similar clockwork toy crafted at the same workshop tables.
+  about: "Toy mouse is a wind-up Crafting product used for low-level Agility training and as an Ava's accumulator novelty pickup."
+  market_strategy:
+    notes:
+      - Niche Agility/POH curio — thin GE demand at 150/4h limit
+      - Crafting margin is usually positive vs clockwork + plank inputs
+  history:
+    - date: "2006-05-31"
+      description: Released alongside the Player-Owned Houses update.
+    - date: "2013-03-28"
+      description: Agility XP per catch reduced from previous higher value to 3 XP.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: "Player-Owned Houses"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wind
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-headband-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-headband-t2.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Trailblazer reloaded headband (t2) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic_headgear
+    tier: mid
+  equipment:
+    slot: head
+    weight: 0.453
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Reward shop
+      price: 5000
+      currency: League points
+  related_items:
+    - item_name: Trailblazer reloaded headband (t1)
+      slug: trailblazer-reloaded-headband-t1
+      relationship: downgrade
+      description: Tier 1 variant of the headband
+    - item_name: Trailblazer reloaded headband (t3)
+      slug: trailblazer-reloaded-headband-t3
+      relationship: upgrade
+      description: Tier 3 variant of the headband
+    - item_name: Trailblazer reloaded top (t2)
+      slug: trailblazer-reloaded-top-t2
+      relationship: set-piece
+      description: Matching tier 2 body piece
+    - item_name: Trailblazer reloaded trousers (t2)
+      slug: trailblazer-reloaded-trousers-t2
+      relationship: set-piece
+      description: Matching tier 2 legs piece
+    - item_name: Trailblazer reloaded boots (t2)
+      slug: trailblazer-reloaded-boots-t2
+      relationship: set-piece
+      description: Matching tier 2 feet piece
+  about: "Trailblazer reloaded headband (t2) is the head slot piece of the tier 2 Relic Hunter outfit from the Trailblazer Reloaded Leagues reward shop."
+  market_strategy:
+    notes:
+      - Supply locked behind Leagues IV reward shop unlocks
+      - Cosmetic only with no combat stats
+      - Demand peaks during Leagues nostalgia cycles
+  history:
+    - date: "2023-11-15"
+      description: Added to the game files.
+    - date: "2023-11-29"
+      description: Made obtainable through the Trailblazer Reloaded reward shop.
+  properties:
+    release_date: "2023-11-29"
+    update: "Trailblazer Reloaded Leagues"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ugthanki-kebab.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ugthanki-kebab.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ugthanki kebab | OSRS Price Data
-description: "Ugthanki kebab: A fresh kebab made from ugthanki meat.. High alch: 12 GP, GE limit: 10,000."
+description: "Ugthanki kebab: A fresh kebab made from ugthanki meat. High alch: 12 GP, GE limit: 10,000."
 osrs:
   id: 1885
   name: Ugthanki kebab
@@ -12,9 +12,70 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 10000
-  about: "Ugthanki kebab is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: mid
+  food:
+    heals: 19
+    effect: Restores 19 Hitpoints per bite.
+  recipes:
+    - name: Ugthanki kebab
+      skill: Cooking
+      level: 1
+      xp: 40
+      materials:
+        - item_name: Ugthanki kebab mix
+          quantity: 1
+        - item_name: Pitta bread
+          quantity: 1
+      tools: []
+      notes: Combine the mix with pitta bread; failure produces a kebab (bad).
+  related_items:
+    - item_id: 1881
+      item_name: Ugthanki kebab mix
+      slug: ugthanki-kebab-mix
+      relationship: component
+      description: Required ingredient mixed into pitta bread.
+    - item_id: 1865
+      item_name: Pitta bread
+      slug: pitta-bread
+      relationship: component
+      description: Bread base for the kebab recipe.
+    - item_id: 4608
+      item_name: Super kebab
+      slug: super-kebab
+      relationship: upgrade
+      description: Created by adding red hot sauce to an Ugthanki kebab.
+  about: Members food made during the Tourist Trap quest line; heals 19 Hitpoints and combines with red hot sauce to make a Super kebab.
+  market_strategy:
+    notes:
+      - Cooking creation profit floats around 100-200 GP per kebab
+      - Demand rises when food prices on standard food climb
+  trading_tips:
+    - Watch pitta bread and kebab mix margins for combo flips
+    - High volume - thin margins, scale carefully on bulk buys
+  history:
+    - date: "2003-04-14"
+      description: Released with the Tourist Trap quest update.
+  properties:
+    release_date: "2003-04-14"
+    update: Tourist Trap
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Tourist Trap
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unpowered-orb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unpowered-orb.mdx
@@ -5,7 +5,7 @@ osrs:
   id: 567
   name: Unpowered orb
   slug: unpowered-orb
-  examine: I'd prefer it if it was powered.
+  examine: "I'd prefer it if it was powered."
   members: true
   icon: Unpowered orb.png
   value: 100
@@ -13,88 +13,83 @@ osrs:
   highalch: 60
   limit: 10000
   material:
-    type: orb
-    tier: base
-  crafting:
-    level: 46
-    xp: 52.5
+    type: glass
+    tier: low
   recipes:
     - skill: crafting
       level: 46
       xp: 52.5
       materials:
         - item_name: Molten glass
-          item_id: 1775
           quantity: 1
-      product: Unpowered orb
-      product_id: 567
-      product_quantity: 1
-      facility: Glassblowing pipe
-  magic:
-    air_orb:
-      level: 66
-      obelisk: Air Obelisk
-      location: Edgeville Dungeon
-    water_orb:
-      level: 56
-      obelisk: Water Obelisk
-      location: Taverley Dungeon
-    earth_orb:
-      level: 60
-      obelisk: Earth Obelisk
-      location: Edgeville Dungeon
-    fire_orb:
-      level: 63
-      obelisk: Fire Obelisk
-      location: Taverley Dungeon
+      output_quantity: 1
+      tools:
+        - Glassblowing pipe
   related_items:
     - item_id: 573
       item_name: Air orb
       slug: air-orb
       relationship: product
-      description: Charged product
+      description: Charged at Air Obelisk
     - item_id: 569
       item_name: Fire orb
       slug: fire-orb
       relationship: product
-      description: Charged product
+      description: Charged at Fire Obelisk
+    - item_id: 571
+      item_name: Water orb
+      slug: water-orb
+      relationship: product
+      description: Charged at Water Obelisk
+    - item_id: 575
+      item_name: Earth orb
+      slug: earth-orb
+      relationship: product
+      description: Charged at Earth Obelisk
     - item_id: 1391
       item_name: Battlestaff
       slug: battlestaff
       relationship: component
-      description: Attachment base
+      description: Attachment base for elemental staves
     - item_id: 1775
       item_name: Molten glass
       slug: molten-glass
       relationship: component
-      description: Crafting material
-  about: |-
-    | Method | Level | XP |
-    |--------|-------|-----|
-    | Glassblowing | 46 Crafting | 52.5 |
-    | Materials | Molten glass + Glassblowing pipe | - |
-
-    | Orb Type | Magic Level | Obelisk Location |
-    |----------|-------------|------------------|
-    | Air orb | 66 | Edgeville Dungeon |
-    | Water orb | 56 | Taverley Dungeon |
-    | Earth orb | 60 | Edgeville Dungeon |
-    | Fire orb | 63 | Taverley Dungeon |
+      description: Crafting input
+  about: "Blown at 46 Crafting from molten glass and charged at one of four elemental obelisks via Magic to produce orbs used in battlestaff creation."
   market_strategy:
     notes:
-      - Charge at obelisks
-      - Battlestaff production
-      - Good Magic XP
-      - Orb charging money making
-      - Battlestaff crafting
-      - Magic training
-      - Crafting training
-      - Glassblowing to create
-      - Obelisk charging for profit
-      - Air orbs most popular
-      - Wilderness air obelisk risky
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Charge at obelisks for elemental orbs
+      - Feeds battlestaff production
+      - Solid Magic XP via obelisk charging
+      - Glassblowing as the main supply lane
+      - Air orbs in Wilderness obelisk carry PK risk
+  trading_tips:
+    - Buy when molten glass dips below break-even
+    - Stockpile around Crafting bonus events
+    - Watch Air Orb premium when Wilderness is hot
+  history:
+    - date: "2002-03-18"
+      description: Released alongside the Magic skill obelisk system.
+    - date: "2016-08-11"
+      description: Recoloured to distinguish from Air orbs.
+  properties:
+    release_date: "2002-03-18"
+    update: Magic Skill Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-brassard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-brassard.mdx
@@ -5,88 +5,90 @@ osrs:
   id: 4757
   name: Verac's brassard
   slug: verac-s-brassard
-  examine: Verac the Defiled's brassard.
+  examine: "Verac the Defiled's brassard."
   members: true
   icon: Verac's brassard.png
   value: 280000
   lowalch: 112000
   highalch: 168000
   limit: 15
+  material:
+    type: barrows-armour
+    tier: high
   equipment:
     slot: body
-    type: barrows
-    set: Verac
-    tradeable: true
-    degradeable: true
-    weight: 7.2
+    weapon_type: melee
+    weight: 4.989
     requirements:
       defence: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -6
-      attack_ranged: 0
-      defence_stab: 81
-      defence_slash: 95
-      defence_crush: 85
-      defence_magic: 0
-      defence_ranged: 81
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 81
+      slash: 95
+      crush: 85
+      magic: 0
+      ranged: 81
+    other_bonus:
       strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 5
-  set_effect:
-    name: Defiler
-    pieces_required: 4
-    description: 25% chance to ignore target's Defence and Protection prayers
   related_items:
     - item_id: 4753
       item_name: Verac's helm
-      slug: veracs-helm
+      slug: verac-s-helm
       relationship: set-piece
-      description: Head slot set piece (+3 prayer)
+      description: Head slot piece (+3 prayer) of the Verac set.
     - item_id: 4759
       item_name: Verac's plateskirt
-      slug: veracs-plateskirt
+      slug: verac-s-plateskirt
       relationship: set-piece
-      description: Legs slot set piece (+4 prayer)
+      description: Legs slot piece (+4 prayer) of the Verac set.
     - item_id: 4755
       item_name: Verac's flail
-      slug: veracs-flail
+      slug: verac-s-flail
       relationship: set-piece
-      description: Weapon set piece (+6 prayer)
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Stab defence | +81 |
-    | Slash defence | +95 |
-    | Crush defence | +85 |
-    | Magic defence | +0 |
-    | Ranged defence | +81 |
-    | Prayer | +5 |
-    | Magic attack | -6 |
-
-    Note: Highest prayer bonus body armor (+5). Lower defence than other Barrows platebodies.
-
-    Defiler:
-    When wearing full Verac's (helm, brassard, plateskirt, flail):
-    - 25% chance to ignore target's Defence and Protection prayers
-    - Hits through Protect from Melee
-
-    Best For:
-    - Prayer bonus body option
-    - Proselyte alternative with better stats
-    - Corp with full set
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
+      description: Weapon piece (+6 prayer) of the Verac set.
+  about: Highest prayer-bonus body slot armour and the chest piece of Verac's set, granting the Defiler effect when worn with the full set.
   market_strategy:
     notes:
-      - Prayer bonus makes it useful standalone
-      - Less defence than Dharok/Guthan/Torag bodies
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Prayer bonus keeps standalone demand from Proselyte upgraders
+      - Full-set buyers spike price ahead of Corp / boss DPS metas
+  trading_tips:
+    - Watch full Verac's set bonus deals - splitting pieces often flips
+    - Account for 15h degrade cost when comparing to Bandos
+  history:
+    - date: "2005-05-09"
+      description: Released with the Barrows update.
+    - date: "2014-11-13"
+      description: Renamed from Veracs brassard to Verac's brassard.
+    - date: "2015-04-30"
+      description: Added a durability check option.
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.989
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+      - Check
+    alchable: true
+    destroy: "If you drop this item it will break. Are you sure you want to drop it?"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vesta-s-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vesta-s-plateskirt.mdx
@@ -1,20 +1,95 @@
 ---
-title: Vesta's plateskirt | OSRS Price Data
+title: "Vesta's plateskirt | OSRS Price Data"
 description: "Vesta's plateskirt: A powerful plateskirt.. High alch: 300,000 GP, GE limit: 10."
 osrs:
   id: 22619
-  name: Vesta's plateskirt
+  name: "Vesta's plateskirt"
   slug: vesta-s-plateskirt
   examine: A powerful plateskirt.
   members: true
-  icon: Vesta's plateskirt.png
+  icon: "Vesta's plateskirt.png"
   value: 500000
   lowalch: 200000
   highalch: 300000
   limit: 10
-  about: "Vesta's plateskirt is a members-only item in Old School RuneScape. High alchemy value: 300,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: statius
+    tier: high
+  equipment:
+    slot: legs
+    weapon_type: melee
+    attack_speed: 1
+    weight: 8.164
+    requirements:
+      defence: 78
+    attack_bonus:
+      stab: 10
+      slash: 10
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 39
+      slash: 42
+      crush: 45
+      magic: 0
+      ranged: 59
+    other_bonus:
+      strength: 3
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Bounty Hunter Store
+      location: Edgeville
+      price: 550 Bounty Hunter points
+  related_items:
+    - item_id: 27924
+      item_name: "Vesta's chainbody"
+      slug: vesta-s-chainbody
+      relationship: set-piece
+      description: Matching chainbody granting 15% melee spec accuracy when paired
+    - item_id: 27932
+      item_name: "Vesta's longsword"
+      slug: vesta-s-longsword
+      relationship: set-piece
+      description: Matching longsword from the Vesta set
+  charges:
+    cost: 5000000 coins
+    charge_count: 100000
+    description: Must be charged with coins before use; reverts to inactive when uncharged.
+  about: "Bounty Hunter Store reward unlocked at 78 Defence; charges with coins and operates only in designated PvP zones such as Castle Wars and Soul Wars."
+  market_strategy:
+    notes:
+      - Acquired by spending Bounty Hunter points, supply tied to BH activity
+      - Pairing with Vesta's chainbody grants +15% melee spec accuracy
+      - Only functional in PvP-designated areas
+  trading_tips:
+    - Track BH event participation for supply cycles
+    - Pre-position before Deadman/PvP tournaments
+  history:
+    - date: "2023-05-24"
+      description: Re-released through the revamped Bounty Hunter Store.
+  properties:
+    release_date: "2023-05-24"
+    update: Bounty Hunter Rework
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8.164
+    options:
+      - Activate
+      - Drop
+    worn_options:
+      - Remove
+      - Uncharge
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/voidwaker-blade.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/voidwaker-blade.mdx
@@ -1,6 +1,6 @@
 ---
 title: Voidwaker blade | OSRS Price Data
-description: "Voidwaker blade: The blade of a broken sword.. High alch: 480,000 GP, GE limit: 8."
+description: "Voidwaker blade: The blade of a broken sword. High alch: 480,000 GP, GE limit: 8."
 osrs:
   id: 27684
   name: Voidwaker blade
@@ -12,9 +12,80 @@ osrs:
   lowalch: 320000
   highalch: 480000
   limit: 8
-  about: "Voidwaker blade is a members-only item in Old School RuneScape. High alchemy value: 480,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: weapon-component
+    tier: high
+  drop_table:
+    sources:
+      - source: "Vet'ion"
+        quantity: "1"
+        rarity: "1/360"
+      - source: "Calvar'ion"
+        quantity: "1"
+        rarity: "1/912"
+  recipes:
+    - name: Voidwaker assembly
+      skill: None
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Voidwaker blade
+          quantity: 1
+        - item_name: Voidwaker hilt
+          quantity: 1
+        - item_name: Voidwaker gem
+          quantity: 1
+        - item_name: Coins
+          quantity: 500000
+      tools: []
+      notes: Combined by Madam Sikaro in Ferox Enclave Dungeon to assemble the Voidwaker.
+  related_items:
+    - item_id: 27687
+      item_name: Voidwaker hilt
+      slug: voidwaker-hilt
+      relationship: component
+      description: Companion piece dropped by Callisto.
+    - item_id: 27681
+      item_name: Voidwaker gem
+      slug: voidwaker-gem
+      relationship: component
+      description: Companion piece dropped by Venenatis.
+    - item_id: 27690
+      item_name: Voidwaker
+      slug: voidwaker
+      relationship: product
+      description: The completed weapon assembled from all three pieces.
+  about: One of three Voidwaker components dropped by Wilderness bosses; combined with the hilt and gem to assemble the Voidwaker.
+  market_strategy:
+    notes:
+      - Demand follows Voidwaker assembly costs
+      - Wilderness boss supply throttles volume
+  trading_tips:
+    - Watch for spikes after Wilderness boss reworks or PvP events
+    - Compare against full Voidwaker price minus hilt and gem
+  history:
+    - date: "2023-01-25"
+      description: Released with the Wilderness Boss Rework update.
+    - date: "2023-02-02"
+      description: No longer converts to coins upon Wilderness death.
+  properties:
+    release_date: "2023-01-25"
+    update: Wilderness Boss Rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.9
+    options:
+      - Inspect
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/volcanic-whip-mix.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/volcanic-whip-mix.mdx
@@ -1,63 +1,78 @@
 ---
 title: Volcanic whip mix | OSRS Price Data
-description: "Volcanic whip mix is a members none slot item. High alch: 1 GP, GE limit: 4."
+description: "Volcanic whip mix: How has lava been stored like this...? Cosmetic upgrade for the abyssal whip. GE limit: 4."
 osrs:
   id: 12771
   name: Volcanic whip mix
   slug: volcanic-whip-mix
-  examine: How has lava been stored like this...?
+  examine: "How has lava been stored like this...?"
   members: true
   icon: Volcanic whip mix.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 4
-  equipment:
-    slot: none
-    weight: 0.001
-  drop_table:
-    primary_source: Last Man Standing shop
-    best_drop_rate: N/A
-    sources:
-      - source: Justine's stuff for the Last Shopper Standing
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: shop
-        drop_rate: 25 LMS points
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Last Man Standing lobby
+      price: 25
+      currency: LMS points
+      stock: Unlimited
+  recipes:
+    - product: Volcanic abyssal whip
+      skill: null
+      level: null
+      xp: 0
+      tools: []
+      materials:
+        - item_name: Abyssal whip
+          quantity: 1
+        - item_name: Volcanic whip mix
+          quantity: 1
   related_items:
     - item_id: 12769
       item_name: Frozen whip mix
       slug: frozen-whip-mix
       relationship: alternative
-      description: Blue whip cosmetic variant
+      description: Blue cosmetic variant of the same recipe
     - item_id: 4151
       item_name: Abyssal whip
       slug: abyssal-whip
       relationship: component
-      description: Required base weapon
-    - item_id: 4178
+      description: Required base weapon for the cosmetic upgrade
+    - item_id: 12774
       item_name: Volcanic abyssal whip
       slug: volcanic-abyssal-whip
-      relationship: upgrade
-      description: Final volcanic whip product
-  about: |-
-    Creates Volcanic abyssal whip:
-    - Use on Abyssal whip
-    - Purely cosmetic change (red/orange color)
-    - Stats remain identical to regular whip
-
-    Reversible:
-    - Can be reverted at any time
-    - Returns whip mix when removed
+      relationship: product
+      description: Final volcanic whip cosmetic
+  about: "Volcanic whip mix is a Last Man Standing cosmetic that recolours an abyssal whip into a volcanic variant with identical stats."
   market_strategy:
     notes:
-      - Cosmetic item only
-      - Popular for fashion
-      - Requires LMS gameplay to obtain directly
-      - "Alternative: Buy from GE"
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Cosmetic item, no stat change
+      - Very low buy limit slows flips
+      - Direct LMS purchase is cheapest for grinders
+  trading_tips:
+    - Recolour is reversible via the whip itself
+    - GE arbitrage versus 25 LMS points
+  history:
+    - date: "2014-09-18"
+      description: Released alongside the Bounty Hunter update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-09-18"
+    update: Bounty Hunter
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    alchable: false
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/watchtower-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/watchtower-teleport-tablet.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Watchtower teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Watchtower centre in Yanille (or Yanille directly with hard Ardougne Diary)
+    type: tablet
+    requirements:
+      quest: Watchtower
+  recipes:
+    - skill: Magic
+      level: 58
+      xp: 0
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Earth rune
+          quantity: 2
+      tools:
+        - Mahogany eagle lectern or marble lectern
+  about: "Watchtower teleport tablet is a single-use scroll that teleports the player to the Watchtower in Yanille. Created at a player-owned house lectern after completing the Watchtower quest."
+  market_strategy:
+    notes:
+      - Requires Watchtower quest to use
+      - Made at POH lectern from law and earth runes
+      - Hard Ardougne Diary unlocks direct Yanille teleport option
+  history:
+    - date: "2018-06-14"
+      description: Toggle option replaced with separate Watchtower, Yanille, and Toggle options.
+    - date: "2017-10-12"
+      description: Examine text updated from "A tablet containing a magic spell".
+    - date: "2015-10-08"
+      description: Toggle destination option added.
+    - date: "2015-02-26"
+      description: Renamed from "Watchtower t'port" to "Watchtower teleport".
+    - date: "2006-05-31"
+      description: Released with player-owned houses.
+  properties:
+    release_date: "2006-05-31"
+    update: PLAYER-OWNED HOUSES!
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Watchtower
+    weight: 0
+    options:
+      - Break
+      - Watchtower
+      - Yanille
+      - Toggle
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/waterskin-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/waterskin-4.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Waterskin(4) is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  charges:
+    max_charges: 4
+    charge_type: water_doses
+    recharge_method: Refill at most water sources in the Kharidian Desert and across Gielinor
+  shops:
+    - shop_name: "Shantay's Shanty"
+      location: Shantay Pass
+      price: 30
+  drop_table:
+    sources:
+      - source: Kalphite Worker
+        quantity: "1"
+        rarity: Common
+      - source: Kalphite Soldier
+        quantity: "1"
+        rarity: Common
+      - source: Lizard
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - item_name: Waterskin(0)
+      slug: waterskin-0
+      relationship: variant
+      description: Empty waterskin
+    - item_name: Waterskin(1)
+      slug: waterskin-1
+      relationship: variant
+      description: One dose remaining
+    - item_name: Waterskin(2)
+      slug: waterskin-2
+      relationship: variant
+      description: Two doses remaining
+    - item_name: Waterskin(3)
+      slug: waterskin-3
+      relationship: variant
+      description: Three doses remaining
+  about: "Waterskin(4) is a full four-dose waterskin used to stave off dehydration while traversing the Kharidian Desert."
+  market_strategy:
+    notes:
+      - Steady demand from desert questers and Pyramid Plunder runners
+      - Refillable at most water sources since 2013, capping price ceiling
+      - Buy limit of 2,000 supports bulk supply for desert content
+  history:
+    - date: "2003-04-14"
+      description: Released with the Tourist Trap quest update.
+    - date: "2013-07-26"
+      description: Waterskins became refillable at most water sources across Gielinor.
+  properties:
+    release_date: "2003-04-14"
+    update: "Tourist Trap Quest Online!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/watson-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/watson-teleport.mdx
@@ -12,9 +12,40 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Watson teleport is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Watson's house in Hosidius, Great Kourend
+    type: item
+  related_items:
+    - item_name: Master scroll book
+      slug: master-scroll-book
+      relationship: component
+      description: Exchanged with Watson to obtain teleports
+  about: "Watson teleport is a single-use tablet that teleports the player to Watson's house in Hosidius, Great Kourend. Obtained by trading empty master scroll books to Watson."
+  market_strategy:
+    notes:
+      - Obtained from Watson via empty master scroll books
+      - Useful Hosidius teleport for clue scroll turn-ins and Mimic access
+      - Works without prior Kourend visitation
+  history:
+    - date: "2019-04-11"
+      description: Released with the Treasure Trails Expansion and Easter 2019 update.
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Teleport
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/whisky.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/whisky.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 13000
-  about: "Whisky is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 5
+    effects:
+      - description: Temporary Strength boost
+  shops:
+    - shop_name: The Asp & Snake Bar
+      location: Pollnivneach
+    - shop_name: Funch's Fine Groceries
+      location: Grand Tree
+    - shop_name: The Lighthouse Store
+      location: Lighthouse
+  drop_table:
+    sources:
+      - source: Drink troll
+        quantity: "1"
+        rarity: 1/10
+      - source: Dinky the drink troll
+        quantity: "1"
+        rarity: 1/10
+  related_items:
+    - item_name: Gnome cocktail
+      slug: gnome-cocktail
+      relationship: product
+      description: Used as a cocktail ingredient
+  about: Whisky is a bottle of Draynor Malt sold by various shops across Gielinor and used as an ingredient in gnome cocktails.
+  market_strategy:
+    notes:
+      - Stocked by multiple shops so margins above shop price are the main profit lever
+      - Daily GE volume is thin so flip in small batches
+  trading_tips:
+    - Check vendor restocks in Pollnivneach and the Grand Tree before buying off the GE
+    - Treat alch value as floor reference only; GE price is typically far above alch
+  history:
+    - date: "2002-02-27"
+      update: Latest RuneScape News
+      description: Added to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: Latest RuneScape News
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-partyhat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-partyhat.mdx
@@ -12,9 +12,38 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 5
-  about: "White partyhat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weapon_type: unarmed
+    requirements:
+      attack: 1
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  about: "White partyhat is a rare cosmetic head slot item originally obtained from Christmas crackers during the 2001 holiday event."
+  history:
+    - date: "2001-12-24"
+      description: Released as a drop from Christmas crackers during the 2001 Christmas event.
+    - date: "2013-07-04"
+      description: Re-released temporarily through the Rare Drops event.
+  properties:
+    release_date: "2001-12-24"
+    update: 2001 Christmas event
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-toy-horsey.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-toy-horsey.mdx
@@ -1,6 +1,6 @@
 ---
 title: White toy horsey | OSRS Price Data
-description: "White toy horsey: A white toy horse.. High alch: 60 GP, GE limit: 150."
+description: "White toy horsey: A white toy horse. High alch: 60 GP, GE limit: 150."
 osrs:
   id: 2522
   name: White toy horsey
@@ -12,9 +12,72 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "White toy horsey is a free-to-play item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Diango's Toy Store (Draynor Village)
+      price: 150
+  recipes:
+    - skill: crafting
+      level: 10
+      xp: 0
+      materials:
+        - item_name: Plank
+          quantity: 1
+      tools:
+        - Crafting table
+      product: White toy horsey
+      product_quantity: 1
+      facility: Player-owned house
+      members_only: true
+  related_items:
+    - item_id: 2520
+      item_name: Toy horsey (red)
+      slug: toy-horsey-red
+      relationship: variant
+      description: Red colour variant.
+    - item_id: 2524
+      item_name: Toy horsey (black)
+      slug: toy-horsey-black
+      relationship: variant
+      description: Black colour variant.
+    - item_id: 2526
+      item_name: Toy horsey (brown)
+      slug: toy-horsey-brown
+      relationship: variant
+      description: Brown colour variant.
+  about: "White toy horsey is a free-to-play joke toy sold by Diango in Draynor Village that, when played with, says 'Just say neigh to gambling!'."
+  market_strategy:
+    notes:
+      - Shop price 150 gp from Diango caps the GE value.
+      - One of four colour variants of the toy horsey.
+      - Crafting at 10 Crafting requires a player-owned house.
+  trading_tips:
+    - Buy in bulk from Diango if GE price drifts above 150 gp.
+    - Cosmetic-only demand — thin liquidity at the 150-per-4h limit.
+  history:
+    - date: "2004-04-01"
+      description: "Released as an April Fools joke item from Diango's Toy Store."
+    - date: "2013-03-18"
+      description: "Forced speech changed to always say 'Just say neigh to gambling!'."
+    - date: "2014-12-10"
+      description: "Renamed from 'Toy horsey' to 'White toy horsey'."
+    - date: "2014-12-18"
+      description: "Fixed a typo in the item's text."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-04-01"
+    update: April Fools (Diango's Toy Store)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.05
+    options:
+      - Play-with
+      - Drop
+    alchable: true
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wood-camo-legs-equipped.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wood-camo-legs-equipped.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Wood camo legs (equipped) is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weapon_type: unarmed
+    requirements:
+      attack: 1
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  recipes:
+    - materials:
+        - item_name: Common kebbit fur
+          quantity: "2"
+        - item_name: Coins
+          quantity: "20"
+      tools:
+        - Fancy Clothes Store
+      skill: Hunter
+      level: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Wood camo top
+      relationship: set-piece
+      description: Matching Hunter camouflage top
+  about: "Wood camo legs disguise the wearer in wooded Hunter areas and reduce inventory weight by 2 kg after the Varlamore Part One update."
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill update.
+    - date: "2024-03-20"
+      description: Added 2 kg weight reduction with the Varlamore Part One release.
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yew-longbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yew-longbow-u.mdx
@@ -1,11 +1,11 @@
 ---
 title: Yew longbow (u) | OSRS Price Data
-description: "Yew longbow (u): An unstrung yew longbow; I need a bowstring for this.. High alch: 384 GP, GE limit: 10,000."
+description: "Yew longbow (u): An unstrung yew longbow; I need a bowstring for this. High alch: 384 GP, GE limit: 10,000."
 osrs:
   id: 66
   name: Yew longbow (u)
   slug: yew-longbow-u
-  examine: An unstrung yew longbow; I need a bowstring for this.
+  examine: "An unstrung yew longbow; I need a bowstring for this."
   members: true
   icon: Yew longbow (u).png
   value: 640
@@ -13,79 +13,78 @@ osrs:
   highalch: 384
   limit: 10000
   material:
-    type: fletching
-    tier: unstrung_bow
-  fletching:
-    level: 70
-    xp: 75
-    method: Bowstring on unstrung bow
-  alch:
-    high: 768
-    low: 512
+    type: yew
+    tier: mid-high
   recipes:
-    - skill: fletching
+    - skill: Fletching
       level: 70
       xp: 75
+      tools:
+        - Knife
+      materials:
+        - item_name: Yew logs
+          quantity: 1
+      product: Yew longbow (u)
+    - skill: Fletching
+      level: 70
+      xp: 75
+      tools: []
       materials:
         - item_name: Yew longbow (u)
-          item_id: 66
           quantity: 1
         - item_name: Bow string
-          item_id: 1777
           quantity: 1
       product: Yew longbow
-      product_id: 855
-      product_quantity: 1
   related_items:
     - item_id: 1515
       item_name: Yew logs
       slug: yew-logs
       relationship: component
-      description: Source material
+      description: Source logs cut into the unstrung bow.
     - item_id: 855
       item_name: Yew longbow
       slug: yew-longbow
       relationship: product
-      description: Finished product
+      description: Strung product made from this unstrung bow.
     - item_id: 1777
       item_name: Bow string
       slug: bow-string
       relationship: component
-      description: Required to string
-    - item_id: 561
-      item_name: Nature rune
-      slug: nature-rune
-      relationship: component
-      description: For High Alchemy
+      description: Required to string the bow.
     - item_id: 70
       item_name: Magic longbow (u)
       slug: magic-longbow-u
       relationship: upgrade
-      description: Higher tier
-  about: |-
-    Use a Bow string on Yew longbow (u) to create a Yew longbow.
-
-    | Action | Fletching Level | XP |
-    |--------|-----------------|-----|
-    | String bow | 70 | 75 |
+      description: Higher tier unstrung longbow.
+  about: "Yew longbow (u) is an unstrung yew longbow cut from yew logs at 70 Fletching; adding a bow string finishes it into a Yew longbow."
   market_strategy:
-    steps:
-      - order: 1
-        action: Buy Yew longbow (u) on GE
-      - order: 2
-        action: Buy Bow string on GE
-      - order: 3
-        action: String into Yew longbow
-      - order: 4
-        action: Sell or High Alch
-    profit_formulas:
-      - Yew longbow price - (Yew longbow (u) + Bow string) = Stringing profit
-      - Yew longbow (u) + Bow string + Nature rune < 768 GP
     notes:
-      - "High Alch value: 768 GP"
-      - If  = profit from alching
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Stringing profit is sensitive to bow string margin and GE tax.
+      - High Alch profitability tracks nature rune cost.
+  trading_tips:
+    - Buy in 10k stacks aligned with the GE limit.
+    - Compare combined cost of unstrung + bow string vs strung Yew longbow before flipping.
+  history:
+    - date: "2002-03-25"
+      description: Released as part of the original Fletching skill.
+    - date: "2005-05-17"
+      description: Renamed from Yew longbow to Yew longbow (u) to distinguish unstrung variants.
+  properties:
+    release_date: "2002-03-25"
+    update: Fletching released
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.332
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Ninth batch — migrate 200 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Worktree-direct authoring; main repo untouched.
- Schema-validated via `astro sync`.

Post-agent normalisation:
- `recipes[].output_quantity` string → number
- `special_attack` bare string → `{ description }` object
- `charges` bare number → `{ max_charges }` object
- `trading_tips[]` / `market_strategy.notes[]` entries with inner colons quoted
- `history[].description` with inner colons quoted (e.g. "Nex: The Fifth General")
- `treasure_trail.reward_tiers` stripped invalid "any" entry

## Test plan

- [x] `astro sync` clean — all 200 entries validate.
- [ ] CI build green.

## Follow-ups

- ~3323 v2 items remain after this batch lands.