### PR TITLE
perf(grafana-dashboard): kill toast spam + CLS on /dashboard/grafana

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAlertsGrafana.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAlertsGrafana.astro
@@ -1,0 +1,43 @@
+---
+import ReactGrafanaAuth from './ReactGrafanaAuth';
+import ReactAlerts from './ReactAlerts';
+---
+
+<section
+	id="alerts-wrapper"
+	class="alerts-wrapper kbve-dashboard-page"
+	aria-label="Prometheus Alerts — ClickHouse-backed history">
+	<div id="alerts-content" class="alerts-content">
+		<ReactGrafanaAuth client:only="react">
+			<div class="not-content alerts-panel">
+				<ReactAlerts client:only="react" variant="full" />
+			</div>
+		</ReactGrafanaAuth>
+	</div>
+</section>
+
+<style>
+	.alerts-wrapper {
+		background: transparent;
+		position: relative;
+		width: 100%;
+	}
+
+	.alerts-content {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 0 1rem 2rem;
+	}
+
+	@media (min-width: 768px) {
+		.alerts-content {
+			padding: 0 1.5rem 2rem;
+		}
+	}
+
+	.alerts-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
@@ -70,4 +70,40 @@ import ReactGrafanaAlerts from './ReactGrafanaAlerts';
 			transform: rotate(360deg);
 		}
 	}
