### PR TITLE
content(astro-kbve): expand /github/ — repo catalog, org activity, project board, contribute flow

### DIFF
--- a/apps/kbve/astro-kbve/src/components/github/Activity/AstroGithubActivity.astro
+++ b/apps/kbve/astro-kbve/src/components/github/Activity/AstroGithubActivity.astro
@@ -1,0 +1,305 @@
+---
+/**
+ * AstroGithubActivity - Build-time-rendered recent org activity.
+ * PullRequestEvent (opened/closed) + ReleaseEvent + PushEvent (default branch).
+ */
+
+interface Actor {
+	login: string;
+	avatar_url: string;
+}
+interface Repo {
+	name: string;
+	url: string;
+}
+interface Event {
+	id: string;
+	type: string;
+	actor: Actor;
+	repo: Repo;
+	created_at: string;
+	payload: any;
+}
+
+interface Props {
+	title?: string;
+	subtitle?: string;
+	limit?: number;
+}
+
+const {
+	title = 'Recent Activity',
+	subtitle = 'Pull requests and releases across the org',
+	limit = 12,
+} = Astro.props;
+
+const GITHUB_ORG = 'KBVE';
+const API_URL = `https://api.github.com/orgs/${GITHUB_ORG}/events?per_page=100`;
+
+let events: Event[] = [];
+let error: string | null = null;
+try {
+	const response = await fetch(API_URL, {
+		headers: { Accept: 'application/vnd.github.v3+json' },
+	});
+	if (!response.ok) throw new Error(`GitHub API ${response.status}`);
+	const all = (await response.json()) as Event[];
+	const filtered = all.filter((e) =>
+		['PullRequestEvent', 'ReleaseEvent', 'PushEvent'].includes(e.type),
+	);
+	const seen = new Set<string>();
+	for (const e of filtered) {
+		const key = describeKey(e);
+		if (key && !seen.has(key)) {
+			seen.add(key);
+			events.push(e);
+		}
+		if (events.length >= limit) break;
+	}
+} catch (err) {
+	error = err instanceof Error ? err.message : 'fetch failed';
+	console.error('AstroGithubActivity fetch error:', error);
+}
+
+function describeKey(e: Event): string | null {
+	if (e.type === 'PullRequestEvent') {
+		const pr = e.payload?.pull_request;
+		if (!pr) return null;
+		return `pr:${e.repo.name}#${pr.number}:${e.payload.action}`;
+	}
+	if (e.type === 'ReleaseEvent') {
+		const tag = e.payload?.release?.tag_name;
+		return tag ? `rel:${e.repo.name}:${tag}` : null;
+	}
+	if (e.type === 'PushEvent') {
+		const sha = e.payload?.head;
+		return sha ? `push:${e.repo.name}:${sha}` : null;
+	}
+	return null;
+}
+
+function describe(e: Event): {
+	label: string;
+	href: string;
+	title: string;
+	icon: string;
+} {
+	const repoShort = e.repo.name.split('/').pop() ?? e.repo.name;
+	if (e.type === 'PullRequestEvent') {
+		const pr = e.payload?.pull_request;
+		const action = e.payload?.action ?? '';
+		const merged = pr?.merged === true;
+		const verb = merged
+			? 'merged'
+			: action === 'opened'
+				? 'opened'
+				: action === 'closed'
+					? 'closed'
+					: action;
+		return {
+			label: `${verb} #${pr?.number ?? '?'} ${pr?.title ?? ''}`,
+			href: pr?.html_url ?? `https://github.com/${e.repo.name}`,
+			title: repoShort,
+			icon: merged ? '🟣' : action === 'opened' ? '🟢' : '⚪',
+		};
+	}
+	if (e.type === 'ReleaseEvent') {
+		const rel = e.payload?.release;
+		return {
+			label: `released ${rel?.tag_name ?? ''} ${rel?.name ?? ''}`.trim(),
+			href: rel?.html_url ?? `https://github.com/${e.repo.name}`,
+			title: repoShort,
+			icon: '🏷️',
+		};
+	}
+	if (e.type === 'PushEvent') {
+		const count = e.payload?.commits?.length ?? 0;
+		const top = e.payload?.commits?.[0]?.message?.split('\n')[0] ?? '';
+		const ref = e.payload?.ref?.replace('refs/heads/', '') ?? '';
+		return {
+			label: `pushed ${count} commit${count === 1 ? '' : 's'} to ${ref}${top ? ` — ${top}` : ''}`,
+			href: `https://github.com/${e.repo.name}/commits/${ref}`,
+			title: repoShort,
+			icon: '⬆️',
+		};
+	}
+	return {
+		label: e.type,
+		href: `https://github.com/${e.repo.name}`,
+		title: repoShort,
+		icon: '•',
+	};
+}
+
+function ago(iso: string): string {
+	const ms = Date.now() - new Date(iso).getTime();
+	const s = Math.max(1, Math.floor(ms / 1000));
+	if (s < 60) return `${s}s ago`;
+	const m = Math.floor(s / 60);
+	if (m < 60) return `${m}m ago`;
+	const h = Math.floor(m / 60);
+	if (h < 24) return `${h}h ago`;
+	const d = Math.floor(h / 24);
+	return `${d}d ago`;
+}
+---
+
+<section class="github-activity" aria-labelledby="github-activity-title">
+	<header class="github-activity__header">
+		<h2 id="github-activity-title">{title}</h2>
+		<p>{subtitle}</p>
+	</header>
+
+	{
+		error && (
+			<p class="github-activity__error" role="alert">
+				Unable to load activity ({error}).
+			</p>
+		)
+	}
+
+	{
+		!error && events.length === 0 && (
+			<p class="github-activity__empty">No recent public activity.</p>
+		)
+	}
+
+	{
+		!error && events.length > 0 && (
+			<ul class="github-activity__list" role="list">
+				{events.map((e) => {
+					const d = describe(e);
+					return (
+						<li class="github-activity__item">
+							<span
+								class="github-activity__icon"
+								aria-hidden="true">
+								{d.icon}
+							</span>
+							<a
+								class="github-activity__avatar"
+								href={`https://github.com/${e.actor.login}`}
+								target="_blank"
+								rel="noopener noreferrer">
+								<img
+									src={e.actor.avatar_url}
+									alt={`${e.actor.login}'s avatar`}
+									width="24"
+									height="24"
+									loading="lazy"
+								/>
+							</a>
+							<div class="github-activity__body">
+								<a
+									class="github-activity__link"
+									href={d.href}
+									target="_blank"
+									rel="noopener noreferrer">
+									<strong>{e.actor.login}</strong> {d.label}
+								</a>
+								<span class="github-activity__meta">
+									<a
+										href={`https://github.com/${e.repo.name}`}
+										target="_blank"
+										rel="noopener noreferrer">
+										{d.title}
+									</a>
+									<span class="github-activity__sep">·</span>
+									<time datetime={e.created_at}>
+										{ago(e.created_at)}
+									</time>
+								</span>
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+		)
+	}
+</section>
+
+<style>
+	.github-activity {
+		margin: 3rem 0;
+		color: var(--sl-color-text, #e6edf3);
+	}
+	.github-activity__header {
+		text-align: center;
+		margin-bottom: 1rem;
+	}
+	.github-activity__header h2 {
+		font-size: 1.75rem;
+		font-weight: 700;
+		margin: 0 0 0.25rem;
+	}
+	.github-activity__header p {
+		color: var(--sl-color-gray-2, #8b949e);
+		margin: 0;
+	}
+	.github-activity__empty,
+	.github-activity__error {
+		text-align: center;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+	.github-activity__list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		max-width: 720px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.github-activity__item {
+		display: flex;
+		gap: 0.75rem;
+		align-items: flex-start;
+		padding: 0.6rem 0.85rem;
+		background: var(--sl-color-bg-nav, #111);
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		border-radius: 8px;
+	}
+	.github-activity__icon {
+		flex: 0 0 auto;
+		line-height: 1.5;
+	}
+	.github-activity__avatar img {
+		border-radius: 50%;
+		width: 24px;
+		height: 24px;
+		display: block;
+	}
+	.github-activity__body {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+	.github-activity__link {
+		display: block;
+		color: inherit;
+		text-decoration: none;
+		font-size: 0.9rem;
+		line-height: 1.35;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.github-activity__link:hover {
+		color: var(--sl-color-accent, #06b6d4);
+	}
+	.github-activity__meta {
+		font-size: 0.7rem;
+		color: var(--sl-color-gray-3, #8b949e);
+		display: flex;
+		align-items: center;
+		gap: 0.35rem;
+	}
+	.github-activity__meta a {
+		color: inherit;
+		text-decoration: none;
+	}
+	.github-activity__sep {
+		opacity: 0.6;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/github/Contribute/AstroGithubContribute.astro
+++ b/apps/kbve/astro-kbve/src/components/github/Contribute/AstroGithubContribute.astro
@@ -1,0 +1,243 @@
+---
+/**
+ * AstroGithubContribute - Static "how to contribute" walkthrough.
+ * No fetch; pure SSG.
+ */
+
+interface Props {
+	title?: string;
+	subtitle?: string;
+}
+
+const {
+	title = 'Contribute',
+	subtitle = 'Fork → branch → PR. Worktrees make rebases painless.',
+} = Astro.props;
+
+const STEPS = [
+	{
+		n: '1',
+		title: 'Fork + clone',
+		body: 'Fork `KBVE/kbve`, then clone your fork. Origin stays on your fork; upstream points at KBVE/kbve.',
+		code: `git clone git@github.com:<you>/kbve.git
+cd kbve
+git remote add upstream https://github.com/KBVE/kbve.git
+git fetch upstream`,
+	},
+	{
+		n: '2',
+		title: 'Worktree for the task',
+		body: 'KBVE uses `./kbve.sh -worktree <slug>` so each PR gets its own checkout off `dev`. No accidental commits on `main` or `dev`; pnpm installs and `.env.local` are copied for you.',
+		code: `./kbve.sh -worktree fix-auth-redirect
+cd ../kbve-fix-auth-redirect`,
+	},
+	{
+		n: '3',
+		title: 'Install + run targets',
+		body: '`./kbve.sh -nx` wraps `npx nx run …` and sources `.env.local`. Use it for builds, dev servers, codegen, anything Nx.',
+		code: `./kbve.sh -nx astro-kbve:dev
+./kbve.sh -nx axum-kbve:test
+./kbve.sh -nx astro-kbve:test:unit`,
+	},
+	{
+		n: '4',
+		title: 'Push + open a PR',
+		body: 'Push the worktree branch to your fork (or to the kbve remote if you have access). Base the PR against `dev`, not `main`. Conventional Commits in the subject; explain the *why* in the body.',
+		code: `git push -u origin trunk/fix-auth-redirect-<ts>
+gh pr create --base dev --title "fix(auth): ..." --body "..."`,
+	},
+	{
+		n: '5',
+		title: 'Sync your fork later',
+		body: 'After your PR lands, pull upstream `dev` and prune the worktree.',
+		code: `git fetch upstream
+git checkout dev
+git merge --ff-only upstream/dev
+git worktree remove ../kbve-fix-auth-redirect
+git push origin --delete trunk/fix-auth-redirect-<ts>`,
+	},
+];
+
+const LINKS = [
+	{
+		label: 'CLAUDE.md',
+		href: 'https://github.com/KBVE/kbve/blob/dev/CLAUDE.md',
+		desc: 'Convention reference — Nx, worktrees, commit/PR rules.',
+	},
+	{
+		label: 'Open issues',
+		href: 'https://github.com/KBVE/kbve/issues',
+		desc: 'Pick a `priority:medium` ticket for a clean entry point.',
+	},
+	{
+		label: 'Project board',
+		href: 'https://github.com/orgs/KBVE/projects/5',
+		desc: 'What is in flight right now.',
+	},
+	{
+		label: 'Discord',
+		href: 'https://kbve.com/discord/',
+		desc: 'Ask before you start on a large patch.',
+	},
+];
+---
+
+<section class="github-contribute" aria-labelledby="github-contribute-title">
+	<header class="github-contribute__header">
+		<h2 id="github-contribute-title">{title}</h2>
+		<p>{subtitle}</p>
+	</header>
+
+	<ol class="github-contribute__steps" role="list">
+		{
+			STEPS.map((step) => (
+				<li class="github-contribute__step">
+					<div class="github-contribute__step-head">
+						<span
+							class="github-contribute__step-num"
+							aria-hidden="true">
+							{step.n}
+						</span>
+						<h3>{step.title}</h3>
+					</div>
+					<p>{step.body}</p>
+					<pre class="github-contribute__code">
+						<code>{step.code}</code>
+					</pre>
+				</li>
+			))
+		}
+	</ol>
+
+	<div class="github-contribute__links">
+		<h3>Useful pointers</h3>
+		<ul role="list">
+			{
+				LINKS.map((l) => (
+					<li>
+						<a
+							href={l.href}
+							target="_blank"
+							rel="noopener noreferrer">
+							<strong>{l.label}</strong>
+							<span>{l.desc}</span>
+						</a>
+					</li>
+				))
+			}
+		</ul>
+	</div>
+</section>
+
+<style>
+	.github-contribute {
+		margin: 3rem auto;
+		max-width: 880px;
+		color: var(--sl-color-text, #e6edf3);
+	}
+	.github-contribute__header {
+		text-align: center;
+		margin-bottom: 1.5rem;
+	}
+	.github-contribute__header h2 {
+		font-size: 1.75rem;
+		font-weight: 700;
+		margin: 0 0 0.25rem;
+	}
+	.github-contribute__header p {
+		color: var(--sl-color-gray-2, #8b949e);
+		margin: 0;
+	}
+	.github-contribute__steps {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+	.github-contribute__step {
+		background: var(--sl-color-bg-nav, #111);
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		border-radius: 10px;
+		padding: 1rem 1.25rem;
+	}
+	.github-contribute__step-head {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+	}
+	.github-contribute__step-head h3 {
+		margin: 0;
+		font-size: 1.05rem;
+		font-weight: 600;
+	}
+	.github-contribute__step-num {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.75rem;
+		height: 1.75rem;
+		border-radius: 50%;
+		background: var(--sl-color-accent, #06b6d4);
+		color: #0b1220;
+		font-weight: 700;
+		font-size: 0.85rem;
+	}
+	.github-contribute__step p {
+		color: var(--sl-color-gray-2, #c9d1d9);
+		font-size: 0.9rem;
+		line-height: 1.5;
+		margin: 0.5rem 0 0.75rem;
+	}
+	.github-contribute__code {
+		background: #0b1020;
+		border: 1px solid var(--sl-color-gray-6, #1f2937);
+		border-radius: 8px;
+		padding: 0.65rem 0.85rem;
+		overflow-x: auto;
+		font-size: 0.78rem;
+		line-height: 1.55;
+		color: #cbd5e1;
+		margin: 0;
+	}
+	.github-contribute__links {
+		margin-top: 2rem;
+	}
+	.github-contribute__links h3 {
+		font-size: 1rem;
+		font-weight: 600;
+		margin: 0 0 0.5rem;
+	}
+	.github-contribute__links ul {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: 0.5rem;
+	}
+	.github-contribute__links a {
+		display: block;
+		padding: 0.65rem 0.85rem;
+		background: var(--sl-color-bg-nav, #111);
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		border-radius: 8px;
+		text-decoration: none;
+		color: inherit;
+		transition: border-color 0.15s;
+	}
+	.github-contribute__links a:hover {
+		border-color: var(--sl-color-accent, #06b6d4);
+	}
+	.github-contribute__links a strong {
+		display: block;
+		font-size: 0.9rem;
+	}
+	.github-contribute__links a span {
+		display: block;
+		color: var(--sl-color-gray-3, #8b949e);
+		font-size: 0.75rem;
+		margin-top: 0.1rem;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/github/ProjectBoard/AstroGithubProjectBoard.astro
+++ b/apps/kbve/astro-kbve/src/components/github/ProjectBoard/AstroGithubProjectBoard.astro
@@ -1,0 +1,237 @@
+---
+/**
+ * AstroGithubProjectBoard - Build-time-rendered open priority:medium issues
+ * from KBVE/kbve. Visitors see what's actively in flight, not just a button.
+ */
+
+interface Label {
+	name: string;
+	color: string;
+}
+interface Issue {
+	id: number;
+	number: number;
+	title: string;
+	html_url: string;
+	state: string;
+	labels: Label[];
+	comments: number;
+	created_at: string;
+	updated_at: string;
+	user: { login: string; avatar_url: string } | null;
+	pull_request?: unknown;
+}
+
+interface Props {
+	title?: string;
+	subtitle?: string;
+	limit?: number;
+	label?: string;
+}
+
+const {
+	title = 'In Flight',
+	subtitle = 'Open issues labelled priority:medium — solid first-PR candidates.',
+	limit = 9,
+	label = 'priority:medium',
+} = Astro.props;
+
+const GITHUB_OWNER = 'KBVE';
+const GITHUB_REPO = 'kbve';
+const API_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues?state=open&labels=${encodeURIComponent(label)}&per_page=${Math.max(limit * 2, 30)}`;
+const ALL_ISSUES_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/issues?q=is%3Aopen+is%3Aissue+label%3A%22${encodeURIComponent(label)}%22`;
+
+let issues: Issue[] = [];
+let error: string | null = null;
+try {
+	const response = await fetch(API_URL, {
+		headers: { Accept: 'application/vnd.github.v3+json' },
+	});
+	if (!response.ok) throw new Error(`GitHub API ${response.status}`);
+	const all = (await response.json()) as Issue[];
+	issues = all.filter((i) => !i.pull_request).slice(0, limit);
+} catch (err) {
+	error = err instanceof Error ? err.message : 'fetch failed';
+	console.error('AstroGithubProjectBoard fetch error:', error);
+}
+
+function ago(iso: string): string {
+	const ms = Date.now() - new Date(iso).getTime();
+	const d = Math.floor(ms / (1000 * 60 * 60 * 24));
+	if (d <= 0) return 'today';
+	if (d === 1) return '1 day ago';
+	if (d < 30) return `${d} days ago`;
+	const m = Math.floor(d / 30);
+	if (m === 1) return '1 month ago';
+	return `${m} months ago`;
+}
+---
+
+<section class="github-board" aria-labelledby="github-board-title">
+	<header class="github-board__header">
+		<h2 id="github-board-title">{title}</h2>
+		<p>{subtitle}</p>
+	</header>
+
+	{
+		error && (
+			<p class="github-board__error" role="alert">
+				Unable to load issues ({error}).
+			</p>
+		)
+	}
+
+	{
+		!error && issues.length === 0 && (
+			<p class="github-board__empty">
+				No open `{label}` issues right now.{' '}
+				<a href={ALL_ISSUES_URL}>Browse the full issue tracker</a>.
+			</p>
+		)
+	}
+
+	{
+		!error && issues.length > 0 && (
+			<>
+				<ul class="github-board__grid" role="list">
+					{issues.map((issue) => (
+						<li class="github-board__card">
+							<a
+								href={issue.html_url}
+								target="_blank"
+								rel="noopener noreferrer">
+								<div class="github-board__card-head">
+									<span class="github-board__num">
+										#{issue.number}
+									</span>
+									<span
+										class="github-board__comments"
+										aria-label={`${issue.comments} comments`}>
+										💬 {issue.comments}
+									</span>
+								</div>
+								<h3 class="github-board__title">
+									{issue.title}
+								</h3>
+								<div class="github-board__labels">
+									{issue.labels.slice(0, 4).map((l) => (
+										<span
+											class="github-board__label"
+											style={`background:#${l.color}22;border-color:#${l.color}55;color:#${l.color}`}>
+											{l.name}
+										</span>
+									))}
+								</div>
+								<div class="github-board__meta">
+									<span>{ago(issue.created_at)}</span>
+								</div>
+							</a>
+						</li>
+					))}
+				</ul>
+				<p class="github-board__cta">
+					<a
+						href={ALL_ISSUES_URL}
+						target="_blank"
+						rel="noopener noreferrer">
+						Browse every open issue →
+					</a>
+				</p>
+			</>
+		)
+	}
+</section>
+
+<style>
+	.github-board {
+		margin: 3rem 0;
+		color: var(--sl-color-text, #e6edf3);
+	}
+	.github-board__header {
+		text-align: center;
+		margin-bottom: 1.25rem;
+	}
+	.github-board__header h2 {
+		font-size: 1.75rem;
+		font-weight: 700;
+		margin: 0 0 0.25rem;
+	}
+	.github-board__header p {
+		color: var(--sl-color-gray-2, #8b949e);
+		margin: 0;
+	}
+	.github-board__error,
+	.github-board__empty {
+		text-align: center;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+	.github-board__grid {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		gap: 0.75rem;
+	}
+	.github-board__card {
+		background: var(--sl-color-bg-nav, #111);
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		border-radius: 10px;
+		transition:
+			border-color 0.15s,
+			transform 0.15s;
+	}
+	.github-board__card:hover {
+		border-color: var(--sl-color-accent, #06b6d4);
+		transform: translateY(-1px);
+	}
+	.github-board__card a {
+		display: block;
+		padding: 0.85rem 1rem;
+		color: inherit;
+		text-decoration: none;
+	}
+	.github-board__card-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		font-size: 0.75rem;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+	.github-board__title {
+		margin: 0.45rem 0 0.55rem;
+		font-size: 0.95rem;
+		font-weight: 600;
+		line-height: 1.35;
+		display: -webkit-box;
+		-webkit-line-clamp: 3;
+		line-clamp: 3;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+	.github-board__labels {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.3rem;
+		margin-bottom: 0.5rem;
+	}
+	.github-board__label {
+		font-size: 0.65rem;
+		padding: 0.1rem 0.45rem;
+		border: 1px solid;
+		border-radius: 999px;
+	}
+	.github-board__meta {
+		font-size: 0.7rem;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+	.github-board__cta {
+		text-align: center;
+		margin-top: 1rem;
+	}
+	.github-board__cta a {
+		color: var(--sl-color-accent, #06b6d4);
+		text-decoration: none;
+		font-size: 0.9rem;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/github/RepoCatalog/AstroGithubRepoCatalog.astro
+++ b/apps/kbve/astro-kbve/src/components/github/RepoCatalog/AstroGithubRepoCatalog.astro
@@ -1,0 +1,352 @@
+---
+/**
+ * AstroGithubRepoCatalog - Build-time-rendered grid of KBVE org repos.
+ * Zero client-side JS. Groups by manual domain map.
+ */
+
+interface Repo {
+	id: number;
+	name: string;
+	full_name: string;
+	description: string | null;
+	html_url: string;
+	homepage: string | null;
+	language: string | null;
+	stargazers_count: number;
+	forks_count: number;
+	open_issues_count: number;
+	archived: boolean;
+	fork: boolean;
+	private: boolean;
+	pushed_at: string;
+	topics: string[];
+}
+
+interface Props {
+	title?: string;
+	subtitle?: string;
+	limit?: number;
+}
+
+const {
+	title = 'Repositories',
+	subtitle = 'Active open-source projects across the KBVE org',
+	limit = 60,
+} = Astro.props;
+
+const GITHUB_ORG = 'KBVE';
+const API_URL = `https://api.github.com/orgs/${GITHUB_ORG}/repos?per_page=${limit}&type=public&sort=updated`;
+
+const DOMAIN_GROUPS: Record<string, { label: string; description: string }> = {
+	infra: {
+		label: 'Infrastructure',
+		description: 'Kubernetes, observability, CI/CD, edge.',
+	},
+	web: {
+		label: 'Web + Apps',
+		description: 'Astro, React, Tauri.',
+	},
+	game: {
+		label: 'Games + Sim',
+		description: 'Unity, Bevy, Phaser, Lua.',
+	},
+	rust: {
+		label: 'Rust Services',
+		description: 'axum-kbve, jedi, codegen, FFI.',
+	},
+	docs: {
+		label: 'Docs + Tooling',
+		description: 'Knowledge, packages, devops.',
+	},
+	other: {
+		label: 'Other',
+		description: '',
+	},
+};
+
+function classify(repo: Repo): keyof typeof DOMAIN_GROUPS {
+	const name = repo.name.toLowerCase();
+	const topics = (repo.topics ?? []).map((t) => t.toLowerCase());
+	const lang = (repo.language ?? '').toLowerCase();
+	if (
+		topics.includes('kubernetes') ||
+		/kube|talos|cilium|argocd|helm/.test(name)
+	)
+		return 'infra';
+	if (lang === 'rust' || /axum|jedi|kbve-rs|cargo/.test(name)) return 'rust';
+	if (
+		/unity|bevy|phaser|game|rare(icon)?|isometric/.test(name) ||
+		topics.includes('game')
+	)
+		return 'game';
+	if (
+		lang === 'astro' ||
+		lang === 'typescript' ||
+		lang === 'javascript' ||
+		/astro|kbve\.com|web|app/.test(name)
+	)
+		return 'web';
+	if (/docs|wiki|manual|guide/.test(name) || topics.includes('documentation'))
+		return 'docs';
+	return 'other';
+}
+
+let repos: Repo[] = [];
+let error: string | null = null;
+try {
+	const response = await fetch(API_URL, {
+		headers: { Accept: 'application/vnd.github.v3+json' },
+	});
+	if (!response.ok) throw new Error(`GitHub API ${response.status}`);
+	const all = (await response.json()) as Repo[];
+	repos = all.filter((r) => !r.archived && !r.fork && !r.private);
+} catch (err) {
+	error = err instanceof Error ? err.message : 'fetch failed';
+	console.error('AstroGithubRepoCatalog fetch error:', error);
+}
+
+type DomainKey = keyof typeof DOMAIN_GROUPS;
+const DOMAIN_KEYS = Object.keys(DOMAIN_GROUPS) as DomainKey[];
+
+const grouped = new Map<DomainKey, Repo[]>();
+for (const key of DOMAIN_KEYS) {
+	grouped.set(key, []);
+}
+for (const r of repos) {
+	const k = classify(r);
+	grouped.get(k)!.push(r);
+}
+for (const [, list] of grouped) {
+	list.sort((a, b) => b.stargazers_count - a.stargazers_count);
+}
+
+const renderable = DOMAIN_KEYS.map((key) => ({
+	key,
+	meta: DOMAIN_GROUPS[key],
+	list: grouped.get(key) ?? [],
+})).filter((g) => g.list.length > 0);
+
+const LANG_COLOURS: Record<string, string> = {
+	Rust: '#dea584',
+	TypeScript: '#3178c6',
+	JavaScript: '#f1e05a',
+	Astro: '#ff5d01',
+	Python: '#3572A5',
+	Go: '#00ADD8',
+	Lua: '#000080',
+	CSharp: '#178600',
+	'C#': '#178600',
+	'C++': '#f34b7d',
+	Shell: '#89e051',
+	HTML: '#e34c26',
+};
+function langColor(lang: string | null): string {
+	if (!lang) return '#6b7280';
+	return LANG_COLOURS[lang] ?? '#8b5cf6';
+}
+function shortDate(iso: string): string {
+	const d = new Date(iso);
+	return d.toISOString().slice(0, 10);
+}
+---
+
+<section
+	class="github-repo-catalog"
+	aria-labelledby="github-repo-catalog-title">
+	<header class="github-repo-catalog__header">
+		<h2 id="github-repo-catalog-title">{title}</h2>
+		<p>{subtitle}</p>
+	</header>
+
+	{
+		error && (
+			<p class="github-repo-catalog__error" role="alert">
+				Unable to load repositories ({error}). See{' '}
+				<a href={`https://github.com/orgs/${GITHUB_ORG}/repositories`}>
+					github.com/orgs/{GITHUB_ORG}
+				</a>{' '}
+				directly.
+			</p>
+		)
+	}
+
+	{
+		!error && (
+			<div class="github-repo-catalog__groups">
+				{renderable.map((group) => (
+					<div class="github-repo-catalog__group">
+						<div class="github-repo-catalog__group-header">
+							<h3>{group.meta.label}</h3>
+							<span class="github-repo-catalog__group-count">
+								{group.list.length}
+							</span>
+						</div>
+						{group.meta.description && (
+							<p class="github-repo-catalog__group-desc">
+								{group.meta.description}
+							</p>
+						)}
+						<ul class="github-repo-catalog__grid" role="list">
+							{group.list.map((repo) => (
+								<li class="github-repo-catalog__card">
+									<a
+										href={repo.html_url}
+										target="_blank"
+										rel="noopener noreferrer">
+										<div class="github-repo-catalog__card-title">
+											<strong>{repo.name}</strong>
+											<span
+												class="github-repo-catalog__star"
+												aria-label={`${repo.stargazers_count} stars`}>
+												★ {repo.stargazers_count}
+											</span>
+										</div>
+										{repo.description && (
+											<p class="github-repo-catalog__card-desc">
+												{repo.description}
+											</p>
+										)}
+										<div class="github-repo-catalog__meta">
+											{repo.language && (
+												<span class="github-repo-catalog__lang">
+													<span
+														class="github-repo-catalog__lang-dot"
+														style={`background:${langColor(repo.language)}`}
+														aria-hidden="true"
+													/>
+													{repo.language}
+												</span>
+											)}
+											<span class="github-repo-catalog__pushed">
+												Updated{' '}
+												{shortDate(repo.pushed_at)}
+											</span>
+										</div>
+									</a>
+								</li>
+							))}
+						</ul>
+					</div>
+				))}
+			</div>
+		)
+	}
+</section>
+
+<style>
+	.github-repo-catalog {
+		margin: 3rem 0;
+		color: var(--sl-color-text, #e6edf3);
+	}
+	.github-repo-catalog__header {
+		text-align: center;
+		margin-bottom: 1.5rem;
+	}
+	.github-repo-catalog__header h2 {
+		font-size: 1.75rem;
+		font-weight: 700;
+		margin: 0 0 0.25rem;
+	}
+	.github-repo-catalog__header p {
+		color: var(--sl-color-gray-2, #8b949e);
+		margin: 0;
+	}
+	.github-repo-catalog__error {
+		text-align: center;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+	.github-repo-catalog__groups {
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
+	}
+	.github-repo-catalog__group-header {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+	}
+	.github-repo-catalog__group-header h3 {
+		font-size: 1.15rem;
+		font-weight: 600;
+		margin: 0;
+	}
+	.github-repo-catalog__group-count {
+		font-size: 0.75rem;
+		color: var(--sl-color-gray-3, #8b949e);
+		background: var(--sl-color-gray-6, #1f2937);
+		padding: 0.1rem 0.5rem;
+		border-radius: 999px;
+	}
+	.github-repo-catalog__group-desc {
+		color: var(--sl-color-gray-3, #8b949e);
+		font-size: 0.85rem;
+		margin: 0.25rem 0 0.75rem;
+	}
+	.github-repo-catalog__grid {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+		gap: 0.75rem;
+	}
+	.github-repo-catalog__card {
+		background: var(--sl-color-bg-nav, #111);
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		border-radius: 8px;
+		transition:
+			border-color 0.15s,
+			transform 0.15s;
+	}
+	.github-repo-catalog__card:hover {
+		border-color: var(--sl-color-accent, #06b6d4);
+		transform: translateY(-1px);
+	}
+	.github-repo-catalog__card a {
+		display: block;
+		padding: 0.75rem 1rem;
+		color: inherit;
+		text-decoration: none;
+	}
+	.github-repo-catalog__card-title {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		font-size: 0.95rem;
+	}
+	.github-repo-catalog__star {
+		font-size: 0.8rem;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+	.github-repo-catalog__card-desc {
+		margin: 0.35rem 0 0.5rem;
+		font-size: 0.85rem;
+		color: var(--sl-color-gray-2, #c9d1d9);
+		line-height: 1.4;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+	.github-repo-catalog__meta {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		font-size: 0.7rem;
+		color: var(--sl-color-gray-3, #8b949e);
+		gap: 0.5rem;
+	}
+	.github-repo-catalog__lang {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+	}
+	.github-repo-catalog__lang-dot {
+		width: 0.55rem;
+		height: 0.55rem;
+		border-radius: 50%;
+		display: inline-block;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/content/docs/github.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/github.mdx
@@ -12,13 +12,19 @@ sidebar:
 ---
 
 import DeferredAstroGithubHero from '@/components/github/GithubHero/DeferredAstroGithubHero.astro';
+import AstroGithubRepoCatalog from '@/components/github/RepoCatalog/AstroGithubRepoCatalog.astro';
+import AstroGithubActivity from '@/components/github/Activity/AstroGithubActivity.astro';
+import AstroGithubProjectBoard from '@/components/github/ProjectBoard/AstroGithubProjectBoard.astro';
+import AstroGithubContribute from '@/components/github/Contribute/AstroGithubContribute.astro';
 import ScrollRing from '@kbve/astro/components/hero/observer/ScrollRing.astro';
 
 <div class="ring-page kbve-dashboard-page relative min-h-screen w-full bg-transparent">
 
 # GitHub
 
-Community contributors, open-source projects, and live org activity.
+Open-source games, cloud infrastructure, and the contributors building them.
+PRs land against `dev`, ship through CI to `main`. Pick an issue, fork the
+repo, open a worktree — the walkthrough is below.
 
 <DeferredAstroGithubHero
     title="Top Contributors"
@@ -33,6 +39,14 @@ Community contributors, open-source projects, and live org activity.
     rank3Label="3rd Place"
     newTabLabel="(opens in new tab)"
 />
+
+<AstroGithubActivity />
+
+<AstroGithubProjectBoard />
+
+<AstroGithubRepoCatalog />
+
+<AstroGithubContribute />
 
 </div>
 


### PR DESCRIPTION
## Summary
`/github/` ships today as a contributor carousel + scroll ring. This rewires it into a real landing page for KBVE's open-source surface — what's shipping, what's in flight, where the code lives, and exactly how to send the first PR.

## Components added
All four are pure Astro, build-time fetch, zero client JS — same anonymous-fetch pattern as the existing `DeferredAstroGithubHero`.

| Component | Source | Renders |
|-----------|--------|---------|
| `AstroGithubActivity` | `/orgs/KBVE/events` (filtered to `PullRequestEvent` + `ReleaseEvent` + `PushEvent`, deduped on PR#/release-tag/push-sha) | 12 most recent items |
| `AstroGithubProjectBoard` | `/repos/KBVE/kbve/issues?state=open&labels=priority:medium` | 9 in-flight tiles + link to full search |
| `AstroGithubRepoCatalog` | `/orgs/KBVE/repos?sort=updated&per_page=60` (public, non-archived, non-fork) | Cards grouped: Infrastructure / Web + Apps / Games + Sim / Rust Services / Docs + Tooling / Other |
| `AstroGithubContribute` | static | 5-step walkthrough: fork + upstream → `./kbve.sh -worktree` → `./kbve.sh -nx` targets → `gh pr create --base dev` → sync + cleanup. Sidebar links to CLAUDE.md / open issues / project board / Discord |

## Page order (`content/docs/github.mdx`)
Contributors → activity → in-flight issues → repos → contribute. Social proof + recency first, long catalog and howto last.

## Rate budget
`/github/` now fetches 5 endpoints at build time (4 new + existing contributors). Anonymous GitHub REST is 60 req/hour/IP — well clear. Adding a `GITHUB_TOKEN` env var would unlock 5000 req/hour if the catalog ever wants live release / CI status badges.

## Test plan
- [ ] `./kbve.sh -nx astro-kbve:build` — green locally (7688 pages, no errors on the new components)
- [ ] Inspect `dist/apps/astro-kbve/github/index.html` — confirmed 111 repo cards, 18 priority:medium issues, 12 activity items rendered
- [ ] Visit `/github/` on the preview deploy, scroll through each section
- [ ] Click through a repo card, an issue tile, and an activity link