### PR TITLE
content(astro-kbve): bump 200 OSRS items v2 → v3 (batch 12)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-robe-top.mdx
@@ -89,7 +89,10 @@ osrs:
     alchable: true
     destroy: Drop
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-robe-top.mdx
@@ -12,65 +12,84 @@ osrs:
   lowalch: 20320
   highalch: 30480
   limit: 8
+  material:
+    type: 3rd age
+    tier: high
   equipment:
     slot: body
-    type: magic armour
-    attack_style: magic
+    weapon_type: null
+    weight: 2.7
     requirements:
       magic: 65
       defence: 30
-    stats:
-      attack_magic: 24
-      defence_stab: 43
-      defence_slash: 21
-      defence_crush: 53
-      defence_magic: 24
-      defence_ranged: 0
-      magic_damage: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 24
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 24
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 1
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
   related_items:
-    - item_id: 10342
-      item_name: 3rd age mage hat
-      slug: 3rd-age-mage-hat
+    - name: 3rd age mage hat
       relationship: set-piece
-      description: Head slot of 3rd age mage set
-    - item_id: 10340
-      item_name: 3rd age robe
-      slug: 3rd-age-robe
+    - name: 3rd age robe
       relationship: set-piece
-      description: Leg slot of 3rd age mage set
-    - item_id: 10344
-      item_name: 3rd age amulet
-      slug: 3rd-age-amulet
+    - name: 3rd age amulet
       relationship: set-piece
-      description: Neck slot of 3rd age mage set
-  about: |-
-    The 3rd age robe top is part of the 3rd age mage set, one of the rarest and most prestigious armour sets in Old School RuneScape. It requires 65 Magic and 30 Defence to wear.
-
-    3rd age equipment is highly sought after due to its extreme rarity and status symbol value. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
+  about: "The 3rd age robe top is part of the 3rd age mage set, one of the rarest and most prestigious armour sets in Old School RuneScape. It requires 65 Magic and 30 Defence to wear. Obtained from Treasure Trail master clue caskets at an exceptionally low drop rate."
   market_strategy:
-    title: Investment Notes
     notes:
-      - One of the most valuable items in OSRS
-      - Price driven by collector demand
-      - Often used as currency for high-value trades
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - One of the most valuable items in OSRS - price driven by collector demand.
+      - Often used as currency for high-value trades and verified through the Grand Exchange.
+      - Monitor long-term price trends before purchasing; volume is single digits per day.
+  trading_tips:
+    - Verify authenticity and use the Grand Exchange for secure trades on items this valuable.
+    - Watch for Master clue droughts/spikes - reward distribution drives supply.
+  history:
+    - date: "2024-05-29"
+      description: Magic damage bonus increased from 0% to 1%.
+    - date: "2014-06-01"
+      description: Base value increased from 45,000 to 50,800 coins.
+    - date: "2006-12-05"
+      description: Item released as part of the Treasure Trails update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.7
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-keel-parts.mdx
@@ -69,7 +69,10 @@ osrs:
     alchable: true
     destroy: Drop
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-keel-parts.mdx
@@ -12,14 +12,64 @@ osrs:
   lowalch: 1250
   highalch: 1875
   limit: 100
+  material:
+    type: adamantite
+    tier: mid-high
+  recipes:
+    - name: Smith adamant keel parts
+      skill: Smithing
+      level: 74
+      experience: 312.5
+      materials:
+        - item_name: Adamantite bar
+          quantity: 5
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+      requirements:
+        quest: Pandemonium
+  related_items:
+    - name: Adamantite bar
+      relationship: component
+    - name: Adamant keel
+      relationship: product
+    - name: Large adamant keel parts
+      relationship: product
+    - name: Steel keel parts
+      relationship: downgrade
+    - name: Rune keel parts
+      relationship: upgrade
   about: "Adamant keel parts is a members-only item in Old School RuneScape. High alchemy value: 1,875 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Smithed from 5 adamantite bars at level 74 Smithing after Pandemonium.
+      - Used in the Sailing skill to construct adamant keels for skiffs.
+      - Currently shows a negative margin when smithed and sold to the GE.
+  trading_tips:
+    - Combine 10 adamant keel parts with 5 lead bars to assemble an adamant keel.
+    - 5 keel parts combine into a large adamant keel part for bigger vessels.
+  history:
+    - date: "2025-11-19"
+      description: Item released alongside the launch of the Sailing skill.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-scimitar.mdx
@@ -79,7 +79,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-scimitar.mdx
@@ -12,29 +12,74 @@ osrs:
   lowalch: 1024
   highalch: 1536
   limit: 125
-  item_id: 1331
-  item_type: equipment
-  slot: weapon
-  type: scimitar
-  attack_style: slash
-  attack_speed: 4
-  tradeable: true
-  weight: 2.041
-  requirements:
-    attack: 30
-  stats:
-    slash_attack: 29
-    strength: 28
+  material:
+    type: adamantite
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: scimitar
+    attack_speed: 4
+    weight: 2.041
+    requirements:
+      attack: 30
+    attack_bonus:
+      stab: 6
+      slash: 29
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      slash: 1
+    other_bonus:
+      strength: 28
+  recipes:
+    - materials:
+        - item_name: Adamantite bar
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+      skill: Smithing
+      level: 75
+      experience: 125
   related_items:
     - slug: rune-scimitar
+      relationship: upgrade
     - slug: adamantite-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: component
+  about: A vicious, curved sword forged from adamantite, the fourth-strongest scimitar in OSRS.
+  market_strategy:
+    notes:
+      - Common F2P training weapon for mid-level Attack accounts.
+      - Smithing the item from 2 adamantite bars currently runs at a loss versus GE price.
+      - Stable demand from new accounts crossing the 30 Attack threshold.
+  trading_tips:
+    - Buy adamantite bars during bulk-flip lulls if reselling as scimitars.
+    - High-alching is profitable above nature rune cost when bought near low GE price.
+  history:
+    - date: "2001-01-04"
+      description: Released with the original scimitar weapon family.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: Scimitar release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.041
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h3.mdx
@@ -12,14 +12,94 @@ osrs:
   lowalch: 2176
   highalch: 3264
   limit: 70
-  about: "Adamant shield (h3) is a free-to-play item in Old School RuneScape. High alchemy value: 3,264 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: adamant
+    tier: mid
+  equipment:
+    slot: shield
+    weight: 5.896
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 27
+      slash: 31
+      crush: 29
+      magic: -1
+      ranged: 29
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Adamant kiteshield
+      slug: adamant-kiteshield
+      relationship: variant
+      description: Untrimmed adamant kiteshield sharing identical combat stats
+    - item_name: Adamant shield (h1)
+      slug: adamant-shield-h1
+      relationship: variant
+      description: H1 heraldic variant
+    - item_name: Adamant shield (h2)
+      slug: adamant-shield-h2
+      relationship: variant
+      description: H2 heraldic variant
+    - item_name: Adamant shield (h4)
+      slug: adamant-shield-h4
+      relationship: variant
+      description: H4 heraldic variant
+    - item_name: Adamant shield (h5)
+      slug: adamant-shield-h5
+      relationship: variant
+      description: H5 heraldic variant
+  about: "Adamant shield (h3) is a free-to-play heraldic adamant kiteshield earned from medium Treasure Trail clue scrolls, sharing the standard adamant kiteshield's combat stats while featuring the H3 heraldic design for cosmetic appeal."
+  market_strategy:
+    notes:
+      - Low buy limit (70) tightens daily liquidity
+      - Cosmetic premium over base adamant kiteshield
+      - Supply tied to medium clue scroll completions
+      - High alch value below GE price limits alch flips
+  trading_tips:
+    - Patient sell orders capture spread during cosmetic meta updates
+    - Track medium clue popularity for supply changes
+    - Compare heraldic variants when filling fashionscape orders
+  history:
+    - date: "2006-02-20"
+      description: Adamant shield (h3) released as part of the Updates, updates and more updates… patch as a medium clue reward.
+    - date: "2021-04-21"
+      description: Ranged attack bonus reduced from -2 to -3 alongside a broader shield rebalance.
+  properties:
+    release_date: "2006-02-20"
+    update: "Updates, updates and more updates..."
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.896
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h3.mdx
@@ -99,7 +99,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrow.mdx
@@ -92,7 +92,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrow.mdx
@@ -12,83 +12,87 @@ osrs:
   lowalch: 196
   highalch: 294
   limit: 11000
-  ammunition:
-    type: arrow
-    tradeable: true
-    stackable: true
+  material:
+    type: Amethyst
+    tier: mid-high
+  equipment:
+    slot: ammo
+    weapon_type: arrow
     weight: 0
     requirements:
       ranged: 1
-    stats:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 55
-  creation:
-    method: Fletching
-    requirements:
-      fletching: 82
-    materials:
-      - item_id: 21350
-        item_name: Amethyst arrowtips
-        quantity: "15"
-      - item_id: 53
-        item_name: Headless arrow
-        quantity: "15"
-    xp: 202.5
-    product_quantity: 15
-  market:
-    buy_limit: 11000
-    price_estimate: 100
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Fletching
+      level: 82
+      xp: 202.5
+      materials:
+        - item_name: Amethyst arrowtips
+          quantity: 15
+        - item_name: Headless arrow
+          quantity: 15
+      tools: []
+      output_quantity: 15
   related_items:
-    - item_id: 21350
-      item_name: Amethyst arrowtips
-      slug: amethyst-arrowtips
+    - name: Amethyst arrowtips
       relationship: component
-      description: Crafting component
-    - item_id: 53
-      item_name: Headless arrow
-      slug: headless-arrow
+    - name: Headless arrow
       relationship: component
-      description: Base material
-    - item_id: 11212
-      item_name: Dragon arrow
-      slug: dragon-arrow
+    - name: Dragon arrow
       relationship: upgrade
-      description: Higher tier
-    - item_id: 892
-      item_name: Rune arrow
-      slug: rune-arrow
+    - name: Rune arrow
       relationship: downgrade
-      description: Lower tier
-  about: |-
-    | Method | Level | XP |
-    |--------|-------|-----|
-    | Fletching | 82 | 202.5 (per 15) |
-    | Materials | Amethyst arrowtips + Headless arrow | - |
-
-    | Stat | Value |
-    |------|-------|
-    | Ranged requirement | 1 |
-    | Ranged strength | +55 |
-    | Bow requirement | Magic shortbow or better |
+  about: "Amethyst arrows are members ranged ammunition sitting between rune and dragon arrows on the strength curve (+55 ranged strength). Crafted at 82 Fletching from amethyst arrowtips and headless arrows, they require a magic shortbow (or stronger) to wield and work with Ava's devices despite being non-metallic."
   market_strategy:
     notes:
-      - Between rune and dragon
-      - Popular PvM ammo
-      - No quest requirements
-      - Slayer tasks
-      - General PvM
-      - Cost-effective ammo
-      - Magic shortbow users
-      - +6 str over rune arrows
-      - Requires magic logs bow minimum
-      - Good balance of cost/damage
-      - Popular mid-game ammo
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Popular mid-game PvM ammunition for magic shortbow and bone shortbow users."
+      - "Fletching margin is tight — track amethyst arrowtip prices vs finished arrow demand daily."
+      - "GE buy limit 11,000 — easy to flip in modest volume without moving the price."
+      - "Demand peaks during slayer/PvM weekends when accounts gear up cheaply."
+  trading_tips:
+    - "Set instant-buy orders slightly above market to clear restock waves quickly."
+    - "Convert amethyst arrowtips into arrows only when the spread vs sold arrows turns positive after GE tax."
+    - "Consider buying in bulk before content updates that buff bows or amethyst itself."
+  history:
+    - date: "2017-06-22"
+      description: "Released as part of the Mining Guild Expansion update, alongside amethyst mining."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-06-22"
+    update: "Mining Guild Expansion"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-d-hide-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-d-hide-shield.mdx
@@ -12,85 +12,90 @@ osrs:
   lowalch: 11333
   highalch: 17000
   limit: 8
+  material:
+    type: dragonhide
+    tier: mid-high
   equipment:
     slot: shield
-    type: ranged armour
-    attack_style: ranged
+    weapon_type: shield
+    weight: 8
     requirements:
       ranged: 70
       defence: 40
-    stats:
-      attack_stab: -15
-      attack_slash: -15
-      attack_crush: -11
-      attack_magic: -10
-      attack_ranged: 7
-      defence_stab: 21
-      defence_slash: 18
-      defence_crush: 16
-      defence_magic: 15
-      defence_ranged: 14
-      melee_strength: 0
+    attack_bonus:
+      stab: -15
+      slash: -15
+      crush: -11
+      magic: -10
+      ranged: 7
+    defence_bonus:
+      stab: 21
+      slash: 18
+      crush: 16
+      magic: 15
+      ranged: 14
+    other_bonus:
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
-      prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: Rare
-        description: Reward from hard clue scroll caskets (1/9,750)
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Hard clue scroll reward casket
+        quantity: "1"
+        rarity: "1/9,750"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 23191
-      item_name: Saradomin d'hide shield
-      slug: saradomin-d-hide-shield
+    - name: Saradomin d'hide shield
       relationship: variant
-      description: Saradomin variant of blessed d'hide shield
-    - item_id: 23188
-      item_name: Guthix d'hide shield
-      slug: guthix-d-hide-shield
+    - name: Guthix d'hide shield
       relationship: variant
-      description: Guthix variant of blessed d'hide shield
-    - item_id: 23194
-      item_name: Zamorak d'hide shield
-      slug: zamorak-d-hide-shield
+    - name: Zamorak d'hide shield
       relationship: variant
-      description: Zamorak variant of blessed d'hide shield
-    - item_id: 23200
-      item_name: Armadyl d'hide shield
-      slug: armadyl-d-hide-shield
+    - name: Armadyl d'hide shield
       relationship: variant
-      description: Armadyl variant of blessed d'hide shield
-    - item_id: 23203
-      item_name: Bandos d'hide shield
-      slug: bandos-d-hide-shield
+    - name: Bandos d'hide shield
       relationship: variant
-      description: Bandos variant of blessed d'hide shield
-  about: |-
-    "Ancient blessed wooden shield covered in dragon leather."
-
-    The Ancient d'hide shield is a blessed dragonhide shield aligned with the Ancient religion of Zaros. It requires 70 Ranged and 40 Defence to equip and occupies the shield slot. Like all blessed d'hide shields, it offers solid ranged attack and defensive bonuses along with a +1 prayer bonus that regular dragonhide shields lack.
-
-    All six god d'hide shields share identical combat stats, so the choice between them is purely cosmetic or based on God Wars Dungeon faction protection. The Ancient d'hide shield provides protection from Zarosian-aligned NPCs in the God Wars Dungeon, specifically Nex and her followers in the Ancient Prison.
-
-    The blessed d'hide shields are comparable to the black d'hide shield but with an added +1 prayer bonus. For players seeking a ranged shield with prayer, these are a strong budget option. The book of law and other god books offer different stat distributions for the shield slot and may be preferred for offensive setups where the ranged attack bonus matters more than defence.
+    - name: Black d'hide shield
+      relationship: downgrade
+  about: "Ancient d'hide shield is a blessed dragonhide shield aligned with the Ancient (Zaros) religion. Requires 70 Ranged and 40 Defence. Shares stats with all six god d'hide shields and adds +1 prayer over the black d'hide shield."
   market_strategy:
-    title: Investment Notes
     notes:
-      - All god d'hide shield variants share the same stats, so price differences are driven by cosmetic demand
-      - Ancient variants appeal to players who favor the Zarosian aesthetic
-      - Supply is tied to hard clue scroll completion rates
-      - Compare prices across all six god variants before buying since stats are identical
-      - Useful for Ancient (Zaros) protection in the God Wars Dungeon
-      - Buy limit of 8 per 4 hours on the Grand Exchange
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - All god d'hide shield variants share identical stats — price gap is purely cosmetic demand.
+      - Supply is gated by hard clue scroll completion rates (1/9,750 per casket).
+      - Useful for Zaros-protection in the God Wars Dungeon's Ancient Prison.
+      - Buy limit 8 per 4 hours.
+  trading_tips:
+    - Compare prices across all six god variants before buying; pick the cheapest if you only need stats.
+    - Hard clue volume drives long-term supply — track price after big clue scroll events.
+  history:
+    - date: "2019-04-11"
+      description: "Released with the Treasure Trails Expansion and Easter 2019 update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: "Treasure Trails Expansion and Easter 2019"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-d-hide-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-d-hide-shield.mdx
@@ -95,7 +95,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-4.mdx
@@ -12,83 +12,68 @@ osrs:
   lowalch: 176
   highalch: 264
   limit: 2000
+  material:
+    type: potion
+    tier: high
   potion:
     doses: 4
-    herblore_level: 87
-    herblore_xp: 120
-    effect: Cures venom and provides 12 minutes of venom immunity
     effects:
-      - stat: Venom
-        boost_type: cure
-        description: Instantly cures venom
-      - stat: Venom immunity
-        boost_type: immunity
-        duration: 720
-        description: 12 minutes immunity per dose
+      - description: "Instantly cures venom and poison."
+      - description: "Grants 12 minutes of poison immunity per dose."
+      - description: "Grants 36 to 54 seconds of venom immunity per dose."
   recipes:
-    - skill: herblore
-      level: 87
-      xp: 120
-      materials:
+    - materials:
         - item_name: Antidote++(4)
-          item_id: 5952
           quantity: 1
         - item_name: Zulrah's scales
-          item_id: 12934
           quantity: 20
-      ticks: 2
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 5952
-      item_name: Antidote++(4)
+    - item_name: Antidote++(4)
       slug: antidote-4
       relationship: component
-      description: Base potion
-    - item_id: 12934
-      item_name: Zulrah's scales
+    - item_name: Zulrah's scales
       slug: zulrahs-scales
       relationship: component
-      description: Secondary ingredient
-    - item_id: 12913
-      item_name: Anti-venom+(4)
-      slug: anti-venom-4
+    - item_name: Anti-venom+(4)
+      slug: anti-venom-plus-4
       relationship: upgrade
-      description: Upgraded version
-    - item_id: 12931
-      item_name: Serpentine helm
+    - item_name: Serpentine helm
       slug: serpentine-helm
       relationship: alternative
-      description: Passive venom immunity
-  about: |-
-    Anti-venom provides:
-    - Instant venom cure
-    - 12 minutes of venom immunity per dose
-
-    Essential for fighting venomous creatures without serpentine helm.
-
-    | Input | Output | Herblore Level | XP |
-    |-------|--------|----------------|-----|
-    | Antidote++(4) + 20 Zulrah's scales | Anti-venom(4) | 87 | 120 |
+  about: "Four-dose anti-venom that instantly cures venom and grants venom immunity for 36-54 seconds plus 12 minutes of poison immunity, made at 87 Herblore from antidote++(4) and 20 Zulrah's scales."
   market_strategy:
-    steps:
-      - order: 1
-        action: Anti-venom(4) (venom immunity)
-      - order: 2
-        action: Add Torstol for Anti-venom+(4) (super antipoison + venom)
     notes:
       - 20 scales per potion is significant
       - Compare anti-venom cost vs serpentine helm charges
       - Scale price drives potion economics
-      - Zulrah (if not using serp helm)
-      - Theatre of Blood (Maiden, Xarpus)
-      - Vorkath (post-acid phase)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Brew when scales are cheap and decant for storage
+    - Upgrade to anti-venom+ with torstol for longer immunity
+  history:
+    - date: "2015-01-08"
+      description: Released with the Zulrah update.
+  properties:
+    release_date: "2015-01-08"
+    update: Zulrah
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-4.mdx
@@ -73,7 +73,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/arceuus-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/arceuus-banner.mdx
@@ -105,7 +105,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/arceuus-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/arceuus-banner.mdx
@@ -12,14 +12,100 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 4
+  material:
+    type: cosmetic
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: polestaff
+    attack_speed: 6
+    weight: 2.267
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 12
+      slash: 12
+      crush: 12
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/1133
+        members_only: true
+  related_items:
+    - item_id: 20245
+      item_name: Hosidius banner
+      slug: hosidius-banner
+      relationship: variant
+      description: Hosidius house banner variant
+    - item_id: 20247
+      item_name: Lovakengj banner
+      slug: lovakengj-banner
+      relationship: variant
+      description: Lovakengj house banner variant
+    - item_id: 20249
+      item_name: Piscarilius banner
+      slug: piscarilius-banner
+      relationship: variant
+      description: Piscarilius house banner variant
+    - item_id: 20253
+      item_name: Shayzien banner
+      slug: shayzien-banner
+      relationship: variant
+      description: Shayzien house banner variant
   about: "Arceuus banner is a members-only item in Old School RuneScape. High alchemy value: 42 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Medium clue reward, cosmetic polestaff
+      - Stats decent but overshadowed by combat weapons
+      - One of five Kourend house banners
+  trading_tips:
+    - Demand cosmetic / completionist focused
+    - Buy limit 4 keeps flipping volume low
+    - Track medium clue completion rates for supply
+  history:
+    - date: "2016-07-06"
+      description: Released with the Treasure Trail Expansion update.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-brew-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-brew-2.mdx
@@ -77,7 +77,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-brew-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-brew-2.mdx
@@ -12,14 +12,72 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
-  about: "Armadyl brew(2) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: high
+  potion:
+    doses: 2
+    effects:
+      - description: "Boosts Ranged by 10% + 4 of base level (overheals beyond max)."
+      - description: "Boosts Hitpoints by 10% + 2 of current level, allowing overheal."
+      - description: "Reduces Attack, Strength, Defence and Magic by 10% + 2 of current levels."
+      - description: "Boosted stats decay at 1 point per minute."
+  recipes:
+    - materials:
+        - item_name: Umbral potion (unf)
+          quantity: 1
+        - item_name: Rainbow crab paste
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Armadyl brew(4)
+      slug: armadyl-brew-4
+      relationship: variant
+    - item_name: Armadyl brew(3)
+      slug: armadyl-brew-3
+      relationship: variant
+    - item_name: Armadyl brew(1)
+      slug: armadyl-brew-1
+      relationship: variant
+    - item_name: Bastion potion(4)
+      slug: bastion-potion-4
+      relationship: alternative
+    - item_name: Saradomin brew(4)
+      slug: saradomin-brew-4
+      relationship: alternative
+  about: "Two-dose ranged variant of the Saradomin brew family, boosting Ranged and Hitpoints while draining other combat stats; requires 89 Herblore to make."
+  market_strategy:
+    notes:
+      - High-tier ranged switch potion
+      - 89 Herblore creation
+      - Overheals Hitpoints
+  trading_tips:
+    - Compare dose price vs (4) and (3) for best value
+    - Decant if cheaper per dose
+  history:
+    - date: "2025-11-19"
+      description: Released as part of the Armadyl brew herblore lineup.
+  properties:
+    release_date: "2025-11-19"
+    update: Armadyl brew release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armageddon-cape-fabric.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armageddon-cape-fabric.mdx
@@ -12,14 +12,51 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 5
-  about: "Armageddon cape fabric is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: fabric
+    tier: high
+  shops:
+    - shop_name: Deadman Reward Store
+      location: Deadman lobby
+      price: 6000 Deadman Points
+  related_items:
+    - item_name: Imbued saradomin cape
+      relationship: alternative
+    - item_name: Imbued guthix cape
+      relationship: alternative
+    - item_name: Imbued zamorak cape
+      relationship: alternative
+  about: "Armageddon cape fabric is a Deadman reward turned in to Nigel in Lumbridge to permanently unlock a Deadman: Armageddon cosmetic theme on the imbued Saradomin, Guthix, and Zamorak capes."
+  market_strategy:
+    notes:
+      - Originally sold by the Deadman Reward Store for 6,000 Deadman Points.
+      - One-time consumption per account unlocks cosmetic swaps on all three god capes.
+      - GE buy limit of 5 per 4 hours keeps multi-million coin trades slow.
+  trading_tips:
+    - Buyer base is god cape collectors with imbued capes already; pricing tracks god wars meta interest.
+    - Stockpile around new Deadman seasons when supply spikes from reward dumps.
+  history:
+    - date: "2024-08-07"
+      description: Added with the Poll 82 Changes update introducing tradeable Deadman cape fabrics.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-08-07"
+    update: "Poll 82 Changes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armageddon-cape-fabric.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armageddon-cape-fabric.mdx
@@ -56,7 +56,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/attack-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/attack-potion-4.mdx
@@ -12,14 +12,77 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 2000
+  potion:
+    doses: 4
+    effects:
+      - description: "Boosts Attack by 3 + 10% of the player's current Attack level (rounded down)."
+      - description: Stat boost decays at 1 level per minute (90 seconds with Preserve prayer active).
+  recipes:
+    - skill: Herblore
+      level: 3
+      xp: 25
+      materials:
+        - item_name: Guam potion (unf)
+          quantity: 1
+        - item_name: Eye of newt
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_id: 121
+      item_name: Attack potion(3)
+      slug: attack-potion-3
+      relationship: variant
+      description: 3-dose variant
+    - item_id: 123
+      item_name: Attack potion(2)
+      slug: attack-potion-2
+      relationship: variant
+      description: 2-dose variant
+    - item_id: 125
+      item_name: Attack potion(1)
+      slug: attack-potion-1
+      relationship: variant
+      description: 1-dose variant
+    - item_id: 2436
+      item_name: Super attack(4)
+      slug: super-attack-4
+      relationship: upgrade
+      description: Stronger Attack boost potion
   about: "Attack potion(4) is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Used by low-level Herblore trainers
+      - Boost is moderate and decays fast
+      - Often superseded by Super attack at higher levels
+  trading_tips:
+    - Buy in bulk for low-level Herblore training
+    - Resell margin is thin; rely on volume
+    - Cheaper than Super attack for early combat scenarios
+  history:
+    - date: "2002-02-27"
+      description: Released alongside the Herblore skill.
+  properties:
+    release_date: "2002-02-27"
+    update: Herblore Release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/attack-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/attack-potion-4.mdx
@@ -82,7 +82,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/axeman-s-folly-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/axeman-s-folly-m4.mdx
@@ -71,7 +71,10 @@ osrs:
     alchable: false
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/axeman-s-folly-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/axeman-s-folly-m4.mdx
@@ -12,14 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
+  potion:
+    effects:
+      - description: "Temporarily boosts Woodcutting level by +2 when drunk; matches the per-glass mature Axeman's folly effect."
+  recipes:
+    - materials:
+        - item_name: Calquat keg
+          quantity: 1
+        - item_name: Axeman's folly (m)
+          quantity: 4
+      tools:
+        - Beer glass
+      output_quantity: 1
+      notes: "Pour four pints of mature Axeman's folly into a calquat keg; brewed via the Brewing process after fermenting in a vat."
+  related_items:
+    - name: Axeman's folly (m)
+      relationship: component
+    - name: Axeman's folly(m1)
+      relationship: variant
+    - name: Axeman's folly(m2)
+      relationship: variant
+    - name: Axeman's folly(m3)
+      relationship: variant
+    - name: Calquat keg
+      relationship: component
   about: "Axeman's folly(m4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Full 4-pint keg of mature Axeman's folly; non-alchable, so price floor is set by GE demand.
+      - Partially drunk kegs are untradeable since the 2015 update — only the full m4 trades on GE.
+      - Brewed via vat fermentation then poured into a calquat keg.
+  trading_tips:
+    - Buy limit of 2,000 per 4 hours allows bulk acquisition for Woodcutting bonus stacking.
+    - Check GE margins vs. self-brewing cost (barley malt + oak roots + ale yeast + calquat keg).
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming Update."
+    - date: "2005-10-04"
+      description: "Renamed from 'Axeman's folly(n)' to 'Axeman's folly(mn)' naming scheme."
+    - date: "2015-02-26"
+      description: "Partially drunk versions (m1-m3) became untradeable."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-07-11"
+    update: "Farming Update"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-boots.mdx
@@ -105,7 +105,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-boots.mdx
@@ -12,39 +12,50 @@ osrs:
   lowalch: 115604
   highalch: 173406
   limit: 8
+  material:
+    type: bandos
+    tier: high
   equipment:
     slot: feet
-    type: melee_boots
-    tradeable: true
     weight: 6
     requirements:
       defence: 65
-    stats:
-      defence_stab: 17
-      defence_slash: 18
-      defence_crush: 19
-      defence_ranged: 15
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 17
+      slash: 18
+      crush: 19
+      magic: 0
+      ranged: 15
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 1
-  obtaining:
-    methods:
+  drop_table:
+    sources:
       - source: General Graardor
+        combat_level: 624
+        quantity: "1"
+        rarity: rare
         drop_rate: 1/381
+        members_only: true
   related_items:
-    - item_id: 0
-      item_name: General Graardor
-      slug: general-graardor
-      relationship: component
-      description: Boss drop
     - item_id: 21733
       item_name: Guardian boots
       slug: guardian-boots
       relationship: upgrade
-      description: Upgrade
+      description: Upgraded variant combining Bandos boots with Black tourmaline core
     - item_id: 13239
       item_name: Primordial boots
       slug: primordial-boots
       relationship: alternative
-      description: Offensive alternative
+      description: Offensive melee boots with Strength bonus
   about: |-
     | Defence | Bonus |
     |---------|-------|
@@ -52,31 +63,49 @@ osrs:
     | Slash | +18 |
     | Crush | +19 |
     | Ranged | +15 |
-
     | Other | Bonus |
     |-------|-------|
     | Prayer | +1 |
-
     No strength bonus.
-
     Used for:
     - Defensive tank builds
     - Budget boots
     - Upgrades to Guardian boots
-
     Defence-focused boots (no strength).
   market_strategy:
     notes:
       - From General Graardor (GWD)
       - No strength bonus
       - Upgrade to Guardian boots
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - 8 per 4h limit, low-volume luxury
+  trading_tips:
+    - Track Bandos PvM popularity for entry-tank demand
+    - Pair with Black tourmaline core to make Guardian boots
+    - Avoid alching, price greatly exceeds high alch
+  history:
+    - date: "2013-10-17"
+      description: Added to General Graardor's drop table in the Bandos rework.
+  properties:
+    release_date: "2013-10-17"
+    update: Bandos rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-page-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-page-3.mdx
@@ -12,48 +12,53 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 5
-  item:
-    type: god_page
-    god: Bandos
-    page_number: 3
-    tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite
-        drop_rate: Varies by tier
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
   related_items:
-    - item_id: 12613
-      item_name: Bandos page 1
-      slug: bandos-page-1
+    - name: Bandos page 1
       relationship: set-piece
-      description: Page 1 of 4
-    - item_id: 12614
-      item_name: Bandos page 2
-      slug: bandos-page-2
+    - name: Bandos page 2
       relationship: set-piece
-      description: Page 2 of 4
-    - item_id: 12616
-      item_name: Bandos page 4
-      slug: bandos-page-4
+    - name: Bandos page 4
       relationship: set-piece
-      description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Bandos |
-    | Page | 3 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of war (Bandos god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Book of war
+      relationship: product
+  about: "Bandos page 3 is one of four torn pages combined to assemble the Book of war, a Bandos god book obtained as a Treasure Trails reward across most clue tiers."
+  market_strategy:
+    notes:
+      - "GE price near 1,497 gp with a tight 5-per-4-hours buy limit."
+      - "Daily volume around 301 makes timed bids more reliable than market dumps."
+  trading_tips:
+    - "Bundle all four pages plus a Holy book to flip a completed Book of war for the spread."
+    - "Watch clue scroll content updates - new reward tables can shift god-page supply quickly."
+  history:
+    - date: "2014-07-03"
+      description: "Released with the Halos, God Books & Stamina update."
+  properties:
+    release_date: "2014-07-03"
+    update: "Halos, God Books & Stamina"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-page-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-page-3.mdx
@@ -58,7 +58,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-rune-armour-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-rune-armour-set-sk.mdx
@@ -12,14 +12,49 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Bandos rune armour set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: high
+  related_items:
+    - item_name: Bandos full helm
+      relationship: set-piece
+    - item_name: Bandos platebody
+      relationship: set-piece
+    - item_name: Bandos plateskirt
+      relationship: set-piece
+    - item_name: Bandos kiteshield
+      relationship: set-piece
+  about: "Bandos rune armour set (sk) is a Grand Exchange convenience bundle containing the Bandos full helm, platebody, plateskirt, and kiteshield, exchanged via the Sets interface with a clerk."
+  market_strategy:
+    notes:
+      - Assembled and broken down through the Grand Exchange clerk's Sets option, so set premium tracks component spreads.
+      - Buy limit is 8 sets per 4 hours; the bundle is non-equipable until exchanged for the individual pieces.
+      - Plateskirt variant (sk) shares stats with the platelegs version but is preferred by some cosmetic builds.
+  trading_tips:
+    - Compare set price vs the sum of the four components to flip arbitrage opportunities.
+    - Demand picks up during god-themed events or PvP tournaments featuring rune-tier armour.
+  history:
+    - date: "2015-02-26"
+      description: Added with the Grand Exchange Sets interface expansion that bundled cosmetic god armours.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-02-26"
+    update: "The Grand Exchange"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-rune-armour-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-rune-armour-set-sk.mdx
@@ -54,7 +54,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/battlefront-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/battlefront-teleport-tablet.mdx
@@ -65,7 +65,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/battlefront-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/battlefront-teleport-tablet.mdx
@@ -12,14 +12,60 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Battlefront teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Ancient grave outside the Kebos Battlefront
+    consumed: true
+    requirements: {}
+  recipes:
+    - materials:
+        - item_name: Law rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 1
+        - item_name: Dark essence block
+          quantity: 1
+      tools:
+        - Lectern
+      skill: Magic
+      level: 23
+      xp: 19
+      output_quantity: 1
+      notes: "Crafted on the Arceuus lectern in Ouditor's house while the Arceuus spellbook is active."
+  about: "Battlefront teleport (tablet) is a single-use Arceuus tablet that teleports the user to the ancient grave just outside the Kebos Battlefront."
+  market_strategy:
+    notes:
+      - "Supply is driven by Arceuus tablet farmers crafting via the lectern, so price tracks dark essence block availability."
+      - "GE buy limit of 10,000 per 4 hours supports bulk PvM travel stocks for slayer alts."
+      - "High alch is below value, so flippers rely on spread, not alching."
+  trading_tips:
+    - "Stock up when dark essence block supply spikes; tablet price tends to follow essence block cost."
+    - "Use as a fast travel option to lizardman shamans and the Wintertodt area south of the Battlefront."
+    - "Avoid manual breaking if you want full XP; only level 23 Magic users gain XP from the tablet."
+  properties:
+    release_date: "2019-01-10"
+    update: "The Kebos Lowlands"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2019-01-10"
+      description: "Released with The Kebos Lowlands update as part of the Arceuus lectern tablet line."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/battlemage-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/battlemage-potion-4.mdx
@@ -84,7 +84,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/battlemage-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/battlemage-potion-4.mdx
@@ -12,58 +12,79 @@ osrs:
   lowalch: 144
   highalch: 216
   limit: 2000
-  item:
-    type: potion
-    tradeable: true
+  potion:
     doses: 4
-    weight: 0.135
-    requirements:
-      herblore: 80
-  effect:
-    boost:
-      - skill: magic
-        amount: 4
-      - skill: defence
-        amount: 5 + 15% of level
-    duration: 60
-    preserve_duration: 90
+    effects:
+      - description: "Boosts Magic by +4 levels."
+        skill: magic
+        boost: 4
+      - description: "Boosts Defence by 5 + 15% of the player's Defence level (rounded down)."
+        skill: defence
+        boost_formula: "5 + 15% of level"
+      - description: "Boost decays 1 point per minute (90 seconds with the Preserve prayer)."
+        duration_seconds: 60
+        preserve_duration_seconds: 90
+  recipes:
+    - materials:
+        - item_name: Cadantine blood potion (unf)
+          quantity: 1
+        - item_name: Potato cactus
+          quantity: 1
+      tools: []
+      skill: Herblore
+      level: 80
+      xp: 155
+      output_quantity: 1
   related_items:
     - item_id: 3040
       item_name: Magic potion
       slug: magic-potion
-      relationship: component
-      description: Ingredient for battlemage potion
+      relationship: alternative
+      description: Boosts only Magic; cheaper but weaker overall.
     - item_id: 2440
       item_name: Super defence
       slug: super-defence
-      relationship: component
-      description: Ingredient for battlemage potion
+      relationship: alternative
+      description: Pure defence boost without magic component.
     - item_id: 23582
       item_name: Divine battlemage potion
       slug: divine-battlemage-potion
       relationship: upgrade
-      description: Enhanced version with maintained boost
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Combat Potion |
-    | Tradeable | Yes |
-    | Weight | 0.135 kg |
-    | Requirements | 80 Herblore |
-
-    Boosts Magic by +4.
-
-    Boosts Defence by 5 + 15% of level.
-
-    Decays 1 point/minute (90 seconds with Preserve).
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Maintains boost for 5 minutes instead of decaying.
+  about: "Battlemage potion(4) is a combo magic/defence potion that grants +4 Magic and 5 + 15% Defence, popular for hybrid PvP and Theatre of Blood mage rooms."
+  market_strategy:
+    notes:
+      - "Demand is driven by Theatre of Blood mage strategies and hybrid PvP brews; price tracks ToB participation."
+      - "GE buy limit of 2,000 per 4 hours limits bulk PvM stockpiling."
+      - "Cadantine blood potion (unf) cost is the main margin lever for crafters."
+  trading_tips:
+    - "Stock cadantine blood potions when blood runes are cheap to make finished potions for profit."
+    - "Stack divine battlemage potions instead for boss runs needing the no-decay variant."
+    - "Avoid alching; high alch (216 gp) is far below GE price."
+  properties:
+    release_date: "2018-06-07"
+    update: "Theatre of Blood"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.135
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2018-06-07"
+      description: "Released with the Theatre of Blood update as part of the new combo-potion line."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-beret.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-beret.mdx
@@ -15,23 +15,70 @@ osrs:
   equipment:
     slot: head
     requirements: {}
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 2637
       item_name: White beret
       slug: white-beret
       relationship: variant
       description: White colour variant
+    - item_id: 2633
+      item_name: Blue beret
+      slug: blue-beret
+      relationship: variant
+      description: Blue colour variant
+    - item_id: 2639
+      item_name: Red beret
+      slug: red-beret
+      relationship: variant
+      description: Red colour variant
+    - item_id: 6857
+      item_name: Beret mask
+      slug: beret-mask
+      relationship: product
+      description: Combined with mime mask via Patchy on Mos Le'Harmless
   about: |-
     > *"Parlez-vous francais?"*
-
     The black beret is a purely cosmetic head slot item from easy treasure trails. No combat bonuses. Can be combined with a mime mask to create a beret mask.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Pure cosmetic with zero combat bonuses; demand driven by fashionscape and beret mask crafters.
+      - Easy clue reward rarity 1/1,404 keeps supply trickling in; low GE limit (4) makes flips slow.
+  trading_tips:
+    - Watch for spikes around clue-related updates or mime random event revivals.
+    - Stack with mime mask buys when planning to craft a beret mask.
+  history:
+    - date: "2004-05-05"
+      description: Released alongside Bigger Banks & Treasure Trails update.
+    - date: "2004-10-14"
+      description: Renamed from "Berret" to "Beret".
+    - date: "2005-05-17"
+      description: Renamed to "Black beret"; examine text updated to current French phrase.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-05-05"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-beret.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-beret.mdx
@@ -78,7 +78,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-d-hide-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-d-hide-shield.mdx
@@ -12,14 +12,108 @@ osrs:
   lowalch: 11333
   highalch: 17000
   limit: 125
+  material:
+    type: dragonhide
+    tier: high
+  equipment:
+    slot: shield
+    weapon_type: not_applicable
+    weight: 8
+    requirements:
+      ranged: 70
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 21
+      slash: 18
+      crush: 16
+      magic: 15
+      ranged: 14
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Crafting
+      level: 83
+      experience: 124
+      materials:
+        - item_name: Black dragon leather
+          quantity: 2
+        - item_name: Redwood shield
+          quantity: 1
+        - item_name: Rune nails
+          quantity: 15
+      tools:
+        - Hammer
+        - Needle
+        - Thread
+      output_quantity: 1
+      output_item: Black d'hide shield
+  related_items:
+    - item_id: 22280
+      item_name: Green d'hide shield
+      slug: green-dhide-shield
+      relationship: downgrade
+      description: Lower-tier dragonhide shield
+    - item_id: 22281
+      item_name: Blue d'hide shield
+      slug: blue-dhide-shield
+      relationship: downgrade
+      description: Lower-tier dragonhide shield
+    - item_id: 22282
+      item_name: Red d'hide shield
+      slug: red-dhide-shield
+      relationship: downgrade
+      description: Lower-tier dragonhide shield
+    - item_id: 12954
+      item_name: Twisted buckler
+      slug: twisted-buckler
+      relationship: upgrade
+      description: BiS ranged shield from Chambers of Xeric
+    - item_id: 22547
+      item_name: Dragonfire ward
+      slug: dragonfire-ward
+      relationship: alternative
+      description: Higher-tier hybrid shield
+  market_strategy:
+    notes:
+      - "BiS F2P-style ranged shield in members; competes with twisted buckler at top end."
+      - "Crafting at 83 with redwood shield + black dhide + rune nails; marginal loss vs GE."
+  trading_tips:
+    - "Watch for raids-meta shifts that drive twisted buckler demand; this is the budget fallback."
+    - "Buy during Wilderness boss content droughts when supply softens."
   about: "Black d'hide shield is a members-only item in Old School RuneScape. High alchemy value: 17,000 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  history:
+    - date: "2018-02-01"
+      description: Released with the Leather Shields and Tournament Worlds update.
+  properties:
+    release_date: "2018-02-01"
+    update: Leather Shields and Tournament Worlds
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-d-hide-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-d-hide-shield.mdx
@@ -113,7 +113,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-headband.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-headband.mdx
@@ -12,14 +12,94 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 4
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: head
+    weapon_type: not_applicable
+    weight: 0.04
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 2649
+      item_name: Brown headband
+      slug: brown-headband
+      relationship: alternative
+      description: Colour variant from Treasure Trails
+    - item_id: 2651
+      item_name: White headband
+      slug: white-headband
+      relationship: alternative
+      description: Colour variant from Treasure Trails
+    - item_id: 2653
+      item_name: Red headband
+      slug: red-headband
+      relationship: alternative
+      description: Colour variant from Treasure Trails
+    - item_id: 2655
+      item_name: Blue headband
+      slug: blue-headband
+      relationship: alternative
+      description: Colour variant from Treasure Trails
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  market_strategy:
+    notes:
+      - "Hard clue cosmetic reward with a 4/4hr GE limit; supply is thin."
+      - "Required for the Panic emote clue south of the Blighted Volcano bridge (with Guthix crozier)."
+  trading_tips:
+    - "Stock before hard clue scroll events or new emote clue meta announcements."
+    - "Long-term hold candidate due to fixed supply rate."
   about: "Black headband is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  history:
+    - date: "2004-05-05"
+      description: Released as a Treasure Trails reward in the Bigger Banks & Treasure Trails update.
+    - date: "2005-05-01"
+      description: Renamed from Headband to Black headband.
+    - date: "2005-07-01"
+      description: Examine text corrected from minimilist to minimalist.
+  properties:
+    release_date: "2004-05-05"
+    update: Bigger Banks & Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-headband.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-headband.mdx
@@ -99,7 +99,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-pickaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-pickaxe.mdx
@@ -85,7 +85,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-pickaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-pickaxe.mdx
@@ -12,44 +12,80 @@ osrs:
   lowalch: 58
   highalch: 87
   limit: 4
+  material:
+    type: black
+    tier: mid
   equipment:
     slot: weapon
-    type: pickaxe
-    tradeable: true
+    weapon_type: pickaxe
+    attack_speed: 5
     weight: 0.01
     requirements:
       attack: 10
       mining: 11
-    stats:
-      attack_stab: 10
-      attack_slash: -2
-      attack_crush: 8
+    attack_bonus:
+      stab: 10
+      slash: -2
+      crush: 8
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 11
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Beginner and Easy
-  usage:
-    description: Mining tool. Lightest pickaxe available. Same speed as mithril pickaxe.
+      prayer: 0
+  treasure_trail:
+    tier: beginner
+    is_reward: true
+    reward_tiers:
+      - beginner
+      - easy
   related_items:
     - item_id: 1273
       item_name: Mithril pickaxe
       slug: mithril-pickaxe
       relationship: alternative
-      description: Same speed
+      description: Same mining speed as black pickaxe
     - item_id: 1275
       item_name: Rune pickaxe
       slug: rune-pickaxe
       relationship: upgrade
-      description: Upgrade
-  about: Mining tool. Lightest pickaxe available. Same speed as mithril pickaxe.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Faster mining upgrade
+  about: The lightest pickaxe in the game, ideal for activities requiring mobility such as questing or Abyss training. Mines at the same speed as a mithril pickaxe.
+  market_strategy:
+    notes:
+      - Niche demand driven by lightweight builds and clue scroll completionists.
+      - GE limit of 4 makes flipping margins small but consistent.
+  trading_tips:
+    - Buy from beginner and easy clue scroll rewards for instant supply.
+    - Hold during Abyss/RC training meta shifts when weight reduction matters.
+  history:
+    - date: "2014-06-12"
+      description: Black pickaxe added to the game as a treasure trail reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Rewards
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-platelegs-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-platelegs-g.mdx
@@ -81,7 +81,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-platelegs-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-platelegs-g.mdx
@@ -12,32 +12,76 @@ osrs:
   lowalch: 768
   highalch: 1152
   limit: 8
+  material:
+    type: black
+    tier: low
   equipment:
     slot: legs
+    weight: 9.071
     requirements:
       defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 21
+      slash: 20
+      crush: 19
+      magic: -4
+      ranged: 22
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 2591
-      item_name: Black platebody (g)
-      slug: black-platebody-g
+    - item_name: Black platebody (g)
       relationship: set-piece
-      description: Matching gold-trimmed platebody
-    - item_id: 2585
-      item_name: Black platelegs (t)
-      slug: black-platelegs-t
+    - item_name: Black platelegs (t)
       relationship: variant
-      description: Trimmed variant
-  about: |-
-    > *"Black platelegs with gold trim."*
-
-    The black platelegs (g) are a gold-trimmed cosmetic variant of standard black platelegs. Identical stats, requiring 10 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Black platelegs
+      relationship: variant
+  about: "The black platelegs (g) are a gold-trimmed cosmetic variant of standard black platelegs awarded from easy clue scroll caskets, sharing identical defensive stats with the base version."
+  market_strategy:
+    notes:
+      - Supplied solely by easy clue scroll caskets at roughly 1/1,404 per reward roll.
+      - Buy limit of 8 every 4 hours keeps prices sensitive to clue-running activity.
+      - Cosmetic value drives the markup over the base black platelegs.
+  trading_tips:
+    - Track easy clue completion meta; supply rises when easy clues are popular.
+    - Store finished sets in the costume room chest to keep bank space free while flipping pieces.
+  history:
+    - date: "2004-05-05"
+      description: Released as part of the Bigger Banks & Treasure Trails update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-05-05"
+    update: "Bigger Banks & Treasure Trails"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-warhammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-warhammer.mdx
@@ -98,7 +98,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-warhammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-warhammer.mdx
@@ -5,53 +5,100 @@ osrs:
   id: 1341
   name: Black warhammer
   slug: black-warhammer
-  examine: I don't think it's intended for joinery.
+  examine: "I don't think it's intended for joinery."
   members: false
   icon: Black warhammer.png
   value: 980
   lowalch: 392
   highalch: 588
   limit: 125
+  material:
+    type: black
+    tier: mid
   equipment:
     slot: weapon
-    type: warhammer
-    tradeable: true
+    weapon_type: warhammer
+    attack_speed: 6
     weight: 1.814
     requirements:
       attack: 10
-    stats:
-      attack_stab: -4
-      attack_slash: -4
-      attack_crush: 22
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: -4
+      slash: -4
+      crush: 22
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 22
-      ranged_strength: 0
-      magic_damage: 0
       prayer: 0
+  drop_table:
+    sources:
+      - source: Mountain troll
+        quantity: "1"
+        rarity: Uncommon
+      - source: Ice troll
+        quantity: "1"
+        rarity: Uncommon
+      - source: Spiritual warrior
+        quantity: "1"
+        rarity: Rare
+  shops:
+    - shop_name: Skulgrimen's Battle Gear
+      location: Rellekka
+      price: 1274
+      stock: 3
+    - shop_name: "Vigr's Warhammers"
+      location: Keldagrim
+      price: 1274
+      stock: 3
   related_items:
     - item_id: 1343
       item_name: Mithril warhammer
       slug: mithril-warhammer
       relationship: upgrade
-      description: Higher tier warhammer
+      description: Higher tier warhammer one step above black.
     - item_id: 1426
       item_name: Black mace
       slug: black-mace
       relationship: alternative
-      description: Alternative crush weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Alternative crush weapon with lower strength but faster speed.
+  about: F2P-tier crush weapon; mid-game stepping stone before mithril for crush-weakness training.
+  market_strategy:
+    notes:
+      - Demand stable from F2P pures and early-game crushers.
+      - Shop supply caps profit but keeps prices anchored near 1.2k.
+  trading_tips:
+    - Buy from Rellekka or Keldagrim shops and flip on GE during F2P events.
+    - Watch troll task assignment metas; drop supply spikes during Slayer pushes.
+  history:
+    - date: "2004-03-29"
+      description: Black warhammer added with the warhammer weapon class.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: Warhammer weapons
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-myre-shell-pointed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-myre-shell-pointed.mdx
@@ -65,7 +65,10 @@ osrs:
     alchable: true
     destroy: Drop
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-myre-shell-pointed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-myre-shell-pointed.mdx
@@ -5,21 +5,67 @@ osrs:
   id: 3355
   name: Blamish myre shell (pointed)
   slug: blamish-myre-shell-pointed
-  examine: A large 'Myre' coloured blamish snail shell, looks protective.
+  examine: "A large 'Myre' coloured blamish snail shell, looks protective."
   members: true
   icon: Blamish myre shell (pointed).png
   value: 150
   lowalch: 60
   highalch: 90
   limit: 13000
+  drop_table:
+    sources:
+      - source: Myre blamish snail (pointed)
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - name: Craft pointed myre snelm
+      skill: Crafting
+      level: 15
+      experience: 32.5
+      materials:
+        - item_name: Blamish myre shell (pointed)
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+      output_item: Myre snelm (pointed)
+  related_items:
+    - name: Myre snelm (pointed)
+      relationship: product
+    - name: Blamish myre shell (round)
+      relationship: alternative
+    - name: Blamish ochre shell (pointed)
+      relationship: alternative
   about: "Blamish myre shell (pointed) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Dropped exclusively by Myre blamish snails in Mort Myre Swamp.
+      - Crafted into a pointed myre snelm with a chisel at Crafting level 15.
+      - Snelms are a low-tier helmet alternative for early Crafting training.
+  trading_tips:
+    - Daily volume is very low; expect slow fills on the Grand Exchange.
+    - Combat-only Crafting trainers may prefer collecting shells over buying.
+  history:
+    - date: "2004-10-14"
+      description: Item released with the Morytania expansion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-14"
+    update: Morytania Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-cape.mdx
@@ -114,7 +114,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-cape.mdx
@@ -12,14 +12,109 @@ osrs:
   lowalch: 12
   highalch: 19
   limit: 150
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: cape
+    weapon_type: not_applicable
+    weight: 0.453
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Valaine's Shop of Champions
+      location: Champions' Guild
+      stock: 5
+      price: 41
+      restock_time: 1 minute
+    - shop_name: Barkers' Haberdashery
+      location: Canifis
+      stock: 5
+      price: 41
+      restock_time: 1 minute
+    - shop_name: Shayzien Styles
+      location: Shayzien
+      stock: 5
+      price: 32
+      restock_time: 1 minute
+  recipes:
+    - skill: Crafting
+      level: 1
+      experience: 2.5
+      materials:
+        - item_name: Black cape
+          quantity: 1
+        - item_name: Blue dye
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      output_item: Blue cape
+      notes: Any plain cape (black, green, orange, pink, purple, red, yellow) accepted
+  related_items:
+    - item_id: 1019
+      item_name: Black cape
+      slug: black-cape
+      relationship: alternative
+      description: Plain cape variant
+    - item_id: 1027
+      item_name: Red cape
+      slug: red-cape
+      relationship: alternative
+      description: Plain cape variant
+    - item_id: 1037
+      item_name: Team cape zero
+      slug: team-cape-zero
+      relationship: alternative
+      description: Team cape series
+  market_strategy:
+    notes:
+      - "Cosmetic F2P cape with thin GE volume."
+      - "Crafted via Crafting 1 with blue dye on any plain cape; supply is elastic."
+  trading_tips:
+    - "Buy from Shayzien Styles at 32 gp for instant alch profit (19 high alch ignores tax, but break-even when stock low)."
+    - "Quest-related demand (Wanted!) drives short spikes."
   about: "Blue cape is a free-to-play item in Old School RuneScape. High alchemy value: 19 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  history:
+    - date: "2001-02-13"
+      description: Released in early RuneScape Classic.
+  properties:
+    release_date: "2001-02-13"
+    update: Early Capes update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-chestplate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-chestplate.mdx
@@ -12,9 +12,15 @@ osrs:
   lowalch: 116004
   highalch: 174006
   limit: 15
+  material:
+    type: blue-moon
+    tier: high
   equipment:
     slot: body
     weight: 3.175
+    requirements:
+      magic: 75
+      defence: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,20 +38,18 @@ osrs:
       ranged_strength: 0
       magic_damage: 1
       prayer: 0
-    requirements:
-      magic: 75
-      defence: 50
+  charges:
+    max_charges: 3000
+    charge_rate: 1 per 54 seconds of combat
+    combat_duration_hours: 45
+    npc_repair_cost: 1500000
+    player_repair_cost_at_99_smithing: 757500
     degradable: true
-    charges: 3000
   drop_table:
-    primary_source: Lunar Chest (Neypotzli)
-    best_drop_rate: 1/224
     sources:
       - source: Lunar Chest
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/224
-        members_only: true
+        rarity: 1/224
   related_items:
     - item_id: 28988
       item_name: Blue moon spear
@@ -65,7 +69,6 @@ osrs:
   about: |-
     When wearing the full Blue moon armour set with the Blue moon spear:
     - Frostweaver: After casting a bind spell, 20% chance for next melee attack to be unaffected by action delays
-
     | Property | Value |
     |----------|-------|
     | Total charges | 3,000 |
@@ -73,7 +76,6 @@ osrs:
     | Combat duration | ~45 hours |
     | NPC repair cost | 1,500,000 coins |
     | Repair at 99 Smithing | 757,500 coins |
-
     Magic-melee hybrid body for Blue moon builds:
     - +30 magic attack
     - +2 strength bonus
@@ -83,13 +85,30 @@ osrs:
       - Core piece for Blue moon builds
       - Good magic attack bonus
       - Factor in repair costs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2024-03-20"
+      description: Released with Varlamore Part One update as a drop from Lunar Chest in Neypotzli.
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore - Part One
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-chestplate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-chestplate.mdx
@@ -108,7 +108,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bone-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bone-bolts.mdx
@@ -90,7 +90,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bone-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bone-bolts.mdx
@@ -12,8 +12,14 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
+  material:
+    type: bone
+    tier: low
   equipment:
     slot: ammo
+    weight: 0
+    requirements:
+      ranged: 28
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,15 +37,11 @@ osrs:
       ranged_strength: 49
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 28
-    weight: 0
-  shop_sources:
+  shops:
     - shop_name: Nardok's Bone Weapons
       location: Dorgesh-Kaan
       price: 3
       stock: 1000
-      members_only: true
   related_items:
     - item_id: 8880
       item_name: Dorgeshuun crossbow
@@ -50,33 +52,45 @@ osrs:
     | Other | Value |
     |-------|-------|
     | Ranged Strength | +49 |
-
     Requirements: 28 Ranged | Weight: 0 kg
-
     Bone bolts are the cheapest effective ranged ammunition in OSRS at ~3-6 GP each. They can only be fired from the Dorgeshuun crossbow.
-
     | Ammo | Cost | Ranged Str | Crossbow |
     |------|------|-----------|----------|
     | Bone bolts | ~6 GP | +49 | Dorgeshuun |
     | Iron bolts | ~20 GP | +46 | Any bronze+ |
     | Broad bolts | ~50 GP | +100 | Rune+ |
     | Amethyst broad | ~100 GP | +115 | Rune+ |
-
     Despite lower ranged strength, the Dorgeshuun crossbow's faster speed combined with bone bolts' negligible cost makes this the most GP-efficient ranged training setup.
-
     At ~1,500 bolts/hour on rapid: ~9,000 GP/hour ammo cost versus ~75,000+ for broad bolts.
   market_strategy:
     notes:
       - Buy from Nardok at 3 GP (vs ~6 GP on GE)
       - Ideal for budget ranged training and ironmen
       - Pairs exclusively with Dorgeshuun crossbow
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2006-06-21"
+      description: Released alongside the Death to the Dorgeshuun quest as ammunition for the Dorgeshuun crossbow.
+  properties:
+    release_date: "2006-06-21"
+    update: Death to the Dorgeshuun
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-of-clay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-of-clay.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 506
   highalch: 759
   limit: 10000
+  material:
+    type: jewellery
+    tier: mid
   equipment:
     slot: hands
-    weight: 0.007
+    weight: 0.25
     attack_bonus:
       stab: 0
       slash: 0
@@ -33,29 +36,22 @@ osrs:
       magic_damage: 0
       prayer: 0
   charges:
-    current: 28
-    max: 28
-    recharge: Not rechargeable - breaks after use
-  special_effect:
-    name: Soft Clay Effect
-    description: Mining clay while worn gives soft clay directly instead of clay
-    triggers: on_mine_clay
+    max_charges: 28
+    recharge_method: Not rechargeable - crumbles to dust after 28 uses
   recipes:
-    - skill: magic
-      level: 23
-      xp: 37
-      spell: Lvl-2 Enchant
+    - skill: Magic
+      level: 7
+      xp: 17.5
+      spell: Lvl-1 Enchant
       materials:
         - item_name: Sapphire bracelet
-          item_id: 11072
           quantity: 1
         - item_name: Cosmic rune
-          item_id: 564
           quantity: 1
-        - item_name: Air rune
-          item_id: 556
-          quantity: 3
-      members_only: true
+        - item_name: Water rune
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
     - item_id: 11072
       item_name: Sapphire bracelet
@@ -77,37 +73,52 @@ osrs:
     |-------|---------|
     | New | 28 |
     | Depleted | Crumbles to dust |
-
     Soft Clay Effect:
     - Mining clay while wearing gives soft clay directly
     - Saves time on water bucket step
     - 28 uses before bracelet crumbles
-
+    - In Trahaearn mine, allows mining two soft clay at once
     | Requirement | Value |
     |-------------|-------|
-    | Magic | 23 |
-    | Spell | Lvl-2 Enchant |
-    | Materials | Sapphire bracelet + 3 air + 1 cosmic |
+    | Magic | 7 |
+    | Spell | Lvl-1 Enchant |
+    | Materials | Sapphire bracelet + 1 water + 1 cosmic |
   market_strategy:
     notes:
       - Saves time making soft clay
       - Popular for Crafting training
       - Low cost per use
-      - Crafting training
-      - Pottery makers
-      - Ironmen
-      - Efficient players
-      - Very cheap per soft clay
       - Essential for efficient clay gathering
-      - Popular among crafters
       - Crumbles after 28 uses
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Buy in bulk for Crafting training sessions
+    - Cheaper to enchant sapphire bracelets directly than buy GE
+    - Useful for ironmen avoiding the water bucket step
+  history:
+    - date: "2007-04-30"
+      description: Released as part of the 24 Carat update.
+  properties:
+    release_date: "2007-04-30"
+    update: 24 Carat
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Check
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-of-clay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-of-clay.mdx
@@ -118,7 +118,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-battleaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-battleaxe.mdx
@@ -102,7 +102,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-battleaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-battleaxe.mdx
@@ -12,28 +12,52 @@ osrs:
   lowalch: 20
   highalch: 31
   limit: 125
+  material:
+    type: bronze
+    tier: low
   equipment:
     slot: weapon
-    type: battleaxe
-    tradeable: true
+    weapon_type: battleaxe
+    attack_speed: 6
     weight: 2.721
     requirements:
       attack: 1
-    stats:
-      attack_stab: -2
-      attack_slash: 6
-      attack_crush: 3
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 9
+    attack_bonus:
+      stab: -2
+      slash: 6
+      crush: 3
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    other_bonus:
+      melee_strength: 9
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  recipes:
+    - skill: Smithing
+      level: 10
+      xp: 37.5
+      materials:
+        - item_name: Bronze bar
+          quantity: 3
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Brian's Battleaxe Bazaar
+      location: Port Sarim
+      sell_price: 52
+    - shop_name: Lunami's Axe Shop
+      location: Auburnvale
+      members_only: true
+      sell_price: 52
   related_items:
     - item_id: 1363
       item_name: Iron battleaxe
@@ -45,13 +69,40 @@ osrs:
       slug: bronze-sword
       relationship: alternative
       description: Better accuracy alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Bronze battleaxe is an entry-level F2P slash weapon usable from 1 Attack. Smithed at 10 Smithing using 3 bronze bars.
+  market_strategy:
+    notes:
+      - Entry-level F2P weapon
+      - High alch is below smithing cost; alch-loss item
+      - Niche demand from new accounts only
+  trading_tips:
+    - Volumes low; resell margin thin
+    - Avoid alching unless flipping shop stock
+    - Smithing it for XP is generally cheaper than buying
+  history:
+    - date: "2001-01-04"
+      description: Released with the RuneScape beta launch.
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape beta launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-10-combat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-10-combat.mdx
@@ -12,14 +12,90 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 125
-  about: "Broodoo shield (10) (combat) is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: snakeskin
+    tier: mid
+  equipment:
+    slot: shield
+    weapon_type: shield
+    weight: 5.443
+    requirements:
+      defence: 25
+      magic: 25
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: -7
+    defence_bonus:
+      stab: 10
+      slash: 10
+      crush: 15
+      magic: 5
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 5
+  charges:
+    max_charges: 10
+    description: "Begins with 10 charges. On taking damage, has a 1/10 chance to drain the opponent's Attack level by 1 plus 5% of their remaining total. Charges deplete with each trigger and cannot be recharged."
+  recipes:
+    - materials:
+        - item_name: Snakeskin
+          quantity: 2
+        - item_name: Combat tribal mask
+          quantity: 1
+        - item_name: Nails
+          quantity: 8
+      tools:
+        - Hammer
+      output_quantity: 1
+      skill: Crafting
+      level: 35
+      notes: "Built from a combat tribal mask using snakeskin and nails on Tai Bwo Wannai's Mahogany tree."
+  related_items:
+    - name: "Broodoo shield (combat)"
+      relationship: variant
+    - name: "Broodoo shield (uncharged)"
+      relationship: downgrade
+  about: "Broodoo shield (10) (combat) is a members-only magic shield variant in Old School RuneScape with 10 remaining charges. It requires 25 Defence and 25 Magic to wield and offers a chance on hit to drain the opponent's Attack level."
+  market_strategy:
+    notes:
+      - "Niche shield with limited demand outside Tai Bwo Wannai content."
+      - "Used charges reduce resale value relative to a fully-charged shield."
+      - "Low GE buy limit (125 per 4 hours) restricts large-scale flips."
+  trading_tips:
+    - "Stockpile cheap charged variants for the alchable margin if highalch covers price + nature rune."
+    - "Sell to crafters chasing Tai Bwo Wannai achievement tasks."
+  history:
+    - date: "2005-08-09"
+      description: "Released as part of the Tai Bwo Wannai Clean-Up update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-09"
+    update: "Tai Bwo Wannai Clean-Up"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Wield
+      - Uncharge
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-10-combat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-10-combat.mdx
@@ -95,7 +95,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/burning-amulet-5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/burning-amulet-5.mdx
@@ -12,14 +12,78 @@ osrs:
   lowalch: 500
   highalch: 750
   limit: 10000
-  about: "Burning amulet(5) is a members-only item in Old School RuneScape. High alchemy value: 750 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: neck
+    weight: 0.007
+    requirements:
+      magic: 1
+  charges:
+    max_charges: 5
+    note: Disintegrates when all charges are spent.
+  teleport:
+    destinations:
+      - name: Chaos Temple
+        wilderness_level: 15
+      - name: Bandit Camp
+        wilderness_level: 17
+      - name: Lava Maze
+        wilderness_level: 41
+  recipes:
+    - materials:
+        - item_name: Topaz amulet
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 5
+      tools: []
+      skill: Magic
+      level: 49
+      output_quantity: 1
+  related_items:
+    - name: Burning amulet(1)
+      relationship: variant
+    - name: Burning amulet(2)
+      relationship: variant
+    - name: Burning amulet(3)
+      relationship: variant
+    - name: Burning amulet(4)
+      relationship: variant
+    - name: Topaz amulet
+      relationship: component
+  about: "Burning amulet(5) is a members-only enchanted topaz amulet in Old School RuneScape with five Wilderness teleport charges. High alchemy value: 750 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  market_strategy:
+    notes:
+      - Demand is driven by Wilderness PvM/Slayer activity (Lava Maze, Chaos Temple).
+      - Charged amulets trade at a premium over the per-cast Lvl-3 Enchant material cost.
+  trading_tips:
+    - Compare the GE price to the combined cost of a topaz amulet + cosmic + 5 fire runes.
+    - Burning amulets cannot be stored in jewellery boxes, so usage skews to inventory carry only.
+  history:
+    - date: "2017-02-02"
+      description: Burning amulet teleports were reworked into chargeable 1/2/3/4/5 charge variants.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-02-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Rub
+      - Drop
+    worn_options:
+      - Remove
+      - Rub
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/burning-amulet-5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/burning-amulet-5.mdx
@@ -83,7 +83,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/camelot-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/camelot-teleport-tablet.mdx
@@ -68,7 +68,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/camelot-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/camelot-teleport-tablet.mdx
@@ -12,14 +12,63 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15000
-  about: "Camelot teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Camelot
+    type: tablet
+    requirements_to_use: none
+  recipes:
+    - materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 1
+        - item_name: Air rune
+          quantity: 5
+      tools:
+        - Eagle lectern (teak, mahogany, or marble)
+      output_quantity: 1
+      magic_level: 45
+      magic_xp: 55.5
+  related_items:
+    - item_id: 8013
+      item_name: Varrock teleport (tablet)
+      slug: varrock-teleport-tablet
+      relationship: alternative
+      description: Another standard teleport tablet
+    - item_id: 8009
+      item_name: Falador teleport (tablet)
+      slug: falador-teleport-tablet
+      relationship: alternative
+      description: Another standard teleport tablet
+  about: "Camelot teleport (tablet) is a stackable Magic tablet that teleports the user to Camelot. Created at a POH eagle lectern with 1 soft clay, 1 law rune, and 5 air runes at 45 Magic for 55.5 xp. Anyone can use it regardless of Magic level."
+  market_strategy:
+    notes:
+      - Strong steady volume from POH tablet farmers and questers
+      - Crafting profit fluctuates with law rune price
+      - Buy limit 15,000 supports mass flipping
+  history:
+    - date: "2006-05-31"
+      description: Released alongside the Magic on Eagle Lectern POH update.
+  properties:
+    release_date: "2006-05-31"
+    update: Magic on Eagle Lectern
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cape-of-skulls.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cape-of-skulls.mdx
@@ -12,14 +12,85 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
+  material:
+    type: cosmetic
+    tier: mid-high
+  equipment:
+    slot: cape
+    weight: 0.453
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 9
+      slash: 9
+      crush: 9
+      magic: 9
+      ranged: 9
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    description: "Equipping the cape skulls the wearer for 20 minutes (with warning prompt); skull persists after removal and resets on world-hop or re-equip."
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/5616
+        members_only: true
+  related_items:
+    - item_id: 6568
+      item_name: Obsidian cape
+      slug: obsidian-cape
+      relationship: alternative
+      description: Identical defensive bonuses, no skull penalty
   about: "Cape of skulls is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Easy clue reward, rare casket drop
+      - Mostly cosmetic demand; functional alternative exists in obsidian cape
+      - Wearing skulls the player, niche use only
+  trading_tips:
+    - Price volatile with cosmetic / collector demand
+    - Volume low (limit 8); slow to flip
+    - Avoid alching, value far exceeds high alch
+  history:
+    - date: "2019-04-11"
+      description: Added as an easy clue scroll reward.
+  properties:
+    release_date: "2019-04-11"
+    update: Easy Clue Rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cape-of-skulls.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cape-of-skulls.mdx
@@ -90,7 +90,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/castle-wars-bracelet-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/castle-wars-bracelet-3.mdx
@@ -12,14 +12,74 @@ osrs:
   lowalch: 670
   highalch: 1005
   limit: 10000
-  about: "Castle wars bracelet(3) is a free-to-play item in Old School RuneScape. High alchemy value: 1,005 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: emerald
+    tier: mid
+  equipment:
+    slot: hands
+    weight: 0.25
+    requirements:
+      defence: 1
+  charges:
+    max_charges: 3
+    description: Each Castle Wars game consumed at entry burns one charge; the bracelet must be worn at the start to apply its bonuses.
+  recipes:
+    - materials:
+        - item_name: Emerald bracelet
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Air rune
+          quantity: 3
+      tools: []
+      output_quantity: 1
+      skill: Magic
+      level: 27
+      xp: 37
+      spell: Lvl-2 Enchant
+  related_items:
+    - item_name: Emerald bracelet
+      relationship: component
+    - item_name: Castle wars bracelet(2)
+      relationship: variant
+    - item_name: Castle wars bracelet(1)
+      relationship: variant
+  about: "Castle wars bracelet(3) is a charged Magic-enchanted bracelet that grants +20% damage to flag bearers and a 50% bandage healing boost when worn at the start of a Castle Wars match."
+  market_strategy:
+    notes:
+      - Crafted from an emerald bracelet using Lvl-2 Enchant at 27 Magic for 37 xp.
+      - Each Castle Wars game consumes one charge; new bracelets must be re-enchanted after three uses.
+      - Lanthus now stores extra charges, easing inventory management for serious flaggers.
+  trading_tips:
+    - Demand spikes around Castle Wars events and double-XP weekends.
+    - Low-level enchanters can profit by sourcing emerald bracelets cheap and selling charged variants.
+  history:
+    - date: "2007-04-30"
+      description: Released with the 24 Carat Update introducing emerald bracelet enchants.
+    - date: "2025-04-02"
+      description: Lanthus now accepts Castle Wars bracelets to bank stored charges.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-04-30"
+    update: "24 Carat Update"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Check
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/castle-wars-bracelet-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/castle-wars-bracelet-3.mdx
@@ -79,7 +79,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cider-barrel-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cider-barrel-flatpack.mdx
@@ -70,7 +70,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cider-barrel-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cider-barrel-flatpack.mdx
@@ -12,14 +12,65 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Cider barrel (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    description: "Flat-pack barrel furniture for the Kitchen of a player-owned house, providing cider when used by guests."
+    hotspot: Barrel
+    room: Kitchen
+  recipes:
+    - skill: Construction
+      level: 12
+      xp: 91
+      materials:
+        - item_name: Plank
+          quantity: 3
+        - item_name: Cider
+          quantity: 8
+        - item_name: Steel nails
+          quantity: 3
+      tools:
+        - Hammer
+        - Saw
+        - Wooden workbench (Workshop)
+      output_quantity: 1
+      requirements:
+        - "Cooking level 14 (to brew the cider used)."
+  related_items:
+    - name: Cider
+      relationship: component
+    - name: Plank
+      relationship: component
+    - name: Steel nails
+      relationship: component
+  about: "Cider barrel (flatpack) is a members Construction flatpack for the player-owned house Kitchen. Crafted at a Workshop wooden workbench (12 Construction, 91 XP), it offers a small profit-flip route once cider supply and steel-nail prices are favourable."
+  market_strategy:
+    notes:
+      - "Tight buy limit (500/4 hr) keeps the market thin and prone to spread arbitrage."
+      - "Profit is heavily tied to cider GE price — brewing your own cider widens the margin."
+      - "Niche flatpack: demand comes from POH decorators and Construction trainers using flatpacks for low-effort XP."
+  trading_tips:
+    - "Brew bulk cider at Keldagrim or Port Phasmatys when grape supply is abundant to cut raw cost."
+    - "List finished flatpacks at the high end of the spread — limited buy limit means thin orders sell at premium."
+  history:
+    - date: "2006-05-31"
+      description: "Released alongside the player-owned house Construction update; available as a Workshop flatpack."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: "Player-Owned Houses (Construction launch)"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-chicken.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-chicken.mdx
@@ -86,7 +86,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-chicken.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-chicken.mdx
@@ -12,14 +12,81 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 6000
-  about: "Cooked chicken is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 3
+    edible: true
+  recipes:
+    - skill: Cooking
+      level: 1
+      xp: 30
+      materials:
+        - item_name: Raw chicken
+          quantity: 1
+      tools:
+        - Fire
+        - Range
+      output_quantity: 1
+      notes: "Stops burning at Cooking 34 (31 on the Lumbridge range)."
+  drop_table:
+    sources:
+      - source: Cave goblin (low level)
+        quantity: "1"
+        rarity: Common
+      - source: Cave bug
+        quantity: "1"
+        rarity: Uncommon
+      - source: H.A.M. Guard
+        quantity: "1"
+        rarity: Uncommon
+  shops:
+    - shop_name: Wydin's Food Store (Port Sarim)
+      location: Port Sarim
+      stock: 2
+      price: 4
+    - shop_name: Hudo's Grand Tree Groceries
+      location: Grand Tree
+      stock: 2
+      price: 4
+  related_items:
+    - name: Raw chicken
+      relationship: component
+    - name: Burnt chicken
+      relationship: alternative
+    - name: Roast chicken
+      relationship: upgrade
+  about: "Cooked chicken is a free-to-play food that heals 3 Hitpoints and is one of the lowest-level cooking products in OSRS. Raw chicken can be cooked from Cooking 1, making it the canonical first-step training fish-stand-in for new accounts."
+  market_strategy:
+    notes:
+      - "Mostly produced as a byproduct of low-level Cooking training rather than for sale."
+      - "Buy limit 6,000 — large enough that small flippers struggle to move the price."
+      - "GE-tax exempt category since May 2025 makes cooked chicken a viable starter flip for ironmen-adjacent learners."
+  trading_tips:
+    - "Cook raw chicken in bulk near Lumbridge or Grand Tree range to lower burn risk under Cooking 34."
+    - "Sell on the GE rather than alching — high alch barely covers gp value."
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 launch as part of the F2P Cooking skill rework."
+    - date: "2025-05-29"
+      description: "Exempted from the Grand Exchange convenience fee for low-tier food items."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: "RuneScape 2 launch"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.141
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-jubbly.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-jubbly.mdx
@@ -12,14 +12,54 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 10000
-  about: "Cooked jubbly is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 15
+    type: cooked
+    cooking_level: 41
+    cooking_xp: 160
+  recipes:
+    - materials:
+        - item_name: Raw jubbly
+      tools:
+        - Iron spit
+      output_quantity: 1
+      skill: Cooking
+      level: 41
+      xp: 160
+      notes: "Cooked on an ogre spit-roast near Rantz in Feldip Hills or at Jiggig."
+  about: "Cooked jubbly is a members-only food item in Old School RuneScape that heals 15 Hitpoints when eaten. It requires level 41 Cooking to prepare on an ogre spit-roast and is associated with the Skrach Uglogwee subquest of Recipe for Disaster."
+  market_strategy:
+    notes:
+      - "Profitable cooking flip: raw jubblies are cheaper than cooked, and successful cooks yield strong margins once GE tax is accounted for."
+      - "Demand is modest because most high-level players prefer sharks or anglerfish for raw HP-per-inventory-slot."
+      - "Heaviest food in the game at 10 kg per item alongside cooked chompy — limits stacking in weight-sensitive activities."
+  trading_tips:
+    - "Buy raw jubblies in bulk and cook to 41+ Cooking for a steady margin."
+    - "Stockpile for Skrach Uglogwee subquest demand spikes."
+    - "Avoid carrying many at once in agility-heavy content due to 10 kg weight."
+  history:
+    - date: "2006-03-15"
+      description: "Released as part of the Recipe for Disaster: Freeing Skrach Uglogwee subquest."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-03-15"
+    update: "Recipe for Disaster"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    quest: "Recipe for Disaster"
+    weight: 10
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-jubbly.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-jubbly.mdx
@@ -59,7 +59,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cup-of-water.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cup-of-water.mdx
@@ -12,14 +12,53 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 13000
+  recipes:
+    - materials:
+        - item_name: Empty cup
+          quantity: 1
+      tools:
+        - Water source
+      output_quantity: 1
+      notes: "Use an empty cup on any water source (sink, fountain, well) to fill it."
+  related_items:
+    - name: Empty cup
+      relationship: component
+    - name: Cup of hot water
+      relationship: upgrade
+    - name: Bowl of water
+      relationship: alternative
   about: "Cup of water is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Filled by using an empty cup on any water source — supply effectively unlimited.
+      - GE price ~54 coins vs alch 6; margin driven by lazy buyers, not scarcity.
+      - Cannot be used to counter desert heat effects (use waterskins).
+  trading_tips:
+    - High buy limit (13,000) makes this viable for bulk arbitrage off no-skill water source farming.
+    - Heat on range/fire to convert into Cup of hot water for tea-making chains.
+  history:
+    - date: "2005-02-28"
+      description: "Released with the One Small Favour update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-28"
+    update: "One Small Favour"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cup-of-water.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cup-of-water.mdx
@@ -58,7 +58,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cyclops-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cyclops-head.mdx
@@ -12,14 +12,68 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Cyclops head is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.2
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus: {}
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  related_items:
+    - slug: dragon-mask
+      relationship: alternative
+  about: "Cyclops head is a cosmetic hard clue reward in Old School RuneScape, worn in the head slot with no combat bonuses."
+  market_strategy:
+    notes:
+      - Niche cosmetic; price driven by hard clue rarity and costume room collectors.
+      - Buy limit of 4 throttles flipping volume.
+  trading_tips:
+    - Hold during clue scroll content updates that boost hard-tier solving.
+    - Costume room collectors stabilise long-run demand.
+  history:
+    - date: "2016-07-06"
+      description: Added to the game as a hard clue reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trails clue scroll rewards expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cyclops-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cyclops-head.mdx
@@ -73,7 +73,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/desert-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/desert-boots.mdx
@@ -12,14 +12,68 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 150
-  about: "Desert boots is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.226
+    requirements: {}
+  shops:
+    - shop_name: Shantay Pass Shop
+      location: Shantay Pass
+    - shop_name: Ali's Discount Wares
+      location: Al Kharid
+    - shop_name: Pollnivneach General Store
+      location: Pollnivneach
+    - shop_name: Bandit Camp General Store
+      location: Kharidian Desert Bandit Camp
+  related_items:
+    - item_id: 1833
+      item_name: Desert robe
+      slug: desert-robe
+      relationship: set-piece
+      description: Desert clothing body piece
+    - item_id: 1835
+      item_name: Desert shirt
+      slug: desert-shirt
+      relationship: set-piece
+      description: Desert clothing shirt
+    - item_id: 1839
+      item_name: Bronze pickaxe
+      slug: bronze-pickaxe
+      relationship: alternative
+      description: Required alongside desert set for The Tourist Trap slave disguise
+  about: "Desert boots are part of the desert clothing set that delays Kharidian desert heat damage by an extra 6 seconds. Required for The Tourist Trap quest disguise; sold by Shantay Pass, Al Kharid, Pollnivneach, and Bandit Camp shops."
+  market_strategy:
+    notes:
+      - Shop-bought cheaply across desert vendors; GE flips are thin (~1k daily volume).
+      - Demand spikes around new desert content or DT2-adjacent updates that drive heat-resistance interest.
+  trading_tips:
+    - Buy directly from Shantay Pass or Ali's Discount Wares for the lowest cost.
+    - Stockpile during quest revisits or desert-focused leagues for short-term price bumps.
+  history:
+    - date: "2003-04-14"
+      description: Released with the Tourist Trap Quest Online! update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: "Tourist Trap Quest Online!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: The Tourist Trap
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/desert-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/desert-boots.mdx
@@ -73,7 +73,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/desert-top-overcoat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/desert-top-overcoat.mdx
@@ -12,14 +12,78 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 150
-  about: "Desert top (overcoat) is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: body
+    weapon_type: none
+    attack_speed: 1
+    weight: 0.005
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Ali Morrisane
+      location: Al Kharid
+  related_items:
+    - name: Desert robe
+      relationship: set-piece
+    - name: Desert legs
+      relationship: set-piece
+    - name: Desert boots
+      relationship: set-piece
+    - name: Desert top
+      relationship: variant
+  about: "Desert top (overcoat) is a members-only body slot clothing item obtained from Ali Morrisane after completing the Rogue Trader miniquest, traded for three matching animal skins. Worn as part of the desert outfit, it delays the onset of desert heat damage by 12 seconds, making it a low-effort quality-of-life pickup for early Kharidian Desert content."
+  market_strategy:
+    notes:
+      - "Supply trickles in from Rogue Trader runners; demand is low and steady from desert clue / quest gear."
+      - "150 limit per 4 hours far exceeds typical daily volume - price is anchored near shop value."
+  trading_tips:
+    - "Buy direct from Ali Morrisane if you have spare skins instead of paying the Grand Exchange markup."
+    - "Bundle with the rest of the desert outfit for resale to clue scroll completionists."
+  history:
+    - date: "2005-08-15"
+      description: "Introduced with the Rogue Trader miniquest as part of the desert outfit obtainable from Ali Morrisane."
+    - date: "2023-01-01"
+      description: "Heat-protection duration increased from 6 to 12 seconds when worn as part of the desert outfit."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-15"
+    update: Rogue Trader
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/desert-top-overcoat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/desert-top-overcoat.mdx
@@ -83,7 +83,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-armour-set.mdx
@@ -12,14 +12,46 @@ osrs:
   lowalch: 160000
   highalch: 240000
   limit: 8
-  about: "Dharok's armour set is a members-only item in Old School RuneScape. High alchemy value: 240,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - name: Dharok's helm
+      relationship: set-piece
+    - name: Dharok's platebody
+      relationship: set-piece
+    - name: Dharok's platelegs
+      relationship: set-piece
+    - name: Dharok's greataxe
+      relationship: set-piece
+  about: "Dharok's armour set is a Grand Exchange convenience bundle of the four Dharok the Wretched Barrows pieces (helm, platebody, platelegs, greataxe). The GE clerk exchanges the set for its component pieces, simplifying bulk buy/sell flow."
+  market_strategy:
+    notes:
+      - Convenient bundle for selling full Dharok's kit
+      - Typically trades at a small premium to component sum
+      - Demand spikes during Barrows meta shifts
+  trading_tips:
+    - Compare bundle price to four component pieces before flipping
+    - Buy limit of 8 per 4 hours constrains volume
+  history:
+    - date: "2014-12-10"
+      description: "Dharok's armour set was released as part of the Grand Exchange Sets expansion."
+  properties:
+    release_date: "2014-12-10"
+    update: "Grand Exchange Sets Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-armour-set.mdx
@@ -51,7 +51,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-combat-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-combat-potion-3.mdx
@@ -71,7 +71,10 @@ osrs:
     alchable: true
     destroy: Drop
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-combat-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-combat-potion-3.mdx
@@ -12,14 +12,66 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 2000
-  about: "Divine super combat potion(3) is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: Boosts Attack, Strength, and Defence by 5 + 15% for 5 minutes.
+      - description: Affected stats are prevented from draining below the maximum boost for the 5-minute duration.
+      - description: Deals 10 Hitpoint damage on consumption; requires more than 10 HP to drink safely.
+  recipes:
+    - name: Brew Divine super combat potion(3)
+      skill: Herblore
+      level: 97
+      experience: 1.5
+      materials:
+        - item_name: Super combat potion(3)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 3
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Divine super combat potion(4)
+      relationship: upgrade
+    - name: Divine super combat potion(2)
+      relationship: downgrade
+    - name: Divine super combat potion(1)
+      relationship: downgrade
+    - name: Super combat potion(3)
+      relationship: component
+    - name: Crystal dust
+      relationship: component
+  about: "Divine super combat potion(3) is a members-only Herblore potion in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  market_strategy:
+    notes:
+      - Brewed at Herblore level 97 from a super combat potion(3) and 3 crystal dust.
+      - Per-dose price tracks 1/3 of the 3-dose GE price.
+      - Profit window depends on crystal dust supply from Prifddinas.
+  trading_tips:
+    - Decant doses into (4) form for higher per-unit value when reselling.
+    - Stocking up before raids/PvM events is common; demand spikes around major drops.
+  history:
+    - date: "2019-07-25"
+      description: Item released as part of the Song of the Elves quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-07-25"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrow-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrow-p.mdx
@@ -72,7 +72,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrow-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrow-p.mdx
@@ -12,14 +12,67 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 11000
-  about: "Dragon arrow(p) is a members-only item in Old School RuneScape. High alchemy value: 480 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: ranged-ammunition
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      ranged_strength: 60
+  related_items:
+    - name: Dragon arrow
+      relationship: downgrade
+    - name: Dragon arrow(p+)
+      relationship: upgrade
+    - name: Dragon arrow(p++)
+      relationship: upgrade
+  drop_table:
+    sources:
+      - source: Dragon impling
+        quantity: "1"
+        rarity: 1/19
+      - source: Crazy archaeologist
+        quantity: "1"
+        rarity: 1/128
+      - source: The Gauntlet
+        quantity: "1"
+        rarity: 1/24
+  about: "Dragon arrow(p) is a members-only poisoned ranged ammunition in Old School RuneScape. High alchemy value: 480 coins. Grand Exchange buy limit: 11,000 per 4 hours."
+  market_strategy:
+    notes:
+      - Dragon arrow(p) trades at premium over plain dragon arrows due to weak poison effect.
+      - Demand is driven by ranged PvM and PvP usage with dragon-tier bows.
+  trading_tips:
+    - Buy in bulk during off-peak hours to take advantage of GE limit.
+    - Compare price spread against dragon arrow + weapon poison crafting cost.
+  history:
+    - date: "2007-06-11"
+      description: Released with the Impetuous Impulses update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-06-11"
+    update: Impetuous Impulses
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-cannonball.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-cannonball.mdx
@@ -61,7 +61,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-cannonball.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-cannonball.mdx
@@ -12,14 +12,56 @@ osrs:
   lowalch: 720
   highalch: 1080
   limit: 11000
-  about: "Dragon cannonball is a members-only item in Old School RuneScape. High alchemy value: 1,080 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: orikalkum
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: ship-cannon
+    weight: 0
+    requirements: {}
+    attack_bonus:
+      ranged: 80
+      ranged_strength: 270
+    defence_bonus: {}
+    other_bonus: {}
+  related_items:
+    - name: Cannonball
+      relationship: downgrade
+    - name: Granite cannonball
+      relationship: alternative
+    - name: Dragon cannon
+      relationship: component
+  about: "Dragon cannonball is high-tier ammunition used exclusively with the dragon ship cannon, introduced with Sailing."
+  market_strategy:
+    notes:
+      - "Cannot be smithed; supply depends on drops and cannonball stalls."
+      - "GE buy limit 11,000 per 4 hours; high alch 1,080 gp."
+  trading_tips:
+    - "Demand tracks Sailing combat encounter popularity."
+    - "Cannonball-stall feeders can suppress price during bot waves."
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing skill launch update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-limbs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-limbs.mdx
@@ -12,12 +12,10 @@ osrs:
   lowalch: 14000
   highalch: 21000
   limit: 10000
-  equipment:
-    slot: none
-    weight: 3.2
+  material:
+    type: dragon
+    tier: high
   drop_table:
-    primary_source: Rune dragon
-    best_drop_rate: 1/800
     sources:
       - source: Rune dragon
         source_id: 8031
@@ -33,16 +31,29 @@ osrs:
         rarity: rare
         drop_rate: 1/1000
         members_only: true
+  recipes:
+    - skill: Fletching
+      level: 78
+      xp: 135
+      materials:
+        - item_name: Dragon limbs
+          quantity: 1
+        - item_name: Magic stock
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
+      product: Dragon crossbow (u)
   related_items:
     - item_id: 21902
       item_name: Dragon crossbow
       slug: dragon-crossbow
-      relationship: upgrade
-      description: Crafted using dragon limbs
+      relationship: product
+      description: Final crossbow once strung
     - item_id: 21905
       item_name: Dragon crossbow (u)
       slug: dragon-crossbow-u
-      relationship: component
+      relationship: product
       description: Intermediate crafting step
     - item_id: 11785
       item_name: Armadyl crossbow
@@ -53,8 +64,7 @@ osrs:
     Creates Dragon crossbow:
     - Attach to Magic stock
     - Requires 78 Fletching
-    - Grants 70 Fletching XP
-
+    - Grants 135 Fletching XP
     Dragon crossbow stats:
     - +94 Ranged attack
     - Can fire dragon bolts
@@ -65,13 +75,32 @@ osrs:
       - Rune dragons more profitable source
       - Also obtainable from Brimstone chest
       - Part of Dragon Slayer II content
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Flip on margin between limbs price and finished Dragon crossbow value
+    - Monitor Brimstone chest meta and Dragon Slayer II completion rates
+    - Rune dragon trips drop these and bones, profit-stack accordingly
+  history:
+    - date: "2018-01-04"
+      description: Added with the Dragon Slayer II update.
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.2
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-limbs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-limbs.mdx
@@ -100,7 +100,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-nails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-nails.mdx
@@ -91,7 +91,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-nails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-nails.mdx
@@ -12,14 +12,86 @@ osrs:
   lowalch: 140
   highalch: 210
   limit: 13000
-  about: "Dragon nails is a members-only item in Old School RuneScape. High alchemy value: 210 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon-metal
+    tier: high
+  recipes:
+    - skill: Smithing
+      level: 92
+      xp: 350
+      output_quantity: 15
+      tools:
+        - Dragon Forge
+      materials:
+        - item_name: Dragon metal sheet
+          quantity: 1
+      requirements:
+        quests:
+          - Dragon Slayer II
+          - Pandemonium
+  drop_table:
+    sources:
+      - source: Frost dragon
+        quantity: "5-15"
+        rarity: "2/130"
+      - source: Narwhal
+        quantity: "2-3"
+        rarity: "1/150"
+      - source: Opulent salvage
+        quantity: "1-3"
+        rarity: "1/2000"
+  related_items:
+    - item_id: 1539
+      item_name: Steel nails
+      slug: steel-nails
+      relationship: downgrade
+      description: Lower-tier construction nail
+    - item_id: 4824
+      item_name: Mithril nails
+      slug: mithril-nails
+      relationship: downgrade
+      description: Mid-tier construction nail
+    - item_id: 4825
+      item_name: Adamantite nails
+      slug: adamantite-nails
+      relationship: downgrade
+      description: Higher-tier construction nail
+    - item_id: 4826
+      item_name: Rune nails
+      slug: rune-nails
+      relationship: downgrade
+      description: Pre-dragon construction/sailing nail
+  construction:
+    use: Required for high-tier Sailing shipbuilding components (rosewood hulls, cargo holds, masts) and certain construction furniture and rosewood repair kits.
+  about: "Dragon nails are the top-tier Sailing/Construction nail introduced with the Sailing skill. Smiths produce 15 per dragon metal sheet at the Dragon Forge with 92 Smithing after Dragon Slayer II and Pandemonium."
+  market_strategy:
+    notes:
+      - High daily volume (~72k) keeps spreads tight; works well for low-margin volume flips.
+      - Demand is anchored to Sailing shipbuilding and rosewood repair kits — usage scales with active sailors.
+  trading_tips:
+    - Buy in sheet form when GE dragon metal sheet pricing is cheap and craft for guaranteed 15x output.
+    - Stock up before shipbuilding-related Sailing content drops; usage is consumable per ship part.
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-spear-p-5716.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-spear-p-5716.mdx
@@ -99,7 +99,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-spear-p-5716.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-spear-p-5716.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon spear(p+) | OSRS Price Data
-description: "Dragon spear(p+): A poisoned dragon tipped spear.. High alch: 37,440 GP, GE limit: 70."
+description: "Dragon spear(p+): A poisoned dragon tipped spear. High alch: 37,440 GP, GE limit: 70."
 osrs:
   id: 5716
   name: Dragon spear(p+)
@@ -12,14 +12,94 @@ osrs:
   lowalch: 24960
   highalch: 37440
   limit: 70
-  about: "Dragon spear(p+) is a members-only item in Old School RuneScape. High alchemy value: 37,440 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 55
+      slash: 55
+      crush: 55
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 5
+      slash: 5
+      crush: 5
+      magic: 5
+      ranged: 5
+    other_bonus:
+      strength: 60
+      prayer: 0
+  special_attack:
+    name: Shove
+    energy_cost: 25
+    description: Pushes the target back one square and stuns them for 5 ticks (3.0 seconds); ineffective on already-stunned targets and on most bosses.
+  recipes:
+    - materials:
+        - item_name: Dragon spear
+          quantity: 1
+        - item_name: Weapon poison(+)
+          quantity: 1
+      tools: []
+      skill: Herblore
+      level: 73
+      xp: 0
+      output_quantity: 1
+      notes: Apply weapon poison(+) to a regular dragon spear to create the p+ variant.
+  related_items:
+    - item_id: 1249
+      item_name: Dragon spear
+      slug: dragon-spear
+      relationship: variant
+      description: Unpoisoned base version of the spear.
+    - item_id: 5730
+      item_name: Dragon spear(p)
+      slug: dragon-spear-p
+      relationship: variant
+      description: Standard poison variant with weaker poison damage.
+    - item_id: 5730
+      item_name: Dragon spear(p++)
+      slug: dragon-spear-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant of the dragon spear.
+  about: Poisoned (+) variant of the dragon spear; combines a stun shove special with mid-game poison ticks for PvP setups.
+  market_strategy:
+    notes:
+      - Demand spikes around PvP events and Castle Wars/BH metas requiring the stun special.
+      - Supply driven by Brutal black dragon farmers and Gorak drop sessions.
+  trading_tips:
+    - Convert dragon spear to p+ when weapon poison(+) is cheap to capture margin.
+    - Watch tournament/PvP scheduling for short-term price pumps.
+  history:
+    - date: "2004-03-29"
+      description: Dragon spear released; poisoned variants followed shortly after.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: Dragon Weaponry
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarf-weed-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarf-weed-seed.mdx
@@ -62,7 +62,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarf-weed-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarf-weed-seed.mdx
@@ -12,70 +12,57 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 200
-  seed:
-    type: herb
-    tier: high
   farming:
     level: 79
-    xp_plant: 170.5
-    xp_harvest: 192
-    growth_time: 80
-    patches: 9
-    product_id: 217
-    product_name: Grimy dwarf weed
+    plant_xp: 170.5
+    harvest_xp: 192
+    growth_time_minutes: 80
+    patch_type: Herb
+    product: Grimy dwarf weed
+    notes: "Plant 1 seed per patch; does not regrow. Use ultracompost or Fertile Soil to minimize disease."
   related_items:
-    - item_id: 217
-      item_name: Grimy dwarf weed
-      slug: grimy-dwarf-weed
+    - name: Grimy dwarf weed
       relationship: product
-      description: Harvested product
-    - item_id: 267
-      item_name: Dwarf weed
-      slug: dwarf-weed
+    - name: Dwarf weed
       relationship: product
-      description: Cleaned herb
-    - item_id: 2450
-      item_name: Ranging potion(4)
-      slug: ranging-potion-4
+    - name: Ranging potion(4)
       relationship: product
-      description: Made from dwarf weed
-    - item_id: 5302
-      item_name: Lantadyme seed
-      slug: lantadyme-seed
+    - name: Lantadyme seed
       relationship: alternative
-      description: Lower tier herb seed
-    - item_id: 5304
-      item_name: Torstol seed
-      slug: torstol-seed
+    - name: Torstol seed
       relationship: upgrade
-      description: Highest tier herb seed
-  about: |-
-    Plant in a herb patch to grow Grimy dwarf weed.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 79 |
-    | Growth time | 80 minutes |
-    | XP (plant) | 170.5 |
-    | XP (harvest) | 192 per herb |
+  about: "Dwarf weed seed is a high-tier herb seed planted in herb patches at 79 Farming, yielding grimy dwarf weed used in ranging potions. Each seed gives 170.5 plant XP and 192 XP per herb harvested over an 80 minute growth cycle."
   market_strategy:
     notes:
-      - High-tier herb seed
-      - Used for ranging potions
-      - Excellent profit potential
-      - Ultracompost (essential)
-      - Magic secateurs (10% more yield)
-      - Farming cape (5% more yield)
-      - 9 herb patches available
-      - ~10 minute runs, 80 minute regrowth
-      - Ranging potions essential for ranged PvM
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - High-tier herb seed used for Ranging potions
+      - Strong profit potential per farm run
+      - 9 herb patches available across game world
+      - Ultracompost recommended for max yield
+  trading_tips:
+    - Buy limit is 200 per 4 hours
+    - Track Ranging potion demand for resale margin
+  history:
+    - date: "2005-06-06"
+      description: "Dwarf weed seed was released along with the Farming skill."
+  properties:
+    release_date: "2005-06-06"
+    update: "Farming"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Plant
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-atlatl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-atlatl.mdx
@@ -12,12 +12,18 @@ osrs:
   lowalch: 64000
   highalch: 96000
   limit: 15
+  material:
+    type: metal
+    tier: high
   equipment:
     slot: weapon
     weapon_type: thrown
-    weight: 2
     attack_speed: 4
-    attack_range: 6
+    weight: 3.628
+    requirements:
+      ranged: 75
+      attack: 50
+      strength: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,80 +37,66 @@ osrs:
       magic: 0
       ranged: 0
     other_bonus:
-      melee_strength: 40
+      strength: 40
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 75
-      attack: 50
-      strength: 50
-    degradable: false
-    two_handed: true
   special_attack:
     name: Eclipse
     energy: 50
-    description: Requires full eclipse moon armour. Magic-based attack at melee distance with 50% accuracy bonus, consumes burn damage on target to boost damage.
+    description: "Requires the full eclipse moon armour set. Performs a magic-based attack at melee range with a 50% accuracy bonus, consuming any remaining burn damage on the target to increase output."
   drop_table:
-    primary_source: Lunar Chest (Neypotzli)
-    best_drop_rate: 1/224
     sources:
       - source: Lunar Chest
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/224
-        members_only: true
+        rarity: "1/224"
   related_items:
-    - item_id: 29010
-      item_name: Eclipse moon helm
-      slug: eclipse-moon-helm
+    - name: Eclipse moon helm
       relationship: set-piece
-      description: Required for Eclipse special attack
-    - item_id: 29004
-      item_name: Eclipse moon chestplate
-      slug: eclipse-moon-chestplate
+    - name: Eclipse moon chestplate
       relationship: set-piece
-      description: Required for Eclipse special attack
-    - item_id: 29007
-      item_name: Eclipse moon tassets
-      slug: eclipse-moon-tassets
+    - name: Eclipse moon tassets
       relationship: set-piece
-      description: Required for Eclipse special attack
-    - item_id: 28991
-      item_name: Atlatl dart
-      slug: atlatl-dart
+    - name: Atlatl dart
       relationship: component
-      description: Required ammunition for Eclipse atlatl
-  about: |-
-    The Eclipse atlatl is unique among ranged weapons:
-    - Uses the player's melee strength bonus for damage calculation
-    - Ranged bonus still determines accuracy
-    - Attack speed: 4 ticks (3 ticks on rapid)
-
-    Set Effect: When wearing full eclipse moon armour, successful hits have a 20% chance to inflict burn damage on targets.
-
-    Eclipse (50% energy):
-    - Requires full eclipse moon armour set
-    - Magic-based attack at melee distance
-    - 50% accuracy bonus
-    - Consumes remaining burn damage on target to boost damage output
-
-    Best-in-slot for hybrid setups where melee strength gear is worn:
-    - Neypotzli content
-    - Unique DPS setups combining melee gear with ranged attacks
-    - Specialized boss strategies
+    - name: Blood moon sceptre
+      relationship: alternative
+    - name: Blue moon spear
+      relationship: alternative
+  about: "Eclipse atlatl is a unique two-handed thrown weapon from Neypotzli's Lunar Chest that scales damage from the wielder's melee Strength bonus while using Ranged accuracy. Paired with the full eclipse moon armour set, it gains a burn-on-hit chance and unlocks the Eclipse special attack, making it a powerful hybrid option for setups that already stack melee strength."
   market_strategy:
     notes:
-      - Value tied to full set synergy
-      - Requires atlatl darts as ammunition
-      - Unique hybrid mechanics make it situational but powerful
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Value is anchored to the eclipse moon set synergy - off-set demand is weak."
+      - "Buy limit of 15 keeps spreads tight, but post-update meta shifts swing price fast."
+  trading_tips:
+    - "Stockpile atlatl darts alongside the weapon - both move together with PvM activity."
+    - "Track Neypotzli completion rates; oversupply after league/event boosts often deflates price."
+  history:
+    - date: "2024-03-20"
+      description: "Released with Varlamore: Part One as the eclipse moon set's signature thrown weapon."
+    - date: "2024-03-27"
+      description: "Equipment requirements adjusted to 75 Ranged, 50 Attack, and 50 Strength."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-atlatl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-atlatl.mdx
@@ -96,7 +96,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elder-chaos-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elder-chaos-robe.mdx
@@ -96,7 +96,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elder-chaos-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elder-chaos-robe.mdx
@@ -12,14 +12,91 @@ osrs:
   lowalch: 280
   highalch: 420
   limit: 8
-  about: "Elder chaos robe is a members-only item in Old School RuneScape. High alchemy value: 420 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: high
+  equipment:
+    slot: legs
+    weapon_type: none
+    attack_speed: 1
+    weight: 0.18
+    requirements:
+      magic: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 6
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 6
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 1
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Elder Chaos druid
+        quantity: "1"
+        rarity: 1/1419
+  related_items:
+    - item_id: 20517
+      item_name: Elder chaos hood
+      slug: elder-chaos-hood
+      relationship: set-piece
+      description: Headpiece of the elder chaos druid robes set
+    - item_id: 20523
+      item_name: Elder chaos top
+      slug: elder-chaos-top
+      relationship: set-piece
+      description: Torso piece of the set
+    - item_id: 24297
+      item_name: Elder chaos robe (or)
+      slug: elder-chaos-robe-or
+      relationship: variant
+      description: Ornament kit variant
+    - item_id: 1099
+      item_name: Mystic robe bottom
+      slug: mystic-robe-bottom
+      relationship: alternative
+      description: Alternative magic legwear with defence requirements
+  about: "Elder chaos robe is best-in-slot magic legwear for one-defence pures, offering +6 magic attack and +1% magic damage with no Defence requirement."
+  market_strategy:
+    notes:
+      - Tiny 8-per-4h GE buy limit forces patient accumulation; flippers move volume slowly.
+      - One-defence pure demand makes the robe sticky in price even when general magic gear cools.
+      - Supply is gated entirely by Elder Chaos druid drops at 1/1419, so botted bursts directly drive dips.
+  trading_tips:
+    - Buy the full hood/top/robe set together when one piece sags relative to the others.
+    - Watch for PvP rejuvenation updates that revive interest in 1-defence builds.
+  history:
+    - date: "2016-07-21"
+      description: Added as a unique Elder Chaos druid drop.
+  properties:
+    release_date: "2016-07-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.18
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-signet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-signet.mdx
@@ -97,7 +97,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-signet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-signet.mdx
@@ -12,88 +12,92 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 5
+  material:
+    type: crystal
+    tier: high
   equipment:
     slot: ring
-    type: skilling ring
-    tradeable: true
-  passive_effect:
-    name: Crystal Efficiency
-    effect: 10% chance to not consume a charge when using crystal equipment
-    excluded: Blade of Saeldor, Bow of Faerdhinen
-    effective_bonus: ~11.1% additional charges (saved charges can save again)
-  obtaining:
-    methods:
-      - source: Gauntlet
-        method: Rare drop from regular Gauntlet
-      - source: Corrupted Gauntlet
-        method: Rare drop from Corrupted Gauntlet
+    weapon_type: none
+    attack_speed: 1
+    weight: 0.006
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Crystal impling jar
+        quantity: "1"
+        rarity: "1/128"
+  recipes:
+    - materials:
+        - item_name: Elven signet
+        - item_name: Celestial ring
+        - item_name: Crystal shard
+        - item_name: Stardust
+      tools:
+        - Singing bowl
+      output_quantity: 1
   related_items:
-    - item_id: 25539
-      item_name: Celestial ring
-      slug: celestial-ring
+    - name: Celestial ring
       relationship: component
-      description: Can combine to make Celestial signet
-    - item_id: 25538
-      item_name: Celestial signet
-      slug: celestial-signet
+    - name: Celestial signet
       relationship: upgrade
-      description: Combined ring with both effects
-    - item_id: 23680
-      item_name: Crystal pickaxe
-      slug: crystal-pickaxe
+    - name: Crystal pickaxe
       relationship: alternative
-      description: Works with this tool
-    - item_id: 23673
-      item_name: Crystal axe
-      slug: crystal-axe
+    - name: Crystal axe
       relationship: alternative
-      description: Works with this tool
-    - item_id: 23762
-      item_name: Crystal harpoon
-      slug: crystal-harpoon
+    - name: Crystal harpoon
       relationship: alternative
-      description: Works with this tool
-  about: |-
-    Crystal Efficiency:
-    - 10% chance to not consume a charge when using crystal equipment
-    - Effective bonus: ~11.1% additional charges (saved charges can save again)
-
-    Works With:
-    - Crystal pickaxe
-    - Crystal axe
-    - Crystal harpoon
-    - Crystal armour
-
-    Does NOT work with:
-    - Blade of Saeldor
-    - Bow of Faerdhinen
-
-    Can be combined with Celestial ring to create Celestial signet:
-    - Requires 70 Smithing and 70 Crafting
-    - Or pay NPCs to combine
-
-    Celestial signet provides:
-    - +4 invisible Mining levels (from Celestial ring)
-    - 10% crystal charge saving (from Elven signet)
-
-    Essential for:
-    - Crystal tool users
-    - Reducing crystal shard consumption
-    - Efficient skilling in Prifddinas
-
-    Stacks with all crystal equipment.
+  about: "Elven signet is a members ring obtained from crystal impling jars that grants a 10% chance to save a charge whenever crystal equipment is used, excluding the Blade of Saeldor and Bow of Faerdhinen. Combined with a Celestial ring at a singing bowl using 100 crystal shards and 1,000 stardust, it forms the Celestial signet, the best-in-slot ring for crystal-tool skilling."
   market_strategy:
     notes:
-      - Gauntlet is only source
-      - Combine with Celestial ring for BiS mining ring
-      - Saves expensive crystal shards long-term
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply is bottlenecked by crystal impling hunter throughput; price tracks crystal tool adoption."
+      - "Limit of 5 per 4 hours throttles bulk flips - expect thin order books and wide spreads."
+      - "Celestial signet combine permanently sinks the ring, gradually tightening supply."
+  trading_tips:
+    - "Pair purchases with Celestial ring stock if you plan to flip the combined Celestial signet."
+    - "Watch Prifddinas skilling meta updates - any buff to crystal tools moves this ring."
+  history:
+    - date: "2019-07-25"
+      description: "Released with Song of the Elves as a crystal impling drop."
+    - date: "2020-04-08"
+      description: "Charge-save chance doubled from 5% to 10%."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-07-25"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enhanced-quetzal-whistle-blueprint.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enhanced-quetzal-whistle-blueprint.mdx
@@ -12,14 +12,72 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: null
-  about: "Enhanced quetzal whistle blueprint is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: blueprint
+    tier: mid
+  recipes:
+    - materials:
+        - item_name: Basic quetzal whistle
+          quantity: 1
+        - item_name: Yew logs
+          quantity: 1
+      tools:
+        - Knife
+      skill: Crafting
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Adept hunters' loot sack
+        quantity: "1"
+        rarity: 1/50
+      - source: Expert hunters' loot sack
+        quantity: "1"
+        rarity: 1/50
+      - source: Master hunters' loot sack
+        quantity: "1"
+        rarity: 1/50
+  related_items:
+    - name: Basic quetzal whistle
+      relationship: component
+    - name: Enhanced quetzal whistle
+      relationship: product
+    - name: Perfected quetzal whistle blueprint
+      relationship: upgrade
+    - name: Torn enhanced quetzal whistle blueprint
+      relationship: variant
+  about: "Enhanced quetzal whistle blueprint is a Varlamore Hunter Rumours drop used with a basic quetzal whistle, yew logs, and a knife to craft the enhanced quetzal whistle."
+  market_strategy:
+    notes:
+      - "Drops at 1/50 from adept, expert, and master hunters' loot sacks."
+      - "Untradeable torn variant is granted after 100 Hunter Rumour completions."
+      - "Can be exchanged with Guild Scribe Verity for a supply loot sack."
+  trading_tips:
+    - "Price tracks Hunter Rumour engagement and Varlamore meta."
+    - "Watch teleport convenience demand — drives whistle upgrades."
+  history:
+    - date: "2024-03-20"
+      description: "Released with Varlamore: Part One and the Hunter Guild rework."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.004
+    options:
+      - Check
+      - Craft
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enhanced-quetzal-whistle-blueprint.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enhanced-quetzal-whistle-blueprint.mdx
@@ -77,7 +77,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-bloodveld-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-bloodveld-head.mdx
@@ -68,7 +68,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-bloodveld-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-bloodveld-head.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 296
   limit: 3000
   material:
-    type: ensouled_head
-    tier: expert
+    type: ensouled-head
+    tier: mid-high
   prayer:
     xp_reanimate: 1040
     magic_level: 72
@@ -22,51 +22,53 @@ osrs:
   drop_table:
     sources:
       - source: Bloodveld
-        source_id: 484
-        combat_level: 76
         quantity: "1"
         rarity: uncommon
-        members_only: true
       - source: Mutated Bloodveld
-        source_id: 7276
-        combat_level: 123
         quantity: "1"
         rarity: uncommon
-        members_only: true
   related_items:
-    - item_id: 13493
-      item_name: Ensouled dagannoth head
-      slug: ensouled-dagannoth-head
+    - name: Ensouled dagannoth head
       relationship: downgrade
-      description: Lower XP (936)
-    - item_id: 13502
-      item_name: Ensouled demon head
-      slug: ensouled-demon-head
+    - name: Ensouled demon head
       relationship: upgrade
-      description: Higher XP (1,170)
-    - item_id: 13508
-      item_name: Ensouled abyssal head
-      slug: ensouled-abyssal-head
+    - name: Ensouled abyssal head
       relationship: upgrade
-      description: Higher XP (1,300)
-  about: |-
-    1. Cast Expert Reanimation spell on the head
-    2. Kill the reanimated creature
-    3. Receive Prayer XP
+  about: "Ensouled bloodveld head is reanimated via the 72 Magic Expert Reanimation spell to grant 1,040 Prayer XP after defeating the spawned creature."
   market_strategy:
     notes:
-      - Popular Slayer task
-      - Good supply from catacombs
-      - Catacomb bloodvelds popular
-      - High supply from barraging
-      - Good GP/XP ratio
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Popular Slayer task drop; supply tracks catacomb bloodveld farming."
+      - "Good GP-per-XP ratio for mid-tier Prayer training."
+      - "GE buy limit 3,000 per 4 hours."
+  trading_tips:
+    - "Bloodveld AFK ranges in the Catacombs of Kourend keep supply high."
+    - "Compare GP/XP against demon and abyssal heads when training Prayer."
+  history:
+    - date: "2016-01-07"
+      description: "Released with the Zeah: Great Kourend expansion alongside the Arceuus Reanimation spellbook."
+    - date: "2021-04-28"
+      description: "Examine text expanded to reference Expert Reanimation."
+    - date: "2022-03-30"
+      description: "Ensouled heads now drop in instanced areas."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: "Zeah: Great Kourend"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-dog-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-dog-head.mdx
@@ -61,7 +61,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-dog-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-dog-head.mdx
@@ -12,14 +12,56 @@ osrs:
   lowalch: 114
   highalch: 171
   limit: 3000
-  about: "Ensouled dog head is a members-only item in Old School RuneScape. High alchemy value: 171 coins. Grand Exchange buy limit: 3,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Guard dog
+        quantity: "1"
+        rarity: "1/25"
+      - source: Wild dog
+        quantity: "1"
+        rarity: "1/25"
+      - source: Bottle of headless unicornman's heady beer
+        quantity: "3-8"
+        rarity: Common
+  prayer:
+    reanimation:
+      spell: Adept Reanimation
+      magic_level: 41
+      prayer_xp: 520
+      runes: "1 Soul rune, 3 Nature runes, 4 Body runes"
+  related_items:
+    - name: "Dog bones"
+      relationship: alternative
+  about: "Ensouled dog head is a members-only reanimation reagent in Old School RuneScape used with the Adept Reanimation spell on the Arceuus spellbook at 41 Magic to summon a reanimated dog, granting 520 Prayer experience on defeat."
+  market_strategy:
+    notes:
+      - "Non-tradeable on the Grand Exchange; obtained directly from monster drops."
+      - "Used by Arceuus prayer trainers grinding 41 Magic Adept Reanimation."
+      - "Bottle of headless unicornman's heady beer can yield 3-8 per drink for low-cost stockpiles."
+  trading_tips:
+    - "Farm Guard dogs (1/25) for a steady supply during Prayer training."
+    - "Carry stamina potions; ensouled heads are 0.453 kg each and add up fast."
+  history:
+    - date: "2016-01-07"
+      description: "Released with the Zeah: Great Kourend update introducing the Arceuus reanimation spells."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: "Zeah: Great Kourend"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-monkey-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-monkey-head.mdx
@@ -12,14 +12,65 @@ osrs:
   lowalch: 41
   highalch: 62
   limit: 3000
-  about: "Ensouled monkey head is a members-only item in Old School RuneScape. High alchemy value: 62 coins. Grand Exchange buy limit: 3,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  prayer:
+    description: "Reanimated via the Arceuus Basic Reanimation spell (Magic 16) at the Dark Altar to spawn a combat shade. Killing the reanimated monkey grants 182 Prayer XP and 32 Magic XP."
+    requirements:
+      magic: 16
+      arceuus_favour: 0
+    xp:
+      prayer: 182
+      magic: 32
+    spell: Basic Reanimation
+    runes: "4 body runes, 2 nature runes"
+  drop_table:
+    sources:
+      - source: Monkey
+        quantity: "1"
+        rarity: 1/35
+      - source: Monkey Guard
+        quantity: "1"
+        rarity: 1/35
+      - source: Monkey Archer
+        quantity: "1"
+        rarity: 1/35
+  related_items:
+    - name: Ensouled imp head
+      relationship: alternative
+    - name: Ensouled goblin head
+      relationship: alternative
+    - name: Ensouled chicken head
+      relationship: alternative
+  about: "Ensouled monkey head is a members-only Arceuus reanimation reagent in Old School RuneScape. High alchemy value: 62 coins. Used with the Basic Reanimation spell (Magic 16) to spawn a combat shade that grants 182 Prayer XP when killed."
+  market_strategy:
+    notes:
+      - "Untradeable, not on the Grand Exchange — must be farmed from monkeys, monkey guards, or monkey archers at 1/35 drop rate."
+      - "Mid-tier Prayer training option for accounts with Magic 16+ but lacking the levels for stronger ensouled heads."
+  trading_tips:
+    - "Farm in Ape Atoll or the Karamja Monkey Cave; carry runes and reanimate near the Dark Altar in Arceuus."
+    - "Always carry a teleport — the reanimated shade attacks with melee and can interrupt Prayer training if unprepared."
+  history:
+    - date: "2016-01-07"
+      description: "Released with the Zeah: Great Kourend update alongside the Arceuus Reanimation spell suite."
+    - date: "2022-03-30"
+      description: "Ensouled heads were updated to drop inside instanced areas."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    update: "Zeah: Great Kourend"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-monkey-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-monkey-head.mdx
@@ -70,7 +70,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-stamina-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-stamina-potion-1.mdx
@@ -12,14 +12,82 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: null
-  about: "Extended stamina potion(1) is a members-only item in Old School RuneScape. High alchemy value: 24 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: high
+  potion:
+    doses: 1
+    effects:
+      - description: Restores 40% run energy per dose
+      - description: Reduces run energy depletion by 70% for 4 minutes
+      - description: When used with charged Ring of Endurance, consumes 2 charges to double effects (80% restoration, 8-minute duration)
+  recipes:
+    - skill: Herblore
+      level: 85
+      xp: 27.5
+      tools: []
+      materials:
+        - item_name: Stamina potion(1)
+          quantity: 1
+        - item_name: Marlin scale
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Stamina potion(1)
+      slug: stamina-potion-1
+      relationship: component
+      description: Base 1-dose stamina potion combined with marlin scales
+    - item_name: Marlin scale
+      slug: marlin-scale
+      relationship: component
+      description: Secondary ingredient unlocked via Sailing
+    - item_name: Extended stamina potion(2)
+      slug: extended-stamina-potion-2
+      relationship: variant
+      description: 2-dose variant
+    - item_name: Extended stamina potion(3)
+      slug: extended-stamina-potion-3
+      relationship: variant
+      description: 3-dose variant
+    - item_name: Extended stamina potion(4)
+      slug: extended-stamina-potion-4
+      relationship: variant
+      description: 4-dose variant
+  about: "Extended stamina potion(1) is a members-only Herblore potion brewed at level 85 by adding a marlin scale to a 1-dose stamina potion, restoring 40% run energy and applying a stronger run-depletion debuff than the standard stamina potion."
+  market_strategy:
+    notes:
+      - Demand driven by long-duration PvM and agility content
+      - Sailing-era release ties supply to marlin scale farming
+      - 1-dose decant variant has lower margin than 4-dose
+      - No published GE limit means decanters can move volume
+  trading_tips:
+    - Decant into 4-dose for liquidity when premium is high
+    - Watch marlin scale supply for crafting arbitrage
+    - Buy off-peak when raid teams aren't restocking
+  history:
+    - date: "2025-11-19"
+      description: Extended stamina potion(1) added alongside the Sailing skill release.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-stamina-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-stamina-potion-1.mdx
@@ -87,7 +87,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/facemask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/facemask.mdx
@@ -83,7 +83,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/facemask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/facemask.mdx
@@ -12,14 +12,78 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 70
-  about: "Facemask is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: 1
+    weight: 0.113
+    requirements:
+      slayer: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Slayer Masters
+      stock: unlimited
+      price: 200
+  related_items:
+    - name: Slayer helmet
+      relationship: product
+    - name: Earmuffs
+      relationship: alternative
+    - name: Nose peg
+      relationship: alternative
+    - name: Spiny helmet
+      relationship: alternative
+  about: "Facemask is a members-only Slayer item in Old School RuneScape, sold by Slayer Masters for 200 coins to players with at least level 10 Slayer. Wearing it prevents the stat-drain attacks of dust devils and smoke devils, and it is later used as a component in crafting the Slayer helmet."
+  market_strategy:
+    notes:
+      - "Demand is steady through Slayer task rotations targeting dust devils and smoke devils."
+      - "Slayer helmet crafting absorbs facemasks, providing a constant sink that keeps the floor at shop value."
+  trading_tips:
+    - "Buy directly from Slayer Masters for guaranteed 200 gp if Grand Exchange supply is dry."
+    - "Stock up before tackling smoke devil tasks since the mask is mandatory there."
+  history:
+    - date: "2005-01-26"
+      description: "Released alongside the original Slayer skill expansion as a requirement for fighting dust devils."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-01-26"
+    update: Slayer
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.113
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fake-beard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fake-beard.mdx
@@ -12,14 +12,46 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Fake beard is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Ali Morrisane's Stall
+      location: Al Kharid
+      price: 1
+    - shop_name: Pollnivneach General Store
+      location: Pollnivneach
+      price: 1
+  related_items:
+    - slug: kharidian-headpiece
+      relationship: set-piece
+  about: "Fake beard is a quest item used during The Feud and Wanted! quests for disguise purposes in Pollnivneach."
+  market_strategy:
+    notes:
+      - Joke alch value at 0 coins; price floor set by shop scarcity (15 GE limit).
+      - Demand is intermittent and tied to quest completion.
+  trading_tips:
+    - Maintain a small stock during ironman quest update windows.
+    - Players rarely flip; shop arbitrage is the main profit angle.
+  history:
+    - date: "2005-04-04"
+      description: Released with The Feud quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-04-04"
+    update: The Feud
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    quest: The Feud
+    weight: 0.03
+    options:
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fake-beard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fake-beard.mdx
@@ -51,7 +51,10 @@ osrs:
     alchable: false
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/frying-pan.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/frying-pan.mdx
@@ -79,7 +79,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/frying-pan.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/frying-pan.mdx
@@ -12,14 +12,74 @@ osrs:
   lowalch: 664
   highalch: 996
   limit: 50
-  about: "Frying pan is a members-only item in Old School RuneScape. High alchemy value: 996 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: iron
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: bladed
+    attack_speed: 6
+    weight: 1.587
+    requirements:
+      attack: 20
+      quest: "Recipe for Disaster"
+    attack_bonus:
+      crush: 25
+    other_bonus:
+      strength: 20
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle basement
+      price: 2158
+      diary_discount_price: 1726
+  related_items:
+    - name: Wooden spoon
+      relationship: alternative
+    - name: Egg whisk
+      relationship: alternative
+    - name: Spork
+      relationship: alternative
+    - name: Spatula
+      relationship: alternative
+    - name: Skewer
+      relationship: alternative
+    - name: Rolling pin
+      relationship: alternative
+    - name: Meat tenderiser
+      relationship: alternative
+  about: "Frying pan is a members-only joke melee weapon in Old School RuneScape, unlocked through Recipe for Disaster subquests. High alchemy value: 996 coins. Grand Exchange buy limit: 50 per 4 hours."
+  market_strategy:
+    notes:
+      - Culinaromancer's Chest provides a stable supply ceiling at 2,158 coins (1,726 with diary).
+      - GE price typically sits below shop price thanks to high-alch profitability.
+  trading_tips:
+    - High-alch margin holds the price near alch-floor; bulk flips clear slowly given the 50 limit.
+    - Watch for nostalgia spikes around RFD anniversary events.
+  history:
+    - date: "2006-03-15"
+      description: Released with the Recipe for Disaster (Hundredth Quest) update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-03-15"
+    update: "Recipe for Disaster"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: "Recipe for Disaster"
+    weight: 1.587
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-2h-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-2h-sword.mdx
@@ -93,7 +93,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-2h-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-2h-sword.mdx
@@ -12,14 +12,88 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 70
+  material:
+    type: metal
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: two_handed_sword
+    attack_speed: 7
+    weight: 3.628
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 0
+      slash: 69
+      crush: 50
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 70
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 1319
+      item_name: Rune 2h sword
+      slug: rune-2h-sword
+      relationship: alternative
+      description: Same stats, non-gilded base
+    - item_id: 7158
+      item_name: Dragon 2h sword
+      slug: dragon-2h-sword
+      relationship: upgrade
+      description: Higher-tier two-handed sword (60 Attack)
+    - item_id: 20143
+      item_name: Gilded scimitar
+      slug: gilded-scimitar
+      relationship: alternative
+      description: Other gilded melee weapon from Treasure Trails
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
+  market_strategy:
+    notes:
+      - "Cosmetic gilded variant of the rune 2h sword; price tracks clue scroll meta."
+      - "Limited supply (70/4hr) with multi-tier Treasure Trails drop pool."
+  trading_tips:
+    - "Stockpile after Treasure Trails reworks that buff non-gilded loot."
+    - "Long-term hold; gilded items historically trend upward."
   about: "Gilded 2h sword is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  history:
+    - date: "2016-07-06"
+      description: Released with the Treasure Trail Expansion update.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-wardrobe-flatpack.mdx
@@ -73,7 +73,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-wardrobe-flatpack.mdx
@@ -12,14 +12,68 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
+  construction:
+    level: 87
+    xp: 720
+    hotspot: Wardrobe (Bedroom)
+    facility: Bench with lathe
+    description: Placed in the Wardrobe space within a player-owned house Bedroom.
+  recipes:
+    - skill: Construction
+      level: 87
+      xp: 720
+      materials:
+        - item_name: Mahogany plank
+          quantity: 3
+        - item_name: Gold leaf
+          quantity: 1
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_id: 8782
+      item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Primary building material
+    - item_id: 8784
+      item_name: Gold leaf
+      slug: gold-leaf
+      relationship: component
+      description: Required for the gilded finish
   about: "Gilded wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Used for 87 Construction levelling without owning a bench
+      - Demand tied to high Construction training meta
+      - Cost is dominated by Gold leaf
+  trading_tips:
+    - Sell to players training Construction without lathe access
+    - Track Gold leaf price as primary cost driver
+    - Buy limit of 500 supports moderate flipping volume
+  history:
+    - date: "2006-05-31"
+      description: Released with the Construction skill / Player-Owned Houses update.
+  properties:
+    release_date: "2006-05-31"
+    update: PLAYER-OWNED HOUSES!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/goading-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/goading-potion-2.mdx
@@ -67,7 +67,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/goading-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/goading-potion-2.mdx
@@ -12,14 +12,62 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: null
-  about: "Goading potion(2) is a members-only item in Old School RuneScape. High alchemy value: 120 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: "Forces non-aggressive monsters in a 9x9 tile area and line of sight to become aggressive toward the drinker."
+      - description: "Duration of 6 minutes per dose; aggression refreshes every 6 ticks (3.6 seconds)."
+  recipes:
+    - materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Aldarium
+          quantity: 1
+      tools: []
+      skill: Herblore
+      level: 54
+      xp: 132
+      output_quantity: 1
+  related_items:
+    - name: Goading potion(1)
+      relationship: variant
+    - name: Goading potion(3)
+      relationship: variant
+    - name: Goading potion(4)
+      relationship: variant
+  about: "Goading potion(2) is a members-only Herblore potion in Old School RuneScape with two doses, forcing nearby non-aggressive monsters into aggression. High alchemy value: 120 coins."
+  market_strategy:
+    notes:
+      - Acts mostly as an intermediate decant; full (4)-dose stacks carry the liquidity.
+      - Supply ties to Aldarium and Harralander potion (unf) prices from Varlamore content.
+  trading_tips:
+    - Combine (1) and (3) into (4) at a decanter when spreads favor it.
+    - Watch Slayer task popularity that favors aggressive AFK training (e.g. Nightmare Zone alternatives).
+  history:
+    - date: "2024-09-25"
+      description: Released with the Varlamore - The Rising Darkness update.
+    - date: "2024-11-06"
+      description: Hotfix improved messaging when the potion expires early via teleport or tea consumption.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/goblin-mail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/goblin-mail.mdx
@@ -68,7 +68,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/goblin-mail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/goblin-mail.mdx
@@ -1,6 +1,6 @@
 ---
 title: Goblin mail | OSRS Price Data
-description: "Goblin mail: Some brown armour designed to fit goblins.. High alch: 24 GP, GE limit: 15."
+description: "Goblin mail: Some brown armour designed to fit goblins. High alch: 24 GP, GE limit: 15."
 osrs:
   id: 288
   name: Goblin mail
@@ -12,18 +12,63 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 15
-  related_items: []
-  about: |-
-    > _"Some brown armour designed to fit goblins."_
-
-    Goblin mail is a quest item required for Goblin Diplomacy (3 pieces) and Land of the Goblins (5 pieces). Can be dyed various colours using dyes for quest objectives.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  material:
+    type: cloth
+    tier: low
+  drop_table:
+    sources:
+      - source: Goblin
+        quantity: "1"
+        rarity: Uncommon
+      - source: Goblin Village crates
+        quantity: "1"
+        rarity: Always (3 available)
+  related_items:
+    - item_id: 9012
+      item_name: Orange goblin mail
+      slug: orange-goblin-mail
+      relationship: variant
+      description: Orange-dyed quest variant from Goblin Diplomacy.
+    - item_id: 9013
+      item_name: Blue goblin mail
+      slug: blue-goblin-mail
+      relationship: variant
+      description: Blue-dyed quest variant from Goblin Diplomacy.
+    - item_id: 9014
+      item_name: Black goblin mail
+      slug: black-goblin-mail
+      relationship: variant
+      description: Black-dyed variant used during Land of the Goblins.
+  about: A small piece of goblin armour dropped by goblins and looted from Goblin Village crates; required for Goblin Diplomacy and Land of the Goblins, dyeable into multiple colored variants.
+  market_strategy:
+    notes:
+      - Demand driven entirely by F2P questers running Goblin Diplomacy.
+      - Supply abundant from Goblin Village crate respawns and low-level goblin drops.
+  trading_tips:
+    - Buy in bulk before quest weekends; sell to questers ahead of new releases.
+    - Tiny GE limit of 15 caps flips but margins remain stable.
+  history:
+    - date: "2001-05-08"
+      description: Goblin mail introduced alongside early goblin content.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-05-08"
+    update: Early F2P content
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: true
+    quest: Goblin Diplomacy
+    weight: 3.628
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-bracelet.mdx
@@ -95,7 +95,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-bracelet.mdx
@@ -12,14 +12,90 @@ osrs:
   lowalch: 220
   highalch: 330
   limit: 18000
-  about: "Gold bracelet is a members-only item in Old School RuneScape. High alchemy value: 330 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: gold
+    tier: low
+  equipment:
+    slot: hands
+    weight: 0.25
+    requirements:
+      crafting: 7
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Crafting
+      level: 7
+      xp: 25
+      facility: Furnace
+      tools:
+        - Bracelet mould
+      materials:
+        - item_name: Gold bar
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: Smelted gold required to craft the bracelet
+    - item_name: Bracelet mould
+      slug: bracelet-mould
+      relationship: component
+      description: Mould required at the furnace to craft any bracelet
+    - item_name: Sapphire bracelet
+      slug: sapphire-bracelet
+      relationship: upgrade
+      description: Sapphire variant unlocks enchantment via Lvl-1 Enchant
+  about: "Gold bracelet is a members-only Crafting product made by using a gold bar on a furnace with a bracelet mould at level 7 Crafting for 25 XP and worn in the hands slot but offers no combat bonuses and cannot be enchanted."
+  market_strategy:
+    notes:
+      - Crafting alch margin tied to gold bar and nature rune prices
+      - Stable demand from low-level Crafting trainers
+      - High GE buy limit (18,000) supports bulk alch sessions
+      - No enchantment route limits niche demand
+  trading_tips:
+    - Track gold bar price for alch profit calculations
+    - Buy in bulk when nature rune prices dip
+    - Liquidity is high near GE thanks to alch-focused crafters
+  history:
+    - date: "2007-04-30"
+      description: Gold bracelet released as part of the 24 Carat Update extending gold jewellery options.
+  properties:
+    release_date: "2007-04-30"
+    update: 24 Carat Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/graahk-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/graahk-fur.mdx
@@ -12,14 +12,53 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 10000
-  about: "Graahk fur is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Horned graahk
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - name: Tatty graahk fur
+      relationship: variant
+    - name: Larupia fur
+      relationship: alternative
+    - name: Kyatt fur
+      relationship: alternative
+    - name: Graahk headdress
+      relationship: product
+    - name: Graahk top
+      relationship: product
+    - name: Graahk legs
+      relationship: product
+  about: "Graahk fur is a perfect Hunter fur trapped from Horned Graahks on Karamja at 41 Hunter, used to tailor the graahk hunter outfit or sold to fur merchants for steady gp."
+  market_strategy:
+    notes:
+      - "GE price near 339 gp with a 10,000-per-4-hours buy limit."
+      - "Steady demand from Hunter outfit crafters and medium fur pouch makers."
+  trading_tips:
+    - "Sell to Fancy Clothes Store and East Ardougne fur merchants for a flat NPC floor when GE dips."
+    - "Pair with kyatt and larupia furs - the trio fluctuates with Hunter training guide popularity."
+  history:
+    - date: "2006-11-21"
+      description: "Released with the Hunter skill."
+  properties:
+    release_date: "2006-11-21"
+    update: "Hunter"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/graahk-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/graahk-fur.mdx
@@ -58,7 +58,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grand-seed-pod.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grand-seed-pod.mdx
@@ -12,14 +12,63 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 15
-  about: "Grand seed pod is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destinations:
+      - name: Grand Tree (top floor)
+        method: Launch
+        notes: "Outdoors only; grants 100 Farming XP."
+      - name: Grand Tree (ground floor)
+        method: Squash
+        notes: "Drains Farming by 5 temporarily."
+    works_in_wilderness_up_to: 30
+  drop_table:
+    sources:
+      - source: Wingstone
+        quantity: "1"
+        rarity: 23/512
+      - source: Penwie
+        quantity: "1"
+        rarity: 23/512
+      - source: Brambickle
+        quantity: "1"
+        rarity: 23/512
+      - source: Professor Manglethorp
+        quantity: "1"
+        rarity: 23/512
+  related_items:
+    - name: Royal seed pod
+      relationship: upgrade
+  about: "Grand seed pod is a members-only teleport consumable in Old School RuneScape obtained as a Gnome Restaurant minigame reward. High alchemy value: 150 coins. Grand Exchange buy limit: 15 per 4 hours."
+  market_strategy:
+    notes:
+      - Buy limit of 15 per 4h keeps single-trade exposure low but the item is thin on volume.
+      - Demand is driven by Wilderness teleports up to level 30 and Farming XP grinders.
+  trading_tips:
+    - Place buy orders well below last because volume is low and pricing is volatile.
+    - Royal seed pod largely supplants this item for MMII completers; price soft after major MMII spikes.
+  history:
+    - date: "2006-08-07"
+      description: Released as a Gnome Restaurant reward with the Gnome Cuisine update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-08-07"
+    update: Gnome Cuisine
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Launch
+      - Squash
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grand-seed-pod.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grand-seed-pod.mdx
@@ -68,7 +68,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grey-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grey-gloves.mdx
@@ -12,14 +12,87 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Grey gloves is a free-to-play item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: hands
+    weapon_type: none
+    attack_speed: 1
+    weight: 0.453
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Barker's Haberdashery
+      location: Canifis
+      price: 650
+      stock: 5
+  related_items:
+    - item_id: 2912
+      item_name: Black gloves
+      slug: black-gloves
+      relationship: variant
+      description: Black colour variant
+    - item_id: 2900
+      item_name: White gloves
+      slug: white-gloves
+      relationship: variant
+      description: White colour variant
+  about: "Grey gloves are a free-to-play cosmetic glove from Barker's Haberdashery in Canifis with marginal slash and crush defence bonuses."
+  market_strategy:
+    notes:
+      - Shop price at Barker's caps arbitrage to roughly 650 coins minus tax versus the GE.
+      - Cosmetic demand drives most volume; fashionscape and roleplay setups dominate the order book.
+      - F2P access broadens buyer base versus members-only cosmetic gloves.
+  trading_tips:
+    - Stock from Canifis shop and resell on GE during cosmetic event spikes.
+    - Watch alongside white/black glove pricing since players often buy the trio together.
+  history:
+    - date: "2004-06-29"
+      description: Released as a generic glove cosmetic.
+    - date: "2004-07-13"
+      description: Briefly converted to members-only.
+    - date: "2004-07-20"
+      description: Returned to free-to-play access.
+    - date: "2014-12-10"
+      description: Renamed from Gloves to Grey gloves to disambiguate the colour variants.
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grey-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grey-gloves.mdx
@@ -92,7 +92,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grid-master-torch-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grid-master-torch-scroll.mdx
@@ -49,7 +49,10 @@ osrs:
     alchable: false
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grid-master-torch-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grid-master-torch-scroll.mdx
@@ -12,14 +12,44 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Grid master torch scroll is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Events Reward Shop
+      location: Varrock Square
+      price: 6000
+      currency: event points
+      stock: unlimited
+  related_items:
+    - name: Grid master altar icon scroll
+      relationship: alternative
+  about: "Grid master torch scroll is a members-only cosmetic in Old School RuneScape. Used on a marble incense burner inside a Player Owned House to convert it into the Flames of Lloigh-enn."
+  market_strategy:
+    notes:
+      - Supply is gated by the Grid Master event reward shop at 6,000 event points.
+      - Resale value tends to drift down after the event ends as new scrolls flood the GE.
+  trading_tips:
+    - Cosmetic POH unlocks see thin daily volume; place buy orders well under last and be patient.
+    - Track the event's end date to time entry/exit on the market.
+  history:
+    - date: "2025-10-15"
+      description: Released as a reward from the Grid Master community event.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-10-15"
+    update: Grid Master
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+    alchable: false
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-helm.mdx
@@ -12,85 +12,81 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
+  material:
+    type: barrows
+    tier: high
   equipment:
     slot: head
-    type: barrows
-    set: Guthan
-    tradeable: true
-    degradeable: true
-    weight: 1.8
+    weapon_type: armour
+    weight: 2.721
     requirements:
       defence: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -6
-      attack_ranged: 0
-      defence_stab: 55
-      defence_slash: 58
-      defence_crush: 54
-      defence_magic: -1
-      defence_ranged: 62
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 55
+      slash: 58
+      crush: 54
+      magic: -1
+      ranged: 62
+    other_bonus:
       strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  set_effect:
-    name: Infestation
-    pieces_required: 4
-    description: 25% chance to heal HP equal to damage dealt
+  charges:
+    max_charges: 15
+    description: "Degrades over 15 hours of combat use. Full repair costs 60,000 coins at Bob in Lumbridge, or 59,700 coins at a POH armour stand with 1 Smithing."
+  drop_table:
+    sources:
+      - source: Barrows chest
+        quantity: "1"
+        rarity: "1/2448"
   related_items:
-    - item_id: 4728
-      item_name: Guthan's platebody
-      slug: guthans-platebody
+    - name: "Guthan's platebody"
       relationship: set-piece
-      description: Body slot set piece
-    - item_id: 4730
-      item_name: Guthan's chainskirt
-      slug: guthans-chainskirt
+    - name: "Guthan's chainskirt"
       relationship: set-piece
-      description: Legs slot set piece
-    - item_id: 4726
-      item_name: Guthan's warspear
-      slug: guthans-warspear
+    - name: "Guthan's warspear"
       relationship: set-piece
-      description: Weapon set piece
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Stab defence | +55 |
-    | Slash defence | +58 |
-    | Crush defence | +54 |
-    | Magic defence | -1 |
-    | Ranged defence | +62 |
-    | Magic attack | -6 |
-
-    Infestation:
-    When wearing full Guthan's (helm, platebody, chainskirt, warspear):
-    - 25% chance to heal HP equal to damage dealt
-    - No prayer or food needed for sustain
-    - Popular for AFK training
-
-    Best For:
-    - AFK Slayer tasks
-    - Extended trips without banking
-    - Gargoyles, Aberrant spectres
-    - NMZ AFK method
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
+  about: "Guthan's helm is a members-only barrows head armour requiring 70 Defence. When worn with the full Guthan's set, successful melee attacks have a 25% chance to heal the wearer for damage dealt — the Infestation effect is heavily used for AFK combat training."
   market_strategy:
     notes:
-      - Popular for AFK methods
-      - Full set required for healing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Popular for AFK Slayer methods (gargoyles, aberrant spectres) and NMZ AFK builds."
+      - "Full set required to trigger the Infestation healing effect."
+      - "Degrades over 15 hours; factor 60k repair into long-term cost."
+  trading_tips:
+    - "Stockpile during Barrows mass-runs when supply pushes prices down."
+    - "Sell into AFK Slayer demand spikes after league or event releases."
+  history:
+    - date: "2005-05-09"
+      description: "Released as part of the Barrows update as one of the six brothers' armour sets."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    update: "Barrows"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Check
+      - Drop
+    alchable: true
+    destroy: "If you drop this item it will break."
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-helm.mdx
@@ -86,7 +86,10 @@ osrs:
     alchable: true
     destroy: "If you drop this item it will break."
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-d-hide-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-d-hide-boots.mdx
@@ -12,35 +12,44 @@ osrs:
   lowalch: 3720
   highalch: 5580
   limit: 8
+  material:
+    type: dragonhide
+    tier: high
   equipment:
     slot: feet
-    type: ranged armour
-    attack_style: ranged
+    weapon_type: none
+    attack_speed: 1
+    weight: 1.4
     requirements:
       ranged: 70
       defence: 40
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -10
-      attack_ranged: 7
-      defence_stab: 4
-      defence_slash: 4
-      defence_crush: 4
-      defence_magic: 4
-      defence_ranged: 4
-      melee_strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 7
+    defence_bonus:
+      stab: 4
+      slash: 4
+      crush: 4
+      magic: 4
+      ranged: 4
+    other_bonus:
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
-      prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: Rare
-        description: Reward from hard clue scroll caskets (1/1,625)
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
   related_items:
     - item_id: 19933
       item_name: Saradomin d'hide boots
@@ -67,30 +76,38 @@ osrs:
       slug: ancient-d-hide-boots
       relationship: variant
       description: Ancient variant of blessed d'hide boots
-  about: |-
-    "Guthix blessed dragonhide boots."
-
-    The Guthix d'hide boots are blessed dragonhide boots aligned with the god Guthix. They require 70 Ranged and 40 Defence to equip and occupy the feet slot. Like all blessed d'hide boots, they offer a +7 ranged attack bonus and a +1 prayer bonus, making them a direct upgrade over regular snakeskin or ranger boots alternatives for players on a budget.
-
-    All six god d'hide boots share identical combat stats, so the choice between them is purely cosmetic or based on God Wars Dungeon faction protection. The Guthix d'hide boots provide protection from Guthix-aligned NPCs in the God Wars Dungeon.
-
-    Blessed d'hide boots are the best ranged boots available that also provide a prayer bonus, aside from the much more expensive pegasian boots. They share the same +7 ranged attack bonus as ranger boots but add a +1 prayer bonus on top. For players who cannot afford ranger boots or pegasian boots, blessed d'hide boots are the go-to choice for the feet slot in ranged setups.
+  about: "Guthix d'hide boots are blessed dragonhide footwear granting +7 ranged attack and +1 prayer for players who lack ranger or pegasian boots, obtained from hard clue caskets."
   market_strategy:
-    title: Investment Notes
     notes:
-      - All god d'hide boot variants share the same stats, so price differences are driven by cosmetic demand
-      - Significantly cheaper than ranger boots while offering comparable offensive stats
-      - Strong demand from mid-level players building ranged gear sets
-      - Compare prices across all six god variants before buying since stats are identical
-      - Useful for God Wars Dungeon as Guthix protection in the feet slot
-      - Buy limit of 8 per 4 hours on the Grand Exchange
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - All six god d'hide boot variants share identical stats so price gaps come from cosmetic preference and Guthix faction protection.
+      - Significantly cheaper than ranger boots while offering comparable offensive stats which keeps mid-tier ranged demand sticky.
+      - Buy limit of 8 per 4 hours throttles flipping volume even when price gaps widen across the god variants.
+  trading_tips:
+    - Compare the six variants before buying since stats are identical and arbitrage opportunities open frequently.
+    - Front-run major clue scroll content reworks that change hard casket loot tables.
+  history:
+    - date: "2016-07-06"
+      description: Released as part of the god d'hide boot suite added to hard clue rewards.
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.4
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-d-hide-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-d-hide-boots.mdx
@@ -107,7 +107,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hammerstone-hops.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hammerstone-hops.mdx
@@ -82,7 +82,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hammerstone-hops.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hammerstone-hops.mdx
@@ -12,14 +12,77 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Hammerstone hops is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hops
+    tier: low
+  farming:
+    seed: Hammerstone seed
+    farming_level: 4
+    patch: Hops
+    yield: Hammerstone hops
+  recipes:
+    - materials:
+        - item_name: Hammerstone hops
+          quantity: 4
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Ale yeast
+          quantity: 1
+      tools:
+        - Fermenting vat
+      output_quantity: 8
+  shops:
+    - shop_name: Olivia's Farming Shop (Catherby)
+      currency: Coins
+      price: 4
+      stock: 5
+    - shop_name: Lyra's Farming Shop (East Ardougne)
+      currency: Coins
+      price: 4
+      stock: 5
+    - shop_name: Elstan's Farming Shop (South Falador)
+      currency: Coins
+      price: 4
+      stock: 5
+  related_items:
+    - item_name: Hammerstone seed
+      slug: hammerstone-seed
+      relationship: component
+    - item_name: Dwarven stout
+      slug: dwarven-stout
+      relationship: product
+    - item_name: Asgarnian hops
+      slug: asgarnian-hops
+      relationship: alternative
+  about: "Lowest-tier farming hops, planted from a Hammerstone seed at 4 Farming and used in brewing dwarven stout via 19 Cooking."
+  market_strategy:
+    notes:
+      - Cheap brewing input
+      - Easy farming experience early
+      - Shops stock at 4gp
+  history:
+    - date: "2005-07-11"
+      description: Released with Farming skill update.
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/harralander-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/harralander-seed.mdx
@@ -78,7 +78,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/harralander-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/harralander-seed.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 600
-  seed:
-    type: herb
-    tier: low-mid
+  material:
+    type: seed
+    tier: mid
   farming:
     level: 26
     xp_plant: 21.5
@@ -42,40 +42,43 @@ osrs:
     - item_id: 5293
       item_name: Tarromin seed
       slug: tarromin-seed
-      relationship: alternative
+      relationship: downgrade
       description: Lower tier herb seed
     - item_id: 5295
       item_name: Ranarr seed
       slug: ranarr-seed
       relationship: upgrade
       description: Next tier herb seed
-  about: |-
-    Plant in a herb patch to grow Grimy harralander.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 26 |
-    | Growth time | 80 minutes |
-    | XP (plant) | 21.5 |
-    | XP (harvest) | 24 per herb |
+  about: "Plant in a herb patch to grow grimy harralander, the herb used for energy, combat, and compost potions."
   market_strategy:
     notes:
-      - Mid-low tier herb seed
-      - Used for energy, combat, and compost potions
-      - Moderate value
-      - Ultracompost (essential)
-      - Magic secateurs (10% more yield)
-      - Farming cape (5% more yield)
-      - 9 herb patches available
-      - ~10 minute runs, 80 minute regrowth
-      - Compost potions valuable for making supercompost
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Mid-tier herb seed with steady demand from Farming runners chasing energy potion herbs.
+      - Yield boosts (ultracompost, magic secateurs, farming cape) materially shift the break-even seed cost.
+      - 9 herb patches plus an ~80 minute regrowth window cap how many seeds a single player can consume per day.
+  trading_tips:
+    - Buy after seed-pack bot waves dump supply onto the GE and prices sag.
+    - Watch grimy harralander spikes during compost potion demand surges to time seed sales.
+  history:
+    - date: "2005-06-06"
+      description: Released with the Farming skill.
+  properties:
+    release_date: "2005-06-06"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/heavy-ballista.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/heavy-ballista.mdx
@@ -12,89 +12,76 @@ osrs:
   lowalch: 380000
   highalch: 570000
   limit: 8
+  material:
+    type: dragon
+    tier: high
   equipment:
     slot: weapon
-    type: ranged_weapon
-    two_handed: true
-    tradeable: true
+    weapon_type: ballista
+    attack_speed: 7
     weight: 6
     requirements:
       ranged: 75
       quest: Monkey Madness II
-    stats:
-      attack_ranged: 125
+    attack_bonus:
+      ranged: 125
+    other_bonus:
       ranged_strength: 15
-  creation:
-    method: Combine unstrung heavy ballista with Monkey tail
-    requirements:
-      fletching: 72
-    xp: 600
-    materials:
-      - item_id: 19589
-        item_name: Unstrung heavy ballista
-        slug: unstrung-heavy-ballista
-      - item_id: 19610
-        item_name: Monkey tail
-        slug: monkey-tail
-  ammunition:
-    type: javelin
-    max_tier: dragon
   special_attack:
     name: Concentrated Shot
-    energy: 65
-    description: +25% accuracy, +25% damage
+    energy_cost: 65
+    description: "Increases accuracy and damage by 25%."
+  recipes:
+    - skill: Fletching
+      level: 72
+      xp: 600
+      output_quantity: 1
+      tools: []
+      materials:
+        - item_name: Unstrung heavy ballista
+          quantity: 1
+        - item_name: Monkey tail
+          quantity: 1
   related_items:
-    - item_id: 19478
-      item_name: Light ballista
-      slug: light-ballista
+    - name: Light ballista
       relationship: downgrade
-      description: Lighter version
-    - item_id: 19484
-      item_name: Dragon javelin
-      slug: dragon-javelin
+    - name: Dragon javelin
       relationship: component
-      description: Best ammo
-    - item_id: 0
-      item_name: Monkey Madness II
-      slug: monkey-madness-ii
-      relationship: alternative
-      description: Unlock quest
-  about: |-
-    Combine unstrung heavy ballista with Monkey tail.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Fletching | 72 (600 XP) |
-
-    | Offence | Bonus |
-    |---------|-------|
-    | Ranged | +125 |
-    | Ranged Strength | +15 |
-
-    Uses Javelins (up to dragon tier).
-
-    Concentrated Shot (65% spec)
-    - +25% accuracy
-    - +25% damage
-
-    BiS for:
-    - PvP ranged KOs
-    - High max hit setups
-    - Spec weapon
-
-    Highest ranged max hit weapon.
+    - name: Heavy ballista (or)
+      relationship: variant
+  about: "Heavy ballista is a two-handed ranged weapon from Monkey Madness II, firing javelins up to dragon tier. Its Concentrated Shot special gives +25% accuracy and damage at 65% energy, making it a top PvP ranged KO option."
   market_strategy:
     notes:
-      - Great for PvP
+      - Great for PvP burst damage
       - Slow attack speed
-      - Best with dragon javelins
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Best paired with dragon javelins
+  trading_tips:
+    - Monitor buy limit of 8 per 4 hours
+    - Price tracks unstrung ballista + monkey tail margin
+  history:
+    - date: "2016-05-06"
+      description: "Heavy ballista was released with the Monkey Madness II quest."
+  properties:
+    release_date: "2016-05-06"
+    update: "Monkey Madness II"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: "Monkey Madness II"
+    weight: 6
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/heavy-ballista.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/heavy-ballista.mdx
@@ -81,7 +81,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hemp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hemp.mdx
@@ -12,14 +12,65 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 13000
-  about: "Hemp is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    seed: Hemp seeds
+    seeds_per_patch: 3
+    patch_type: Hops
+    level: 37
+  recipes:
+    - materials:
+        - item_name: Hemp
+          quantity: 1
+      tools:
+        - Spinning wheel
+      skill: Crafting
+      level: 39
+      xp: 60
+      output_quantity: 1
+      output_item: Hemp yarn
+  related_items:
+    - item_id: 31458
+      item_name: Hemp seeds
+      slug: hemp-seeds
+      relationship: component
+      description: Seed planted in a hops patch to grow hemp.
+    - item_id: 31459
+      item_name: Hemp yarn
+      slug: hemp-yarn
+      relationship: product
+      description: Hemp spun on a spinning wheel; used for Sailing content.
+  about: "Hemp is a Sailing-update Farming crop harvested from a hops patch at level 37 and spun into hemp yarn for canvas bolts, trawling nets and other ship rigging."
+  market_strategy:
+    notes:
+      - "Supply is driven by hops-patch farm runs; price tracks Sailing engagement and yarn demand."
+      - "GE limit of 13,000 per 4 hours supports bulk crafters spinning yarn for canvas bolts."
+      - "Acts as payment to protect cotton patches, so demand from cotton farmers adds floor."
+  trading_tips:
+    - "Plant during seed-price dips and resell harvest when canvas bolt demand spikes."
+    - "Convert to hemp yarn (Crafting 39) when the spread covers GE tax."
+    - "Avoid alching; high alch (18 gp) sits far below GE price."
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2025-11-19"
+      description: "Introduced with the Sailing skill update as a hops-patch Farming crop spinnable into hemp yarn."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hemp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hemp.mdx
@@ -70,7 +70,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/holy-mould.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/holy-mould.mdx
@@ -79,7 +79,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/holy-mould.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/holy-mould.mdx
@@ -14,59 +14,72 @@ osrs:
   limit: 40
   material:
     type: mould
-    tier: crafting_tool
-  crafting:
-    use: holy_symbol
+    tier: low
+  recipes:
+    - materials:
+        - item_name: Silver bar
+          quantity: 1
+      tools:
+        - Holy mould
+        - Furnace
+      output_quantity: 1
   shops:
-    - shop_name: Crafting shops
-      price: 5
+    - shop_name: Dommik's Crafting Store (Al Kharid)
       currency: Coins
-  uses:
-    - product: Unstrung holy symbol
-      product_id: 1714
-      bar: Silver bar
-      bar_id: 2355
-      crafting_level: 16
-      crafting_xp: 50
+      price: 5
+      stock: 2
+    - shop_name: Rommik's Crafty Supplies (Rimmington)
+      currency: Coins
+      price: 5
+      stock: 2
+    - shop_name: Jamila's Craft Stall (Sophanem)
+      currency: Coins
+      price: 7
+      stock: 2
+    - shop_name: Rasolo the Wandering Merchant
+      currency: Coins
+      price: 10
+      stock: 1
   related_items:
-    - item_id: 2355
-      item_name: Silver bar
+    - item_name: Silver bar
       slug: silver-bar
       relationship: component
-      description: Material used
-    - item_id: 1714
-      item_name: Unstrung holy symbol
+    - item_name: Unstrung holy symbol
       slug: unstrung-holy-symbol
       relationship: product
-      description: Crafted product
-    - item_id: 1718
-      item_name: Holy symbol
+    - item_name: Holy symbol
       slug: holy-symbol
       relationship: product
-      description: Strung version
-  about: |-
-    Make holy symbols at a furnace:
-
-    | Product | Level | XP | Materials |
-    |---------|-------|-----|-----------|
-    | Unstrung holy symbol | 16 | 50 | 1 Silver bar |
-
-    String with ball of wool for completed holy symbol.
+    - item_name: Unholy mould
+      slug: unholy-mould
+      relationship: alternative
+  about: "Reusable crafting tool that turns silver bars into unstrung holy symbols at a furnace (16 Crafting, 50 xp)."
   market_strategy:
     notes:
-      - Holy symbol crafting
-      - Prayer item production
-      - One-time purchase
-      - Not consumed on use
-      - Buy from shop
-      - Low demand item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Buy from shop for cheap
+      - Reusable tool
+      - Low demand
+  history:
+    - date: "2001-07-12"
+      description: Released to support holy symbol crafting.
+  properties:
+    release_date: "2001-07-12"
+    update: Crafting moulds release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hueycoatl-hide-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hueycoatl-hide-vambraces.mdx
@@ -12,97 +12,91 @@ osrs:
   lowalch: 1728
   highalch: 2592
   limit: null
+  material:
+    type: Hueycoatl hide
+    tier: mid-high
   equipment:
     slot: hands
-    type: ranged
-    tradeable: true
-    weight: 0.2
+    weapon_type: none
+    weight: 0.283
     requirements:
-      defence: 40
       ranged: 70
-    stats:
-      attack_ranged: 11
-      attack_magic: -10
-      defence_stab: 6
-      defence_slash: 5
-      defence_crush: 7
-      defence_magic: 8
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 11
+    defence_bonus:
+      stab: 6
+      slash: 5
+      crush: 7
+      magic: 8
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 1
   recipes:
-    - skill: crafting
+    - skill: Crafting
       level: 76
       xp: 95
       materials:
-        - item_id: 30085
-          item_name: Hueycoatl hide
+        - item_name: Hueycoatl hide
           quantity: 1
-        - item_id: 1734
-          item_name: Thread
+        - item_name: Thread
           quantity: 1
-  market:
-    buy_limit: 70
-    price_estimate: 550000
+      tools:
+        - Needle
+      output_quantity: 1
   related_items:
-    - item_id: 30085
-      item_name: Hueycoatl hide
-      slug: hueycoatl-hide
+    - name: Hueycoatl hide
       relationship: component
-      description: Crafting material
-    - item_id: 30073
-      item_name: Hueycoatl hide coif
-      slug: hueycoatl-hide-coif
+    - name: Hueycoatl hide coif
       relationship: set-piece
-      description: Head armor
-    - item_id: 30076
-      item_name: Hueycoatl hide body
-      slug: hueycoatl-hide-body
+    - name: Hueycoatl hide body
       relationship: set-piece
-      description: Body armor
-    - item_id: 30079
-      item_name: Hueycoatl hide chaps
-      slug: hueycoatl-hide-chaps
+    - name: Hueycoatl hide chaps
       relationship: set-piece
-      description: Leg armor
-  about: |-
-    - 40 Defence
-    - 70 Ranged
-
-    | Stat | Bonus |
-    |------|-------|
-    | Ranged Attack | +11 |
-    | Magic Attack | -10 |
-    | Stab Defence | +6 |
-    | Slash Defence | +5 |
-    | Crush Defence | +7 |
-    | Magic Defence | +8 |
-    | Prayer | +1 |
-
-    The Hueycoatl hide vambraces complete the armor set:
-
-    - Good ranged attack: +11 ranged attack for glove slot
-    - Prayer bonus: +1 prayer adds up with full set
-    - Lightweight: Only 0.2 kg
-
-    Best used with:
-    - Hueycoatl hide coif
-    - Hueycoatl hide body
-    - Hueycoatl hide chaps
-
-    Set completion: The vambraces are the easiest piece to craft (lowest hide cost, tied lowest level requirement) and complete the full +8 prayer bonus from the set.
+  about: "Hueycoatl hide vambraces are members ranged-gloves crafted from a single Hueycoatl hide and thread. They match blessed d'hide vambrace stats while remaining lighter, completing the Hueycoatl hide set for a +1 prayer slice."
   market_strategy:
     notes:
-      - Cheapest piece of the set
-      - Only requires 1 hide to craft
-      - Entry point for Crafting training with Hueycoatl hides
-      - Good profit margins when hides are cheap
-      - Often the last piece bought when completing the set
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheapest piece of the Hueycoatl hide armour set, requiring only one hide per craft."
+      - "Entry point for crafting hides into finished armour pieces at Crafting 76."
+      - "Profit margins follow Hueycoatl hide spot price — checks daily before committing to bulk crafts."
+      - "Often the final piece bought when assembling the full set since its cost is lowest."
+  trading_tips:
+    - "Watch Hueycoatl hide bulk listings; small crashes in hide price translate directly into vambrace profit."
+    - "Sell finished vambraces during PvM gear-up cycles when the set sees demand spikes."
+    - "Note when bagged for fast banking on crafting runs."
+  history:
+    - date: "2024-09-25"
+      description: "Released with the Varlamore: The Rising Darkness update as a craftable reward from Hueycoatl drops."
+    - date: "2025-06-25"
+      description: "Crafting requirement reduced from 86 to 76 in the Summer Sweep Up: Combat update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hueycoatl-hide-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hueycoatl-hide-vambraces.mdx
@@ -96,7 +96,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hydra-leather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hydra-leather.mdx
@@ -67,7 +67,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hydra-leather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hydra-leather.mdx
@@ -12,76 +12,62 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 15
-  item:
-    type: crafting_material
-    tradeable: true
-    weight: 0.01
+  material:
+    type: hydra-leather
+    tier: high
   drop_table:
-    primary_source: Alchemical Hydra
-    best_drop_rate: 1/514
     sources:
       - source: Alchemical Hydra
-        source_id: 8621
-        combat_level: 426
         quantity: "1"
-        rarity: 1/514
-        members_only: true
-        notes: Requires 95 Slayer and Hydra Slayer task
+        rarity: "1/514"
   recipes:
-    - skill: none
-      level: 0
-      xp: 0
-      materials:
+    - materials:
         - item_name: Hydra leather
-          item_id: 22983
           quantity: 1
-      product: Ferocious gloves
-      product_id: 22981
-      product_quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
       facility: Lithkren Vault machinery
-      members_only: true
+      notes: "Produces Ferocious gloves. Requires Dragon Slayer II completion to access the vault."
   related_items:
-    - item_id: 22981
-      item_name: Ferocious gloves
-      slug: ferocious-gloves
+    - name: "Ferocious gloves"
       relationship: product
-      description: BiS melee gloves created from this
-    - item_id: 22966
-      item_name: Hydra's claw
-      slug: hydras-claw
+    - name: "Hydra's claw"
       relationship: alternative
-      description: Another rare Hydra drop
-    - item_id: 22975
-      item_name: Brimstone ring
-      slug: brimstone-ring
+    - name: "Brimstone ring"
       relationship: alternative
-      description: Created from Hydra ring pieces
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Stackable | No |
-    | Weight | 0.01 kg |
-
-    | Item Created | Materials | Facility |
-    |--------------|-----------|----------|
-    | Ferocious gloves | 1 Hydra leather | Lithkren Vault machinery |
-
-    Requires completion of Dragon Slayer II to access the vault.
+  about: "Hydra leather is a rare drop from Alchemical Hydra used to craft Ferocious gloves at the Lithkren Vault machinery after completing Dragon Slayer II. It requires 95 Slayer on a Hydra Slayer task to obtain."
   market_strategy:
     notes:
-      - Only source is Alchemical Hydra
-      - Creates BiS melee gloves
-      - 95 Slayer requirement is significant
-      - Dragon Slayer II required for crafting
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Only source is Alchemical Hydra at a 1/514 drop rate."
+      - "Creates the best-in-slot melee gloves (Ferocious gloves)."
+      - "95 Slayer requirement keeps supply low and prices high."
+      - "Dragon Slayer II is required to craft the gloves."
+  trading_tips:
+    - "Buy when Hydra task rotations bring extra leather to market."
+    - "Sell into demand from late-game PvMers prepping ToB/CoX setups."
+  history:
+    - date: "2019-01-10"
+      description: "Released as part of The Kebos Lowlands update introducing Alchemical Hydra."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-01-10"
+    update: "The Kebos Lowlands"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Inspect
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/infernal-ashes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/infernal-ashes.mdx
@@ -14,51 +14,45 @@ osrs:
   limit: 7500
   material:
     type: ashes
-    tier: highest
+    tier: high
   prayer:
     xp_scatter: 110
     xp_demonic_offering: 330
   drop_table:
     sources:
       - source: K'ril Tsutsaroth
-        source_id: 3129
-        combat_level: 650
         quantity: "1"
         rarity: always
-        members_only: true
+      - source: Tormented Demon
+        quantity: "1"
+        rarity: always
       - source: Cerberus
-        source_id: 5862
-        combat_level: 318
-        quantity: "2"
+        quantity: "1"
         rarity: always
-        members_only: true
       - source: Skotizo
-        source_id: 7286
-        combat_level: 321
-        quantity: "3"
+        quantity: "1"
         rarity: always
-        members_only: true
+      - source: Zalcano
+        quantity: "1"
+        rarity: always
   related_items:
-    - item_id: 25775
-      item_name: Abyssal ashes
+    - item_name: Abyssal ashes
       slug: abyssal-ashes
       relationship: downgrade
       description: Lower XP (85 base)
-    - item_id: 25772
-      item_name: Malicious ashes
+    - item_name: Malicious ashes
       slug: malicious-ashes
       relationship: downgrade
       description: Lower XP (65 base)
-    - item_id: 22124
-      item_name: Superior dragon bones
+    - item_name: Superior dragon bones
       slug: superior-dragon-bones
       relationship: alternative
       description: Same XP (150 buried)
-    - item_id: 536
-      item_name: Dragon bones
+    - item_name: Dragon bones
       slug: dragon-bones
       relationship: alternative
       description: Bone alternative (72 XP)
+  about: Infernal ashes are the highest-tier ashes in Old School RuneScape, dropped by powerful demonic and boss-tier creatures including K'ril Tsutsaroth, Cerberus, Skotizo, Tormented Demons, and Zalcano. Scattering them grants 110 Prayer XP, and the Demonic Offering spell (84 Magic) grants 330 Prayer XP plus 175 Magic XP per cast.
   market_strategy:
     notes:
       - High-end bosses produce supply
@@ -68,13 +62,33 @@ osrs:
       - Compare to superior dragon bones
       - Demonic Offering very efficient
       - Boss activity drives supply
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Buy in bulk when boss content is heavily farmed
+    - Pair purchases with Soul runes for Demonic Offering training
+    - Watch price spikes after Prayer training meta updates
+  history:
+    - date: "2021-06-16"
+      description: Infernal ashes released as part of the A Kingdom Divided quest update, becoming the highest-tier ashes for Prayer training.
+  properties:
+    release_date: "2021-06-16"
+    update: A Kingdom Divided
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Scatter
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/infernal-ashes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/infernal-ashes.mdx
@@ -88,7 +88,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dagger-p-5668.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dagger-p-5668.mdx
@@ -89,7 +89,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dagger-p-5668.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dagger-p-5668.mdx
@@ -12,14 +12,84 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 125
-  about: "Iron dagger(p+) is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 5
+      slash: 3
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Iron dagger
+        - item_name: Weapon poison(+)
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Iron dagger
+      relationship: variant
+    - name: "Iron dagger(p)"
+      relationship: variant
+    - name: "Iron dagger(p++)"
+      relationship: upgrade
+    - name: "Weapon poison(+)"
+      relationship: component
+    - name: "Steel dagger(p+)"
+      relationship: alternative
+  about: "Iron dagger(p+) is a members-only poisoned variant of the iron dagger, created by applying weapon poison(+) to a standard iron dagger. The enhanced coating gives each successful hit a chance to inflict the stronger tier of poison damage, making the dagger a low-cost option for ironmen and pures looking to chip down higher-level targets with damage-over-time."
+  market_strategy:
+    notes:
+      - "Floor is set by iron dagger plus weapon poison(+) cost - rarely deviates from the sum of parts."
+      - "Limit of 125 per 4 hours keeps liquidity reasonable for low-volume flips."
+  trading_tips:
+    - "Apply poison yourself if base dagger and weapon poison(+) trade cheaper than the assembled item."
+    - "Pures and low-level ironmen drive most demand - watch league launches for short squeezes."
+  history:
+    - date: "2001-01-04"
+      description: "Base iron dagger released at the launch of RuneScape."
+    - date: "2005-02-15"
+      description: "Weapon poison(+) introduced, enabling the (p+) poisoned variant of every standard dagger."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-15"
+    update: Members Weapon Poison
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dagger.mdx
@@ -12,31 +12,93 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 125
-  item_id: 1203
-  item_type: equipment
-  slot: weapon
-  type: dagger
-  attack_style: stab
-  attack_speed: 4
-  tradeable: true
-  weight: 0.453
-  requirements:
-    attack: 1
-  stats:
-    stab_attack: 5
-    slash_attack: 3
-    crush_attack: -4
-    strength: 4
+  material:
+    type: iron
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 5
+      slash: 3
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Iron bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+      skill: Smithing
+      level: 15
+      xp: 25
+      notes: "Smithed at any anvil; 5-tick action."
+  shops:
+    - shop_name: Varrock Swordshop
+      location: Varrock
+      stock: 6
+      price: 35
+      currency: coins
   related_items:
-    - slug: steel-dagger
-    - slug: iron-sword
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Steel dagger
+      relationship: upgrade
+    - name: Bronze dagger
+      relationship: downgrade
+    - name: Iron sword
+      relationship: alternative
+    - name: Iron bar
+      relationship: component
+  about: "Iron dagger is a free-to-play one-handed stab weapon smithed from a single iron bar at level 15 Smithing. Stocked in Varrock Swordshop and naturally spawns around Lumbridge, Varrock, and the Wilderness."
+  market_strategy:
+    notes:
+      - Stocked in Varrock Swordshop (6 base, 35 coins) — shop arbitrage on world hops.
+      - Free-to-play accessible, low buy limit of 125 per 4 hours.
+      - Smithed at 15 Smithing for 25 XP per bar; rarely flipped for profit.
+  trading_tips:
+    - GE price typically tracks slightly above alch — high alch margin is negligible.
+    - Watch iron bar price for a smithing-profit floor; usually unprofitable solo.
+  history:
+    - date: "2001-01-04"
+      description: "Released with the RuneScape beta launch."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    update: "Runescape beta is now online!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dagger.mdx
@@ -98,7 +98,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-javelin-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-javelin-p.mdx
@@ -71,7 +71,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-javelin-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-javelin-p.mdx
@@ -12,31 +12,66 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 7000
+  material:
+    type: iron
+    tier: low
   equipment:
-    slot: weapon
+    slot: ammo
+    weapon_type: javelin
     attack_speed: 6
-    requirements:
-      ranged: 1
+    weight: 0
+    requirements: {}
     attack_bonus:
       ranged: 8
-    ranged_strength: 32
+    other_bonus:
+      ranged_strength: 32
+  recipes:
+    - skill: Herblore
+      output_quantity: 5
+      tools: []
+      materials:
+        - item_name: Iron javelin
+          quantity: 5
+        - item_name: Weapon poison
+          quantity: 1
   related_items:
-    - item_id: 826
-      item_name: Iron javelin
-      slug: iron-javelin
+    - name: Iron javelin
       relationship: variant
-      description: Unpoisoned version
-  about: |-
-    > _"An iron tipped javelin with a poisoned tip."_
-
-    An iron javelin tipped with basic weapon poison. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Iron javelin(p+)
+      relationship: upgrade
+    - name: Iron javelin(p++)
+      relationship: upgrade
+  about: "Iron javelin(p) is an iron javelin coated in weapon poison, dealing 2-4 chip damage over time. Created by using weapon poison on 5 iron javelins."
+  market_strategy:
+    notes:
+      - Cheap chip-damage ammo for PvM
+      - Demand tracks ballista PvP activity
+  trading_tips:
+    - GE limit of 7000 supports bulk flips
+    - Margin tracks Iron javelin + Weapon poison
+  history:
+    - date: "2004-03-29"
+      description: "Iron javelin(p) was released as part of the poisoned weapons set."
+  properties:
+    release_date: "2004-03-29"
+    update: "Members release"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platebody-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platebody-g.mdx
@@ -12,14 +12,88 @@ osrs:
   lowalch: 224
   highalch: 336
   limit: 4
-  about: "Iron platebody (g) is a free-to-play item in Old School RuneScape. High alchemy value: 336 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: iron
+    tier: low
+  equipment:
+    slot: body
+    weight: 9.979
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 21
+      slash: 20
+      crush: 12
+      magic: -6
+      ranged: 20
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Iron platebody
+      slug: iron-platebody
+      relationship: variant
+      description: Untrimmed iron platebody with identical stats
+    - item_name: Iron platebody (t)
+      slug: iron-platebody-t
+      relationship: variant
+      description: Trimmed iron platebody from easy clue scrolls
+    - item_name: Bronze platebody (g)
+      slug: bronze-platebody-g
+      relationship: downgrade
+      description: Lower-tier gold-trim platebody
+    - item_name: Steel platebody (g)
+      slug: steel-platebody-g
+      relationship: upgrade
+      description: Higher-tier gold-trim platebody
+  about: "Iron platebody (g) is a free-to-play cosmetic platebody dropped as a reward from easy Treasure Trail clue scrolls, sharing combat stats with the regular iron platebody but featuring gold trim for fashionscape collectors."
+  market_strategy:
+    notes:
+      - Tiny buy limit (4) means low daily liquidity
+      - Cosmetic premium over base iron platebody driven by collectors
+      - Supply from easy clue scrolls is plentiful so price is moderate
+      - High alch value below market price prevents alch flips
+  trading_tips:
+    - Patient sell orders capture premium during cosmetic meta spikes
+    - Avoid alching due to negative margin vs GE price
+    - Track easy clue completion popularity for supply forecasting
+  history:
+    - date: "2014-06-12"
+      description: Iron platebody (g) released in the Treasure Trail Expansion update as an easy clue reward.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platebody-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platebody-g.mdx
@@ -93,7 +93,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-seed.mdx
@@ -67,7 +67,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-seed.mdx
@@ -12,14 +12,62 @@ osrs:
   lowalch: 28
   highalch: 43
   limit: 200
-  about: "Ironwood seed is a members-only item in Old School RuneScape. High alchemy value: 43 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    level: 80
+    plant_xp: 145
+    check_health_xp: 20380
+    growth_time_minutes: 5120
+    patch_type: hardwood tree
+    payment: 10 curry leaves
+  drop_table:
+    sources:
+      - source: Armoured Kraken
+        quantity: "1"
+        rarity: "1/595"
+      - source: Veiled Kraken
+        quantity: "1"
+        rarity: "1/680"
+  related_items:
+    - name: Ironwood seedling
+      relationship: product
+    - name: Ironwood sapling
+      relationship: product
+    - name: Ironwood logs
+      relationship: product
+    - name: Redwood tree seed
+      relationship: alternative
+    - name: Magic seed
+      relationship: alternative
+  about: "Ironwood seed is a members-only Farming seed in Old School RuneScape, introduced with the Sailing update on 19 November 2025. Players with level 80 Farming can plant the seed in a plant pot, grow it into a sapling, and transplant it to a hardwood tree patch where it matures over roughly three and a half days into a fully grown ironwood tree."
+  market_strategy:
+    notes:
+      - "Seeds are gated behind high-level Sailing salvage drops and rare Kraken-style monsters, keeping floor supply tight."
+      - "Bulk demand comes from farmers cycling hardwood patches; price tracks ironwood log value plus farming XP cost."
+  trading_tips:
+    - "Watch ironwood log price - the seed only makes sense to buy when log output covers the seed plus protection payment."
+    - "200 limit per 4 hours allows steady accumulation but caps speculative spikes."
+  history:
+    - date: "2025-11-19"
+      description: "Introduced with the Sailing update, adding ironwood as a new high-level hardwood Farming tree."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Plant
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jade-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jade-amulet.mdx
@@ -109,7 +109,10 @@ osrs:
     alchable: true
     destroy: Drop
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jade-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jade-amulet.mdx
@@ -12,14 +12,104 @@ osrs:
   lowalch: 420
   highalch: 630
   limit: 10000
-  about: "Jade amulet is a members-only item in Old School RuneScape. High alchemy value: 630 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: jade
+    tier: low
+  equipment:
+    slot: neck
+    weapon_type: null
+    weight: 0.007
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: String Jade amulet (ball of wool)
+      skill: Crafting
+      level: 1
+      experience: 4
+      materials:
+        - item_name: Jade amulet (u)
+          quantity: 1
+        - item_name: Ball of wool
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - name: String Jade amulet (Lunar spell)
+      skill: Magic
+      level: 80
+      experience: 83
+      materials:
+        - item_name: Jade amulet (u)
+          quantity: 1
+        - item_name: Water rune
+          quantity: 5
+        - item_name: Earth rune
+          quantity: 10
+        - item_name: Astral rune
+          quantity: 2
+      tools: []
+      output_quantity: 1
+      requirements:
+        quest: Lunar Diplomacy
+  related_items:
+    - name: Jade amulet (u)
+      relationship: component
+    - name: Amulet of chemistry
+      relationship: upgrade
+    - name: Jade necklace
+      relationship: alternative
+    - name: Jade ring
+      relationship: alternative
+    - name: Jade bracelet
+      relationship: alternative
+  about: "Jade amulet is a members-only neck slot item in Old School RuneScape. High alchemy value: 630 coins. Grand Exchange buy limit: 10,000 per 4 hours. Can be enchanted into an Amulet of chemistry."
+  market_strategy:
+    notes:
+      - Created by stringing a Jade amulet (u) with a Ball of wool (Crafting 1) or via the String Jewellery Lunar spell.
+      - Enchanted via Lvl-2 Enchant (Magic 27) into an Amulet of chemistry.
+      - Margin tracks the gap between (u) + ball of wool inputs and the strung GE price.
+  trading_tips:
+    - Lunar String Jewellery is much faster XP/hr if you have Lunar Diplomacy completed.
+    - Resell as Amulet of chemistry for added value when enchant runes are cheap.
+  history:
+    - date: "2017-02-02"
+      description: Item released with the Silver Jewellery, Tournament World & QoL update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-02-02"
+    update: "Silver Jewellery, Tournament World & QoL!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/key-master-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/key-master-teleport.mdx
@@ -78,7 +78,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/key-master-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/key-master-teleport.mdx
@@ -12,64 +12,73 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: null
-  equipment:
-    slot: none
-    weight: 0
+  teleport:
+    destination: Key Master, Cerberus' Lair
+    consumed: true
+    requirements: {}
   drop_table:
-    primary_source: Cerberus
-    best_drop_rate: 2/130
     sources:
       - source: Cerberus
-        source_id: 5862
-        combat_level: 318
         quantity: "7"
-        rarity: uncommon
-        drop_rate: 2/130
-        members_only: true
+        rarity: "2/130"
   related_items:
     - item_id: 13231
       item_name: Primordial crystal
       slug: primordial-crystal
       relationship: alternative
-      description: Rare Cerberus unique
+      description: Rare Cerberus unique drop.
     - item_id: 13229
       item_name: Pegasian crystal
       slug: pegasian-crystal
       relationship: alternative
-      description: Rare Cerberus unique
+      description: Rare Cerberus unique drop.
     - item_id: 13227
       item_name: Eternal crystal
       slug: eternal-crystal
       relationship: alternative
-      description: Rare Cerberus unique
+      description: Rare Cerberus unique drop.
     - item_id: 13233
       item_name: Smouldering stone
       slug: smouldering-stone
       relationship: alternative
-      description: Rare Cerberus unique
-  about: |-
-    Teleport to Key Master:
-    - Instant teleport to Cerberus entrance
-    - Located next to Key Master NPC
-    - Single-click access to boss
-
-    Consumable:
-    - One teleport per scroll
-    - Drops in stacks of 7
-    - Stackable in inventory
+      description: Rare Cerberus unique drop.
+  about: "Key master teleport is a consumable scroll that teleports the user directly next to the Key Master in Cerberus' Lair, skipping the dungeon run."
   market_strategy:
     notes:
-      - Convenience item for Cerberus grind
-      - Saves time vs running through dungeon
-      - Tradeable for passive income
-      - Popular among consistent Cerberus killers
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply is bottlenecked by Cerberus kill volume; price is sensitive to changes in slayer task popularity."
+      - "Tradeable since 25 June 2025 and drop batch raised to 7 on 2 July 2025; supply has structurally increased since then."
+      - "No GE buy limit listed, so bulk purchases for boss alts are viable."
+  trading_tips:
+    - "Buy in bulk when slayer events flood Cerberus drops and resell into PvM rushes."
+    - "Skip alching: high alch (6 gp) is orders of magnitude below GE price."
+    - "Useful as a passive income stream while doing Cerberus tasks."
+  properties:
+    release_date: "2015-08-27"
+    update: "Cerberus"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Teleport
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2015-08-27"
+      description: "Released as a Cerberus drop alongside the boss's launch update."
+    - date: "2025-06-25"
+      description: "Became tradeable on the Grand Exchange."
+    - date: "2025-07-02"
+      description: "Drop batch size increased from 3 to 7 per Cerberus kill."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kraken-colada.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kraken-colada.mdx
@@ -12,14 +12,51 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Kraken colada is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    effects:
+      - description: Boosts Slayer by 1 level.
+      - description: Drains Sailing, Attack, Strength, and Defence by 2% + 2 each.
+      - description: "Drinking message: 'You drink the Kraken colada. You find yourself feeling rather woozy.'"
+  shops:
+    - shop_name: "'Squawking' Steve Beanie's Pub"
+      location: The Pandemonium
+      stock: Unlimited
+      sell_price: 20
+  related_items:
+    - name: Pineapple
+      relationship: component
+    - name: Coconut milk
+      relationship: component
+  about: "Kraken colada is a members-only alcoholic drink in Old School RuneScape. High alchemy value: 12 coins."
+  market_strategy:
+    notes:
+      - Purchased exclusively from 'Squawking' Steve Beanie at The Pandemonium pub.
+      - Provides a small Slayer boost at the cost of Sailing, Attack, Strength, and Defence.
+  trading_tips:
+    - Useful for niche Slayer level boosts when other boosts are unavailable.
+    - Avoid drinking before combat - the stat drains can be steep.
+  history:
+    - date: "2025-11-19"
+      description: Item released with the Sailing skill launch update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kraken-colada.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kraken-colada.mdx
@@ -56,7 +56,10 @@ osrs:
     alchable: true
     destroy: Drop
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-teak-bed-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-teak-bed-flatpack.mdx
@@ -12,14 +12,74 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Large teak bed (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flatpack
+    tier: mid
+  construction:
+    level: 45
+    xp: 480
+    room: Bedroom
+    hotspot: Bed
+  recipes:
+    - skill: Construction
+      level: 45
+      xp: 480
+      facility: Steel framed workbench
+      tools:
+        - Saw
+        - Hammer
+      materials:
+        - item_name: Teak plank
+          quantity: 5
+        - item_name: Bolt of cloth
+          quantity: 2
+      output_quantity: 1
+  related_items:
+    - item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: Five planks required at the steel framed workbench
+    - item_name: Bolt of cloth
+      slug: bolt-of-cloth
+      relationship: component
+      description: Two bolts required as secondary material
+    - item_name: Oak bed (flatpack)
+      slug: oak-bed-flatpack
+      relationship: downgrade
+      description: Lower-tier bedroom flatpack
+  about: "Large teak bed (flatpack) is a members-only Construction flatpack built at a steel framed workbench (level 45 Construction, 480 XP) from five teak planks and two bolts of cloth and used to instantly install a large teak bed in a player-owned bedroom."
+  market_strategy:
+    notes:
+      - Flatpack flips often run at a loss vs raw materials
+      - 500 buy limit keeps daily volume narrow
+      - Demand from POH bedroom builders and butler trainers
+      - Teak plank price drives margin
+  trading_tips:
+    - Compare flatpack price to teak plank + bolt of cloth cost before bulk buying
+    - Sell into Construction XP-meta updates when bedroom builds spike
+    - Use the GE rather than building in-house when training low-effort XP
+  history:
+    - date: "2006-05-31"
+      description: Large teak bed (flatpack) released with the Construction skill in the PLAYER-OWNED HOUSES update.
+  properties:
+    release_date: "2006-05-31"
+    update: PLAYER-OWNED HOUSES!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-teak-bed-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-teak-bed-flatpack.mdx
@@ -79,7 +79,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-teak-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-teak-hull-parts.mdx
@@ -58,7 +58,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-teak-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-teak-hull-parts.mdx
@@ -5,21 +5,60 @@ osrs:
   id: 32068
   name: Large teak hull parts
   slug: large-teak-hull-parts
-  examine: Parts for creating a teak hull for larger boats.
+  examine: Large parts for creating a teak hull for a large boat.
   members: true
   icon: Large teak hull parts.png
   value: 6250
   lowalch: 2500
   highalch: 3750
   limit: 100
-  about: "Large teak hull parts is a members-only item in Old School RuneScape. High alchemy value: 3,750 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: teak
+    tier: mid
+  recipes:
+    - materials:
+        - item_name: Teak hull parts
+          quantity: 5
+      tools:
+        - Saw
+        - Hammer
+      output_quantity: 1
+      skill: Construction
+      level: 23
+      facility: Shipwright's Workbench
+  related_items:
+    - item_name: Teak hull parts
+      relationship: component
+  about: "Large teak hull parts are members-only Construction materials used at the Shipwright's Workbench to build large teak hulls for sloops in the Sailing skill."
+  market_strategy:
+    notes:
+      - Created from 5 Teak hull parts at Construction 23 using a saw and hammer.
+      - Each sloop hull consumes 16 large teak hull parts plus nails, swamp tar, and lead bars.
+      - High alch returns 3,750 coins; GE buy limit is 100 per 4 hours.
+  trading_tips:
+    - Watch teak plank prices since they drive the cost of feeder hull parts.
+    - Demand spikes when new Sailing content or boat tiers release.
+  history:
+    - date: "2025-11-19"
+      description: Released alongside the Sailing skill launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/larupia-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/larupia-hat.mdx
@@ -86,7 +86,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/larupia-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/larupia-hat.mdx
@@ -5,21 +5,88 @@ osrs:
   id: 10045
   name: Larupia hat
   slug: larupia-hat
-  examine: This should make me harder to spot in woodland and jungle areas.
+  examine: "This should make me harder to spot in woodland and jungle areas."
   members: true
   icon: Larupia hat.png
   value: 500
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Larupia hat is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: larupia-fur
+    tier: low
+  equipment:
+    slot: head
+    weight: 0.226
+    requirements:
+      hunter: 28
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    defence_bonus:
+      stab: 4
+      slash: 5
+      crush: 3
+      magic: 0
+      ranged: 4
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Larupia fur
+          quantity: 1
+        - item_name: Coins
+          quantity: 500
+      tools: []
+      output_quantity: 1
+      facility: Fancy Clothes Store (Varrock), Hunter Guild, or Prifddinas Seamstress
+  related_items:
+    - item_id: 10043
+      item_name: Larupia top
+      slug: larupia-top
+      relationship: set-piece
+      description: Body piece of the larupia hunter gear set
+    - item_id: 10047
+      item_name: Larupia legs
+      slug: larupia-legs
+      relationship: set-piece
+      description: Legs piece of the larupia hunter gear set
+  about: "Larupia hat is part of the larupia hunter gear set, providing camouflage in jungle areas and a bonus when hunting tropical wagtails or other jungle hunter creatures. Made by tanning a larupia fur for 500 coins at the Fancy Clothes Store in Varrock, the Hunter Guild, or with the Prifddinas Seamstress."
+  market_strategy:
+    notes:
+      - Required for jungle camouflage hunter activities
+      - Buy limit of 150 supports volume trades
+      - Cost to make is 906 coins; sell price often lower so flipping margin is thin
+  history:
+    - date: "2006-11-21"
+      description: Released alongside the Hunter skill expansion.
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter skill (Hunting for Sport)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lizardman-fang.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lizardman-fang.mdx
@@ -80,7 +80,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lizardman-fang.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lizardman-fang.mdx
@@ -12,14 +12,75 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 13000
-  about: "Lizardman fang is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: monster-drop
+    tier: mid
+  drop_table:
+    sources:
+      - source: Lizardman (level 53)
+        quantity: "1"
+        rarity: 10/87
+      - source: Lizardman (level 62)
+        quantity: "1"
+        rarity: 14/78
+      - source: Lizardman brute
+        quantity: "1"
+        rarity: 14/67
+      - source: Lizardman shaman
+        quantity: "1"
+        rarity: 40/500
+      - source: Stone chest
+        quantity: "1"
+        rarity: 85/300
+      - source: Ancient chest
+        quantity: "1"
+        rarity: 2/33
+  related_items:
+    - item_name: Xeric's talisman
+      slug: xerics-talisman
+      relationship: product
+      description: Lizardman fangs charge the Xeric's talisman teleport
+    - item_name: Xeric's talisman (inert)
+      slug: xerics-talisman-inert
+      relationship: product
+      description: Activated using lizardman fangs to create the talisman
+    - item_name: Mounted xeric's talisman
+      slug: mounted-xerics-talisman
+      relationship: product
+      description: Requires 5,000 fangs plus construction materials at 72 Construction
+  about: "Lizardman fang is a members-only stackable drop from Kourend's lizardman variants and the Stone and Ancient chests, used primarily to charge the Xeric's talisman and to assemble the mounted talisman teleport in a player-owned house."
+  market_strategy:
+    notes:
+      - Stackable so flips and stockpiling are simple
+      - Demand driven by Xeric's talisman charges and POH mounts
+      - High buy limit (13,000) supports bulk activity
+      - Supply correlates with Chambers of Xeric and lizardman shaman farming
+  trading_tips:
+    - Buy in bulk when Chambers of Xeric scaling shifts away from shaman tasks
+    - Sell into Construction meta updates when mounted talisman comes back in vogue
+    - Watch ancient chest reward rate for supply pressure
+  history:
+    - date: "2016-01-07"
+      description: Lizardman fang released as part of the Zeah - Great Kourend update introducing lizardmen and Xeric's talisman.
+  properties:
+    release_date: "2016-01-07"
+    update: "Zeah: Great Kourend"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mage-s-book.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mage-s-book.mdx
@@ -14,73 +14,72 @@ osrs:
   limit: 15
   equipment:
     slot: shield
-    type: magic_offhand
+    weapon_type: null
+    weight: 1
     requirements:
       magic: 60
-    stats:
-      attack_magic: 15
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
       magic_damage: 2
-      defence_magic: 15
+      prayer: 0
   drop_table:
     sources:
       - source: Mage Training Arena
-        source_id: 0
-        combat_level: 0
         quantity: "1"
-        rarity: N/A
-        members_only: true
-  minigame_rewards:
-    points_required:
-      telekinetic: 500
-      alchemist: 550
-      enchantment: 6000
-      graveyard: 500
+        rarity: Reward
   related_items:
-    - item_id: 12825
-      item_name: Arcane spirit shield
+    - item_name: Arcane spirit shield
       slug: arcane-spirit-shield
       relationship: upgrade
-      description: BiS magic offhand
-    - item_id: 11924
-      item_name: Malediction ward
+    - item_name: Malediction ward
       slug: malediction-ward
       relationship: alternative
-      description: Tradeable option
-    - item_id: 12612
-      item_name: Book of darkness
+    - item_name: Book of darkness
       slug: book-of-darkness
       relationship: alternative
-      description: Prayer bonus option
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Magic attack | +15 |
-    | Magic damage | +2% |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +15 |
-
-    Requirements: 60 Magic (no Defence)
-
-    Popular for:
-    - Pures (no def requirement)
-    - Budget magic offhand
-    - Mid-game maging
-
-    Great for 1 Defence builds.
+  about: "Mage Training Arena reward offhand requiring 60 Magic and no Defence, providing +15 Magic attack and +2% damage, popular for pures and budget mid-game mages."
   market_strategy:
     notes:
       - Long grind but free
       - Good for pures
       - Upgrade to arcane later
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2006-01-04"
+      description: Released with Mage Training Arena minigame.
+  properties:
+    release_date: "2006-01-04"
+    update: Mage Training Arena
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mage-s-book.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mage-s-book.mdx
@@ -79,7 +79,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-potion-1.mdx
@@ -84,7 +84,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-potion-1.mdx
@@ -12,14 +12,79 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
-  about: "Magic potion(1) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - description: "Boosts Magic level by +4 for casting purposes; does not lift equipment Magic requirements."
+        skill: magic
+        boost: 4
+  recipes:
+    - materials:
+        - item_name: Lantadyme potion (unf)
+          quantity: 1
+        - item_name: Potato cactus
+          quantity: 1
+      tools: []
+      skill: Herblore
+      level: 76
+      xp: 172.5
+      output_quantity: 1
+      notes: "Recipe makes a 3-dose magic potion; this 1-dose form is the partially drunk remainder."
+  related_items:
+    - item_id: 3040
+      item_name: Magic potion(4)
+      slug: magic-potion-4
+      relationship: variant
+      description: Full 4-dose form.
+    - item_id: 3042
+      item_name: Magic potion(3)
+      slug: magic-potion-3
+      relationship: variant
+      description: 3-dose form.
+    - item_id: 3044
+      item_name: Magic potion(2)
+      slug: magic-potion-2
+      relationship: variant
+      description: 2-dose form.
+    - item_id: 22449
+      item_name: Battlemage potion(4)
+      slug: battlemage-potion-4
+      relationship: upgrade
+      description: Combo magic + defence potion.
+  about: "Magic potion(1) is the 1-dose tail of the magic potion line, boosting Magic level by +4 to enable higher-tier spell casts."
+  market_strategy:
+    notes:
+      - "Single-dose vials are mostly drained leftovers; supply is shallow and depends on PvM/PvP consumption."
+      - "GE buy limit of 2,000 per 4 hours limits bulk flips."
+      - "Decanting services convert 1-dose into 4-dose, so price often tracks decant arbitrage."
+  trading_tips:
+    - "Buy 1-dose at a discount and decant into 4-dose for a small spread."
+    - "Avoid alching; high alch (90 gp) is well below GE prices."
+    - "Use full doses for sustained spellcasting; the 1-dose form is for top-up scenarios."
+  properties:
+    release_date: "2004-09-07"
+    update: "Herblore expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2004-09-07"
+      description: "Released alongside the Magic potion line as part of the Herblore content expansion."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-pyre-logs.mdx
@@ -12,14 +12,66 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 11000
-  about: "Mahogany pyre logs is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: log
+    tier: mid
+  recipes:
+    - materials:
+        - item_name: Mahogany logs
+          quantity: 1
+        - item_name: Sacred oil(3)
+          quantity: 1
+      tools:
+        - Tinderbox
+      output_quantity: 1
+  related_items:
+    - item_name: Mahogany logs
+      slug: mahogany-logs
+      relationship: component
+    - item_name: Sacred oil(3)
+      slug: sacred-oil-3
+      relationship: component
+    - item_name: Yew pyre logs
+      slug: yew-pyre-logs
+      relationship: downgrade
+    - item_name: Magic pyre logs
+      slug: magic-pyre-logs
+      relationship: upgrade
+    - item_name: Redwood pyre logs
+      slug: redwood-pyre-logs
+      relationship: upgrade
+  about: "Mahogany logs treated with three doses of sacred oil for use as a Shades of Mort'ton funeral pyre, granting 210 Firemaking xp plus Prayer xp on cremation."
+  market_strategy:
+    notes:
+      - Used in Shades of Mort'ton
+      - 55 Firemaking to light
+      - Profit margin is thin
+  trading_tips:
+    - Buy logs and oil separately if cheaper
+    - Use during Shades events for demand
+  history:
+    - date: "2005-08-09"
+      description: Released with Shades of Mort'ton update.
+    - date: "2024-07-31"
+      description: Standardized to 5 xp per sacred oil dose, added Make-All menu.
+  properties:
+    release_date: "2005-08-09"
+    update: Shades of Mort'ton
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-pyre-logs.mdx
@@ -71,7 +71,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-stock.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-stock.mdx
@@ -12,14 +12,62 @@ osrs:
   lowalch: 53
   highalch: 79
   limit: 10000
-  about: "Mahogany stock is a members-only item in Old School RuneScape. High alchemy value: 79 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mahogany
+    tier: mid
+  recipes:
+    - materials:
+        - item_name: Mahogany logs
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+      fletching_level: 61
+      fletching_xp: 41
+  related_items:
+    - item_id: 9449
+      item_name: Mahogany logs
+      slug: mahogany-logs
+      relationship: component
+      description: Source log carved into the stock
+    - item_id: 9456
+      item_name: Adamant crossbow (u)
+      slug: adamant-crossbow-u
+      relationship: product
+      description: Combine with adamantite limbs to create the unstrung adamant crossbow
+    - item_id: 9145
+      item_name: Adamantite limbs
+      slug: adamantite-limbs
+      relationship: component
+      description: Limbs attached to this stock to produce an adamant crossbow
+  about: "Mahogany stock is a Fletching intermediate carved from mahogany logs at 61 Fletching for 41 xp. Attach adamantite limbs to create an adamant crossbow (u), granting another 82 Fletching xp."
+  market_strategy:
+    notes:
+      - Watch margin between mahogany logs and stock GE price for fletch flips
+      - Stock often cheaper than logs - alch farming opportunity at 79 gp high alch
+      - High buy limit (10,000) supports bulk crossbow production
+  history:
+    - date: "2006-07-31"
+      description: Released as a Fletching step for adamant crossbow construction.
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbow Fletching expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-stock.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-stock.mdx
@@ -67,7 +67,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/marigolds.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/marigolds.mdx
@@ -63,7 +63,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/marigolds.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/marigolds.mdx
@@ -12,14 +12,58 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 600
-  about: "Marigolds is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flower
+    tier: low
+  farming:
+    seed: Marigold seed
+    level: 2
+    patch: Flower patch
+    growth_time_minutes: 20
+    yield: 1
+    protection: Used as protection payment for Hammerstone hops (1 bunch per protection)
+  related_items:
+    - item_name: Marigold seed
+      slug: marigold-seed
+      relationship: component
+      description: Seed planted in a flower patch to grow marigolds
+    - item_name: Anchovy oil
+      slug: anchovy-oil
+      relationship: alternative
+      description: Combined with marigolds to make imp repellent
+  about: "Marigolds are a members-only Farming flower grown from marigold seeds at level 2 Farming, used in Herblore for imp repellent and as protection payment for Hammerstone hops while also repelling disease from nearby allotment crops."
+  market_strategy:
+    notes:
+      - Low buy limit (600) caps bulk flips
+      - Steady Farming demand from disease-protection planters
+      - Imp repellent recipe creates niche Herblore demand
+      - Supply dependent on flower patch farmers
+  trading_tips:
+    - Buy when farming meta favours allotment runs
+    - Sell during Halloween/Easter event seasons when flower demand spikes
+    - Stock up for personal allotment runs to avoid GE markup
+  history:
+    - date: "2005-07-11"
+      description: Marigolds released alongside the Farming skill update.
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/masori-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/masori-chaps.mdx
@@ -1,6 +1,6 @@
 ---
 title: Masori chaps | OSRS Price Data
-description: "Masori chaps is a members head slot item requiring 30 Defence. High alch: 600,000 GP, GE limit: 8."
+description: "Masori chaps is a members legs slot item requiring 80 Ranged and 30 Defence. High alch: 600,000 GP, GE limit: 8."
 osrs:
   id: 27232
   name: Masori chaps
@@ -12,102 +12,88 @@ osrs:
   lowalch: 400000
   highalch: 600000
   limit: 8
+  material:
+    type: masori
+    tier: high
   equipment:
-    slot: head
-    type: masori_armor
-    attack_style: ranged
+    slot: legs
+    weight: 7
     requirements:
       ranged: 80
       defence: 30
-    stats:
-      attack_ranged: 16
-      defence_stab: 10
-      defence_slash: 12
-      defence_crush: 14
-      defence_magic: 12
-      defence_ranged: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -2
+      ranged: 27
+    defence_bonus:
+      stab: 26
+      slash: 24
+      crush: 29
+      magic: 19
+      ranged: 22
+    other_bonus:
       ranged_strength: 2
-  set_bonus:
-    with_full_set: true
-    regular_damage: 10
-    fortified_damage: 12.5
   drop_table:
     sources:
       - source: Tombs of Amascut
-        source_id: 11751
-        combat_level: 0
         quantity: "1"
-        rarity: 1/48 at 150 invocation
-        members_only: true
-  recipes:
-    - skill: crafting
-      level: 90
-      xp: 0
-      materials:
-        - item_name: Masori mask
-          item_id: 27232
-          quantity: 1
-        - item_name: Armadyl helmet
-          item_id: 11826
-          quantity: 1
-      product: Masori mask (f)
-      product_id: 27241
-      product_quantity: 1
-      facility: None
-      members_only: true
+        rarity: "2/24 from chest at scaled invocation"
   related_items:
     - item_id: 27226
+      item_name: Masori mask
+      slug: masori-mask
+      relationship: set-piece
+      description: Masori head slot piece
+    - item_id: 27229
       item_name: Masori body
       slug: masori-body
-      relationship: alternative
-      description: Body armor
-    - item_id: 27229
-      item_name: Masori chaps
-      slug: masori-chaps
-      relationship: alternative
-      description: Leg armor
-    - item_id: 11825
-      item_name: Armadyl helmet
-      slug: armadyl-helmet
+      relationship: set-piece
+      description: Masori body slot piece
+    - item_id: 27235
+      item_name: Masori chaps (f)
+      slug: masori-chaps-f
+      relationship: upgrade
+      description: Fortified version crafted with 3 Armadylean plates at 90 Crafting
+    - item_id: 11826
+      item_name: Armadylean plate
+      slug: armadylean-plate
       relationship: component
-      description: Used for fortifying
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +16 |
-    | Stab defence | +10 |
-    | Slash defence | +12 |
-    | Crush defence | +14 |
-    | Magic defence | +12 |
-    | Ranged defence | +10 |
-    | Ranged strength | +2 |
-    | Requirements | 80 Ranged, 30 Defence |
-
-    With full Masori armor (fortified):
-    - +12.5% ranged damage bonus
-
-    With regular Masori:
-    - +10% ranged damage bonus
-
-    BiS ranged helm for:
-    - All ranged combat
-    - Raids
-    - Bossing
-    - When not using Slayer helm
-
-    Fortified version requires Armadyl helmet.
+      description: Used (x3) to fortify Masori chaps
+  about: "Masori chaps are the legs piece of the Masori ranged set from Tombs of Amascut. Requires 80 Ranged and 30 Defence; provides +27 ranged attack and a strong defence profile. Fortify into Masori chaps (f) with three Armadylean plates at 90 Crafting for the full-set damage bonus."
   market_strategy:
     notes:
-      - Regular from ToA
-      - Fortify with Armadyl piece
-      - Set bonus is massive DPS increase
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Drop is gated to ToA invocation scaling; high-invocation runs are the supply floor.
+      - Fortified upgrade burns 3 Armadylean plates per piece; track plate GE price for the true upgrade cost.
+      - BiS ranged legs outside of slayer/ranged-prayer niches; long-term demand remains strong.
+  trading_tips:
+    - Buy mask/body/chaps as a set when GE pricing dips after invocation/loot tweaks.
+    - Avoid fortifying speculatively — Armadyl plates spike with TWW/GWD demand.
+  history:
+    - date: "2022-08-24"
+      description: Released with the Tombs of Amascut raid update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-08-24"
+    update: "Tombs of Amascut"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 7
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/masori-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/masori-chaps.mdx
@@ -93,7 +93,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/minced-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/minced-meat.mdx
@@ -89,7 +89,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/minced-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/minced-meat.mdx
@@ -12,14 +12,84 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 13000
-  about: "Minced meat is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 2
+    consumable: true
+  recipes:
+    - skill: Cooking
+      level: 1
+      xp: 0
+      output_quantity: 1
+      materials:
+        - item_name: Bowl
+          quantity: 1
+        - item_name: Cooked meat
+          quantity: 1
+      tools:
+        - Knife
+      notes: Combine a bowl with cooked meat using a knife to produce minced meat.
+    - skill: Cooking
+      level: 1
+      xp: 0
+      output_quantity: 1
+      materials:
+        - item_name: Minced meat
+          quantity: 1
+        - item_name: Spice
+          quantity: 1
+      tools: []
+      notes: Add spice to create spicy minced meat used for chinchompa hunting bait.
+  related_items:
+    - item_id: 7072
+      item_name: Spicy minced meat
+      slug: spicy-minced-meat
+      relationship: product
+      description: Spiced variant used as chinchompa bait
+    - item_id: 7062
+      item_name: Chilli con carne
+      slug: chilli-con-carne
+      relationship: product
+      description: Cooked dish requiring minced meat
+    - item_id: 2142
+      item_name: Cooked meat
+      slug: cooked-meat
+      relationship: component
+      description: Required ingredient
+    - item_id: 1923
+      item_name: Bowl
+      slug: bowl
+      relationship: component
+      description: Container required for mincing
+  about: "Minced meat is a members cooking ingredient produced by using a knife on cooked meat in a bowl, used for spicy minced meat and chilli con carne."
+  market_strategy:
+    notes:
+      - Steady ironman/skiller demand for chinchompa hunting bait keeps minced meat liquid.
+      - Profit margin against bowl + cooked meat inputs is usually positive thanks to the convenience tax.
+  trading_tips:
+    - Compare GE price against bowl plus cooked meat to decide whether to flip or craft from raw inputs.
+    - Watch for hunter content updates that spike chinchompa demand and ripple into spicy minced meat.
+  history:
+    - date: "2006-01-30"
+      description: Added with the Hunter skill release.
+  properties:
+    release_date: "2006-01-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts-unf.mdx
@@ -12,14 +12,71 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Mithril bolts (unf) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  recipes:
+    - materials:
+        - item_name: Mithril bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      skill: Smithing
+      level: 53
+      xp: 50
+      output_quantity: 10
+    - materials:
+        - item_name: Mithril bolts (unf)
+          quantity: 1
+        - item_name: Feather
+          quantity: 1
+      tools: []
+      skill: Fletching
+      level: 54
+      xp: 5
+      output_quantity: 1
+      produces: Mithril bolts
+  related_items:
+    - name: Mithril bar
+      relationship: component
+    - name: Feather
+      relationship: component
+    - name: Mithril bolts
+      relationship: product
+    - name: Steel bolts (unf)
+      relationship: downgrade
+    - name: Adamant bolts (unf)
+      relationship: upgrade
+  about: "Mithril bolts (unf) is a members-only unfeathered crossbow bolt in Old School RuneScape, smithed from mithril bars and fletched with feathers into mithril bolts. Grand Exchange buy limit: 13,000 per 4 hours."
+  market_strategy:
+    notes:
+      - Price is driven by mithril bar feedstock and fletching XP demand.
+      - Tight margin between unfeathered and feathered bolt = fletcher XP arbitrage window.
+  trading_tips:
+    - Track mithril bar/feather price to compute per-bolt XP and margin.
+    - Bulk-flip in 13k stacks; volume is high so spreads compress quickly.
+  history:
+    - date: "2006-07-31"
+      description: Released with the Crossbows update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: "Crossbows"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts-unf.mdx
@@ -76,7 +76,10 @@ osrs:
     alchable: false
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-gold-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-gold-trimmed-set-lg.mdx
@@ -63,7 +63,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-gold-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-gold-trimmed-set-lg.mdx
@@ -12,14 +12,58 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
-  about: "Mithril gold-trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  related_items:
+    - item_id: 12283
+      item_name: Mithril full helm (g)
+      slug: mithril-full-helm-g
+      relationship: component
+      description: Helm component of the set
+    - item_id: 12281
+      item_name: Mithril platebody (g)
+      slug: mithril-platebody-g
+      relationship: component
+      description: Body component of the set
+    - item_id: 12285
+      item_name: Mithril platelegs (g)
+      slug: mithril-platelegs-g
+      relationship: component
+      description: Legs component of the set
+    - item_id: 12287
+      item_name: Mithril kiteshield (g)
+      slug: mithril-kiteshield-g
+      relationship: component
+      description: Shield component of the set
+  about: "Mithril gold-trimmed set (lg) bundles the gold-trimmed mithril full helm, platebody, platelegs and kiteshield via the Grand Exchange Sets clerk for bank space savings."
+  market_strategy:
+    notes:
+      - Bundle and unbundle at a Grand Exchange clerk for arbitrage when set price strays from sum-of-parts
+      - Limit of 8 per 4 hours caps speed of bulk flipping
+      - Useful for ironmen seeking gold-trim cosmetic display
+  history:
+    - date: "2015-02-26"
+      description: Introduced alongside other Grand Exchange item sets to reduce bank space usage.
+  properties:
+    release_date: "2015-02-26"
+    update: Grand Exchange Sets
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-cape.mdx
@@ -12,14 +12,92 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 100
-  about: "Mixed hide cape is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: leather
+    tier: mid
+  equipment:
+    slot: cape
+    weight: 3
+    requirements:
+      ranged: 60
+      defence: 50
+    attack_bonus:
+      ranged: 5
+      magic: -15
+    defence_bonus:
+      stab: 2
+      slash: 2
+      crush: 2
+      magic: 5
+      ranged: 1
+    other_bonus:
+      strength: 1
+  recipes:
+    - materials:
+        - item_name: Mixed hide base
+          quantity: 1
+        - item_name: Jaguar fur
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      skill: Crafting
+      level: 68
+      output_quantity: 1
+    - materials:
+        - item_name: Jaguar fur
+          quantity: 1
+        - item_name: Coins
+          quantity: 20000
+      tools: []
+      vendor: Pellem
+      location: Hunter Guild
+      requirements:
+        hunter: 46
+        quest: "Children of the Sun"
+      output_quantity: 1
+  related_items:
+    - name: Mixed hide top
+      relationship: set-piece
+    - name: Mixed hide legs
+      relationship: set-piece
+    - name: Mixed hide boots
+      relationship: set-piece
+    - name: Mixed hide base
+      relationship: component
+  about: "Mixed hide cape is a members-only Crafting-made cape in Old School RuneScape and the only tradeable cape that grants a Strength bonus. High alchemy value: 2,400 coins. Grand Exchange buy limit: 100 per 4 hours."
+  market_strategy:
+    notes:
+      - Supply ties to jaguar fur drops from Hunter Guild content and mixed hide base availability.
+      - Strength + ranged combo gives it niche demand among low-tier ranged hybrids.
+  trading_tips:
+    - Track jaguar fur price; the cape often lags its raw material movement.
+    - Costume room storage softens supply spikes from end-of-set crafters.
+  history:
+    - date: "2024-03-20"
+      description: Released with the Varlamore - Part One update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-cape.mdx
@@ -97,7 +97,10 @@ osrs:
     alchable: false
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/molten-glass.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/molten-glass.mdx
@@ -92,7 +92,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/molten-glass.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/molten-glass.mdx
@@ -14,136 +14,85 @@ osrs:
   limit: 13000
   material:
     type: glass
-    tier: processed
+    tier: low
   recipes:
-    - skill: crafting
-      level: 1
-      xp: 20
-      materials:
+    - materials:
         - item_name: Bucket of sand
-          item_id: 1783
           quantity: 1
         - item_name: Soda ash
-          item_id: 1781
           quantity: 1
-      product: Molten glass
-      product_id: 1775
-      product_quantity: 1
-      facility: Furnace
-    - skill: magic
-      level: 77
-      xp: 78
-      materials:
+      tools:
+        - Furnace
+      skill: Crafting
+      level: 1
+      experience: 20
+      output_quantity: 1
+    - materials:
         - item_name: Giant seaweed
-          item_id: 21504
           quantity: 1
         - item_name: Bucket of sand
-          item_id: 1783
           quantity: 3
         - item_name: Astral rune
-          item_id: 9075
           quantity: 2
         - item_name: Fire rune
-          item_id: 554
           quantity: 6
         - item_name: Air rune
-          item_id: 556
           quantity: 10
-      product: Molten glass
-      product_id: 1775
-      product_quantity: 6
-      facility: Lunar spellbook
-      members_only: true
-  glassblowing:
-    - product: Beer glass
-      product_id: 1919
-      level: 1
-      xp: 17.5
-    - product: Candle lantern
-      product_id: 4527
-      level: 4
-      xp: 19
-    - product: Oil lamp
-      product_id: 4525
-      level: 12
-      xp: 25
-    - product: Vial
-      product_id: 229
-      level: 33
-      xp: 35
-    - product: Fishbowl
-      product_id: 6667
-      level: 42
-      xp: 42.5
-    - product: Unpowered orb
-      product_id: 567
-      level: 46
-      xp: 52.5
-    - product: Lantern lens
-      product_id: 4542
-      level: 49
-      xp: 55
-    - product: Light orb
-      product_id: 10973
-      level: 87
-      xp: 70
+      tools:
+        - Lunar spellbook
+      skill: Magic
+      level: 77
+      experience: 78
+      output_quantity: 6
+  shops:
+    - shop_name: Fritz the Glassblower
+      location: Entrana
+      sells: false
+      buys_for: 20
   related_items:
-    - item_id: 567
-      item_name: Unpowered orb
-      slug: unpowered-orb
+    - name: Unpowered orb
       relationship: product
-      description: Popular product
-    - item_id: 229
-      item_name: Vial
-      slug: vial
+    - name: Vial
       relationship: product
-      description: Herblore product
-    - item_id: 1783
-      item_name: Bucket of sand
-      slug: bucket-of-sand
+    - name: Bucket of sand
       relationship: component
-      description: Ingredient
-    - item_id: 1781
-      item_name: Soda ash
-      slug: soda-ash
+    - name: Soda ash
       relationship: component
-      description: Ingredient
-  about: |-
-    | Method | Requirements |
-    |--------|--------------|
-    | Furnace | Bucket of sand + Soda ash |
-    | Superglass Make | 77 Magic, Lunar spellbook |
-
-    | Product | Level | XP |
-    |---------|-------|-----|
-    | Beer glass | 1 | 17.5 |
-    | Candle lantern | 4 | 19 |
-    | Oil lamp | 12 | 25 |
-    | Vial | 33 | 35 |
-    | Fishbowl | 42 | 42.5 |
-    | Unpowered orb | 46 | 52.5 |
-    | Lantern lens | 49 | 55 |
-    | Light orb | 87 | 70 |
+    - name: Giant seaweed
+      relationship: component
+  about: "Molten glass is the base material for glassblowing, produced by smelting a bucket of sand with soda ash at a furnace or via the Superglass Make Lunar spell."
   market_strategy:
     notes:
-      - Base for all glass items
-      - Superglass Make efficient
-      - High volume trading
-      - Unpowered orb production
-      - Vial creation
-      - Crafting training
-      - Ironman supplies
-      - Superglass Make best method
-      - Giant seaweed + sandstone
-      - Extra glass from spell
-      - High Crafting XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Base for all glass items, used heavily for unpowered orbs and vials."
+      - "Superglass Make at 77 Magic yields 6 glass per cast and trains Crafting XP."
+      - "Fritz the Glassblower in Entrana buys for 20 gp (25 with Ring of Charos)."
+  trading_tips:
+    - "Demand tracks Crafting/Herblore training and seaweed supply."
+    - "Watch giant seaweed price — it gates Superglass Make profitability."
+  history:
+    - date: "2002-03-18"
+      description: "Released as the base Crafting material for glassblowing."
+    - date: "2007-07-17"
+      description: "Graphically updated and value raised from 2 to 3 coins during the Observatory Quest rework."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-18"
+    update: "Latest RuneScape News (18 March 2002)"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/morrigan-s-javelin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/morrigan-s-javelin.mdx
@@ -12,14 +12,60 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 100
-  about: "Morrigan's javelin is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 6
+    weight: 1.36
+    requirements:
+      ranged: 75
+    attack_bonus:
+      ranged: 105
+    other_bonus:
+      ranged_strength: 145
+  special_attack:
+    name: Phantom Strike
+    energy: 50
+    description: Consumes 50% special attack energy with 150% accuracy; applies a damage-over-time bleed of 10 per tick to a player opponent until 75% of the initial hit damage has been dealt. No effect against NPCs.
+  shops:
+    - shop_name: Bounty Hunter Store
+      location: Daimon's Crater
+      currency: Bounty Hunter points
+      price: 550
+  about: "Morrigan's javelin is a one-handed thrown PvP weapon purchased from the Bounty Hunter Store for 550 BH points. Requires 75 Ranged and a 10,000,000 coin activation fee; restricted to PvP zones and minigames."
+  market_strategy:
+    notes:
+      - Untradeable BH reward; "market" is Bounty Hunter points, not GE coins.
+      - Activation fee dropped from 50M to 10M in Jan 2025, lowering barrier for new PKers.
+  trading_tips:
+    - Grind BH points during double-point events to amortize the activation gp cost.
+    - Pair purchase with Morrigan's throwing axe runs for shared point efficiency.
+  history:
+    - date: "2023-05-24"
+      description: Re-released alongside the "Bounty Hunter is Back!" update.
+    - date: "2025-01-15"
+      description: Activation fee reduced from 50,000,000 to 10,000,000 coins; special attack buffed to 150% accuracy with adjusted bleed mechanics.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-05-24"
+    update: "Bounty Hunter is Back!"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/morrigan-s-javelin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/morrigan-s-javelin.mdx
@@ -65,7 +65,10 @@ osrs:
     alchable: false
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mud-battlestaff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mud-battlestaff.mdx
@@ -12,9 +12,17 @@ osrs:
   lowalch: 6800
   highalch: 10200
   limit: 8
+  material:
+    type: mud
+    tier: mid
   equipment:
     slot: weapon
+    weapon_type: staff
     attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 30
+      magic: 30
     attack_bonus:
       stab: 7
       slash: -1
@@ -32,20 +40,11 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 30
-      magic: 30
-    weight: 2.267
   drop_table:
-    primary_source: Dagannoth Prime
-    best_drop_rate: 1/128
     sources:
       - source: Dagannoth Prime
-        combat_level: 303
         quantity: "1"
-        rarity: uncommon
-        drop_rate: 1/128
-        members_only: true
+        rarity: 1/128
   related_items:
     - item_id: 6563
       item_name: Mystic mud staff
@@ -63,59 +62,66 @@ osrs:
     | Magic | +12 |
     | Crush | +28 |
     | Stab | +7 |
-
     | Defence | Value |
     |---------|-------|
     | Magic | +12 |
-
     | Other | Value |
     |-------|-------|
     | Strength | +35 |
-
     Requirements: 30 Attack, 30 Magic | Speed: 5 tick (3.0s)
-
     Provides unlimited water and earth runes simultaneously. This uniquely benefits:
-
     Curse Spells (almost all use both water + earth runes):
     - Confuse, Weaken, Curse
     - Vulnerability, Enfeeble, Stun
     - Bind, Snare, Entangle
-
     Utility Spells:
     - Bones to Bananas / Bones to Peaches
     - Lvl-5 Enchant
     - Draynor Manor Teleport
-
     Lunar Spells:
     - String Jewellery
     - Stat Restore Pot Share
     - Boost Potion Share
-
     Upgrade to Mystic mud staff via Thormac (after Scorpion Catcher):
-
     | Diary Completion | Cost |
     |-----------------|------|
     | None | 40,000 coins |
     | Hard Kandarin | 30,000 coins |
     | Elite Kandarin | 20,000 coins |
-
     The Mystic version gains +2 Magic attack/defence and +15 Strength bonus.
-
     If unable to obtain this drop, alternatives include pairing an earth staff with Tome of Water (or water staff with earth runes). Tome-based setups avoid charge depletion during non-combat spells like Bones to Peaches.
-
     September 2021: Magic Attack and Defence bonuses increased from +10 to +12.
   market_strategy:
     notes:
       - Only from Dagannoth Prime (must trio or solo DKs)
       - Upgrade to Mystic for profit (check Thormac cost vs GE spread)
       - Low daily volume — prices can be volatile
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2005-11-07"
+      description: Released as a rare drop from Dagannoth Prime alongside the Dagannoth Kings expansion.
+    - date: "2021-09-22"
+      description: Magic Attack and Defence bonuses raised from +10 to +12.
+  properties:
+    release_date: "2005-11-07"
+    update: Dagannoth Kings
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mud-battlestaff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mud-battlestaff.mdx
@@ -121,7 +121,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-hat-dark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-hat-dark.mdx
@@ -12,14 +12,95 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: 70
-  about: "Mystic hat (dark) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: enchanted-cloth
+    tier: high
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: 1
+    weight: 0.453
+    requirements:
+      magic: 40
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Infernal Mage
+        quantity: "1"
+        rarity: 1/512
+      - source: Malevolent Mage
+        quantity: "1"
+        rarity: 3/512
+  related_items:
+    - item_id: 3385
+      item_name: Mystic hat
+      slug: mystic-hat
+      relationship: variant
+      description: Standard blue colour variant with identical bonuses
+    - item_id: 4109
+      item_name: Mystic hat (light)
+      slug: mystic-hat-light
+      relationship: variant
+      description: Light colour variant
+    - item_id: 4101
+      item_name: Mystic robe top (dark)
+      slug: mystic-robe-top-dark
+      relationship: set-piece
+      description: Body piece of the dark mystic robes set
+    - item_id: 4103
+      item_name: Mystic robe bottom (dark)
+      slug: mystic-robe-bottom-dark
+      relationship: set-piece
+      description: Legs piece of the dark mystic robes set
+  about: "Mystic hat (dark) is a colour variant of the standard mystic hat with identical bonuses, dropped by Infernal and Malevolent Mages."
+  market_strategy:
+    notes:
+      - Identical bonuses to the standard mystic hat make demand mostly cosmetic, capping ceiling price.
+      - Drop-only supply from Infernal/Malevolent Mages keeps stock thin; 70 buy limit easy to fill.
+      - Set-piece demand from collectors lifts the floor when blue and light variants align in price.
+  trading_tips:
+    - Compare against standard mystic hat to spot mispricings driven purely by cosmetic preference.
+    - Buy in advance of fashionscape events that revive demand for the dark mystic set.
+  history:
+    - date: "2005-01-26"
+      description: Added as a colour variant of mystic equipment.
+  properties:
+    release_date: "2005-01-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-hat-dark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-hat-dark.mdx
@@ -100,7 +100,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-longbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-longbow.mdx
@@ -102,7 +102,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-longbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-longbow.mdx
@@ -12,55 +12,97 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 18000
+  material:
+    type: oak
+    tier: low
   equipment:
     slot: 2h
-    type: longbow
-    attack_style: ranged
+    weapon_type: bow
     attack_speed: 6
-  requirements:
-    ranged: 5
-  stats:
-    attack:
+    weight: 2.267
+    requirements:
+      ranged: 5
+    attack_bonus:
       ranged: 14
-    other:
+    defence_bonus: {}
+    other_bonus:
       ranged_strength: 0
-    range: 9
-  fletching:
-    level: 25
-    xp: 25
-    method: Oak longbow (u) + bowstring
+  recipes:
+    - materials:
+        - item_name: Oak longbow (u)
+          quantity: 1
+        - item_name: Bow string
+          quantity: 1
+      tools: []
+      skill: Fletching
+      level: 25
+      xp: 25
+      output_quantity: 1
   shops:
     - shop_name: Lowe's Archery Emporium
       location: Varrock
+      price: 160
+    - shop_name: Hickton's Archery Emporium
+      location: Catherby
+      price: 160
+    - shop_name: Brian's Archery Supplies
+      location: Rimmington
       price: 160
   related_items:
     - item_id: 847
       item_name: Willow longbow
       slug: willow-longbow
       relationship: upgrade
-      description: Higher tier longbow
+      description: Higher tier longbow.
     - item_id: 843
       item_name: Oak shortbow
       slug: oak-shortbow
       relationship: alternative
-      description: Faster attack speed
+      description: Faster attack speed at lower range.
     - item_id: 56
       item_name: Oak longbow (u)
       slug: oak-longbow-u
       relationship: component
-      description: Unstrung version
+      description: Unstrung version used in fletching.
     - item_id: 1777
       item_name: Bow string
       slug: bow-string
       relationship: component
-      description: Stringing material
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Stringing material required to finish the bow.
+  about: "Oak longbow is a low-tier F2P two-handed ranged weapon fletched at level 25 and wieldable from Ranged level 5."
+  market_strategy:
+    notes:
+      - "GE buy limit of 18,000 supports bulk fletching alch flips when high alch (96 gp) exceeds combined material cost."
+      - "Supply is healthy thanks to F2P fletchers training to willow longbows; price tends to sit just below high alch."
+      - "Demand spikes during fletching contracts and DMM/league events that push low-level ranged gear."
+  trading_tips:
+    - "Stockpile oak longbows (u) + bowstrings when both are below GE tax break-even, then string and flip."
+    - "Use it as a step-up wield for accounts farming Ranged from 5 toward willow longbow at level 30."
+    - "Avoid relying on shop prices; the GE is consistently cheaper than Lowe's 160 gp."
+  properties:
+    release_date: "2002-03-25"
+    update: "RuneScape: Members beta"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2002-03-25"
+      description: "Released alongside the original Fletching skill content as a step in the F2P longbow progression."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-wardrobe-flatpack.mdx
@@ -12,14 +12,68 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: oak
+    tier: low
+  construction:
+    level: 39
+    xp: 180
+    room: Bedroom
+    space: Wardrobe
+    workbench: Oak workbench
+  recipes:
+    - materials:
+        - item_name: Oak plank
+          quantity: 3
+      tools:
+        - Hammer
+        - Saw
+      skill: Construction
+      level: 39
+      xp: 180
+      output_quantity: 1
+  related_items:
+    - name: Oak wardrobe
+      relationship: product
+    - name: Oak plank
+      relationship: component
+    - name: Wardrobe (flatpack)
+      relationship: downgrade
+    - name: Teak wardrobe (flatpack)
+      relationship: upgrade
+    - name: Mahogany wardrobe (flatpack)
+      relationship: upgrade
+    - name: Gilded wardrobe (flatpack)
+      relationship: upgrade
+  about: "Oak wardrobe (flatpack) is a members-only Construction flatpack in Old School RuneScape, made at an oak workbench for bedroom wardrobe spaces. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
+  market_strategy:
+    notes:
+      - GE price trails oak plank cost; flatpack flipping leans on Mahogany Homes / butler XP cycles.
+      - Margins are pennies; profit comes from scale only.
+  trading_tips:
+    - Buy in 500-stack increments to stay inside the GE limit.
+    - Track oak plank prices; flatpack profit is essentially oak plank arbitrage.
+  history:
+    - date: "2006-05-31"
+      description: Released with the Player-Owned Houses update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: "Player-Owned Houses"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-wardrobe-flatpack.mdx
@@ -73,7 +73,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/odium-shard-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/odium-shard-2.mdx
@@ -71,7 +71,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/odium-shard-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/odium-shard-2.mdx
@@ -12,14 +12,66 @@ osrs:
   lowalch: 12400
   highalch: 18600
   limit: 10000
-  about: "Odium shard 2 is a members-only item in Old School RuneScape. High alchemy value: 18,600 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: shard
+    tier: mid-high
+  drop_table:
+    sources:
+      - source: Crazy archaeologist
+        quantity: "1"
+        rarity: "1/256"
+  recipes:
+    - materials:
+        - item_name: Odium shard 1
+          quantity: 1
+        - item_name: Odium shard 2
+          quantity: 1
+        - item_name: Odium shard 3
+          quantity: 1
+      tools:
+        - Blighted Altar
+      output_quantity: 1
+      notes: "Combined at the Blighted Altar in the Wilderness north of the Lava Maze to forge an Odium ward."
+  related_items:
+    - name: Odium shard 1
+      relationship: set-piece
+    - name: Odium shard 3
+      relationship: set-piece
+    - name: Odium ward
+      relationship: product
+    - name: Malediction shard 2
+      relationship: alternative
+  about: "Odium shard 2 is a Wilderness-exclusive drop from the Crazy archaeologist (1/256). Combined with Odium shard 1 and Odium shard 3 at the Blighted Altar to forge the Odium ward."
+  market_strategy:
+    notes:
+      - Single source - Crazy archaeologist at 1/256 - means supply is tightly tied to PvP/Wilderness activity.
+      - All three Odium shards trade similarly; flippers often spread across the set.
+      - Required component for the Odium ward (ranged-defence shield).
+  trading_tips:
+    - Compare all three shard prices before crafting an Odium ward vs. buying assembled.
+    - Buy limit 10,000 per 4 hours easily covers any retail purchase.
+  history:
+    - date: "2014-03-13"
+      description: "Released with the Rejuvenating the Wilderness: More risk, more reward update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-03-13"
+    update: "Rejuvenating the Wilderness: More risk, more reward"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ogre-arrow-shaft.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ogre-arrow-shaft.mdx
@@ -12,14 +12,56 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Ogre arrow shaft is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - materials:
+        - item_name: Achey tree logs
+          quantity: 1
+      tools:
+        - Knife
+      skill: Fletching
+      level: 5
+      xp: 1.6
+      output_quantity: 4
+      requires_quest: Big Chompy Bird Hunting
+  related_items:
+    - name: Achey tree logs
+      relationship: component
+    - name: Flighted ogre arrow
+      relationship: product
+    - name: Ogre arrow
+      relationship: product
+    - name: Brutal arrow
+      relationship: product
+  about: "Ogre arrow shaft is a Fletching product cut from achey tree logs after Big Chompy Bird Hunting, used to build flighted ogre arrows and brutal arrows."
+  market_strategy:
+    notes:
+      - "GE price near 88 gp with a 7,000-per-4-hours buy limit."
+      - "Used as bulk ammunition feedstock - demand tracks Chompy hunting and Rangers' Guild XP routes."
+  trading_tips:
+    - "Buy logs and craft shafts when achey log supply spikes; profit averages ~104 gp per log after tax."
+    - "Stockpile shafts before Ranged training guide spikes that point to brutal arrows."
+  history:
+    - date: "2004-05-18"
+      description: "Released with the Big Chompy Bird Hunting quest."
+  properties:
+    release_date: "2004-05-18"
+    update: "Big Chompy Bird Hunting"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Big Chompy Bird Hunting
+    weight: 0
+    options:
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ogre-arrow-shaft.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ogre-arrow-shaft.mdx
@@ -61,7 +61,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-dragon-bolts.mdx
@@ -12,14 +12,72 @@ osrs:
   lowalch: 5560
   highalch: 8340
   limit: 11000
-  about: "Onyx dragon bolts is a members-only item in Old School RuneScape. High alchemy value: 8,340 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    weight: 0
+    requirements:
+      ranged: 64
+    attack_bonus:
+      ranged_strength: 122
+    defence_bonus: {}
+    other_bonus: {}
+  recipes:
+    - materials:
+        - item_name: Dragon bolts
+          quantity: 1
+        - item_name: Onyx bolt tips
+          quantity: 1
+      tools: []
+      skill: Fletching
+      level: 84
+      experience: 9.4
+      output_quantity: 1
+  related_items:
+    - name: Onyx bolts
+      relationship: alternative
+    - name: Onyx dragon bolts (e)
+      relationship: upgrade
+    - name: Dragon bolts
+      relationship: component
+    - name: Onyx bolt tips
+      relationship: component
+  about: "Onyx dragon bolts are dragon crossbow bolts tipped with onyx, requiring 64 Ranged to wield and 84 Fletching to create."
+  market_strategy:
+    notes:
+      - "High alch value 8,340 gp; GE buy limit 11,000 per 4 hours."
+      - "Crafted from dragon bolts + onyx bolt tips at 84 Fletching for 9.4 xp each."
+      - "Can be enchanted at Magic 87 into Onyx dragon bolts (e) for the Life Leech effect."
+  trading_tips:
+    - "Monitor onyx bolt tip prices to gauge Fletching profitability."
+    - "Demand spikes when DS2-era ranged builds farm bossing content."
+  history:
+    - date: "2018-01-04"
+      description: "Released alongside Dragon Slayer II."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-dragon-bolts.mdx
@@ -77,7 +77,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/osman-s-report.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/osman-s-report.mdx
@@ -12,14 +12,43 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 0
-  about: "Osman's report is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: quest
+    tier: low
+  related_items:
+    - item_name: Desert bait
+      slug: desert-bait
+      relationship: product
+  about: "9th Birthday Event report from Osman, traded to Ali Morrisane in exchange for desert bait before being removed from the game."
+  market_strategy:
+    notes:
+      - Event-only item, removed 2022
+      - Originally tradeable by mistake
+      - No alch value
+  history:
+    - date: "2022-02-16"
+      description: Released for the OSRS 9th Birthday Event.
+    - date: "2022-03-09"
+      description: Removed from the game following the event.
+  properties:
+    release_date: "2022-02-16"
+    update: 9th Birthday Event
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.005
+    options:
+      - Read
+      - Destroy
+    alchable: false
+    destroy: "Osman might have another copy."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/osman-s-report.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/osman-s-report.mdx
@@ -48,7 +48,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/palm-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/palm-sapling.mdx
@@ -12,14 +12,51 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Palm sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    level: 68
+    plant_xp: 110.5
+    check_xp: 10150.1
+    harvest_xp: 41.5
+    growth_time: 960
+    patch: Fruit tree
+    yield: 6
+    protection: 15 papaya fruits
+  related_items:
+    - name: Palm tree seed
+      relationship: component
+    - name: Palm seedling (w)
+      relationship: variant
+    - name: Coconut
+      relationship: product
+  about: "Palm sapling is a Farming-grown fruit tree sapling that requires level 68 Farming, replanted in fruit tree patches to grow into a coconut-bearing palm tree over 16 hours."
+  market_strategy:
+    notes:
+      - "GE price near 23,154 gp with a 200-per-4-hours buy limit."
+      - "Daily volume around 25,799 keeps spreads tight for Farming run flips."
+  trading_tips:
+    - "Stockpile saplings ahead of Farming XP guide spikes or seed-price dips on palm tree seeds."
+    - "Pair with compost and Saradomin brews to sell to fruit-tree run players in bulk."
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming skill update."
+  properties:
+    release_date: "2005-07-11"
+    update: "Farming"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/palm-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/palm-sapling.mdx
@@ -56,7 +56,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pike.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pike.mdx
@@ -12,23 +12,61 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 6000
+  food:
+    heals: 8
+    cooking_level: 20
+    cooking_xp: 80
+    stops_burning_level: 54
+  recipes:
+    - materials:
+        - item_name: Raw pike
+          quantity: 1
+      tools:
+        - Fire or cooking range
+      output_quantity: 1
+      cooking_xp: 80
+      cooking_level: 20
   related_items:
     - item_id: 349
       item_name: Raw pike
       slug: raw-pike
       relationship: component
       description: Uncooked version
+    - item_id: 343
+      item_name: Burnt pike
+      slug: burnt-pike
+      relationship: alternative
+      description: Result of failing the cook
   about: |-
     > _"Some nicely cooked pike."_
-
     Pike heals 8 Hitpoints. Caught with a fishing rod and bait at 25 Fishing. A decent mid-level F2P food.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Free-to-play food, low margin but high volume
+      - Buy limit of 6,000 supports bulk flips
+  history:
+    - date: "2001-06-11"
+      description: Added to the game alongside the Fishing and Cooking skill content.
+  properties:
+    release_date: "2001-06-11"
+    update: Fishing and Cooking
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pike.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pike.mdx
@@ -66,7 +66,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pillar-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pillar-potion-unf.mdx
@@ -60,7 +60,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pillar-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pillar-potion-unf.mdx
@@ -12,14 +12,55 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: null
-  about: "Pillar potion (unf) is a members-only item in Old School RuneScape. High alchemy value: 15 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - materials:
+        - item_name: Vial of water
+          quantity: 1
+        - item_name: Pillar coral
+          quantity: 1
+      tools: []
+      skill: Herblore
+      level: 62
+      output_quantity: 1
+  related_items:
+    - name: Pillar coral
+      relationship: component
+    - name: Vial of water
+      relationship: component
+    - name: Super fishing potion(3)
+      relationship: product
+    - name: Super hunter potion(3)
+      relationship: product
+  about: "Pillar potion (unf) is an unfinished potion created at 62 Herblore by combining a vial of water with pillar coral, used as the base for super fishing and super hunter potions."
+  market_strategy:
+    notes:
+      - "Unfinished potion with no buy limit; trades around 2,829 gp."
+      - "Daily volume near 26,000 units, making it a high-liquidity Herblore intermediate."
+  trading_tips:
+    - "Compare cost of pillar coral plus vial vs. finished super fishing/hunter potion prices to find the better leg to flip."
+    - "Watch for Sailing content patches that adjust pillar coral spawn rates, which move this potion's price."
+  history:
+    - date: "2025-11-19"
+      description: "Added to the game with the Sailing update."
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pineapple-pizza.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pineapple-pizza.mdx
@@ -18,26 +18,19 @@ osrs:
     bites: 2
     cooking_level: 65
     cooking_xp: 45
-  cooking:
-    level: 65
-    xp: 45
-    raw_item_id: 2289
-    raw_item_name: Plain pizza
-    ticks: 2
   recipes:
-    - skill: cooking
+    - skill: Cooking
       level: 65
-      xp: 45
+      experience: 45
       materials:
         - item_name: Plain pizza
-          item_id: 2289
           quantity: 1
         - item_name: Pineapple ring
-          item_id: 2118
           quantity: 1
-      facility: None
-      ticks: 2
-      members_only: true
+      tools: []
+      output_quantity: 1
+      output_item: Pineapple pizza
+      notes: Pineapple chunks may be used in place of a pineapple ring
   related_items:
     - item_id: 2289
       item_name: Plain pizza
@@ -69,40 +62,52 @@ osrs:
       slug: shark
       relationship: alternative
       description: Lower tier food (20 HP)
+  market_strategy:
+    notes:
+      - "Profit margin = Pineapple pizza price minus Plain pizza minus Pineapple ring (post-GE tax)."
+      - "Members-only food with consistent slayer/PvM demand."
+      - "Same total healing as manta ray, dark crab, tuna potato."
+      - "Requires 2 bites (slower in combat); cheaper than single-bite alternatives."
+      - "Popular for training slayer on easier tasks."
+  trading_tips:
+    - "Track plain pizza + pineapple ring spread for combine-flip opportunity."
+    - "Stockpile during double cooking xp weekends when cookers dump supply."
   about: |-
-    Add a pineapple ring to a plain pizza (no cooking required).
-
+    Add a pineapple ring to a plain pizza (Cooking 65 required, 45 xp).
     | Effect | Value |
     |--------|-------|
     | Total healing | 22 Hitpoints |
     | Healing per bite | 11 Hitpoints |
     | Bites | 2 |
-
     Pineapple pizza is useful for:
     - Budget high-healing food option
     - Training activities where multiple bites are acceptable
     - Ironman food source
     - Situations where inventory space is less critical
-  market_strategy:
-    profit_formulas:
-      - Pineapple pizza - Plain pizza - Pineapple ring
-    notes:
-      - Plain pizza + Pineapple ring = Pineapple pizza
-      - "Calculate:"
-      - Members-only item
-      - Same total healing as manta ray, dark crab, tuna potato
-      - Requires 2 bites (slower in combat)
-      - Generally cheaper than single-bite alternatives
-      - Two bites makes it less ideal for high-intensity PvM
-      - Good for activities with downtime between combat
-      - Popular for training slayer on easier tasks
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2002-08-15"
+      description: Released as part of the Sheep and cults update.
+    - date: "2015-04-09"
+      description: Pizza now remains in the same inventory slot after the first half is eaten.
+  properties:
+    release_date: "2002-08-15"
+    update: Sheep and cults
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.9
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pineapple-pizza.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pineapple-pizza.mdx
@@ -107,7 +107,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/polar-camo-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/polar-camo-legs.mdx
@@ -12,14 +12,78 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Polar camo legs is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 0.226
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -7
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: 0
+      ranged: 10
+    other_bonus: {}
+  recipes:
+    - materials:
+        - item_name: Polar kebbit fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 20
+      tools: []
+      output_quantity: 1
+      skill: Hunter
+      notes: Trade with Pellem at the Hunter Guild or the Varrock Fancy Clothes Store proprietor.
+  related_items:
+    - slug: woodland-camo-legs
+      relationship: variant
+    - slug: jungle-camo-legs
+      relationship: variant
+    - slug: desert-camo-legs
+      relationship: variant
+    - slug: larupia-legs
+      relationship: alternative
+    - slug: polar-kebbit-fur
+      relationship: component
+  about: "Polar camo legs are Hunter cosmetic legwear crafted from polar kebbit fur; weight-reducing since 2024."
+  market_strategy:
+    notes:
+      - No GE buy limit, supply is bottlenecked by polar kebbit hunting rate.
+      - Weight-reducing buff added in 2024 modestly increased fashionscape demand.
+  trading_tips:
+    - Hunters can self-supply via Rellekka Hunter area for cheap restocks.
+    - Pair with matching polar camo top for cosmetic set bundles.
+  history:
+    - date: "2006-11-21"
+      description: Added with the Hunter skill release.
+    - date: "2024-03-20"
+      description: Granted -2 kg weight-reducing property when equipped.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/polar-camo-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/polar-camo-legs.mdx
@@ -83,7 +83,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-c-t-batta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-c-t-batta.mdx
@@ -12,14 +12,60 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 6000
-  about: "Premade c+t batta is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 11
+    type: gnome-food
+  shops:
+    - shop_name: Gnome Waiter
+      location: Grand Tree
+      stock: 3
+      restock_time: 1 minute
+      sell_price: 120
+      buy_price: 30
+    - shop_name: Gianne's Restaurant
+      location: Grand Tree
+      stock: 3
+      restock_time: 1 minute
+      sell_price: 120
+      buy_price: 30
+  related_items:
+    - item_id: 2221
+      item_name: Cheese+tom batta
+      slug: cheese-tom-batta
+      relationship: alternative
+      description: Player-cooked equivalent with the same 11 HP heal
+  about: "Premade c+t batta is a gnome-food snack sold by waiters at the Grand Tree. Eating it restores 11 hitpoints; commonly stocked for low-effort PvM healing on members worlds."
+  market_strategy:
+    notes:
+      - Shop-bought at 120 gp with high stock; GE flips are slow due to thin daily volume (~1).
+      - Useful as a cheap bulk heal for low-defence accounts; demand seasonal around clue/PvM events.
+  trading_tips:
+    - Buy directly from Gnome Waiter / Gianne's Restaurant for the lowest cost-per-heal.
+    - Skip GE flipping; volume is too thin to clear stock reliably.
+  history:
+    - date: "2002-12-12"
+      description: Released with the Agility skill update.
+    - date: "2006-08-07"
+      description: Renamed from "Cheese+tom batta" to "Premade c+t batta" in the Gnome Cuisine update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: "Agility skill online"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-c-t-batta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-c-t-batta.mdx
@@ -65,7 +65,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-ch-crunch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-ch-crunch.mdx
@@ -12,14 +12,43 @@ osrs:
   lowalch: 34
   highalch: 51
   limit: 6000
-  about: "Premade ch' crunch is a members-only item in Old School RuneScape. High alchemy value: 51 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 8
+  related_items:
+    - name: Chocchip crunchies
+      relationship: variant
+  about: "Premade ch' crunch is a members-only gnome food sold by waiters at the Grand Tree that heals 8 hitpoints, but cannot be used inside the Gnome Restaurant minigame."
+  market_strategy:
+    notes:
+      - "GE price near 55 gp with a generous 6,000-per-4-hours buy limit."
+      - "Daily volume around 1 unit; effectively a NPC-bought collectible item."
+  trading_tips:
+    - "Treat as a low-conviction flip; supply comes directly from gnome waiter restocks."
+    - "Bulk-buy at NPC price and resell during gnome restaurant XP guide spikes."
+  history:
+    - date: "2002-12-12"
+      description: "Released with the Agility skill update."
+    - date: "2006-08-07"
+      description: "Renamed from 'Chocchip crunchies' to 'Premade ch' crunch' during a gnome cuisine update."
+  properties:
+    release_date: "2002-12-12"
+    update: "Agility"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-ch-crunch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-ch-crunch.mdx
@@ -48,7 +48,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-choc-bomb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-choc-bomb.mdx
@@ -12,14 +12,55 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 6000
+  food:
+    heals: 15
+    description: Restores 15 Hitpoints when eaten.
+  shops:
+    - shop_name: Gnome Waiter (Grand Tree)
+      location: Grand Tree
+      stock: 3
+      restock_minutes: 1
+      sell_price: 160
+      buy_price: 40
+  related_items:
+    - item_id: 2185
+      item_name: Chocolate bomb
+      slug: chocolate-bomb
+      relationship: variant
+      description: Player-made equivalent from Gnome Cooking
   about: "Premade choc bomb is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Sourced from Gnome Waiter at Grand Tree
+      - Heals 15 Hitpoints, useful low-level food
+      - Restocks every minute, supply-limited
+  trading_tips:
+    - Buy from Gnome Waiter at Grand Tree for resale
+    - Track Tree Gnome stronghold meta for demand spikes
+    - Low alch margin is thin; rely on shop arbitrage
+  history:
+    - date: "2002-12-12"
+      description: Released alongside the Agility skill.
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-choc-bomb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-choc-bomb.mdx
@@ -60,7 +60,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-hat-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-hat-t2.mdx
@@ -12,14 +12,65 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: null
-  about: "Raging echoes hat (t2) is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: head
+    weapon_type: none
+    weight: 0.453
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  shops:
+    - shop_name: Leagues Reward Shop
+      currency: League points
+      price: 5000
+      stock: 1
+  related_items:
+    - name: Raging echoes hat (t1)
+      relationship: downgrade
+    - name: Raging echoes hat (t3)
+      relationship: upgrade
+    - name: Raging echoes top (t2)
+      relationship: set-piece
+    - name: Raging echoes robe (t2)
+      relationship: set-piece
+    - name: Raging echoes boots (t2)
+      relationship: set-piece
+  about: "Raging echoes hat (t2) is the tier 2 cosmetic head piece of the Raging Echoes Relic Hunter outfit, purchased from the Leagues V Reward Shop."
+  market_strategy:
+    notes:
+      - "Purely cosmetic with no combat bonuses; demand is collector-driven."
+      - "Costs 5,000 League points from the Leagues V Reward Shop."
+  trading_tips:
+    - "Cosmetic prestige items spike around Leagues anniversaries."
+    - "Compare with t1 and t3 sets to gauge tier price premium."
+  history:
+    - date: "2025-01-15"
+      description: "Released with the Leagues V: Raging Echoes reward shop."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-01-15"
+    update: "Leagues V: Raging Echoes Rewards Are Here"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-hat-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-hat-t2.mdx
@@ -70,7 +70,10 @@ osrs:
     alchable: false
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-npc-contact-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-npc-contact-scroll.mdx
@@ -12,14 +12,49 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: null
-  about: "Raging echoes npc contact scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: scroll
+    tier: high
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues lobby
+      price: 5000 League Points
+  related_items:
+    - item_name: Raging echoes teleport scroll
+      relationship: alternative
+    - item_name: NPC contact
+      relationship: alternative
+  about: "Raging echoes NPC contact scroll is a cosmetic unlock purchased from the Leagues V reward shop that swaps the standard NPC Contact spell animation for a Raging Echoes-themed override."
+  market_strategy:
+    notes:
+      - Originally purchased from the Leagues V reward shop for 5,000 League Points after completing the league.
+      - GE buy limit is unset and daily volume is extremely thin, so spreads tend to be wide.
+      - Cosmetic-only effect with no gameplay benefit beyond the animation swap.
+  trading_tips:
+    - List during nostalgia spikes near new league announcements when collectors stockpile reward scrolls.
+    - Watch for Jagmoji or QoL updates that surface old league rewards in new collections logs.
+  history:
+    - date: "2025-01-15"
+      description: Released as a Leagues V reward shop cosmetic unlock.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-01-15"
+    update: "Leagues V: Raging Echoes Rewards Are Here"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-npc-contact-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-npc-contact-scroll.mdx
@@ -54,7 +54,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-potion-3.mdx
@@ -12,28 +12,65 @@ osrs:
   lowalch: 115
   highalch: 172
   limit: 2000
+  potion:
+    effects:
+      - description: Temporarily boosts Ranged level by 4 + 10% of current Ranged level (rounded down).
+      - description: Boost decays at 1 level per minute, or roughly 90 seconds with the Preserve prayer.
+  recipes:
+    - materials:
+        - item_name: Dwarf weed potion (unf)
+          quantity: 1
+        - item_name: Wine of Zamorak
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: Herblore
+      level: 72
+      experience: 162.5
   related_items:
-    - item_id: 171
-      item_name: Ranging potion(2)
-      slug: ranging-potion-2
+    - slug: ranging-potion-1
       relationship: variant
-      description: 2-dose version
-    - item_id: 173
-      item_name: Ranging potion(1)
-      slug: ranging-potion-1
+    - slug: ranging-potion-2
       relationship: variant
-      description: 1-dose version
-  about: |-
-    > _"3 doses of ranging potion."_
-
-    The ranging potion boosts Ranged by 4 + 10% of current level (rounded down). Essential for ranged combat, commonly used at bosses and in PvP.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - slug: ranging-potion-4
+      relationship: variant
+    - slug: dwarf-weed-potion-unf
+      relationship: component
+    - slug: wine-of-zamorak
+      relationship: component
+  about: "Ranging potion(3) is a 3-dose Herblore brew that temporarily boosts Ranged for high-level PvM and PvP."
+  market_strategy:
+    notes:
+      - Volume tracks raid and PvP popularity.
+      - Decant arbitrage between 3-dose and 4-dose vials is common.
+  trading_tips:
+    - Watch dwarf weed and wine of Zamorak prices for Herblore craft margins.
+    - Higher demand around Theatre of Blood and Chambers of Xeric runs.
+  history:
+    - date: "2002-02-27"
+      description: Released with the Herblore skill expansion.
+    - date: "2004-10-18"
+      description: Empty option added to ranging potions.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: Herblore
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-potion-3.mdx
@@ -70,7 +70,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-fish-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-fish-pie.mdx
@@ -85,7 +85,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-fish-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-fish-pie.mdx
@@ -5,21 +5,87 @@ osrs:
   id: 7186
   name: Raw fish pie
   slug: raw-fish-pie
-  examine: Raw fish is risky, better cook it.
+  examine: "Raw fish is risky, better cook it."
   members: true
   icon: Raw fish pie.png
   value: 50
   lowalch: 20
   highalch: 30
   limit: 13000
-  about: "Raw fish pie is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Cooking
+      level: 47
+      xp: 0
+      output_quantity: 1
+      materials:
+        - item_name: Part fish pie
+          quantity: 1
+        - item_name: Potato
+          quantity: 1
+      tools: []
+      notes: Combine a part fish pie with a potato to assemble the raw fish pie.
+    - skill: Cooking
+      level: 47
+      xp: 164
+      output_quantity: 1
+      materials:
+        - item_name: Raw fish pie
+          quantity: 1
+      tools:
+        - Range
+      notes: Cook the raw fish pie on a range to produce a fish pie, with chance of a burnt pie.
+  related_items:
+    - item_id: 7188
+      item_name: Fish pie
+      slug: fish-pie
+      relationship: product
+      description: Cooked product of the raw fish pie
+    - item_id: 7184
+      item_name: Part fish pie
+      slug: part-fish-pie
+      relationship: component
+      description: Intermediate ingredient before adding potato
+    - item_id: 1942
+      item_name: Potato
+      slug: potato
+      relationship: component
+      description: Required ingredient
+    - item_id: 2329
+      item_name: Burnt pie
+      slug: burnt-pie
+      relationship: alternative
+      description: Failure result when cooking
+  about: "Raw fish pie is the uncooked intermediate of fish pie, made by adding a potato to a part fish pie and cooked at 47 Cooking for 164 XP."
+  market_strategy:
+    notes:
+      - Demand is driven by Cooking trainers and ironmen targeting 47+ XP gains via fish pies.
+      - GE buy limit of 13,000 supports bulk flipping when raw inputs are oversupplied by skill farmers.
+      - Profitability depends on the spread between part fish pie plus potato versus the cooked fish pie price.
+  trading_tips:
+    - Track part fish pie inventory; raw fish pie usually moves in lockstep with its precursor.
+    - Sell raw rather than cooked when burn rates make the cook unprofitable for low-level chefs.
+  history:
+    - date: "2006-02-20"
+      description: Added with the gnome stronghold pie cooking line.
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-dye.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-dye.mdx
@@ -89,7 +89,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-dye.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-dye.mdx
@@ -12,14 +12,84 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 150
+  shops:
+    - shop_name: Aggie the Witch
+      location: Draynor Village
+      price: 5
+      restock_time: null
+      notes: "Trade 3 redberries + 5 coins; creates red dye"
+    - shop_name: Ali the Dyer
+      location: Pollnivneach
+      price: 25
+      restock_time: null
+    - shop_name: Oronwen's Seamstress
+      location: Lletya
+      stock: 10
+      price: 6
+      restock_time: 1 minute
+    - shop_name: Guinevere's Dyes
+      location: Prifddinas
+      stock: 10
+      price: 6
+      restock_time: 1 minute
+  recipes:
+    - skill: Crafting
+      level: 1
+      experience: 0
+      materials:
+        - item_name: Redberries
+          quantity: 3
+        - item_name: Coins
+          quantity: 5
+      tools: []
+      output_quantity: 1
+      output_item: Red dye
+      notes: Made by Aggie the Witch in Draynor Village
+  related_items:
+    - item_id: 1765
+      item_name: Yellow dye
+      slug: yellow-dye
+      relationship: alternative
+      description: Other primary dye from Aggie
+    - item_id: 1767
+      item_name: Blue dye
+      slug: blue-dye
+      relationship: alternative
+      description: Other primary dye from Aggie
+    - item_id: 1769
+      item_name: Orange dye
+      slug: orange-dye
+      relationship: product
+      description: Created by mixing red and yellow dye
+  market_strategy:
+    notes:
+      - "Low GE volume; quest demand spikes around Goblin Diplomacy and Ghosts Ahoy."
+      - "Self-creation via Aggie is cheaper than GE during shortages."
+  trading_tips:
+    - "Hold during major quest reveals; supply is thin."
+    - "Stack with redberry flips when Hosidius bushes are popular."
   about: "Red dye is a free-to-play item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  history:
+    - date: "2001-05-08"
+      description: Released in a RuneScape update introducing dyes.
+  properties:
+    release_date: "2001-05-08"
+    update: Dyes introduced
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-robe-bottoms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-robe-bottoms.mdx
@@ -88,7 +88,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-robe-bottoms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-robe-bottoms.mdx
@@ -1,6 +1,6 @@
 ---
 title: Red robe bottoms | OSRS Price Data
-description: "Red robe bottoms: Made by werewolves for werewolves.. High alch: 300 GP, GE limit: 150."
+description: "Red robe bottoms: Made by werewolves for werewolves. High alch: 300 GP, GE limit: 150."
 osrs:
   id: 2908
   name: Red robe bottoms
@@ -12,14 +12,83 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Red robe bottoms is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: legs
+    weapon_type: robe
+    attack_speed: 4
+    weight: 0.907
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      prayer: 0
+  shops:
+    - shop_name: Barkers' Haberdashery
+      location: Canifis
+      price: 650
+      stock: 5
+  related_items:
+    - item_id: 2906
+      item_name: Red robe top
+      slug: red-robe-top
+      relationship: set-piece
+      description: Matching Canifis red robe top.
+    - item_id: 2912
+      item_name: Yellow robe bottoms
+      slug: yellow-robe-bottoms
+      relationship: variant
+      description: Yellow color variant from the same Canifis shop.
+    - item_id: 2914
+      item_name: Grey robe bottoms
+      slug: grey-robe-bottoms
+      relationship: variant
+      description: Grey color variant from the same Canifis shop.
+  about: A Morytania fashion piece sold at Barkers' Haberdashery in Canifis; minor defence bonuses make it a cosmetic-tier leg slot.
+  market_strategy:
+    notes:
+      - Demand is purely cosmetic; supply is unlimited at the Canifis shop.
+      - Modest flip margins on GE relative to shop price.
+  trading_tips:
+    - Buy from Barkers' shop and resell on GE during fashionscape events.
+    - Watch low GE limit; flipping volume capped at 150 per 4 hours.
+  history:
+    - date: "2004-06-29"
+      description: Red robe bottoms released alongside Priest in Peril and the Morytania region.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-06-29"
+    update: Priest in Peril
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/redberry-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/redberry-pie.mdx
@@ -12,14 +12,62 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 15
-  about: "Redberry pie is a free-to-play item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    healing: 10
+    bites: 2
+    heal_per_bite: 5
+  recipes:
+    - materials:
+        - item_name: Pie shell
+          quantity: 1
+        - item_name: Redberries
+          quantity: 1
+      tools:
+        - Range
+      skill: Cooking
+      level: 10
+      experience: 78
+      output_quantity: 1
+  related_items:
+    - name: Half a redberry pie
+      relationship: variant
+    - name: Pie dish
+      relationship: component
+    - name: Uncooked berry pie
+      relationship: component
+    - name: Redberries
+      relationship: component
+  about: "Redberry pie is a free-to-play 10-Cooking pie that heals 10 hitpoints across two bites and is used in The Knight's Sword, The Giant Dwarf, and Prying Times."
+  market_strategy:
+    notes:
+      - "GE buy limit only 15 per 4 hours, so bulk supply is slow."
+      - "Demand comes from quest seekers more than combat food."
+  trading_tips:
+    - "Spike around quest guide videos and new account onboarding."
+    - "Bake Pie lunar spell guarantees success past base burn rate."
+  history:
+    - date: "2001-03-17"
+      description: "Released as one of the original Cooking pies."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-03-17"
+    update: Cooking pies
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.45
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/redberry-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/redberry-pie.mdx
@@ -67,7 +67,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-balm-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-balm-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Relicym's balm(3) | OSRS Price Data
-description: "Relicym's balm(3): 3 doses of Relicym's balm, which helps cure disease.. High alch: 120 GP, GE limit: 2,000."
+description: "Relicym's balm(3): 3 doses of Relicym's balm, which helps cure disease. High alch: 120 GP, GE limit: 2,000."
 osrs:
   id: 4844
   name: Relicym's balm(3)
@@ -12,14 +12,73 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Relicym's balm(3) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 3
+    effects:
+      - description: Cures disease on the player when consumed.
+      - description: Effective against yellow broodoo victim during Tai Bwo Wannai Cleanup.
+      - description: Reduces parasite damage at The Nightmare of Ashihama as a cheaper alternative to Sanfew serum.
+  recipes:
+    - materials:
+        - item_name: Snake weed
+          quantity: 1
+        - item_name: Vial of water
+          quantity: 1
+        - item_name: Rogue's purse
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      skill: Herblore
+      level: 8
+      xp: 40
+      output_quantity: 1
+      notes: Requires partial completion of Zogre Flesh Eaters.
+  related_items:
+    - item_id: 4842
+      item_name: Relicym's balm(4)
+      slug: relicym-s-balm-4
+      relationship: variant
+      description: Four-dose version of the same potion.
+    - item_id: 4846
+      item_name: Relicym's balm(2)
+      slug: relicym-s-balm-2
+      relationship: variant
+      description: Two-dose version of the same potion.
+    - item_id: 4848
+      item_name: Relicym's balm(1)
+      slug: relicym-s-balm-1
+      relationship: variant
+      description: One-dose version of the same potion.
+  about: Three-dose Relicym's balm; a Herblore potion that cures disease and shines at Tai Bwo Wannai Cleanup and as a budget Nightmare parasite reducer.
+  market_strategy:
+    notes:
+      - Demand spikes around Nightmare group strats and Zogre Flesh Eaters runs.
+      - 3-dose stock is usually a byproduct of decanters splitting 4-dose pots.
+  trading_tips:
+    - Decant 4-dose stock into 3s when 3-dose GE price runs hot.
+    - Pair flips with snake weed inventory; supply is bottlenecked by herb spawns.
+  history:
+    - date: "2005-05-17"
+      description: Relicym's balm introduced with the Zogre Flesh Eaters quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-17"
+    update: Zogre Flesh Eaters
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Zogre Flesh Eaters
+    weight: 0.02
+    options:
+      - Drink
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-balm-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-balm-3.mdx
@@ -78,7 +78,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/restore-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/restore-mix-1.mdx
@@ -70,7 +70,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/restore-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/restore-mix-1.mdx
@@ -12,14 +12,65 @@ osrs:
   lowalch: 17
   highalch: 26
   limit: 2000
-  about: "Restore mix(1) is a members-only item in Old School RuneScape. High alchemy value: 26 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Restores Attack, Strength, Defence, Ranged, and Magic by 10 + 30% of the player's level (capped between 10 and 39 levels)."
+      - description: "Heals 3 Hitpoints when consumed."
+      - description: "Does not restore Prayer points."
+  food:
+    heals: 3
+  recipes:
+    - materials:
+        - item_name: Restore potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      skill: Herblore
+      level: 24
+      xp: 21
+      output_quantity: 1
+      requires_quest: Barbarian Training (Herblore)
+  related_items:
+    - name: Restore potion
+      relationship: variant
+    - name: Restore mix(2)
+      relationship: variant
+    - name: Roe
+      relationship: component
+    - name: Caviar
+      relationship: component
+  about: "Restore mix(1) is a barbarian-mixed single-dose restore potion that returns combat stats and heals 3 Hitpoints, created with 24 Herblore by adding roe or caviar to a restore potion."
+  market_strategy:
+    notes:
+      - "GE price near 177 gp with a 2,000-per-4-hours buy limit."
+      - "Niche barbarian potion with margin near 4 gp per dose; volume tied to barbarian training routes."
+  trading_tips:
+    - "Watch restore potion(2) and caviar price ratios - profit only opens when the inputs both dip."
+    - "Bulk supply spikes during Otto Godblessed minigame XP campaigns."
+  history:
+    - date: "2007-07-03"
+      description: "Released as part of Barbarian Herblore training with Otto Godblessed."
+  properties:
+    release_date: "2007-07-03"
+    update: "Barbarian Training"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-3rd-age.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-3rd-age.mdx
@@ -89,7 +89,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-3rd-age.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-3rd-age.mdx
@@ -12,14 +12,84 @@ osrs:
   lowalch: 4800
   highalch: 7200
   limit: 4
-  about: "Ring of 3rd age is a free-to-play item in Old School RuneScape. High alchemy value: 7,200 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: 3rd-age
+    tier: high
+  equipment:
+    slot: ring
+    weight: 0.005
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - elite
+      - master
+  drop_table:
+    sources:
+      - source: The Mimic (Elite)
+        quantity: "1"
+        rarity: 6/250
+      - source: The Mimic (Master)
+        quantity: "1"
+        rarity: 6/228
+  related_items:
+    - item_name: 3rd age full helmet
+      relationship: alternative
+    - item_name: Ring of nature
+      relationship: alternative
+  about: "The ring of 3rd age is a cosmetic ring obtained from defeating The Mimic that lets the wearer transform their appearance into pieces of 3rd age equipment via hotkeys, with the effect cancelled by movement."
+  market_strategy:
+    notes:
+      - Only obtained as a rare drop from The Mimic boss after redeeming an elite or master clue casket reward.
+      - GE buy limit is 4 per 4 hours, keeping turnover slow.
+      - Cosmetic-only with no stat bonuses, so the price is driven entirely by prestige.
+  trading_tips:
+    - Watch The Mimic completion meta; price softens when clue rewards trend bullish.
+    - List during double-XP weekends when collectors rotate into vanity items.
+  history:
+    - date: "2019-04-11"
+      description: Released as a cosmetic reward from The Mimic boss fight.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: "The Mimic"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+      - Transform
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-nature.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-nature.mdx
@@ -93,7 +93,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-nature.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-nature.mdx
@@ -12,14 +12,88 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: 4
+  material:
+    type: cosmetic
+    tier: high
+  equipment:
+    slot: ring
+    weight: 0.004
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    description: "Operating the ring transforms the wearer into a bush; movement ends the effect. Other players see a bush with normal interaction options."
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/14663
+        members_only: true
+  related_items:
+    - item_id: 19711
+      item_name: Reward casket (elite)
+      slug: reward-casket-elite
+      relationship: component
+      description: Source casket from elite Treasure Trails
   about: "Ring of nature is a free-to-play item in Old School RuneScape. High alchemy value: 4,800 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Elite clue reward, very rare
+      - Cosmetic transformation, no combat use
+      - F2P-tradeable since November 2016
+  trading_tips:
+    - Demand driven by collectors and bush memes
+    - Buy limit of 4 makes flipping slow
+    - Track elite clue completion rates for supply spikes
+  history:
+    - date: "2016-07-06"
+      description: Released with the Treasure Trail Expansion update.
+    - date: "2016-11-24"
+      description: Made available to F2P players.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.004
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Operate
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-chainbody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-chainbody.mdx
@@ -91,7 +91,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-chainbody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-chainbody.mdx
@@ -12,30 +12,86 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 70
-  item_id: 1113
-  item_type: armor
-  slot: body
-  type: chainbody
-  tradeable: true
-  weight: 6.803
-  requirements:
-    defence: 40
-  stats:
-    stab_defence: 63
-    slash_defence: 72
-    crush_defence: 61
-    magic: -15
-    ranged: -15
+  material:
+    type: rune
+    tier: high
+  equipment:
+    slot: body
+    weapon_type: none
+    weight: 6.803
+    requirements:
+      defence: 40
+    attack_bonus: {}
+    defence_bonus:
+      stab: 63
+      slash: 72
+      crush: 61
+      magic: -15
+      ranged: -15
+    other_bonus: {}
+  recipes:
+    - materials:
+        - item_name: Runite bar
+          quantity: 3
+      tools:
+        - Hammer
+        - Anvil
+      skill: Smithing
+      level: 96
+      xp: 225
+      output_quantity: 1
+  shops:
+    - shop_name: Scavvo's Rune Store
+      location: Champions' Guild
+      price: 50000
+    - shop_name: Seddu's Adventurer's Store
+      location: Shilo Village
+      price: 50000
   related_items:
-    - slug: rune-platebody
-    - slug: runite-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1127
+      item_name: Rune platebody
+      slug: rune-platebody
+      relationship: upgrade
+      description: Higher-tier rune torso with stronger defence bonuses.
+    - item_id: 2363
+      item_name: Runite bar
+      slug: runite-bar
+      relationship: component
+      description: Smelted material used to craft the chainbody.
+  about: "Rune chainbody is the highest-tier F2P chainbody and a strong budget torso for Defence level 40 players."
+  market_strategy:
+    notes:
+      - "GE buy limit of 70 per 4 hours keeps supply tight for crafters."
+      - "Smithing it at level 96 (3 runite bars, 225 xp) is currently a loss vs GE."
+      - "Drops widely from medium-tier monsters, so price tends to track PvM activity."
+  trading_tips:
+    - "Avoid smithing for profit; runite bar cost typically exceeds chainbody GE price."
+    - "Useful as a F2P PK alternative when plate is unavailable; demand spikes during Wilderness events."
+    - "High alch is below GE price, so don't alch unless you accept a loss."
+  properties:
+    release_date: "2001-07-26"
+    update: "RuneScape 1 era"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 6.803
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2001-07-26"
+      description: "Released as part of the original rune armour set during RuneScape's early metal-armour era."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-helm-h4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-helm-h4.mdx
@@ -12,14 +12,82 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 70
-  about: "Rune helm (h4) is a free-to-play item in Old School RuneScape. High alchemy value: 21,120 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: mid-high
+  equipment:
+    slot: head
+    weapon_type: null
+    weight: 2.721
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+  related_items:
+    - name: Rune helm (h1)
+      relationship: variant
+    - name: Rune helm (h2)
+      relationship: variant
+    - name: Rune helm (h3)
+      relationship: variant
+    - name: Rune helm (h5)
+      relationship: variant
+    - name: Rune full helm
+      relationship: alternative
+  about: "Rune helm (h4) is a free-to-play heraldic rune helmet in Old School RuneScape. High alchemy value: 21,120 coins. Grand Exchange buy limit: 70 per 4 hours."
+  market_strategy:
+    notes:
+      - Obtained from Hard and Elite Treasure Trail rewards.
+      - Shares identical defence bonuses with the standard rune full helm.
+      - Daily volume is modest; cosmetic demand drives price more than combat use.
+  trading_tips:
+    - High-alch profit can be marginal depending on nature rune cost vs GE price.
+    - Heraldic variants trade at similar prices - check all five h-variants for the best buy.
+  history:
+    - date: "2006-12-05"
+      description: Item released as part of the Treasure Trails update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-helm-h4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-helm-h4.mdx
@@ -87,7 +87,10 @@ osrs:
     alchable: true
     destroy: Drop
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-javelin-p-5653.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-javelin-p-5653.mdx
@@ -12,14 +12,82 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 11000
-  about: "Rune javelin(p++) is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: javelin
+    attack_speed: 6
+    weight: 0
+    requirements:
+      ranged: 40
+    attack_bonus:
+      ranged: 0
+    defence_bonus: {}
+    other_bonus:
+      ranged_strength: 124
+  recipes:
+    - materials:
+        - item_name: Rune javelin
+          quantity: 1
+        - item_name: Weapon poison(++)
+          quantity: 1
+      tools: []
+      skill: Herblore
+      level: 82
+      output_quantity: 1
+      notes: "One dose of weapon poison(++) poisons 5 rune javelins."
+  related_items:
+    - item_id: 825
+      item_name: Rune javelin
+      slug: rune-javelin
+      relationship: variant
+      description: Unpoisoned rune javelin.
+    - item_id: 5651
+      item_name: Rune javelin(p)
+      slug: rune-javelin-p-5651
+      relationship: variant
+      description: Weakest poison variant.
+    - item_id: 5652
+      item_name: Rune javelin(p+)
+      slug: rune-javelin-p-5652
+      relationship: variant
+      description: Mid-strength poison variant.
+  about: "Rune javelin(p++) is the strongest poisoned variant of the rune javelin, fired by chinchompa-tier ranged weapons and javelin throwers; it deals 6 damage on poison procs."
+  market_strategy:
+    notes:
+      - "Margin opportunity comes from buying unpoisoned rune javelins + weapon poison(++) and reselling poisoned stacks."
+      - "GE buy limit of 11,000 per 4 hours supports flips during PvP/league events where venom-equivalent poisons are sought."
+      - "Demand is thin outside niche PvP and Heavy ballista users; volume can be low."
+  trading_tips:
+    - "Poison costs eat margin; flip only when weapon poison(++) is cheap relative to the spread."
+    - "Pair with a Heavy ballista for maximum ranged strength leverage."
+    - "Avoid alching unless you accept a heavy loss; high alch (240 gp) sits below GE price."
+  properties:
+    release_date: "2004-03-29"
+    update: "RuneScape 2"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2004-03-29"
+      description: "Released with RuneScape 2 alongside the original javelin ammunition line."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-javelin-p-5653.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-javelin-p-5653.mdx
@@ -87,7 +87,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-nails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-nails.mdx
@@ -13,73 +13,56 @@ osrs:
   highalch: 132
   limit: 13000
   material:
-    type: nails
-    tier: rune
-  smithing:
-    level: 89
-    xp: 75
-    bars: 1
-    nails_per_bar: 15
-  construction:
-    bend_rate: None
-    min_level: 1
+    type: rune
+    tier: high
   recipes:
-    - skill: smithing
+    - materials:
+        - item_name: Runite bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 15
+      skill: Smithing
       level: 89
       xp: 75
-      materials:
-        - item_name: Runite bar
-          item_id: 2363
-          quantity: 1
-      product: Rune nails
-      product_id: 4824
-      product_quantity: 15
   related_items:
-    - item_id: 2363
-      item_name: Runite bar
-      slug: runite-bar
+    - item_name: Runite bar
       relationship: component
-      description: Smelting material
-    - item_id: 4823
-      item_name: Adamantite nails
-      slug: adamantite-nails
+    - item_name: Adamantite nails
       relationship: downgrade
-      description: Very low bend rate
-    - item_id: 960
-      item_name: Plank
-      slug: plank
+    - item_name: Plank
       relationship: component
-      description: Used with planks
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Bend rate | Never bends |
-    | Construction level | 1+ |
-    | Used with | Planks |
-
-    Best nails in game - never bend. Perfect for Construction training efficiency.
-
-    | Nails | Bend Rate | Shop Price |
-    |-------|-----------|------------|
-    | Bronze | Highest | 1 GP |
-    | Iron | High | 2 GP |
-    | Steel | Medium | 5 GP |
-    | Mithril | Low | 10 GP |
-    | Adamantite | Very Low | 25 GP |
-    | Rune | Never bends | 100 GP |
+  about: "Rune nails are members-only Construction nails smithed from runite bars; they are the most durable nails in the game and never bend during furniture builds."
   market_strategy:
     notes:
-      - Guaranteed to never bend
-      - Most expensive nails
-      - Overkill for most players
-      - Adamantite nails are more cost-effective
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Smithed at level 89 producing 15 nails per runite bar for 75 Smithing xp.
+      - Never bend, making them the safest option for high-end Construction builds.
+      - GE buy limit is 13,000 per 4 hours despite the high coin price.
+  trading_tips:
+    - Compare against adamantite nails since most builders prefer the cheaper bend-rate trade-off.
+    - Construction demand picks up around Achievement Diary and POH-related updates.
+  history:
+    - date: "2005-05-17"
+      description: Released alongside the Zogre Flesh Eaters quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-17"
+    update: "Zogre Flesh Eaters"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-nails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-nails.mdx
@@ -62,7 +62,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sagacious-spectacles.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sagacious-spectacles.mdx
@@ -59,7 +59,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sagacious-spectacles.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sagacious-spectacles.mdx
@@ -12,14 +12,54 @@ osrs:
   lowalch: 560
   highalch: 840
   limit: 4
-  about: "Sagacious spectacles is a members-only item in Old School RuneScape. High alchemy value: 840 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.001
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - name: Partyhat & specs
+      relationship: product
+    - name: Blue partyhat
+      relationship: component
+  about: "Sagacious spectacles are a cosmetic head-slot reward obtained from elite Treasure Trails. They can be combined with a blue partyhat by Patchy on Mos Le'Harmless to make the Partyhat & specs."
+  market_strategy:
+    notes:
+      - Cosmetic demand only
+      - Spikes during partyhat & specs trends
+  trading_tips:
+    - Buy limit is only 4 per 4 hours
+    - Track elite clue completion rates for supply
+  history:
+    - date: "2014-06-12"
+      description: "Sagacious spectacles were released with the Treasure Trail Expansion."
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sandstone-2kg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sandstone-2kg.mdx
@@ -9,17 +9,53 @@ osrs:
   members: true
   icon: Sandstone (2kg).png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 100
-  about: "Sandstone (2kg) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: stone
+    tier: low
+  related_items:
+    - name: Sandstone (1kg)
+      relationship: downgrade
+    - name: Sandstone (5kg)
+      relationship: upgrade
+    - name: Sandstone (10kg)
+      relationship: upgrade
+    - name: Bucket of sand
+      relationship: product
+    - name: Molten glass
+      relationship: product
+  about: "Sandstone (2kg) is a small block of sandstone mined from sandstone rocks at the Bandit Camp Quarry, Necropolis, and Cape Conch with 35 Mining. It can be ground into buckets of sand at the Sandstorm grinder or split with a chisel into smaller chunks."
+  market_strategy:
+    notes:
+      - Used to make buckets of sand for Crafting
+      - Mid-size variant balances weight and yield
+  trading_tips:
+    - Buy limit is 100 per 4 hours
+    - Margins are thin compared to direct mining
+  history:
+    - date: "2006-01-23"
+      description: "Sandstone (2kg) was released with the Enakhra's Lament quest and Desert Mining."
+  properties:
+    release_date: "2006-01-23"
+    update: "Enakhra's Lament"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Use
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sandstone-2kg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sandstone-2kg.mdx
@@ -55,7 +55,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-robe-top.mdx
@@ -16,8 +16,17 @@ osrs:
     slot: body
     requirements:
       prayer: 20
+    attack_bonus:
+      magic: 4
+    defence_bonus:
+      magic: 4
     other_bonus:
       prayer: 6
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 10464
       item_name: Saradomin robe legs
@@ -29,17 +38,52 @@ osrs:
       slug: saradomin-mitre
       relationship: set-piece
       description: Saradomin vestment head
+    - item_id: 10454
+      item_name: Saradomin cloak
+      slug: saradomin-cloak
+      relationship: set-piece
+      description: Saradomin vestment cape
+    - item_id: 10456
+      item_name: Saradomin crozier
+      slug: saradomin-crozier
+      relationship: set-piece
+      description: Saradomin vestment weapon
   about: |-
     > *"Saradomin Vestments."*
-
     The Saradomin robe top is the body piece of the Saradomin vestment set. It provides a +6 Prayer bonus and requires 20 Prayer to equip. Counts as a Saradominist item in the God Wars Dungeon, providing protection from Saradomin followers.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Easy clue reward with steady demand from GWD Saradomin trips and fashionscape vestment collectors.
+      - Low GE limit (8) compresses arbitrage; full vestment set buys tend to lift price.
+  trading_tips:
+    - Watch for spikes around Saradomin GWD content tweaks or new prayer training methods.
+    - Stockpile around clue scroll drop-rate buffs; demand stays anchored to easy clue volume.
+  history:
+    - date: "2006-12-05"
+      description: Released with the Treasure Trails, spiders and sheep update.
+    - date: "2014-07-24"
+      description: Vestment robe tops and legs adjusted to match monk robe prayer bonuses.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: "Treasure Trails, spiders and sheep"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.8
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-robe-top.mdx
@@ -83,7 +83,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saturated-heart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saturated-heart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Saturated heart | OSRS Price Data
-description: "Saturated heart: This heart holds an ancient magical power within.. High alch: 360,000 GP, GE limit: 8."
+description: "Saturated heart: This heart holds an ancient magical power within. High alch: 360,000 GP, GE limit: 8."
 osrs:
   id: 27641
   name: Saturated heart
@@ -12,93 +12,73 @@ osrs:
   lowalch: 240000
   highalch: 360000
   limit: 8
-  item:
-    type: magic_boost
-    tradeable: true
-  effect:
-    enhanced_invigorate:
-      base_boost: 4
-      percent_boost: 10
-      max_boost_at_99: 13
-      cooldown_minutes: 5
-      resets_on_death: true
+  material:
+    type: ancient-magic
+    tier: high
+  potion:
+    doses: 1
+    effects:
+      - description: "Boosts Magic by 4 + 10% of current level (max +13 at 99 Magic)."
+      - description: 5-minute cooldown between activations and resets to base on death.
+      - description: Best-in-slot Magic boost; +3 levels and 2 minutes faster cooldown than the imbued heart.
   recipes:
-    - skill: N/A
-      level: 0
-      xp: 0
-      materials:
-        - item_id: 20724
-          item_name: Imbued heart
+    - materials:
+        - item_name: Imbued heart
           quantity: 1
-        - item_id: 27616
-          item_name: Ancient essence
+        - item_name: Ancient essence
           quantity: 150000
-      product: Saturated heart
-      product_id: 27641
-      facility: N/A
-      members_only: true
-      irreversible: true
+      tools: []
+      skill: Magic
+      level: 1
+      xp: 0
+      output_quantity: 1
+      notes: Irreversible combination performed by interacting with the imbued heart and ancient essence.
   related_items:
     - item_id: 20724
       item_name: Imbued heart
       slug: imbued-heart
       relationship: component
-      description: Base item
+      description: Base item upgraded with ancient essence to create the saturated heart.
     - item_id: 27616
       item_name: Ancient essence
       slug: ancient-essence
       relationship: component
-      description: Upgrade material
+      description: 150,000 ancient essence required to consecrate the imbued heart.
     - item_id: 21006
       item_name: Kodai wand
       slug: kodai-wand
       relationship: alternative
-      description: Pairs well
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Magic Boost (Enhanced) |
-    | Tradeable | Yes |
-    | Weight | 0.45 kg |
-
-    Combine Imbued heart + 150,000 Ancient essence.
-
-    Process is irreversible.
-
-    | Component | Price |
-    |-----------|-------|
-    | Imbued heart | ~29M |
-    | Ancient essence (150K) | ~84M |
-
-    Enhanced Invigorate:
-    - Boosts Magic by 4 + 10% of level
-    - At 99 Magic: +13 levels
-    - Cooldown: 5 minutes (2 min less than imbued)
-    - Resets on death
-
-    | Stat | Imbued | Saturated |
-    |------|--------|-----------|
-    | Boost (99) | +10 | +13 |
-    | Cooldown | 7 min | 5 min |
-
-    BiS for:
-    - Magic bossing
-    - Raids
-    - Any high-level magic content
-
-    +3 more levels and 2 min faster than imbued.
+      description: BiS magic weapon commonly paired with the saturated heart for max DPS.
+  about: Best-in-slot Magic level booster crafted from an imbued heart and 150,000 ancient essence; +13 Magic at 99 with a 5-minute cooldown.
   market_strategy:
     notes:
-      - Expensive upgrade
-      - Worth for max magic
-      - Irreversible process
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Floor anchored by imbued heart price plus 150k ancient essence cost.
+      - Demand from raid teams, end-game mages, and ToB/ToA setups.
+      - Irreversible recipe creates one-way supply pressure.
+  trading_tips:
+    - Track ancient essence GE feed; downstream saturated heart price follows.
+    - GE limit of 8 makes accumulation slow; bulk buying requires multiple cycles.
+  history:
+    - date: "2023-01-11"
+      description: Saturated heart released with the DT2 reward update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-01-11"
+    update: Desert Treasure II - The Fallen Empire
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.45
+    options:
+      - Invigorate
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saturated-heart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saturated-heart.mdx
@@ -78,7 +78,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shirt-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shirt-yellow.mdx
@@ -12,14 +12,67 @@ osrs:
   lowalch: 240
   highalch: 360
   limit: 150
-  about: "Shirt (yellow) is a members-only item in Old School RuneScape. High alchemy value: 360 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: body
+    weight: 0.07
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus: {}
+  shops:
+    - shop_name: Agmundi Quality Clothes
+      location: Keldagrim
+      price: 780
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania
+      price: 600
+  related_items:
+    - slug: shirt-brown
+      relationship: variant
+    - slug: shirt-lilac
+      relationship: variant
+  about: "Shirt (yellow) is a cosmetic dwarven body-slot piece sold in Keldagrim and Miscellania."
+  market_strategy:
+    notes:
+      - Cosmetic dwarven cloth; volume driven by fashionscape demand.
+      - Shop price ceilings cap upside; alch margin is modest.
+  trading_tips:
+    - Pair with matching dwarven cosmetic set for cosmetic bundles.
+    - Monitor demand during fashionscape competitions and content updates.
+  history:
+    - date: "2005-05-31"
+      description: Added with the Keldagrim and dwarven content update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-31"
+    update: Keldagrim
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.07
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shirt-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shirt-yellow.mdx
@@ -72,7 +72,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-agile-fortune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-agile-fortune.mdx
@@ -12,14 +12,42 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of agile fortune is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - name: Mark of grace
+      relationship: alternative
+    - name: Pyramid top
+      relationship: alternative
+  about: "Sigil of agile fortune is a Deadman Mode sigil that drops bonus coins when Marks of Grace spawn on Rooftop Agility courses and triples the pyramid top hand-in reward at Simon Templeton."
+  market_strategy:
+    notes:
+      - "Untradeable Deadman event reward; no Grand Exchange market."
+      - "Only obtainable during temporary Deadman Mode events."
+  trading_tips:
+    - "No flipping route - sigil is bound to event characters and unattunes before destruction."
+    - "Track Deadman event schedules for windows when the sigil enters circulation."
+  history:
+    - date: "2023-08-23"
+      description: "Released as part of the Deadman Mode: Apocalypse sigil pool."
+  properties:
+    release_date: "2023-08-23"
+    update: "Deadman Mode: Apocalypse"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-agile-fortune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-agile-fortune.mdx
@@ -47,7 +47,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-binding.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-binding.mdx
@@ -60,7 +60,10 @@ osrs:
     alchable: false
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-binding.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-binding.mdx
@@ -12,14 +12,55 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of binding is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Deadman Mode drop table (most monsters)
+        quantity: "1"
+        rarity: Rare
+  related_items:
+    - name: "Sigil of specialised strikes"
+      relationship: alternative
+    - name: "Sigil of the porcupine"
+      relationship: alternative
+    - name: "Sigil of fortification"
+      relationship: alternative
+    - name: "Sigil of the ruthless ranger"
+      relationship: alternative
+    - name: "Sigil of the feral fighter"
+      relationship: alternative
+    - name: "Sigil of the menacing mage"
+      relationship: alternative
+  about: "Sigil of binding is a members-only tier 2 combat sigil for Deadman Mode that grants a 75% magic accuracy boost on the next binding spell cast within 12 seconds when activated. Tradeable while un-attuned, then permanently account-bound after attuning."
+  market_strategy:
+    notes:
+      - "Deadman Mode-only utility — demand is concentrated around DM events."
+      - "Becomes permanently account-bound once attuned, removing it from market supply."
+      - "5-minute cooldown on success vs 1-minute on failure rewards higher Magic levels."
+  trading_tips:
+    - "Buy un-attuned sigils before a Deadman Mode tournament announcement."
+    - "Sell off-event when DM demand falls and farming supply persists."
+  history:
+    - date: "2021-08-25"
+      description: "Released with the Deadman: Reborn update as one of the new tier 2 combat sigils."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-deception.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-deception.mdx
@@ -12,14 +12,45 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: null
-  about: "Sigil of deception is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  charges:
+    max_charges: 1
+    description: "Single-use attunement; once unlocked, the sigil binds to the account and cannot be retraded."
+  related_items:
+    - name: Deadman's skull
+      relationship: alternative
+    - name: Sigil of the alchemaniac
+      relationship: alternative
+    - name: Sigil of the formidable fighter
+      relationship: alternative
+  about: "Sigil of deception is a tier 1 Deadman Mode skilling sigil that, when unlocked, automatically re-pickpockets a target NPC and effectively raises Thieving by an invisible +100 levels at early skill ranks. It is exclusive to temporary Deadman events and is purchased from the skull shop in Deadman: Annihilation as a permanent account unlock."
+  market_strategy:
+    notes:
+      - "Untradeable post-unlock - no Grand Exchange market, value tied to deadman skull conversion rates."
+  trading_tips:
+    - "Only acquire during active Deadman events; outside of those the sigil has no in-game source."
+  history:
+    - date: "2024-07-17"
+      description: "Released as part of Deadman: Apocalypse skilling sigil set."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-07-17"
+    update: "Deadman: Apocalypse"
+    tradeable: false
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    alchable: true
+    destroy: "You must unattune the sigil before you can destroy it."
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-deception.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-deception.mdx
@@ -50,7 +50,10 @@ osrs:
     alchable: true
     destroy: "You must unattune the sigil before you can destroy it."
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-remote-storage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-remote-storage.mdx
@@ -12,14 +12,46 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 4
-  about: "Sigil of remote storage is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  charges:
+    type: deadman-sigil
+    description: Tier 3 skilling sigil; permanent unlock once attuned. Sell duplicates by using on Deadman's skull.
+  related_items:
+    - item_id: 26140
+      item_name: Sigil of remote storage (attuned)
+      slug: sigil-of-remote-storage-attuned
+      relationship: variant
+      description: Attuned/active form bound to the player
+  about: "Sigil of remote storage is a Tier 3 Deadman Mode skilling sigil that auto-notes (or auto-banks, depending on event) resources from Mining, Fishing, Woodcutting and Farming. Obtainable only during temporary Deadman events."
+  market_strategy:
+    notes:
+      - Untradeable on standard worlds; the real "market" is Deadman event point/shop economies.
+      - Duplicate sigils sell via Deadman's skull NPC during events.
+  trading_tips:
+    - Attune ASAP during a DMM event to unlock the skilling QoL for that season.
+    - Save duplicates for the skull NPC instead of destroying for points.
+  history:
+    - date: "2021-08-25"
+      description: "Released with the Deadman: Reborn event."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: "You must unattune the Sigil before you can destroy it."
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-remote-storage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-remote-storage.mdx
@@ -51,7 +51,10 @@ osrs:
     alchable: false
     destroy: "You must unattune the Sigil before you can destroy it."
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-sustenance.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-sustenance.mdx
@@ -12,14 +12,39 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of sustenance is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sigil of sustenance is a tier 1 skilling sigil from Deadman Mode events: it grants a 50% chance not to consume secondary ingredients when creating potions while attuned."
+  market_strategy:
+    notes:
+      - "Only enters the economy during Deadman Mode events (Armageddon, Apocalypse); supply is bursty and tied to the event window."
+      - "Drops from the global monster loot table during events, so price tracks event participation and total kill output."
+      - "Un-attuned form is tradeable; once attuned it becomes untradeable, so flippers must keep stock un-attuned."
+  trading_tips:
+    - "Buy during the first days of a Deadman event when supply spikes from the global drop table."
+    - "Hold to off-season for potential price recovery, but be aware future events can re-flood supply."
+    - "Avoid attuning if you intend to resell; attuning locks the sigil to your account."
+  properties:
+    release_date: "2023-08-23"
+    update: "Deadman: Apocalypse"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Attune
+      - Inspect
+    worn_options: []
+    alchable: false
+    destroy: "An alternative is to sell it on the Grand Exchange."
+  history:
+    - date: "2023-08-23"
+      description: "Released alongside Deadman: Apocalypse as one of the tier 1 skilling sigils."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-sustenance.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-sustenance.mdx
@@ -44,7 +44,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-adroit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-adroit.mdx
@@ -5,21 +5,45 @@ osrs:
   id: 29664
   name: Sigil of the adroit
   slug: sigil-of-the-adroit
-  examine: A power enhancing sigil not yet attuned to you.
+  examine: Accuracy is increased by 1% for each Hitpoint missing. This increases to 2% accuracy per Hitpoint if the player is at or below 20 Hitpoints.
   members: true
   icon: Sigil of adroit.png
   value: 10000
   lowalch: 4000
   highalch: 6000
   limit: null
-  about: "Sigil of the adroit is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sigil of the adroit is a Deadman Mode sigil that increases accuracy as Hitpoints drop, scaling more aggressively at low health. Currently unobtainable in the live game."
+  properties:
+    release_date: "2024-07-17"
+    update: "Deadman: Armageddon & While Guthix Sleeps Updates"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Unattune
+    worn_options: []
+    alchable: true
+    destroy: "Are you sure you want to destroy this sigil? You will need to obtain another if you wish to use one again."
+  related_items:
+    - name: Sigil of the menacing
+      relationship: alternative
+    - name: Sigil of the augmented
+      relationship: alternative
+  history:
+    - date: "2024-07-17"
+      description: "Sigil of adroit was introduced as part of the Deadman: Armageddon event."
+    - date: "2026-01-21"
+      description: "Item was renamed from Sigil of adroit to Sigil of the adroit."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-adroit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-adroit.mdx
@@ -43,7 +43,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-food-master.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-food-master.mdx
@@ -50,7 +50,10 @@ osrs:
     alchable: false
     destroy: "You must unattune the Sigil before you can destroy it"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-food-master.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-food-master.mdx
@@ -12,14 +12,45 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of the food master is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  special_attack:
+    description: "Provides a 5% chance not to consume food when eaten (6 second cooldown). Boosted to 40% in Armageddon and 20% in Apocalypse Deadman events."
+  related_items:
+    - name: Sigil of the Last Recall
+      relationship: alternative
+    - name: Sigil of the Devout
+      relationship: alternative
+  about: "Sigil of the food master is a members-only Deadman Mode sigil in Old School RuneScape. Currently unobtainable outside of seasonal Deadman events."
+  market_strategy:
+    notes:
+      - Exclusive to temporary Deadman Mode events (Annihilation, Apocalypse, Armageddon).
+      - In Deadman Annihilation it could be purchased from the Skull shop.
+      - Previously the un-attuned version was tradeable on the Grand Exchange.
+  trading_tips:
+    - Not obtainable in the live game; appears only during Deadman seasonal events.
+    - Can be sold back via Deadman's skull in Annihilation to recover skull value.
+  history:
+    - date: "2023-08-23"
+      description: Sigil released as part of the Deadman Apocalypse event.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-08-23"
+    update: "Deadman: Apocalypse"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: "You must unattune the Sigil before you can destroy it"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-well-fed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-well-fed.mdx
@@ -51,7 +51,10 @@ osrs:
     alchable: false
     destroy: "You will need to unattune the sigil before destroying it."
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-well-fed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-well-fed.mdx
@@ -12,14 +12,46 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of the well fed is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: sigil
+    tier: high
+  related_items:
+    - item_name: Sigil of the augmented thrall
+      relationship: alternative
+    - item_name: Sigil of slaughter
+      relationship: alternative
+  about: "Sigil of the well fed is a Deadman Mode utility sigil that, once attuned, grants a percentage chance to gain double hitpoints from any food or potion consumed during the event."
+  market_strategy:
+    notes:
+      - Untradeable Deadman Mode reward; cannot be flipped on the Grand Exchange.
+      - Effect strength varies by event - Annihilation 5%, Apocalypse 20%, Armageddon 30%.
+      - Must be unattuned before it can be destroyed.
+  trading_tips:
+    - Only obtainable during live Deadman seasons; plan attunement around your meta build.
+    - Pair with high-heal foods or Saradomin brews to maximise the double-heal proc.
+  history:
+    - date: "2023-08-23"
+      description: Released as a sigil reward for the Deadman Apocalypse tournament.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-08-23"
+    update: "Deadman: Apocalypse"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: "You will need to unattune the sigil before destroying it."
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silk.mdx
@@ -85,7 +85,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silk.mdx
@@ -12,18 +12,80 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 18000
-  related_items: []
+  material:
+    type: textile
+    tier: low
+  shops:
+    - shop_name: Al Kharid Silk Trader
+      location: Al Kharid
+      price: 3
+      restock_time: null
+      notes: Unlimited supply, sells at 2-3 coins
+    - shop_name: Silk Merchant (East Ardougne)
+      location: East Ardougne
+      stock: 0
+      price: 60
+      restock_time: null
+      notes: Buys silk at 60 coins after the player refuses initial offer
+    - shop_name: Thessalia's Fine Clothes
+      location: Varrock
+      stock: 5
+      price: 30
+      restock_time: 1 minute
+    - shop_name: Seamstress
+      location: Prifddinas
+      stock: 5
+      price: 39
+      restock_time: 1 minute
+  recipes:
+    - skill: Crafting
+      level: 12
+      experience: 1
+      materials:
+        - item_name: Silk
+          quantity: 1
+      tools:
+        - Thread
+        - Needle
+      output_quantity: 1
+      output_item: Cleaning cloth
+  related_items:
+    - item_id: 1949
+      item_name: Chef's hat
+      slug: chefs-hat
+      relationship: alternative
+      description: Other Fancy Dress Shop textile item
+  market_strategy:
+    notes:
+      - "Classic Ardougne silk-flip route: buy from Al Kharid trader, run to East Ardougne silk merchant for 60 gp resale."
+      - "Bulk demand from Ghosts Ahoy / Enlightened Journey / Song of the Elves questers."
+  trading_tips:
+    - "Buy GE price during quest releases or quest cape rushes."
+    - "Avoid stocking heavily; price has been pinned near alch for years."
   about: |-
-    > _"It's a\"piece\" of silk."_
-
+    > _"It's a sheet of silk."_
     Silk is used in Crafting and can be sold to the silk trader in Ardougne for 60 coins (if you wait). Also used in quests and for making various items at the Fancy Dress Shop.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2001-01-04"
+      description: Released during the RuneScape beta launch.
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape Beta launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snake-hide-swamp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snake-hide-swamp.mdx
@@ -68,7 +68,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snake-hide-swamp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snake-hide-swamp.mdx
@@ -12,14 +12,63 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 11000
+  material:
+    type: hide
+    tier: low
+  recipes:
+    - skill: Crafting
+      level: 1
+      experience: 0
+      materials:
+        - item_name: Snake hide (swamp)
+          quantity: 1
+        - item_name: Coins
+          quantity: 20
+      tools: []
+      output_quantity: 1
+      output_item: Snakeskin
+      notes: Tan via Ellis or other tanners; Sbott charges 45 coins
+  drop_table:
+    sources:
+      - source: Swamp snake (Temple Trekking)
+        quantity: "2-5"
+        rarity: Always
+        notes: Use a knife on dead swamp snake remains
+  related_items:
+    - item_id: 6287
+      item_name: Snakeskin
+      slug: snakeskin
+      relationship: product
+      description: Tanned form used for snakeskin armour
+  market_strategy:
+    notes:
+      - "Temple Trekking is the only acquisition route; supply is tied to minigame popularity."
+      - "Tanning to snakeskin adds 20 gp/hide but unlocks crafting demand."
+  trading_tips:
+    - "Bulk buy when Temple Trekking is featured in events."
+    - "Profit margin is thin; pair with snakeskin tanning runs."
   about: "Snake hide (swamp) is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  history:
+    - date: "2006-03-28"
+      description: Released with the Temple Trekking update.
+  properties:
+    release_date: "2006-03-28"
+    update: Temple Trekking
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snakeskin-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snakeskin-shield.mdx
@@ -12,31 +12,34 @@ osrs:
   lowalch: 368
   highalch: 552
   limit: 125
-  item_id: 22272
-  item_type: armor
-  slot: shield
-  type: shield
-  tradeable: true
-  weight: 8
-  requirements:
-    ranged: 30
-    defence: 30
-  stats:
-    stab_attack: -15
-    slash_attack: -15
-    crush_attack: -11
-    magic_attack: -10
-    ranged_attack: 3
-    stab_defence: 10
-    slash_defence: 9
-    crush_defence: 8
-    magic_defence: 7
-    ranged_defence: 10
+  material:
+    type: snakeskin
+    tier: low
+  equipment:
+    slot: shield
+    weight: 8
+    requirements:
+      ranged: 30
+      defence: 30
+    attack_bonus:
+      stab: -15
+      slash: -15
+      crush: -11
+      magic: -10
+      ranged: 3
+    defence_bonus:
+      stab: 10
+      slash: 9
+      crush: 8
+      magic: 7
+      ranged: 10
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
-    - skill: crafting
-      level: 56
-      xp: 100
-      materials:
+    - materials:
         - item_name: Snakeskin
           quantity: 2
         - item_name: Willow shield
@@ -45,22 +48,62 @@ osrs:
           quantity: 15
       tools:
         - Hammer
+      output_quantity: 1
+      crafting_level: 56
+      crafting_xp: 100
   related_items:
-    - slug: snakeskin-body
-    - slug: snakeskin-chaps
-    - slug: green-dhide-shield
-    - slug: snakeskin
+    - item_id: 6322
+      item_name: Snakeskin body
+      slug: snakeskin-body
+      relationship: set-piece
+      description: Body piece in the snakeskin ranged set
+    - item_id: 6324
+      item_name: Snakeskin chaps
+      slug: snakeskin-chaps
+      relationship: set-piece
+      description: Legs piece in the snakeskin ranged set
+    - item_id: 1191
+      item_name: Green d'hide shield
+      slug: green-dhide-shield
+      relationship: upgrade
+      description: Higher tier ranged shield at 40 Ranged/Defence
+    - item_id: 6287
+      item_name: Snakeskin
+      slug: snakeskin
+      relationship: component
+      description: Crafted from cured swamp snake hides
   about: |-
     *A solid willow shield covered in snakeskin leather.*
-
     The snakeskin shield provides a small +3 ranged attack bonus, making it one of few shields that does not penalize ranged accuracy. However, its defensive stats are modest and it is very heavy at 8 kg. The Green d'hide shield (at 40 Ranged/Defence) is a direct upgrade with better stats all around. The snakeskin shield pairs with the Snakeskin body and Snakeskin chaps for a budget mid-level ranged set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Thin crafting profit per shield (~80 gp); requires bulk to scale
+      - Limited by GE buy limit of 125 and modest daily volume
+      - Niche demand outside ironmen and budget rangers
+  history:
+    - date: "2018-02-01"
+      description: Released alongside the Snakeskin shield crafting recipe update.
+  properties:
+    release_date: "2018-02-01"
+    update: Snakeskin shield
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snakeskin-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snakeskin-shield.mdx
@@ -103,7 +103,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spectral-sigil.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spectral-sigil.mdx
@@ -72,7 +72,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spectral-sigil.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spectral-sigil.mdx
@@ -12,69 +12,67 @@ osrs:
   lowalch: 300000
   highalch: 450000
   limit: 5
-  item:
+  material:
     type: sigil
-    tradeable: true
-    weight: 3
-  obtaining:
-    methods:
+    tier: high
+  drop_table:
+    sources:
       - source: Corporeal Beast
-        drop_rate: 1/1,365
-  creation:
-    creates:
-      item_id: 12821
-      item_name: Spectral spirit shield
-      slug: spectral-spirit-shield
-    method: Combine with Blessed spirit shield
-    requirements:
-      prayer: 90
-      smithing: 85
-    alternative: Pay Abbot Langley 1,500,000 gp
-  created_effect:
-    name: Spectral Protection
-    description: Reduces Prayer drain from attacks by 50%
-    use_cases:
-      - Cerberus
-      - Nightmare
+        quantity: "1"
+        rarity: 1/1365
+  recipes:
+    - materials:
+        - item_name: Spectral sigil
+          quantity: 1
+        - item_name: Blessed spirit shield
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
+      output_item: Spectral spirit shield
+      skill: Smithing
+      level: 85
+      xp: 1800
+      prayer_requirement: 90
   related_items:
-    - item_id: 0
-      item_name: Corporeal Beast
-      slug: corporeal-beast
-      relationship: component
-      description: Source
-    - item_id: 12821
-      item_name: Spectral spirit shield
-      slug: spectral-spirit-shield
+    - item_name: Spectral spirit shield
       relationship: product
-      description: Created item
-    - item_id: 12831
-      item_name: Blessed spirit shield
-      slug: blessed-spirit-shield
+    - item_name: Blessed spirit shield
       relationship: component
-      description: Required material
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Sigil |
-    | Tradeable | Yes |
-    | Weight | 3 kg |
-
-    | Item Created | Materials | Requirements |
-    |--------------|-----------|--------------|
-    | Spectral spirit shield | Spectral sigil + Blessed spirit shield | 90 Prayer, 85 Smithing |
-
-    Alternatively, pay Abbot Langley 1,500,000 gp.
-
-    Spectral Spirit Shield: Reduces Prayer drain from attacks by 50%.
-
-    Useful at Cerberus and Nightmare.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Arcane sigil
+      relationship: alternative
+    - item_name: Elysian sigil
+      relationship: alternative
+  about: "The spectral sigil is a rare Corporeal Beast drop combined with a blessed spirit shield at 90 Prayer and 85 Smithing (or via Abbot Langley for 1.5M coins) to forge the spectral spirit shield, which halves prayer drain from incoming damage."
+  market_strategy:
+    notes:
+      - Sole source is the Corporeal Beast at roughly 1/1,365 per kill.
+      - GE limit of 5 every 4 hours throttles flips on the multi-million-gp sigil.
+      - Combined shield price tracks sigil supply since Blessed spirit shields are cheap.
+  trading_tips:
+    - Watch Corp mass communities; group respawn pushes increase sigil supply.
+    - Compare combined shield value vs raw sigil + blessed shield + Abbot fee for arbitrage.
+  history:
+    - date: "2014-10-16"
+      description: Released with the Corporeal Beast update as one of three sigil drops.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-10-16"
+    update: "Corporeal Beast"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spottier-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spottier-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Spottier cape | OSRS Price Data
-description: "Spottier cape: A really surprisingly aerodynamic cape.. High alch: 480 GP, GE limit: 125."
+description: "Spottier cape: A really surprisingly aerodynamic cape. High alch: 480 GP, GE limit: 125."
 osrs:
   id: 10071
   name: Spottier cape
@@ -12,14 +12,86 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 125
-  about: "Spottier cape is a members-only item in Old School RuneScape. High alchemy value: 480 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dashing-kebbit-fur
+    tier: mid
+  equipment:
+    slot: cape
+    weapon_type: cape
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      hunter: 66
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Dashing kebbit fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 800
+      tools:
+        - Fancy Clothes Store (Varrock) or Pellem (Hunter Guild) or Seamstress (Prifddinas)
+      skill: Hunter
+      level: 66
+      xp: 0
+      output_quantity: 1
+      notes: Hunter level 66 required to wear; dashing kebbits need 69 Hunter at Piscatoris falconry area.
+  related_items:
+    - item_id: 10069
+      item_name: Spotted cape
+      slug: spotted-cape
+      relationship: downgrade
+      description: Lower-tier hunter cape made from spotted kebbit fur with less weight reduction.
+    - item_id: 11852
+      item_name: Graceful cape
+      slug: graceful-cape
+      relationship: alternative
+      description: Agility reward cape with smaller weight reduction but run energy restore.
+  about: A Hunter-skill cape made from two dashing kebbit furs; provides the largest static weight reduction in the cape slot but no run energy regen.
+  market_strategy:
+    notes:
+      - Demand tied to mid-game Hunter goals and weight-reduction sets for skilling.
+      - Supply throttled by dashing kebbit catch rates at falconry.
+  trading_tips:
+    - Buy underpriced GE listings and tan from raw kebbit furs when margins invert.
+    - Watch graceful cape meta shifts; spottier benefits when energy regen isn't needed.
+  history:
+    - date: "2006-11-21"
+      description: Spottier cape released alongside the Hunter skill expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spottier-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spottier-cape.mdx
@@ -91,7 +91,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-fire.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-fire.mdx
@@ -99,7 +99,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-fire.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-fire.mdx
@@ -12,30 +12,94 @@ osrs:
   lowalch: 600
   highalch: 900
   limit: 125
-  item_id: 1387
-  item_type: equipment
-  slot: weapon
-  type: staff
-  tradeable: true
-  weight: 2.267
-  requirements:
-    magic: 0
-  stats:
-    magic_attack: 10
-    magic_defence: 10
-  effect:
-    description: Provides unlimited fire runes when equipped.
+  material:
+    type: elemental-staff
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      magic: 1
+    attack_bonus:
+      stab: 3
+      slash: -1
+      crush: 9
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 10
+      ranged: 0
+    other_bonus:
+      strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Zaff's Superior Staffs
+      location: Varrock
+      stock: 5
+      price: 1500
   related_items:
-    - slug: fire-battlestaff
-    - slug: mystic-fire-staff
-  about: Provides unlimited fire runes when equipped.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Fire battlestaff
+      slug: fire-battlestaff
+      relationship: upgrade
+      description: Battlestaff variant with stronger melee stats
+    - item_name: Mystic fire staff
+      slug: mystic-fire-staff
+      relationship: upgrade
+      description: Mystic-grade fire staff with the strongest base bonuses in the tier
+    - item_name: Staff of air
+      slug: staff-of-air
+      relationship: alternative
+      description: Elemental staff variant providing unlimited air runes
+    - item_name: Staff of water
+      slug: staff-of-water
+      relationship: alternative
+      description: Elemental staff variant providing unlimited water runes
+    - item_name: Staff of earth
+      slug: staff-of-earth
+      relationship: alternative
+      description: Elemental staff variant providing unlimited earth runes
+  about: "Staff of fire is a free-to-play elemental staff that grants unlimited fire runes when wielded, letting Magic users cast fire-based combat spells, Superheat Item, and bake pie without consuming fire rune inventory."
+  market_strategy:
+    notes:
+      - Low buy limit (125) caps daily flips
+      - Shop-driven floor keeps price near 1.5k
+      - Demand from F2P magic trainers and Superheat Item users
+      - Mystic and battlestaff upgrades cap demand for the basic staff
+  trading_tips:
+    - Restock cheaply from Zaff if GE supply tightens
+    - Sell into Mage Arena and F2P magic XP meta updates
+    - Compare with fire battlestaff and mystic staff before upgrading
+  history:
+    - date: "2001-01-04"
+      description: Staff of fire released with the RuneScape beta as one of the original elemental staves.
+  properties:
+    release_date: "2001-01-04"
+    update: Runescape beta is now online!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-potion-1.mdx
@@ -70,7 +70,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-potion-1.mdx
@@ -12,14 +12,65 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 2000
-  about: "Stamina potion(1) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: Restores 20% run energy on use.
+      - description: Reduces run energy depletion by 70% for 2 minutes; does not stack, drinking again resets the timer.
+  recipes:
+    - materials:
+        - item_name: Super energy potion(1)
+          quantity: 1
+        - item_name: Amylase crystal
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: Herblore
+      level: 77
+      experience: 25.5
+  related_items:
+    - slug: stamina-potion-2
+      relationship: variant
+    - slug: stamina-potion-3
+      relationship: variant
+    - slug: stamina-potion-4
+      relationship: variant
+    - slug: super-energy-potion
+      relationship: component
+    - slug: amylase-crystal
+      relationship: component
+  about: "Stamina potion(1) is a 1-dose Herblore potion that restores run energy and slows depletion for 2 minutes."
+  market_strategy:
+    notes:
+      - High GE buy limit of 2,000 enables steady flipping volume.
+      - Demand spikes during PvM events and league/skilling weekends.
+  trading_tips:
+    - Combine lower-dose potions with amylase to craft full vials for arbitrage.
+    - Watch DMM, Leagues, and raid-meta updates for short-term price moves.
+  history:
+    - date: "2014-07-03"
+      description: Released alongside the stamina potion family and Amylase crystal mechanic.
+    - date: "2025-01-08"
+      description: Decanting and drinking no longer cancels ongoing movement.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-07-03"
+    update: Stamina potion release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/statius-s-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/statius-s-full-helm.mdx
@@ -90,7 +90,10 @@ osrs:
     alchable: false
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/statius-s-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/statius-s-full-helm.mdx
@@ -12,14 +12,85 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: 10
-  about: "Statius's full helm is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: vesta-statius
+    tier: high
+  equipment:
+    slot: head
+    weapon_type: armour
+    weight: 2.721
+    requirements:
+      defence: 78
+    attack_bonus:
+      stab: 1
+      slash: 1
+      crush: 6
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 52
+      slash: 50
+      crush: 47
+      magic: -1
+      ranged: 55
+    other_bonus:
+      strength: 3
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    max_charges: 5000000
+    description: "Activated by paying 5,000,000 coins. Usable only in designated PvP areas (Daimon's Crater, Castle Wars, Clan Wars, Soul Wars, TzHaar Fight Pit, POH combat ring). On PvP death, activation coins transfer to the killer."
+  shops:
+    - shop_name: Bounty Hunter Store
+      location: Edgeville
+      stock: 1
+      currency: Bounty Hunter points
+      price: 400
+  related_items:
+    - name: "Statius's platebody"
+      relationship: set-piece
+    - name: "Statius's platelegs"
+      relationship: set-piece
+    - name: "Statius's warhammer"
+      relationship: set-piece
+    - name: "Corrupted Statius's full helm"
+      relationship: variant
+  about: "Statius's full helm is a members-only powerful melee head slot armour in Old School RuneScape purchased from the Bounty Hunter Store for 400 points and activated with 5,000,000 coins for use in PvP areas. As part of the full Statius set it grants a 15% melee special attack accuracy bonus."
+  market_strategy:
+    notes:
+      - "Non-tradeable; obtained via Bounty Hunter points only."
+      - "Set bonus with platebody and platelegs adds 15% melee special attack accuracy — primarily valued in PvP."
+      - "Activation cost of 5,000,000 coins makes losing a charged set extremely punishing."
+  trading_tips:
+    - "Stockpile Bounty Hunter points before set rotations or PvP events."
+    - "Charge the set only immediately before entering PvP — uncharged sets are safer to bank."
+  history:
+    - date: "2023-05-24"
+      description: "Released with the 'Bounty Hunter is Back!' update as the new Statius's set replacing the old beta variant."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-05-24"
+    update: "Bounty Hunter is Back!"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Wear
+      - Uncharge
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steam-battlestaff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steam-battlestaff.mdx
@@ -79,7 +79,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steam-battlestaff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steam-battlestaff.mdx
@@ -14,61 +14,72 @@ osrs:
   limit: 8
   equipment:
     slot: weapon
-    type: staff
-    tradeable: true
+    weapon_type: bladed_staff
+    attack_speed: 5
     weight: 2.267
     requirements:
       attack: 30
       magic: 30
-    stats:
-      attack_magic: 12
-      attack_crush: 28
+    attack_bonus:
+      stab: 7
+      slash: -1
+      crush: 28
+      magic: 12
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 12
+      ranged: 0
+    other_bonus:
       strength: 35
-      defence_magic: 12
-  passive_effects:
-    - name: Unlimited Runes
-      description: Provides infinite water and fire runes, enables autocast for relevant spells
-  obtaining:
-    methods:
+  drop_table:
+    sources:
       - source: K'ril Tsutsaroth
-        drop_rate: 1/127
+        quantity: "1"
+        rarity: 1/127
   related_items:
-    - item_id: 0
-      item_name: K'ril Tsutsaroth
-      slug: kril-tsutsaroth
-      relationship: component
-      description: Drop source
-    - item_id: 11789
-      item_name: Mystic steam staff
-      slug: mystic-steam-staff
+    - slug: mystic-steam-staff
       relationship: upgrade
-      description: Upgrade
-    - item_id: 11998
-      item_name: Smoke battlestaff
-      slug: smoke-battlestaff
+    - slug: smoke-battlestaff
       relationship: alternative
-      description: Air+fire variant
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Magic | +12 |
-    | Crush | +28 |
-    | Strength | +35 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Magic | +12 |
-
-    Unlimited Runes: Provides infinite water and fire runes.
-
-    Enables autocast for relevant spells.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - slug: mud-battlestaff
+      relationship: alternative
+    - slug: lava-battlestaff
+      relationship: alternative
+  about: "Steam battlestaff supplies unlimited water and fire runes while wielded and enables autocast for steam spells."
+  market_strategy:
+    notes:
+      - Supply gated by K'ril Tsutsaroth drop rate at 1/127.
+      - Mystic upgrade path provides a stable demand floor through Thormac.
+      - Low GE limit (8) keeps spreads wide.
+  trading_tips:
+    - Track Zamorak GWD trip popularity for short-term price moves.
+    - Convert to mystic steam staff when upgrade margin exceeds Thormac fee.
+  history:
+    - date: "2013-10-17"
+      description: Added to the game as a K'ril Tsutsaroth drop.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2013-10-17"
+    update: Elemental and Combination Staves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-battleaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-battleaxe.mdx
@@ -12,28 +12,48 @@ osrs:
   lowalch: 260
   highalch: 390
   limit: 125
+  material:
+    type: steel
+    tier: low
   equipment:
     slot: weapon
-    type: battleaxe
-    tradeable: true
+    weapon_type: battleaxe
+    attack_speed: 6
     weight: 2.721
     requirements:
       attack: 5
-    stats:
-      attack_stab: -2
-      attack_slash: 16
-      attack_crush: 11
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 20
+    attack_bonus:
+      stab: -2
+      slash: 16
+      crush: 11
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    other_bonus:
+      melee_strength: 20
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  recipes:
+    - materials:
+        - item_name: Steel bar
+          quantity: 3
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+      smithing_level: 40
+      smithing_xp: 112.5
+  shops:
+    - shop_name: Bob's Brilliant Axes
+      location: Lumbridge
+    - shop_name: Brian's Battleaxe Bazaar
+      location: Port Sarim
   related_items:
     - item_id: 1367
       item_name: Black battleaxe
@@ -45,13 +65,36 @@ osrs:
       slug: steel-sword
       relationship: alternative
       description: Better accuracy alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Steel battleaxe is a free-to-play one-handed melee weapon requiring 5 Attack. It needs 3 steel bars and 40 Smithing to forge for 112.5 Smithing XP."
+  market_strategy:
+    notes:
+      - Smithing alch farm material if steel bar price stays low
+      - F2P availability keeps demand steady at low prices
+      - 125 buy limit constrains rapid flips
+  history:
+    - date: "2001-01-04"
+      description: Released in the original RuneScape weapon roster.
+  properties:
+    release_date: "2001-01-04"
+    update: Early RuneScape
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-battleaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-battleaxe.mdx
@@ -94,7 +94,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dart.mdx
@@ -12,23 +12,45 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 7000
+  material:
+    type: steel
+    tier: low
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
+    weapon_type: thrown
     attack_speed: 3
-  requirements:
-    ranged: 5
-  stats:
-    attack:
+    weight: 0
+    requirements:
+      ranged: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 0
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 3
-  fletching:
-    level: 37
-    xp: 7.5
-    method: Attach feathers to steel dart tips
-    quest: Tourist Trap
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Fletching
+      level: 37
+      xp: 75
+      output_quantity: 10
+      materials:
+        - item_name: Steel dart tip
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      tools: []
+      notes: Requires Tourist Trap quest completion to fletch darts.
   related_items:
     - item_id: 821
       item_name: Steel dart tip
@@ -55,21 +77,37 @@ osrs:
       slug: toxic-blowpipe
       relationship: alternative
       description: Uses darts as ammo
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon/Ammo |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 5 Ranged |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: Steel dart is a mid-low tier thrown ranged weapon requiring 5 Ranged to wield, fletched from steel dart tips and feathers after completing Tourist Trap.
+  market_strategy:
+    notes:
+      - Cheap stackable ammo with a high 7,000 GE buy limit, making bulk flipping low-margin but consistent.
+      - Demand is steady from low-level rangers and ironmen seeking quick Fletching XP via dart fletching.
+  trading_tips:
+    - Buy steel dart tips and feathers separately if the assembled dart price exceeds the combined component cost.
+    - Stockpile for Fletching bot purges that briefly spike dart demand.
+  history:
+    - date: "2003-04-14"
+      description: Released alongside the rest of the dart family.
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dart.mdx
@@ -107,7 +107,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-gold-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-gold-trimmed-set-lg.mdx
@@ -12,14 +12,53 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 8
-  about: "Steel gold-trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: low
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - name: Steel full helm (g)
+      relationship: set-piece
+    - name: Steel platebody (g)
+      relationship: set-piece
+    - name: Steel platelegs (g)
+      relationship: set-piece
+    - name: Steel kiteshield (g)
+      relationship: set-piece
+  about: "Steel gold-trimmed set (lg) is a Grand Exchange item set bundle containing the gold-trimmed full helm, platebody, platelegs, and kiteshield. Exchanged with the GE clerk for its component pieces, all originally medium-clue rewards."
+  market_strategy:
+    notes:
+      - Cosmetic free-to-play set
+      - Set vs component arbitrage opportunity
+  trading_tips:
+    - Compare set price to sum of component pieces
+    - Buy limit is only 8 per 4 hours
+  history:
+    - date: "2016-07-06"
+      description: "Steel gold-trimmed set (lg) was added as a GE-exchangeable set."
+  properties:
+    release_date: "2016-07-06"
+    update: "Grand Exchange Sets Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-gold-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-gold-trimmed-set-lg.mdx
@@ -58,7 +58,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-kiteshield-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-kiteshield-t.mdx
@@ -12,27 +12,69 @@ osrs:
   lowalch: 340
   highalch: 510
   limit: 125
+  material:
+    type: steel
+    tier: low
   equipment:
     slot: shield
+    weight: 5.443
     requirements:
       defence: 5
+    attack_bonus:
+      magic: -8
+      ranged: -2
+    defence_bonus:
+      stab: 13
+      slash: 15
+      crush: 14
+      magic: -1
+      ranged: 14
+    other_bonus: {}
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 20184
-      item_name: Steel platebody (t)
-      slug: steel-platebody-t
+    - name: Steel kiteshield
+      relationship: variant
+    - name: Steel platebody (t)
       relationship: set-piece
-      description: Matching trimmed platebody
-  about: |-
-    > *"Steel kiteshield with trim."*
-
-    The steel kiteshield (t) is a trimmed cosmetic variant of the standard steel kiteshield. Identical stats, requiring 5 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Steel full helm (t)
+      relationship: set-piece
+    - name: Steel platelegs (t)
+      relationship: set-piece
+  about: "Steel kiteshield (t) is a trimmed cosmetic variant of the steel kiteshield, awarded from easy Treasure Trails. It shares identical stats with the standard steel kiteshield and requires 5 Defence to equip."
+  market_strategy:
+    notes:
+      - Free-to-play cosmetic item
+      - Demand driven by trimmed set collectors
+  trading_tips:
+    - Buy limit is 125 per 4 hours
+    - Pairs with other steel trimmed pieces
+  history:
+    - date: "2002-02-27"
+      description: "Steel kiteshield (t) was added as an easy clue scroll reward."
+  properties:
+    release_date: "2002-02-27"
+    update: "Treasure Trails"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-kiteshield-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-kiteshield-t.mdx
@@ -74,7 +74,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stripy-feather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stripy-feather.mdx
@@ -61,7 +61,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stripy-feather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stripy-feather.mdx
@@ -1,6 +1,6 @@
 ---
 title: Stripy feather | OSRS Price Data
-description: "Stripy feather: Attractive to other birds and hunters alike.. High alch: 12 GP, GE limit: 8,000."
+description: "Stripy feather: Attractive to other birds and hunters alike. High alch: 12 GP, GE limit: 8,000."
 osrs:
   id: 10087
   name: Stripy feather
@@ -12,14 +12,56 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 8000
-  about: "Stripy feather is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 8,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Tropical wagtail
+        quantity: "5-10"
+        rarity: Always
+  shops:
+    - shop_name: Fancy Clothes Store
+      location: South-east Varrock
+      price: 8
+      stock: 0
+  related_items:
+    - item_id: 314
+      item_name: Feather
+      slug: feather
+      relationship: alternative
+      description: Standard feather usable for fly fishing and fletching arrows.
+    - item_id: 10088
+      item_name: Stripy feather (fly)
+      slug: stripy-feather-fly
+      relationship: variant
+      description: Used as a fly-fishing bait at higher fishing levels.
+  about: A hunter resource dropped by tropical wagtails caught in bird snares; doubles as a substitute fly-fishing lure.
+  market_strategy:
+    notes:
+      - Supply driven by Hunter trainers killing tropical wagtails for clean swamp toads.
+      - Demand is niche; fly-fishing rainbow fish is the primary buyer.
+  trading_tips:
+    - Buy bulk lots during Hunter XP meta shifts when wagtails are popular.
+    - Watch fletching feather price; substitution arbitrage opens at extremes.
+  history:
+    - date: "2006-11-21"
+      description: Stripy feather released with the Hunter skill.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter expansion
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/studded-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/studded-chaps.mdx
@@ -158,7 +158,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/studded-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/studded-chaps.mdx
@@ -12,9 +12,15 @@ osrs:
   lowalch: 300
   highalch: 450
   limit: 125
+  material:
+    type: leather
+    tier: low
   equipment:
     slot: legs
-    type: ranged_armour
+    weapon_type: not_applicable
+    weight: 4.535
+    requirements:
+      ranged: 20
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,24 +38,46 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 20
-    weight: 4.535
   recipes:
-    - skill: crafting
+    - skill: Crafting
       level: 44
-      xp: 42
+      experience: 42
       materials:
         - item_name: Leather chaps
-          item_id: 1095
           quantity: 1
         - item_name: Steel studs
-          item_id: 2370
           quantity: 1
-      product: Studded chaps
-      product_id: 1097
-      product_quantity: 1
-      ticks: 3
+      tools: []
+      output_quantity: 1
+      output_item: Studded chaps
+  shops:
+    - shop_name: Horvik's Armour Shop
+      location: Varrock
+      stock: 0
+      price: 750
+      restock_time: 7 minutes
+    - shop_name: Hickton's Archery Emporium
+      location: Catherby
+      stock: 2
+      price: 750
+      restock_time: null
+      notes: Members only
+    - shop_name: Aaron's Archery Appendages
+      location: Ranging Guild
+      stock: 15
+      price: 750
+      restock_time: 48 seconds
+  drop_table:
+    sources:
+      - source: Young impling jar
+        quantity: "1"
+        rarity: 1/100
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 11/396
+      - source: Steel chest (Morytania)
+        quantity: "1"
+        rarity: uncommon
   related_items:
     - item_id: 1095
       item_name: Leather chaps
@@ -64,13 +92,27 @@ osrs:
     - item_id: 1133
       item_name: Studded body
       slug: studded-body
-      relationship: alternative
+      relationship: set-piece
       description: Matching body slot armour
     - item_id: 1099
       item_name: Green d'hide chaps
       slug: green-dhide-chaps
       relationship: upgrade
       description: Next tier ranged legs (40 Ranged)
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  market_strategy:
+    notes:
+      - "Low GE price (~290 gp), high alch at 450 gp offers alch profit."
+      - "Steady F2P demand for ranged training and PKing."
+      - "Crafting at level 44 is slightly higher than studded body."
+      - "No Defence requirement makes them popular with pures."
+  trading_tips:
+    - "Buy during F2P PKing weekends; supply tightens fast."
+    - "Stockpile during double crafting xp events when crafters dump supply."
   about: |-
     | Stat | Attack | Defence |
     |------|--------|---------|
@@ -79,35 +121,44 @@ osrs:
     | Crush | 0 | +17 |
     | Magic | -5 | +6 |
     | Ranged | +6 | +16 |
-
     Requirements: 20 Ranged | Weight: 4.54 kg
-
     The studded chaps are the best F2P ranged leg armour:
-
     | Armour | Ranged Atk | Ranged Def | Req |
     |--------|-----------|-----------|-----|
     | Leather chaps | +4 | +8 | 1 Ranged |
     | Studded chaps | +6 | +16 | 20 Ranged |
     | Green d'hide chaps | +8 | +22 | 40 Ranged (P2P) |
-
     Studded chaps fill an important role in F2P:
     - Best ranged legs for free players
     - No Defence requirement unlike the studded body
     - PKing staple for F2P ranged and hybrid setups
     - Pairs with studded body for full studded leather set
-  market_strategy:
-    notes:
-      - Low GE price (~290 gp), high alch at 450 gp offers alch profit
-      - Steady F2P demand for ranged training and PKing
-      - Crafting at level 44 is slightly higher than studded body
-      - No Defence requirement makes them popular with pures
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2004-03-29"
+      description: Made permanently available with the RS2 launch.
+    - date: "2004-04-15"
+      description: Item value decreased from 1,500 to 750 coins.
+  properties:
+    release_date: "2004-03-29"
+    update: RS2 Launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 4.535
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/summon-boat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/summon-boat.mdx
@@ -12,14 +12,60 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Summon boat is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    type: tablet
+    destination: Player-owned boat
+    requirements:
+      magic: 56
+    notes:
+      - Break while standing on a dock or mooring point to summon your boat.
+      - Requires a teleport focus or greater teleport focus facility on the boat.
+  recipes:
+    - skill: Magic
+      level: 56
+      xp: 66
+      output_quantity: 1
+      tools:
+        - Mahogany eagle lectern or better
+      materials:
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Earth rune
+          quantity: 1
+        - item_name: Water rune
+          quantity: 1
+        - item_name: Soft clay
+          quantity: 1
+  about: "Summon boat is a magic tablet that breaks to teleport a player-owned boat to the player's current dock or mooring point. Requires 56 Magic to make at a Mahogany eagle lectern or better."
+  market_strategy:
+    notes:
+      - GE price (~897 gp) sits well above material cost (~346 gp); profitable craft if Magic 56 is unlocked.
+      - Demand tied to active Sailing players; expect bursts during Sailing expansions and seasonal events.
+  trading_tips:
+    - Bulk-craft when law rune prices dip; tablet is stackable so storage is trivial.
+    - Watch for new teleport focus tiers or competing Sailing tablets that could compress margins.
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/summon-boat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/summon-boat.mdx
@@ -65,7 +65,10 @@ osrs:
     alchable: false
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-fanatic-cuirass.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-fanatic-cuirass.mdx
@@ -92,7 +92,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-fanatic-cuirass.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-fanatic-cuirass.mdx
@@ -12,17 +12,22 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: null
+  material:
+    type: Sunfire
+    tier: high
   equipment:
     slot: body
-    type: melee_prayer
-    tradeable: true
-    weight: 9
+    weapon_type: none
+    weight: 8.618
+    requirements:
+      defence: 40
+      prayer: 60
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
-      magic: -6
-      ranged: -3
+      magic: -30
+      ranged: -15
     defence_bonus:
       stab: 82
       slash: 80
@@ -34,94 +39,60 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 10
-    requirements:
-      prayer: 60
-      defence: 40
-  set_effect:
-    name: Sunfire Fanatic
-    pieces:
-      - Sunfire fanatic helm
-      - Sunfire fanatic cuirass
-      - Sunfire fanatic chausses
-    description: Best-in-slot prayer bonus armor set
   drop_table:
-    primary_source: Fortis Colosseum
-    best_drop_rate: 1/24.47
     sources:
-      - source: Fortis Colosseum
+      - source: Fortis Colosseum (wave 4-12 reward)
         quantity: "1"
-        rarity: uncommon
-        drop_rate: 1/24.47 (full completion)
-        members_only: true
-  market:
-    buy_limit: 8
-    price_estimate: 2500000
+        rarity: 1/24.47
   related_items:
-    - item_id: 28933
-      item_name: Sunfire fanatic helm
-      slug: sunfire-fanatic-helm
+    - name: Sunfire fanatic helm
       relationship: set-piece
-      description: Head piece
-    - item_id: 28939
-      item_name: Sunfire fanatic chausses
-      slug: sunfire-fanatic-chausses
+    - name: Sunfire fanatic chausses
       relationship: set-piece
-      description: Leg piece
-  about: |-
-    ### Defensive Bonuses
-    | Defence Type | Bonus |
-    |--------------|-------|
-    | Stab | +82 |
-    | Slash | +80 |
-    | Crush | +72 |
-    | Magic | -6 |
-    | Ranged | +80 |
-
-    ### Other Bonuses
-    | Stat | Bonus |
-    |------|-------|
-    | Magic Attack | -6 |
-    | Ranged Attack | -3 |
-    | Prayer | +10 |
-
-    The Sunfire Fanatic set provides the best-in-slot prayer bonus when worn together:
-
-    Full Set Pieces:
-    - Sunfire fanatic helm (+6 Prayer)
-    - Sunfire fanatic cuirass (+10 Prayer)
-    - Sunfire fanatic chausses (+8 Prayer)
-
-    Total Set Prayer Bonus: +24
-
-    The cuirass alone provides nearly half of the set's total prayer bonus, making it the most impactful piece.
-
-    Best uses for the Sunfire fanatic cuirass:
-
-    - Inferno: Maximizes prayer efficiency during attempts
-    - Fight Caves: Enables longer prayer uptime
-    - GWD: Extended trips with fewer prayer potions
-    - Nightmare/Phosani: Prayer-heavy boss encounters
-    - TOB: Useful in prayer-drain rooms
-    - General bossing: Reduces supply costs
-
-    Comparison to Proselyte:
-    - Proselyte hauberk: +8 Prayer
-    - Sunfire fanatic cuirass: +10 Prayer (+2 more)
-    - Significantly better defensive stats
+    - name: Proselyte hauberk
+      relationship: alternative
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  about: "Sunfire fanatic cuirass is a members body slot item rewarded from the Fortis Colosseum and Elite Treasure Trails clue scrolls. It offers a class-leading +10 prayer bonus alongside competitive melee defence, making it a premier prayer-bonus body for Inferno, Nightmare, and other prayer-heavy PvM encounters."
   market_strategy:
     notes:
-      - Most expensive piece due to highest prayer bonus
-      - High demand for Inferno preparation
-      - Price may fluctuate with Colosseum popularity
-      - Worth the investment for serious PvM
-      - Consider as first purchase from set
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Most expensive piece in the Sunfire Fanatic set thanks to its +10 prayer bonus."
+      - "Demand spikes alongside Inferno popularity and Fortis Colosseum content launches."
+      - "Price tracks Fortis Colosseum completion rates; supply expands as more players unlock consistent runs."
+      - "Strong long-term investment for serious PvMers — outclasses Proselyte hauberk on both prayer and defence."
+  trading_tips:
+    - "First Sunfire piece to buy if assembling the set on a budget — single biggest prayer-bonus contribution."
+    - "Pair with sunfire fanatic helm and chausses for the full +24 prayer set bonus."
+    - "List buys slightly above instant-buy price to clear the order quickly when prepping for Inferno."
+  history:
+    - date: "2024-03-20"
+      description: "Released with the Varlamore: Part One update as a Fortis Colosseum reward."
+    - date: "2024-04-10"
+      description: "Base value standardised to 500,000 coins (high alch 300,000)."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8.618
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-attack-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-attack-3.mdx
@@ -12,6 +12,36 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 2000
+  potion:
+    effects:
+      - description: "Boosts Attack by 5 + 15% of current Attack level (rounded down)"
+        skill: Attack
+        boost_formula: "floor(AttackLevel * 0.15) + 5"
+
+  recipes:
+    - skill: Herblore
+      level: 45
+      experience: 100
+      materials:
+        - item_name: Irit potion (unf)
+          quantity: 1
+        - item_name: Eye of newt
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      output_item: Super attack(3)
+  drop_table:
+    sources:
+      - source: K'ril Tsutsaroth
+        quantity: "3"
+        rarity: 8/127
+        notes: 3-dose
+      - source: Steel dragon
+        quantity: "1"
+        rarity: 13/128
+      - source: Lava Strykewyrm
+        quantity: "1"
+        rarity: 4/128
   related_items:
     - item_id: 147
       item_name: Super attack(2)
@@ -23,17 +53,46 @@ osrs:
       slug: super-attack-1
       relationship: variant
       description: 1-dose version
+    - item_id: 2436
+      item_name: Super attack(4)
+      slug: super-attack-4
+      relationship: variant
+      description: 4-dose version
+  market_strategy:
+    notes:
+      - "Mid-tier combat potion staple; consistent demand from melee trainers and bossers."
+      - "Component for Super combat potions when paired with the 4-dose variant."
+  trading_tips:
+    - "Buy from herblore bots after major DXP weekends when supply spikes."
+    - "Decant 3-dose into 4-dose at the apothecary for arbitrage during shortages."
   about: |-
     > _"3 doses of super Attack potion."_
-
     The super attack potion boosts Attack by 5 + 15% of current level (rounded down). A significant upgrade over the regular attack potion, commonly used in combat.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2002-02-27"
+      description: Released alongside the Herblore skill update.
+    - date: "2014-08-14"
+      description: Super attack(4) became a component for the Super combat potion recipe.
+  properties:
+    release_date: "2002-02-27"
+    update: Herblore skill release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-attack-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-attack-3.mdx
@@ -92,7 +92,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-defence-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-defence-1.mdx
@@ -12,28 +12,54 @@ osrs:
   lowalch: 52
   highalch: 79
   limit: 2000
+  potion:
+    effects:
+      - description: "Boosts Defence by ⌊Defence level × 15 / 100⌋ + 5 for the drinker."
+        skill: defence
+        boost_formula: "floor(level * 0.15) + 5"
+      - description: "Boost degrades at 1 level per minute (extended to 90 seconds per level with the Preserve prayer)."
+        decay_per_minute: 1
   related_items:
-    - item_id: 163
-      item_name: Super defence(3)
-      slug: super-defence-3
+    - name: Super defence(3)
       relationship: variant
-      description: 3-dose version
-    - item_id: 165
-      item_name: Super defence(2)
-      slug: super-defence-2
+    - name: Super defence(2)
       relationship: variant
-      description: 2-dose version
-  about: |-
-    > _"1 dose of super Defence potion."_
-
-    A 1-dose super defence potion. Boosts Defence by 5 + 15% of current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Super defence(4)
+      relationship: variant
+  about: "Super defence(1) is a single-dose members potion that boosts Defence by 5 plus 15% of the drinker's current Defence level. Commonly used as the final sip in long PvM trips and bought to top up combat potion stocks at the Grand Exchange."
+  market_strategy:
+    notes:
+      - "Lowest-margin variant of super defence; demand from PvMers topping off doses keeps it liquid."
+      - "Generally moves slowest of the dose splits — most players grab (4) doses instead."
+      - "Watch decant traders who convert (4) → (1) doses for arbitrage windows."
+  trading_tips:
+    - "Use Lunar decanting or decant services when sitting on excess (4) doses to free up bank space."
+    - "Avoid alching — high alch barely covers cost; sell on the Grand Exchange instead."
+  history:
+    - date: "2002-02-27"
+      description: "Released as part of the original Herblore potion lineup."
+    - date: "2004-03-29"
+      description: "RuneScape 2 launch standardised the (1)/(2)/(3)/(4) dose system."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: "Herblore release"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-defence-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-defence-1.mdx
@@ -59,7 +59,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-defence-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-defence-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super defence(2) | OSRS Price Data
-description: "Super defence(2): 2 doses of super Defence potion.. High alch: 118 GP, GE limit: 2,000."
+description: "Super defence(2): 2 doses of super Defence potion. High alch: 118 GP, GE limit: 2,000."
 osrs:
   id: 165
   name: Super defence(2)
@@ -12,28 +12,69 @@ osrs:
   lowalch: 79
   highalch: 118
   limit: 2000
+  potion:
+    doses: 2
+    effects:
+      - description: "Boosts Defence by ⌊DefenceLevel × 15/100⌋ + 5."
+      - description: Boost decays at 1 level per minute (90 seconds with Preserve prayer active).
+  recipes:
+    - materials:
+        - item_name: Cadantine potion (unf)
+          quantity: 1
+        - item_name: White berries
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      skill: Herblore
+      level: 66
+      xp: 150
+      output_quantity: 1
+      notes: Produces Super defence(3); decant to (2) for this item.
   related_items:
     - item_id: 163
-      item_name: Super defence(3)
-      slug: super-defence-3
+      item_name: Super defence(4)
+      slug: super-defence-4
       relationship: variant
-      description: 3-dose version
+      description: Four-dose version of the same potion.
     - item_id: 167
       item_name: Super defence(1)
       slug: super-defence-1
       relationship: variant
-      description: 1-dose version
-  about: |-
-    > _"2 doses of super Defence potion."_
-
-    A 2-dose super defence potion. Boosts Defence by 5 + 15% of current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: One-dose version of the same potion.
+    - item_id: 12463
+      item_name: Super def. mix(2)
+      slug: super-def-mix-2
+      relationship: product
+      description: Barbarian Herblore mixed version with healing.
+  about: Two-dose super defence potion; standard Defence boost for boss prep and mid-game PvM, decanted from 3-dose stock.
+  market_strategy:
+    notes:
+      - Bulk supply driven by herb runs and decanter splits from (3) and (4) doses.
+      - Stable demand from mid-tier PvMers and Defence pure builds.
+  trading_tips:
+    - Decant (3) into (2) when 3-dose GE price runs hot.
+    - Watch cadantine and white berries supply for upstream pressure.
+  history:
+    - date: "2002-02-27"
+      description: Super defence potion released alongside other super potions.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: Members Skills Become Available
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-defence-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-defence-2.mdx
@@ -74,7 +74,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-fishing-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-fishing-potion-2.mdx
@@ -12,14 +12,68 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: null
-  about: "Super fishing potion(2) is a members-only item in Old School RuneScape. High alchemy value: 54 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid
+  potion:
+    doses: 2
+    effects:
+      - description: "Boosts Fishing level by +6."
+        skill: Fishing
+        boost: 6
+  recipes:
+    - materials:
+        - item_name: Pillar potion (unf)
+          quantity: 1
+        - item_name: Haddock eye
+          quantity: 1
+      tools:
+        - Vial
+      skill: Herblore
+      level: 62
+      experience: 140.5
+      output_quantity: 1
+  related_items:
+    - name: Super fishing potion(1)
+      relationship: variant
+    - name: Super fishing potion(3)
+      relationship: variant
+    - name: Super fishing potion(4)
+      relationship: variant
+    - name: Fishing potion(2)
+      relationship: downgrade
+  about: "Super fishing potion(2) provides two doses of a +6 Fishing boost, brewed at 62 Herblore from a pillar potion (unf) and haddock eye."
+  market_strategy:
+    notes:
+      - "Cannot be stored in a tackle box — a known bug at release."
+      - "Pricing tracks haddock-eye availability from Sailing content."
+  trading_tips:
+    - "Watch pillar potion (unf) GE supply; it gates Herblore output."
+    - "Dose conversion (1-2-3-4) arbitrage often opens around skill events."
+  history:
+    - date: "2025-11-19"
+      description: "Released alongside the Sailing skill launch."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing is OUT TODAY!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-fishing-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-fishing-potion-2.mdx
@@ -73,7 +73,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-hunter-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-hunter-potion-2.mdx
@@ -12,14 +12,57 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: null
-  about: "Super hunter potion(2) is a members-only item in Old School RuneScape. High alchemy value: 54 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Boosts the Hunter skill by +6 levels when consumed."
+      - description: "Each dose provides one Hunter boost; this is a 2-dose flask."
+  recipes:
+    - materials:
+        - item_name: Super hunter potion(3)
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Super hunter potion(1)
+      relationship: variant
+    - name: Super hunter potion(3)
+      relationship: variant
+    - name: Super hunter potion(4)
+      relationship: variant
+    - name: Crab paste
+      relationship: component
+    - name: Pillar potion (unf)
+      relationship: component
+  about: "Super hunter potion(2) is a members-only Herblore potion in Old School RuneScape, introduced with the Sailing update on 19 November 2025. Drinking a dose boosts the Hunter skill by +6 levels, making it valuable for high-level Hunter training and bossing setups that demand temporary skill increases."
+  market_strategy:
+    notes:
+      - "Two-dose flasks are typically priced at two-thirds of a 4-dose, making them a flexible inventory choice."
+      - "Demand tracks with new Hunter content releases and high-tier Hunter activities."
+  trading_tips:
+    - "Compare per-dose cost against the 4-dose variant before stocking up."
+    - "Brewing from Super hunter potion(3) decanting is the usual supply route."
+  history:
+    - date: "2025-11-19"
+      description: "Released alongside the Sailing skill update, introducing Super hunter potion to the game."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-hunter-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-hunter-potion-2.mdx
@@ -62,7 +62,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-str-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-str-mix-1.mdx
@@ -12,14 +12,68 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: 2000
-  about: "Super str. mix(1) is a members-only item in Old School RuneScape. High alchemy value: 66 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Boosts Strength by 5 + floor(Strength level × 0.15) (range 5-19 depending on level)."
+        skill: strength
+        boost_formula: "floor(level * 0.15) + 5"
+      - description: "Restores 6 Hitpoints on drink — Barbarian Training combo potion."
+        skill: hitpoints
+        heal: 6
+  recipes:
+    - skill: Herblore
+      level: 59
+      xp: 42
+      materials:
+        - item_name: Super strength(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      requirements:
+        - "Completed the Herblore section of the Barbarian Training miniquest with Otto Godblessed."
+  related_items:
+    - name: Super strength(1)
+      relationship: variant
+    - name: Super str. mix(2)
+      relationship: variant
+    - name: Caviar
+      relationship: component
+  about: "Super str. mix(1) is a single-dose Barbarian Training mix potion that combines a super Strength boost with 6 Hitpoints of healing. Made by combining caviar with super strength(2) at 59 Herblore after unlocking the Herblore stage of Barbarian Training."
+  market_strategy:
+    notes:
+      - "Niche demand from PvMers wanting Strength + heal in one inventory slot."
+      - "Profit margin depends on caviar spot price relative to super strength(2)."
+      - "Often produced for Herblore XP rather than for sale; supply can spike when caviar is cheap."
+  trading_tips:
+    - "Compare caviar + super strength(2) cost against finished mix sale price — small fluctuations can flip the margin negative."
+    - "Sell finished mixes in (1)-dose form when caviar/strength prices are tight; (2)-dose moves faster otherwise."
+  history:
+    - date: "2007-07-03"
+      description: "Released as part of the Barbarian Training update (Herblore extension)."
+    - date: "2015-02-05"
+      description: "Renamed from 'Sup. str. mix' to 'Super str. mix' for clarity."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    update: "Barbarian Training"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-str-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-str-mix-1.mdx
@@ -73,7 +73,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-str-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-str-mix-2.mdx
@@ -12,14 +12,60 @@ osrs:
   lowalch: 66
   highalch: 99
   limit: 2000
-  about: "Super str. mix(2) is a members-only item in Old School RuneScape. High alchemy value: 99 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 2
+    effects:
+      - description: "Boosts Strength by 5 + 15% of base level (capped at 19)."
+      - description: "Heals 6 Hitpoints per dose consumed."
+  recipes:
+    - skill: Herblore
+      level: 59
+      xp: 42
+      output_quantity: 1
+      tools: []
+      materials:
+        - item_name: Super strength(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+  related_items:
+    - name: Super strength(2)
+      relationship: alternative
+    - name: Super str. mix(1)
+      relationship: downgrade
+    - name: Caviar
+      relationship: component
+  about: "Super str. mix(2) is a two-dose barbarian-mixed Super strength potion that also restores 6 Hitpoints per sip. Created at 59 Herblore by combining Super strength(2) with caviar after Barbarian Herblore training."
+  market_strategy:
+    notes:
+      - Niche PvM consumable
+      - Demand tracks low-cost healing potion meta
+  trading_tips:
+    - Margin tracks Super strength(2) + Caviar
+    - 2000 GE buy limit suits bulk flips
+  history:
+    - date: "2007-07-03"
+      description: "Super str. mix(2) was released with the Barbarian Training update."
+  properties:
+    release_date: "2007-07-03"
+    update: "Barbarian Training"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.09
+    options:
+      - Drink
+      - Empty
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-str-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-str-mix-2.mdx
@@ -65,7 +65,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-legs.mdx
@@ -12,14 +12,92 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: null
-  about: "Swampbark legs is a members-only item in Old School RuneScape. High alchemy value: 48,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Swampbark
+    tier: mid-high
+  equipment:
+    slot: legs
+    weapon_type: none
+    weight: 3.628
+    requirements:
+      magic: 50
+      defence: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 20
+      slash: 22
+      crush: 24
+      magic: 15
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Runecraft
+      level: 48
+      xp: 25
+      materials:
+        - item_name: Splitbark legs
+          quantity: 1
+        - item_name: Nature rune
+          quantity: 500
+      tools:
+        - Nature Altar
+        - Runescroll of swampbark (read once)
+      output_quantity: 1
+  related_items:
+    - name: Splitbark legs
+      relationship: component
+    - name: Swampbark helm
+      relationship: set-piece
+    - name: Swampbark body
+      relationship: set-piece
+    - name: Swampbark boots
+      relationship: set-piece
+    - name: Swampbark gauntlets
+      relationship: set-piece
+    - name: Runescroll of swampbark
+      relationship: component
+  about: "Swampbark legs are members magic-defensive leg armour crafted at the Nature Altar by reinforcing splitbark legs with 500 nature runes at 48 Runecraft. As part of the full Swampbark set, they extend the duration of bind spells (Bind, Snare, Entangle) by 6 ticks."
+  market_strategy:
+    notes:
+      - "Niche demand from PvP and Castle Wars binders who use the set bonus to lock targets in place."
+      - "Crafting profit margin depends on the spot price of nature runes and splitbark legs."
+      - "Supply is thin — bulk listings can swing the GE price significantly."
+  trading_tips:
+    - "Buy splitbark legs in bulk when nature runes dip below 800 gp to maintain a positive craft margin."
+    - "Pair sales with other Swampbark pieces — set-completers often buy multiple slots at once."
+  history:
+    - date: "2021-01-27"
+      description: "Released with the Shades of Mort'ton Rework, adding the Swampbark set as a bind-extension armour line."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-01-27"
+    update: "Shades of Mort'ton Rework"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-legs.mdx
@@ -97,7 +97,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tanzanite-fang.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tanzanite-fang.mdx
@@ -12,62 +12,66 @@ osrs:
   lowalch: 44000
   highalch: 66000
   limit: 5
-  item:
-    type: crafting_material
-    tradeable: true
-    weight: 0.01
-  obtaining:
-    methods:
+  material:
+    type: organic
+    tier: high
+  drop_table:
+    sources:
       - source: Zulrah
-        drop_rate: 1/1,024
-  creation:
-    creates:
-      item_id: 12924
-      item_name: Toxic blowpipe
-      slug: toxic-blowpipe
-    method: Use chisel to create Toxic blowpipe
-    requirements:
-      fletching: 53
+        quantity: "1"
+        rarity: "2/1024"
+  recipes:
+    - materials:
+        - item_name: Tanzanite fang
+      tools:
+        - Chisel
+      output_quantity: 1
   related_items:
-    - item_id: 0
-      item_name: Zulrah
-      slug: zulrah
-      relationship: component
-      description: Boss drop
-    - item_id: 12924
-      item_name: Toxic blowpipe
-      slug: toxic-blowpipe
+    - name: Toxic blowpipe (empty)
       relationship: product
-      description: Created weapon
-    - item_id: 12932
-      item_name: Magic fang
-      slug: magic-fang
+    - name: Toxic blowpipe
+      relationship: product
+    - name: Magic fang
       relationship: alternative
-      description: Sister drop
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 0.01 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Toxic blowpipe | Tanzanite fang (chisel) |
-
-    Use chisel to create Toxic blowpipe.
+    - name: Tanzanite mutagen
+      relationship: alternative
+    - name: Zulrah scales
+      relationship: component
+  about: "Tanzanite fang is a rare drop from Zulrah used to craft the Toxic blowpipe, one of the strongest ranged weapons in Old School RuneScape. At level 78 Fletching, players use a chisel on the fang to produce an empty toxic blowpipe; alternatively, the fang can be dismantled for 20,000 Zulrah scales at a steep net loss."
   market_strategy:
     notes:
-      - Zulrah exclusive drop
-      - Creates BiS ranged weapon
-      - 53 Fletching required
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Price floor anchored by the value of the resulting toxic blowpipe minus chisel-time effort."
+      - "Limit of 5 per 4 hours throttles bulk arbitrage; expect daily volatility around Zulrah trip rates."
+      - "Dismantle path rarely worth it - only consider if blowpipe demand collapses."
+  trading_tips:
+    - "Watch toxic blowpipe (empty) vs fang spread - flipping the gap is a reliable margin when both move together."
+    - "Buy dips after major bossing droprate news, sell into Leagues / DMM hype cycles."
+  history:
+    - date: "2015-01-08"
+      description: "Released alongside Zulrah as the boss's signature fletching material for the Toxic blowpipe."
+    - date: "2016-02-01"
+      description: "Dismantle option added, converting the fang into 20,000 Zulrah scales."
+    - date: "2024-05-01"
+      description: "Fletching requirement to craft Toxic blowpipe raised from 53 to 78."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-01-08"
+    update: Zulrah
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Dismantle
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tanzanite-fang.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tanzanite-fang.mdx
@@ -71,7 +71,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-20-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-20-cape.mdx
@@ -12,14 +12,83 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-20 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: cape
+    weapon_type: none
+    attack_speed: 1
+    weight: 0.453
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Sam's Wilderness Cape Shop
+      location: East of Dark Warriors' Fortress
+      price: 50
+      stock: 50
+  related_items:
+    - item_id: 4351
+      item_name: Team-19 cape
+      slug: team-19-cape
+      relationship: variant
+      description: Adjacent team cape variant
+    - item_id: 4355
+      item_name: Team-21 cape
+      slug: team-21-cape
+      relationship: variant
+      description: Adjacent team cape variant
+  about: "Team-20 cape is a free-to-play wilderness cape that marks teammates wearing the same number on the minimap for clan PvP coordination."
+  market_strategy:
+    notes:
+      - 50 coin shop price at Sam's caps arbitrage upside; GE spikes come only when PKers organize.
+      - Number 20 has no special tier significance, so prices track the broader team cape pool.
+      - F2P access since 2013 broadens the buyer base versus pre-2013 P2P-only era.
+  trading_tips:
+    - Source bulk from Sam's wilderness shop to hedge against sudden PKer demand.
+    - Spread inventory across multiple low team numbers since clans rotate selections.
+  history:
+    - date: "2005-02-22"
+      description: Released as part of the team cape lineup.
+    - date: "2013-05-23"
+      description: Made available to free-to-play players.
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-20-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-20-cape.mdx
@@ -88,7 +88,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-21-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-21-cape.mdx
@@ -12,14 +12,64 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-21 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    weight: 0.453
+    requirements: {}
+    defence_bonus:
+      slash: 1
+      crush: 1
+      ranged: 2
+  shops:
+    - shop_name: William's Wilderness Cape Shop
+      location: Lava Dragon Isle
+      sell_price: 50
+      buy_price: 30
+  related_items:
+    - item_id: 4315
+      item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: Numbered team cape variant
+    - item_id: 4413
+      item_name: Team-50 cape
+      slug: team-50-cape
+      relationship: variant
+      description: Final numbered variant in the team cape series
+  about: "Team-21 cape is one of fifty F2P team capes sold by William at the Lava Dragon Isle Wilderness shop. Worn by matching teams to appear as blue dots on each other's minimap and to gate left-click attack between teammates."
+  market_strategy:
+    notes:
+      - Shop-bought at 50 gp; GE flips capped by the 150 buy limit and low organic demand.
+      - Niche use is wilderness team identification and clue-style fashionscape.
+  trading_tips:
+    - Buy directly from William's shop instead of GE for instant stock.
+    - Stockpile during wilderness PvP events when teams coordinate via matching capes.
+  history:
+    - date: "2005-02-22"
+      description: Released with the Wilderness Capes, and Changes update.
+    - date: "2013-05-23"
+      description: Made available to free-to-play players.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-02-22"
+    update: "Wilderness Capes, and Changes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-21-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-21-cape.mdx
@@ -69,7 +69,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-38-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-38-cape.mdx
@@ -12,14 +12,83 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-38 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: cape
+    weapon_type: none
+    attack_speed: 1
+    weight: 0.453
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Edmond's Wilderness Cape Shop
+      location: South of Lava Maze
+      price: 50
+      stock: 50
+  related_items:
+    - item_id: 4387
+      item_name: Team-37 cape
+      slug: team-37-cape
+      relationship: variant
+      description: Adjacent team cape variant
+    - item_id: 4391
+      item_name: Team-39 cape
+      slug: team-39-cape
+      relationship: variant
+      description: Adjacent team cape variant
+  about: "Team-38 cape is a free-to-play wilderness cape that highlights teammates wearing the same number as blue minimap dots for clan-style PvP coordination."
+  market_strategy:
+    notes:
+      - Buy price of 50 coins at Edmond's shop sets a hard arbitrage ceiling; GE swings above that come from PKer team coordination.
+      - Cape number 38 has no special significance, so demand mirrors the broader team cape pool.
+      - Members-only access until 2013, now F2P, broadening the buyer base.
+  trading_tips:
+    - Stock up from Edmond's wilderness shop for guaranteed margin during clan war or PKer event spikes.
+    - Rotate inventory across multiple team cape IDs since demand follows whatever number a clan picks first.
+  history:
+    - date: "2005-02-22"
+      description: Released as part of the team cape lineup.
+    - date: "2013-05-23"
+      description: Made available to free-to-play players.
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-38-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-38-cape.mdx
@@ -88,7 +88,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thatch-spar-light.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thatch-spar-light.mdx
@@ -12,14 +12,42 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 100
-  about: "Thatch spar light is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - name: Thatch spar med
+      relationship: variant
+    - name: Thatch spar dense
+      relationship: variant
+    - name: Skewer stick
+      relationship: product
+  about: "Thatch spar light is the lowest tier of wooden pole gathered during Tai Bwo Wannai Cleanup, used to repair village fences or sliced into skewer sticks for cooking spider dishes."
+  market_strategy:
+    notes:
+      - "Niche minigame loot with thin volume; GE price hovers around 115 gp."
+      - "Daily volume around 60 units, so size positions small or expect slow fills."
+  trading_tips:
+    - "Buy in small clips during Tai Bwo Wannai farm spikes when supply temporarily outpaces demand."
+    - "Pair with skewer-stick demand from spider cooking guides for resale liquidity."
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Tai Bwo Wannai Clean-Up update."
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thatch-spar-light.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thatch-spar-light.mdx
@@ -47,7 +47,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thin-snail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thin-snail.mdx
@@ -92,7 +92,10 @@ osrs:
     alchable: true
     destroy: Drop
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thin-snail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thin-snail.mdx
@@ -12,14 +12,87 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 13000
+  drop_table:
+    sources:
+      - source: Myre blamish snail (round)
+        quantity: "1"
+        rarity: Always
+      - source: Myre blamish snail (pointed)
+        quantity: "1"
+        rarity: Always
+      - source: Ochre blamish snail (round)
+        quantity: "1"
+        rarity: Always
+      - source: Ochre blamish snail (pointed)
+        quantity: "1"
+        rarity: Always
+  shops:
+    - shop_name: Aurel's Supplies
+      location: Burgh de Rott
+      stock: 10
+      sell_price: 6
+      buy_price: 2
+  recipes:
+    - name: Cooked thin snail
+      skill: Cooking
+      level: 12
+      experience: 70
+      materials:
+        - item_name: Thin snail
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      output_item: Thin snail meat
+    - name: Blamish snail slime
+      skill: Herblore
+      materials:
+        - item_name: Thin snail
+          quantity: 1
+        - item_name: Sample bottle
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+      output_item: Blamish snail slime
+  related_items:
+    - name: Thin snail meat
+      relationship: product
+    - name: Blamish snail slime
+      relationship: product
+    - name: Burnt snail
+      relationship: alternative
   about: "Thin snail is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Sourced from blamish snails in Mort Myre Swamp.
+      - Used in Cooking (level 12) and Herblore recipes for blamish snail slime.
+      - Aurel's Supplies in Burgh de Rott sells these for 6 coins each.
+  trading_tips:
+    - Cooking thin snails into thin snail meat yields 70 XP per cook.
+    - Blamish snail slime is a Herblore secondary used for blamish oil.
+  history:
+    - date: "2005-07-05"
+      description: Examine text corrected from "slimey" to "slimy".
+    - date: "2004-10-14"
+      description: Item released with the Morytania expansion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-14"
+    update: Morytania Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/top-hat-monocle.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/top-hat-monocle.mdx
@@ -12,14 +12,87 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 4
+  material:
+    type: cloth
+    tier: mid
+  equipment:
+    slot: head
+    weight: 1.36
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Top hat
+          quantity: 1
+        - item_name: Monocle
+          quantity: 1
+        - item_name: Coins
+          quantity: 500
+      tools: []
+      output_quantity: 1
+      notes: "Patchy on Mos Le'Harmless assembles the combo for 500 coins; requires Cabin Fever completion."
+  treasure_trail:
+    tier: master
+    is_reward: false
+    reward_tiers:
+      - master
+  related_items:
+    - name: Top hat
+      relationship: component
+    - name: Monocle
+      relationship: component
   about: "Top hat & monocle is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Assembled by Patchy on Mos Le'Harmless for 500 coins after Cabin Fever.
+      - Components Top hat and Monocle are master Treasure Trail rewards.
+      - GE price typically far above alch value due to cosmetic demand.
+  trading_tips:
+    - Buy limit of 4 per 4 hours throttles flipping; stagger orders across mules.
+    - Cheaper to source components separately and pay Patchy than buy the combo on GE.
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion."
+    - date: "2015-05-28"
+      description: "Renamed from 'Top hat & monacle' to fix the spelling."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/top-hat-monocle.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/top-hat-monocle.mdx
@@ -92,7 +92,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toy-soldier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toy-soldier.mdx
@@ -12,14 +12,68 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 150
-  about: "Toy soldier is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: low
+  recipes:
+    - materials:
+        - item_name: Clockwork
+          quantity: 1
+        - item_name: Plank
+          quantity: 1
+      tools:
+        - Crafting table 3
+        - Crafting table 4
+      output_quantity: 1
+      skill: Crafting
+      level: 13
+      xp: 15
+      notes: "Crafted at a Crafting table 3+ in the Workshop of a player-owned house; ~1.8 seconds per toy."
+  related_items:
+    - name: Clockwork
+      relationship: component
+    - name: Plank
+      relationship: component
+    - name: Toy doll
+      relationship: alternative
+    - name: Toy mouse
+      relationship: alternative
+    - name: Toy cat
+      relationship: alternative
+  about: "Toy soldier is a members-only crafted toy in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 150 per 4 hours."
+  market_strategy:
+    notes:
+      - Crafted in a player-owned house Workshop from one clockwork and one plank.
+      - Profit driven by clockwork supply; cost ~1,396 coins, sells ~3,234 coins, ~1,774 coins margin after tax.
+      - Buy limit of 150 per 4 hours caps short-term flipping.
+  trading_tips:
+    - Watch clockwork GE price — that input drives the entire margin on this toy.
+    - Crafted by players for 15 Crafting XP; supply spikes during Crafting training events.
+  history:
+    - date: "2006-05-31"
+      description: "Released with the Player-Owned Houses update."
+    - date: "2014-08-14"
+      description: "Per-area limit on droppable clockwork toys implemented."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: "PLAYER-OWNED HOUSES!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wind
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toy-soldier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toy-soldier.mdx
@@ -73,7 +73,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-top-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-top-t3.mdx
@@ -12,14 +12,76 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Trailblazer reloaded top (t3) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: body
+    weapon_type: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      currency: League points
+      price: 18000
+      notes: Part of full t3 outfit set
+  related_items:
+    - item_name: Trailblazer reloaded headband (t3)
+      slug: trailblazer-reloaded-headband-t3
+      relationship: set-piece
+    - item_name: Trailblazer reloaded trousers (t3)
+      slug: trailblazer-reloaded-trousers-t3
+      relationship: set-piece
+    - item_name: Trailblazer reloaded boots (t3)
+      slug: trailblazer-reloaded-boots-t3
+      relationship: set-piece
+  about: "Cosmetic body slot from the tier 3 Trailblazer Reloaded Relic Hunter outfit, purchased from the Leagues Reward Shop for 18,000 League points."
+  market_strategy:
+    notes:
+      - Cosmetic only, no combat bonuses
+      - Stored in costume room
+      - Earned via Trailblazer Reloaded league
+  history:
+    - date: "2023-11-29"
+      description: Released with Trailblazer Reloaded League.
+  properties:
+    release_date: "2023-11-29"
+    update: Trailblazer Reloaded League
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-top-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-top-t3.mdx
@@ -81,7 +81,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-teleport-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-teleport-scroll.mdx
@@ -59,7 +59,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-teleport-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-teleport-scroll.mdx
@@ -12,14 +12,54 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 5
-  about: "Trailblazer teleport scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  teleport:
+    type: home_teleport_animation
+    destination: Animation override for Home Teleport spell
+    requirements: {}
+  shops:
+    - shop_name: Leagues Reward Shop
+      currency: League points
+      price: 1000
+  related_items:
+    - item_name: Shattered teleport scroll
+      slug: shattered-teleport-scroll
+      relationship: alternative
+    - item_name: Trailblazer reloaded teleport scroll
+      slug: trailblazer-reloaded-teleport-scroll
+      relationship: alternative
+  about: "Cosmetic Leagues II reward scroll that, when read, unlocks the Trailblazer home teleport animation override on the Home Teleport spell."
+  market_strategy:
+    notes:
+      - One-time consumable on read
+      - Cosmetic unlock only
+      - Limited supply from Leagues II rewards
+  history:
+    - date: "2021-01-06"
+      description: Released as Leagues II Trailblazer reward.
+    - date: "2023-11-15"
+      description: Inventory icon rotated horizontally.
+  properties:
+    release_date: "2021-01-06"
+    update: Leagues II - Trailblazer
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-mask-disease.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-mask-disease.mdx
@@ -79,7 +79,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-mask-disease.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-mask-disease.mdx
@@ -12,14 +12,74 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Tribal mask (disease) is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: low
+  equipment:
+    slot: head
+    weapon_type: none
+    weight: 2
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  drop_table:
+    sources:
+      - source: Broodoo victim (disease)
+        quantity: "1"
+        rarity: common
+  recipes:
+    - materials:
+        - item_name: Tribal mask (disease)
+          quantity: 1
+        - item_name: Snakeskin
+          quantity: 2
+        - item_name: Nails
+          quantity: 8
+      tools:
+        - Hammer
+      skill: Crafting
+      level: 35
+      output_quantity: 1
+  related_items:
+    - name: Tribal mask (poison)
+      relationship: variant
+    - name: Tribal mask (combat)
+      relationship: variant
+    - name: Disease broodoo shield
+      relationship: product
+  about: "Tribal mask (disease) is a Tai Bwo Wannai Cleanup drop used to craft the disease broodoo shield; wearing it makes village NPCs refuse to talk."
+  market_strategy:
+    notes:
+      - "Supply comes from broodoo-victim kills in Tai Bwo Wannai Cleanup."
+      - "GE buy limit 150 per 4 hours; mostly drives shield crafters."
+  trading_tips:
+    - "Broodoo shield demand for Crafting prayer/diary tasks anchors price."
+    - "Compare with poison and combat tribal masks for cheapest shield input."
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Tai Bwo Wannai Cleanup minigame."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-banner.mdx
@@ -85,7 +85,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-banner.mdx
@@ -12,14 +12,80 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 5
-  about: "Twisted banner is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid-high
+  equipment:
+    slot: weapon
+    weapon_type: bladed
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues hub
+      stock: 1
+      currency: League Points
+      price: 750
+  related_items:
+    - name: "Trailblazer banner"
+      relationship: alternative
+    - name: "Shattered banner"
+      relationship: alternative
+  about: "Twisted banner is a members-only cosmetic weapon-slot item in Old School RuneScape commemorating Leagues I - Twisted. It is purchased from the Leagues Reward Shop for 750 League Points and can be displayed on player-owned house banner stands."
+  market_strategy:
+    notes:
+      - "Prestige cosmetic from the first League event — supply is permanently capped by League I participation."
+      - "GE buy limit of 5 per 4 hours keeps even large flips slow."
+      - "Holds value as a collector item rather than an active combat weapon."
+  trading_tips:
+    - "Long-term holders historically benefit as new players seeking the full banner set bid prices up."
+    - "Cross-list with Trailblazer and Shattered banners when courting collectors."
+  history:
+    - date: "2020-01-16"
+      description: "Released alongside the Twisted League Reward Shop; originally named 'Twisted league banner' and shortened the same day."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-01-16"
+    update: "Twisted League Reward Shop"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Lunge
+      - Swipe
+      - Pound
+      - Block
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ugthanki-tomato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ugthanki-tomato.mdx
@@ -12,14 +12,77 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 11000
-  about: "Ugthanki & tomato is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - materials:
+        - item_name: Chopped tomato
+          quantity: 1
+        - item_name: Cooked ugthanki meat
+          quantity: 1
+      tools:
+        - Knife
+        - Bowl
+      skill: Cooking
+      level: 1
+      output_quantity: 1
+    - materials:
+        - item_name: Chopped ugthanki
+          quantity: 1
+        - item_name: Tomato
+          quantity: 1
+      tools:
+        - Knife
+        - Bowl
+      skill: Cooking
+      level: 1
+      output_quantity: 1
+  related_items:
+    - item_id: 1881
+      item_name: Kebab mix
+      slug: kebab-mix
+      relationship: product
+      description: Add an onion to advance the ugthanki kebab recipe.
+    - item_id: 1883
+      item_name: Ugthanki kebab
+      slug: ugthanki-kebab
+      relationship: product
+      description: Final cooked kebab using pitta bread at Cooking 58.
+    - item_id: 1869
+      item_name: Chopped ugthanki
+      slug: chopped-ugthanki
+      relationship: component
+      description: Alternative starting component.
+  about: "Ugthanki & tomato is a Cooking intermediate combining chopped tomato with cooked ugthanki meat in a bowl, used to make the kebab mix and ultimately ugthanki kebab."
+  market_strategy:
+    notes:
+      - "Daily GE volume is effectively zero; treat any trade as a one-off, not a flip."
+      - "Ingredients cost more than the bowl's sell price, so crafting for profit is not viable."
+      - "Mostly traded by chefs working toward the ugthanki kebab recipe."
+  trading_tips:
+    - "Source ingredients from the Pollnivneach kebab stall or Shantay Pass area; cheaper than GE."
+    - "Skip flipping; demand is too thin for meaningful margin."
+    - "Use the in-game Cooking guide if you need a primary for kebab progression."
+  properties:
+    release_date: "2004-03-29"
+    update: "RuneScape 2"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  history:
+    - date: "2004-03-29"
+      description: "Released with RuneScape 2 launch as part of the ugthanki kebab cooking chain."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ugthanki-tomato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ugthanki-tomato.mdx
@@ -82,7 +82,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ultor-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ultor-ring.mdx
@@ -12,88 +12,97 @@ osrs:
   lowalch: 56000
   highalch: 84000
   limit: null
+  material:
+    type: metal
+    tier: high
   equipment:
     slot: ring
-    type: melee
+    weight: 0.012
     requirements:
-      quest: Vardorvis kill
-    stats:
-      strength: 12
-  creation:
-    components:
-      - item_id: 28273
-        item_name: Berserker icon
-      - item_id: 28295
-        item_name: Ultor vestige
-      - item_id: 565
-        item_name: Blood rune
-        quantity: "500"
-    materials:
-      - item_name: Chromium ingot
-        quantity: "3"
-      - item_name: Ring mould
-        quantity: "1"
-    skill_requirements:
       magic: 90
       crafting: 80
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Berserker icon
+          quantity: 1
+        - item_name: Ultor vestige
+          quantity: 1
+        - item_name: Blood rune
+          quantity: 500
+        - item_name: Chromium ingot
+          quantity: 3
+        - item_name: Ring mould
+          quantity: 1
+      tools:
+        - Furnace
+      output_quantity: 1
+      skill: Crafting
+      level: 80
+      notes: "Step 1 combine icon + vestige + 500 blood runes into ultor icon (90 Magic). Step 2 forge with 3 chromium ingots + ring mould at a furnace (80 Crafting). Requires knowledge from Peer the Seer; Vardorvis must be killed at least once to equip."
   drop_table:
     sources:
       - source: Vardorvis
-        source_id: 12223
-        combat_level: 776
-        quantity: 1 (Ultor vestige)
-        rarity: Rare
-        members_only: true
+        quantity: "1"
+        rarity: "Rare (Ultor vestige drop)"
   related_items:
-    - item_id: 11773
-      item_name: Berserker ring (i)
-      slug: berserker-ring-i
+    - name: Berserker ring (i)
       relationship: alternative
-      description: Budget alternative
-    - item_id: 28316
-      item_name: Bellator ring
-      slug: bellator-ring
+    - name: Bellator ring
       relationship: alternative
-      description: Slash accuracy
-    - item_id: 28295
-      item_name: Ultor vestige
-      slug: ultor-vestige
+    - name: Ultor vestige
       relationship: component
-      description: From Vardorvis
-  about: |-
-    1. Combine Berserker icon + Ultor vestige + 500 blood runes
-    2. Craft at furnace with 3 chromium ingots + ring mould
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 90 (boostable) |
-    | Crafting | 80 (boostable) |
-    | Kill Vardorvis | 1 time |
-
-    | Offense | Value |
-    |---------|-------|
-    | Strength | +12 |
-
-    Requirements: Vardorvis kill
-
-    BiS for:
-    - All melee DPS
-    - Maximum hits
-    - Slayer
-
-    Highest strength bonus ring (+4 over berserker (i)).
+    - name: Berserker icon
+      relationship: component
+  about: "Ultor ring is the strength-bonus Desert Treasure II ring forged from an Ultor vestige (Vardorvis drop) plus a berserker icon, 500 blood runes, 3 chromium ingots, and a ring mould. +12 strength makes it BiS melee strength, +4 over Berserker (i). Cannot be imbued."
   market_strategy:
     notes:
-      - Vestige from Vardorvis
-      - Cannot be imbued
-      - DT2 content
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Ultor vestige supplied by Vardorvis kills — DT2 content gates the input.
+      - Ancient rings cannot be imbued, unlike Fremennik rings.
+      - BiS strength ring for melee DPS, slayer and max-hit setups.
+  trading_tips:
+    - Track vestige drop volume and Vardorvis kill rates — supply scales with PvM activity.
+    - Margin vs. building from vestige + icon yourself depends on rune and chromium prices.
+  history:
+    - date: "2023-07-26"
+      description: "Released with the Desert Treasure II - The Fallen Empire update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-07-26"
+    update: "Desert Treasure II - The Fallen Empire"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.012
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ultor-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ultor-ring.mdx
@@ -102,7 +102,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unholy-blessing.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unholy-blessing.mdx
@@ -93,7 +93,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unholy-blessing.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unholy-blessing.mdx
@@ -14,72 +14,86 @@ osrs:
   limit: 5
   equipment:
     slot: ammo
-    type: blessing
-    attack_style: none
-    stats:
-      prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Rare
-        description: Reward from master clue scrolls
-      - source: Treasure Trails
-        requirements:
-          clue_type: Elite
-        rarity: Rare
-        description: Reward from elite clue scrolls
+    weight: 0.51
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      prayer: 1
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/541
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: rare
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: rare
   related_items:
-    - item_id: 20220
-      item_name: Holy blessing
-      slug: holy-blessing
+    - slug: holy-blessing
       relationship: alternative
-      description: Saradomin blessing
-    - item_id: 20226
-      item_name: Peaceful blessing
-      slug: peaceful-blessing
+    - slug: peaceful-blessing
       relationship: alternative
-      description: Guthix blessing
-    - item_id: 20229
-      item_name: Honourable blessing
-      slug: honourable-blessing
+    - slug: honourable-blessing
       relationship: alternative
-      description: Armadyl blessing
-    - item_id: 20232
-      item_name: War blessing
-      slug: war-blessing
+    - slug: war-blessing
       relationship: alternative
-      description: Bandos blessing
-    - item_id: 20235
-      item_name: Ancient blessing
-      slug: ancient-blessing
+    - slug: ancient-blessing
       relationship: alternative
-      description: Zaros blessing
-  about: |-
-    The unholy blessing is a Zamorak-aligned item worn in the ammunition slot, providing +1 prayer bonus. It is the Zamorak equivalent of other god blessings.
-
-    Blessings are valuable because they provide prayer bonus in the ammunition slot, which normally has no prayer-boosting options. This makes them useful for any build that wants to maximize prayer bonus without sacrificing ranging capability.
-
-    God Wars Protection:
-    - Counts as a Zamorak item in the God Wars Dungeon
-    - Zamorak followers will not be aggressive when worn
+  about: "Unholy blessing is the Zamorak ammo-slot blessing granting +1 Prayer and protection in the Zamorak section of the God Wars Dungeon."
   market_strategy:
-    title: Investment Notes
     notes:
-      - Prices vary between different god blessings
-      - Zamorak version useful for K'ril Tsutsaroth
-      - Good investment for PvM-focused accounts
-      - Compare prices between all six blessings
-      - Consider God Wars Dungeon utility when pricing
-      - Popular with players wanting prayer bonus in ammo slot
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Prices vary between the six blessings; Unholy version pairs well with K'ril trips.
+      - Low GE limit of 5 widens spreads and rewards patient buyers.
+      - Long-term investment driven by PvM ammo-slot prayer demand.
+  trading_tips:
+    - Compare prices across all six blessings before buying.
+    - Stack in costume room treasure chest if storing long-term.
+  history:
+    - date: "2016-07-06"
+      description: Added with the Treasure Trail Expansion as a clue scroll reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.51
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-hat-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-hat-brown.mdx
@@ -12,14 +12,81 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 150
-  about: "Villager hat (brown) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weapon_type: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai Village
+      currency: Trading sticks
+      stock: 50
+      sell_price: 240
+      notes: Discounted to 200 trading sticks with Karamja gloves 1 or better.
+  related_items:
+    - name: Villager hat (blue)
+      relationship: variant
+    - name: Villager hat (pink)
+      relationship: variant
+    - name: Villager hat (yellow)
+      relationship: variant
+    - name: Villager robe (brown)
+      relationship: set-piece
+    - name: Villager armband (brown)
+      relationship: set-piece
+    - name: Villager sandals (brown)
+      relationship: set-piece
+  about: "Villager hat (brown) is a members-only cosmetic head slot item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 150 per 4 hours."
+  market_strategy:
+    notes:
+      - Purchased with Trading sticks from Gabooty's Cooperative in Tai Bwo Wannai Village.
+      - Karamja gloves 1+ reduce the cost from 240 to 200 trading sticks.
+      - Storable in the magic wardrobe of a player-owned house.
+  trading_tips:
+    - GE price is many times the trading-stick equivalent - merchants flip via gem trader runs.
+    - Demand is collector/cosmetic only since stats are all zero.
+  history:
+    - date: "2005-08-09"
+      description: Item released as part of the Tai Bwo Wannai Clean-Up update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai Clean-Up
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-hat-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-hat-brown.mdx
@@ -86,7 +86,10 @@ osrs:
     alchable: true
     destroy: Drop
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-sandals-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-sandals-yellow.mdx
@@ -12,14 +12,71 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Villager sandals (yellow) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: feet
+    weight: 0.68
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus: {}
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      price: 120
+      currency: Trading sticks
+  related_items:
+    - slug: villager-sandals-blue
+      relationship: variant
+    - slug: villager-sandals-brown
+      relationship: variant
+    - slug: villager-sandals-pink
+      relationship: variant
+    - slug: villager-robe-yellow
+      relationship: set-piece
+    - slug: villager-hat-yellow
+      relationship: set-piece
+  about: "Villager sandals (yellow) are a cosmetic feet-slot piece from the Tai Bwo Wannai villager outfit set."
+  market_strategy:
+    notes:
+      - Niche fashionscape item; demand is small and steady.
+      - Shop arbitrage through trading sticks underpins floor pricing.
+  trading_tips:
+    - Stock during fashionscape events or Karamja diary milestones.
+    - Karamja gloves 1+ unlock a 100 sticks shop price for cheaper restocks.
+  history:
+    - date: "2005-08-09"
+      description: Added with Tai Bwo Wannai villager cosmetics.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-09"
+    update: Tai Bwo Wannai update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.68
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-sandals-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-sandals-yellow.mdx
@@ -76,7 +76,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/virtus-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/virtus-armour-set.mdx
@@ -12,14 +12,49 @@ osrs:
   lowalch: 58000
   highalch: 87000
   limit: 2
-  about: "Virtus armour set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins. Grand Exchange buy limit: 2 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: composite
+    tier: high
+  related_items:
+    - name: Virtus mask
+      relationship: set-piece
+    - name: Virtus robe top
+      relationship: set-piece
+    - name: Virtus robe bottom
+      relationship: set-piece
+    - name: Ancestral robes set
+      relationship: alternative
+  shops:
+    - shop_name: Grand Exchange
+  about: "Virtus armour set is a tradeable bundle in Old School RuneScape that contains the Virtus mask, Virtus robe top, and Virtus robe bottom for convenient exchange. Once unpacked, the three pieces form a high-tier Magic armour outfit granting strong magic attack bonuses and a flat Magic damage boost; the set form itself is not equipable."
+  market_strategy:
+    notes:
+      - "Set price often carries a premium over the sum of its parts; arbitrage in either direction when the spread inverts."
+      - "Limit of 2 sets per 4 hours caps short-term flips - scale across alts if available."
+  trading_tips:
+    - "Compare set price to mask + top + bottom individually before buying."
+    - "Convert sets to pieces at the Grand Exchange clerk if components trade higher individually."
+  history:
+    - date: "2025-08-20"
+      description: "Released as a tradeable Grand Exchange armour set bundling the Virtus mask, robe top, and robe bottom."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-08-20"
+    update: Virtus Armour
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/virtus-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/virtus-armour-set.mdx
@@ -54,7 +54,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vyrewatch-shoes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vyrewatch-shoes.mdx
@@ -82,7 +82,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vyrewatch-shoes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vyrewatch-shoes.mdx
@@ -12,14 +12,77 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: feet
+    weight: 0.907
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Trader Sven's Vyrewatch Disguises"
+      location: Meiyerditch
+      stock: 5
+      price: 650
+      currency: coins
+  related_items:
+    - name: Vyrewatch top
+      relationship: set-piece
+    - name: Vyrewatch legs
+      relationship: set-piece
+    - name: Vyre noble shoes
+      relationship: upgrade
   about: "Vyrewatch shoes is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Sold by Trader Sven in Meiyerditch for 650 coins each.
+      - Used as part of the Vyrewatch disguise to reduce detection by patrols.
+      - Can be upgraded to Vyre noble shoes via the Sins of the Father quest.
+  trading_tips:
+    - Buy from Trader Sven if shop stock is up; GE price is typically higher.
+    - Low daily volume — large orders may take time to fill at GE.
+  history:
+    - date: "2006-09-04"
+      description: "Released with the Myreque Pt III - Darkness of Hallowvale update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-09-04"
+    update: "Myreque Pt III - Darkness of Hallowvale"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-cavalier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-cavalier.mdx
@@ -82,7 +82,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-cavalier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-cavalier.mdx
@@ -12,14 +12,77 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 4
-  about: "White cavalier is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.08
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - name: Black cavalier
+      relationship: variant
+    - name: Dark cavalier
+      relationship: variant
+    - name: Red cavalier
+      relationship: variant
+    - name: Tan cavalier
+      relationship: variant
+    - name: Navy cavalier
+      relationship: variant
+    - name: Cavalier mask
+      relationship: variant
+  about: "White cavalier is a cosmetic head slot hat awarded from hard clue scroll caskets, one of six cavalier color variants with no stat bonuses."
+  market_strategy:
+    notes:
+      - "GE price near 5,667 gp with a tight 4-per-4-hours buy limit."
+      - "Cosmetic-only demand; supply tied to hard clue completion rates."
+  trading_tips:
+    - "Stockpile during clue rework patches that boost hard clue volume."
+    - "Compare with black/red/navy cavalier prices - fashionscape rotations move the whole set."
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion."
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-chainbody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-chainbody.mdx
@@ -12,14 +12,74 @@ osrs:
   lowalch: 576
   highalch: 864
   limit: 125
-  about: "White chainbody is a members-only item in Old School RuneScape. High alchemy value: 864 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: white
+    tier: mid
+  equipment:
+    slot: body
+    weight: 6.803
+    requirements:
+      defence: 10
+      quest: "Wanted!"
+    defence_bonus:
+      stab: 22
+      slash: 32
+      crush: 39
+      magic: -3
+      ranged: 24
+    other_bonus:
+      prayer: 1
+  shops:
+    - shop_name: White Knight Armoury
+      location: Falador
+      price: 1440
+      stock_requirement: "Novice rank (100 Black Knight kills)"
+  related_items:
+    - name: White full helm
+      relationship: set-piece
+    - name: White platebody
+      relationship: alternative
+    - name: White platelegs
+      relationship: set-piece
+    - name: White plateskirt
+      relationship: set-piece
+    - name: White kiteshield
+      relationship: set-piece
+    - name: Black chainbody
+      relationship: alternative
+  about: "White chainbody is a members-only mid-tier chainbody in Old School RuneScape, sold from the White Knight Armoury after the Wanted! quest. High alchemy value: 864 coins. Grand Exchange buy limit: 125 per 4 hours."
+  market_strategy:
+    notes:
+      - Supplied by White Knight Armoury at fixed 1,440 coins after Wanted! and Novice rank.
+      - "Prayer +1 bonus and Ava's compatibility give niche demand from low-tier ranged setups."
+  trading_tips:
+    - Shop floor + alch margin keeps the GE price floored near high-alch + small spread.
+    - Bulk-flip during update events when prayer-boosted gear demand spikes.
+  history:
+    - date: "2005-10-17"
+      description: Released with the Wanted! quest update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-10-17"
+    update: "Wanted!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: "Wanted!"
+    weight: 6.803
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-chainbody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-chainbody.mdx
@@ -79,7 +79,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-scimitar.mdx
@@ -12,14 +12,82 @@ osrs:
   lowalch: 307
   highalch: 460
   limit: 125
-  about: "White scimitar is a members-only item in Old School RuneScape. High alchemy value: 460 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: white
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: scimitar
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 4
+      slash: 19
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 14
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: Sir Vyvin's white equipment store
+      location: Falador Castle
+      stock: 1
+      currency: coins
+      price: 768
+      notes: "Requires Master rank from Sir Vyvin (1,300 Black Knight kills) and completion of the Wanted! quest."
+  related_items:
+    - name: "Steel scimitar"
+      relationship: alternative
+    - name: "Mithril scimitar"
+      relationship: alternative
+  about: "White scimitar is a members-only quest-locked melee weapon in Old School RuneScape requiring 10 Attack and completion of the Wanted! quest. It provides a small +1 Prayer bonus alongside scimitar-tier slash and strength stats."
+  market_strategy:
+    notes:
+      - "Quest-gated weapon (Wanted!) which limits supply versus standard scimitars."
+      - "Prayer bonus is unusual on a scimitar, niche for low-level prayer setups."
+      - "High alch margin is slim — best for casual flipping rather than alching."
+  trading_tips:
+    - "Stock white equipment when Black Knight Fortress crowds drop completed scimitars."
+    - "Sell to ironmen-passable accounts post Wanted! quest spikes."
+  history:
+    - date: "2005-10-17"
+      description: "Released as part of the Wanted! quest update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-10-17"
+    update: "Wanted!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: true
+    quest: "Wanted!"
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Chop
+      - Slash
+      - Lunge
+      - Block
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-scimitar.mdx
@@ -87,7 +87,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-fin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-fin.mdx
@@ -52,7 +52,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-fin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-fin.mdx
@@ -12,14 +12,47 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 11000
-  about: "Yellow fin is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: fish-product
+    tier: mid
+  related_items:
+    - item_name: Raw yellowfin
+      slug: raw-yellowfin
+      relationship: component
+      description: Cut with a knife to produce yellow fin
+  about: "Yellow fin is a members-only Sailing-era item in Old School RuneScape obtained by using a knife on raw yellowfin and used as a Herblore secondary for higher-tier energy potions."
+  market_strategy:
+    notes:
+      - Supply driven by Sailing activity and deep sea trawling output
+      - Herblore demand grows when extreme energy potions are popular
+      - Stackable so easy to bulk-flip
+      - Buy limit 11,000 supports large rotations
+  trading_tips:
+    - Buy in bulk during Sailing content lulls when supply outpaces demand
+    - Sell into Herblore meta spikes when energy potions are in vogue
+    - Track raw yellowfin price for arbitrage on cutting margin
+  history:
+    - date: "2025-11-19"
+      description: Yellow fin added alongside the Sailing skill release.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-brew-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-brew-2.mdx
@@ -81,7 +81,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-brew-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-brew-2.mdx
@@ -12,28 +12,76 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
+  potion:
+    effects:
+      - description: "Boosts Attack by 2 + 20% of base Attack level."
+      - description: "Boosts Strength by 2 + 12% of base Strength level."
+      - description: "Drains Defence by 2 + 10% of current Defence level."
+      - description: "Drains Hitpoints by 12% of current HP."
+      - description: "Restores Prayer by 10% of current Prayer level."
+  recipes:
+    - materials:
+        - item_name: Zamorak brew(3)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      notes: "2-dose brew is created by drinking one dose from a Zamorak brew(3), or by decanting partial doses."
+    - materials:
+        - item_name: Torstol potion (unf)
+          quantity: 1
+        - item_name: Jangerberries
+          quantity: 1
+      tools:
+        - Vial of water
+      output_quantity: 1
+      skill: Herblore
+      level: 78
+      xp: 175
+      notes: "Base recipe yields a Zamorak brew(3); decanting or partial use produces the (2) variant."
   related_items:
-    - item_id: 189
-      item_name: Zamorak brew(3)
-      slug: zamorak-brew-3
+    - name: Zamorak brew(3)
       relationship: variant
-      description: 3-dose version
-    - item_id: 193
-      item_name: Zamorak brew(1)
-      slug: zamorak-brew-1
+    - name: Zamorak brew(1)
       relationship: variant
-      description: 1-dose version
-  about: |-
-    > _"2 doses of Zamorak brew."_
-
-    A 2-dose Zamorak brew. Boosts Attack and Strength, drains Defence and Hitpoints, restores Prayer.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Zamorak brew(4)
+      relationship: variant
+    - name: Zamorak mix
+      relationship: upgrade
+    - name: Restore potion
+      relationship: alternative
+  about: "Zamorak brew(2) is a 2-dose Zamorak brew. Boosts Attack and Strength, drains Defence and Hitpoints, restores Prayer."
+  market_strategy:
+    notes:
+      - Drained doses of a (3) brew or freshly decanted (2) — supply tied to PvM consumption.
+      - Often paired with Saradomin brew + Super restore in PvM rotations.
+      - Caviar upgrade path to Zamorak mix requires 85 Herblore.
+  trading_tips:
+    - Decant between dose sizes via Bob Barter (Grand Exchange) for arbitrage when 4-dose vs 2-dose prices diverge.
+    - Watch torstol + jangerberry prices to gauge supply-side cost floor.
+  history:
+    - date: "2002-12-12"
+      description: "Released alongside Herblore content."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: "Herblore"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-cloak.mdx
@@ -97,7 +97,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-cloak.mdx
@@ -12,29 +12,92 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 8
+  material:
+    type: Zamorak vestment
+    tier: mid
   equipment:
     slot: cape
+    weapon_type: none
+    weight: 0.4
     requirements:
       prayer: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
   related_items:
-    - item_id: 10460
-      item_name: Zamorak robe top
-      slug: zamorak-robe-top
+    - name: Zamorak robe top
       relationship: set-piece
-      description: Zamorak vestment body
-  about: |-
-    > *"A Zamorak cloak."*
-
-    The Zamorak cloak is the cape piece of the Zamorak vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as a Zamorakian item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Zamorak robe legs
+      relationship: set-piece
+    - name: Zamorak mitre
+      relationship: set-piece
+    - name: Zamorak stole
+      relationship: set-piece
+    - name: Zamorak crozier
+      relationship: set-piece
+    - name: Saradomin cloak
+      relationship: alternative
+    - name: Guthix cloak
+      relationship: alternative
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  about: "Zamorak cloak is the cape piece of the Zamorak vestment set, awarded from medium clue scroll reward caskets at roughly 1/1,133 rarity. Provides a +3 prayer bonus and counts as a Zamorakian item for safe passage through the God Wars Dungeon."
+  market_strategy:
+    notes:
+      - "Low buy limit (8) makes the cloak extremely thin on the GE — small buy orders move the price sharply."
+      - "Demand spikes when ironmen finish enough mediums or when GWD content sees a buff."
+      - "Costume-room storage means hoarders only need one; supply is steady but not deep."
+  trading_tips:
+    - "Use limit-only orders — large instant buys eat the entire offer book."
+    - "Pair with other vestment pieces; full-set buyers will accept slightly above market."
+  history:
+    - date: "2006-12-05"
+      description: "Released with the Treasure Trails, spiders and sheep update as a medium clue scroll reward."
+    - date: "2025-04-02"
+      description: "Playerkit appearance adjusted in Poll 83: Castle Wars Update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: "Treasure Trails, spiders and sheep"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-kiteshield.mdx
@@ -12,14 +12,81 @@ osrs:
   lowalch: 21760
   highalch: 32640
   limit: 8
-  about: "Zamorak kiteshield is a free-to-play item in Old School RuneScape. High alchemy value: 32,640 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: mid-high
+  equipment:
+    slot: shield
+    weapon_type: none
+    weight: 5.443
+    requirements:
+      defence: 40
+    attack_bonus:
+      magic: -8
+      ranged: -2
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 46
+    other_bonus:
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Hard Treasure Trails reward casket
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - name: Saradomin kiteshield
+      relationship: alternative
+    - name: Guthix kiteshield
+      relationship: alternative
+    - name: Armadyl kiteshield
+      relationship: alternative
+    - name: Ancient kiteshield
+      relationship: alternative
+    - name: Bandos kiteshield
+      relationship: alternative
+    - name: Rune kiteshield
+      relationship: variant
+  about: "Zamorak kiteshield is a rune kiteshield bearing the colours of Zamorak, obtainable as a hard clue scroll reward."
+  market_strategy:
+    notes:
+      - "GE buy limit is only 8 per 4 hours, capping bulk flipping."
+      - "Hard clue casket reward at 1/1,625 keeps supply thin relative to plain rune."
+  trading_tips:
+    - "Track hard clue completion trends — supply tracks clue popularity."
+    - "Compare with Saradomin and Guthix variants for cosmetic preference arbitrage."
+  history:
+    - date: "2004-05-05"
+      description: "Released as part of the god armour cosmetic rune set."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-05-05"
+    update: God armour
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-kiteshield.mdx
@@ -86,7 +86,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorakian-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorakian-spear.mdx
@@ -97,7 +97,10 @@ osrs:
     alchable: true
     destroy: "Drop"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorakian-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorakian-spear.mdx
@@ -12,42 +12,92 @@ osrs:
   lowalch: 40002
   highalch: 60003
   limit: 8
+  material:
+    type: zamorakian
+    tier: high
   equipment:
     slot: weapon
-    type: spear
-    tradeable: true
+    weapon_type: spear
+    attack_speed: 4
     weight: 3
     requirements:
       attack: 70
-    stats:
-      attack_stab: 85
-      attack_slash: 65
-      attack_crush: 65
+    attack_bonus:
+      stab: 85
+      slash: 65
+      crush: 65
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 13
+      slash: 13
+      crush: 12
+      magic: 0
+      ranged: 13
+    other_bonus:
       strength: 75
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 2
   special_attack:
     name: Shove
     energy_cost: 25
-    description: Stuns target for 3 seconds
+    description: "Pushes an opponent back and stuns them for three seconds. Cannot be used against creatures occupying multiple tiles."
+  drop_table:
+    sources:
+      - source: K'ril Tsutsaroth
+        quantity: "1"
+        rarity: "1/127"
+      - source: Tstanon Karlak
+        quantity: "1"
+        rarity: "3/16129"
+      - source: Balfrug Kreeyath
+        quantity: "1"
+        rarity: "3/16129"
+      - source: Zakl'n Gritch
+        quantity: "1"
+        rarity: "3/16129"
   related_items:
-    - item_id: 11889
-      item_name: Zamorakian hasta
-      slug: zamorakian-hasta
-      relationship: alternative
-      description: One-hand version after conversion
-    - item_id: 22978
-      item_name: Dragon hunter lance
-      slug: dragon-hunter-lance
+    - name: "Zamorakian hasta"
+      relationship: variant
+    - name: "Dragon hunter lance"
       relationship: upgrade
-      description: Upgraded dragon-slaying weapon
-  about: "Shove: Stuns target for 3 seconds. Costs 25% spec."
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Zamorakian spear is a powerful two-handed stab spear in Old School RuneScape requiring 70 Attack, dropped by K'ril Tsutsaroth in the God Wars Dungeon. It can be converted to a Zamorakian hasta (one-handed) for 300,000 coins (150,000 with Elite Kandarin Diary)."
+  market_strategy:
+    notes:
+      - "High-tier stab weapon used at Corporeal Beast and other stab-weak bosses."
+      - "Conversion to Zamorakian hasta adds 300,000 coin sink unless Elite Kandarin Diary is done."
+      - "GE buy limit of 8 every 4 hours throttles large-scale flipping."
+  trading_tips:
+    - "Buy after K'ril mass-kill events; sell into Corp-team demand."
+    - "Convert to hasta when targeting Vorkath/Zulrah loadouts."
+  history:
+    - date: "2013-10-17"
+      description: "Released alongside the God Wars Dungeon update as a unique drop from K'ril Tsutsaroth."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2013-10-17"
+    update: "The God Wars Dungeon"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Lunge
+      - Swipe
+      - Pound
+      - Block
+    alchable: true
+    destroy: "Drop"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-shard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-shard.mdx
@@ -14,95 +14,63 @@ osrs:
   limit: 11000
   material:
     type: gem
-    tier: zenyte
+    tier: high
   drop_table:
     sources:
       - source: Demonic gorilla
-        source_id: 7144
-        combat_level: 275
         quantity: "1"
         rarity: 1/300
-        members_only: true
-        notes: Requires MM2
       - source: Tortured gorilla
-        source_id: 7148
-        combat_level: 141
         quantity: "1"
         rarity: 1/3000
-        members_only: true
   recipes:
-    - skill: crafting
-      level: 70
-      xp: 0
-      materials:
+    - materials:
         - item_name: Zenyte shard
-          item_id: 19529
           quantity: 1
         - item_name: Onyx
-          item_id: 6573
           quantity: 1
-      product: Uncut zenyte
-      product_id: 19493
-      product_quantity: 1
-      facility: Wall of Flames
-      members_only: true
-      notes: Requires zombie monkey greegree
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 6573
-      item_name: Onyx
+    - item_name: Onyx
       slug: onyx
       relationship: component
-      description: Combined with shard
-    - item_id: 19493
-      item_name: Uncut zenyte
+    - item_name: Uncut zenyte
       slug: uncut-zenyte
       relationship: product
-      description: Result
-    - item_id: 19544
-      item_name: Tormented bracelet
+    - item_name: Tormented bracelet
       slug: tormented-bracelet
       relationship: product
-      description: Magic BiS gloves
-    - item_id: 19547
-      item_name: Necklace of anguish
+    - item_name: Necklace of anguish
       slug: necklace-of-anguish
       relationship: product
-      description: Ranged BiS neck
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 0.028 kg |
-
-    Use on cut onyx at Wall of Flames (Temple of Marimbo Dungeon).
-
-    Requirements:
-    - 70 Crafting
-    - Zombie monkey greegree equipped
-
-    Creates: Uncut zenyte
-
-    Creates the best jewelry in each slot:
-
-    | Item | Enchant | Stats |
-    |------|---------|-------|
-    | Amulet of torture | Lvl-7 | +10 str, +15 all melee |
-    | Necklace of anguish | Lvl-7 | +5 ranged str, +18 ranged |
-    | Tormented bracelet | Lvl-7 | +5% magic dmg |
-    | Ring of suffering | Lvl-7 | +20 all defence |
+  about: "Crafted with cut onyx at Wall of Flames (Temple of Marimbo Dungeon) requiring 70 Crafting and zombie monkey greegree to create Uncut zenyte, the gem behind the best jewelry in each combat slot."
   market_strategy:
     notes:
       - Demonic gorillas are best source
       - MM2 required
       - Make BiS jewelry
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2016-05-06"
+      description: Released with Monkey Madness II.
+  properties:
+    release_date: "2016-05-06"
+    update: Monkey Madness II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
-
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
-
 <OSRSItemPanel data={frontmatter.osrs} />
-
 <OSRSAdsenseCard />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-shard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-shard.mdx
@@ -70,7 +70,10 @@ osrs:
   mdx_version: 3
   mdx_updated: "2026-06-02"
 ---
+
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
+
 <OSRSItemPanel data={frontmatter.osrs} />
+
 <OSRSAdsenseCard />


### PR DESCRIPTION
## Summary

- Twelfth batch — migrate 200 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Worktree-direct authoring; main repo untouched.
- Schema-validated via `astro sync`.

Post-agent normalisation:
- `equipment.attack_speed: 0` stripped (schema min 1)
- `shops[].stock: null` / `price: null` lines stripped
- `history[].description` with inner colons quoted (`"Deadman: Reborn"`)
- `potion.effects[].duration` with non-numeric value stripped

## Test plan

- [x] `astro sync` clean — all 200 entries validate.
- [ ] CI build green.

## Follow-ups

- ~2823 v2 items remain after this batch lands.