+
+	/* Card hover lifted out of React state — kills the per-render
+	   hover-state work that was forcing every sibling card to re-render
+	   on pointer enter, and removes the sticky-hover bug on touch
+	   devices where a tap leaves the card raised until the next tap. */
+	:global(.kbve-stat-card.is-clickable) {
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	:global(.kbve-stat-card.is-clickable:hover) {
+		border-color: var(--sl-color-gray-4, #6b7280);
+		transform: translateY(-2px);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+	}
+
+	@media (hover: none) {
+		:global(.kbve-stat-card.is-clickable:hover) {
+			transform: none;
+			box-shadow: none;
+		}
+		:global(.kbve-stat-card.is-clickable:active) {
+			border-color: var(--sl-color-gray-4, #6b7280);
+			transform: scale(0.98);
+		}
+	}
+
+	/* Mobile: shrink chart panel padding + heading so the inner
+	   ResponsiveContainer claws back horizontal space the 1.5rem
+	   padding would steal on a narrow viewport. */
+	:global(.kbve-chart-panel) {
+		padding: clamp(0.75rem, 3vw, 1.5rem) !important;
+	}
+
+	:global(.kbve-chart-panel h3) {
+		font-size: clamp(0.95rem, 2.4vw, 1.1rem) !important;
+	}
 </style>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
@@ -25,15 +25,20 @@ import ReactGrafanaAlerts from './ReactGrafanaAlerts';
 					<ReactGrafanaAlerts client:only="react" />
 				</div>
 
-				<!-- Island: Node section (stat cards, drill-downs, charts) -->
-				<div id="grafana-nodes">
+				<!-- Section: Nodes — title is server-rendered at build time
+				     so it lands in the initial HTML; React island only owns
+				     the dynamic stat cards / drill-downs / charts. -->
+				<section id="grafana-nodes" class="kbve-dash-section">
+					<h2 class="kbve-dash-section-title">Nodes</h2>
 					<ReactGrafanaNodes client:only="react" />
-				</div>
+				</section>
 
-				<!-- Island: K8s section (stat cards, drill-downs, pods chart) -->
-				<div id="grafana-k8s">
+				<!-- Section: Kubernetes — same pattern, static title +
+				     React-only dynamic body. -->
+				<section id="grafana-k8s" class="kbve-dash-section">
+					<h2 class="kbve-dash-section-title">Kubernetes</h2>
 					<ReactGrafanaK8s client:only="react" />
-				</div>
+				</section>
 			</div>
 		</ReactGrafanaAuth>
 	</div>
@@ -63,6 +68,23 @@ import ReactGrafanaAlerts from './ReactGrafanaAlerts';
 		display: flex;
 		flex-direction: column;
 		gap: 1.5rem;
+	}
+
+	/* Server-rendered section titles — moved out of React so they land
+	   in the initial HTML and don't wait on hydration. */
+	.kbve-dash-section {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.kbve-dash-section-title {
+		color: var(--sl-color-text, #e6edf3);
+		margin: 0;
+		font-size: clamp(1.05rem, 2.6vw, 1.3rem);
+		font-weight: 600;
+		padding-bottom: 0.5rem;
+		border-bottom: 1px solid var(--sl-color-gray-5, #262626);
 	}
 
 	:global(@keyframes spin) {

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaK8s.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaK8s.tsx
@@ -286,20 +286,9 @@ export default function ReactGrafanaK8s() {
 	const timeRange = useStore(grafanaService.$timeRange);
 
 	return (
-		<section>
-			<h2
-				style={{
-					color: 'var(--sl-color-text, #e6edf3)',
-					margin: '0 0 1rem 0',
-					fontSize: '1.3rem',
-					fontWeight: 600,
-					paddingBottom: '0.5rem',
-					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
-				}}>
-				Kubernetes
-			</h2>
-
+		<>
 			<div
+				className="kbve-card-grid"
 				style={{
 					display: 'grid',
 					gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))',
@@ -458,6 +447,6 @@ export default function ReactGrafanaK8s() {
 					<ChartSkeleton height={250} />
 				)}
 			</div>
-		</section>
+		</>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaK8s.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaK8s.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	grafanaService,
@@ -140,10 +140,11 @@ function StatCard({
 	sparkline?: SparklinePoint[];
 	onClick?: () => void;
 }) {
-	const [hovered, setHovered] = useState(false);
-
 	return (
 		<div
+			className={
+				onClick ? 'kbve-stat-card is-clickable' : 'kbve-stat-card'
+			}
 			style={{
 				display: 'flex',
 				flexDirection: 'column',
@@ -158,19 +159,8 @@ function StatCard({
 				minHeight: 156,
 				cursor: onClick ? 'pointer' : 'default',
 				borderTop: '2px solid var(--sl-color-accent, #06b6d4)',
-				borderColor:
-					hovered && onClick
-						? 'var(--sl-color-gray-4, #6b7280)'
-						: undefined,
-				transform: hovered && onClick ? 'translateY(-2px)' : undefined,
-				boxShadow:
-					hovered && onClick
-						? '0 4px 12px rgba(0,0,0,0.3)'
-						: undefined,
 			}}
-			onClick={onClick}
-			onMouseEnter={() => setHovered(true)}
-			onMouseLeave={() => setHovered(false)}>
+			onClick={onClick}>
 			<div
 				style={{
 					display: 'flex',
@@ -419,6 +409,7 @@ export default function ReactGrafanaK8s() {
 
 			{/* Running Pods chart */}
 			<div
+				className="kbve-chart-panel"
 				style={{
 					padding: '1.5rem',
 					borderRadius: '12px',

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaK8s.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaK8s.tsx
@@ -53,6 +53,25 @@ const tooltipStyle = {
 const axisStroke = 'var(--sl-color-gray-3, #8b949e)';
 const gridStroke = 'var(--sl-color-gray-5, #262626)';
 
+// Skeleton keeps the chart container height reserved while the first
+// range query is in flight, preventing the late-arriving pods chart
+// from pushing siblings down on cold load.
+function ChartSkeleton({ height }: { height: number }) {
+	return (
+		<div
+			aria-hidden
+			style={{
+				width: '100%',
+				height,
+				borderRadius: '8px',
+				background:
+					'repeating-linear-gradient(90deg, var(--sl-color-gray-6, #1c1c1c) 0 24px, var(--sl-color-gray-5, #262626) 24px 48px)',
+				opacity: 0.5,
+			}}
+		/>
+	);
+}
+
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
@@ -77,28 +96,31 @@ function TrendIndicator({ trend }: { trend: TrendInfo }) {
 	);
 }
 
-function SparklineChart({
+function SparklineSlot({
 	data,
 	color,
 }: {
-	data: SparklinePoint[];
+	data?: SparklinePoint[];
 	color: string;
 }) {
-	if (data.length < 2) return null;
+	// Slot is always rendered to reserve 36px in the card layout — keeps
+	// StatCard at a stable height while sparkline data hydrates.
 	return (
 		<div style={{ width: '100%', height: 36, marginTop: 'auto' }}>
-			<ResponsiveContainer width="100%" height={36}>
-				<LineChart data={data}>
-					<Line
-						type="monotone"
-						dataKey="v"
-						stroke={color}
-						strokeWidth={1.5}
-						dot={false}
-						isAnimationActive={false}
-					/>
-				</LineChart>
-			</ResponsiveContainer>
+			{data && data.length >= 2 && (
+				<ResponsiveContainer width="100%" height={36}>
+					<LineChart data={data}>
+						<Line
+							type="monotone"
+							dataKey="v"
+							stroke={color}
+							strokeWidth={1.5}
+							dot={false}
+							isAnimationActive={false}
+						/>
+					</LineChart>
+				</ResponsiveContainer>
+			)}
 		</div>
 	);
 }
@@ -133,7 +155,7 @@ function StatCard({
 				background: 'var(--sl-color-bg-nav, #111)',
 				transition:
 					'border-color 0.2s, transform 0.15s, box-shadow 0.15s',
-				minHeight: 120,
+				minHeight: 156,
 				cursor: onClick ? 'pointer' : 'default',
 				borderTop: '2px solid var(--sl-color-accent, #06b6d4)',
 				borderColor:
@@ -185,7 +207,7 @@ function StatCard({
 					: '--'}
 			</div>
 			{trend && <TrendIndicator trend={trend} />}
-			{sparkline && <SparklineChart data={sparkline} color="#06b6d4" />}
+			<SparklineSlot data={sparkline} color="#06b6d4" />
 		</div>
 	);
 }
@@ -396,24 +418,24 @@ export default function ReactGrafanaK8s() {
 			)}
 
 			{/* Running Pods chart */}
-			{k8sTimeSeries.length > 0 && (
-				<div
+			<div
+				style={{
+					padding: '1.5rem',
+					borderRadius: '12px',
+					border: '1px solid var(--sl-color-gray-5, #262626)',
+					background: 'var(--sl-color-bg-nav, #111)',
+					marginTop: '1rem',
+				}}>
+				<h3
 					style={{
-						padding: '1.5rem',
-						borderRadius: '12px',
-						border: '1px solid var(--sl-color-gray-5, #262626)',
-						background: 'var(--sl-color-bg-nav, #111)',
-						marginTop: '1rem',
+						color: 'var(--sl-color-text, #e6edf3)',
+						margin: '0 0 1rem 0',
+						fontSize: '1.1rem',
+						fontWeight: 600,
 					}}>
-					<h3
-						style={{
-							color: 'var(--sl-color-text, #e6edf3)',
-							margin: '0 0 1rem 0',
-							fontSize: '1.1rem',
-							fontWeight: 600,
-						}}>
-						Running Pods ({timeRange})
-					</h3>
+					Running Pods ({timeRange})
+				</h3>
+				{k8sTimeSeries.length > 0 ? (
 					<ResponsiveContainer width="100%" height={250}>
 						<AreaChart data={k8sTimeSeries}>
 							<CartesianGrid
@@ -441,8 +463,10 @@ export default function ReactGrafanaK8s() {
 							/>
 						</AreaChart>
 					</ResponsiveContainer>
-				</div>
-			)}
+				) : (
+					<ChartSkeleton height={250} />
+				)}
+			</div>
 		</section>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaNodes.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaNodes.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	grafanaService,
@@ -164,7 +164,6 @@ function EnhancedStatCard({
 	invertTrend?: boolean;
 	onClick?: () => void;
 }) {
-	const [hovered, setHovered] = useState(false);
 	const hasThreshold = thresholds && value != null;
 	const thresholdColor = hasThreshold
 		? getThresholdColor(value, thresholds)
@@ -175,6 +174,9 @@ function EnhancedStatCard({
 
 	return (
 		<div
+			className={
+				onClick ? 'kbve-stat-card is-clickable' : 'kbve-stat-card'
+			}
 			style={{
 				display: 'flex',
 				flexDirection: 'column',
@@ -189,19 +191,8 @@ function EnhancedStatCard({
 				minHeight: 156,
 				cursor: onClick ? 'pointer' : 'default',
 				borderTop: `2px solid ${accentColor}`,
-				borderColor:
-					hovered && onClick
-						? 'var(--sl-color-gray-4, #6b7280)'
-						: undefined,
-				transform: hovered && onClick ? 'translateY(-2px)' : undefined,
-				boxShadow:
-					hovered && onClick
-						? '0 4px 12px rgba(0,0,0,0.3)'
-						: undefined,
 			}}
-			onClick={onClick}
-			onMouseEnter={() => setHovered(true)}
-			onMouseLeave={() => setHovered(false)}>
+			onClick={onClick}>
 			<div
 				style={{
 					display: 'flex',
@@ -495,6 +486,7 @@ export default function ReactGrafanaNodes() {
 
 			{/* CPU & Memory chart */}
 			<div
+				className="kbve-chart-panel"
 				style={{
 					padding: '1.5rem',
 					borderRadius: '12px',
@@ -559,6 +551,7 @@ export default function ReactGrafanaNodes() {
 
 			{/* Network Traffic chart */}
 			<div
+				className="kbve-chart-panel"
 				style={{
 					padding: '1.5rem',
 					borderRadius: '12px',
@@ -625,6 +618,7 @@ export default function ReactGrafanaNodes() {
 
 			{/* Disk Usage chart */}
 			<div
+				className="kbve-chart-panel"
 				style={{
 					padding: '1.5rem',
 					borderRadius: '12px',

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaNodes.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaNodes.tsx
@@ -333,20 +333,9 @@ export default function ReactGrafanaNodes() {
 	const timeRange = useStore(grafanaService.$timeRange);
 
 	return (
-		<section>
-			<h2
-				style={{
-					color: 'var(--sl-color-text, #e6edf3)',
-					margin: '0 0 1rem 0',
-					fontSize: '1.3rem',
-					fontWeight: 600,
-					paddingBottom: '0.5rem',
-					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
-				}}>
-				Nodes
-			</h2>
-
+		<>
 			<div
+				className="kbve-card-grid"
 				style={{
 					display: 'grid',
 					gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))',
@@ -672,6 +661,6 @@ export default function ReactGrafanaNodes() {
 					<ChartSkeleton height={250} />
 				)}
 			</div>
-		</section>
+		</>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaNodes.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaNodes.tsx
@@ -56,6 +56,25 @@ const tooltipStyle = {
 const axisStroke = 'var(--sl-color-gray-3, #8b949e)';
 const gridStroke = 'var(--sl-color-gray-5, #262626)';
 
+// Skeleton sized to the parent chart's exact height — keeps the page
+// layout stable while the first range query is in flight (prevents the
+// ~1050px cumulative shift on cold load).
+function ChartSkeleton({ height }: { height: number }) {
+	return (
+		<div
+			aria-hidden
+			style={{
+				width: '100%',
+				height,
+				borderRadius: '8px',
+				background:
+					'repeating-linear-gradient(90deg, var(--sl-color-gray-6, #1c1c1c) 0 24px, var(--sl-color-gray-5, #262626) 24px 48px)',
+				opacity: 0.5,
+			}}
+		/>
+	);
+}
+
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
@@ -93,28 +112,31 @@ function TrendIndicator({
 	);
 }
 
-function SparklineChart({
+function SparklineSlot({
 	data,
 	color,
 }: {
-	data: SparklinePoint[];
+	data?: SparklinePoint[];
 	color: string;
 }) {
-	if (data.length < 2) return null;
+	// Slot is always rendered to reserve 36px in the card layout — keeps
+	// EnhancedStatCard at a stable height while sparkline data hydrates.
 	return (
 		<div style={{ width: '100%', height: 36, marginTop: 'auto' }}>
-			<ResponsiveContainer width="100%" height={36}>
-				<LineChart data={data}>
-					<Line
-						type="monotone"
-						dataKey="v"
-						stroke={color}
-						strokeWidth={1.5}
-						dot={false}
-						isAnimationActive={false}
-					/>
-				</LineChart>
-			</ResponsiveContainer>
+			{data && data.length >= 2 && (
+				<ResponsiveContainer width="100%" height={36}>
+					<LineChart data={data}>
+						<Line
+							type="monotone"
+							dataKey="v"
+							stroke={color}
+							strokeWidth={1.5}
+							dot={false}
+							isAnimationActive={false}
+						/>
+					</LineChart>
+				</ResponsiveContainer>
+			)}
 		</div>
 	);
 }
@@ -164,7 +186,7 @@ function EnhancedStatCard({
 				background: 'var(--sl-color-bg-nav, #111)',
 				transition:
 					'border-color 0.2s, transform 0.15s, box-shadow 0.15s',
-				minHeight: 120,
+				minHeight: 156,
 				cursor: onClick ? 'pointer' : 'default',
 				borderTop: `2px solid ${accentColor}`,
 				borderColor:
@@ -216,9 +238,7 @@ function EnhancedStatCard({
 			{trend && (
 				<TrendIndicator trend={trend} invertColors={invertTrend} />
 			)}
-			{sparkline && (
-				<SparklineChart data={sparkline} color={sparkColor} />
-			)}
+			<SparklineSlot data={sparkline} color={sparkColor} />
 		</div>
 	);
 }
@@ -474,24 +494,24 @@ export default function ReactGrafanaNodes() {
 			)}
 
 			{/* CPU & Memory chart */}
-			{timeSeries.length > 0 && (
-				<div
+			<div
+				style={{
+					padding: '1.5rem',
+					borderRadius: '12px',
+					border: '1px solid var(--sl-color-gray-5, #262626)',
+					background: 'var(--sl-color-bg-nav, #111)',
+					marginTop: '1rem',
+				}}>
+				<h3
 					style={{
-						padding: '1.5rem',
-						borderRadius: '12px',
-						border: '1px solid var(--sl-color-gray-5, #262626)',
-						background: 'var(--sl-color-bg-nav, #111)',
-						marginTop: '1rem',
+						color: 'var(--sl-color-text, #e6edf3)',
+						margin: '0 0 1rem 0',
+						fontSize: '1.1rem',
+						fontWeight: 600,
 					}}>
-					<h3
-						style={{
-							color: 'var(--sl-color-text, #e6edf3)',
-							margin: '0 0 1rem 0',
-							fontSize: '1.1rem',
-							fontWeight: 600,
-						}}>
-						CPU & Memory ({timeRange})
-					</h3>
+					CPU & Memory ({timeRange})
+				</h3>
+				{timeSeries.length > 0 ? (
 					<ResponsiveContainer width="100%" height={300}>
 						<AreaChart data={timeSeries}>
 							<CartesianGrid
@@ -532,28 +552,30 @@ export default function ReactGrafanaNodes() {
 							/>
 						</AreaChart>
 					</ResponsiveContainer>
-				</div>
-			)}
+				) : (
+					<ChartSkeleton height={300} />
+				)}
+			</div>
 
 			{/* Network Traffic chart */}
-			{networkTimeSeries.length > 0 && (
-				<div
+			<div
+				style={{
+					padding: '1.5rem',
+					borderRadius: '12px',
+					border: '1px solid var(--sl-color-gray-5, #262626)',
+					background: 'var(--sl-color-bg-nav, #111)',
+					marginTop: '1rem',
+				}}>
+				<h3
 					style={{
-						padding: '1.5rem',
-						borderRadius: '12px',
-						border: '1px solid var(--sl-color-gray-5, #262626)',
-						background: 'var(--sl-color-bg-nav, #111)',
-						marginTop: '1rem',
+						color: 'var(--sl-color-text, #e6edf3)',
+						margin: '0 0 1rem 0',
+						fontSize: '1.1rem',
+						fontWeight: 600,
 					}}>
-					<h3
-						style={{
-							color: 'var(--sl-color-text, #e6edf3)',
-							margin: '0 0 1rem 0',
-							fontSize: '1.1rem',
-							fontWeight: 600,
-						}}>
-						Network Traffic ({timeRange})
-					</h3>
+					Network Traffic ({timeRange})
+				</h3>
+				{networkTimeSeries.length > 0 ? (
 					<ResponsiveContainer width="100%" height={250}>
 						<AreaChart data={networkTimeSeries}>
 							<CartesianGrid
@@ -596,28 +618,30 @@ export default function ReactGrafanaNodes() {
 							/>
 						</AreaChart>
 					</ResponsiveContainer>
-				</div>
-			)}
+				) : (
+					<ChartSkeleton height={250} />
+				)}
+			</div>
 
 			{/* Disk Usage chart */}
-			{diskTimeSeries.length > 0 && (
-				<div
+			<div
+				style={{
+					padding: '1.5rem',
+					borderRadius: '12px',
+					border: '1px solid var(--sl-color-gray-5, #262626)',
+					background: 'var(--sl-color-bg-nav, #111)',
+					marginTop: '1rem',
+				}}>
+				<h3
 					style={{
-						padding: '1.5rem',
-						borderRadius: '12px',
-						border: '1px solid var(--sl-color-gray-5, #262626)',
-						background: 'var(--sl-color-bg-nav, #111)',
-						marginTop: '1rem',
+						color: 'var(--sl-color-text, #e6edf3)',
+						margin: '0 0 1rem 0',
+						fontSize: '1.1rem',
+						fontWeight: 600,
 					}}>
-					<h3
-						style={{
-							color: 'var(--sl-color-text, #e6edf3)',
-							margin: '0 0 1rem 0',
-							fontSize: '1.1rem',
-							fontWeight: 600,
-						}}>
-						Disk Usage ({timeRange})
-					</h3>
+					Disk Usage ({timeRange})
+				</h3>
+				{diskTimeSeries.length > 0 ? (
 					<ResponsiveContainer width="100%" height={250}>
 						<AreaChart data={diskTimeSeries}>
 							<CartesianGrid
@@ -650,8 +674,10 @@ export default function ReactGrafanaNodes() {
 							/>
 						</AreaChart>
 					</ResponsiveContainer>
-				</div>
-			)}
+				) : (
+					<ChartSkeleton height={250} />
+				)}
+			</div>
 		</section>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/homeService.ts
@@ -781,6 +781,12 @@ class HomeService {
 
 	// --- Auth ---
 
+	// Idempotent guard so successive initAuth() calls across Astro
+	// client-router navigations don't stack $auth.subscribe handlers
+	// (each remount of ReactHomeAuth used to add another listener,
+	// multiplying staff-toast frequency over time).
+	private _authSub: (() => void) | null = null;
+
 	public async initAuth(): Promise<void> {
 		try {
 			await initSupa();
@@ -791,7 +797,7 @@ class HomeService {
 			if (!session?.access_token) {
 				this.$authState.set('unauthenticated');
 				addToast({
-					id: `auth-anon-${Date.now()}`,
+					id: 'home-auth-anon',
 					message: 'Please sign in to access the dashboard.',
 					severity: 'info',
 					duration: 4000,
@@ -801,45 +807,57 @@ class HomeService {
 
 			this.$accessToken.set(session.access_token as string);
 
-			// Read staff flag from $auth — resolveStaffFlag() in supa.ts
-			// already upgraded flags to STAFF during initSupa() if the
-			// user has staff permissions.
 			const { flags } = $auth.get();
 			const isStaff = hasAuthFlag(flags, AuthFlags.STAFF);
 			this.$isStaff.set(isStaff);
 
 			this.$authState.set('authenticated');
 
-			const authName = $auth.get().name;
-			addToast({
-				id: `auth-ok-${Date.now()}`,
-				message: authName
-					? `Welcome back, ${authName}`
-					: 'Signed in successfully',
-				severity: 'success',
-				duration: 4000,
-			});
-
-			// Also subscribe in case profile-controller sets it later
-			const syncStaff = () => {
-				const { flags } = $auth.get();
-				if (hasAuthFlag(flags, AuthFlags.STAFF)) {
-					if (!this.$isStaff.get()) {
-						this.$isStaff.set(true);
-						addToast({
-							id: `staff-ok-${Date.now()}`,
-							message: 'Staff access enabled',
-							severity: 'info',
-							duration: 3000,
-						});
-					}
+			// Welcome toast is gated per browser session so Starlight's
+			// client-side routing doesn't fire it on every navigation.
+			if (
+				typeof sessionStorage !== 'undefined' &&
+				!sessionStorage.getItem('home-auth-welcomed')
+			) {
+				const authName = $auth.get().name;
+				addToast({
+					id: 'home-auth-ok',
+					message: authName
+						? `Welcome back, ${authName}`
+						: 'Signed in successfully',
+					severity: 'success',
+					duration: 4000,
+				});
+				try {
+					sessionStorage.setItem('home-auth-welcomed', '1');
+				} catch {
+					// sessionStorage may be unavailable (private mode, etc.) —
+					// failing to set means we re-show the toast once next nav,
+					// which is acceptable degradation.
 				}
-			};
-			$auth.subscribe(syncStaff);
+			}
+
+			if (!this._authSub) {
+				const syncStaff = () => {
+					const { flags } = $auth.get();
+					if (hasAuthFlag(flags, AuthFlags.STAFF)) {
+						if (!this.$isStaff.get()) {
+							this.$isStaff.set(true);
+							addToast({
+								id: 'home-staff-ok',
+								message: 'Staff access enabled',
+								severity: 'info',
+								duration: 3000,
+							});
+						}
+					}
+				};
+				this._authSub = $auth.subscribe(syncStaff);
+			}
 		} catch {
 			this.$authState.set('unauthenticated');
 			addToast({
-				id: `auth-err-${Date.now()}`,
+				id: 'home-auth-err',
 				message: 'Session expired — please sign in again.',
 				severity: 'warning',
 				duration: 5000,
@@ -977,7 +995,7 @@ class HomeService {
 				failures.push('Forgejo');
 			if (failures.length > 0) {
 				addToast({
-					id: `svc-err-${Date.now()}`,
+					id: 'home-svc-err',
 					message: `${failures.join(', ')} unavailable`,
 					severity: 'warning',
 					duration: 5000,
@@ -987,7 +1005,7 @@ class HomeService {
 
 		if (this.$edgeStatus.get() === 'unavailable') {
 			addToast({
-				id: `edge-err-${Date.now()}`,
+				id: 'home-edge-err',
 				message: 'Edge service unavailable',
 				severity: 'warning',
 				duration: 5000,

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/grafana/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/grafana/index.mdx
@@ -15,10 +15,10 @@ tags:
 ---
 
 import AstroGrafanaDashboard from '@/components/dashboard/AstroGrafanaDashboard.astro';
-import AstroAlerts from '@/components/dashboard/AstroAlerts.astro';
+import AstroAlertsGrafana from '@/components/dashboard/AstroAlertsGrafana.astro';
 
 <AstroGrafanaDashboard />
 
 # Alerts
 
-<AstroAlerts />
+<AstroAlertsGrafana />


### PR DESCRIPTION
## Summary

Tier-1 fixes + flow/mobile add-on from the grafana dashboard perf audit. User-perceived quality only — no backend changes, no API shape changes.

### Commits

**1. Toast spam + CLS** (`8229454d9`)

- **Toast IDs stabilized** (`homeService.ts`) — `Date.now()` suffixes replaced with stable IDs (`home-auth-ok`, `home-staff-ok`, `home-svc-err`, etc.). `addToast` keys `$toasts` by id, duplicate calls collapse instead of stacking on every Starlight client-router nav.
- **Welcome toast gated per browser session** — sessionStorage flag prevents re-firing on every navigation. Falls back gracefully if sessionStorage is unavailable.
- **`$auth.subscribe(syncStaff)` is idempotent** — private `_authSub` guard ensures one subscriber per service instance lifetime, regardless of how many `initAuth()` calls fire across remounts.
- **Grafana page no longer loads homeService** — new `AstroAlertsGrafana.astro` wraps `ReactAlerts` in `ReactGrafanaAuth` (reusing the auth state grafanaService already established on this page) instead of `ReactHomeAuth` (which fired 5 service fetches + multi-toast surface).
- **CLS killed on chart hydration** — the four `{condition && <Chart>}` patterns in `ReactGrafanaNodes` + `ReactGrafanaK8s` now always render their outer containers and swap inner content between the recharts `AreaChart` and a fixed-height `ChartSkeleton`. Page no longer jumps ~1050 px when the first range query resolves on cold load.
- **Sparkline slot reserved** — `SparklineChart` (rendered only when `data.length >= 2`) → `SparklineSlot` (always renders the 36 px slot, conditionally renders the chart inside). Card `minHeight` bumped 120 → 156.

**2. Mobile-safe card hover + chart panel padding** (`9981fef47`)

- **CSS `:hover` migration** — drop `useState(hovered)` + `onMouseEnter/onMouseLeave` from both card components. Hover lift now lives in a single `.kbve-stat-card.is-clickable:hover` global rule. Two wins:
  - Kills the per-render hover-state work that was forcing every sibling card to re-render whenever the pointer crossed one.
  - Fixes the sticky-hover bug on touch devices where a tap left the card raised until the next tap. `@media (hover: none)` swaps the lift for an `:active` scale, plus `-webkit-tap-highlight-color: transparent` to drop the default touch flash.
- **Mobile chart panel padding** — tag the four chart panel containers with `.kbve-chart-panel`, add `padding: clamp(0.75rem, 3vw, 1.5rem)` so charts claw back the horizontal space the fixed `1.5rem` padding was stealing on narrow viewports. Headings scaled with `clamp(0.95rem, 2.4vw, 1.1rem)`.
- `useState` import dropped from both card files since nothing else used it.

## Verification

- [x] `npx nx run astro-kbve:build` — clean (7688 pages, 201s, no errors)

## Test plan (manual)

- [ ] Desktop: visit `/dashboard/grafana/` cold (clear sessionStorage) — at most one welcome toast
- [ ] Navigate away + back via Starlight router → no second welcome toast
- [ ] Sign in, verify staff toast fires once (not N times after multiple nav)
- [ ] Chart area should be reserved from first paint; no scroll jump when CPU/memory/network/disk/pods charts populate
- [ ] No `ReactHomeAuth` network activity on `/dashboard/grafana/` (only `grafanaService` requests)
- [ ] Mobile (≤480 px): card tap shows scale-down feedback, no sticky hover after tap
- [ ] Mobile: chart panels use ~0.75 rem padding (was 1.5 rem), headings shrink to ~0.95 rem
- [ ] Mobile: stat-card grid still wraps cleanly at 360 px viewport
- [ ] Other dashboard pages still load via `ReactHomeAuth` correctly

## Tiers still pending (separate PRs)

- **Tier 2.1** axum LRU proxy cache (biggest perceived-speed win, 2-3 hr backend)
- **Tier 2.3** `client:visible` on below-fold islands (30 min)
- **Tier 2.2** client-side request dedupe (1 hr)
- **Tier 2.4 / cleanup** delete dead `ReactGrafanaDashboard.tsx` (2011 LOC, marked deprecated)
- **Tier 3.2** `uplot` canvas swap for area charts (deferred, ~1 day)