### PR TITLE
debug(kbve-spider): rebuild registry on join + /spider-debug command

### DIFF
--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -298,7 +298,7 @@ commands.add_command(
 			local owner_idx = storage.ally_owners and storage.ally_owners[unit_number] or "?"
 			local valid = ally and ally.valid
 			local cmdable = valid and ally.commandable or nil
-			local has_cmd = cmdable and cmdable.has_command() or false
+			local has_cmd = cmdable and cmdable.has_command or false
 			local pos_str = valid and string.format("(%d,%d)", math.floor(ally.position.x), math.floor(ally.position.y)) or "<gone>"
 			player.print(string.format(
 				"  unit=%d name=%s owner=%s surface=%d pos=%s valid=%s has_command=%s",
@@ -314,7 +314,7 @@ commands.add_command(
 					total_world = total_world + 1
 					local in_reg = allies[a.unit_number] ~= nil
 					local cmdable_a = a.commandable
-					local has_cmd_a = cmdable_a and cmdable_a.has_command() or false
+					local has_cmd_a = cmdable_a and cmdable_a.has_command or false
 					player.print(string.format(
 						"  world: unit=%d surface=%s pos=(%d,%d) in_registry=%s force=%s has_command=%s",
 						a.unit_number, surface.name,
@@ -605,7 +605,7 @@ local function follow_loop()
 							end
 						else
 							local commandable = ally.commandable
-							if commandable and not commandable.has_command() then
+							if commandable and not commandable.has_command then
 								commandable.set_command{
 									type = defines.command.wander,
 									ticks_to_wait = 240,
@@ -689,7 +689,7 @@ script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 						if not in_group then
 							pcall(function()
 								local commandable = s.commandable
-								if commandable and not commandable.has_command() then
+								if commandable and not commandable.has_command then
 									commandable.set_command{
 										type = defines.command.wander,
 										ticks_to_wait = 600,

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -134,11 +134,14 @@ script.on_event(defines.events.on_entity_damaged, function(event)
 		local health_ratio = e.get_health_ratio() or 1
 		if health_ratio < cached_flee_threshold then
 			storage.fleeing[key] = true
-			e.set_command{
-				type = defines.command.flee,
-				from = cause,
-				distraction = defines.distraction.none,
-			}
+			local commandable = e.commandable
+			if commandable then
+				commandable.set_command{
+					type = defines.command.flee,
+					from = cause,
+					distraction = defines.distraction.none,
+				}
+			end
 			surface.create_entity{
 				name = SPRINT_STICKER,
 				position = e.position,
@@ -294,16 +297,39 @@ commands.add_command(
 			local name = storage.ally_names and storage.ally_names[unit_number] or "?"
 			local owner_idx = storage.ally_owners and storage.ally_owners[unit_number] or "?"
 			local valid = ally and ally.valid
-			local has_cmd = valid and ally.has_command() or false
+			local cmdable = valid and ally.commandable or nil
+			local has_cmd = cmdable and cmdable.has_command() or false
 			local pos_str = valid and string.format("(%d,%d)", math.floor(ally.position.x), math.floor(ally.position.y)) or "<gone>"
 			player.print(string.format(
 				"  unit=%d name=%s owner=%s surface=%d pos=%s valid=%s has_command=%s",
 				unit_number, tostring(name), tostring(owner_idx), surface_index, pos_str, tostring(valid), tostring(has_cmd)
 			))
 		end
-		if n == 0 then
-			player.print("  registry empty — try /c remote.call or just walk around for one tick")
+
+		local total_world = 0
+		for _, surface in pairs(game.surfaces) do
+			local found = surface.find_entities_filtered{ name = SPIDER_ALLY }
+			for _, a in pairs(found) do
+				if a.valid and a.unit_number then
+					total_world = total_world + 1
+					local in_reg = allies[a.unit_number] ~= nil
+					local cmdable_a = a.commandable
+					local has_cmd_a = cmdable_a and cmdable_a.has_command() or false
+					player.print(string.format(
+						"  world: unit=%d surface=%s pos=(%d,%d) in_registry=%s force=%s has_command=%s",
+						a.unit_number, surface.name,
+						math.floor(a.position.x), math.floor(a.position.y),
+						tostring(in_reg), a.force.name, tostring(has_cmd_a)
+					))
+				end
+			end
 		end
+		player.print(string.format("[kbve-spider] world scan: %d kbve-spider-ally entities found", total_world))
+
+		local pending = storage.pending_eggs or {}
+		local pn = 0
+		for _ in pairs(pending) do pn = pn + 1 end
+		player.print(string.format("[kbve-spider] pending eggs: %d", pn))
 	end
 )
 
@@ -558,29 +584,35 @@ local function follow_loop()
 							-- is nil for spectators / editor mode, in which
 							-- case we fall back to a static destination so the
 							-- ally at least catches up to the cursor.
-							local target_entity = owner.character
-							if target_entity and target_entity.valid then
-								ally.set_command{
-									type = defines.command.go_to_location,
-									destination_entity = target_entity,
+							local commandable = ally.commandable
+							if commandable then
+								local target_entity = owner.character
+								if target_entity and target_entity.valid then
+									commandable.set_command{
+										type = defines.command.go_to_location,
+										destination_entity = target_entity,
+										distraction = defines.distraction.by_enemy,
+										radius = FOLLOW_DESTINATION_RADIUS,
+									}
+								else
+									commandable.set_command{
+										type = defines.command.go_to_location,
+										destination = { x = opos.x, y = opos.y },
+										distraction = defines.distraction.by_enemy,
+										radius = FOLLOW_DESTINATION_RADIUS,
+									}
+								end
+							end
+						else
+							local commandable = ally.commandable
+							if commandable and not commandable.has_command() then
+								commandable.set_command{
+									type = defines.command.wander,
+									ticks_to_wait = 240,
+									wander_in_group = false,
 									distraction = defines.distraction.by_enemy,
-									radius = FOLLOW_DESTINATION_RADIUS,
-								}
-							else
-								ally.set_command{
-									type = defines.command.go_to_location,
-									destination = { x = opos.x, y = opos.y },
-									distraction = defines.distraction.by_enemy,
-									radius = FOLLOW_DESTINATION_RADIUS,
 								}
 							end
-						elseif not ally.has_command() then
-							ally.set_command{
-								type = defines.command.wander,
-								ticks_to_wait = 240,
-								wander_in_group = false,
-								distraction = defines.distraction.by_enemy,
-							}
 						end
 					end)
 				end
@@ -656,8 +688,9 @@ script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 						if ok_ug and ug then in_group = true end
 						if not in_group then
 							pcall(function()
-								if not s.has_command() then
-									s.set_command{
+								local commandable = s.commandable
+								if commandable and not commandable.has_command() then
+									commandable.set_command{
 										type = defines.command.wander,
 										ticks_to_wait = 600,
 										wander_in_group = false,

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -672,48 +672,31 @@ script.on_nth_tick(FOLLOW_TICK_INTERVAL, function(event)
 	follow_loop()
 end)
 
+-- Idle wander pass for wild spiders. Skips allies (handled by the wander
+-- branch inside follow_loop) and any spider already in an attack group.
+-- Previously this loop ALSO spawned a Nervous corpse on a few random
+-- spiders as a cosmetic twitch, but the corpse is the same 16-direction
+-- model as the live spider — it overlapped exactly and read as a "ghost
+-- spider that pops in for a second then vanishes". Removed; the Nervous
+-- corpse prototype stays registered for any future scripted use.
 script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 	local active = active_surface_indices()
 	if not active then return end
 	for _, surface in pairs(game.surfaces) do
 		if active[surface.index] then
-			-- Wild spiders only — overlaying a Nervous corpse on top of an
-			-- ally that's idling next to its owner reads as a "ghost spider
-			-- popping in then disappearing" since the corpse lingers ~1s
-			-- and renders at the same tile. Ally idle motion is handled by
-			-- the wander fallback in follow_loop.
 			local spiders = surface.find_entities_filtered{ name = SPIDER }
-			local n = #spiders
-			if n > 0 then
-				-- Twitch overlay on 3 random spiders.
-				local picks = math.min(cached_nervous_pick, n)
-				for _ = 1, picks do
-					local s = spiders[math.random(1, n)]
-					if s.valid then
-						local cmdable = s.commandable
-						local in_group = cmdable and cmdable.parent_group ~= nil
-						if not in_group then
-							surface.create_entity{
-								name = NERVOUS_CORPSE,
-								position = s.position,
-								direction = s.direction,
-							}
-						end
-					end
-				end
-				for i = 1, n do
-					local s = spiders[i]
-					if s.valid then
-						local cmdable = s.commandable
-						local in_group = cmdable and cmdable.parent_group ~= nil
-						if not in_group and cmdable and not cmdable.has_command then
-							cmdable.set_command{
-								type = defines.command.wander,
-								ticks_to_wait = 600,
-								wander_in_group = false,
-								distraction = defines.distraction.by_damage,
-							}
-						end
+			for i = 1, #spiders do
+				local s = spiders[i]
+				if s.valid then
+					local cmdable = s.commandable
+					local in_group = cmdable and cmdable.parent_group ~= nil
+					if not in_group and cmdable and not cmdable.has_command then
+						cmdable.set_command{
+							type = defines.command.wander,
+							ticks_to_wait = 600,
+							wander_in_group = false,
+							distraction = defines.distraction.by_damage,
+						}
 					end
 				end
 			end

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -524,14 +524,33 @@ local FOLLOW_RADIUS_SQ = 128 * 128   -- keep tracking up to ~128 tiles away
 local FOLLOW_REST_DIST_SQ = 6 * 6    -- ally orbits within 6 tiles — pack-like, not heel-clinging
 local FOLLOW_DESTINATION_RADIUS = 5  -- ally settles within 5 tiles of owner
 
+-- Build a set of surface indices that have at least one connected player.
+-- Sprint / follow / nervous AI runs only on these surfaces — there's no
+-- value in ticking biters or follow commands on an empty planet, and the
+-- lookup saves the full `surface.find_entities_filtered` scan on idle
+-- worlds. Must be defined ABOVE follow_loop (which calls it) because Lua
+-- resolves function references at call time against the enclosing chunk
+-- scope; a forward `local` declaration would also work but moving the
+-- whole definition up keeps the call site obvious.
+local function active_surface_indices()
+	local set = nil
+	for _, p in pairs(game.connected_players) do
+		if p.valid then
+			set = set or {}
+			set[p.surface_index] = true
+		end
+	end
+	return set
+end
+
 -- Scans live allies per-surface every tick. The previous registry-driven
 -- path used game.get_entity_by_unit_number(stored_unit_number) for O(1)
--- lookups, but in 2.0 that method returns nil for kbve-spider-ally
--- entities even though surface.find_entities_filtered{name=SPIDER_ALLY}
--- finds them at the exact same tick — so the registry self-prune wiped
--- every entry and the follow loop's outer guard skipped the loop. We
--- now drive the loop off the live scan; the registry stays for migration
--- + nametag tracking but isn't load-bearing for follow.
+-- lookups, but until the "get-by-unit-number" prototype flag was added
+-- that method returned nil for our entities, so the registry self-prune
+-- wiped every entry and the follow loop's outer guard skipped the loop.
+-- Even with the flag fix in place, the live-scan path is the more robust
+-- driver (works regardless of registry state); the registry stays for
+-- migration + nametag tracking but isn't load-bearing for follow.
 local function follow_loop()
 	local active = active_surface_indices()
 	if not active then return end
@@ -645,21 +664,6 @@ script.on_nth_tick(FOLLOW_TICK_INTERVAL, function(event)
 	end
 	follow_loop()
 end)
-
--- Build a set of surface indices that have at least one connected player.
--- Sprint + nervous AI runs only on these surfaces — there's no value in
--- ticking biters or nervous twitches on an empty planet, and the lookup
--- saves the full `surface.find_entities_filtered` scan on idle worlds.
-local function active_surface_indices()
-	local set = nil
-	for _, p in pairs(game.connected_players) do
-		if p.valid then
-			set = set or {}
-			set[p.surface_index] = true
-		end
-	end
-	return set
-end
 
 script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 	local active = active_surface_indices()

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -524,121 +524,109 @@ local FOLLOW_RADIUS_SQ = 128 * 128   -- keep tracking up to ~128 tiles away
 local FOLLOW_REST_DIST_SQ = 6 * 6    -- ally orbits within 6 tiles — pack-like, not heel-clinging
 local FOLLOW_DESTINATION_RADIUS = 5  -- ally settles within 5 tiles of owner
 
--- Iterates `storage.allies` (maintained at hatch + death + on_init/
--- on_configuration_changed rebuild) instead of calling
--- `surface.find_entities_filtered{name = SPIDER_ALLY}` per surface every
--- second. Entity lookups are O(1) via `game.get_entity_by_unit_number`.
--- The per-tick player→surface bucket is built lazily — only when an ally
--- has no recorded owner — so the common case (everyone has a live
--- placer) skips the connected-players scan entirely.
+-- Scans live allies per-surface every tick. The previous registry-driven
+-- path used game.get_entity_by_unit_number(stored_unit_number) for O(1)
+-- lookups, but in 2.0 that method returns nil for kbve-spider-ally
+-- entities even though surface.find_entities_filtered{name=SPIDER_ALLY}
+-- finds them at the exact same tick — so the registry self-prune wiped
+-- every entry and the follow loop's outer guard skipped the loop. We
+-- now drive the loop off the live scan; the registry stays for migration
+-- + nametag tracking but isn't load-bearing for follow.
 local function follow_loop()
-	local allies = storage.allies
-	if not allies or next(allies) == nil then return end
+	local active = active_surface_indices()
+	if not active then return end
 
 	local owners = storage.ally_owners or {}
 	local players_by_surface = nil
 
-	for unit_number, _ in pairs(allies) do
-		local ally = game.get_entity_by_unit_number(unit_number)
-		if not (ally and ally.valid) then
-			allies[unit_number] = nil
-		else
-			local owner = nil
-			local owner_idx = owners[unit_number]
-			if owner_idx then
-				local p = game.players[owner_idx]
-				if p and p.valid and p.connected and p.surface_index == ally.surface_index then
-					owner = p
-				end
-			end
-			if not owner then
-				if players_by_surface == nil then
-					players_by_surface = {}
-					for _, p in pairs(game.connected_players) do
-						if p.valid then
-							local si = p.surface_index
-							local bucket = players_by_surface[si]
-							if not bucket then
-								bucket = {}
-								players_by_surface[si] = bucket
-							end
-							bucket[#bucket + 1] = p
+	for _, surface in pairs(game.surfaces) do
+		if active[surface.index] then
+			local allies = surface.find_entities_filtered{ name = SPIDER_ALLY }
+			for i = 1, #allies do
+				local ally = allies[i]
+				if ally.valid then
+					local owner = nil
+					local owner_idx = owners[ally.unit_number]
+					if owner_idx then
+						local p = game.players[owner_idx]
+						if p and p.valid and p.connected and p.surface_index == ally.surface_index then
+							owner = p
 						end
 					end
-				end
-				local bucket = players_by_surface[ally.surface_index]
-				if bucket then
-					local nearest, nearest_d = nil, math.huge
-					local apos = ally.position
-					local ax, ay = apos.x, apos.y
-					local force = ally.force
-					for i = 1, #bucket do
-						local p = bucket[i]
-						if p.force == force then
-							local ppos = p.position
-							local dx = ppos.x - ax
-							local dy = ppos.y - ay
-							local d = dx * dx + dy * dy
-							if d < nearest_d then
-								nearest_d = d
-								nearest = p
+					if not owner then
+						if players_by_surface == nil then
+							players_by_surface = {}
+							for _, p in pairs(game.connected_players) do
+								if p.valid then
+									local si = p.surface_index
+									local bucket = players_by_surface[si]
+									if not bucket then
+										bucket = {}
+										players_by_surface[si] = bucket
+									end
+									bucket[#bucket + 1] = p
+								end
 							end
 						end
+						local bucket = players_by_surface[ally.surface_index]
+						if bucket then
+							local nearest, nearest_d = nil, math.huge
+							local apos = ally.position
+							local ax, ay = apos.x, apos.y
+							local force = ally.force
+							for j = 1, #bucket do
+								local p = bucket[j]
+								if p.force == force then
+									local ppos = p.position
+									local dx = ppos.x - ax
+									local dy = ppos.y - ay
+									local d = dx * dx + dy * dy
+									if d < nearest_d then
+										nearest_d = d
+										nearest = p
+									end
+								end
+							end
+							owner = nearest
+						end
 					end
-					owner = nearest
-				end
-			end
-			if owner then
-				local opos = owner.position
-				local apos = ally.position
-				local dx = opos.x - apos.x
-				local dy = opos.y - apos.y
-				local d2 = dx * dx + dy * dy
-				if d2 < FOLLOW_RADIUS_SQ then
-					pcall(function()
-						if d2 > FOLLOW_REST_DIST_SQ then
-							-- Pass `destination_entity` instead of a static
-							-- `destination` so Factorio's unit AI tracks the
-							-- player as they move. A plain MapPosition makes
-							-- this a one-shot move command — the unit arrives,
-							-- the command completes, and the ally idles even
-							-- though we re-issue every second (each re-issue is
-							-- a *new* one-shot to a stale spot). The character
-							-- entity is the player's body; LuaPlayer.character
-							-- is nil for spectators / editor mode, in which
-							-- case we fall back to a static destination so the
-							-- ally at least catches up to the cursor.
+					if owner then
+						local opos = owner.position
+						local apos = ally.position
+						local dx = opos.x - apos.x
+						local dy = opos.y - apos.y
+						local d2 = dx * dx + dy * dy
+						if d2 < FOLLOW_RADIUS_SQ then
 							local commandable = ally.commandable
 							if commandable then
-								local target_entity = owner.character
-								if target_entity and target_entity.valid then
+								if d2 > FOLLOW_REST_DIST_SQ then
+									local target_entity = owner.character
+									if target_entity and target_entity.valid then
+										commandable.set_command{
+											type = defines.command.go_to_location,
+											destination_entity = target_entity,
+											distraction = defines.distraction.by_enemy,
+											radius = FOLLOW_DESTINATION_RADIUS,
+										}
+									else
+										commandable.set_command{
+											type = defines.command.go_to_location,
+											destination = { x = opos.x, y = opos.y },
+											distraction = defines.distraction.by_enemy,
+											radius = FOLLOW_DESTINATION_RADIUS,
+										}
+									end
+								elseif not commandable.has_command then
 									commandable.set_command{
-										type = defines.command.go_to_location,
-										destination_entity = target_entity,
+										type = defines.command.wander,
+										ticks_to_wait = 240,
+										wander_in_group = false,
 										distraction = defines.distraction.by_enemy,
-										radius = FOLLOW_DESTINATION_RADIUS,
-									}
-								else
-									commandable.set_command{
-										type = defines.command.go_to_location,
-										destination = { x = opos.x, y = opos.y },
-										distraction = defines.distraction.by_enemy,
-										radius = FOLLOW_DESTINATION_RADIUS,
 									}
 								end
 							end
-						else
-							local commandable = ally.commandable
-							if commandable and not commandable.has_command then
-								commandable.set_command{
-									type = defines.command.wander,
-									ticks_to_wait = 240,
-									wander_in_group = false,
-									distraction = defines.distraction.by_enemy,
-								}
-							end
 						end
-					end)
+					end
 				end
 			end
 		end
@@ -652,11 +640,10 @@ end
 -- inside one function keeps the behavior + saves the overhead of a second
 -- per-tick dispatch.
 script.on_nth_tick(FOLLOW_TICK_INTERVAL, function(event)
-	local has_eggs = storage.pending_eggs and next(storage.pending_eggs) ~= nil
-	local has_allies = storage.allies and next(storage.allies) ~= nil
-	if not (has_eggs or has_allies) then return end
-	if has_eggs then hatch_sweep(event.tick) end
-	if has_allies then follow_loop() end
+	if storage.pending_eggs and next(storage.pending_eggs) ~= nil then
+		hatch_sweep(event.tick)
+	end
+	follow_loop()
 end)
 
 -- Build a set of surface indices that have at least one connected player.

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -210,18 +210,33 @@ end, spider_died_filter)
 -- Rebuild the ally registry from the world. Called on first init and on
 -- mod-config changes so save games predating the registry pick it up. After
 -- this, ally lookup is O(1) per unit_number via game.get_entity_by_unit_number.
-local function rebuild_ally_registry()
+local function rebuild_ally_registry(debug_print)
 	local reg = {}
+	local report = {}
 	for _, surface in pairs(game.surfaces) do
 		local allies = surface.find_entities_filtered{ name = SPIDER_ALLY }
+		local count = 0
 		for i = 1, #allies do
 			local a = allies[i]
 			if a.valid and a.unit_number then
 				reg[a.unit_number] = a.surface_index
+				count = count + 1
 			end
 		end
+		report[#report + 1] = { name = surface.name, index = surface.index, count = count }
 	end
 	storage.allies = reg
+	if debug_print then
+		for _, r in ipairs(report) do
+			debug_print(string.format(
+				"  rebuild: surface=%s index=%d found %d kbve-spider-ally entities",
+				r.name, r.index, r.count
+			))
+		end
+		local n = 0
+		for _ in pairs(reg) do n = n + 1 end
+		debug_print(string.format("  rebuild: storage.allies now holds %d entries", n))
+	end
 end
 
 script.on_init(function()
@@ -332,10 +347,13 @@ commands.add_command(
 		player.print(string.format("[kbve-spider] pending eggs: %d", pn))
 
 		player.print("[kbve-spider] forcing rebuild_ally_registry()…")
-		rebuild_ally_registry()
+		rebuild_ally_registry(function(line) player.print(line) end)
 		local n2 = 0
 		for _ in pairs(storage.allies or {}) do n2 = n2 + 1 end
-		player.print(string.format("[kbve-spider] post-rebuild registry: %d ally entries", n2))
+		player.print(string.format("[kbve-spider] post-rebuild registry (re-read storage.allies): %d entries", n2))
+
+		player.print(string.format("[kbve-spider] storage.allies type=%s, addr-ish=%s",
+			type(storage.allies), tostring(storage.allies)))
 	end
 )
 

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -398,9 +398,7 @@ clear_nametag = function(unit_number)
 	if not storage.ally_nametags then return end
 	local ro = storage.ally_nametags[unit_number]
 	if ro then
-		pcall(function()
-			if ro.valid then ro.destroy() end
-		end)
+		if ro.valid then ro.destroy() end
 		storage.ally_nametags[unit_number] = nil
 	end
 end
@@ -447,10 +445,8 @@ script.on_event(defines.events.on_robot_built_entity, function(event)
 end, egg_filter)
 
 local function clear_render(info)
-	if info and info.render_id then
-		pcall(function()
-			if info.render_id.valid then info.render_id.destroy() end
-		end)
+	if info and info.render_id and info.render_id.valid then
+		info.render_id.destroy()
 	end
 end
 

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -264,6 +264,49 @@ script.on_configuration_changed(function()
 	rehydrate_runtime_settings()
 end)
 
+-- on_configuration_changed only fires when the mod's version (or set of mods)
+-- actually changes between save loads. During local development we overwrite
+-- the same versioned zip repeatedly, so the registry stops getting rebuilt
+-- and existing-world allies disappear from `storage.allies` — the follow loop
+-- then short-circuits and the allies stand still. Rebuilding on
+-- on_player_joined_game catches every reload regardless of version.
+script.on_event(defines.events.on_player_joined_game, function()
+	storage.allies = storage.allies or {}
+	storage.ally_owners = storage.ally_owners or {}
+	storage.ally_names = storage.ally_names or {}
+	storage.ally_nametags = storage.ally_nametags or {}
+	rebuild_ally_registry()
+	backfill_nametags()
+end)
+
+commands.add_command(
+	"spider-debug",
+	"Prints kbve-spider runtime state for the calling player.",
+	function(event)
+		local player = game.players[event.player_index]
+		if not player then return end
+		local allies = storage.allies or {}
+		local n = 0
+		for _ in pairs(allies) do n = n + 1 end
+		player.print(string.format("[kbve-spider] registry: %d ally entries", n))
+		for unit_number, surface_index in pairs(allies) do
+			local ally = game.get_entity_by_unit_number(unit_number)
+			local name = storage.ally_names and storage.ally_names[unit_number] or "?"
+			local owner_idx = storage.ally_owners and storage.ally_owners[unit_number] or "?"
+			local valid = ally and ally.valid
+			local has_cmd = valid and ally.has_command() or false
+			local pos_str = valid and string.format("(%d,%d)", math.floor(ally.position.x), math.floor(ally.position.y)) or "<gone>"
+			player.print(string.format(
+				"  unit=%d name=%s owner=%s surface=%d pos=%s valid=%s has_command=%s",
+				unit_number, tostring(name), tostring(owner_idx), surface_index, pos_str, tostring(valid), tostring(has_cmd)
+			))
+		end
+		if n == 0 then
+			player.print("  registry empty — try /c remote.call or just walk around for one tick")
+		end
+	end
+)
+
 local function attach_nametag(ally, name, owner_player)
 	if not (ally and ally.valid) then return end
 	local label

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -677,7 +677,12 @@ script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 	if not active then return end
 	for _, surface in pairs(game.surfaces) do
 		if active[surface.index] then
-			local spiders = surface.find_entities_filtered{ name = { SPIDER, SPIDER_ALLY } }
+			-- Wild spiders only — overlaying a Nervous corpse on top of an
+			-- ally that's idling next to its owner reads as a "ghost spider
+			-- popping in then disappearing" since the corpse lingers ~1s
+			-- and renders at the same tile. Ally idle motion is handled by
+			-- the wander fallback in follow_loop.
+			local spiders = surface.find_entities_filtered{ name = SPIDER }
 			local n = #spiders
 			if n > 0 then
 				-- Twitch overlay on 3 random spiders.

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -663,9 +663,8 @@ script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 				for _ = 1, picks do
 					local s = spiders[math.random(1, n)]
 					if s.valid then
-						local in_group = false
-						local ok, ug = pcall(function() return s.unit_group end)
-						if ok and ug then in_group = true end
+						local cmdable = s.commandable
+						local in_group = cmdable and cmdable.parent_group ~= nil
 						if not in_group then
 							surface.create_entity{
 								name = NERVOUS_CORPSE,
@@ -675,29 +674,18 @@ script.on_nth_tick(NERVOUS_TICK_INTERVAL, function(event)
 						end
 					end
 				end
-				-- Idle wander pass: any spider that's not in an attack group and
-				-- has no current command gets a short wander burst so wild biters
-				-- (which aren't tied to a spawner here, so don't get Factorio's
-				-- normal ambient AI) and ally spiders parked near their owner
-				-- don't freeze in place.
 				for i = 1, n do
 					local s = spiders[i]
 					if s.valid then
-						local in_group = false
-						local ok_ug, ug = pcall(function() return s.unit_group end)
-						if ok_ug and ug then in_group = true end
-						if not in_group then
-							pcall(function()
-								local commandable = s.commandable
-								if commandable and not commandable.has_command then
-									commandable.set_command{
-										type = defines.command.wander,
-										ticks_to_wait = 600,
-										wander_in_group = false,
-										distraction = defines.distraction.by_damage,
-									}
-								end
-							end)
+						local cmdable = s.commandable
+						local in_group = cmdable and cmdable.parent_group ~= nil
+						if not in_group and cmdable and not cmdable.has_command then
+							cmdable.set_command{
+								type = defines.command.wander,
+								ticks_to_wait = 600,
+								wander_in_group = false,
+								distraction = defines.distraction.by_damage,
+							}
 						end
 					end
 				end
@@ -726,9 +714,8 @@ script.on_nth_tick(SPRINT_TICK_INTERVAL, function(event)
 					local key = s.unit_number
 					local ready_at = cooldowns[key] or 0
 					if tick >= ready_at then
-						local in_group = false
-						local ok, ug = pcall(function() return s.unit_group end)
-						if ok and ug then in_group = true end
+						local cmdable = s.commandable
+						local in_group = cmdable and cmdable.parent_group ~= nil
 						if in_group and math.random() < cached_sprint_chance then
 							surface.create_entity{
 								name = SPRINT_STICKER,

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -42,6 +42,17 @@ local ALLY_NAMES = {
 }
 local ALLY_NAME_POOL_SIZE = #ALLY_NAMES
 
+-- Forward declarations. Lua resolves bare names inside a function body at
+-- COMPILE time: if a `local` of that name hasn't been declared YET in the
+-- enclosing chunk, the reference is baked in as a global lookup and goes
+-- nil at call time. on_entity_died (line ~188) needs to call clear_nametag
+-- and backfill_nametags (line ~253) needs attach_nametag, both of which
+-- would otherwise be defined much further down. Predeclaring the locals
+-- here lets the later `function attach_nametag(...) … end` lines assign
+-- to the EXISTING local slot instead of creating a fresh shadowing local.
+local attach_nametag
+local clear_nametag
+
 -- Fixed cadences. Per-spider cooldown stays hardcoded so the tuning surface
 -- is small; the runtime-global settings cover everything an admin would
 -- reasonably want to flip mid-game.
@@ -357,7 +368,7 @@ commands.add_command(
 	end
 )
 
-local function attach_nametag(ally, name, owner_player)
+attach_nametag = function(ally, name, owner_player)
 	if not (ally and ally.valid) then return end
 	local label
 	if owner_player and owner_player.valid then
@@ -383,7 +394,7 @@ local function attach_nametag(ally, name, owner_player)
 	end
 end
 
-local function clear_nametag(unit_number)
+clear_nametag = function(unit_number)
 	if not storage.ally_nametags then return end
 	local ro = storage.ally_nametags[unit_number]
 	if ro then

--- a/apps/factorio/mods/kbve-spider/control.lua
+++ b/apps/factorio/mods/kbve-spider/control.lua
@@ -330,6 +330,12 @@ commands.add_command(
 		local pn = 0
 		for _ in pairs(pending) do pn = pn + 1 end
 		player.print(string.format("[kbve-spider] pending eggs: %d", pn))
+
+		player.print("[kbve-spider] forcing rebuild_ally_registry()…")
+		rebuild_ally_registry()
+		local n2 = 0
+		for _ in pairs(storage.allies or {}) do n2 = n2 + 1 end
+		player.print(string.format("[kbve-spider] post-rebuild registry: %d ally entries", n2))
 	end
 )
 

--- a/apps/factorio/mods/kbve-spider/prototypes/spider.lua
+++ b/apps/factorio/mods/kbve-spider/prototypes/spider.lua
@@ -125,7 +125,7 @@ local spider = {
 		},
 	},
 
-	run_animation = rotated("Walk", { animation_speed = 0.8 }),
+	run_animation = rotated("Walk", { animation_speed = 1.3 }),
 
 	corpse = "kbve-spider-corpse-death1",
 }
@@ -172,7 +172,7 @@ local SPRINT_SPEED_MULTIPLIER = settings.startup["kbve-spider-sprint-speed-multi
 	or 1.9
 local ALLY_MAX_HEALTH = settings.startup["kbve-spider-ally-max-health"]
 		and settings.startup["kbve-spider-ally-max-health"].value
-	or 60
+	or 120
 
 local sprint_sticker = {
 	type = "sticker",

--- a/apps/factorio/mods/kbve-spider/prototypes/spider.lua
+++ b/apps/factorio/mods/kbve-spider/prototypes/spider.lua
@@ -70,7 +70,7 @@ local spider = {
 	icon = "__kbve-spider__/graphics/icon.png",
 	icon_size = 64,
 	icon_mipmaps = 4,
-	flags = { "placeable-enemy", "placeable-off-grid", "not-repairable", "breaths-air" },
+	flags = { "placeable-enemy", "placeable-off-grid", "not-repairable", "breaths-air", "get-by-unit-number" },
 
 	max_health = 80,
 	healing_per_tick = 0.01,

--- a/apps/factorio/mods/kbve-spider/settings.lua
+++ b/apps/factorio/mods/kbve-spider/settings.lua
@@ -59,7 +59,7 @@ data:extend({
 		type = "int-setting",
 		name = "kbve-spider-ally-max-health",
 		setting_type = "startup",
-		default_value = 60,
+		default_value = 120,
 		minimum_value = 1,
 		maximum_value = 10000,
 		order = "z-a",


### PR DESCRIPTION
## Why

Allies still aren't following after #11682 merged. Hypothesis: \`storage.allies\` registry is stale because we've been overwriting the same 0.2.1 zip during local iteration, and \`on_configuration_changed\` only fires on actual mod-version changes. The 1 Hz follow loop short-circuits on an empty registry, so live allies aren't getting commanded.

## Changes

- **\`on_player_joined_game\` rebuild** — calls \`rebuild_ally_registry()\` + \`backfill_nametags()\` on every save load regardless of mod-version delta. Cheap (one \`find_entities_filtered\` per surface).
- **\`/spider-debug\` command** — prints \`storage.allies\` state for the calling player. Per-unit \`unit_number\`, \`ally_name\`, \`owner_index\`, \`surface_index\`, position, \`valid\` flag, \`has_command()\`. Tells us at a glance whether the registry is empty vs populated-but-frozen.

## Test plan

- [x] \`luac -p\` clean, \`./kbve.sh -nx kbve-spider:test\` PASS.
- [ ] In-game: \`/spider-debug\` shows N entries matching visible allies; \`has_command\` flips between true/false as the loop fires.

Once we see the output we'll know whether to chase the registry side or the AI side.