### PR TITLE
content(astro-kbve): bump 100 OSRS items v2 → v3 (batch 11)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-druidic-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-druidic-cloak.mdx
@@ -1,6 +1,6 @@
 ---
 title: 3rd age druidic cloak | OSRS Price Data
-description: "3rd age druidic cloak is a members cape slot item requiring 65 Defence. High alch: 120,000 GP, GE limit: 8."
+description: "3rd age druidic cloak is a members cape slot item requiring 65 Prayer. High alch: 120,000 GP, GE limit: 8."
 osrs:
   id: 23345
   name: 3rd age druidic cloak
@@ -12,27 +12,34 @@ osrs:
   lowalch: 80000
   highalch: 120000
   limit: 8
+  material:
+    type: 3rd age
+    tier: high
   equipment:
     slot: cape
-    type: prayer cape
-    attack_style: none
+    weight: 0.4
     requirements:
-      defence: 65
       prayer: 65
-    stats:
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      prayer_bonus: 7
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Extremely Rare
-        description: Rarest reward from master clue scrolls
+    attack_bonus:
+      magic: 1
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
+    other_bonus:
+      prayer: 3
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/313168
   related_items:
     - item_id: 23336
       item_name: 3rd age druidic robe top
@@ -50,11 +57,12 @@ osrs:
       relationship: set-piece
       description: Weapon slot of 3rd age druidic set
   about: |-
-    The 3rd age druidic cloak is part of the 3rd age druidic set, the rarest and most prestigious prayer-focused armour set in Old School RuneScape. It requires 65 Defence and 65 Prayer to wear.
+    The 3rd age druidic cloak is part of the 3rd age druidic set, the rarest and most prestigious prayer-focused armour set in Old School RuneScape. It requires 65 Prayer to wear.
 
-    The druidic set is considered one of the most valuable item sets in the game due to its extreme rarity. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
+    The druidic set is considered one of the most valuable item sets in the game due to its extreme rarity. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate of 1/313,168.
+
+    It shares stats with Vestment cloaks and can be stored in a costume room treasure chest.
   market_strategy:
-    title: Investment Notes
     notes:
       - Among the most valuable items in OSRS
       - Extremely rare collector's item
@@ -62,8 +70,28 @@ osrs:
       - Verify authenticity when trading high-value items
       - Use Grand Exchange for secure trades
       - Consider using trusted middlemen for trades exceeding max cash
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2019-04-11"
+      description: Released with the Treasure Trails Expansion and Easter 2019 update as a master clue reward.
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/agility-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/agility-potion-3.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
+  potion:
+    effects:
+      - description: "Temporarily raises Agility level by 3."
+      - description: "Lasts until the boost decays naturally (one level per minute)."
+  recipes:
+    - skill: Herblore
+      level: 34
+      xp: 80
+      materials:
+        - item_name: Toadflax potion (unf)
+          quantity: 1
+        - item_name: Toad's legs
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Agility potion(1)
+      relationship: variant
+    - name: Agility potion(2)
+      relationship: variant
+    - name: Agility potion(4)
+      relationship: variant
+    - name: Agility mix(2)
+      relationship: upgrade
+    - name: Toadflax potion (unf)
+      relationship: component
+    - name: Toad's legs
+      relationship: component
+  market_strategy:
+    notes:
+      - "Used by skillers training Agility to push through stat-gated courses."
+      - "Demand spikes around Wilderness Agility and Ardougne rooftop training pushes."
+      - "Decanted from 4-dose potions, so 3-dose price tracks 4-dose closely."
+  trading_tips:
+    - "Compare per-dose price vs. 4-dose to spot decant arbitrage."
+    - "Stock up on toadflax + toad's legs to craft when demand outpaces supply."
+  history:
+    - date: "2004-07-27"
+      description: "Agility potion released as part of the Herblore expansion."
+  properties:
+    release_date: "2004-07-27"
+    update: Herblore
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   about: "Agility potion(3) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/air-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/air-talisman.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Air talisman is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: magical
+    tier: low
+  drop_table:
+    sources:
+      - source: Air Wizard
+        quantity: "1"
+        rarity: 1/20
+      - source: Dagannoth Prime
+        quantity: "25"
+        rarity: 7/128
+      - source: Abyssal creatures
+        quantity: "1"
+        rarity: Common
+      - source: Rock crabs
+        quantity: "1"
+        rarity: Uncommon
+  recipes:
+    - name: Air tiara
+      skill: Runecraft
+      level: 1
+      experience: 25
+      materials:
+        - item_name: Silver tiara
+          quantity: 1
+        - item_name: Air talisman
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Air tiara
+      relationship: product
+    - name: Air rune
+      relationship: alternative
+    - name: Elemental talisman
+      relationship: alternative
+  about: "Air talisman is a free-to-play runecrafting talisman used to enter the Air Altar. It can be combined with a silver tiara to permanently create an air tiara and is a secondary in combination runecrafting for dust, mist, and smoke runes."
+  history:
+    - date: "2004-03-29"
+      description: Released alongside RuneScape 2's launch.
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2 launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.015
+    options:
+      - Locate
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ankou-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ankou-gloves.mdx
@@ -9,12 +9,77 @@ osrs:
   members: true
   icon: Ankou gloves.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 4
+  material:
+    type: cosmetic
+    tier: high
+  equipment:
+    slot: hands
+    weapon_type: na
+    weight: 0.5
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  drop_table:
+    sources:
+      - source: "Reward casket (master)"
+        quantity: "1"
+        rarity: "1/12,765"
+  related_items:
+    - item_name: Ankou mask
+      slug: ankou-mask
+      relationship: set-piece
+      description: Ankou outfit headpiece
+    - item_name: Ankou's leggings
+      slug: ankous-leggings
+      relationship: set-piece
+      description: Ankou outfit legs
+    - item_name: Ankou top
+      slug: ankou-top
+      relationship: set-piece
+      description: Ankou outfit body
+    - item_name: Ankou socks
+      slug: ankou-socks
+      relationship: set-piece
+      description: Ankou outfit feet
   about: "Ankou gloves is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Master clue cosmetic; price tracks rare-cosmetic supply
+      - No combat bonuses; demand is fashion-driven
+      - 1/12,765 drop from master reward caskets keeps supply thin
+      - Part of full Ankou outfit (mask, top, leggings, socks, gloves)
+      - Buy limit only 4 per 4 hours
+  history:
+    - date: "2016-07-06"
+      description: "Released with the Treasure Trail Expansion update."
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-2-12917.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-2-12917.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 88
   highalch: 133
   limit: 2000
-  about: "Anti-venom+(2) is a members-only item in Old School RuneScape. High alchemy value: 133 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: Instantly cures poison and venom on the player.
+      - description: Grants immunity to poison for 15 minutes and immunity to venom for approximately 3 minutes.
+  recipes:
+    - skill: Herblore
+      level: 94
+      experience: 125
+      materials:
+        - item_name: Anti-venom(4)
+          quantity: 1
+        - item_name: Torstol
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Anti-venom+(4)
+      relationship: variant
+    - name: Anti-venom+(3)
+      relationship: variant
+    - name: Anti-venom+(1)
+      relationship: variant
+    - name: Anti-venom(4)
+      relationship: component
+  about: "Anti-venom+(2) is a 2-dose super antivenom potion in Old School RuneScape created at Herblore level 94 by adding torstol to Anti-venom(4) for 125 experience. Each dose cures and grants temporary immunity to both poison and venom."
+  market_strategy:
+    notes:
+      - Core supply for high-level Slayer bosses (Zulrah, venomous monsters) — demand tracks PvM cycles.
+      - Crafted from Anti-venom(4) and torstol; arbitrage tied to torstol seed/herb prices.
+      - Unfinished torstol potions can substitute for raw torstol since the 2022 update.
+  trading_tips:
+    - Compare price-per-dose against Anti-venom+(4) and Anti-venom+(3) for the best venom coverage value.
+    - Watch torstol price swings — feedstock moves the floor.
+  history:
+    - date: "2015-01-08"
+      description: Released with the Zulrah update; created from Anti-venom(4) plus torstol at Herblore level 94.
+    - date: "2022-11-16"
+      description: Update allowed unfinished torstol potions to substitute for raw torstol when brewing Anti-venom+.
+  properties:
+    release_date: "2015-01-08"
+    update: Zulrah
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-1.mdx
@@ -12,6 +12,11 @@ osrs:
   lowalch: 57
   highalch: 86
   limit: 2000
+  potion:
+    effects:
+      - description: Cures poison on consumption.
+      - description: Grants 90 seconds of poison immunity.
+      - description: Two doses in succession can cure venom (first reduces venom to poison, second removes poison).
   related_items:
     - item_id: 175
       item_name: Antipoison(3)
@@ -23,12 +28,35 @@ osrs:
       slug: antipoison-2
       relationship: variant
       description: 2-dose version
-  about: |-
-    > _"1 dose of antipoison potion."_
-
-    A 1-dose antipoison. Cures poison and grants 90 seconds immunity.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "A 1-dose antipoison. Cures poison and grants 90 seconds immunity."
+  market_strategy:
+    notes:
+      - Single-dose antipoisons are typically obtained by drinking a multi-dose vial; standalone demand is thin compared to (3) and (4) doses.
+      - Liquidity is limited by the 2,000 GE buy limit; price tends to hover near alch value.
+  trading_tips:
+    - Decant 1-dose potions up to higher doses with Bob Barter in the Grand Exchange basement for resale margin.
+    - Compare against (2), (3), and (4) dose prices to spot decanting arbitrage windows.
+  history:
+    - date: "2002-02-27"
+      description: Antipoison potions added to the game alongside the Herblore skill.
+    - date: "2018-05-03"
+      description: Antipoison made purchasable from the Apothecary in Varrock for free-to-play players.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-4.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 144
   highalch: 216
   limit: 2000
-  about: "Antipoison(4) is a free-to-play item in Old School RuneScape. High alchemy value: 216 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - description: "Cures poison and grants 90 seconds of poison immunity per dose."
+      - description: "Two doses can be used to cure venom by first reducing it to poison, then clearing it."
+  recipes:
+    - skill: Herblore
+      level: 5
+      experience: 37.5
+      materials:
+        - item_name: Marrentill potion (unf)
+          quantity: 1
+        - item_name: Unicorn horn dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      output: Antipoison(3)
+  related_items:
+    - item_id: 175
+      item_name: Antipoison(3)
+      slug: antipoison-3
+      relationship: variant
+      description: 3-dose version
+    - item_id: 177
+      item_name: Antipoison(2)
+      slug: antipoison-2
+      relationship: variant
+      description: 2-dose version
+    - item_id: 179
+      item_name: Antipoison(1)
+      slug: antipoison-1
+      relationship: variant
+      description: 1-dose version
+    - item_name: Superantipoison(4)
+      slug: superantipoison-4
+      relationship: upgrade
+      description: Stronger antipoison
+  about: "Antipoison(4) holds four doses of antipoison; each cures poison and grants ~90 seconds of immunity. Two doses also cure venom by stepping it down through poison. Crafted by adding unicorn horn dust to a marrentill potion (unf) at level 5 Herblore."
+  market_strategy:
+    notes:
+      - High GE buy limit (2,000) makes bulk flipping easy
+      - Demand spikes during poison-heavy slayer tasks and PvM events
+      - Herblore supply caps the price near production cost
+  trading_tips:
+    - Buy dips around alch value for safe margins
+    - Stockpile before raids/Slayer streamer events
+  history:
+    - date: "2002-02-27"
+      description: Antipoison potions added with the Herblore skill release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: Herblore
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antler-guard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antler-guard.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: null
-  about: "Antler guard is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    requirements:
+      prayer: 50
+    attack_bonus:
+      stab: 15
+      slash: 15
+      crush: 15
+      magic: 9
+      ranged: 9
+    defence_bonus:
+      stab: -15
+      slash: -15
+      crush: -15
+      magic: -15
+      ranged: -15
+    other_bonus:
+      strength: 5
+      ranged_strength: 2
+      prayer: 5
+    notes: "Tribrid offensive shield — offers attack/strength bonuses across melee, ranged, and magic at the cost of full defensive stats."
+  drop_table:
+    sources:
+      - source: Elder custodian stalker
+        quantity: "1"
+        rarity: "1/650"
+      - source: Ancient Custodian
+        quantity: "1"
+        rarity: "1/650"
+      - source: Mature custodian stalker
+        quantity: "1"
+        rarity: "1/800"
+  about: "Tribrid offensive shield from Varlamore: The Final Dawn — +15 melee attack, +9 magic/ranged, and +5 strength/prayer at the cost of -15 defences across the board."
+  market_strategy:
+    notes:
+      - No GE buy limit, but supply is gated by custodian stalker drops; price tracks DPS comparisons vs other tribrid shields.
+      - Watch for Sulphur Nagua / Custodian update tweaks — drop-rate or BiS reshuffles move the price hard.
+  trading_tips:
+    - Buy dips during PvM update lulls; tribrid shields trend up when new high-tier multi-style content is announced.
+    - Pair price tracking with elven custodian content updates for swing trades.
+  history:
+    - date: "2025-07-23"
+      description: "Released with the Varlamore: The Final Dawn update."
+    - date: "2026-01"
+      description: Erroneously removed from custodian drop tables, briefly making it unobtainable.
+    - date: "2026-01-24"
+      description: Restored to custodian drop tables.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-07-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-brew-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-brew-1.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 2000
+  material:
+    type: potion
+    tier: high
+  potion:
+    doses: 1
+    effects:
+      - description: "Boosts Ranged level by 10% + 4 of the player's base Ranged level."
+      - description: "Boosts Hitpoints by 10% + 2 of the player's base Hitpoints level."
+      - description: "Reduces Attack, Strength, Defence and Magic each by 10% + 2 of current level."
+  recipes:
+    - skill: herblore
+      level: 89
+      xp: 205
+      materials:
+        - item_name: Unfinished umbral potion
+          quantity: 1
+        - item_name: Rainbow crab paste
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      facility: Herblore
+  related_items:
+    - item_name: Armadyl brew(2)
+      slug: armadyl-brew-2
+      relationship: variant
+      description: Two-dose variant
+    - item_name: Armadyl brew(3)
+      slug: armadyl-brew-3
+      relationship: variant
+      description: Three-dose variant
+    - item_name: Armadyl brew(4)
+      slug: armadyl-brew-4
+      relationship: variant
+      description: Four-dose variant
+    - item_name: Vial of water
+      slug: vial-of-water
+      relationship: product
+      description: Empty vial after consumption
   about: "Armadyl brew(1) is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Ranged-focused brew for high-tier PvM
+      - Released with the Sailing update
+      - High-level herblore product (89)
+      - Doses fragment naturally during decant
+      - Bossing demand drives liquidity
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing update."
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-dragonhide-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-dragonhide-set.mdx
@@ -12,9 +12,44 @@ osrs:
   lowalch: 3800
   highalch: 5700
   limit: 8
-  about: "Armadyl dragonhide set is a members-only item in Old School RuneScape. High alchemy value: 5,700 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - name: Armadyl coif
+      relationship: set-piece
+    - name: Armadyl d'hide body
+      relationship: set-piece
+    - name: Armadyl chaps
+      relationship: set-piece
+    - name: Armadyl bracers
+      relationship: set-piece
+  about: "Armadyl dragonhide set is a members-only item in Old School RuneScape. It packages the Armadyl coif, body, chaps and bracers into a single tradeable bundle via the Grand Exchange Sets interface, saving bank space for ranged armour collectors and PvM players."
+  market_strategy:
+    notes:
+      - "Exchanged through the Grand Exchange Sets interface; only profitable if the bundle trades at or near the sum of its four components."
+      - "Compare against the live combined cost of Armadyl coif, body, chaps and bracers before buying or selling the set."
+      - "High alch value (5,700 gp) is far below the component cost, so alching is never the exit strategy."
+  trading_tips:
+    - "Watch the spread between the set price and the four-piece component total to spot arbitrage."
+    - "Buy limit of 8 per 4 hours caps flipping volume; scale across multiple worlds/accounts if needed."
+    - "Sets see demand spikes after ranged content updates or popular streamer PvM runs."
+  history:
+    - date: "2015-03-19"
+      description: "Released alongside the Grand Exchange Sets system for dragonhide armours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-03-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    alchable: true
+    options:
+      - Use
+      - Drop
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/axeman-s-folly-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/axeman-s-folly-4.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Axeman's folly(4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Temporarily boosts Woodcutting by 2 levels."
+      - description: "Lowers Attack by 3 levels."
+  recipes:
+    - materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Hammerstone hops
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: The stuff
+          quantity: 1
+      tools:
+        - Brewing vat
+      output_quantity: 2
+      notes: "Mature Axeman's folly batch fills two 4-pint kegs."
+  related_items:
+    - item_id: 5823
+      item_name: Axeman's folly(1)
+      slug: axeman-s-folly-1
+      relationship: variant
+      description: Single-pint variant
+    - item_id: 5821
+      item_name: Axeman's folly(2)
+      slug: axeman-s-folly-2
+      relationship: variant
+      description: Two-pint variant
+    - item_id: 5819
+      item_name: Axeman's folly(3)
+      slug: axeman-s-folly-3
+      relationship: variant
+      description: Three-pint variant
+  about: "Axeman's folly(4) is a brewed ale keg from the Forgettable Tale of a Drunken Dwarf quest reward brewery line. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  history:
+    - date: "2005-07-11"
+      description: Released alongside the Farming skill update.
+    - date: "2015-02-26"
+      description: Partially drunk variants made untradeable on the Grand Exchange.
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/axeman-s-folly-m.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/axeman-s-folly-m.mdx
@@ -1,20 +1,66 @@
 ---
 title: Axeman's folly(m) | OSRS Price Data
-description: "Axeman's folly(m): This looks a good deal stronger than normal Axeman's Folly.. High alch: 1 GP, GE limit: 2,000."
+description: "Axeman's folly(m): This looks a good deal stronger than normal Axeman's Folly. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5753
   name: Axeman's folly(m)
   slug: axeman-s-folly-m
   examine: This looks a good deal stronger than normal Axeman's Folly.
   members: true
-  icon: Axeman's folly(m).png
+  icon: "Axeman's folly(m).png"
   value: 2
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Axeman's folly(m) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: beer
+    tier: mid
+  potion:
+    effects:
+      - description: "Restores 2 Hitpoints when consumed."
+      - description: "Temporarily boosts Woodcutting level by 2."
+      - description: "Drains Attack level by 4."
+      - description: "Drains Strength level by 4."
+  recipes:
+    - skill: Cooking
+      level: 49
+      materials:
+        - item_name: Mature stew
+          quantity: 8
+      tools:
+        - Brewery
+        - Beer glass
+      product: "Axeman's folly(m)"
+      output_quantity: 8
+  about: "Axeman's folly(m) is the matured version of Axeman's Folly, brewed via Player-Owned House breweries. It restores 2 Hitpoints, boosts Woodcutting by 2, and drains both Attack and Strength by 4 levels. Members-only with a Grand Exchange buy limit of 2,000 per 4 hours."
+  market_strategy:
+    notes:
+      - Brewery output drives supply; price climbs when active brewers are scarce
+      - Niche utility — only Woodcutters seeking a +2 boost over the regular variant
+      - Bulk buyers tend to be 99 Woodcutting goal players
+  trading_tips:
+    - Watch GE volume; thin liquidity can spike prices on small buys
+    - Confirm matured (m) tag before purchase — easy to confuse with regular Axeman's Folly
+  history:
+    - date: "2005-07-11"
+      description: Released with the Farming update as a Player-Owned House brewery product.
+  properties:
+    release_date: "2005-07-11"
+    update: Farming update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-willow-tree.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-willow-tree.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10000
+  construction:
+    level: 30
+    experience: 100
+    notes: Plants in a Garden hotspot; awards both Construction and Farming experience. Requires a filled watering can in the inventory.
+  farming:
+    level: 30
+    experience: 100
+    notes: Planting also grants 100 Farming experience.
+  shops:
+    - shop_name: Garden Supplier (Falador Park)
+      price: 10000
+    - shop_name: Garden Supplier (Farming Guild)
+      price: 10000
+  related_items:
+    - name: Bagged dead tree
+      relationship: variant
+    - name: Bagged nice tree
+      relationship: variant
+    - name: Bagged oak tree
+      relationship: variant
+    - name: Bagged maple tree
+      relationship: variant
+    - name: Bagged yew tree
+      relationship: variant
+    - name: Bagged magic tree
+      relationship: variant
   about: "Bagged willow tree is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Sold flat at 10,000 gp from both Garden Supplier shops; arbitrage opportunity vs GE price.
