### PR TITLE
content(astro-kbve): bump 200 OSRS items v2 → v3 (batch 13)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platelegs.mdx
@@ -12,24 +12,91 @@ osrs:
   lowalch: 2560
   highalch: 3840
   limit: 125
-  item_id: 1073
-  item_type: armor
-  slot: legs
-  type: platelegs
-  tradeable: true
-  weight: 10.432
-  requirements:
-    defence: 30
-  stats:
-    stab_defence: 33
-    slash_defence: 31
-    crush_defence: 29
-    ranged_defence: 31
+  material:
+    type: adamant
+    tier: mid
+  equipment:
+    slot: legs
+    weight: 10.432
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 33
+      slash: 31
+      crush: 29
+      magic: -4
+      ranged: 31
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Smith Adamant platelegs
+      skill: Smithing
+      level: 86
+      experience: 187.5
+      materials:
+        - item_name: Adamantite bar
+          quantity: 3
+      tools:
+        - Hammer
+      facility: Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Zeke's Superior Scimitars
+      location: Al Kharid
+      price: 6400
+      stock: 10
   related_items:
-    - slug: rune-platelegs
-    - slug: adamant-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Adamant platebody
+      relationship: set-piece
+    - name: Adamant plateskirt
+      relationship: alternative
+    - name: Rune platelegs
+      relationship: upgrade
+    - name: Mithril platelegs
+      relationship: downgrade
+    - name: Adamantite bar
+      relationship: component
+  about: "Adamant platelegs is a mid-tier free-to-play melee leg armour requiring 30 Defence to wear, smithed at level 86 Smithing from 3 adamantite bars for 187.5 experience, and dropped commonly by demons and spectres."
+  market_strategy:
+    notes:
+      - Mid-tier free-to-play melee leg slot popular with low-level PKers and ironmen.
+      - Crafting margin is negative versus GE price, so smithing is for XP, not profit.
+      - Treasure trail and demon drops add steady supply, capping price ceiling.
+  trading_tips:
+    - Buy from GE for combat use rather than crafting unless training Smithing.
+    - Watch demon-task spawns as a market source.
+    - Pair with Adamant platebody for the matching melee set.
+  history:
+    - date: "2001-01-04"
+      description: Added to the game at launch as part of the adamantite tier.
+  properties:
+    release_date: "2001-01-04"
+    update: New skill - Cooking
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 10.432
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-sq-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-sq-shield.mdx
@@ -12,25 +12,82 @@ osrs:
   lowalch: 1536
   highalch: 2304
   limit: 125
-  item_id: 1183
-  item_type: armor
-  slot: shield
-  type: square_shield
-  tradeable: true
-  weight: 4.082
-  requirements:
-    defence: 30
-  stats:
-    stab_defence: 24
-    slash_defence: 26
-    crush_defence: 22
-    magic_defence: 0
-    ranged_defence: 24
+  material:
+    type: Adamant
+    tier: mid
+  equipment:
+    slot: shield
+    weight: 4.082
+    requirements:
+      defence: 30
+    attack_bonus:
+      magic: -6
+    defence_bonus:
+      stab: 24
+      slash: 26
+      crush: 22
+      ranged: 24
+  recipes:
+    - skill: Smithing
+      level: 78
+      experience: 125
+      materials:
+        - item_name: Adamantite bar
+          quantity: 2
+      tools:
+        - Hammer
+      facilities:
+        - Anvil
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Cyclops
+        quantity: "1"
+        rarity: Uncommon
+      - source: Dark beast
+        quantity: "1"
+        rarity: Uncommon
+      - source: Crystal chest
+        quantity: "1"
+        rarity: Uncommon
   related_items:
-    - slug: rune-sq-shield
-    - slug: adamant-kiteshield
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Rune sq shield
+      relationship: upgrade
+    - name: Mithril sq shield
+      relationship: downgrade
+    - name: Adamant kiteshield
+      relationship: alternative
+  about: "Adamant sq shield is a free-to-play medium square shield craftable from 2 adamantite bars at 78 Smithing. It requires 30 Defence to equip and provides solid all-around melee defence at the adamant tier."
+  market_strategy:
+    notes:
+      - Smithing recipe sets a price floor near bar cost
+      - F2P availability widens demand pool
+      - Outclassed by kiteshield for most equipment purposes
+  trading_tips:
+    - Compare adamant bar cost vs shield price for smithing profit
+    - Watch F2P clue and skilling event spikes
+  history:
+    - date: "2001-01-04"
+      description: Released into the game.
+  properties:
+    release_date: "2001-01-04"
+    update: Old School RuneScape release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 4.082
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/agility-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/agility-mix-1.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 2000
-  about: "Agility mix(1) is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Temporarily boosts Agility by 3 levels."
+        duration: 0
+      - description: "Heals 6 Hitpoints when consumed."
+        duration: 0
+  recipes:
+    - materials:
+        - item_name: Agility potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: Herblore
+      level: 37
+      xp: 27
+      notes: "Requires the Barbarian Herblore training to mix. Combining a 2-dose Agility potion with caviar yields two single-dose Agility mix vials."
+  related_items:
+    - item_id: 11461
+      item_name: Agility mix(2)
+      slug: agility-mix-2
+      relationship: variant
+      description: 2-dose version of the same potion
+    - item_id: 3033
+      item_name: Agility potion(4)
+      slug: agility-potion-4
+      relationship: alternative
+      description: Non-barbarian variant without the healing effect
+  about: "The Agility mix(1) is a single-dose Barbarian Herblore variant of the Agility potion that boosts Agility by 3 and heals 6 Hitpoints."
+  market_strategy:
+    notes:
+      - "Demand spikes during agility-heavy training events (Wilderness Agility, advanced rooftops, Sepulchre)."
+      - "Barbarian Herblore gating limits supply; only players past the unlock can mix the potion profitably."
+      - "Margin is dictated by Agility potion(2) and caviar input costs; track both for crafting flips."
+  trading_tips:
+    - "Watch caviar prices closely - it is the swing input that decides crafting profitability."
+    - "List during peak NA/EU evenings when agility training volumes drive same-day fills."
+  history:
+    - date: "2007-07-03"
+      description: "Released as part of the Barbarian Training update introducing Barbarian Herblore mixes."
+  properties:
+    release_date: "2007-07-03"
+    update: "Barbarian Training"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/agility-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/agility-potion-4.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Agility potion(4) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Temporarily raises Agility level by 3."
+        duration: 60
+  recipes:
+    - materials:
+        - item_name: Toadflax potion (unf)
+          quantity: 1
+        - item_name: Toad's legs
+          quantity: 1
+      tools:
+        - Herblore level 34
+      output_quantity: 1
+      skill: Herblore
+      experience: 80
+  about: "Agility potion(4) is a members-only potion that temporarily boosts the Agility level by 3. Required in 4-dose form for the Tai Bwo Wannai Trio quest."
+  market_strategy:
+    notes:
+      - "High alch 120 gp vs typical GE price (~268 gp for 4-dose) — not profitable to alch."
+      - "GE buy limit 2,000 per 4 hours."
+      - "Decant 4-dose into 1/2/3 doses for finer market arbitrage."
+  trading_tips:
+    - "Players without Herblore 34 buy 4-dose for quest requirements."
+    - "Demand spikes during Agility-XP events and BA/Wintertodt prep."
+  history:
+    - date: "2004-07-27"
+      description: "Released alongside the Agility skill in the 'Agility, Potions and Parties!' update."
+    - date: "2004-10-04"
+      description: "Empty option added to potions for inventory management."
+  properties:
+    release_date: "2004-07-27"
+    update: "Agility, Potions and Parties!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-javelin-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-javelin-p.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 168
   highalch: 252
   limit: 7000
-  about: "Amethyst javelin(p) is a members-only item in Old School RuneScape. High alchemy value: 252 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Amethyst
+    tier: mid-high
+  equipment:
+    slot: ammo
+    weapon_type: thrown
+    weight: 0
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      prayer: 0
+      ranged_strength: 135
+  recipes:
+    - materials:
+        - item_name: Amethyst javelin
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Amethyst javelin
+      relationship: variant
+    - name: Amethyst javelin(p+)
+      relationship: upgrade
+    - name: Amethyst javelin(p++)
+      relationship: upgrade
+    - name: Dragon javelin(p)
+      relationship: upgrade
+    - name: Light ballista
+      relationship: alternative
+    - name: Heavy ballista
+      relationship: alternative
+  about: "Amethyst javelin(p) is the poison-tipped variant of the amethyst javelin, ammunition for light and heavy ballistas; second-strongest javelin behind dragon."
+  market_strategy:
+    notes:
+      - "Used as ballista ammo at high-end PvM and PvP — steady consumption."
+      - "GE limit 7,000 per 4 hours allows decent flip volume."
+      - "Stackable but NOT noteable — bank in stacks, not notes."
+  trading_tips:
+    - "Compare poison-applied price vs base javelin + poison cost."
+    - "Demand correlates with Wilderness / DMM ballista metas."
+  history:
+    - date: "2017-06-22"
+      description: "Released as part of the Mining Guild Expansion update."
+  properties:
+    release_date: "2017-06-22"
+    update: "Mining Guild Expansion"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory.mdx
@@ -12,9 +12,14 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 10000
+  material:
+    type: enchanted
+    tier: high
   equipment:
     slot: neck
+    weapon_type: none
     weight: 0.01
+    requirements: {}
     attack_bonus:
       stab: 10
       slash: 10
@@ -29,22 +34,24 @@ osrs:
       ranged: 3
     other_bonus:
       melee_strength: 6
-      ranged_strength: 0
-      magic_damage: 0
       prayer: 3
   charges:
+    description: "Holds up to 4 standard charges (6 at Fountain of Rune). Teleports consume one charge each. Recharge at Fountain of Heroes (Edgeville) or Fountain of Rune (Wilderness)."
     current: 4
     max: 6
-    recharge: Fountain of Rune
-  special_effect:
-    name: Glory Effect
-    description: Teleports to Edgeville, Karamja, Draynor, Al Kharid. Increases gem mining chance.
-    triggers: on_use
+  teleport:
+    destinations:
+      - Edgeville
+      - Karamja (Musa Point)
+      - Draynor Village
+      - Al Kharid
   recipes:
-    - skill: magic
+    - skill: Magic
       level: 68
       xp: 78
       spell: Lvl-5 Enchant
+      tools: []
+      output_quantity: 1
       materials:
         - item_name: Dragonstone amulet
           item_id: 1702
@@ -63,54 +70,63 @@ osrs:
       item_name: Amulet of glory(6)
       slug: amulet-of-glory-6
       relationship: variant
-      description: Fully charged
+      description: Fully charged six-charge variant
     - item_id: 19707
       item_name: Eternal glory
       slug: eternal-glory
       relationship: upgrade
-      description: Unlimited charges
+      description: Unlimited teleport charges
     - item_id: 6585
       item_name: Amulet of fury
       slug: amulet-of-fury
       relationship: upgrade
-      description: Combat upgrade
+      description: Combat upgrade with stronger stats
     - item_id: 1615
       item_name: Dragonstone
       slug: dragonstone
       relationship: component
-      description: Gem component
-  about: |-
-    | Stat | Bonus |
-    |------|-------|
-    | All attack styles | +10 |
-    | All defences | +3 |
-    | Strength | +6 |
-    | Prayer | +3 |
-
-    - Edgeville
-    - Karamja (Musa Point)
-    - Draynor Village
-    - Al Kharid
-
-    | Effect | Description |
-    |--------|-------------|
-    | Gem chance | Increased while mining |
-    | Charges | 4 (6 at Fountain of Rune) |
+      description: Gem component used in crafting
+  about: "Iconic dragonstone amulet that teleports to Edgeville, Karamja, Draynor Village, and Al Kharid while granting strong all-style combat bonuses; staple for nearly every account."
   market_strategy:
     notes:
-      - Edgeville teleport popular
-      - Mining gem bonus
-      - Hybrid combat stats
-      - Teleportation
-      - Mining gem chance
-      - Hybrid PvM
-      - New accounts
-      - Recharge at Fountain of Rune
-      - Mount in POH for unlimited
-      - Edgeville most used teleport
-      - Eternal glory rare upgrade
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Edgeville teleport is the most popular use case
+      - Mining gem chance bonus while worn
+      - Strong hybrid combat stats for low-mid game
+      - Recharge at Fountain of Rune for the 6-charge variant
+      - Mount in POH for unlimited teleports without consuming charges
+      - Eternal glory drop from Revenants is a rare upgrade
+  trading_tips:
+    - Buy uncharged on the GE, charge yourself, then sell as (4) or (6)
+    - Stack inventory of charged glories for early-game alts
+    - Watch Wilderness boss meta updates for demand spikes
+  history:
+    - date: "2002-02-27"
+      description: Amulet of glory released as part of the dragonstone jewellery expansion.
+    - date: "2004-03-29"
+      description: Charge variants became permanent items with the RuneScape 2 launch.
+    - date: "2014-03-27"
+      description: Fountain of Rune added, enabling the 6-charge recharge.
+  properties:
+    release_date: "2002-02-27"
+    update: Dragonstone amulets
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Rub
+      - Drop
+    worn_options:
+      - Rub
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-platebody.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
-  about: "Ancient platebody is a free-to-play item in Old School RuneScape. High alchemy value: 39,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Rune
+    tier: mid
+  equipment:
+    slot: body
+    weight: 9.979
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 82
+      slash: 80
+      crush: 72
+      magic: -6
+      ranged: 80
+    other_bonus:
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  related_items:
+    - name: Rune platebody
+      relationship: variant
+    - name: Ancient platelegs
+      relationship: set-piece
+    - name: Ancient plateskirt
+      relationship: set-piece
+    - name: Ancient full helm
+      relationship: set-piece
+    - name: Ancient kiteshield
+      relationship: set-piece
+  about: "Ancient platebody is a free-to-play rune-tier body armour styled in the colours of the Ancient god Zaros. It is obtained exclusively from hard Treasure Trail reward caskets and requires 40 Defence plus completion of Dragon Slayer I to equip."
+  market_strategy:
+    notes:
+      - Hard clue exclusive supply keeps prices elevated
+      - Demand from cosmetic and clue completionists
+      - F2P availability widens the buyer pool
+  trading_tips:
+    - Watch hard clue popularity for supply swings
+    - Compare set value against individual pieces
+  history:
+    - date: "2014-06-12"
+      description: Released with the Treasure Trail Expansion update.
+    - date: "2016-04-07"
+      description: Made available to free-to-play players.
+    - date: "2021-04-21"
+      description: Ranged attack bonus reduced from -10 to -15.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "You can always get another from a reward casket from a Hard Treasure Trail."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-wyvern-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-wyvern-shield.mdx
@@ -12,104 +12,88 @@ osrs:
   lowalch: 800000
   highalch: 1200000
   limit: 8
+  material:
+    type: metal
+    tier: high
   equipment:
     slot: shield
-    weight: 6.803
+    weapon_type: none
+    weight: 4.535
+    requirements:
+      defence: 75
+      magic: 70
     attack_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
       magic: 5
-      ranged: 0
     defence_bonus:
       stab: 50
       slash: 55
       crush: 52
       magic: 20
       ranged: 52
-    other_bonus:
-      melee_strength: 0
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
-    requirements:
-      defence: 75
-      magic: 70
-  special_effect:
-    name: Wyvern Protection
-    description: Provides protection against wyvern icy breath when charged. Absorbs icy breath to gain charges.
-    triggers: passive
+    other_bonus: {}
+  special_attack:
+    description: "Provides protection against wyvern icy breath when charged. Absorbs icy breath to gain charges; right-click to release stored breath as a discharge attack."
+  charges:
+    max_charges: 50
+    charge_source: Wyvern icy breath / fossils / numulites
   recipes:
     - skill: smithing
       level: 66
       xp: 2000
       materials:
         - item_name: Elemental shield
-          item_id: 2890
           quantity: 1
         - item_name: Wyvern visage
-          item_id: 21637
           quantity: 1
-      facility: Anvil
-      members_only: true
+      tools:
+        - Hammer
+      facility: Strange Machine
+      output_quantity: 1
   related_items:
-    - item_id: 2890
-      item_name: Elemental shield
-      slug: elemental-shield
+    - slug: elemental-shield
+      name: Elemental shield
       relationship: component
-      description: Base shield component
-    - item_id: 21637
-      item_name: Wyvern visage
-      slug: wyvern-visage
+    - slug: wyvern-visage
+      name: Wyvern visage
       relationship: component
-      description: Ancient wyvern drop
-    - item_id: 11284
-      item_name: Dragonfire shield
-      slug: dragonfire-shield
+    - slug: dragonfire-shield
+      name: Dragonfire shield
       relationship: alternative
-      description: Dragon protection variant
-    - item_id: 22003
-      item_name: Dragonfire ward
-      slug: dragonfire-ward
+    - slug: dragonfire-ward
+      name: Dragonfire ward
       relationship: alternative
-      description: Ranged variant
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Magic | +5 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Stab | +50 |
-    | Slash | +55 |
-    | Crush | +52 |
-    | Magic | +20 |
-    | Ranged | +52 |
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Smithing | 66 |
-    | Materials | Elemental shield + Wyvern visage |
-    | XP | 2,000 |
-
-    Provides full protection against wyvern icy breath when charged.
-
-    Charging: Absorb icy breath attacks to charge (max 50 charges).
-
-    Discharge: Right-click to release stored icy breath.
+  about: "Provides full protection against wyvern icy breath when charged. Charging: absorb icy breath attacks to charge (max 50 charges). Discharge: right-click to release stored icy breath."
   market_strategy:
     notes:
       - Required for ancient wyverns
       - Good magic defence
       - Niche but useful
-      - Ancient wyvern tasks
-      - Magic-focused builds
-      - Wyvern farming
       - Uncharged is tradeable
       - Charged version untradeable
       - Create from wyvern visage for profit
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2017-09-07"
+      description: Ancient wyvern shield released with the Fossil Island update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-09-07"
+    update: Fossil Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.535
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+      - Discharge
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-4-12913.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-4-12913.mdx
@@ -12,76 +12,69 @@ osrs:
   lowalch: 177
   highalch: 266
   limit: 2000
-  item:
-    type: potion
-    tradeable: true
-    weight: 0.035
+  potion:
+    doses: 4
+    effects:
+      - description: "Instantly cures venom and poison on consumption."
+      - description: "Grants poison immunity."
+        duration: 900
+      - description: "Grants venom immunity (approximately 3.6 minutes)."
+        duration: 216
   recipes:
-    - skill: herblore
-      level: 94
-      xp: 125
-      base: Anti-venom(4)
-      secondary: Torstol
-  effect:
-    name: Venom and Poison Immunity
-    instant: Cures venom and poison
-    poison_immunity: 15 minutes
-    venom_immunity: ~3.6 minutes
-  upgrades:
-    - item_name: Extended anti-venom+
-      materials: Araxyte venom sacks
-  use_cases:
-    - Zulrah
-    - Vorkath (if no anti-dragon shield)
-    - Araxxor
-    - Verzik Vitur
+    - materials:
+        - item_name: "Anti-venom(4)"
+          quantity: 1
+        - item_name: Torstol
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skills:
+        - skill: Herblore
+          level: 94
+          xp: 125
+      notes: "Unfinished torstol potions can substitute for torstol since 16 November 2022."
   related_items:
-    - item_id: 12905
-      item_name: Anti-venom
-      slug: anti-venom
+    - name: "Anti-venom(4)"
       relationship: downgrade
-      description: Base potion
-    - item_id: 269
-      item_name: Torstol
-      slug: torstol
+    - name: "Anti-venom+(3)"
+      relationship: variant
+    - name: "Extended anti-venom+(4)"
+      relationship: upgrade
+    - name: Torstol
       relationship: component
-      description: Ingredient
-    - item_id: 0
-      item_name: Zulrah
-      slug: zulrah
-      relationship: product
-      description: Primary use
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Potion |
-    | Tradeable | Yes |
-    | Weight | 0.035 kg |
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore | 94 |
-    | Base | Anti-venom(4) |
-    | Secondary | Torstol |
-    | XP | 125 |
-
-    Instantly cures venom and poison.
-
-    Immunity:
-    - Poison: 15 minutes
-    - Venom: ~3.6 minutes
-
-    | Item | Requirements |
-    |------|--------------|
-    | Extended anti-venom+ | Araxyte venom sacks |
-
-    Essential for:
-    - Zulrah
-    - Vorkath (if no anti-dragon shield)
-    - Araxxor
-    - Verzik Vitur
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Anti-venom+(4) is a four-dose super antivenom potion used to cure poison and venom instantly, with long immunity windows essential at Zulrah, Vorkath, Araxxor, and Verzik Vitur. High alchemy value: 266 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Material cost tracks torstol and Zulrah scale supply; margin is thin but stable."
+      - "Decanting between dose sizes can yield arbitrage in volatile windows."
+  trading_tips:
+    - "Watch torstol prices for buy-side margins on Herblore production."
+    - "Combine with Extended anti-venom+ flips around boss meta shifts."
+  history:
+    - date: "2015-01-08"
+      description: "Anti-venom+ released alongside Zulrah."
+    - date: "2022-11-16"
+      description: "Unfinished torstol potions accepted as a torstol substitute in the recipe."
+    - date: "2026-04-22"
+      description: "Wiki refresh confirmed alch and recipe details."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-01-08"
+    update: "Zulrah"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Antidote+ mix(1) | OSRS Price Data
-description: "Antidote+ mix(1): One dose of fishy extra strength antidote potion.. High alch: 86 GP, GE limit: 2,000."
+description: "Antidote+ mix(1): One dose of fishy extra strength antidote potion. High alch: 86 GP, GE limit: 2,000."
 osrs:
   id: 11503
   name: Antidote+ mix(1)
@@ -12,9 +12,67 @@ osrs:
   lowalch: 57
   highalch: 86
   limit: 2000
-  about: "Antidote+ mix(1) is a members-only item in Old School RuneScape. High alchemy value: 86 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Antidote+ mix(1) is a single-dose barbarian potion that cures poison, grants 9 minutes of poison immunity, and restores 6 Hitpoints. It is created by combining an antidote+(2) with caviar after completing the Barbarian Herblore training."
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures poison."
+        duration: 0
+      - description: "Grants 9 minutes of poison immunity."
+        duration: 540
+      - description: "Restores 6 Hitpoints on consumption."
+        skill: Hitpoints
+        duration: 0
+  recipes:
+    - name: Antidote+ mix(1)
+      skill: Herblore
+      level: 74
+      experience: 52
+      materials:
+        - item_name: Antidote+(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Antidote+(2)
+      relationship: component
+    - name: Antidote+ mix(2)
+      relationship: upgrade
+    - name: Antidote++ mix(1)
+      relationship: upgrade
+    - name: Antidote+
+      relationship: variant
+  market_strategy:
+    notes:
+      - "Barbarian mixes cost more to make than the base antidote+, trading the extra cost for 6 HP healing."
+      - "Demand from PvM where poison protection plus hp regen is wanted in a single sip."
+      - "Buy limit 2,000 supports moderate-scale flipping."
+  trading_tips:
+    - "Compare antidote+(2) + caviar cost vs GE to spot creation arbitrage."
+    - "Most useful for low-Prayer bossing where every HP matters."
+    - "Stocks spike during bounty/PVM weekends."
+  history:
+    - date: "2007-07-03"
+      description: "Antidote+ mix added with the Barbarian Herblore update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-mitre.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-mitre.mdx
@@ -12,25 +12,85 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
+  material:
+    type: cloth
+    tier: mid
   equipment:
     slot: head
+    weight: 0.3
     requirements:
       prayer: 40
       magic: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
     other_bonus:
+      strength: 0
       prayer: 5
+  drop_table:
+    sources:
+      - source: "Reward casket (medium)"
+        quantity: "1"
+        rarity: "1/1,133"
+      - source: "Elite Treasure Trail (Shadow Dungeon emote clue)"
+        quantity: "1"
+        rarity: "Clue-tier"
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - medium
+      - elite
   related_items:
-    - item_id: 12253
-      item_name: Armadyl robe top
-      slug: armadyl-robe-top
+    - item_name: "Armadyl robe top"
       relationship: set-piece
-      description: Armadyl vestment body
-  about: |-
-    > *"An Armadyl mitre."*
-
-    The Armadyl mitre is a head slot item from the Armadyl vestment set. It provides a +5 Prayer bonus and requires 40 Prayer and 40 Magic to equip. Counts as an Armadylean item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: "Armadyl robe legs"
+      relationship: set-piece
+    - item_name: "Armadyl stole"
+      relationship: set-piece
+    - item_name: "Armadyl cloak"
+      relationship: set-piece
+    - item_name: "Armadyl crozier"
+      relationship: set-piece
+  about: "Armadyl mitre is a members head slot piece from the Armadyl vestment set; +5 Prayer bonus, counts as Armadylean in God Wars Dungeon."
+  market_strategy:
+    notes:
+      - "Demand from Kree'arra learners and god-aligned cosmetic builds."
+      - "Stable price floor due to small clue drop pool and 8/4h buy limit."
+  trading_tips:
+    - "Pair stock with vestment-set demand; full sets sell faster than singles."
+    - "Spikes during clue-scroll bonus weekends."
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/atlatl-dart-shaft.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/atlatl-dart-shaft.mdx
@@ -1,6 +1,6 @@
 ---
 title: Atlatl dart shaft | OSRS Price Data
-description: "Atlatl dart shaft: An atlatl dart shaft.. High alch: 132 GP, GE limit: 11,000."
+description: "Atlatl dart shaft: An atlatl dart shaft. High alch: 132 GP, GE limit: 11,000."
 osrs:
   id: 31004
   name: Atlatl dart shaft
@@ -12,9 +12,49 @@ osrs:
   lowalch: 88
   highalch: 132
   limit: 11000
-  about: "Atlatl dart shaft is a members-only item in Old School RuneScape. High alchemy value: 132 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: low
+  about: "Atlatl dart shaft is a members-only stackable Fletching material introduced with the Varlamore: The Final Dawn update. Players cut ent branches with a knife at 74 Fletching to produce 100 shafts per branch, then combine them with feathers to create headless atlatl darts."
+  recipes:
+    - skill: Fletching
+      level: 74
+      experience: 30
+      materials:
+        - item_name: Ent's roots
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 100
+      output_item: Atlatl dart shaft
+  properties:
+    release_date: "2025-07-23"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  market_strategy:
+    notes:
+      - "Bulk Fletching consumable for crafting headless atlatl darts."
+      - "Price tracks the cost of ent branches and feather demand."
+      - "Large 11,000 buy limit supports volume flips."
+  trading_tips:
+    - "Buy in bulk when ent branch supply spikes after weekly resets."
+    - "Cross-check against feather price to model headless dart margins."
+    - "Watch for Varlamore content patches that shift Fletching meta."
+  history:
+    - date: "2025-07-23"
+      description: "Released with the Varlamore: The Final Dawn update as a Fletching intermediate."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/attack-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/attack-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Attack potion(1) | OSRS Price Data
-description: "Attack potion(1): 1 dose of Attack potion.. High alch: 3 GP, GE limit: 2,000."
+description: "Attack potion(1): 1 dose of Attack potion. High alch: 3 GP, GE limit: 2,000."
 osrs:
   id: 125
   name: Attack potion(1)
@@ -12,23 +12,53 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 2000
+  potion:
+    doses: 1
+    effects:
+      - skill: Attack
+        description: "Temporarily boosts the player's Attack level by floor(level x 0.10) + 3."
+        duration: 60
   related_items:
     - item_id: 121
       item_name: Attack potion(3)
       slug: attack-potion-3
       relationship: variant
-      description: 3-dose version
+      description: 3-dose version.
     - item_id: 123
       item_name: Attack potion(2)
       slug: attack-potion-2
       relationship: variant
-      description: 2-dose version
-  about: |-
-    > _"1 dose of Attack potion."_
-
-    A 1-dose attack potion. Boosts Attack by 3 + 10% of current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: 2-dose version.
+  about: "Attack potion(1) is a single-dose Herblore potion that temporarily boosts the player's Attack level by 3 plus 10% of the base level. It is the lowest-tier Attack-boosting potion and the first potion most players brew while training Herblore."
+  properties:
+    release_date: "2002-02-27"
+    update: "Herblore release"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  market_strategy:
+    notes:
+      - "Low-margin Herblore byproduct with tiny per-unit profit potential."
+      - "Demand is intermittent; mostly consumed by low-level pures and ironmen alts."
+      - "2,000 buy limit constrains bulk flipping volume."
+  trading_tips:
+    - "Buy partial doses for decanting into higher-dose attack potions."
+    - "Track guam + eye of newt prices to gauge production cost floor."
+    - "Sell stacks before low-level combat events when pures stock up."
+  history:
+    - date: "2002-02-27"
+      description: "Released with the Herblore skill as the entry-level Attack-boosting potion."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bale-of-flax.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bale-of-flax.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 50
   highalch: 75
   limit: 13000
-  about: "Bale of flax is a members-only item in Old School RuneScape. High alchemy value: 75 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: raw
+    tier: low
+  drop_table:
+    sources:
+      - source: "Rummaging Vale offerings (Vale Totems minigame)"
+        quantity: "5-6"
+        rarity: "50/399"
+  related_items:
+    - name: Flax
+      relationship: product
+    - name: Bow string spool
+      relationship: alternative
+  about: "Bale of flax is a members-only resource pack in Old School RuneScape. High alchemy value: 75 coins. Grand Exchange buy limit: 13,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Each bale unpacks into 25 flax; requires 25 empty inventory slots, or unpack directly to the bank with the bank open."
+      - "Sourced from rummaging Vale offerings in the Vale Totems minigame (5-6 bales at 50/399 rarity)."
+      - "Common feedstock for bow string crafting via spinning wheel or Spin Flax spell with a bow string spool."
+  trading_tips:
+    - "Compare GE price to 25× flax spot price for unpack arbitrage."
+    - "Buy limit of 13,000 per 4 hours supports large-scale bow string production."
+    - "Watch for Spin Flax/bow string spool meta shifts that drive bale demand."
+  history:
+    - date: "2025-07-23"
+      description: "Released alongside the Varlamore: The Final Dawn update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-07-23"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Unpack
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-page-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-page-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bandos page 2 | OSRS Price Data
-description: "Bandos page 2: This seems to have been torn from a book.... High alch: 240 GP, GE limit: 5."
+description: "Bandos page 2: This seems to have been torn from a book. High alch: 240 GP, GE limit: 5."
 osrs:
   id: 12614
   name: Bandos page 2
@@ -12,16 +12,32 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 5
-  item:
-    type: god_page
-    god: Bandos
-    page_number: 2
-    tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite
-        drop_rate: Varies by tier
+  drop_table:
+    sources:
+      - source: Treasure Trails (Easy)
+        quantity: "1"
+        rarity: Rare
+      - source: Treasure Trails (Medium)
+        quantity: "1"
+        rarity: Rare
+      - source: Treasure Trails (Hard)
+        quantity: "1"
+        rarity: Rare
+      - source: Treasure Trails (Elite)
+        quantity: "1"
+        rarity: Rare
+      - source: Treasure Trails (Master)
+        quantity: "1"
+        rarity: Rare
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
   related_items:
     - item_id: 12613
       item_name: Bandos page 1
@@ -38,17 +54,36 @@ osrs:
       slug: bandos-page-4
       relationship: set-piece
       description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Bandos |
-    | Page | 2 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of war (Bandos god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Bandos page 2 is one of four pages that combine with Book of war (damaged) to form the complete Book of war (Bandos god book), a Prayer-restoring book held in the shield slot."
+  market_strategy:
+    notes:
+      - Pages are required components for completing the Book of war.
+      - Demand spikes when god books trend in PvP or Treasure Trails content.
+      - Supply is steady from all Treasure Trail tiers above beginner.
+  trading_tips:
+    - Buy individual pages rather than completed books if you can flip them faster.
+    - Check the price of the completed Book of war versus the sum of all 4 pages plus the damaged book.
+    - Stack pages when restocking the GE since they are stackable.
+  history:
+    - date: "2014-07-03"
+      description: Item released as part of the God Books update.
+  properties:
+    release_date: "2014-07-03"
+    update: God Books
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-platebody.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bandos platebody | OSRS Price Data
-description: "Bandos platebody: Rune platebody in the colours of Bandos.. High alch: 39,000 GP, GE limit: 8."
+description: "Bandos platebody: Rune platebody in the colours of Bandos. High alch: 39,000 GP, GE limit: 8."
 osrs:
   id: 12480
   name: Bandos platebody
@@ -12,9 +12,96 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
-  about: "Bandos platebody is a free-to-play item in Old School RuneScape. High alchemy value: 39,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: mid-high
+  equipment:
+    slot: body
+    weight: 9.979
+    requirements:
+      defence: 40
+      quest: Dragon Slayer I
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 82
+      slash: 80
+      crush: 72
+      magic: -6
+      ranged: 80
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Treasure Trails (Hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_id: 1127
+      item_name: Rune platebody
+      slug: rune-platebody
+      relationship: alternative
+      description: Standard rune platebody with identical stats.
+    - item_id: 12482
+      item_name: Bandos platelegs
+      slug: bandos-platelegs
+      relationship: set-piece
+      description: Matching Bandos-themed platelegs.
+    - item_id: 12484
+      item_name: Bandos full helm
+      slug: bandos-full-helm
+      relationship: set-piece
+      description: Matching Bandos-themed full helm.
+    - item_id: 12486
+      item_name: Bandos kiteshield
+      slug: bandos-kiteshield
+      relationship: set-piece
+      description: Matching Bandos-themed kiteshield.
+  about: "Bandos platebody is a cosmetic rune platebody re-colored to Bandos heraldry obtained from Hard Treasure Trails; stats match the standard rune platebody."
+  market_strategy:
+    notes:
+      - Supply comes exclusively from Hard Treasure Trails at roughly 1/1625.
+      - Price tracks the prestige cosmetic market rather than combat demand.
+      - Bandos imagery keeps modest collector demand.
+  trading_tips:
+    - Watch for price spikes when Treasure Trails content updates ship.
+    - Compare to other heraldic rune sets to gauge cosmetic premium.
+    - Note that wearing it requires Dragon Slayer I, narrowing the buyer pool slightly.
+  history:
+    - date: "2014-06-12"
+      description: Item released as part of the Treasure Trails expansion.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trails Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    quest: Dragon Slayer I
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandosian-components.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandosian-components.mdx
@@ -12,62 +12,103 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: null
-  item:
-    type: crafting material
-    tradeable: true
-    weight: 0.095
-  obtaining:
-    - source: Ancient Forge
-      method: Break down Bandos armour
-      requirements: Hammer and Ancient Forge access
-      yields:
-        - item_name: Bandos chestplate
-          components: 3
-        - item_name: Bandos tassets
-          components: 2
+  material:
+    type: crafting
+    tier: high
   recipes:
-    - skill: smithing
+    - name: Bandosian components (break down Bandos chestplate)
+      materials:
+        - item_name: Bandos chestplate
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 3
+      location: Ancient Forge
+    - name: Bandosian components (break down Bandos tassets)
+      materials:
+        - item_name: Bandos tassets
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 2
+      location: Ancient Forge
+    - name: Restore Torva full helm
+      materials:
+        - item_name: Torva full helm (damaged)
+          quantity: 1
+        - item_name: Bandosian components
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
+      skill: Smithing
       level: 90
       xp: 2250
-      uses:
-        - item_name: Torva full helm
-          components: 1
-        - item_name: Torva platebody
-          components: 2
-        - item_name: Torva platelegs
-          components: 2
+    - name: Restore Torva platebody
+      materials:
+        - item_name: Torva platebody (damaged)
+          quantity: 1
+        - item_name: Bandosian components
+          quantity: 2
+      tools:
+        - Hammer
+      output_quantity: 1
+      skill: Smithing
+      level: 90
+      xp: 2250
+    - name: Restore Torva platelegs
+      materials:
+        - item_name: Torva platelegs (damaged)
+          quantity: 1
+        - item_name: Bandosian components
+          quantity: 2
+      tools:
+        - Hammer
+      output_quantity: 1
+      skill: Smithing
+      level: 90
+      xp: 2250
   related_items:
-    - item_id: 11832
-      item_name: Bandos chestplate
-      slug: bandos-chestplate
+    - name: Bandos chestplate
       relationship: component
-      description: Source (yields 3 components)
-    - item_id: 11834
-      item_name: Bandos tassets
-      slug: bandos-tassets
+    - name: Bandos tassets
       relationship: component
-      description: Source (yields 2 components)
-    - item_id: 26384
-      item_name: Torva platebody
-      slug: torva-platebody
+    - name: Torva full helm
       relationship: product
-      description: Repaired with components
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 0.095 kg |
-
-    Restore damaged Torva armour (90 Smithing, 2,250 XP each):
-
-    | Item | Components Needed |
-    |------|-------------------|
-    | Torva full helm | 1 |
-    | Torva platebody | 2 |
-    | Torva platelegs | 2 |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Torva platebody
+      relationship: product
+    - name: Torva platelegs
+      relationship: product
+  about: "Bandosian components are a high-grade crafting material salvaged from Bandos armour at the Ancient Forge. They are consumed at 90 Smithing to restore damaged Torva armour, awarding 2,250 Smithing XP per repair."
+  market_strategy:
+    notes:
+      - Sourced by breaking down Bandos chestplate (3 components) or tassets (2 components)
+      - Required to repair damaged Torva armour at the Ancient Forge
+      - No GE buy limit makes bulk movement viable
+  trading_tips:
+    - Margin tracks Bandos armour GE prices closely
+    - Demand spikes when new Torva owners need repairs after Nex farming
+  history:
+    - date: "2022-01-05"
+      description: Released alongside Nex - The Fifth General.
+    - date: "2022-08-17"
+      description: Item value increased from 1 to 100,000 coins.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-01-05"
+    update: "Nex: The Fifth General"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.095
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/basalt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/basalt.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 10000
-  about: "Basalt is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: stone
+    tier: low
+  recipes:
+    - name: Icy basalt
+      materials:
+        - item_name: Basalt
+          quantity: 1
+        - item_name: Efh salt
+          quantity: 3
+        - item_name: Te salt
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - name: Stony basalt
+      materials:
+        - item_name: Basalt
+          quantity: 1
+        - item_name: Urt salt
+          quantity: 3
+        - item_name: Te salt
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Icy basalt
+      relationship: product
+    - name: Stony basalt
+      relationship: product
+    - name: Te salt
+      relationship: component
+    - name: Efh salt
+      relationship: component
+    - name: Urt salt
+      relationship: component
+  about: "Basalt is a members-only crushed rock mined from basalt rocks in the Salt Mine (72 Mining required). It is used with salts to craft icy basalt and stony basalt and is required in bulk to attune Portal Nexus rooms in a player-owned house."
+  market_strategy:
+    notes:
+      - Mined in the Salt Mine after completion of Making Friends with My Arm
+      - Bulk consumed for Portal Nexus and Portal Chamber attunements
+      - Combined with salts to make icy and stony basalt
+  trading_tips:
+    - Watch demand spike when players construct Portal Nexus rooms
+    - Stockpile during low-volume periods for resale to Construction trainers
+  history:
+    - date: "2018-09-06"
+      description: Released alongside Making Friends with My Arm, Deadman Autumn Finals and Full Mobile Launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-09-06"
+    update: "Making Friends With My Arm, Deadman Autumn Finals and Full Mobile Launch"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/beer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/beer.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Beer is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Restores 1 Hitpoint when drunk."
+      - description: "Temporarily boosts Strength by 2% + 1."
+      - description: "Drains Attack by 6% + 1."
+  shops:
+    - shop_name: Blue Moon Inn
+      location: Varrock
+      price: 2
+      stock: 2
+    - shop_name: Flying Horse Inn
+      location: East Ardougne
+      price: 2
+      stock: 2
+    - shop_name: Rellekka Longhall Bar
+      location: Rellekka
+      price: 2
+      stock: 2
+  related_items:
+    - name: Beer glass
+      relationship: component
+    - name: Asgarnian ale
+      relationship: alternative
+    - name: Dwarven stout
+      relationship: alternative
+  about: "Beer is a free-to-play drink sold by tavern keepers across Gielinor. Drinking it restores a single Hitpoint, gives a small Strength boost, and temporarily drains Attack, making it a budget pre-fight strength enhancer."
+  market_strategy:
+    notes:
+      - "Large 2,000 buy limit and bottomless shop supply keep margins razor-thin."
+      - "Demand is mostly novelty / clue scroll requirements; tradeable at minimum GE prices."
+  trading_tips:
+    - "Buy direct from Varrock or Ardougne bartenders at 2 gp; flipping vs GE is rarely worthwhile."
+    - "Useful as a Strength micro-boost for low-level F2P combat tasks."
+  history:
+    - date: "2001-01-04"
+      description: "Added to the game with the original release."
+    - date: "2015-02-26"
+      description: "Player-owned house keg variants became members-only following the Grand Exchange update."
+  properties:
+    release_date: "2001-01-04"
+    update: RuneScape Launch
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/berserker-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/berserker-helm.mdx
@@ -12,79 +12,69 @@ osrs:
   lowalch: 24000
   highalch: 36000
   limit: 70
+  material:
+    type: metal
+    tier: mid
   equipment:
     slot: head
+    weight: 2.721
+    requirements:
+      defence: 45
     attack_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
       magic: -5
       ranged: -5
     defence_bonus:
       stab: 31
       slash: 29
       crush: 33
-      magic: 0
       ranged: 30
     other_bonus:
-      melee_strength: 3
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
-    requirements:
-      defence: 45
-    weight: 2.721
+      strength: 3
+  shops:
+    - shop_name: Skulgrimen's Battle Gear
+      location: Rellekka
+      price: 78000
+  drop_table:
+    sources:
+      - source: Dagannoth
+        quantity: "1"
+        rarity: Rare
+      - source: Barbarian Assault (High Gamble)
+        quantity: "1"
+        rarity: Uncommon
   related_items:
-    - item_id: 3753
-      item_name: Warrior helm
-      slug: warrior-helm
+    - name: Warrior helm
       relationship: alternative
-      description: Slash attack variant
-    - item_id: 3755
-      item_name: Farseer helm
-      slug: farseer-helm
+    - name: Farseer helm
       relationship: alternative
-      description: Magic variant
-    - item_id: 3749
-      item_name: Archer helm
-      slug: archer-helm
+    - name: Archer helm
       relationship: alternative
-      description: Ranged variant
-    - item_id: 10828
-      item_name: Helm of neitiznot
-      slug: helm-of-neitiznot
+    - name: Helm of neitiznot
       relationship: upgrade
-      description: Superior melee helm (+3 Str, +3 Prayer)
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +31 |
-    | Slash | +29 |
-    | Crush | +33 |
-    | Ranged | +30 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +3 |
-
-    Requirements: 45 Defence | Weight: 2.72 kg
-
-    The +3 Strength bonus makes this the key Fremennik helm for melee. It matches the Helm of neitiznot's Strength bonus but lacks the +3 Prayer. Popular with combat pures at 45 Defence who can't access the Neitiznot helm (requires The Fremennik Isles).
-
-    | Stat | Berserker | Warrior | Farseer | Archer | Neitiznot |
-    |------|-----------|---------|---------|--------|-----------|
-    | Best Atk | +0 | +5 slash | +6 magic | +6 ranged | +3 crush |
-    | Str/Bonus | +3 Str | +0 | +0 | +0 | +3 Str, +3 Pray |
-    | Stab Def | +31 | +31 | +8 | +6 | +31 |
-    | Best Def | +33 crush | +33 slash | +12 crush | +10 crush | +34 crush |
-    | Req | 45 Def | 45 Def | 45 Def | 45 Def | 55 Def |
+  about: "Berserker helm is the strength-oriented Fremennik helm awarded after completing The Fremennik Trials. Its +3 strength bonus matches the helm of Neitiznot and obsidian helmet, making it the iconic 45 Defence pure helmet."
   market_strategy:
     notes:
       - Popular with 45 Defence pures
       - Cheaper alternative to Helm of neitiznot
       - Supply from Barbarian Assault and Dagannoth drops
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2004-11-02"
+      description: "Released via The Fremennik Trials update."
+  properties:
+    release_date: "2004-11-02"
+    update: The Fremennik Trials
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: The Fremennik Trials
+    weight: 2.721
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-boater.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-boater.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 4
-  about: "Black boater is a members-only item in Old School RuneScape. High alchemy value: 135 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.01
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - name: Red boater
+      relationship: variant
+    - name: Orange boater
+      relationship: variant
+    - name: Green boater
+      relationship: variant
+    - name: Blue boater
+      relationship: variant
+    - name: Pink boater
+      relationship: variant
+    - name: Purple boater
+      relationship: variant
+    - name: White boater
+      relationship: variant
+  about: "Black boater is a cosmetic head slot item awarded from medium-tier Treasure Trail caskets, part of the eight-colour boater set. It is also used in a Master clue emote step at Castle Drakan."
+  market_strategy:
+    notes:
+      - "Buy limit only 4 per 4 hours; cosmetic clue reward with thin volume and steep spreads."
+      - "Demand is fashionscape plus Master clue emote requirement at Castle Drakan, so price tends to be sticky."
+  trading_tips:
+    - "Roughly 1/1,133 from medium reward caskets; stockpile slowly across multiple buy cycles due to the 4-per-window limit."
+    - "Worn alongside splitbark body and dragon sq shield for the Master emote clue (Wave by the sickle floor marking)."
+  history:
+    - date: "2006-02-20"
+      description: "Released as part of the Updates, updates and more updates... patch."
+  properties:
+    release_date: "2006-02-20"
+    update: "Updates, updates and more updates..."
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-helm-h3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-helm-h3.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 422
   highalch: 633
   limit: 70
-  about: "Black helm (h3) is a free-to-play item in Old School RuneScape. High alchemy value: 633 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: head
+    weight: 2.721
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 12
+      slash: 13
+      crush: 10
+      magic: -1
+      ranged: -3
+    other_bonus:
+      strength: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Reward casket (easy)"
+        quantity: "1"
+        rarity: "1/1,404"
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - name: Black full helm
+      relationship: alternative
+    - name: Black helm (h1)
+      relationship: variant
+    - name: Black helm (h2)
+      relationship: variant
+    - name: Black helm (h4)
+      relationship: variant
+    - name: Black helm (h5)
+      relationship: variant
+  about: "Black helm (h3) is a free-to-play heraldic helm in Old School RuneScape. High alchemy value: 633 coins. Grand Exchange buy limit: 70 per 4 hours."
+  market_strategy:
+    notes:
+      - "Easy clue scroll reward from Reward casket (easy) at approximately 1/1,404."
+      - "Shares defence stats with the Black full helm but features a unique heraldic crest."
+      - "Storable in a costume room treasure chest, keeping bank slots free for collectors."
+  trading_tips:
+    - "Demand is collector-driven; check costume room popularity and clue scroll meta."
+    - "Buy limit of 70 per 4 hours allows steady accumulation but limits quick flips."
+    - "Compare against other h-series variants when assembling a full clue set."
+  history:
+    - date: "2006-12-05"
+      description: "Released as part of the Treasure Trails, spiders and sheep update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    update: "Treasure Trails, spiders and sheep"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-kiteshield.mdx
@@ -12,24 +12,85 @@ osrs:
   lowalch: 652
   highalch: 979
   limit: 125
-  item_id: 1195
-  item_type: armor
-  slot: shield
-  type: kiteshield
-  tradeable: true
-  weight: 5.443
-  requirements:
-    defence: 10
-  stats:
-    stab_defence: 17
-    slash_defence: 19
-    crush_defence: 18
-    ranged_defence: 18
+  material:
+    type: black
+    tier: low
+  equipment:
+    slot: shield
+    weight: 5.443
+    requirements:
+      defence: 10
+    attack_bonus:
+      magic: -1
+      ranged: -3
+    defence_bonus:
+      stab: 17
+      slash: 19
+      crush: 18
+      magic: -1
+      ranged: 18
+  shops:
+    - shop_name: Quality Armour Shop
+      location: Keldagrim
+      stock: 0
+      price: 2121
+  drop_table:
+    sources:
+      - source: Ice giant
+        quantity: "1"
+        rarity: Uncommon
+      - source: Spiritual warrior
+        quantity: "1"
+        rarity: Rare
+      - source: Treasure Trails (easy)
+        quantity: "1"
+        rarity: Reward
   related_items:
-    - slug: mithril-kiteshield
-    - slug: black-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Mithril kiteshield
+      relationship: upgrade
+    - name: Steel kiteshield
+      relationship: downgrade
+    - name: Black platebody
+      relationship: set-piece
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  about: "The black kiteshield is a free-to-play shield requiring 10 Defence to wield, providing solid defensive bonuses for mid-level players."
+  market_strategy:
+    notes:
+      - Demand comes from free-to-play training accounts and Treasure Trail completionists.
+      - Price tends to hover near high alch value, limiting flip margins.
+  trading_tips:
+    - Watch for low-tier clue scroll meta shifts that bump demand briefly.
+    - Buy at or below alch value and resell into clue-stash demand windows.
+  history:
+    - date: "2001-12-08"
+      description: Black kiteshield added to the game.
+    - date: "2004-05-05"
+      description: Graphical update applied to black armour set.
+    - date: "2021-04-21"
+      description: Ranged attack bonus reduced from -2 to -3.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-12-08"
+    update: Latest RuneScape News (8 December 2001)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-spear-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-spear-p.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 300
   highalch: 450
   limit: 8
-  about: "Black spear(p) is a members-only item in Old School RuneScape. High alchemy value: 450 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Black
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 15
+      slash: 15
+      crush: 15
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 16
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Black spear
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Black spear
+      relationship: variant
+    - name: Black spear(p+)
+      relationship: upgrade
+    - name: Black spear(p++)
+      relationship: upgrade
+    - name: Black spear(kp)
+      relationship: variant
+  about: "Black spear(p) is the poison-tipped variant of the black spear, a two-handed melee weapon with stab, slash, and crush attack styles."
+  market_strategy:
+    notes:
+      - "Tiny GE buy limit (8 per 4 hours) — niche market."
+      - "Poisoned variants typically trade at a premium over the unpoisoned base."
+      - "High alch 450 gp is below typical GE price — alching loses money."
+  trading_tips:
+    - "Apply Weapon poison to unpoisoned Black spear if base + poison < poisoned price."
+    - "Demand mostly from low-level pures and skillers."
+  history:
+    - date: "2005-05-17"
+      description: "Released as part of the Barrows Changes update."
+  properties:
+    release_date: "2005-05-17"
+    update: "Barrows Changes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-tourmaline-core.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-tourmaline-core.mdx
@@ -14,56 +14,59 @@ osrs:
   limit: 5
   material:
     type: upgrade_material
-    tradeable: true
-    weight: 0.001
+    tier: high
   drop_table:
     sources:
       - source: Grotesque Guardians
-        rate: 1/1,000
-        requirements:
-          slayer: 75
-  uses:
-    - result_id: 21733
-      result_name: Guardian boots
+        quantity: "2"
+        rarity: 1/1000
+  recipes:
+    - output: Guardian boots
+      output_quantity: 1
       materials:
-        - Bandos boots
-        - Black tourmaline core
-  market:
-    buy_limit: 8
-    price_estimate: 7500000
+        - item_name: Bandos boots
+          quantity: 1
+        - item_name: Black tourmaline core
+          quantity: 1
+      tools: []
+      requirements:
+        slayer: 75
   related_items:
-    - item_id: 11923
-      item_name: Grotesque Guardians
-      slug: grotesque-guardians
+    - name: Grotesque Guardians
       relationship: component
-      description: Boss drop
-    - item_id: 11836
-      item_name: Bandos boots
-      slug: bandos-boots
+    - name: Bandos boots
       relationship: component
-      description: Base item
-    - item_id: 21733
-      item_name: Guardian boots
-      slug: guardian-boots
+    - name: Guardian boots
       relationship: product
-      description: Created boots
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Upgrade Material |
-    | Tradeable | Yes |
-    | Weight | 0.001 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Guardian boots | Bandos boots + Black tourmaline core |
+  about: "Black tourmaline core combines with Bandos boots to create Guardian boots, currently best-in-slot tank boots. Dropped 2-per-kill at 1/1,000 by the Grotesque Guardians on the Slayer Tower rooftop (75 Slayer)."
   market_strategy:
     notes:
-      - From Grotesque Guardians only
-      - 75 Slayer required for boss
-      - Creates BiS tank boots
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Sole drop source is Grotesque Guardians (1/1,000 for 2), so supply is bound to Slayer Tower rooftop activity.
+      - Low daily volume (~93) — patient market making beats trying to flip fast.
+      - Demand is upgrade-driven; Guardian boots BiS status keeps long-term floor.
+  trading_tips:
+    - Margin equation = Guardian boots price minus Bandos boots — buy core when that gap exceeds GE ask.
+    - Watch Slayer task buffs or Grotesque Guardians changes for supply shocks.
+  history:
+    - date: "2017-10-26"
+      description: Released with the Grotesque Guardians update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-10-26"
+    update: Grotesque Guardians
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-overload-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-overload-4.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 50
-  about: "Blighted overload (4) is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Boosts Attack and Strength by floor(0.15 x level) + 8."
+        duration: 300
+      - description: "Boosts Ranged by floor(level / 10) + 7."
+        duration: 300
+      - description: "Boosts Magic by floor(level / 10) + 1."
+        duration: 300
+      - description: "Reduces Defence by floor(level / 10) + 1."
+        duration: 300
+      - description: "Inflicts 10 damage over 6 seconds when consumed."
+        duration: 6
+  recipes:
+    - materials:
+        - item_name: Super combat potion (4)
+          quantity: 1
+        - item_name: Ranging potion (4)
+          quantity: 1
+        - item_name: Magic potion (4)
+          quantity: 1
+        - item_name: Chitin
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: Herblore
+      level: 83
+  related_items:
+    - name: Blighted overload (3)
+      relationship: variant
+    - name: Blighted overload (2)
+      relationship: variant
+    - name: Blighted overload (1)
+      relationship: variant
+    - name: Super combat potion (4)
+      relationship: component
+    - name: Ranging potion (4)
+      relationship: component
+    - name: Magic potion (4)
+      relationship: component
+    - name: Chitin
+      relationship: component
+  about: "Blighted overload (4) is a Deadman Mode exclusive potion holding four doses of a combined combat boost. It boosts Attack, Strength, Ranged, and Magic while reducing Defence, but inflicts 10 damage over 6 seconds when consumed."
+  market_strategy:
+    notes:
+      - "Tradeable on the Grand Exchange but only consumable on Deadman Mode worlds."
+      - "Made from a super combat potion, ranging potion, magic potion, and chitin at Herblore level 83."
+      - "Profit after tax was approximately 14,902 coins per craft as of release pricing."
+  trading_tips:
+    - "Demand spikes during Deadman Mode tournaments and seasonal events."
+    - "Watch the price of chitin and ranging/magic potions to time crafting profitably."
+  history:
+    - date: "2024-07-17"
+      description: "Released alongside the Deadman Mode: Apocalypse event."
+    - date: "2026-01-21"
+      description: "Self-damage on consumption reduced from 25 to 10; Defence decay threshold raised to 90% of base level."
+  properties:
+    release_date: "2024-07-17"
+    update: "Deadman Mode: Apocalypse"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Drink
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-super-restore-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-super-restore-4.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 2000
-  about: "Blighted super restore(4) is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Restores Prayer points by 8 + 27% of player's Prayer level per dose, only usable in the Wilderness."
+        skill: Prayer
+        amount: "8 + 27% of level"
+        duration: 0
+      - description: "Restores all drained skills (except Hitpoints, Prayer, and Summoning) by 1 + 25% of their base level per dose."
+        skill: All skills (except Hitpoints/Prayer/Summoning)
+        amount: "1 + 25% of base level"
+        duration: 0
+  shops:
+    - shop_name: Justine's stuff for the Last Man Standing
+      location: Ferox Enclave
+      price: 1
+      currency: Last Man Standing points
+    - shop_name: Bounty Hunter Store
+      location: Edgeville
+      price: 2
+      currency: Bounty Hunter points
+    - shop_name: Soul Wars Reward Shop
+      location: Ferox Enclave
+      price: 10
+      currency: Zeal Tokens
+  related_items:
+    - name: Super restore(4)
+      relationship: alternative
+    - name: Blighted super restore(3)
+      relationship: variant
+    - name: Blighted super restore(2)
+      relationship: variant
+    - name: Blighted super restore(1)
+      relationship: variant
+  about: "Blighted super restore(4) is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 2,000 per 4 hours. Restricted to use inside the Wilderness."
+  market_strategy:
+    notes:
+      - Demand is tied to Wilderness PKing volume; price tracks PvP activity rather than skilling.
+      - Acquired via reward shops (LMS, Bounty Hunter, Soul Wars), so supply scales with minigame engagement.
+      - 2,000/4h buy limit per account permits bulk PK stockpiling without hitting cap fast.
+  trading_tips:
+    - Watch updates to Last Man Standing, Bounty Hunter, or Soul Wars rewards — point-cost changes shift supply.
+    - Price typically rises during double XP / PvP weekends as PKers re-stock supplies.
+  history:
+    - date: "2020-04-23"
+      description: Released as part of the Bounty Hunter Returns update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2020-04-23"
+    update: Bounty Hunter Returns
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-chestplate-broken.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-chestplate-broken.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 116004
   highalch: 174006
   limit: 15
-  about: "Blood moon chestplate (broken) is a members-only item in Old School RuneScape. High alchemy value: 174,006 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  charges:
+    max_charges: 3000
+    charge_cost_seconds: 54
+    repair_cost_npc: 1500000
+    repair_cost_self: "1,500,000 minus 7,500 per Smithing level (e.g. 757,500 at 99 Smithing)"
+  related_items:
+    - name: Blood moon chestplate
+      relationship: variant
+    - name: Blood moon helm (broken)
+      relationship: set-piece
+    - name: Blood moon tassets (broken)
+      relationship: set-piece
+  about: "Blood moon chestplate (broken) is the fully-degraded form of the blood moon chestplate, dropped by the Blood Moon boss in Varlamore. Repair at an armour stand or via a repair NPC to restore charges."
+  market_strategy:
+    notes:
+      - Acquired by running blood moon chestplate to 0 charges or as a direct drop from Blood Moon.
+      - Price floor is essentially repaired chestplate value minus repair cost — track both ends.
+      - Buy limit of 15 / 4h is generous; flips usually constrained by liquidity, not cap.
+  trading_tips:
+    - Compare (working chestplate price) vs (broken price + 1.5M repair) before buying broken to flip.
+    - Smithing 99 cuts repair to 757.5k — armour stand repair is much more profitable for high-level smiths.
+  history:
+    - date: "2024-03-20"
+      description: Released as part of the Varlamore - Part One update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-robe-top.mdx
@@ -14,23 +14,70 @@ osrs:
   limit: 150
   equipment:
     slot: body
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.907
+  shops:
+    - shop_name: Fine Fashions
+      location: Tree Gnome Stronghold
+      price: 180
+      stock: 5
   related_items:
-    - item_id: 630
-      item_name: Blue boots
-      slug: blue-boots
+    - name: Blue boots
       relationship: set-piece
-      description: Matching boots
-    - item_id: 650
-      item_name: Blue robe bottoms
-      slug: blue-robe-bottoms
+    - name: Blue robe bottoms
       relationship: set-piece
-      description: Matching bottoms
-  about: |-
-    > _"A blue robe top."_
-
-    The blue robe top is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Blue hat
+      relationship: set-piece
+  about: "Blue robe top is part of the gnome fashion line sold at Fine Fashions in the Tree Gnome Stronghold. It offers minor slash and crush defence and is primarily worn for its cosmetic look."
+  market_strategy:
+    notes:
+      - "Bottomless shop supply at Fine Fashions caps speculation; flips rely on GE convenience premium."
+      - "Buy limit of 150 makes mass-flipping impractical."
+  trading_tips:
+    - "Pick up in bulk from the Grand Tree shop and resell on the GE if the price gap covers gnome-glider fare."
+    - "Pairs well with matching robe bottoms for cosmetic transmog sales."
+  history:
+    - date: "2002-12-12"
+      description: "Released as part of the gnome fashion collection at Fine Fashions."
+    - date: "2014-12-10"
+      description: "Renamed from 'Robe top' to 'Blue robe top' for clarity with the new colour variants."
+  properties:
+    release_date: "2002-12-12"
+    update: Tree Gnome Stronghold
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-spiky-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-spiky-vambraces.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 125
-  about: "Blue spiky vambraces is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Blue dragonhide
+    tier: mid
+  equipment:
+    slot: hands
+    weapon_type: gloves
+    weight: 0.283
+    requirements:
+      ranged: 50
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 9
+    defence_bonus:
+      stab: 4
+      slash: 3
+      crush: 5
+      magic: 4
+      ranged: 0
+    other_bonus:
+      strength: 2
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Blue d'hide vambraces
+          quantity: 1
+        - item_name: Kebbit claws
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: Crafting
+      level: 32
+  related_items:
+    - name: Blue d'hide vambraces
+      relationship: component
+    - name: Kebbit claws
+      relationship: component
+    - name: Green spiky vambraces
+      relationship: alternative
+    - name: Red spiky vambraces
+      relationship: alternative
+    - name: Black spiky vambraces
+      relationship: alternative
+  about: "Blue spiky vambraces are ranged gloves crafted by adding kebbit claws to blue d'hide vambraces at Crafting level 32, granting a small +2 strength bonus over the plain version while keeping the same +9 ranged attack."
+  market_strategy:
+    notes:
+      - "Requires 50 Ranged to equip and 32 Crafting to produce."
+      - "Profit margin tracks the spread between blue d'hide vambraces, kebbit claws, and the spiky output."
+      - "Buy limit of 125 per 4h fits mid-volume crafting flips."
+  trading_tips:
+    - "Watch hunter kebbit supplies and craft batches when claws dip below break-even."
+    - "Stay aware of newer ranged glove releases that can sap demand for the spiky tier."
+  history:
+    - date: "2006-11-21"
+      description: "Released as part of the spiky vambraces line alongside falconry hunter rewards."
+    - date: "2020-04-01"
+      description: "Renamed from 'Blue spiky vambs' to 'Blue spiky vambraces'."
+  properties:
+    release_date: "2006-11-21"
+    update: "Hunter Skill Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bone-dagger-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bone-dagger-p.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 70
-  about: "Bone dagger (p) is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bone
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 5
+      slash: 3
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Backstab
+    energy_cost: 75
+    description: "Guarantees a hit if the target has not been previously damaged in combat or if you were not their last attacker. Reduces the target's Defence by the damage dealt, but only when their Defence is still at base level."
+  related_items:
+    - name: Bone dagger
+      relationship: variant
+    - name: "Bone dagger (p+)"
+      relationship: upgrade
+    - name: "Bone dagger (p++)"
+      relationship: upgrade
+  about: "Bone dagger (p) is a poisoned variant of the Dorgeshuun stab sword, available from Nardok's Bone Weapons in the Dorgeshuun Mines and from medium Treasure Trail caskets. Its Backstab special attack costs 75% energy and guarantees a hit on undamaged targets, reducing their Defence by the damage dealt."
+  market_strategy:
+    notes:
+      - "Buy limit 70 per 4 hours; low GE volume with niche PvP and clue collector demand."
+      - "Price sits at a small premium over the un-poisoned bone dagger; arbitrage depends on weapon poison cost."
+  trading_tips:
+    - "Backstab spec is strongest as an opener in PvP/PvM when you have not yet attacked the target."
+    - "Shop refresh from Nardok's Bone Weapons (2,000 coins) caps the upside on the un-poisoned variant; poison premium is what trades on GE."
+  history:
+    - date: "2006-06-21"
+      description: "Released as part of the Death to the Dorgeshuun! update."
+  properties:
+    release_date: "2006-06-21"
+    update: "Death to the Dorgeshuun!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-10-poison.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-10-poison.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 125
-  about: "Broodoo shield (10) (poison) is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: shield
+    weight: 5.443
+    requirements:
+      defence: 25
+      magic: 25
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 10
+      slash: 10
+      crush: 15
+      magic: 5
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 5
+  charges:
+    current: 10
+    description: "Starts with 10 charges. Each hit absorbed consumes a charge while the passive effect can trigger. Defensive bonuses remain even after the shield runs out of charges."
+  special_attack:
+    description: "Passive: 10% chance on incoming hit to drain the opponent's Defence by 1. Only triggers when the target is above half HP and at base Defence level."
+  recipes:
+    - materials:
+        - item_name: Snakeskin
+          quantity: 1
+        - item_name: Tribal mask (poison)
+          quantity: 1
+        - item_name: Bronze nails
+          quantity: 15
+      tools:
+        - Hammer
+      output_quantity: 1
+      skill: Crafting
+      level: 35
+      notes: "Crafted from a poison-tier tribal mask, snakeskin, and bronze nails after Tai Bwo Wannai Clean-Up."
+  related_items:
+    - item_id: 6217
+      item_name: Broodoo shield (10) (green)
+      slug: broodoo-shield-10-green
+      relationship: variant
+      description: Green variant of the same shield tier
+    - item_id: 6219
+      item_name: Broodoo shield (10) (blue)
+      slug: broodoo-shield-10-blue
+      relationship: variant
+      description: Blue variant of the same shield tier
+  about: "The Broodoo shield (10) (poison) is a charged tribal shield crafted after Tai Bwo Wannai Clean-Up that can passively drain enemy Defence."
+  market_strategy:
+    notes:
+      - "Charge-limited durability caps long-term demand; expect cyclical pricing tied to crafting interest."
+      - "Daily volume is thin because the shield is overshadowed by stronger meta options."
+      - "Crafting from snakeskin and tribal mask (poison) is profitable only when material prices dip."
+  trading_tips:
+    - "Time flips around clue meta or Tai Bwo Wannai content updates when broodoo shields become novelty buys."
+    - "List in smaller lots to avoid sitting on stock at a thin order book."
+  history:
+    - date: "2005-08-09"
+      description: "Released as part of the Tai Bwo Wannai Clean-Up update."
+  properties:
+    release_date: "2005-08-09"
+    update: "Tai Bwo Wannai Clean-Up"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/burning-claw.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/burning-claw.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 160000
   highalch: 240000
   limit: 8
-  about: "Burning claw is a members-only item in Old School RuneScape. High alchemy value: 240,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: demonic
+    tier: high
+  drop_table:
+    sources:
+      - source: Tormented Demon
+        quantity: "1"
+        rarity: 499/250000
+  recipes:
+    - materials:
+        - item_name: Burning claw
+          quantity: 2
+      tools: []
+      output_quantity: 1
+      output_item: Burning claws
+  related_items:
+    - item_id: 29577
+      item_name: Burning claws
+      slug: burning-claws
+      relationship: product
+      description: Combine two burning claws to form the finished weapon
+    - item_name: Tormented Demon
+      relationship: alternative
+      description: Source NPC that drops the burning claw
+  about: Burning claw is a rare Tormented Demon drop; two are combined to forge the Burning claws weapon.
+  market_strategy:
+    notes:
+      - High capital lock per flip with only 8 buy limit per 4 hours.
+      - Price tracks Tormented Demon popularity and Burning claws weapon demand.
+  trading_tips:
+    - Buy individual claws when their combined cost is meaningfully below the assembled Burning claws price.
+    - Watch DT2 boss meta shifts; demand surges when Burning claws are buffed or trend in PvM guides.
+  history:
+    - date: "2024-07-10"
+      description: Added with the While Guthix Sleeps update as a Tormented Demon drop.
+  properties:
+    release_date: "2024-07-10"
+    update: While Guthix Sleeps
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/butterfly-net.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/butterfly-net.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 125
-  about: "Butterfly net is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: tool
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: none
+    weight: 0.226
+    requirements:
+      hunter: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Aleck's Hunter Emporium"
+      location: Yanille
+      stock: 5
+      price: 24
+      sell_price: 14
+    - shop_name: "Hunting Supplies"
+      location: Nardah
+      stock: 5
+      price: 24
+      sell_price: 14
+  related_items:
+    - name: Magic butterfly net
+      relationship: upgrade
+    - name: Impling jar
+      relationship: alternative
+    - name: Butterfly jar
+      relationship: alternative
+  about: "Butterfly net is a members Hunter tool used to catch butterflies, moths, implings, and bats. Equipping it is mandatory for those Hunter activities and starter copies are available from Elnock Inquisitor in Puro-Puro. High alchemy value: 12 coins. Grand Exchange buy limit: 125 per 4 hours."
+  market_strategy:
+    notes:
+      - "Cheap commodity; demand follows new Hunter trainers."
+      - "Magic butterfly net is the strict upgrade for serious Hunter trips."
+  trading_tips:
+    - "Starter copies from Elnock Inquisitor saturate supply; flip during Hunter content updates."
+    - "Bundle with impling jars for new player kits."
+  history:
+    - date: "2006-11-21"
+      description: "Butterfly net released with the Hunter skill."
+    - date: "2026-04-22"
+      description: "Wiki refresh confirmed shop pricing and alch values."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: "Hunter"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wield
+      - "Check totals"
+      - Drop
+    worn_options:
+      - "Check Totals"
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/candle-lantern-black.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/candle-lantern-black.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 40
-  about: "Candle lantern (black) is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Firemaking
+      level: 4
+      experience: 0
+      materials:
+        - item_name: Candle lantern (empty)
+          quantity: 1
+        - item_name: Black candle
+          quantity: 1
+      tools:
+        - Tinderbox
+      output_quantity: 1
+  related_items:
+    - name: Candle lantern (empty)
+      relationship: component
+    - name: Black candle
+      relationship: component
+    - name: Candle lantern (white)
+      relationship: alternative
+    - name: Candle lantern (black) lit
+      relationship: variant
+  about: "Candle lantern (black) is an unlit light source built by inserting a black candle into an empty candle lantern at Firemaking 4. Once lit it can be carried into dark areas such as the Lumbridge Swamp Caves."
+  market_strategy:
+    notes:
+      - "Low buy limit (40) and niche demand cap volume; price is anchored to the candle-lantern crafting chain."
+      - "Mostly purchased by clue scroll and emote completionists exploring Lumbridge caves."
+  trading_tips:
+    - "Source empty lanterns plus a stack of black candles and combine; flipping the lit version is rarely worthwhile."
+  history:
+    - date: "2005-03-14"
+      description: "Released alongside the Lumbridge Swamp Caves and the new light source mechanics."
+    - date: "2021-11-17"
+      description: "Placing a lit candle into the lantern now requires Firemaking level 4."
+  properties:
+    release_date: "2005-03-14"
+    update: Lumbridge Swamp Caves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cat-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cat-mask.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 960
   highalch: 1440
   limit: 4
-  about: "Cat mask is a members-only item in Old School RuneScape. High alchemy value: 1,440 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: head
+    weapon_type: none
+    weight: 2.267
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_id: 12365
+      item_name: Penguin mask
+      slug: penguin-mask
+      relationship: alternative
+      description: Other animal mask from medium clue rewards
+    - item_id: 12363
+      item_name: Wolf mask
+      slug: wolf-mask
+      relationship: alternative
+      description: Other animal mask from medium clue rewards
+  about: "Cosmetic head slot mask rewarded from medium Treasure Trails; no combat bonuses and storable in the costume room treasure chest."
+  market_strategy:
+    notes:
+      - Pure cosmetic value; demand tied to fashionscape trends
+      - Tight buy limit of 4 every 4 hours keeps individual flips slow
+      - Medium clue completion rate sets supply ceiling
+      - Cat-themed events and pets occasionally spike interest
+  trading_tips:
+    - Buy during low-volume hours when supply outpaces demand
+    - Sell during cat-themed seasonal events
+    - Watch other animal masks to gauge full-set collector interest
+  history:
+    - date: "2014-06-12"
+      description: Cat mask added as part of the Treasure Trail Expansion rewards.
+    - date: "2024-08-14"
+      description: Item briefly renamed to Cat h during a graphical update, then corrected days later.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cave-eel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cave-eel.mdx
@@ -1,20 +1,74 @@
 ---
 title: Cave eel | OSRS Price Data
-description: "Cave eel: It's a bit slimy.. High alch: 9 GP, GE limit: 10,000."
+description: "Cave eel: It's a bit slimy. High alch: 9 GP, GE limit: 10,000."
 osrs:
   id: 5003
   name: Cave eel
   slug: cave-eel
-  examine: It's a bit slimy.
+  examine: "It's a bit slimy."
   members: true
   icon: Cave eel.png
   value: 15
   lowalch: 6
   highalch: 9
   limit: 10000
-  about: "Cave eel is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 9
+    effect: Restores 8-12 Hitpoints when consumed.
+  recipes:
+    - materials:
+        - item_name: Raw cave eel
+          quantity: 1
+      tools:
+        - Fire or Range
+      output_quantity: 1
+  related_items:
+    - item_id: 5001
+      item_name: Raw cave eel
+      slug: raw-cave-eel
+      relationship: component
+      description: Uncooked version
+    - item_id: 5004
+      item_name: Burnt cave eel
+      slug: burnt-cave-eel
+      relationship: alternative
+      description: Failure result while cooking.
+    - item_id: 333
+      item_name: Trout
+      slug: trout
+      relationship: alternative
+      description: Comparable low-level cooked fish.
+  about: "Cave eel is a members-only cooked fish requiring Cooking level 38 from raw cave eel; it heals up to 12 Hitpoints and stops burning at Cooking 74."
+  market_strategy:
+    notes:
+      - Low GE volume because food meta favours higher-tier fish.
+      - Primary demand comes from low-level Cooking trainers.
+      - Heimlich-tier consumable, price tends to hug high alch floor.
+  trading_tips:
+    - Stock raw cave eels and cook to flip if alch margin allows.
+    - Avoid speculative buys; demand spikes are rare.
+    - Compare GE price to high alch before listing to ensure positive margin.
+  history:
+    - date: "2005-05-31"
+      description: Cave eel released alongside the Lumbridge Caves area.
+  properties:
+    release_date: "2005-05-31"
+    update: Lumbridge Caves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cave-goblin-wire.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cave-goblin-wire.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 11000
-  about: "Cave goblin wire is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: crafting_component
+    tier: mid
+  drop_table:
+    sources:
+      - source: Cave goblin (pickpocket)
+        quantity: "1"
+        rarity: Common
+      - source: Dorgesh-Kaan wire machine
+        quantity: "1"
+        rarity: Common
+      - source: Dorgesh-Kaan average chest
+        quantity: "1"
+        rarity: Uncommon
+  recipes:
+    - materials:
+        - item_name: Empty light orb
+          quantity: 1
+        - item_name: Cave goblin wire
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      output_item: Light orb
+      requirements:
+        crafting: 51
+        xp: 104
+  related_items:
+    - item_name: Light orb
+      relationship: product
+      description: Crafted by combining wire with an empty light orb
+    - item_name: Empty light orb
+      relationship: component
+      description: Crafted from molten glass and paired with the wire
+    - item_name: Cave goblin
+      relationship: alternative
+      description: Source NPC pickpocketed for wire
+  about: "Cave goblin wire is sourced from Dorgesh-Kaan via Thieving and is the cave goblin lighting system's wiring component, primarily used to craft light orbs."
+  market_strategy:
+    notes:
+      - Light orb demand from Construction (Dorgeshuun light source) creates a thin but consistent buy side.
+      - Elite Lumbridge Diary doubles thieving yields, so supply spikes when more accounts hit Elite.
+  trading_tips:
+    - Flip alongside light orbs when Construction events boost orb demand.
+    - Watch for player streamers/clue meta featuring Sherlock's master clue step that bumps short-term demand.
+  history:
+    - date: "2007-03-20"
+      description: Released with the Dorgesh-Kaan city update.
+  properties:
+    release_date: "2007-03-20"
+    update: Dorgesh-Kaan
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chain.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chain.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: null
-  about: "Chain is a members-only item in Old School RuneScape. High alchemy value: 90 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: low
+  recipes:
+    - materials:
+        - item_name: "Steel bar"
+          quantity: 1
+      tools:
+        - "Hammer"
+        - "Anvil"
+      output_quantity: 1
+      skill: smithing
+      level: 34
+      experience: 37.5
+  related_items:
+    - item_name: "Steel bar"
+      relationship: component
+    - item_name: "Bronze chainshot"
+      relationship: product
+    - item_name: "Iron chainshot"
+      relationship: product
+    - item_name: "Steel chainshot"
+      relationship: product
+    - item_name: "Mithril chainshot"
+      relationship: product
+    - item_name: "Adamant chainshot"
+      relationship: product
+    - item_name: "Rune chainshot"
+      relationship: product
+  about: "Chain is a members-only smithed item used as a component for chainshot cannonball variants and the Ivandis flail in Old School RuneScape. High alchemy value: 90 coins."
+  market_strategy:
+    notes:
+      - "Margins versus steel-bar input are razor thin; only profitable in bulk through chainshot demand."
+      - "Volume is tied to cannon-using boss meta; supply scales with smithing AFK farms."
+  trading_tips:
+    - "Track steel bar price as the floor; chain rarely undercuts the bar by more than a few gp."
+    - "Spikes around Sailing-themed content and chainshot DPS testing windows."
+  history:
+    - date: "2025-11-19"
+      description: "Released as part of the Sailing update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-delight-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-delight-flatpack.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
+  material:
+    type: wood
+    tier: low
+  recipes:
+    - materials:
+        - item_name: Oak plank
+          quantity: 3
+        - item_name: Steel bar
+          quantity: 2
+        - item_name: Chef's delight
+          quantity: 8
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+      requirements: "Requires 48 Construction. Built at a steel framed workbench in a player-owned house. Grants 224 Construction experience."
+  related_items:
+    - name: Chef's delight
+      relationship: component
+    - name: Oak plank
+      relationship: component
+    - name: Steel bar
+      relationship: component
   about: "Chef's delight (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Built at a steel framed workbench requiring 48 Construction, granting 224 experience per flatpack."
+      - "Used at the Barrel space hotspot in the Kitchen of a player-owned house."
+      - "Often traded for cheap Construction experience or to skip skill requirements."
+  trading_tips:
+    - "Margin comes from selling to lazy Construction trainers who skip oak plank gathering."
+    - "Check the GE buy limit of 500 per 4 hours per account when bulk flipping."
+    - "Compare cost vs. raw oak planks + chef's delights + steel bars to find arbitrage."
+  history:
+    - date: "2006-05-31"
+      description: "Released alongside the Construction skill update introducing player-owned houses."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: "Construction (Player-Owned Houses)"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cleaver.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cleaver.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 10240
   highalch: 15360
   limit: 50
-  about: "Cleaver is a members-only item in Old School RuneScape. High alchemy value: 15,360 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Metal
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: slash_sword
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 40
+      "quest": "Recipe for Disaster"
+    attack_bonus:
+      stab: 7
+      slash: 45
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 44
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Culinaromancer's Chest"
+      location: Lumbridge Castle basement
+      stock: 1
+      price: 33280
+      notes: "Discounted to 26,624 coins with the Lumbridge & Draynor Diary completion bonus."
+  related_items:
+    - item_id: 1333
+      item_name: Rune scimitar
+      slug: rune-scimitar
+      relationship: alternative
+      description: Same combat stats as the cleaver
+  about: "The cleaver is a members-only slash sword purchased from the Culinaromancer's Chest after completing Recipe for Disaster. It shares stats with the rune scimitar."
+  market_strategy:
+    notes:
+      - "Most players buy the cleaver only as a Recipe for Disaster collectible since the rune scimitar is far cheaper."
+      - "Grand Exchange volume is consistently low; expect slow flips and wide spreads."
+      - "High alch value is well below shop price, so alching is unprofitable."
+  trading_tips:
+    - "Treat the cleaver as a collector's item rather than a daily flip target."
+    - "Pair purchases with diary-bonus discounts at the Culinaromancer's Chest when reselling on the GE."
+  history:
+    - date: "2006-03-15"
+      description: "Released with the Recipe for Disaster quest, the hundredth quest in RuneScape."
+  properties:
+    release_date: "2006-03-15"
+    update: "Hundredth Quest - Recipe for Disaster!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: "Recipe for Disaster"
+    weight: 1.814
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/combat-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/combat-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Combat mix(1) | OSRS Price Data
-description: "Combat mix(1): One dose of fishy combat potion.. High alch: 31 GP, GE limit: 2,000."
+description: "Combat mix(1): One dose of fishy combat potion. High alch: 31 GP, GE limit: 2,000."
 osrs:
   id: 11447
   name: Combat mix(1)
@@ -12,9 +12,66 @@ osrs:
   lowalch: 20
   highalch: 31
   limit: 2000
-  about: "Combat mix(1) is a members-only item in Old School RuneScape. High alchemy value: 31 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Combat mix(1) is a single-dose barbarian potion created by combining a combat potion(2) with caviar. It boosts Attack and Strength while also healing 3 hitpoints, making it useful for combat training and PvM."
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Attack level by 3-12 depending on current Attack level."
+        skill: Attack
+        duration: 0
+      - description: "Boosts Strength level by 3-12 depending on current Strength level."
+        skill: Strength
+        duration: 0
+      - description: "Restores 3 Hitpoints."
+        skill: Hitpoints
+        duration: 0
+  recipes:
+    - name: Combat mix(1)
+      skill: Herblore
+      level: 40
+      experience: 28
+      materials:
+        - item_name: Combat potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Combat potion(1)
+      relationship: alternative
+    - name: Combat mix(2)
+      relationship: upgrade
+    - name: Combat potion
+      relationship: variant
+  market_strategy:
+    notes:
+      - "Barbarian potions cost slightly more to make than their potion counterparts, but offer healing benefit."
+      - "Demand depends on barbarian training and PvM activity."
+  trading_tips:
+    - "Compare ingredient cost (combat potion(2) + caviar) to GE price to find profitable flips."
+    - "Useful for low-Prayer PvM where a few HP regen helps survival."
+    - "Buy limit of 2,000 allows moderate-scale flipping."
+  history:
+    - date: "2007-07-03"
+      description: "Combat mix added with the Barbarian Herblore update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-worm-acquisition.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-worm-acquisition.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: null
   highalch: null
   limit: 50
-  about: "Contract of worm acquisition is a members-only item in Old School RuneScape. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: consumable
+    tier: high
+  related_items:
+    - item_id: 30835
+      item_name: Contract of catalyst acquisition
+      slug: contract-of-catalyst-acquisition
+      relationship: variant
+      description: Another Yama contract variant
+    - item_id: 30836
+      item_name: Contract of familiar acquisition
+      slug: contract-of-familiar-acquisition
+      relationship: variant
+      description: Another Yama contract variant
+    - item_id: 30837
+      item_name: Contract of harmony acquisition
+      slug: contract-of-harmony-acquisition
+      relationship: variant
+      description: Another Yama contract variant
+    - item_id: 30838
+      item_name: Contract of oathplate acquisition
+      slug: contract-of-oathplate-acquisition
+      relationship: variant
+      description: Another Yama contract variant
+  about: "Yama contract that escalates the fight and guarantees 250 diabolic worms on victory; the contract burns when combat begins."
+  market_strategy:
+    notes:
+      - Tied directly to diabolic worm demand
+      - GE limit raised from 5 to 50 on 29 May 2025 reducing scarcity premium
+      - Single-use item with guaranteed payout makes value floor predictable
+      - Contract burns on use, ensuring constant churn
+  trading_tips:
+    - Track diabolic worm price to model implied contract value
+    - Buy when worm prices spike before raid or PvM meta updates
+    - Monitor Yama balance announcements for phase-threshold changes
+  history:
+    - date: "2025-05-14"
+      description: Contract of worm acquisition released alongside the Yama boss expansion.
+    - date: "2025-05-22"
+      description: Proper contract terms text implemented in-game.
+    - date: "2025-05-23"
+      description: Contract terms updated regarding demonbane weapon vulnerability.
+    - date: "2025-05-29"
+      description: GE buy limit raised from 5 to 50; Yama phase thresholds adjusted to 75% and 50% health.
+  properties:
+    release_date: "2025-05-14"
+    update: Yama
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Use
+      - Read
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-meat.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 6000
-  about: "Cooked meat is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 3
+    edible: true
+  recipes:
+    - name: Cook raw beef into Cooked meat
+      skill: Cooking
+      level: 1
+      experience: 30
+      materials:
+        - item_name: Raw beef
+          quantity: 1
+      tools: []
+      facility: Fire or Range
+      output_quantity: 1
+    - name: Cook raw rat meat into Cooked meat
+      skill: Cooking
+      level: 1
+      experience: 30
+      materials:
+        - item_name: Raw rat meat
+          quantity: 1
+      tools: []
+      facility: Fire or Range
+      output_quantity: 1
+    - name: Cook raw bear meat into Cooked meat
+      skill: Cooking
+      level: 1
+      experience: 30
+      materials:
+        - item_name: Raw bear meat
+          quantity: 1
+      tools: []
+      facility: Fire or Range
+      output_quantity: 1
+  related_items:
+    - name: Raw beef
+      relationship: component
+    - name: Raw rat meat
+      relationship: component
+    - name: Burnt meat
+      relationship: alternative
+    - name: Stew
+      relationship: product
+    - name: Meat pizza
+      relationship: product
+  about: "Cooked meat is a free-to-play level 1 Cooking food that heals 3 hitpoints, produced by cooking raw beef, rat meat, bear meat, boar meat, or yak meat on a fire or range for 30 Cooking experience."
+  market_strategy:
+    notes:
+      - Lowest tier cooked food, primarily used as early-game Cooking XP product.
+      - Demand from Witch's Potion questers and cheap food users keeps small volume moving.
+      - Buy limit of 6,000 enables modest flipping for cooks selling bulk.
+  trading_tips:
+    - Buy raw beef in bulk and cook through level 1-30 for cheap Cooking experience.
+    - Sell cooked meat to early-game ironmen and stew/pizza cooks.
+    - Stop burning entirely at level 34 (or 31 with Lumbridge range after Cook's Assistant).
+  history:
+    - date: "2001-01-04"
+      description: Added at game launch as the basic Cooking output.
+  properties:
+    release_date: "2001-01-04"
+    update: New skill - Cooking
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.283
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cornflour.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cornflour.mdx
@@ -9,12 +9,47 @@ osrs:
   members: false
   icon: Cornflour.png
   value: 1
-  lowalch: 1
+  lowalch: 0
   highalch: 1
   limit: 15
-  about: "Cornflour is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - materials:
+        - item_name: Sweetcorn
+          quantity: 1
+        - item_name: Pot
+          quantity: 1
+      tools:
+        - Windmill
+      output_quantity: 1
+      notes: "Using sweetcorn at a windmill with a pot actually yields a pot of cornflour, not loose cornflour."
+  about: "Cornflour is a free-to-play item in Old School RuneScape that exists in the game cache but is not normally obtainable in regular play."
+  market_strategy:
+    notes:
+      - "Item is classified as unobtainable; it persists in game data but cannot be reliably acquired."
+      - "A separate tradeable quest version remains listed on the Grand Exchange even though players cannot earn it."
+      - "High alchemy returns 1 coin; low alchemy returns 0 coins."
+  trading_tips:
+    - "Avoid speculating on cornflour as supply is fixed and listings are stale."
+    - "Players seeking cornflour for crafting purposes should look for 'pot of cornflour' instead, which is the actual milling output."
+  history:
+    - date: "2006-03-15"
+      description: "Released with the Recipe for Disaster quest update, the hundredth quest in RuneScape."
+  properties:
+    release_date: "2006-03-15"
+    update: "Hundredth Quest - Recipe for Disaster!"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-voidwaker.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-voidwaker.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: null
-  about: "Corrupted voidwaker is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Corrupted alloy
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 65
+    attack_bonus:
+      stab: 56
+      slash: 64
+      crush: -2
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 2
+      ranged: 0
+    other_bonus:
+      strength: 64
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Disrupt
+    energy_cost: 50
+    description: "Delivers guaranteed magic damage between 50% and 150% of the wielder's maximum melee hit. Grants 2 Magic experience per damage dealt and ignores melee defensive bonuses."
+  related_items:
+    - name: Voidwaker
+      relationship: variant
+    - name: Trinket of advanced weaponry
+      relationship: component
+    - name: Corrupted Armadyl godsword
+      relationship: alternative
+  about: "Corrupted voidwaker is a one-handed stab sword obtained exclusively during temporary Deadman Mode events by opening a Trinket of Advanced Weaponry. It mirrors the Voidwaker's Disrupt special attack but carries roughly 20% lower combat bonuses than the regular variant."
+  market_strategy:
+    notes:
+      - "Only listed on the Grand Exchange during active Deadman Mode events."
+      - "Drop rate from Trinket of Advanced Weaponry is 1/8 inside breaches."
+      - "Demand is concentrated around the start of a Deadman season when PvP supplies stack."
+  trading_tips:
+    - "Stock up before Deadman finals where the special attack is meta against high-defence targets."
+    - "Price collapses post-event as the item becomes unobtainable but unusable in main worlds."
+  history:
+    - date: "2023-08-23"
+      description: "Released for Deadman Mode: Apocalypse alongside other corrupted weaponry."
+  properties:
+    release_date: "2023-08-23"
+    update: "Deadman Mode: Apocalypse"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cotton-boll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cotton-boll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cotton boll | OSRS Price Data
-description: "Cotton boll: I should use this with a spinning wheel.. High alch: 60 GP."
+description: "Cotton boll: I should use this with a spinning wheel. High alch: 60 GP."
 osrs:
   id: 31460
   name: Cotton boll
@@ -12,9 +12,63 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: null
-  about: "Cotton boll is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    level: 71
+    patch: Hops
+    seed: Cotton seed
+  recipes:
+    - materials:
+        - item_name: Cotton boll
+          quantity: 1
+      tools:
+        - Spinning wheel
+      output_quantity: 1
+  related_items:
+    - item_id: 31458
+      item_name: Cotton seed
+      slug: cotton-seed
+      relationship: component
+      description: Planted to grow cotton bolls.
+    - item_id: 5946
+      item_name: Cotton yarn
+      slug: cotton-yarn
+      relationship: product
+      description: Spun from cotton boll at a spinning wheel.
+    - item_id: 31599
+      item_name: Haemostatic dressing (1)
+      slug: haemostatic-dressing-1
+      relationship: product
+      description: Crafted using cotton yarn from cotton boll.
+  about: "Cotton boll is a Sailing-era Farming product harvested from cotton seeds at Farming 71; spinning it produces cotton yarn used in Sailing crafts and haemostatic dressings."
+  market_strategy:
+    notes:
+      - Supply scales with Farming 71+ players running cotton runs.
+      - Demand pegged to haemostatic dressing crafting and Sailing shipbuilding.
+      - GE has no buy limit, allowing flexible bulk flips.
+  trading_tips:
+    - Compare cotton boll vs. cotton yarn price for spin margin.
+    - Watch Sailing meta updates for spikes in shipbuilding demand.
+    - Bulk buy after farming surplus events to anticipate craft trains.
+  history:
+    - date: "2025-11-19"
+      description: Cotton boll released with the Sailing skill update.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cream-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cream-hat.mdx
@@ -14,18 +14,51 @@ osrs:
   limit: 150
   equipment:
     slot: head
+    weight: 0.453
+    attack_bonus:
+      magic: 3
+    defence_bonus:
+      magic: 3
+  shops:
+    - shop_name: Fine Fashions
+      location: Grand Tree
+      stock: 5
+      price: 160
   related_items:
-    - item_id: 642
-      item_name: Cream robe top
-      slug: cream-robe-top
+    - name: Cream robe top
       relationship: set-piece
-      description: Matching top
-  about: |-
-    > _"A cream hat."_
-
-    The cream hat is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "The cream hat is a cosmetic head slot item that is part of the gnome clothing set, offering a small magic attack and defence bonus."
+  market_strategy:
+    notes:
+      - Cosmetic demand drives most trade; volume stays low and price is supply-driven.
+      - Buy from Fine Fashions in the Grand Tree for instant flips when stock is up.
+  trading_tips:
+    - Stock up at the Grand Tree shop and resell on the Grand Exchange for a steady margin.
+    - Watch fashion-scape trends; price can spike around themed events.
+  history:
+    - date: "2002-12-12"
+      description: Released alongside the Agility skill update.
+    - date: "2014-12-10"
+      description: Renamed from "Hat" to "Cream hat" in the Trading Post update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill online
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crier-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crier-hat.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Crier hat is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.3
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
+  related_items:
+    - item_name: Crier coat
+      relationship: set-piece
+      description: Body slot piece of the Crier outfit
+    - item_name: Crier bell
+      relationship: set-piece
+      description: Off-hand accessory completing the Crier outfit
+  about: "Crier hat is a cosmetic head slot reward from Medium Treasure Trails and forms part of the Crier outfit alongside the Crier coat and bell."
+  market_strategy:
+    notes:
+      - Tiny GE buy limit of 4 every 4 hours throttles bulk flipping.
+      - Demand cycles with fashionscape and Clue Hunter content from streamers.
+  trading_tips:
+    - Buy during clue stamp / clue scroll league seasons when supply outpaces demand.
+    - Resell into Crier outfit set discussions or fashionscape competitions.
+  history:
+    - date: "2014-06-12"
+      description: Added with the Treasure Trail Expansion update as a Medium clue reward.
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-tool-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-tool-seed.mdx
@@ -12,113 +12,94 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 100
-  item:
-    type: crafting material
-    tradeable: true
-    weight: 0
-  obtaining:
-    - source: Zalcano
-      drop_rate: 39/8,000 (~1/205)
+  material:
+    type: crystal
+    tier: high
+  drop_table:
+    sources:
+      - source: Zalcano
+        quantity: "1"
+        rarity: 39/8000
   recipes:
-    - skill: smithing
+    - skill: Smithing
       level: 76
-      xp: 6000
+      experience: 6000
+      tools:
+        - Singing bowl
       materials:
-        - item_id: 23953
-          item_name: Crystal tool seed
+        - item_name: Crystal tool seed
           quantity: 1
-        - item_id: 6739
-          item_name: Dragon axe
+        - item_name: Dragon axe
           quantity: 1
-        - item_id: 23962
-          item_name: Crystal shard
+        - item_name: Crystal shard
           quantity: 120
-      facility: Singing bowl
-      product: Crystal axe
-      product_id: 23673
-    - skill: smithing
+      output_quantity: 1
+    - skill: Smithing
       level: 76
-      xp: 6000
+      experience: 6000
+      tools:
+        - Singing bowl
       materials:
-        - item_id: 23953
-          item_name: Crystal tool seed
+        - item_name: Crystal tool seed
           quantity: 1
-        - item_id: 11920
-          item_name: Dragon pickaxe
+        - item_name: Dragon pickaxe
           quantity: 1
-        - item_id: 23962
-          item_name: Crystal shard
+        - item_name: Crystal shard
           quantity: 120
-      facility: Singing bowl
-      product: Crystal pickaxe
-      product_id: 23680
-    - skill: smithing
+      output_quantity: 1
+    - skill: Smithing
       level: 76
-      xp: 6000
+      experience: 6000
+      tools:
+        - Singing bowl
       materials:
-        - item_id: 23953
-          item_name: Crystal tool seed
+        - item_name: Crystal tool seed
           quantity: 1
-        - item_id: 21028
-          item_name: Dragon harpoon
+        - item_name: Dragon harpoon
           quantity: 1
-        - item_id: 23962
-          item_name: Crystal shard
+        - item_name: Crystal shard
           quantity: 120
-      facility: Singing bowl
-      product: Crystal harpoon
-      product_id: 23762
+      output_quantity: 1
   related_items:
-    - item_id: 23962
-      item_name: Crystal shard
-      slug: crystal-shard
+    - name: Crystal shard
       relationship: component
-      description: Required material for crafting
-    - item_id: 6739
-      item_name: Dragon axe
-      slug: dragon-axe
+    - name: Dragon axe
       relationship: component
-      description: Required base for crystal axe
-    - item_id: 11920
-      item_name: Dragon pickaxe
-      slug: dragon-pickaxe
+    - name: Dragon pickaxe
       relationship: component
-      description: Required base for crystal pickaxe
-    - item_id: 23673
-      item_name: Crystal axe
-      slug: crystal-axe
+    - name: Dragon harpoon
+      relationship: component
+    - name: Crystal axe
       relationship: product
-      description: Created tool
-    - item_id: 23680
-      item_name: Crystal pickaxe
-      slug: crystal-pickaxe
+    - name: Crystal pickaxe
       relationship: product
-      description: Created tool
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-
-    Craft at singing bowl with 120 crystal shards + dragon tool:
-
-    | Tool Created | Requirements |
-    |--------------|--------------|
-    | Crystal axe | 76 Smithing, 76 Crafting |
-    | Crystal pickaxe | 76 Smithing, 76 Crafting |
-    | Crystal harpoon | 76 Smithing, 76 Crafting |
-    | Crystal felling axe | 76 Smithing, 76 Crafting |
-
-    Grants 6,000 Smithing and 6,000 Crafting XP per tool.
-
-    Alternatives:
-    - Exchange for 100 crystal shards (Amrod)
-    - Convert to crystal acorn
-
-    Note: Pay 60 extra shards for NPC crafting if lacking requirements.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Crystal harpoon
+      relationship: product
+    - name: Crystal acorn
+      relationship: alternative
+  about: "Crystal tool seed is sung at a Singing bowl with 120 crystal shards plus a dragon counterpart to create a crystal axe, pickaxe, harpoon, or felling axe. Each crafting attempt grants 6,000 Smithing and 6,000 Crafting XP. Players lacking the level 76 Smithing and Crafting requirements can pay Conwenna or Reese 60 extra shards. Sole drop source is Zalcano at 39/8,000."
+  market_strategy:
+    notes:
+      - Sole source is Zalcano boss drop
+      - Convertible to crystal acorn or exchanged for 100 crystal shards via Amrod
+      - High value due to crystal axe/pickaxe demand
+  history:
+    - date: "2019-07-25"
+      description: "Released during the Song of the Elves update."
+  properties:
+    release_date: "2019-07-25"
+    update: Song of the Elves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-greataxe-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-greataxe-0.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 83200
   highalch: 124800
   limit: 15
-  about: "Dharok's greataxe 0 is a members-only item in Old School RuneScape. High alchemy value: 124,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Barrows
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: two-handed
+    attack_speed: 7
+    weight: 3.175
+    requirements:
+      attack: 70
+      strength: 70
+    attack_bonus:
+      slash: 103
+      crush: 95
+    other_bonus:
+      strength: 105
+  charges:
+    max_charges: 15
+    charge_type: hours of combat
+    repair_cost: 100000
+    poh_repair_cost: 99500
+    poh_repair_requirement: 1 Smithing
+  drop_table:
+    sources:
+      - source: Barrows chest
+        quantity: "1"
+        rarity: "7 x 1/2448"
+  related_items:
+    - name: Dharok's greataxe 25
+      relationship: variant
+    - name: Dharok's greataxe 50
+      relationship: variant
+    - name: Dharok's greataxe 75
+      relationship: variant
+    - name: Dharok's greataxe 100
+      relationship: variant
+    - name: Dharok's helm
+      relationship: set-piece
+    - name: Dharok's platebody
+      relationship: set-piece
+    - name: Dharok's platelegs
+      relationship: set-piece
+  about: "Dharok's greataxe 0 is the fully degraded form of Dharok the Wretched's two-handed Barrows greataxe. Part of Dharok's set, it triggers the Wretched Strength effect that increases damage as the wearer's hitpoints drop. The 0 charge variant must be repaired before use."
+  market_strategy:
+    notes:
+      - Repair cost gap drives spread between charged variants
+      - Set demand spikes during Barrows-related events
+      - Dharok PKing meta keeps consistent buyer base
+  trading_tips:
+    - Buy 0 charge variants and repair for arbitrage when spread exceeds 100k
+    - Track Barrows brothers slayer task popularity
+  history:
+    - date: "2005-05-09"
+      description: Released as part of the Barrows update.
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-bolts-e.mdx
@@ -1,6 +1,6 @@
 ---
 title: Diamond bolts (e) | OSRS Price Data
-description: "Diamond bolts (e) is a members ammo slot item requiring 61 Ranged. High alch: 126 GP, GE limit: 11,000."
+description: "Diamond bolts (e) is a members ammo slot item. High alch: 126 GP, GE limit: 11,000."
 osrs:
   id: 9243
   name: Diamond bolts (e)
@@ -12,27 +12,38 @@ osrs:
   lowalch: 84
   highalch: 126
   limit: 11000
+  material:
+    type: metal
+    tier: mid
   equipment:
     slot: ammo
-    type: enchanted_bolts
-    tradeable: true
+    weapon_type: crossbow
     weight: 0
     requirements:
-      ranged: 61
-  effect:
+      ranged: 1
+    attack_bonus:
+      ranged: 0
+    other_bonus:
+      ranged_strength: 105
+  special_attack:
     name: Armour Piercing
-    description: Ignores portion of target's defence
-  enchanting:
-    spell: Enchant Crossbow Bolt (Diamond)
-    magic_level: 57
-    runes:
-      - item_name: Earth rune
-        quantity: "10"
-      - item_name: Law rune
-        quantity: "2"
-      - item_name: Cosmic rune
-        quantity: "1"
-    bolts_per_cast: 10
+    description: "10% activation chance (5% in PvP) to increase max hit by 15% and guarantee a successful hit, ignoring a portion of the target's defence. Rises to 11% with the Kandarin Hard Diary."
+  recipes:
+    - skill: Magic
+      level: 57
+      experience: 67
+      materials:
+        - item_name: Diamond bolts
+          quantity: 10
+        - item_name: Earth rune
+          quantity: 10
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Cosmic rune
+          quantity: 1
+      tools: []
+      output_quantity: 10
+      output_item: Diamond bolts (e)
   related_items:
     - item_id: 9340
       item_name: Diamond bolts
@@ -44,20 +55,38 @@ osrs:
       slug: ruby-bolts-e
       relationship: alternative
       description: High HP boss alternative
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Ammo |
-    | Type | Enchanted Bolts |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 61 Ranged |
-
-    Armour Piercing: Ignores portion of target's defence.
-
-    Effective against high-defence targets.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Diamond bolts (e) are enchanted diamond-tipped adamantite crossbow bolts with an Armour Piercing effect that bypasses defence and boosts maximum damage. They are popular for high-defence PvM targets and PvP setups."
+  properties:
+    release_date: "2006-07-31"
+    update: "Crossbows update"
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  market_strategy:
+    notes:
+      - "Staple high-tier crossbow ammo; demand remains stable across the metagame."
+      - "Price tied to diamond gem supply, magic enchanting throughput, and PvM trends."
+      - "11,000 buy limit supports large bulk purchases for ironmen alts and resellers."
+  trading_tips:
+    - "Watch the unenchanted-to-enchanted spread for crafting profit windows."
+    - "Stock up before raid resets and seasonal boss events."
+    - "Compare margins versus Ruby bolts (e) when bossing meta shifts."
+  history:
+    - date: "2006-07-31"
+      description: "Released as part of the crossbows expansion update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-bracelet.mdx
@@ -12,51 +12,99 @@ osrs:
   lowalch: 1530
   highalch: 2295
   limit: 10000
+  material:
+    type: jewellery
+    tier: mid-high
   equipment:
     slot: hands
-    requirements:
-      crafting: 58
+    weapon_type: none
+    weight: 0.25
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
   recipes:
-    - skill: crafting
+    - skill: Crafting
       level: 58
       xp: 95
-      inputs:
+      tools:
+        - Bracelet mould
+        - Furnace
+      output_quantity: 1
+      materials:
         - item_name: Diamond
+          item_id: 1601
           quantity: 1
         - item_name: Gold bar
+          item_id: 2357
           quantity: 1
+    - skill: Magic
+      level: 57
+      xp: 67
+      spell: Lvl-4 Enchant
+      tools: []
       output_quantity: 1
+      materials:
+        - item_name: Diamond bracelet
+          item_id: 11092
+          quantity: 1
+        - item_name: Cosmic rune
+          item_id: 564
+          quantity: 1
+        - item_name: Earth rune
+          item_id: 557
+          quantity: 10
   related_items:
     - item_id: 11085
       item_name: Ruby bracelet
       slug: ruby-bracelet
       relationship: downgrade
-      description: Previous tier bracelet
+      description: Previous tier gem bracelet
     - item_id: 11115
       item_name: Dragonstone bracelet
       slug: dragonstone-bracelet
       relationship: upgrade
-      description: Next tier bracelet
-  about: |-
-    Crafting (Level 58): Diamond + Gold bar at a furnace with bracelet mould (95 XP)
-
-    > *"A diamond bracelet."*
-
-    Lvl-4 Enchant (57 Magic): 1 cosmic rune + 10 earth runes (67 XP)
-
-    The Abyssal bracelet allows entry to the Abyss without being skulled (5 charges). Normally, using the Mage of Zamorak to enter the Abyss skulls you, risking all items on death. This bracelet removes that risk.
-
-    Useful for:
-    - Runecrafting via the Abyss without skull risk
-    - Protecting expensive equipment while crafting runes
-    - Ironman accounts who can't afford to lose gear
+      description: Next tier gem bracelet
+    - item_id: 11104
+      item_name: Abyssal bracelet
+      slug: abyssal-bracelet
+      relationship: product
+      description: Enchanted form used to enter the Abyss without being skulled
+  about: "Crafted from a diamond and gold bar at level 58 Crafting, then enchanted with Lvl-4 Enchant into an Abyssal bracelet for Runecrafting via the Abyss without the skull penalty."
   market_strategy:
     notes:
-      - Steady Runecrafting demand
-      - 5 charges per bracelet — consumed regularly
-      - Cheap to enchant
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Steady Runecrafting demand drives the enchanted Abyssal bracelet market
+      - Five charges per bracelet keeps consumption rate high
+      - Cheap to enchant; profit margin is thin but consistent
+      - Crafting Lvl-4 Enchant gives modest Magic XP
+  trading_tips:
+    - Watch Runecrafting meta updates for demand spikes
+    - Bulk-craft when diamond and gold bar prices dip
+    - Sell enchanted Abyssal bracelets rather than the base diamond bracelet for better margin
+  history:
+    - date: "2007-04-30"
+      description: Diamond bracelet released alongside the gem bracelet rework.
+    - date: "2018-02-22"
+      description: Inventory sprite rotated to differentiate from the enchanted Abyssal bracelet.
+  properties:
+    release_date: "2007-04-30"
+    update: Stuff
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-ranging-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-ranging-potion-1.mdx
@@ -12,73 +12,68 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 2000
-  item:
+  material:
     type: potion
-    tradeable: true
+    tier: high
+  potion:
     doses: 1
-  effect:
-    boost:
-      - skill: ranged
-        amount: +4 + 10%
-        duration: 300
-    divine_effect: Stats cannot naturally drain below boosted level during duration
-    health_cost: 10
+    effects:
+      - description: "Boosts Ranged by 4 + 10% of current level for the duration"
+        duration: 500
+      - description: "Stat will not drain below the boosted level during the duration"
+      - description: "Drinking inflicts 10 damage to the player (requires more than 10 Hitpoints)"
   recipes:
-    - skill: herblore
-      level: 74
+    - name: Divine ranging potion(1)
       materials:
-        - item_id: 2444
-          item_name: Ranging potion
+        - item_name: Ranging potion(1)
           quantity: 1
-        - item_id: 23867
-          item_name: Crystal dust
+        - item_name: Crystal dust
           quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: Herblore
+      level: 74
   related_items:
-    - item_id: 2444
-      item_name: Ranging potion
-      slug: ranging-potion
+    - name: Ranging potion
       relationship: component
-      description: Base potion
-    - item_id: 23867
-      item_name: Crystal dust
-      slug: crystal-dust
+    - name: Crystal dust
       relationship: component
-      description: Ingredient from Gauntlet
-    - item_id: 23685
-      item_name: Divine super combat potion
-      slug: divine-super-combat-potion
+    - name: Divine super combat potion
       relationship: alternative
-      description: Melee equivalent
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Potion |
-    | Tradeable | Yes |
-    | Stackable | No |
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore | 74 |
-    | XP | Varies |
-
-    Ingredients:
-    - Ranging potion
-    - Crystal dust
-
-    Stat Boost: +4 + 10% to Ranged.
-
-    Duration: 5 minutes.
-
-    Divine Effect: Stats cannot naturally drain below boosted level during duration.
-
-    Health Cost: Deals 10 damage when consumed (need 11+ HP).
+    - name: Divine magic potion
+      relationship: alternative
+    - name: Divine bastion potion
+      relationship: alternative
+  about: "Divine ranging potion(1) is a single-dose Herblore potion that boosts Ranged by 4 + 10% of the player's current level for five minutes and prevents the boosted stat from draining naturally. Drinking inflicts 10 damage, so the player must have more than 10 Hitpoints."
   market_strategy:
     notes:
-      - Best ranged boost potion
-      - Use for bossing
-      - Crystal dust from Gauntlet
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Crafted at 74 Herblore from a ranging potion and crystal dust
+      - Best-in-slot ranged boost for bossing where stats must not drain
+      - Crystal dust supply comes from The Gauntlet
+  trading_tips:
+    - Track Gauntlet completion volume for crystal dust feed
+    - Tax-adjusted profit varies with ranging potion base price
+  history:
+    - date: "2019-07-25"
+      description: Released alongside Song of the Elves.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-07-25"
+    update: "Song of the Elves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bitter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bitter.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Dragon bitter is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 1
+    effects:
+      - description: "Boosts Strength by 2 levels"
+      - description: "Reduces Attack by 5% + 2 levels"
+  shops:
+    - shop_name: Dragon Inn
+      location: Yanille
+      stock: 5
+      price: 2
+    - shop_name: The Deeper Lode
+      location: Lovakengj
+      stock: 10
+      price: 2
+  related_items:
+    - name: Dragon bitter(m)
+      relationship: variant
+    - name: Beer glass
+      relationship: component
+  about: "Dragon bitter is a members-only alcoholic ale brewed and served in Yanille's Dragon Inn. Drinking it boosts Strength by 2 levels while temporarily reducing Attack, restoring 1 hitpoint per glass."
+  market_strategy:
+    notes:
+      - Shop-sold drives a stable supply ceiling near 2 gp
+      - High GE limit (2000) supports bulk flips
+      - Matured variant offers brewing upgrade path
+  trading_tips:
+    - Buy from shops at 2 gp and flip for marginal profit
+    - Watch for brewing skill events that boost ale demand
+  history:
+    - date: "2002-10-23"
+      description: Released as part of the Updates galore update.
+    - date: "2005-07-11"
+      description: Received a visual recolor during the Farming update.
+  properties:
+    release_date: "2002-10-23"
+    update: Updates galore
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-chainbody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-chainbody.mdx
@@ -12,8 +12,13 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: 70
+  material:
+    type: dragon
+    tier: high
   equipment:
     slot: body
+    requirements:
+      defence: 60
     attack_bonus:
       stab: 0
       slash: 0
@@ -27,64 +32,70 @@ osrs:
       magic: -3
       ranged: 80
     other_bonus:
-      melee_strength: 0
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 60
+    weight: 6.803
   drop_table:
-    primary_source: Kalphite Queen
-    best_drop_rate: 1/128
     sources:
       - source: Kalphite Queen
-        combat_level: 333
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/128
-        members_only: true
+        rarity: "1/128"
       - source: Thermonuclear smoke devil
-        combat_level: 301
         quantity: "1"
-        rarity: very rare
-        drop_rate: 1/2000
-        members_only: true
+        rarity: "1/2000"
+      - source: Smoke devil
+        quantity: "1"
+        rarity: "1/32768"
+      - source: Dust devil
+        quantity: "1"
+        rarity: "1/32768"
+      - source: Barbarian Assault (High gamble)
+        quantity: "1"
+        rarity: "1/16000"
   related_items:
-    - item_id: 21892
-      item_name: Dragon platebody
-      slug: dragon-platebody
+    - name: Dragon platebody
       relationship: upgrade
-      description: Superior dragon body armour
-    - item_id: 1127
-      item_name: Rune platebody
-      slug: rune-platebody
+    - name: Rune platebody
       relationship: downgrade
-      description: Budget alternative
-    - item_id: 11832
-      item_name: Bandos chestplate
-      slug: bandos-chestplate
+    - name: Bandos chestplate
       relationship: upgrade
-      description: BiS melee body (non-degradable)
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +81 |
-    | Slash | +93 |
-    | Crush | +83 |
-    | Magic | -3 |
-    | Ranged | +80 |
-
-    Mid-tier melee body armour:
-    - Budget alternative to Bandos chestplate
-    - 60 Defence requirement
-    - Does not degrade
+    - name: Dragon chainbody ornament kit
+      relationship: component
+  about: "Dragon chainbody is a mid-tier melee body armour requiring 60 Defence. Dropped by Kalphite Queen and Thermonuclear smoke devil, it can be upgraded into a Dragon platebody at 90 Smithing or cosmetically trimmed with an ornament kit."
   market_strategy:
     notes:
-      - Dropped by Kalphite Queen
-      - Budget melee option before BCP
-      - Cosmetic appeal for fashionscape
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply is bottlenecked by Kalphite Queen activity; price reacts to slayer task rotation."
+      - "Buy limit of 70 keeps spreads wide; ideal for medium-size flips."
+      - "Component value for dragon platebody upgrades provides a floor."
+  trading_tips:
+    - "Track the spread vs dragon platebody; high gap signals smith-upgrade arbitrage."
+    - "Demand bumps when KQ becomes a slayer task rotation focus."
+  history:
+    - date: "2004-09-07"
+      description: "Released as the first dragon body armour with the Kalphite Queen drop."
+    - date: "2014-10-30"
+      description: "Dragon platebody upgrade added, providing a sink for chainbodies."
+  properties:
+    release_date: "2004-09-07"
+    update: Kalphite Queen
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-crossbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-crossbow-u.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 10000
-  about: "Dragon crossbow (u) is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  recipes:
+    - name: "Dragon crossbow (u)"
+      skill: Fletching
+      level: 78
+      xp: 135
+      materials:
+        - item_name: Magic stock
+          quantity: 1
+        - item_name: Dragon limbs
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
+    - name: Dragon crossbow
+      skill: Fletching
+      level: 78
+      xp: 70
+      materials:
+        - item_name: "Dragon crossbow (u)"
+          quantity: 1
+        - item_name: Crossbow string
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Dragon crossbow
+      relationship: upgrade
+    - name: Dragon limbs
+      relationship: component
+    - name: Magic stock
+      relationship: component
+    - name: Crossbow string
+      relationship: component
+    - name: "Rune crossbow (u)"
+      relationship: downgrade
+  about: "Dragon crossbow (u) is the unstrung dragon crossbow produced from a magic stock and dragon limbs at 78 Fletching, requiring a crossbow string to finish into the dragon crossbow."
+  market_strategy:
+    notes:
+      - Price is anchored by dragon limbs cost and the strung dragon crossbow margin.
+      - Liquidity is moderate; volume rises around Fletching-related boosts.
+  trading_tips:
+    - Compare strung vs. unstrung price to find a stringing profit window.
+    - Watch dragon limb supply from Dragon Slayer II routing players.
+  history:
+    - date: "2018-01-04"
+      description: Added with the Dragon Slayer II update.
+    - date: "2021-07-07"
+      description: Female player stringing animation positioning corrected.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-01-04"
+    update: Dragon Slayer II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - String
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hasta-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hasta-p.mdx
@@ -5,16 +5,92 @@ osrs:
   id: 22734
   name: Dragon hasta(p)
   slug: dragon-hasta-p
-  examine: A poison-tipped, one-handed dragon hasta
+  examine: A poison-tipped, one-handed dragon hasta.
   members: true
   icon: Dragon hasta(p).png
   value: 62400
   lowalch: 24960
   highalch: 37440
   limit: 70
-  about: "Dragon hasta(p) is a members-only item in Old School RuneScape. High alchemy value: 37,440 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 55
+      slash: 55
+      crush: 55
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: -1
+      crush: -1
+      magic: 0
+      ranged: -1
+    other_bonus:
+      strength: 60
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Unleash
+    description: "Increases accuracy and damage by 5% per 5% special attack energy and ignores the Protect from Melee prayer's damage reduction."
+    energy_cost: 50
+  recipes:
+    - materials:
+        - item_name: Dragon hasta
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      notes: "Apply weapon poison to a Dragon hasta to create the poisoned variant."
+  related_items:
+    - name: Dragon hasta
+      relationship: variant
+    - name: "Dragon hasta(p+)"
+      relationship: upgrade
+    - name: "Dragon hasta(kp)"
+      relationship: variant
+  about: "Dragon hasta(p) is a poisoned, one-handed dragon spear obtained by applying weapon poison to a Dragon hasta. Requires 60 Attack plus Barbarian Training and shares stats with the unpoisoned hasta. High alchemy value: 37,440 coins. Grand Exchange buy limit: 70 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand is niche; flips revolve around Barbarian Assault and poisoned-variant collectors."
+      - "Margins follow weapon poison and base Dragon hasta prices."
+  trading_tips:
+    - "Cross-check poisoned and unpoisoned hasta prices for cheap conversion arbitrage."
+    - "Keep an eye on Barbarian Training meta updates for demand spikes."
+  history:
+    - date: "2019-01-10"
+      description: "Dragon hasta released with The Kebos Lowlands update."
+    - date: "2025-03-19"
+      description: "Adjusted as part of the Clan Events Improvements update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-01-10"
+    update: "The Kebos Lowlands"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-kiteshield-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-kiteshield-ornament-kit.mdx
@@ -12,60 +12,53 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  item:
-    type: ornament_kit
-    tradeable: true
-    target_item: Dragon kiteshield
-    target_id: 22002
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Master
-        drop_rate: Rare from reward casket
+  material:
+    type: cosmetic
+    tier: high
+  drop_table:
+    sources:
+      - source: "Reward casket (master)"
+        quantity: "1"
+        rarity: "1/25,530"
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
   related_items:
-    - item_id: 22002
-      item_name: Dragon kiteshield
-      slug: dragon-kiteshield
-      relationship: product
-      description: Base item to upgrade
-    - item_id: 22245
-      item_name: Dragon kiteshield (or)
-      slug: dragon-kiteshield-or
-      relationship: product
-      description: Ornamented version
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ornament Kit |
-    | Target | Dragon kiteshield |
-    | Tradeable | Yes |
-
-    Use on a Dragon kiteshield to create a Dragon kiteshield (or).
-
-    The ornament kit:
-    - Adds gold trim to the kiteshield
-    - Purely cosmetic change
-    - Does not affect stats
-    - Can be reverted
-
-    Materials:
-    - Dragon kiteshield
-    - Dragon kiteshield ornament kit
-
-    Result:
-    - Dragon kiteshield (or) - gold trimmed version
-
-    The ornamented kiteshield can be reverted to return:
-    - Dragon kiteshield
-    - Dragon kiteshield ornament kit
+    - name: Dragon kiteshield
+      relationship: component
+    - name: Dragon kiteshield (g)
+      relationship: upgrade
+  about: "Dragon kiteshield ornament kit is a members-only cosmetic upgrade in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
   market_strategy:
     notes:
-      - Master clue exclusive
-      - Cosmetic upgrade only
-      - Part of dragon (or) set
-      - Collection log item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Sourced exclusively from Master clue reward caskets at roughly 1/25,530 rate."
+      - "Combines with a dragon kiteshield to form the trimmed dragon kiteshield (g); the kit is reversible if the trimmed shield is detached."
+      - "Buy limit of 4 per 4 hours keeps the GE supply thin and prices volatile."
+  trading_tips:
+    - "Track Master clue popularity for supply spikes around clue events."
+    - "Combined dragon kiteshield (g) is untradeable; players pay premium for the kit + base shield combo."
+    - "Limited GE buy limit makes patient buy-in or sniping at off-peak hours essential."
+  history:
+    - date: "2018-01-25"
+      description: "Released as part of the Barbarian Assault Ranged Rework update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-01-25"
+    update: "Barbarian Assault Ranged Rework"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-knife-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-knife-p.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 66
   highalch: 99
   limit: 7000
-  about: "Dragon knife(p) is a members-only item in Old School RuneScape. High alchemy value: 99 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 60
+    attack_bonus:
+      ranged: 28
+    defence_bonus: {}
+    other_bonus:
+      ranged_strength: 30
+  special_attack:
+    name: Duality
+    description: "Throws two knives in quick succession at the target."
+    energy_cost: 25
+  recipes:
+    - skill: Herblore
+      level: 73
+      tools: []
+      output_quantity: 1
+      result: Dragon knife(p)
+      materials:
+        - item_name: Dragon knife
+          item_id: 22804
+          quantity: 1
+        - item_name: Weapon poison
+          item_id: 187
+          quantity: 1
+  related_items:
+    - item_id: 22804
+      item_name: Dragon knife
+      slug: dragon-knife
+      relationship: variant
+      description: Unpoisoned base variant
+    - item_id: 22808
+      item_name: Dragon knife(p+)
+      slug: dragon-knife-p-plus
+      relationship: upgrade
+      description: Stronger weapon poison variant
+    - item_id: 22810
+      item_name: Dragon knife(p++)
+      slug: dragon-knife-p-plus-plus
+      relationship: upgrade
+      description: Strongest weapon poison variant
+  about: "Poisoned variant of the dragon throwing knife with a Duality special attack that throws two knives in quick succession; staple ranged spec weapon for PvP and certain PvM phases."
+  market_strategy:
+    notes:
+      - Used heavily as a PvP/PvM special attack weapon
+      - Demand pulses with PKing meta and bossing strategies
+      - Poison tier upgrades (p+, p++) cannibalize base p demand
+      - Stackable inventory makes bulk purchases efficient
+  trading_tips:
+    - Buy base dragon knife and poison yourself when herblore margins are wide
+    - Track Duality use in popular boss guides as a demand signal
+    - Watch p+/p++ price spreads to decide tier to apply
+  history:
+    - date: "2019-01-10"
+      description: Dragon knife released with the Wrath of the Rangers update.
+  properties:
+    release_date: "2019-01-10"
+    update: Wrath of the Rangers
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-plateskirt.mdx
@@ -12,8 +12,14 @@ osrs:
   lowalch: 108000
   highalch: 162000
   limit: 70
+  material:
+    type: dragon
+    tier: high
   equipment:
     slot: legs
+    weight: 9.071
+    requirements:
+      defence: 60
     attack_bonus:
       stab: 0
       slash: 0
@@ -27,53 +33,71 @@ osrs:
       magic: -4
       ranged: 65
     other_bonus:
-      melee_strength: 0
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 60
-    weight: 9.071
   drop_table:
     sources:
       - source: Chaos Elemental
         combat_level: 305
         quantity: "1"
-        rarity: uncommon
-        drop_rate: 1/128
-        members_only: true
+        rarity: 1/128
+      - source: Skeletal Wyvern
+        combat_level: 140
+        quantity: "1"
+        rarity: 1/512
+      - source: Rune dragon
+        combat_level: 380
+        quantity: "1"
+        rarity: 1/127
+      - source: Adamant dragon
+        combat_level: 338
+        quantity: "1"
+        rarity: 1/110
   related_items:
-    - item_id: 4087
-      item_name: Dragon platelegs
-      slug: dragon-platelegs
+    - name: Dragon platelegs
       relationship: alternative
-      description: Identical stats, different appearance
-    - item_id: 21892
-      item_name: Dragon platebody
-      slug: dragon-platebody
+    - name: Dragon platebody
       relationship: set-piece
-      description: Matching body armour
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +68 |
-    | Slash | +66 |
-    | Crush | +63 |
-    | Ranged | +65 |
-    | Magic | -4 |
-
-    Requirements: 60 Defence | Weight: 9.07 kg
-
-    The dragon plateskirt has exactly the same stats as the Dragon platelegs. The only difference is cosmetic appearance. The plateskirt is typically cheaper on the GE due to lower demand.
-
-    An ornament kit from Treasure Trails can be applied for a cosmetic change without affecting stats.
+    - name: Dragon legs/skirt ornament kit
+      relationship: upgrade
+    - name: Dragon plateskirt (g)
+      relationship: variant
+    - name: Rune plateskirt
+      relationship: downgrade
+  about: "Dragon plateskirt is a high-tier members melee leg armour requiring 60 Defence, sharing identical stats with Dragon platelegs but typically trading cheaper on the Grand Exchange due to fashionscape preferences."
   market_strategy:
     notes:
-      - Identical stats to platelegs but usually cheaper
-      - Budget option for 60 Defence leg armour
-      - Cosmetic preference drives the price difference
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Identical stats to Dragon platelegs but usually cheaper.
+      - Budget option for 60 Defence leg armour.
+      - Cosmetic preference and skirt-style fashionscape drive the price gap.
+  trading_tips:
+    - Choose plateskirt over platelegs for identical stats at a discount.
+    - Apply a Dragon legs/skirt ornament kit for a gold-trim cosmetic upgrade.
+    - Source from Chaos Elemental or Skeletal Wyvern tasks for ironman supply.
+  history:
+    - date: "2005-03-29"
+      description: Released alongside Dragon platelegs as a cosmetic skirt variant of the dragon melee set.
+  properties:
+    release_date: "2005-03-29"
+    update: Dragon plate armour
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-bolts-e.mdx
@@ -14,65 +14,78 @@ osrs:
   limit: 11000
   equipment:
     slot: ammo
-    type: enchanted_bolts
-    tradeable: true
     weight: 0
     requirements:
       ranged: 61
-  effect:
-    name: Dragon's Breath
+    attack_bonus:
+      ranged: 0
+    other_bonus:
+      ranged_strength: 117
+  special_attack:
+    name: "Dragon's Breath"
     activation_chance: 6
-    description: Deals 20% of visible Ranged level as dragonfire (+22% with Zaryte crossbow)
-    blocked_by: Protect from Magic or dragonfire immunity
-  enchanting:
-    spell: Enchant Crossbow Bolt (Dragonstone)
-    magic_level: 68
-    runes:
-      - item_name: Earth rune
-        quantity: "15"
-      - item_name: Soul rune
-        quantity: "1"
-      - item_name: Cosmic rune
-        quantity: "1"
-    bolts_per_cast: 10
+    description: "6% chance on hit to deal dragonfire damage equal to 20% of the attacker's visible Ranged level (22% with the Zaryte crossbow). Blocked by Protect from Magic and dragonfire immunity. The Hard Kandarin Diary raises activation chance to 6.6%."
+  recipes:
+    - name: "Enchant Crossbow Bolt (Dragonstone)"
+      skill: Magic
+      level: 68
+      xp: 78
+      materials:
+        - item_name: Dragonstone bolts
+          quantity: 10
+        - item_name: Earth rune
+          quantity: 15
+        - item_name: Soul rune
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+      tools: []
+      output_quantity: 10
+  drop_table:
+    sources:
+      - source: "Kree'arra"
+        quantity: "5-10"
+        rarity: Uncommon
+      - source: Alchemical Hydra
+        quantity: "100-120"
+        rarity: Common
   related_items:
-    - item_id: 9341
-      item_name: Dragonstone bolts
-      slug: dragonstone-bolts
+    - name: Dragonstone bolts
       relationship: component
-      description: Base item
-    - item_id: 21957
-      item_name: Dragonstone dragon bolts (e)
-      slug: dragonstone-dragon-bolts-e
+    - name: Dragonstone dragon bolts (e)
       relationship: alternative
-      description: Dragon variant
-    - item_id: 11785
-      item_name: Armadyl crossbow
-      slug: armadyl-crossbow
+    - name: Armadyl crossbow
       relationship: alternative
-      description: Compatible weapon
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ammunition |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 61 Ranged |
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 68 |
-    | Base item | Dragonstone bolts (10) |
-    | Runes | 15 Earth, 1 Soul, 1 Cosmic |
-
-    Enchant Crossbow Bolt (Dragonstone) spell. Enchants 10 bolts per cast.
-
-    Dragon's Breath:
-    - 6% activation chance
-    - Deals 20% of visible Ranged level as dragonfire (+22% with Zaryte crossbow)
-    - Blocked by Protect from Magic or dragonfire immunity
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Dragonstone bolts (e) are enchanted runite bolts tipped with dragonstone, requiring 61 Ranged. Their Dragon's Breath effect makes them one of the strongest non-special bolts for high Ranged players."
+  market_strategy:
+    notes:
+      - Demand is driven by PvM bossing (Vorkath, Zulrah, general high-tier slayer).
+      - Profit from enchanting depends on rune and dragonstone bolt price spread.
+  trading_tips:
+    - Track Magic rune prices and dragonstone bolt cost vs. enchanted price for an enchanting margin.
+    - Buy in bulk before major PvM updates, sell during DPS-meta shifts.
+  history:
+    - date: "2006-07-31"
+      description: Added with the Crossbows update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarf-weed-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarf-weed-potion-unf.mdx
@@ -12,62 +12,59 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 10000
-  potion:
-    type: unfinished
-    tier: high
-  herblore:
-    level: 72
-    xp: 0
-    method: Add dwarf weed to vial of water
   recipes:
-    - skill: herblore
+    - skill: Herblore
       level: 72
       xp: 0
       materials:
         - item_name: Vial of water
-          item_id: 227
           quantity: 1
         - item_name: Dwarf weed
-          item_id: 267
           quantity: 1
-      product: Dwarf weed potion (unf)
-      product_id: 109
-      product_quantity: 1
+      tools: []
+      output: Dwarf weed potion (unf)
+      output_quantity: 1
       members_only: true
   related_items:
-    - item_id: 267
-      item_name: Dwarf weed
-      slug: dwarf-weed
+    - name: Dwarf weed
       relationship: component
-      description: Herb ingredient
-    - item_id: 227
-      item_name: Vial of water
-      slug: vial-of-water
+    - name: Vial of water
       relationship: component
-      description: Base liquid
-    - item_id: 245
-      item_name: Wine of zamorak
-      slug: wine-of-zamorak
+    - name: Wine of zamorak
       relationship: component
-      description: Secondary for ranging potion
-    - item_id: 2444
-      item_name: Ranging potion(4)
-      slug: ranging-potion-4
+    - name: Ranging potion(3)
       relationship: product
-      description: Final product
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Unfinished Potion |
-    | Tradeable | Yes |
-    | Weight | 0.056 kg |
-    | Requirements | 72 Herblore |
-
-    Add secondary ingredient to create:
-    - Ranging potion (+ wine of zamorak)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Ancient brew(3)
+      relationship: product
+    - name: Menaphite remedy(3)
+      relationship: product
+  about: "Dwarf weed potion (unf) is an unfinished potion made by adding dwarf weed to a vial of water at 72 Herblore. Finishing with wine of zamorak yields a Ranging potion (72), nihil dust yields Ancient brew (85), and lily of the sands yields Menaphite remedy (88)."
+  market_strategy:
+    notes:
+      - "Bulk Herblore intermediate; buy limit 10,000 makes it easy to scale ranging potion and ancient brew runs."
+      - "Price sits between dwarf weed + vial of water cost and the cheapest finishing route; arbitrage swings on dwarf weed supply."
+  trading_tips:
+    - "Finishing into Ranging potion (3) gives 162.5 XP at 72 Herblore, Ancient brew (3) gives 190 XP at 85, Menaphite remedy (3) gives 200 XP at 88."
+    - "Making the unf yourself awards 0 XP, so only press the combine step if dwarf weed + vial is meaningfully cheaper than the unf on GE."
+  history:
+    - date: "2002-02-27"
+      description: "Released with the Herblore skill launch."
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwellberries.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwellberries.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 13000
-  about: "Dwellberries is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 2
+  farming:
+    seed: Dwellberry seed
+    level: 36
+    patch: Bush
+  drop_table:
+    sources:
+      - source: Tarn Razorlor
+        quantity: "1"
+        rarity: Uncommon
+      - source: Zombie (level 100)
+        quantity: "1"
+        rarity: Uncommon
+  shops:
+    - shop_name: Hudo's Grand Tree Groceries
+      location: Grand Tree
+      price: 4
+      stock: 5
+    - shop_name: Heckel Funch's Grand Tree Groceries
+      location: Grand Tree
+      price: 4
+      stock: 2
+  recipes:
+    - materials:
+        - item_name: Dwellberries
+          quantity: 1
+      tools:
+        - Compost bin
+      output_quantity: 1
+      output: Compost
+    - materials:
+        - item_name: Dwellberries
+          quantity: 1
+        - item_name: Gnome bowl mix
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      output: Worm hole
+      skill: Cooking
+      level: 36
+  related_items:
+    - name: Dwellberry seed
+      relationship: component
+    - name: Blue dye
+      relationship: alternative
+    - name: Cadava berries
+      relationship: alternative
+  about: "Dwellberries are blue gnome berries used in Plague City, Curse of Arrav, gnome cookery, and compost. They can be farmed from a dwellberry bush at Farming level 36, gathered from McGrubor's Wood, bought from Grand Tree grocers, or rolled from monsters in Tarn's Lair."
+  market_strategy:
+    notes:
+      - "High Grand Exchange buy limit (13,000) keeps prices stable for bulk gnome cooking."
+      - "Shops in the Grand Tree restock at 4 coins, so flips above GE price are common."
+      - "Demand spikes alongside gnome cocktail and gnome bowl chef tasks."
+  trading_tips:
+    - "Buy from Hudo and Heckel Funch when prices spike on the Grand Exchange."
+    - "Pair with gnome cocktail/bowl materials to flip restock runs."
+  history:
+    - date: "2002-08-27"
+      description: "Released alongside the Plague City quest."
+  properties:
+    release_date: "2002-08-27"
+    update: "Plague City"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    quest: Plague City
+    weight: 0.014
+    options:
+      - Eat
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dynamite.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dynamite.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dynamite | OSRS Price Data
-description: "Dynamite: A pot of dynamite for blast mining, with a fuse ready to light.. High alch: 30 GP, GE limit: 13,000."
+description: "Dynamite: A pot of dynamite for blast mining, with a fuse ready to light. High alch: 30 GP, GE limit: 13,000."
 osrs:
   id: 13573
   name: Dynamite
@@ -12,9 +12,63 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 13000
-  about: "Dynamite is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Dynamite is a members-only consumable used in the Blast Mining minigame in Lovakengj. Players insert it into rock cavities to expose ore veins and gain Firemaking experience. It can be crafted from a dynamite pot and a ball of wool or purchased from the Blast Mining supply shop."
+  recipes:
+    - skill: Firemaking
+      level: 1
+      experience: 0
+      materials:
+        - item_name: Dynamite pot
+          quantity: 1
+        - item_name: Ball of wool
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      output_item: Dynamite
+  shops:
+    - shop_name: Blast Mining supply shop
+      location: Lovakengj
+      price: 575
+      currency: coins
+      stock: 2000
+  related_items:
+    - item_name: Dynamite pot
+      slug: dynamite-pot
+      relationship: component
+      description: Combined with a ball of wool to create dynamite.
+  properties:
+    release_date: "2016-01-07"
+    update: "Blast Mining"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Light
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  market_strategy:
+    notes:
+      - "Bulk consumable for Blast Mining XP runs; demand tied to active blast miners."
+      - "Shop stock of 2,000 at 575 gp caps long-term GE price ceiling."
+      - "Large 13,000 buy limit supports high-volume flipping."
+  trading_tips:
+    - "Buy bulk from the Blast Mining shop when stock refreshes for shop-arbitrage."
+    - "Sell on the GE during peak Lovakengj training hours."
+    - "Track price relative to volcanic sulphur and saltpetre inputs."
+  history:
+    - date: "2016-01-07"
+      description: "Released as part of the Blast Mining minigame in Lovakengj."
+    - date: "2017-02-16"
+      description: "Players gained the ability to left-click place dynamite directly into rock cavities."
+    - date: "2024-05-15"
+      description: "Blast Mining shop price reduced from 1,150 to 575 coins and stock doubled to 2,000 units."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-moon-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-moon-armour-set.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 58000
   highalch: 87000
   limit: 2
-  about: "Eclipse moon armour set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins. Grand Exchange buy limit: 2 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: mid-high
+  related_items:
+    - slug: eclipse-moon-helm
+      name: Eclipse moon helm
+      relationship: component
+    - slug: eclipse-moon-chestplate
+      name: Eclipse moon chestplate
+      relationship: component
+    - slug: eclipse-moon-tassets
+      name: Eclipse moon tassets
+      relationship: component
+    - slug: eclipse-atlatl
+      name: Eclipse atlatl
+      relationship: component
+    - slug: blood-moon-armour-set
+      name: Blood moon armour set
+      relationship: alternative
+    - slug: blue-moon-armour-set
+      name: Blue moon armour set
+      relationship: alternative
+  about: "Grand Exchange item set containing the Eclipse moon helm, chestplate, tassets and Eclipse atlatl. Exchange individual components with a Grand Exchange clerk using the Sets option."
+  history:
+    - date: "2025-08-20"
+      description: Eclipse moon armour set added to the Grand Exchange sets interface.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-08-20"
+    update: Perilous Moons
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/egg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/egg.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 13000
-  about: "Egg is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: low
+  recipes:
+    - name: Uncooked cake
+      materials:
+        - item_name: Cake tin
+          quantity: 1
+        - item_name: Pot of flour
+          quantity: 1
+        - item_name: Bucket of milk
+          quantity: 1
+        - item_name: Egg
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: Cooking
+      level: 40
+    - name: Uncooked egg
+      materials:
+        - item_name: Egg
+          quantity: 1
+        - item_name: Bowl
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: Cooking
+      level: 13
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle
+    - shop_name: Sigmund the Merchant
+      location: Rellekka
+  related_items:
+    - name: Uncooked cake
+      relationship: product
+    - name: Uncooked egg
+      relationship: product
+    - name: Chicken
+      relationship: alternative
+    - name: Spirit angler
+      relationship: alternative
+  about: "Egg is a free-to-play Cooking ingredient with multiple chicken-coop spawn points across Gielinor. It is used in recipes like uncooked cake (40 Cooking) and uncooked egg (13 Cooking) and is a required item in Cook's Assistant and Recipe for Disaster subquests."
+  market_strategy:
+    notes:
+      - Free spawns at Falador Farm, Lumbridge, Entrana and Kebos Lowlands chicken coops
+      - GE limit of 13,000 supports bulk baker flips
+      - Stocked by Culinaromancer's Chest and Sigmund the Merchant
+  trading_tips:
+    - Free-collect from coops, list above GE midpoint for steady margin
+    - Watch demand spikes near Easter and birthday events
+  history:
+    - date: "2001-01-04"
+      description: Available since the original launch period of RuneScape Classic.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    quest: "Cook's Assistant"
+    weight: 0.02
+    options:
+      - Eat
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-amulet.mdx
@@ -16,42 +16,78 @@ osrs:
     slot: neck
     requirements:
       crafting: 31
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.007
   recipes:
-    - skill: crafting
+    - skill: Crafting
       level: 31
-      xp: 70
-      inputs:
-        - item_name: Emerald
-          quantity: 1
+      experience: 70
+      materials:
         - item_name: Gold bar
           quantity: 1
+        - item_name: Emerald
+          quantity: 1
+        - item_name: Amulet mould
+          quantity: 1
+      tools:
+        - Furnace
       output_quantity: 1
   related_items:
-    - item_id: 1694
-      item_name: Sapphire amulet
-      slug: sapphire-amulet
+    - name: Sapphire amulet
       relationship: downgrade
-      description: Previous tier amulet
-    - item_id: 1698
-      item_name: Ruby amulet
-      slug: ruby-amulet
+    - name: Ruby amulet
       relationship: upgrade
-      description: Next tier amulet
-  about: |-
-    Crafting (Level 31): Emerald + Gold bar at a furnace with amulet mould (70 XP). String with ball of wool.
-
-    > *"An emerald amulet."*
-
-    Lvl-2 Enchant (27 Magic): 1 cosmic rune + 3 air runes (37 XP)
-
-    The Amulet of defence provides +7 to all defence styles — the best pure-defence amulet without offensive bonuses. Niche use for tanks and skillers.
+    - name: Amulet of defence
+      relationship: upgrade
+    - name: Emerald amulet (u)
+      relationship: component
+  about: "Emerald amulet is a strung neck-slot jewel crafted at Crafting level 31 by combining a gold bar, emerald, and amulet mould at a furnace, then stringing the unstrung version with a ball of wool. Enchanting it with Lvl-2 Enchant produces the Amulet of defence."
   market_strategy:
     notes:
-      - Amulet of defence has low demand (most prefer offensive amulets)
-      - Crafting training material
-      - Enchanting for Magic XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand is split between Crafting trainers and enchanters chasing Magic xp."
+      - "Buy limit of 10,000 keeps spreads tight; flips work best in bulk."
+      - "Enchanted Amulet of defence rarely outperforms offensive amulets, capping ceiling."
+  trading_tips:
+    - "Compare profit per emerald vs ruby and diamond amulets when training Crafting."
+    - "Enchanters can buy in bulk and resell as Amulet of defence for thin Magic-xp margins."
+  history:
+    - date: "2001-05-08"
+      description: "Released alongside the original gem crafting system."
+  properties:
+    release_date: "2001-05-08"
+    update: Crafting Skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/empty-candle-lantern.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/empty-candle-lantern.mdx
@@ -12,9 +12,44 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Empty candle lantern is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: glass
+    tier: low
+  recipes:
+    - skill: Crafting
+      level: 4
+      experience: 19
+      tools:
+        - Glassblowing pipe
+      materials:
+        - item_name: Molten glass
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - name: Candle lantern (white)
+      relationship: product
+    - name: Candle lantern (black)
+      relationship: product
+  about: "Empty candle lantern is created by glassblowing molten glass at level 4 Crafting. Once a white or black candle is inserted, it becomes a functional lantern usable in dark areas. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  history:
+    - date: "2005-03-14"
+      description: "Released via the Lumbridge Swamp Caves update."
+    - date: "2015-02-26"
+      description: "Renamed from Candle lantern to Empty candle lantern."
+  properties:
+    release_date: "2005-03-14"
+    update: Lumbridge Swamp Caves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enchant-ruby-or-topaz.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enchant-ruby-or-topaz.mdx
@@ -9,12 +9,65 @@ osrs:
   members: true
   icon: Enchant ruby or topaz.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: 0
+  highalch: 0
   limit: 10000
-  about: "Enchant ruby or topaz is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - materials:
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 5
+        - item_name: Soft clay
+          quantity: 1
+      tools:
+        - Teak demon lectern
+        - Mahogany demon lectern
+      output_quantity: 1
+      skills:
+        - skill: Magic
+          level: 49
+          xp: 44.3
+      notes: "Created at a demon lectern inside a Player-Owned House."
+  related_items:
+    - name: Ruby
+      relationship: alternative
+    - name: Red topaz
+      relationship: alternative
+  about: "Enchant ruby or topaz is a Magic tablet that casts the Level-3 Enchant spell on ruby or red topaz jewellery without needing runes or a Magic level. Created at a demon lectern with 49 Magic. High alchemy value: 0 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Tablet margin tracks soft clay and cosmic rune spot prices."
+      - "Useful for ironmen-adjacent Crafting routes where casting natively is inconvenient."
+  trading_tips:
+    - "Bulk-produce when cosmic runes dip below median."
+    - "Sell into the demand spike around ruby ring/topaz jewellery flips."
+  history:
+    - date: "2006-05-31"
+      description: "Enchantment tablets released with the Construction skill update."
+    - date: "2017-02-23"
+      description: "Renamed from 'Enchant ruby' to 'Enchant ruby or topaz'."
+    - date: "2018-03-22"
+      description: "'Break' replaced with an 'Info' right-click option."
+    - date: "2026-04-22"
+      description: "Wiki refresh confirmed alch and recipe details."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    update: "Construction"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Info
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/essence-impling-jar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/essence-impling-jar.mdx
@@ -12,9 +12,47 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
-  about: "Essence impling jar is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: other
+    tier: low
+  related_items:
+    - slug: baby-impling-jar
+      name: Baby impling jar
+      relationship: alternative
+    - slug: young-impling-jar
+      name: Young impling jar
+      relationship: alternative
+    - slug: gourmet-impling-jar
+      name: Gourmet impling jar
+      relationship: alternative
+    - slug: empty-impling-jar
+      name: Empty impling jar
+      relationship: component
+  about: "Captured essence impling. Loot for pure essence, runes (mind, body, chaos, cosmic, death, law, blood, soul, nature) and 1/50 chance of a medium clue scroll. Returns an empty impling jar 90% of the time."
+  history:
+    - date: "2007-06-11"
+      description: Essence impling jar released as part of Impetuous Impulses minigame.
+    - date: "2015-03-25"
+      description: Essence impling jar became Grand Exchange tradeable.
+    - date: "2016-04-07"
+      description: Medium clue scrolls added to the loot table.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-06-11"
+    update: Impetuous Impulses
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Loot
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-3.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 132
   highalch: 198
   limit: 2000
-  about: "Extended antifire(3) is a members-only item in Old School RuneScape. High alchemy value: 198 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 3
+    effects:
+      - description: "Grants partial dragonfire protection for 12 minutes per dose (36 minutes total at 3 doses); full immunity when paired with an anti-dragon or dragonfire shield."
+        duration: 2160
+    skill_requirements:
+      herblore: 84
+  recipes:
+    - materials:
+        - item_name: "Antifire potion(3)"
+          quantity: 1
+        - item_name: "Lava scale shard"
+          quantity: 3
+      tools: []
+      output_quantity: 1
+      skill: herblore
+      level: 84
+      experience: 82.5
+  related_items:
+    - item_name: "Extended antifire(4)"
+      relationship: variant
+    - item_name: "Extended antifire(2)"
+      relationship: variant
+    - item_name: "Extended antifire(1)"
+      relationship: variant
+    - item_name: "Antifire potion(3)"
+      relationship: component
+    - item_name: "Lava scale shard"
+      relationship: component
+  about: "Extended antifire(3) is a members three-dose herblore potion that extends dragonfire protection to 12 minutes per dose."
+  market_strategy:
+    notes:
+      - "Demand spikes around dragon-slayer slayer tasks and Vorkath rotations."
+      - "Three-dose pricing tracks four-dose / inputs; arbitrage windows are short."
+  trading_tips:
+    - "Watch lava scale shard supply from Konar/Wyrm tasks for floor changes."
+    - "Sell stacks ahead of new draconic content events."
+  history:
+    - date: "2014-03-27"
+      description: "Released alongside the Wilderness Feedback / Anti-dragon updates and lava scale shard introduction."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-03-27"
+    update: "Wilderness Feedback"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eye-of-newt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eye-of-newt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Eye of newt | OSRS Price Data
-description: "Eye of newt: It seems to be looking at me.. High alch: 1 GP, GE limit: 13,000."
+description: "Eye of newt: It seems to be looking at me. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 221
   name: Eye of newt
@@ -12,93 +12,97 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
+  about: "Eye of newt is a free-to-play Herblore secondary ingredient used to make Attack potions and Super attack potions. It's widely available from shops and drops from various low-level monsters."
+  properties:
+    release_date: "2001-04-06"
+    update: Runescape Launched
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
   material:
-    type: secondary
-    tier: basic
+    type: Secondary
+    tier: low
   drop_table:
     sources:
       - source: Banshee
-        source_id: 1612
-        combat_level: 23
         quantity: "1"
-        rarity: common
-        members_only: true
+        rarity: Common
       - source: Cave bug
-        source_id: 481
-        combat_level: 6
         quantity: "1"
-        rarity: common
-        members_only: true
+        rarity: Common
       - source: Cave crawler
-        source_id: 406
-        combat_level: 23
         quantity: "1"
-        rarity: common
-        members_only: true
+        rarity: Common
+      - source: Newtroost
+        quantity: "4-10"
+        rarity: Always
+  shops:
+    - shop_name: Betty's Magic Emporium
+      location: Port Sarim
+      stock: 50
+      price: 3
+      restock_time: 60
+    - shop_name: Jatix's Herblore Shop
+      location: Taverley
+      stock: 50
+      price: 3
+      restock_time: 60
   recipes:
-    - skill: herblore
+    - name: Attack potion(3)
+      skill: Herblore
       level: 3
-      xp: 25
+      experience: 25
       materials:
         - item_name: Guam potion (unf)
-          item_id: 91
           quantity: 1
         - item_name: Eye of newt
-          item_id: 221
           quantity: 1
-      product: Attack potion(3)
-      product_id: 121
-      product_quantity: 1
-    - skill: herblore
+      tools: []
+      output_quantity: 1
+    - name: Super attack(3)
+      skill: Herblore
       level: 45
-      xp: 100
+      experience: 100
       materials:
         - item_name: Irit potion (unf)
-          item_id: 101
           quantity: 1
         - item_name: Eye of newt
-          item_id: 221
           quantity: 1
-      product: Super attack(3)
-      product_id: 2428
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 91
-      item_name: Guam potion (unf)
-      slug: guam-potion-unf
+    - name: Guam potion (unf)
       relationship: component
-      description: For attack potion
-    - item_id: 121
-      item_name: Attack potion(3)
-      slug: attack-potion-3
+    - name: Attack potion(3)
       relationship: product
-      description: Basic combat potion
-    - item_id: 2428
-      item_name: Super attack(3)
-      slug: super-attack-3
+    - name: Super attack(3)
       relationship: product
-      description: Advanced combat potion
-    - item_id: 249
-      item_name: Guam leaf
-      slug: guam-leaf
+    - name: Guam leaf
       relationship: component
-      description: Partner herb
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Herblore Secondary |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-
-    Secondary ingredient for:
-    - Attack potion (with guam potion unf)
-    - Super attack (with irit potion unf)
-
-    Essential low-level herblore ingredient.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - "Essential low-level Herblore secondary; demand tied to potion training meta."
+      - "Cheap, high-volume item; large buy limit (13,000) supports bulk purchases."
+      - "Shop sources keep the price stable; flips have thin margins."
+  trading_tips:
+    - "Buy in bulk for low-level Herblore training potions."
+    - "Compare GE price vs. shop price (3gp) for arbitrage opportunities."
+    - "Stockpile during Herblore double-XP events."
+  history:
+    - date: "2001-04-06"
+      description: "Eye of newt added at game launch."
+    - date: "2007-02-26"
+      description: "Item became available on the Grand Exchange."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/facility-bottle-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/facility-bottle-empty.mdx
@@ -5,16 +5,37 @@ osrs:
   id: 33074
   name: Facility bottle (empty)
   slug: facility-bottle-empty
-  examine: With proper application of directed exhalations, this complicated technology doubles as a folk instrument.
+  examine: "With proper application of directed exhalations, this complicated technology doubles as a folk instrument."
   members: true
   icon: Facility bottle (empty).png
   value: 57693
   lowalch: 23077
   highalch: 34615
   limit: 100
-  about: "Facility bottle (empty) is a members-only item in Old School RuneScape. High alchemy value: 34,615 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  shops:
+    - shop_name: Shipwright Seb
+      location: Shipyard
+      price: 75000
+  about: "Facility bottle (empty) stores boat facilities so they can be moved between facility hotspots and boats. Used at the Shipyard with a hammer and saw. High alchemy value: 34,615 coins. Grand Exchange buy limit: 100 per 4 hours."
+  history:
+    - date: "2026-01-28"
+      description: "Released in the Deadman: Annihilation update."
+    - date: "2026-02-25"
+      description: "Appearance updated to distinguish it from the boat bottle."
+  properties:
+    release_date: "2026-01-28"
+    update: "Deadman: Annihilation"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    alchable: false
+    destroy: Destroy
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fire-orb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fire-orb.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fire orb | OSRS Price Data
-description: "Fire orb: A magic glowing orb.. High alch: 180 GP, GE limit: 11,000."
+description: "Fire orb: A magic glowing orb. High alch: 180 GP, GE limit: 11,000."
 osrs:
   id: 569
   name: Fire orb
@@ -14,77 +14,94 @@ osrs:
   limit: 11000
   material:
     type: orb
-    tier: charged
-  magic:
-    charge_level: 63
-    charge_xp: 73
-    runes:
-      - item_name: Fire rune
-        item_id: 554
-        quantity: "30"
-      - item_name: Cosmic rune
-        item_id: 564
-        quantity: "3"
-    obelisk: Fire Obelisk
-    location: Taverley Dungeon
+    tier: mid
   recipes:
-    - skill: crafting
-      level: 62
-      xp: 125
-      materials:
+    - materials:
+        - item_name: Unpowered orb
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 30
+        - item_name: Cosmic rune
+          quantity: 3
+      tools:
+        - Obelisk of Fire (Taverley Dungeon)
+      output_quantity: 1
+    - materials:
         - item_name: Battlestaff
-          item_id: 1391
           quantity: 1
         - item_name: Fire orb
-          item_id: 569
           quantity: 1
-      product: Fire battlestaff
-      product_id: 1393
-      product_quantity: 1
-      facility: None
-      members_only: true
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Cerberus
+        quantity: "1"
+        rarity: Common
+      - source: Killerwatt
+        quantity: "1"
+        rarity: Uncommon
+      - source: Lava dragon
+        quantity: "1"
+        rarity: Uncommon
+      - source: Tormented demon
+        quantity: "1"
+        rarity: Uncommon
   related_items:
     - item_id: 1393
       item_name: Fire battlestaff
       slug: fire-battlestaff
       relationship: product
-      description: Final product
+      description: Crafted by attaching the fire orb to a battlestaff.
     - item_id: 567
       item_name: Unpowered orb
       slug: unpowered-orb
       relationship: component
-      description: Base item
+      description: Base item charged at the Obelisk of Fire.
     - item_id: 564
       item_name: Cosmic rune
       slug: cosmic-rune
       relationship: component
-      description: Spell component
+      description: Required to cast the Charge Fire Orb spell.
     - item_id: 1391
       item_name: Battlestaff
       slug: battlestaff
       relationship: component
-      description: Attachment base
-  about: |-
-    | Method | Level | Runes |
-    |--------|-------|-------|
-    | Charge Fire Orb | 63 Magic | 30 Fire, 3 Cosmic |
-    | Location | Fire Obelisk (Taverley Dungeon) | - |
-    | XP | 73 Magic | - |
+      description: Attachment base for the fire battlestaff.
+  about: "Fire orb is a charged orb created by casting Charge Fire Orb (Magic 63) on an unpowered orb at the Obelisk of Fire in Taverley Dungeon; it is the key component for fire battlestaves."
   market_strategy:
     notes:
-      - No Wilderness risk
-      - Taverley Dungeon location
-      - Fire battlestaff production
-      - Fire battlestaff crafting
-      - Crafting training
-      - Tome of fire combo
-      - Safe alternative to air orbs
-      - Safe location (no PKers)
-      - Lower Magic requirement
-      - Fire runes cheap
-      - Less profit than air orbs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Steady demand from Crafting trainers making fire battlestaves.
+      - Wilderness-free charging keeps the supply stable.
+      - Fire battlestaff arbitrage forms the dominant flip path.
+      - Less profitable than air orbs but lower Magic requirement.
+  trading_tips:
+    - Track fire battlestaff vs. fire orb spread for crafting margin.
+    - Stock unpowered orbs and runes for cheap mass production.
+    - Combine with Tome of fire for spell-cost savings while charging.
+    - Watch buy limit changes affecting throughput.
+  history:
+    - date: "2002-03-18"
+      description: Fire orb released alongside the Charge Fire Orb spell and Obelisk of Fire.
+    - date: "2020-09-10"
+      description: Grand Exchange buy limit raised from 10,000 to 11,000.
+  properties:
+    release_date: "2002-03-18"
+    update: Charge Orb Spells
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-haddock.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-haddock.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: null
+  material:
+    type: fish
+    tier: low
+  recipes:
+    - materials:
+        - item_name: Empty fish crate
+          quantity: 1
+        - item_name: Raw haddock
+          quantity: 10
+      tools: []
+      output_quantity: 1
+      requirements: "Created via Sailing's deep sea trawling: empty a trawling net carrying 10 raw haddock with an empty fish crate in the cargo hold, or use raw haddock on an empty crate."
+  related_items:
+    - name: Empty fish crate
+      relationship: component
+    - name: Raw haddock
+      relationship: component
+    - name: Fish crate (shrimps)
+      relationship: alternative
+    - name: Fish crate (anchovies)
+      relationship: alternative
   about: "Fish crate (haddock) is a members-only item in Old School RuneScape. High alchemy value: 3 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Output of the Sailing skill's deep sea trawling pipeline; emptied at a bank to return its raw haddock for cooking or resale."
+      - "Filled fish crates can only be emptied while standing inside a bank; emptying elsewhere destroys the contents."
+      - "Margin depends on raw haddock and empty fish crate spot prices; compare bundle GE value against component sum."
+  trading_tips:
+    - "Always empty filled crates with a banking interface open to avoid item loss."
+    - "Bulk traders should track raw haddock GE price to size the arbitrage window."
+    - "Check Sailing meta updates; new players grinding the skill can flood supply."
+  history:
+    - date: "2025-11-19"
+      description: "Released alongside the launch of the Sailing skill."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-yellowfin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fish-crate-yellowfin.mdx
@@ -11,10 +11,64 @@ osrs:
   value: 5
   lowalch: 2
   highalch: 3
-  limit: null
-  about: "Fish crate (yellowfin) is a members-only item in Old School RuneScape. High alchemy value: 3 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit: 250
+  recipes:
+    - name: Fish crate (yellowfin)
+      skill: Sailing
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Fish crate
+          quantity: 1
+        - item_name: Raw yellowfin
+          quantity: 10
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Fish crate
+      relationship: component
+    - name: Raw yellowfin
+      relationship: component
+    - name: Camphor crate
+      relationship: product
+    - name: "Fish crate (haddock)"
+      relationship: alternative
+    - name: "Fish crate (halibut)"
+      relationship: alternative
+    - name: "Fish crate (bluefin)"
+      relationship: alternative
+    - name: "Fish crate (marlin)"
+      relationship: alternative
+    - name: "Fish crate (giant krill)"
+      relationship: alternative
+  about: "Fish crate (yellowfin) is a Sailing crate holding 10 raw yellowfin, produced by emptying a trawling net into an empty fish crate stored in a ship's cargo hold. Emptying at a bank returns a camphor crate."
+  market_strategy:
+    notes:
+      - Price tracks raw yellowfin plus empty crate cost minus emptying friction.
+      - Used by Sailing/Fishing routers transporting bulk yellowfin for processing.
+  trading_tips:
+    - Compare raw yellowfin per crate to crate price for filling-vs-buying decisions.
+    - Watch Sailing meta updates and trawling buffs that shift supply.
+  history:
+    - date: "2025-11-19"
+      description: Released alongside the Sailing skill.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/frost-dragon-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/frost-dragon-bones.mdx
@@ -1,6 +1,6 @@
 ---
 title: Frost dragon bones | OSRS Price Data
-description: "Frost dragon bones: They're rather cold.. High alch: 96 GP, GE limit: 7,500."
+description: "Frost dragon bones: They're rather cold. High alch: 96 GP, GE limit: 7,500."
 osrs:
   id: 31729
   name: Frost dragon bones
@@ -12,9 +12,54 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 7500
-  about: "Frost dragon bones is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Frost dragon bones are a Prayer training item dropped by Frost dragons. They grant 100 Prayer XP when buried and up to 700 XP per bone at the Wilderness Chaos Temple, making them one of the strongest Prayer training options in OSRS."
+  properties:
+    release_date: "2025-11-19"
+    update: Frost Dragons
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.6
+    options:
+      - Bury
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  prayer:
+    base_xp: 100
+    altar_xp: 350
+    ectofuntus_xp: 400
+  drop_table:
+    sources:
+      - source: Frost dragon
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - name: Blessed frost dragon bones
+      relationship: upgrade
+    - name: Frost dragon bonemeal
+      relationship: variant
+    - name: Superior dragon bones
+      relationship: alternative
+    - name: Dragon bones
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Top-tier Prayer training fodder; price closely tracks Prayer XP/gp meta."
+      - "Buy limit 7,500 supports large training sessions and bulk purchases."
+      - "Supply driven by Frost dragon farming demand."
+  trading_tips:
+    - "Compare XP/gp against superior dragon bones at gilded altar before committing."
+    - "Bulk buy ahead of major Prayer XP events or training streams."
+    - "Wilderness Chaos Temple users effectively pay half-price; price reflects this."
+  history:
+    - date: "2025-11-19"
+      description: "Frost dragon bones added with the Frost Dragons content update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/giant-boot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/giant-boot.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 5600
   highalch: 8400
   limit: 4
-  about: "Giant boot is a members-only item in Old School RuneScape. High alchemy value: 8,400 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: high
+  equipment:
+    slot: head
+    weight: 0.5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/1275
+  related_items:
+    - name: Reward casket (elite)
+      relationship: alternative
+  about: "Giant boot is a members-only cosmetic head slot item obtained as a rare reward from elite Treasure Trails. It offers no combat bonuses and is worn purely for novelty."
+  market_strategy:
+    notes:
+      - Only sourced from elite Reward caskets at 1/1,275 rarity
+      - Buy limit of 4 keeps day-to-day liquidity low
+      - Storable in a costume room treasure chest
+  trading_tips:
+    - Margin depends on collector demand rather than utility
+    - Track elite clue volumes for supply shocks
+  history:
+    - date: "2019-04-11"
+      description: Released with the Treasure Trails Expansion and Easter 2019 update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    update: "Treasure Trails Expansion and Easter 2019"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-spear.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 8320
   highalch: 12480
   limit: 70
-  about: "Gilded spear is a members-only item in Old School RuneScape. High alchemy value: 12,480 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: mid-high
+  equipment:
+    slot: weapon
+    weapon_type: two-handed
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 36
+      slash: 36
+      crush: 36
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 42
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Reward casket (hard)"
+        quantity: "1"
+        rarity: "1/35,750"
+      - source: "Reward casket (elite)"
+        quantity: "1"
+        rarity: "1/32,257.5"
+      - source: "Reward casket (master)"
+        quantity: "1"
+        rarity: "1/149,776"
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
+  related_items:
+    - item_name: "Rune spear"
+      relationship: alternative
+    - item_name: "Gilded scimitar"
+      relationship: set-piece
+    - item_name: "Gilded 2h sword"
+      relationship: set-piece
+  about: "Gilded spear is a cosmetic two-handed weapon obtained as a rare clue scroll reward; shares stats with the rune spear but cannot be poisoned."
+  market_strategy:
+    notes:
+      - "Cosmetic showpiece; demand driven by gilded-set collectors, not PvM viability."
+      - "Tiny GE volume (single digits/day) makes price swings sharp."
+  trading_tips:
+    - "List asks near recent merch averages — thin order book rewards patience."
+    - "Anchor buy bids during clue scroll bonus weekends when supply spikes."
+  history:
+    - date: "2016-07-06"
+      description: "Added with the Treasure Trail Expansion update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gnome-goggles.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gnome-goggles.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Gnome goggles is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Gnome Restaurant minigame (hard delivery reward)"
+        quantity: "1"
+        rarity: Rare
+  related_items:
+    - name: Gnome scarf
+      relationship: alternative
+    - name: Mint cake
+      relationship: alternative
+  about: "Gnome goggles is a cosmetic head-slot item awarded for completing hard deliveries in the Gnome Restaurant minigame; offers no combat bonuses."
+  market_strategy:
+    notes:
+      - "Tiny GE limit (4 per 4 hours) makes flipping slow."
+      - "Supply is gated by Gnome Restaurant minigame engagement — very thin."
+      - "High alch 600 gp far below GE price — never alch."
+  trading_tips:
+    - "Demand from fashionscape collectors and Gnome Restaurant log hunters."
+    - "Long-term hold candidate due to limited supply pipeline."
+  history:
+    - date: "2006-08-07"
+      description: "Released alongside the Gnome Cuisine update as a Gnome Restaurant reward."
+  properties:
+    release_date: "2006-08-07"
+    update: "Gnome Cuisine"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-partyhat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-partyhat.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 5
-  about: "Green partyhat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.056
+  related_items:
+    - name: Red partyhat
+      relationship: alternative
+    - name: Yellow partyhat
+      relationship: alternative
+    - name: Blue partyhat
+      relationship: alternative
+    - name: White partyhat
+      relationship: alternative
+    - name: Purple partyhat
+      relationship: alternative
+  about: "Green partyhat is a free-to-play rare holiday cosmetic in Old School RuneScape originally distributed during the 2001 Christmas event. It carries no combat bonuses but is a prestigious wealth item due to its scarcity."
+  market_strategy:
+    notes:
+      - "Extreme rarity holiday item; price driven by collectors and wealth display rather than utility."
+      - "GE buy limit of 5 means whales tend to fill orders slowly; small flips are viable."
+      - "Watch for player-economy events that briefly re-introduce partyhats (e.g., World 666 in 2016)."
+  trading_tips:
+    - "Use the Grand Exchange history tab to detect long-term trend reversals before committing capital."
+    - "Cross-check with other partyhat colours; the set typically moves together."
+  history:
+    - date: "2001-12-24"
+      description: "Released during the original Christmas event as a holiday drop."
+    - date: "2016-06-04"
+      description: "Briefly available again as a reward during the World 666 event."
+  properties:
+    release_date: "2001-12-24"
+    update: Christmas Event 2001
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.056
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/greenman-carving.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/greenman-carving.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 3698
   highalch: 5547
   limit: null
-  about: "Greenman carving is a members-only item in Old School RuneScape. High alchemy value: 5,547 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - materials:
+        - item_name: Greenman mask
+          quantity: 1
+        - item_name: Ent branch
+          quantity: 5
+        - item_name: Yew logs
+          quantity: 1
+      tools:
+        - Knife
+        - Fletching level 79
+      output_quantity: 1
+      skill: Fletching
+      experience: 70
+  related_items:
+    - name: Greenman mask
+      relationship: component
+    - name: Ent branch
+      relationship: component
+    - name: Yew logs
+      relationship: component
+  about: "Greenman carving is a Fletching-crafted decoration built from a Greenman mask, 5 ent branches and yew logs; mounted in player-owned house dining, combat, or throne rooms."
+  market_strategy:
+    notes:
+      - "No GE buy limit listed — can move volume but supply is thin."
+      - "Recipe profit depends on Greenman mask spread (the dominant cost input)."
+      - "High alch 5,547 gp well below GE price — never alch."
+  trading_tips:
+    - "Demand from POH builders chasing Construction XP / fashionscape POHs."
+    - "Watch Greenman mask price (Halloween event drop) — it dominates carving cost."
+  history:
+    - date: "2025-07-23"
+      description: "Released with the Varlamore: The Final Dawn update."
+  properties:
+    release_date: "2025-07-23"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Build
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/greenman-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/greenman-mask.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Greenman mask is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: head
+    weight: 0.1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Rummaging Vale offerings (Vale Totems minigame)"
+        quantity: "1"
+        rarity: "1/500"
+  shops:
+    - shop_name: "Vale Research Exchange"
+      currency: "Research points"
+      cost: 500
+      stock: 1
+  related_items:
+    - name: Greenman statue
+      relationship: product
+    - name: Greenman carving
+      relationship: product
+  about: "Greenman mask is a members-only cosmetic head slot item in Old School RuneScape. High alchemy value: 1 coin. Grand Exchange buy limit: 4 per 4 hours."
+  market_strategy:
+    notes:
+      - "Dropped at 1/500 from rummaging Vale offerings in the Vale Totems minigame, or bought for 500 research points from the Vale Research Exchange."
+      - "Six style variants unlocked by applying 300 tree leaves each (normal, oak, willow, maple, yew, magic) for 20 Fletching xp per unlock."
+      - "Stored in the magic wardrobe of a costume room, freeing bank space for collectors."
+  trading_tips:
+    - "Supply is rate-gated; expect price volatility tied to Vale Totems popularity."
+    - "Buy limit of 4 per 4 hours makes large flips slow but stable."
+    - "Demand from cosmetic collectors and POH fletchers wanting greenman statues."
+  history:
+    - date: "2025-07-23"
+      description: "Released as part of the Varlamore: The Final Dawn update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-07-23"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Change-style
+      - Destroy
+    worn_options:
+      - Change-style
+      - Remove
+    alchable: false
+    destroy: "Destroy"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grey-toy-horsey.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grey-toy-horsey.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Grey toy horsey is a free-to-play item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: low
+  shops:
+    - shop_name: Diango's Toy Store
+      location: Draynor Village
+      price: 150
+  recipes:
+    - skill: Crafting
+      level: 10
+      tools:
+        - Crafting table
+      materials:
+        - item_name: Plank
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - name: Brown toy horsey
+      relationship: variant
+    - name: White toy horsey
+      relationship: variant
+    - name: Black toy horsey
+      relationship: variant
+  about: "Grey toy horsey is a free-to-play joke collectible sold by Diango as a humorous response to player requests for horses. It can also be crafted at level 10 Crafting using a plank on a crafting table. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
+  history:
+    - date: "2004-04-01"
+      description: "Released via the RuneScape chat improved! update."
+    - date: "2013-03-18"
+      description: "Forced speech changed to Just say neigh to gambling! as part of gambling policy enforcement."
+    - date: "2014-12-10"
+      description: "Renamed from Toy horsey to Grey toy horsey."
+    - date: "2014-12-18"
+      description: "Typo fix applied."
+  properties:
+    release_date: "2004-04-01"
+    update: "RuneScape chat improved!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.05
+    alchable: true
+    options:
+      - Play-with
+      - Drop
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-tarromin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-tarromin.mdx
@@ -12,18 +12,64 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 13000
+  drop_table:
+    sources:
+      - source: Bandit (level 22)
+        quantity: "1"
+        rarity: 1/24.6
+      - source: Elder Chaos druid
+        quantity: "1"
+        rarity: 1/16.7
+      - source: Aberrant spectre
+        quantity: "1"
+        rarity: 1/11.7
+      - source: Deviant spectre
+        quantity: "1"
+        rarity: 1/19.8
+      - source: Twisted Banshee
+        quantity: "1"
+        rarity: 1/26.8
+  farming:
+    seed: Tarromin seed
+    farming_level: 19
+    patches:
+      - Herb patch
   related_items:
-    - item_id: 253
-      item_name: Tarromin
-      slug: tarromin
+    - name: Tarromin
       relationship: product
-      description: Cleaned version
-  about: |-
-    > _"It needs cleaning."_
-
-    Grimy tarromin requires 11 Herblore to clean (5 XP). Used in strength potions and serum 207.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Tarromin seed
+      relationship: component
+    - name: Strength potion (unf)
+      relationship: product
+    - name: Serum 207 (unf)
+      relationship: product
+  about: "Grimy tarromin is the uncleaned form of the tarromin herb, requiring level 11 Herblore to clean for 5 Herblore experience. Cleaned tarromin is used to make strength potions, serum 207, and tarromin tar."
+  market_strategy:
+    notes:
+      - "Healthy 13,000 buy limit and very high daily volume; spread is usually tight."
+      - "Price tracks demand for strength potions and tarromin tar (serum 207) plus farmer supply from tarromin seeds."
+  trading_tips:
+    - "Cleaning at 11 Herblore yields 5 XP each; bulk-clean only when the price gap to clean tarromin exceeds the click value."
+    - "Bandits at level 22 and Elder Chaos druids are reliable farm targets if buying GE supply tightens."
+  history:
+    - date: "2002-02-27"
+      description: "Released into the game as part of the Herblore skill rollout."
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grubby-key.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grubby-key.mdx
@@ -5,16 +5,63 @@ osrs:
   id: 23499
   name: Grubby key
   slug: grubby-key
-  examine: It looks like the key to a chest (Used to open the grubby chest in Forthos Dungeon).
+  examine: "It looks like the key to a chest (Used to open the grubby chest in Forthos Dungeon)."
   members: true
   icon: Grubby key.png
   value: 32
   lowalch: 12
   highalch: 19
   limit: 11000
-  about: "Grubby key is a members-only item in Old School RuneScape. High alchemy value: 19 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Sarachnis
+        quantity: "1"
+        rarity: 1/15
+      - source: Red dragon
+        quantity: "1"
+        rarity: 1/50
+      - source: Undead Druid
+        quantity: "1"
+        rarity: 1/75
+      - source: Baby red dragon
+        quantity: "1"
+        rarity: 1/80
+      - source: Temple Spider
+        quantity: "1"
+        rarity: 1/100
+  related_items:
+    - name: Pristine spider silk
+      relationship: alternative
+    - name: Grubby chest
+      relationship: component
+  about: "Grubby key opens the Grubby chest deep inside Forthos Dungeon. Drops from Sarachnis, red dragons, temple spiders, undead druids, and exchangeable from Brother Aimeri."
+  market_strategy:
+    notes:
+      - Strong daily volume (~5.5k trades) means flips clear quickly even at sharp margins.
+      - Drop rate from Sarachnis (1/15) is the dominant supply; Sarachnis kph trends drive price.
+      - Grubby chest reward economy (notably hydra leather) is the main demand driver.
+  trading_tips:
+    - Track hydra leather and Forthos chest output prices — when chest +EV rises, grubby key follows.
+    - 11,000/4h GE limit allows scaled flipping with multiple offers.
+  history:
+    - date: "2019-07-04"
+      description: Released with the Forthos Dungeon update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-07-04"
+    update: Forthos Dungeon
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthixian-temple-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthixian-temple-teleport.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: null
-  about: "Guthixian temple teleport is a members-only item in Old School RuneScape. High alchemy value: 6 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: "Ancient Guthixian Temple entrance"
+    requirements:
+      "quest": "While Guthix Sleeps"
+    notes: "Attempting to use the scroll without completing While Guthix Sleeps shows: 'You need to complete the While Guthix Sleeps quest before you can teleport to Ancient Guthixian Temple.'"
+  drop_table:
+    sources:
+      - source: Tormented demon
+        quantity: "2"
+        rarity: "1/12"
+  about: "The Guthixian temple teleport is a one-click scroll dropped by Tormented Demons that ports the player to the Ancient Guthixian Temple. Requires While Guthix Sleeps to activate."
+  market_strategy:
+    notes:
+      - "Drops in pairs from a relatively rare Tormented Demon roll, so supply tracks Tormented Demon trip frequency."
+      - "Demand is steady from players running While Guthix Sleeps content or chasing Ancient Guthixian Temple objectives."
+      - "Can be stacked in the master scroll book, allowing players to free up inventory for travel."
+  trading_tips:
+    - "Watch for price drops during Tormented Demon meta spikes when supply outpaces demand."
+    - "List in bulk lots after extended Tormented Demon trips to capture spread on a thinly traded item."
+  history:
+    - date: "2024-07-24"
+      description: "Released with the Deadman: Armageddon and While Guthix Sleeps Tweaks update."
+  properties:
+    release_date: "2024-07-24"
+    update: "Deadman: Armageddon & While Guthix Sleeps Tweaks"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    quest: "While Guthix Sleeps"
+    weight: 0
+    options:
+      - Teleport
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/haemostatic-dressing-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/haemostatic-dressing-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Haemostatic dressing (1) | OSRS Price Data
-description: "Haemostatic dressing (1): 1 application of haemostatic dressing.. High alch: 150 GP."
+description: "Haemostatic dressing (1): 1 application of haemostatic dressing. High alch: 150 GP."
 osrs:
   id: 31599
   name: Haemostatic dressing (1)
@@ -12,9 +12,79 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: null
-  about: "Haemostatic dressing (1) is a members-only item in Old School RuneScape. High alchemy value: 150 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Cures the Bleeding status effect and heals 5 Hitpoints when applied."
+        duration: 0
+      - description: "Can be applied even when not currently bleeding."
+        duration: 0
+  recipes:
+    - materials:
+        - item_name: Haemostatic poultice
+          quantity: 1
+        - item_name: Cotton yarn
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_id: 31601
+      item_name: Haemostatic dressing (2)
+      slug: haemostatic-dressing-2
+      relationship: variant
+      description: 2-application variant.
+    - item_id: 31603
+      item_name: Haemostatic dressing (3)
+      slug: haemostatic-dressing-3
+      relationship: variant
+      description: 3-application variant.
+    - item_id: 31605
+      item_name: Haemostatic dressing (4)
+      slug: haemostatic-dressing-4
+      relationship: variant
+      description: 4-application variant.
+    - item_id: 31597
+      item_name: Haemostatic poultice
+      slug: haemostatic-poultice
+      relationship: component
+      description: Base ingredient before adding cotton yarn.
+    - item_id: 5946
+      item_name: Cotton yarn
+      slug: cotton-yarn
+      relationship: component
+      description: Secondary crafted from cotton bolls.
+  about: "Haemostatic dressing (1) is a single-application Herblore consumable from the Sailing update that cures the Bleeding status and heals a small amount of Hitpoints."
+  market_strategy:
+    notes:
+      - Demand tied to bleeding mechanics introduced in Sailing content.
+      - Supply driven by Herblore 56 producers and cotton boll availability.
+      - Price likely correlates with cotton yarn cost.
+  trading_tips:
+    - Compare dose-size GE prices for decant arbitrage.
+    - Watch updates that adjust bleed sources for demand swings.
+    - Stack alternative anti-bleed items when prices spike during raids meta shifts.
+  history:
+    - date: "2025-11-05"
+      description: Added to the game as unobtainable during Sailing prep.
+    - date: "2025-11-19"
+      description: Made available alongside the Sailing skill launch.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Apply
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/haemostatic-dressing-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/haemostatic-dressing-4.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 2000
-  about: "Haemostatic dressing (4) is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Cures the bleed status effect on application and heals 5 Hitpoints if a bleed was successfully stopped. Can also be used outside of combat."
+        duration: 0
+  recipes:
+    - name: "Haemostatic dressing (4)"
+      skill: Herblore
+      level: 56
+      xp: 100
+      materials:
+        - item_name: Haemostatic poultice
+          quantity: 1
+        - item_name: Cotton yarn
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: "Haemostatic dressing (3)"
+      relationship: variant
+    - name: "Haemostatic dressing (2)"
+      relationship: variant
+    - name: "Haemostatic dressing (1)"
+      relationship: variant
+    - name: Haemostatic poultice
+      relationship: component
+    - name: Cotton yarn
+      relationship: component
+  about: "Haemostatic dressing (4) is a four-application Herblore bleed cure made from a haemostatic poultice and cotton yarn, healing 5 Hitpoints when it successfully stops a bleed."
+  market_strategy:
+    notes:
+      - Demand is driven by bossing and PvP setups where bleed effects are common.
+      - Price reflects haemostatic poultice secondaries and cotton yarn cost.
+  trading_tips:
+    - Track poultice and cotton yarn spreads for Herblore profit windows.
+    - Stock up before PvP weeks and bleed-heavy boss updates.
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing is OUT TODAY!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Apply
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/holy-book-page-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/holy-book-page-set.mdx
@@ -5,16 +5,46 @@ osrs:
   id: 13149
   name: Holy book page set
   slug: holy-book-page-set
-  examine: A set containing the four pages of Saradomin's Holy Book.
+  examine: "A set containing the four pages of Saradomin's Holy Book."
   members: true
   icon: Holy book page set.png
   value: 7000
   lowalch: 2800
   highalch: 4200
   limit: 5
-  about: "Holy book page set is a members-only item in Old School RuneScape. High alchemy value: 4,200 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - name: Saradomin page 1
+      relationship: component
+    - name: Saradomin page 2
+      relationship: component
+    - name: Saradomin page 3
+      relationship: component
+    - name: Saradomin page 4
+      relationship: component
+    - name: Holy book
+      relationship: product
+  about: "Holy book page set bundles all four Saradomin pages into a single tradeable set. Players exchange one of each Saradomin page (1-4) at a Grand Exchange clerk via the Sets option. High alchemy value: 4,200 coins. Grand Exchange buy limit: 5 per 4 hours."
+  history:
+    - date: "2015-03-19"
+      description: "Released via the Boss Pets, Sets, Chat & More update."
+    - date: "2015-03-26"
+      description: "God page sets became noteable when packed."
+    - date: "2017-04-27"
+      description: "Recoloured during the Diverse Dungeons update."
+  properties:
+    release_date: "2015-03-19"
+    update: "Boss Pets, Sets, Chat & More"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/huasca-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/huasca-potion-unf.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 10000
-  about: "Huasca potion (unf) is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - materials:
+        - item_name: "Huasca"
+          quantity: 1
+        - item_name: "Vial of water"
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: herblore
+      level: 58
+      experience: 0
+      notes: "Zahur can also process clean Huasca into the unfinished potion for a fee."
+  related_items:
+    - item_name: "Huasca"
+      relationship: component
+    - item_name: "Vial of water"
+      relationship: component
+    - item_name: "Prayer regeneration potion(3)"
+      relationship: product
+    - item_name: "Aga paste"
+      relationship: product
+  about: "Huasca potion (unf) is a members unfinished herblore potion used to brew prayer regeneration potions and Aga paste; 58 Herblore to create."
+  market_strategy:
+    notes:
+      - "Demand correlates with prayer regeneration potion usage at Inferno-tier PvM."
+      - "Floor anchored to Huasca herb supply; Zahur processing fee caps upside."
+  trading_tips:
+    - "Watch Huasca farming-patch yields and Aldarium supply for combined price moves."
+    - "Bulk buys reward patience; thin margins per unit but 10k limit enables flips."
+  history:
+    - date: "2024-09-25"
+      description: "Released with the Varlamore: The Rising Darkness update."
+    - date: "2025-01-08"
+      description: "Zahur granted the ability to process Huasca into unfinished potions."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iorwerth-camp-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iorwerth-camp-teleport.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Iorwerth camp teleport is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: Iorwerth Camp
+    type: scroll
+    requirements:
+      quest: Regicide
+  drop_table:
+    sources:
+      - source: Easy Treasure Trail reward casket
+        quantity: "1"
+        rarity: Uncommon
+      - source: Medium Treasure Trail reward casket
+        quantity: "1"
+        rarity: Uncommon
+      - source: Hard Treasure Trail reward casket
+        quantity: "1"
+        rarity: Uncommon
+      - source: Elite Treasure Trail reward casket
+        quantity: "1"
+        rarity: Uncommon
+      - source: Master Treasure Trail reward casket
+        quantity: "1"
+        rarity: Uncommon
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
+  related_items:
+    - name: Lletya teleport
+      relationship: alternative
+    - name: Prifddinas teleport
+      relationship: alternative
+  about: "Iorwerth camp teleport is a one-click scroll obtained from clue caskets that warps the user to Iorwerth Camp in Tirannwn, used primarily to reach Lord Iorwerth for hard clue steps."
+  market_strategy:
+    notes:
+      - Supply is gated to clue scroll reward casket loot, keeping volume thin.
+      - Demand spikes when hard/elite clue popularity surges or for hard clue completion routes.
+  trading_tips:
+    - Hoard during slow clue weeks and resell when DMM/league events drive clue activity.
+    - Watch master clue meta - Lord Iorwerth steps push price up.
+  history:
+    - date: "2014-06-12"
+      description: Added with the Treasure Trail Expansion.
+    - date: "2019-07-25"
+      description: Renamed from "Elf camp teleport" to "Iorwerth camp teleport".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Teleport
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/irit-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/irit-seed.mdx
@@ -12,65 +12,64 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 600
-  seed:
-    type: herb
-    tier: mid
   farming:
+    seed: Irit seed
     level: 44
+    patch: Herb
+    growth_time: 80
     xp_plant: 43
     xp_harvest: 48.5
-    growth_time: 80
-    patches: 9
-    product_id: 209
-    product_name: Grimy irit leaf
+    product: Grimy irit leaf
+  drop_table:
+    sources:
+      - source: Master Farmer
+        quantity: "1"
+        rarity: 1/302
+      - source: Seed pack
+        quantity: "1"
+        rarity: Common
+      - source: Hespori
+        quantity: "1"
+        rarity: Common
   related_items:
-    - item_id: 209
-      item_name: Grimy irit leaf
-      slug: grimy-irit-leaf
+    - name: Grimy irit leaf
       relationship: product
-      description: Harvested product
-    - item_id: 259
-      item_name: Irit leaf
-      slug: irit-leaf
+    - name: Irit leaf
       relationship: product
-      description: Cleaned herb
-    - item_id: 3026
-      item_name: Super antipoison(4)
-      slug: super-antipoison-4
+    - name: Super antipoison(4)
       relationship: product
-      description: Made from irit
-    - item_id: 5296
-      item_name: Toadflax seed
-      slug: toadflax-seed
+    - name: Toadflax seed
       relationship: alternative
-      description: Lower tier herb seed
-    - item_id: 5298
-      item_name: Avantoe seed
-      slug: avantoe-seed
+    - name: Avantoe seed
       relationship: upgrade
-      description: Next tier herb seed
-  about: |-
-    Plant in a herb patch to grow Grimy irit leaf.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 44 |
-    | Growth time | 80 minutes |
-    | XP (plant) | 43 |
-    | XP (harvest) | 48.5 per herb |
+  about: "Irit seeds are mid-tier members herb seeds planted in herb patches at Farming level 44, producing grimy irit leaves used in super antipoison and other Herblore potions over an 80 minute growth cycle."
   market_strategy:
     notes:
-      - Mid-tier herb seed
-      - Used for super antipoison potions
-      - Moderate profit potential
-      - Ultracompost (essential)
-      - Magic secateurs (10% more yield)
-      - Farming cape (5% more yield)
-      - 9 herb patches available
-      - ~10 minute runs, 80 minute regrowth
-      - Super antipoisons useful for many PvM activities
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Mid-tier herb seed mainly used for super antipoison potions."
+      - "Magic secateurs, farming cape, and ultracompost stack to boost yield."
+      - "Nine herb patches make full irit runs roughly 10 minutes with 80 minute regrowth."
+  trading_tips:
+    - "Bulk buy when Master Farmer pickpocket meta shifts depress the price."
+    - "Watch super antipoison demand spikes around poison-heavy bossing content."
+  history:
+    - date: "2005-06-06"
+      description: "Released alongside the herb patch farming expansion."
+  properties:
+    release_date: "2005-06-06"
+    update: "Farming Skill Expansion"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Inspect
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bolts-p-9294.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-bolts-p-9294.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Iron bolts (p+) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: ammo
+    weight: 0
+    other_bonus:
+      ranged_strength: 46
+  recipes:
+    - skill: Fletching
+      materials:
+        - item_name: Iron bolts
+          quantity: 5
+        - item_name: Weapon poison(+)
+          quantity: 1
+      output_quantity: 5
+  related_items:
+    - name: Iron bolts
+      relationship: variant
+    - name: Iron bolts (p)
+      relationship: variant
+    - name: Iron bolts (p++)
+      relationship: upgrade
+  about: "Iron bolts (p+) are iron crossbow bolts treated with extra-strength weapon poison. They deal +46 ranged strength and can apply a poison effect on hit. High alchemy value: 1 coin. Grand Exchange buy limit: 11,000 per 4 hours."
+  history:
+    - date: "2006-07-31"
+      description: "Iron bolts released as part of the Crossbows update."
+    - date: "2018-01-04"
+      description: "Naming convention updated to add spaces around poison designations."
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-full-helm-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-full-helm-g.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 4
-  about: "Iron full helm (g) is a free-to-play item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: iron
+    tier: low
+  equipment:
+    slot: head
+    weight: 2.721
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 6
+      slash: 7
+      crush: 5
+      magic: -1
+      ranged: 7
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  related_items:
+    - name: Iron full helm
+      relationship: variant
+    - name: Iron platebody (g)
+      relationship: set-piece
+    - name: Iron platelegs (g)
+      relationship: set-piece
+    - name: Iron plateskirt (g)
+      relationship: set-piece
+    - name: Iron kiteshield (g)
+      relationship: set-piece
+  about: "Iron full helm (g) is a free-to-play cosmetic Treasure Trail reward in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 4 per 4 hours."
+  market_strategy:
+    notes:
+      - Supply is gated by easy clue rewards (1/1,404), making it a thin but steady market.
+      - GE buy limit of 4 per 4 hours sharply caps flipping velocity.
+      - Part of the iron gold-trim set — price tracks demand for the full ornamental set.
+  trading_tips:
+    - List buy offers a few percent under last GE price to actually fill given low daily volume.
+    - Demand spikes when costume room or POH content gets attention.
+  history:
+    - date: "2014-06-12"
+      description: Added with the Treasure Trail Expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-full-helm-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-full-helm-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron full helm (t) | OSRS Price Data
-description: "Iron full helm (t): Iron full helm with trim.. High alch: 96 GP, GE limit: 4."
+description: "Iron full helm (t): Iron full helm with trim. High alch: 96 GP, GE limit: 4."
 osrs:
   id: 12231
   name: Iron full helm (t)
@@ -12,9 +12,69 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 4
-  about: "Iron full helm (t) is a free-to-play item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: head
+    weight: 2.721
+    requirements:
+      defence: 1
+    defence_bonus:
+      stab: 6
+      slash: 7
+      crush: 5
+      magic: -1
+      ranged: 6
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Iron full helm
+      slug: iron-full-helm
+      relationship: variant
+      description: Untrimmed base helm with identical stats.
+  about: "Iron full helm (t) is a free-to-play cosmetic helm with gold trim awarded from easy Treasure Trail clue caskets. It shares defensive stats with the standard iron full helm and is valued mainly for its decorative appearance and clue-hunter status."
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  market_strategy:
+    notes:
+      - "Cosmetic clue reward with thin organic demand; price driven by collectors."
+      - "Tiny GE buy limit of 4 makes large-scale flipping impractical."
+      - "Easy-clue completion volume sets long-term supply."
+  trading_tips:
+    - "Buy slow during clue-event seasons and resell to costume collectors."
+    - "Compare with standard iron full helm to gauge cosmetic premium."
+    - "Watch for cosmetic overrides that could change demand."
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion as an easy-clue casket reward."
+    - date: "2021-04-21"
+      description: "Ranged attack penalty adjusted as part of an equipment stat pass."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-hasta-p-11391.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-hasta-p-11391.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron hasta(p++) | OSRS Price Data
-description: "Iron hasta(p++): A poison-tipped, one-handed iron hasta.. High alch: 54 GP, GE limit: 125."
+description: "Iron hasta(p++): A poison-tipped, one-handed iron hasta. High alch: 54 GP, GE limit: 125."
 osrs:
   id: 11391
   name: Iron hasta(p++)
@@ -12,9 +12,88 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 125
-  about: "Iron hasta(p++) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Iron hasta(p++) is the strongest poisoned variant of the iron hasta, a one-handed stab spear made via Barbarian Smithing. The poison++ tip inflicts the highest-tier poison damage on hit, making it useful for low-Attack PvP and training."
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  material:
+    type: Iron
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 41
+    attack_bonus:
+      stab: 8
+      slash: 8
+      crush: 8
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -2
+      slash: -2
+      crush: -2
+      magic: 0
+      ranged: -2
+    other_bonus:
+      strength: 10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Iron hasta
+      skill: Smithing
+      level: 20
+      experience: 50
+      materials:
+        - item_name: Iron bar
+          quantity: 1
+        - item_name: Oak logs
+          quantity: 1
+      tools:
+        - Barbarian Smithing anvil
+      output_quantity: 1
+  related_items:
+    - name: Iron hasta
+      relationship: variant
+    - name: Iron hasta(p)
+      relationship: variant
+    - name: Iron hasta(p+)
+      relationship: variant
+    - name: Iron hasta(kp)
+      relationship: variant
+    - name: Steel hasta(p++)
+      relationship: upgrade
+  market_strategy:
+    notes:
+      - "Niche item due to low-tier melee bonuses; demand mainly from poison PvP and pure builds."
+      - "Crafting cost typically exceeds GE price due to oak log + iron bar inputs."
+  trading_tips:
+    - "Compare to other low-tier poisoned spears for budget pure setups."
+    - "Buy limit of 125 limits scale; small-volume flips only."
+    - "Demand spikes with PvP events featuring stab requirements."
+  history:
+    - date: "2007-07-03"
+      description: "Iron hasta and poisoned variants added with Barbarian Training."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-kiteshield-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-kiteshield-g.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 4
-  about: "Iron kiteshield (g) is a free-to-play item in Old School RuneScape. High alchemy value: 144 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Iron
+    tier: low
+  equipment:
+    slot: shield
+    weapon_type: shield
+    weight: 5.443
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -2
+    defence_bonus:
+      stab: 8
+      slash: 10
+      crush: 9
+      magic: -1
+      ranged: 9
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  related_items:
+    - name: Iron kiteshield
+      relationship: variant
+    - name: Iron kiteshield (t)
+      relationship: variant
+    - name: Steel kiteshield (g)
+      relationship: alternative
+  about: "Iron kiteshield (g) is a gold-trimmed cosmetic variant of the iron kiteshield obtained from easy reward caskets. It carries identical defensive bonuses to the plain version with a slightly improved ranged attack penalty and is free-to-play tradeable."
+  market_strategy:
+    notes:
+      - "Only obtainable from easy clue scroll caskets at roughly a 1/1,404 roll."
+      - "Free-to-play tradeable so demand spikes around F2P cosmetic events."
+      - "Low buy limit (4 per 4h) means thin spreads but easy daily flips."
+  trading_tips:
+    - "Stockpile during easy clue scroll meta updates and resell to cosmetics collectors."
+    - "Watch GE volume for casket loot dumps that briefly depress the price."
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trails Expansion as a rare easy clue reward."
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trails Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-kiteshield-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-kiteshield-t.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 4
-  about: "Iron kiteshield (t) is a free-to-play item in Old School RuneScape. High alchemy value: 144 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: iron
+    tier: low
+  equipment:
+    slot: shield
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 8
+      slash: 10
+      crush: 9
+      magic: -1
+      ranged: 9
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 5.443
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - name: Iron kiteshield
+      relationship: variant
+    - name: Iron kiteshield (g)
+      relationship: alternative
+  about: "Iron kiteshield (t) is a trimmed cosmetic variant of the iron kiteshield obtained exclusively from easy clue scroll caskets. It cannot be smithed and offers the same defensive profile as the base shield."
+  market_strategy:
+    notes:
+      - "Supply tied entirely to easy clue scroll completions; price moves with clue activity."
+      - "Buy limit of 4 every 4 hours keeps volume thin; large fills take patience."
+  trading_tips:
+    - "Pairs with the (g) gold-trimmed variant; track both as cosmetic substitutes."
+    - "Demand spikes around clue scroll meta events or trimming completionist accounts."
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trail Expansion easy clue rewards."
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-thrownaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-thrownaxe.mdx
@@ -12,31 +12,81 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 7000
+  material:
+    type: iron
+    tier: low
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 5
+    weight: 0
     requirements:
       ranged: 1
     attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 5
-    ranged_strength: 7
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 7
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Axing
+    description: Thrownaxes feature a special attack that bounces the projectile between nearby targets, hitting up to two additional enemies for reduced damage.
+    energy_cost: 100
+  shops:
+    - shop_name: Tribal Weapons Salesman
+      location: Ranging Guild
+      price: 9
+      stock: 800
   related_items:
-    - item_id: 800
-      item_name: Bronze thrownaxe
-      slug: bronze-thrownaxe
-      relationship: variant
-      description: Lower tier thrownaxe
-    - item_id: 802
-      item_name: Steel thrownaxe
-      slug: steel-thrownaxe
-      relationship: variant
-      description: Higher tier thrownaxe
-  about: |-
-    > _"A finely balanced throwing axe."_
-
-    The iron thrownaxe requires 1 Ranged. Features the thrownaxe special attack that bounces between multiple targets.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Bronze thrownaxe
+      relationship: downgrade
+    - name: Steel thrownaxe
+      relationship: upgrade
+    - name: Mithril thrownaxe
+      relationship: upgrade
+  about: "Iron thrownaxe is a members-only stackable ranged weapon with a special attack that bounces between nearby targets, bought from the Tribal Weapons Salesman at the Ranging Guild rather than smithed."
+  market_strategy:
+    notes:
+      - Demand is niche; mostly used for the bouncing special attack against grouped low-level NPCs.
+      - Cannot be smithed, so supply is constrained to shop restock and player trades.
+      - GE buy limit of 7,000 supports modest flips for special-attack hunters.
+  trading_tips:
+    - Buy from Tribal Weapons Salesman for 9 coins each when GE supply is dry.
+    - Stack large quantities to leverage the bouncing special attack at AFK NPC clusters.
+    - Pair with higher-tier thrownaxes for damage progression as Ranged level grows.
+  history:
+    - date: "2004-03-29"
+      description: Released with the RuneScape 2 launch.
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2 launch
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-trimmed-set-lg.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 8
-  about: "Iron trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Iron
+    tier: low
+  recipes:
+    - materials:
+        - item_name: Iron full helm (t)
+          quantity: 1
+        - item_name: Iron platebody (t)
+          quantity: 1
+        - item_name: Iron platelegs (t)
+          quantity: 1
+        - item_name: Iron kiteshield (t)
+          quantity: 1
+      tools:
+        - Grand Exchange clerk
+      output_quantity: 1
+  related_items:
+    - name: Iron full helm (t)
+      relationship: component
+    - name: Iron platebody (t)
+      relationship: component
+    - name: Iron platelegs (t)
+      relationship: component
+    - name: Iron kiteshield (t)
+      relationship: component
+    - name: Iron gold-trimmed set (lg)
+      relationship: alternative
+    - name: Iron armour set (lg)
+      relationship: alternative
+  about: "Iron trimmed set (lg) is a Grand Exchange-exchangeable bundle of the four trimmed iron legs-variant pieces, used to save bank space."
+  market_strategy:
+    notes:
+      - "Set arbitrage: compare set GE price vs sum of individual trimmed pieces."
+      - "Limit 8 per 4 hours caps flip throughput."
+      - "High alch 540 gp negligible vs typical set price — never alch."
+  trading_tips:
+    - "Use the GE Sets tab to assemble/disassemble and capture spreads."
+    - "Trimmed iron is rare cosmetic — supply is driven by hard clue casket drops of the parts."
+  history:
+    - date: "2015-02-26"
+      description: "Released with The Grand Exchange update as part of the Item Sets interface."
+  properties:
+    release_date: "2015-02-26"
+    update: "The Grand Exchange"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jaguar-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jaguar-fur.mdx
@@ -11,10 +11,71 @@ osrs:
   value: 80
   lowalch: 32
   highalch: 48
-  limit: null
-  about: "Jaguar fur is a members-only item in Old School RuneScape. High alchemy value: 48 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit: 10000
+  material:
+    type: fur
+    tier: low
+  drop_table:
+    sources:
+      - source: Jaguar
+        quantity: "1"
+        rarity: Always
+      - source: Black jaguar
+        quantity: "1"
+        rarity: Always
+      - source: White jaguar
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - materials:
+        - item_name: Mixed hide base
+          quantity: 1
+        - item_name: Jaguar fur
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+      output_item: Mixed hide cape
+      skills:
+        - skill: Crafting
+          level: 68
+          xp: 62
+  related_items:
+    - name: Mixed hide cape
+      relationship: product
+    - name: Mixed hide base
+      relationship: component
+  about: "Jaguar fur is a members-only crafting material dropped by jaguars in the Varlamore region. Used with a mixed hide base to craft a mixed hide cape at 68 Crafting. High alchemy value: 48 coins."
+  market_strategy:
+    notes:
+      - "Supply depends on Varlamore jaguar farmers; price tracks crafting demand."
+      - "Profitable alch is unlikely; flip via Crafting demand instead."
+  trading_tips:
+    - "Stock up before any Varlamore content drop that boosts hunting activity."
+    - "Pair sourcing with mixed hide bases to streamline cape production."
+  history:
+    - date: "2024-03-20"
+      description: "Jaguar fur released with the Varlamore: The Final Dawn expansion."
+    - date: "2026-04-22"
+      description: "Wiki refresh confirmed alch values and crafting recipe."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jerboa-tail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jerboa-tail.mdx
@@ -9,12 +9,70 @@ osrs:
   members: true
   icon: Jerboa tail.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 18000
-  about: "Jerboa tail is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hunter_drop
+    tier: mid
+  drop_table:
+    sources:
+      - source: Embertailed jerboa (Hunter)
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - materials:
+        - item_name: Teak logs
+          quantity: 1
+        - item_name: Hunter spear tip
+          quantity: 1
+        - item_name: Jerboa tail
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+      output_item: Hunter's spear
+      requirements:
+        hunter: 39
+  related_items:
+    - item_name: Embertailed jerboa
+      relationship: alternative
+      description: Hunter creature that yields the tail
+    - item_name: Hunter's spear
+      relationship: product
+      description: Crafted with jerboa tail, teak logs, and a hunter spear tip
+    - item_name: Pyre fox
+      relationship: alternative
+      description: Hunter creature baited using jerboa tails (+3% catch rate)
+  about: "Jerboa tail is a Varlamore Hunter drop from embertailed jerboas, used as pyre fox bait and crafted into Hunter's spears during At First Light progression."
+  market_strategy:
+    notes:
+      - Supply scales with Hunter players grinding embertailed jerboas for 39+ Hunter XP.
+      - Demand split between pyre fox hunters and Hunter's spear crafters.
+  trading_tips:
+    - Buy on weekend Hunter XP spikes when supply briefly outruns crafting demand.
+    - Bundle with Hunter spear tips to flip Hunter's spears during pyre fox meta swings.
+  history:
+    - date: "2024-03-20"
+      description: Added with Varlamore Part One alongside embertailed jerboas and pyre foxes.
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: Part One"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    quest: At First Light
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/karambwan-vessel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/karambwan-vessel.mdx
@@ -1,6 +1,6 @@
 ---
 title: Karambwan vessel | OSRS Price Data
-description: "Karambwan vessel: A wide bodied and thin necked vessel, encrusted with sea salt.. High alch: 3 GP, GE limit: 15."
+description: "Karambwan vessel: A wide bodied and thin necked vessel, encrusted with sea salt. High alch: 3 GP, GE limit: 15."
 osrs:
   id: 3157
   name: Karambwan vessel
@@ -12,9 +12,49 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 15
-  about: "Karambwan vessel is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Karambwan vessel is a fishing trap used to catch karambwan on the eastern coast of Karamja. It is first obtained during the Tai Bwo Wannai Trio quest and must be baited with raw karambwanji to function."
+  properties:
+    release_date: "2004-09-14"
+    update: Tai Bwo Wannai Trio
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.0
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Tiadeche's Karambwan Stall
+      location: Tai Bwo Wannai Village
+      stock: 5
+      price: 2
+      restock_time: 60
+  related_items:
+    - name: Karambwan vessel (loaded)
+      relationship: variant
+    - name: Raw karambwan
+      relationship: product
+    - name: Raw karambwanji
+      relationship: component
+  market_strategy:
+    notes:
+      - "Specialist fishing tool with niche demand; cheaper to buy from Tiadeche than the GE."
+      - "Demand correlates with karambwan fishing for the Cooking-fish stacked food meta."
+      - "Buy limit of 15 keeps the market tiny — most players just buy from the shop."
+  trading_tips:
+    - "Most efficient acquisition is direct purchase from Tiadeche at 2gp each."
+    - "GE flipping is largely impractical at this scale."
+    - "Useful to keep a spare during karambwan trips in case of loss."
+  history:
+    - date: "2004-09-14"
+      description: "Karambwan vessel added with Tai Bwo Wannai Trio quest."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/katana.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/katana.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 9600
   highalch: 14400
   limit: 8
-  about: "Katana is a members-only item in Old School RuneScape. High alchemy value: 14,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: mid-high
+  equipment:
+    slot: weapon
+    weapon_type: two-handed
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 7
+      slash: 45
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 3
+      slash: 7
+      crush: 7
+      magic: 0
+      ranged: -3
+    other_bonus:
+      strength: 40
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Reward casket (elite)"
+        quantity: "1"
+        rarity: "1/1,275"
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  about: "Katana is a members-only two-handed sword in Old School RuneScape, obtained from elite Treasure Trails. High alchemy value: 14,400 coins. Grand Exchange buy limit: 8 per 4 hours."
+  market_strategy:
+    notes:
+      - "Casual flavor weapon; demand limited to collectors and Kill Bill cosplay setups."
+      - "Buy limit of 8 keeps inventory rotation slow; flips need patience."
+  trading_tips:
+    - "Track elite clue completion rate spikes for supply influxes."
+    - "Stat-stick value is irrelevant; only cosmetic appeal drives the price."
+  history:
+    - date: "2014-06-12"
+      description: "Added to the game as part of the Treasure Trail Expansion update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kitchen-table-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kitchen-table-flatpack.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Kitchen table (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: low
+  recipes:
+    - name: Build Kitchen table flatpack
+      skill: Construction
+      level: 12
+      experience: 87
+      materials:
+        - item_name: Plank
+          quantity: 3
+        - item_name: Steel nails
+          quantity: 3
+      tools:
+        - Hammer
+        - Saw
+      facility: Workbench
+      output_quantity: 1
+  construction:
+    level: 12
+    experience: 87
+    hotspot: Table space
+    room: Kitchen
+  related_items:
+    - name: Plank
+      relationship: component
+    - name: Steel nails
+      relationship: component
+    - name: Oak kitchen table (flatpack)
+      relationship: upgrade
+    - name: Teak kitchen table (flatpack)
+      relationship: upgrade
+  about: "Kitchen table (flatpack) is a Construction-level 12 furniture pack built at a workbench from 3 planks and 3 steel nails, then placed in a player-owned house Kitchen Table space hotspot for 87 Construction experience."
+  market_strategy:
+    notes:
+      - Low alch and GE price make this useful only as a cheap Construction XP product.
+      - Common bulk-buy item for low-level Construction trainers.
+      - Buy limit of 500 supports moderate flipping volume but tight per-unit margin.
+  trading_tips:
+    - Stockpile via workbench when planks and nails are cheap, then resell or use for housing.
+    - Useful early-level Construction XP path for ironmen avoiding Plank Make magic.
+    - Check GE spread vs material cost before flipping.
+  history:
+    - date: "2006-05-31"
+      description: Introduced with the Construction skill update.
+  properties:
+    release_date: "2006-05-31"
+    update: Construction skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-wooden-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-wooden-hull-parts.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 500
   highalch: 750
   limit: 100
-  about: "Large wooden hull parts is a members-only item in Old School RuneScape. High alchemy value: 750 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: low
+  recipes:
+    - materials:
+        - item_name: Wooden hull parts
+          quantity: 5
+      tools: []
+      output_quantity: 1
+      requirements: "Requires 1 Construction. Combined at a shipwrights' workbench, granting 2.5 Construction experience."
+  related_items:
+    - name: Wooden hull parts
+      relationship: component
+    - name: Wooden hull
+      relationship: product
+  about: "Large wooden hull parts is a members-only Sailing/Construction component in Old School RuneScape. High alchemy value: 750 coins. Grand Exchange buy limit: 100 per 4 hours."
+  market_strategy:
+    notes:
+      - "Crafted by combining 5 wooden hull parts at a shipwrights' workbench for 2.5 Construction experience."
+      - "Used to build wooden hulls for sloops; 16 large parts (400 planks) needed per sloop."
+      - "Sloops ship with a wooden hull by default, so primary demand comes from hull downgrades or off-meta builds."
+  trading_tips:
+    - "Profit margin tracks wooden hull parts spot price; flip when smaller parts dip."
+    - "Buy limit of 100 per 4 hours caps quick scaling — bulk traders need multiple windows."
+    - "Demand stays low because sloops come pre-fitted with wooden hulls; watch for Sailing meta shifts."
+  history:
+    - date: "2025-11-19"
+      description: "Released alongside the launch of the Sailing skill."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lava-dragon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lava-dragon-mask.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Lava dragon mask is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: high
+  equipment:
+    slot: head
+    weight: 2.267
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/14662
+  related_items:
+    - name: Reward casket (elite)
+      relationship: alternative
+    - name: Green dragon mask
+      relationship: alternative
+    - name: Blue dragon mask
+      relationship: alternative
+    - name: Red dragon mask
+      relationship: alternative
+    - name: Black dragon mask
+      relationship: alternative
+    - name: Steel dragon mask
+      relationship: alternative
+    - name: Mithril dragon mask
+      relationship: alternative
+    - name: Bronze dragon mask
+      relationship: alternative
+    - name: Iron dragon mask
+      relationship: alternative
+  about: "Lava dragon mask is a cosmetic members-only head slot item won from elite Treasure Trails. It is part of the dragon mask collection and offers no combat bonuses."
+  market_strategy:
+    notes:
+      - Only sourced from elite Reward caskets on the mega-rare drop table
+      - Buy limit of 4 keeps liquidity thin and prices volatile
+      - Storable in the costume room treasure chest
+  trading_tips:
+    - Track elite clue completions for supply trends
+    - Collector demand drives long-term floor
+  history:
+    - date: "2014-06-12"
+      description: Released as part of the Treasure Trails Expansion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trails Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lovakengj-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lovakengj-banner.mdx
@@ -1,20 +1,109 @@
 ---
 title: Lovakengj banner | OSRS Price Data
-description: "Lovakengj banner: A lovakite banner baring the sigil of house Lovakengj.. High alch: 42 GP, GE limit: 4."
+description: "Lovakengj banner: A lovakite banner bearing the sigil of house Lovakengj. High alch: 42 GP, GE limit: 4."
 osrs:
   id: 20257
   name: Lovakengj banner
   slug: lovakengj-banner
-  examine: A lovakite banner baring the sigil of house Lovakengj.
+  examine: A lovakite banner bearing the sigil of house Lovakengj.
   members: true
   icon: Lovakengj banner.png
   value: 70
   lowalch: 28
   highalch: 42
   limit: 4
-  about: "Lovakengj banner is a members-only item in Old School RuneScape. High alchemy value: 42 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: lovakite
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: polestaff
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_id: 20253
+      item_name: Arceuus banner
+      slug: arceuus-banner
+      relationship: alternative
+      description: Matching House banner from Arceuus.
+    - item_id: 20255
+      item_name: Hosidius banner
+      slug: hosidius-banner
+      relationship: alternative
+      description: Matching House banner from Hosidius.
+    - item_id: 20259
+      item_name: Piscarilius banner
+      slug: piscarilius-banner
+      relationship: alternative
+      description: Matching House banner from Piscarilius.
+    - item_id: 20261
+      item_name: Shayzien banner
+      slug: shayzien-banner
+      relationship: alternative
+      description: Matching House banner from Shayzien.
+  about: "Lovakengj banner is a cosmetic polestaff bearing the Lovakengj sigil, obtained as a medium clue reward; it offers no combat bonuses and is stored in the costume room treasure chest."
+  market_strategy:
+    notes:
+      - Strict 4-per-4h GE limit caps flipping throughput.
+      - Supply comes only from medium clue caskets (1/1133).
+      - Cosmetic demand bumps when Kourend content updates ship.
+  trading_tips:
+    - Buy in singletons to respect the tight buy limit.
+    - Compare price across all five House banners for collector flips.
+    - Watch Kourend favour reworks for potential cosmetic demand spikes.
+  history:
+    - date: "2016-07-06"
+      description: Lovakengj banner released with the Kingdom of Kourend update.
+    - date: "2019-01-01"
+      description: Examine text corrected from "baring" to "bearing".
+  properties:
+    release_date: "2016-07-06"
+    update: Kingdom of Kourend
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-roots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-roots.mdx
@@ -9,8 +9,8 @@ osrs:
   members: true
   icon: Magic roots.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 11000
   material:
     type: farming_product
@@ -20,75 +20,95 @@ osrs:
     source: Magic tree
     seed_id: 5316
     seed_name: Magic seed
+    notes: Dig the stump with a spade after felling a fully grown Magic tree to harvest 1-4 roots scaled with Farming level.
   recipes:
-    - skill: herblore
-      level: 79
-      xp: 155
-      materials:
+    - materials:
         - item_name: Irit potion (unf)
-          item_id: 2481
           quantity: 1
         - item_name: Magic roots
-          item_id: 6051
           quantity: 1
-      product: Antidote++(3)
-      product_id: 5954
-      members_only: true
-    - skill: herblore
-      level: 79
-      xp: 155
-      materials:
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+      output_item: Antidote++ (3)
+      requirements:
+        herblore: 79
+        xp: 155
+    - materials:
         - item_name: Coconut milk
-          item_id: 5935
           quantity: 1
         - item_name: Irit leaf
-          item_id: 259
           quantity: 1
         - item_name: Magic roots
-          item_id: 6051
           quantity: 1
-      product: Antidote++(3)
-      product_id: 5954
-      members_only: true
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+      output_item: Antidote++ (3)
+      requirements:
+        herblore: 79
+        xp: 155
+    - materials:
+        - item_name: Magic roots
+          quantity: 1
+      tools:
+        - Spinning wheel
+      output_quantity: 1
+      output_item: Magic string
+      requirements:
+        crafting: 19
   related_items:
     - item_id: 5316
       item_name: Magic seed
       slug: magic-seed
       relationship: component
-      description: Tree seed that yields roots
+      description: Tree seed that grows into the Magic tree
     - item_id: 5952
-      item_name: Antidote++(4)
+      item_name: Antidote++ (4)
       slug: antidote-4
       relationship: product
-      description: Main herblore product
+      description: Main Herblore product made with Magic roots
     - item_id: 5935
       item_name: Coconut milk
       slug: coconut-milk
-      relationship: component
-      description: Alternative base for antidote++
+      relationship: alternative
+      description: Alternative base for Antidote++
     - item_id: 259
       item_name: Irit leaf
       slug: irit-leaf
       relationship: component
-      description: Herb for antidote++
+      description: Herb used in the Antidote++ recipe
+    - item_name: Magic string
+      relationship: product
+      description: Spun from Magic roots at a spinning wheel
+  about: "Magic roots are a Farming by-product harvested by digging up a felled Magic tree stump; they feed the Antidote++ Herblore loop."
   market_strategy:
-    title: Antidote++ Chain
-    steps:
-      - order: 1
-        action: Magic roots for antidote++
-      - order: 2
-        action: Antidote++ + scales for anti-venom
-      - order: 3
-        action: Anti-venom + torstol for anti-venom+
     notes:
-      - Plant magic trees for seeds + XP + roots
-      - Roots are bonus income from tree runs
-      - Consider tree protection payments
-      - Can passively collect magic roots
-      - Set workers to hardwood/mahogany
-      - Roots as secondary reward
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Supply tied to Magic tree farm runs and dragonhide stringers leveling Crafting.
+      - Antidote++ → Anti-venom → Anti-venom+ chain is the primary demand sink.
+  trading_tips:
+    - Buy roots when Magic seeds spike (lower fresh supply incoming) and resell during PvM venom-poison demand windows.
+    - Stockpile during low Bounty Hunter PK seasons when antidote demand softens.
+  history:
+    - date: "2005-07-11"
+      description: Added with the Farming skill release.
+  properties:
+    release_date: "2005-07-11"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-blackjack-o.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-blackjack-o.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 640
   highalch: 960
   limit: 125
-  about: "Maple blackjack(o) is a members-only item in Old School RuneScape. High alchemy value: 960 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: blackjack
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 30
+      thieving: 30
+    attack_bonus:
+      crush: 24
+    other_bonus:
+      strength: 20
+  related_items:
+    - name: Maple blackjack
+      relationship: alternative
+    - name: Maple blackjack(d)
+      relationship: alternative
+    - name: Oak blackjack(o)
+      relationship: alternative
+    - name: Willow blackjack(o)
+      relationship: alternative
+  about: "Maple blackjack(o) is a members-only offensive blackjack used to lure and knockout NPCs in the Rogue Trader miniquest. High alchemy value: 960 coins. Grand Exchange buy limit: 125 per 4 hours."
+  history:
+    - date: "2005-08-15"
+      description: "Released with the Rogue Trader update."
+    - date: "2006-08-22"
+      description: "Renamed from Maple blackjack(a) to Maple blackjack(o)."
+  properties:
+    release_date: "2005-08-15"
+    update: Rogue Trader
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-shield.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 128
   highalch: 192
   limit: 18000
-  about: "Maple shield is a members-only item in Old School RuneScape. High alchemy value: 192 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: mid
+  equipment:
+    slot: shield
+    weight: 3.175
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 7
+      slash: 8
+      crush: 6
+      magic: 2
+      ranged: 7
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Maple logs
+          quantity: 2
+      tools:
+        - Knife
+      output_quantity: 1
+      output_item: Maple shield
+      requirements:
+        fletching: 57
+        xp: 116.5
+  related_items:
+    - item_name: Maple logs
+      relationship: component
+      description: Raw material fletched into the shield
+    - item_name: Willow shield
+      relationship: downgrade
+      description: Lower-tier leather shield
+    - item_name: Yew shield
+      relationship: upgrade
+      description: Higher-tier Fletched shield
+  about: "Maple shield is a 40 Defence shield fletched from two Maple logs at 57 Fletching, part of the leather/Fletched shield line introduced in 2018."
+  market_strategy:
+    notes:
+      - Fletching-driven supply with steady downward price pressure outside of Defence pures.
+      - Modest profit per craft, mostly used for Fletching XP rather than GP.
+  trading_tips:
+    - Use as a Fletching XP filler during low-margin Maple log prices.
+    - Avoid bulk flipping; daily volume keeps margins thin.
+  history:
+    - date: "2018-02-01"
+      description: Added with the Leather Shields and Tournament Worlds update.
+  properties:
+    release_date: "2018-02-01"
+    update: Leather Shields and Tournament Worlds
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-stock.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-stock.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 10000
-  about: "Maple stock is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: mid
+  recipes:
+    - skill: Fletching
+      level: 54
+      xp: 32
+      tools:
+        - Knife
+      output_quantity: 1
+      materials:
+        - item_name: Maple logs
+          item_id: 1517
+          quantity: 1
+    - skill: Fletching
+      level: 54
+      xp: 64
+      tools: []
+      output_quantity: 1
+      result: Mithril crossbow (u)
+      materials:
+        - item_name: Maple stock
+          item_id: 9448
+          quantity: 1
+        - item_name: Mithril limbs
+          item_id: 9425
+          quantity: 1
+  related_items:
+    - item_id: 9442
+      item_name: Willow stock
+      slug: willow-stock
+      relationship: downgrade
+      description: Lower-tier crossbow stock
+    - item_id: 9450
+      item_name: Yew stock
+      slug: yew-stock
+      relationship: upgrade
+      description: Higher-tier crossbow stock
+    - item_id: 9461
+      item_name: Mithril crossbow (u)
+      slug: mithril-crossbow-u
+      relationship: product
+      description: Unstrung crossbow assembled with mithril limbs
+  about: "Crossbow stock fletched from a single maple log at level 54 Fletching for 32 XP; combined with mithril limbs to begin a mithril crossbow."
+  market_strategy:
+    notes:
+      - Tied to maple log prices and Fletching training demand
+      - Thin margin per unit; volume is the play
+      - Mithril crossbow demand drives downstream pull
+      - Steady but low daily GE volume
+  trading_tips:
+    - Buy maple logs in bulk during peak woodcutting hours
+    - Sell during evening fletching prime time
+    - Bundle with mithril limbs to capture full mithril crossbow margin
+  history:
+    - date: "2006-07-31"
+      description: Maple stock released with the Crossbows fletching expansion.
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-purple-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-purple-hat.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 150
-  about: "Menaphite purple hat is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: head
+    weapon_type: none
+    weight: 0.005
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  shops:
+    - shop_name: Ali's Discount Wares
+      location: Al Kharid
+      currency: coins
+  related_items:
+    - slug: menaphite-purple-robe
+      name: Menaphite purple robe
+      relationship: set-piece
+    - slug: menaphite-purple-kilt
+      name: Menaphite purple kilt
+      relationship: set-piece
+    - slug: menaphite-red-hat
+      name: Menaphite red hat
+      relationship: alternative
+  about: "Menaphite purple hat is a members-only item in Old School RuneScape. Delays desert heat effects by 12 additional seconds when worn. Used in master-tier emote clues."
+  history:
+    - date: "2005-08-15"
+      description: Menaphite purple hat released alongside The Feud quest area.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-15"
+    update: The Feud
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-purple-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-purple-robe.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 150
-  about: "Menaphite purple robe is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 0.005
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: false
+  related_items:
+    - name: Menaphite purple hat
+      relationship: set-piece
+    - name: Menaphite purple top
+      relationship: set-piece
+    - name: Menaphite purple kilt
+      relationship: set-piece
+    - name: Menaphite red robe
+      relationship: alternative
+  about: "Menaphite purple robe is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 150 per 4 hours. Delays desert heat damage onset by 12 seconds when worn in Pollnivneach."
+  market_strategy:
+    notes:
+      - "Cosmetic legs slot item with no combat bonuses; demand driven by Menaphite outfit collectors and Master clue emote (Yawn at Pyramid Plunder)."
+      - "Buy limit of 150 per 4 hours; low daily volume so prices can swing on minor demand spikes."
+  trading_tips:
+    - "Acquired via Rogue Trader miniquest by trading three dyes to Siamun through Ali Morrisane."
+    - "Provides 20-tick desert heat protection in Pollnivneach since the 22 March 2023 update."
+  history:
+    - date: "2005-08-15"
+      description: "Released as part of the Rogue Trader update."
+    - date: "2023-03-22"
+      description: "Added 20-tick desert heat protection bonus when worn in Pollnivneach."
+  properties:
+    release_date: "2005-08-15"
+    update: Rogue Trader
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wear
+      - Use
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mind-helmet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mind-helmet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mind helmet | OSRS Price Data
-description: "Mind helmet: A magic helmet.. High alch: 1,800 GP, GE limit: 70."
+description: "Mind helmet: A magic helmet. High alch: 1,800 GP, GE limit: 70."
 osrs:
   id: 9733
   name: Mind helmet
@@ -12,9 +12,85 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 70
-  about: "Mind helmet is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Mind helmet is a members-only magic-defence helmet crafted at the Elemental Workshop after completing the Elemental Workshop II quest. It is part of the mind armour set and provides minor magic defence with no offensive bonuses."
+  properties:
+    release_date: "2006-10-02"
+    update: "Elemental Workshop II"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.113
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  material:
+    type: Mind
+    tier: low
+  equipment:
+    slot: head
+    weight: 0.113
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 6
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - name: Mind helmet
+      skill: Smithing
+      level: 30
+      experience: 30
+      materials:
+        - item_name: Primed mind bar
+          quantity: 1
+        - item_name: Beaten book
+          quantity: 1
+      tools:
+        - Workbench (Elemental Workshop)
+      output_quantity: 1
+  related_items:
+    - name: Mind shield
+      relationship: set-piece
+    - name: Primed mind bar
+      relationship: component
+    - name: Beaten book
+      relationship: component
+    - name: Body helmet
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Niche cosmetic / minor magic defence helm, low demand."
+      - "Often used for the Kandarin Medium Diary task."
+      - "Supply is limited by Elemental Workshop II completion."
+  trading_tips:
+    - "Targets Kandarin Diary completionists buying to satisfy the task."
+    - "Buy limit of 70 allows light flipping but volumes are thin."
+    - "Hold during diary update / promotion windows for resale."
+  history:
+    - date: "2006-10-02"
+      description: "Mind helmet added with Elemental Workshop II."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dart.mdx
@@ -12,62 +12,88 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 7000
+  material:
+    type: mithril
+    tier: low
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
-    attack_speed: 3
-  requirements:
-    ranged: 20
-  stats:
-    attack:
+    weapon_type: thrown
+    attack_speed: 2
+    weight: 0
+    requirements:
+      ranged: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 0
-    other:
-      ranged_strength: 11
-  fletching:
-    level: 52
-    xp: 11.2
-    method: Attach feathers to mithril dart tips
-    quest: Tourist Trap
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 9
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: "Mithril dart tip"
+          quantity: 1
+        - item_name: "Feather"
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: fletching
+      level: 52
+      experience: 11.2
+      notes: "Requires completion of The Tourist Trap quest."
   drop_table:
     sources:
-      - source: Cyclops
-        source_id: 4291
-        combat_level: 56
-        quantity: 5-12
-        rarity: common
-        members_only: true
+      - source: "Cyclops"
+        quantity: "1"
+        rarity: "Common"
   related_items:
-    - item_id: 822
-      item_name: Mithril dart tip
-      slug: mithril-dart-tip
+    - item_name: "Mithril dart tip"
       relationship: component
-      description: Fletching material
-    - item_id: 314
-      item_name: Feather
-      slug: feather
+    - item_name: "Feather"
       relationship: component
-      description: Fletching material
-    - item_id: 810
-      item_name: Adamant dart
-      slug: adamant-dart
+    - item_name: "Adamant dart"
       relationship: upgrade
-      description: Higher tier
-    - item_id: 806
-      item_name: Steel dart
-      slug: steel-dart
+    - item_name: "Steel dart"
       relationship: downgrade
-      description: Lower tier
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon/Ammo |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 20 Ranged |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Mithril dart is a members thrown weapon used for cheap ranged training; 20 Ranged to wield and stackable in the inventory."
+  market_strategy:
+    notes:
+      - "Massive daily volume (10M+) makes price discovery instant; margins compress to single gp."
+      - "Demand driven by training accounts, low-level slayer, and Vorkath dart-stacking."
+  trading_tips:
+    - "Flip in 7k limit chunks; chase 1–2 gp margin on bulk."
+    - "Watch mithril dart tip + feather inputs — net cost gates the floor."
+  history:
+    - date: "2003-04-14"
+      description: "Released alongside the other tiered throwing darts."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    update: "Members Beta"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-pickaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-pickaxe.mdx
@@ -12,26 +12,77 @@ osrs:
   lowalch: 520
   highalch: 780
   limit: 40
-  item_id: 1273
-  item_type: equipment
-  slot: weapon
-  type: pickaxe
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 20
-    mining: 21
-  stats:
-    stab: 12
-    slash: -2
-    crush: 10
-    strength: 13
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: pickaxe
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      attack: 20
+      mining: 21
+    attack_bonus:
+      stab: 12
+      slash: -2
+      crush: 10
+    other_bonus:
+      strength: 13
+  shops:
+    - shop_name: "Nurmof's Pickaxe Shop"
+      location: Dwarven Mines
+      stock: 5
+      price: 1300
+    - shop_name: Pickaxe-Is-Mine
+      location: Keldagrim
+      stock: 3
+      price: 1690
+    - shop_name: "Yarsul's Prodigious Pickaxes"
+      location: Mining Guild
+      stock: 3
+      price: 1300
+    - shop_name: "Gwyn's Mining Emporium"
+      location: Prifddinas
+      stock: 3
+      price: 1300
   related_items:
-    - slug: adamant-pickaxe
-    - slug: black-pickaxe
-  about: Mining tool. 5-tick cycle, faster than steel.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Adamant pickaxe
+      relationship: upgrade
+    - name: Steel pickaxe
+      relationship: downgrade
+    - name: Black pickaxe
+      relationship: alternative
+  about: "The mithril pickaxe is a free-to-play mining tool that mines at a 5-tick cycle, matching the black pickaxe and offering a balance of weight and speed before adamant."
+  market_strategy:
+    notes:
+      - Shop supply at Nurmof's keeps the GE price anchored near base value.
+      - Demand is steady from low-level miners and ironmen routing through F2P.
+  trading_tips:
+    - Buy from Nurmof or Yarsul shops and resell on GE for a small but reliable margin.
+    - Avoid stockpiling - low buy limit caps flip volume.
+  history:
+    - date: "2003-05-27"
+      description: Added with the Sleeping bags and pickaxes update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-05-27"
+    update: Sleeping bags and pickaxes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-thrownaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-thrownaxe.mdx
@@ -12,31 +12,79 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 7000
+  material:
+    type: mithril
+    tier: mid
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 5
+    weight: 0
     requirements:
       ranged: 20
     attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 12
-    ranged_strength: 16
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 16
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Authentic Throwing Weapons
+      location: Ranging Guild
+      price: 91
+      stock: 600
+      currency: Coins
   related_items:
-    - item_id: 802
-      item_name: Steel thrownaxe
-      slug: steel-thrownaxe
-      relationship: variant
-      description: Lower tier thrownaxe
-    - item_id: 804
-      item_name: Adamant thrownaxe
-      slug: adamant-thrownaxe
-      relationship: variant
-      description: Higher tier thrownaxe
-  about: |-
-    > _"A finely balanced throwing axe."_
-
-    The mithril thrownaxe requires 20 Ranged. Mid-tier thrownaxe with the bouncing special attack.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Steel thrownaxe
+      relationship: downgrade
+    - name: Adamant thrownaxe
+      relationship: upgrade
+  about: "Mithril thrownaxe is a members-only thrown ranged weapon requiring 20 Ranged. Mid-tier projectile sold from the Ranging Guild's Authentic Throwing Weapons shop."
+  market_strategy:
+    notes:
+      - Constant supply from the Ranging Guild shop (600 stock, fast restock) caps price near shop value.
+      - 7,000/4h GE buy limit suits bulk flipping during PvP/Slayer events.
+      - High alch value below GE price — never alch.
+  trading_tips:
+    - Buy from Ranging Guild shop for higher margin than GE if you don't need GE-volume fills.
+    - Watch ranged training meta (e.g., thrown weapon buffs) for short-term price moves.
+  history:
+    - date: "2003-12-01"
+      description: Added to the RuneScape 2 Beta cache.
+    - date: "2004-01-21"
+      description: Became obtainable in the RuneScape 2 Beta.
+    - date: "2004-03-29"
+      description: Permanently available with the launch of RuneScape 2.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    update: RuneScape 2 launch
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-dust-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-dust-staff.mdx
@@ -5,16 +5,101 @@ osrs:
   id: 20739
   name: Mystic dust staff
   slug: mystic-dust-staff
-  examine: It's a slightly more magical stick.
+  examine: "It's a slightly more magical stick."
   members: true
   icon: Mystic dust staff.png
   value: 42500
   lowalch: 17000
   highalch: 25500
   limit: 8
-  about: "Mystic dust staff is a members-only item in Old School RuneScape. High alchemy value: 25,500 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mystic
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: bladed_staff
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 40
+      magic: 40
+    attack_bonus:
+      stab: 10
+      slash: -1
+      crush: 40
+      magic: 14
+    defence_bonus:
+      magic: 14
+    other_bonus:
+      melee_strength: 50
+  recipes:
+    - skill: Magic
+      level: 40
+      tools: []
+      output_quantity: 1
+      result: Mystic dust staff
+      materials:
+        - item_name: Dust battlestaff
+          item_id: 20736
+          quantity: 1
+        - item_name: Coins
+          item_id: 995
+          quantity: 40000
+  related_items:
+    - item_id: 20736
+      item_name: Dust battlestaff
+      slug: dust-battlestaff
+      relationship: downgrade
+      description: Base battlestaff upgraded into the mystic variant by Thormac
+    - item_id: 1409
+      item_name: Mystic mud staff
+      slug: mystic-mud-staff
+      relationship: variant
+      description: Other combination mystic staff
+    - item_id: 6563
+      item_name: Mystic lava staff
+      slug: mystic-lava-staff
+      relationship: variant
+      description: Lava combination mystic staff
+    - item_id: 6565
+      item_name: Mystic steam staff
+      slug: mystic-steam-staff
+      relationship: variant
+      description: Steam combination mystic staff
+  about: "Upgraded dust battlestaff from Thormac that provides unlimited air and earth runes plus autocast access; requires 40 Attack and 40 Magic to wield."
+  market_strategy:
+    notes:
+      - Demand follows dust rune (air+earth) combo spell usage
+      - Tight buy limit of 8 makes individual flips slow
+      - Kandarin Diary completion lowers Thormac fee, encouraging supply
+      - Niche compared to Trident or Sang setups
+  trading_tips:
+    - Compare against dust battlestaff + Thormac fee for crafted margin
+    - Buy when Kandarin Diary completion volumes rise
+    - Watch elemental combination spell meta updates for demand spikes
+  history:
+    - date: "2016-09-15"
+      description: Mystic dust staff added to Thormac's upgrade list following dust battlestaff release.
+  properties:
+    release_date: "2016-09-15"
+    update: Elemental Staves
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: Scorpion Catcher
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-mist-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-mist-staff.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 17000
   highalch: 25500
   limit: 8
+  material:
+    type: magical
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 40
+      magic: 40
+    attack_bonus:
+      stab: 10
+      crush: 40
+      magic: 14
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 14
+    other_bonus:
+      magic_damage: 0
+  recipes:
+    - materials:
+        - item_name: Mist battlestaff
+          quantity: 1
+        - item_name: Coins
+          quantity: 40000
+      tools: []
+      output_quantity: 1
+      requirements: "Completion of Scorpion Catcher. Cost reduced to 30,000 with Hard Kandarin Diary, or 20,000 with Elite Kandarin Diary. Spoken to Thormac in the Sorcerer's Tower."
+  related_items:
+    - name: Mist battlestaff
+      relationship: component
+    - name: Mystic air staff
+      relationship: alternative
+    - name: Mystic water staff
+      relationship: alternative
   about: "Mystic mist staff is a members-only item in Old School RuneScape. High alchemy value: 25,500 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Upgraded from mist battlestaff via Thormac for 40,000 coins (reduced with Kandarin Diary tiers)."
+      - "Provides unlimited air and water runes when wielded, useful for hybrid spells like Water Strike through Water Surge."
+      - "Buy limit of 8 per 4 hours; check GE margin against mist battlestaff cost plus Thormac fee before flipping."
+  trading_tips:
+    - "Compare GE price to mist battlestaff + Thormac fee to spot arbitrage."
+    - "Players with Elite Kandarin Diary can produce these cheapest (20,000 coin upgrade)."
+    - "Demand is steady from low-level mages training combined magic."
+  history:
+    - date: "2016-09-15"
+      description: "Released as part of the Superior Slayer Encounters update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-09-15"
+    update: "Superior Slayer Encounters"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-mud-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-mud-staff.mdx
@@ -12,9 +12,17 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 8
+  material:
+    type: mystic
+    tier: high
   equipment:
     slot: weapon
+    weapon_type: staff
     attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 40
+      magic: 40
     attack_bonus:
       stab: 10
       slash: -1
@@ -28,59 +36,62 @@ osrs:
       magic: 14
       ranged: 0
     other_bonus:
-      melee_strength: 50
+      strength: 50
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 40
-      magic: 40
-    weight: 2.267
+  recipes:
+    - materials:
+        - item_name: Mud battlestaff
+          quantity: 1
+      tools:
+        - Thormac (NPC)
+      output_quantity: 1
+      notes: "Thormac upgrades the Mud battlestaff for 40,000 coins (30,000 with Hard Kandarin Diary, 20,000 with Elite). Requires Scorpion Catcher quest."
   related_items:
-    - item_id: 6562
-      item_name: Mud battlestaff
-      slug: mud-battlestaff
+    - name: Mud battlestaff
       relationship: component
-      description: Base staff for upgrade
-    - item_id: 3054
-      item_name: Mystic lava staff
-      slug: mystic-lava-staff
+    - name: Mystic lava staff
       relationship: alternative
-      description: Earth+Fire combination
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +14 |
-    | Crush | +40 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +14 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +50 |
-
-    Requirements: 40 Attack, 40 Magic
-
-    Provides unlimited water and earth runes simultaneously — the most valuable combination staff:
-    - Ice Barrage — saves water runes (death + blood still needed)
-    - Lunar spells — many require water + earth (Humidify, Fertile Soil, etc.)
-    - Mage Training Arena — saves runes during Alchemy room
-    - Charge Water/Earth Orb — saves respective runes
-    - Autocast with standard spellbook
-
-    A Mystic mud staff upgrade kit (from Master Treasure Trails) can be applied for a cosmetic variant. The kit is purely visual — no stat changes.
-
-    The mud battlestaff (base component) is a rare drop from Dagannoth Prime (1/128). Combined with Thormac's fee, the total cost is significantly higher than other mystic staves. The water+earth combination is also the most useful for high-level PvM.
+    - name: Mystic steam staff
+      relationship: alternative
+    - name: Mystic mud staff upgrade kit
+      relationship: variant
+  about: "Mystic mud staff is a members magic weapon that provides unlimited water and earth runes simultaneously, enabling efficient Lunar casting, Ice Barrage, and rune-orb charging. Created by Thormac after completing Scorpion Catcher. High alchemy value: 27,000 coins. Grand Exchange buy limit: 8 per 4 hours."
   market_strategy:
     notes:
-      - Mud battlestaff is the expensive component (DK Prime 1/128)
-      - Thormac cost varies with Kandarin diary tier
-      - Higher value than other mystic staves due to rarity + utility
-      - Used in endgame PvM (Barrage tasks, Lunar spells)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Mud battlestaff is the expensive component (Dagannoth Prime 1/128)."
+      - "Thormac cost varies with Kandarin diary tier."
+      - "Higher value than other mystic staves due to rarity and utility."
+      - "Used in endgame PvM (Barrage tasks, Lunar spells)."
+  trading_tips:
+    - "Compare Mud battlestaff + Thormac fee vs the Mystic mud staff GE price for an upgrade flip."
+    - "Hard/Elite Kandarin Diary cuts the upgrade fee, widening the margin window."
+  history:
+    - date: "2005-11-07"
+      description: "Mystic mud staff released alongside the mystic battle staff family."
+    - date: "2026-04-22"
+      description: "Wiki refresh confirmed alch, requirements, and recipe details."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-11-07"
+    update: "Mystic battle staves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: "Scorpion Catcher"
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-robe-top-dark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-robe-top-dark.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 48000
   highalch: 72000
   limit: 70
-  about: "Mystic robe top (dark) is a members-only item in Old School RuneScape. High alchemy value: 72,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mystic
+    tier: mid-high
+  equipment:
+    slot: body
+    weapon_type: none
+    weight: 2.721
+    requirements:
+      magic: 40
+      defence: 20
+    attack_bonus:
+      magic: 20
+    defence_bonus:
+      stab: 3
+      slash: 5
+      crush: 7
+      magic: 20
+      ranged: -10
+    other_bonus: {}
+  drop_table:
+    sources:
+      - source: Gargoyle
+        quantity: "1"
+        rarity: 1/512
+      - source: Marble gargoyle
+        quantity: "1"
+        rarity: 3/512
+  related_items:
+    - item_id: 4089
+      item_name: Mystic robe top
+      slug: mystic-robe-top
+      relationship: variant
+      description: Blue variant of the same robe
+    - item_id: 4113
+      item_name: Mystic robe top (light)
+      slug: mystic-robe-top-light
+      relationship: variant
+      description: Light recolour variant
+    - item_id: 6916
+      item_name: Infinity top
+      slug: infinity-top
+      relationship: upgrade
+      description: Higher-tier magic body slot armour
+  about: "Dark recolour of the mystic robe top dropped by Gargoyles and Marble gargoyles; tradeable variant with identical stats to the blue mystic robe top."
+  market_strategy:
+    notes:
+      - Drop volume tied to Gargoyle and Marble gargoyle slayer task popularity
+      - Marble gargoyles drop at triple the rate, inflating supply when Stronghold Slayer Cave is in meta
+      - Cosmetic variant; identical stats to blue and light mystic encourage style premiums
+      - Buy limit of 70 keeps individual sells tight
+  trading_tips:
+    - Watch slayer task rotation announcements for supply spikes
+    - Buy during Slayer Master rework news, sell when cosmetic demand returns
+    - Compare against blue and light variants for fashion-scape premium pricing
+  history:
+    - date: "2005-01-26"
+      description: Mystic robe top released as part of the Slayer Skill update.
+    - date: "2006-01-23"
+      description: Examine text updated to specify a dark magical robe.
+    - date: "2014-12-04"
+      description: Item renamed to Mystic robe top (dark) to disambiguate from the blue variant.
+  properties:
+    release_date: "2005-01-26"
+    update: Slayer Skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-steam-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-steam-staff.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 8
-  about: "Mystic steam staff is a members-only item in Old School RuneScape. High alchemy value: 27,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mystic
+    tier: mid-high
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 40
+      magic: 40
+    attack_bonus:
+      stab: 10
+      slash: -1
+      crush: 40
+      magic: 14
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 14
+      ranged: 0
+    other_bonus:
+      strength: 50
+      prayer: 0
+      magic_damage: 0
+  recipes:
+    - materials:
+        - item_name: "Steam battlestaff"
+          quantity: 1
+        - item_name: "Coins"
+          quantity: 40000
+      tools: []
+      output_quantity: 1
+      notes: "Thormac upgrades the steam battlestaff; cost drops to 20,000 with full Seers' Village hard diary."
+  related_items:
+    - item_name: "Steam battlestaff"
+      relationship: component
+    - item_name: "Mystic mud staff"
+      relationship: alternative
+    - item_name: "Mystic lava staff"
+      relationship: alternative
+    - item_name: "Mystic smoke staff"
+      relationship: alternative
+  about: "Mystic steam staff is a members-only magic weapon that provides unlimited water and fire runes; created by Thormac after a Scorpion Catcher quest from a steam battlestaff."
+  market_strategy:
+    notes:
+      - "Demand tied to Standard-spellbook autocasters that benefit from free water + fire runes."
+      - "Floor price tethered to steam battlestaff + Thormac upgrade fee."
+  trading_tips:
+    - "Watch steam battlestaff supply; the staff floor moves with it."
+    - "Diary completion shifts upgrade cost from 40k to 20k — sell pressure rises when more players unlock the discount."
+  history:
+    - date: "2013-10-17"
+      description: "Released alongside the mystic mud, lava, and smoke staves."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2013-10-17"
+    update: "Mystic Battlestaves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: "Scorpion Catcher"
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-cape-rack-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-cape-rack-flatpack.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak cape rack (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Oak
+    tier: low
+  recipes:
+    - materials:
+        - item_name: Oak plank
+          quantity: 4
+      tools:
+        - Saw
+        - Hammer
+        - Steel framed workbench
+        - Construction level 54
+      output_quantity: 1
+      skill: Construction
+      experience: 240
+  construction:
+    level: 54
+    experience: 240
+    room: Costume room
+  related_items:
+    - name: Oak plank
+      relationship: component
+    - name: Cape rack
+      relationship: alternative
+    - name: Teak cape rack (flatpack)
+      relationship: upgrade
+  about: "Oak cape rack (flatpack) is a flatpacked Construction item built at a Steel framed workbench, used to install an oak cape rack in the Costume room of a player-owned house."
+  market_strategy:
+    notes:
+      - "Flatpack creation is a loss vs raw oak planks at current prices."
+      - "Used as a Construction XP method for ironmen / niche flippers."
+      - "High alch only 6 gp — never alchable for profit."
+  trading_tips:
+    - "Bulk demand from house decorators and ironmen filling Costume rooms."
+    - "Limit 500 / 4 hours allows moderate flip volume."
+  history:
+    - date: "2006-10-18"
+      description: "Released with the Player-Owned House Costume Room update."
+  properties:
+    release_date: "2006-10-18"
+    update: "Player-Owned House Costume Room"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Build
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/opal-amulet-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/opal-amulet-u.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 10000
-  about: "Opal amulet (u) is a members-only item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: silver
+    tier: low
+  recipes:
+    - name: Craft Opal amulet (u)
+      skill: Crafting
+      level: 27
+      experience: 55
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+        - item_name: Opal
+          quantity: 1
+      tools:
+        - Amulet mould
+      facility: Furnace
+      output_quantity: 1
+  related_items:
+    - name: Silver bar
+      relationship: component
+    - name: Opal
+      relationship: component
+    - name: Opal amulet
+      relationship: upgrade
+    - name: Amulet of bounty
+      relationship: upgrade
+    - name: Ball of wool
+      relationship: component
+  about: "Opal amulet (u) is an unstrung jewellery piece crafted at a furnace by combining a silver bar with an opal using an amulet mould, requiring level 27 Crafting and granting 55 Crafting experience."
+  market_strategy:
+    notes:
+      - Intermediate crafting product used by Crafting trainers to produce strung amulets.
+      - Supply is driven by silver bar and opal availability on the Grand Exchange.
+      - Demand spikes when Amulet of bounty (used in farming) is in fashion for clue scroll routes.
+  trading_tips:
+    - Buy silver bars and opals in bulk to craft the unstrung amulet for personal use or resale.
+    - String with a ball of wool to convert into an Opal amulet for further enchantment.
+    - Watch alch margins as the high alch value (540) often exceeds Grand Exchange price.
+  history:
+    - date: "2017-02-02"
+      description: Added to the game alongside the gem-amulet rework.
+  properties:
+    release_date: "2017-02-02"
+    update: Jagex Account Guardian
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.004
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/opal-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/opal-necklace.mdx
@@ -1,6 +1,6 @@
 ---
 title: Opal necklace | OSRS Price Data
-description: "Opal necklace: I wonder if this is valuable.. High alch: 630 GP, GE limit: 10,000."
+description: "Opal necklace: I wonder if this is valuable. High alch: 630 GP, GE limit: 10,000."
 osrs:
   id: 21090
   name: Opal necklace
@@ -12,9 +12,75 @@ osrs:
   lowalch: 420
   highalch: 630
   limit: 10000
-  about: "Opal necklace is a members-only item in Old School RuneScape. High alchemy value: 630 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: gem
+    tier: low
+  equipment:
+    slot: neck
+    weight: 0.01
+    requirements:
+      defence: 1
+  about: "Opal necklace is a members-only Crafting product made by combining a silver bar and a cut opal at a furnace with a necklace mould. It is most commonly used as the base for the Lvl-1 Enchant spell to create dodgy necklaces, which protect against thieving NPC damage."
+  recipes:
+    - skill: Crafting
+      level: 16
+      experience: 35
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+        - item_name: Opal
+          quantity: 1
+      tools:
+        - Necklace mould
+        - Furnace
+      output_quantity: 1
+      output_item: Opal necklace
+  related_items:
+    - item_name: Opal
+      slug: opal
+      relationship: component
+      description: Gem inset into the necklace.
+    - item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: Metal base for the necklace.
+    - item_name: Dodgy necklace
+      slug: dodgy-necklace
+      relationship: product
+      description: Enchanted form that protects against thieving damage.
+  properties:
+    release_date: "2017-02-02"
+    update: "Opals, Jades & Topaz"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  market_strategy:
+    notes:
+      - "Crafting product whose price tracks silver bar + opal input costs."
+      - "Demand driven by Magic enchanters making dodgy necklaces for Thieving."
+      - "Large 10,000 buy limit supports volume flips."
+  trading_tips:
+    - "Watch the silver bar + opal basket vs. necklace price for crafting margins."
+    - "Stock up before Thieving events that boost dodgy necklace demand."
+    - "Sell during Crafting bonus weekends for short-term price pops."
+  history:
+    - date: "2017-02-02"
+      description: "Released with the Opals, Jades & Topaz update."
+    - date: "2017-02-16"
+      description: "Sprite rotated for visual consistency with other necklaces."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/orange-slices.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/orange-slices.mdx
@@ -9,12 +9,54 @@ osrs:
   members: true
   icon: Orange slices.png
   value: 2
-  lowalch: 1
+  lowalch: 0
   highalch: 1
   limit: 13000
-  about: "Orange slices is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 2
+  recipes:
+    - materials:
+        - item_name: Orange
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+      notes: "Slice an orange with a knife to produce orange slices."
+  related_items:
+    - name: Orange
+      relationship: component
+    - name: Pineapple punch
+      relationship: product
+  about: "Orange slices is a members-only food item used in gnome cocktail cooking, most notably Pineapple punch. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Slicing oranges can be a small flip when the ratio favors slices."
+      - "Demand is driven by gnome cocktail training."
+  trading_tips:
+    - "Buy whole oranges in bulk and process with a knife for a steady margin."
+    - "Stockpile during cocktail-training meta shifts."
+  history:
+    - date: "2002-12-12"
+      description: "Orange slices released as part of the Gnome Cooking content."
+    - date: "2026-04-22"
+      description: "Wiki refresh confirmed alch values and recipe."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: "Gnome Cooking"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.09
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pink-skirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pink-skirt.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 150
-  about: "Pink skirt is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: legs
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Skeleton Mage
+        combat_level: 83
+        quantity: "1"
+        rarity: 2/128
+  shops:
+    - shop_name: Thessalia's Fine Clothes
+      location: Varrock
+      price: 2
+      stock: 10
+    - shop_name: Fancy Clothes Store
+      location: Varrock
+      price: 2
+      stock: 10
+    - shop_name: Floria's Fashion
+      location: Civitas illa Fortis
+      price: 2
+      stock: 10
+  related_items:
+    - name: Pink robe bottoms
+      relationship: alternative
+    - name: Pink robe top
+      relationship: set-piece
+    - name: Skirt
+      relationship: alternative
+  about: "Pink skirt is a free-to-play cosmetic legs slot item bought from Varrock clothing shops or dropped by Skeleton Mages, primarily used as a disguise component in the Prince Ali Rescue quest."
+  market_strategy:
+    notes:
+      - Cosmetic-only item with zero combat bonuses, demand is fashionscape-driven.
+      - Quest helpers buy in small batches around Prince Ali Rescue runs.
+      - Shop price floor of 2 coins caps downside; GE arbitrage rare due to low margin.
+  trading_tips:
+    - Source cheaply from Thessalia's or Fancy Clothes Store in Varrock when GE is dry.
+    - Stock a single piece for Prince Ali Rescue and Forgettable Tale quests.
+    - Combine with Pink robe top for a matched cosmetic outfit.
+  history:
+    - date: "2001-01-04"
+      description: Added to the game alongside the early Varrock clothing shops.
+  properties:
+    release_date: "2001-01-04"
+    update: New skill - Cooking
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/polar-camo-legs-equipped.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/polar-camo-legs-equipped.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Polar camo legs (equipped) is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 0.226
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -7
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: 0
+      ranged: 10
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: Crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Polar kebbit fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 20
+      tools: []
+      output: Polar camo legs
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - name: Polar camo top
+      relationship: set-piece
+    - name: Larupia hat
+      relationship: alternative
+    - name: Desert camo legs
+      relationship: variant
+    - name: Woodland camo legs
+      relationship: variant
+    - name: Jungle camo legs
+      relationship: variant
+  about: "Polar camo legs is the legs slot piece of the polar Hunter camouflage outfit, crafted from 2 polar kebbit furs plus 20 coins at the Fancy Clothes Store, Hunter Guild, or Prifddinas Seamstress. Reduces equipped weight by 2 kg and provides ranged defence at the cost of ranged attack."
+  market_strategy:
+    notes:
+      - "Functional gear used for tracking polar kebbits and traversing polar Hunter areas without spooking quarry."
+      - "Supply is uncapped via player crafting; price tracks polar kebbit fur cost plus a thin convenience premium."
+  trading_tips:
+    - "Self-crafting from polar kebbit furs is almost always cheaper than buying assembled legs on GE."
+    - "Pair with the matching polar camo top for the full -4 kg outfit weight reduction in polar Hunter zones."
+  history:
+    - date: "2006-11-21"
+      description: "Released as part of the HUNTER SKILL! update."
+  properties:
+    release_date: "2006-11-21"
+    update: HUNTER SKILL!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-potion-4.mdx
@@ -13,30 +13,19 @@ osrs:
   highalch: 114
   limit: 2000
   potion:
-    doses: 4
-    herblore_level: 38
-    herblore_xp: 87.5
-    effect: Restores 7-31 Prayer points based on Prayer level
     effects:
-      - stat: Prayer
-        boost_formula: 7 + floor(level / 4)
+      - description: "Restores Prayer points equal to 7 + floor(Prayer level / 4) per dose."
+        duration: 0
+      - description: "Higher restoration when wearing Prayer cape, Max cape, holy wrench, or Ring of the gods (i)."
+        duration: 0
   recipes:
-    - skill: herblore
-      level: 38
-      xp: 87.5
-      materials:
-        - item_name: Ranarr weed
-          item_id: 257
+    - materials:
+        - item_name: Ranarr potion (unf)
           quantity: 1
         - item_name: Snape grass
-          item_id: 231
           quantity: 1
-        - item_name: Vial of water
-          item_id: 227
-          quantity: 1
-          consumed: true
-      ticks: 2
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
     - item_id: 257
       item_name: Ranarr weed
@@ -52,38 +41,53 @@ osrs:
       item_name: Super restore(4)
       slug: super-restore-4
       relationship: alternative
-      description: Also restores stats
+      description: Also restores stats and prayer.
     - item_id: 10925
       item_name: Sanfew serum(4)
       slug: sanfew-serum-4
       relationship: upgrade
-      description: Premium version (cures poison)
+      description: Premium version that cures poison.
     - item_id: 2436
       item_name: Prayer potion(3)
       slug: prayer-potion-3
       relationship: variant
       description: 3-dose version
-  about: |-
-    Prayer potions are essential for:
-    - All boss fights
-    - Slayer tasks with protection prayers
-    - Raids (CoX, ToB, ToA)
-    - PvP combat
-    - Wilderness activities
+  about: "Prayer potion(4) is a 4-dose Herblore potion that restores Prayer points, essential for bossing, raids, Slayer, and PvP encounters."
   market_strategy:
-    profit_formulas:
-      - Prayer potion(4) - Ranarr weed - Snape grass - Vial of water
     notes:
-      - "Calculate:"
-      - High volume, consistent demand
-      - Essential consumable = stable prices
-      - Buy 4-dose, decant to 3-dose (or vice versa)
-      - Check price differences between dose sizes
-      - Use decanting NPC in GE
-      - One of the highest volume potions traded
-      - Price follows Ranarr weed price closely
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - High volume, consistent demand from PvM and PvP content.
+      - Price tracks Ranarr weed and Snape grass closely.
+      - Decanting between dose sizes can offer small arbitrage.
+      - Restock spikes around boss meta shifts.
+  trading_tips:
+    - Buy 4-dose and decant to 3-dose (or vice versa) at GE decanters.
+    - Check price differences between dose sizes before flipping.
+    - Use the 2000 buy limit to scale up flipping volume.
+    - Track Ranarr weed prices as the primary cost driver.
+  history:
+    - date: "2002-02-27"
+      description: Prayer potion released alongside the Herblore skill in RuneScape Classic.
+    - date: "2004-03-29"
+      description: 4-dose variant made permanently available with the launch of RuneScape 2.
+  properties:
+    release_date: "2002-02-27"
+    update: Herblore Skill
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-regeneration-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-regeneration-potion-3.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 2000
-  about: "Prayer regeneration potion(3) is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Restores 1 prayer point every 12 game ticks for 8 minutes per dose, totalling roughly 66 prayer points restored over the duration."
+        duration: 480
+      - description: "Holy wrench, Prayer cape, and Ring of the gods (i) do not increase the amount restored by this potion."
+        duration: 0
+  recipes:
+    - materials:
+        - item_name: Huasca potion (unf)
+          quantity: 1
+        - item_name: Aldarium
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+      skill: Herblore
+      level: 58
+      xp: 132
+      notes: "Mixing produces a 3-dose Prayer regeneration potion."
+  related_items:
+    - item_id: 30125
+      item_name: Prayer regeneration potion(4)
+      slug: prayer-regeneration-potion-4
+      relationship: variant
+      description: 4-dose version of the same potion
+    - item_id: 30131
+      item_name: Prayer regeneration potion(2)
+      slug: prayer-regeneration-potion-2
+      relationship: variant
+      description: 2-dose version of the same potion
+    - item_id: 30134
+      item_name: Prayer regeneration potion(1)
+      slug: prayer-regeneration-potion-1
+      relationship: variant
+      description: 1-dose version of the same potion
+  about: "The Prayer regeneration potion(3) restores prayer over time, giving 66 prayer points across an 8 minute window per dose."
+  market_strategy:
+    notes:
+      - "Demand comes from extended PvM trips where slow-tick prayer regeneration sustains protection prayers without bank trips."
+      - "Crafted from huasca potion (unf) and aldarium, so margins shift with those inputs."
+      - "Volume is highest right after Varlamore content updates, normalising as supply catches up."
+  trading_tips:
+    - "Cross-check aldarium and huasca potion (unf) prices before flipping; thin margins are common."
+    - "Buy in bulk before high-prayer DPS events and resell during evening peak hours."
+  history:
+    - date: "2024-09-25"
+      description: "Released as part of the Varlamore: The Rising Darkness update."
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.06
+    options:
+      - Drink
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-veg-ball.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-veg-ball.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 6000
-  about: "Premade veg ball is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: mid
+  food:
+    heal: 12
+  shops:
+    - shop_name: Gnome Waiter
+      location: The Grand Tree
+      price: 150
+      stock: 3
+  related_items:
+    - name: Veg ball
+      relationship: alternative
+  about: "Premade veg ball is a members-only gnome food item bought from the Gnome Waiter at the Grand Tree. Eating it restores 12 Hitpoints, but the premade variant cannot be used in the Gnome Restaurant minigame."
+  market_strategy:
+    notes:
+      - Bought from Gnome Waiter for 150 coins (stock of 3, 1-minute restock)
+      - Heals 12 Hitpoints when consumed
+      - Cannot substitute for player-cooked veg ball in the Gnome Restaurant minigame
+  trading_tips:
+    - Low GE volume - rely on shop buyout flips
+    - Spikes in demand correlate with new gnome content releases
+  history:
+    - date: "2002-12-12"
+      description: Released alongside the Agility skill update.
+    - date: "2006-08-08"
+      description: Renamed from "Veg ball" to "Premade veg ball" to distinguish it from the player-crafted version.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: "Agility"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-harness-m.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-harness-m.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 70
-  about: "Proselyte harness m is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: blessed
+    tier: mid
+  shops:
+    - shop_name: Sir Tiffy Cashien's Armour Shop
+      location: Falador Park
+      price: 25000
+      stock: 10
+      notes: Requires completion of The Slug Menace quest.
+  related_items:
+    - name: Proselyte sallet
+      relationship: component
+    - name: Proselyte hauberk
+      relationship: component
+    - name: Proselyte cuisse
+      relationship: component
+    - name: Proselyte harness f
+      relationship: alternative
+  about: "Proselyte harness m is a packaged male Temple Knight armour set sold by Sir Tiffy Cashien after the Slug Menace quest, which unpacks into a Proselyte sallet, hauberk, and cuisse for prayer-focused melee setups."
+  market_strategy:
+    notes:
+      - Demand is driven by prayer-bonus seekers leveling melee with Piety or Chivalry.
+      - Premium over individual GE prices for the pack reflects convenience and shop-supply stability.
+      - Limited buy limit (70) keeps margins modest unless Proselyte armour becomes meta.
+  trading_tips:
+    - Buy directly from Sir Tiffy Cashien if you have completed The Slug Menace for a stable 25,000 coin price.
+    - Unpack only when ready to equip - resealing is not possible.
+    - Compare GE prices for individual pieces before unpacking to capture spreads.
+  history:
+    - date: "2006-09-20"
+      description: Released with The Slug Menace quest as a Temple Knight armour pack.
+  properties:
+    release_date: "2006-09-20"
+    update: The Slug Menace
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    quest: The Slug Menace
+    weight: 14.514
+    options:
+      - Unpack
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-tasset.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-tasset.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 70
-  about: "Proselyte tasset is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: mid
+  equipment:
+    slot: legs
+    weapon_type: none
+    weight: 8.164
+    requirements:
+      defence: 30
+      prayer: 20
+    attack_bonus:
+      magic: -4
+    defence_bonus:
+      stab: 33
+      slash: 31
+      crush: 29
+      ranged: 31
+    other_bonus:
+      prayer: 6
+  shops:
+    - shop_name: Proselyte Temple Knight Armoury
+      location: Falador Park
+      currency: coins
+      price: 10000
+  related_items:
+    - slug: proselyte-sallet
+      name: Proselyte sallet
+      relationship: set-piece
+    - slug: proselyte-hauberk
+      name: Proselyte hauberk
+      relationship: set-piece
+    - slug: proselyte-cuisse
+      name: Proselyte cuisse
+      relationship: alternative
+    - slug: initiate-cuisse
+      name: Initiate cuisse
+      relationship: downgrade
+  about: "Proselyte Temple Knight leg armour with +6 prayer bonus. Requires The Slug Menace quest completion, 30 Defence and 20 Prayer to equip. Sold by the Proselyte Temple Knight Armoury in Falador Park."
+  history:
+    - date: "2006-09-20"
+      description: Proselyte tasset released alongside The Slug Menace quest.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-09-20"
+    update: The Slug Menace
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: true
+    quest: The Slug Menace
+    weight: 8.164
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-nexus-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-nexus-scroll.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: null
+  material:
+    type: cosmetic
+    tier: high
+  shops:
+    - shop_name: "Leagues Reward Shop"
+      currency: "League Points"
+      cost: 4000
+      stock: 1
+  related_items:
+    - name: Crystalline portal nexus
+      relationship: alternative
+    - name: Trailblazer reloaded nexus scroll
+      relationship: alternative
   about: "Raging echoes nexus scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Purchased from the Leagues Reward Shop for 4,000 League Points after completing Leagues V: Raging Echoes."
+      - "Cosmetic-only; applies a Raging Echoes themed skin to the crystalline portal nexus in a player-owned house."
+      - "Does not work on lower-tier nexus variants, only the top-tier crystalline portal nexus."
+  trading_tips:
+    - "Supply is capped by Leagues V participation; prices tend to spike after Leagues ends."
+    - "Players completing Leagues V can convert excess league points into scrolls for GE flipping."
+    - "Track end-of-season demand for collector premium pricing."
+  history:
+    - date: "2025-01-15"
+      description: "Released as part of the Leagues V: Raging Echoes reward shop offerings."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-01-15"
+    update: "Leagues V: Raging Echoes Rewards"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Use
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-scrying-pool-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-scrying-pool-scroll.mdx
@@ -12,9 +12,44 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: null
-  about: "Raging echoes scrying pool scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  construction:
+    description: "Applied to a Scrying Pool in a Player Owned House to retheme it to Leagues V: Raging Echoes. Removing the ornament in build mode returns the scroll."
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Reward shop
+      price: 3000
+      currency: League Points
+  related_items:
+    - name: Scrying pool
+      relationship: component
+  about: "Raging echoes scrying pool scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Cosmetic POH decoration earned from Leagues V."
+  market_strategy:
+    notes:
+      - Very thin GE liquidity (around 4 trades/day) — expect long order fills.
+      - Supply only enters the game from Leagues V reward shop redemptions; price is collector-driven.
+      - No GE buy limit; large flips are still capped by available offers.
+  trading_tips:
+    - Place buy offers well above last GE price to actually fill, given the tiny volume.
+    - Demand spikes during Leagues anniversaries or POH content updates.
+  history:
+    - date: "2025-01-15"
+      description: Released with the Leagues V Raging Echoes reward shop.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-01-15"
+    update: "Leagues V: Raging Echoes Rewards Are Here"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    alchable: false
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-chicken.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-chicken.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw chicken | OSRS Price Data
-description: "Raw chicken: I need to cook this first.. High alch: 1 GP, GE limit: 13,000."
+description: "Raw chicken: I need to cook this first. High alch: 0 GP, GE limit: 13,000."
 osrs:
   id: 2138
   name: Raw chicken
@@ -9,12 +9,80 @@ osrs:
   members: false
   icon: Raw chicken.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: 0
+  highalch: 0
   limit: 13000
-  about: "Raw chicken is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Raw chicken is a free-to-play food item in Old School RuneScape, primarily obtained as a drop from chickens and roosters. It is the raw form of cooked chicken and is used in cooking training as well as several quests."
+  properties:
+    release_date: "2001-12-08"
+    update: Runescape Launched
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.17
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Chicken
+        quantity: "1"
+        rarity: Always
+      - source: Rooster
+        quantity: "1"
+        rarity: Always
+      - source: Evil Chicken
+        quantity: "1"
+        rarity: Always
+  shops:
+    - shop_name: Wydin's Food Store
+      location: Port Sarim
+      stock: 5
+      price: 1
+      restock_time: 60
+    - shop_name: Rufus' Meat Emporium
+      location: Canifis
+      stock: 10
+      price: 1
+      restock_time: 60
+  recipes:
+    - name: Cooked chicken
+      skill: Cooking
+      level: 1
+      experience: 30
+      materials:
+        - item_name: Raw chicken
+          quantity: 1
+      tools:
+        - Fire or Range
+      output_quantity: 1
+  related_items:
+    - name: Cooked chicken
+      relationship: product
+    - name: Burnt chicken
+      relationship: alternative
+    - name: Raw rabbit
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Raw chicken has a high buy limit (13,000) making it suitable for bulk cooking training."
+      - "Prices fluctuate based on Cooking training demand from low-level players."
+  trading_tips:
+    - "Buy raw chickens in bulk for fast Cooking XP from level 1-34."
+    - "Compare cost vs. cooked chicken price to evaluate profit/loss from cooking."
+    - "Can be obtained free by killing chickens in Lumbridge."
+  history:
+    - date: "2001-12-08"
+      description: "Raw chicken added to the game alongside the chicken NPC."
+    - date: "2007-02-26"
+      description: "Item became available on the Grand Exchange."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-rat-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-rat-meat.mdx
@@ -9,12 +9,68 @@ osrs:
   members: false
   icon: Raw rat meat.png
   value: 1
-  lowalch: 1
+  lowalch: 0
   highalch: 1
   limit: 13000
-  about: "Raw rat meat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - materials:
+        - item_name: Raw rat meat
+          quantity: 1
+      tools:
+        - Fire
+        - Range
+      output_quantity: 1
+      skill: Cooking
+      level: 1
+      xp: 30
+      notes: "Cooks into cooked meat; may produce burnt meat at very low levels."
+  drop_table:
+    sources:
+      - source: Giant rat
+        quantity: "1"
+        rarity: Always
+        notes: "The level 3 Lumbridge Swamp variant always drops raw rat meat."
+      - source: Brine rat
+        quantity: "1"
+        rarity: Always
+      - source: Brine rat
+        quantity: "18 (noted)"
+        rarity: Uncommon
+      - source: Dungeon rat
+        quantity: "1"
+        rarity: Always
+  shops:
+    - shop_name: "Rufus' Meat Emporium"
+      location: Canifis
+      stock: 10
+      price: 1
+  about: "Raw rat meat is a free-to-play food ingredient used for low-level Cooking training, hunter bait for sabre-toothed kebbits, and the Druidic Ritual quest."
+  market_strategy:
+    notes:
+      - "Steady demand from low-level Cooking trainers keeps GE price slightly above shop value."
+      - "Hunter players use raw rat meat as bait for sabre-toothed kebbits, providing secondary demand."
+      - "Alch value is zero, so the price floor sits at GE bid liquidity, not high alchemy."
+  trading_tips:
+    - "Buy directly from Rufus' Meat Emporium and resell on the GE when stock is well above ten."
+    - "Pair with raw chicken and raw beef listings to capture multi-item flips."
+  history:
+    - date: "2001-01-04"
+      description: "Released alongside early Cooking content."
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.141
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-balm-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-balm-1.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 30
   highalch: 45
   limit: 2000
-  about: "Relicym's balm(1) is a members-only item in Old School RuneScape. High alchemy value: 45 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: low
+  potion:
+    effects:
+      - description: "Weakens the strength of disease when drunk; multiple doses fully suppress disease but do not grant immunity."
+        duration: 0
+  recipes:
+    - materials:
+        - item_name: Relicym's balm(2)
+          quantity: 1
+      tools: []
+      output_quantity: 2
+      requirements: "Obtained by drinking doses from a 2-, 3-, or 4-dose balm, or by decanting at a Grand Exchange decanter. Originally brewed by mixing rogue's purse with snake weed in a vial of water (8 Herblore, 40 Herblore xp) after partial completion of Zogre Flesh Eaters."
+  related_items:
+    - name: Relicym's balm(2)
+      relationship: variant
+    - name: Relicym's balm(3)
+      relationship: variant
+    - name: Relicym's balm(4)
+      relationship: variant
+    - name: Sanfew serum (1)
+      relationship: alternative
+  about: "Relicym's balm(1) is a members-only potion in Old School RuneScape. High alchemy value: 45 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Single-dose Relicym's balm produced by drinking down larger doses or decanting at the Grand Exchange."
+      - "Used for disease suppression in Zogre Flesh Eaters content; lacks Sanfew serum's full immunity."
+      - "Often arbitraged against the 4-dose version when decanters create dose imbalances."
+  trading_tips:
+    - "Watch decanter spreads — single doses often trade below 1/4 of the 4-dose price."
+    - "Demand is niche; bulk traders should keep limits in mind to avoid dead inventory."
+    - "Use as Herblore xp filler during low-supply ingredient markets."
+  history:
+    - date: "2005-05-17"
+      description: "Released alongside the Zogre Flesh Eaters quest, adding rogue's purse and snake weed potions."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-17"
+    update: "Zogre Flesh Eaters"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/restore-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/restore-potion-3.mdx
@@ -12,6 +12,23 @@ osrs:
   lowalch: 35
   highalch: 52
   limit: 2000
+  potion:
+    effects:
+      - description: "Restores temporarily reduced Attack, Strength, Defence, Ranged, and Magic by 10 + 30% of the stat's max level (rounded down). Does not restore Prayer points and cannot boost a stat above its base level."
+        duration: 0
+  recipes:
+    - materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Red spiders' eggs
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+      skill: Herblore
+      level: 22
+      xp: 62.5
+      notes: "Mixing produces a 3-dose Restore potion."
   related_items:
     - item_id: 129
       item_name: Restore potion(2)
@@ -23,12 +40,34 @@ osrs:
       slug: restore-potion-1
       relationship: variant
       description: 1-dose version
-  about: |-
-    > _"3 doses of restore potion."_
-
-    The restore potion restores temporarily reduced Attack, Strength, Defence, Ranged, and Magic by 10 + 30% of the stat's max level. Does not restore Prayer or boost above base level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "The restore potion restores temporarily reduced Attack, Strength, Defence, Ranged, and Magic by 10 + 30% of the stat's max level. Does not restore Prayer or boost above base level."
+  market_strategy:
+    notes:
+      - "Demand comes from mid-level PvM where players use it to recover combat stats drained by monsters."
+      - "Super restore (4) is generally preferred at higher levels, capping growth potential for plain restore potions."
+      - "Bulk crafting from harralander potion (unf) and red spiders' eggs is profitable when herb prices dip."
+  trading_tips:
+    - "Watch the price of harralander and red spiders' eggs to spot cheap crafting margins."
+    - "Convert between 1, 2, 3, and 4 dose versions to capture per-dose pricing inefficiencies."
+  history:
+    - date: "2002-02-27"
+      description: "Released as part of the original Herblore content."
+  properties:
+    release_date: "2002-02-27"
+    update: "Latest RuneScape News (27 February 2002)"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-dueling-8.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-dueling-8.mdx
@@ -12,91 +12,81 @@ osrs:
   lowalch: 510
   highalch: 765
   limit: 15000
+  material:
+    type: gold
+    tier: low
   equipment:
     slot: ring
-    type: teleport_jewelry
-    attack_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
-      magic: 0
-      ranged: 0
-    defence_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
-      magic: 0
-      ranged: 0
-    other_bonus:
-      melee_strength: 0
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
-  properties:
-    tradeable: true
-    tradeable_ge: true
-    weight: 0.003
+    weapon_type: none
+    weight: 0.006
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  charges:
+    max_charges: 8
+    behavior: Crumbles to dust when depleted.
+    teleports:
+      - Emir's Arena
+      - Castle Wars
+      - Ferox Enclave
+      - Fortis Colosseum
   recipes:
     - skill: magic
       level: 27
       xp: 37
       materials:
         - item_name: Emerald ring
-          item_id: 1639
           quantity: 1
         - item_name: Cosmic rune
-          item_id: 564
           quantity: 1
         - item_name: Air rune
-          item_id: 556
           quantity: 3
+      tools: []
+      facility: Anywhere
+      output_quantity: 1
   related_items:
-    - item_id: 3853
-      item_name: Games necklace
-      slug: games-necklace
+    - slug: games-necklace
+      name: Games necklace
       relationship: alternative
-      description: More teleport locations
-    - item_id: 1639
-      item_name: Emerald ring
-      slug: emerald-ring
+    - slug: emerald-ring
+      name: Emerald ring
       relationship: component
-      description: Base item for enchantment
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Ring |
-    | Type | Teleport Jewelry |
-    | Tradeable | Yes |
-    | Weight | 0.003 kg |
-
-    Enchant Emerald ring with Lvl-2 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 27 |
-    | Cosmic rune | 1 |
-    | Air rune | 3 |
-
-    - Emir's Arena
-    - Castle Wars
-    - Ferox Enclave
-    - Fortis Colosseum (requires Hero title)
-
-    Charges: 8 (crumbles when depleted)
-
-    Essential for:
-    - Castle Wars access
-    - Ferox Enclave (restore pool)
-    - Quick banking
-
-    Very useful utility teleport.
+  about: "Enchanted emerald ring providing 8 teleports to Emir's Arena, Castle Wars, Ferox Enclave, and Fortis Colosseum (requires Hero title). Crumbles when depleted."
   market_strategy:
     notes:
       - Ferox for HP/Prayer restore
       - Common training teleport
       - Cheap and useful
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2004-04-20"
+      description: Ring of dueling released alongside duel arena teleport functionality.
+    - date: "2025-05-29"
+      description: Ring of dueling exempted from the Grand Exchange convenience fee.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-04-20"
+    update: Duel Arena
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Rub
+      - Wear
+      - Drop
+    worn_options:
+      - Emir's Arena
+      - Castle Wars
+      - Ferox Enclave
+      - Fortis Colosseum
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/robe-top-of-darkness.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/robe-top-of-darkness.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 48000
   highalch: 72000
   limit: 70
-  about: "Robe top of darkness is a members-only item in Old School RuneScape. High alchemy value: 72,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Cloth
+    tier: mid
+  equipment:
+    slot: body
+    weight: 2.721
+    requirements:
+      magic: 40
+      defence: 20
+    attack_bonus:
+      magic: 20
+    defence_bonus:
+      magic: 20
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/851
+  related_items:
+    - name: Robe bottom of darkness
+      relationship: set-piece
+    - name: Hood of darkness
+      relationship: set-piece
+    - name: Gloves of darkness
+      relationship: set-piece
+    - name: Boots of darkness
+      relationship: set-piece
+  about: "Robe top of darkness is a members-only magic body equipment obtained from master Treasure Trail reward caskets. Part of the robes of darkness set, it aligns with the Zaros faction and provides protection while in the Ancient Prison of the God Wars Dungeon."
+  market_strategy:
+    notes:
+      - Master clue exclusive supply at 1/851
+      - God Wars Dungeon Ancient Prison utility drives demand
+      - Set piece for full robes of darkness collection
+  trading_tips:
+    - Track master clue completion volumes
+    - Compare set value vs individual piece pricing
+  history:
+    - date: "2016-07-06"
+      description: Released as part of the Treasure Trail Expansion update.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "You can always get another from a reward casket from a Master Treasure Trail."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rocking-chair-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rocking-chair-flatpack.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Rocking chair (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flatpack
+    tier: low
+  construction:
+    skill: Construction
+    level: 14
+    xp: 87
+    facility: Wooden workbench
+    location: Parlour chair space
+  recipes:
+    - skill: Construction
+      level: 14
+      xp: 87
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+      materials:
+        - item_name: Plank
+          item_id: 960
+          quantity: 3
+        - item_name: Steel nails
+          item_id: 4824
+          quantity: 3
+  related_items:
+    - item_id: 8499
+      item_name: Wooden chair (flatpack)
+      slug: wooden-chair-flatpack
+      relationship: downgrade
+      description: Lower-tier parlour chair flatpack
+    - item_id: 8501
+      item_name: Oak chair (flatpack)
+      slug: oak-chair-flatpack
+      relationship: upgrade
+      description: Higher-tier parlour chair flatpack
+  about: "Construction flatpack assembled from 3 planks and 3 steel nails at a wooden workbench; gives 87 Construction XP per build and can be sold on the GE for chair-space training."
+  market_strategy:
+    notes:
+      - Low XP-per-GP versus higher-tier flatpacks
+      - Steady but small daily volume on the GE
+      - Useful for ironmen leveling Construction with limited resources
+      - Watch plank and steel nail prices for crafting margin
+  trading_tips:
+    - Buy planks and nails in bulk during off-peak hours
+    - Sell finished flatpacks during Construction training spikes
+    - Compare XP/gp with mahogany flatpacks before committing supply
+  history:
+    - date: "2006-05-31"
+      description: Rocking chair flatpack released with the Construction skill and Player-Owned Houses update.
+  properties:
+    release_date: "2006-05-31"
+    update: Construction
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rosewood-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rosewood-sapling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rosewood sapling | OSRS Price Data
-description: "Rosewood sapling: This sapling is ready to be replanted in a tree patch.. High alch: 1 GP."
+description: "Rosewood sapling: This sapling is ready to be replanted in a tree patch. High alch: 1 GP."
 osrs:
   id: 31508
   name: Rosewood sapling
@@ -12,9 +12,69 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Rosewood sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  farming:
+    level: 92
+    patch: Hardwood tree
+    xp_plant: 252
+    xp_check_health: 23100
+    growth_minutes: 5760
+    protection: 8 dragonfruit
+  recipes:
+    - materials:
+        - item_name: Rosewood seed
+          quantity: 1
+        - item_name: Plant pot (filled)
+          quantity: 1
+      tools:
+        - Watering can
+      output_quantity: 1
+  related_items:
+    - item_id: 31506
+      item_name: Rosewood seed
+      slug: rosewood-seed
+      relationship: component
+      description: Sown in a plant pot to grow the sapling.
+    - item_id: 31510
+      item_name: Rosewood logs
+      slug: rosewood-logs
+      relationship: product
+      description: Harvested from a fully grown rosewood tree.
+    - item_id: 22871
+      item_name: Mahogany sapling
+      slug: mahogany-sapling
+      relationship: alternative
+      description: Lower-tier hardwood sapling.
+  about: "Rosewood sapling is a Sailing-era hardwood sapling planted in hardwood tree patches at Farming 92; it grows over four days into a rosewood tree that yields rosewood logs."
+  market_strategy:
+    notes:
+      - Demand driven by Farming 92+ players growing rosewood for Sailing builds.
+      - Supply requires a watering can, plant pot, and Farming time investment.
+      - No GE buy limit lets bulk farmers offload runs quickly.
+  trading_tips:
+    - Compare sapling vs. seed + plant pot cost for production margin.
+    - Track rosewood log demand from Sailing shipbuilding for downstream signals.
+    - Avoid alching; high alch yields only 1 coin.
+  history:
+    - date: "2025-11-19"
+      description: Rosewood sapling released with the Sailing skill and hardwood tree expansion.
+  properties:
+    release_date: "2025-11-19"
+    update: Sailing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Plant
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-full-helm-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-full-helm-t.mdx
@@ -12,22 +12,82 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 8
+  material:
+    type: Rune
+    tier: high
   equipment:
     slot: head
+    weight: 2.721
     requirements:
       defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: "1/1,625"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
     - item_id: 2623
       item_name: Rune platebody (t)
       slug: rune-platebody-t
       relationship: set-piece
       description: Matching trimmed platebody
-  about: |-
-    > *"Rune full helm with trim."*
-
-    The rune full helm (t) is a trimmed cosmetic variant of the standard rune full helm. Identical stats, requiring 40 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1163
+      item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: alternative
+      description: Untrimmed cosmetic equivalent with identical stats
+  about: "The rune full helm (t) is a trimmed cosmetic variant of the standard rune full helm. Identical stats, requiring 40 Defence. Hard clue scroll reward."
+  market_strategy:
+    notes:
+      - "Supply is entirely driven by hard clue scroll completions, so price tracks active clue meta."
+      - "Stats are identical to the regular rune full helm, so value sits in cosmetic prestige."
+      - "Low GE volume produces wide spreads; offer just above the highest bid for steady fills."
+  trading_tips:
+    - "Cross-reference rune platebody (t) and rune kiteshield (t) listings to time set completions for resale."
+    - "Hard clue droughts can spike trimmed-set demand; hold for cosmetic flips during major collector events."
+  history:
+    - date: "2004-05-05"
+      description: "Released with the Bigger Banks & Treasure Trails update."
+  properties:
+    release_date: "2004-05-05"
+    update: "Bigger Banks & Treasure Trails"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-helm-h2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-helm-h2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune helm (h2) | OSRS Price Data
-description: "Rune helm (h2): A rune helmet with a heraldic design.. High alch: 21,120 GP, GE limit: 70."
+description: "Rune helm (h2): A rune helmet with a heraldic design. High alch: 21,120 GP, GE limit: 70."
 osrs:
   id: 10288
   name: Rune helm (h2)
@@ -12,9 +12,76 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 70
-  about: "Rune helm (h2) is a free-to-play item in Old School RuneScape. High alchemy value: 21,120 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: mid-high
+  equipment:
+    slot: head
+    weight: 2.721
+    requirements:
+      defence: 40
+    attack_bonus:
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+  related_items:
+    - item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: variant
+      description: Untrimmed base helm with identical defensive stats.
+  about: "Rune helm (h2) is a free-to-play heraldic variant of the rune full helm, obtained from hard and elite Treasure Trail clue scroll rewards. It shares the standard rune full helm's defensive stats and is valued by collectors for its rare heraldic design."
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: rare
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: rare
+  properties:
+    release_date: "2006-12-05"
+    update: "Treasure Trails Update"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  market_strategy:
+    notes:
+      - "Premium cosmetic clue reward with heraldic design; collector demand drives price."
+      - "Low GE buy limit of 70 caps flipping volume."
+      - "Stat parity with rune full helm makes value purely cosmetic."
+  trading_tips:
+    - "Stock up during hard/elite clue meta downturns when supply outpaces demand."
+    - "Track elite clue completion rates for long-term price trends."
+    - "Cross-check with other heraldic variants for spread plays."
+  history:
+    - date: "2006-12-05"
+      description: "Released as a heraldic Treasure Trail reward variant."
+    - date: "2021-04-21"
+      description: "Ranged attack penalty adjusted from -2 to -3 as part of an equipment stat pass."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-trimmed-set-lg.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Rune trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Rune
+    tier: mid-high
+  recipes:
+    - materials:
+        - item_name: Rune full helm (t)
+          quantity: 1
+        - item_name: Rune platebody (t)
+          quantity: 1
+        - item_name: Rune platelegs (t)
+          quantity: 1
+        - item_name: Rune kiteshield (t)
+          quantity: 1
+      tools:
+        - Grand Exchange clerk
+      output_quantity: 1
+  related_items:
+    - name: Rune full helm (t)
+      relationship: component
+    - name: Rune platebody (t)
+      relationship: component
+    - name: Rune platelegs (t)
+      relationship: component
+    - name: Rune kiteshield (t)
+      relationship: component
+    - name: Rune gold-trimmed set (lg)
+      relationship: alternative
+    - name: Rune armour set (lg)
+      relationship: alternative
+  about: "Rune trimmed set (lg) is a Grand Exchange-exchangeable bundle of the four trimmed rune legs-variant pieces, used to save bank space."
+  market_strategy:
+    notes:
+      - "Set arbitrage: compare set price vs sum of individual trimmed pieces."
+      - "Tiny buy limit (8 per 4 hours) limits flip volume."
+      - "High alch 48k well below typical GE price — not alchable for profit."
+  trading_tips:
+    - "Use the GE Sets tab to assemble/disassemble sets and capture arbitrage spreads."
+    - "Trimmed sets are cosmetic — demand is driven by collectors, not combat."
+  history:
+    - date: "2015-02-26"
+      description: "Released with The Grand Exchange update as part of the Item Sets interface."
+  properties:
+    release_date: "2015-02-26"
+    update: "The Grand Exchange"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bolts-p-9305.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bolts-p-9305.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 11000
-  about: "Runite bolts (p++) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Runite
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: bolt
+    weight: 0
+    requirements:
+      ranged: 61
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 115
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Runite bolts
+          quantity: 1
+        - item_name: Weapon poison++
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Runite bolts
+      relationship: variant
+    - name: Runite bolts (p)
+      relationship: variant
+    - name: Runite bolts (p+)
+      relationship: variant
+    - name: Dragon bolts
+      relationship: upgrade
+  about: "Runite bolts (p++) are super-poisoned runite crossbow bolts requiring 61 Ranged. They share +115 ranged strength with the unpoisoned variant but apply weapon poison++ damage on hit, sitting fourth in the bolt damage ladder behind dragon, onyx-tipped, and dragonstone-tipped bolts."
+  market_strategy:
+    notes:
+      - "Crafted by applying weapon poison++ to plain runite bolts; price tracks the spread between unpoisoned bolts and weapon poison++."
+      - "Common ammo for PvP and slayer crossbow loadouts that can't roll enchanted gems."
+      - "Buy limit of 11,000 per 4h makes bulk flips feasible during boss meta shifts."
+  trading_tips:
+    - "Watch weapon poison++ supply – cheap poison turns the (p++) variant into easy GP."
+    - "Pair with rune crossbow / armadyl crossbow demand spikes for safespot Slayer tasks."
+  history:
+    - date: "2006-07-31"
+      description: "Released alongside the rest of the runite bolt line and the crossbow rework."
+  properties:
+    release_date: "2006-07-31"
+    update: "Crossbows Rework"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/salve-graveyard-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/salve-graveyard-teleport-tablet.mdx
@@ -9,12 +9,67 @@ osrs:
   members: true
   icon: Salve graveyard teleport (tablet).png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 10000
-  about: "Salve graveyard teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: River Salve graveyard (near Mort Myre Swamp entrance)
+    requirements:
+      quest: Priest in Peril
+  recipes:
+    - materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 1
+        - item_name: Soul rune
+          quantity: 2
+        - item_name: Dark essence block
+          quantity: 1
+      tools:
+        - Arceuus lectern
+      output_quantity: 1
+      output_item: Salve graveyard teleport (tablet)
+      requirements:
+        magic: 40
+        xp: 30
+  related_items:
+    - item_name: Salve graveyard teleport
+      relationship: alternative
+      description: Spell version cast directly from the Arceuus spellbook
+    - item_name: Dark essence block
+      relationship: component
+      description: Essence material consumed when imbuing the tablet
+  about: "Salve graveyard teleport (tablet) is a one-click teleport tablet to the River Salve graveyard, made at an Arceuus lectern."
+  market_strategy:
+    notes:
+      - Steady consumption from Barrows runners and Morytania task players.
+      - Profit margin floats with soul rune and dark essence block prices.
+  trading_tips:
+    - Crafters should watch soul rune dips to stack tablets cheaply.
+    - Flippers can lean on the 10,000 buy limit for high-volume churn.
+  history:
+    - date: "2016-05-12"
+      description: Released alongside the Arceuus teleport tablets (Necromancy Teleport Tablets update).
+  properties:
+    release_date: "2016-05-12"
+    update: Necromancy Teleport Tablets
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Priest in Peril
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-s-light.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-s-light.mdx
@@ -1,6 +1,6 @@
 ---
 title: Saradomin's light | OSRS Price Data
-description: "Saradomin's light is a members none slot item. High alch: 20,760 GP, GE limit: 5."
+description: "Saradomin's light is a members item dropped by Commander Zilyana. High alch: 20,760 GP, GE limit: 5."
 osrs:
   id: 13256
   name: Saradomin's light
@@ -12,55 +12,50 @@ osrs:
   lowalch: 13840
   highalch: 20760
   limit: 5
-  equipment:
-    slot: none
+  about: "Saradomin's light is a rare drop from Commander Zilyana in the God Wars Dungeon. It can be consumed to permanently remove the darkness effect in Zamorak's Fortress, or attached to a Staff of the dead to create the cosmetic Staff of light."
+  properties:
+    release_date: "2015-09-03"
+    update: God Wars Dungeon Rewards
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.25
+    options:
+      - Consume
+      - Drop
+    alchable: true
+    destroy: "Drop"
   drop_table:
-    primary_source: Commander Zilyana
-    best_drop_rate: 1/254
     sources:
       - source: Commander Zilyana
-        source_id: 2205
-        combat_level: 596
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/254
-        members_only: true
+        rarity: "1/254"
   related_items:
-    - item_id: 11791
-      item_name: Staff of the dead
-      slug: staff-of-the-dead
+    - name: Staff of the dead
       relationship: component
-      description: Combined to create Staff of light
-    - item_id: 22296
-      item_name: Staff of light
-      slug: staff-of-light
+    - name: Staff of light
       relationship: upgrade
-      description: Created by combining with Staff of the dead
-    - item_id: 11806
-      item_name: Saradomin godsword
-      slug: saradomin-godsword
+    - name: Saradomin godsword
       relationship: alternative
-      description: Another unique from Commander Zilyana
-    - item_id: 11838
-      item_name: Saradomin sword
-      slug: saradomin-sword
+    - name: Saradomin sword
       relationship: alternative
-      description: Another unique from Commander Zilyana
-  about: |-
-    Removes Zamorak's Fortress darkness:
-    - Can permanently remove darkness in Zamorak's Fortress
-
-    Creates Staff of light:
-    - Attach to Staff of the dead to create Staff of light
-    - Staff of light has identical stats but different appearance
   market_strategy:
     notes:
-      - More common than other GWD uniques (1/254 vs 1/508)
-      - Used for Staff of light cosmetic upgrade
-      - Niche utility item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "More common than other GWD uniques (1/254 vs 1/508)."
+      - "Primarily used for Staff of light cosmetic upgrade."
+      - "Niche utility item with limited demand."
+  trading_tips:
+    - "Demand stems from Staff of light cosmetic conversion and Zamorak Fortress visibility."
+    - "Stable price tied to GWD farm rates and Staff of the dead supply."
+    - "Buy limit of 5 limits scale; flip in moderate volume."
+  history:
+    - date: "2015-09-03"
+      description: "Saradomin's light added as a Commander Zilyana drop."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/seers-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/seers-ring.mdx
@@ -5,73 +5,85 @@ osrs:
   id: 6731
   name: Seers ring
   slug: seers-ring
-  examine: A mysterious ring that can fill the wearer with magical power...
+  examine: "A mysterious ring that can fill the wearer with magical power..."
   members: true
   icon: Seers ring.png
   value: 10000
   lowalch: 4000
   highalch: 6000
   limit: 8
+  material:
+    type: enchanted
+    tier: high
   equipment:
     slot: ring
-    type: ring
-    stats:
-      attack_magic: 6
-    imbue:
-      location: Soul Wars/Nightmare Zone
-      imbued_magic: 12
+    weapon_type: none
+    weight: 0.004
+    requirements: {}
+    attack_bonus:
+      magic: 6
+    defence_bonus:
+      magic: 6
+    other_bonus:
+      magic_damage: 0.2
   drop_table:
     sources:
       - source: Dagannoth Prime
-        source_id: 2265
-        combat_level: 303
         quantity: "1"
         rarity: 1/128
-        members_only: true
   related_items:
     - item_id: 6737
       item_name: Berserker ring
       slug: berserker-ring
       relationship: alternative
-      description: Melee equivalent
+      description: Melee equivalent Dagannoth Kings ring
     - item_id: 6733
       item_name: Archers ring
       slug: archers-ring
       relationship: alternative
-      description: Ranged equivalent
-    - item_id: 19550
-      item_name: Ring of suffering
-      slug: ring-of-suffering
+      description: Ranged equivalent Dagannoth Kings ring
+    - item_id: 6735
+      item_name: Warrior ring
+      slug: warrior-ring
       relationship: alternative
-      description: Defensive alternative
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Magic attack | +6 |
-    | Requirements | None |
-
-    Best-in-slot magic accuracy ring (for damage).
-
-    Imbue at Soul Wars or Nightmare Zone for doubled stats:
-
-    | Stat | Imbued |
-    |------|--------|
-    | Magic attack | +12 |
-
-    BiS magic ring for:
-    - All magic combat
-    - Bossing
-    - Slayer
-    - Max magic setups
-
-    Imbue is essential - doubles the bonus.
+      description: Defensive melee Dagannoth Kings ring
+  about: "Best-in-slot magic accuracy ring dropped by Dagannoth Prime. Imbue at Nightmare Zone, Soul Wars, or Emir's Arena to double magic bonuses and bring magic damage to 0.5%."
   market_strategy:
     notes:
-      - DKs are efficient to farm
-      - Imbue immediately
-      - Cheapest DK ring
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Dagannoth Kings are efficient to farm for all four ring variants
+      - Imbue immediately after purchase to maximize value
+      - Cheapest of the Dagannoth Kings rings
+      - Demand spikes when magic-heavy content is released
+  trading_tips:
+    - Buy from DK farmers for resale margin
+    - Stockpile before magic content updates
+    - Imbued version commands a premium and is the practical end-user form
+  history:
+    - date: "2005-11-07"
+      description: Seers ring released alongside Dagannoth Kings in Waterbirth Island Dungeon.
+    - date: "2016-12-01"
+      description: Magic attack bonus buffed from +4 to +6 in a 50% stat update.
+    - date: "2024-05-29"
+      description: Magic damage increased from 0% to 0.2%.
+  properties:
+    release_date: "2005-11-07"
+    update: Waterbirth Island
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.004
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/serpentine-visage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/serpentine-visage.mdx
@@ -12,64 +12,64 @@ osrs:
   lowalch: 42000
   highalch: 63000
   limit: 5
-  item:
-    type: crafting_material
-    tradeable: true
-    weight: 1
-  obtaining:
-    methods:
+  material:
+    type: Serpentine
+    tier: high
+  recipes:
+    - skill: Crafting
+      level: 52
+      experience: 120
+      materials:
+        - item_name: Serpentine visage
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+  drop_table:
+    sources:
       - source: Zulrah
-        drop_rate: 2 x 1/1,024
-  creation:
-    creates:
-      item_id: 12929
-      item_name: Serpentine helm (uncharged)
-      slug: serpentine-helm
-    method: Use chisel to create Serpentine helm
-    requirements:
-      crafting: 52
-    xp: 120
-    dismantle:
-      result_id: 12934
-      result_name: Zulrah's scales
-      quantity: "20000"
+        quantity: "1"
+        rarity: "2 x 1/1024"
   related_items:
-    - item_id: 0
-      item_name: Zulrah
-      slug: zulrah
+    - name: Zulrah
       relationship: component
-      description: Boss drop
-    - item_id: 12929
-      item_name: Serpentine helm
-      slug: serpentine-helm
+    - name: Serpentine helm (uncharged)
       relationship: product
-      description: Created helm
-    - item_id: 12934
-      item_name: Zulrah's scales
-      slug: zulrahs-scales
-      relationship: downgrade
-      description: Dismantle result
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 1 kg |
-
-    | Item Created | Materials | Requirements |
-    |--------------|-----------|--------------|
-    | Serpentine helm (uncharged) | Serpentine visage + chisel | 52 Crafting |
-
-    Grants 120 Crafting XP when crafted.
-
-    Can be dismantled for 20,000 Zulrah's scales.
+    - name: Zulrah's scales
+      relationship: alternative
+    - name: Tanzanite helm (uncharged)
+      relationship: alternative
+    - name: Magma helm (uncharged)
+      relationship: alternative
+  about: "Serpentine visage is a rare drop from Zulrah used to craft the uncharged Serpentine helm at 52 Crafting. It can alternatively be dismantled into 20,000 Zulrah's scales, the helm's charge currency."
   market_strategy:
     notes:
-      - Zulrah exclusive drop
-      - Creates venom-immune helm
-      - 52 Crafting to process
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Exclusive Zulrah drop at 2/1024 throttles supply
+      - Dismantle floor at 20k scales x scale price sets price floor
+      - Venom-immune helm drives steady ironman crafting demand
+  trading_tips:
+    - Compare GE price vs 20k Zulrah's scales for dismantle arbitrage
+    - Monitor Zulrah PvM popularity for supply waves
+  history:
+    - date: "2015-01-08"
+      description: Released with the Zulrah update.
+  properties:
+    release_date: "2015-01-08"
+    update: Zulrah
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Dismantle
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-boots-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-boots-t1.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Shattered boots (t1) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: high
+  equipment:
+    slot: feet
+    weapon_type: none
+    weight: 0.34
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues lobby
+      stock: 0
+      price: 1000
+      currency: League points
+  related_items:
+    - name: "Shattered hood (t1)"
+      relationship: set-piece
+    - name: "Shattered top (t1)"
+      relationship: set-piece
+    - name: "Shattered trousers (t1)"
+      relationship: set-piece
+    - name: "Shattered cape (t1)"
+      relationship: set-piece
+    - name: "Shattered boots (t2)"
+      relationship: upgrade
+  about: "Shattered boots (t1) are a cosmetic feet slot reward from the Leagues IV: Shattered Relics outfit, purchasable for 1,000 League points. They contribute no combat stats and act as a set-piece for the Shattered Relic Hunter outfit. High alchemy value: 9,000 coins."
+  market_strategy:
+    notes:
+      - "Demand is collector-driven; supply was capped at the Leagues IV event window."
+      - "Price tends to drift with rare-cosmetic flips and outfit-completion demand."
+  trading_tips:
+    - "Pair flips with other Shattered set pieces for completion premiums."
+    - "Costume room storage means listings come and go in waves."
+  history:
+    - date: "2022-01-19"
+      description: "Shattered boots (t1) added to the game as part of Leagues IV preparations."
+    - date: "2022-03-16"
+      description: "Made obtainable through the PvP Arena: Rewards Beta and Leagues reward shop."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2022-01-19"
+    update: "Leagues IV: Shattered Relics"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-relics-variety-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-relics-variety-ornament-kit.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 5
-  about: "Shattered relics variety ornament kit is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - name: Abyssal whip
+      relationship: alternative
+    - name: Abyssal tentacle
+      relationship: alternative
+    - name: Rune crossbow
+      relationship: alternative
+    - name: Holy book
+      relationship: alternative
+    - name: Book of balance
+      relationship: alternative
+    - name: Unholy book
+      relationship: alternative
+  about: "Shattered relics variety ornament kit is a cosmetic kit that reskins an Abyssal whip, Abyssal tentacle, Rune crossbow, or God book with a Leagues III - Shattered Relics theme; the transformation is reversible."
+  market_strategy:
+    notes:
+      - "Originally available only from the Leagues III reward shop (1,500 League Points) — supply is fixed and slowly bleeding out of the economy."
+      - "Tiny GE limit (5 per 4 hours) keeps the market thin."
+      - "High alch 15k is far below GE value — never alch."
+  trading_tips:
+    - "Demand spikes when fashionscape / Leagues nostalgia content drops."
+    - "Long-term hold candidate — finite supply, cosmetic appeal."
+  history:
+    - date: "2022-01-19"
+      description: "Added to game files alongside Leagues III - Shattered Relics."
+    - date: "2022-03-16"
+      description: "Became obtainable as a PvP Arena: Rewards Beta tie-in / Leagues reward shop offering."
+  properties:
+    release_date: "2022-03-16"
+    update: "PvP Arena: Rewards Beta"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Apply
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-trousers-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-trousers-t2.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Shattered trousers (t2) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: legs
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - name: Shattered hood (t2)
+      relationship: set-piece
+    - name: Shattered top (t2)
+      relationship: set-piece
+    - name: Shattered cape (t2)
+      relationship: set-piece
+    - name: Shattered boots (t2)
+      relationship: set-piece
+    - name: Shattered trousers (t1)
+      relationship: downgrade
+    - name: Shattered trousers (t3)
+      relationship: upgrade
+  about: "Shattered trousers (t2) is a cosmetic legs slot piece of the tier 2 Shattered Relic Hunter outfit, purchased for 3,000 League points from the Leagues Reward Shop and tradeable on the Grand Exchange."
+  market_strategy:
+    notes:
+      - "No GE buy limit listed; pricing follows Leagues nostalgia cycles and fashionscape demand."
+      - "Cosmetic-only stats (+0 across the board); collectors and set completers drive volume."
+  trading_tips:
+    - "Originally cost 3,000 League points from the Leagues Reward Shop; resupply is gated by future Leagues events."
+    - "Pair with the matching hood, top, cape, and boots for the complete tier 2 Shattered Relic Hunter look."
+  history:
+    - date: "2022-03-16"
+      description: "Released as part of the PvP Arena: Rewards Beta update via the Leagues Reward Shop."
+  properties:
+    release_date: "2022-03-16"
+    update: "PvP Arena: Rewards Beta"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-devotion.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-devotion.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of devotion | OSRS Price Data
-description: "Sigil of devotion: A power enhancing sigil not yet attuned to you.. High alch: 12,000 GP, GE limit: 8."
+description: "Sigil of devotion: A power enhancing sigil not yet attuned to you. High alch: 12,000 GP, GE limit: 8."
 osrs:
   id: 26099
   name: Sigil of devotion
@@ -12,9 +12,36 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of devotion is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sigil of devotion is a members-only item in Old School RuneScape. It is a power-enhancing sigil that has not yet been attuned to its bearer, intended to be activated for prayer or combat benefits in Deadman-style modes."
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Activate
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  market_strategy:
+    notes:
+      - "Limited Grand Exchange buy limit of 8 per 4 hours makes large-scale flipping slow."
+      - "Demand is tied to special Deadman-style game modes and event seasons."
+      - "High alch value of 12,000 sets a coarse floor for resale pricing."
+  trading_tips:
+    - "Buy in small lots when seasonal Deadman hype is low."
+    - "Track patch notes for any Deadman or sigil rebalance announcements."
+    - "Compare GE mid price against high alch before committing capital."
+  history:
+    - date: "2021-08-25"
+      description: "Released as a sigil item associated with Deadman-style content."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-freedom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-freedom.mdx
@@ -12,9 +12,42 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of freedom is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  related_items:
+    - name: Sigil of consistency
+      relationship: alternative
+    - name: Sigil of resilience
+      relationship: alternative
+    - name: Sigil of escaping
+      relationship: alternative
+  about: "Sigil of freedom is a Deadman Mode consumable sigil that, once attuned and activated, immediately breaks any player-cast bind effects on the holder. The un-attuned form drops from most monsters on the Deadman drop table and is tradeable on the Grand Exchange."
+  market_strategy:
+    notes:
+      - "Demand is tied exclusively to active Deadman Mode seasons; outside seasonal windows price softens with thin volume."
+      - "Buy limit 10 per 4 hours; single Deadman events can spike price sharply on PvP escape utility."
+  trading_tips:
+    - "Un-attuned form is the GE-tradeable variant; attuning binds it to the character and removes resale value."
+    - "Activation is a one-shot anti-bind escape and consumes the sigil, so plan inventory around expected freezes."
+  history:
+    - date: "2021-08-25"
+      description: "Released as part of the Deadman: Reborn update."
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    alchable: false
+    destroy: "An alternative is to sell it on the Grand Exchange"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-rampage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-rampage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of rampage | OSRS Price Data
-description: "Sigil of rampage: A power enhancing sigil not yet attuned to you.. High alch: 18,000 GP, GE limit: 4."
+description: "Sigil of rampage: A power enhancing sigil not yet attuned to you. Deadman Mode exclusive."
 osrs:
   id: 26135
   name: Sigil of rampage
@@ -12,9 +12,43 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 4
-  about: "Sigil of rampage is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sigil of rampage is a Deadman Mode reward sigil that boosts damage and accuracy when the player rotates combat styles. Each rampage stack adds a percentage bonus, but using the same style consecutively resets the count."
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  related_items:
+    - name: Sigil of aggression
+      relationship: alternative
+    - name: Sigil of consistency
+      relationship: alternative
+    - name: Sigil of devotion
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Untradeable Deadman Mode reward, no Grand Exchange market."
+      - "Acquired from the Deadman Mode skull shop during seasonal events."
+      - "Does not stack with Sigil of Aggression."
+  trading_tips:
+    - "Not tradeable; obtain via Deadman Mode skull shop."
+    - "Pair with frequent style-switching loadouts to maximise rampage uptime."
+    - "Plan attack rotations to keep two distinct styles ready."
+  history:
+    - date: "2021-08-25"
+      description: "Sigil of rampage introduced with Deadman: Reborn."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-guardian-angel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-guardian-angel.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 4
-  about: "Sigil of the guardian angel is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Deadman Mode drop table
+        quantity: "1"
+        rarity: Rare
+  related_items:
+    - name: Sigil of the menacing mage
+      relationship: alternative
+    - name: Sigil of the ranging fortunes
+      relationship: alternative
+    - name: Sigil of the formidable fighter
+      relationship: alternative
+  about: "Sigil of the guardian angel is a tier 3 utility sigil used during Deadman Mode events. When attuned, it is consumed on PvP death instead of dropping a Bank Key, sparing the player a life loss while still scattering inventory as if skulled."
+  market_strategy:
+    notes:
+      - "Only obtainable through the Deadman Mode drop table during active events."
+      - "Cannot be traded or alchemised; value is purely defensive utility."
+      - "Must be unattuned before the destroy option becomes available."
+  trading_tips:
+    - "Stock and attune early in a Deadman season to guard against PK ambushes."
+    - "Sigils stack with Bank Key mechanics so plan inventory loadouts around expected skull risk."
+  history:
+    - date: "2021-08-25"
+      description: "Released as part of the Deadman: Reborn event."
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Activate
+    alchable: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-menacing-mage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-menacing-mage.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of the menacing mage is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Deadman Mode drop table
+        quantity: "1"
+        rarity: Rare
+  related_items:
+    - name: Sigil of the guardian angel
+      relationship: alternative
+    - name: Sigil of the ranging fortunes
+      relationship: alternative
+    - name: Sigil of the formidable fighter
+      relationship: alternative
+  about: "Sigil of the menacing mage is a tier 2 combat sigil for Deadman Mode that gives a 15% chance on magic hits to curse the target, dealing 18 damage over 6 seconds (33% less in worlds 3-60) and healing the caster for the same amount."
+  market_strategy:
+    notes:
+      - "Only obtainable during temporary Deadman Mode events."
+      - "Duplicates can be exchanged on Deadman's skull for points or coins."
+      - "Stacks well with magic-focused Deadman builds."
+  trading_tips:
+    - "Use as a starting sigil for high-volume magic loadouts in Deadman: Annihilation."
+    - "Sell duplicate sigils on Deadman's skull rather than alching since alch value is zero."
+  history:
+    - date: "2021-08-25"
+      description: "Released alongside the Deadman: Reborn event."
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Activate
+    alchable: false
+    destroy: "You can sell duplicate sigils by using them on Deadman's skull."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bolts.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 11000
-  about: "Silver bolts is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  equipment:
+    slot: ammo
+    weight: 0
+    requirements:
+      ranged: 20
+    other_bonus:
+      ranged_strength: 36
+  recipes:
+    - skill: Fletching
+      level: 43
+      experience: 2.5
+      materials:
+        - item_name: Silver bolts (unf)
+          quantity: 1
+        - item_name: Feather
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - name: Silver bolts (unf)
+      relationship: component
+    - name: Silver bolts (p)
+      relationship: variant
+    - name: Silver bolts (p+)
+      relationship: variant
+    - name: Silver bolts (p++)
+      relationship: variant
+  about: "Silver bolts are crossbow ammunition made by attaching feathers to silver bolts (unf) at level 43 Fletching. They are fired from iron crossbows or better and are notably effective against Vampyre Juvinates. High alchemy value: 3 coins. Grand Exchange buy limit: 11,000 per 4 hours."
+  history:
+    - date: "2006-07-31"
+      description: "Released during the Crossbows update."
+  properties:
+    release_date: "2006-07-31"
+    update: Crossbows
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sinister-key.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sinister-key.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 11000
-  about: "Sinister key is a members-only item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  drop_table:
+    sources:
+      - source: Magpie impling jar
+        quantity: "1"
+        rarity: 1/21
+      - source: Salarin the Twisted
+        quantity: "1"
+        rarity: 10/128
+      - source: Chaos Fanatic
+        quantity: "1"
+        rarity: 4/128
+  related_items:
+    - name: Sinister chest
+      relationship: component
+    - name: Lockpick
+      relationship: alternative
+  about: "Sinister key opens the sinister chest in the Yanille Agility dungeon, yielding nine noted grimy herbs (2 harralander, 3 ranarr, 1 irit, 1 avantoe, 1 kwuarm, 1 torstol)."
+  market_strategy:
+    notes:
+      - Strong daily demand from herb-flippers; the chest payout sets a price floor.
+      - Drops scale with Salarin the Twisted and Chaos Fanatic kills plus Magpie impling rates (1/21).
+      - 11,000/4h GE limit suits bulk flipping when chest contents trend upward.
+  trading_tips:
+    - Profit = (ranarr + torstol + kwuarm + irit + avantoe + 2 harralander) noted prices minus (sinister key + travel) — track this gap.
+    - Watch herb prices, especially ranarr and torstol, for the dominant signal on key valuation.
+  history:
+    - date: "2002-12-12"
+      description: Added with the Agility skill release.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    update: Agility skill release
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-armour-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Skeletal armour set | OSRS Price Data
-description: "Skeletal armour set is a members-only OSRS item. High alch: 87,000 GP, GE limit: 2."
+description: "Skeletal armour set: A set containing a Skeletal helm, Skeletal top, Skeletal bottoms, Skeletal boots and Skeletal gloves. High alch: 87,000 GP, GE limit: 2."
 osrs:
   id: 31154
   name: Skeletal armour set
@@ -12,9 +12,60 @@ osrs:
   lowalch: 58000
   highalch: 87000
   limit: 2
-  about: "Skeletal armour set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins. Grand Exchange buy limit: 2 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bone
+    tier: mid
+  about: "Skeletal armour set is a members-only Grand Exchange Sets bundle containing all five Skeletal armour pieces. Players exchange the five individual pieces with a Grand Exchange clerk to receive the set, primarily to save trade slots when flipping or transferring the gear."
+  related_items:
+    - item_name: Skeletal helm
+      slug: skeletal-helm
+      relationship: set-piece
+      description: Headgear component of the set.
+    - item_name: Skeletal top
+      slug: skeletal-top
+      relationship: set-piece
+      description: Body component of the set.
+    - item_name: Skeletal bottoms
+      slug: skeletal-bottoms
+      relationship: set-piece
+      description: Legs component of the set.
+    - item_name: Skeletal gloves
+      slug: skeletal-gloves
+      relationship: set-piece
+      description: Hands component of the set.
+    - item_name: Skeletal boots
+      slug: skeletal-boots
+      relationship: set-piece
+      description: Feet component of the set.
+  properties:
+    release_date: "2025-08-20"
+    update: "More Doom Tweaks, Poll 84, & Summer Sweep Up Changes"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  market_strategy:
+    notes:
+      - "Set arbitrage opportunity between bundle price and the five-piece component basket."
+      - "Low GE buy limit of 2 per 4 hours throttles large-scale flipping."
+      - "Watch component prices on Skeletal helm and gloves, which dominate the basket value."
+  trading_tips:
+    - "Calculate basket value of all five pieces before buying or selling the set."
+    - "Use the set form to consolidate trade slots when moving between alts."
+    - "Sell at peak hours when prayer/training demand spikes."
+  history:
+    - date: "2025-08-20"
+      description: "Added as a Grand Exchange Sets bundle with the Summer Sweep Up update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sliced-banana.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sliced-banana.mdx
@@ -9,12 +9,54 @@ osrs:
   members: false
   icon: Sliced banana.png
   value: 2
-  lowalch: 1
+  lowalch: 0
   highalch: 1
   limit: 15
-  about: "Sliced banana is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  food:
+    heals: 2
+  recipes:
+    - materials:
+        - item_name: Banana
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+      notes: "Slash weapons such as whips and claws also work."
+  related_items:
+    - name: Banana
+      relationship: component
+    - name: "Karamjan rum (sliced banana)"
+      relationship: product
+  about: "Sliced banana is a free-to-play food item in Old School RuneScape. Sliced from a banana using a knife or slash weapon; combine with Karamjan rum to make Karamjan rum (sliced banana). High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
+  market_strategy:
+    notes:
+      - "Crafting margin vs raw banana is small; profit depends on banana spot price."
+      - "Low alch returns 0 coins; not a viable alch target."
+  trading_tips:
+    - "Buy bananas in bulk for slicing flips."
+    - "Useful inventory item during the Pirate's Treasure quest setup."
+  history:
+    - date: "2004-09-14"
+      description: "Sliced banana released alongside the Pirate's Treasure quest update."
+    - date: "2026-04-22"
+      description: "Wiki refresh confirmed alch values and recipe details."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-09-14"
+    update: "Pirate's Treasure"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.028
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/soul-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/soul-rune.mdx
@@ -12,80 +12,75 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 25000
-  rune:
-    type: catalytic
-    element: soul
-  runecraft:
-    level: 90
-    xp: 29.7
-    altar: Soul Altar
-    altar_location: Arceuus
-    essence_type: dark
-    method: Dark essence fragments
   recipes:
-    - skill: runecraft
+    - skill: Runecraft
       level: 90
-      xp: 29.7
+      experience: 29.7
       materials:
         - item_name: Dark essence fragments
-          item_id: 7938
           quantity: 1
-      product: Soul rune
-      product_id: 566
-      product_quantity: 1
-      facility: Soul altar
-      members_only: true
+      tools:
+        - Soul altar
+        - Chisel
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Dust devil
+        quantity: "1"
+        rarity: Common
+      - source: Skeletal wyvern
+        quantity: "1"
+        rarity: Common
+      - source: Cerberus
+        quantity: "1"
+        rarity: Uncommon
+      - source: Nex
+        quantity: "1"
+        rarity: Uncommon
+  shops:
+    - shop_name: Wizards' Guild Store
+      location: Yanille
+      price: 300
+      stock: 50
   related_items:
-    - item_id: 565
-      item_name: Blood rune
-      slug: blood-rune
+    - name: Blood rune
       relationship: alternative
-      description: Paired for barrages
-    - item_id: 560
-      item_name: Death rune
-      slug: death-rune
+    - name: Death rune
       relationship: alternative
-      description: Ancient magic
-    - item_id: 7938
-      item_name: Dark essence fragments
-      slug: dark-essence-fragments
+    - name: Dark essence fragments
       relationship: component
-      description: Crafting material
-    - item_id: 561
-      item_name: Nature rune
-      slug: nature-rune
+    - name: Nature rune
       relationship: alternative
-      description: Similar tier
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Runecraft Level | 90 |
-    | Method | Dark essence at Soul Altar |
-    | XP per rune | 29.7 |
-
-    | Spell | Soul Runes | Spellbook |
-    |-------|------------|-----------|
-    | Blood Barrage | 1 | Ancient |
-    | Shadow Barrage | 2 | Ancient |
-    | Teleother spells | 1 | Lunar |
-    | Vulnerability | 1 | Standard |
-    | Reanimation spells | Varies | Arceuus |
-    | Enchant dragonstone | 1 | Standard |
+  about: "Soul rune is a high-level catalytic rune crafted at Arceuus' Soul Altar using dark essence fragments at Runecraft 90. It powers Ancient barrage spells, Lunar teleother magic, Arceuus reanimations, and charges Tumeken's shadow."
   market_strategy:
     notes:
-      - 90 RC required (high barrier)
-      - Dark essence fragments method
-      - Profitable but intensive
-      - Blood Barrage (PvM staple)
-      - Shadow spells
-      - Arceuus reanimation
-      - High-level enchanting
-      - Used with blood runes for barrages
-      - Arceuus training creates demand
-      - Price relatively stable
-      - Fewer suppliers than blood runes
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Runecraft 90 barrier keeps supplier count low and price stable."
+      - "Demand is driven by Blood Barrage usage and Arceuus reanimation training."
+      - "GE buy limit of 25,000 supports large bulk flips."
+  trading_tips:
+    - "Pair with blood runes; their consumption ratio in Barrage spells correlates closely."
+    - "Watch for runecraft-related QoL updates that could shift the dark essence pipeline."
+  history:
+    - date: "2002-10-23"
+      description: "Added to the game alongside the original Ancient Magicks release."
+    - date: "2019-04-04"
+      description: "Soul Altar in Arceuus added, making soul runes player-craftable."
+  properties:
+    release_date: "2002-10-23"
+    update: Ancient Magicks
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spice.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spice.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 92
   highalch: 138
   limit: 11000
-  about: "Spice is a members-only item in Old School RuneScape. High alchemy value: 138 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Spice is a members-only cooking ingredient in Old School RuneScape used to make curry and several spicy food items. High alchemy value: 138 coins. Grand Exchange buy limit: 11,000 per 4 hours."
+  drop_table:
+    sources:
+      - source: Gourmet implings
+        quantity: "1"
+        rarity: Common
+      - source: Baby implings
+        quantity: "1"
+        rarity: Uncommon
+      - source: Opulent salvage
+        quantity: "1"
+        rarity: Uncommon
+  shops:
+    - shop_name: "Culinaromancer's Chest"
+      location: Lumbridge Castle cellar
+      stock: 10
+      price: 299
+    - shop_name: Ardougne Spice Stall
+      location: East Ardougne market
+      stock: 1
+      price: 230
+    - shop_name: Prifddinas Spice Stall
+      location: Prifddinas
+      stock: 1
+      price: 230
+    - shop_name: Fortis Spice Stall
+      location: Fortis
+      stock: 1
+      price: 230
+  recipes:
+    - name: Uncooked curry
+      skill: Cooking
+      level: 60
+      xp: 0
+      materials:
+        - item_name: Uncooked stew
+          quantity: 1
+        - item_name: Spice
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - name: Uncooked curry
+      relationship: product
+    - name: Curry
+      relationship: product
+    - name: Spicy stew
+      relationship: product
+  market_strategy:
+    notes:
+      - Gourmet implings are the primary farming source for bulk supply.
+      - Demand is steady but modest; price tends to track impling hunting popularity.
+  trading_tips:
+    - Buy from Spice stalls if Thieving 65 is available for a profitable margin.
+    - Watch for Recipe for Disaster reward shop discounts via Lumbridge Diary.
+  history:
+    - date: "2002-04-30"
+      description: Spice was introduced to the game.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-04-30"
+    update: Latest RuneScape News (30 April 2002)
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spider-cave-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spider-cave-teleport.mdx
@@ -12,9 +12,45 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: null
-  about: "Spider cave teleport is a members-only item in Old School RuneScape. High alchemy value: 6 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  teleport:
+    destination: "Morytania Spider Cave"
+    type: scroll
+    requirements:
+      quests:
+        - "Priest in Peril"
+  drop_table:
+    sources:
+      - source: "Araxxor"
+        quantity: "3"
+        rarity: "8/115"
+  about: "Spider cave teleport is a members-only scroll dropped by Araxxor that warps the user to the entrance of the Morytania Spider Cave. High alchemy value: 6 coins."
+  market_strategy:
+    notes:
+      - "Volume-driven utility teleport; pricing tracks Araxxor scroll supply."
+      - "Spikes when Araxxor is the boss-of-the-week or featured in events."
+  trading_tips:
+    - "Watch GE volume against Araxxor kill-tracker channels to time entries."
+    - "Bulk-flip in 100+ stacks; per-unit margins are thin."
+  history:
+    - date: "2024-08-28"
+      description: "Released as part of the Araxxor update; added as a drop from Araxxor."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-08-28"
+    update: "Araxxor"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Teleport
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stale-baguette.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stale-baguette.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 5
+  equipment:
+    slot: weapon
+    weapon_type: crush
+    attack_speed: 6
+    weight: 2.267
+    requirements: {}
+    attack_bonus:
+      stab: -100
+      slash: -100
+      crush: -50
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: -10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Mystery box
+        quantity: "1"
+        rarity: 1/256
+      - source: Sandwich lady
+        quantity: "1"
+        rarity: 1/448
   about: "Stale baguette is a free-to-play item in Old School RuneScape. High alchemy value: 135 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - Very low daily volume around 98 trades; expect slow fills at the Grand Exchange.
+      - Treated as a novelty/collector item, so price can swing on small order flow.
+      - GE buy limit of 5 per 4 hours caps any meaningful flipping volume.
+  trading_tips:
+    - List buy and sell offers slightly outside the current GE margin to clear within a day.
+    - Watch for Last Man Standing or F2P cosmetic content that can spike short-term demand.
+  history:
+    - date: "2016-08-04"
+      description: Added to the game as part of the Last Man Standing update.
+    - date: "2019-09-16"
+      description: Added to fancy dress box storage.
+    - date: "2022-03-30"
+      description: Male character wield positioning corrected.
+    - date: "2022-11-23"
+      description: Sandwich Lady drop rate adjusted.
+    - date: "2025-08-13"
+      description: Made available to free-to-play players.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-08-04"
+    update: Last Man Standing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-full-helm-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-full-helm-g.mdx
@@ -12,22 +12,80 @@ osrs:
   lowalch: 220
   highalch: 330
   limit: 125
+  material:
+    type: steel
+    tier: low
   equipment:
     slot: head
+    weight: 2.721
     requirements:
       defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 9
+      slash: 10
+      crush: 7
+      magic: -1
+      ranged: 9
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 20169
-      item_name: Steel platebody (g)
-      slug: steel-platebody-g
+    - name: Steel full helm
+      relationship: variant
+    - name: "Steel full helm (t)"
+      relationship: variant
+    - name: "Steel platebody (g)"
       relationship: set-piece
-      description: Matching gold-trimmed platebody
-  about: |-
-    > *"Steel full helm with gold trim."*
-
-    The steel full helm (g) is a gold-trimmed cosmetic variant of the standard steel full helm. Identical stats, requiring 5 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: "Steel platelegs (g)"
+      relationship: set-piece
+    - name: "Steel plateskirt (g)"
+      relationship: set-piece
+    - name: "Steel kiteshield (g)"
+      relationship: set-piece
+  about: "Steel full helm (g) is a gold-trimmed cosmetic variant of the standard steel full helm with identical combat stats and the same level 5 Defence requirement. Obtained exclusively as a reward from easy-tier Treasure Trails."
+  market_strategy:
+    notes:
+      - "Cosmetic clue scroll reward; price is driven entirely by trim-set collectors, not combat utility."
+      - "Buy limit 125 per 4 hours; daily volume is light so spreads can widen quickly."
+  trading_tips:
+    - "Stats are identical to a regular steel full helm; pay the trim premium only for fashionscape and set completion."
+    - "Acquired from easy clue caskets at roughly 1/1,404 drop rate."
+  history:
+    - date: "2016-07-06"
+      description: "Released as part of the Treasure Trail Expansion update."
+    - date: "2021-04-14"
+      description: "Ranged attack bonus reduced from -2 to -3 alongside other helmet adjustments."
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-ring.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Steel ring is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: high
+  equipment:
+    slot: ring
+    weight: 3
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 24
+      slash: 24
+      crush: 24
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Deranged archaeologist
+        quantity: "1"
+        rarity: 3/131
+  related_items:
+    - name: Ring of suffering (i)
+      relationship: alternative
+  about: "Steel ring is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins. Best-in-slot melee defensive ring, surpassing the ring of suffering (i) for pure melee defence."
+  market_strategy:
+    notes:
+      - Sole source is Deranged Archaeologist (3/131), so supply is bound to PvM activity at that boss.
+      - Best-in-slot melee defensive ring property keeps long-term demand steady from PvM and pure tanks.
+      - No GE buy limit listed; large flips still cap by available offers.
+  trading_tips:
+    - Track Deranged Archaeologist kill volume on streams/PVM trackers as a supply leading indicator.
+    - Compare price to Ring of suffering (i) margins when valuing it for melee setups.
+  history:
+    - date: "2025-06-25"
+      description: Released as part of the Summer Sweep Up Combat update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-06-25"
+    update: "Summer Sweep Up: Combat"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/studded-chaps-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/studded-chaps-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Studded chaps (t) | OSRS Price Data
-description: "Studded chaps (t) is a F2P legs slot item requiring 20 Defence. High alch: 450 GP, GE limit: 8."
+description: "Studded chaps (t): Those studs should provide a bit more protection. Nice trim too! High alch: 450 GP, GE limit: 8."
 osrs:
   id: 7368
   name: Studded chaps (t)
@@ -12,23 +12,75 @@ osrs:
   lowalch: 300
   highalch: 450
   limit: 8
+  material:
+    type: leather
+    tier: low
   equipment:
     slot: legs
+    weight: 4.535
     requirements:
       ranged: 20
-      defence: 20
+      defence: 1
+    defence_bonus:
+      stab: 15
+      slash: 16
+      crush: 17
+      magic: 6
+      ranged: 16
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 7364
       item_name: Studded body (t)
       slug: studded-body-t
       relationship: set-piece
-      description: Matching trimmed body
-  about: |-
-    > *"Trimmed studded leather chaps."*
-
-    The studded chaps (t) are a trimmed cosmetic variant of studded chaps. Identical stats, requiring 20 Ranged and 20 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching trimmed body.
+    - item_name: Studded chaps
+      slug: studded-chaps
+      relationship: variant
+      description: Untrimmed base chaps with identical stats.
+  about: "Studded chaps (t) are a trimmed cosmetic variant of studded chaps, awarded from easy Treasure Trail clue caskets. They share identical Ranger stats with the untrimmed version and are valued mainly by collectors and clue completionists."
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  properties:
+    release_date: "2006-02-20"
+    update: "Treasure Trails"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 4.535
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  market_strategy:
+    notes:
+      - "Cosmetic clue reward with thin organic demand; collector market drives price."
+      - "Tiny GE buy limit of 8 makes large-scale flipping impractical."
+      - "Easy-clue completion volume sets long-term supply."
+  trading_tips:
+    - "Buy during clue downturns and resell to costume collectors."
+    - "Stack with matching Studded body (t) for set premium plays."
+    - "Watch for cosmetic outfit announcements that could spike demand."
+  history:
+    - date: "2006-02-20"
+      description: "Released as a Treasure Trail clue casket reward."
+    - date: "2006-03-15"
+      description: "Made available to free-to-play players."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-energy-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-energy-2.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 2000
-  about: "Super energy(2) is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    effects:
+      - description: "Restores 20% run energy per dose, totalling 40% across the 2 doses."
+        duration: 0
+  related_items:
+    - name: Super energy(4)
+      relationship: variant
+    - name: Super energy(3)
+      relationship: variant
+    - name: Super energy(1)
+      relationship: variant
+    - name: Stamina potion(4)
+      relationship: upgrade
+    - name: Energy potion(4)
+      relationship: downgrade
+  about: "Super energy(2) is a two-dose run energy restoration potion. Each dose restores 20% run energy, giving a total of 40% across both doses, making it a budget alternative to stamina potions for travel-heavy activities."
+  market_strategy:
+    notes:
+      - "Made by combining amylase crystals with a super energy potion at Herblore level 77 to upgrade into stamina potions."
+      - "Two-dose vials are common decants from four-dose stock; price tends to track 1/2 of a (4)."
+      - "Demand is steady from agility, slayer, and bossing trips that can't justify stamina costs."
+  trading_tips:
+    - "Convert into stamina potions whenever amylase crystals dip below the spread vs stamina (4)."
+    - "Decant batches with Bob Barter at the GE to flip 2-dose stock into 4-dose units."
+  history:
+    - date: "2004-09-01"
+      description: "Released with the Herblore expansion that introduced super energy potions."
+  properties:
+    release_date: "2004-09-01"
+    update: "Herblore Skill Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-kebab.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-kebab.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Super kebab is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: mid
+  food:
+    heal_range: "Heals 3 HP + 7% of Hitpoints level on success"
+    effects:
+      - description: "20/32 chance to heal 3 HP plus 7% of player's Hitpoints level"
+      - description: "11/32 chance of no effect"
+      - description: "1/32 chance of draining a random non-Hitpoints stat by 3"
+  recipes:
+    - name: Super kebab (from normal kebab)
+      materials:
+        - item_name: Kebab
+          quantity: 1
+        - item_name: Red hot sauce
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - name: Super kebab (from ugthanki kebab)
+      materials:
+        - item_name: Ugthanki kebab
+          quantity: 1
+        - item_name: Red hot sauce
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - name: Super kebab (from bad ugthanki kebab)
+      materials:
+        - item_name: Bad ugthanki kebab
+          quantity: 1
+        - item_name: Red hot sauce
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  shops:
+    - shop_name: Ali the Kebab seller
+      location: Pollnivneach
+      price: 5
+  related_items:
+    - name: Kebab
+      relationship: component
+    - name: Ugthanki kebab
+      relationship: component
+    - name: Bad ugthanki kebab
+      relationship: component
+    - name: Red hot sauce
+      relationship: component
+  about: "Super kebab is a members-only food made by adding red hot sauce to a kebab variant. It has a 20/32 chance of healing 3 plus 7% of the player's Hitpoints level, an 11/32 chance of nothing, and a 1/32 chance of draining a random non-HP stat by 3."
+  market_strategy:
+    notes:
+      - Bought from Ali the Kebab seller in Pollnivneach for 5 coins
+      - Random effect makes it unreliable for serious PvM
+      - GE limit of 15 keeps it a niche flip
+  trading_tips:
+    - Buy from NPC and resell on GE for steady margin
+    - Demand is tied to novelty rather than utility
+  history:
+    - date: "2005-04-04"
+      description: Released with the Ali Morrisane and Pollnivneach update.
+    - date: "2005-04-11"
+      description: Reclassified as a members-only item.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-04-04"
+    update: "Ali Morrisane and Pollnivneach"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/superantipoison-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/superantipoison-4.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 144
   highalch: 216
   limit: 2000
-  about: "Superantipoison(4) is a members-only item in Old School RuneScape. High alchemy value: 216 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 4
+    effects:
+      - description: "Cures poison and grants 6 minutes of poison immunity per dose (24 minutes total at 4 doses); two doses cures venom by stepping it down through poison."
+        duration: 1440
+    skill_requirements:
+      herblore: 48
+  recipes:
+    - materials:
+        - item_name: "Irit potion (unf)"
+          quantity: 1
+        - item_name: "Unicorn horn dust"
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: herblore
+      level: 48
+      experience: 106.3
+      notes: "Produces a 3-dose superantipoison; combine doses to make a 4-dose flask."
+  related_items:
+    - item_name: "Superantipoison(3)"
+      relationship: variant
+    - item_name: "Superantipoison(2)"
+      relationship: variant
+    - item_name: "Superantipoison(1)"
+      relationship: variant
+    - item_name: "Antidote+(4)"
+      relationship: upgrade
+    - item_name: "Antipoison(4)"
+      relationship: downgrade
+    - item_name: "Irit potion (unf)"
+      relationship: component
+    - item_name: "Unicorn horn dust"
+      relationship: component
+  about: "Superantipoison(4) is a members anti-poison potion that cures poison and steps down venom; 24 minutes of immunity across all 4 doses."
+  market_strategy:
+    notes:
+      - "Demand tracks venom-heavy bosses (Zulrah, Vorkath, ToB) and high-level slayer."
+      - "Antidote+ has eclipsed it for most PvM; price floor anchored to herblore alch / inputs."
+  trading_tips:
+    - "Pair stock with herb-run cycles; unicorn horn dust spikes drag this potion with it."
+    - "Bulk flip into raid resets; demand pulses around boss events."
+  history:
+    - date: "2002-02-27"
+      description: "Released alongside the original superantipoison three-dose flask."
+    - date: "2004-03-29"
+      description: "Four-dose variant added with the launch of RuneScape 2."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-02-27"
+    update: "Herblore Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-14-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-14-cape.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-14 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Cloth
+    tier: low
+  equipment:
+    slot: cape
+    weight: 0.453
+    requirements:
+      defence: 1
+    defence_bonus:
+      slash: 1
+      crush: 1
+      ranged: 2
+  shops:
+    - shop_name: Darren's Wilderness Cape Shop
+      location: East of the Wilderness Agility Course
+      stock: 5
+      price: 50
+  related_items:
+    - name: Team-1 cape
+      relationship: variant
+    - name: Team-2 cape
+      relationship: variant
+    - name: Team-50 cape
+      relationship: variant
+  about: "Team-14 cape is one of fifty team capes purchasable from Darren's Wilderness Cape Shop. Players wearing matching team capes appear as blue dots on each other's minimaps, useful for organized clan PvP and Wilderness events."
+  market_strategy:
+    notes:
+      - Shop-stocked at 50 gp caps upside
+      - F2P cape with niche team-identification use
+      - 150 GE limit supports light flipping
+  trading_tips:
+    - Buy from Darren's shop and flip GE at minor margin
+    - Team capes spike during clan events and tournaments
+  history:
+    - date: "2005-02-22"
+      description: Released with the Wilderness Capes, and Changes update.
+  properties:
+    release_date: "2005-02-22"
+    update: Wilderness Capes, and Changes
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-29-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-29-cape.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-29 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: cape
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Simon's Wilderness Cape Shop"
+      location: Chaos Temple
+      stock: 30
+      price: 50
+  related_items:
+    - item_id: 4315
+      item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: Another team cape with different colours
+  about: "The Team-29 cape is one of the many team capes purchased from Simon Templeton's Wilderness Cape Shop. Matching team capes change PvP attack interactions and minimap dots."
+  market_strategy:
+    notes:
+      - "Player-matching mechanics drive most demand, especially during organised team events or PvP gatherings."
+      - "Shop restock price is 50 coins, so the GE rarely drifts far above that floor."
+      - "Volume is thin; flips are best executed when a team event spike pushes the price above shop value."
+  trading_tips:
+    - "Stock up cheaply from Simon Templeton when planning to participate in team events."
+    - "Avoid bulk speculation; long-term price ceiling is constrained by shop availability."
+  history:
+    - date: "2005-02-22"
+      description: "Released as part of the Wilderness Capes, and Changes update."
+    - date: "2013-05-23"
+      description: "Made available to free-to-play players."
+  properties:
+    release_date: "2005-02-22"
+    update: "Wilderness Capes, and Changes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tonalztics-of-ralos-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tonalztics-of-ralos-uncharged.mdx
@@ -11,13 +11,17 @@ osrs:
   value: 600000
   lowalch: 240000
   highalch: 360000
-  limit: null
+  limit: 8
+  material:
+    type: ancient_ranged
+    tier: high
   equipment:
     slot: weapon
-    type: thrown
-    tradeable: true
-    weight: 2
-    attack_speed: 7
+    weapon_type: thrown
+    attack_speed: 6
+    weight: 3
+    requirements:
+      ranged: 75
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,79 +35,70 @@ osrs:
       magic: 0
       ranged: 0
     other_bonus:
-      melee_strength: 0
+      strength: 0
       ranged_strength: 55
       magic_damage: 0
       prayer: 2
-    requirements:
-      ranged: 75
   special_attack:
     name: Division
-    energy: 50
-    description: Reduces target's Defence by 10% of their Magic level per hit
-  charging:
-    material_id: 28924
-    material_name: Sunfire splinters
+    energy_cost: 50
+    description: "Reduces the target's Defence level by 10% of their Magic level on a successful hit; stacks per hit."
+  charges:
+    material: Sunfire splinters
     max_charges: 20000
-    charged_version_id: 28922
+    charged_form: Tonalztics of ralos (charged)
+    notes: When charged the weapon strikes twice per attack with independent damage rolls.
   drop_table:
-    primary_source: Fortis Colosseum
-    best_drop_rate: 1/83.61
     sources:
-      - source: Fortis Colosseum
+      - source: Fortis Colosseum reward chest (waves 7-12)
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/83.61 (waves 7-12)
-        members_only: true
-  market:
-    buy_limit: 8
-    price_estimate: 44248618
+        rarity: 1/83.61
   related_items:
     - item_id: 28922
       item_name: Tonalztics of ralos (charged)
       slug: tonalztics-of-ralos-charged
       relationship: variant
-      description: Charged version
+      description: Charged form that hits twice per attack
     - item_id: 28924
       item_name: Sunfire splinters
       slug: sunfire-splinters
       relationship: component
-      description: Charging material
-  about: |-
-    | Stat | Bonus |
-    |------|-------|
-    | Ranged Attack | +115 |
-    | Ranged Strength | +55 |
-    | Prayer | +2 |
-
-    Division (50% special attack energy)
-
-    The special attack reduces the target's Defence by 10% of their Magic level with each hit. This makes it particularly effective against high-Magic opponents in PvP and certain PvM encounters.
-
-    The Tonalztics of ralos can be charged using Sunfire splinters:
-
-    - Maximum Charges: 20,000
-    - Material Required: Sunfire splinters (Item ID: 28924)
-    - Charged Version: Tonalztics of ralos (charged) (Item ID: 28922)
-
-    When charged, the weapon gains additional power and hits twice per attack, making it significantly more effective.
-
-    Best uses for the Tonalztics of ralos:
-
-    - High-level bossing where Defence reduction is valuable
-    - PvP encounters against mages
-    - Fortis Colosseum speed runs
-    - General ranged combat with prayer bonus
-
-    Note: The uncharged version only hits once. Charge with Sunfire splinters for double hits.
+      description: Charging material consumed per attack
+    - item_name: Sol Heredit
+      relationship: alternative
+      description: Final Fortis Colosseum boss tied to the weapon's drop chain
+  about: "Tonalztics of ralos (uncharged) is a Varlamore-era thrown weapon from the Fortis Colosseum that becomes a two-hit shredder when charged with Sunfire splinters."
   market_strategy:
     notes:
-      - Price fluctuates based on Colosseum popularity
-      - Sunfire splinters needed for charging add to total cost
-      - Consider buying during off-peak hours
-      - Check charged version price for comparison
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Price tracks Fortis Colosseum popularity and recent buffs/nerfs to Sol Heredit drops.
+      - Sunfire splinter cost factors into the effective DPS premium versus charged form.
+  trading_tips:
+    - Buy during PvM content droughts when Colosseum runners over-supply chests.
+    - Compare uncharged + splinters total cost vs charged listing before settling either side.
+  history:
+    - date: "2024-03-20"
+      description: Released with the Varlamore expansion as a Fortis Colosseum reward.
+  properties:
+    release_date: "2024-03-20"
+    update: Varlamore
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wield
+      - Charge
+      - Drop
+    worn_options:
+      - Remove
+      - Special Attack
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-boots-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-boots-t3.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 5
-  about: "Trailblazer boots (t3) is a members-only item in Old School RuneScape. High alchemy value: 90,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: mid-high
+  equipment:
+    slot: feet
+    weapon_type: none
+    weight: 0.34
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  related_items:
+    - slug: trailblazer-hood-t3
+      name: Trailblazer hood (t3)
+      relationship: set-piece
+    - slug: trailblazer-top-t3
+      name: Trailblazer top (t3)
+      relationship: set-piece
+    - slug: trailblazer-trousers-t3
+      name: Trailblazer trousers (t3)
+      relationship: set-piece
+    - slug: trailblazer-boots-t2
+      name: Trailblazer boots (t2)
+      relationship: downgrade
+  about: "Trailblazer boots (t3) is a cosmetic Leagues reward purchasable from the Leagues Reward Shop for 15,000 League points. Part of the Trailblazer Relic Hunter (T3) cosmetic outfit set."
+  history:
+    - date: "2021-01-06"
+      description: Trailblazer boots (t3) released alongside the Trailblazer League finale rewards.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-01-06"
+    update: Trailblazer League
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-hood-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-hood-t1.mdx
@@ -12,9 +12,38 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: 5
-  about: "Trailblazer hood (t1) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: head
+    weight: 0.453
+  related_items:
+    - name: Trailblazer hood (t2)
+      relationship: upgrade
+    - name: Trailblazer hood (t3)
+      relationship: upgrade
+    - name: Trailblazer top (t1)
+      relationship: set-piece
+    - name: Trailblazer trousers (t1)
+      relationship: set-piece
+    - name: Trailblazer boots (t1)
+      relationship: set-piece
+  about: "Trailblazer hood (t1) is a cosmetic head slot item from the Trailblazer Relic Hunter outfit, purchased from the Leagues Reward Shop for 1,000 League points. High alchemy value: 9,000 coins. Grand Exchange buy limit: 5 per 4 hours."
+  history:
+    - date: "2021-01-06"
+      description: "Released via the Soul Wars and 20th Anniversary Event update as a Leagues III reward."
+  properties:
+    release_date: "2021-01-06"
+    update: Soul Wars and 20th Anniversary Event
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-headband-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-headband-t1.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Trailblazer reloaded headband (t1) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: head
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues IV - Trailblazer Reloaded
+      price: 1000
+      currency: League points
+  related_items:
+    - name: Trailblazer reloaded headband (t2)
+      relationship: upgrade
+    - name: Trailblazer reloaded headband (t3)
+      relationship: upgrade
+    - name: Trailblazer reloaded top (t1)
+      relationship: set-piece
+    - name: Trailblazer reloaded trousers (t1)
+      relationship: set-piece
+    - name: Trailblazer reloaded boots (t1)
+      relationship: set-piece
+  about: "Trailblazer reloaded headband (t1) is a cosmetic head slot item from the Trailblazer Reloaded Relic Hunter outfit. Players purchase it from the Leagues Reward Shop for 1,000 League points during Leagues IV."
+  market_strategy:
+    notes:
+      - Acquired with League points from Leagues IV
+      - Cosmetic only with no combat bonuses
+      - Storable in costume room armour case or outfit stand
+  trading_tips:
+    - Collector demand drives the secondary market
+    - Supply is fixed to league participants who unlocked the tier
+  history:
+    - date: "2023-11-29"
+      description: Released with the Chambers of Xeric Changes update as a Leagues IV reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-11-29"
+    update: "Chambers of Xeric Changes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-top-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-top-t2.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Trailblazer reloaded top (t2) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: mid
+  equipment:
+    slot: body
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - name: Trailblazer reloaded top (t1)
+      relationship: downgrade
+    - name: Trailblazer reloaded top (t3)
+      relationship: upgrade
+    - name: Trailblazer reloaded headband (t2)
+      relationship: set-piece
+    - name: Trailblazer reloaded trousers (t2)
+      relationship: set-piece
+    - name: Trailblazer reloaded boots (t2)
+      relationship: set-piece
+  about: "Trailblazer reloaded top (t2) is a members cosmetic body slot reward from the Trailblazer Reloaded League shop, costing 5,000 League points, with no combat bonuses and a tier 2 visual style matching the rest of the Relic Hunter outfit."
+  market_strategy:
+    notes:
+      - Cosmetic-only piece, demand driven entirely by fashionscape collectors.
+      - Supply is limited to whatever Leagues participants choose to sell after the event.
+      - No GE buy limit and not alchable - liquidity skews thin, prices swing on hype cycles.
+  trading_tips:
+    - Buy during post-League market dumps when supply spikes.
+    - Pair with matching tier 2 trousers, headband, and boots for the full outfit.
+    - Store in a Costume Room armour case to save bank space.
+  history:
+    - date: "2023-11-29"
+      description: Released as a Trailblazer Reloaded League reward shop cosmetic.
+  properties:
+    release_date: "2023-11-29"
+    update: Leagues IV - Trailblazer Reloaded
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tzhaar-ket-om-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tzhaar-ket-om-ornament-kit.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Tzhaar-ket-om ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  related_items:
+    - name: Tzhaar-ket-om
+      relationship: component
+    - name: Tzhaar-ket-om (or)
+      relationship: product
+  about: "Tzhaar-ket-om ornament kit is a cosmetic kit obtained as a rare reward from hard Treasure Trails. It can be applied to the Tzhaar-ket-om to create the ornamented variant, which becomes untradeable but can be reverted by detaching the kit."
+  market_strategy:
+    notes:
+      - Rare hard clue reward (1/1625) keeps supply scarce
+      - Demand driven by clue completionists and fashionscape collectors
+      - Detachable kit retains resale value after attachment
+  trading_tips:
+    - Track hard clue completion trends for supply shifts
+    - Compare price against base Tzhaar-ket-om for ornamented premium
+  history:
+    - date: "2019-04-11"
+      description: Released with the Treasure Trails Expansion and Easter 2019 update.
+  properties:
+    release_date: "2019-04-11"
+    update: Treasure Trails Expansion and Easter 2019
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "You can always get another from a reward casket from a Hard Treasure Trail."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unblessed-symbol.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unblessed-symbol.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 10000
-  about: "Unblessed symbol is a free-to-play item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  equipment:
+    slot: neck
+    weight: 0.007
+  recipes:
+    - name: Unblessed symbol
+      skill: Crafting
+      level: 1
+      xp: 4
+      materials:
+        - item_name: Unstrung symbol
+          quantity: 1
+        - item_name: Ball of wool
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Skeleton (Tarn's Lair)
+        quantity: "1"
+        rarity: Uncommon
+  related_items:
+    - name: Unstrung symbol
+      relationship: component
+    - name: Ball of wool
+      relationship: component
+    - name: Holy symbol
+      relationship: upgrade
+  about: "The unblessed symbol is a free-to-play Crafting product made from an unstrung symbol and a ball of wool, used as the base for the holy symbol after a Prayer altar blessing."
+  market_strategy:
+    notes:
+      - Demand mostly tracks holy symbol routing for low Prayer setups.
+      - Crafting tax keeps it close to materials cost; volume is shallow.
+  trading_tips:
+    - Compare unstrung symbol plus ball of wool against this item's price for craft-flip profit.
+    - Buy in bulk before league/DMM events that boost low-tier symbol demand.
+  history:
+    - date: "2001-07-12"
+      description: Released with the improved prayer system update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-07-12"
+    update: Improved prayer system and more!
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncharged-trident-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncharged-trident-e.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 39200
   highalch: 58800
   limit: 8
-  about: "Uncharged trident (e) is a members-only item in Old School RuneScape. High alchemy value: 58,800 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Trident
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: powered_staff
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      magic: 75
+    attack_bonus:
+      magic: 15
+    defence_bonus:
+      magic: 15
+  charges:
+    max_charges: 20000
+    charge_type: casts
+    per_charge_cost:
+      - item_name: Death rune
+        quantity: 1
+      - item_name: Chaos rune
+        quantity: 1
+      - item_name: Fire rune
+        quantity: 5
+      - item_name: Coins
+        quantity: 10
+  recipes:
+    - skill: None
+      level: 0
+      experience: 0
+      materials:
+        - item_name: Uncharged trident
+          quantity: 1
+        - item_name: Kraken tentacle
+          quantity: 10
+      tools: []
+      facilities:
+        - Lieve McCracken
+      output_quantity: 1
+  related_items:
+    - name: Uncharged trident
+      relationship: component
+    - name: Trident of the seas (e)
+      relationship: product
+    - name: Kraken tentacle
+      relationship: component
+    - name: Uncharged toxic trident (e)
+      relationship: upgrade
+  about: "Uncharged trident (e) is the enhanced empty variant of the trident of the seas, created by Lieve McCracken from an uncharged trident and 10 kraken tentacles. It holds up to 20,000 charges (eight times the base trident) and must be charged with death runes, chaos runes, fire runes, and coins before it can attack."
+  market_strategy:
+    notes:
+      - Kraken tentacle cost dominates total price
+      - Higher charge cap appeals to long-session PvMers
+      - Pathway item toward toxic trident upgrade
+  trading_tips:
+    - Compare cost vs base trident + tentacles for arbitrage
+    - Watch kraken tentacle supply for ripple effects
+  history:
+    - date: "2018-02-08"
+      description: Released with the PvM QoL updates.
+  properties:
+    release_date: "2018-02-08"
+    update: PvM QoL updates
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncooked-mushroom-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncooked-mushroom-pie.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 13000
-  about: "Uncooked mushroom pie is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: mid
+  recipes:
+    - name: Uncooked mushroom pie
+      materials:
+        - item_name: Sulliuscep cap
+          quantity: 1
+        - item_name: Pie shell
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      skill: Cooking
+      level: 60
+      xp: 200
+    - name: Mushroom pie
+      materials:
+        - item_name: Uncooked mushroom pie
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+      skill: Cooking
+      level: 60
+      xp: 200
+  related_items:
+    - name: Sulliuscep cap
+      relationship: component
+    - name: Pie shell
+      relationship: component
+    - name: Mushroom pie
+      relationship: product
+    - name: Burnt pie
+      relationship: alternative
+  about: "Uncooked mushroom pie is a members-only Cooking ingredient created at level 60 by combining a sulliuscep cap with a pie shell. Baking it on a range yields a mushroom pie or a burnt pie on failure."
+  market_strategy:
+    notes:
+      - Made at 60 Cooking from a sulliuscep cap and pie shell
+      - Cooks into mushroom pie for 200 XP per bake
+      - GE limit of 13,000 supports bulk cooking flips
+  trading_tips:
+    - Watch sulliuscep cap and pie shell margins for profitability
+    - Burn rate at lower levels can devalue stock
+  history:
+    - date: "2017-09-07"
+      description: Released as part of the Fossil Island update.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-09-07"
+    update: "Fossil Island"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unfired-cup.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unfired-cup.mdx
@@ -12,9 +12,47 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Unfired cup is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  recipes:
+    - skill: Crafting
+      level: 3
+      experience: 8.5
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+      tools:
+        - Potter's wheel
+      output_quantity: 4
+  related_items:
+    - name: Soft clay
+      relationship: component
+    - name: Cup
+      relationship: product
+  about: "Unfired cup is a Crafting intermediate created at a potter's wheel from soft clay. It was originally intended for mass-producing empty cups for forester's tea, a feature that was scrapped before release."
+  market_strategy:
+    notes:
+      - "No GE buy limit; supply driven entirely by Crafting trainers."
+      - "Minimal demand because the planned forester's tea use never shipped."
+  trading_tips:
+    - "Better to buy soft clay and craft directly if you need Crafting xp; flipping unfired cups is rarely profitable."
+  history:
+    - date: "2023-06-28"
+      description: "Added to the game alongside the potter's wheel recipe."
+  properties:
+    release_date: "2023-06-28"
+    update: Forestry Part Two
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unpowered-symbol.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unpowered-symbol.mdx
@@ -1,6 +1,6 @@
 ---
 title: Unpowered symbol | OSRS Price Data
-description: "Unpowered symbol: An unblessed symbol of Zamorak.. High alch: 120 GP, GE limit: 10,000."
+description: "Unpowered symbol: An unblessed symbol of Zamorak. High alch: 120 GP, GE limit: 10,000."
 osrs:
   id: 1722
   name: Unpowered symbol
@@ -12,9 +12,94 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 10000
-  about: "Unpowered symbol is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: silver
+    tier: low
+  equipment:
+    slot: neck
+    weight: 0.007
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - materials:
+        - item_name: Unstrung symbol
+          quantity: 1
+        - item_name: Ball of wool
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_id: 1716
+      item_name: Holy symbol
+      slug: holy-symbol
+      relationship: alternative
+      description: Saradomin variant blessed at altar.
+    - item_id: 1724
+      item_name: Unholy symbol
+      slug: unholy-symbol
+      relationship: product
+      description: Zamorakian symbol blessed from this unpowered version.
+    - item_id: 1720
+      item_name: Unstrung symbol
+      slug: unstrung-symbol
+      relationship: component
+      description: Crafted from a silver bar before stringing.
+    - item_id: 1759
+      item_name: Ball of wool
+      slug: ball-of-wool
+      relationship: component
+      description: Used to string the symbol.
+  about: "Unpowered symbol is the unblessed Zamorakian neck symbol crafted by stringing an unstrung symbol with wool; it is blessed into an Unholy symbol by Spirit of Scorpius or via Prayer 50."
+  market_strategy:
+    notes:
+      - Demand from Prayer trainers blessing into unholy symbols.
+      - Supply abundant from Crafting 16 silver-bar production paths.
+      - GE buy limit of 10,000 supports steady volume flipping.
+  trading_tips:
+    - Compare spread between unstrung and unpowered symbols for crafting margin.
+    - Track unholy symbol price for blessing arbitrage at Spirit of Scorpius.
+    - Buy near alch floor to set risk-managed flips.
+  history:
+    - date: "2003-03-17"
+      description: Unpowered symbol released as the Zamorakian counterpart to the Holy symbol.
+    - date: "2004-11-17"
+      description: Examine text refined from "unholy" to "unblessed".
+  properties:
+    release_date: "2003-03-17"
+    update: Zamorakian Symbols
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unstrung-symbol.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unstrung-symbol.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 10000
-  about: "Unstrung symbol is a free-to-play item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: silver
+    tier: low
+  recipes:
+    - name: Craft Unstrung symbol
+      skill: Crafting
+      level: 16
+      experience: 50
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+      tools:
+        - Holy mould
+      facility: Furnace
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Skeleton (Tarn's Lair)
+        quantity: "1"
+        rarity: Uncommon
+  shops:
+    - shop_name: Aris's Silver Stall
+      location: East Ardougne
+      price: 200
+      stock: 5
+    - shop_name: Herquin's Gems
+      location: Falador
+      price: 200
+      stock: 5
+  related_items:
+    - name: Silver bar
+      relationship: component
+    - name: Unblessed symbol
+      relationship: upgrade
+    - name: Holy symbol
+      relationship: upgrade
+    - name: Ball of wool
+      relationship: component
+  about: "Unstrung symbol is a free-to-play Crafting product made at a furnace from a silver bar and a holy mould at level 16, granting 50 Crafting experience; strung with a ball of wool then blessed to become a Holy symbol."
+  market_strategy:
+    notes:
+      - Common Crafting XP product used by F2P trainers.
+      - Net loss per cast versus silver bar cost makes Crafting XP its main value driver.
+      - Demand stays steady from low-level Prayer users seeking a holy symbol amulet.
+  trading_tips:
+    - Watch silver bar prices and craft when bars are below the GE symbol price.
+    - String with a ball of wool and bless through Brother Jered for the holy symbol upgrade.
+    - Buy from Ardougne shops if GE is dry; only a couple stocked at a time.
+  history:
+    - date: "2001-07-12"
+      description: Released with early Crafting expansion.
+  properties:
+    release_date: "2001-07-12"
+    update: Crafting silver items
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.004
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-plateskirt.mdx
@@ -12,81 +12,67 @@ osrs:
   lowalch: 110000
   highalch: 165000
   limit: 15
+  material:
+    type: barrows
+    tier: high
   equipment:
     slot: legs
-    type: barrows
-    set: Verac
-    tradeable: true
-    degradeable: true
-    weight: 4.5
+    weapon_type: none
+    weight: 4.535
     requirements:
       defence: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -21
-      attack_ranged: 0
-      defence_stab: 85
-      defence_slash: 82
-      defence_crush: 83
-      defence_magic: 0
-      defence_ranged: 84
-      strength: 0
-      ranged_strength: 0
-      magic_damage: 0
+    attack_bonus:
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 85
+      slash: 82
+      crush: 83
+      ranged: 84
+    other_bonus:
       prayer: 4
-  set_effect:
-    name: Defiler
-    pieces_required: 4
-    description: 25% chance to ignore target's Defence and Protection prayers
   related_items:
-    - item_id: 4753
-      item_name: Verac's helm
-      slug: veracs-helm
+    - slug: veracs-helm
+      name: Verac's helm
       relationship: set-piece
-      description: Head slot set piece (+3 prayer)
-    - item_id: 4757
-      item_name: Verac's brassard
-      slug: veracs-brassard
+    - slug: veracs-brassard
+      name: Verac's brassard
       relationship: set-piece
-      description: Body slot set piece (+5 prayer)
-    - item_id: 4755
-      item_name: Verac's flail
-      slug: veracs-flail
+    - slug: veracs-flail
+      name: Verac's flail
       relationship: set-piece
-      description: Weapon set piece (+6 prayer)
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Stab defence | +85 |
-    | Slash defence | +82 |
-    | Crush defence | +83 |
-    | Magic defence | +0 |
-    | Ranged defence | +84 |
-    | Prayer | +4 |
-    | Magic attack | -21 |
-
-    Note: Same melee defence as Dharok/Torag legs but with +4 prayer bonus.
-
-    Defiler:
-    When wearing full Verac's (helm, brassard, plateskirt, flail):
-    - 25% chance to ignore target's Defence and Protection prayers
-    - Hits through Protect from Melee
-
-    Best For:
-    - Prayer bonus legs option
-    - Same defence as other Barrows legs
-    - Lighter than other platelegs
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
+  about: "Same melee defence as Dharok/Torag legs but with +4 prayer bonus. Part of Verac's Defiler set effect (25% chance to ignore target Defence and Protection prayers)."
   market_strategy:
     notes:
       - Useful for prayer setups
       - Combines well with Proselyte
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2005-05-09"
+      description: "Verac's plateskirt released with the Barrows update."
+    - date: "2015-04-16"
+      description: '"Check" option added for durability viewing.'
+    - date: "2021-04-28"
+      description: Ranged attack bonus reduced from -7 to -11.
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    update: Barrows
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.535
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/warrior-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/warrior-ring.mdx
@@ -12,38 +12,59 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 8
-  item_id: 6735
-  type: equipment
-  tradeable: true
-  weight: 0.004
-  buy_limit: 8
+  material:
+    type: gold
+    tier: high
   equipment:
     slot: ring
-    type: ring
-    requirements:
-      skills: []
-    stats:
-      attack_slash: 4
-      defence_slash: 4
-    imbue:
-      location: Nightmare Zone
-      points: 650000
-      effect: Doubles all bonuses
+    weapon_type: none
+    weight: 0.004
+    requirements: {}
+    attack_bonus:
+      slash: 4
+    defence_bonus:
+      slash: 4
+    other_bonus: {}
   drop_table:
     sources:
       - source: Dagannoth Rex
-        rate: 1/128
-        members_only: true
+        quantity: "1"
+        rarity: 1/128
   related_items:
     - slug: warrior-ring-i
       name: Warrior ring (i)
-      relation: imbued_version
+      relationship: upgrade
     - slug: berserker-ring
       name: Berserker ring
-      relation: strength_alternative
-  about: Can be imbued at Nightmare Zone (650,000 points) to double bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: alternative
+    - slug: warrior-icon
+      name: Warrior icon
+      relationship: product
+  about: "Can be imbued at Nightmare Zone (650,000 points) to double bonuses."
+  history:
+    - date: "2005-11-07"
+      description: Warrior ring released as a drop from Dagannoth Rex.
+    - date: "2008-09-23"
+      description: "Imbued variant introduced via Nightmare Zone rewards."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-11-07"
+    update: The Fremennik Isles
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.004
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-lily.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-lily.mdx
@@ -12,39 +12,46 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 600
-  item:
-    type: flower
-    tradeable: true
-    weight: 0.02
-    requirements:
-      farming: 58
-  effect:
-    allotment_protection: true
-    description: Fully grown white lily protects adjacent allotment patches from disease
-    composting: Creates supercompost when added to compost bin
+  farming:
+    seed: White lily seed
+    level: 58
+    patch: Flower
+    grow_time_minutes: 160
+    protects: Allotment patches from disease when fully grown
+    notes: "Add to a compost bin to produce supercompost."
   related_items:
-    - item_id: 22887
-      item_name: White lily seed
-      slug: white-lily-seed
+    - name: White lily seed
       relationship: component
-      description: Seed planted to grow white lily
-    - item_id: 6420
-      item_name: Supercompost
-      slug: supercompost
+    - name: Supercompost
       relationship: product
-      description: Created by composting white lily
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Flower |
-    | Tradeable | Yes |
-    | Weight | 0.02 kg |
-
-    Allotment protection: Fully grown white lily protects adjacent allotment patches from disease.
-
-    Composting: Creates supercompost when added to compost bin.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "White lily is a Farming flower grown from a white lily seed at level 58 in a flower patch. Once fully grown it protects all adjacent allotment patches from disease and can be turned into supercompost."
+  market_strategy:
+    notes:
+      - "Demand driven by Farming runs that need a guaranteed flower protector; price tracks allotment seed activity."
+      - "Buy limit of 600 supports modest bulk flipping."
+      - "Supercompost conversion provides a price floor when compost demand spikes."
+  trading_tips:
+    - "Spread out purchases over multiple GE windows to avoid hitting the 600 buy limit."
+    - "Watch for Farming-skilling streamer events; prices often move with patch run popularity."
+  history:
+    - date: "2019-01-10"
+      description: "Released as part of The Kebos Lowlands expansion alongside new Farming content."
+  properties:
+    release_date: "2019-01-10"
+    update: The Kebos Lowlands
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wizard-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wizard-boots.mdx
@@ -12,82 +12,73 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 8
+  material:
+    type: cloth
+    tier: mid
   equipment:
     slot: feet
-    type: magic_boots
-    attack_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
-      magic: 4
-      ranged: 0
-    defence_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
-      magic: 4
-      ranged: 0
-    other_bonus:
-      melee_strength: 0
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
+    weapon_type: none
+    weight: 0.283
     requirements:
       magic: 20
-  properties:
-    tradeable: true
-    tradeable_ge: true
-    weight: 0.5
+    attack_bonus:
+      magic: 4
+    defence_bonus:
+      magic: 4
+    other_bonus: {}
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   drop_table:
-    primary_source: Medium clue casket
-    best_drop_rate: 1/1,133
     sources:
       - source: Medium clue casket
-        source_id: 0
-        combat_level: 0
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/1,133
+        rarity: 1/1133
   related_items:
-    - item_id: 13235
-      item_name: Eternal boots
-      slug: eternal-boots
+    - slug: eternal-boots
+      name: Eternal boots
       relationship: upgrade
-      description: BiS magic boots
-    - item_id: 6920
-      item_name: Infinity boots
-      slug: infinity-boots
+    - slug: infinity-boots
+      name: Infinity boots
       relationship: upgrade
-      description: +5 magic bonus
-    - item_id: 2577
-      item_name: Ranger boots
-      slug: ranger-boots
+    - slug: ranger-boots
+      name: Ranger boots
       relationship: alternative
-      description: Ranged equivalent from same clue tier
-    - item_id: 12598
-      item_name: Holy sandals
-      slug: holy-sandals
+    - slug: holy-sandals
+      name: Holy sandals
       relationship: alternative
-      description: Prayer equivalent from same clue tier
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Magic attack | +4 |
-    | Magic defence | +4 |
-
-    Budget magic boots option:
-    - Early game magic training
-    - F2P-style mage builds
-    - Much cheaper than Eternal boots
-
-    Note: Infinity boots (+5 magic) are better but require Mage Training Arena.
+  about: "Budget magic boots option for early game magic training and F2P-style mage builds. Much cheaper than Eternal boots; Infinity boots (+5 magic) are better but require Mage Training Arena."
   market_strategy:
     notes:
       - Medium clue reward
       - Budget option for magic setups
       - Often stocked by clue hunters
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  history:
+    - date: "2004-05-05"
+      description: Wizard boots released as a Treasure Trails medium reward.
+    - date: "2005-06-22"
+      description: Item renamed from "Wizard's boots" to "Wizard boots".
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-05-05"
+    update: Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-feather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-feather.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 5
   highalch: 7
   limit: 8000
-  about: "Yellow feather is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 8,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: feather
+    tier: low
+  drop_table:
+    sources:
+      - source: Golden warbler
+        quantity: "5-10"
+        rarity: Always
+  shops:
+    - shop_name: "Aaron's Archery Appendages"
+      location: Varrock
+      stock: 0
+      price: 13
+      sell_price: 5
+  related_items:
+    - name: Feather
+      relationship: alternative
+    - name: Golden warbler feather
+      relationship: alternative
+  about: "Yellow feather is a members-only Hunter drop obtained from golden warblers in the Uzer Hunter area. Functions as a substitute for ordinary feathers in fletching. High alchemy value: 7 coins. Grand Exchange buy limit: 8,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Supply scales with Hunter trainers running golden warblers."
+      - "Demand is niche compared to standard feathers."
+  trading_tips:
+    - "Buy from Hunter trainers in bulk; resell on the GE when feather demand spikes."
+    - "Useful as fletching feed at slight markup over plain feathers."
+  history:
+    - date: "2006-11-21"
+      description: "Yellow feather released with the Hunter skill update."
+    - date: "2007-07-09"
+      description: "Initially released as 'Orange feather'; later renamed and recoloured to 'Yellow feather'."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    update: "Hunter"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-mix-1.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 50
   highalch: 75
   limit: 2000
-  about: "Zamorak mix(1) is a members-only item in Old School RuneScape. High alchemy value: 75 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  potion:
+    doses: 1
+    effects:
+      - description: "Boosts Attack by 20% + 2"
+      - description: "Boosts Strength by 12% + 2"
+      - description: "Drains Defence by 10% + 2"
+        duration: 0
+      - description: "Restores Prayer points by 10% of total Prayer level"
+      - description: "Deals damage equal to floor((current HP - 1) / 8) and heals 6 Hitpoints on the same tick"
+  recipes:
+    - materials:
+        - item_name: Zamorak brew (2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      output_item: Zamorak mix (1)
+      requirements:
+        herblore: 85
+        xp: 58
+        quest: Heroes' Quest
+  related_items:
+    - item_name: Zamorak brew (2)
+      relationship: component
+      description: Two-dose Zamorak brew combined with caviar to produce the mix
+    - item_name: Caviar
+      relationship: component
+      description: Barbarian Herblore ingredient added to the brew
+    - item_id: 11522
+      item_name: Zamorak mix (2)
+      slug: zamorak-mix-2
+      relationship: variant
+      description: Two-dose Zamorak mix variant
+    - item_name: Zamorak brew (4)
+      relationship: alternative
+      description: Standard non-mix Zamorak brew used in PvP and PvM
+  about: "Zamorak mix (1) is a one-dose Barbarian Herblore mix made from Zamorak brew(2) and caviar; restores prayer and HP on top of the standard Zamorak brew boost."
+  market_strategy:
+    notes:
+      - Niche use case (free prayer restore + heal) keeps demand thin but consistent.
+      - Caviar supply via Barbarian fishing dictates production cost more than Zamorak brew price.
+  trading_tips:
+    - Profitable when Zamorak brew (2) and caviar combined cost is below GE price of the mix minus tax.
+    - Stack ahead of league/seasonal events where Barbarian Herblore receives buffs.
+  history:
+    - date: "2007-07-03"
+      description: Added with the Barbarian Training (Barbarian Herblore) update.
+  properties:
+    release_date: "2007-07-03"
+    update: Barbarian Training
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Heroes' Quest
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-page-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-page-3.mdx
@@ -12,43 +12,64 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 5
-  item:
-    type: god_page
-    god: Zamorak
-    page_number: 3
-    tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy/Medium/Hard/Elite
-        drop_rate: Varies by tier
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
   related_items:
     - item_id: 3831
       item_name: Zamorak page 1
       slug: zamorak-page-1
       relationship: set-piece
-      description: Page 1 of 4
+      description: Page 1 of 4 of the Unholy book (Zamorak)
     - item_id: 3832
       item_name: Zamorak page 2
       slug: zamorak-page-2
       relationship: set-piece
-      description: Page 2 of 4
+      description: Page 2 of 4 of the Unholy book (Zamorak)
     - item_id: 3834
       item_name: Zamorak page 4
       slug: zamorak-page-4
       relationship: set-piece
-      description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Zamorak |
-    | Page | 3 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Unholy book (Zamorak god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Page 4 of 4 of the Unholy book (Zamorak)
+    - item_id: 3840
+      item_name: Unholy book
+      slug: unholy-book
+      relationship: product
+      description: Completed Zamorak god book formed from all 4 pages
+  about: Zamorak page 3 is one of four torn pages used to complete the Unholy book (Zamorak god book). Obtained as a reward from Treasure Trails (Easy through Elite).
+  market_strategy:
+    notes:
+      - Niche demand tied to god-book completion; price spikes during clue scroll events.
+      - GE limit of 5 every 4 hours makes bulk flipping slow.
+  trading_tips:
+    - Buy pages individually when cheaper than the assembled book / 4.
+    - Sell to Grand Exchange Clerk as an unholy book page set for slightly better margins during demand spikes.
+  history:
+    - date: "2004-11-17"
+      description: Added to the game with the Horror From The Deep update.
+  properties:
+    release_date: "2004-11-17"
+    update: Horror From The Deep
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-plateskirt.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
-  about: "Zamorak plateskirt is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: Rune
+    tier: mid-high
+  equipment:
+    slot: legs
+    weight: 9.071
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
+      strength: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - name: Rune plateskirt
+      relationship: variant
+    - name: Zamorak platebody
+      relationship: set-piece
+    - name: Zamorak full helm
+      relationship: set-piece
+    - name: Zamorak kiteshield
+      relationship: set-piece
+    - name: Zamorak platelegs
+      relationship: alternative
+  about: "Zamorak plateskirt is a rune-tier plateskirt obtained from hard Treasure Trail rewards; wearing any Zamorak armour piece pacifies followers of Zamorak in the God Wars Dungeon."
+  market_strategy:
+    notes:
+      - "Drop rate 1/1625 from hard reward caskets keeps supply scarce."
+      - "Tiny GE limit (8 per 4 hours) — best for slow accumulation, not high-velocity flips."
+      - "High alch 38.4k typically well below GE price — never alch."
+  trading_tips:
+    - "Demand from GWD passage-style trips and collection log hunters."
+    - "Watch prices around Treasure Trail content updates and DMM seasons."
+  history:
+    - date: "2004-10-26"
+      description: "Released as a hard clue scroll reward in the Treasure Trails update."
+  properties:
+    release_date: "2004-10-26"
+    update: "Treasure Trails"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-stole.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-stole.mdx
@@ -14,32 +14,73 @@ osrs:
   limit: 8
   equipment:
     slot: neck
+    weight: 0.01
     requirements:
       prayer: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
     other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 10
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard
-        description: Reward from hard clue scrolls
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 10470
-      item_name: Saradomin stole
-      slug: saradomin-stole
+    - name: Saradomin stole
       relationship: variant
-      description: Saradomin equivalent stole
-    - item_id: 10468
-      item_name: Zamorak robe legs
-      slug: zamorak-robe-legs
+    - name: Guthix stole
+      relationship: variant
+    - name: Zamorak mitre
       relationship: set-piece
-      description: Zamorak vestment legs piece
-  about: |-
-    > *"A Zamorak stole."*
-
-    The Zamorak stole is a neck slot item from the Zamorak vestment set. It provides a +10 Prayer bonus and requires 60 Prayer to equip. As a Zamorakian item, it provides protection in the God Wars Dungeon Zamorak encampment. One of the highest prayer bonus items available in the neck slot.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - name: Zamorak cloak
+      relationship: set-piece
+    - name: Zamorak robe top
+      relationship: set-piece
+    - name: Zamorak robe legs
+      relationship: set-piece
+  about: "Zamorak stole is a neck slot vestment piece requiring 60 Prayer to equip, granting a +10 Prayer bonus alongside +2 Magic attack and defence. Counts as a Zamorakian item in the God Wars Dungeon and stores in the costume room treasure chest."
+  market_strategy:
+    notes:
+      - "Buy limit only 8 per 4 hours; price is sensitive to Zamorak vestment set demand and prayer/setup builds."
+      - "Hard clue reward with thin volume; spreads widen when fewer hard caskets are being opened."
+  trading_tips:
+    - "Pair with the rest of the Zamorak vestment set for the highest neck-slot prayer bonus available at 60 Prayer."
+    - "Useful as Zamorakian protection inside the God Wars Dungeon Zamorak encampment, avoiding aggro."
+  history:
+    - date: "2006-12-05"
+      description: "Released as part of the Treasure Trails update."
+  properties:
+    release_date: "2006-12-05"
+    update: Treasure Trails
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-amulet.mdx
@@ -12,54 +12,65 @@ osrs:
   lowalch: 80800
   highalch: 121200
   limit: 8
+  material:
+    type: Zenyte
+    tier: high
   equipment:
     slot: neck
+    weight: 0.01
     requirements:
-      crafting: 98
+      crafting: 1
   recipes:
-    - skill: crafting
-      level: 98
-      xp: 200
-      inputs:
-        - item_name: Zenyte
+    - skill: Crafting
+      level: 1
+      experience: 4
+      materials:
+        - item_name: Zenyte amulet (u)
           quantity: 1
-        - item_name: Gold bar
+        - item_name: Ball of wool
           quantity: 1
+      tools: []
       output_quantity: 1
   related_items:
-    - item_id: 6581
-      item_name: Onyx amulet
-      slug: onyx-amulet
+    - name: Zenyte amulet (u)
+      relationship: component
+    - name: Amulet of torture
+      relationship: product
+    - name: Onyx amulet
       relationship: downgrade
-      description: Previous tier amulet
-  about: |-
-    Crafting (Level 98): Zenyte + Gold bar at a furnace with amulet mould (200 XP). String with ball of wool.
-
-    The highest Crafting requirement of any jewelry piece.
-
-    > *"A zenyte amulet."*
-
-    Lvl-7 Enchant (93 Magic): 1 cosmic rune + 20 soul runes + 20 blood runes (110 XP)
-
-    The Amulet of torture is the best-in-slot melee amulet:
-    - +15 Stab/Slash/Crush attack
-    - +10 Strength
-    - +2 Prayer
-    - Highest melee accuracy and Strength bonus of any neck slot item
-
-    | Jewelry | Slot | Enchanted | Combat Style |
-    |---------|------|-----------|-------------|
-    | Zenyte amulet | Neck | Amulet of torture | Melee BiS |
-    | Zenyte necklace | Neck | Necklace of anguish | Ranged BiS |
-    | Zenyte bracelet | Hands | Tormented bracelet | Magic BiS |
-    | Zenyte ring | Ring | Ring of suffering | Defensive BiS |
+    - name: Zenyte
+      relationship: component
+  about: "Zenyte amulet is the strung form of the highest-tier amulet jewellery in Old School RuneScape. It is created by stringing a Zenyte amulet (u) with a ball of wool, then enchanted via Lvl-7 Enchant (93 Magic) into the Amulet of torture - the best-in-slot melee neckwear."
   market_strategy:
     notes:
-      - Zenyte shard (Demonic gorillas 1/300) + onyx = zenyte
-      - 98 Crafting is very high — limits supply
-      - Torture has permanent BiS demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Zenyte shard supply from Demonic gorillas (1/300) caps throughput
+      - 98 Crafting requirement on the unstrung version limits competition
+      - Amulet of torture BiS status keeps long-term demand
+  trading_tips:
+    - Compare unstrung + ball of wool cost vs strung price
+    - Watch demonic gorilla slayer trends for zenyte shard flow
+  history:
+    - date: "2016-05-06"
+      description: Released as part of the Monkey Madness II update.
+  properties:
+    release_date: "2016-05-06"
+    update: Monkey Madness II
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

- Thirteenth batch — migrate 200 randomly-sampled OSRS MDX entries from `mdx_version: 2` to `3` with full wiki enrichment.
- Worktree-direct authoring; main repo untouched.
- Schema-validated via `astro sync` AND full production build (`astro build`) locally — 7688 pages built in 187s. Matches CI manifest-guard build path.

## Test plan

- [x] `astro sync` clean.
- [x] `astro build` green (full local production build).
- [ ] CI manifest guard / build green on GitHub Actions.

## Follow-ups

- ~2623 v2 items remain after this batch lands.