+      - High alch loss makes the item poor for alch training despite the 6,000 gp alch.
+      - Demand driven by house decorators; relatively niche but steady.
+  trading_tips:
+    - Buy from Garden Supplier shops below the GE price for risk-free margin.
+    - Stock at shops resets over time; rotate visits for bulk supply.
+  history:
+    - date: "2006-05-31"
+      description: Released with the Construction skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: Construction
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Plant
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ballista-limbs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ballista-limbs.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
-  about: "Ballista limbs is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Demonic gorilla
+        quantity: "1"
+        rarity: "1/500"
+      - source: Tortured gorilla
+        quantity: "1"
+        rarity: "1/5000"
+  recipes:
+    - skill: Fletching
+      level: 72
+      experience: 30
+      output_quantity: 1
+      tools: []
+      materials:
+        - item_name: Ballista limbs
+          quantity: 1
+        - item_name: Heavy frame
+          quantity: 1
+      notes: "Produces an Incomplete heavy ballista."
+    - skill: Fletching
+      level: 47
+      experience: 15
+      output_quantity: 1
+      tools: []
+      materials:
+        - item_name: Ballista limbs
+          quantity: 1
+        - item_name: Light frame
+          quantity: 1
+      notes: "Produces an Incomplete light ballista."
+  related_items:
+    - item_id: 19589
+      item_name: Heavy frame
+      slug: heavy-frame
+      relationship: component
+      description: Combined with limbs to start the heavy ballista build.
+    - item_id: 19586
+      item_name: Light frame
+      slug: light-frame
+      relationship: component
+      description: Combined with limbs to start the light ballista build.
+    - item_id: 19481
+      item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: product
+      description: Final two-handed ranged weapon assembled from these limbs.
+  about: "Demonic gorilla drop; combined with a light or heavy frame in Fletching to start ballista assembly. Requires Monkey Madness II completion to use as a weapon."
+  market_strategy:
+    notes:
+      - Supply is almost entirely demonic gorilla drops; price tracks gorilla popularity and Heavy ballista BiS status.
+      - Tiny 8-per-day GE buy limit makes this thin and easy to manipulate over short windows.
+  trading_tips:
+    - Watch Heavy ballista price moves; limb price typically lags by a few hours.
+    - Stack multiple GE accounts within ToS to hit larger weekly buy quantities for assembly flips.
+  history:
+    - date: "2016-05-06"
+      description: Ballista limbs added with the Monkey Madness II update; introduced demonic gorillas as their source.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-chestplate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-chestplate.mdx
@@ -14,11 +14,11 @@ osrs:
   limit: 8
   equipment:
     slot: body
+    weapon_type: unarmed
     weight: 9.979
+    requirements:
+      defence: 65
     attack_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
       magic: -15
       ranged: -10
     defence_bonus:
@@ -29,56 +29,68 @@ osrs:
       ranged: -8
     other_bonus:
       melee_strength: 4
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
-    requirements:
-      defence: 65
+      prayer: 1
   drop_table:
-    primary_source: General Graardor
-    best_drop_rate: 1/381
     sources:
       - source: General Graardor
-        source_id: 2215
-        combat_level: 624
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/381
-        members_only: true
+        rarity: "1/381"
+      - source: Sergeant Strongstack
+        quantity: "1"
+        rarity: "1/16,256"
+      - source: Sergeant Steelwill
+        quantity: "1"
+        rarity: "1/16,256"
+      - source: Sergeant Grimspike
+        quantity: "1"
+        rarity: "1/16,256"
   related_items:
-    - item_id: 11834
-      item_name: Bandos tassets
-      slug: bandos-tassets
+    - name: Bandos tassets
       relationship: set-piece
-      description: Matching leg armor
-    - item_id: 26382
-      item_name: Torva platebody
-      slug: torva-platebody
+    - name: Bandos boots
+      relationship: set-piece
+    - name: Torva platebody
       relationship: upgrade
-      description: Ultimate upgrade
-    - item_id: 10551
-      item_name: Fighter torso
-      slug: fighter-torso
+    - name: Fighter torso
       relationship: alternative
-      description: Budget alternative (untradeable)
-    - item_id: 11128
-      item_name: Bandos boots
-      slug: bandos-boots
-      relationship: set-piece
-      description: Matching boots
+    - name: Rune platebody
+      relationship: downgrade
+  market_strategy:
+    notes:
+      - "Primary supply is General Graardor at 1/381 unique rolls; market sensitive to GWD trip popularity."
+      - "Still a top melee body for trips where +4 Strength matters more than +1 from Torva."
+      - "Used as a Torva platebody component, sinking supply over time."
+  trading_tips:
+    - "Watch Torva platebody recipe demand for upward pressure on Bandos chestplate."
+    - "Volume rises during double XP/league events and falls during dry farming streams."
+  history:
+    - date: "2013-10-17"
+      description: "Released as part of the God Wars Dungeon update for Old School."
+  properties:
+    release_date: "2013-10-17"
+    update: God Wars Dungeon
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   about: |-
     BiS melee body for:
     - All melee combat
     - Bossing
     - Slayer
     - Tank setups
-  market_strategy:
-    notes:
-      - GWD is popular grind
-      - Required for Torva platebody
-      - Still BiS defence
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-tassets.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-tassets.mdx
@@ -12,9 +12,14 @@ osrs:
   lowalch: 115964
   highalch: 173946
   limit: 8
+  material:
+    type: bandos
+    tier: high
   equipment:
     slot: legs
     weight: 9.071
+    requirements:
+      defence: 65
     attack_bonus:
       stab: 0
       slash: 0
@@ -25,60 +30,69 @@ osrs:
       stab: 71
       slash: 63
       crush: 66
-      magic: -21
-      ranged: -7
+      magic: -4
+      ranged: 93
     other_bonus:
-      melee_strength: 2
+      strength: 2
       ranged_strength: 0
       magic_damage: 0
-      prayer: 0
-    requirements:
-      defence: 65
+      prayer: 1
   drop_table:
-    primary_source: General Graardor
-    best_drop_rate: 1/381
     sources:
       - source: General Graardor
-        source_id: 2215
-        combat_level: 624
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/381
-        members_only: true
+        rarity: 1/381
+      - source: Sergeant Strongstack
+        quantity: "1"
+        rarity: 1/16256
+      - source: Sergeant Steelwill
+        quantity: "1"
+        rarity: 1/16256
+      - source: Sergeant Grimspike
+        quantity: "1"
+        rarity: 1/16256
   related_items:
-    - item_id: 11832
-      item_name: Bandos chestplate
-      slug: bandos-chestplate
+    - name: Bandos chestplate
       relationship: set-piece
-      description: Matching body armor
-    - item_id: 26384
-      item_name: Torva platelegs
-      slug: torva-platelegs
+    - name: Bandos boots
+      relationship: set-piece
+    - name: Torva platelegs
       relationship: upgrade
-      description: Ultimate upgrade
-    - item_id: 21298
-      item_name: Obsidian platelegs
-      slug: obsidian-platelegs
+    - name: Obsidian platelegs
       relationship: alternative
-      description: Budget alternative
-    - item_id: 11128
-      item_name: Bandos boots
-      slug: bandos-boots
-      relationship: set-piece
-      description: Matching boots
-  about: |-
-    BiS melee legs for:
-    - All melee combat
-    - Bossing
-    - Slayer
-    - Tank setups
+  about: "Bandos tassets are a top-tier melee leg slot item in Old School RuneScape requiring 65 Defence, dropped by General Graardor and his bodyguards in the God Wars Dungeon. They provide a +2 Strength bonus and serve as the upgrade path component for Torva platelegs."
   market_strategy:
     notes:
-      - GWD is popular grind
-      - Required for Torva platelegs
-      - Still BiS defence
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Long-standing BiS-tier melee legs for many setups; demand stays steady from GWD farming and PvM gearing.
+      - 1/381 drop from General Graardor caps supply — GWD trip volume drives price.
+      - Required component for Torva platelegs, providing a permanent demand floor.
+  trading_tips:
+    - Track GWD popularity (events, double drop weeks) for short-term price dips.
+    - Compare against Torva platelegs spread; if delta narrows, upgrade pressure rises.
+  history:
+    - date: "2013-10-17"
+      description: Released with the God Wars Dungeon update; dropped by General Graardor and his bodyguards.
+    - date: "2014-01-30"
+      description: Item value adjusted from 272,500 to 289,910 coins.
+  properties:
+    release_date: "2013-10-17"
+    update: The God Wars Dungeon has been uncovered!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dart.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Black dart is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: black
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 6
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Burthorpe Imperial Guard soldiers
+        quantity: "1"
+        rarity: 9/128
+  related_items:
+    - item_id: 806
+      item_name: Bronze dart
+      slug: bronze-dart
+      relationship: alternative
+      description: Entry-tier thrown weapon
+    - item_id: 3094
+      item_name: Black dart(p)
+      slug: black-dart-p
+      relationship: variant
+      description: Poisoned variant
+  about: "Black dart is a thrown weapon obtained only from Burthorpe Imperial Guard soldiers, since it cannot be fletched. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
+  history:
+    - date: "2004-08-09"
+      description: Released with the Death Plateau quest update.
+    - date: "2021-06-30"
+      description: Ranged Attack bonus decreased from +7 to 0.
+  properties:
+    release_date: "2004-08-09"
+    update: Death Plateau
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-vengeance-sack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-vengeance-sack.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 10000
+  prayer:
+    spellbook: Lunar
+    spell: Vengeance
+    requirements:
+      magic: 94
+    notes: Consumed when casting Vengeance or Vengeance Other in PvP-enabled zones. Removes the rune requirement entirely.
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      cost: "1 Last Man Standing point per 50"
+    - shop_name: Soul Wars Reward Shop
+      cost: "10 Zeal Tokens per 50"
+  related_items:
+    - name: Blighted anglerfish
+      relationship: variant
+    - name: Blighted manta ray
+      relationship: variant
+    - name: Blighted karambwan
+      relationship: variant
+    - name: Blighted ancient ice sack
+      relationship: variant
+    - name: Blighted surge sack
+      relationship: variant
+    - name: Blighted teleport spell sack
+      relationship: variant
   about: "Blighted vengeance sack is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Bulk-consumed by PKers casting Vengeance without runes; steady wilderness demand.
+      - Sourced from LMS and Soul Wars reward shops; reward-token-to-gp arbitrage drives floor price.
+      - Drops from numerous wilderness Slayer monsters as a secondary supply stream.
+  trading_tips:
+    - Track LMS/Soul Wars point values relative to GE price to gauge floor.
+    - Stack-buy in bulk for high-tier PvP loadouts.
+  history:
+    - date: "2020-04-23"
+      description: Released with the Blighted Items update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-04-23"
+    update: Blighted Items
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-dragonhide-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-dragonhide-set.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 125
-  about: "Blue dragonhide set is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragonhide
+    tier: mid
+  recipes:
+    - materials:
+        - item_name: Blue d'hide body
+          quantity: 1
+        - item_name: Blue d'hide chaps
+          quantity: 1
+        - item_name: Blue d'hide vambraces
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      notes: Exchange the three components with a Grand Exchange clerk via the Sets option.
+  related_items:
+    - name: Blue d'hide body
+      relationship: component
+    - name: Blue d'hide chaps
+      relationship: component
+    - name: Blue d'hide vambraces
+      relationship: component
+    - name: Green dragonhide set
+      relationship: variant
+    - name: Red dragonhide set
+      relationship: variant
+    - name: Black dragonhide set
+      relationship: variant
+  about: "Blue dragonhide set is a members-only Grand Exchange Sets bundle in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 125 per 4 hours."
+  market_strategy:
+    notes:
+      - GE Sets exist purely for one-click flipping; price tracks the three components plus a typical premium.
+      - Useful for merchants accumulating large stacks of d'hide armour without filling bank slots.
+      - Set price minus component price spread closes during high liquidity periods.
+  trading_tips:
+    - Compare the set price to the sum of body/chaps/vambraces; buy and break the cheaper side.
+    - High alch is unprofitable; sets are flipped, not alched.
+  history:
+    - date: "2007-08-01"
+      description: Released with the Grand Exchange armour Sets update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-08-01"
+    update: Grand Exchange Sets
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/book-of-law-page-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/book-of-law-page-set.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 3000
   highalch: 4500
   limit: 5
-  about: "Book of law page set is a members-only item in Old School RuneScape. High alchemy value: 4,500 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: organic
+    tier: low
+  shops:
+    - shop_name: Grand Exchange Sets
+      location: Grand Exchange
+      price: 7500
+  recipes:
+    - name: Book of law page set
+      skill: null
+      level: null
+      experience: null
+      materials:
+        - item_name: Armadyl page 1
+          quantity: 1
+        - item_name: Armadyl page 2
+          quantity: 1
+        - item_name: Armadyl page 3
+          quantity: 1
+        - item_name: Armadyl page 4
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Armadyl page 1
+      relationship: component
+    - name: Armadyl page 2
+      relationship: component
+    - name: Armadyl page 3
+      relationship: component
+    - name: Armadyl page 4
+      relationship: component
+    - name: Book of law
+      relationship: product
+  about: "Book of law page set is a Grand Exchange convenience bundle that packages all four pages of Armadyl's Book of Law into a single tradeable item. Useful for restoring the Book of law without juggling four individual page entries."
+  market_strategy:
+    notes:
+      - Set typically carries a small premium over the sum of its component page prices.
+      - Low daily volume; expect slow flips and watch for arbitrage vs. the loose pages.
+  trading_tips:
+    - Compare set price vs. sum of individual page prices before buying.
+    - Use Grand Exchange Sets exchange to pack or unpack pages.
+  history:
+    - date: "2015-03-19"
+      description: "Released as part of the Boss Pets, Sets, Chat and More update."
+    - date: "2015-03-26"
+      description: God page sets became noted when packed for improved storage efficiency.
+  properties:
+    release_date: "2015-03-19"
+    update: "Boss Pets, Sets, Chat & More"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broken-zombie-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broken-zombie-axe.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 64000
   highalch: 96000
   limit: null
+  material:
+    type: zombie
+    tier: high
+  drop_table:
+    sources:
+      - source: "Armoured zombie (Zemouregal's Base)"
+        quantity: "1"
+        rarity: "1/800"
+      - source: "Armoured zombie (Zemouregal's Fort)"
+        quantity: "1"
+        rarity: "1/600"
+  recipes:
+    - skill: smithing
+      level: 70
+      xp: 500
+      materials:
+        - item_name: Broken zombie axe
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+      facility: Anvil
+      product: Zombie axe
+  related_items:
+    - item_name: Zombie axe
+      slug: zombie-axe
+      relationship: product
+      description: Repaired usable axe
+    - item_name: Armoured zombie
+      slug: armoured-zombie
+      relationship: alternative
+      description: Source monster
   about: "Broken zombie axe is a members-only item in Old School RuneScape. High alchemy value: 96,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Rare drop from armoured zombies in Defender of Varrock content
+      - Requires 70 Smithing to repair into the usable Zombie axe
+      - Repair yields 500 Smithing XP
+      - High alch makes it a viable alch fodder in bulk if undervalued
+      - Tradeable broken state lets non-repairers flip to crafters
+  history:
+    - date: "2024-02-21"
+      description: "Released with the Defender of Varrock update."
+  properties:
+    release_date: "2024-02-21"
+    update: Defender of Varrock
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Inspect
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-javelin-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-javelin-p.mdx
@@ -12,24 +12,82 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 7000
+  material:
+    type: bronze
+    tier: low
   equipment:
-    slot: weapon
+    slot: ammo
+    weapon_type: thrown
     attack_speed: 6
+    weight: 0
+    requirements: {}
     attack_bonus:
-      ranged: 6
-    ranged_strength: 25
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 25
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Bronze javelin
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 825
-      item_name: Bronze javelin
-      slug: bronze-javelin
+    - name: Bronze javelin
       relationship: variant
-      description: Unpoisoned version
-  about: |-
-    > _"A bronze tipped javelin with a poisoned tip."_
-
-    A bronze javelin tipped with basic weapon poison. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Bronze javelin(p+)
+      relationship: variant
+    - name: Bronze javelin(p++)
+      relationship: variant
+    - name: Iron javelin(p)
+      relationship: upgrade
+  about: "Bronze javelin(p) is a members-only thrown weapon in Old School RuneScape. Poison variant of the bronze javelin, dealing additional damage over time. High alchemy value: 2 coins. Grand Exchange buy limit: 7,000 per 4 hours."
+  market_strategy:
+    notes:
+      - Bottom-tier poisoned javelin; mostly used by ironmen needing thrown ammo.
+      - Spread vs unpoisoned variant equals weapon poison vial cost.
+      - Low alch makes the item unsuitable for alch training.
+  trading_tips:
+    - Buy unpoisoned and poison yourself if weapon poison is cheap on the GE.
+    - Lowest tier javelin; most demand sits on iron+ tiers.
+  history:
+    - date: "2004-03-29"
+      description: Released with the RS2 launch javelin lineup.
+    - date: "2016-10-31"
+      description: Ranged Strength bonus reduced from +30 to +25 in the ranged rebalance.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bullseye-lantern.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bullseye-lantern.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 168
   highalch: 252
   limit: 10000
+  material:
+    type: light_source
+    tier: mid-high
+  related_items:
+    - item_name: Bullseye lantern (unf)
+      slug: bullseye-lantern-unf
+      relationship: component
+      description: Unfinished lantern frame
+    - item_name: Lantern lens
+      slug: lantern-lens
+      relationship: component
+      description: Required lens component
+    - item_name: Bullseye lantern (oil)
+      slug: bullseye-lantern-oil
+      relationship: variant
+      description: Oil-filled version ready to light
   about: "Bullseye lantern is a members-only item in Old School RuneScape. High alchemy value: 252 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Required for Lumbridge Swamp Caves exploration
+      - Niche demand from quest and exploration players
+      - Safer alternative to candle lanterns in swamp gas areas
+      - Crafted from unfinished frame plus lens plus oil
+      - Stable low-volume market
+  history:
+    - date: "2005-03-14"
+      description: "Released with the Lumbridge Swamp Caves update."
+  properties:
+    release_date: "2005-03-14"
+    update: Lumbridge Swamp Caves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Light
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cannon-furnace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cannon-furnace.mdx
@@ -13,27 +13,49 @@ osrs:
   highalch: 112500
   limit: 70
   related_items:
-    - item_id: 6
-      item_name: Cannon base
-      slug: cannon-base
+    - name: Cannon base
       relationship: set-piece
-      description: Multicannon base component
-    - item_id: 8
-      item_name: Cannon stand
-      slug: cannon-stand
+    - name: Cannon stand
       relationship: set-piece
-      description: Multicannon stand component
-    - item_id: 10
-      item_name: Cannon barrels
-      slug: cannon-barrels
+    - name: Cannon barrels
       relationship: set-piece
-      description: Multicannon barrels component
-  about: |-
-    > _"This powers the multicannon."_
-
-    The cannon furnace is the fourth and final component placed when assembling a dwarf multicannon. Requires completion of the Dwarf Cannon quest to use. Once placed, the cannon can be loaded with cannonballs and fired. Tradeable on the Grand Exchange.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Dwarf multicannon
+      relationship: product
+  about: "Cannon furnace is the fourth and final component placed when assembling a dwarf multicannon, requiring completion of the Dwarf Cannon quest. Once the full set is placed, the cannon can be loaded with cannonballs and fired automatically at nearby enemies."
+  shops:
+    - shop_name: Multicannon parts for sale
+      location: Ice Mountain
+      price: 200625
+  market_strategy:
+    notes:
+      - Required component for the dwarf multicannon — demand tracks Slayer activity.
+      - Backed by the Nulodion shop at 200,625 gp; GE flips work only on dips below shop price.
+      - Quest-locked behind Dwarf Cannon, so buyer pool is filtered to mid/late-game members.
+  trading_tips:
+    - Use the shop price ceiling to set short bids.
+    - Watch demand spikes during double Slayer events when AFK ranged camping picks up.
+  history:
+    - date: "2003-05-27"
+      description: Released with the new Dwarf Cannon quest as the final component of the dwarf multicannon.
+    - date: "2004-09-14"
+      description: Examine text updated from "Used to make the cannon's ammo" to "This powers the multicannon." during the late-2004 polish pass.
+  properties:
+    release_date: "2003-05-27"
+    update: New Dwarf Cannon Quest
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    quest: Dwarf Cannon
+    weight: 5
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cider-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cider-4.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Cider(4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: Drinking a pint heals 1 Hitpoints and temporarily boosts Attack by 2 while reducing Strength by 2.
+      - description: Effects mirror drinking a glass of cider; each keg holds 4 pints.
+  related_items:
+    - name: Cider(3)
+      relationship: variant
+    - name: Cider(2)
+      relationship: variant
+    - name: Cider(1)
+      relationship: variant
+    - name: Beer glass
+      relationship: component
+  about: "Cider(4) is a members-only beverage keg in Old School RuneScape brewed at level 14 Cooking from 4 apple mush, 1 ale yeast, and 2 calquat kegs at a brewery, yielding 8 pints (two full kegs)."
+  market_strategy:
+    notes:
+      - Largely a brewing supply / cosmetic drink; no alch value.
+      - Partially drunk kegs were made untradeable in 2015, so only sealed Cider(4) kegs hit the GE.
+      - Buy limit of 2,000 per 4 hours allows decent flipping volume despite low unit price.
+  trading_tips:
+    - Watch brewery output cycles for supply gluts.
+    - Pair with Calquat keg price to estimate brewer margins.
+  history:
+    - date: "2005-07-11"
+      description: Released as part of the Farming update; brewed at a brewery via the Cooking skill.
+    - date: "2015-02-26"
+      description: Partially drunk versions made untradeable during the Grand Exchange update; only full Cider(4) kegs remain tradeable.
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-divine-severance.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-divine-severance.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: null
   highalch: null
   limit: 50
-  about: "Contract of divine severance is a members-only item in Old School RuneScape. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: organic
+    tier: mid
+  drop_table:
+    sources:
+      - source: Lesser demon (Chasm of Fire)
+        quantity: "1"
+        rarity: 1/123
+      - source: Greater demon (Chasm of Fire)
+        quantity: "1"
+        rarity: 1/81
+      - source: Black demon (Chasm of Fire)
+        quantity: "1"
+        rarity: 1/53
+      - source: Dossier
+        quantity: "1"
+        rarity: 260/1740
+      - source: Yama
+        quantity: "1"
+        rarity: Always (returned on success)
+  related_items:
+    - name: Purifying sigil
+      relationship: product
+    - name: Soulflame horn
+      relationship: alternative
+  about: "Contract of divine severance is consumed to challenge Yama for a more difficult encounter that drops the right piece of the Purifying Sigil. The contract is returned upon a successful kill. Drop rate from Chasm of Fire demons doubles while the green sigil effect is active."
+  market_strategy:
+    notes:
+      - Demand spikes during sigil-meta updates; track Yama drop logs for supply shifts.
+      - Doubled drop rate with the green sigil active makes farmed supply elastic.
+  trading_tips:
+    - Use heavy ranged weapons in Chasm of Fire for best drop efficiency.
+    - Stack with green sigil for doubled rate.
+  history:
+    - date: "2025-05-14"
+      description: "Released as part of the Yama, the Master of Pacts update."
+    - date: "2025-05-24"
+      description: Fixed a bug making the fight impossible in phase 3.
+    - date: "2025-05-29"
+      description: "Grand Exchange buy limit raised from 5 to 50; phase thresholds adjusted to 75 percent and 50 percent health."
+    - date: "2025-06-04"
+      description: Void flare health reduced from 83 to 81.
+  properties:
+    release_date: "2025-05-14"
+    update: "Yama, the Master of Pacts"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Read
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-kyatt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-kyatt.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 10000
-  about: "Cooked kyatt is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    effects:
+      - description: "Heals 17 Hitpoints total: 9 on consumption, then 8 more after a 7-tick (~4.2 second) delay."
+      - description: Behaves as a combo-style food that frees up an action while the delayed heal lands.
+  recipes:
+    - skill: Cooking
+      level: 51
+      experience: 143
+      output_quantity: 1
+      tools:
+        - Fire or cooking range
+      materials:
+        - item_name: Raw kyatt
+          quantity: 1
+      notes: "Requires 25 Hunters' Rumours completed before raw kyatt can be obtained."
+  related_items:
+    - item_id: 29150
+      item_name: Raw kyatt
+      slug: raw-kyatt
+      relationship: component
+      description: Raw form cooked into this product.
+  about: "Cooked kyatt is a Hunter-skill food cooked at 51 Cooking that delivers a 9 + 8 split heal totalling 17 HP."
+  market_strategy:
+    notes:
+      - Profit on cooked kyatt is tied to raw kyatt supply from Hunters' Rumours; raw price + small margin sets the floor.
+      - Split-heal design makes it attractive for tick-eating PvM content, supporting steady demand.
+  trading_tips:
+    - Buy raw kyatt, cook to 51+ Cooking, and flip for the gp/xp + margin combo.
+    - Watch Hunters' Rumours throughput in updates to anticipate raw kyatt price swings.
+  history:
+    - date: "2024-03-20"
+      description: Cooked kyatt added with the Hunters' Rumours / Varlamore content expansion.
+    - date: "2026-05-13"
+      description: Inventory icon graphically updated for improved vibrancy.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crossbow.mdx
@@ -12,20 +12,66 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 125
+  material:
+    type: wood
+    tier: low
   equipment:
     slot: weapon
+    weapon_type: crossbow
     attack_speed: 6
+    weight: 8
     requirements:
       ranged: 1
     attack_bonus:
       ranged: 6
-  related_items: []
+  shops:
+    - shop_name: "Lowe's Archery Emporium"
+      location: Varrock
+      price: 70
+    - shop_name: "Hickton's Archery Emporium"
+      location: Catherby
+      price: 70
+  related_items:
+    - item_id: 877
+      item_name: Bronze bolts
+      slug: bronze-bolts
+      relationship: component
+      description: Ammunition fired by the basic crossbow
+    - item_id: 9419
+      item_name: Mith grapple
+      slug: mith-grapple
+      relationship: component
+      description: Special ammunition usable with the basic crossbow
   about: |-
     > _"This fires crossbow bolts."_
 
-    The crossbow is the most basic crossbow, requiring 1 Ranged. Fires bronze bolts and above. Slower than shortbows but usable with a shield for defensive setups.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The crossbow is the most basic crossbow, requiring 1 Ranged. Fires bronze bolts and mith grapples only. Slower than shortbows but usable with a shield for defensive setups. It is the heaviest one-handed weapon in the game at 8kg.
+  market_strategy:
+    notes:
+      - F2P-available baseline weapon — supply is plentiful
+      - Low alchemy margin; flips rarely worth the slot
+      - Mith grapple compatibility keeps niche demand among questers
+  history:
+    - date: "2001-01-04"
+      description: Added to the game.
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 8
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dagon-hai-robe-bottom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dagon-hai-robe-bottom.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 36000
   highalch: 54000
   limit: null
-  about: "Dagon'hai robe bottom is a members-only item in Old School RuneScape. High alchemy value: 54,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: high
+  equipment:
+    slot: legs
+    weight: 1.814
+    requirements:
+      magic: 70
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 18
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 14
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 1
+      prayer: 2
+  drop_table:
+    sources:
+      - source: Larran's big chest
+        quantity: "1"
+        rarity: "1/256"
+  related_items:
+    - name: Dagon'hai hat
+      relationship: set-piece
+    - name: Dagon'hai robe top
+      relationship: set-piece
+  about: "Dagon'hai robe bottom is a members-only Magic legs slot item in Old School RuneScape. High alchemy value: 54,000 coins."
+  market_strategy:
+    notes:
+      - Sole supply via Larran's big chest in the Wilderness; supply tightly coupled to wildy slayer activity.
+      - High alch of 54,000 gp provides a strong price floor relative to GE price.
+      - Magic damage bonus buff in May 2024 lifted demand from PvMers running mid-tier magic setups.
+  trading_tips:
+    - Watch Wilderness slayer task popularity and Larran's chest key supply.
+    - Spread between set price and individual pieces is usually wide; usually flip pieces individually.
+  history:
+    - date: "2019-10-24"
+      description: Released as a unique drop from Larran's big chest with the Wilderness Slayer rework.
+    - date: "2024-05-08"
+      description: Magic damage bonus increased from 0% to 1%.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-10-24"
+    update: Wilderness Slayer Rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dark-tuxedo-cuffs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dark-tuxedo-cuffs.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 4
-  about: "Dark tuxedo cuffs is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: hands
+    weight: 0.5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/12750
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - name: Dark tuxedo jacket
+      relationship: set-piece
+    - name: Dark tuxedo trousers
+      relationship: set-piece
+    - name: Dark tuxedo shoes
+      relationship: set-piece
+    - name: Dark tuxedo cane
+      relationship: set-piece
+  about: "Dark tuxedo cuffs are a cosmetic hands-slot item in Old School RuneScape obtained as a 1/12,750 reward from elite Treasure Trail caskets. They form part of the dark tuxedo outfit and can be stored in the costume room treasure chests."
+  market_strategy:
+    notes:
+      - Cosmetic clue reward — value is driven by outfit completionists.
+      - Extremely thin supply (1/12,750 elite casket); GE limit of 4 per 4 hours.
+      - Stores in the POH costume room; Ultimate Ironmen can only retrieve once the full set is stored.
+  trading_tips:
+    - Track elite clue casket completion rates around content updates for supply spikes.
+    - Compare against the white/regular tuxedo cuffs to price the dark variant premium.
+  history:
+    - date: "2016-07-06"
+      description: Released as part of the Treasure Trail Expansion update; obtainable as an elite clue reward.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/defence-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/defence-potion-3.mdx
@@ -12,23 +12,68 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 2000
+  potion:
+    doses: 3
+    effects:
+      - skill: Defence
+        description: "Boosts Defence by 3 + 10% of current Defence level (rounded down). Effect decays at 1 point per minute (90 seconds with Preserve)."
+  recipes:
+    - skill: Herblore
+      level: 30
+      experience: 75
+      materials:
+        - item_name: Ranarr potion (unf)
+          quantity: "1"
+        - item_name: White berries
+          quantity: "1"
+      tools: []
+      output_quantity: 1
+      notes: "Use white berries on a ranarr potion (unf) at 30 Herblore for 75 XP."
+  shops:
+    - shop_name: "Warrior Guild Potion Shop"
+      location: "Warriors' Guild, Burthorpe"
+      members: true
   related_items:
-    - item_id: 135
-      item_name: Defence potion(2)
-      slug: defence-potion-2
+    - name: Defence potion(4)
       relationship: variant
-      description: 2-dose version
-    - item_id: 137
-      item_name: Defence potion(1)
-      slug: defence-potion-1
+    - name: Defence potion(2)
       relationship: variant
-      description: 1-dose version
-  about: |-
-    > _"3 doses of Defence potion."_
-
-    The defence potion boosts Defence by 3 + 10% of current level (rounded down). A mid-level Herblore potion useful for early combat training.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Defence potion(1)
+      relationship: variant
+    - name: Super defence(3)
+      relationship: upgrade
+  about: "Defence potion(3) is a 3-dose Herblore potion in Old School RuneScape that boosts the drinker's Defence level by 3 + 10% of current Defence. A mid-level Herblore product used for early combat training and budget tanking; sold by the Warriors' Guild Potion Shop and crafted from ranarr potion (unf) + white berries at 30 Herblore."
+  market_strategy:
+    notes:
+      - "Mid-tier Herblore output; consumable demand is dwarfed by Super defence and Sara brews."
+      - "Mostly used by ironmen, early questers, and Warriors' Guild trips."
+      - "Buy limit of 2,000 per 4 hours allows decent bulk flipping when crafting decoupling appears."
+  trading_tips:
+    - "Compare GE price against ranarr potion (unf) + white berries — these are the canonical decant arbitrage inputs."
+    - "Watch for decanting opportunities: 3-dose vs 4-dose price gaps create steady profit from NPC decanters."
+    - "Stock up before Combat Academy or new low-level PvM content releases."
+  history:
+    - date: "2002-02-27"
+      description: "Released with the Herblore skill rework."
+    - date: "2004-03-29"
+      description: "4-dose variant added permanently with RuneScape 2 launch."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    alchable: true
+    options:
+      - Drink
+      - Empty
+      - Drop
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/desert-camo-top-equipped.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/desert-camo-top-equipped.mdx
@@ -1,6 +1,6 @@
 ---
 title: Desert camo top (equipped) | OSRS Price Data
-description: "Desert camo top (equipped): This should make me harder to spot in desert areas.. High alch: 12 GP."
+description: "Desert camo top (equipped): This should make me harder to spot in desert areas. High alch: 12 GP."
 osrs:
   id: 28851
   name: Desert camo top (equipped)
@@ -12,9 +12,56 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Desert camo top (equipped) is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: body
+    weight: -3
+  recipes:
+    - skill: Hunter
+      materials:
+        - item_name: Desert devil fur
+          quantity: 2
+      tools:
+        - 20 coins
+      product: Desert camo top
+      output_quantity: 1
+  related_items:
+    - item_id: 28849
+      item_name: Desert camo top
+      slug: desert-camo-top
+      relationship: variant
+      description: Inventory version of the desert camo top
+  about: Desert camo top (equipped) is the worn-state variant of the Hunter camouflage body piece. It provides camouflage in desert areas and was rebalanced in Varlamore Part One to reduce weight by 3kg when equipped.
+  market_strategy:
+    notes:
+      - Made on demand from desert devil furs at the Hunter Guild and other camo NPCs
+      - Negligible flip margin; primarily Hunter completionist gear
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill launch.
+    - date: "2024-03-20"
+      description: "Updated in Varlamore: Part One to reduce equipped weight by 3kg."
+  properties:
+    release_date: "2006-11-21"
+    update: "HUNTER SKILL!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: -3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-magic-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-magic-potion-2.mdx
@@ -1,20 +1,89 @@
 ---
 title: Divine magic potion(2) | OSRS Price Data
-description: "Divine magic potion(2): 2 doses of divine magic potion.. High alch: 54 GP, GE limit: 2,000."
+description: "Divine magic potion(2): 2 doses of divine magic potion. High alch: 54 GP, GE limit: 2,000."
 osrs:
   id: 23751
   name: Divine magic potion(2)
   slug: divine-magic-potion-2
   examine: 2 doses of divine magic potion.
   members: true
-  icon: Divine magic potion(2).png
+  icon: "Divine magic potion(2).png"
   value: 90
   lowalch: 36
   highalch: 54
   limit: 2000
-  about: "Divine magic potion(2) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid-high
+  potion:
+    effects:
+      - description: "Boosts Magic by 4 levels for 5 minutes; Magic cannot naturally drain below the boost during this window."
+      - description: "Drinking deals 10 Hitpoints of damage; requires at least 11 Hitpoints to consume."
+  recipes:
+    - skill: Herblore
+      level: 78
+      xp: 1
+      materials:
+        - item_name: Magic potion(2)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 2
+      tools: []
+      product: Divine magic potion(2)
+      output_quantity: 1
+  related_items:
+    - item_id: 23749
+      item_name: Divine magic potion(4)
+      slug: divine-magic-potion-4
+      relationship: variant
+      description: 4-dose version
+    - item_id: 23753
+      item_name: Divine magic potion(3)
+      slug: divine-magic-potion-3
+      relationship: variant
+      description: 3-dose version
+    - item_id: 23754
+      item_name: Divine magic potion(1)
+      slug: divine-magic-potion-1
+      relationship: variant
+      description: 1-dose version
+    - item_id: 3040
+      item_name: Magic potion(2)
+      slug: magic-potion-2
+      relationship: component
+      description: Base potion used in the recipe
+  about: "2-dose variant of the Divine magic potion. Boosts Magic by 4 levels for 5 minutes while preventing natural drain, at the cost of 10 Hitpoints per dose."
+  market_strategy:
+    notes:
+      - Compare dose-per-GP against 3 and 4 dose variants before decanting
+      - Demand tied to PvP and high-level Magic content
+      - Crystal dust supply (Song of the Elves required) caps brewers, supporting prices
+  trading_tips:
+    - Watch for decanting profit between (4) (3) (2) and (1) variants
+    - Volume spikes during Magic-heavy content patches
+  history:
+    - date: "2019-07-25"
+      description: Released with the Song of the Elves quest update.
+    - date: "2020-07-02"
+      description: Inventory icon updated to match standard potion aesthetics.
+  properties:
+    release_date: "2019-07-25"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hunter-wand.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hunter-wand.mdx
@@ -12,44 +12,40 @@ osrs:
   lowalch: 120000
   highalch: 180000
   limit: 8
+  material:
+    type: magical
+    tier: high
   equipment:
     slot: weapon
-    type: wand
-    tradeable: true
+    weapon_type: staff_and_wand
+    attack_speed: 5
     weight: 2
     requirements:
       magic: 65
-    stats:
-      attack_magic: 16
-      defence_magic: 16
+    attack_bonus:
+      magic: 16
+    defence_bonus:
+      magic: 16
+    other_bonus:
       magic_damage: 10
-  effect:
-    name: Dragonbane
-    description: 75% accuracy and damage increase vs dragons, wyrms, wyverns, hydras
-    stacks_with:
-      - Slayer helmet (i)
-      - Elite Void Knight
-  autocasts:
-    - Standard spellbook
-    - Ancient spellbook
+  special_attack:
+    description: "Dragonbane effect: 75% accuracy increase and 40% damage increase against draconic creatures (dragons, wyrms, wyverns, hydras). Stacks multiplicatively with Slayer helmet (i) and Elite Void Knight equipment."
   drop_table:
     sources:
       - source: The Hueycoatl
-        rate: 1/105
-  market:
-    buy_limit: 8
-    price_estimate: 16395392
+        quantity: "1"
+        rarity: 1/105
   related_items:
     - item_id: 22978
       item_name: Dragon hunter lance
       slug: dragon-hunter-lance
       relationship: alternative
-      description: Melee dragonbane
+      description: Melee dragonbane weapon
     - item_id: 21012
       item_name: Dragon hunter crossbow
       slug: dragon-hunter-crossbow
       relationship: alternative
-      description: Ranged dragonbane
+      description: Ranged dragonbane weapon
   about: |-
     | Stat | Bonus |
     |------|-------|
@@ -60,7 +56,7 @@ osrs:
     The Dragon hunter wand possesses the powerful Dragonbane effect:
 
     - 75% accuracy boost against draconic creatures
-    - 75% damage boost against draconic creatures
+    - 40% damage boost against draconic creatures
     - Affects: Dragons, Wyrms, Wyverns, and Hydras
 
     Stacking: The dragonbane effect stacks multiplicatively with:
@@ -83,8 +79,32 @@ osrs:
       - Price correlates with Hydra and dragon boss popularity
       - Consider flipping around new content releases featuring dragons
       - Pairs well with other magic gear upgrades
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2024-09-25"
+      description: "Released with the Varlamore: The Rising Darkness update as a drop from The Hueycoatl."
+    - date: "2024-11-27"
+      description: Received +16 Magic defence bonus.
+    - date: "2025-06-25"
+      description: Bonuses increased from 50% accuracy/20% damage to 75% accuracy/40% damage; Ancient Magicks autocast added.
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elkhorn-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elkhorn-potion-unf.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: null
-  about: "Elkhorn potion (unf) is a members-only item in Old School RuneScape. High alchemy value: 15 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Herblore
+      level: 56
+      materials:
+        - item_name: Vial of water
+          quantity: 1
+        - item_name: Elkhorn coral
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_id: 31664
+      item_name: Haemostatic poultice
+      slug: haemostatic-poultice
+      relationship: product
+      description: Finished potion product
+    - item_name: Elkhorn coral
+      slug: elkhorn-coral
+      relationship: component
+      description: Primary ingredient
+    - item_name: Vial of water
+      slug: vial-of-water
+      relationship: component
+      description: Base liquid
+  about: "Elkhorn potion (unf) is an unfinished Herblore potion created by adding an elkhorn coral to a vial of water at level 56 Herblore. Adding squid paste completes it into a Haemostatic poultice. Introduced in the Sailing update."
+  market_strategy:
+    notes:
+      - No GE buy limit
+      - Acts as a Herblore intermediate, demand driven by Haemostatic poultice usage
+      - Often unprofitable to produce directly
+  trading_tips:
+    - Track elkhorn coral and squid paste prices together
+    - Bulk-make only when poultice demand spikes
+  history:
+    - date: "2025-11-05"
+      description: Added to the game as an unobtainable item.
+    - date: "2025-11-19"
+      description: Made obtainable with the Sailing release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drink
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/evil-chicken-feet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/evil-chicken-feet.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Evil chicken feet is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.25
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - name: Evil chicken head
+      relationship: set-piece
+    - name: Evil chicken wings
+      relationship: set-piece
+    - name: Evil chicken legs
+      relationship: set-piece
+  about: "Evil chicken feet is a members-only item in Old School RuneScape obtained by offering bird's eggs at the shrine in the Woodcutting Guild with a 1/300 chance per offering. It forms part of the evil chicken outfit set."
+  market_strategy:
+    notes:
+      - Cosmetic outfit piece with no combat bonuses; value driven by completionists and outfit collectors.
+      - Rare drop from bird's egg offerings at the Woodcutting Guild shrine; supply is naturally constrained.
+      - GE buy limit of 4 per 4 hours restricts flipping volume.
+  trading_tips:
+    - Watch for outfit set demand spikes during seasonal events.
+    - Compare price against the other three outfit pieces to gauge set premium.
+  history:
+    - date: "2016-07-21"
+      description: Released as part of the Broken Armour & Open Beta update; obtainable from the shrine in the Woodcutting Guild.
+  properties:
+    release_date: "2016-07-21"
+    update: Broken Armour & Open Beta
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eye-of-ayak-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eye-of-ayak-uncharged.mdx
@@ -5,16 +5,73 @@ osrs:
   id: 31115
   name: Eye of ayak (uncharged)
   slug: eye-of-ayak-uncharged
-  examine: This staff is imbued with demonic power. It is currently uncharged.
+  examine: "This staff is imbued with demonic power. It is currently uncharged."
   members: true
   icon: Eye of ayak (uncharged).png
   value: 6000000
   lowalch: 2400000
   highalch: 3600000
   limit: 8
-  about: "Eye of ayak (uncharged) is a members-only item in Old School RuneScape. High alchemy value: 3,600,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ayak
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 3
+    weight: 2
+    requirements:
+      magic: 83
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 30
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 5
+      crush: 5
+      magic: 10
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 2
+  charges:
+    max_charges: 50000
+    description: "Charge with death/chaos runes or demon tears; lasts roughly 25 hours of continuous combat."
+  drop_table:
+    sources:
+      - source: Doom of Mokhaiotl
+        quantity: "1"
+        rarity: 1/2000
+  related_items:
+    - item_id: 31117
+      item_name: Eye of ayak
+      slug: eye-of-ayak
+      relationship: variant
+      description: Charged form of the staff
+  about: "Eye of ayak (uncharged) is the dormant form of the powered staff dropped by Doom of Mokhaiotl in Varlamore. Must be charged before it can be equipped. High alchemy value: 3,600,000 coins. Grand Exchange buy limit: 8 per 4 hours."
+  history:
+    - date: "2025-07-23"
+      description: "Released with Varlamore: The Final Dawn."
+    - date: "2026-01-15"
+      description: Fixed invisibility bugs that affected Akkha and Yama encounters.
+  properties:
+    release_date: "2025-07-23"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fat-snail-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fat-snail-meat.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 6000
+  food:
+    heals: 9
+    cooking_level: 22
+    cooking_xp: 95
+  recipes:
+    - skill: Cooking
+      level: 22
+      xp: 95
+      materials:
+        - item_name: Thin snail
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Giant Snail
+        quantity: "1"
+        rarity: Always
+      - source: Brine rat
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - name: Thin snail
+      relationship: component
+    - name: Thin snail meat
+      relationship: alternative
+    - name: Lean snail meat
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Cooked from thin snails dropped during Tale of the Bald Druid-area giant snail hunts."
+      - "Heals 7-9 HP, niche food but cheap calories for early members."
+      - "Margins stay thin; mostly a flipping item between F2P-friendly food rotations."
+  trading_tips:
+    - "Watch for slayer task spikes that flood the market with snail meat."
+    - "Buy in noted bulk if alchemy floor is close to GE price for low-risk holds."
+  history:
+    - date: "2004-10-14"
+      description: "Released as part of the Morytania expansion."
+    - date: "2005-07-04"
+      description: "Examine text corrected from slimey to slimy."
+  properties:
+    release_date: "2004-10-14"
+    update: Morytania Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   about: "Fat snail meat is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-halibut.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-halibut.mdx
@@ -11,10 +11,57 @@ osrs:
   value: 5
   lowalch: 2
   highalch: 3
-  limit: null
-  about: "Fish crate (halibut) is a members-only item in Old School RuneScape. High alchemy value: 3 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit: 250
+  recipes:
+    - skill: Fishing
+      materials:
+        - item_name: Empty fish crate
+          quantity: "1"
+        - item_name: Raw halibut
+          quantity: "10"
+      tools:
+        - Trawling net
+        - Cargo hold (Sailing ship)
+      output_quantity: 1
+      notes: "Empty a trawling net containing at least 10 raw halibut while an empty fish crate is in the ship's cargo hold; the crate auto-packs 10 halibut and chills them with ice."
+  related_items:
+    - name: Empty fish crate
+      relationship: component
+    - name: Raw halibut
+      relationship: component
+    - name: Fish crate (sardine)
+      relationship: alternative
+    - name: Fish crate (mackerel)
+      relationship: alternative
+  about: "Fish crate (halibut) is a Sailing-skill storage container holding 10 raw halibut on ice in Old School RuneScape. Created by emptying a trawling net into an empty fish crate stored in a ship's cargo hold, it compresses deep-sea catches into one cargo slot. Crates can only be unpacked at a bank."
+  market_strategy:
+    notes:
+      - "Sailing content support item — value follows raw halibut demand."
+      - "Crafting cost (empty crate + 10 raw halibut) is currently higher than GE price, so most flow comes from deep-sea trawling output."
+      - "Daily GE limit of 250 caps short-term flipping volume."
+  trading_tips:
+    - "Compare GE price against (1 empty fish crate + 10 raw halibut) for opportunistic flips."
+    - "Demand tracks Sailing skill engagement; expect spikes after Sailing content patches."
+    - "Best unpacked at a bank to recover the empty crate for reuse."
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing skill launch, alongside deep-sea trawling fish crates."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    alchable: true
+    options:
+      - Empty
+      - Drop
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fox-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fox-fur.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: null
+  material:
+    type: hide
+    tier: low
+  drop_table:
+    sources:
+      - source: Pyre fox
+        quantity: "1"
+        rarity: Always (hunted via deadfall traps at 57 Hunter)
+  recipes:
+    - skill: crafting
+      level: 35
+      xp: 30
+      materials:
+        - item_name: Fox fur
+          quantity: 1
+      tools:
+        - Needle
+        - Thread
+      output_quantity: 1
+      facility: Crafting
+      product: Small meat pouch
+    - skill: crafting
+      level: 71
+      xp: 210
+      materials:
+        - item_name: Fox fur
+          quantity: 1
+      tools:
+        - Needle
+        - Thread
+      output_quantity: 1
+      facility: Crafting
+      product: Mixed hide legs
+  related_items:
+    - item_name: Small meat pouch
+      slug: small-meat-pouch
+      relationship: product
+      description: Crafted from fox fur
+    - item_name: Mixed hide legs
+      slug: mixed-hide-legs
+      relationship: product
+      description: High-level crafted product
+    - item_name: Pyre fox
+      slug: pyre-fox
+      relationship: alternative
+      description: Hunter creature that drops fox fur
   about: "Fox fur is a members-only item in Old School RuneScape. High alchemy value: 6 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Obtained from hunting pyre foxes (57 Hunter)
+      - Crafted into small meat pouches or mixed hide legs
+      - Steady demand from Varlamore hunter and crafting trainers
+      - No GE buy limit listed
+      - Mid-volume drop with stable trading
+  history:
+    - date: "2024-03-20"
+      description: "Released with the Varlamore: Part One update."
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-brown-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-brown-shirt.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik brown shirt is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: body
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Accoutrements
+      location: Rellekka
+      price: 325
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania and Etceteria Dungeon
+      price: 250
+  related_items:
+    - name: Fremennik blue shirt
+      relationship: variant
+    - name: Fremennik red shirt
+      relationship: variant
+    - name: Fremennik beige shirt
+      relationship: variant
+    - name: Fremennik grey shirt
+      relationship: variant
+  about: "Fremennik brown shirt is a cosmetic body slot item sold by Yrsa's Accoutrements in Rellekka and the Miscellanian Clothes Shop. Part of the Fremennik clothing collection released with The Fremennik Trials quest."
+  history:
+    - date: "2004-11-02"
+      description: Released as part of The Fremennik Trials update.
+    - date: "2014-12-10"
+      description: Renamed from Fremennik shirt to Fremennik brown shirt.
+  properties:
+    release_date: "2004-11-02"
+    update: The Fremennik Trials
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-elegant-blouse.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-elegant-blouse.mdx
@@ -12,21 +12,55 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  material:
+    type: cloth
+    tier: mid
   equipment:
     slot: body
-    requirements: {}
+    weight: 0.1
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
     - item_id: 12345
       item_name: Gold elegant skirt
       slug: gold-elegant-skirt
       relationship: set-piece
       description: Matching elegant skirt
-  about: |-
-    > *"A well made elegant ladies' gold blouse."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the gold elegant clothing set (women's variant). Pairs with the gold elegant skirt.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Purely cosmetic treasure trail reward with no combat stats. Part of the gold elegant clothing set (women's variant). Pairs with the gold elegant skirt and is obtained from medium clue scroll caskets."
+  market_strategy:
+    notes:
+      - Steady cosmetic demand from clue hunters and fashionscape collectors
+      - Low GE limit means small flips clear quickly
+      - Supply scales with medium clue volume
+  trading_tips:
+    - Pair with gold elegant skirt for set premium
+    - Hold during DMM or clue events for price spikes
+  history:
+    - date: "2014-06-12"
+      description: Released with the Treasure Trail Expansion update.
+    - date: "2014-12-10"
+      description: Renamed from "Gold ele' blouse" to "Gold elegant blouse".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-elegant-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-elegant-legs.mdx
@@ -12,21 +12,53 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  material:
+    type: cloth
+    tier: mid
   equipment:
     slot: legs
-    requirements: {}
+    weight: 0.1
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
     - item_id: 12347
       item_name: Gold elegant shirt
       slug: gold-elegant-shirt
       relationship: set-piece
       description: Matching elegant shirt
-  about: |-
-    > *"A rather elegant pair of men's gold pantaloons."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the gold elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "A rather elegant pair of men's gold pantaloons. Purely cosmetic treasure trail reward with no combat stats. Part of the gold elegant clothing set."
+  market_strategy:
+    notes:
+      - Cosmetic clue reward — demand driven by fashionscape
+      - Thin GE volume; large flips difficult
+      - Set premium when paired with the gold elegant shirt
+  history:
+    - date: "2014-06-12"
+      description: Released with the Treasure Trails Expansion as a medium clue reward.
+    - date: "2014-12-10"
+      description: "Renamed from 'Gold ele' legs' to 'Gold elegant legs' in the Trading Post update."
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/graahk-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/graahk-top.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 150
-  about: "Graahk top is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: fur
+    tier: low
+  equipment:
+    slot: body
+    weight: 0.226
+    requirements:
+      hunter: 38
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 10
+      slash: 15
+      crush: 19
+      magic: 0
+      ranged: 12
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Graahk fur
+          quantity: 1
+        - item_name: Coins
+          quantity: 150
+      tools: []
+      output_quantity: 1
+      notes: Tailored by the Fancy Clothes Store in Varrock, the Hunter Guild Seamstress, or the Prifddinas seamstress. Tattered fur also accepted.
+  shops:
+    - shop_name: Fancy Clothes Store (Varrock)
+      price: 150
+  related_items:
+    - name: Graahk legs
+      relationship: set-piece
+    - name: Graahk headdress
+      relationship: set-piece
+    - name: Larupia top
+      relationship: variant
+    - name: Kyatt top
+      relationship: variant
+  about: "Graahk top is a members-only camouflage body slot item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 150 per 4 hours."
+  market_strategy:
+    notes:
+      - Demand driven by Hunter players running Karamja jungle camo sets.
+      - Graahk fur supply from carnivorous chinchompa-tier hunting trips drives floor price.
+      - Flavor text is misleading; the set does NOT affect Hunter trap rates.
+  trading_tips:
+    - Compare GE price vs Fancy Clothes Store tailoring cost when graahk fur is cheap.
+    - Stock up around Hunter level milestones for resale spikes.
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-chaps.mdx
@@ -12,59 +12,63 @@ osrs:
   lowalch: 1560
   highalch: 2340
   limit: 125
+  material:
+    type: dragonhide
+    tier: mid
   equipment:
     slot: legs
-    type: ranged_armour
-    ranged_requirement: 40
-    defence_requirement: 0
-  attack_bonuses:
-    ranged: 8
-  defence_bonuses:
-    ranged: 22
-    magic: 14
-  crafting:
-    level: 60
-    xp: 124
+    weapon_type: na
+    weight: 5.443
+    requirements:
+      ranged: 40
+    attack_bonus:
+      ranged: 8
+    defence_bonus:
+      stab: 12
+      slash: 15
+      crush: 18
+      magic: -10
+      ranged: 17
+    other_bonus:
+      ranged_strength: 0
   recipes:
     - skill: crafting
       level: 60
       xp: 124
       materials:
         - item_name: Green dragon leather
-          item_id: 1745
           quantity: 2
         - item_name: Thread
-          item_id: 1734
           quantity: 1
-      product: Green d'hide chaps
-      product_id: 1099
-      product_quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
       facility: Needle and thread
+  shops:
+    - shop_name: "Scavvo's Rune Store"
+      location: "Champions' Guild"
+    - shop_name: "Seddu's Adventurer's Store"
+      location: Nardah
   related_items:
-    - item_id: 1753
-      item_name: Green dragonhide
+    - item_name: Green dragonhide
       slug: green-dragonhide
       relationship: component
       description: Raw material
-    - item_id: 1745
-      item_name: Green dragon leather
+    - item_name: Green dragon leather
       slug: green-dragon-leather
       relationship: component
       description: Tanned hide
-    - item_id: 1135
-      item_name: Green d'hide body
+    - item_name: Green d'hide body
       slug: green-dhide-body
-      relationship: alternative
+      relationship: set-piece
       description: Matching body
-    - item_id: 1065
-      item_name: Green d'hide vambraces
+    - item_name: Green d'hide vambraces
       slug: green-dhide-vambraces
-      relationship: alternative
+      relationship: set-piece
       description: Matching gloves
-    - item_id: 2493
-      item_name: Blue d'hide chaps
+    - item_name: Blue d'hide chaps
       slug: blue-dhide-chaps
-      relationship: alternative
+      relationship: upgrade
       description: Higher tier chaps
   about: |-
     | Method | Level | Materials |
@@ -77,8 +81,8 @@ osrs:
     | Ranged requirement | 40 |
     | Defence requirement | None |
     | Ranged attack | +8 |
-    | Ranged defence | +22 |
-    | Magic defence | +14 |
+    | Ranged defence | +17 |
+    | Magic defence | -10 |
   market_strategy:
     notes:
       - First dragonhide leg tier
@@ -91,8 +95,28 @@ osrs:
       - 2 leather per chaps
       - Lower crafting level than body
       - Good XP per leather
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 launch."
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2 Launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-dragonhide-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-dragonhide-set.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 125
-  about: "Green dragonhide set is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragonhide
+    tier: mid
+  related_items:
+    - item_id: 1135
+      item_name: Green d'hide body
+      slug: green-dhide-body
+      relationship: component
+      description: Set component
+    - item_id: 1099
+      item_name: Green d'hide chaps
+      slug: green-dhide-chaps
+      relationship: component
+      description: Set component
+    - item_id: 1065
+      item_name: Green d'hide vambraces
+      slug: green-dhide-vambraces
+      relationship: component
+      description: Set component
+    - item_id: 12867
+      item_name: Blue dragonhide set
+      slug: blue-dragonhide-set
+      relationship: variant
+      description: Higher tier dragonhide set
+  about: "Green dragonhide set is a Grand Exchange convenience bundle containing the green d'hide body, chaps, and vambraces. Exchanged via the GE clerk Sets interface to save bank space when moving green dragonhide armour. Released in 2014 and opened to free-to-play in 2015."
+  market_strategy:
+    notes:
+      - Set price typically trades around the combined component value
+      - Cross-trade arbitrage opportunities between set and individual pieces
+      - Stable mid-tier ranged armour demand
+  trading_tips:
+    - Compare set vs unbundled component prices for flips
+    - Bulk buy components, package as set, sell during GE shortages
+  history:
+    - date: "2014-12-10"
+      description: Added with the Grand Exchange Sets interface update.
+    - date: "2015-02-26"
+      description: Made available to free-to-play players.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-12-10"
+    update: Grand Exchange Sets
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-crozier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-crozier.mdx
@@ -12,12 +12,38 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
+  material:
+    type: guthix
+    tier: mid
   equipment:
     slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2
     requirements:
       prayer: 60
+    attack_bonus:
+      stab: 7
+      slash: 0
+      crush: 25
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 10
+      ranged: 0
     other_bonus:
+      melee_strength: 32
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 6
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 10472
       item_name: Guthix stole
@@ -28,8 +54,21 @@ osrs:
     > *"A Guthix crozier."*
 
     The Guthix crozier is a weapon slot staff from the Guthix vestment set. It provides a +6 Prayer bonus and requires 60 Prayer to wield. Counts as a Guthixian item in the God Wars Dungeon. Primarily used for prayer bonus and fashionscape.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2006-12-05"
+      description: Released as a Treasure Trails hard clue reward in the Guthix vestment set.
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/holy-symbol.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/holy-symbol.mdx
@@ -14,57 +14,70 @@ osrs:
   limit: 125
   equipment:
     slot: neck
-    type: symbol
-    prayer_bonus: 8
+    weapon_type: none
+    weight: 0.007
     requirements:
       prayer: 31
-  crafting:
-    skill: crafting
-    level: 31
-    xp: 50
-    materials:
-      - item_name: Unstrung symbol
-        item_id: 1714
-        quantity: "1"
-      - item_name: Ball of wool
-        item_id: 1759
-        quantity: "1"
+    defence_bonus:
+      stab: 2
+      slash: 2
+      crush: 2
+      magic: 2
+      ranged: 2
+    other_bonus:
+      prayer: 8
+  recipes:
+    - skill: Crafting
+      level: 31
+      experience: 4
+      materials:
+        - item_name: Unstrung symbol
+          quantity: "1"
+        - item_name: Ball of wool
+          quantity: "1"
+      tools: []
+      output_quantity: 1
+      notes: "Use a ball of wool on an unstrung symbol to string it, then have Brother Jered bless it (requires 31 Prayer)."
   related_items:
-    - item_id: 1724
-      item_name: Unholy symbol
-      slug: unholy-symbol
+    - name: Unholy symbol
       relationship: alternative
-      description: Zamorak counterpart (+8 Prayer)
-    - item_id: 1704
-      item_name: Amulet of glory
-      slug: amulet-of-glory
+    - name: Amulet of glory
       relationship: alternative
-      description: Better combat stats, no prayer bonus
-    - item_id: 19492
-      item_name: Amulet of the damned
-      slug: amulet-of-the-damned
+    - name: Amulet of the damned
       relationship: upgrade
-      description: For Barrows sets
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Neck |
-    | Prayer Bonus | +8 |
-    | Prayer Req | 31 |
-
-    - Prayer bonus for protection prayers
-    - Used in some quests
-    - Budget prayer gear option
+    - name: Unstrung symbol
+      relationship: component
+  about: "Holy symbol is a free-to-play neck-slot amulet blessed in the name of Saradomin, granting +8 Prayer bonus and minor defence bonuses across the board. Popular as a budget Prayer training amulet alongside Proselyte armour, and required for Animal Magnetism and The Great Brain Robbery."
   market_strategy:
     notes:
-      - Low demand item
-      - Crafting supplies often more valuable
-      - Quest requirement creates some demand
-      - Often cheaper to craft
-      - Low volume trading
-      - Consider for quest supplies flips
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Low-demand consumable that mostly moves to ironmen, questers and budget Prayer trainers."
+      - "Crafting from an unstrung symbol + ball of wool + blessing is typically cheaper than buying off the GE."
+      - "Quest requirement (Animal Magnetism, The Great Brain Robbery) creates steady but small demand spikes."
+  trading_tips:
+    - "Flip in small lots; the buy limit is 125 but volume is shallow."
+    - "Compare GE price to the cost of an unstrung symbol + ball of wool — large gaps mean profitable crafting flips."
+    - "Stock up before mass-quest events or Deadman seasons when prayer gear demand rises."
+  history:
+    - date: "2001-07-12"
+      description: "Released as part of the original Prayer skill content."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-07-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.007
+    alchable: true
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-leatherskirt-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-leatherskirt-0.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 18800
   highalch: 28200
   limit: 15
+  material:
+    type: barrows
+    tier: high
+  equipment:
+    slot: legs
+    weapon_type: na
+    weight: 5.443
+    requirements:
+      ranged: 70
+      defence: 70
+    attack_bonus:
+      ranged: 17
+    defence_bonus:
+      stab: 26
+      slash: 20
+      crush: 28
+      magic: 35
+      ranged: 33
+    other_bonus: {}
+  charges:
+    max_charges: 0
+    note: "Stage 0 represents fully degraded Barrows equipment; must be repaired before use."
+  related_items:
+    - item_name: Karil's leatherskirt
+      slug: karils-leatherskirt
+      relationship: variant
+      description: Fully charged version
+    - item_name: Karil's leatherskirt 25
+      slug: karils-leatherskirt-25
+      relationship: variant
+      description: Partially used charges
+    - item_name: Karil's leatherskirt 50
+      slug: karils-leatherskirt-50
+      relationship: variant
+      description: Mid-degradation variant
+    - item_name: Karil's leatherskirt 75
+      slug: karils-leatherskirt-75
+      relationship: variant
+      description: Lightly used variant
+    - item_name: Karil's leathertop
+      slug: karils-leathertop
+      relationship: set-piece
+      description: Matching body piece
   about: "Karil's leatherskirt 0 is a members-only item in Old School RuneScape. High alchemy value: 28,200 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Fully degraded Karil's leatherskirt; cannot be used until repaired
+      - Repair at Bob in Lumbridge or at an armour stand
+      - Holds liquidity from players repairing for resale arbitrage
+      - Drops from Karil the Tainted in the Barrows minigame
+      - Demand tied to ranged setups for ToA/CoX/PvM content
+  history:
+    - date: "2005-05-09"
+      description: "Released with the Barrows update."
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: "If you drop this item it will break."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lantern-lens.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lantern-lens.mdx
@@ -15,35 +15,28 @@ osrs:
   material:
     type: glass_product
     tier: mid-high
-  crafting:
-    level: 49
-    xp: 55
   recipes:
     - skill: crafting
       level: 49
       xp: 55
       materials:
         - item_name: Molten glass
-          item_id: 1775
           quantity: 1
-      product: Lantern lens
-      product_id: 4542
-      product_quantity: 1
+      tools:
+        - Glassblowing pipe
+      output_quantity: 1
       facility: Glassblowing pipe
       members_only: true
   related_items:
-    - item_id: 1775
-      item_name: Molten glass
+    - item_name: Molten glass
       slug: molten-glass
       relationship: component
       description: Raw material
-    - item_id: 4527
-      item_name: Bullseye lantern (unf)
+    - item_name: Bullseye lantern (unf)
       slug: bullseye-lantern-unf
       relationship: product
       description: Lantern component
-    - item_id: 4548
-      item_name: Bullseye lantern
+    - item_name: Bullseye lantern
       slug: bullseye-lantern
       relationship: product
       description: Final product
@@ -69,8 +62,26 @@ osrs:
       - Used in dark areas
       - Good crafting XP
       - Niche market
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2005-03-14"
+      description: "Item released with the Lumbridge Swamp Caves update."
+  properties:
+    release_date: "2005-03-14"
+    update: Lumbridge Swamp Caves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-bronze-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-bronze-keel-parts.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 70
   highalch: 105
   limit: 100
-  about: "Large bronze keel parts is a members-only item in Old School RuneScape. High alchemy value: 105 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: low
+  recipes:
+    - materials:
+        - item_name: Bronze keel parts
+          quantity: 5
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+      notes: "Smithing 10, 5 XP per piece; Pandemonium quest required."
+  related_items:
+    - item_id: 32018
+      item_name: Bronze keel parts
+      slug: bronze-keel-parts
+      relationship: component
+      description: Smaller keel piece smithed into large variants
+    - item_id: 32022
+      item_name: Bronze keel
+      slug: bronze-keel
+      relationship: product
+      description: Assembled keel used for sloop construction
+  about: "Large bronze keel parts are a Sailing/Smithing component used to assemble bronze keels for larger boats; requires Pandemonium quest completion and 10 Smithing. High alchemy value: 105 coins. Grand Exchange buy limit: 100 per 4 hours."
+  history:
+    - date: "2025-11-19"
+      description: Released alongside the Sailing skill and Pandemonium quest update.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-camphor-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-camphor-hull-parts.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 12500
   highalch: 18750
   limit: 100
-  about: "Large camphor hull parts is a members-only item in Old School RuneScape. High alchemy value: 18,750 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    level: 53
+    experience: 0
+    hotspot: Shipwrights' workbench
+    notes: "Assembled at the Shipwrights' workbench from 5 camphor hull parts in 5 ticks; used to construct large camphor hulls for sloops with Sailing."
+  recipes:
+    - skill: Construction
+      level: 53
+      experience: 0
+      output_quantity: 1
+      tools:
+        - Saw
+        - Hammer
+      materials:
+        - item_name: Camphor hull parts
+          quantity: 5
+      notes: "Crafted at the Shipwrights' workbench; 5 ticks (3 seconds) per craft."
+  related_items:
+    - item_id: 32072
+      item_name: Camphor hull parts
+      slug: camphor-hull-parts
+      relationship: component
+      description: Standard hull parts combined into the large variant.
+  about: "Sailing-era component crafted at the Shipwrights' workbench (53 Construction) — 16 large parts plus extras build a full camphor hull for sloops at 67 Sailing / 59 Construction."
+  market_strategy:
+    notes:
+      - Demand is tied to Sailing skill progress; sloop hull builds consume these in bulk.
+      - 100 GE buy limit caps daily flow; spread is sensitive to camphor log supply and recent Sailing XP nerfs.
+  trading_tips:
+    - Watch camphor hull parts supply — large parts price tracks 5x that input plus tax.
+    - November 2025 hotfix halved Construction XP at shipwrights' benches; budget for fewer Construction-trainer buyers.
+  history:
+    - date: "2025-11-19"
+      description: Released alongside the Sailing skill update.
+    - date: "2025-11"
+      description: Hotfix halved Construction XP from the Shipwrights' workbench.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lemon-slices.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lemon-slices.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Lemon slices is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    edible: true
+    notes: Edible but provides no meaningful heal; primarily a Gnome Cocktail ingredient.
+  recipes:
+    - materials:
+        - item_name: Lemon
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+      notes: Use a knife on a lemon; produces lemon slices in 2 game ticks. No Cooking level required.
+  related_items:
+    - name: Lemon
+      relationship: component
+    - name: Lemon chunks
+      relationship: alternative
+    - name: Mixed blast
+      relationship: product
+    - name: Fruit blast
+      relationship: product
+  about: "Lemon slices is a members-only Gnome Cooking ingredient in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
+  market_strategy:
+    notes:
+      - Cocktail ingredient feeding fruit blast production; demand follows gnome cooking trends.
+      - High alch of 1 gp makes the item useless for alch training.
+      - Buying lemons and slicing manually can be cheaper than buying slices directly.
+  trading_tips:
+    - Compare lemon price plus slicing time vs lemon slices price for arbitrage.
+    - Bulk demand from Gnome Cooking outfits and diaries.
+  history:
+    - date: "2002-12-12"
+      description: Released as part of the Gnome Restaurant cooking content.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Gnome Cooking
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/log-brace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/log-brace.mdx
@@ -5,16 +5,76 @@ osrs:
   id: 28146
   name: Log brace
   slug: log-brace
-  examine: With some rope, adamantite bars and steel nails, I can create a sturdy harness.
+  examine: "With some rope, adamantite bars and steel nails, I can create a sturdy harness."
   members: true
   icon: Log brace.png
   value: 3000
   lowalch: 1200
   highalch: 1800
   limit: 40
-  about: "Log brace is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: "Forestry Shop"
+      location: "Forestry events"
+      members: true
+      currency: "Anima-infused bark"
+      notes: "Costs 3,000 anima-infused bark plus 300 maple logs and 300 yew logs per brace."
+  recipes:
+    - skill: Smithing
+      level: 75
+      experience: 0
+      materials:
+        - item_name: Log brace
+          quantity: "1"
+        - item_name: Steel nails
+          quantity: "45"
+        - item_name: Rope
+          quantity: "2"
+        - item_name: Adamantite bar
+          quantity: "3"
+      tools:
+        - Hammer
+      output_quantity: 1
+      notes: "Combine the log brace with the listed materials at 75 Smithing and 75 Woodcutting to craft a Sturdy harness — the upgrade that converts a Forestry kit into a Forestry basket."
+  related_items:
+    - name: Sturdy harness
+      relationship: product
+    - name: Forestry kit
+      relationship: alternative
+    - name: Forestry basket
+      relationship: upgrade
+    - name: Anima-infused bark
+      relationship: component
+  about: "Log brace is a Forestry-event item used to upgrade a Forestry kit into a Forestry basket via a sturdy harness in Old School RuneScape. Bought from the Forestry Shop for 3,000 anima-infused bark plus 300 maple and 300 yew logs; combined with 45 steel nails, 2 rope, and 3 adamantite bars at 75 Smithing and 75 Woodcutting to produce the sturdy harness."
+  market_strategy:
+    notes:
+      - "Effectively a bark-sink — supply is gated by Forestry event participation, not GE flippers."
+      - "Daily GE limit of 40 keeps the market thin and price-volatile."
+      - "Demand tied to players chasing the Forestry basket upgrade for log-store convenience."
+  trading_tips:
+    - "GE price is heavily anchored to anima-infused bark farming time, not direct gold cost."
+    - "Watch for Forestry buffs or QoL changes — these patches push demand sharply on the limited supply."
+    - "Buy in small lots; the 40-per-4h limit makes large orders impractical."
+  history:
+    - date: "2023-06-28"
+      description: "Released with the Forestry update as a sturdy-harness component."
+    - date: "2023-10-25"
+      description: "Inventory icon and model graphically updated."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-06-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    alchable: true
+    options:
+      - Use
+      - Drop
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-essence-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-essence-mix-1.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 52
   highalch: 78
   limit: 2000
-  about: "Magic essence mix(1) is a members-only item in Old School RuneScape. High alchemy value: 78 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - description: Boosts Magic by 3 levels.
+      - description: Restores 6 Hitpoints per dose.
+  recipes:
+    - materials:
+        - item_name: Magic essence(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      skill: Herblore
+      level: 61
+      experience: 43
+      output_quantity: 1
+      notes: Requires Barbarian Herblore training; produces a 1-dose Magic essence mix.
+  related_items:
+    - name: Magic essence mix(2)
+      relationship: variant
+    - name: Magic essence(1)
+      relationship: alternative
+    - name: Caviar
+      relationship: component
+  about: "Magic essence mix(1) is a members-only barbarian herblore potion in Old School RuneScape. High alchemy value: 78 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  market_strategy:
+    notes:
+      - Barbarian mix variants are typically more expensive than the base potion due to caviar cost.
+      - Niche demand from PvMers wanting extra HP heal alongside the Magic boost.
+      - Cannot be substituted for regular magic essence in Fairytale II.
+  trading_tips:
+    - Check if buying the (2) variant and decanting is cheaper than buying (1).
+    - Caviar supply from sturgeon fishing influences price floor.
+  history:
+    - date: "2007-07-03"
+      description: Released as part of the Barbarian Herblore additions.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/marlin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/marlin.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: null
+  food:
+    heals: 24
+    cooking_level: 91
+    cooking_xp: 225
+  recipes:
+    - skill: Cooking
+      level: 91
+      xp: 225
+      materials:
+        - item_name: Raw marlin
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  related_items:
+    - name: Raw marlin
+      relationship: component
+    - name: Shark
+      relationship: alternative
+    - name: Anglerfish
+      relationship: alternative
+    - name: Manta ray
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Highest single-bite heal in the game at 24 HP per bite."
+      - "Released with the Sailing skill; supply scales with Sailing/Fishing activity."
+      - "Approximately 743k/hr profit cooking raw marlin at level 99 Cooking."
+  trading_tips:
+    - "Watch raw marlin price relative to cooked marlin to model cook margin."
+    - "Spikes around new PvM content that values per-bite healing over total HP."
+  history:
+    - date: "2025-11-19"
+      description: "Released alongside the Sailing skill update."
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.65
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   about: "Marlin is a members-only item in Old School RuneScape. High alchemy value: 102 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-knife-p-5664.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-knife-p-5664.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 10
   highalch: 16
   limit: 7000
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 20
+    attack_bonus:
+      ranged: 11
+    defence_bonus: {}
+    other_bonus:
+      ranged_strength: 10
+  related_items:
+    - item_name: Mithril knife
+      slug: mithril-knife
+      relationship: variant
+      description: Unpoisoned base variant
+    - item_name: Mithril knife(p)
+      slug: mithril-knife-p
+      relationship: variant
+      description: Poison variant
+    - item_name: Mithril knife(p+)
+      slug: mithril-knife-p-plus
+      relationship: variant
+      description: Stronger poison variant
+    - item_name: Adamant knife(p++)
+      slug: adamant-knife-p-plus-plus
+      relationship: upgrade
+      description: Higher tier poisoned knife
   about: "Mithril knife(p++) is a members-only item in Old School RuneScape. High alchemy value: 16 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Thrown ranged weapon with poison++ application
+      - Niche use for poison-stacked PvM and PvP
+      - Low high-alch value, demand driven by combat usage
+      - Stackable so trades execute in bulk lots
+      - Upgrade path to adamant/rune variants
+  history:
+    - date: "2003-04-14"
+      description: "Released as part of the New Throwing Weapons update."
+  properties:
+    release_date: "2003-04-14"
+    update: New Throwing Weapons
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-scimitar.mdx
@@ -12,24 +12,82 @@ osrs:
   lowalch: 416
   highalch: 624
   limit: 125
-  item_id: 1329
-  item_type: equipment
-  slot: weapon
-  type: scimitar
-  attack_style: slash
-  attack_speed: 4
-  tradeable: true
-  weight: 1.587
-  requirements:
-    attack: 20
-  stats:
-    slash_attack: 21
-    strength: 20
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: scimitar
+    attack_speed: 4
+    weight: 1.587
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 5
+      slash: 21
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 20
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Smithing
+      level: 55
+      experience: 100
+      materials:
+        - item_name: Mithril bar
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
   related_items:
-    - slug: adamant-scimitar
-    - slug: mithril-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Adamant scimitar
+      relationship: upgrade
+    - name: Steel scimitar
+      relationship: downgrade
+    - name: Mithril bar
+      relationship: component
+  about: "Mithril scimitar is a free-to-play one-handed slash weapon in Old School RuneScape requiring 20 Attack to wield. It is smithed from 2 mithril bars at Smithing level 55 for 100 experience and offers a fast 4-tick attack with +21 slash and +20 strength."
+  market_strategy:
+    notes:
+      - Common training weapon for low-mid Attack accounts; demand is steady and broad.
+      - Cheaper to buy on the GE than to smith from mithril bars.
+      - F2P accessible, so flips compete with high volume and thin margins.
+  trading_tips:
+    - Watch mithril bar price; if bar price falls, scimitar floor follows.
+    - Buy in bulk during off-peak hours; GE limit of 125 per 4 hours allows decent flip cycles.
+  history:
+    - date: "2001-01-04"
+      description: Released as part of the original RuneScape weapon lineup.
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape beta launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.587
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/monk-s-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/monk-s-robe-top.mdx
@@ -12,29 +12,30 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 125
+  material:
+    type: cloth
+    tier: low
   equipment:
     slot: body
-    type: robes
-    prayer_bonus: 6
-    combat_stats:
-      stab_defence: 0
-      slash_defence: 0
-      crush_defence: 0
-      magic_defence: 0
-      ranged_defence: 0
+    weapon_type: na
+    weight: 0.907
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus:
+      prayer: 6
+  prayer:
+    bonus: 6
   related_items:
-    - item_id: 542
-      item_name: Monk's robe
+    - item_name: Monk's robe
       slug: monks-robe
       relationship: set-piece
       description: Legs (+5 Prayer)
-    - item_id: 9674
-      item_name: Proselyte hauberk
+    - item_name: Proselyte hauberk
       slug: proselyte-hauberk
       relationship: upgrade
       description: Better defence and prayer (+8)
-    - item_id: 5575
-      item_name: Initiate hauberk
+    - item_name: Initiate hauberk
       slug: initiate-hauberk
       relationship: upgrade
       description: Defence and prayer (+6)
@@ -63,8 +64,28 @@ osrs:
       - Not worth flipping
       - Free to obtain
       - Used for fashion/clues only
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2001-07-12"
+      description: "Released with the Improved prayer system update."
+  properties:
+    release_date: "2001-07-12"
+    update: Improved prayer system
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-robe-bottom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-robe-bottom.mdx
@@ -12,8 +12,15 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 125
+  material:
+    type: mystic
+    tier: mid
   equipment:
     slot: legs
+    weight: 1.814
+    requirements:
+      magic: 40
+      defence: 20
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,9 +38,20 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      magic: 40
-      defence: 20
+  drop_table:
+    sources:
+      - source: Dragon impling jar
+        quantity: "1"
+        rarity: 1/19
+      - source: Kraken
+        quantity: "1"
+        rarity: 1/128
+      - source: Corporeal Beast
+        quantity: "1"
+        rarity: 18/512
+      - source: Alchemical Hydra
+        quantity: "1"
+        rarity: 1/128
   related_items:
     - item_id: 4091
       item_name: Mystic robe top
@@ -78,8 +96,23 @@ osrs:
       - High supply from Slayer drops
       - Commonly paired with mystic top for mid-game magic
       - Dark/dusk variants trade at premium
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2005-01-26"
+      description: Item released.
+    - date: "2007-08-06"
+      description: Graphically updated.
+  properties:
+    release_date: "2005-01-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nightmare-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nightmare-staff.mdx
@@ -12,106 +12,79 @@ osrs:
   lowalch: 240000
   highalch: 360000
   limit: 8
+  material:
+    type: magical
+    tier: high
   equipment:
-    slot: 2h
-    type: powered-staff
-    attack_style: magic
-    attack_speed: 4
+    slot: weapon
+    weapon_type: powered_staff
+    attack_speed: 5
+    weight: 1.5
     requirements:
       magic: 72
       hitpoints: 50
-    stats:
-      attack_magic: 16
-      defence_magic: 14
+    attack_bonus:
+      magic: 16
+    defence_bonus:
+      magic: 14
+    other_bonus:
       magic_damage: 15
-  effect:
-    autocast_standard: true
-    autocast_ancient: true
-  upgrades:
-    - item_id: 24421
-      item_name: Volatile nightmare staff
-      component_id: 24511
-      component_name: Volatile orb
-      description: Damage spec variant
-    - item_id: 24425
-      item_name: Eldritch nightmare staff
-      component_id: 24517
-      component_name: Eldritch orb
-      description: Prayer restore variant
-    - item_id: 24423
-      item_name: Harmonised nightmare staff
-      component_id: 24514
-      component_name: Harmonised orb
-      description: Fast casting variant
   drop_table:
     sources:
       - source: The Nightmare
-        source_id: 9425
-        combat_level: 814
         quantity: "1"
-        rarity: Rare
-        drop_rate: 1/300 - 1/171
-        members_only: true
+        rarity: "1/300 - 1/171"
       - source: Phosani's Nightmare
-        source_id: 9416
-        combat_level: 814
         quantity: "1"
-        rarity: Rare
-        drop_rate: 1/533
-        members_only: true
+        rarity: "1/533"
   related_items:
     - item_id: 24421
       item_name: Volatile nightmare staff
       slug: volatile-nightmare-staff
       relationship: upgrade
-      description: Damage spec
+      description: Damage spec variant
     - item_id: 24425
       item_name: Eldritch nightmare staff
       slug: eldritch-nightmare-staff
       relationship: upgrade
-      description: Prayer restore
+      description: Prayer restore variant
     - item_id: 24423
       item_name: Harmonised nightmare staff
       slug: harmonised-nightmare-staff
       relationship: upgrade
-      description: Fast casting
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Magic attack | +16 |
-    | Magic damage | +15% |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +14 |
-
-    Requirements: 72 Magic, 50 Hitpoints
-
-    Autocast:
-    - Standard spells
-    - Ancient Magicks
-
-    Attach orbs to enhance:
-
-    | Orb | Effect | Total Cost |
-    |-----|--------|------------|
-    | Volatile | Damage spec | ~81M |
-    | Eldritch | Prayer restore spec | ~212M |
-    | Harmonised | Fast standard spells | ~219M |
-
-    Base staff for:
-    - Magic combat
-    - Component for upgraded staves
-    - Budget +15% damage option
-
-    Foundation for nightmare staff variants.
+      description: Fast casting variant
+  about: "Nightmare staff is a powered staff dropped by The Nightmare and Phosani's Nightmare. Provides +16 magic attack, +15% magic damage, and serves as the base for three upgrade variants via orb attachments: Volatile (damage spec), Eldritch (prayer restore), and Harmonised (fast casting). Requires 72 Magic and 50 Hitpoints to wield, can autocast both standard and Ancient Magicks."
   market_strategy:
     notes:
-      - Nightmare is only source
-      - Buy for upgrade path
-      - All variants are strong
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - The Nightmare is only source for the base staff
+      - Acquired primarily as a base for the three upgrade variants
+      - All variants are top-tier magic weapons
+      - Slow buy/sell due to high price and niche use
+  trading_tips:
+    - Watch Nightmare team kills for supply spikes
+    - Volatile variant is typically the best damage upgrade
+    - Harmonised variant is meta for Ancient spellbook content
+  history:
+    - date: "2020-02-06"
+      description: Released alongside The Nightmare boss.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-02-06"
+    update: The Nightmare of Ashihama
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.5
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nimbleness-charm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nimbleness-charm.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: null
-  about: "Nimbleness charm is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: magical
+    tier: high
+  drop_table:
+    sources:
+      - source: Breach bosses (Permanent Deadman world 345)
+        quantity: "1"
+        rarity: Uncommon
+      - source: Monsters 200+ combat (Permanent Deadman world 345)
+        quantity: "1"
+        rarity: Uncommon
+  related_items:
+    - name: Stockpiling charm
+      relationship: alternative
+    - name: Accumulation charm
+      relationship: alternative
+    - name: Vulnerability charm
+      relationship: alternative
+    - name: Broken charm
+      relationship: alternative
+  about: "Nimbleness charm is a Deadman Mode utility charm that, while held in the inventory, multiplies Marks of Grace spawns from one to five, ignores Agility shortcut level requirements, and enables auto-pickpocketing of NPCs until stunned."
+  history:
+    - date: "2025-03-12"
+      description: Released as part of the Permanent Deadman - World 345 Improvements update.
+    - date: "2026-01-21"
+      description: Item value increased from 10,000 to 100,000 coins.
+  properties:
+    release_date: "2025-03-12"
+    update: "Permanent Deadman: World 345 Improvements"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-bed-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-bed-flatpack.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak bed (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    level: 30
+    xp: 210
+    materials:
+      - item_name: Oak plank
+        quantity: 3
+      - item_name: Bolt of cloth
+        quantity: 2
+    tools:
+      - Hammer
+      - Saw
+    facility: Oak workbench
+  recipes:
+    - materials:
+        - item_name: Oak plank
+          quantity: 3
+        - item_name: Bolt of cloth
+          quantity: 2
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+      notes: "Built at an Oak workbench (Construction 30, 210 XP)."
+  related_items:
+    - item_id: 8576
+      item_name: Wooden bed (flatpack)
+      slug: wooden-bed-flatpack
+      relationship: downgrade
+      description: Tier below in the bed flatpack chain
+    - item_id: 8580
+      item_name: Large oak bed (flatpack)
+      slug: large-oak-bed-flatpack
+      relationship: upgrade
+      description: Larger oak bed flatpack
+  about: "Oak bed (flatpack) is a Construction flatpack built at an Oak workbench, used to furnish player-owned house bedrooms. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
+  history:
+    - date: "2006-05-31"
+      description: Released with the Player-Owned Houses update.
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-sapling.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
+  farming:
+    seed: Acorn
+    farming_level: 15
+    planting_xp: 14
+    check_xp: 467.3
+    growth_time_minutes: 160
+    patches:
+      - Tree patch
+    protection: "1 basket of tomatoes"
+  recipes:
+    - skill: Farming
+      level: 15
+      xp: 14
+      materials:
+        - item_name: Oak seedling
+          quantity: 1
+      tools:
+        - Watering can
+      output_quantity: 1
+  related_items:
+    - name: Acorn
+      relationship: component
+    - name: Oak seedling
+      relationship: component
+    - name: Oak tree
+      relationship: product
+    - name: Oak logs
+      relationship: product
+    - name: Plant pot (filled)
+      relationship: component
+  market_strategy:
+    notes:
+      - "Used by Farming trainers to plant oak trees once every growth window."
+      - "Demand driven by lower-level Farming methods and tree-run rotations."
+      - "Cheap to produce in bulk; profit lies in the planting/checking XP, not flips."
+  trading_tips:
+    - "Watch acorn price - oak saplings flip when seedling crafting profit turns positive."
+    - "Buy in noted bulk if questing or diary tasks demand specific Farming progress."
+  history:
+    - date: "2005-07-11"
+      description: "Released as part of the Farming skill launch."
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Plant
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   about: "Oak sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/old-demon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/old-demon-mask.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 4
-  about: "Old demon mask is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: high
+  equipment:
+    slot: head
+    weight: 0.8
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/851
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  about: "Old demon mask is a cosmetic head slot item awarded from master Treasure Trails. It replicates the older graphical model of lesser demons reminiscent of RuneScape Classic demon sprites."
+  history:
+    - date: "2016-07-06"
+      description: Released as part of the Treasure Trail Expansion update.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/paddewwa-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/paddewwa-teleport-tablet.mdx
@@ -9,12 +9,76 @@ osrs:
   members: true
   icon: Paddewwa teleport (tablet).png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 10000
-  about: "Paddewwa teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: "Edgeville Dungeon (Paddewwa)"
+    quest_requirement: "Desert Treasure I"
+    spellbook: Ancient
+    notes: "Break the tablet to teleport instantly to the Edgeville Dungeon. Tablets bypass the 54 Magic requirement of the spell version and grant no XP on use."
+  recipes:
+    - skill: Magic
+      level: 54
+      experience: 64
+      materials:
+        - item_name: Soft clay
+          quantity: "1"
+        - item_name: Law rune
+          quantity: "2"
+        - item_name: Air rune
+          quantity: "1"
+        - item_name: Fire rune
+          quantity: "1"
+      tools:
+        - Ancient lectern (Player-owned house Study)
+      output_quantity: 1
+      notes: "Cast Paddewwa Teleport at an Ancient lectern in a player-owned house Study. Requires Desert Treasure I and Ancient Magicks spellbook."
+  related_items:
+    - name: Senntisten teleport (tablet)
+      relationship: alternative
+    - name: Kharyrll teleport (tablet)
+      relationship: alternative
+    - name: Lassar teleport (tablet)
+      relationship: alternative
+    - name: Dareeyak teleport (tablet)
+      relationship: alternative
+    - name: Carrallangar teleport (tablet)
+      relationship: alternative
+    - name: Annakarl teleport (tablet)
+      relationship: alternative
+    - name: Ghorrock teleport (tablet)
+      relationship: alternative
+  about: "Paddewwa teleport (tablet) is a soft-clay teleport tablet that breaks to send the user instantly to the Edgeville Dungeon (Paddewwa). Made at an Ancient lectern in a player-owned house Study from 1 soft clay, 2 law runes, 1 air rune and 1 fire rune; requires Desert Treasure I and 54 Magic to craft, but anyone can break the finished tablet."
+  market_strategy:
+    notes:
+      - "Convenient teleport for ironmen and runners who want sub-1-second access to Edgeville Dungeon (Vannaka, KBD lobby route, slayer caves)."
+      - "Soft-clay tablets feed off the soft clay / law rune supply chain — track both for crafting profit margins."
+      - "Stackable + tradeable + huge GE limit (10,000) makes it a high-volume flip target."
+  trading_tips:
+    - "Compare GE price vs (1 soft clay + 2 law runes + 1 air rune + 1 fire rune) for crafting-profit signals."
+    - "Demand rises with PvM patches that drive players through the Edgeville Dungeon area."
+    - "Stackable storage means buyers grab in 100/1,000 unit blocks — list large stacks for tight spreads."
+  history:
+    - date: "2014-09-18"
+      description: "Released alongside Ancient lectern teleport tablets when player-owned house lecterns were expanded."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-09-18"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest: "Desert Treasure I"
+    quest_item: false
+    weight: 0
+    alchable: false
+    options:
+      - Break
+      - Drop
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/piscatoris-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/piscatoris-teleport.mdx
@@ -12,48 +12,54 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  item:
-    type: teleport_scroll
-    destination: Piscatoris
-    tradeable: true
-    stackable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite/Master
-        drop_rate: Varies by tier
+  teleport:
+    destination: Piscatoris Fishing Colony (outside the tunnel entrance)
+    requirements: None
+    consumable: true
+    notes: "Quick access to Monkfish fishing spots, Hunter areas, and Western Provinces Diary tasks."
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
+    notes: "Dropped at all clue tiers except Beginner. Master 1/190.6, Elite 1/203, Hard 1/340.5, plus rare Medium/Easy hits."
   related_items:
     - item_id: 12409
       item_name: Tai bwo wannai teleport
       slug: tai-bwo-wannai-teleport
       relationship: alternative
       description: Another clue teleport scroll
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Teleport Scroll |
-    | Destination | Piscatoris |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-
-    Right-click and select "Teleport" to travel to Piscatoris.
-
-    Teleport Location:
-    - Piscatoris Fishing Colony
-    - Near the fishing spots
-    - Close to monkfish area
-
-    - Monkfish fishing
-    - Western Provinces Diary
-    - Piscatoris Hunter area
-    - Clue scroll steps
+  about: "Stackable, tradeable scroll that teleports the player outside the Piscatoris Fishing Colony tunnel — handy for Monkfish, Hunter, and clue steps."
   market_strategy:
     notes:
-      - Useful for fishing
-      - Hunter activities nearby
-      - Stock up for clue hunting
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Demand is driven by Monkfish fishers, Hunter trainers, and clue-step efficiency runners.
+      - Supply is fully clue-scroll driven; price tracks clue-completion volume and reward roll rates.
+  trading_tips:
+    - Stockpile during clue-volume update spikes (HMT / DMM / leagues) when scroll supply increases.
+    - Compare per-cast cost vs alternative spellbook teleports to gauge fair value.
+  history:
+    - date: "2014-06-12"
+      description: Piscatoris teleport scroll added with the Treasure Trail Expansion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Teleport
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-fr-t-batta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-fr-t-batta.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 6000
-  about: "Premade fr't batta is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 11
+  related_items:
+    - name: Fruit batta
+      relationship: variant
+  about: "Premade fr't batta is a members-only food item in Old School RuneScape sold by the Gnome Waiter at the Grand Tree for 120 coins. Eating it restores 11 Hitpoints, matching the player-crafted Fruit batta."
+  shops:
+    - shop_name: Hudo's Grocery Store
+      location: Grand Tree
+      stock: 3
+      price: 120
+      restock_time: 1 minute
+  market_strategy:
+    notes:
+      - Shop-sold premade food; supply is effectively unlimited via Gnome Waiter restocks.
+      - Healing of 11 HP is mid-tier; serves as cheap filler food when shrimp/swordfish are out.
+      - Buy limit of 6,000 per 4 hours allows large flips but daily volume is typically thin.
+  trading_tips:
+    - Compare against shop price (120 gp) — flips only work when GE bid drops well below shop cost.
+    - Bulk buy from the Gnome Waiter when restocking; sell on GE during quest spikes.
+  history:
+    - date: "2002-12-12"
+      description: Released alongside the Agility skill update; originally named "Fruit batta".
+    - date: "2006-08-07"
+      description: Renamed from "Fruit batta" to "Premade fr't batta" during the Gnome Cuisine update.
+  properties:
+    release_date: "2002-12-12"
+    update: Agility
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-spiky-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-spiky-vambraces.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 1440
   highalch: 2160
   limit: 125
+  material:
+    type: dragonhide
+    tier: high
+  equipment:
+    slot: hands
+    weight: 0.283
+    requirements:
+      ranged: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 10
+    defence_bonus:
+      stab: 5
+      slash: 4
+      crush: 6
+      magic: 6
+      ranged: 0
+    other_bonus:
+      strength: 2
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Red d'hide vambraces
+          quantity: 1
+        - item_name: Kebbit claws
+          quantity: 1
+      tools: []
+      skill: Crafting
+      level: 32
+      experience: 5.8
+      output_quantity: 1
+  related_items:
+    - name: Green spiky vambraces
+      relationship: variant
+    - name: Blue spiky vambraces
+      relationship: variant
+    - name: Black spiky vambraces
+      relationship: variant
+    - name: Red d'hide vambraces
+      relationship: component
+    - name: Kebbit claws
+      relationship: component
   about: "Red spiky vambraces is a members-only item in Old School RuneScape. High alchemy value: 2,160 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - High alch value 2,160 gp; viable for alch training when bought below high alch.
+      - Crafted from red d'hide vambraces plus kebbit claws at 32 Crafting.
+      - Modest demand from Ranged players seeking extra strength bonus.
+  trading_tips:
+    - Compare crafting cost vs GE price before buying out the materials.
+    - Eclectic implings provide a steady noted supply that pressures price ceilings.
+  history:
+    - date: "2006-11-21"
+      description: Released with the kebbit claw spiky vambraces variants.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dragon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dragon-mask.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Rune dragon mask is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: mid
+  equipment:
+    slot: head
+    weight: 2.267
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_id: 12518
+      item_name: Steel dragon mask
+      slug: steel-dragon-mask
+      relationship: variant
+      description: Other dragon mask
+    - item_id: 12520
+      item_name: Mithril dragon mask
+      slug: mithril-dragon-mask
+      relationship: variant
+      description: Other dragon mask
+  about: "Rune dragon mask is a cosmetic head slot item rewarded from elite treasure trails at a 1/1,275 rate from the reward casket. Provides no combat stats and is part of the dragon mask collection of fashionscape rewards."
+  market_strategy:
+    notes:
+      - Supply rate tied to elite clue volume
+      - Low daily volume, slow flips
+      - Steady cosmetic demand from collectors
+  trading_tips:
+    - Watch GE during elite clue events for dips
+    - Hold for long-term cosmetic appreciation
+  history:
+    - date: "2019-04-11"
+      description: Released as an elite clue scroll reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trail Improvements
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-knife-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-knife-p.mdx
@@ -12,21 +12,66 @@ osrs:
   lowalch: 66
   highalch: 99
   limit: 7000
+  material:
+    type: rune
+    tier: high
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
+    weight: 0
     requirements:
       ranged: 40
     attack_bonus:
       ranged: 15
-    ranged_strength: 24
-  related_items: []
+    other_bonus:
+      ranged_strength: 24
+  related_items:
+    - name: Rune knife
+      relationship: variant
+    - name: Rune knife(p+)
+      relationship: upgrade
+    - name: Rune knife(p++)
+      relationship: upgrade
+    - name: Adamant knife(p)
+      relationship: downgrade
+    - name: Dragon knife(p)
+      relationship: upgrade
+  market_strategy:
+    notes:
+      - "Poisoned variant of the rune knife, used for ranged combat with poison damage over time."
+      - "Demand driven by PvP players and slayer tasks where poison stacks help."
+      - "Often crafted by players (92 Smithing) then poisoned, so supply is steady."
+  trading_tips:
+    - "Compare margin against unpoisoned rune knife plus a weapon poison."
+    - "Bulk buyers usually prefer (p+) or (p++) for stronger poison ticks."
+  history:
+    - date: "2003-04-14"
+      description: "Rune knife and its poisoned variants released as part of the throwing knife update."
+  properties:
+    release_date: "2003-04-14"
+    update: Throwing Knives
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Use
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   about: |-
     > _"A very sharp rune knife with a poisoned tip."_
 
     A rune knife tipped with basic weapon poison. Requires 40 Ranged. The highest standard tier of poisoned knife. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody-h3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody-h3.mdx
@@ -12,22 +12,75 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
+  material:
+    type: metal
+    tier: high
   equipment:
     slot: body
+    weight: 9.979
     requirements:
       defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 82
+      slash: 80
+      crush: 72
+      magic: -6
+      ranged: 80
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/8125
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 23209
-      item_name: Rune platebody (h1)
-      slug: rune-platebody-h1
+    - name: Rune platebody (h1)
       relationship: variant
-      description: Heraldic variant 1
-  about: |-
-    > *"Provides excellent protection with a heraldic design."*
-
-    The rune platebody (h3) is a heraldic cosmetic variant of the rune platebody. Identical stats, requiring 40 Defence and Dragon Slayer I quest.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Rune platebody (h2)
+      relationship: variant
+    - name: Rune platebody (h4)
+      relationship: variant
+    - name: Rune platebody (h5)
+      relationship: variant
+  about: "The rune platebody (h3) is a heraldic cosmetic variant of the rune platebody awarded from hard Treasure Trails. Identical stats to the standard rune platebody, requires 40 Defence to wear."
+  history:
+    - date: "2019-04-11"
+      description: Released as part of the Treasure Trails Expansion and Easter 2019 update.
+    - date: "2021-04-21"
+      description: Ranged attack bonus decreased.
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platelegs.mdx
@@ -12,25 +12,96 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 70
-  item_id: 1079
-  item_type: armor
-  slot: legs
-  type: platelegs
-  tradeable: true
-  weight: 9.071
-  requirements:
-    defence: 40
-  stats:
-    stab_defence: 51
-    slash_defence: 49
-    crush_defence: 47
-    magic: -21
-    ranged: -11
+  material:
+    type: rune
+    tier: high
+  equipment:
+    slot: legs
+    weapon_type: none
+    weight: 9.071
+    requirements:
+      defence: 40
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -21
+      ranged: 49
+  recipes:
+    - skill: Smithing
+      level: 99
+      experience: 225
+      materials:
+        - item_name: Runite bar
+          quantity: "3"
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+      notes: "Use 3 runite bars on an anvil with a hammer at 99 Smithing for 225 XP."
+  shops:
+    - shop_name: "Champions' Guild Armoury"
+      location: "Champions' Guild, south of Varrock"
+      members: false
+    - shop_name: "Brian's Armour Shop"
+      location: "Prifddinas"
+      members: true
+  drop_table:
+    sources:
+      - source: "Chaos Elemental"
+        quantity: "1"
+        rarity: "1/512"
+      - source: "K'ril Tsutsaroth"
+        quantity: "1"
+        rarity: "Common"
+      - source: "Rune dragon"
+        quantity: "1"
+        rarity: "1/256"
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - slug: rune-plateskirt
-    - slug: runite-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Rune plateskirt
+      relationship: alternative
+    - name: Runite bar
+      relationship: component
+    - name: Adamant platelegs
+      relationship: downgrade
+    - name: Dragon platelegs
+      relationship: upgrade
+  about: "Rune platelegs are the rune-tier leg armour in Old School RuneScape, requiring 40 Defence to wear. The strongest free-to-play platelegs, they offer top-tier melee defence at a budget price and double as a popular high alch target. Smithable at 99 Smithing from 3 runite bars for 225 XP."
+  market_strategy:
+    notes:
+      - "Steady high-alch staple: large gap between GE price and 38,400 gp alch keeps demand consistent."
+      - "Drops from a wide range of mid-to-high level monsters, so supply is broad and stable."
+      - "F2P-tradeable item — flips can run across both game modes."
+  trading_tips:
+    - "Watch the GE-vs-high-alch margin; when GE price dips below ~38,000 alching becomes profitable."
+    - "Smithing 99 alts can craft profitably when runite bar prices dip."
+    - "Stable, blue-chip flip — low daily volatility but reliable margin in volume."
+  history:
+    - date: "2001-07-26"
+      description: "Released alongside the rune armour tier as the strongest F2P platelegs."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-07-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    alchable: true
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-plateskirt.mdx
@@ -12,8 +12,14 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 70
+  material:
+    type: rune
+    tier: high
   equipment:
     slot: legs
+    weight: 8.164
+    requirements:
+      defence: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -27,48 +33,67 @@ osrs:
       magic: -4
       ranged: 49
     other_bonus:
-      melee_strength: 0
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 40
-    weight: 8.164
+  recipes:
+    - skill: Smithing
+      level: 99
+      experience: 225
+      materials:
+        - item_name: Runite bar
+          quantity: 3
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
   related_items:
-    - item_id: 1079
-      item_name: Rune platelegs
-      slug: rune-platelegs
+    - name: Rune platelegs
       relationship: alternative
-      description: Identical stats, different appearance
-    - item_id: 4585
-      item_name: Dragon plateskirt
-      slug: dragon-plateskirt
+    - name: Dragon plateskirt
       relationship: upgrade
-      description: 60 Defence upgrade
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +51 |
-    | Slash | +49 |
-    | Crush | +47 |
-    | Ranged | +49 |
-    | Magic | -4 |
-
-    Requirements: 40 Defence | Weight: 8.16 kg
-
-    The rune plateskirt has exactly the same stats as the rune platelegs. The only difference is cosmetic. The plateskirt is typically slightly cheaper.
-
-    As the best F2P leg armour, the rune plateskirt/platelegs are essential for:
-    - F2P PKing — standard leg slot
-    - F2P PvM — best available defence
-    - Treasure Trail rewards — common F2P clue reward
+  about: "Rune plateskirt is the best free-to-play leg armour, identical in stats to rune platelegs but cosmetically a skirt and slightly cheaper. Requires 40 Defence to wear and 99 Smithing to craft from 3 runite bars."
+  shops:
+    - shop_name: Champions' Guild
+      location: Champions' Guild
+    - shop_name: Nardah armour shop
+      location: Nardah
+    - shop_name: Blast Furnace shop
+      location: Keldagrim
+    - shop_name: Prifddinas armour shop
+      location: Prifddinas
   market_strategy:
     notes:
-      - F2P accessible — broad demand
-      - Usually cheaper than rune platelegs
-      - Smithing requires 99 (3 runite bars)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - F2P accessible — broad demand across PKing and PvM.
+      - Usually cheaper than rune platelegs since stats are identical and many players prefer the platelegs cosmetic.
+      - Smithing requires 99 with 3 runite bars; supply is hand-crafted plus shop and drop sources.
+      - Common reward from F2P treasure trails.
+  trading_tips:
+    - Compare price against rune platelegs to gauge the cosmetic discount.
+    - Buy after F2P clue cycles when supply spikes from treasure trail rewards.
+  history:
+    - date: "2001-07-26"
+      description: Released into the game as part of the rune armour set.
+  properties:
+    release_date: "2001-07-26"
+    update: RuneScape Classic launch era
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 8.164
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sandwich-lady-bottom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sandwich-lady-bottom.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 4
-  about: "Sandwich lady bottom is a free-to-play item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weapon_type: none
+    weight: 0.907
+  treasure_trail:
+    tier: beginner
+    is_reward: true
+    reward_tiers:
+      - beginner
+  drop_table:
+    sources:
+      - source: "Reward casket (beginner)"
+        quantity: "1"
+        rarity: "1/360"
+  related_items:
+    - name: Sandwich lady top
+      relationship: set-piece
+    - name: Sandwich lady hat
+      relationship: set-piece
+    - name: Sandwich lady bottom (broken)
+      relationship: variant
+  about: "Sandwich lady bottom is a cosmetic leg-slot reward from beginner Treasure Trails in Old School RuneScape. Part of the three-piece Sandwich lady outfit, it provides no combat bonuses and can be stored in a player-owned house treasure chest when the beginner clue interface is open."
+  market_strategy:
+    notes:
+      - "Pure cosmetic — value driven by completionists and the outfit fashion market."
+      - "Tiny buy limit (4 per 4 hours) keeps trades thin and prices volatile on small order flow."
+      - "Demand spikes when the Sandwich lady outfit becomes a fashion meme or collector chase."
+  trading_tips:
+    - "Set-piece items often correlate; track top/hat prices for arbitrage opportunities."
+    - "Beginner clues are extremely common, but this drop is 1/360 — supply is steady but slow."
+    - "Long-hold cosmetic flips work better than rapid scalp trades due to the 4 unit buy limit."
+  history:
+    - date: "2019-04-11"
+      description: "Released as a beginner Treasure Trail cosmetic reward."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    alchable: true
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sanfew-serum-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sanfew-serum-3.mdx
@@ -1,28 +1,41 @@
 ---
 title: Sanfew serum(3) | OSRS Price Data
-description: "Sanfew serum(3) is a 3-dose members potion that restores 4-16 prayer points, cures poison/venom, restores stats. High alch: 144 GP, GE limit: 2,000."
+description: "Sanfew serum(3) is a 3-dose members potion that restores prayer/stats, cures poison/venom, and grants disease immunity. High alch: 144 GP, GE limit: 2,000."
 osrs:
   id: 10927
   name: Sanfew serum(3)
   slug: sanfew-serum-3
   examine: A 3 dose Sanfew Serum.
   members: true
-  icon: Sanfew serum(3).png
+  icon: "Sanfew serum(3).png"
   value: 240
   lowalch: 96
   highalch: 144
   limit: 2000
+  material:
+    type: potion
+    tier: mid-high
   potion:
-    doses: 3
-    herblore_level: 65
-    herblore_xp: 160
-    effect: Restores 4-16 Prayer points, cures poison/venom, restores stats
     effects:
-      - stat: Prayer
-        boost_formula: 4 + floor(level / 4)
-      - stat: Cure poison
-        boost_type: cure
-        description: Cures poison and venom
+      - description: "Restores Prayer points and all stats (except Hitpoints) per dose: 4 + 30% of base level."
+      - description: "Cures poison and venom and grants 6 minutes of poison immunity."
+      - description: "Cures disease and grants 15 minutes of disease immunity."
+  recipes:
+    - skill: Herblore
+      level: 65
+      xp: 160
+      materials:
+        - item_name: Super restore(3)
+          quantity: 1
+        - item_name: Unicorn horn dust
+          quantity: 1
+        - item_name: Snake weed
+          quantity: 1
+        - item_name: Nail beast nails
+          quantity: 1
+      tools: []
+      product: Sanfew serum(3)
+      output_quantity: 1
   related_items:
     - item_id: 10925
       item_name: Sanfew serum(4)
@@ -34,19 +47,46 @@ osrs:
       slug: sanfew-serum-2
       relationship: variant
       description: 2-dose version
+    - item_id: 10931
+      item_name: Sanfew serum(1)
+      slug: sanfew-serum-1
+      relationship: variant
+      description: 1-dose version
     - item_id: 3024
       item_name: Super restore(4)
       slug: super-restore-4
       relationship: component
-      description: Base potion
-  about: 3-dose variant of Sanfew serum.
+      description: Base potion used in the recipe
+  about: 3-dose variant of Sanfew serum. Requires partial completion of Zogre Flesh Eaters and 65 Herblore to brew. Combines super restore, superantipoison, and Relicym's balm effects.
   market_strategy:
     notes:
       - Compare 4-dose vs 3-dose prices
       - Decanting can profit in either direction
-      - Use decanting NPC in GE
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Use decanting NPC in the Grand Exchange
+  trading_tips:
+    - Watch dose-per-GP ratio against Sanfew serum(4) before bulk buys
+    - Common bossing supply — demand peaks with raid/COX activity
+  history:
+    - date: "2007-03-13"
+      description: Released with the Burgh de Rott Ramble update.
+  properties:
+    release_date: "2007-03-13"
+    update: Burgh de Rott Ramble
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/scythe-of-vitur-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/scythe-of-vitur-uncharged.mdx
@@ -12,95 +12,89 @@ osrs:
   lowalch: 1600000
   highalch: 2400000
   limit: 8
+  material:
+    type: metal
+    tier: high
   equipment:
     slot: weapon
-    type: scythe
-    tradeable: true
+    weapon_type: scythe
+    attack_speed: 5
     weight: 3.175
     requirements:
       attack: 80
       strength: 90
-    stats:
-      uncharged:
-        attack_stab: 50
-        attack_slash: 75
-        attack_crush: 10
-        attack_magic: -6
-        strength: 50
-        defence_stab: -2
-        defence_slash: 6
-      charged:
-        attack_stab: 70
-        attack_slash: 125
-        attack_crush: 30
-        strength: 75
-        defence_slash: 8
-        defence_crush: 10
-  special_mechanic:
-    name: Cleave
-    description: "Attacks in 1x3 arc, hitting up to 3 targets. Against large monsters (2x2+): 1st hit 100% damage, 2nd hit 50% damage, 3rd hit 25% damage."
-  charging:
-    cost: 1 Vial of blood + 200 Blood runes
-    charges_per_vial: 100
+    attack_bonus:
+      stab: 50
+      slash: 75
+      crush: 10
+      magic: -6
+      ranged: 0
+    defence_bonus:
+      stab: -2
+      slash: 6
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 50
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    description: "Cleave attack hits in a 1x3 arc on up to 3 tiles. Against large monsters (2x2 or larger), 1st hit deals 100 percent, 2nd hit 50 percent, and 3rd hit 25 percent damage."
+  charges:
     max_charges: 20000
+    charge_method: 1 vial of blood plus 200 blood runes per 100 charges at the Vyre well in Ver Sinhaza
     cost_per_attack: 537
+  drop_table:
+    sources:
+      - source: Theatre of Blood
+        quantity: "1"
+        rarity: Rare
   related_items:
-    - item_id: 22481
-      item_name: Sanguinesti staff
-      slug: sanguinesti-staff
+    - name: Scythe of vitur
+      relationship: upgrade
+    - name: Sanguinesti staff
       relationship: alternative
-      description: ToB mage weapon
-    - item_id: 22324
-      item_name: Ghrazi rapier
-      slug: ghrazi-rapier
+    - name: Ghrazi rapier
       relationship: alternative
-      description: ToB melee weapon
-    - item_id: 22446
-      item_name: Vial of blood
-      slug: vial-of-blood
+    - name: Vial of blood
       relationship: component
-      description: Required for charging
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Stab | +50 |
-    | Slash | +75 |
-    | Crush | +10 |
-    | Magic | -6 |
-    | Strength | +50 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Stab | -2 |
-    | Slash | +6 |
-
-    | Offence | Bonus |
-    |---------|-------|
-    | Stab | +70 |
-    | Slash | +125 |
-    | Crush | +30 |
-    | Strength | +75 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Slash | +8 |
-    | Crush | +10 |
-
-    Cleave: Attacks in 1x3 arc, hitting up to 3 targets. Against large monsters (2x2+):
-    - 1st hit: 100% damage
-    - 2nd hit: 50% damage
-    - 3rd hit: 25% damage
-
-    BiS for large monsters at ToB, Nightmare, and GWD.
-
-    | Cost | Charges |
-    |------|---------|
-    | 1 Vial of blood + 200 Blood runes | 100 |
-    | Max charges | 20,000 |
-
-    ~537 gp per attack. Charge at Vyre well in Ver Sinhaza.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Blood rune
+      relationship: component
+  about: "Scythe of vitur (uncharged) is the unpowered form of the powerful two-handed melee scythe from Theatre of Blood. Charged at the Vyre well in Ver Sinhaza with vials of blood and blood runes, it becomes BiS for large monsters at ToB, Nightmare, and GWD due to its cleave mechanic."
+  market_strategy:
+    notes:
+      - High-value item with limited daily volume; expect slow flips.
+      - Charging cost roughly 537 gp per attack determines effective DPS economics.
+  trading_tips:
+    - Charge at the Vyre well in Ver Sinhaza.
+    - Uncharge to trade or alch; charged form is untradeable.
+  history:
+    - date: "2018-06-07"
+      description: Released as part of the Theatre of Blood update.
+  properties:
+    release_date: "2018-06-07"
+    update: Theatre of Blood
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Charge
+      - Drop
+    worn_options:
+      - Check
+      - Uncharge
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-eternal-jeweller.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-eternal-jeweller.mdx
@@ -9,12 +9,47 @@ osrs:
   members: true
   icon: Sigil of the eternal jeweller.png
   value: 10000
-  lowalch: 4000
-  highalch: 6000
+  lowalch: null
+  highalch: null
   limit: 10
-  about: "Sigil of the eternal jeweller is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: "Deadman Mode drop table (most monsters)"
+        quantity: "1"
+        rarity: "Rare"
+  related_items:
+    - name: Sigil of the formidable mage
+      relationship: alternative
+    - name: Sigil of the menacing mage
+      relationship: alternative
+  about: "Sigil of the eternal jeweller is a Tier 1 utility sigil exclusive to temporary Deadman Mode events in Old School RuneScape. Once attuned, it prevents jewellery teleports — Ring of Duelling, Ring of Wealth, Amulet of Glory, Games Necklace, Skills Necklace, Combat Bracelet, Necklace of Passage, Slayer Ring, Digsite Pendant, Master Scroll Book and Burning Amulet — from consuming charges."
+  market_strategy:
+    notes:
+      - "Only obtainable inside temporary Deadman Mode seasons; untradeable in normal worlds."
+      - "GE limit and alch values listed are placeholders — the item is not on the live Grand Exchange."
+      - "Value is purely from in-event utility, not flipping."
+  trading_tips:
+    - "Not tradeable: there is no flipping market. Drop value is in survivability during DMM events."
+    - "Pair with high-charge teleport jewellery (Ring of Wealth, Amulet of Glory) to maximise the no-cost teleport benefit."
+  history:
+    - date: "2021-08-25"
+      description: "Released as a Tier 1 utility sigil for the Deadman: Reborn temporary tournament."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    alchable: false
+    options:
+      - Attune
+      - Drop
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skirt-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skirt-blue.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 250
   highalch: 375
   limit: 150
-  about: "Skirt (blue) is a members-only item in Old School RuneScape. High alchemy value: 375 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: legs
+    weight: 0.08
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Agmundi Quality Clothes
+      location: Keldagrim
+      price: 812
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania and Etceteria Dungeon
+      price: 625
+  related_items:
+    - name: Skirt (brown)
+      relationship: variant
+    - name: Skirt (lilac)
+      relationship: variant
+  about: "Skirt (blue) is a cosmetic legs slot item sold by Keldagrim and Miscellania clothes shops, part of the Dwarven clothing collection introduced with The Giant Dwarf quest update."
+  history:
+    - date: "2005-05-31"
+      description: "Released as part of the Keldagrim - The Dwarven City update."
+  properties:
+    release_date: "2005-05-31"
+    update: "Keldagrim - The Dwarven City"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spiked-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spiked-boots.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 15
-  about: "Spiked boots is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.34
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 2
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Climbing boots
+          quantity: 1
+        - item_name: Iron bar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      notes: "Obtained from Dunstan in Burthorpe after partial Death Plateau."
+  related_items:
+    - item_id: 3105
+      item_name: Climbing boots
+      slug: climbing-boots
+      relationship: component
+      description: Base footwear traded with Dunstan
+    - item_id: 2351
+      item_name: Iron bar
+      slug: iron-bar
+      relationship: component
+      description: Smelted bar used in spike fitting
+  about: "Spiked boots is a members-only quest item from Death Plateau, used during Desert Treasure I's Ice Path segment. High alchemy value: 18 coins. Grand Exchange buy limit: 15 per 4 hours."
+  history:
+    - date: "2004-08-09"
+      description: Released with the Death Plateau quest update.
+  properties:
+    release_date: "2004-08-09"
+    update: Death Plateau
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: true
+    quest: Death Plateau
+    weight: 0.34
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-chainbody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-chainbody.mdx
@@ -12,25 +12,78 @@ osrs:
   lowalch: 300
   highalch: 450
   limit: 125
-  item_id: 1105
-  item_type: armor
-  slot: body
-  type: chainbody
-  tradeable: true
-  weight: 6.803
-  requirements:
-    defence: 5
-  stats:
-    stab_defence: 17
-    slash_defence: 25
-    crush_defence: 30
-    magic_defence: -3
-    ranged_defence: 19
+  material:
+    type: steel
+    tier: low
+  equipment:
+    slot: body
+    weight: 6.803
+    requirements:
+      defence: 5
+    defence_bonus:
+      stab: 17
+      slash: 25
+      crush: 30
+      magic: -3
+      ranged: 19
+  recipes:
+    - skill: Smithing
+      level: 41
+      experience: 112.5
+      materials:
+        - item_name: Steel bar
+          quantity: 3
+      tools:
+        - Hammer
+      facilities:
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Horvik's Armour Shop
+      location: Varrock
+    - shop_name: Wayne's Chains - Just Chains
+      location: Falador
   related_items:
-    - slug: black-chainbody
-    - slug: steel-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1107
+      item_name: Black chainbody
+      slug: black-chainbody
+      relationship: alternative
+      description: Lower tier chainbody
+    - item_id: 1119
+      item_name: Steel platebody
+      slug: steel-platebody
+      relationship: alternative
+      description: Steel body alternative
+  about: "Steel chainbody is a free-to-play body armour requiring 5 Defence to wear. Smithed at level 41 Smithing from 3 steel bars (112.5 XP) or purchased from armour shops. Less common than the platebody since chainbodies allow ranged attacks while worn."
+  market_strategy:
+    notes:
+      - Low-tier armour, modest demand from new accounts
+      - Smithing supply keeps prices near alch floor
+      - High alch margin can yield profit when GE drops
+  trading_tips:
+    - Buy below high alch value for free guaranteed profit via alching
+    - Track new player events for demand spikes
+  history:
+    - date: "2001-01-04"
+      description: Added with the initial Smithing skill release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: Smithing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 6.803
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-set-lg.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 560
   highalch: 840
   limit: 8
-  about: "Steel set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 840 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: low
+  related_items:
+    - item_id: 1119
+      item_name: Steel platebody
+      slug: steel-platebody
+      relationship: component
+      description: Set component
+    - item_id: 1069
+      item_name: Steel platelegs
+      slug: steel-platelegs
+      relationship: component
+      description: Set component
+    - item_id: 1157
+      item_name: Steel full helm
+      slug: steel-full-helm
+      relationship: component
+      description: Set component
+    - item_id: 1191
+      item_name: Steel kiteshield
+      slug: steel-kiteshield
+      relationship: component
+      description: Set component
+    - item_id: 13066
+      item_name: Steel set (sk)
+      slug: steel-set-sk
+      relationship: variant
+      description: Skirt variant of the set
+  about: "Steel set (lg) is a Grand Exchange convenience bundle containing the steel full helm, platebody, platelegs, and kiteshield. Exchanged via the GE clerk Sets interface and primarily used to free bank/inventory space when moving full steel armour."
+  market_strategy:
+    notes:
+      - Set typically trades at a premium over the sum of its components
+      - Useful for arbitrage when GE prices misalign
+      - Free-to-play demand from new ironmen and shop suppliers
+  trading_tips:
+    - Compare set price vs combined component price for flips
+    - Buy components, package as set, sell during GE supply gaps
+  history:
+    - date: "2015-02-26"
+      description: Steel armour set added to the Grand Exchange Sets interface.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-02-26"
+    update: Grand Exchange Sets
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunbeam-ale.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunbeam-ale.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: null
+  food:
+    heals: 1
+    cooking_level: 1
+  potion:
+    effects:
+      - description: "Heals 1 Hitpoint and provides a temporary +1 boost to Agility and Strength."
+      - description: "Reduces Attack by 5% plus 1 level for the duration of the boost."
+  shops:
+    - shop_name: "Varlamore pub vendors"
+      location: Varlamore
+      stock: 5
+      price: 8
+  related_items:
+    - name: Moonlight mead
+      relationship: alternative
+    - name: Mature dwarven stout
+      relationship: alternative
+    - name: Asgarnian ale
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Sold by Varlamore pub vendors for 8 coins; cannot be brewed."
+      - "Useful for +1 Agility boost where Summer pies are scarce or overkill."
+      - "Niche flips on diary-task spikes when players want a temporary Agility buff."
+  trading_tips:
+    - "Buy direct from pub vendors and flip when GE price diverges from shop price."
+    - "Watch for boost meta changes; Strength boost overlap with Strength potions limits demand."
+  history:
+    - date: "2024-03-20"
+      description: "Released as part of the Varlamore: Part One update."
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   about: "Sunbeam ale is a members-only item in Old School RuneScape. High alchemy value: 4 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunlight-antelope-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunlight-antelope-fur.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: null
-  about: "Sunlight antelope fur is a members-only item in Old School RuneScape. High alchemy value: 6 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hide
+    tier: mid
+  drop_table:
+    sources:
+      - source: Sunlight antelope
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - skill: Crafting
+      level: 65
+      materials:
+        - item_name: Sunlight antelope fur
+          quantity: 1
+      tools:
+        - Needle
+        - Thread
+      output_quantity: 1
+      output: Large meat pouch
+    - skill: Crafting
+      level: 69
+      materials:
+        - item_name: Sunlight antelope fur
+          quantity: 1
+      tools:
+        - Needle
+        - Thread
+      output_quantity: 1
+      output: Mixed hide boots
+    - skill: Crafting
+      level: 72
+      materials:
+        - item_name: Sunlight antelope fur
+          quantity: 1
+      tools:
+        - Needle
+        - Thread
+      output_quantity: 1
+      output: Mixed hide top
+  related_items:
+    - item_name: Moonlight antelope fur
+      slug: moonlight-antelope-fur
+      relationship: variant
+      description: Higher tier antelope fur
+    - item_name: Large meat pouch
+      slug: large-meat-pouch
+      relationship: product
+      description: Crafted product
+    - item_name: Mixed hide boots
+      slug: mixed-hide-boots
+      relationship: product
+      description: Crafted product
+  about: "Sunlight antelope fur is obtained from pitfall trapping Sunlight antelopes in Varlamore at level 72 Hunter. Used in Crafting to make Large meat pouches (65), Mixed hide boots (69), and Mixed hide tops (72)."
+  market_strategy:
+    notes:
+      - No GE buy limit, easy to bulk-flip
+      - Steady demand from Crafting trainers
+      - Supply spikes during Varlamore hunting events
+  trading_tips:
+    - Track GE around DXP and Varlamore promo periods
+    - Pair with moonlight antelope furs for mixed hide combos
+  history:
+    - date: "2024-03-20"
+      description: "Added with the Varlamore: Part One update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: The Hunt for Tecu"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-energy-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-energy-3.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 92
   highalch: 138
   limit: 2000
-  about: "Super energy(3) is a members-only item in Old School RuneScape. High alchemy value: 138 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: Restores 20% of run energy per dose.
+      - description: Does not slow energy depletion like Stamina potions; only restores energy.
+  recipes:
+    - skill: Herblore
+      level: 52
+      experience: 117.5
+      output_quantity: 1
+      tools:
+        - Vial of water (for Avantoe potion (unf))
+      materials:
+        - item_name: Avantoe potion (unf)
+          quantity: 1
+        - item_name: Mort myre fungus
+          quantity: 1
+      notes: "Produces Super energy(3); decant to any dose with Bob Barter."
+  related_items:
+    - item_id: 3016
+      item_name: Super energy(4)
+      slug: super-energy-4
+      relationship: variant
+      description: 4-dose version
+    - item_id: 3020
+      item_name: Super energy(2)
+      slug: super-energy-2
+      relationship: variant
+      description: 2-dose version
+    - item_id: 3022
+      item_name: Super energy(1)
+      slug: super-energy-1
+      relationship: variant
+      description: 1-dose version
+  about: "3-dose super energy potion — each sip refills 20% run energy. Made at 52 Herblore from Avantoe potion (unf) + Mort myre fungus."
+  market_strategy:
+    notes:
+      - Demand is steady from clue-runners, agility trainers, and PvMers who skip stamina mixes.
+      - Decanting margin between (3) and (4) is the usual flip; watch the 2,000 GE buy limit.
+  trading_tips:
+    - Buy unf + fungus and craft your own when GE prices spread; gp/xp is decent.
+    - Compare (1)/(2)/(3)/(4) per-dose pricing for decant arbitrage; Bob Barter is the fastest path.
+  history:
+    - date: "2004-09-01"
+      description: Super energy potions added to the Herblore skill.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-09-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.06
+    options:
+      - Drink
+      - Empty
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swift-albatross-feather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swift-albatross-feather.mdx
@@ -1,20 +1,62 @@
 ---
 title: Swift albatross feather | OSRS Price Data
-description: "Swift albatross feather: An elegant feather from an albatross, not so swift anymore.. High alch: 4,800 GP, GE limit: 15."
+description: "Swift albatross feather: An elegant feather from an albatross, not so swift anymore. High alch: 4,800 GP, GE limit: 15."
 osrs:
   id: 31952
   name: Swift albatross feather
   slug: swift-albatross-feather
-  examine: An elegant feather from an albatross, not so swift anymore.
+  examine: An elegant feather from an albatross. Not so swift anymore.
   members: true
   icon: Swift albatross feather.png
   value: 8000
   lowalch: 3200
   highalch: 4800
   limit: 15
-  about: "Swift albatross feather is a members-only item in Old School RuneScape. High alchemy value: 4,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: material
+    tier: mid-high
+  drop_table:
+    sources:
+      - source: Albatross
+        quantity: "1"
+        rarity: 1/35
+  related_items:
+    - item_id: 31934
+      item_name: Gale catcher
+      slug: gale-catcher
+      relationship: product
+      description: Sailing ship attachment built using five feathers (requires 79 Sailing, 70 Construction)
+  about: "A Sailing-era material dropped by Albatross (combat level 110). Five feathers are required to build a gale catcher on a boat at 79 Sailing and 70 Construction."
+  market_strategy:
+    notes:
+      - Demand rises with active Sailing players upgrading ships
+      - Low buy limit (15) constrains big flips; small-margin scalping only
+      - Drop rate 1/35 from Albatross — supply tied to combat farming
+  trading_tips:
+    - Watch GE volume for Sailing content patches
+    - Stack quietly across 4-hour windows due to the 15-unit cap
+  history:
+    - date: "2025-11-05"
+      description: Added to the game (Technical Pre-Release; unobtainable).
+    - date: "2025-11-19"
+      description: Made obtainable with the Sailing skill release.
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Inspect
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-drawers-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-drawers-flatpack.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Teak drawers (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    level: 33
+    experience: 180
+    hotspot: Wardrobe space (Bedroom)
+    notes: "Flatpack form of Teak drawers; place to install in a player-owned house bedroom without on-the-fly Construction crafting."
+  recipes:
+    - skill: Construction
+      level: 51
+      experience: 180
+      output_quantity: 1
+      tools:
+        - Hammer
+        - Saw
+      materials:
+        - item_name: Teak plank
+          quantity: 2
+      notes: "Built at a Steel framed workbench (Workshop) in a player-owned house; takes 5 game ticks (3 seconds)."
+  related_items:
+    - item_id: 8782
+      item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: Plank used in construction.
+  about: "Flatpack version of Teak drawers — built at the Steel framed workbench from 2 teak planks at 51 Construction, then placed in a POH bedroom."
+  market_strategy:
+    notes:
+      - Demand comes from POH builders who buy flatpacks rather than train Construction on-site.
+      - Low 500 GE buy limit keeps volume thin; pricing is sensitive to teak plank costs.
+  trading_tips:
+    - Track teak plank GE pricing; when planks dip, crafted flatpacks become an arbitrage opportunity.
+    - Steel framed workbench bench-flipping is more profitable than alching; never alch — sell to construction trainers instead.
+  history:
+    - date: "2006-05-31"
+      description: Teak drawers and their flatpack variant introduced with the Construction skill expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-42-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-42-cape.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-42 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: cape
+    weight: 0.453
+    defence_bonus:
+      slash: 1
+      crush: 1
+      ranged: 2
+  shops:
+    - shop_name: Ian's Wilderness Cape Shop
+      location: Forgotten Cemetery
+      price: 50
+  related_items:
+    - item_id: 4313
+      item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: Other team cape variant
+  about: "Team-42 cape is a free-to-play team cape sold by Ian at the Wilderness Cape Shop in the Forgotten Cemetery. Worn primarily to identify same-team players in PvP — matching cape wearers show as blue minimap dots and cannot left-click attack each other. Offers minor defence bonuses."
+  market_strategy:
+    notes:
+      - Cheap supply from shop floor
+      - Demand from PvP/team events
+      - Very low margins, only viable in bulk
+  trading_tips:
+    - Stockpile cheaply during quiet PvP weeks
+    - Sell during clan wars / DMM seasons
+  history:
+    - date: "2005-02-22"
+      description: Released as part of the team capes set sold at Wilderness Cape Shops.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-22"
+    update: Team Capes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tome-of-water-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tome-of-water-empty.mdx
@@ -11,10 +11,70 @@ osrs:
   value: 19500
   lowalch: 7800
   highalch: 11700
-  limit: null
+  limit: 15
+  equipment:
+    slot: shield
+    weapon_type: unarmed
+    weight: 1
+    requirements:
+      magic: 1
+    attack_bonus:
+      magic: 8
+    defence_bonus:
+      magic: 8
+  charges:
+    max_charges: 20000
+    charged_form: Tome of water
+    charge_item: Soaked pages
+    charges_per_item: 20
+    description: "Holds up to 20,000 charges via soaked pages (20 per page). When charged and equipped, supplies unlimited water runes and boosts water magic damage."
+  drop_table:
+    sources:
+      - source: Tempoross
+        quantity: "1"
+        rarity: "1/1,600"
+  related_items:
+    - name: Tome of water
+      relationship: variant
+    - name: Tome of fire (empty)
+      relationship: alternative
+    - name: Tome of earth (empty)
+      relationship: alternative
+    - name: Soaked pages
+      relationship: component
+    - name: Tempoross
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Drops from Tempoross at 1/1,600; supply rises with skiller activity at the boss."
+      - "Charged form gives unlimited water runes and 10-20% damage boost on water spells."
+      - "Empty tome flips against charged tome plus soaked-page production cost."
+  trading_tips:
+    - "Compare empty + (charges * page cost) vs. charged tome to spot arbitrage."
+    - "Demand jumps with new magic gear that pairs with high-tier spell rotations."
+  history:
+    - date: "2021-03-24"
+      description: "Released alongside the Tempoross fishing boss."
+  properties:
+    release_date: "2021-03-24"
+    update: Tempoross
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   about: "Tome of water (empty) is a members-only item in Old School RuneScape. High alchemy value: 11,700 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-platebody-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-platebody-0.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 112000
   highalch: 168000
   limit: 15
+  material:
+    type: barrows
+    tier: high
+  equipment:
+    slot: body
+    weight: 9.979
+    requirements:
+      defence: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 122
+      slash: 120
+      crush: 107
+      magic: -6
+      ranged: 132
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    max_charges: 100
+    current_charges: 0
+    notes: Fully degraded. Tradeable in this state; must be repaired at an armour stand or NPC before equipping back to full durability.
+  related_items:
+    - name: Torag's platebody
+      relationship: variant
+    - name: Torag's platebody 25
+      relationship: variant
+    - name: Torag's platebody 50
+      relationship: variant
+    - name: Torag's platebody 75
+      relationship: variant
+    - name: Torag's helm 0
+      relationship: set-piece
+    - name: Torag's platelegs 0
+      relationship: set-piece
+    - name: Torag's hammers 0
+      relationship: set-piece
   about: "Torag's platebody 0 is a members-only item in Old School RuneScape. High alchemy value: 168,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Fully degraded variant; cheaper than charged versions but requires repair before use.
+      - Repair cost scales with Smithing level at a POH armour stand vs flat NPC cost.
+      - Demand tied to Barrows runners flipping fully degraded armour for repair-and-resell arbitrage.
+  trading_tips:
+    - Watch the spread between 0 charge and fully repaired variants vs NPC repair cost (90k full repair).
+    - High Smithing makes repair-and-flip noticeably more profitable.
+  history:
+    - date: "2005-05-09"
+      description: Released as part of the Barrows update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tortoise-shell.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tortoise-shell.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 7500
-  about: "Tortoise shell is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: organic
+    tier: low
+  drop_table:
+    sources:
+      - source: Tortoise
+        quantity: "1"
+        rarity: 10/128
+      - source: Tortoise (with riders)
+        quantity: "1"
+        rarity: 8/128
+      - source: Mutated tortoise
+        quantity: "1"
+        rarity: 2/64
+      - source: Warped tortoise
+        quantity: "1"
+        rarity: 2/64
+  shops:
+    - shop_name: Barlak (sell)
+      location: Dorgesh-Kaan
+      price: 600
+  related_items:
+    - name: Perfect shell
+      relationship: alternative
+  about: "Tortoise shell is dropped by tortoise monsters and can be sold to Barlak in Dorgesh-Kaan for 600 coins. Unlike perfect shells, tortoise shells do not grant Crafting experience when sold."
+  history:
+    - date: "2006-04-24"
+      description: Released as part of the Wilderness graphical update.
+  properties:
+    release_date: "2006-04-24"
+    update: Wilderness graphical update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 6.803
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toy-doll-wound.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toy-doll-wound.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 150
-  about: "Toy doll (wound) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Crafting
+      level: 18
+      experience: 15
+      materials:
+        - item_name: Clockwork
+          quantity: 1
+        - item_name: Plank
+          quantity: 1
+      tools:
+        - Crafting table 3
+      output_quantity: 1
+      facility: Player-owned house workshop
+  related_items:
+    - name: Toy doll
+      relationship: variant
+    - name: Toy soldier
+      relationship: alternative
+    - name: Toy mouse
+      relationship: alternative
+    - name: Toy cat
+      relationship: alternative
+    - name: Clockwork
+      relationship: component
+    - name: Plank
+      relationship: component
+  about: "Toy doll (wound) is a members-only wound-up clockwork toy crafted at a Crafting table 3 in a player-owned house workshop from one clockwork and one plank at Crafting level 18 for 15 experience."
+  market_strategy:
+    notes:
+      - Niche flip — demand is largely from POH owners and clockwork toy collectors.
+      - Profit per unit depends on the spread between clockwork and the wound toy.
+      - Buy limit of 150 per 4 hours caps flipping volume.
+  trading_tips:
+    - Compare against unwound toy doll price to gauge crafting margin.
+    - Watch for spikes when clockwork supply tightens.
+  history:
+    - date: "2006-05-31"
+      description: Released as part of the Player-Owned Houses update; crafted via the workshop using a clockwork and a plank.
+    - date: "2014-08-04"
+      description: Update limited the number of clockwork toys that can be dropped in an area to curb pickup-blocking scams.
+  properties:
+    release_date: "2006-05-31"
+    update: Player-Owned Houses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wind
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-rug.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-rug.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 5
-  about: "Trailblazer rug is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    level: 60
+    xp: 60
+    materials:
+      - item_name: Trailblazer rug
+        quantity: 1
+      - item_name: Bolt of cloth
+        quantity: 4
+    tools:
+      - Hammer
+      - Saw
+    facility: League Hall rug hotspot
+  shops:
+    - shop_name: Leagues Reward Shop
+      currency: League Points
+      price: 5000
+      location: Leagues hub
+  related_items:
+    - item_id: 25092
+      item_name: Trailblazer banner
+      slug: trailblazer-banner
+      relationship: alternative
+      description: Companion Leagues Trophy Room reward
+  about: "Trailblazer rug is a Trailblazer League reward purchased from the Leagues Reward Shop for 5,000 League Points and built in the League Trophy Room of a Player-Owned House. High alchemy value: 30,000 coins. Grand Exchange buy limit: 5 per 4 hours."
+  history:
+    - date: "2020-10-28"
+      description: Item added to game ahead of Trailblazer League launch.
+    - date: "2021-01-06"
+      description: Made obtainable from the Leagues Reward Shop; value raised from 5,000 to 50,000 and made members-only.
+  properties:
+    release_date: "2021-01-06"
+    update: Soul Wars and 20th Anniversary Event
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tuna-and-corn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tuna-and-corn.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 45
   highalch: 67
   limit: 13000
-  about: "Tuna and corn is a members-only item in Old School RuneScape. High alchemy value: 67 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    effects:
+      - description: Heals 13 Hitpoints when eaten.
+      - description: Intermediate component for Tuna potato at 68 Cooking, which heals 22 Hitpoints.
+  recipes:
+    - skill: Cooking
+      level: 67
+      experience: 0
+      output_quantity: 1
+      tools:
+        - Knife
+      materials:
+        - item_name: Chopped tuna
+          quantity: 1
+        - item_name: Bowl of sweetcorn
+          quantity: 1
+      notes: "Alternatively combine cooked tuna with a bowl of sweetcorn or assemble from sweetcorn + tuna + bowl."
+  related_items:
+    - item_id: 7060
+      item_name: Tuna potato
+      slug: tuna-potato
+      relationship: product
+      description: Upgrade made by adding this to a potato with butter at 68 Cooking.
+    - item_id: 359
+      item_name: Tuna
+      slug: tuna
+      relationship: component
+      description: Cooked tuna used as the base ingredient.
+    - item_id: 7054
+      item_name: Bowl of sweetcorn
+      slug: bowl-of-sweetcorn
+      relationship: component
+      description: Sweetcorn portion of the dish.
+  about: "67 Cooking dish that heals 13 HP; primarily made as a stepping stone toward Tuna potato (22 HP)."
+  market_strategy:
+    notes:
+      - Volume is driven almost entirely by tuna potato production for high-level food stockpiles.
+      - Margin is thin per-bowl; profit usually comes from large batches assembled while training Cooking.
+  trading_tips:
+    - Pair purchases with cooked tuna and sweetcorn flips; the spread between inputs and tuna potato output is the real profit lane.
+    - Watch boss-meta shifts toward tuna potato to time buys.
+  history:
+    - date: "2006-01-30"
+      description: Tuna and corn added with the cooking expansion that introduced sweetcorn-based recipes.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-01-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-dragonstone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-dragonstone.mdx
@@ -1,6 +1,6 @@
 ---
 title: Uncut dragonstone | OSRS Price Data
-description: "Uncut dragonstone: This would be worth more cut.. High alch: 600 GP, GE limit: 10,000."
+description: "Uncut dragonstone: This would be worth more cut. High alch: 600 GP, GE limit: 10,000."
 osrs:
   id: 1631
   name: Uncut dragonstone
@@ -12,25 +12,45 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 10000
-  item:
-    type: material
-    tradeable: true
+  material:
+    type: gem
+    tier: high
+  drop_table:
+    sources:
+      - source: Crystal chest
+        quantity: "1"
+        rarity: Always
+      - source: Callisto
+        quantity: "1"
+        rarity: Common
+      - source: "Vet'ion"
+        quantity: "1"
+        rarity: Common
+      - source: Venenatis
+        quantity: "1"
+        rarity: Common
+  shops:
+    - shop_name: "TzHaar-Hur-Tel's Equipment Store"
+      location: Mor Ul Rek
+      currency: Tokkul
+      price: 1500
   recipes:
-    - skill: crafting
+    - skill: Crafting
       level: 55
       xp: 137.5
       materials:
-        - item_id: 1631
-          item_name: Uncut dragonstone
+        - item_name: Uncut dragonstone
           quantity: 1
+      tools:
+        - Chisel
       product: Dragonstone
-      product_id: 1615
+      output_quantity: 1
   related_items:
     - item_id: 1615
       item_name: Dragonstone
       slug: dragonstone
       relationship: product
-      description: Cut form
+      description: Cut form of the gem
     - item_id: 989
       item_name: Crystal key
       slug: crystal-key
@@ -44,8 +64,32 @@ osrs:
     | Weight | 0.003 kg |
 
     Cut with 55 Crafting for dragonstone (137.5 XP).
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+
+    Primary sources are the Crystal Chest in Taverley, the wilderness bosses (Callisto, Vet'ion, Venenatis), and TzHaar gem shops in Mor Ul Rek (1,500 Tokkul).
+  market_strategy:
+    notes:
+      - Stable demand from Crafting trainers and jewellery makers
+      - Crystal chest farming pushes consistent supply
+      - Watch for Tokkul exchange runs from TzHaar shops
+  history:
+    - date: "2002-02-27"
+      description: Added to the game.
+  properties:
+    release_date: "2002-02-27"
+    update: Quest - Heroes Quest
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.003
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/varlamorian-kebab.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/varlamorian-kebab.mdx
@@ -12,9 +12,47 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Varlamorian kebab is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    effects:
+      - description: "Most common (~20/32 chance): heals 3 + 7% of max HP."
+      - description: "Common (~8/32 chance): heals 6 + 14% of max HP."
+      - description: "Rare (~3/32 chance): heals 7 + 24% of max HP and boosts Attack, Strength, and Defence by 2."
+      - description: "Rarest (~1/32 chance): no effect."
+      - description: "Average healing roughly 4 + 10% of the player's Hitpoints level."
+      - description: "Unlike a standard kebab, it never drains stats."
+  shops:
+    - shop_name: Emelio's Kebab Shop
+      location: Varlamore
+      stock: 20
+      buy_price: 2
+      notes: "Requires completion of the Meat and Greet quest; restocks every 12 seconds."
+  about: "Varlamorian kebab is a members-only food sold by Emelio after Meat and Greet; rarely boosts melee stats and never drains."
+  market_strategy:
+    notes:
+      - Shop-sourced at 2 gp with no GE buy limit; profit is driven entirely by sale margin over shop price.
+      - Demand spikes when PvM content rewards a stat-boost food meta; otherwise volume is thin.
+  trading_tips:
+    - Hoover Emelio's stock with hop-worlding then flip on the GE while the buy queue is empty.
+    - Track Meat and Greet completions and Varlamore content updates for demand swings.
+  history:
+    - date: "2024-09-25"
+      description: Varlamorian kebab released as part of the Meat and Greet quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-09-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/virtus-robe-bottom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/virtus-robe-bottom.mdx
@@ -12,53 +12,56 @@ osrs:
   lowalch: 160000
   highalch: 240000
   limit: 8
+  material:
+    type: virtus
+    tier: high
   equipment:
     slot: legs
-    type: magic armour
-    tradeable: true
     weight: 3.79
     requirements:
       magic: 78
       defence: 75
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 26
-      attack_ranged: 0
-      defence_stab: 31
-      defence_slash: 28
-      defence_crush: 34
-      defence_magic: 22
-      defence_ranged: 0
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 26
+      ranged: 0
+    defence_bonus:
+      stab: 31
+      slash: 28
+      crush: 34
+      magic: 22
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 2
       prayer: 1
-  obtaining:
-    - source: The Whisperer
-      drop_rate: 1/1,536
-    - source: Duke Sucellus
-      drop_rate: 1/2,160
-    - source: The Leviathan
-      drop_rate: 1/2,304
-    - source: Vardorvis
-      drop_rate: 1/3,264
-  set_bonus:
-    name: Virtus Set
-    standard: +2% magic damage per piece (6% total)
-    ancient_magicks: +5% magic damage per piece (15% total)
-  gwd_protection: Provides Zaros protection in GWD Ancient Prison
+  drop_table:
+    sources:
+      - source: The Whisperer
+        quantity: "1"
+        rarity: 1/1536
+      - source: Duke Sucellus
+        quantity: "1"
+        rarity: 1/2160
+      - source: The Leviathan
+        quantity: "1"
+        rarity: 1/2304
+      - source: Vardorvis
+        quantity: "1"
+        rarity: 1/3264
   related_items:
     - item_id: 26241
       item_name: Virtus mask
       slug: virtus-mask
-      relationship: alternative
+      relationship: set-piece
       description: Set helm piece
     - item_id: 26243
       item_name: Virtus robe top
       slug: virtus-robe-top
-      relationship: alternative
+      relationship: set-piece
       description: Set body piece
   about: |-
     | Offence | Bonus |
@@ -82,8 +85,24 @@ osrs:
     - Ancient Magicks: +5% per piece (15% total)
 
     Provides Zaros protection in GWD Ancient Prison.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2023-07-26"
+      description: "Released with Desert Treasure II: The Fallen Empire."
+    - date: "2024-05-29"
+      description: Magic damage bonus increased from 1% to 2%.
+  properties:
+    release_date: "2023-07-26"
+    update: "Desert Treasure II: The Fallen Empire"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.79
+    alchable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/waterskin-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/waterskin-0.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 10000
-  about: "Waterskin(0) is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  charges:
+    max_charges: 4
+    description: "Empty waterskin. Holds up to four doses of water for surviving the Kharidian Desert's heat."
+    refill_method: "Refill from any water source (fountain, sink, well), bucket of water, jug of water, bowl of water, vial of water, the Humidify spell, or by slicing a Kharidian cactus."
+  related_items:
+    - name: Waterskin(4)
+      relationship: variant
+    - name: Waterskin(3)
+      relationship: variant
+    - name: Waterskin(2)
+      relationship: variant
+    - name: Waterskin(1)
+      relationship: variant
+    - name: Circlet of water
+      relationship: alternative
+  about: "Waterskin(0) is the empty form of the Kharidian Desert survival waterskin in Old School RuneScape. Refill it at any water source or with the Humidify spell to convert it back to a Waterskin(4) before braving desert heat damage."
+  market_strategy:
+    notes:
+      - "Bulk consumable: high buy limit (10,000) makes it suitable for stocking up before long desert trips."
+      - "Empty skins are usually cheapest variant — pair with Humidify or bucket refills for bulk preparation."
+      - "Low alch value (9 gp) means alching is never profitable; flip on consumable demand."
+  trading_tips:
+    - "Stock empty skins when prepping for Pyramid Plunder, Smoke Devils, or Menaphos content."
+    - "Bulk-buy at GE then Humidify (Lunar Magic) to refill an entire inventory at once."
+    - "Watch for demand spikes around new desert content releases or Menaphos quests."
+  history:
+    - date: "2003-04-14"
+      description: "Released as part of the original Kharidian Desert heat survival system."
+    - date: "2005-07-05"
+      description: "Examine text corrected to fix a typo."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    alchable: true
+    options:
+      - Drink
+      - Empty
+      - Drop
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wild-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wild-pie.mdx
@@ -17,32 +17,53 @@ osrs:
     cooking_level: 85
     cooking_xp: 240
   recipes:
-    - skill: cooking
+    - skill: Cooking
       level: 85
       xp: 240
-      inputs:
-        - item_name: Pastry dough
+      materials:
+        - item_name: Raw wild pie
           quantity: 1
-        - item_name: Pie dish
-          quantity: 1
-        - item_name: Raw bear meat
-          quantity: 1
-        - item_name: Raw chompy
-          quantity: 1
-        - item_name: Raw rabbit
-          quantity: 1
+      tools:
+        - Cooking range
       output_quantity: 1
   related_items:
-    - item_id: 7198
-      item_name: Admiral pie
-      slug: admiral-pie
+    - name: Raw wild pie
+      relationship: component
+    - name: Admiral pie
       relationship: alternative
-      description: +5 Fishing boost
-    - item_id: 7170
-      item_name: Mud pie
-      slug: mud-pie
+    - name: Mud pie
       relationship: alternative
-      description: Run energy drain pie
+    - name: Half a wild pie
+      relationship: variant
+    - name: Pie dish
+      relationship: component
+  market_strategy:
+    notes:
+      - "High demand for Slayer boosting; +5 Slayer is the highest available boost."
+      - "Raw chompy requires Big Chompy Bird Hunting quest, restricting supply."
+      - "Bake Pie spell (Lunar) avoids burning and stabilises production cost."
+  trading_tips:
+    - "Watch raw chompy and raw bear meat prices to model production cost."
+    - "Spikes around new boss releases that gate behind Slayer levels."
+  history:
+    - date: "2006-02-20"
+      description: "Wild pie released alongside the Recipe for Disaster questline content."
+  properties:
+    release_date: "2006-02-20"
+    update: Recipe for Disaster
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   about: |-
     | Skill | Boost |
     |-------|-------|
@@ -62,13 +83,8 @@ osrs:
     | Spicy stew (orange) | -5 to +5 | Random | 1 HP |
 
     Wild pie is reliable (+5 guaranteed) versus spicy stew which is random. However, spicy stew can potentially boost any skill.
-  market_strategy:
-    notes:
-      - High demand for Slayer boosting
-      - Raw chompy requires Big Chompy Bird Hunting quest
-      - Bake Pie spell avoids burning
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zaryte-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zaryte-vambraces.mdx
@@ -14,43 +14,66 @@ osrs:
   limit: 7
   equipment:
     slot: hands
-    type: ranged
-    attack_style: ranged
+    weapon_type: unarmed
+    weight: 1
     requirements:
       ranged: 80
-    stats:
-      attack_ranged: 18
-      defence_ranged: 2
+      defence: 45
+    attack_bonus:
+      ranged: 18
+    defence_bonus:
+      stab: 5
+      slash: 5
+      crush: 5
+      magic: 5
+      ranged: 8
+    other_bonus:
+      ranged_strength: 2
       prayer: 1
-  effect:
-    passive: true
-    bolt_save_chance: 10
-    description: 10% chance to prevent incoming damage from consuming enchanted bolt effects
+  special_attack:
+    description: "Passive 10% chance to prevent incoming damage from consuming enchanted bolt effects."
   drop_table:
     sources:
       - source: Nex
-        source_id: 11278
-        combat_level: 1001
         quantity: "1"
-        rarity: Rare
-        drop_rate: 1/43 per unique roll
-        members_only: true
+        rarity: "1/172"
   related_items:
-    - item_id: 25865
-      item_name: Zaryte crossbow
-      slug: zaryte-crossbow
+    - name: Zaryte crossbow
       relationship: alternative
-      description: Nex crossbow
-    - item_id: 7462
-      item_name: Barrows gloves
-      slug: barrows-gloves
+    - name: Barrows gloves
+      relationship: downgrade
+    - name: Necklace of anguish
       relationship: alternative
-      description: Budget alternative
-    - item_id: 19547
-      item_name: Necklace of anguish
-      slug: necklace-of-anguish
+    - name: Pegasian boots
       relationship: alternative
-      description: Ranged amulet
+  market_strategy:
+    notes:
+      - "Only from Nex; supply gated by uniques rolled at 1/172 per kill."
+      - "Best-in-slot Ranged gloves, the only hand item with Ranged strength bonus."
+      - "Pairs with Zaryte crossbow and other end-game ranged loadouts."
+  trading_tips:
+    - "Price moves with Nex popularity and bond-funded grinder cycles."
+    - "Watch for combat updates that change BiS ranges or bolt-effect mechanics."
+  history:
+    - date: "2022-01-05"
+      description: "Released as part of the Nex: The Fifth General update."
+  properties:
+    release_date: "2022-01-05"
+    update: "Nex: The Fifth General"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   about: |-
     | Stat | Value |
     |------|-------|
@@ -69,13 +92,8 @@ osrs:
     - Bossing
     - Raids
     - Crossbow builds
-  market_strategy:
-    notes:
-      - Only from Nex
-      - Best ranged hand slot
-      - Pairs with Zaryte crossbow
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Eleventh batch — migrate 100 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Worktree-direct authoring; main repo untouched.
- Schema-validated via `astro sync`.

Post-agent fix: `history[].description` with inner colons quoted (`Varlamore: The Final Dawn`).

## Test plan

- [x] `astro sync` clean — all 100 entries validate.
- [ ] CI build green.

## Follow-ups

- ~3023 v2 items remain after this batch lands.